### PR TITLE
fix(laravel): broaden JS/TS patterns for flexible frontend structure

### DIFF
--- a/packages/cli/src/frameworks/detector-service.ts
+++ b/packages/cli/src/frameworks/detector-service.ts
@@ -107,13 +107,13 @@ async function detectAtPath(
       // Only LOW confidence -> use priority system
       lowConfidence.sort((a, b) => b.priority - a.priority);
       const { priority, ...winner } = lowConfidence[0];
-      results.push(winner);
-      
+    results.push(winner);
+    
       // Skipped = remaining low confidence
       const skipped = lowConfidence.slice(1);
-      if (skipped.length > 0) {
-        const skippedNames = skipped.map(d => d.name).join(', ');
-        console.log(`  → Skipping ${skippedNames} at ${relativePath} (${winner.name} takes precedence)`);
+    if (skipped.length > 0) {
+      const skippedNames = skipped.map(d => d.name).join(', ');
+      console.log(`  → Skipping ${skippedNames} at ${relativePath} (${winner.name} takes precedence)`);
       }
     }
   } else if (detectedAtPath.length === 1) {

--- a/packages/cli/src/frameworks/laravel/config.ts
+++ b/packages/cli/src/frameworks/laravel/config.ts
@@ -17,12 +17,12 @@ export async function generateLaravelConfig(
       'resources/**/*.php',
       'tests/**/*.php',
       '*.php',
-      // Frontend assets (Vue/React/Inertia)
-      'resources/js/**/*.js',
-      'resources/js/**/*.ts',
-      'resources/js/**/*.jsx',
-      'resources/js/**/*.tsx',
-      'resources/js/**/*.vue',
+      // Frontend assets (Vue/React/Inertia) - Broadened for flexibility
+      '**/*.js',
+      '**/*.ts',
+      '**/*.jsx',
+      '**/*.tsx',
+      '**/*.vue',
       // Blade templates
       'resources/views/**/*.blade.php',
       // Documentation

--- a/packages/cli/test/integration/laravel-frontend.test.ts
+++ b/packages/cli/test/integration/laravel-frontend.test.ts
@@ -45,12 +45,12 @@ describe('Laravel Frontend Integration', () => {
     expect(config.include).toContain('app/**/*.php');
     expect(config.include).toContain('resources/**/*.php');
 
-    // Verify frontend files are included
-    expect(config.include).toContain('resources/js/**/*.js');
-    expect(config.include).toContain('resources/js/**/*.ts');
-    expect(config.include).toContain('resources/js/**/*.jsx');
-    expect(config.include).toContain('resources/js/**/*.tsx');
-    expect(config.include).toContain('resources/js/**/*.vue');
+    // Verify frontend files are included (broadened patterns for flexibility)
+    expect(config.include).toContain('**/*.js');
+    expect(config.include).toContain('**/*.ts');
+    expect(config.include).toContain('**/*.jsx');
+    expect(config.include).toContain('**/*.tsx');
+    expect(config.include).toContain('**/*.vue');
 
     // Verify Blade templates are included
     expect(config.include).toContain('resources/views/**/*.blade.php');


### PR DESCRIPTION
PROBLEM:
Laravel's frontend patterns were too restrictive (resources/js/**/*.js), similar to the Node.js pattern bug. This caused files in non-standard locations (frontend/, client/, src/) to be missed.

IMPACT:
- Affects Laravel apps with custom frontend structure
- Affects Inertia.js apps with frontend in non-standard dirs
- Affects monorepos with frontend outside resources/js/

SOLUTION:
- Broadened JS/TS/Vue patterns to **/*.js, **/*.ts, **/*.vue
- Kept PHP patterns specific (Laravel structure is opinionated for PHP)
- Exclude patterns already comprehensive (no changes needed)
- Updated tests to match new patterns

WHY PHP PATTERNS STAY SPECIFIC:
Laravel enforces directory structure for PHP via composer autoloading and framework conventions. But frontend (JS/TS/Vue) can be anywhere.

TESTING:
- All 413 tests pass
- Laravel frontend integration tests updated and verified