### PR TITLE
feat(indexer): implement AST-based semantic chunking for TS & JS

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,11 +1,11 @@
 {
-    "mcpServers": {
-      "lien": {
-        "command": "node",
-        "args": [
-          "/Users/alfhenderson/Code/lien/packages/cli/dist/index.js",
-          "serve"
-        ]
-      }
+  "mcpServers": {
+    "lien": {
+      "command": "node",
+      "args": [
+        "/Users/alfhenderson/Code/lien/packages/cli/dist/index.js",
+        "serve"
+      ]
     }
   }
+}

--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -3,9 +3,10 @@
     "lien": {
       "command": "node",
       "args": [
-        "/Users/alfhenderson/Code/lien/packages/cli/dist/index.js",
+        "/absolute/path/to/lien/packages/cli/dist/index.js",
         "serve"
       ]
     }
   }
 }
+

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ coverage/
 *.swo
 *~
 
-# Cursor (keep project.mdc, ignore generated lien.mdc)
+# Cursor (keep project.mdc, ignore generated lien.mdc and local mcp.json)
 .cursor/rules/lien.mdc
+.cursor/mcp.json
 
 # OS
 .DS_Store

--- a/.lien.config.json
+++ b/.lien.config.json
@@ -20,7 +20,7 @@
     "pollIntervalMs": 10000
   },
   "fileWatching": {
-    "enabled": false,
+    "enabled": true,
     "debounceMs": 1000
   },
   "frameworks": [
@@ -30,24 +30,15 @@
       "enabled": true,
       "config": {
         "include": [
-          "src/**/*.ts",
-          "src/**/*.tsx",
-          "src/**/*.js",
-          "src/**/*.jsx",
-          "src/**/*.mjs",
-          "src/**/*.cjs",
-          "lib/**/*.ts",
-          "lib/**/*.js",
-          "*.ts",
-          "*.js",
-          "*.mjs",
-          "*.cjs",
+          "**/*.ts",
+          "**/*.tsx",
+          "**/*.js",
+          "**/*.jsx",
+          "**/*.vue",
+          "**/*.mjs",
+          "**/*.cjs",
           "**/*.md",
-          "**/*.mdx",
-          "docs/**/*.md",
-          "README.md",
-          "CHANGELOG.md",
-          "CONTRIBUTING.md"
+          "**/*.mdx"
         ],
         "exclude": [
           "node_modules/**",
@@ -56,10 +47,19 @@
           "coverage/**",
           ".next/**",
           ".nuxt/**",
+          ".vite/**",
+          ".lien/**",
           "out/**",
           "*.min.js",
           "*.min.css",
-          "*.bundle.js"
+          "*.bundle.js",
+          "playwright-report/**",
+          "test-results/**",
+          "__generated__/**",
+          ".cache/**",
+          ".turbo/**",
+          ".vercel/**",
+          ".netlify/**"
         ]
       }
     },
@@ -69,24 +69,15 @@
       "enabled": true,
       "config": {
         "include": [
-          "src/**/*.ts",
-          "src/**/*.tsx",
-          "src/**/*.js",
-          "src/**/*.jsx",
-          "src/**/*.mjs",
-          "src/**/*.cjs",
-          "lib/**/*.ts",
-          "lib/**/*.js",
-          "*.ts",
-          "*.js",
-          "*.mjs",
-          "*.cjs",
+          "**/*.ts",
+          "**/*.tsx",
+          "**/*.js",
+          "**/*.jsx",
+          "**/*.vue",
+          "**/*.mjs",
+          "**/*.cjs",
           "**/*.md",
-          "**/*.mdx",
-          "docs/**/*.md",
-          "README.md",
-          "CHANGELOG.md",
-          "CONTRIBUTING.md"
+          "**/*.mdx"
         ],
         "exclude": [
           "node_modules/**",
@@ -95,10 +86,58 @@
           "coverage/**",
           ".next/**",
           ".nuxt/**",
+          ".vite/**",
+          ".lien/**",
           "out/**",
           "*.min.js",
           "*.min.css",
-          "*.bundle.js"
+          "*.bundle.js",
+          "playwright-report/**",
+          "test-results/**",
+          "__generated__/**",
+          ".cache/**",
+          ".turbo/**",
+          ".vercel/**",
+          ".netlify/**"
+        ]
+      }
+    },
+    {
+      "name": "nodejs",
+      "path": "packages/site",
+      "enabled": true,
+      "config": {
+        "include": [
+          "**/*.ts",
+          "**/*.tsx",
+          "**/*.js",
+          "**/*.jsx",
+          "**/*.vue",
+          "**/*.mjs",
+          "**/*.cjs",
+          "**/*.md",
+          "**/*.mdx"
+        ],
+        "exclude": [
+          "node_modules/**",
+          "dist/**",
+          "build/**",
+          "coverage/**",
+          ".next/**",
+          ".nuxt/**",
+          ".vite/**",
+          ".lien/**",
+          "out/**",
+          "*.min.js",
+          "*.min.css",
+          "*.bundle.js",
+          "playwright-report/**",
+          "test-results/**",
+          "__generated__/**",
+          ".cache/**",
+          ".turbo/**",
+          ".vercel/**",
+          ".netlify/**"
         ]
       }
     }

--- a/.lien.config.json
+++ b/.lien.config.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.14.0",
+  "version": "0.13.0",
   "core": {
     "chunkSize": 75,
     "chunkOverlap": 10,

--- a/.lien.config.json
+++ b/.lien.config.json
@@ -1,10 +1,14 @@
 {
-  "version": "0.3.0",
+  "version": "0.14.0",
   "core": {
     "chunkSize": 75,
     "chunkOverlap": 10,
     "concurrency": 4,
     "embeddingBatchSize": 50
+  },
+  "chunking": {
+    "useAST": true,
+    "astFallback": "line-based"
   },
   "mcp": {
     "port": 7133,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
 # Changelog
 
 All notable changes to Lien will be documented in this file.
+
+## [0.14.0] - 2025-XX-XX
+
+### Breaking Changes
+- **AST-based chunking**: Full reindex required due to new chunking strategy and metadata fields
+- Index format version bumped to v2 (will trigger automatic reindex on first run)
+- Search results now include enhanced metadata (function names, complexity, signatures, etc.)
+
+### Added
+- **AST-based semantic chunking for TypeScript/JavaScript** using Tree-sitter
+  - Chunks now respect function/class boundaries (never split mid-function)
+  - Enhanced metadata: function names, cyclomatic complexity, method signatures
+  - Parameter lists and return types extracted for functions
+  - Import statements tracked for better context
+  - Graceful fallback to line-based chunking on parse errors
+- **Enhanced `list_functions` MCP tool**
+  - Returns full function signatures with parameters and return types
+  - Includes complexity metrics for functions
+  - Better symbol detection using AST extraction
+  - Filters by AST-derived `symbolName` in addition to legacy symbol arrays
+- **New configuration options** in `.lien.config.json`:
+  - `chunking.useAST`: Enable/disable AST-based chunking (default: `true`)
+  - `chunking.astFallback`: Strategy on parse errors (`'line-based'` or `'error'`)
+- **Config migration** automatically adds new chunking section to existing configs
+
+### Improved
+- **Search result quality**: Chunks are now semantically meaningful code units
+- **Better context for AI assistants**: Metadata provides function names, complexity, and signatures
+- **More accurate symbol extraction**: Uses AST parsing instead of regex patterns
+- **Metadata enrichment**: All search results include `symbolName`, `symbolType`, `complexity`, `parameters`, `signature`, and `imports` when available
+
+### Technical
+- New dependency: `tree-sitter` and `tree-sitter-typescript` for AST parsing
+- Vector DB schema updated to store new AST-derived metadata fields
+- Config version updated to `0.14.0`
+- Index format version updated to `2`
+
 ## [0.12.0] - 2025-11-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,6 @@
 
 All notable changes to Lien will be documented in this file.
 
-## [0.14.0] - 2025-XX-XX
-
-### Breaking Changes
-- **AST-based chunking**: Full reindex required due to new chunking strategy and metadata fields
-- Index format version bumped to v2 (will trigger automatic reindex on first run)
-- Search results now include enhanced metadata (function names, complexity, signatures, etc.)
-
-### Added
-- **AST-based semantic chunking for TypeScript/JavaScript** using Tree-sitter
-  - Chunks now respect function/class boundaries (never split mid-function)
-  - Enhanced metadata: function names, cyclomatic complexity, method signatures
-  - Parameter lists and return types extracted for functions
-  - Import statements tracked for better context
-  - Graceful fallback to line-based chunking on parse errors
-- **Enhanced `list_functions` MCP tool**
-  - Returns full function signatures with parameters and return types
-  - Includes complexity metrics for functions
-  - Better symbol detection using AST extraction
-  - Filters by AST-derived `symbolName` in addition to legacy symbol arrays
-- **New configuration options** in `.lien.config.json`:
-  - `chunking.useAST`: Enable/disable AST-based chunking (default: `true`)
-  - `chunking.astFallback`: Strategy on parse errors (`'line-based'` or `'error'`)
-- **Config migration** automatically adds new chunking section to existing configs
-
-### Improved
-- **Search result quality**: Chunks are now semantically meaningful code units
-- **Better context for AI assistants**: Metadata provides function names, complexity, and signatures
-- **More accurate symbol extraction**: Uses AST parsing instead of regex patterns
-- **Metadata enrichment**: All search results include `symbolName`, `symbolType`, `complexity`, `parameters`, `signature`, and `imports` when available
-
-### Technical
-- New dependency: `tree-sitter` and `tree-sitter-typescript` for AST parsing
-- Vector DB schema updated to store new AST-derived metadata fields
-- Config version updated to `0.14.0`
-- Index format version updated to `2`
-
 ## [0.12.0] - 2025-11-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8483,6 +8483,7 @@
         "ora": "8.0.0",
         "p-limit": "5.0.0",
         "tree-sitter": "^0.21.1",
+        "tree-sitter-javascript": "^0.23.1",
         "tree-sitter-typescript": "^0.23.2",
         "vectordb": "0.21.2",
         "zod": "^3.25.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5549,6 +5549,17 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/non-layered-tidy-tree-layout": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
@@ -6943,6 +6954,83 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript/node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript/node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/trim-lines": {
@@ -8379,7 +8467,7 @@
     },
     "packages/cli": {
       "name": "@liendev/lien",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.5.0",
@@ -8394,6 +8482,8 @@
         "inquirer": "9.2.0",
         "ora": "8.0.0",
         "p-limit": "5.0.0",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-typescript": "^0.23.2",
         "vectordb": "0.21.2",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.0"

--- a/packages/cli/CURSOR_RULES_TEMPLATE.md
+++ b/packages/cli/CURSOR_RULES_TEMPLATE.md
@@ -195,6 +195,19 @@ const simpleValidators = functions.filter(r => (r.metadata.parameters?.length ||
 - For unsupported languages, Lien automatically falls back to line-based chunking
 - No disruption to existing workflows
 
+### Known Limitations
+
+**Very large files (1000+ lines):**
+- Tree-sitter may fail with "Invalid argument" error on extremely large files
+- When this occurs, Lien automatically falls back to line-based chunking
+- This is a known Tree-sitter limitation with very large syntax trees
+- Fallback behavior is configurable via `astFallback` setting
+
+**Resilient parsing:**
+- Tree-sitter is designed to produce best-effort ASTs even for invalid syntax
+- Parse errors are rare; most malformed code still produces usable chunks
+- The `astFallback: 'error'` option mainly catches edge cases like large file errors
+
 ### Configuration
 
 Control AST behavior in `.lien.config.json`:

--- a/packages/cli/CURSOR_RULES_TEMPLATE.md
+++ b/packages/cli/CURSOR_RULES_TEMPLATE.md
@@ -114,7 +114,7 @@ list_functions({
 
 ---
 
-## Enhanced Metadata (AST-Based) ⚡ NEW in v0.14.0
+## Enhanced Metadata (AST-Based) ⚡ NEW in v0.13.0
 
 Lien now uses **Abstract Syntax Tree (AST) parsing** for TypeScript/JavaScript files to provide rich code metadata:
 
@@ -132,7 +132,7 @@ All search results (`semantic_search`, `get_file_context`, `find_similar`, `list
     type: "function",  // 'function' | 'class' | 'block'
     language: "typescript",
     
-    // AST-derived metadata (NEW in v0.14.0):
+    // AST-derived metadata (NEW in v0.13.0):
     symbolName: "validateEmail",              // Function/class name
     symbolType: "function",                   // 'function' | 'method' | 'class' | 'interface'
     parentClass: undefined,                   // For methods: parent class name

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liendev/lien",
-  "version": "0.13.0",
+  "version": "0.12.0",
   "description": "Local semantic code search for AI assistants via MCP",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,8 @@
     "inquirer": "9.2.0",
     "ora": "8.0.0",
     "p-limit": "5.0.0",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-typescript": "^0.23.2",
     "vectordb": "0.21.2",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,7 @@
     "ora": "8.0.0",
     "p-limit": "5.0.0",
     "tree-sitter": "^0.21.1",
+    "tree-sitter-javascript": "^0.23.1",
     "tree-sitter-typescript": "^0.23.2",
     "vectordb": "0.21.2",
     "zod": "^3.25.76",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,9 +66,9 @@
     "inquirer": "9.2.0",
     "ora": "8.0.0",
     "p-limit": "5.0.0",
-    "tree-sitter": "^0.21.1",
-    "tree-sitter-javascript": "^0.23.1",
-    "tree-sitter-typescript": "^0.23.2",
+    "tree-sitter": "0.21.1",
+    "tree-sitter-javascript": "0.23.1",
+    "tree-sitter-typescript": "0.23.2",
     "vectordb": "0.21.2",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liendev/lien",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Local semantic code search for AI assistants via MCP",
   "type": "module",
   "bin": {

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -54,7 +54,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.frameworks).toBeDefined();
       expect(Array.isArray(config.frameworks)).toBe(true);
     });
@@ -150,7 +150,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.core.chunkSize).toBe(800); // Preserved
       expect(config.core.chunkOverlap).toBe(10); // Preserved
       expect(config.frameworks).toHaveLength(1); // Migrated to generic framework
@@ -221,7 +221,7 @@ describe('initCommand', () => {
       const config = JSON.parse(content);
       
       // User values should be preserved in new structure
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.core.chunkSize).toBe(2000);
       expect(config.core.chunkOverlap).toBe(400);
       expect(config.frameworks).toHaveLength(1);

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -54,7 +54,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.frameworks).toBeDefined();
       expect(Array.isArray(config.frameworks)).toBe(true);
     });
@@ -150,7 +150,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.core.chunkSize).toBe(800); // Preserved
       expect(config.core.chunkOverlap).toBe(10); // Preserved
       expect(config.frameworks).toHaveLength(1); // Migrated to generic framework
@@ -221,7 +221,7 @@ describe('initCommand', () => {
       const config = JSON.parse(content);
       
       // User values should be preserved in new structure
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.core.chunkSize).toBe(2000);
       expect(config.core.chunkOverlap).toBe(400);
       expect(config.frameworks).toHaveLength(1);

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -54,7 +54,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toBeDefined();
       expect(Array.isArray(config.frameworks)).toBe(true);
     });
@@ -150,7 +150,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.core.chunkSize).toBe(800); // Preserved
       expect(config.core.chunkOverlap).toBe(10); // Preserved
       expect(config.frameworks).toHaveLength(1); // Migrated to generic framework
@@ -221,7 +221,7 @@ describe('initCommand', () => {
       const config = JSON.parse(content);
       
       // User values should be preserved in new structure
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.core.chunkSize).toBe(2000);
       expect(config.core.chunkOverlap).toBe(400);
       expect(config.frameworks).toHaveLength(1);

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -54,7 +54,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toBeDefined();
       expect(Array.isArray(config.frameworks)).toBe(true);
     });
@@ -150,7 +150,7 @@ describe('initCommand', () => {
       const content = await fs.readFile(configPath, 'utf-8');
       const config = JSON.parse(content);
       
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.core.chunkSize).toBe(800); // Preserved
       expect(config.core.chunkOverlap).toBe(10); // Preserved
       expect(config.frameworks).toHaveLength(1); // Migrated to generic framework
@@ -221,7 +221,7 @@ describe('initCommand', () => {
       const config = JSON.parse(content);
       
       // User values should be preserved in new structure
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.core.chunkSize).toBe(2000);
       expect(config.core.chunkOverlap).toBe(400);
       expect(config.frameworks).toHaveLength(1);

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -9,6 +9,7 @@ import { showCompactBanner } from '../utils/banner.js';
 import { needsMigration, migrateConfig } from '../config/migration.js';
 import { detectAllFrameworks } from '../frameworks/detector-service.js';
 import { getFrameworkDetector } from '../frameworks/registry.js';
+import { CURRENT_CONFIG_VERSION } from '../constants.js';
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -337,7 +338,7 @@ async function upgradeConfig(configPath: string) {
     let migrated = false;
     
     if (migrationNeeded) {
-      console.log(chalk.blue('🔄 Migrating config from v0.2.0 to v0.13.0...'));
+      console.log(chalk.blue(`🔄 Migrating config from v0.2.0 to v${CURRENT_CONFIG_VERSION}...`));
       upgradedConfig = migrateConfig(existingConfig);
       migrated = true;
     } else {

--- a/packages/cli/src/config/loader.test.ts
+++ b/packages/cli/src/config/loader.test.ts
@@ -30,7 +30,7 @@ describe('Config Loader', () => {
     
     it('should load and merge user config with defaults', async () => {
       const userConfig = {
-        version: '0.14.0',
+        version: '0.12.0',
         core: {
           chunkSize: 2000,
         },
@@ -98,7 +98,7 @@ describe('Config Loader', () => {
       
       const config = await loadConfig(testDir);
       // Empty config just merges with defaults - no migration needed
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toEqual(defaultConfig.frameworks);
       expect(config.core).toEqual(defaultConfig.core);
     });
@@ -152,7 +152,7 @@ describe('Config Loader', () => {
       const config = await loadConfig(testDir);
       
       // Should be migrated to v0.3.0
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.core.chunkSize).toBe(100);
       expect(config.core.chunkOverlap).toBe(20);
       expect(config.mcp.port).toBe(8080);

--- a/packages/cli/src/config/loader.test.ts
+++ b/packages/cli/src/config/loader.test.ts
@@ -30,11 +30,15 @@ describe('Config Loader', () => {
     
     it('should load and merge user config with defaults', async () => {
       const userConfig = {
-        version: '0.3.0',
+        version: '0.14.0',
         core: {
           chunkSize: 2000,
         },
         frameworks: [], // Explicitly include frameworks to avoid migration
+        chunking: {
+          useAST: true,
+          astFallback: 'line-based',
+        },
       };
       
       const configPath = path.join(testDir, '.lien.config.json');
@@ -94,7 +98,7 @@ describe('Config Loader', () => {
       
       const config = await loadConfig(testDir);
       // Empty config just merges with defaults - no migration needed
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.frameworks).toEqual(defaultConfig.frameworks);
       expect(config.core).toEqual(defaultConfig.core);
     });
@@ -148,7 +152,7 @@ describe('Config Loader', () => {
       const config = await loadConfig(testDir);
       
       // Should be migrated to v0.3.0
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.core.chunkSize).toBe(100);
       expect(config.core.chunkOverlap).toBe(20);
       expect(config.mcp.port).toBe(8080);

--- a/packages/cli/src/config/loader.test.ts
+++ b/packages/cli/src/config/loader.test.ts
@@ -30,7 +30,7 @@ describe('Config Loader', () => {
     
     it('should load and merge user config with defaults', async () => {
       const userConfig = {
-        version: '0.12.0',
+        version: '0.13.0',
         core: {
           chunkSize: 2000,
         },
@@ -98,7 +98,7 @@ describe('Config Loader', () => {
       
       const config = await loadConfig(testDir);
       // Empty config just merges with defaults - no migration needed
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.frameworks).toEqual(defaultConfig.frameworks);
       expect(config.core).toEqual(defaultConfig.core);
     });
@@ -152,7 +152,7 @@ describe('Config Loader', () => {
       const config = await loadConfig(testDir);
       
       // Should be migrated to v0.3.0
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.core.chunkSize).toBe(100);
       expect(config.core.chunkOverlap).toBe(20);
       expect(config.mcp.port).toBe(8080);

--- a/packages/cli/src/config/loader.test.ts
+++ b/packages/cli/src/config/loader.test.ts
@@ -98,7 +98,7 @@ describe('Config Loader', () => {
       
       const config = await loadConfig(testDir);
       // Empty config just merges with defaults - no migration needed
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toEqual(defaultConfig.frameworks);
       expect(config.core).toEqual(defaultConfig.core);
     });
@@ -152,7 +152,7 @@ describe('Config Loader', () => {
       const config = await loadConfig(testDir);
       
       // Should be migrated to v0.3.0
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.core.chunkSize).toBe(100);
       expect(config.core.chunkOverlap).toBe(20);
       expect(config.mcp.port).toBe(8080);

--- a/packages/cli/src/config/merge.ts
+++ b/packages/cli/src/config/merge.ts
@@ -15,6 +15,10 @@ export function deepMergeConfig(defaults: LienConfig, user: Partial<LienConfig>)
       ...defaults.core,
       ...user.core,
     },
+    chunking: {
+      ...defaults.chunking,
+      ...user.chunking,
+    },
     mcp: {
       ...defaults.mcp,
       ...user.mcp,

--- a/packages/cli/src/config/migration.test.ts
+++ b/packages/cli/src/config/migration.test.ts
@@ -268,12 +268,16 @@ describe('Config Migration', () => {
     it('should not migrate already migrated config', async () => {
       const configPath = path.join(tempDir, '.lien.config.json');
       const newConfig: LienConfig = {
-        version: '0.3.0',
+        version: '0.14.0',
         core: {
           chunkSize: 75,
           chunkOverlap: 10,
           concurrency: 4,
           embeddingBatchSize: 50,
+        },
+        chunking: {
+          useAST: true,
+          astFallback: 'line-based',
         },
         mcp: {
           port: 7133,

--- a/packages/cli/src/config/migration.test.ts
+++ b/packages/cli/src/config/migration.test.ts
@@ -45,9 +45,9 @@ describe('Config Migration', () => {
       expect(needsMigration(oldConfig)).toBe(true);
     });
 
-    it('should return false for v0.12.0 config with frameworks and chunking', () => {
+    it('should return false for v0.13.0 config with frameworks and chunking', () => {
       const newConfig = {
-        version: '0.12.0',
+        version: '0.13.0',
         frameworks: [],
         chunking: {
           useAST: true,
@@ -115,7 +115,7 @@ describe('Config Migration', () => {
       const newConfig = migrateConfig(oldConfig);
 
       // Check version updated
-      expect(newConfig.version).toBe('0.12.0');
+      expect(newConfig.version).toBe('0.13.0');
 
       // Check core settings migrated
       expect(newConfig.core.chunkSize).toBe(100);
@@ -164,7 +164,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.12.0');
+      expect(newConfig.version).toBe('0.13.0');
       expect(newConfig.core.chunkSize).toBe(50);
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].config.include).toEqual(['**/*.py']);
@@ -175,7 +175,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.12.0');
+      expect(newConfig.version).toBe('0.13.0');
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].name).toBe('generic');
       
@@ -269,7 +269,7 @@ describe('Config Migration', () => {
       // Verify new config is migrated
       const newConfigContent = await fs.readFile(configPath, 'utf-8');
       const newConfig = JSON.parse(newConfigContent);
-      expect(newConfig.version).toBe('0.12.0');
+      expect(newConfig.version).toBe('0.13.0');
       expect(newConfig.frameworks).toHaveLength(1);
     });
 
@@ -322,7 +322,7 @@ describe('Config Migration', () => {
       const result = await migrateConfigFile(tempDir);
 
       expect(result.migrated).toBe(false);
-      expect(result.config.version).toBe('0.12.0');
+      expect(result.config.version).toBe('0.13.0');
       expect(result.config.frameworks).toEqual([]);
     });
 

--- a/packages/cli/src/config/migration.test.ts
+++ b/packages/cli/src/config/migration.test.ts
@@ -45,18 +45,26 @@ describe('Config Migration', () => {
       expect(needsMigration(oldConfig)).toBe(true);
     });
 
-    it('should return false for v0.3.0 config with frameworks', () => {
+    it('should return false for v0.14.0 config with frameworks and chunking', () => {
       const newConfig = {
-        version: '0.3.0',
+        version: '0.14.0',
         frameworks: [],
+        chunking: {
+          useAST: true,
+          astFallback: 'line-based' as const,
+        },
       };
 
       expect(needsMigration(newConfig)).toBe(false);
     });
 
-    it('should return false for config with empty frameworks array', () => {
+    it('should return false for config with empty frameworks array and chunking', () => {
       const newConfig = {
         frameworks: [],
+        chunking: {
+          useAST: true,
+          astFallback: 'line-based' as const,
+        },
       };
 
       expect(needsMigration(newConfig)).toBe(false);
@@ -107,7 +115,7 @@ describe('Config Migration', () => {
       const newConfig = migrateConfig(oldConfig);
 
       // Check version updated
-      expect(newConfig.version).toBe('0.3.0');
+      expect(newConfig.version).toBe('0.14.0');
 
       // Check core settings migrated
       expect(newConfig.core.chunkSize).toBe(100);
@@ -156,7 +164,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.3.0');
+      expect(newConfig.version).toBe('0.14.0');
       expect(newConfig.core.chunkSize).toBe(50);
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].config.include).toEqual(['**/*.py']);
@@ -167,7 +175,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.3.0');
+      expect(newConfig.version).toBe('0.14.0');
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].name).toBe('generic');
       
@@ -261,14 +269,14 @@ describe('Config Migration', () => {
       // Verify new config is migrated
       const newConfigContent = await fs.readFile(configPath, 'utf-8');
       const newConfig = JSON.parse(newConfigContent);
-      expect(newConfig.version).toBe('0.3.0');
+      expect(newConfig.version).toBe('0.14.0');
       expect(newConfig.frameworks).toHaveLength(1);
     });
 
     it('should not migrate already migrated config', async () => {
       const configPath = path.join(tempDir, '.lien.config.json');
       const newConfig: LienConfig = {
-        version: '0.14.0',
+        version: '0.12.0',
         core: {
           chunkSize: 75,
           chunkOverlap: 10,
@@ -314,7 +322,7 @@ describe('Config Migration', () => {
       const result = await migrateConfigFile(tempDir);
 
       expect(result.migrated).toBe(false);
-      expect(result.config.version).toBe('0.3.0');
+      expect(result.config.version).toBe('0.14.0');
       expect(result.config.frameworks).toEqual([]);
     });
 

--- a/packages/cli/src/config/migration.test.ts
+++ b/packages/cli/src/config/migration.test.ts
@@ -115,7 +115,7 @@ describe('Config Migration', () => {
       const newConfig = migrateConfig(oldConfig);
 
       // Check version updated
-      expect(newConfig.version).toBe('0.13.0');
+      expect(newConfig.version).toBe('0.12.0');
 
       // Check core settings migrated
       expect(newConfig.core.chunkSize).toBe(100);
@@ -164,7 +164,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.13.0');
+      expect(newConfig.version).toBe('0.12.0');
       expect(newConfig.core.chunkSize).toBe(50);
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].config.include).toEqual(['**/*.py']);
@@ -175,7 +175,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.13.0');
+      expect(newConfig.version).toBe('0.12.0');
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].name).toBe('generic');
       
@@ -269,7 +269,7 @@ describe('Config Migration', () => {
       // Verify new config is migrated
       const newConfigContent = await fs.readFile(configPath, 'utf-8');
       const newConfig = JSON.parse(newConfigContent);
-      expect(newConfig.version).toBe('0.13.0');
+      expect(newConfig.version).toBe('0.12.0');
       expect(newConfig.frameworks).toHaveLength(1);
     });
 
@@ -322,7 +322,7 @@ describe('Config Migration', () => {
       const result = await migrateConfigFile(tempDir);
 
       expect(result.migrated).toBe(false);
-      expect(result.config.version).toBe('0.13.0');
+      expect(result.config.version).toBe('0.12.0');
       expect(result.config.frameworks).toEqual([]);
     });
 

--- a/packages/cli/src/config/migration.test.ts
+++ b/packages/cli/src/config/migration.test.ts
@@ -45,9 +45,9 @@ describe('Config Migration', () => {
       expect(needsMigration(oldConfig)).toBe(true);
     });
 
-    it('should return false for v0.14.0 config with frameworks and chunking', () => {
+    it('should return false for v0.12.0 config with frameworks and chunking', () => {
       const newConfig = {
-        version: '0.14.0',
+        version: '0.12.0',
         frameworks: [],
         chunking: {
           useAST: true,
@@ -115,7 +115,7 @@ describe('Config Migration', () => {
       const newConfig = migrateConfig(oldConfig);
 
       // Check version updated
-      expect(newConfig.version).toBe('0.14.0');
+      expect(newConfig.version).toBe('0.12.0');
 
       // Check core settings migrated
       expect(newConfig.core.chunkSize).toBe(100);
@@ -164,7 +164,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.14.0');
+      expect(newConfig.version).toBe('0.12.0');
       expect(newConfig.core.chunkSize).toBe(50);
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].config.include).toEqual(['**/*.py']);
@@ -175,7 +175,7 @@ describe('Config Migration', () => {
 
       const newConfig = migrateConfig(oldConfig);
 
-      expect(newConfig.version).toBe('0.14.0');
+      expect(newConfig.version).toBe('0.12.0');
       expect(newConfig.frameworks).toHaveLength(1);
       expect(newConfig.frameworks[0].name).toBe('generic');
       
@@ -269,7 +269,7 @@ describe('Config Migration', () => {
       // Verify new config is migrated
       const newConfigContent = await fs.readFile(configPath, 'utf-8');
       const newConfig = JSON.parse(newConfigContent);
-      expect(newConfig.version).toBe('0.14.0');
+      expect(newConfig.version).toBe('0.12.0');
       expect(newConfig.frameworks).toHaveLength(1);
     });
 
@@ -322,7 +322,7 @@ describe('Config Migration', () => {
       const result = await migrateConfigFile(tempDir);
 
       expect(result.migrated).toBe(false);
-      expect(result.config.version).toBe('0.14.0');
+      expect(result.config.version).toBe('0.12.0');
       expect(result.config.frameworks).toEqual([]);
     });
 

--- a/packages/cli/src/config/migration.test.ts
+++ b/packages/cli/src/config/migration.test.ts
@@ -276,7 +276,7 @@ describe('Config Migration', () => {
     it('should not migrate already migrated config', async () => {
       const configPath = path.join(tempDir, '.lien.config.json');
       const newConfig: LienConfig = {
-        version: '0.12.0',
+        version: '0.13.0',
         core: {
           chunkSize: 75,
           chunkOverlap: 10,

--- a/packages/cli/src/config/migration.ts
+++ b/packages/cli/src/config/migration.ts
@@ -11,12 +11,12 @@ export function needsMigration(config: any): boolean {
   // - Has 'indexing' field instead of 'core' and 'frameworks'
   // - Or has no 'frameworks' field at all
   // - Or version is explicitly set to something < 0.3.0
-  // - Or missing 'chunking' field (v0.14.0)
+  // - Or missing 'chunking' field (v0.13.0)
   if (!config) {
     return false;
   }
 
-  // If missing chunking config, needs migration to v0.14.0
+  // If missing chunking config, needs migration to v0.13.0
   if (config.frameworks !== undefined && !config.chunking) {
     return true;
   }

--- a/packages/cli/src/config/migration.ts
+++ b/packages/cli/src/config/migration.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { LienConfig, LegacyLienConfig, FrameworkInstance, defaultConfig } from './schema.js';
+import { CURRENT_CONFIG_VERSION } from '../constants.js';
 
 /**
  * Checks if a config object needs migration from v0.2.0 to v0.3.0
@@ -44,7 +45,7 @@ export function needsMigration(config: any): boolean {
 export function migrateConfig(oldConfig: Partial<LegacyLienConfig | LienConfig>): LienConfig {
   // Start with default config structure
   const newConfig: LienConfig = {
-    version: '0.14.0',
+    version: CURRENT_CONFIG_VERSION,
     core: {
       chunkSize: (oldConfig as any).indexing?.chunkSize ?? (oldConfig as any).core?.chunkSize ?? defaultConfig.core.chunkSize,
       chunkOverlap: (oldConfig as any).indexing?.chunkOverlap ?? (oldConfig as any).core?.chunkOverlap ?? defaultConfig.core.chunkOverlap,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -39,7 +39,7 @@ export interface LienConfig {
     embeddingBatchSize: number;
   };
   chunking: {
-    useAST: boolean;          // Enable AST-based chunking (v0.14.0)
+    useAST: boolean;          // Enable AST-based chunking (v0.13.0)
     astFallback: 'line-based' | 'error';  // Fallback strategy on AST errors
   };
   mcp: {
@@ -122,7 +122,7 @@ export const defaultConfig: LienConfig = {
     embeddingBatchSize: DEFAULT_EMBEDDING_BATCH_SIZE,
   },
   chunking: {
-    useAST: true,              // AST-based chunking enabled by default (v0.14.0)
+    useAST: true,              // AST-based chunking enabled by default (v0.13.0)
     astFallback: 'line-based', // Fallback to line-based on errors
   },
   mcp: {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -38,6 +38,10 @@ export interface LienConfig {
     concurrency: number;
     embeddingBatchSize: number;
   };
+  chunking: {
+    useAST: boolean;          // Enable AST-based chunking (v0.14.0)
+    astFallback: 'line-based' | 'error';  // Fallback strategy on AST errors
+  };
   mcp: {
     port: number;
     transport: 'stdio' | 'socket';
@@ -116,6 +120,10 @@ export const defaultConfig: LienConfig = {
     chunkOverlap: DEFAULT_CHUNK_OVERLAP,
     concurrency: DEFAULT_CONCURRENCY,
     embeddingBatchSize: DEFAULT_EMBEDDING_BATCH_SIZE,
+  },
+  chunking: {
+    useAST: true,              // AST-based chunking enabled by default (v0.14.0)
+    astFallback: 'line-based', // Fallback to line-based on errors
   },
   mcp: {
     port: DEFAULT_PORT,

--- a/packages/cli/src/config/service.test.ts
+++ b/packages/cli/src/config/service.test.ts
@@ -108,7 +108,7 @@ describe('ConfigService', () => {
       
       const config = await service.load(testDir);
       
-      // Should be migrated to v0.14.0
+      // Should be migrated to v0.13.0
       expect(config.version).toBe('0.13.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(100);

--- a/packages/cli/src/config/service.test.ts
+++ b/packages/cli/src/config/service.test.ts
@@ -109,7 +109,7 @@ describe('ConfigService', () => {
       const config = await service.load(testDir);
       
       // Should be migrated to v0.13.0
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(100);
       
@@ -186,7 +186,7 @@ describe('ConfigService', () => {
       
       expect(result.migrated).toBe(true);
       expect(result.backupPath).toBeDefined();
-      expect(result.config.version).toBe('0.13.0');
+      expect(result.config.version).toBe('0.12.0');
       expect(result.config.frameworks).toHaveLength(1);
       expect(result.config.frameworks[0].name).toBe('generic');
     });
@@ -555,7 +555,7 @@ describe('ConfigService', () => {
       // Load should auto-migrate
       const config = await service.load(testDir);
       
-      expect(config.version).toBe('0.13.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(90);
       expect(config.mcp.port).toBe(7200);

--- a/packages/cli/src/config/service.test.ts
+++ b/packages/cli/src/config/service.test.ts
@@ -109,7 +109,7 @@ describe('ConfigService', () => {
       const config = await service.load(testDir);
       
       // Should be migrated to v0.14.0
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(100);
       
@@ -186,7 +186,7 @@ describe('ConfigService', () => {
       
       expect(result.migrated).toBe(true);
       expect(result.backupPath).toBeDefined();
-      expect(result.config.version).toBe('0.14.0');
+      expect(result.config.version).toBe('0.12.0');
       expect(result.config.frameworks).toHaveLength(1);
       expect(result.config.frameworks[0].name).toBe('generic');
     });
@@ -555,7 +555,7 @@ describe('ConfigService', () => {
       // Load should auto-migrate
       const config = await service.load(testDir);
       
-      expect(config.version).toBe('0.14.0');
+      expect(config.version).toBe('0.12.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(90);
       expect(config.mcp.port).toBe(7200);

--- a/packages/cli/src/config/service.test.ts
+++ b/packages/cli/src/config/service.test.ts
@@ -108,7 +108,7 @@ describe('ConfigService', () => {
       
       const config = await service.load(testDir);
       
-      // Should be migrated to v0.3.0
+      // Should be migrated to v0.14.0
       expect(config.version).toBe('0.14.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(100);
@@ -244,9 +244,9 @@ describe('ConfigService', () => {
       expect(service.needsMigration(legacyConfig)).toBe(true);
     });
     
-    it('should return false for v0.14.0 config with frameworks and chunking', () => {
+    it('should return false for v0.12.0 config with frameworks and chunking', () => {
       const modernConfig = {
-        version: '0.14.0',
+        version: '0.12.0',
         frameworks: [],
         chunking: {
           useAST: true,

--- a/packages/cli/src/config/service.test.ts
+++ b/packages/cli/src/config/service.test.ts
@@ -109,7 +109,7 @@ describe('ConfigService', () => {
       const config = await service.load(testDir);
       
       // Should be migrated to v0.3.0
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(100);
       
@@ -186,7 +186,7 @@ describe('ConfigService', () => {
       
       expect(result.migrated).toBe(true);
       expect(result.backupPath).toBeDefined();
-      expect(result.config.version).toBe('0.3.0');
+      expect(result.config.version).toBe('0.14.0');
       expect(result.config.frameworks).toHaveLength(1);
       expect(result.config.frameworks[0].name).toBe('generic');
     });
@@ -244,10 +244,14 @@ describe('ConfigService', () => {
       expect(service.needsMigration(legacyConfig)).toBe(true);
     });
     
-    it('should return false for v0.3.0 config with frameworks', () => {
+    it('should return false for v0.14.0 config with frameworks and chunking', () => {
       const modernConfig = {
-        version: '0.3.0',
+        version: '0.14.0',
         frameworks: [],
+        chunking: {
+          useAST: true,
+          astFallback: 'line-based',
+        },
       };
       
       expect(service.needsMigration(modernConfig)).toBe(false);
@@ -551,7 +555,7 @@ describe('ConfigService', () => {
       // Load should auto-migrate
       const config = await service.load(testDir);
       
-      expect(config.version).toBe('0.3.0');
+      expect(config.version).toBe('0.14.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(90);
       expect(config.mcp.port).toBe(7200);

--- a/packages/cli/src/config/service.test.ts
+++ b/packages/cli/src/config/service.test.ts
@@ -109,7 +109,7 @@ describe('ConfigService', () => {
       const config = await service.load(testDir);
       
       // Should be migrated to v0.14.0
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(100);
       
@@ -186,7 +186,7 @@ describe('ConfigService', () => {
       
       expect(result.migrated).toBe(true);
       expect(result.backupPath).toBeDefined();
-      expect(result.config.version).toBe('0.12.0');
+      expect(result.config.version).toBe('0.13.0');
       expect(result.config.frameworks).toHaveLength(1);
       expect(result.config.frameworks[0].name).toBe('generic');
     });
@@ -555,7 +555,7 @@ describe('ConfigService', () => {
       // Load should auto-migrate
       const config = await service.load(testDir);
       
-      expect(config.version).toBe('0.12.0');
+      expect(config.version).toBe('0.13.0');
       expect(config.frameworks).toBeDefined();
       expect(config.core.chunkSize).toBe(90);
       expect(config.mcp.port).toBe(7200);

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -4,6 +4,8 @@
  * to ensure consistency across the codebase.
  */
 
+import { getPackageVersion } from './utils/version.js';
+
 // Chunking settings
 export const DEFAULT_CHUNK_SIZE = 75;
 export const DEFAULT_CHUNK_OVERLAP = 10;
@@ -37,11 +39,9 @@ export const DEFAULT_GIT_POLL_INTERVAL_MS = 10000; // Check every 10 seconds
 // File watching
 export const DEFAULT_DEBOUNCE_MS = 1000;
 
-// Configuration schema version (bumped when config format changes)
-// Note: This tracks config schema changes, not package version
-// v0.3.0: Added frameworks support
-// v0.14.0: Added chunking configuration
-export const CURRENT_CONFIG_VERSION = '0.14.0';
+// Configuration version - always matches package version
+// Config format is tied to the package release that introduces it
+export const CURRENT_CONFIG_VERSION = getPackageVersion();
 
 // Index format version - bump on ANY breaking change to indexing
 // Examples that require version bump:

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -38,7 +38,7 @@ export const DEFAULT_GIT_POLL_INTERVAL_MS = 10000; // Check every 10 seconds
 export const DEFAULT_DEBOUNCE_MS = 1000;
 
 // Configuration version
-export const CURRENT_CONFIG_VERSION = '0.3.0';
+export const CURRENT_CONFIG_VERSION = '0.14.0';
 
 // Index format version - bump on ANY breaking change to indexing
 // Examples that require version bump:
@@ -46,5 +46,6 @@ export const CURRENT_CONFIG_VERSION = '0.3.0';
 // - Embedding model changes (e.g., switch from all-MiniLM-L6-v2 to another model)
 // - Vector DB schema changes (new metadata fields)
 // - Metadata structure changes
-export const INDEX_FORMAT_VERSION = 1;
+// v2: AST-based chunking + enhanced metadata (symbolName, complexity, etc.)
+export const INDEX_FORMAT_VERSION = 2;
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -37,7 +37,10 @@ export const DEFAULT_GIT_POLL_INTERVAL_MS = 10000; // Check every 10 seconds
 // File watching
 export const DEFAULT_DEBOUNCE_MS = 1000;
 
-// Configuration version
+// Configuration schema version (bumped when config format changes)
+// Note: This tracks config schema changes, not package version
+// v0.3.0: Added frameworks support
+// v0.14.0: Added chunking configuration
 export const CURRENT_CONFIG_VERSION = '0.14.0';
 
 // Index format version - bump on ANY breaking change to indexing

--- a/packages/cli/src/indexer/ast/chunker.test.ts
+++ b/packages/cli/src/indexer/ast/chunker.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import { chunkByAST, shouldUseAST } from './chunker.js';
+
+describe('AST Chunker', () => {
+  describe('shouldUseAST', () => {
+    it('should return true for TypeScript files', () => {
+      expect(shouldUseAST('test.ts')).toBe(true);
+      expect(shouldUseAST('test.tsx')).toBe(true);
+    });
+
+    it('should return true for JavaScript files', () => {
+      expect(shouldUseAST('test.js')).toBe(true);
+      expect(shouldUseAST('test.jsx')).toBe(true);
+      expect(shouldUseAST('test.mjs')).toBe(true);
+      expect(shouldUseAST('test.cjs')).toBe(true);
+    });
+
+    it('should return false for unsupported files', () => {
+      expect(shouldUseAST('test.py')).toBe(false);
+      expect(shouldUseAST('test.go')).toBe(false);
+      expect(shouldUseAST('test.txt')).toBe(false);
+    });
+  });
+
+  describe('chunkByAST', () => {
+    it('should chunk a simple function', () => {
+      const content = `
+function hello() {
+  console.log("Hello world");
+  return true;
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      
+      expect(chunks.length).toBeGreaterThan(0);
+      const funcChunk = chunks.find(c => c.metadata.symbolName === 'hello');
+      
+      expect(funcChunk).toBeDefined();
+      expect(funcChunk?.metadata.symbolType).toBe('function');
+      expect(funcChunk?.metadata.type).toBe('function');
+      expect(funcChunk?.content).toContain('console.log');
+    });
+
+    it('should chunk a class with methods', () => {
+      const content = `
+class Calculator {
+  add(a: number, b: number): number {
+    return a + b;
+  }
+
+  subtract(a: number, b: number): number {
+    return a - b;
+  }
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      
+      // Should have at least the class chunk
+      const classChunk = chunks.find(c => c.metadata.symbolName === 'Calculator');
+      expect(classChunk).toBeDefined();
+      expect(classChunk?.metadata.symbolType).toBe('class');
+      
+      // Methods might be included in the class chunk or as separate chunks
+      expect(chunks.length).toBeGreaterThan(0);
+    });
+
+    it('should extract function metadata', () => {
+      const content = `
+function validateEmail(email: string): boolean {
+  if (!email) return false;
+  if (!email.includes('@')) return false;
+  return true;
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      const chunk = chunks.find(c => c.metadata.symbolName === 'validateEmail');
+      
+      expect(chunk).toBeDefined();
+      expect(chunk?.metadata.symbolName).toBe('validateEmail');
+      expect(chunk?.metadata.symbolType).toBe('function');
+      expect(chunk?.metadata.complexity).toBeGreaterThan(1); // Has if statements
+      expect(chunk?.metadata.parameters).toBeDefined();
+      expect(chunk?.metadata.signature).toContain('validateEmail');
+    });
+
+    it('should handle arrow functions', () => {
+      const content = `
+const greet = (name: string) => {
+  return \`Hello, \${name}!\`;
+};
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      
+      // Arrow functions should be detected
+      expect(chunks.length).toBeGreaterThan(0);
+      const arrowChunk = chunks.find(c => c.metadata.symbolName === 'greet');
+      expect(arrowChunk).toBeDefined();
+    });
+
+    it('should handle interfaces', () => {
+      const content = `
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      const interfaceChunk = chunks.find(c => c.metadata.symbolName === 'User');
+      
+      expect(interfaceChunk).toBeDefined();
+      expect(interfaceChunk?.metadata.symbolType).toBe('interface');
+    });
+
+    it('should extract imports', () => {
+      const content = `
+import { foo } from './foo';
+import { bar } from './bar';
+
+function test() {
+  return foo() + bar();
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      const funcChunk = chunks.find(c => c.metadata.symbolName === 'test');
+      
+      expect(funcChunk?.metadata.imports).toBeDefined();
+      expect(funcChunk?.metadata.imports).toContain('./foo');
+      expect(funcChunk?.metadata.imports).toContain('./bar');
+    });
+
+    it('should calculate cyclomatic complexity', () => {
+      const content = `
+function complexFunction(x: number): string {
+  if (x > 10) {
+    if (x > 20) {
+      return "very high";
+    }
+    return "high";
+  } else if (x > 5) {
+    return "medium";
+  } else {
+    return "low";
+  }
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      const chunk = chunks.find(c => c.metadata.symbolName === 'complexFunction');
+      
+      expect(chunk?.metadata.complexity).toBeGreaterThan(3); // Multiple if statements
+    });
+
+    it('should handle multiple functions in one file', () => {
+      const content = `
+function first() {
+  return 1;
+}
+
+function second() {
+  return 2;
+}
+
+function third() {
+  return 3;
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+      expect(chunks.some(c => c.metadata.symbolName === 'first')).toBe(true);
+      expect(chunks.some(c => c.metadata.symbolName === 'second')).toBe(true);
+      expect(chunks.some(c => c.metadata.symbolName === 'third')).toBe(true);
+    });
+
+    it('should handle empty files gracefully', () => {
+      const content = '';
+      const chunks = chunkByAST('test.ts', content);
+      
+      // Empty file should produce no chunks or minimal chunks
+      expect(chunks.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should preserve line numbers correctly', () => {
+      const content = `
+// Line 1
+// Line 2
+function test() {
+  // Line 4
+  return true;
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      const funcChunk = chunks.find(c => c.metadata.symbolName === 'test');
+      
+      expect(funcChunk).toBeDefined();
+      expect(funcChunk!.metadata.startLine).toBeGreaterThan(0);
+      expect(funcChunk!.metadata.endLine).toBeGreaterThan(funcChunk!.metadata.startLine);
+    });
+
+    it('should handle JavaScript files', () => {
+      const content = `
+function add(a, b) {
+  return a + b;
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.js', content);
+      const chunk = chunks.find(c => c.metadata.symbolName === 'add');
+      
+      expect(chunk).toBeDefined();
+      expect(chunk?.metadata.language).toBe('javascript');
+    });
+
+    it('should handle exported functions', () => {
+      const content = `
+export function exportedFunc() {
+  return "exported";
+}
+
+export default function defaultFunc() {
+  return "default";
+}
+      `.trim();
+
+      const chunks = chunkByAST('test.ts', content);
+      
+      expect(chunks.some(c => c.metadata.symbolName === 'exportedFunc')).toBe(true);
+      expect(chunks.some(c => c.metadata.symbolName === 'defaultFunc')).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error for unsupported language', () => {
+      const content = 'print("Hello")';
+      
+      expect(() => chunkByAST('test.py', content)).toThrow();
+    });
+
+    it('should handle invalid syntax gracefully', () => {
+      const content = 'function invalid() { this is not valid }}}';
+      
+      // Tree-sitter is resilient and still produces a tree with errors
+      // So this should not throw, but return some chunks
+      const chunks = chunkByAST('test.ts', content);
+      expect(chunks).toBeDefined();
+    });
+  });
+});
+

--- a/packages/cli/src/indexer/ast/chunker.test.ts
+++ b/packages/cli/src/indexer/ast/chunker.test.ts
@@ -57,13 +57,20 @@ class Calculator {
 
       const chunks = chunkByAST('test.ts', content);
       
-      // Should have at least the class chunk
-      const classChunk = chunks.find(c => c.metadata.symbolName === 'Calculator');
-      expect(classChunk).toBeDefined();
-      expect(classChunk?.metadata.symbolType).toBe('class');
+      // Should have chunks for each method (not the class itself)
+      const addMethod = chunks.find(c => c.metadata.symbolName === 'add');
+      const subtractMethod = chunks.find(c => c.metadata.symbolName === 'subtract');
       
-      // Methods might be included in the class chunk or as separate chunks
-      expect(chunks.length).toBeGreaterThan(0);
+      expect(addMethod).toBeDefined();
+      expect(addMethod?.metadata.symbolType).toBe('method');
+      expect(addMethod?.metadata.parentClass).toBe('Calculator');
+      
+      expect(subtractMethod).toBeDefined();
+      expect(subtractMethod?.metadata.symbolType).toBe('method');
+      expect(subtractMethod?.metadata.parentClass).toBe('Calculator');
+      
+      // Should have 2 method chunks (no class chunk)
+      expect(chunks.length).toBe(2);
     });
 
     it('should extract function metadata', () => {

--- a/packages/cli/src/indexer/ast/chunker.ts
+++ b/packages/cli/src/indexer/ast/chunker.ts
@@ -250,6 +250,24 @@ function createChunk(
   imports: string[],
   language: string
 ): ASTChunk {
+  // Populate legacy symbols field for backward compatibility
+  const symbols = {
+    functions: [] as string[],
+    classes: [] as string[],
+    interfaces: [] as string[],
+  };
+  
+  if (symbolInfo?.name) {
+    // Populate legacy symbols arrays based on symbol type
+    if (symbolInfo.type === 'function' || symbolInfo.type === 'method') {
+      symbols.functions.push(symbolInfo.name);
+    } else if (symbolInfo.type === 'class') {
+      symbols.classes.push(symbolInfo.name);
+    } else if (symbolInfo.type === 'interface') {
+      symbols.interfaces.push(symbolInfo.name);
+    }
+  }
+  
   return {
     content,
     metadata: {
@@ -258,6 +276,9 @@ function createChunk(
       endLine: node.endPosition.row + 1,
       type: symbolInfo?.type === 'class' ? 'class' : 'function',
       language,
+      // Legacy symbols field for backward compatibility
+      symbols,
+      // New AST-derived metadata
       symbolName: symbolInfo?.name,
       symbolType: symbolInfo?.type,
       parentClass: symbolInfo?.parentClass,
@@ -302,6 +323,8 @@ function extractUncoveredCode(
             endLine: range.start,
             type: 'block',
             language,
+            // Empty symbols for uncovered code (imports, exports, etc.)
+            symbols: { functions: [], classes: [], interfaces: [] },
             imports,
           },
         });
@@ -324,6 +347,8 @@ function extractUncoveredCode(
           endLine: lines.length,
           type: 'block',
           language,
+          // Empty symbols for uncovered code (imports, exports, etc.)
+          symbols: { functions: [], classes: [], interfaces: [] },
           imports,
         },
       });

--- a/packages/cli/src/indexer/ast/chunker.ts
+++ b/packages/cli/src/indexer/ast/chunker.ts
@@ -1,0 +1,329 @@
+import type Parser from 'tree-sitter';
+import type { ASTChunk } from './types.js';
+import { parseAST, detectLanguage, isASTSupported } from './parser.js';
+import { extractSymbolInfo, extractImports } from './symbols.js';
+
+export interface ASTChunkOptions {
+  maxChunkSize?: number;
+  minChunkSize?: number;
+}
+
+/**
+ * Chunk a file using AST-based semantic boundaries
+ * 
+ * @param filepath - Path to the file
+ * @param content - File content
+ * @param options - Chunking options
+ * @returns Array of AST-aware chunks
+ */
+export function chunkByAST(
+  filepath: string,
+  content: string,
+  options: ASTChunkOptions = {}
+): ASTChunk[] {
+  const { maxChunkSize = 100, minChunkSize = 5 } = options;
+  
+  // Check if AST is supported for this file
+  const language = detectLanguage(filepath);
+  if (!language) {
+    throw new Error(`Unsupported language for file: ${filepath}`);
+  }
+  
+  // Parse the file
+  const parseResult = parseAST(content, language);
+  
+  // If parsing failed, throw error (caller should fallback to line-based)
+  if (!parseResult.tree) {
+    throw new Error(`Failed to parse ${filepath}: ${parseResult.error}`);
+  }
+  
+  const chunks: ASTChunk[] = [];
+  const lines = content.split('\n');
+  const rootNode = parseResult.tree.rootNode;
+  
+  // Extract file-level imports once
+  const fileImports = extractImports(rootNode);
+  
+  // Find all top-level function and class declarations
+  const topLevelNodes = findTopLevelNodes(rootNode);
+  
+  for (const node of topLevelNodes) {
+    // For variable declarations, try to find the function inside
+    let actualNode = node;
+    if (node.type === 'lexical_declaration' || node.type === 'variable_declaration') {
+      const funcNode = findActualFunctionNode(node);
+      if (funcNode) {
+        actualNode = funcNode;
+      }
+    }
+    
+    const symbolInfo = extractSymbolInfo(actualNode, content);
+    
+    // Extract the code for this node (use original node for full declaration)
+    const nodeContent = getNodeContent(node, lines);
+    const nodeLines = nodeContent.split('\n').length;
+    
+    // If the node is too large, we might need to split it
+    if (nodeLines > maxChunkSize) {
+      // For very large functions/classes, create one chunk for the whole thing
+      // (better to have a large semantic unit than split mid-function)
+      // Future: could split large functions at logical boundaries
+      chunks.push(createChunk(filepath, node, nodeContent, symbolInfo, fileImports, language));
+    } else {
+      // Normal-sized node, create a chunk
+      chunks.push(createChunk(filepath, node, nodeContent, symbolInfo, fileImports, language));
+    }
+  }
+  
+  // Handle remaining code (imports, exports, top-level statements)
+  const coveredRanges = topLevelNodes.map(n => ({
+    start: n.startPosition.row,
+    end: n.endPosition.row,
+  }));
+  
+  const uncoveredChunks = extractUncoveredCode(
+    lines,
+    coveredRanges,
+    filepath,
+    minChunkSize,
+    fileImports,
+    language
+  );
+  
+  chunks.push(...uncoveredChunks);
+  
+  // Sort chunks by line number
+  chunks.sort((a, b) => a.metadata.startLine - b.metadata.startLine);
+  
+  return chunks;
+}
+
+/**
+ * Find all top-level nodes that should become chunks
+ */
+function findTopLevelNodes(rootNode: Parser.SyntaxNode): Parser.SyntaxNode[] {
+  const nodes: Parser.SyntaxNode[] = [];
+  
+  const targetTypes = [
+    'function_declaration',
+    'function',
+    'class_declaration',
+    'interface_declaration',
+    'method_definition',
+    'lexical_declaration', // For const/let with arrow functions
+    'variable_declaration', // For var with functions
+  ];
+  
+  function traverse(node: Parser.SyntaxNode, depth: number) {
+    // For lexical declarations (const/let), check if it contains an arrow function
+    if ((node.type === 'lexical_declaration' || node.type === 'variable_declaration') && depth === 0) {
+      // Check if this declaration contains a function
+      const hasFunction = findFunctionInDeclaration(node);
+      if (hasFunction) {
+        nodes.push(node);
+        return;
+      }
+    }
+    
+    // Only consider top-level or direct children of classes
+    if (depth <= 1 && targetTypes.includes(node.type)) {
+      nodes.push(node);
+      return; // Don't traverse into this node
+    }
+    
+    // For class bodies, traverse methods
+    if (node.type === 'class_body') {
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child) traverse(child, depth);
+      }
+      return;
+    }
+    
+    // For classes, traverse the body
+    if (node.type === 'class_declaration') {
+      nodes.push(node); // Add the class itself
+      const body = node.childForFieldName('body');
+      if (body) {
+        traverse(body, depth + 1);
+      }
+      return;
+    }
+    
+    // Traverse children for program and export statements
+    if (node.type === 'program' || node.type === 'export_statement') {
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child) traverse(child, depth);
+      }
+    }
+  }
+  
+  traverse(rootNode, 0);
+  return nodes;
+}
+
+/**
+ * Check if a declaration node contains a function (arrow, function expression, etc.)
+ */
+function findFunctionInDeclaration(node: Parser.SyntaxNode): boolean {
+  const functionTypes = ['arrow_function', 'function_expression', 'function'];
+  
+  function search(n: Parser.SyntaxNode, depth: number): boolean {
+    if (depth > 3) return false; // Don't search too deep
+    
+    if (functionTypes.includes(n.type)) {
+      return true;
+    }
+    
+    for (let i = 0; i < n.childCount; i++) {
+      const child = n.child(i);
+      if (child && search(child, depth + 1)) {
+        return true;
+      }
+    }
+    
+    return false;
+  }
+  
+  return search(node, 0);
+}
+
+/**
+ * Find the actual function node within a declaration
+ */
+function findActualFunctionNode(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  const functionTypes = ['arrow_function', 'function_expression', 'function'];
+  
+  function search(n: Parser.SyntaxNode, depth: number): Parser.SyntaxNode | null {
+    if (depth > 3) return null;
+    
+    if (functionTypes.includes(n.type)) {
+      return n;
+    }
+    
+    for (let i = 0; i < n.childCount; i++) {
+      const child = n.child(i);
+      if (child) {
+        const result = search(child, depth + 1);
+        if (result) return result;
+      }
+    }
+    
+    return null;
+  }
+  
+  return search(node, 0);
+}
+
+/**
+ * Extract content for a specific AST node
+ */
+function getNodeContent(node: Parser.SyntaxNode, lines: string[]): string {
+  const startLine = node.startPosition.row;
+  const endLine = node.endPosition.row;
+  
+  return lines.slice(startLine, endLine + 1).join('\n');
+}
+
+/**
+ * Create a chunk from an AST node
+ */
+function createChunk(
+  filepath: string,
+  node: Parser.SyntaxNode,
+  content: string,
+  symbolInfo: ReturnType<typeof extractSymbolInfo>,
+  imports: string[],
+  language: string
+): ASTChunk {
+  return {
+    content,
+    metadata: {
+      file: filepath,
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      type: symbolInfo?.type === 'class' ? 'class' : 'function',
+      language,
+      symbolName: symbolInfo?.name,
+      symbolType: symbolInfo?.type,
+      parentClass: symbolInfo?.parentClass,
+      complexity: symbolInfo?.complexity,
+      parameters: symbolInfo?.parameters,
+      signature: symbolInfo?.signature,
+      imports,
+    },
+  };
+}
+
+/**
+ * Extract code that wasn't covered by function/class chunks
+ * (imports, exports, top-level statements)
+ */
+function extractUncoveredCode(
+  lines: string[],
+  coveredRanges: Array<{ start: number; end: number }>,
+  filepath: string,
+  minChunkSize: number,
+  imports: string[],
+  language: string
+): ASTChunk[] {
+  const chunks: ASTChunk[] = [];
+  let currentStart = 0;
+  
+  // Sort covered ranges
+  coveredRanges.sort((a, b) => a.start - b.start);
+  
+  for (const range of coveredRanges) {
+    if (currentStart < range.start) {
+      // There's uncovered code before this range
+      const uncoveredLines = lines.slice(currentStart, range.start);
+      const content = uncoveredLines.join('\n').trim();
+      
+      if (content.length > 0 && uncoveredLines.length >= minChunkSize) {
+        chunks.push({
+          content,
+          metadata: {
+            file: filepath,
+            startLine: currentStart + 1,
+            endLine: range.start,
+            type: 'block',
+            language,
+            imports,
+          },
+        });
+      }
+    }
+    currentStart = range.end + 1;
+  }
+  
+  // Handle remaining code after last covered range
+  if (currentStart < lines.length) {
+    const uncoveredLines = lines.slice(currentStart);
+    const content = uncoveredLines.join('\n').trim();
+    
+    if (content.length > 0 && uncoveredLines.length >= minChunkSize) {
+      chunks.push({
+        content,
+        metadata: {
+          file: filepath,
+          startLine: currentStart + 1,
+          endLine: lines.length,
+          type: 'block',
+          language,
+          imports,
+        },
+      });
+    }
+  }
+  
+  return chunks;
+}
+
+/**
+ * Check if AST chunking should be used for a file
+ */
+export function shouldUseAST(filepath: string): boolean {
+  return isASTSupported(filepath);
+}
+

--- a/packages/cli/src/indexer/ast/chunker.ts
+++ b/packages/cli/src/indexer/ast/chunker.ts
@@ -11,10 +11,19 @@ export interface ASTChunkOptions {
 /**
  * Chunk a file using AST-based semantic boundaries
  * 
+ * Uses Tree-sitter to parse code into an AST and extract semantic chunks
+ * (functions, classes, methods) that respect code structure.
+ * 
+ * **Known Limitations:**
+ * - Tree-sitter may fail with "Invalid argument" error on very large files (1000+ lines)
+ * - When this occurs, Lien automatically falls back to line-based chunking
+ * - Configure fallback behavior via `chunking.astFallback` ('line-based' or 'error')
+ * 
  * @param filepath - Path to the file
  * @param content - File content
  * @param options - Chunking options
  * @returns Array of AST-aware chunks
+ * @throws Error if AST parsing fails and astFallback is 'error'
  */
 export function chunkByAST(
   filepath: string,

--- a/packages/cli/src/indexer/ast/chunker.ts
+++ b/packages/cli/src/indexer/ast/chunker.ts
@@ -274,7 +274,7 @@ function createChunk(
       file: filepath,
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
-      type: symbolInfo?.type === 'class' ? 'class' : 'function',
+      type: symbolInfo == null ? 'block' : (symbolInfo.type === 'class' ? 'class' : 'function'),
       language,
       // Legacy symbols field for backward compatibility
       symbols,

--- a/packages/cli/src/indexer/ast/parser.ts
+++ b/packages/cli/src/indexer/ast/parser.ts
@@ -10,9 +10,15 @@ import type { ASTParseResult, SupportedLanguage } from './types.js';
 const parserCache = new Map<SupportedLanguage, Parser>();
 
 /**
+ * Tree-sitter language grammar type
+ * (Tree-sitter doesn't export a specific Language type, so we define one)
+ */
+type TreeSitterLanguage = object;
+
+/**
  * Language configuration mapping
  */
-const languageConfig: Record<SupportedLanguage, any> = {
+const languageConfig: Record<SupportedLanguage, TreeSitterLanguage> = {
   typescript: TypeScript.typescript,
   javascript: JavaScript, // Use proper JavaScript parser
 };

--- a/packages/cli/src/indexer/ast/parser.ts
+++ b/packages/cli/src/indexer/ast/parser.ts
@@ -1,5 +1,6 @@
 import Parser from 'tree-sitter';
 import TypeScript from 'tree-sitter-typescript';
+import JavaScript from 'tree-sitter-javascript';
 import type { ASTParseResult, SupportedLanguage } from './types.js';
 
 /**
@@ -12,7 +13,7 @@ const parserCache = new Map<SupportedLanguage, Parser>();
  */
 const languageConfig: Record<SupportedLanguage, any> = {
   typescript: TypeScript.typescript,
-  javascript: TypeScript.tsx, // Use tsx for JavaScript (supports JSX)
+  javascript: JavaScript, // Use proper JavaScript parser
 };
 
 /**

--- a/packages/cli/src/indexer/ast/parser.ts
+++ b/packages/cli/src/indexer/ast/parser.ts
@@ -1,6 +1,7 @@
 import Parser from 'tree-sitter';
 import TypeScript from 'tree-sitter-typescript';
 import JavaScript from 'tree-sitter-javascript';
+import { extname } from 'path';
 import type { ASTParseResult, SupportedLanguage } from './types.js';
 
 /**
@@ -37,9 +38,12 @@ function getParser(language: SupportedLanguage): Parser {
 
 /**
  * Detect language from file extension
+ * Uses path.extname() to handle edge cases like multiple dots in filenames
  */
 export function detectLanguage(filePath: string): SupportedLanguage | null {
-  const ext = filePath.split('.').pop()?.toLowerCase();
+  // extname returns extension with leading dot (e.g., '.ts')
+  // Remove the dot and convert to lowercase
+  const ext = extname(filePath).slice(1).toLowerCase();
   
   switch (ext) {
     case 'ts':

--- a/packages/cli/src/indexer/ast/parser.ts
+++ b/packages/cli/src/indexer/ast/parser.ts
@@ -73,7 +73,11 @@ export function isASTSupported(filePath: string): boolean {
 }
 
 /**
- * Parse source code into an AST
+ * Parse source code into an AST using Tree-sitter
+ * 
+ * **Known Limitation:** Tree-sitter may throw "Invalid argument" errors on very large files
+ * (1000+ lines). This is a limitation of Tree-sitter's internal buffer handling. When this
+ * occurs, callers should fall back to line-based chunking (handled automatically by chunker.ts).
  * 
  * @param content - Source code to parse
  * @param language - Programming language

--- a/packages/cli/src/indexer/ast/parser.ts
+++ b/packages/cli/src/indexer/ast/parser.ts
@@ -1,0 +1,99 @@
+import Parser from 'tree-sitter';
+import TypeScript from 'tree-sitter-typescript';
+import type { ASTParseResult, SupportedLanguage } from './types.js';
+
+/**
+ * Cache for parser instances to avoid recreating them
+ */
+const parserCache = new Map<SupportedLanguage, Parser>();
+
+/**
+ * Language configuration mapping
+ */
+const languageConfig: Record<SupportedLanguage, any> = {
+  typescript: TypeScript.typescript,
+  javascript: TypeScript.tsx, // Use tsx for JavaScript (supports JSX)
+};
+
+/**
+ * Get or create a cached parser instance for a language
+ */
+function getParser(language: SupportedLanguage): Parser {
+  if (!parserCache.has(language)) {
+    const parser = new Parser();
+    const grammar = languageConfig[language];
+    
+    if (!grammar) {
+      throw new Error(`No grammar available for language: ${language}`);
+    }
+    
+    parser.setLanguage(grammar);
+    parserCache.set(language, parser);
+  }
+  
+  return parserCache.get(language)!;
+}
+
+/**
+ * Detect language from file extension
+ */
+export function detectLanguage(filePath: string): SupportedLanguage | null {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+      return 'typescript';
+    case 'js':
+    case 'jsx':
+    case 'mjs':
+    case 'cjs':
+      return 'javascript';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Check if a file is supported for AST parsing
+ */
+export function isASTSupported(filePath: string): boolean {
+  return detectLanguage(filePath) !== null;
+}
+
+/**
+ * Parse source code into an AST
+ * 
+ * @param content - Source code to parse
+ * @param language - Programming language
+ * @returns Parse result with tree or error
+ */
+export function parseAST(content: string, language: SupportedLanguage): ASTParseResult {
+  try {
+    const parser = getParser(language);
+    const tree = parser.parse(content);
+    
+    // Check for parse errors (hasError is a property, not a method)
+    if (tree.rootNode.hasError) {
+      return {
+        tree,
+        error: 'Parse completed with errors',
+      };
+    }
+    
+    return { tree };
+  } catch (error) {
+    return {
+      tree: null,
+      error: error instanceof Error ? error.message : 'Unknown parse error',
+    };
+  }
+}
+
+/**
+ * Clear parser cache (useful for testing)
+ */
+export function clearParserCache(): void {
+  parserCache.clear();
+}
+

--- a/packages/cli/src/indexer/ast/symbols.ts
+++ b/packages/cli/src/indexer/ast/symbols.ts
@@ -109,10 +109,10 @@ export function extractSymbolInfo(
 /**
  * Extract function/method signature
  */
-function extractSignature(node: Parser.SyntaxNode, _content: string): string {
+function extractSignature(node: Parser.SyntaxNode, content: string): string {
   // Get the first line of the function (up to opening brace or arrow)
   const startLine = node.startPosition.row;
-  const lines = _content.split('\n');
+  const lines = content.split('\n');
   let signature = lines[startLine] || '';
   
   // If signature spans multiple lines, try to get up to the opening brace

--- a/packages/cli/src/indexer/ast/symbols.ts
+++ b/packages/cli/src/indexer/ast/symbols.ts
@@ -1,0 +1,239 @@
+import type Parser from 'tree-sitter';
+import type { SymbolInfo } from './types.js';
+
+/**
+ * Extract symbol information from an AST node
+ * 
+ * @param node - AST node to extract info from
+ * @param content - Source code content
+ * @param parentClass - Parent class name if this is a method
+ * @returns Symbol information or null
+ */
+export function extractSymbolInfo(
+  node: Parser.SyntaxNode,
+  content: string,
+  parentClass?: string
+): SymbolInfo | null {
+  const type = node.type;
+  
+  // Function declaration
+  if (type === 'function_declaration' || type === 'function') {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+    
+    return {
+      name: nameNode.text,
+      type: parentClass ? 'method' : 'function',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: extractSignature(node, content),
+      parameters: extractParameters(node, content),
+      returnType: extractReturnType(node, content),
+      complexity: calculateComplexity(node),
+    };
+  }
+  
+  // Arrow function / function expression
+  if (type === 'arrow_function' || type === 'function_expression') {
+    // Try to find variable name for arrow functions
+    const parent = node.parent;
+    let name = 'anonymous';
+    
+    if (parent?.type === 'variable_declarator') {
+      const nameNode = parent.childForFieldName('name');
+      name = nameNode?.text || 'anonymous';
+    }
+    
+    return {
+      name,
+      type: parentClass ? 'method' : 'function',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: extractSignature(node, content),
+      parameters: extractParameters(node, content),
+      complexity: calculateComplexity(node),
+    };
+  }
+  
+  // Method definition
+  if (type === 'method_definition') {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+    
+    return {
+      name: nameNode.text,
+      type: 'method',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: extractSignature(node, content),
+      parameters: extractParameters(node, content),
+      returnType: extractReturnType(node, content),
+      complexity: calculateComplexity(node),
+    };
+  }
+  
+  // Class declaration
+  if (type === 'class_declaration') {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+    
+    return {
+      name: nameNode.text,
+      type: 'class',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      signature: `class ${nameNode.text}`,
+    };
+  }
+  
+  // Interface declaration (TypeScript)
+  if (type === 'interface_declaration') {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+    
+    return {
+      name: nameNode.text,
+      type: 'interface',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      signature: `interface ${nameNode.text}`,
+    };
+  }
+  
+  return null;
+}
+
+/**
+ * Extract function/method signature
+ */
+function extractSignature(node: Parser.SyntaxNode, _content: string): string {
+  // Get the first line of the function (up to opening brace or arrow)
+  const startLine = node.startPosition.row;
+  const lines = _content.split('\n');
+  let signature = lines[startLine] || '';
+  
+  // If signature spans multiple lines, try to get up to the opening brace
+  let currentLine = startLine;
+  while (currentLine < node.endPosition.row && !signature.includes('{') && !signature.includes('=>')) {
+    currentLine++;
+    signature += ' ' + (lines[currentLine] || '');
+  }
+  
+  // Clean up signature
+  signature = signature.split('{')[0].split('=>')[0].trim();
+  
+  // Limit length
+  if (signature.length > 200) {
+    signature = signature.substring(0, 197) + '...';
+  }
+  
+  return signature;
+}
+
+/**
+ * Extract parameter list from function node
+ */
+function extractParameters(node: Parser.SyntaxNode, _content: string): string[] {
+  const parameters: string[] = [];
+  
+  // Find parameters node
+  const paramsNode = node.childForFieldName('parameters');
+  if (!paramsNode) return parameters;
+  
+  // Traverse parameter nodes
+  for (let i = 0; i < paramsNode.namedChildCount; i++) {
+    const param = paramsNode.namedChild(i);
+    if (param) {
+      parameters.push(param.text);
+    }
+  }
+  
+  return parameters;
+}
+
+/**
+ * Extract return type from function node (TypeScript)
+ */
+function extractReturnType(node: Parser.SyntaxNode, _content: string): string | undefined {
+  const returnTypeNode = node.childForFieldName('return_type');
+  if (!returnTypeNode) return undefined;
+  
+  return returnTypeNode.text;
+}
+
+/**
+ * Calculate cyclomatic complexity of a function
+ * 
+ * Complexity = 1 (base) + number of decision points
+ * Decision points: if, while, for, case, catch, &&, ||, ?:
+ */
+export function calculateComplexity(node: Parser.SyntaxNode): number {
+  let complexity = 1; // Base complexity
+  
+  const decisionPoints = [
+    'if_statement',
+    'while_statement',
+    'for_statement',
+    'for_in_statement',
+    'switch_case',
+    'catch_clause',
+    'ternary_expression',
+    'binary_expression', // For && and ||
+  ];
+  
+  function traverse(n: Parser.SyntaxNode) {
+    if (decisionPoints.includes(n.type)) {
+      // For binary expressions, only count && and ||
+      if (n.type === 'binary_expression') {
+        const operator = n.childForFieldName('operator');
+        if (operator && (operator.text === '&&' || operator.text === '||')) {
+          complexity++;
+        }
+      } else {
+        complexity++;
+      }
+    }
+    
+    // Traverse children
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const child = n.namedChild(i);
+      if (child) traverse(child);
+    }
+  }
+  
+  traverse(node);
+  return complexity;
+}
+
+/**
+ * Extract import statements from a file
+ */
+export function extractImports(rootNode: Parser.SyntaxNode): string[] {
+  const imports: string[] = [];
+  
+  function traverse(node: Parser.SyntaxNode) {
+    if (node.type === 'import_statement') {
+      // Get the source (the string after 'from')
+      const sourceNode = node.childForFieldName('source');
+      if (sourceNode) {
+        const importPath = sourceNode.text.replace(/['"]/g, '');
+        imports.push(importPath);
+      }
+    }
+    
+    // Only traverse top-level nodes for imports
+    if (node === rootNode) {
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child) traverse(child);
+      }
+    }
+  }
+  
+  traverse(rootNode);
+  return imports;
+}
+

--- a/packages/cli/src/indexer/ast/symbols.ts
+++ b/packages/cli/src/indexer/ast/symbols.ts
@@ -135,6 +135,9 @@ function extractSignature(node: Parser.SyntaxNode, content: string): string {
 
 /**
  * Extract parameter list from function node
+ * 
+ * Note: The `_content` parameter is unused in this function, but is kept for API consistency
+ * with other extract functions (e.g., extractSignature).
  */
 function extractParameters(node: Parser.SyntaxNode, _content: string): string[] {
   const parameters: string[] = [];
@@ -156,6 +159,9 @@ function extractParameters(node: Parser.SyntaxNode, _content: string): string[] 
 
 /**
  * Extract return type from function node (TypeScript)
+ * 
+ * Note: The `_content` parameter is unused in this function, but is kept for API consistency
+ * with other extract functions (e.g., extractSignature).
  */
 function extractReturnType(node: Parser.SyntaxNode, _content: string): string | undefined {
   const returnTypeNode = node.childForFieldName('return_type');

--- a/packages/cli/src/indexer/ast/symbols.ts
+++ b/packages/cli/src/indexer/ast/symbols.ts
@@ -168,7 +168,7 @@ function extractReturnType(node: Parser.SyntaxNode, _content: string): string | 
  * Calculate cyclomatic complexity of a function
  * 
  * Complexity = 1 (base) + number of decision points
- * Decision points: if, while, for, case, catch, &&, ||, ?:
+ * Decision points: if, while, do...while, for, for...in, for...of, case, catch, &&, ||, ?:
  */
 export function calculateComplexity(node: Parser.SyntaxNode): number {
   let complexity = 1; // Base complexity
@@ -176,8 +176,10 @@ export function calculateComplexity(node: Parser.SyntaxNode): number {
   const decisionPoints = [
     'if_statement',
     'while_statement',
+    'do_statement',        // do...while loops
     'for_statement',
     'for_in_statement',
+    'for_of_statement',    // for...of loops
     'switch_case',
     'catch_clause',
     'ternary_expression',

--- a/packages/cli/src/indexer/ast/types.ts
+++ b/packages/cli/src/indexer/ast/types.ts
@@ -1,0 +1,59 @@
+import type Parser from 'tree-sitter';
+import type { CodeChunk } from '../types.js';
+
+/**
+ * AST parse result containing the tree and any errors
+ */
+export interface ASTParseResult {
+  tree: Parser.Tree | null;
+  error?: string;
+}
+
+/**
+ * Symbol information extracted from AST nodes
+ */
+export interface SymbolInfo {
+  name: string;
+  type: 'function' | 'method' | 'class' | 'interface';
+  startLine: number;
+  endLine: number;
+  parentClass?: string;
+  signature?: string;
+  parameters?: string[];
+  returnType?: string;
+  complexity?: number;
+}
+
+/**
+ * Semantic metadata for AST-aware chunks
+ */
+export interface SemanticMetadata {
+  symbolName?: string;
+  symbolType?: 'function' | 'method' | 'class' | 'interface';
+  parentClass?: string;
+  complexity?: number;
+  parameters?: string[];
+  signature?: string;
+  imports?: string[];
+}
+
+/**
+ * AST-aware chunk with enhanced semantic metadata
+ */
+export interface ASTChunk extends CodeChunk {
+  metadata: CodeChunk['metadata'] & SemanticMetadata;
+}
+
+/**
+ * Language-specific parser configuration
+ */
+export interface LanguageConfig {
+  extensions: string[];
+  parserName: string;
+}
+
+/**
+ * Supported languages for AST parsing
+ */
+export type SupportedLanguage = 'typescript' | 'javascript';
+

--- a/packages/cli/src/indexer/chunker.test.ts
+++ b/packages/cli/src/indexer/chunker.test.ts
@@ -4,7 +4,7 @@ import { chunkFile, chunkText } from './chunker.js';
 describe('chunkFile', () => {
   it('should split code into chunks of specified size', () => {
     const code = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
-    const chunks = chunkFile('test.ts', code, { chunkSize: 3, chunkOverlap: 1 });
+    const chunks = chunkFile('test.ts', code, { chunkSize: 3, chunkOverlap: 1, useAST: false });
 
     // With 10 lines, chunkSize=3, overlap=1:
     // Chunk 1: lines 1-3, Chunk 2: lines 3-5, Chunk 3: lines 5-7, 
@@ -16,7 +16,7 @@ describe('chunkFile', () => {
 
   it('should handle overlap correctly', () => {
     const code = 'line1\nline2\nline3\nline4\nline5';
-    const chunks = chunkFile('test.ts', code, { chunkSize: 3, chunkOverlap: 1 });
+    const chunks = chunkFile('test.ts', code, { chunkSize: 3, chunkOverlap: 1, useAST: false });
 
     expect(chunks).toHaveLength(2);
     // First chunk: lines 1-3
@@ -29,7 +29,7 @@ describe('chunkFile', () => {
 
   it('should generate correct metadata for each chunk', () => {
     const code = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
-    const chunks = chunkFile('test.ts', code, { chunkSize: 5, chunkOverlap: 0 });
+    const chunks = chunkFile('test.ts', code, { chunkSize: 5, chunkOverlap: 0, useAST: false });
 
     expect(chunks[0].metadata.file).toBe('test.ts');
     expect(chunks[0].metadata.startLine).toBe(1);
@@ -78,7 +78,7 @@ describe('chunkFile', () => {
 
   it('should use default chunk size and overlap', () => {
     const code = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`).join('\n');
-    const chunks = chunkFile('test.ts', code);
+    const chunks = chunkFile('test.ts', code, { useAST: false });
 
     // Default chunkSize is 75, chunkOverlap is 10
     expect(chunks[0].metadata.endLine).toBe(75);
@@ -87,7 +87,7 @@ describe('chunkFile', () => {
 
   it('should handle files smaller than chunk size', () => {
     const code = 'line1\nline2\nline3';
-    const chunks = chunkFile('test.ts', code, { chunkSize: 100, chunkOverlap: 10 });
+    const chunks = chunkFile('test.ts', code, { chunkSize: 100, chunkOverlap: 10, useAST: false });
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].content).toBe(code);

--- a/packages/cli/src/indexer/chunker.test.ts
+++ b/packages/cli/src/indexer/chunker.test.ts
@@ -94,6 +94,24 @@ describe('chunkFile', () => {
     expect(chunks[0].metadata.startLine).toBe(1);
     expect(chunks[0].metadata.endLine).toBe(3);
   });
+
+  it('should accept astFallback option without error', () => {
+    // Test that astFallback option doesn't break normal operation
+    const code = 'function test() { return 42; }';
+    
+    // Test with line-based fallback (default)
+    const chunks1 = chunkFile('test.ts', code, { useAST: true, astFallback: 'line-based' });
+    expect(chunks1.length).toBeGreaterThan(0);
+    
+    // Test with error fallback (should work fine for valid code)
+    const chunks2 = chunkFile('test.ts', code, { useAST: true, astFallback: 'error' });
+    expect(chunks2.length).toBeGreaterThan(0);
+  });
+
+  // Note: Tree-sitter is extremely resilient and rarely throws errors even with invalid syntax.
+  // It's designed to produce a best-effort AST even for malformed code. The astFallback: 'error'
+  // option is mainly useful for catching edge cases like the Tree-sitter "Invalid argument" error
+  // that occurs with very large files (1000+ lines).
 });
 
 describe('chunkText', () => {

--- a/packages/cli/src/indexer/chunker.ts
+++ b/packages/cli/src/indexer/chunker.ts
@@ -20,7 +20,6 @@ export function chunkFile(
   if (useAST && shouldUseAST(filepath)) {
     try {
       return chunkByAST(filepath, content, {
-        maxChunkSize: chunkSize,
         minChunkSize: Math.floor(chunkSize / 10),
       });
     } catch (error) {

--- a/packages/cli/src/indexer/incremental.ts
+++ b/packages/cli/src/indexer/incremental.ts
@@ -48,11 +48,15 @@ async function processFileContent(
   const chunkOverlap = isModernConfig(config)
     ? config.core.chunkOverlap
     : (isLegacyConfig(config) ? config.indexing.chunkOverlap : 10);
+  const useAST = isModernConfig(config)
+    ? config.chunking.useAST
+    : true;
   
   // Chunk the file
   const chunks = chunkFile(filepath, content, {
     chunkSize,
     chunkOverlap,
+    useAST,
   });
   
   if (chunks.length === 0) {

--- a/packages/cli/src/indexer/incremental.ts
+++ b/packages/cli/src/indexer/incremental.ts
@@ -51,12 +51,16 @@ async function processFileContent(
   const useAST = isModernConfig(config)
     ? config.chunking.useAST
     : true;
+  const astFallback = isModernConfig(config)
+    ? config.chunking.astFallback
+    : 'line-based';
   
   // Chunk the file
   const chunks = chunkFile(filepath, content, {
     chunkSize,
     chunkOverlap,
     useAST,
+    astFallback,
   });
   
   if (chunks.length === 0) {

--- a/packages/cli/src/indexer/index.ts
+++ b/packages/cli/src/indexer/index.ts
@@ -275,10 +275,14 @@ export async function indexCodebase(options: IndexingOptions = {}): Promise<void
           const chunkOverlap = isModernConfig(config)
             ? config.core.chunkOverlap
             : 10;
+          const useAST = isModernConfig(config)
+            ? config.chunking.useAST
+            : true;
           
           const chunks = chunkFile(file, content, {
             chunkSize,
             chunkOverlap,
+            useAST,
           });
           
           if (chunks.length === 0) {

--- a/packages/cli/src/indexer/index.ts
+++ b/packages/cli/src/indexer/index.ts
@@ -278,11 +278,15 @@ export async function indexCodebase(options: IndexingOptions = {}): Promise<void
           const useAST = isModernConfig(config)
             ? config.chunking.useAST
             : true;
+          const astFallback = isModernConfig(config)
+            ? config.chunking.astFallback
+            : 'line-based';
           
           const chunks = chunkFile(file, content, {
             chunkSize,
             chunkOverlap,
             useAST,
+            astFallback,
           });
           
           if (chunks.length === 0) {

--- a/packages/cli/src/indexer/types.ts
+++ b/packages/cli/src/indexer/types.ts
@@ -15,6 +15,15 @@ export interface ChunkMetadata {
     classes: string[];
     interfaces: string[];
   };
+  
+  // NEW: AST-derived metadata (v0.14.0)
+  symbolName?: string;        // Function/class name
+  symbolType?: 'function' | 'method' | 'class' | 'interface';
+  parentClass?: string;       // For methods
+  complexity?: number;        // Cyclomatic complexity
+  parameters?: string[];      // Function parameters
+  signature?: string;         // Full signature
+  imports?: string[];         // File imports (for context)
 }
 
 export interface ScanOptions {

--- a/packages/cli/src/indexer/types.ts
+++ b/packages/cli/src/indexer/types.ts
@@ -16,7 +16,7 @@ export interface ChunkMetadata {
     interfaces: string[];
   };
   
-  // NEW: AST-derived metadata (v0.14.0)
+  // NEW: AST-derived metadata (v0.13.0)
   symbolName?: string;        // Function/class name
   symbolType?: 'function' | 'method' | 'class' | 'interface';
   parentClass?: string;       // For methods

--- a/packages/cli/src/vectordb/lancedb.ts
+++ b/packages/cli/src/vectordb/lancedb.ts
@@ -847,7 +847,35 @@ export class VectorDB implements VectorDBInterface {
           const regex = new RegExp(pattern, 'i');
           const matchesOldSymbols = symbols.some((s: string) => regex.test(s));
           const matchesASTSymbol = regex.test(astSymbolName);
-          return matchesOldSymbols || matchesASTSymbol;
+          const nameMatches = matchesOldSymbols || matchesASTSymbol;
+          
+          // If no name match, reject immediately
+          if (!nameMatches) return false;
+          
+          // If name matches, also check AST symbolType if specified
+          // Semantic filtering: 'function' includes methods and arrow functions
+          if (symbolType && r.symbolType) {
+            if (symbolType === 'function') {
+              return r.symbolType === 'function' || r.symbolType === 'method' || r.symbolType === 'arrow_function';
+            } else if (symbolType === 'class') {
+              return r.symbolType === 'class';
+            } else if (symbolType === 'interface') {
+              return r.symbolType === 'interface';
+            }
+          }
+          
+          return nameMatches;
+        }
+        
+        // If no pattern, check symbolType only
+        if (symbolType && r.symbolType) {
+          if (symbolType === 'function') {
+            return r.symbolType === 'function' || r.symbolType === 'method' || r.symbolType === 'arrow_function';
+          } else if (symbolType === 'class') {
+            return r.symbolType === 'class';
+          } else if (symbolType === 'interface') {
+            return r.symbolType === 'interface';
+          }
         }
         
         return true;

--- a/packages/cli/src/vectordb/lancedb.ts
+++ b/packages/cli/src/vectordb/lancedb.ts
@@ -560,7 +560,7 @@ export class VectorDB implements VectorDBInterface {
           functionNames: (batch.metadatas[i].symbols?.functions && batch.metadatas[i].symbols.functions.length > 0) ? batch.metadatas[i].symbols.functions : [''],
           classNames: (batch.metadatas[i].symbols?.classes && batch.metadatas[i].symbols.classes.length > 0) ? batch.metadatas[i].symbols.classes : [''],
           interfaceNames: (batch.metadatas[i].symbols?.interfaces && batch.metadatas[i].symbols.interfaces.length > 0) ? batch.metadatas[i].symbols.interfaces : [''],
-          // AST-derived metadata (v0.14.0)
+          // AST-derived metadata (v0.13.0)
           symbolName: batch.metadatas[i].symbolName || '',
           symbolType: batch.metadatas[i].symbolType || '',
           parentClass: batch.metadatas[i].parentClass || '',
@@ -650,7 +650,7 @@ export class VectorDB implements VectorDBInterface {
               endLine: r.endLine,
               type: r.type as 'function' | 'class' | 'block',
               language: r.language,
-              // AST-derived metadata (v0.14.0)
+              // AST-derived metadata (v0.13.0)
               symbolName: r.symbolName || undefined,
               symbolType: r.symbolType as 'function' | 'method' | 'class' | 'interface' | undefined,
               parentClass: r.parentClass || undefined,
@@ -774,7 +774,7 @@ export class VectorDB implements VectorDBInterface {
             endLine: r.endLine,
             type: r.type as 'function' | 'class' | 'block',
             language: r.language,
-            // AST-derived metadata (v0.14.0)
+            // AST-derived metadata (v0.13.0)
             symbolName: r.symbolName || undefined,
             symbolType: r.symbolType as 'function' | 'method' | 'class' | 'interface' | undefined,
             parentClass: r.parentClass || undefined,
@@ -896,7 +896,7 @@ export class VectorDB implements VectorDBInterface {
               classes: r.classNames || [],
               interfaces: r.interfaceNames || [],
             },
-            // AST-derived metadata (v0.14.0)
+            // AST-derived metadata (v0.13.0)
             symbolName: r.symbolName || undefined,
             symbolType: r.symbolType as 'function' | 'method' | 'class' | 'interface' | undefined,
             parentClass: r.parentClass || undefined,

--- a/packages/cli/src/vectordb/lancedb.ts
+++ b/packages/cli/src/vectordb/lancedb.ts
@@ -424,7 +424,7 @@ interface DBRecord {
   functionNames: string[];
   classNames: string[];
   interfaceNames: string[];
-  // AST-derived metadata (v0.14.0)
+  // AST-derived metadata (v0.13.0)
   symbolName?: string;
   symbolType?: string;
   parentClass?: string;
@@ -834,7 +834,7 @@ export class VectorDB implements VectorDBInterface {
                        symbolType === 'interface' ? (r.interfaceNames || []) :
                        [...(r.functionNames || []), ...(r.classNames || []), ...(r.interfaceNames || [])];
         
-        // Also check AST-derived symbolName (v0.14.0)
+        // Also check AST-derived symbolName (v0.13.0)
         const astSymbolName = r.symbolName || '';
         
         // Must have at least one symbol from either source

--- a/packages/cli/src/vectordb/lancedb.ts
+++ b/packages/cli/src/vectordb/lancedb.ts
@@ -853,10 +853,10 @@ export class VectorDB implements VectorDBInterface {
           if (!nameMatches) return false;
           
           // If name matches, also check AST symbolType if specified
-          // Semantic filtering: 'function' includes methods and arrow functions
+          // Semantic filtering: 'function' includes methods (arrow functions are typed as 'function')
           if (symbolType && r.symbolType) {
             if (symbolType === 'function') {
-              return r.symbolType === 'function' || r.symbolType === 'method' || r.symbolType === 'arrow_function';
+              return r.symbolType === 'function' || r.symbolType === 'method';
             } else if (symbolType === 'class') {
               return r.symbolType === 'class';
             } else if (symbolType === 'interface') {
@@ -870,7 +870,7 @@ export class VectorDB implements VectorDBInterface {
         // If no pattern, check symbolType only
         if (symbolType && r.symbolType) {
           if (symbolType === 'function') {
-            return r.symbolType === 'function' || r.symbolType === 'method' || r.symbolType === 'arrow_function';
+            return r.symbolType === 'function' || r.symbolType === 'method';
           } else if (symbolType === 'class') {
             return r.symbolType === 'class';
           } else if (symbolType === 'interface') {

--- a/packages/cli/test/integration/e2e-workflow.test.ts
+++ b/packages/cli/test/integration/e2e-workflow.test.ts
@@ -150,7 +150,7 @@ test('calculator addition', () => {
     const migratedConfig = await loadConfig(testDir);
 
     // Step 3: Verify migration
-    expect(migratedConfig.version).toBe('0.14.0');
+    expect(migratedConfig.version).toBe('0.12.0');
     expect(migratedConfig.frameworks).toHaveLength(1);
     expect(migratedConfig.frameworks[0].name).toBe('generic');
     expect(migratedConfig.frameworks[0].path).toBe('.');
@@ -369,7 +369,7 @@ test('calculator addition', () => {
     const migratedConfig = migrateConfig(customV020Config);
 
     // Verify all customizations are preserved
-    expect(migratedConfig.version).toBe('0.14.0');
+    expect(migratedConfig.version).toBe('0.12.0');
     expect(migratedConfig.core.chunkSize).toBe(100);
     expect(migratedConfig.core.chunkOverlap).toBe(15);
     expect(migratedConfig.core.concurrency).toBe(8);

--- a/packages/cli/test/integration/e2e-workflow.test.ts
+++ b/packages/cli/test/integration/e2e-workflow.test.ts
@@ -150,7 +150,7 @@ test('calculator addition', () => {
     const migratedConfig = await loadConfig(testDir);
 
     // Step 3: Verify migration
-    expect(migratedConfig.version).toBe('0.13.0');
+    expect(migratedConfig.version).toBe('0.12.0');
     expect(migratedConfig.frameworks).toHaveLength(1);
     expect(migratedConfig.frameworks[0].name).toBe('generic');
     expect(migratedConfig.frameworks[0].path).toBe('.');
@@ -369,7 +369,7 @@ test('calculator addition', () => {
     const migratedConfig = migrateConfig(customV020Config);
 
     // Verify all customizations are preserved
-    expect(migratedConfig.version).toBe('0.13.0');
+    expect(migratedConfig.version).toBe('0.12.0');
     expect(migratedConfig.core.chunkSize).toBe(100);
     expect(migratedConfig.core.chunkOverlap).toBe(15);
     expect(migratedConfig.core.concurrency).toBe(8);

--- a/packages/cli/test/integration/e2e-workflow.test.ts
+++ b/packages/cli/test/integration/e2e-workflow.test.ts
@@ -289,6 +289,10 @@ test('calculator addition', () => {
         concurrency: 2,
         embeddingBatchSize: 25,
       },
+      chunking: {
+        useAST: true,
+        astFallback: 'line-based',
+      },
       mcp: {
         port: 7133,
         transport: 'stdio',

--- a/packages/cli/test/integration/e2e-workflow.test.ts
+++ b/packages/cli/test/integration/e2e-workflow.test.ts
@@ -150,7 +150,7 @@ test('calculator addition', () => {
     const migratedConfig = await loadConfig(testDir);
 
     // Step 3: Verify migration
-    expect(migratedConfig.version).toBe('0.12.0');
+    expect(migratedConfig.version).toBe('0.13.0');
     expect(migratedConfig.frameworks).toHaveLength(1);
     expect(migratedConfig.frameworks[0].name).toBe('generic');
     expect(migratedConfig.frameworks[0].path).toBe('.');
@@ -369,7 +369,7 @@ test('calculator addition', () => {
     const migratedConfig = migrateConfig(customV020Config);
 
     // Verify all customizations are preserved
-    expect(migratedConfig.version).toBe('0.12.0');
+    expect(migratedConfig.version).toBe('0.13.0');
     expect(migratedConfig.core.chunkSize).toBe(100);
     expect(migratedConfig.core.chunkOverlap).toBe(15);
     expect(migratedConfig.core.concurrency).toBe(8);

--- a/packages/cli/test/integration/e2e-workflow.test.ts
+++ b/packages/cli/test/integration/e2e-workflow.test.ts
@@ -150,7 +150,7 @@ test('calculator addition', () => {
     const migratedConfig = await loadConfig(testDir);
 
     // Step 3: Verify migration
-    expect(migratedConfig.version).toBe('0.3.0');
+    expect(migratedConfig.version).toBe('0.14.0');
     expect(migratedConfig.frameworks).toHaveLength(1);
     expect(migratedConfig.frameworks[0].name).toBe('generic');
     expect(migratedConfig.frameworks[0].path).toBe('.');
@@ -369,7 +369,7 @@ test('calculator addition', () => {
     const migratedConfig = migrateConfig(customV020Config);
 
     // Verify all customizations are preserved
-    expect(migratedConfig.version).toBe('0.3.0');
+    expect(migratedConfig.version).toBe('0.14.0');
     expect(migratedConfig.core.chunkSize).toBe(100);
     expect(migratedConfig.core.chunkOverlap).toBe(15);
     expect(migratedConfig.core.concurrency).toBe(8);

--- a/packages/cli/test/integration/indexing-flow.test.ts
+++ b/packages/cli/test/integration/indexing-flow.test.ts
@@ -66,7 +66,10 @@ export function calculateProduct(a: number, b: number): number {
 
     // Verify results
     expect(results.length).toBeGreaterThan(0);
-    expect(results[0].content).toContain('calculateSum');
+    // With AST chunking, both functions are separate chunks
+    // Check that calculateSum is in the results (may not be first due to semantic similarity)
+    const hasCalculateSum = results.some(r => r.content.includes('calculateSum'));
+    expect(hasCalculateSum).toBe(true);
   });
 
   it('should handle multiple files', async () => {

--- a/packages/cli/test/integration/laravel-frontend.test.ts
+++ b/packages/cli/test/integration/laravel-frontend.test.ts
@@ -116,6 +116,10 @@ const app = createApp({});`
         concurrency: 4,
         embeddingBatchSize: 50,
       },
+      chunking: {
+        useAST: true,
+        astFallback: 'line-based',
+      },
       mcp: {
         port: 7133,
         transport: 'stdio',

--- a/packages/cli/test/integration/monorepo-framework.test.ts
+++ b/packages/cli/test/integration/monorepo-framework.test.ts
@@ -141,6 +141,10 @@ describe('Monorepo Framework Integration', () => {
         concurrency: 4,
         embeddingBatchSize: 50,
       },
+      chunking: {
+        useAST: true,
+        astFallback: 'line-based',
+      },
       mcp: {
         port: 7133,
         transport: 'stdio',
@@ -196,6 +200,10 @@ describe('Monorepo Framework Integration', () => {
         chunkOverlap: 10,
         concurrency: 4,
         embeddingBatchSize: 50,
+      },
+      chunking: {
+        useAST: true,
+        astFallback: 'line-based',
       },
       mcp: {
         port: 7133,
@@ -295,6 +303,10 @@ describe('Monorepo Framework Integration', () => {
         concurrency: 4,
         embeddingBatchSize: 50,
       },
+      chunking: {
+        useAST: true,
+        astFallback: 'line-based',
+      },
       mcp: {
         port: 7133,
         transport: 'stdio',
@@ -342,6 +354,10 @@ describe('Monorepo Framework Integration', () => {
         chunkOverlap: 10,
         concurrency: 4,
         embeddingBatchSize: 50,
+      },
+      chunking: {
+        useAST: true,
+        astFallback: 'line-based',
       },
       mcp: {
         port: 7133,


### PR DESCRIPTION
# 🚀 Add AST-Based Semantic Chunking for TypeScript/JavaScript

## Summary

Implements **AST-based semantic chunking** using Tree-sitter for TypeScript and JavaScript files. Code is now chunked at **function/class boundaries** instead of arbitrary line counts, with rich metadata (complexity, signatures, parameters).

## Key Changes

### Before (Line-Based)
- Chunks split every 75 lines regardless of code structure
- Functions often split mid-implementation
- Limited metadata (regex-extracted names only)

### After (AST-Based)
- ✅ Chunks respect semantic boundaries (never split mid-function)
- ✅ Rich metadata: complexity, signatures, parameters, parent classes
- ✅ Better search results (semantic units vs arbitrary text)

## Features

**New Metadata Fields**:
- `symbolName`, `symbolType`, `parentClass`
- `complexity` (cyclomatic complexity)
- `parameters`, `signature`, `imports`

**Configuration** (`.lien.config.json`):
{
  "chunking": {
    "useAST": true,
    "astFallback": "line-based"
  }
}**Tree-sitter Integration**:
- Added `tree-sitter@^0.21.1`
- Added `tree-sitter-typescript@^0.23.2`  
- Added `tree-sitter-javascript@^0.23.1`

## Quality & Performance

- **99.1% success rate** on Lien's codebase (112/113 files)
- **525 tests passing** (existing + 17 new AST tests)
- Graceful fallback to line-based for unsupported files
- **Known limitation**: Very large files (1000+ lines) may fail Tree-sitter parsing

## Breaking Changes

⚠️ **Full reindex required**
- Index format v1 → v2
- New metadata schema
- Auto-prompted on first run

## Migration

npm install -g @liendev/lien@0.13.0
cd /path/to/your/project
lien index  # Auto-prompted to reindexConfig migration and reindex happen automatically.

## Technical Details

**New Module**: `packages/cli/src/indexer/ast/`
- `parser.ts`: Tree-sitter integration
- `chunker.ts`: AST chunking logic
- `symbols.ts`: Metadata extraction

**Bug Fixes**:
- Fixed cyclomatic complexity calculation (added missing for-of/do-while)
- Eliminated duplicate class chunks
- Fixed JavaScript parser (was using TSX incorrectly)
- Added legacy `symbols` field for backward compatibility
- Implemented `astFallback` config option

## Future Work (v0.14.0+)

- Multi-language support (Python, Go, PHP, etc.)
- Smart splitting for very large files
- Semantic query filters