### PR TITLE
feat(indexer): add regex-based chunking for Shopify Liquid templates

### DIFF
--- a/packages/cli/CURSOR_RULES_TEMPLATE.md
+++ b/packages/cli/CURSOR_RULES_TEMPLATE.md
@@ -240,7 +240,7 @@ Lien provides specialized chunking for Shopify themes with **complete dependency
     language: "liquid",
     symbolName: "Hero Section",        // Extracted from schema JSON
     symbolType: "schema",
-    imports: undefined                  // Schema blocks don't render snippets
+    imports: undefined                  // No render/include/section tags found in this block
   }
 }
 

--- a/packages/cli/src/frameworks/shopify/config.ts
+++ b/packages/cli/src/frameworks/shopify/config.ts
@@ -14,6 +14,7 @@ export async function generateShopifyConfig(
       'sections/**/*.liquid',
       'snippets/**/*.liquid',
       'templates/**/*.liquid', // Matches any nesting level (e.g., templates/customers/account.liquid)
+      'templates/**/*.json',   // JSON template definitions (Shopify 2.0+)
       
       // Theme editor blocks (Online Store 2.0)
       'blocks/**/*.liquid',

--- a/packages/cli/src/indexer/chunker.ts
+++ b/packages/cli/src/indexer/chunker.ts
@@ -3,6 +3,7 @@ import { detectLanguage } from './scanner.js';
 import { extractSymbols } from './symbol-extractor.js';
 import { shouldUseAST, chunkByAST } from './ast/chunker.js';
 import { chunkLiquidFile } from './liquid-chunker.js';
+import { chunkJSONTemplate } from './json-template-chunker.js';
 
 export interface ChunkOptions {
   chunkSize?: number;
@@ -21,6 +22,11 @@ export function chunkFile(
   // Special handling for Liquid files
   if (filepath.endsWith('.liquid')) {
     return chunkLiquidFile(filepath, content, chunkSize, chunkOverlap);
+  }
+  
+  // Special handling for Shopify JSON template files (templates/**/*.json)
+  if (filepath.endsWith('.json') && filepath.includes('templates/')) {
+    return chunkJSONTemplate(filepath, content);
   }
   
   // Try AST-based chunking for supported languages

--- a/packages/cli/src/indexer/chunker.ts
+++ b/packages/cli/src/indexer/chunker.ts
@@ -25,7 +25,10 @@ export function chunkFile(
   }
   
   // Special handling for Shopify JSON template files (templates/**/*.json)
-  if (filepath.endsWith('.json') && filepath.includes('templates/')) {
+  // Use regex to ensure 'templates/' is a path segment, not part of another name
+  // Matches: templates/product.json OR some-path/templates/customers/account.json
+  // Rejects: my-templates/config.json OR node_modules/pkg/templates/file.json (filtered by scanner)
+  if (filepath.endsWith('.json') && /(?:^|\/)templates\//.test(filepath)) {
     return chunkJSONTemplate(filepath, content);
   }
   

--- a/packages/cli/src/indexer/chunker.ts
+++ b/packages/cli/src/indexer/chunker.ts
@@ -2,6 +2,7 @@ import { CodeChunk } from './types.js';
 import { detectLanguage } from './scanner.js';
 import { extractSymbols } from './symbol-extractor.js';
 import { shouldUseAST, chunkByAST } from './ast/chunker.js';
+import { chunkLiquidFile } from './liquid-chunker.js';
 
 export interface ChunkOptions {
   chunkSize?: number;
@@ -16,6 +17,11 @@ export function chunkFile(
   options: ChunkOptions = {}
 ): CodeChunk[] {
   const { chunkSize = 75, chunkOverlap = 10, useAST = true, astFallback = 'line-based' } = options;
+  
+  // Special handling for Liquid files
+  if (filepath.endsWith('.liquid')) {
+    return chunkLiquidFile(filepath, content, chunkSize, chunkOverlap);
+  }
   
   // Try AST-based chunking for supported languages
   if (useAST && shouldUseAST(filepath)) {

--- a/packages/cli/src/indexer/json-template-chunker.ts
+++ b/packages/cli/src/indexer/json-template-chunker.ts
@@ -43,7 +43,7 @@ function extractSectionReferences(jsonContent: string): string[] {
     return Array.from(sectionTypes);
   } catch (error) {
     // Invalid JSON - return empty array
-    console.warn(`Failed to parse JSON template: ${error instanceof Error ? error.message : String(error)}`);
+    console.warn(`[Lien] Failed to parse JSON template: ${error instanceof Error ? error.message : String(error)}`);
     return [];
   }
 }

--- a/packages/cli/src/indexer/json-template-chunker.ts
+++ b/packages/cli/src/indexer/json-template-chunker.ts
@@ -1,0 +1,91 @@
+import type { CodeChunk } from './types.js';
+
+/**
+ * Shopify JSON template chunking
+ * 
+ * JSON template files define which sections appear on a template page.
+ * We extract section references to track dependencies.
+ * 
+ * Example structure:
+ * {
+ *   "sections": {
+ *     "main": { "type": "main-product", "settings": {...} },
+ *     "recommendations": { "type": "product-recommendations", "settings": {...} }
+ *   },
+ *   "order": ["main", "recommendations"]
+ * }
+ */
+
+/**
+ * Extract section types from a Shopify JSON template
+ * 
+ * These are the actual section file names (e.g., "main-product" → sections/main-product.liquid)
+ */
+function extractSectionReferences(jsonContent: string): string[] {
+  try {
+    const template = JSON.parse(jsonContent);
+    const sectionTypes = new Set<string>();
+    
+    // Extract from sections object
+    if (template.sections && typeof template.sections === 'object') {
+      for (const section of Object.values(template.sections)) {
+        if (typeof section === 'object' && section !== null && 'type' in section) {
+          sectionTypes.add((section as { type: string }).type);
+        }
+      }
+    }
+    
+    return Array.from(sectionTypes);
+  } catch (error) {
+    // Invalid JSON - return empty array
+    console.warn(`Failed to parse JSON template: ${error instanceof Error ? error.message : String(error)}`);
+    return [];
+  }
+}
+
+/**
+ * Extract the template name from the filepath
+ * 
+ * templates/customers/account.json → "customers/account"
+ * templates/product.json → "product"
+ */
+function extractTemplateName(filepath: string): string | undefined {
+  // Match everything after templates/ up to .json
+  const match = filepath.match(/templates\/(.+)\.json$/);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Chunk a Shopify JSON template file
+ * 
+ * JSON templates are typically small (define section layout),
+ * so we keep them as a single chunk and extract section references.
+ */
+export function chunkJSONTemplate(
+  filepath: string,
+  content: string
+): CodeChunk[] {
+  // Skip empty files
+  if (content.trim().length === 0) {
+    return [];
+  }
+  
+  const lines = content.split('\n');
+  const templateName = extractTemplateName(filepath);
+  const sectionReferences = extractSectionReferences(content);
+  
+  return [{
+    content,
+    metadata: {
+      file: filepath,
+      startLine: 1,
+      endLine: lines.length,
+      language: 'json',
+      type: 'template',
+      symbolName: templateName,
+      symbolType: 'template',
+      imports: sectionReferences.length > 0 ? sectionReferences : undefined,
+    },
+  }];
+}
+

--- a/packages/cli/src/indexer/json-template-chunker.ts
+++ b/packages/cli/src/indexer/json-template-chunker.ts
@@ -29,8 +29,13 @@ function extractSectionReferences(jsonContent: string): string[] {
     // Extract from sections object
     if (template.sections && typeof template.sections === 'object') {
       for (const section of Object.values(template.sections)) {
-        if (typeof section === 'object' && section !== null && 'type' in section) {
-          sectionTypes.add((section as { type: string }).type);
+        if (
+          typeof section === 'object' && 
+          section !== null && 
+          'type' in section && 
+          typeof section.type === 'string'
+        ) {
+          sectionTypes.add(section.type);
         }
       }
     }

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -247,7 +247,7 @@ export function chunkLiquidFile(
             metadata: {
               file: filepath,
               startLine: block.startLine + offset + 1, // 1-indexed
-              endLine: block.startLine + endOffset + 1, // 1-indexed
+              endLine: block.startLine + endOffset, // 1-indexed (endOffset already accounts for exclusivity)
               language: 'liquid',
               type: 'block',
               symbolName, // Preserve symbol name for all split chunks

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -286,7 +286,7 @@ export function chunkLiquidFile(
       
       // Add overlap for next chunk
       currentChunk = currentChunk.slice(-chunkOverlap);
-      chunkStartLine = i + 1 - chunkOverlap;
+      chunkStartLine = Math.max(0, i + 1 - chunkOverlap);
     }
   }
   

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -43,6 +43,12 @@ function removeComments(content: string): string {
  * - {% include 'snippets/header' %} → 'snippets/header'
  * - {% section 'announcement-bar' %} → 'announcement-bar'
  * 
+ * Limitations:
+ * - Does not handle escaped quotes in snippet names (e.g., {% render 'name\'s' %})
+ * - This is acceptable because Shopify snippet names map to filenames, and
+ *   filesystem restrictions prevent quotes in filenames (snippets/name's.liquid is invalid)
+ * - In practice, Shopify snippet names use only alphanumeric, dash, and underscore
+ * 
  * Note: Expects content with comments already removed for performance
  * 
  * @param contentWithoutComments - Content with Liquid comments already removed
@@ -51,6 +57,7 @@ function extractRenderTags(contentWithoutComments: string): string[] {
   const dependencies = new Set<string>();
   
   // Match {% render 'snippet-name' %} or {% render "snippet-name" %}
+  // Note: Does not handle escaped quotes - see function docs for rationale
   const renderPattern = /\{%-?\s*render\s+['"]([^'"]+)['"]/g;
   let match;
   

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -84,12 +84,19 @@ function extractRenderTags(contentWithoutComments: string): string[] {
 
 /**
  * Find all special Liquid blocks in the template
+ * 
+ * Limitation: Does not support nested blocks of the same type.
+ * - Matches first start tag with first end tag
+ * - This is acceptable because Shopify Liquid does not allow nested blocks
+ * - Example invalid: {% schema %}...{% schema %}...{% endschema %} (Shopify rejects this)
+ * - If malformed input contains nested blocks, only outermost block is extracted
  */
 function findLiquidBlocks(content: string): LiquidBlock[] {
   const lines = content.split('\n');
   const blocks: LiquidBlock[] = [];
   
   // Regex patterns for Liquid blocks
+  // Note: Matches first start → first end (no nesting support, which is correct for Shopify)
   const blockPatterns = [
     { type: 'schema' as const, start: /\{%-?\s*schema\s*-?%\}/, end: /\{%-?\s*endschema\s*-?%\}/ },
     { type: 'style' as const, start: /\{%-?\s*style\s*-?%\}/, end: /\{%-?\s*endstyle\s*-?%\}/ },

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -23,32 +23,40 @@ function extractSchemaName(schemaContent: string): string | undefined {
 }
 
 /**
- * Extract snippet/partial names from {% render %} and {% include %} tags
+ * Extract dependencies from {% render %}, {% include %}, and {% section %} tags
  * 
  * Examples:
  * - {% render 'product-card' %} → 'product-card'
  * - {% render "cart-item", product: product %} → 'cart-item'
  * - {% include 'snippets/header' %} → 'snippets/header'
+ * - {% section 'announcement-bar' %} → 'announcement-bar'
  */
 function extractRenderTags(content: string): string[] {
-  const snippets = new Set<string>();
+  const dependencies = new Set<string>();
   
   // Match {% render 'snippet-name' %} or {% render "snippet-name" %}
   const renderPattern = /\{%-?\s*render\s+['"]([^'"]+)['"]/g;
   let match;
   
   while ((match = renderPattern.exec(content)) !== null) {
-    snippets.add(match[1]);
+    dependencies.add(match[1]);
   }
   
   // Match {% include 'snippet-name' %} or {% include "snippet-name" %}
   const includePattern = /\{%-?\s*include\s+['"]([^'"]+)['"]/g;
   
   while ((match = includePattern.exec(content)) !== null) {
-    snippets.add(match[1]);
+    dependencies.add(match[1]);
   }
   
-  return Array.from(snippets);
+  // Match {% section 'section-name' %} or {% section "section-name" %}
+  const sectionPattern = /\{%-?\s*section\s+['"]([^'"]+)['"]/g;
+  
+  while ((match = sectionPattern.exec(content)) !== null) {
+    dependencies.add(match[1]);
+  }
+  
+  return Array.from(dependencies);
 }
 
 /**
@@ -110,7 +118,7 @@ function findLiquidBlocks(content: string): LiquidBlock[] {
  * - {% schema %} blocks (kept together, extract section name)
  * - {% style %} blocks (kept together)  
  * - {% javascript %} blocks (kept together)
- * - {% render %} and {% include %} tags (tracked as imports)
+ * - {% render %}, {% include %}, and {% section %} tags (tracked as imports)
  * - Regular template content (chunked by lines)
  */
 export function chunkLiquidFile(

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -101,9 +101,9 @@ function findLiquidBlocks(content: string): LiquidBlock[] {
       
       if (startIdx === -1) break;
       
-      // Find end tag
+      // Find end tag (allow same line for single-line blocks)
       const endIdx = lines.findIndex((line, idx) => 
-        idx > startIdx && pattern.end.test(line)
+        idx >= startIdx && pattern.end.test(line)
       );
       
       if (endIdx === -1) {

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -205,7 +205,7 @@ export function chunkLiquidFile(
             metadata: {
               file: filepath,
               startLine: block.startLine + offset + 1, // 1-indexed
-              endLine: block.startLine + endOffset,
+              endLine: block.startLine + endOffset + 1, // 1-indexed
               language: 'liquid',
               type: 'block',
               symbolName, // Preserve symbol name for all split chunks

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -1,0 +1,197 @@
+import type { CodeChunk } from './types.js';
+
+/**
+ * Liquid-specific chunking for Shopify themes
+ * 
+ * Uses regex to identify special Liquid blocks (schema, style, javascript)
+ * and keeps them as single semantic units
+ */
+
+interface LiquidBlock {
+  type: 'schema' | 'style' | 'javascript' | 'template';
+  startLine: number;
+  endLine: number;
+  content: string;
+}
+
+/**
+ * Extract schema name from JSON content
+ */
+function extractSchemaName(schemaContent: string): string | undefined {
+  const nameMatch = schemaContent.match(/"name"\s*:\s*"([^"]+)"/);
+  return nameMatch ? nameMatch[1] : undefined;
+}
+
+/**
+ * Find all special Liquid blocks in the template
+ */
+function findLiquidBlocks(content: string): LiquidBlock[] {
+  const lines = content.split('\n');
+  const blocks: LiquidBlock[] = [];
+  
+  // Regex patterns for Liquid blocks
+  const blockPatterns = [
+    { type: 'schema' as const, start: /\{%-?\s*schema\s*-?%\}/, end: /\{%-?\s*endschema\s*-?%\}/ },
+    { type: 'style' as const, start: /\{%-?\s*style\s*-?%\}/, end: /\{%-?\s*endstyle\s*-?%\}/ },
+    { type: 'javascript' as const, start: /\{%-?\s*javascript\s*-?%\}/, end: /\{%-?\s*endjavascript\s*-?%\}/ },
+  ];
+  
+  for (const pattern of blockPatterns) {
+    let searchStart = 0;
+    
+    while (searchStart < lines.length) {
+      // Find start tag
+      const startIdx = lines.findIndex((line, idx) => 
+        idx >= searchStart && pattern.start.test(line)
+      );
+      
+      if (startIdx === -1) break;
+      
+      // Find end tag
+      const endIdx = lines.findIndex((line, idx) => 
+        idx > startIdx && pattern.end.test(line)
+      );
+      
+      if (endIdx === -1) {
+        // No end tag found, treat rest as template
+        break;
+      }
+      
+      // Extract block content
+      const blockContent = lines.slice(startIdx, endIdx + 1).join('\n');
+      
+      blocks.push({
+        type: pattern.type,
+        startLine: startIdx,
+        endLine: endIdx,
+        content: blockContent,
+      });
+      
+      searchStart = endIdx + 1;
+    }
+  }
+  
+  return blocks.sort((a, b) => a.startLine - b.startLine);
+}
+
+/**
+ * Chunk a Liquid template file
+ * 
+ * Special handling for:
+ * - {% schema %} blocks (kept together)
+ * - {% style %} blocks (kept together)  
+ * - {% javascript %} blocks (kept together)
+ * - Regular template content (chunked by lines)
+ */
+export function chunkLiquidFile(
+  filepath: string,
+  content: string,
+  chunkSize: number = 75,
+  chunkOverlap: number = 10
+): CodeChunk[] {
+  const lines = content.split('\n');
+  const blocks = findLiquidBlocks(content);
+  const chunks: CodeChunk[] = [];
+  
+  // Track which lines are covered by special blocks
+  const coveredLines = new Set<number>();
+  
+  // Create chunks for special blocks
+  for (const block of blocks) {
+    // Mark lines as covered
+    for (let i = block.startLine; i <= block.endLine; i++) {
+      coveredLines.add(i);
+    }
+    
+    // Extract metadata
+    let symbolName: string | undefined;
+    if (block.type === 'schema') {
+      symbolName = extractSchemaName(block.content);
+    }
+    
+    chunks.push({
+      content: block.content,
+      metadata: {
+        file: filepath,
+        startLine: block.startLine + 1, // 1-indexed
+        endLine: block.endLine + 1,
+        language: 'liquid',
+        type: 'block',
+        symbolName,
+        symbolType: block.type,
+        imports: [],
+      },
+    });
+  }
+  
+  // Chunk uncovered template content
+  let currentChunk: string[] = [];
+  let chunkStartLine = 0;
+  
+  for (let i = 0; i < lines.length; i++) {
+    // Skip lines covered by special blocks
+    if (coveredLines.has(i)) {
+      // Flush current chunk if any
+      if (currentChunk.length > 0) {
+        chunks.push({
+          content: currentChunk.join('\n'),
+          metadata: {
+            file: filepath,
+            startLine: chunkStartLine + 1,
+            endLine: i,
+            language: 'liquid',
+            type: 'template',
+            imports: [],
+          },
+        });
+        currentChunk = [];
+      }
+      continue;
+    }
+    
+    // Start new chunk if needed
+    if (currentChunk.length === 0) {
+      chunkStartLine = i;
+    }
+    
+    currentChunk.push(lines[i]);
+    
+    // Flush if chunk is full
+    if (currentChunk.length >= chunkSize) {
+      chunks.push({
+        content: currentChunk.join('\n'),
+        metadata: {
+          file: filepath,
+          startLine: chunkStartLine + 1,
+          endLine: i + 1,
+          language: 'liquid',
+          type: 'template',
+          imports: [],
+        },
+      });
+      
+      // Add overlap for next chunk
+      currentChunk = currentChunk.slice(-chunkOverlap);
+      chunkStartLine = i + 1 - chunkOverlap;
+    }
+  }
+  
+  // Flush remaining chunk
+  if (currentChunk.length > 0) {
+    chunks.push({
+      content: currentChunk.join('\n'),
+      metadata: {
+        file: filepath,
+        startLine: chunkStartLine + 1,
+        endLine: lines.length,
+        language: 'liquid',
+        type: 'template',
+        imports: [],
+      },
+    });
+  }
+  
+  // Sort by line number
+  return chunks.sort((a, b) => a.metadata.startLine - b.metadata.startLine);
+}
+

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -28,7 +28,7 @@ interface LiquidBlock {
  * }
  * {% endschema %}
  * 
- * Returns: "My \"Special\" Section" (with quotes preserved)
+ * Returns: 'My "Special" Section' (with literal quotes, unescaped)
  */
 function extractSchemaName(schemaContent: string): string | undefined {
   try {

--- a/packages/cli/src/indexer/liquid-chunker.ts
+++ b/packages/cli/src/indexer/liquid-chunker.ts
@@ -192,19 +192,23 @@ export function chunkLiquidFile(
       // Flush current chunk if any
       if (currentChunk.length > 0) {
         const chunkContent = currentChunk.join('\n');
-        const imports = extractRenderTags(chunkContent);
         
-        chunks.push({
-          content: chunkContent,
-          metadata: {
-            file: filepath,
-            startLine: chunkStartLine + 1,
-            endLine: i,
-            language: 'liquid',
-            type: 'template',
-            imports: imports.length > 0 ? imports : undefined,
-          },
-        });
+        // Only push non-empty chunks
+        if (chunkContent.trim().length > 0) {
+          const imports = extractRenderTags(chunkContent);
+          
+          chunks.push({
+            content: chunkContent,
+            metadata: {
+              file: filepath,
+              startLine: chunkStartLine + 1,
+              endLine: i,
+              language: 'liquid',
+              type: 'template',
+              imports: imports.length > 0 ? imports : undefined,
+            },
+          });
+        }
         currentChunk = [];
       }
       continue;
@@ -220,19 +224,23 @@ export function chunkLiquidFile(
     // Flush if chunk is full
     if (currentChunk.length >= chunkSize) {
       const chunkContent = currentChunk.join('\n');
-      const imports = extractRenderTags(chunkContent);
       
-      chunks.push({
-        content: chunkContent,
-        metadata: {
-          file: filepath,
-          startLine: chunkStartLine + 1,
-          endLine: i + 1,
-          language: 'liquid',
-          type: 'template',
-          imports: imports.length > 0 ? imports : undefined,
-        },
-      });
+      // Only push non-empty chunks
+      if (chunkContent.trim().length > 0) {
+        const imports = extractRenderTags(chunkContent);
+        
+        chunks.push({
+          content: chunkContent,
+          metadata: {
+            file: filepath,
+            startLine: chunkStartLine + 1,
+            endLine: i + 1,
+            language: 'liquid',
+            type: 'template',
+            imports: imports.length > 0 ? imports : undefined,
+          },
+        });
+      }
       
       // Add overlap for next chunk
       currentChunk = currentChunk.slice(-chunkOverlap);
@@ -243,6 +251,12 @@ export function chunkLiquidFile(
   // Flush remaining chunk
   if (currentChunk.length > 0) {
     const chunkContent = currentChunk.join('\n');
+    
+    // Skip empty or whitespace-only chunks
+    if (chunkContent.trim().length === 0) {
+      return chunks.sort((a, b) => a.metadata.startLine - b.metadata.startLine);
+    }
+    
     const imports = extractRenderTags(chunkContent);
     
     chunks.push({

--- a/packages/cli/src/indexer/types.ts
+++ b/packages/cli/src/indexer/types.ts
@@ -7,7 +7,7 @@ export interface ChunkMetadata {
   file: string;
   startLine: number;
   endLine: number;
-  type: 'function' | 'class' | 'block';
+  type: 'function' | 'class' | 'block' | 'template';
   language: string;
   // Extracted symbols for direct querying
   symbols?: {
@@ -18,7 +18,7 @@ export interface ChunkMetadata {
   
   // NEW: AST-derived metadata (v0.13.0)
   symbolName?: string;        // Function/class name
-  symbolType?: 'function' | 'method' | 'class' | 'interface';
+  symbolType?: 'function' | 'method' | 'class' | 'interface' | 'schema' | 'style' | 'javascript' | 'template' | 'block';
   parentClass?: string;       // For methods
   complexity?: number;        // Cyclomatic complexity
   parameters?: string[];      // Function parameters

--- a/packages/cli/src/indexer/types.ts
+++ b/packages/cli/src/indexer/types.ts
@@ -18,7 +18,7 @@ export interface ChunkMetadata {
   
   // NEW: AST-derived metadata (v0.13.0)
   symbolName?: string;        // Function/class name
-  symbolType?: 'function' | 'method' | 'class' | 'interface' | 'schema' | 'style' | 'javascript' | 'template' | 'block';
+  symbolType?: 'function' | 'method' | 'class' | 'interface' | 'schema' | 'style' | 'javascript' | 'template';
   parentClass?: string;       // For methods
   complexity?: number;        // Cyclomatic complexity
   parameters?: string[];      // Function parameters

--- a/packages/cli/test/integration/json-template-chunking.test.ts
+++ b/packages/cli/test/integration/json-template-chunking.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import { chunkFile } from '../../src/indexer/chunker.js';
+
+describe('Shopify JSON Template Chunking', () => {
+  it('should extract section references from JSON template', () => {
+    const content = `{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "settings": {
+        "padding_top": 36
+      }
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {}
+    }
+  },
+  "order": ["main", "recommendations"]
+}`;
+    
+    const chunks = chunkFile('templates/product.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.language).toBe('json');
+    expect(chunks[0].metadata.type).toBe('template');
+    expect(chunks[0].metadata.symbolType).toBe('template');
+    expect(chunks[0].metadata.imports).toBeDefined();
+    expect(chunks[0].metadata.imports).toContain('main-product');
+    expect(chunks[0].metadata.imports).toContain('product-recommendations');
+  });
+
+  it('should extract template name from filepath', () => {
+    const content = `{
+  "sections": {
+    "main": { "type": "main-account", "settings": {} }
+  },
+  "order": ["main"]
+}`;
+    
+    const chunks = chunkFile('templates/customers/account.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('customers/account');
+  });
+
+  it('should handle empty sections object', () => {
+    const content = `{
+  "sections": {},
+  "order": []
+}`;
+    
+    const chunks = chunkFile('templates/page.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.imports).toBeUndefined();
+  });
+
+  it('should handle JSON template without sections field', () => {
+    const content = `{
+  "order": []
+}`;
+    
+    const chunks = chunkFile('templates/minimal.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.imports).toBeUndefined();
+  });
+
+  it('should handle invalid JSON gracefully', () => {
+    const content = `{
+  "sections": {
+    invalid json here
+  }
+}`;
+    
+    const chunks = chunkFile('templates/broken.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.imports).toBeUndefined(); // No imports extracted from invalid JSON
+  });
+
+  it('should handle empty JSON template files', () => {
+    const chunks = chunkFile('templates/empty.json', '');
+    
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('should handle whitespace-only JSON files', () => {
+    const chunks = chunkFile('templates/whitespace.json', '   \n\n   ');
+    
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('should handle multiple section references', () => {
+    const content = `{
+  "sections": {
+    "announcement": { "type": "announcement-bar", "settings": {} },
+    "header": { "type": "header", "settings": {} },
+    "main": { "type": "main-collection", "settings": {} },
+    "filters": { "type": "collection-filters", "settings": {} },
+    "footer": { "type": "footer", "settings": {} }
+  },
+  "order": ["announcement", "header", "main", "filters", "footer"]
+}`;
+    
+    const chunks = chunkFile('templates/collection.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.imports).toHaveLength(5);
+    expect(chunks[0].metadata.imports).toContain('announcement-bar');
+    expect(chunks[0].metadata.imports).toContain('header');
+    expect(chunks[0].metadata.imports).toContain('main-collection');
+    expect(chunks[0].metadata.imports).toContain('collection-filters');
+    expect(chunks[0].metadata.imports).toContain('footer');
+  });
+
+  it('should deduplicate section references', () => {
+    const content = `{
+  "sections": {
+    "header1": { "type": "header", "settings": {} },
+    "header2": { "type": "header", "settings": {} },
+    "main": { "type": "main-page", "settings": {} }
+  },
+  "order": ["header1", "header2", "main"]
+}`;
+    
+    const chunks = chunkFile('templates/page.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    // Should have only 2 unique section types
+    expect(chunks[0].metadata.imports).toHaveLength(2);
+    expect(chunks[0].metadata.imports).toContain('header');
+    expect(chunks[0].metadata.imports).toContain('main-page');
+  });
+
+  it('should only process JSON files in templates directory', () => {
+    // Other JSON files (config, locales) should use regular chunking
+    const content = `{
+  "theme_name": "My Theme",
+  "sections": {
+    "main": { "type": "should-not-extract" }
+  }
+}`;
+    
+    const chunks = chunkFile('config/settings_schema.json', content);
+    
+    // Should NOT extract section references (not a template file)
+    expect(chunks[0].metadata.imports).toBeUndefined();
+  });
+
+  it('should handle nested template paths', () => {
+    const content = `{
+  "sections": {
+    "main": { "type": "main-login", "settings": {} }
+  },
+  "order": ["main"]
+}`;
+    
+    const chunks = chunkFile('templates/customers/login.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('customers/login');
+    expect(chunks[0].metadata.imports).toContain('main-login');
+  });
+
+  it('should handle real-world Shopify template structure', () => {
+    const content = `{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "vendor": { "type": "text", "settings": { "text": "{{ product.vendor }}" } },
+        "title": { "type": "title", "settings": {} },
+        "price": { "type": "price", "settings": {} }
+      },
+      "block_order": ["vendor", "title", "price"],
+      "settings": {
+        "enable_sticky_info": true,
+        "media_size": "medium"
+      }
+    },
+    "related-products": {
+      "type": "related-products",
+      "settings": {
+        "heading": "You may also like",
+        "products_to_show": 4
+      }
+    }
+  },
+  "order": ["main", "related-products"]
+}`;
+    
+    const chunks = chunkFile('templates/product.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('product');
+    expect(chunks[0].metadata.imports).toContain('main-product');
+    expect(chunks[0].metadata.imports).toContain('related-products');
+    expect(chunks[0].metadata.imports).toHaveLength(2);
+  });
+
+  it('should handle sections with complex settings objects', () => {
+    const content = `{
+  "sections": {
+    "hero": {
+      "type": "image-banner",
+      "settings": {
+        "image": "shopify://shop_images/hero.jpg",
+        "image_overlay_opacity": 40,
+        "image_height": "medium",
+        "desktop_content_position": "middle-center",
+        "show_text_box": false,
+        "desktop_content_alignment": "center",
+        "color_scheme": "background-1",
+        "mobile_content_alignment": "center",
+        "stack_images_on_mobile": true,
+        "show_text_below": true
+      }
+    }
+  },
+  "order": ["hero"]
+}`;
+    
+    const chunks = chunkFile('templates/index.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.imports).toEqual(['image-banner']);
+  });
+});
+

--- a/packages/cli/test/integration/json-template-chunking.test.ts
+++ b/packages/cli/test/integration/json-template-chunking.test.ts
@@ -227,5 +227,29 @@ describe('Shopify JSON Template Chunking', () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0].metadata.imports).toEqual(['image-banner']);
   });
+
+  it('should handle malformed type values (non-string)', () => {
+    const content = `{
+  "sections": {
+    "valid": { "type": "main-product", "settings": {} },
+    "invalid_number": { "type": 123, "settings": {} },
+    "invalid_null": { "type": null, "settings": {} },
+    "invalid_array": { "type": ["array"], "settings": {} },
+    "another_valid": { "type": "product-recommendations", "settings": {} }
+  },
+  "order": ["valid", "invalid_number", "invalid_null", "invalid_array", "another_valid"]
+}`;
+    
+    const chunks = chunkFile('templates/malformed.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    // Should only extract valid string types, ignoring malformed ones
+    expect(chunks[0].metadata.imports).toHaveLength(2);
+    expect(chunks[0].metadata.imports).toContain('main-product');
+    expect(chunks[0].metadata.imports).toContain('product-recommendations');
+    // Should NOT contain non-string types
+    expect(chunks[0].metadata.imports).not.toContain(123);
+    expect(chunks[0].metadata.imports).not.toContain(null);
+  });
 });
 

--- a/packages/cli/test/integration/json-template-chunking.test.ts
+++ b/packages/cli/test/integration/json-template-chunking.test.ts
@@ -149,6 +149,36 @@ describe('Shopify JSON Template Chunking', () => {
     expect(chunks[0].metadata.imports).toBeUndefined();
   });
 
+  it('should handle templates directory with framework path prefix', () => {
+    // When framework.path !== '.', files have prefix like 'shopify-theme/templates/...'
+    const content = `{
+  "sections": {
+    "main": { "type": "main-product", "settings": {} }
+  },
+  "order": ["main"]
+}`;
+    
+    const chunks = chunkFile('shopify-theme/templates/product.json', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('product');
+    expect(chunks[0].metadata.imports).toContain('main-product');
+  });
+
+  it('should NOT match templates substring in other directory names', () => {
+    // Should not match 'my-templates', 'templates-backup', etc.
+    const content = `{
+  "sections": {
+    "main": { "type": "should-not-extract" }
+  }
+}`;
+    
+    const chunks = chunkFile('my-templates/product.json', content);
+    
+    // Should use regular JSON chunking (no section extraction)
+    expect(chunks[0].metadata.imports).toBeUndefined();
+  });
+
   it('should handle nested template paths', () => {
     const content = `{
   "sections": {

--- a/packages/cli/test/integration/liquid-chunking.test.ts
+++ b/packages/cli/test/integration/liquid-chunking.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import { chunkFile } from '../../src/indexer/chunker.js';
+
+describe('Liquid Chunking (Regex-based)', () => {
+  it('should keep schema blocks together as single chunk', () => {
+    const content = `
+<div class="container">
+  {{ product.title }}
+</div>
+
+{% schema %}
+{
+  "name": "USPS Multicolumn",
+  "settings": [
+    {
+      "type": "text",
+      "id": "title"
+    }
+  ],
+  "blocks": []
+}
+{% endschema %}
+
+<div>More template</div>
+`.trim();
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    // Should have at least 2 chunks: template before schema, schema block, template after
+    expect(chunks.length).toBeGreaterThan(0);
+    
+    // Find the schema chunk
+    const schemaChunk = chunks.find(c => c.content.includes('{% schema %}'));
+    expect(schemaChunk).toBeDefined();
+    expect(schemaChunk?.metadata.symbolType).toBe('schema');
+    expect(schemaChunk?.metadata.symbolName).toBe('USPS Multicolumn');
+    
+    // Schema block should be a single chunk
+    expect(schemaChunk?.content).toContain('{% schema %}');
+    expect(schemaChunk?.content).toContain('{% endschema %}');
+  });
+  
+  it('should keep style blocks together', () => {
+    const content = `
+<div>Content</div>
+
+{% style %}
+.container {
+  background: red;
+  padding: 20px;
+}
+{% endstyle %}
+
+<div>More content</div>
+`.trim();
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    const styleChunk = chunks.find(c => c.content.includes('{% style %}'));
+    expect(styleChunk).toBeDefined();
+    expect(styleChunk?.metadata.symbolType).toBe('style');
+    expect(styleChunk?.content).toContain('.container');
+  });
+  
+  it('should keep javascript blocks together', () => {
+    const content = `
+<div>Content</div>
+
+{% javascript %}
+function init() {
+  console.log('Section initialized');
+  setupEventListeners();
+}
+{% endjavascript %}
+
+<div>More content</div>
+`.trim();
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    const jsChunk = chunks.find(c => c.content.includes('{% javascript %}'));
+    expect(jsChunk).toBeDefined();
+    expect(jsChunk?.metadata.symbolType).toBe('javascript');
+    expect(jsChunk?.content).toContain('console.log');
+  });
+  
+  it('should chunk template content normally', () => {
+    const content = `
+<div>{{ product.title }}</div>
+{% if product.available %}
+  <span>Available</span>
+{% endif %}
+{{ product.description }}
+`.trim();
+    
+    const chunks = chunkFile('snippets/test.liquid', content);
+    
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0].metadata.language).toBe('liquid');
+    expect(chunks[0].metadata.type).toBe('template');
+  });
+  
+  it('should handle multiple schema and style blocks', () => {
+    const content = `
+{% schema %}
+{"name": "Header"}
+{% endschema %}
+
+<div>Template</div>
+
+{% style %}
+.header { color: blue; }
+{% endstyle %}
+
+<div>More template</div>
+`.trim();
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    const schemaChunks = chunks.filter(c => c.metadata.symbolType === 'schema');
+    const styleChunks = chunks.filter(c => c.metadata.symbolType === 'style');
+    
+    expect(schemaChunks.length).toBe(1);
+    expect(styleChunks.length).toBe(1);
+  });
+
+  it('should handle schema without name field', () => {
+    const content = `
+{% schema %}
+{
+  "settings": [],
+  "blocks": []
+}
+{% endschema %}
+`.trim();
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    const schemaChunk = chunks.find(c => c.metadata.symbolType === 'schema');
+    expect(schemaChunk).toBeDefined();
+    expect(schemaChunk?.metadata.symbolName).toBeUndefined();
+  });
+
+  it('should handle schema with invalid JSON gracefully', () => {
+    const content = `
+{% schema %}
+{
+  "name": "Test Section
+  invalid json here
+}
+{% endschema %}
+`.trim();
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    const schemaChunk = chunks.find(c => c.metadata.symbolType === 'schema');
+    expect(schemaChunk).toBeDefined();
+    expect(schemaChunk?.metadata.symbolName).toBeUndefined(); // Should not crash
+  });
+
+  it('should handle all three special blocks in one file', () => {
+    const content = `
+<div>Header template</div>
+
+{% schema %}
+{
+  "name": "Complex Section",
+  "settings": []
+}
+{% endschema %}
+
+<div>Middle template</div>
+
+{% style %}
+.section { padding: 20px; }
+{% endstyle %}
+
+<div>More template</div>
+
+{% javascript %}
+console.log('loaded');
+{% endjavascript %}
+
+<div>Footer template</div>
+`.trim();
+    
+    const chunks = chunkFile('sections/complex.liquid', content);
+    
+    expect(chunks.length).toBeGreaterThan(3); // At least the 3 special blocks + template chunks
+    
+    const schemaChunk = chunks.find(c => c.metadata.symbolType === 'schema');
+    const styleChunk = chunks.find(c => c.metadata.symbolType === 'style');
+    const jsChunk = chunks.find(c => c.metadata.symbolType === 'javascript');
+    
+    expect(schemaChunk).toBeDefined();
+    expect(styleChunk).toBeDefined();
+    expect(jsChunk).toBeDefined();
+    
+    // Verify they're in order
+    const schemaIdx = chunks.indexOf(schemaChunk!);
+    const styleIdx = chunks.indexOf(styleChunk!);
+    const jsIdx = chunks.indexOf(jsChunk!);
+    
+    expect(schemaIdx).toBeLessThan(styleIdx);
+    expect(styleIdx).toBeLessThan(jsIdx);
+  });
+
+  it('should handle snippets without special blocks', () => {
+    const content = `
+{% comment %}
+  Snippet: product-card
+  Usage: {% render 'product-card', product: product %}
+{% endcomment %}
+
+<div class="product-card">
+  <h3>{{ product.title }}</h3>
+  <p>{{ product.price }}</p>
+  {% if product.available %}
+    <button>Add to Cart</button>
+  {% endif %}
+</div>
+`.trim();
+    
+    const chunks = chunkFile('snippets/product-card.liquid', content);
+    
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.every(c => c.metadata.language === 'liquid')).toBe(true);
+    expect(chunks.every(c => c.metadata.type === 'template')).toBe(true);
+    
+    // Should not have any special block types
+    expect(chunks.some(c => c.metadata.symbolType === 'schema')).toBe(false);
+    expect(chunks.some(c => c.metadata.symbolType === 'style')).toBe(false);
+    expect(chunks.some(c => c.metadata.symbolType === 'javascript')).toBe(false);
+  });
+
+  it('should respect line numbers correctly', () => {
+    const content = `Line 1
+Line 2
+{% schema %}
+Line 4
+Line 5
+{% endschema %}
+Line 7`;
+    
+    const chunks = chunkFile('test.liquid', content);
+    
+    const schemaChunk = chunks.find(c => c.metadata.symbolType === 'schema');
+    expect(schemaChunk?.metadata.startLine).toBe(3);
+    expect(schemaChunk?.metadata.endLine).toBe(6);
+  });
+});

--- a/packages/cli/test/integration/liquid-chunking.test.ts
+++ b/packages/cli/test/integration/liquid-chunking.test.ts
@@ -373,4 +373,63 @@ Line 7`;
     const templateChunk = chunks.find(c => c.metadata.type === 'template');
     expect(templateChunk?.metadata.imports).toContain('product-card');
   });
+
+  it('should track {% section %} tags as imports', () => {
+    const content = `
+<!doctype html>
+<html>
+<body>
+  {% section 'header' %}
+  <main>{{ content_for_layout }}</main>
+  {% section 'footer' %}
+</body>
+</html>
+`.trim();
+    
+    const chunks = chunkFile('layout/theme.liquid', content);
+    
+    const templateChunk = chunks.find(c => c.metadata.type === 'template');
+    expect(templateChunk?.metadata.imports).toBeDefined();
+    expect(templateChunk?.metadata.imports).toContain('header');
+    expect(templateChunk?.metadata.imports).toContain('footer');
+  });
+
+  it('should track mixed render, include, and section tags', () => {
+    const content = `
+<div class="layout">
+  {% section 'announcement-bar' %}
+  {% render 'header-logo' %}
+  {% include 'navigation' %}
+  
+  <main>{{ content_for_layout }}</main>
+  
+  {% section 'footer' %}
+</div>
+`.trim();
+    
+    const chunks = chunkFile('layout/theme.liquid', content);
+    
+    const templateChunk = chunks.find(c => c.metadata.type === 'template');
+    expect(templateChunk?.metadata.imports).toContain('announcement-bar');
+    expect(templateChunk?.metadata.imports).toContain('header-logo');
+    expect(templateChunk?.metadata.imports).toContain('navigation');
+    expect(templateChunk?.metadata.imports).toContain('footer');
+    expect(templateChunk?.metadata.imports?.length).toBe(4);
+  });
+
+  it('should handle section tags with whitespace control', () => {
+    const content = `
+<body>
+  {%- section 'header' -%}
+  {{ content_for_layout }}
+  {%- section 'footer' -%}
+</body>
+`.trim();
+    
+    const chunks = chunkFile('layout/minimal.liquid', content);
+    
+    const templateChunk = chunks.find(c => c.metadata.type === 'template');
+    expect(templateChunk?.metadata.imports).toContain('header');
+    expect(templateChunk?.metadata.imports).toContain('footer');
+  });
 });

--- a/packages/cli/test/integration/liquid-chunking.test.ts
+++ b/packages/cli/test/integration/liquid-chunking.test.ts
@@ -953,3 +953,18 @@ ${schemaLines}
     }
   });
 });
+
+  it('should handle escaped quotes in schema names', () => {
+    const content = `{% schema %}
+{
+  "name": "My \\"Special\\" Section",
+  "settings": []
+}
+{% endschema %}`;
+    
+    const chunks = chunkFile('sections/escaped-quotes.liquid', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolType).toBe('schema');
+    expect(chunks[0].metadata.symbolName).toBe('My "Special" Section');
+  });

--- a/packages/cli/test/integration/liquid-chunking.test.ts
+++ b/packages/cli/test/integration/liquid-chunking.test.ts
@@ -652,4 +652,79 @@ Line 7`;
     expect(chunks[0].metadata.type).toBe('template');
     expect(chunks[0].content).toBe(content);
   });
+
+  it('should handle single-line schema blocks', () => {
+    const content = '{% schema %}{"name": "Compact Section", "settings": []}{% endschema %}';
+    
+    const chunks = chunkFile('sections/compact.liquid', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolType).toBe('schema');
+    expect(chunks[0].metadata.symbolName).toBe('Compact Section');
+    expect(chunks[0].metadata.type).toBe('block');
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(1);
+  });
+
+  it('should handle single-line style blocks', () => {
+    const content = '{% style %}.compact { color: red; }{% endstyle %}';
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolType).toBe('style');
+    expect(chunks[0].metadata.type).toBe('block');
+    expect(chunks[0].content).toBe(content);
+  });
+
+  it('should handle single-line javascript blocks', () => {
+    const content = '{% javascript %}console.log("compact");{% endjavascript %}';
+    
+    const chunks = chunkFile('sections/test.liquid', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolType).toBe('javascript');
+    expect(chunks[0].metadata.type).toBe('block');
+    expect(chunks[0].content).toBe(content);
+  });
+
+  it('should handle mix of single-line and multi-line blocks', () => {
+    const content = `
+<div>Template</div>
+{% schema %}{"name": "Mixed"}{% endschema %}
+{% style %}
+.multi-line {
+  color: blue;
+}
+{% endstyle %}
+{% javascript %}console.log("single");{% endjavascript %}
+<div>More template</div>
+`.trim();
+    
+    const chunks = chunkFile('sections/mixed.liquid', content);
+    
+    const schemaChunk = chunks.find(c => c.metadata.symbolType === 'schema');
+    const styleChunk = chunks.find(c => c.metadata.symbolType === 'style');
+    const jsChunk = chunks.find(c => c.metadata.symbolType === 'javascript');
+    
+    expect(schemaChunk).toBeDefined();
+    expect(schemaChunk?.metadata.symbolName).toBe('Mixed');
+    expect(schemaChunk?.metadata.startLine).toBe(schemaChunk?.metadata.endLine); // Single line
+    
+    expect(styleChunk).toBeDefined();
+    expect(styleChunk?.metadata.endLine).toBeGreaterThan(styleChunk!.metadata.startLine); // Multi-line
+    
+    expect(jsChunk).toBeDefined();
+    expect(jsChunk?.metadata.startLine).toBe(jsChunk?.metadata.endLine); // Single line
+  });
+
+  it('should handle single-line blocks with whitespace control', () => {
+    const content = '{%- schema -%}{"name": "Compact"}{%- endschema -%}';
+    
+    const chunks = chunkFile('sections/compact-ws.liquid', content);
+    
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolType).toBe('schema');
+    expect(chunks[0].metadata.symbolName).toBe('Compact');
+  });
 });

--- a/packages/cli/test/integration/liquid-chunking.test.ts
+++ b/packages/cli/test/integration/liquid-chunking.test.ts
@@ -952,7 +952,6 @@ ${schemaLines}
       expect(nextChunk.metadata.startLine).toBeLessThanOrEqual(currentChunk.metadata.endLine + 1);
     }
   });
-});
 
   it('should handle escaped quotes in schema names', () => {
     const content = `{% schema %}
@@ -968,3 +967,4 @@ ${schemaLines}
     expect(chunks[0].metadata.symbolType).toBe('schema');
     expect(chunks[0].metadata.symbolName).toBe('My "Special" Section');
   });
+});


### PR DESCRIPTION
# Add regex-based chunking for Shopify Liquid templates

## 🎯 Summary

Adds specialized semantic chunking for Shopify Liquid files with complete dependency tracking. Improves AI context for Shopify theme development by preserving important blocks and tracking template relationships.

## 📝 Changes

**New Files:**
- `liquid-chunker.ts` (247 lines) - Regex-based Liquid chunker
- `liquid-chunking.test.ts` (435 lines) - 20 comprehensive tests

**Modified:**
- `chunker.ts` - Route `.liquid` files to specialized chunker
- `types.ts` - Add Liquid-specific `symbolType` values
- `CURSOR_RULES_TEMPLATE.md` - Document Liquid support for AI assistants

**Total:** +760 lines, 4 commits

## ✨ Features

### 1. Special Block Preservation
- `{% schema %}` → Kept intact, section name extracted (`symbolName`)
- `{% style %}` → Preserved for scoped CSS
- `{% javascript %}` → Kept together

### 2. Complete Dependency Tracking
Tracks all template relationships in `metadata.imports`:
- `{% render 'snippet' %}` - Snippet dependencies
- `{% include 'snippet' %}` - Legacy includes  
- `{% section 'header' %}` - Section usage in layouts

**Dependency graph example:**