### PR TITLE
feat(mcp): rename get_file_context to get_files_context with multi-fi…

### DIFF
--- a/packages/cli/CURSOR_RULES_TEMPLATE.md
+++ b/packages/cli/CURSOR_RULES_TEMPLATE.md
@@ -15,14 +15,14 @@ You have access to Lien semantic search tools. USE THEM INSTEAD OF grep/ripgrep/
 | "Where is X implemented?" | `semantic_search` | grep |
 | "How does X work?" | `semantic_search` | reading random files |
 | "Find all Controllers" | `list_functions` | grep |
-| Edit a file | `get_file_context` FIRST | direct edit |
+| Edit a file | `get_files_context` FIRST | direct edit |
 | Find similar code | `find_similar` | manual search |
 
 ## Before ANY Code Change
 
 REQUIRED sequence:
 1. `semantic_search` → find relevant files
-2. `get_file_context` → understand the file + check `testAssociations`
+2. `get_files_context` → understand the file + check `testAssociations`
 3. Make changes
 4. Remind user to run affected tests
 
@@ -33,10 +33,11 @@ REQUIRED sequence:
 - NOT function names (use grep for exact names)
 - Returns relevance category: `highly_relevant`, `relevant`, `loosely_related`, `not_relevant`
 
-**`get_file_context({ filepath: "path/to/file.ts" })`**
+**`get_files_context({ filepaths: "path/to/file.ts" })`** or **`get_files_context({ filepaths: ["file1.ts", "file2.ts"] })`**
 - MANDATORY before editing any file
 - Returns `testAssociations`: which tests cover this file
 - Shows file dependencies and relationships
+- Accepts single filepath or array of filepaths for batch operations
 
 **`list_functions({ pattern: ".*Controller.*" })`**
 - Fast symbol lookup by naming pattern
@@ -49,7 +50,7 @@ REQUIRED sequence:
 
 ## Test Associations
 
-`get_file_context` returns `testAssociations` showing which tests cover the file.
+`get_files_context` returns `testAssociations` showing which tests cover the file.
 ALWAYS check this before modifying source code.
 After changes, remind the user: "This file is covered by [test files] - run these to verify."
 
@@ -59,14 +60,14 @@ After changes, remind the user: "This file is covered by [test files] - run thes
 ```
 1. semantic_search({ query: "X implementation" })
 2. Review results (check relevance scores)
-3. get_file_context({ filepath: "identified/file.ts" })
+3. get_files_context({ filepaths: "identified/file.ts" })
 4. Answer with specific code locations
 ```
 
 ### Pattern 2: Edit or Change Code
 ```
 1. semantic_search({ query: "area being modified" })
-2. get_file_context({ filepath: "target/file.ts" })
+2. get_files_context({ filepaths: "target/file.ts" })
 3. Check testAssociations in response
 4. Make changes
 5. Tell user which tests to run
@@ -107,4 +108,4 @@ For everything else: **Lien first.**
 
 ---
 
-REMINDER: semantic_search and get_file_context FIRST. grep is the fallback, not the default.
+REMINDER: semantic_search and get_files_context FIRST. grep is the fallback, not the default.

--- a/packages/cli/src/mcp/schemas/file.schema.ts
+++ b/packages/cli/src/mcp/schemas/file.schema.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 export const GetFilesContextSchema = z.object({
   filepaths: z.union([
     z.string().min(1, "Filepath cannot be empty"),
-    z.array(z.string()).min(1, "Array must contain at least one filepath").max(50, "Maximum 50 files per request")
+    z.array(z.string().min(1, "Filepath cannot be empty")).min(1, "Array must contain at least one filepath").max(50, "Maximum 50 files per request")
   ]).describe(
     "Single filepath or array of filepaths (relative to workspace root).\n\n" +
     "Single file: 'src/components/Button.tsx'\n" +

--- a/packages/cli/src/mcp/schemas/file.schema.ts
+++ b/packages/cli/src/mcp/schemas/file.schema.ts
@@ -1,17 +1,21 @@
 import { z } from 'zod';
 
 /**
- * Schema for get_file_context tool input.
+ * Schema for get_files_context tool input.
  * 
  * Validates file paths and context options for retrieving file-specific code chunks.
+ * Supports both single file and batch operations.
  */
-export const GetFileContextSchema = z.object({
-  filepath: z.string()
-    .min(1, "Filepath cannot be empty")
-    .describe(
-      "Relative path to file from workspace root.\n\n" +
-      "Example: 'src/components/Button.tsx'"
-    ),
+export const GetFilesContextSchema = z.object({
+  filepaths: z.union([
+    z.string().min(1, "Filepath cannot be empty"),
+    z.array(z.string()).min(1, "Array must contain at least one filepath").max(50, "Maximum 50 files per request")
+  ]).describe(
+    "Single filepath or array of filepaths (relative to workspace root).\n\n" +
+    "Single file: 'src/components/Button.tsx'\n" +
+    "Multiple files: ['src/auth.ts', 'src/user.ts']\n\n" +
+    "Maximum 50 files per request for batch operations."
+  ),
     
   includeRelated: z.boolean()
     .default(true)
@@ -26,5 +30,5 @@ export const GetFileContextSchema = z.object({
 /**
  * Inferred TypeScript type for file context input
  */
-export type GetFileContextInput = z.infer<typeof GetFileContextSchema>;
+export type GetFilesContextInput = z.infer<typeof GetFilesContextSchema>;
 

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SemanticSearchSchema,
   FindSimilarSchema,
-  GetFileContextSchema,
+  GetFilesContextSchema,
   ListFunctionsSchema,
 } from './index.js';
 
@@ -110,25 +110,25 @@ describe('FindSimilarSchema', () => {
   });
 });
 
-describe('GetFileContextSchema', () => {
+describe('GetFilesContextSchema', () => {
   it('should validate correct input', () => {
-    const result = GetFileContextSchema.parse({
-      filepath: 'src/index.ts',
+    const result = GetFilesContextSchema.parse({
+      filepaths: 'src/index.ts',
       includeRelated: false,
     });
-    expect(result.filepath).toBe('src/index.ts');
+    expect(result.filepaths).toBe('src/index.ts');
     expect(result.includeRelated).toBe(false);
   });
   
   it('should apply default includeRelated', () => {
-    const result = GetFileContextSchema.parse({
-      filepath: 'src/index.ts',
+    const result = GetFilesContextSchema.parse({
+      filepaths: 'src/index.ts',
     });
     expect(result.includeRelated).toBe(true);
   });
   
   it('should reject empty filepath', () => {
-    expect(() => GetFileContextSchema.parse({ filepath: '' }))
+    expect(() => GetFilesContextSchema.parse({ filepaths: '' }))
       .toThrow('Filepath cannot be empty');
   });
   
@@ -141,20 +141,20 @@ describe('GetFileContextSchema', () => {
     ];
     
     paths.forEach(path => {
-      const result = GetFileContextSchema.parse({ filepath: path });
-      expect(result.filepath).toBe(path);
+      const result = GetFilesContextSchema.parse({ filepaths: path });
+      expect(result.filepaths).toBe(path);
     });
   });
   
   it('should accept explicit includeRelated values', () => {
-    const resultTrue = GetFileContextSchema.parse({
-      filepath: 'test.ts',
+    const resultTrue = GetFilesContextSchema.parse({
+      filepaths: 'test.ts',
       includeRelated: true,
     });
     expect(resultTrue.includeRelated).toBe(true);
     
-    const resultFalse = GetFileContextSchema.parse({
-      filepath: 'test.ts',
+    const resultFalse = GetFilesContextSchema.parse({
+      filepaths: 'test.ts',
       includeRelated: false,
     });
     expect(resultFalse.includeRelated).toBe(false);

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -159,6 +159,20 @@ describe('GetFilesContextSchema', () => {
     });
     expect(resultFalse.includeRelated).toBe(false);
   });
+  
+  it('should reject array with empty strings', () => {
+    const invalid = GetFilesContextSchema.safeParse({ 
+      filepaths: ['', 'src/auth.ts'] 
+    });
+    expect(invalid.success).toBe(false);
+  });
+  
+  it('should reject array with all empty strings', () => {
+    const invalid = GetFilesContextSchema.safeParse({ 
+      filepaths: ['', ''] 
+    });
+    expect(invalid.success).toBe(false);
+  });
 });
 
 describe('ListFunctionsSchema', () => {

--- a/packages/cli/src/mcp/server.error-handling.test.ts
+++ b/packages/cli/src/mcp/server.error-handling.test.ts
@@ -5,7 +5,7 @@ describe('MCP Server Error Handling', () => {
   describe('Unknown tool error', () => {
     it('should create structured error for unknown tool', () => {
       const toolName = 'non_existent_tool';
-      const availableTools = ['semantic_search', 'find_similar', 'get_file_context', 'list_functions'];
+      const availableTools = ['semantic_search', 'find_similar', 'get_files_context', 'list_functions'];
       
       const error = new LienError(
         `Unknown tool: ${toolName}`,
@@ -45,7 +45,7 @@ describe('MCP Server Error Handling', () => {
         LienErrorCode.INVALID_INPUT,
         { 
           requestedTool: 'typo_search',
-          availableTools: ['semantic_search', 'find_similar', 'get_file_context', 'list_functions']
+          availableTools: ['semantic_search', 'find_similar', 'get_files_context', 'list_functions']
         }
       );
       

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -225,7 +225,7 @@ export async function startMCPServer(options: MCPServerOptions): Promise<void> {
                 );
                 
                 // Map back to original indices
-                relatedChunksMap = new Array(filepaths.length).fill([]);
+                relatedChunksMap = Array.from({ length: filepaths.length }, () => []);
                 filesWithChunks.forEach(({ filepath, index }, i) => {
                   const related = relatedSearches[i];
                   // Filter out chunks from the same file

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -41,7 +41,7 @@ Provide at least 10 characters of code to match against. Results include a relev
     'get_files_context',
     `Get context for one or more files including dependencies and test coverage.
 
-MANDATORY before editing files. Accepts single path or array of paths.
+MANDATORY: Call this BEFORE editing any file. Accepts single path or array of paths.
 
 Single file:
   get_files_context({ filepaths: "src/auth.ts" })

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -2,7 +2,7 @@ import { toMCPToolSchema } from './utils/zod-to-json-schema.js';
 import {
   SemanticSearchSchema,
   FindSimilarSchema,
-  GetFileContextSchema,
+  GetFilesContextSchema,
   ListFunctionsSchema,
 } from './schemas/index.js';
 
@@ -37,16 +37,24 @@ Results include a relevance category (highly_relevant, relevant, loosely_related
 Provide at least 10 characters of code to match against. Results include a relevance category for each match.`
   ),
   toMCPToolSchema(
-    GetFileContextSchema,
-    'get_file_context',
-    `Get full context for a file including related code and dependencies.
+    GetFilesContextSchema,
+    'get_files_context',
+    `Get context for one or more files including dependencies and test coverage.
 
-IMPORTANT: Call this BEFORE editing any file to understand:
-- What the file does
-- What depends on it
-- Related test files (via testAssociations)
+MANDATORY before editing files. Accepts single path or array of paths.
 
-Results include a relevance category for each related chunk. Typical flow: semantic_search → find file → get_file_context → make changes.`
+Single file:
+  get_files_context({ filepaths: "src/auth.ts" })
+
+Multiple files (batch):
+  get_files_context({ filepaths: ["src/auth.ts", "src/user.ts"] })
+
+Returns for each file:
+- All chunks and related code
+- testAssociations (which tests cover this file)
+- Relevance scoring
+
+Batch calls are more efficient than multiple single-file calls.`
   ),
   toMCPToolSchema(
     ListFunctionsSchema,

--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -18,13 +18,21 @@ export interface SearchResultResponse {
 }
 
 /**
- * Response for get_file_context tool
+ * Response for get_files_context tool (single file)
  */
-export interface FileContextResponse {
+export interface FilesContextResponse {
   indexInfo: IndexMetadata;
   file: string;
   chunks: SearchResult[];
   note?: string;
+}
+
+/**
+ * Response for get_files_context tool (multiple files)
+ */
+export interface FilesContextMultiResponse {
+  indexInfo: IndexMetadata;
+  files: Record<string, { chunks: SearchResult[] }>;
 }
 
 /**

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -91,21 +91,25 @@ Similar format to `semantic_search`, returns semantically similar code chunks.
 - **Consistency**: Ensure new code matches existing patterns
 - **Duplication Detection**: Locate duplicated logic across the codebase
 
-## get_file_context
+## get_files_context
 
-Get all chunks and related context for a specific file.
+Get all chunks and related context for one or more files.
 
 ### Parameters
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `filepath` | string | Yes | - | Path to file (relative to project root) |
+| `filepaths` | string \| string[] | Yes | - | Path(s) to file (relative to project root). Single path or array of paths (max 50). |
 | `includeRelated` | boolean | No | true | Include related chunks from other files |
 
 ### Usage
 
 ```
 Show context for src/utils/auth.ts
+```
+
+```
+Get context for multiple files: ["src/auth.ts", "src/user.ts"]
 ```
 
 ```
@@ -146,10 +150,33 @@ Get file context for app/Models/User.php without related files
 
 ### Features
 
-- Returns all chunks from the specified file
+- Returns all chunks from the specified file(s)
 - Includes test associations (which tests cover this file)
 - Optionally includes related chunks from other files
 - Useful before editing a file to understand dependencies
+- Supports batch operations for multiple files (up to 50)
+
+### Response Format
+
+For a single file, returns:
+```json
+{
+  "indexInfo": { ... },
+  "file": "src/utils/auth.ts",
+  "chunks": [ ... ]
+}
+```
+
+For multiple files, returns:
+```json
+{
+  "indexInfo": { ... },
+  "files": {
+    "src/auth.ts": { "chunks": [ ... ] },
+    "src/user.ts": { "chunks": [ ... ] }
+  }
+}
+```
 
 ## list_functions
 
@@ -257,10 +284,11 @@ All search results include test association metadata:
 - Looking for classes/functions matching a naming pattern
 - Getting architectural overview
 
-### Use `get_file_context` when:
+### Use `get_files_context` when:
 - You identified a file via search and need to understand it
 - About to edit a file (check dependencies first)
 - Need to understand test coverage
+- Reviewing multiple files together (e.g., PR review)
 
 ### Use `find_similar` when:
 - Refactoring multiple similar pieces of code


### PR DESCRIPTION
# feat(mcp): Rename `get_file_context` to `get_files_context` with multi-file support

## Summary

Adds batch operation support to the MCP file context tool, enabling efficient multi-file queries for PR reviews and refactoring workflows.

**Changes:**
- Renamed `get_file_context` → `get_files_context`
- Parameter `filepath` → `filepaths` (accepts string or array of 1-50 files)
- Backward compatible response format for single files
- New structured response for multi-file queries

## Breaking Changes

⚠️ Parameter name changed: `filepath` → `filepaths`

- get_file_context({ filepath: "src/auth.ts" })
+ get_files_context({ filepaths: "src/auth.ts" })## Usage

**Single file:**
get_files_context({ filepaths: "src/auth.ts" })
// Returns: { indexInfo, file, chunks }**Multiple files:**
get_files_context({ filepaths: ["src/auth.ts", "src/user.ts"] })
// Returns: { indexInfo, files: { "src/auth.ts": { chunks }, ... } }## Implementation

- Schema uses union type: `z.union([z.string().min(1), z.array(z.string()).min(1).max(50)])`
- Handler normalizes input and returns appropriate format
- Validation prevents empty arrays, empty strings, and >50 files

## Testing

✅ All 715 tests passing  
✅ TypeScript/build passing  
✅ Dogfooded on Lien's codebase  
✅ New validation tests for array handling

## Benefits

- **Efficiency**: Single call for multiple files vs N separate calls
- **PR Reviews**: Get context for all changed files at once
- **Refactoring**: Understand related files together