### PR TITLE
feat(frameworks): add generic PHP framework detector

### DIFF
--- a/packages/cli/src/frameworks/php/config.ts
+++ b/packages/cli/src/frameworks/php/config.ts
@@ -1,0 +1,48 @@
+import { FrameworkConfig } from '../../config/schema.js';
+
+/**
+ * Generate generic PHP framework configuration
+ */
+export async function generatePhpConfig(
+  _rootDir: string,
+  _relativePath: string
+): Promise<FrameworkConfig> {
+  return {
+    include: [
+      // PHP source code
+      'src/**/*.php',
+      'lib/**/*.php',
+      'app/**/*.php',
+      'tests/**/*.php',
+      '*.php',
+      
+      // Common PHP project files
+      'config/**/*.php',
+      'public/**/*.php',
+      
+      // Documentation
+      '**/*.md',
+      '**/*.mdx',
+      'docs/**/*.md',
+      'README.md',
+      'CHANGELOG.md',
+    ],
+    exclude: [
+      'vendor/**',
+      'node_modules/**',
+      'dist/**',
+      'build/**',
+      'storage/**',
+      'cache/**',
+      
+      // Test artifacts
+      'coverage/**',
+      'test-results/**',
+      '.phpunit.cache/**',
+      
+      // Build outputs
+      '__generated__/**',
+    ],
+  };
+}
+

--- a/packages/cli/src/frameworks/php/detector.test.ts
+++ b/packages/cli/src/frameworks/php/detector.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { mkdtemp } from 'fs/promises';
+import os from 'os';
+import { phpDetector } from './detector.js';
+
+describe('PHP Detector', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(path.join(os.tmpdir(), 'lien-php-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should detect generic PHP project with composer.json', async () => {
+    // Create a generic PHP project (not Laravel)
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          php: '^8.1',
+          'monolog/monolog': '^3.0'
+        }
+      })
+    );
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    expect(result.detected).toBe(true);
+    expect(result.name).toBe('php');
+    expect(result.confidence).toBe('high');
+    expect(result.evidence).toContain('Found composer.json');
+  });
+
+  it('should NOT detect Laravel projects (let Laravel detector handle it)', async () => {
+    // Create a Laravel project
+    await fs.mkdir(path.join(testDir, 'app'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          'laravel/framework': '^11.0'
+        }
+      })
+    );
+    await fs.writeFile(path.join(testDir, 'artisan'), '#!/usr/bin/env php\n');
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    // Should NOT detect - Laravel detector will handle this
+    expect(result.detected).toBe(false);
+  });
+
+  it('should detect PHP project with PHPUnit', async () => {
+    await fs.mkdir(path.join(testDir, 'tests'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { php: '^8.1' },
+        'require-dev': {
+          'phpunit/phpunit': '^10.0'
+        }
+      })
+    );
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    expect(result.detected).toBe(true);
+    expect(result.evidence.some(e => e.includes('PHPUnit'))).toBe(true);
+  });
+
+  it('should detect PHP project with Pest', async () => {
+    await fs.mkdir(path.join(testDir, 'tests'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { php: '^8.1' },
+        'require-dev': {
+          'pestphp/pest': '^2.0'
+        }
+      })
+    );
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    expect(result.detected).toBe(true);
+    expect(result.evidence.some(e => e.includes('Pest'))).toBe(true);
+  });
+
+  it('should NOT detect project without composer.json', async () => {
+    // Create a directory with no composer.json
+    await fs.mkdir(testDir, { recursive: true });
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    expect(result.detected).toBe(false);
+  });
+
+  it('should detect PHP version from composer.json', async () => {
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          php: '^8.2'
+        }
+      })
+    );
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    expect(result.detected).toBe(true);
+    expect(result.version).toBe('^8.2');
+    expect(result.evidence.some(e => e.includes('PHP ^8.2'))).toBe(true);
+  });
+
+  it('should detect Symfony projects', async () => {
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          php: '^8.1',
+          'symfony/symfony': '^6.0'
+        }
+      })
+    );
+
+    const result = await phpDetector.detect(testDir, '.');
+
+    expect(result.detected).toBe(true);
+    expect(result.evidence.some(e => e.includes('Symfony'))).toBe(true);
+  });
+});
+

--- a/packages/cli/src/frameworks/php/detector.test.ts
+++ b/packages/cli/src/frameworks/php/detector.test.ts
@@ -72,6 +72,7 @@ describe('PHP Detector', () => {
 
     expect(result.detected).toBe(true);
     expect(result.evidence.some(e => e.includes('PHPUnit'))).toBe(true);
+    expect(result.evidence.some(e => e.includes('PHP project structure'))).toBe(true);
   });
 
   it('should detect PHP project with Pest', async () => {
@@ -90,6 +91,7 @@ describe('PHP Detector', () => {
 
     expect(result.detected).toBe(true);
     expect(result.evidence.some(e => e.includes('Pest'))).toBe(true);
+    expect(result.evidence.some(e => e.includes('PHP project structure'))).toBe(true);
   });
 
   it('should NOT detect project without composer.json', async () => {
@@ -125,7 +127,7 @@ describe('PHP Detector', () => {
       JSON.stringify({ 
         require: { 
           php: '^8.1',
-          'symfony/symfony': '^6.0'
+          'symfony/framework-bundle': '^6.0'
         }
       })
     );

--- a/packages/cli/src/frameworks/php/detector.ts
+++ b/packages/cli/src/frameworks/php/detector.ts
@@ -1,0 +1,118 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { FrameworkDetector, DetectionResult } from '../types.js';
+import { generatePhpConfig } from './config.js';
+
+/**
+ * Generic PHP framework detector
+ * Detects any PHP project with composer.json
+ */
+export const phpDetector: FrameworkDetector = {
+  name: 'php',
+  priority: 50, // Generic, yields to specific frameworks like Laravel
+  
+  async detect(rootDir: string, relativePath: string): Promise<DetectionResult> {
+    const fullPath = path.join(rootDir, relativePath);
+    const result: DetectionResult = {
+      detected: false,
+      name: 'php',
+      path: relativePath,
+      confidence: 'low',
+      evidence: [],
+    };
+    
+    // Check for composer.json
+    const composerJsonPath = path.join(fullPath, 'composer.json');
+    let composerJson: any = null;
+    
+    try {
+      const content = await fs.readFile(composerJsonPath, 'utf-8');
+      composerJson = JSON.parse(content);
+      result.evidence.push('Found composer.json');
+    } catch {
+      // No composer.json, not a PHP project
+      return result;
+    }
+    
+    // Check if this is a Laravel project (Laravel detector should handle it)
+    const hasLaravel = 
+      composerJson.require?.['laravel/framework'] ||
+      composerJson['require-dev']?.['laravel/framework'];
+    
+    if (hasLaravel) {
+      // This is a Laravel project - let the Laravel detector handle it
+      // Return not detected to avoid redundant "php" + "laravel" detection
+      return result;
+    }
+    
+    // At this point, we know it's a generic PHP project (not Laravel)
+    result.detected = true;
+    result.confidence = 'high';
+    
+    // Check for common PHP directories
+    const phpDirs = ['src', 'lib', 'app', 'tests'];
+    let foundDirs = 0;
+    
+    for (const dir of phpDirs) {
+      try {
+        const dirPath = path.join(fullPath, dir);
+        const stats = await fs.stat(dirPath);
+        if (stats.isDirectory()) {
+          foundDirs++;
+        }
+      } catch {
+        // Directory doesn't exist
+      }
+    }
+    
+    if (foundDirs > 0) {
+      result.evidence.push(`Found PHP project structure (${foundDirs} directories)`);
+    }
+    
+    // Check for PHP version
+    if (composerJson.require?.php) {
+      result.version = composerJson.require.php;
+      result.evidence.push(`PHP ${composerJson.require.php}`);
+    }
+    
+    // Check for testing frameworks
+    const testFrameworks = [
+      { name: 'phpunit/phpunit', display: 'PHPUnit' },
+      { name: 'pestphp/pest', display: 'Pest' },
+      { name: 'codeception/codeception', display: 'Codeception' },
+      { name: 'behat/behat', display: 'Behat' },
+    ];
+    
+    for (const framework of testFrameworks) {
+      if (
+        composerJson.require?.[framework.name] || 
+        composerJson['require-dev']?.[framework.name]
+      ) {
+        result.evidence.push(`${framework.display} test framework detected`);
+        break; // Only mention first test framework found
+      }
+    }
+    
+    // Check for common PHP tools/frameworks
+    const tools = [
+      { name: 'symfony/symfony', display: 'Symfony' },
+      { name: 'doctrine/orm', display: 'Doctrine ORM' },
+      { name: 'guzzlehttp/guzzle', display: 'Guzzle HTTP' },
+      { name: 'monolog/monolog', display: 'Monolog' },
+    ];
+    
+    for (const tool of tools) {
+      if (composerJson.require?.[tool.name]) {
+        result.evidence.push(`${tool.display} detected`);
+        break; // Only mention first tool found
+      }
+    }
+    
+    return result;
+  },
+  
+  async generateConfig(rootDir: string, relativePath: string) {
+    return generatePhpConfig(rootDir, relativePath);
+  },
+};
+

--- a/packages/cli/src/frameworks/php/detector.ts
+++ b/packages/cli/src/frameworks/php/detector.ts
@@ -97,7 +97,7 @@ export const phpDetector: FrameworkDetector = {
     const tools = [
       { name: 'symfony/framework-bundle', display: 'Symfony' },
       { name: 'symfony/http-kernel', display: 'Symfony' },
-      { name: 'symfony/symfony', display: 'Symfony (legacy)' },
+      { name: 'symfony/symfony', display: 'Symfony (monolithic)' },
       { name: 'doctrine/orm', display: 'Doctrine ORM' },
       { name: 'guzzlehttp/guzzle', display: 'Guzzle HTTP' },
       { name: 'monolog/monolog', display: 'Monolog' },

--- a/packages/cli/src/frameworks/php/detector.ts
+++ b/packages/cli/src/frameworks/php/detector.ts
@@ -95,7 +95,9 @@ export const phpDetector: FrameworkDetector = {
     
     // Check for common PHP tools/frameworks
     const tools = [
-      { name: 'symfony/symfony', display: 'Symfony' },
+      { name: 'symfony/framework-bundle', display: 'Symfony' },
+      { name: 'symfony/http-kernel', display: 'Symfony' },
+      { name: 'symfony/symfony', display: 'Symfony (legacy)' },
       { name: 'doctrine/orm', display: 'Doctrine ORM' },
       { name: 'guzzlehttp/guzzle', display: 'Guzzle HTTP' },
       { name: 'monolog/monolog', display: 'Monolog' },

--- a/packages/cli/src/frameworks/registry.ts
+++ b/packages/cli/src/frameworks/registry.ts
@@ -9,7 +9,7 @@ import { shopifyDetector } from './shopify/detector.js';
  * Frameworks will be added as they are implemented
  * 
  * Order doesn't matter for detection as priority system handles conflicts,
- * but listed here in order of specificity for clarity:
+ * but listed here in order from generic to specific for clarity:
  * - Generic language detectors (Node.js, PHP)
  * - Specific framework detectors (Laravel, Shopify)
  */

--- a/packages/cli/src/frameworks/registry.ts
+++ b/packages/cli/src/frameworks/registry.ts
@@ -1,14 +1,21 @@
 import { FrameworkDetector } from './types.js';
 import { nodejsDetector } from './nodejs/detector.js';
+import { phpDetector } from './php/detector.js';
 import { laravelDetector } from './laravel/detector.js';
 import { shopifyDetector } from './shopify/detector.js';
 
 /**
  * Registry of all available framework detectors
  * Frameworks will be added as they are implemented
+ * 
+ * Order doesn't matter for detection as priority system handles conflicts,
+ * but listed here in order of specificity for clarity:
+ * - Generic language detectors (Node.js, PHP)
+ * - Specific framework detectors (Laravel, Shopify)
  */
 export const frameworkDetectors: FrameworkDetector[] = [
   nodejsDetector,
+  phpDetector,
   laravelDetector,
   shopifyDetector,
 ];

--- a/packages/cli/test/integration/framework-priority.test.ts
+++ b/packages/cli/test/integration/framework-priority.test.ts
@@ -153,5 +153,60 @@ describe('Framework Priority/Conflict Resolution', () => {
     const rootFramework = results.find(r => r.path === '.');
     expect(rootFramework?.name).toBe('nodejs');
   });
+
+  it('should detect generic PHP project without Laravel', async () => {
+    // Create a generic PHP project (e.g., PHPInsights, PHPUnit, Symfony, etc.)
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.mkdir(path.join(testDir, 'tests'), { recursive: true });
+    
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          php: '^8.1',
+          'symfony/console': '^6.0'
+        },
+        'require-dev': {
+          'phpunit/phpunit': '^10.0'
+        }
+      })
+    );
+
+    const results = await detectAllFrameworks(testDir);
+
+    // Should detect PHP (not Laravel)
+    expect(results.length).toBe(1);
+    expect(results[0].name).toBe('php');
+    expect(results[0].confidence).toBe('high');
+  });
+
+  it('should detect ONLY Laravel (not PHP) when Laravel framework is present', async () => {
+    // This ensures we don't show redundant "php" + "laravel" 
+    // (Laravel detector is more specific and should take precedence)
+    await fs.mkdir(path.join(testDir, 'app'), { recursive: true });
+    await fs.mkdir(path.join(testDir, 'routes'), { recursive: true });
+    
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          php: '^8.1',
+          'laravel/framework': '^11.0'
+        }
+      })
+    );
+    await fs.writeFile(path.join(testDir, 'artisan'), '#!/usr/bin/env php\n');
+
+    const results = await detectAllFrameworks(testDir);
+
+    // Should detect ONLY Laravel (PHP detector should skip)
+    expect(results.length).toBe(1);
+    expect(results[0].name).toBe('laravel');
+    expect(results[0].confidence).toBe('high');
+    
+    // Ensure PHP is NOT detected
+    const phpDetection = results.find(r => r.name === 'php');
+    expect(phpDetection).toBeUndefined();
+  });
 });
 

--- a/packages/cli/test/integration/framework-priority.test.ts
+++ b/packages/cli/test/integration/framework-priority.test.ts
@@ -208,5 +208,31 @@ describe('Framework Priority/Conflict Resolution', () => {
     const phpDetection = results.find(r => r.name === 'php');
     expect(phpDetection).toBeUndefined();
   });
+
+  it('should detect Symfony projects as generic PHP', async () => {
+    // Symfony projects should be detected as generic PHP
+    // (unless we add a specific Symfony detector in the future)
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.mkdir(path.join(testDir, 'config'), { recursive: true });
+    
+    await fs.writeFile(
+      path.join(testDir, 'composer.json'),
+      JSON.stringify({ 
+        require: { 
+          php: '^8.1',
+          'symfony/framework-bundle': '^6.0',
+          'symfony/http-kernel': '^6.0'
+        }
+      })
+    );
+
+    const results = await detectAllFrameworks(testDir);
+
+    // Should detect as PHP (no specific Symfony detector yet)
+    expect(results.length).toBe(1);
+    expect(results[0].name).toBe('php');
+    expect(results[0].confidence).toBe('high');
+    expect(results[0].evidence.some(e => e.includes('Symfony'))).toBe(true);
+  });
 });
 


### PR DESCRIPTION
Add support for detecting generic PHP projects (not just Laravel). Previously, only Laravel-specific PHP projects were detected, causing generic PHP projects like PHPInsights to be missed entirely.

Changes:
- Add generic PHP framework detector with priority 50 (same as Node.js)
- PHP detector skips Laravel projects to avoid redundancy
- Detects composer.json, PHP version, testing frameworks, and project structure
- Add comprehensive test suite (7 tests)
- Update framework priority tests with PHP test cases

Fixes issue where PHPInsights repo was only detected as Node.js despite being primarily a PHP project.

Test Results:
- All 791 tests pass
- New PHP detector tests: 7/7 passed
- Framework priority tests: 6/6 passed