### PR TITLE
feat(mcp): add get_complexity tool for tech debt analysis

### DIFF
--- a/packages/cli/CURSOR_RULES_TEMPLATE.md
+++ b/packages/cli/CURSOR_RULES_TEMPLATE.md
@@ -18,6 +18,7 @@ You have access to Lien semantic search tools. USE THEM INSTEAD OF grep/ripgrep/
 | Edit a file | `get_files_context` FIRST | direct edit |
 | Find similar code | `find_similar` | manual search |
 | "What depends on this file?" | `get_dependents` | manual grep |
+| "What's complex?" / "Tech debt?" | `get_complexity` | manual analysis |
 
 ## Before ANY Code Change
 
@@ -58,6 +59,12 @@ REQUIRED sequence:
   - Dependency count (how many files import it)
   - Complexity metrics (how complex the dependent code is)
 - Highlights top 5 most complex dependents when complexity data available
+
+**`get_complexity({ top: 10 })`**
+- Find most complex functions in the codebase
+- Use for tech debt analysis and refactoring prioritization
+- Returns complexity, dependent count, and risk level for each violation
+- Optional: `files` to filter specific files, `threshold` to set minimum complexity
 
 ## Test Associations
 

--- a/packages/cli/src/mcp/schemas/complexity.schema.ts
+++ b/packages/cli/src/mcp/schemas/complexity.schema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Schema for get_complexity tool input.
+ * 
+ * Validates parameters for complexity analysis queries,
+ * enabling tech debt analysis and refactoring prioritization.
+ */
+export const GetComplexitySchema = z.object({
+  files: z.array(z.string().min(1, "Filepath cannot be empty"))
+    .optional()
+    .describe(
+      "Specific files to analyze. If omitted, analyzes entire codebase.\n\n" +
+      "Example: ['src/auth.ts', 'src/api/user.ts']"
+    ),
+    
+  top: z.number()
+    .int()
+    .min(1, "Top must be at least 1")
+    .max(50, "Top cannot exceed 50")
+    .default(10)
+    .describe(
+      "Return top N most complex functions. Default: 10\n\n" +
+      "Use higher values to see more violations."
+    ),
+    
+  threshold: z.number()
+    .int()
+    .min(1, "Threshold must be at least 1")
+    .optional()
+    .describe(
+      "Only return functions above this complexity threshold.\n\n" +
+      "Note: Violations are first identified using the threshold from lien.config.json (default: 10). " +
+      "This parameter filters those violations to show only items above the specified value. " +
+      "Setting threshold below the config threshold will not show additional functions."
+    ),
+});
+
+/**
+ * Inferred TypeScript type for get_complexity input
+ */
+export type GetComplexityInput = z.infer<typeof GetComplexitySchema>;
+

--- a/packages/cli/src/mcp/schemas/index.ts
+++ b/packages/cli/src/mcp/schemas/index.ts
@@ -13,4 +13,5 @@ export * from './similarity.schema.js';
 export * from './file.schema.js';
 export * from './symbols.schema.js';
 export * from './dependents.schema.js';
+export * from './complexity.schema.js';
 

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -5,6 +5,7 @@ import {
   GetFilesContextSchema,
   ListFunctionsSchema,
   GetDependentsSchema,
+  GetComplexitySchema,
 } from './index.js';
 
 describe('SemanticSearchSchema', () => {
@@ -300,6 +301,86 @@ describe('GetDependentsSchema', () => {
       depth: 1.5 
     }))
       .toThrow();
+  });
+});
+
+describe('GetComplexitySchema', () => {
+  it('should accept empty object with defaults', () => {
+    const result = GetComplexitySchema.parse({});
+    expect(result.top).toBe(10);
+    expect(result.files).toBeUndefined();
+    expect(result.threshold).toBeUndefined();
+  });
+  
+  it('should accept top parameter', () => {
+    const result = GetComplexitySchema.parse({ top: 20 });
+    expect(result.top).toBe(20);
+  });
+  
+  it('should accept files array', () => {
+    const result = GetComplexitySchema.parse({ files: ['src/auth.ts', 'src/api/user.ts'] });
+    expect(result.files).toEqual(['src/auth.ts', 'src/api/user.ts']);
+  });
+  
+  it('should accept threshold parameter', () => {
+    const result = GetComplexitySchema.parse({ threshold: 15 });
+    expect(result.threshold).toBe(15);
+  });
+  
+  it('should accept all parameters together', () => {
+    const result = GetComplexitySchema.parse({ 
+      files: ['src/auth.ts'], 
+      top: 5, 
+      threshold: 20 
+    });
+    expect(result.files).toEqual(['src/auth.ts']);
+    expect(result.top).toBe(5);
+    expect(result.threshold).toBe(20);
+  });
+  
+  it('should reject top > 50', () => {
+    expect(() => GetComplexitySchema.parse({ top: 100 }))
+      .toThrow('Top cannot exceed 50');
+  });
+  
+  it('should reject top < 1', () => {
+    expect(() => GetComplexitySchema.parse({ top: 0 }))
+      .toThrow('Top must be at least 1');
+  });
+  
+  it('should reject non-integer top', () => {
+    expect(() => GetComplexitySchema.parse({ top: 5.5 }))
+      .toThrow();
+  });
+  
+  it('should reject threshold < 1', () => {
+    expect(() => GetComplexitySchema.parse({ threshold: 0 }))
+      .toThrow('Threshold must be at least 1');
+  });
+  
+  it('should reject non-integer threshold', () => {
+    expect(() => GetComplexitySchema.parse({ threshold: 10.5 }))
+      .toThrow();
+  });
+  
+  it('should reject files array with empty strings', () => {
+    expect(() => GetComplexitySchema.parse({ files: ['', 'src/auth.ts'] }))
+      .toThrow('Filepath cannot be empty');
+  });
+  
+  it('should accept minimum valid top', () => {
+    const result = GetComplexitySchema.parse({ top: 1 });
+    expect(result.top).toBe(1);
+  });
+  
+  it('should accept maximum valid top', () => {
+    const result = GetComplexitySchema.parse({ top: 50 });
+    expect(result.top).toBe(50);
+  });
+  
+  it('should accept minimum valid threshold', () => {
+    const result = GetComplexitySchema.parse({ threshold: 1 });
+    expect(result.threshold).toBe(1);
   });
 });
 

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -15,8 +15,8 @@ describe('MCP Tools Schema', () => {
       expect(tools.length).toBeGreaterThan(0);
     });
     
-  it('should have exactly 5 tools', () => {
-    expect(tools.length).toBe(5);
+  it('should have exactly 6 tools', () => {
+    expect(tools.length).toBe(6);
   });
     
     it('should have all required properties for each tool', () => {

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -5,6 +5,7 @@ import {
   GetFilesContextSchema,
   ListFunctionsSchema,
   GetDependentsSchema,
+  GetComplexitySchema,
 } from './schemas/index.js';
 
 /**
@@ -105,5 +106,22 @@ Returns:
 - Risk level (low/medium/high/critical) based on dependent count and complexity
 
 Example: get_dependents({ filepath: "src/utils/validate.ts" })`
+  ),
+  toMCPToolSchema(
+    GetComplexitySchema,
+    'get_complexity',
+    `Get complexity analysis for files or the entire codebase.
+
+Use for tech debt analysis and refactoring prioritization:
+- "What are the most complex functions?"
+- "Show me tech debt hotspots"
+- "What should I refactor?"
+
+Examples:
+  get_complexity({ top: 10 })
+  get_complexity({ files: ["src/auth.ts", "src/api/user.ts"] })
+  get_complexity({ threshold: 15 })
+
+Returns complexity violations with risk levels and dependent counts.`
   ),
 ];


### PR DESCRIPTION
Add new MCP tool to expose complexity metrics from the index:
- New schema at schemas/complexity.schema.ts with files, top, threshold params
- Handler reuses existing ComplexityAnalyzer for violation detection
- Returns violations sorted by complexity with risk levels and dependent counts

Use cases:
- 'What are the most complex functions?'
- 'Show me tech debt hotspots'
- 'What should I refactor?'

Examples:
  get_complexity({ top: 10 }) get_complexity({ files: ['src/auth.ts'] }) get_complexity({ threshold: 15 })