### PR TITLE
fix(mcp): use proper log levels instead of error for all messages

### DIFF
--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -243,7 +243,7 @@ export async function handleGetDependents(
       const allChunks = await vectorDB.scanWithFilter({ limit: SCAN_LIMIT });
       const hitLimit = allChunks.length === SCAN_LIMIT;
       if (hitLimit) {
-        log(`WARNING: Scanned ${SCAN_LIMIT} chunks (limit reached). Results may be incomplete.`);
+        log(`Scanned ${SCAN_LIMIT} chunks (limit reached). Results may be incomplete.`, 'warning');
       }
       log(`Scanning ${allChunks.length} chunks for imports...`);
 

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -100,7 +100,7 @@ export async function handleGetFilesContext(
 
       // Warn if we hit the limit (similar to get_dependents tool)
       if (allChunks.length === SCAN_LIMIT) {
-        log(`WARNING: Scanned ${SCAN_LIMIT} chunks (limit reached). Test associations may be incomplete for large codebases.`);
+        log(`Scanned ${SCAN_LIMIT} chunks (limit reached). Test associations may be incomplete for large codebases.`, 'warning');
       }
 
       // Path normalization cache to avoid repeated string operations

--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -4,6 +4,17 @@ import type { LocalEmbeddings } from '../embeddings/local.js';
 import type { LienConfig } from '../config/schema.js';
 
 /**
+ * MCP log levels matching the protocol specification.
+ */
+export type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error';
+
+/**
+ * Logging function type for MCP server.
+ * Supports optional log level (defaults to 'info' for informational messages).
+ */
+export type LogFn = (message: string, level?: LogLevel) => void;
+
+/**
  * Shared context passed to all tool handlers.
  * Contains dependencies and utilities needed by handlers.
  */
@@ -16,8 +27,8 @@ export interface ToolContext {
   config: LienConfig;
   /** Workspace root directory */
   rootDir: string;
-  /** Logging function (logs to stderr in MCP) */
-  log: (message: string) => void;
+  /** Logging function (logs via MCP notifications with proper levels) */
+  log: LogFn;
   /** Check if index has been updated and reconnect if needed */
   checkAndReconnect: () => Promise<void>;
   /** Get current index metadata for responses */


### PR DESCRIPTION
MCP clients like Cursor were displaying all Lien logs as [error] because we used console.error for all output. This changes the logging to use MCP's sendLoggingMessage() with proper severity levels:

- info: Normal operational messages (tool calls, results found)
- warning: Non-fatal issues (scan limits reached, indexing failures)
- error: Only actual errors

Also adds LogLevel type and updates LogFn signature to accept optional level.

---

<!-- lien-stats -->
### 🔍 Lien Complexity

| Violations | Max | Delta | Status |
|:----------:|:---:|:-----:|:------:|
| 0 | 14 | +0 ➡️ | ➡️ No change |
<!-- /lien-stats -->