### PR TITLE
refactor(vectordb): migrate from deprecated vectordb to @lancedb/lancedb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -382,32 +382,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@apache-arrow/ts": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@apache-arrow/ts/-/ts-14.0.2.tgz",
-      "integrity": "sha512-CtwAvLkK0CZv7xsYeCo91ml6PvlfzAmAJZkRYuz2GNBwfYufj5SVi0iuSMwIMkcU/szVwvLdzORSLa5PlF/2ug==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/command-line-args": "5.2.0",
-        "@types/command-line-usage": "5.0.2",
-        "@types/node": "20.3.0",
-        "@types/pad-left": "2.1.1",
-        "command-line-args": "5.2.1",
-        "command-line-usage": "7.0.1",
-        "flatbuffers": "23.5.26",
-        "json-bignum": "^0.0.3",
-        "pad-left": "^2.1.0",
-        "tslib": "^2.5.3"
-      }
-    },
-    "node_modules/@apache-arrow/ts/node_modules/@types/node": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
-      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -1092,70 +1066,133 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lancedb/vectordb-darwin-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.21.2.tgz",
-      "integrity": "sha512-NAQnIKLw9K33KMODNXBEW0qC8/safWzZtqbVC7j1GcE7PSk0Uc6x7w5nrH5gvleZggjaxY9jaRVTqmtg7PNmqw==",
+    "node_modules/@lancedb/lancedb-darwin-arm64": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.17.0.tgz",
+      "integrity": "sha512-lYzjA9ZX5VEr2TjSIVS2CutI+VjD0InnoyI2cbPESM3qIrjR+qOLG5dt2TFRzQZdzAbWHaB61Mr43yZv//KUag==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
+      "license": "Apache 2.0",
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
     },
-    "node_modules/@lancedb/vectordb-darwin-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-darwin-x64/-/vectordb-darwin-x64-0.21.2.tgz",
-      "integrity": "sha512-PudbltlbRiXvBf/bkAaDPL8+RqcI4TG69u00rQHxwkhH7PgPYRTUjfzfaQfiDXZuLXuZHQq703RyoHOqzsHN0Q==",
+    "node_modules/@lancedb/lancedb-darwin-x64": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.17.0.tgz",
+      "integrity": "sha512-yZeTQth/y2IoOWCAViK5V0ZWUWII1Me5eICJUkXw+0U62IMniOsQUbVXQOPViTe/9hyvlIS3GFw6gAqBZETuaA==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
+      "license": "Apache 2.0",
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
     },
-    "node_modules/@lancedb/vectordb-linux-arm64-gnu": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-linux-arm64-gnu/-/vectordb-linux-arm64-gnu-0.21.2.tgz",
-      "integrity": "sha512-3lJ8lootlwLmhqabCdg0DKftv0Ujep6NTWAoLWK/6VQe2IgHmu/ZPRNQkOSZ5tnYlmRyDiMDMB2tlAzo45sV8Q==",
+    "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.17.0.tgz",
+      "integrity": "sha512-AZ+jkFqzzDmOUEuQVRz5Qc+PxEGD7CLnmvHaK05dx+yMg//767n1ffUO8YcNGuYeaWwq5SjAvVBT1azbOvME2w==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
+      "license": "Apache 2.0",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@lancedb/vectordb-linux-x64-gnu": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.21.2.tgz",
-      "integrity": "sha512-5I2drMOIyRODlAHPsipQBTrRRgcOZ45N5GsuhqcKnz3Tg8GAdc1MQKyK3BrdJzKHLPdRtIyRJ6QTLB3wZvDsQQ==",
-      "cpu": [
-        "x64"
       ],
-      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-arm64-musl": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.17.0.tgz",
+      "integrity": "sha512-2MBtQuX9BFO14WC49Tsp5W8IajKf7q+/0CNOYvESTqsz8QXGZhMMxeipiTcLGpECV18zkSuhBYibeeo5IXxviQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache 2.0",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
     },
-    "node_modules/@lancedb/vectordb-win32-x64-msvc": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-win32-x64-msvc/-/vectordb-win32-x64-msvc-0.21.2.tgz",
-      "integrity": "sha512-gjpFukq0NTQSRpWPNIpq4XFtaudjSNBT6DMsagC61D2nx9ZLEdSAdU0wdkeluQwhoMvNnXEPdP9HxDSFUXk+Ww==",
+    "node_modules/@lancedb/lancedb-linux-x64-gnu": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.17.0.tgz",
+      "integrity": "sha512-xkGZef0z3idtvij+dflB827zq9Crrb2BvXIESzygl5Y8WzsfwioNKlcAZ5LKHfVSh+seQcPGj7AmXZaPX8f38Q==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
+      "license": "Apache 2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-x64-musl": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.17.0.tgz",
+      "integrity": "sha512-PktOkmJrM+WTpf3AIgQjD3kiFNO27APDuxvpacOgqWC0lGmFOFcxtJoUYarhiylD0prfUQLXdVW+6hawuTg4rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache 2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.17.0.tgz",
+      "integrity": "sha512-NrBUokcsqHEkNgVoiS0oa4iUhY+Zkra4SW32nk5n3bzdaeyQ4tEDiqBUJVcu51POqVh86ngDtNSlt+UpSnCBQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache 2.0",
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-win32-x64-msvc": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.17.0.tgz",
+      "integrity": "sha512-D5e56RDnKzCr41XriNQyeycAWpE2UMZJF5oVocIaFnwqje0emtOWXieVUpRb1it8Tycc76VCNxvjXvMDNhAD0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache 2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@liendev/action": {
       "resolved": "packages/action",
@@ -1213,11 +1250,6 @@
         "raw-body": "^3.0.0",
         "zod": "^3.23.8"
       }
-    },
-    "node_modules/@neon-rs/load": {
-      "version": "0.0.74",
-      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.74.tgz",
-      "integrity": "sha512-/cPZD907UNz55yrc/ud4wDgQKtU1TvkD9jeqZWG6J4IMmZkp6zgjkQcKA8UvpkZlcpPHvc8J17sGzLFbP/LUYg=="
     },
     "node_modules/@octokit/auth-token": {
       "version": "4.0.0",
@@ -1824,6 +1856,16 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2841,12 +2883,18 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/axios": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3123,6 +3171,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3441,6 +3492,9 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4217,6 +4271,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4281,6 +4338,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -4332,6 +4392,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4340,6 +4403,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4354,6 +4420,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -4365,6 +4434,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4641,12 +4713,15 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -4675,6 +4750,9 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4708,6 +4786,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4736,6 +4817,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4759,6 +4843,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -4820,6 +4907,9 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4851,6 +4941,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4862,6 +4955,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4876,6 +4972,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5455,6 +5554,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5608,6 +5710,9 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5616,6 +5721,9 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6249,7 +6357,10 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -6337,6 +6448,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/regex": {
       "version": "6.0.1",
@@ -7575,37 +7692,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/vectordb": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/vectordb/-/vectordb-0.21.2.tgz",
-      "integrity": "sha512-5tiwUq0jDtfIpcr7NY+kNCTecHCzSq0AqQtMzJphH7z6H6gfrw9t5/Aoy5/QnS0uAWIgqvCbE5qneQOFGxE+Og==",
-      "cpu": [
-        "x64",
-        "arm64"
-      ],
-      "deprecated": "Use @lancedb/lancedb instead.",
-      "license": "Apache-2.0",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "@neon-rs/load": "^0.0.74",
-        "axios": "^1.4.0"
-      },
-      "optionalDependencies": {
-        "@lancedb/vectordb-darwin-arm64": "0.21.2",
-        "@lancedb/vectordb-darwin-x64": "0.21.2",
-        "@lancedb/vectordb-linux-arm64-gnu": "0.21.2",
-        "@lancedb/vectordb-linux-x64-gnu": "0.21.2",
-        "@lancedb/vectordb-win32-x64-msvc": "0.21.2"
-      },
-      "peerDependencies": {
-        "@apache-arrow/ts": "^14.0.2",
-        "apache-arrow": "^14.0.2"
-      }
-    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -8758,6 +8844,7 @@
       "version": "0.18.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@lancedb/lancedb": "^0.17.0",
         "@modelcontextprotocol/sdk": "0.5.0",
         "@types/figlet": "1.7.0",
         "@xenova/transformers": "2.17.0",
@@ -8775,7 +8862,6 @@
         "tree-sitter-php": "^0.24.2",
         "tree-sitter-python": "^0.25.0",
         "tree-sitter-typescript": "0.23.2",
-        "vectordb": "0.21.2",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.0"
       },
@@ -8795,6 +8881,54 @@
       "engines": {
         "node": ">=22.21.0"
       }
+    },
+    "packages/cli/node_modules/@lancedb/lancedb": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.17.0.tgz",
+      "integrity": "sha512-AgQ4dqHBjoEpVdND5tmzhy0OJxwP4gJnEjOz3jVh7ip+8EYhR44wO6XbEhpxvvGfXyyepDrulo3bpL1323eNSg==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "Apache 2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "reflect-metadata": "^0.2.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@lancedb/lancedb-darwin-arm64": "0.17.0",
+        "@lancedb/lancedb-darwin-x64": "0.17.0",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.17.0",
+        "@lancedb/lancedb-linux-arm64-musl": "0.17.0",
+        "@lancedb/lancedb-linux-x64-gnu": "0.17.0",
+        "@lancedb/lancedb-linux-x64-musl": "0.17.0",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.17.0",
+        "@lancedb/lancedb-win32-x64-msvc": "0.17.0"
+      },
+      "peerDependencies": {
+        "apache-arrow": ">=15.0.0 <=18.1.0"
+      }
+    },
+    "packages/cli/node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "packages/cli/node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT",
+      "peer": true
     },
     "packages/cli/node_modules/@xenova/transformers": {
       "version": "2.17.0",
@@ -8818,6 +8952,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/apache-arrow": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
+      "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
       }
     },
     "packages/cli/node_modules/bl": {
@@ -8890,6 +9045,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+    },
+    "packages/cli/node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "packages/cli/node_modules/glob": {
       "version": "10.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,7 @@
     "tree-sitter-php": "^0.24.2",
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-typescript": "0.23.2",
-    "vectordb": "0.21.2",
+    "@lancedb/lancedb": "^0.17.0",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.0"
   },

--- a/packages/cli/src/vectordb/lancedb.ts
+++ b/packages/cli/src/vectordb/lancedb.ts
@@ -1,4 +1,4 @@
-import * as lancedb from 'vectordb';
+import * as lancedb from '@lancedb/lancedb';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
@@ -262,7 +262,7 @@ export class VectorDB implements VectorDBInterface {
       const sample = await this.table
         .search(Array(EMBEDDING_DIMENSION).fill(0))
         .limit(Math.min(count, 5))
-        .execute();
+        .toArray();
       
       const hasRealData = (sample as unknown as any[]).some((r: any) => 
         r.content && 

--- a/packages/cli/src/vectordb/query.test.ts
+++ b/packages/cli/src/vectordb/query.test.ts
@@ -15,7 +15,7 @@ describe('VectorDB Query Operations', () => {
       const mockTable = {
         search: vi.fn().mockReturnValue({
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: 'src/test.ts',
@@ -44,7 +44,7 @@ describe('VectorDB Query Operations', () => {
       const mockTable = {
         search: vi.fn().mockReturnValue({
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: '',
               file: 'src/empty.ts',
@@ -85,7 +85,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: 'src/test.ts',
@@ -109,7 +109,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function testHelper() {}',
               file: 'src/test-helper.ts',
@@ -142,7 +142,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: 'src/test.ts',
@@ -179,7 +179,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: 'src/test.ts',
@@ -215,7 +215,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: 'src/test.ts',
@@ -253,7 +253,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'class TestClass {}',
               file: 'src/test.ts',
@@ -280,7 +280,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'interface ITest {}',
               file: 'src/test.ts',
@@ -307,7 +307,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function testHelper() {}',
               file: 'src/test.ts',
@@ -345,7 +345,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function testHelper() {}',
               file: 'src/test.ts',
@@ -387,7 +387,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: 'src/test.ts',
@@ -415,7 +415,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: '',
               file: 'src/empty.ts',
@@ -450,7 +450,7 @@ describe('VectorDB Query Operations', () => {
         search: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
-          execute: vi.fn().mockResolvedValue([
+          toArray: vi.fn().mockResolvedValue([
             {
               content: 'function test() {}',
               file: '',

--- a/packages/cli/src/vectordb/query.ts
+++ b/packages/cli/src/vectordb/query.ts
@@ -144,7 +144,7 @@ export async function search(
     const results = await table
       .search(Array.from(queryVector))
       .limit(limit + 20)
-      .execute();
+      .toArray();
     
     const filtered = (results as unknown as DBRecord[])
       .filter((r: DBRecord) => 
@@ -196,7 +196,7 @@ export async function scanWithFilter(
       .where('file != ""')
       .limit(Math.max(limit * 5, 200));
     
-    const results = await query.execute();
+    const results = await query.toArray();
     
     let filtered = (results as unknown as DBRecord[]).filter((r: DBRecord) => 
       r.content && 
@@ -294,7 +294,7 @@ export async function querySymbols(
       .where('file != ""')
       .limit(Math.max(limit * 10, 500));
     
-    const results = await query.execute();
+    const results = await query.toArray();
     
     let filtered = (results as unknown as DBRecord[]).filter((r: DBRecord) => {
       if (!r.content || r.content.trim().length === 0) {


### PR DESCRIPTION
The vectordb package is deprecated in favor of @lancedb/lancedb. This migration updates the package and adapts to API changes:

- Replace vectordb@0.21.2 with @lancedb/lancedb@^0.17.0
- Update import from 'vectordb' to '@lancedb/lancedb'
- Change .execute() to .toArray() for query results
- Update test mocks to use new toArray() API

All 864 tests pass and the build succeeds.

---

<!-- lien-stats -->
### 🔍 Lien Complexity

| Violations | Max | Delta | Status |
|:----------:|:---:|:-----:|:------:|
| 2 | 46 | +0 ➡️ | ➡️ No change |
<!-- /lien-stats -->