### PR TITLE
refactor(indexer): reduce analyzeDependencies complexity from 32 to 5

### DIFF
--- a/packages/cli/src/indexer/dependency-analyzer.ts
+++ b/packages/cli/src/indexer/dependency-analyzer.ts
@@ -56,6 +56,9 @@ export interface DependencyAnalysisResult {
 
 /**
  * Creates a cached path normalizer to avoid repeated string operations.
+ * 
+ * @param workspaceRoot - The workspace root directory for path normalization
+ * @returns A function that normalizes and caches file paths
  */
 function createPathNormalizer(workspaceRoot: string): (path: string) => string {
   const cache = new Map<string, string>();
@@ -71,6 +74,10 @@ function createPathNormalizer(workspaceRoot: string): (path: string) => string {
 /**
  * Builds an index mapping normalized import paths to chunks that import them.
  * Enables O(1) lookup instead of O(n*m) iteration.
+ * 
+ * @param chunks - All chunks from the vector database
+ * @param normalizePathCached - Cached path normalization function
+ * @returns Map of normalized import paths to chunks that import them
  */
 function buildImportIndex(
   chunks: SearchResult[],
@@ -96,6 +103,10 @@ function buildImportIndex(
 
 /**
  * Finds all chunks that import the target file using index + fuzzy matching.
+ * 
+ * @param normalizedTarget - The normalized path of the target file
+ * @param importIndex - Index mapping import paths to chunks
+ * @returns Array of chunks that import the target file (deduplicated)
  */
 function findDependentChunks(
   normalizedTarget: string,
@@ -136,6 +147,10 @@ function findDependentChunks(
 
 /**
  * Groups chunks by their canonical file path.
+ * 
+ * @param chunks - Array of chunks to group
+ * @param workspaceRoot - The workspace root directory
+ * @returns Map of canonical file paths to their chunks
  */
 function groupChunksByFile(
   chunks: SearchResult[],
@@ -158,6 +173,9 @@ function groupChunksByFile(
 
 /**
  * Calculates complexity metrics for each file based on its chunks.
+ * 
+ * @param chunksByFile - Map of file paths to their chunks
+ * @returns Array of complexity info for files with complexity data
  */
 function calculateFileComplexities(
   chunksByFile: Map<string, SearchResult[]>
@@ -189,6 +207,9 @@ function calculateFileComplexities(
 
 /**
  * Calculates overall complexity metrics from per-file data.
+ * 
+ * @param fileComplexities - Array of per-file complexity info
+ * @returns Aggregated complexity metrics, or undefined if no data
  */
 function calculateOverallComplexityMetrics(
   fileComplexities: FileComplexityInfo[]
@@ -227,6 +248,10 @@ function calculateOverallComplexityMetrics(
 
 /**
  * Determines risk level based on complexity thresholds.
+ * 
+ * @param avgComplexity - Average complexity across all files
+ * @param maxComplexity - Maximum complexity found in any file
+ * @returns Risk level based on complexity thresholds
  */
 function calculateComplexityRiskBoost(avgComplexity: number, maxComplexity: number): RiskLevel {
   if (avgComplexity > COMPLEXITY_THRESHOLDS.CRITICAL_AVG || maxComplexity > COMPLEXITY_THRESHOLDS.CRITICAL_MAX) {
@@ -243,6 +268,9 @@ function calculateComplexityRiskBoost(avgComplexity: number, maxComplexity: numb
 
 /**
  * Calculates risk level based on dependent count.
+ * 
+ * @param count - Number of dependent files
+ * @returns Risk level based on dependent count thresholds
  */
 function calculateRiskLevelFromCount(count: number): RiskLevel {
   if (count <= DEPENDENT_COUNT_THRESHOLDS.LOW) {

--- a/packages/cli/src/indexer/dependency-analyzer.ts
+++ b/packages/cli/src/indexer/dependency-analyzer.ts
@@ -55,6 +55,209 @@ export interface DependencyAnalysisResult {
 }
 
 /**
+ * Creates a cached path normalizer to avoid repeated string operations.
+ */
+function createPathNormalizer(workspaceRoot: string): (path: string) => string {
+  const cache = new Map<string, string>();
+  return (path: string): string => {
+    const cached = cache.get(path);
+    if (cached !== undefined) return cached;
+    const normalized = normalizePath(path, workspaceRoot);
+    cache.set(path, normalized);
+    return normalized;
+  };
+}
+
+/**
+ * Builds an index mapping normalized import paths to chunks that import them.
+ * Enables O(1) lookup instead of O(n*m) iteration.
+ */
+function buildImportIndex(
+  chunks: SearchResult[],
+  normalizePathCached: (path: string) => string
+): Map<string, SearchResult[]> {
+  const importIndex = new Map<string, SearchResult[]>();
+  
+  for (const chunk of chunks) {
+    const imports = chunk.metadata.imports || [];
+    for (const imp of imports) {
+      const normalizedImport = normalizePathCached(imp);
+      let chunkList = importIndex.get(normalizedImport);
+      if (!chunkList) {
+        chunkList = [];
+        importIndex.set(normalizedImport, chunkList);
+      }
+      chunkList.push(chunk);
+    }
+  }
+  
+  return importIndex;
+}
+
+/**
+ * Finds all chunks that import the target file using index + fuzzy matching.
+ */
+function findDependentChunks(
+  normalizedTarget: string,
+  importIndex: Map<string, SearchResult[]>
+): SearchResult[] {
+  const dependentChunks: SearchResult[] = [];
+  const seenChunkIds = new Set<string>();
+  
+  const addChunk = (chunk: SearchResult): void => {
+    const chunkId = `${chunk.metadata.file}:${chunk.metadata.startLine}-${chunk.metadata.endLine}`;
+    if (!seenChunkIds.has(chunkId)) {
+      dependentChunks.push(chunk);
+      seenChunkIds.add(chunkId);
+    }
+  };
+  
+  // Direct index lookup (fastest path)
+  const directMatches = importIndex.get(normalizedTarget);
+  if (directMatches) {
+    for (const chunk of directMatches) {
+      addChunk(chunk);
+    }
+  }
+  
+  // Fuzzy match for relative imports and path variations
+  // Note: This is O(M) where M = unique import paths. For large codebases with many
+  // violations, consider caching fuzzy match results at a higher level.
+  for (const [normalizedImport, chunks] of importIndex.entries()) {
+    if (normalizedImport !== normalizedTarget && matchesFile(normalizedImport, normalizedTarget)) {
+      for (const chunk of chunks) {
+        addChunk(chunk);
+      }
+    }
+  }
+  
+  return dependentChunks;
+}
+
+/**
+ * Groups chunks by their canonical file path.
+ */
+function groupChunksByFile(
+  chunks: SearchResult[],
+  workspaceRoot: string
+): Map<string, SearchResult[]> {
+  const chunksByFile = new Map<string, SearchResult[]>();
+  
+  for (const chunk of chunks) {
+    const canonical = getCanonicalPath(chunk.metadata.file, workspaceRoot);
+    let existing = chunksByFile.get(canonical);
+    if (!existing) {
+      existing = [];
+      chunksByFile.set(canonical, existing);
+    }
+    existing.push(chunk);
+  }
+  
+  return chunksByFile;
+}
+
+/**
+ * Calculates complexity metrics for each file based on its chunks.
+ */
+function calculateFileComplexities(
+  chunksByFile: Map<string, SearchResult[]>
+): FileComplexityInfo[] {
+  const fileComplexities: FileComplexityInfo[] = [];
+  
+  for (const [filepath, chunks] of chunksByFile.entries()) {
+    const complexities = chunks
+      .map(c => c.metadata.complexity)
+      .filter((c): c is number => typeof c === 'number' && c > 0);
+    
+    if (complexities.length > 0) {
+      const sum = complexities.reduce((a, b) => a + b, 0);
+      const avg = sum / complexities.length;
+      const max = Math.max(...complexities);
+      
+      fileComplexities.push({
+        filepath,
+        avgComplexity: Math.round(avg * 10) / 10,
+        maxComplexity: max,
+        complexityScore: sum,
+        chunksWithComplexity: complexities.length,
+      });
+    }
+  }
+  
+  return fileComplexities;
+}
+
+/**
+ * Calculates overall complexity metrics from per-file data.
+ */
+function calculateOverallComplexityMetrics(
+  fileComplexities: FileComplexityInfo[]
+): DependencyAnalysisResult['complexityMetrics'] | undefined {
+  if (fileComplexities.length === 0) {
+    return undefined;
+  }
+  
+  const allAvgs = fileComplexities.map(f => f.avgComplexity);
+  const allMaxes = fileComplexities.map(f => f.maxComplexity);
+  const totalAvg = allAvgs.reduce((a, b) => a + b, 0) / allAvgs.length;
+  const globalMax = Math.max(...allMaxes);
+  
+  // Identify high-complexity dependents (top 5)
+  const highComplexityDependents = fileComplexities
+    .filter(f => f.maxComplexity > COMPLEXITY_THRESHOLDS.HIGH_COMPLEXITY_DEPENDENT)
+    .sort((a, b) => b.maxComplexity - a.maxComplexity)
+    .slice(0, 5)
+    .map(f => ({
+      filepath: f.filepath,
+      maxComplexity: f.maxComplexity,
+      avgComplexity: f.avgComplexity,
+    }));
+  
+  // Calculate complexity-based risk boost
+  const complexityRiskBoost = calculateComplexityRiskBoost(totalAvg, globalMax);
+  
+  return {
+    averageComplexity: Math.round(totalAvg * 10) / 10,
+    maxComplexity: globalMax,
+    filesWithComplexityData: fileComplexities.length,
+    highComplexityDependents,
+    complexityRiskBoost,
+  };
+}
+
+/**
+ * Determines risk level based on complexity thresholds.
+ */
+function calculateComplexityRiskBoost(avgComplexity: number, maxComplexity: number): RiskLevel {
+  if (avgComplexity > COMPLEXITY_THRESHOLDS.CRITICAL_AVG || maxComplexity > COMPLEXITY_THRESHOLDS.CRITICAL_MAX) {
+    return 'critical';
+  }
+  if (avgComplexity > COMPLEXITY_THRESHOLDS.HIGH_AVG || maxComplexity > COMPLEXITY_THRESHOLDS.HIGH_MAX) {
+    return 'high';
+  }
+  if (avgComplexity > COMPLEXITY_THRESHOLDS.MEDIUM_AVG || maxComplexity > COMPLEXITY_THRESHOLDS.MEDIUM_MAX) {
+    return 'medium';
+  }
+  return 'low';
+}
+
+/**
+ * Calculates risk level based on dependent count.
+ */
+function calculateRiskLevelFromCount(count: number): RiskLevel {
+  if (count === 0 || count <= DEPENDENT_COUNT_THRESHOLDS.LOW) {
+    return 'low';
+  }
+  if (count <= DEPENDENT_COUNT_THRESHOLDS.MEDIUM) {
+    return 'medium';
+  }
+  if (count <= DEPENDENT_COUNT_THRESHOLDS.HIGH) {
+    return 'high';
+  }
+  return 'critical';
+}
+
+/**
  * Analyzes dependencies for a given file by finding all chunks that import it.
  * 
  * @param targetFilepath - The file to analyze dependencies for
@@ -67,161 +270,43 @@ export function analyzeDependencies(
   allChunks: SearchResult[],
   workspaceRoot: string
 ): DependencyAnalysisResult {
-  // Path normalization cache to avoid repeated string operations
-  const pathCache = new Map<string, string>();
-  const normalizePathCached = (path: string): string => {
-    if (pathCache.has(path)) return pathCache.get(path)!;
-    const normalized = normalizePath(path, workspaceRoot);
-    pathCache.set(path, normalized);
-    return normalized;
-  };
-
-  // Build import-to-chunk index for O(n) instead of O(n*m) lookup
-  // Key: normalized import path, Value: array of chunks that import it
-  const importIndex = new Map<string, SearchResult[]>();
-  for (const chunk of allChunks) {
-    const imports = chunk.metadata.imports || [];
-    for (const imp of imports) {
-      const normalizedImport = normalizePathCached(imp);
-      if (!importIndex.has(normalizedImport)) {
-        importIndex.set(normalizedImport, []);
-      }
-      importIndex.get(normalizedImport)!.push(chunk);
-    }
-  }
-
-  // Find all chunks that import the target file using index + fuzzy matching
+  // Create cached path normalizer
+  const normalizePathCached = createPathNormalizer(workspaceRoot);
+  
+  // Build import index for efficient lookup
+  const importIndex = buildImportIndex(allChunks, normalizePathCached);
+  
+  // Find all dependent chunks
   const normalizedTarget = normalizePathCached(targetFilepath);
-  const dependentChunks: SearchResult[] = [];
-  // Track chunks we've already added to avoid duplicates
-  const seenChunkIds = new Set<string>();
-
-  // First: Try direct index lookup (fastest path)
-  if (importIndex.has(normalizedTarget)) {
-    for (const chunk of importIndex.get(normalizedTarget)!) {
-      const chunkId = `${chunk.metadata.file}:${chunk.metadata.startLine}-${chunk.metadata.endLine}`;
-      if (!seenChunkIds.has(chunkId)) {
-        dependentChunks.push(chunk);
-        seenChunkIds.add(chunkId);
-      }
-    }
-  }
-
-  // Second: Fuzzy match against all unique import paths in the index
-  // This handles relative imports and path variations
-  // Note: This is O(M) where M = unique import paths. For large codebases with many
-  // violations, consider caching fuzzy match results at a higher level (e.g., in
-  // ComplexityAnalyzer) to avoid repeated iterations.
-  for (const [normalizedImport, chunks] of importIndex.entries()) {
-    // Skip exact match (already processed in direct lookup above)
-    if (normalizedImport !== normalizedTarget && matchesFile(normalizedImport, normalizedTarget)) {
-      for (const chunk of chunks) {
-        const chunkId = `${chunk.metadata.file}:${chunk.metadata.startLine}-${chunk.metadata.endLine}`;
-        if (!seenChunkIds.has(chunkId)) {
-          dependentChunks.push(chunk);
-          seenChunkIds.add(chunkId);
-        }
-      }
-    }
-  }
-
-  // Group chunks by file for complexity analysis
-  const chunksByFile = new Map<string, SearchResult[]>();
-  for (const chunk of dependentChunks) {
-    const canonical = getCanonicalPath(chunk.metadata.file, workspaceRoot);
-    const existing = chunksByFile.get(canonical) || [];
-    existing.push(chunk);
-    chunksByFile.set(canonical, existing);
-  }
-
-  // Calculate complexity metrics per file
-  const fileComplexities: FileComplexityInfo[] = [];
-
-  for (const [filepath, chunks] of chunksByFile.entries()) {
-    const complexities = chunks
-      .map(c => c.metadata.complexity)
-      .filter((c): c is number => typeof c === 'number' && c > 0);
-
-    if (complexities.length > 0) {
-      const sum = complexities.reduce((a, b) => a + b, 0);
-      const avg = sum / complexities.length;
-      const max = Math.max(...complexities);
-
-      fileComplexities.push({
-        filepath,
-        avgComplexity: Math.round(avg * 10) / 10,
-        maxComplexity: max,
-        complexityScore: sum,
-        chunksWithComplexity: complexities.length,
-      });
-    }
-  }
-
-  // Calculate overall complexity metrics
-  let complexityMetrics: DependencyAnalysisResult['complexityMetrics'];
-
-  if (fileComplexities.length > 0) {
-    const allAvgs = fileComplexities.map(f => f.avgComplexity);
-    const allMaxes = fileComplexities.map(f => f.maxComplexity);
-    const totalAvg = allAvgs.reduce((a, b) => a + b, 0) / allAvgs.length;
-    const globalMax = Math.max(...allMaxes);
-
-    // Identify high-complexity dependents
-    const highComplexityDependents = fileComplexities
-      .filter(f => f.maxComplexity > COMPLEXITY_THRESHOLDS.HIGH_COMPLEXITY_DEPENDENT)
-      .sort((a, b) => b.maxComplexity - a.maxComplexity)
-      .slice(0, 5) // Top 5
-      .map(f => ({
-        filepath: f.filepath,
-        maxComplexity: f.maxComplexity,
-        avgComplexity: f.avgComplexity,
-      }));
-
-    // Calculate complexity-based risk boost
-    let complexityRiskBoost: RiskLevel = 'low';
-    if (totalAvg > COMPLEXITY_THRESHOLDS.CRITICAL_AVG || globalMax > COMPLEXITY_THRESHOLDS.CRITICAL_MAX) {
-      complexityRiskBoost = 'critical';
-    } else if (totalAvg > COMPLEXITY_THRESHOLDS.HIGH_AVG || globalMax > COMPLEXITY_THRESHOLDS.HIGH_MAX) {
-      complexityRiskBoost = 'high';
-    } else if (totalAvg > COMPLEXITY_THRESHOLDS.MEDIUM_AVG || globalMax > COMPLEXITY_THRESHOLDS.MEDIUM_MAX) {
-      complexityRiskBoost = 'medium';
-    }
-
-    complexityMetrics = {
-      averageComplexity: Math.round(totalAvg * 10) / 10,
-      maxComplexity: globalMax,
-      filesWithComplexityData: fileComplexities.length,
-      highComplexityDependents,
-      complexityRiskBoost,
-    };
-  }
-
+  const dependentChunks = findDependentChunks(normalizedTarget, importIndex);
+  
+  // Group by file for analysis
+  const chunksByFile = groupChunksByFile(dependentChunks, workspaceRoot);
+  
+  // Calculate complexity metrics
+  const fileComplexities = calculateFileComplexities(chunksByFile);
+  const complexityMetrics = calculateOverallComplexityMetrics(fileComplexities);
+  
   // Build dependents list
-  const uniqueFiles = Array.from(chunksByFile.keys()).map(filepath => ({
+  const dependents = Array.from(chunksByFile.keys()).map(filepath => ({
     filepath,
     isTestFile: isTestFile(filepath),
   }));
-
-  // Calculate risk level based on dependent count
-  const count = uniqueFiles.length;
-  let riskLevel: RiskLevel =
-    count === 0 ? 'low' :
-    count <= DEPENDENT_COUNT_THRESHOLDS.LOW ? 'low' :
-    count <= DEPENDENT_COUNT_THRESHOLDS.MEDIUM ? 'medium' :
-    count <= DEPENDENT_COUNT_THRESHOLDS.HIGH ? 'high' : 'critical';
-
-  // Boost risk level if complexity is high
+  
+  // Calculate risk level
+  let riskLevel = calculateRiskLevelFromCount(dependents.length);
+  
+  // Boost risk level if complexity warrants it
   if (complexityMetrics?.complexityRiskBoost) {
     if (RISK_ORDER[complexityMetrics.complexityRiskBoost] > RISK_ORDER[riskLevel]) {
       riskLevel = complexityMetrics.complexityRiskBoost;
     }
   }
-
+  
   return {
-    dependents: uniqueFiles,
-    dependentCount: count,
+    dependents,
+    dependentCount: dependents.length,
     riskLevel,
     complexityMetrics,
   };
 }
-

--- a/packages/cli/src/indexer/dependency-analyzer.ts
+++ b/packages/cli/src/indexer/dependency-analyzer.ts
@@ -245,7 +245,7 @@ function calculateComplexityRiskBoost(avgComplexity: number, maxComplexity: numb
  * Calculates risk level based on dependent count.
  */
 function calculateRiskLevelFromCount(count: number): RiskLevel {
-  if (count === 0 || count <= DEPENDENT_COUNT_THRESHOLDS.LOW) {
+  if (count <= DEPENDENT_COUNT_THRESHOLDS.LOW) {
     return 'low';
   }
   if (count <= DEPENDENT_COUNT_THRESHOLDS.MEDIUM) {


### PR DESCRIPTION
Extract 7 focused helper functions from the monolithic analyzeDependencies:
- createPathNormalizer: Cached path normalization
- buildImportIndex: O(1) import lookup index
- findDependentChunks: Direct + fuzzy match lookup
- groupChunksByFile: File-based chunk grouping
- calculateFileComplexities: Per-file complexity metrics
- calculateOverallComplexityMetrics: Aggregate complexity metrics
- calculateRiskLevelFromCount: Count-based risk assessment
- calculateComplexityRiskBoost: Complexity-based risk boost

Each helper is single-responsibility, testable, and easier to understand. All 13 existing tests pass with no behavior changes.

---

<!-- lien-stats -->
### 🔍 Lien Complexity

| Violations | Max | Delta | Status |
|:----------:|:---:|:-----:|:------:|
| 0 | 8 | -32 ⬇️ | ✅ Improved |
<!-- /lien-stats -->