### PR TITLE
refactor(mcp): decompose handleGetFilesContext into focused helpers

### DIFF
--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -1,21 +1,37 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getCanonicalPath, normalizePath, matchesFile, isTestFile } from './utils/path-matching.js';
+import {
+  searchFileChunks,
+  findRelatedChunks,
+  findTestAssociations,
+  deduplicateChunks,
+  buildFilesData,
+  createPathCache,
+} from './handlers/get-files-context.js';
 
 /**
- * Unit tests for get_files_context response structure.
+ * Unit tests for get_files_context handler and helper functions.
  * 
- * Tests the fix for multi-file response structure:
- * - Single file input returns backward-compatible format
- * - Multiple file input returns keyed structure with test associations
- * - Exact file path matching (not substring matching)
- * - Chunks are correctly deduplicated
- * - Test associations are included in both formats
+ * Tests cover:
+ * - Path matching utilities (existing)
+ * - Response structure validation (existing)
+ * - New extracted helper functions:
+ *   - searchFileChunks
+ *   - findRelatedChunks
+ *   - findTestAssociations
+ *   - deduplicateChunks
+ *   - buildFilesData
+ *   - createPathCache
  */
 
-describe('get_files_context - Response Structure', () => {
-  const workspaceRoot = '/fake/workspace';
-  
-  describe('Path Matching Utilities', () => {
+const workspaceRoot = '/fake/workspace';
+
+// ============================================================================
+// Path Matching Utilities (Existing Tests)
+// ============================================================================
+
+describe('get_files_context - Path Matching Utilities', () => {
+  describe('Path Matching', () => {
     it('should canonicalize paths correctly', () => {
       expect(getCanonicalPath('/fake/workspace/src/auth.ts', workspaceRoot)).toBe('src/auth.ts');
       expect(getCanonicalPath('src/auth.ts', workspaceRoot)).toBe('src/auth.ts');
@@ -64,7 +80,317 @@ describe('get_files_context - Response Structure', () => {
       expect(isTestFile('latest/config.ts')).toBe(false);
     });
   });
-  
+});
+
+// ============================================================================
+// Helper Function Tests (New)
+// ============================================================================
+
+describe('get_files_context - Helper Functions', () => {
+  describe('createPathCache', () => {
+    it('should cache normalized paths', () => {
+      const { normalize, cache } = createPathCache(workspaceRoot);
+      
+      // First call should add to cache
+      const result1 = normalize('src/auth.ts');
+      expect(result1).toBe('src/auth');
+      expect(cache.has('src/auth.ts')).toBe(true);
+      
+      // Second call should return cached value
+      const result2 = normalize('src/auth.ts');
+      expect(result2).toBe('src/auth');
+      
+      // Different path should also be cached
+      normalize('src/user.ts');
+      expect(cache.size).toBe(2);
+    });
+    
+    it('should handle multiple unique paths', () => {
+      const { normalize, cache } = createPathCache(workspaceRoot);
+      
+      normalize('src/auth.ts');
+      normalize('src/user.ts');
+      normalize('src/api/index.ts');
+      
+      expect(cache.size).toBe(3);
+    });
+  });
+
+  describe('searchFileChunks', () => {
+    it('should filter chunks to only matching files', async () => {
+      const mockEmbeddings = {
+        embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      };
+      
+      const mockVectorDB = {
+        search: vi.fn().mockResolvedValue([
+          { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
+          { content: 'chunk2', metadata: { file: 'src/user.ts', startLine: 1, endLine: 10 }, score: 0.8 },
+          { content: 'chunk3', metadata: { file: 'src/auth.ts', startLine: 11, endLine: 20 }, score: 0.7 },
+        ]),
+      };
+      
+      const ctx = {
+        vectorDB: mockVectorDB as any,
+        embeddings: mockEmbeddings as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      const result = await searchFileChunks(['src/auth.ts'], ctx);
+      
+      // Should only include chunks from auth.ts
+      expect(result[0]).toHaveLength(2);
+      expect(result[0].every(r => r.metadata.file === 'src/auth.ts')).toBe(true);
+    });
+    
+    it('should batch embed multiple filepaths', async () => {
+      const mockEmbeddings = {
+        embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      };
+      
+      const mockVectorDB = {
+        search: vi.fn().mockResolvedValue([]),
+      };
+      
+      const ctx = {
+        vectorDB: mockVectorDB as any,
+        embeddings: mockEmbeddings as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      await searchFileChunks(['src/auth.ts', 'src/user.ts', 'src/api.ts'], ctx);
+      
+      // Should embed all 3 filepaths
+      expect(mockEmbeddings.embed).toHaveBeenCalledTimes(3);
+      // Should search for all 3 filepaths
+      expect(mockVectorDB.search).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('findRelatedChunks', () => {
+    it('should return empty arrays when no files have chunks', async () => {
+      const ctx = {
+        vectorDB: { search: vi.fn() } as any,
+        embeddings: { embed: vi.fn() } as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      const result = await findRelatedChunks(
+        ['src/auth.ts', 'src/user.ts'],
+        [[], []], // No chunks found
+        ctx
+      );
+      
+      expect(result).toEqual([[], []]);
+      expect(ctx.embeddings.embed).not.toHaveBeenCalled();
+    });
+    
+    it('should exclude chunks from the same file', async () => {
+      const mockEmbeddings = {
+        embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      };
+      
+      const mockVectorDB = {
+        search: vi.fn().mockResolvedValue([
+          { content: 'related1', metadata: { file: 'src/auth.ts', startLine: 50, endLine: 60 }, score: 0.85 },
+          { content: 'related2', metadata: { file: 'src/utils.ts', startLine: 1, endLine: 10 }, score: 0.8 },
+        ]),
+      };
+      
+      const ctx = {
+        vectorDB: mockVectorDB as any,
+        embeddings: mockEmbeddings as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      const fileChunksMap = [
+        [{ content: 'auth chunk', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 }],
+      ];
+      
+      const result = await findRelatedChunks(['src/auth.ts'], fileChunksMap as any, ctx);
+      
+      // Should exclude src/auth.ts chunk, only include src/utils.ts
+      expect(result[0]).toHaveLength(1);
+      expect(result[0][0].metadata.file).toBe('src/utils.ts');
+    });
+  });
+
+  describe('findTestAssociations', () => {
+    it('should find test files that import target', () => {
+      const mockChunks = [
+        {
+          metadata: {
+            file: 'src/__tests__/auth.test.ts',
+            imports: ['../auth', '../utils'],
+          },
+        },
+        {
+          metadata: {
+            file: 'src/__tests__/user.test.ts',
+            imports: ['../user', '../auth'],
+          },
+        },
+        {
+          metadata: {
+            file: 'src/helper.ts',
+            imports: ['./auth'],
+          },
+        },
+      ];
+      
+      const ctx = {
+        vectorDB: {} as any,
+        embeddings: {} as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      const result = findTestAssociations(['src/auth.ts'], mockChunks, ctx);
+      
+      expect(result[0]).toHaveLength(2);
+      expect(result[0]).toContain('src/__tests__/auth.test.ts');
+      expect(result[0]).toContain('src/__tests__/user.test.ts');
+    });
+    
+    it('should not include non-test files', () => {
+      const mockChunks = [
+        {
+          metadata: {
+            file: 'src/helper.ts',
+            imports: ['./auth'],
+          },
+        },
+      ];
+      
+      const ctx = {
+        vectorDB: {} as any,
+        embeddings: {} as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      const result = findTestAssociations(['src/auth.ts'], mockChunks, ctx);
+      
+      expect(result[0]).toHaveLength(0);
+    });
+    
+    it('should handle chunks with no imports', () => {
+      const mockChunks = [
+        {
+          metadata: {
+            file: 'src/__tests__/auth.test.ts',
+            // No imports property
+          },
+        },
+      ];
+      
+      const ctx = {
+        vectorDB: {} as any,
+        embeddings: {} as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+      
+      const result = findTestAssociations(['src/auth.ts'], mockChunks, ctx);
+      
+      expect(result[0]).toHaveLength(0);
+    });
+  });
+
+  describe('deduplicateChunks', () => {
+    it('should remove duplicate chunks by file + line range', () => {
+      const chunks = [
+        { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
+        { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.85 }, // Duplicate
+        { content: 'chunk2', metadata: { file: 'src/auth.ts', startLine: 11, endLine: 20 }, score: 0.8 },
+      ];
+      
+      const result = deduplicateChunks(chunks as any, [], workspaceRoot);
+      
+      expect(result).toHaveLength(2);
+      expect(result[0].metadata.startLine).toBe(1);
+      expect(result[1].metadata.startLine).toBe(11);
+    });
+    
+    it('should merge file chunks and related chunks', () => {
+      const fileChunks = [
+        { content: 'file', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
+      ];
+      const relatedChunks = [
+        { content: 'related', metadata: { file: 'src/utils.ts', startLine: 1, endLine: 10 }, score: 0.8 },
+      ];
+      
+      const result = deduplicateChunks(fileChunks as any, relatedChunks as any, workspaceRoot);
+      
+      expect(result).toHaveLength(2);
+    });
+    
+    it('should handle absolute paths via canonicalization', () => {
+      const chunks = [
+        { content: 'chunk1', metadata: { file: '/fake/workspace/src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
+        { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.85 }, // Same after canonicalization
+      ];
+      
+      const result = deduplicateChunks(chunks as any, [], workspaceRoot);
+      
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('buildFilesData', () => {
+    it('should combine chunks and test associations per file', () => {
+      const filepaths = ['src/auth.ts', 'src/user.ts'];
+      const fileChunksMap = [
+        [{ content: 'auth', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 }],
+        [{ content: 'user', metadata: { file: 'src/user.ts', startLine: 1, endLine: 10 }, score: 0.8 }],
+      ];
+      const relatedChunksMap = [
+        [{ content: 'related', metadata: { file: 'src/utils.ts', startLine: 1, endLine: 10 }, score: 0.7 }],
+        [],
+      ];
+      const testAssociationsMap = [
+        ['src/__tests__/auth.test.ts'],
+        ['src/__tests__/user.test.ts'],
+      ];
+      
+      const result = buildFilesData(
+        filepaths,
+        fileChunksMap as any,
+        relatedChunksMap as any,
+        testAssociationsMap,
+        workspaceRoot
+      );
+      
+      expect(Object.keys(result)).toEqual(['src/auth.ts', 'src/user.ts']);
+      expect(result['src/auth.ts'].chunks).toHaveLength(2); // file + related
+      expect(result['src/auth.ts'].testAssociations).toEqual(['src/__tests__/auth.test.ts']);
+      expect(result['src/user.ts'].chunks).toHaveLength(1);
+      expect(result['src/user.ts'].testAssociations).toEqual(['src/__tests__/user.test.ts']);
+    });
+    
+    it('should handle empty related chunks', () => {
+      const result = buildFilesData(
+        ['src/auth.ts'],
+        [[{ content: 'auth', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 }]] as any,
+        [], // Empty related chunks
+        [['src/__tests__/auth.test.ts']],
+        workspaceRoot
+      );
+      
+      expect(result['src/auth.ts'].chunks).toHaveLength(1);
+    });
+  });
+});
+
+// ============================================================================
+// Response Format Validation (Existing Tests)
+// ============================================================================
+
+describe('get_files_context - Response Structure', () => {
   describe('Response Format Validation', () => {
     it('should have correct structure for single file response', () => {
       // Expected format for single file input
@@ -297,4 +623,3 @@ describe('get_files_context - Response Structure', () => {
     });
   });
 });
-


### PR DESCRIPTION
Extract helper functions to reduce complexity:
- searchFileChunks: Batch embedding and vector search
- findRelatedChunks: Find semantically similar code
- findTestAssociations: Scan for test file imports
- deduplicateChunks: Remove duplicate chunks
- buildFilesData: Combine results into response

Complexity metrics improved significantly:
- Time to understand: 6h 31m → 1h 3m (6x faster)
- Halstead effort: 422,031 → 67,729 (84% reduction)
- Predicted bugs: 2.486 → 0.753 (70% fewer)
- Severity: error → warning

All helper functions are exported for unit testing.

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Improved!** Complexity reduced by 356.486. 1 pre-existing issue remains in touched files.

| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | -328 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->