### PR TITLE
refactor(indexer): extract ChunkBatchProcessor from performFullIndex

### DIFF
--- a/packages/cli/src/indexer/chunk-batch-processor.test.ts
+++ b/packages/cli/src/indexer/chunk-batch-processor.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChunkBatchProcessor, processEmbeddingMicroBatches } from './chunk-batch-processor.js';
+import type { VectorDB } from '../vectordb/lancedb.js';
+import type { EmbeddingService } from '../embeddings/types.js';
+import type { IndexingProgressTracker } from './progress-tracker.js';
+import type { CodeChunk } from './types.js';
+
+// Mock implementations
+function createMockVectorDB(): VectorDB {
+  return {
+    insertBatch: vi.fn().mockResolvedValue(undefined),
+    dbPath: '/mock/path',
+  } as unknown as VectorDB;
+}
+
+function createMockEmbeddings(): EmbeddingService {
+  return {
+    embedBatch: vi.fn().mockImplementation((texts: string[]) =>
+      Promise.resolve(texts.map(() => new Float32Array([0.1, 0.2, 0.3])))
+    ),
+  } as unknown as EmbeddingService;
+}
+
+function createMockProgressTracker(): IndexingProgressTracker {
+  return {
+    setMessage: vi.fn(),
+    incrementFiles: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    getProcessedCount: vi.fn().mockReturnValue(0),
+  } as unknown as IndexingProgressTracker;
+}
+
+function createMockChunk(id: number): CodeChunk {
+  return {
+    content: `chunk content ${id}`,
+    metadata: {
+      file: `file${id}.ts`,
+      startLine: 1,
+      endLine: 10,
+      type: 'function' as const,
+      language: 'typescript',
+    },
+  };
+}
+
+describe('ChunkBatchProcessor', () => {
+  let mockVectorDB: VectorDB;
+  let mockEmbeddings: EmbeddingService;
+  let mockProgressTracker: IndexingProgressTracker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVectorDB = createMockVectorDB();
+    mockEmbeddings = createMockEmbeddings();
+    mockProgressTracker = createMockProgressTracker();
+  });
+
+  describe('addChunks', () => {
+    it('should accumulate chunks without triggering processing below threshold', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 10, embeddingBatchSize: 5 },
+        mockProgressTracker
+      );
+
+      const chunks = [createMockChunk(1), createMockChunk(2)];
+      await processor.addChunks(chunks, 'file1.ts', Date.now());
+
+      // Should not have called insertBatch yet (below threshold)
+      expect(mockVectorDB.insertBatch).not.toHaveBeenCalled();
+
+      const results = processor.getResults();
+      expect(results.indexedFiles).toHaveLength(1);
+      expect(results.indexedFiles[0].filepath).toBe('file1.ts');
+      expect(results.indexedFiles[0].chunkCount).toBe(2);
+    });
+
+    it('should trigger processing when threshold is reached', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 3, embeddingBatchSize: 10 },
+        mockProgressTracker
+      );
+
+      // Add chunks to reach threshold
+      await processor.addChunks([createMockChunk(1), createMockChunk(2)], 'file1.ts', Date.now());
+      await processor.addChunks([createMockChunk(3), createMockChunk(4)], 'file2.ts', Date.now());
+
+      // Should have triggered processing (4 >= 3 threshold)
+      expect(mockVectorDB.insertBatch).toHaveBeenCalled();
+    });
+
+    it('should handle empty chunks array', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 10, embeddingBatchSize: 5 },
+        mockProgressTracker
+      );
+
+      await processor.addChunks([], 'empty.ts', Date.now());
+
+      const results = processor.getResults();
+      expect(results.indexedFiles).toHaveLength(0);
+    });
+
+    it('should handle concurrent addChunks calls safely', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 100, embeddingBatchSize: 50 },
+        mockProgressTracker
+      );
+
+      // Simulate concurrent file processing
+      const promises = Array.from({ length: 10 }, (_, i) =>
+        processor.addChunks(
+          [createMockChunk(i * 2), createMockChunk(i * 2 + 1)],
+          `file${i}.ts`,
+          Date.now()
+        )
+      );
+
+      await Promise.all(promises);
+
+      const results = processor.getResults();
+      expect(results.indexedFiles).toHaveLength(10);
+    });
+  });
+
+  describe('flush', () => {
+    it('should process all remaining chunks', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 100, embeddingBatchSize: 5 }, // High threshold
+        mockProgressTracker
+      );
+
+      await processor.addChunks([createMockChunk(1), createMockChunk(2)], 'file1.ts', Date.now());
+
+      // Not triggered yet (below threshold)
+      expect(mockVectorDB.insertBatch).not.toHaveBeenCalled();
+
+      // Flush should process remaining
+      await processor.flush();
+
+      expect(mockVectorDB.insertBatch).toHaveBeenCalled();
+    });
+
+    it('should handle flush with no pending chunks', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 10, embeddingBatchSize: 5 },
+        mockProgressTracker
+      );
+
+      // Flush with nothing added
+      await processor.flush();
+
+      expect(mockVectorDB.insertBatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getResults', () => {
+    it('should return correct chunk count after processing', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 2, embeddingBatchSize: 10 },
+        mockProgressTracker
+      );
+
+      await processor.addChunks([createMockChunk(1)], 'file1.ts', 1000);
+      await processor.addChunks([createMockChunk(2), createMockChunk(3)], 'file2.ts', 2000);
+      await processor.flush();
+
+      const results = processor.getResults();
+      expect(results.processedChunks).toBe(3);
+      expect(results.indexedFiles).toHaveLength(2);
+    });
+
+    it('should return file entries with correct metadata', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 100, embeddingBatchSize: 50 },
+        mockProgressTracker
+      );
+
+      const mtime = Date.now();
+      await processor.addChunks([createMockChunk(1), createMockChunk(2)], 'src/auth.ts', mtime);
+
+      const results = processor.getResults();
+      expect(results.indexedFiles[0]).toEqual({
+        filepath: 'src/auth.ts',
+        chunkCount: 2,
+        mtime,
+      });
+    });
+  });
+
+  describe('batch processing', () => {
+    it('should respect embeddingBatchSize for large batches', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        mockEmbeddings,
+        { batchThreshold: 5, embeddingBatchSize: 2 },
+        mockProgressTracker
+      );
+
+      // Add 6 chunks to trigger processing
+      const chunks = Array.from({ length: 6 }, (_, i) => createMockChunk(i));
+      await processor.addChunks(chunks, 'large-file.ts', Date.now());
+
+      // Should have processed in batches of 2 (3 calls for 6 chunks)
+      expect(mockEmbeddings.embedBatch).toHaveBeenCalledTimes(3);
+    });
+  });
+});
+
+describe('processEmbeddingMicroBatches', () => {
+  it('should process texts in micro-batches', async () => {
+    const mockEmbeddings = createMockEmbeddings();
+    const texts = ['text1', 'text2', 'text3', 'text4', 'text5'];
+
+    const results = await processEmbeddingMicroBatches(texts, mockEmbeddings);
+
+    expect(results).toHaveLength(5);
+    expect(results[0]).toBeInstanceOf(Float32Array);
+  });
+
+  it('should handle empty input', async () => {
+    const mockEmbeddings = createMockEmbeddings();
+
+    const results = await processEmbeddingMicroBatches([], mockEmbeddings);
+
+    expect(results).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/indexer/chunk-batch-processor.ts
+++ b/packages/cli/src/indexer/chunk-batch-processor.ts
@@ -1,0 +1,236 @@
+/**
+ * ChunkBatchProcessor - Handles concurrent chunk accumulation and batch processing.
+ *
+ * Extracted from performFullIndex to:
+ * 1. Encapsulate mutex/lock management complexity
+ * 2. Make the batch processing logic testable
+ * 3. Separate concerns (accumulation vs processing vs coordination)
+ *
+ * Key responsibilities:
+ * - Accumulate chunks from concurrent file processing
+ * - Batch chunks for embedding generation
+ * - Manage concurrent access with mutex pattern
+ * - Process batches through embedding → vectordb pipeline
+ */
+
+import type { VectorDB } from '../vectordb/lancedb.js';
+import type { EmbeddingService } from '../embeddings/types.js';
+import type { IndexingProgressTracker } from './progress-tracker.js';
+import type { CodeChunk } from './types.js';
+import { getEmbeddingMessage, getIndexingMessage } from '../utils/loading-messages.js';
+import { EMBEDDING_MICRO_BATCH_SIZE } from '../constants.js';
+
+/** A chunk with its content ready for embedding */
+export interface ChunkWithContent {
+  chunk: CodeChunk;
+  content: string;
+}
+
+/** Configuration for batch processing */
+export interface BatchProcessorConfig {
+  /** Number of chunks to accumulate before triggering a batch */
+  batchThreshold: number;
+  /** Size of embedding batches (for API/memory limits) */
+  embeddingBatchSize: number;
+}
+
+/** Result of adding chunks - includes file metadata for manifest */
+export interface FileIndexEntry {
+  filepath: string;
+  chunkCount: number;
+  mtime: number;
+}
+
+/**
+ * Process embeddings in micro-batches to prevent event loop blocking.
+ * Yields to the event loop between batches for UI responsiveness.
+ */
+export async function processEmbeddingMicroBatches(
+  texts: string[],
+  embeddings: EmbeddingService
+): Promise<Float32Array[]> {
+  const results: Float32Array[] = [];
+  
+  for (let j = 0; j < texts.length; j += EMBEDDING_MICRO_BATCH_SIZE) {
+    const microBatch = texts.slice(j, Math.min(j + EMBEDDING_MICRO_BATCH_SIZE, texts.length));
+    const microResults = await embeddings.embedBatch(microBatch);
+    results.push(...microResults);
+    
+    // Yield to event loop for UI responsiveness
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  
+  return results;
+}
+
+/**
+ * ChunkBatchProcessor handles the complex concurrent chunk accumulation
+ * and batch processing logic for indexing.
+ *
+ * Usage:
+ * ```typescript
+ * const processor = new ChunkBatchProcessor(vectorDB, embeddings, config, tracker);
+ *
+ * // From concurrent file processing tasks:
+ * await processor.addChunks(chunks, filepath, mtime);
+ *
+ * // After all files processed:
+ * await processor.flush();
+ *
+ * // Get results:
+ * const { processedChunks, indexedFiles } = processor.getResults();
+ * ```
+ */
+export class ChunkBatchProcessor {
+  private readonly accumulator: ChunkWithContent[] = [];
+  private readonly indexedFiles: FileIndexEntry[] = [];
+  private processedChunkCount = 0;
+
+  // Mutex state for concurrent access protection
+  private addChunksLock: Promise<void> | null = null;
+  private processingQueue: Promise<void> | null = null;
+
+  constructor(
+    private readonly vectorDB: VectorDB,
+    private readonly embeddings: EmbeddingService,
+    private readonly config: BatchProcessorConfig,
+    private readonly progressTracker: IndexingProgressTracker
+  ) {}
+
+  /**
+   * Add chunks from a processed file.
+   * Thread-safe: uses mutex to prevent race conditions with concurrent calls.
+   *
+   * @param chunks - Code chunks to add
+   * @param filepath - Source file path (for manifest)
+   * @param mtime - File modification time in ms (for change detection)
+   */
+  async addChunks(
+    chunks: CodeChunk[],
+    filepath: string,
+    mtime: number
+  ): Promise<void> {
+    if (chunks.length === 0) {
+      return;
+    }
+
+    // Wait for any in-progress add operation (mutex acquire)
+    if (this.addChunksLock) {
+      await this.addChunksLock;
+    }
+
+    // Create new lock promise
+    let releaseLock!: () => void;
+    this.addChunksLock = new Promise<void>(resolve => {
+      releaseLock = resolve;
+    });
+
+    try {
+      // Critical section: modify shared state
+      for (const chunk of chunks) {
+        this.accumulator.push({
+          chunk,
+          content: chunk.content,
+        });
+      }
+
+      // Track file for manifest
+      this.indexedFiles.push({
+        filepath,
+        chunkCount: chunks.length,
+        mtime,
+      });
+
+      // Process if batch threshold reached
+      if (this.accumulator.length >= this.config.batchThreshold) {
+        await this.triggerProcessing();
+      }
+    } finally {
+      // Release mutex
+      releaseLock();
+      this.addChunksLock = null;
+    }
+  }
+
+  /**
+   * Flush any remaining accumulated chunks.
+   * Call this after all files have been processed.
+   */
+  async flush(): Promise<void> {
+    this.progressTracker.setMessage('Processing final chunks...');
+    await this.triggerProcessing();
+  }
+
+  /**
+   * Get processing results.
+   */
+  getResults(): { processedChunks: number; indexedFiles: FileIndexEntry[] } {
+    return {
+      processedChunks: this.processedChunkCount,
+      indexedFiles: [...this.indexedFiles],
+    };
+  }
+
+  /**
+   * Trigger batch processing. Uses queue-based synchronization
+   * to prevent TOCTOU race conditions.
+   */
+  private async triggerProcessing(): Promise<void> {
+    // Chain onto existing processing promise to create a queue
+    if (this.processingQueue) {
+      this.processingQueue = this.processingQueue.then(() => this.doProcess());
+    } else {
+      this.processingQueue = this.doProcess();
+    }
+    return this.processingQueue;
+  }
+
+  /**
+   * The actual batch processing logic.
+   * Processes accumulated chunks through embedding → vectordb pipeline.
+   */
+  private async doProcess(): Promise<void> {
+    if (this.accumulator.length === 0) {
+      return;
+    }
+
+    const currentPromise = this.processingQueue;
+
+    try {
+      // Drain accumulator atomically
+      const toProcess = this.accumulator.splice(0, this.accumulator.length);
+
+      // Process in batches for memory/API limits
+      for (let i = 0; i < toProcess.length; i += this.config.embeddingBatchSize) {
+        const batch = toProcess.slice(
+          i,
+          Math.min(i + this.config.embeddingBatchSize, toProcess.length)
+        );
+        const texts = batch.map(item => item.content);
+
+        // Generate embeddings
+        this.progressTracker.setMessage(getEmbeddingMessage());
+        const embeddingVectors = await processEmbeddingMicroBatches(texts, this.embeddings);
+        this.processedChunkCount += batch.length;
+
+        // Insert into vector database
+        this.progressTracker.setMessage(`Inserting ${batch.length} chunks into vector space...`);
+        await this.vectorDB.insertBatch(
+          embeddingVectors,
+          batch.map(item => item.chunk.metadata),
+          texts
+        );
+
+        // Yield to event loop
+        await new Promise(resolve => setImmediate(resolve));
+      }
+
+      this.progressTracker.setMessage(getIndexingMessage());
+    } finally {
+      // Clear queue reference if we're the current operation
+      if (this.processingQueue === currentPromise) {
+        this.processingQueue = null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extract complex mutex and batch processing logic into dedicated ChunkBatchProcessor class to reduce performFullIndex complexity.

Changes:
- Create ChunkBatchProcessor class to encapsulate chunk accumulation, mutex management, and batch processing pipeline
- Extract processFileForIndexing() for single file processing
- Extract saveIndexResults() for finalization logic
- Add comprehensive tests for ChunkBatchProcessor (11 tests)

Complexity improvements:
- performFullIndex: ~210 lines → ~50 lines
- Max complexity: 298 halstead effort → 5
- Violations: 1 error → 0

All 936 tests pass. Dogfooded on lien codebase: 198 files, 1164 chunks.

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Improved!** This PR reduces complexity by 317.498.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->