### PR TITLE
refactor(frameworks): extract conflict resolution from detectAtPath

### DIFF
--- a/packages/cli/src/frameworks/detector-service.test.ts
+++ b/packages/cli/src/frameworks/detector-service.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  groupByConfidence,
+  selectByPriority,
+  resolveFrameworkConflicts,
+  runAllDetectors,
+  type DetectionWithPriority,
+} from './detector-service.js';
+import { frameworkDetectors } from './registry.js';
+
+// Helper to create mock detections
+function createDetection(
+  name: string,
+  confidence: 'high' | 'medium' | 'low',
+  priority: number = 0
+): DetectionWithPriority {
+  return {
+    detected: true,
+    name,
+    path: '.',
+    confidence,
+    evidence: [`${name} detected`],
+    priority,
+  };
+}
+
+describe('groupByConfidence', () => {
+  it('should group detections by confidence level', () => {
+    const detections = [
+      createDetection('nodejs', 'high', 10),
+      createDetection('laravel', 'high', 5),
+      createDetection('generic', 'medium', 3),
+      createDetection('fallback', 'low', 1),
+    ];
+
+    const grouped = groupByConfidence(detections);
+
+    expect(grouped.high).toHaveLength(2);
+    expect(grouped.medium).toHaveLength(1);
+    expect(grouped.low).toHaveLength(1);
+    expect(grouped.high.map(d => d.name)).toEqual(['nodejs', 'laravel']);
+  });
+
+  it('should handle empty arrays for missing confidence levels', () => {
+    const detections = [createDetection('nodejs', 'high', 10)];
+
+    const grouped = groupByConfidence(detections);
+
+    expect(grouped.high).toHaveLength(1);
+    expect(grouped.medium).toHaveLength(0);
+    expect(grouped.low).toHaveLength(0);
+  });
+
+  it('should handle empty input', () => {
+    const grouped = groupByConfidence([]);
+
+    expect(grouped.high).toHaveLength(0);
+    expect(grouped.medium).toHaveLength(0);
+    expect(grouped.low).toHaveLength(0);
+  });
+});
+
+describe('selectByPriority', () => {
+  it('should select highest priority as winner', () => {
+    const detections = [
+      createDetection('low-priority', 'medium', 1),
+      createDetection('high-priority', 'medium', 10),
+      createDetection('mid-priority', 'medium', 5),
+    ];
+
+    const { winner, skipped } = selectByPriority(detections);
+
+    expect(winner.name).toBe('high-priority');
+    expect(skipped).toHaveLength(2);
+    expect(skipped.map(d => d.name)).toEqual(['mid-priority', 'low-priority']);
+  });
+
+  it('should handle single detection', () => {
+    const detections = [createDetection('only-one', 'medium', 5)];
+
+    const { winner, skipped } = selectByPriority(detections);
+
+    expect(winner.name).toBe('only-one');
+    expect(skipped).toHaveLength(0);
+  });
+
+  it('should handle equal priorities (stable sort)', () => {
+    const detections = [
+      createDetection('first', 'medium', 5),
+      createDetection('second', 'medium', 5),
+    ];
+
+    const { winner, skipped } = selectByPriority(detections);
+
+    // Both have same priority, first in sorted order wins
+    expect(winner).toBeDefined();
+    expect(skipped).toHaveLength(1);
+  });
+
+  it('should throw error for empty array', () => {
+    expect(() => selectByPriority([])).toThrow('selectByPriority requires at least one detection');
+  });
+});
+
+describe('resolveFrameworkConflicts', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  describe('no conflicts', () => {
+    it('should return empty array for no detections', () => {
+      const result = resolveFrameworkConflicts([], '.');
+      expect(result).toEqual([]);
+    });
+
+    it('should return single detection without priority field', () => {
+      const detections = [createDetection('nodejs', 'high', 10)];
+
+      const result = resolveFrameworkConflicts(detections, '.');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('nodejs');
+      expect((result[0] as any).priority).toBeUndefined();
+    });
+  });
+
+  describe('hybrid projects (multiple HIGH confidence)', () => {
+    it('should keep all HIGH confidence frameworks', () => {
+      const detections = [
+        createDetection('nodejs', 'high', 10),
+        createDetection('shopify', 'high', 5),
+      ];
+
+      const result = resolveFrameworkConflicts(detections, '.');
+
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.name)).toContain('nodejs');
+      expect(result.map(r => r.name)).toContain('shopify');
+    });
+
+    it('should log hybrid project detection', () => {
+      const detections = [
+        createDetection('nodejs', 'high', 10),
+        createDetection('laravel', 'high', 5),
+      ];
+
+      resolveFrameworkConflicts(detections, '.');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Detected hybrid project')
+      );
+    });
+
+    it('should skip lower confidence detections in hybrid scenario', () => {
+      const detections = [
+        createDetection('nodejs', 'high', 10),
+        createDetection('shopify', 'high', 5),
+        createDetection('generic', 'medium', 3),
+      ];
+
+      const result = resolveFrameworkConflicts(detections, '.');
+
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.name)).not.toContain('generic');
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping lower confidence')
+      );
+    });
+  });
+
+  describe('single HIGH confidence', () => {
+    it('should keep single HIGH and skip lower confidence', () => {
+      const detections = [
+        createDetection('nodejs', 'high', 10),
+        createDetection('generic', 'medium', 5),
+        createDetection('fallback', 'low', 1),
+      ];
+
+      const result = resolveFrameworkConflicts(detections, '.');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('nodejs');
+    });
+  });
+
+  describe('MEDIUM confidence priority resolution', () => {
+    it('should select highest priority MEDIUM when no HIGH exists', () => {
+      const detections = [
+        createDetection('low-priority', 'medium', 1),
+        createDetection('high-priority', 'medium', 10),
+      ];
+
+      const result = resolveFrameworkConflicts(detections, 'subdir');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('high-priority');
+    });
+
+    it('should log skipped frameworks with path context', () => {
+      const detections = [
+        createDetection('winner', 'medium', 10),
+        createDetection('loser', 'medium', 1),
+      ];
+
+      resolveFrameworkConflicts(detections, 'packages/api');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('packages/api')
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('winner takes precedence')
+      );
+    });
+  });
+
+  describe('LOW confidence priority resolution', () => {
+    it('should select highest priority LOW when no HIGH or MEDIUM exists', () => {
+      const detections = [
+        createDetection('low-priority', 'low', 1),
+        createDetection('high-priority', 'low', 10),
+      ];
+
+      const result = resolveFrameworkConflicts(detections, '.');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('high-priority');
+    });
+
+    it('should not log if only one LOW confidence detection', () => {
+      const detections = [createDetection('only-low', 'low', 5)];
+
+      resolveFrameworkConflicts(detections, '.');
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('priority field stripping', () => {
+    it('should strip priority from all returned results', () => {
+      const detections = [
+        createDetection('nodejs', 'high', 10),
+        createDetection('laravel', 'high', 5),
+      ];
+
+      const result = resolveFrameworkConflicts(detections, '.');
+
+      result.forEach(r => {
+        expect((r as any).priority).toBeUndefined();
+      });
+    });
+  });
+});
+
+describe('runAllDetectors', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should run all registered detectors', async () => {
+    // This tests against the real registry - verifies integration
+    const results = await runAllDetectors(__dirname, '.');
+
+    // Should return an array (may be empty if no frameworks detected in test dir)
+    expect(Array.isArray(results)).toBe(true);
+  });
+
+  it('should include priority from detector in results', async () => {
+    // Create a temp directory structure that will trigger detection
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const os = await import('os');
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-'));
+
+    try {
+      // Create package.json to trigger Node.js detection
+      await fs.writeFile(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'test-project', version: '1.0.0' })
+      );
+
+      const results = await runAllDetectors(tempDir, '.');
+
+      // Should detect Node.js
+      expect(results.length).toBeGreaterThan(0);
+
+      // Each result should have a priority field
+      results.forEach(result => {
+        expect(typeof result.priority).toBe('number');
+      });
+
+      // Should find nodejs detector result
+      const nodejsResult = results.find(r => r.name === 'nodejs');
+      expect(nodejsResult).toBeDefined();
+      expect(nodejsResult?.detected).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('should filter out non-detected frameworks', async () => {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const os = await import('os');
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-'));
+
+    try {
+      // Create empty directory - no frameworks should be detected
+      const results = await runAllDetectors(tempDir, '.');
+
+      // All results should have detected: true (non-detected are filtered)
+      results.forEach(result => {
+        expect(result.detected).toBe(true);
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('should continue execution if a detector throws', async () => {
+    // Mock a detector that throws
+    const originalDetectors = [...frameworkDetectors];
+
+    // Add a throwing detector to the registry temporarily
+    const throwingDetector = {
+      name: 'throwing-detector',
+      priority: 0,
+      detect: async () => {
+        throw new Error('Detector error');
+      },
+      generateConfig: async () => ({} as any),
+    };
+
+    frameworkDetectors.unshift(throwingDetector);
+
+    try {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-'));
+
+      try {
+        // Create package.json to trigger Node.js detection
+        await fs.writeFile(
+          path.join(tempDir, 'package.json'),
+          JSON.stringify({ name: 'test-project', version: '1.0.0' })
+        );
+
+        // Should not throw, should log error and continue
+        const results = await runAllDetectors(tempDir, '.');
+
+        // Should have logged the error
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Error running detector 'throwing-detector'"),
+          expect.any(Error)
+        );
+
+        // Should still get results from other detectors
+        expect(results.some(r => r.name === 'nodejs')).toBe(true);
+      } finally {
+        await fs.rm(tempDir, { recursive: true });
+      }
+    } finally {
+      // Restore original detectors
+      frameworkDetectors.length = 0;
+      frameworkDetectors.push(...originalDetectors);
+    }
+  });
+});

--- a/packages/cli/src/frameworks/detector-service.ts
+++ b/packages/cli/src/frameworks/detector-service.ts
@@ -3,6 +3,164 @@ import path from 'path';
 import { DetectionResult, DetectionOptions, defaultDetectionOptions } from './types.js';
 import { frameworkDetectors } from './registry.js';
 
+/** Detection result with internal priority for conflict resolution */
+export type DetectionWithPriority = DetectionResult & { priority: number };
+
+/** Detections grouped by confidence level */
+export interface GroupedDetections {
+  high: DetectionWithPriority[];
+  medium: DetectionWithPriority[];
+  low: DetectionWithPriority[];
+}
+
+/**
+ * Strip the internal priority property from a detection result.
+ */
+function stripPriority(detection: DetectionWithPriority): DetectionResult {
+  const { priority, ...result } = detection;
+  return result;
+}
+
+/**
+ * Log skipped frameworks when lower confidence detections are ignored.
+ */
+function logSkippedFrameworks(
+  skipped: DetectionWithPriority[],
+  context?: { relativePath: string; winnerName: string }
+): void {
+  if (skipped.length === 0) return;
+
+  const names = skipped.map(d => d.name).join(', ');
+
+  if (context) {
+    console.log(`  → Skipping ${names} at ${context.relativePath} (${context.winnerName} takes precedence)`);
+  } else {
+    console.log(`  → Skipping lower confidence detections: ${names}`);
+  }
+}
+
+/**
+ * Group detections by confidence level.
+ */
+export function groupByConfidence(detections: DetectionWithPriority[]): GroupedDetections {
+  return {
+    high: detections.filter(d => d.confidence === 'high'),
+    medium: detections.filter(d => d.confidence === 'medium'),
+    low: detections.filter(d => d.confidence === 'low'),
+  };
+}
+
+/**
+ * Select the winner from a list using priority (highest priority wins).
+ * Returns the winner and the remaining (skipped) detections.
+ *
+ * @throws Error if detections array is empty
+ */
+export function selectByPriority(
+  detections: DetectionWithPriority[]
+): { winner: DetectionWithPriority; skipped: DetectionWithPriority[] } {
+  if (detections.length === 0) {
+    throw new Error('selectByPriority requires at least one detection');
+  }
+  const sorted = [...detections].sort((a, b) => b.priority - a.priority);
+  return {
+    winner: sorted[0],
+    skipped: sorted.slice(1),
+  };
+}
+
+/**
+ * Resolve conflicts when multiple frameworks are detected at the same path.
+ *
+ * Resolution rules (applied in order):
+ * 1. Multiple HIGH confidence → keep ALL (hybrid project support)
+ * 2. Single HIGH confidence → keep it, skip lower confidence
+ * 3. No HIGH but have MEDIUM → use priority to select winner
+ * 4. Only LOW confidence → use priority to select winner
+ *
+ * @param detections - All detected frameworks with their priorities
+ * @param relativePath - Path being analyzed (for logging)
+ * @returns Array of resolved detection results
+ */
+export function resolveFrameworkConflicts(
+  detections: DetectionWithPriority[],
+  relativePath: string
+): DetectionResult[] {
+  // No detections
+  if (detections.length === 0) {
+    return [];
+  }
+
+  // Single detection - no conflict
+  if (detections.length === 1) {
+    return [stripPriority(detections[0])];
+  }
+
+  // Multiple detections - apply resolution rules
+  const grouped = groupByConfidence(detections);
+
+  // Rule 1: Multiple HIGH confidence → hybrid project (keep all)
+  if (grouped.high.length > 1) {
+    const names = grouped.high.map(d => d.name).join(' + ');
+    console.log(`  → Detected hybrid project: ${names}`);
+    logSkippedFrameworks([...grouped.medium, ...grouped.low]);
+    return grouped.high.map(stripPriority);
+  }
+
+  // Rule 2: Single HIGH confidence → keep it
+  if (grouped.high.length === 1) {
+    logSkippedFrameworks([...grouped.medium, ...grouped.low]);
+    return [stripPriority(grouped.high[0])];
+  }
+
+  // Rule 3: No HIGH but have MEDIUM → use priority
+  if (grouped.medium.length > 0) {
+    const { winner, skipped } = selectByPriority(grouped.medium);
+    logSkippedFrameworks([...skipped, ...grouped.low], {
+      relativePath,
+      winnerName: winner.name,
+    });
+    return [stripPriority(winner)];
+  }
+
+  // Rule 4: Only LOW confidence → use priority
+  const { winner, skipped } = selectByPriority(grouped.low);
+  if (skipped.length > 0) {
+    logSkippedFrameworks(skipped, { relativePath, winnerName: winner.name });
+  }
+  return [stripPriority(winner)];
+}
+
+/**
+ * Run all framework detectors at a path and collect results.
+ *
+ * @param rootDir - Project root directory
+ * @param relativePath - Path relative to root being scanned
+ * @returns Array of detection results with priorities
+ */
+export async function runAllDetectors(
+  rootDir: string,
+  relativePath: string
+): Promise<DetectionWithPriority[]> {
+  const results: DetectionWithPriority[] = [];
+
+  for (const detector of frameworkDetectors) {
+    try {
+      const result = await detector.detect(rootDir, relativePath);
+      if (result.detected) {
+        results.push({
+          ...result,
+          priority: detector.priority ?? 0,
+        });
+      }
+    } catch (error) {
+      console.error(`Error running detector '${detector.name}' at ${relativePath}:`, error);
+    }
+  }
+
+  return results;
+}
+
 /**
  * Detect all frameworks in a monorepo by recursively scanning subdirectories
  * @param rootDir - Absolute path to project root
@@ -16,18 +174,21 @@ export async function detectAllFrameworks(
   const opts = { ...defaultDetectionOptions, ...options };
   const results: DetectionResult[] = [];
   const visited = new Set<string>();
-  
+
   // Detect at root first
   await detectAtPath(rootDir, '.', results, visited);
-  
+
   // Recursively scan subdirectories
   await scanSubdirectories(rootDir, '.', results, visited, 0, opts);
-  
+
   return results;
 }
 
 /**
- * Detect frameworks at a specific path
+ * Detect frameworks at a specific path.
+ *
+ * Runs all detectors and resolves conflicts using confidence-based rules.
+ * Now delegates to focused helper functions for better testability.
  */
 async function detectAtPath(
   rootDir: string,
@@ -35,91 +196,19 @@ async function detectAtPath(
   results: DetectionResult[],
   visited: Set<string>
 ): Promise<void> {
-  // Mark as visited
+  // Guard: already visited
   const fullPath = path.join(rootDir, relativePath);
   if (visited.has(fullPath)) {
     return;
   }
   visited.add(fullPath);
-  
-  // Run all detectors and collect results
-  const detectedAtPath: Array<DetectionResult & { priority: number }> = [];
-  
-  for (const detector of frameworkDetectors) {
-    try {
-      const result = await detector.detect(rootDir, relativePath);
-      if (result.detected) {
-        detectedAtPath.push({
-          ...result,
-          priority: detector.priority ?? 0,
-        });
-      }
-    } catch (error) {
-      // Log error but continue with other detectors
-      console.error(`Error running detector '${detector.name}' at ${relativePath}:`, error);
-    }
-  }
-  
-  // Conflict resolution: Allow multiple HIGH-confidence frameworks to coexist
-  // This enables hybrid projects (e.g., Shopify + Node.js, Laravel + Node.js)
-  if (detectedAtPath.length > 1) {
-    // Separate frameworks by confidence level
-    const highConfidence = detectedAtPath.filter(d => d.confidence === 'high');
-    const mediumConfidence = detectedAtPath.filter(d => d.confidence === 'medium');
-    const lowConfidence = detectedAtPath.filter(d => d.confidence === 'low');
-    
-    if (highConfidence.length > 1) {
-      // Multiple HIGH-confidence frameworks -> keep all (hybrid/monorepo behavior)
-      // Strip internal priority property before adding to results
-      const cleanResults = highConfidence.map(({ priority, ...result }) => result);
-      results.push(...cleanResults);
-      const names = highConfidence.map(d => d.name).join(' + ');
-      console.log(`  → Detected hybrid project: ${names}`);
-      
-      // Log skipped medium/low confidence detections
-      if (mediumConfidence.length > 0 || lowConfidence.length > 0) {
-        const skippedNames = [...mediumConfidence, ...lowConfidence].map(d => d.name).join(', ');
-        console.log(`  → Skipping lower confidence detections: ${skippedNames}`);
-      }
-    } else if (highConfidence.length === 1) {
-      // Only one HIGH-confidence framework
-      const { priority, ...result } = highConfidence[0];
-      results.push(result);
-      
-      // Log skipped medium/low confidence detections
-      if (mediumConfidence.length > 0 || lowConfidence.length > 0) {
-        const skippedNames = [...mediumConfidence, ...lowConfidence].map(d => d.name).join(', ');
-        console.log(`  → Skipping lower confidence detections: ${skippedNames}`);
-      }
-    } else if (mediumConfidence.length > 0) {
-      // No HIGH confidence, but have MEDIUM -> use priority system
-      mediumConfidence.sort((a, b) => b.priority - a.priority);
-      const { priority, ...winner } = mediumConfidence[0];
-      results.push(winner);
-      
-      // Skipped = remaining medium + all low confidence
-      const skipped = [...mediumConfidence.slice(1), ...lowConfidence];
-      if (skipped.length > 0) {
-        const skippedNames = skipped.map(d => d.name).join(', ');
-        console.log(`  → Skipping ${skippedNames} at ${relativePath} (${winner.name} takes precedence)`);
-      }
-    } else if (lowConfidence.length > 0) {
-      // Only LOW confidence -> use priority system
-      lowConfidence.sort((a, b) => b.priority - a.priority);
-      const { priority, ...winner } = lowConfidence[0];
-    results.push(winner);
-    
-      // Skipped = remaining low confidence
-      const skipped = lowConfidence.slice(1);
-    if (skipped.length > 0) {
-      const skippedNames = skipped.map(d => d.name).join(', ');
-      console.log(`  → Skipping ${skippedNames} at ${relativePath} (${winner.name} takes precedence)`);
-      }
-    }
-  } else if (detectedAtPath.length === 1) {
-    const { priority, ...result } = detectedAtPath[0];
-    results.push(result);
-  }
+
+  // Run detectors
+  const detections = await runAllDetectors(rootDir, relativePath);
+
+  // Resolve conflicts and add to results
+  const resolved = resolveFrameworkConflicts(detections, relativePath);
+  results.push(...resolved);
 }
 
 /**


### PR DESCRIPTION
Extract deeply nested if/else conflict resolution logic into focused helper functions to reduce cognitive complexity.

Changes:
- Extract `resolveFrameworkConflicts()` - main conflict resolution with early returns
- Extract `groupByConfidence()` - group detections by high/medium/low
- Extract `selectByPriority()` - priority-based selection with winner/skipped
- Extract `runAllDetectors()` - detector execution loop
- Extract `logSkippedFrameworks()` - remove logging duplication
- Add 17 comprehensive tests for extracted functions

Complexity improvements:
- Cognitive complexity: 58 → 7
- Halstead effort: 283 (~4h 43m) → <60
- Violations: 2 errors → 0
- Nesting depth: 4+ levels → 1-2 levels

All 953 tests pass. Dogfooded: 199 files, 1178 chunks indexed.

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Improved!** This PR reduces complexity by 359.631.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->