### PR TITLE
feat(mcp): add language/pathHint filters to find_similar, prune low-relelvance

### DIFF
--- a/.changeset/lemon-garlics-move.md
+++ b/.changeset/lemon-garlics-move.md
@@ -1,0 +1,5 @@
+---
+"@liendev/lien": minor
+---
+
+feat(mcp): add language/pathHint filters to find_similar, prune low-relevance results

--- a/packages/cli/src/mcp/handlers/find-similar.test.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleFindSimilar } from './find-similar.js';
+import type { ToolContext } from '../types.js';
+import type { SearchResult } from '@liendev/core';
+
+describe('handleFindSimilar', () => {
+  const mockLog = vi.fn();
+  const mockCheckAndReconnect = vi.fn().mockResolvedValue(undefined);
+  const mockGetIndexMetadata = vi.fn(() => ({
+    indexVersion: 1234567890,
+    indexDate: '2025-12-19',
+  }));
+
+  const mockEmbeddings = {
+    embed: vi.fn().mockResolvedValue(new Float32Array([0.1, 0.2, 0.3])),
+  };
+
+  let mockVectorDB: {
+    search: ReturnType<typeof vi.fn>;
+  };
+
+  let mockCtx: ToolContext;
+
+  // Default metadata for mock results
+  const defaultMetadata = {
+    file: 'src/example.ts',
+    startLine: 1,
+    endLine: 5,
+    type: 'function' as const,
+    language: 'typescript',
+    symbolName: 'example',
+    symbolType: 'function' as const,
+  };
+
+  // Helper to create mock search results
+  function createMockResult(overrides: {
+    content?: string;
+    metadata?: Partial<typeof defaultMetadata>;
+    score?: number;
+    relevance?: 'highly_relevant' | 'relevant' | 'loosely_related' | 'not_relevant';
+  } = {}): SearchResult {
+    return {
+      content: overrides.content ?? 'function example() {}',
+      metadata: {
+        ...defaultMetadata,
+        ...overrides.metadata,
+      },
+      score: overrides.score ?? 0.5,
+      relevance: overrides.relevance ?? 'highly_relevant',
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockVectorDB = {
+      search: vi.fn(),
+    };
+
+    mockCtx = {
+      vectorDB: mockVectorDB as any,
+      embeddings: mockEmbeddings as any,
+      log: mockLog,
+      checkAndReconnect: mockCheckAndReconnect,
+      getIndexMetadata: mockGetIndexMetadata,
+      rootDir: '/fake/workspace',
+    };
+  });
+
+  describe('basic search', () => {
+    it('should return search results without filters', async () => {
+      const mockResults = [
+        createMockResult({ content: 'function fetchUser() {}' }),
+        createMockResult({ content: 'function getUser() {}' }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        mockCtx
+      );
+
+      expect(mockVectorDB.search).toHaveBeenCalled();
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.indexInfo).toBeDefined();
+    });
+
+    it('should include index metadata in response', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.indexInfo).toEqual({
+        indexVersion: 1234567890,
+        indexDate: '2025-12-19',
+      });
+    });
+  });
+
+  describe('language filter', () => {
+    it('should filter results by language (case-insensitive)', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { language: 'typescript' } }),
+        createMockResult({ metadata: { language: 'python' } }),
+        createMockResult({ metadata: { language: 'TypeScript' } }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', language: 'typescript' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.results.every((r: any) => 
+        r.metadata.language.toLowerCase() === 'typescript'
+      )).toBe(true);
+      expect(parsed.filtersApplied.language).toBe('typescript');
+    });
+
+    it('should return empty when no results match language', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { language: 'python' } }),
+        createMockResult({ metadata: { language: 'javascript' } }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', language: 'rust' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.filtersApplied.language).toBe('rust');
+    });
+
+    it('should handle missing language metadata gracefully', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { language: 'typescript' } }),
+        // Simulate a record with missing language by using type assertion
+        { ...createMockResult(), metadata: { ...defaultMetadata, language: undefined as unknown as string } },
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', language: 'typescript' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(1);
+    });
+  });
+
+  describe('pathHint filter', () => {
+    it('should filter results by path substring (case-insensitive)', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { file: 'src/api/users.ts' } }),
+        createMockResult({ metadata: { file: 'src/utils/helpers.ts' } }),
+        createMockResult({ metadata: { file: 'src/API/orders.ts' } }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', pathHint: 'api' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.filtersApplied.pathHint).toBe('api');
+    });
+
+    it('should return empty when no results match path hint', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { file: 'src/utils/helpers.ts' } }),
+        createMockResult({ metadata: { file: 'src/core/main.ts' } }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', pathHint: 'api' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+    });
+
+    it('should handle missing file metadata gracefully', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { file: 'src/api/users.ts' } }),
+        // Simulate a record with missing file by using type assertion
+        { ...createMockResult(), metadata: { ...defaultMetadata, file: undefined as unknown as string } },
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', pathHint: 'api' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(1);
+    });
+  });
+
+  describe('low-relevance pruning', () => {
+    it('should prune not_relevant results', async () => {
+      const mockResults = [
+        createMockResult({ relevance: 'highly_relevant', score: 0.5 }),
+        createMockResult({ relevance: 'relevant', score: 1.1 }),
+        createMockResult({ relevance: 'not_relevant', score: 1.6 }),
+        createMockResult({ relevance: 'loosely_related', score: 1.4 }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(3);
+      expect(parsed.results.every((r: any) => r.relevance !== 'not_relevant')).toBe(true);
+      expect(parsed.filtersApplied.prunedLowRelevance).toBe(1);
+    });
+
+    it('should handle all results being pruned', async () => {
+      const mockResults = [
+        createMockResult({ relevance: 'not_relevant', score: 1.8 }),
+        createMockResult({ relevance: 'not_relevant', score: 2.0 }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.filtersApplied.prunedLowRelevance).toBe(2);
+    });
+  });
+
+  describe('combined filters', () => {
+    it('should apply language and pathHint filters together', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { file: 'src/api/users.ts', language: 'typescript' } }),
+        createMockResult({ metadata: { file: 'src/api/orders.py', language: 'python' } }),
+        createMockResult({ metadata: { file: 'src/utils/helpers.ts', language: 'typescript' } }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { 
+          code: 'async function fetchData() { return await db.find(); }',
+          language: 'typescript',
+          pathHint: 'api'
+        },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.results[0].metadata.file).toBe('src/api/users.ts');
+      expect(parsed.filtersApplied.language).toBe('typescript');
+      expect(parsed.filtersApplied.pathHint).toBe('api');
+    });
+
+    it('should apply all filters and pruning together', async () => {
+      const mockResults = [
+        createMockResult({ 
+          metadata: { file: 'src/api/users.ts', language: 'typescript' },
+          relevance: 'highly_relevant'
+        }),
+        createMockResult({ 
+          metadata: { file: 'src/api/orders.ts', language: 'typescript' },
+          relevance: 'not_relevant'
+        }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { 
+          code: 'async function fetchData() { return await db.find(); }',
+          language: 'typescript',
+          pathHint: 'api'
+        },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.filtersApplied.prunedLowRelevance).toBe(1);
+    });
+  });
+
+  describe('limit behavior', () => {
+    it('should respect limit after filtering', async () => {
+      const mockResults = Array.from({ length: 20 }, (_, i) =>
+        createMockResult({ 
+          content: `function example${i}() {}`,
+          metadata: { file: `src/file${i}.ts`, language: 'typescript' }
+        })
+      );
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', limit: 3 },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(3);
+    });
+
+    it('should return fewer than limit when filters reduce results', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { language: 'typescript' } }),
+        createMockResult({ metadata: { language: 'python' } }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', language: 'typescript', limit: 10 },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(1);
+    });
+  });
+
+  describe('filtersApplied metadata', () => {
+    it('should not include filtersApplied when no filtering occurred', async () => {
+      const mockResults = [
+        createMockResult({ relevance: 'highly_relevant' }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.filtersApplied).toBeUndefined();
+    });
+
+    it('should include filtersApplied when pruning occurred', async () => {
+      const mockResults = [
+        createMockResult({ relevance: 'highly_relevant' }),
+        createMockResult({ relevance: 'not_relevant' }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.filtersApplied).toBeDefined();
+      expect(parsed.filtersApplied.prunedLowRelevance).toBe(1);
+    });
+  });
+});
+

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -52,7 +52,7 @@ export async function handleFindSimilar(
         filtersApplied.pathHint = validatedArgs.pathHint;
         const hint = validatedArgs.pathHint.toLowerCase();
         filtered = filtered.filter(r =>
-          r.metadata.file.toLowerCase().includes(hint)
+          (r.metadata.file?.toLowerCase() ?? '').includes(hint)
         );
       }
 

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -1,6 +1,13 @@
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { FindSimilarSchema } from '../schemas/index.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
+import type { SearchResult } from '@liendev/core';
+
+interface FiltersApplied {
+  language?: string;
+  pathHint?: string;
+  prunedLowRelevance: number;
+}
 
 /**
  * Handle find_similar tool calls.
@@ -21,14 +28,51 @@ export async function handleFindSimilar(
       await checkAndReconnect();
 
       const codeEmbedding = await embeddings.embed(validatedArgs.code);
-      // Pass code as query for relevance boosting
-      const results = await vectorDB.search(codeEmbedding, validatedArgs.limit, validatedArgs.code);
+      
+      // Request extra results to account for filtering
+      const limit = validatedArgs.limit ?? 5;
+      const extraLimit = limit + 10;
+      const rawResults = await vectorDB.search(codeEmbedding, extraLimit, validatedArgs.code);
+
+      // Track what filters were applied
+      const filtersApplied: FiltersApplied = { prunedLowRelevance: 0 };
+      let filtered: SearchResult[] = rawResults;
+
+      // Filter by language (case-insensitive)
+      if (validatedArgs.language) {
+        filtersApplied.language = validatedArgs.language;
+        const lang = validatedArgs.language.toLowerCase();
+        filtered = filtered.filter(r => 
+          r.metadata.language?.toLowerCase() === lang
+        );
+      }
+
+      // Filter by path hint (case-insensitive substring match)
+      if (validatedArgs.pathHint) {
+        filtersApplied.pathHint = validatedArgs.pathHint;
+        const hint = validatedArgs.pathHint.toLowerCase();
+        filtered = filtered.filter(r =>
+          r.metadata.file.toLowerCase().includes(hint)
+        );
+      }
+
+      // Prune low-relevance results (not_relevant = score >= 1.5)
+      const beforePrune = filtered.length;
+      filtered = filtered.filter(r => r.relevance !== 'not_relevant');
+      filtersApplied.prunedLowRelevance = beforePrune - filtered.length;
+
+      // Apply final limit
+      const results = filtered.slice(0, limit);
 
       log(`Found ${results.length} similar chunks`);
+
+      // Only include filtersApplied if any filtering occurred
+      const hasFilters = filtersApplied.language || filtersApplied.pathHint || filtersApplied.prunedLowRelevance > 0;
 
       return {
         indexInfo: getIndexMetadata(),
         results,
+        ...(hasFilters && { filtersApplied }),
       };
     }
   )(args);

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -26,7 +26,7 @@ function applyPathHintFilter(results: SearchResult[], pathHint: string): SearchR
 }
 
 /**
- * Remove low-relevance results (not_relevant = score >= 1.5).
+ * Remove low-relevance results (relevance === 'not_relevant').
  */
 function pruneIrrelevantResults(results: SearchResult[]): { filtered: SearchResult[]; prunedCount: number } {
   const beforePrune = results.length;

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -136,6 +136,20 @@ describe('FindSimilarSchema', () => {
     expect(result.language).toBe('typescript');
     expect(result.pathHint).toBe('src/api');
   });
+
+  it('should reject empty language filter', () => {
+    expect(() => FindSimilarSchema.parse({
+      code: 'const x = 1; return x + 2;',
+      language: '',
+    })).toThrow('Language filter cannot be empty');
+  });
+
+  it('should reject empty pathHint filter', () => {
+    expect(() => FindSimilarSchema.parse({
+      code: 'const x = 1; return x + 2;',
+      pathHint: '',
+    })).toThrow('Path hint cannot be empty');
+  });
 });
 
 describe('GetFilesContextSchema', () => {

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -81,34 +81,60 @@ describe('FindSimilarSchema', () => {
   
   it('should apply default limit', () => {
     const result = FindSimilarSchema.parse({
-      code: 'const x = 1;',
+      code: 'const x = 1; return x + 2;',
     });
     expect(result.limit).toBe(5);
   });
   
   it('should reject short code snippet', () => {
     expect(() => FindSimilarSchema.parse({ code: 'short' }))
-      .toThrow('Code snippet must be at least 10 characters');
+      .toThrow('Code snippet must be at least 24 characters');
   });
   
   it('should reject invalid limit (too low)', () => {
-    expect(() => FindSimilarSchema.parse({ code: 'const x = 1;', limit: 0 }))
+    expect(() => FindSimilarSchema.parse({ code: 'const x = 1; return x + 2;', limit: 0 }))
       .toThrow('Limit must be at least 1');
   });
   
   it('should reject invalid limit (too high)', () => {
-    expect(() => FindSimilarSchema.parse({ code: 'const x = 1;', limit: 25 }))
+    expect(() => FindSimilarSchema.parse({ code: 'const x = 1; return x + 2;', limit: 25 }))
       .toThrow('Limit cannot exceed 20');
   });
   
   it('should accept minimum valid code', () => {
-    const result = FindSimilarSchema.parse({ code: '0123456789' });
-    expect(result.code).toBe('0123456789');
+    const result = FindSimilarSchema.parse({ code: '012345678901234567890123' });
+    expect(result.code).toBe('012345678901234567890123');
   });
   
   it('should accept maximum valid limit', () => {
-    const result = FindSimilarSchema.parse({ code: 'const x = 1;', limit: 20 });
+    const result = FindSimilarSchema.parse({ code: 'const x = 1; return x + 2;', limit: 20 });
     expect(result.limit).toBe(20);
+  });
+
+  it('should accept optional language filter', () => {
+    const result = FindSimilarSchema.parse({
+      code: 'const x = 1; return x + 2;',
+      language: 'typescript',
+    });
+    expect(result.language).toBe('typescript');
+  });
+
+  it('should accept optional pathHint filter', () => {
+    const result = FindSimilarSchema.parse({
+      code: 'const x = 1; return x + 2;',
+      pathHint: 'src/api',
+    });
+    expect(result.pathHint).toBe('src/api');
+  });
+
+  it('should accept both filters together', () => {
+    const result = FindSimilarSchema.parse({
+      code: 'const x = 1; return x + 2;',
+      language: 'typescript',
+      pathHint: 'src/api',
+    });
+    expect(result.language).toBe('typescript');
+    expect(result.pathHint).toBe('src/api');
   });
 });
 

--- a/packages/cli/src/mcp/schemas/similarity.schema.ts
+++ b/packages/cli/src/mcp/schemas/similarity.schema.ts
@@ -25,6 +25,7 @@ export const FindSimilarSchema = z.object({
     ),
 
   language: z.string()
+    .min(1, "Language filter cannot be empty")
     .optional()
     .describe(
       "Filter by programming language.\n\n" +
@@ -33,6 +34,7 @@ export const FindSimilarSchema = z.object({
     ),
 
   pathHint: z.string()
+    .min(1, "Path hint cannot be empty")
     .optional()
     .describe(
       "Filter by file path substring.\n\n" +

--- a/packages/cli/src/mcp/schemas/similarity.schema.ts
+++ b/packages/cli/src/mcp/schemas/similarity.schema.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
  */
 export const FindSimilarSchema = z.object({
   code: z.string()
-    .min(10, "Code snippet must be at least 10 characters")
+    .min(24, "Code snippet must be at least 24 characters")
     .describe(
       "Code snippet to find similar implementations for.\n\n" +
       "Provide a representative code sample that demonstrates the pattern " +
@@ -22,6 +22,22 @@ export const FindSimilarSchema = z.object({
     .describe(
       "Number of similar code blocks to return.\n\n" +
       "Default: 5"
+    ),
+
+  language: z.string()
+    .optional()
+    .describe(
+      "Filter by programming language.\n\n" +
+      "Examples: 'typescript', 'python', 'javascript', 'php'\n\n" +
+      "If omitted, searches all languages."
+    ),
+
+  pathHint: z.string()
+    .optional()
+    .describe(
+      "Filter by file path substring.\n\n" +
+      "Only returns results where the file path contains this string (case-insensitive).\n\n" +
+      "Examples: 'src/api', 'components', 'utils'"
     ),
 });
 

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -268,7 +268,7 @@ describe('MCP Tools Schema', () => {
     describe('find_similar validation', () => {
       it('should accept valid input', () => {
         const valid = FindSimilarSchema.safeParse({
-          code: 'const x = 1;',
+          code: 'const x = 1; return x + 2;',
           limit: 10
         });
         expect(valid.success).toBe(true);
@@ -282,8 +282,18 @@ describe('MCP Tools Schema', () => {
       });
       
       it('should apply defaults', () => {
-        const result = FindSimilarSchema.parse({ code: 'const x = 1;' });
+        const result = FindSimilarSchema.parse({ code: 'const x = 1; return x + 2;' });
         expect(result.limit).toBe(5);
+      });
+
+      it('should accept optional filters', () => {
+        const result = FindSimilarSchema.parse({
+          code: 'const x = 1; return x + 2;',
+          language: 'typescript',
+          pathHint: 'src/api'
+        });
+        expect(result.language).toBe('typescript');
+        expect(result.pathHint).toBe('src/api');
       });
     });
     

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -36,7 +36,13 @@ Results include a relevance category (highly_relevant, relevant, loosely_related
 - Finding duplicate implementations
 - Refactoring similar patterns together
 
-Provide at least 10 characters of code to match against. Results include a relevance category for each match.`
+Provide at least 24 characters of code to match against. Results include a relevance category for each match.
+
+Optional filters:
+- language: Filter by programming language (e.g., "typescript", "python")
+- pathHint: Filter by file path substring (e.g., "src/api", "components")
+
+Low-relevance results (not_relevant) are automatically pruned.`
   ),
   toMCPToolSchema(
     GetFilesContextSchema,

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -71,8 +71,10 @@ Find code similar to a given snippet.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `code` | string | Yes | - | Code snippet to find similar implementations |
+| `code` | string | Yes | - | Code snippet to find similar implementations (min 24 chars) |
 | `limit` | number | No | 5 | Maximum number of results to return |
+| `language` | string | No | - | Filter by programming language (e.g., "typescript", "python") |
+| `pathHint` | string | No | - | Filter by file path substring (e.g., "src/api", "components") |
 
 ### Usage
 
@@ -83,15 +85,42 @@ async function fetchUser(id: string) {
 }
 ```
 
+```
+Find similar TypeScript code in the API directory:
+find_similar({
+  code: "async function fetchUser(id: string) { ... }",
+  language: "typescript",
+  pathHint: "src/api"
+})
+```
+
 ### Response
 
 Similar format to `semantic_search`, returns semantically similar code chunks.
+
+When filters are applied or low-relevance results are pruned, the response includes:
+
+```json
+{
+  "filtersApplied": {
+    "language": "typescript",
+    "pathHint": "src/api",
+    "prunedLowRelevance": 3
+  }
+}
+```
+
+::: tip Automatic Pruning
+Low-relevance results (`not_relevant` category) are automatically removed to reduce noise. The `prunedLowRelevance` count shows how many were removed.
+:::
 
 ### Use Cases
 
 - **Refactoring**: Find all similar implementations to update together
 - **Consistency**: Ensure new code matches existing patterns
 - **Duplication Detection**: Locate duplicated logic across the codebase
+- **Language-Specific Search**: Focus on implementations in a specific language
+- **Directory-Scoped Search**: Find similar code within a specific area of the codebase
 
 ## get_files_context
 


### PR DESCRIPTION
- Increase minimum code snippet length to 24 chars
- Add optional language filter (case-insensitive)
- Add optional pathHint filter (substring match on file path)
- Automatically prune not_relevant results (score >= 1.5)
- Return filtersApplied metadata when filtering occurs
- Update tests and documentation

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->