### PR TITLE
test(mcp): add handler tests for semantic_search and get_dependents

### DIFF
--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -1,0 +1,536 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleGetDependents } from './get-dependents.js';
+import type { ToolContext } from '../types.js';
+import type { SearchResult } from '@liendev/core';
+import { QdrantDB } from '@liendev/core';
+
+// Mock the dependency-analyzer module
+vi.mock('./dependency-analyzer.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./dependency-analyzer.js')>();
+  return {
+    ...original,
+    findDependents: vi.fn(),
+  };
+});
+
+import { findDependents, calculateRiskLevel } from './dependency-analyzer.js';
+
+describe('handleGetDependents', () => {
+  const mockLog = vi.fn();
+  const mockCheckAndReconnect = vi.fn().mockResolvedValue(undefined);
+  const mockGetIndexMetadata = vi.fn(() => ({
+    indexVersion: 1234567890,
+    indexDate: '2025-12-19',
+  }));
+
+  const mockEmbeddings = {
+    embed: vi.fn(),
+  };
+
+  let mockVectorDB: {
+    scanWithFilter: ReturnType<typeof vi.fn>;
+    scanCrossRepo: ReturnType<typeof vi.fn>;
+  };
+
+  let mockCtx: ToolContext;
+
+  // Helper to create mock analysis result
+  function createMockAnalysis(overrides: {
+    dependents?: Array<{ filepath: string; isTestFile: boolean }>;
+    hitLimit?: boolean;
+    complexityMetrics?: {
+      averageComplexity: number;
+      maxComplexity: number;
+      filesWithComplexityData: number;
+      highComplexityDependents: Array<{ filepath: string; maxComplexity: number; avgComplexity: number }>;
+      complexityRiskBoost: 'low' | 'medium' | 'high' | 'critical';
+    };
+  } = {}) {
+    return {
+      dependents: overrides.dependents ?? [
+        { filepath: 'src/consumer.ts', isTestFile: false },
+      ],
+      chunksByFile: new Map(),
+      fileComplexities: [],
+      complexityMetrics: overrides.complexityMetrics ?? {
+        averageComplexity: 5,
+        maxComplexity: 8,
+        filesWithComplexityData: 1,
+        highComplexityDependents: [],
+        complexityRiskBoost: 'low' as const,
+      },
+      hitLimit: overrides.hitLimit ?? false,
+      allChunks: [] as SearchResult[],
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockVectorDB = {
+      scanWithFilter: vi.fn(),
+      scanCrossRepo: vi.fn(),
+    };
+
+    mockCtx = {
+      vectorDB: mockVectorDB as any,
+      embeddings: mockEmbeddings as any,
+      log: mockLog,
+      checkAndReconnect: mockCheckAndReconnect,
+      getIndexMetadata: mockGetIndexMetadata,
+      rootDir: '/fake/workspace',
+    };
+
+    // Default mock for findDependents
+    vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+  });
+
+  describe('basic functionality', () => {
+    it('should return dependents with indexInfo', async () => {
+      const mockAnalysis = createMockAnalysis({
+        dependents: [
+          { filepath: 'src/auth.ts', isTestFile: false },
+          { filepath: 'src/user.ts', isTestFile: false },
+        ],
+      });
+      vi.mocked(findDependents).mockResolvedValue(mockAnalysis);
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils/validate.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.filepath).toBe('src/utils/validate.ts');
+      expect(parsed.dependentCount).toBe(2);
+      expect(parsed.dependents).toHaveLength(2);
+      expect(parsed.indexInfo).toEqual({
+        indexVersion: 1234567890,
+        indexDate: '2025-12-19',
+      });
+    });
+
+    it('should call findDependents with correct parameters', async () => {
+      await handleGetDependents(
+        { filepath: 'src/utils/helpers.ts' },
+        mockCtx
+      );
+
+      expect(findDependents).toHaveBeenCalledWith(
+        mockVectorDB,
+        'src/utils/helpers.ts',
+        false, // crossRepo default
+        mockLog
+      );
+    });
+
+    it('should call checkAndReconnect before analysis', async () => {
+      await handleGetDependents(
+        { filepath: 'src/test.ts' },
+        mockCtx
+      );
+
+      expect(mockCheckAndReconnect).toHaveBeenCalled();
+    });
+
+    it('should handle no dependents gracefully', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        dependents: [],
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/isolated.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(0);
+      expect(parsed.dependents).toHaveLength(0);
+      expect(parsed.riskLevel).toBe('low');
+    });
+  });
+
+  describe('risk level calculation', () => {
+    it('should return low risk for few dependents', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        dependents: [
+          { filepath: 'src/a.ts', isTestFile: false },
+          { filepath: 'src/b.ts', isTestFile: false },
+        ],
+        complexityMetrics: {
+          averageComplexity: 3,
+          maxComplexity: 5,
+          filesWithComplexityData: 2,
+          highComplexityDependents: [],
+          complexityRiskBoost: 'low',
+        },
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.riskLevel).toBe('low');
+    });
+
+    it('should include complexity metrics in response', async () => {
+      const complexityMetrics = {
+        averageComplexity: 12,
+        maxComplexity: 25,
+        filesWithComplexityData: 5,
+        highComplexityDependents: [
+          { filepath: 'src/complex.ts', maxComplexity: 25, avgComplexity: 15 },
+        ],
+        complexityRiskBoost: 'high' as const,
+      };
+
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        dependents: Array(20).fill(null).map((_, i) => ({
+          filepath: `src/file${i}.ts`,
+          isTestFile: false,
+        })),
+        complexityMetrics,
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/core.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.complexityMetrics).toEqual(complexityMetrics);
+    });
+
+    it('should boost risk level when complexity is high', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        dependents: [
+          { filepath: 'src/a.ts', isTestFile: false },
+        ],
+        complexityMetrics: {
+          averageComplexity: 20,
+          maxComplexity: 30,
+          filesWithComplexityData: 1,
+          highComplexityDependents: [
+            { filepath: 'src/a.ts', maxComplexity: 30, avgComplexity: 20 },
+          ],
+          complexityRiskBoost: 'critical',
+        },
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      // Even with 1 dependent, complexity can boost the risk
+      expect(['high', 'critical']).toContain(parsed.riskLevel);
+    });
+  });
+
+  describe('hitLimit behavior', () => {
+    it('should include warning note when scan limit is reached', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        hitLimit: true,
+        dependents: Array(50).fill(null).map((_, i) => ({
+          filepath: `src/file${i}.ts`,
+          isTestFile: false,
+        })),
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/widely-used.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('Warning');
+      expect(parsed.note).toContain('10000');
+      expect(parsed.note).toContain('incomplete');
+    });
+
+    it('should not include note when scan limit is not reached', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        hitLimit: false,
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/normal.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toBeUndefined();
+    });
+  });
+
+  describe('cross-repo search with Qdrant', () => {
+    let mockQdrantDB: any;
+
+    beforeEach(() => {
+      // Create a mock that passes instanceof QdrantDB check
+      mockQdrantDB = {
+        scanWithFilter: vi.fn(),
+        scanCrossRepo: vi.fn(),
+      };
+      Object.setPrototypeOf(mockQdrantDB, QdrantDB.prototype);
+
+      mockCtx = {
+        vectorDB: mockQdrantDB,
+        embeddings: mockEmbeddings as any,
+        log: mockLog,
+        checkAndReconnect: mockCheckAndReconnect,
+        getIndexMetadata: mockGetIndexMetadata,
+        rootDir: '/fake/workspace',
+      };
+    });
+
+    it('should pass crossRepo=true to findDependents when enabled', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents(
+        { filepath: 'src/shared/utils.ts', crossRepo: true },
+        mockCtx
+      );
+
+      expect(findDependents).toHaveBeenCalledWith(
+        mockQdrantDB,
+        'src/shared/utils.ts',
+        true,
+        mockLog
+      );
+    });
+
+    it('should include groupedByRepo when crossRepo=true with Qdrant', async () => {
+      const mockChunks: SearchResult[] = [
+        {
+          content: 'import { util } from "./utils"',
+          metadata: {
+            file: 'repo-a/src/consumer.ts',
+            repoId: 'repo-a',
+            startLine: 1,
+            endLine: 5,
+            type: 'block',
+            language: 'typescript',
+          },
+          score: 0,
+          relevance: 'highly_relevant',
+        },
+        {
+          content: 'import { util } from "./utils"',
+          metadata: {
+            file: 'repo-b/src/other.ts',
+            repoId: 'repo-b',
+            startLine: 1,
+            endLine: 5,
+            type: 'block',
+            language: 'typescript',
+          },
+          score: 0,
+          relevance: 'highly_relevant',
+        },
+      ];
+
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({
+          dependents: [
+            { filepath: 'repo-a/src/consumer.ts', isTestFile: false },
+            { filepath: 'repo-b/src/other.ts', isTestFile: false },
+          ],
+        }),
+        allChunks: mockChunks,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'shared/utils.ts', crossRepo: true },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.groupedByRepo).toBeDefined();
+    });
+  });
+
+  describe('cross-repo fallback (non-Qdrant)', () => {
+    it('should not include groupedByRepo when not using Qdrant', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils.ts', crossRepo: true },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.groupedByRepo).toBeUndefined();
+    });
+
+    it('should still pass crossRepo to findDependents (which handles warning)', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents(
+        { filepath: 'src/utils.ts', crossRepo: true },
+        mockCtx
+      );
+
+      expect(findDependents).toHaveBeenCalledWith(
+        mockVectorDB,
+        'src/utils.ts',
+        true,
+        mockLog
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('should reject empty filepath', async () => {
+      const result = await handleGetDependents(
+        { filepath: '' },
+        mockCtx
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error).toBe('Invalid parameters');
+      expect(parsed.details).toContainEqual(
+        expect.objectContaining({
+          field: 'filepath',
+          message: expect.stringContaining('cannot be empty'),
+        })
+      );
+    });
+
+    it('should accept valid filepath', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents(
+        { filepath: 'src/valid/path.ts' },
+        mockCtx
+      );
+
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should use default depth of 1', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents(
+        { filepath: 'src/test.ts' },
+        mockCtx
+      );
+
+      // Should not error - depth defaults to 1
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('logging', () => {
+    it('should log the filepath being analyzed', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents(
+        { filepath: 'src/important.ts' },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        'Finding dependents of: src/important.ts'
+      );
+    });
+
+    it('should indicate cross-repo in log when enabled', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents(
+        { filepath: 'src/shared.ts', crossRepo: true },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        'Finding dependents of: src/shared.ts (cross-repo)'
+      );
+    });
+
+    it('should log dependent count and risk level', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        dependents: [
+          { filepath: 'src/a.ts', isTestFile: false },
+          { filepath: 'src/b.ts', isTestFile: false },
+          { filepath: 'src/c.ts', isTestFile: false },
+        ],
+      }));
+
+      await handleGetDependents(
+        { filepath: 'src/utils.ts' },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining('Found 3 dependent files')
+      );
+    });
+  });
+
+  describe('test file identification', () => {
+    it('should include isTestFile flag for each dependent', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({
+        dependents: [
+          { filepath: 'src/auth.ts', isTestFile: false },
+          { filepath: 'src/__tests__/auth.test.ts', isTestFile: true },
+        ],
+      }));
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependents).toContainEqual(
+        expect.objectContaining({ filepath: 'src/auth.ts', isTestFile: false })
+      );
+      expect(parsed.dependents).toContainEqual(
+        expect.objectContaining({ filepath: 'src/__tests__/auth.test.ts', isTestFile: true })
+      );
+    });
+  });
+});
+
+describe('calculateRiskLevel (unit tests)', () => {
+  it('should return low for 0 dependents', () => {
+    expect(calculateRiskLevel(0, 'low')).toBe('low');
+  });
+
+  it('should return low for 1-5 dependents with low complexity', () => {
+    expect(calculateRiskLevel(1, 'low')).toBe('low');
+    expect(calculateRiskLevel(5, 'low')).toBe('low');
+  });
+
+  it('should return medium for 6-15 dependents with low complexity', () => {
+    expect(calculateRiskLevel(6, 'low')).toBe('medium');
+    expect(calculateRiskLevel(15, 'low')).toBe('medium');
+  });
+
+  it('should return high for 16-30 dependents with low complexity', () => {
+    expect(calculateRiskLevel(16, 'low')).toBe('high');
+    expect(calculateRiskLevel(30, 'low')).toBe('high');
+  });
+
+  it('should return critical for 31+ dependents', () => {
+    expect(calculateRiskLevel(31, 'low')).toBe('critical');
+    expect(calculateRiskLevel(100, 'low')).toBe('critical');
+  });
+
+  it('should boost risk level when complexity is higher', () => {
+    // Low dependent count but high complexity should boost to high
+    expect(calculateRiskLevel(2, 'high')).toBe('high');
+    expect(calculateRiskLevel(2, 'critical')).toBe('critical');
+  });
+
+  it('should not downgrade risk level from complexity', () => {
+    // High dependent count should not be reduced by low complexity
+    expect(calculateRiskLevel(50, 'low')).toBe('critical');
+  });
+});
+

--- a/packages/cli/src/mcp/handlers/semantic-search.test.ts
+++ b/packages/cli/src/mcp/handlers/semantic-search.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleSemanticSearch } from './semantic-search.js';
+import type { ToolContext } from '../types.js';
+import type { SearchResult } from '@liendev/core';
+import { QdrantDB } from '@liendev/core';
+
+describe('handleSemanticSearch', () => {
+  const mockLog = vi.fn();
+  const mockCheckAndReconnect = vi.fn().mockResolvedValue(undefined);
+  const mockGetIndexMetadata = vi.fn(() => ({
+    indexVersion: 1234567890,
+    indexDate: '2025-12-19',
+  }));
+
+  const mockEmbeddings = {
+    embed: vi.fn().mockResolvedValue(new Float32Array([0.1, 0.2, 0.3])),
+  };
+
+  // Default metadata for mock results
+  const defaultMetadata = {
+    file: 'src/example.ts',
+    startLine: 1,
+    endLine: 10,
+    type: 'function' as const,
+    language: 'typescript',
+    symbolName: 'example',
+    symbolType: 'function' as const,
+  };
+
+  // Helper to create mock search results
+  function createMockResult(overrides: {
+    content?: string;
+    metadata?: Partial<typeof defaultMetadata & { repoId?: string }>;
+    score?: number;
+    relevance?: 'highly_relevant' | 'relevant' | 'loosely_related' | 'not_relevant';
+  } = {}): SearchResult {
+    return {
+      content: overrides.content ?? 'function example() { return true; }',
+      metadata: {
+        ...defaultMetadata,
+        ...overrides.metadata,
+      },
+      score: overrides.score ?? 0.5,
+      relevance: overrides.relevance ?? 'highly_relevant',
+    };
+  }
+
+  let mockVectorDB: {
+    search: ReturnType<typeof vi.fn>;
+    searchCrossRepo: ReturnType<typeof vi.fn>;
+  };
+
+  let mockCtx: ToolContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockVectorDB = {
+      search: vi.fn(),
+      searchCrossRepo: vi.fn(),
+    };
+
+    mockCtx = {
+      vectorDB: mockVectorDB as any,
+      embeddings: mockEmbeddings as any,
+      log: mockLog,
+      checkAndReconnect: mockCheckAndReconnect,
+      getIndexMetadata: mockGetIndexMetadata,
+      rootDir: '/fake/workspace',
+    };
+  });
+
+  describe('basic search', () => {
+    it('should return search results with indexInfo', async () => {
+      const mockResults = [
+        createMockResult({ content: 'function handleAuth() {}' }),
+        createMockResult({ content: 'function validateUser() {}' }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleSemanticSearch(
+        { query: 'handles user authentication' },
+        mockCtx
+      );
+
+      expect(mockVectorDB.search).toHaveBeenCalled();
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.indexInfo).toEqual({
+        indexVersion: 1234567890,
+        indexDate: '2025-12-19',
+      });
+    });
+
+    it('should respect limit parameter', async () => {
+      const mockResults = [
+        createMockResult({ content: 'result 1' }),
+        createMockResult({ content: 'result 2' }),
+        createMockResult({ content: 'result 3' }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      await handleSemanticSearch(
+        { query: 'test query here', limit: 10 },
+        mockCtx
+      );
+
+      // Verify limit was passed to search
+      expect(mockVectorDB.search).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        10,
+        'test query here'
+      );
+    });
+
+    it('should use default limit of 5 when not specified', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      await handleSemanticSearch(
+        { query: 'test query here' },
+        mockCtx
+      );
+
+      expect(mockVectorDB.search).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        5,
+        'test query here'
+      );
+    });
+
+    it('should call checkAndReconnect before searching', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      await handleSemanticSearch(
+        { query: 'test query here' },
+        mockCtx
+      );
+
+      expect(mockCheckAndReconnect).toHaveBeenCalled();
+    });
+
+    it('should embed the query before searching', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      await handleSemanticSearch(
+        { query: 'handles authentication' },
+        mockCtx
+      );
+
+      expect(mockEmbeddings.embed).toHaveBeenCalledWith('handles authentication');
+    });
+
+    it('should handle empty results gracefully', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      const result = await handleSemanticSearch(
+        { query: 'nonexistent feature' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.indexInfo).toBeDefined();
+    });
+  });
+
+  describe('cross-repo search with Qdrant', () => {
+    // Create a mock that passes instanceof QdrantDB check
+    let mockQdrantDB: any;
+
+    beforeEach(() => {
+      // Create a mock object and set its prototype to QdrantDB.prototype
+      mockQdrantDB = {
+        search: vi.fn(),
+        searchCrossRepo: vi.fn(),
+      };
+      Object.setPrototypeOf(mockQdrantDB, QdrantDB.prototype);
+
+      mockCtx = {
+        vectorDB: mockQdrantDB,
+        embeddings: mockEmbeddings as any,
+        log: mockLog,
+        checkAndReconnect: mockCheckAndReconnect,
+        getIndexMetadata: mockGetIndexMetadata,
+        rootDir: '/fake/workspace',
+      };
+    });
+
+    it('should use searchCrossRepo when crossRepo=true and using Qdrant', async () => {
+      const mockResults = [
+        createMockResult({ metadata: { repoId: 'repo-a' } }),
+        createMockResult({ metadata: { repoId: 'repo-b' } }),
+      ];
+      mockQdrantDB.searchCrossRepo.mockResolvedValue(mockResults);
+
+      const result = await handleSemanticSearch(
+        { query: 'cross repo search', crossRepo: true },
+        mockCtx
+      );
+
+      expect(mockQdrantDB.searchCrossRepo).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        5,
+        { repoIds: undefined }
+      );
+      expect(mockQdrantDB.search).not.toHaveBeenCalled();
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.groupedByRepo).toBeDefined();
+    });
+
+    it('should group results by repository when crossRepo=true', async () => {
+      const mockResults = [
+        createMockResult({ content: 'result 1', metadata: { repoId: 'repo-a' } }),
+        createMockResult({ content: 'result 2', metadata: { repoId: 'repo-a' } }),
+        createMockResult({ content: 'result 3', metadata: { repoId: 'repo-b' } }),
+      ];
+      mockQdrantDB.searchCrossRepo.mockResolvedValue(mockResults);
+
+      const result = await handleSemanticSearch(
+        { query: 'test cross repo', crossRepo: true },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.groupedByRepo).toBeDefined();
+      expect(parsed.groupedByRepo['repo-a']).toHaveLength(2);
+      expect(parsed.groupedByRepo['repo-b']).toHaveLength(1);
+    });
+
+    it('should filter by repoIds when provided', async () => {
+      mockQdrantDB.searchCrossRepo.mockResolvedValue([]);
+
+      await handleSemanticSearch(
+        { query: 'filtered search', crossRepo: true, repoIds: ['repo-a', 'repo-c'] },
+        mockCtx
+      );
+
+      expect(mockQdrantDB.searchCrossRepo).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        5,
+        { repoIds: ['repo-a', 'repo-c'] }
+      );
+    });
+  });
+
+  describe('cross-repo fallback (non-Qdrant)', () => {
+    it('should fall back to single-repo search when crossRepo=true but not using Qdrant', async () => {
+      const mockResults = [createMockResult()];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleSemanticSearch(
+        { query: 'test fallback query', crossRepo: true },
+        mockCtx
+      );
+
+      // Should log a warning
+      expect(mockLog).toHaveBeenCalledWith(
+        'Warning: crossRepo=true requires Qdrant backend. Falling back to single-repo search.'
+      );
+
+      // Should use regular search, not searchCrossRepo
+      expect(mockVectorDB.search).toHaveBeenCalled();
+      expect(mockVectorDB.searchCrossRepo).not.toHaveBeenCalled();
+
+      // Should not include groupedByRepo in response
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.groupedByRepo).toBeUndefined();
+    });
+
+    it('should still return results when falling back', async () => {
+      const mockResults = [
+        createMockResult({ content: 'fallback result 1' }),
+        createMockResult({ content: 'fallback result 2' }),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleSemanticSearch(
+        { query: 'test fallback results', crossRepo: true },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.indexInfo).toBeDefined();
+    });
+  });
+
+  describe('validation', () => {
+    it('should reject queries shorter than 3 characters', async () => {
+      const result = await handleSemanticSearch(
+        { query: 'ab' },
+        mockCtx
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error).toBe('Invalid parameters');
+      expect(parsed.details).toContainEqual(
+        expect.objectContaining({
+          field: 'query',
+          message: expect.stringContaining('at least 3 characters'),
+        })
+      );
+    });
+
+    it('should reject empty query', async () => {
+      const result = await handleSemanticSearch(
+        { query: '' },
+        mockCtx
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error).toBe('Invalid parameters');
+    });
+
+    it('should reject limit below 1', async () => {
+      const result = await handleSemanticSearch(
+        { query: 'valid query', limit: 0 },
+        mockCtx
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.details).toContainEqual(
+        expect.objectContaining({
+          field: 'limit',
+          message: expect.stringContaining('at least 1'),
+        })
+      );
+    });
+
+    it('should reject limit above 50', async () => {
+      const result = await handleSemanticSearch(
+        { query: 'valid query', limit: 100 },
+        mockCtx
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.details).toContainEqual(
+        expect.objectContaining({
+          field: 'limit',
+          message: expect.stringContaining('cannot exceed 50'),
+        })
+      );
+    });
+
+    it('should accept valid parameters at boundary values', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      // Test minimum valid query (3 chars)
+      const result1 = await handleSemanticSearch(
+        { query: 'abc' },
+        mockCtx
+      );
+      expect(result1.isError).toBeUndefined();
+
+      // Test maximum valid limit (50)
+      const result2 = await handleSemanticSearch(
+        { query: 'valid query', limit: 50 },
+        mockCtx
+      );
+      expect(result2.isError).toBeUndefined();
+    });
+  });
+
+  describe('logging', () => {
+    it('should log search query', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      await handleSemanticSearch(
+        { query: 'authentication handler' },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        'Searching for: "authentication handler"'
+      );
+    });
+
+    it('should indicate cross-repo in log when enabled', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+
+      await handleSemanticSearch(
+        { query: 'cross repo test', crossRepo: true },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        'Searching for: "cross repo test" (cross-repo)'
+      );
+    });
+
+    it('should log result count', async () => {
+      const mockResults = [
+        createMockResult(),
+        createMockResult(),
+        createMockResult(),
+      ];
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      await handleSemanticSearch(
+        { query: 'test query here' },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith('Found 3 results');
+    });
+  });
+});
+


### PR DESCRIPTION
- Add semantic-search.test.ts with 19 tests covering:
  - Basic search with indexInfo response
  - Limit parameter handling
  - Cross-repo search with Qdrant (groupedByRepo)
  - Cross-repo fallback with warning for non-Qdrant
  - Schema validation (query length, limit bounds)
  - Logging behavior

- Add get-dependents.test.ts with 27 tests covering:
  - Basic functionality with risk levels
  - Complexity metrics in response
  - hitLimit propagation with warning note
  - Cross-repo search with Qdrant
  - Cross-repo fallback for non-Qdrant
  - Schema validation (empty filepath)
  - Test file identification
  - Unit tests for calculateRiskLevel function

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->