### PR TITLE
feat(mcp): add warning notes for cross-repo fallback and scan limits

### DIFF
--- a/.changeset/strict-pugs-fetch.md
+++ b/.changeset/strict-pugs-fetch.md
@@ -1,0 +1,5 @@
+---
+"@liendev/lien": minor
+---
+
+Add warning notes to MCP tool responses for cross-repo fallback and scan limit scenarios

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -2,11 +2,33 @@ import collect from 'collect.js';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetComplexitySchema } from '../schemas/index.js';
 import { ComplexityAnalyzer, QdrantDB } from '@liendev/core';
-import type { ComplexityViolation, FileComplexityData } from '@liendev/core';
-import type { ToolContext, MCPToolResult } from '../types.js';
+import type { ComplexityViolation, FileComplexityData, ComplexityReport, VectorDBInterface } from '@liendev/core';
+import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ChunkWithRepo = { metadata: { file: string; repoId?: string } };
+type TransformedViolation = ReturnType<typeof transformViolation>;
+
+interface CrossRepoResult {
+  chunks: ChunkWithRepo[];
+  fallback: boolean;
+}
+
+interface ProcessedViolations {
+  violations: TransformedViolation[];
+  topViolations: TransformedViolation[];
+  bySeverity: { error: number; warning: number };
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
 
 /**
- * Transform a violation with file-level metadata for API response
+ * Transform a violation with file-level metadata for API response.
  */
 function transformViolation(v: ComplexityViolation, fileData: FileComplexityData) {
   return {
@@ -28,26 +50,20 @@ function transformViolation(v: ComplexityViolation, fileData: FileComplexityData
 }
 
 /**
- * Handle get_complexity tool calls.
- * Analyzes complexity for files or the entire codebase.
- */
-/**
  * Group complexity violations by repository ID.
  */
 function groupViolationsByRepo(
-  violations: Array<{ filepath: string; [key: string]: any }>,
-  allChunks: Array<{ metadata: { file: string; repoId?: string } }>
-): Record<string, typeof violations> {
+  violations: TransformedViolation[],
+  allChunks: ChunkWithRepo[]
+): Record<string, TransformedViolation[]> {
   const fileToRepo = new Map<string, string>();
   
-  // Build map of filepath -> repoId
   for (const chunk of allChunks) {
     const repoId = chunk.metadata.repoId || 'unknown';
     fileToRepo.set(chunk.metadata.file, repoId);
   }
   
-  // Group violations by repo
-  const grouped: Record<string, typeof violations> = {};
+  const grouped: Record<string, TransformedViolation[]> = {};
   for (const violation of violations) {
     const repoId = fileToRepo.get(violation.filepath) || 'unknown';
     if (!grouped[repoId]) {
@@ -59,6 +75,78 @@ function groupViolationsByRepo(
   return grouped;
 }
 
+/**
+ * Fetch chunks for cross-repo analysis.
+ * Returns fallback=true if cross-repo was requested but Qdrant unavailable.
+ */
+async function fetchCrossRepoChunks(
+  vectorDB: VectorDBInterface,
+  crossRepo: boolean | undefined,
+  repoIds: string[] | undefined,
+  log: LogFn
+): Promise<CrossRepoResult> {
+  if (!crossRepo) {
+    return { chunks: [], fallback: false };
+  }
+  
+  if (vectorDB instanceof QdrantDB) {
+    const chunks = await vectorDB.scanCrossRepo({ limit: 100000, repoIds });
+    log(`Scanned ${chunks.length} chunks across repos`);
+    return { chunks, fallback: false };
+  }
+  
+  return { chunks: [], fallback: true };
+}
+
+/**
+ * Process violations from complexity report.
+ * Transforms, filters, and sorts violations.
+ */
+function processViolations(
+  report: ComplexityReport,
+  threshold: number | undefined,
+  top: number
+): ProcessedViolations {
+  const allViolations: TransformedViolation[] = collect(Object.entries(report.files))
+    .flatMap(([/* filepath unused */, fileData]) => 
+      fileData.violations.map(v => transformViolation(v, fileData))
+    )
+    .sortByDesc('complexity')
+    .all() as unknown as TransformedViolation[];
+
+  const violations = threshold !== undefined
+    ? allViolations.filter(v => v.complexity >= threshold)
+    : allViolations;
+
+  const severityCounts = collect(violations).countBy('severity').all() as { error?: number; warning?: number };
+
+  return {
+    violations,
+    topViolations: violations.slice(0, top),
+    bySeverity: {
+      error: severityCounts['error'] || 0,
+      warning: severityCounts['warning'] || 0,
+    },
+  };
+}
+
+/**
+ * Build warning note for cross-repo fallback.
+ */
+function buildCrossRepoFallbackNote(fallback: boolean): string | undefined {
+  return fallback
+    ? 'Cross-repo analysis requires Qdrant backend. Fell back to single-repo analysis.'
+    : undefined;
+}
+
+// ============================================================================
+// Main Handler
+// ============================================================================
+
+/**
+ * Handle get_complexity tool calls.
+ * Analyzes complexity for files or the entire codebase.
+ */
 export async function handleGetComplexity(
   args: unknown,
   ctx: ToolContext
@@ -72,48 +160,27 @@ export async function handleGetComplexity(
       log(`Analyzing complexity${crossRepo ? ' (cross-repo)' : ''}...`);
       await checkAndReconnect();
 
-      // For cross-repo, we need to use scanCrossRepo to get all chunks
-      // then pass them to ComplexityAnalyzer
-      let allChunks: Array<{ metadata: { file: string; repoId?: string } }> = [];
-      let crossRepoFallback = false;
-      
-      if (crossRepo && vectorDB instanceof QdrantDB) {
-        // Get all chunks across repos for cross-repo analysis
-        allChunks = await vectorDB.scanCrossRepo({ 
-          limit: 100000,
-          repoIds 
-        });
-        log(`Scanned ${allChunks.length} chunks across repos`);
-      } else if (crossRepo) {
-        // Track fallback for note in response
-        crossRepoFallback = true;
-      }
+      // Step 1: Fetch cross-repo chunks if needed
+      const { chunks: allChunks, fallback } = await fetchCrossRepoChunks(
+        vectorDB,
+        crossRepo,
+        repoIds,
+        log
+      );
 
+      // Step 2: Run complexity analysis
       const analyzer = new ComplexityAnalyzer(vectorDB);
-      
-      // Pass cross-repo parameters to analyzer
-      const report = await analyzer.analyze(files, crossRepo && vectorDB instanceof QdrantDB ? crossRepo : false, repoIds);
+      const report = await analyzer.analyze(files, crossRepo && !fallback, repoIds);
       log(`Analyzed ${report.summary.filesAnalyzed} files`);
 
-      // Transform violations using collect.js
-      type TransformedViolation = ReturnType<typeof transformViolation>;
-      const allViolations: TransformedViolation[] = collect(Object.entries(report.files))
-        .flatMap(([/* filepath unused */, fileData]) => 
-          fileData.violations.map(v => transformViolation(v, fileData))
-        )
-        .sortByDesc('complexity')
-        .all() as unknown as TransformedViolation[];
+      // Step 3: Process violations
+      const { violations, topViolations, bySeverity } = processViolations(
+        report,
+        threshold,
+        top ?? 10
+      );
 
-      // Apply custom threshold filter if provided
-      const violations = threshold !== undefined
-        ? allViolations.filter(v => v.complexity >= threshold)
-        : allViolations;
-
-      const topViolations = violations.slice(0, top);
-
-      // Calculate severity counts - countBy returns { error?: number, warning?: number }
-      const bySeverity = collect(violations).countBy('severity').all() as { error?: number; warning?: number };
-
+      // Step 4: Build response
       const response: any = {
         indexInfo: getIndexMetadata(),
         summary: {
@@ -121,23 +188,21 @@ export async function handleGetComplexity(
           avgComplexity: report.summary.avgComplexity,
           maxComplexity: report.summary.maxComplexity,
           violationCount: violations.length,
-          bySeverity: {
-            error: bySeverity['error'] || 0,
-            warning: bySeverity['warning'] || 0,
-          },
+          bySeverity,
         },
         violations: topViolations,
       };
 
-      // Group by repo if cross-repo search
-      if (crossRepo && vectorDB instanceof QdrantDB && allChunks.length > 0) {
+      // Add cross-repo grouping if applicable
+      if (crossRepo && !fallback && allChunks.length > 0) {
         response.groupedByRepo = groupViolationsByRepo(topViolations, allChunks);
       }
       
-      // Add note for cross-repo fallback
-      if (crossRepoFallback) {
+      // Add fallback note if applicable
+      const note = buildCrossRepoFallbackNote(fallback);
+      if (note) {
         log('Warning: crossRepo=true requires Qdrant backend. Falling back to single-repo analysis.', 'warning');
-        response.note = 'Cross-repo analysis requires Qdrant backend. Fell back to single-repo analysis.';
+        response.note = note;
       }
 
       return response;

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -246,8 +246,8 @@ describe('handleGetDependents', () => {
       );
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.note).toContain('Warning');
-      expect(parsed.note).toContain('10000');
+      expect(parsed.note).toContain('10,000');
+      expect(parsed.note).toContain('limit reached');
       expect(parsed.note).toContain('incomplete');
     });
 

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -39,6 +39,17 @@ export async function handleGetDependents(
         })`
       );
 
+      // Build note(s) for warnings
+      const notes: string[] = [];
+      const crossRepoFallback = crossRepo && !(vectorDB instanceof QdrantDB);
+      
+      if (crossRepoFallback) {
+        notes.push('Cross-repo search requires Qdrant backend. Fell back to single-repo search.');
+      }
+      if (analysis.hitLimit) {
+        notes.push('Scanned 10,000 chunks (limit reached). Results may be incomplete.');
+      }
+
       const response: any = {
         indexInfo: getIndexMetadata(),
         filepath: validatedArgs.filepath,
@@ -46,9 +57,7 @@ export async function handleGetDependents(
         riskLevel,
         dependents: analysis.dependents,
         complexityMetrics: analysis.complexityMetrics,
-        note: analysis.hitLimit
-          ? `Warning: Scanned 10000 chunks (limit reached). Results may be incomplete.`
-          : undefined,
+        ...(notes.length > 0 && { note: notes.join(' ') }),
       };
 
       // Group by repo if cross-repo search

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -275,6 +275,54 @@ export function buildFilesData(
   return filesData;
 }
 
+/**
+ * Build warning note when scan limit is reached.
+ */
+function buildScanLimitNote(hitScanLimit: boolean): string | undefined {
+  return hitScanLimit
+    ? 'Scanned 10,000 chunks (limit reached). Test associations may be incomplete for large codebases.'
+    : undefined;
+}
+
+/** Index metadata shape from context */
+interface IndexInfo {
+  indexVersion: number;
+  indexDate: string;
+}
+
+/**
+ * Build response for single file request.
+ */
+function buildSingleFileResponse(
+  filepath: string,
+  filesData: Record<string, FileData>,
+  indexInfo: IndexInfo,
+  note?: string
+) {
+  return {
+    indexInfo,
+    file: filepath,
+    chunks: filesData[filepath].chunks,
+    testAssociations: filesData[filepath].testAssociations,
+    ...(note && { note }),
+  };
+}
+
+/**
+ * Build response for multiple files request.
+ */
+function buildMultiFileResponse(
+  filesData: Record<string, FileData>,
+  indexInfo: IndexInfo,
+  note?: string
+) {
+  return {
+    indexInfo,
+    files: filesData,
+    ...(note && { note }),
+  };
+}
+
 // ============================================================================
 // Main Handler
 // ============================================================================
@@ -368,30 +416,13 @@ export async function handleGetFilesContext(
       );
       log(`Found ${totalChunks} total chunks`);
 
-      // Build note if scan limit was hit
-      const note = hitScanLimit
-        ? 'Scanned 10,000 chunks (limit reached). Test associations may be incomplete for large codebases.'
-        : undefined;
-
-      // Step 5: Return appropriate response format
-      if (isSingleFile) {
-        // Single file: return backward-compatible format
-        const filepath = filepaths[0];
-        return {
-          indexInfo: getIndexMetadata(),
-          file: filepath,
-          chunks: filesData[filepath].chunks,
-          testAssociations: filesData[filepath].testAssociations,
-          ...(note && { note }),
-        };
-      } else {
-        // Multiple files: return keyed structure
-        return {
-          indexInfo: getIndexMetadata(),
-          files: filesData,
-          ...(note && { note }),
-        };
-      }
+      // Step 5: Build and return response
+      const note = buildScanLimitNote(hitScanLimit);
+      const indexInfo = getIndexMetadata();
+      
+      return isSingleFile
+        ? buildSingleFileResponse(filepaths[0], filesData, indexInfo, note)
+        : buildMultiFileResponse(filesData, indexInfo, note);
     }
   )(args);
 }

--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -62,6 +62,8 @@ export interface IndexMetadata {
 export interface SearchResultResponse {
   indexInfo: IndexMetadata;
   results: SearchResult[];
+  /** Warning note when cross-repo fallback occurs or other issues */
+  note?: string;
 }
 
 /**
@@ -84,6 +86,8 @@ export interface FilesContextMultiResponse {
     chunks: SearchResult[];
     testAssociations: string[];
   }>;
+  /** Warning note when scan limit reached or other issues */
+  note?: string;
 }
 
 /**


### PR DESCRIPTION
## Add warning notes to MCP tool responses

Surfaces warnings in tool responses so AI assistants can communicate limitations to users:
Cross-repo fallback: When crossRepo=true but Qdrant backend isn't available, adds note explaining the fallback to single-repo search
Scan limits: When scan limit is reached (10k/100k chunks), adds note that results may be incomplete
Affected tools: semantic_search, get_complexity, get_dependents, get_files_context

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Improved!** This PR reduces complexity by 162.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->