### PR TITLE
feat(mcp): add test/production split to get_dependents

### DIFF
--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -31,12 +31,11 @@ export async function handleGetDependents(
 
       const riskLevel = calculateRiskLevel(
         analysis.dependents.length,
-        analysis.complexityMetrics.complexityRiskBoost
+        analysis.complexityMetrics.complexityRiskBoost,
+        analysis.productionDependentCount
       );
       log(
-        `Found ${analysis.dependents.length} dependent files (risk: ${riskLevel}${
-          analysis.complexityMetrics.filesWithComplexityData > 0 ? ', complexity-boosted' : ''
-        })`
+        `Found ${analysis.dependents.length} dependents (${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
       );
 
       // Build note(s) for warnings
@@ -54,6 +53,8 @@ export async function handleGetDependents(
         indexInfo: getIndexMetadata(),
         filepath: validatedArgs.filepath,
         dependentCount: analysis.dependents.length,
+        productionDependentCount: analysis.productionDependentCount,
+        testDependentCount: analysis.testDependentCount,
         riskLevel,
         dependents: analysis.dependents,
         complexityMetrics: analysis.complexityMetrics,


### PR DESCRIPTION
- Add productionDependentCount and testDependentCount to response
- Calculate risk level based on production dependents only
- Update log message to show prod/test breakdown
- Add comprehensive tests for new functionality

This prevents inflated risk levels when most dependents are test files. A file with 1 production dependent and 10 test dependents now correctly shows 'low' risk instead of 'medium'.

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +14 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->