### PR TITLE
feat(mcp): add symbol-level usage tracking to get_dependents

### DIFF
--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -592,13 +592,39 @@ function extractSymbolUsagesFromChunks(chunks: SearchResult[], targetSymbol: str
 
 /**
  * Extract a code snippet for a call site with bounds checking.
+ * If the target line is blank, searches nearby lines for context.
  */
 function extractSnippet(lines: string[], callLine: number, startLine: number, symbolName: string): string {
   const lineIndex = callLine - startLine;
+  const placeholder = `${symbolName}(...)`;
   
-  if (lineIndex >= 0 && lineIndex < lines.length) {
-    return lines[lineIndex].trim() || `${symbolName}(...)`;
+  if (lineIndex < 0 || lineIndex >= lines.length) {
+    return placeholder;
   }
-  return `${symbolName}(...)`;
+  
+  // Try the direct line first
+  const directLine = lines[lineIndex].trim();
+  if (directLine) {
+    return directLine;
+  }
+  
+  // If direct line is blank, search for nearby non-blank context
+  // Search backwards first (prefer earlier lines)
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    const candidate = lines[i].trim();
+    if (candidate) {
+      return candidate;
+    }
+  }
+  
+  // Search forwards
+  for (let i = lineIndex + 1; i < lines.length; i++) {
+    const candidate = lines[i].trim();
+    if (candidate) {
+      return candidate;
+    }
+  }
+  
+  return placeholder;
 }
 

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -528,8 +528,10 @@ function fileImportsSymbol(
         // Direct symbol import
         if (symbols.includes(targetSymbol)) return true;
         // Namespace import (e.g., * as utils) - grants access to all exports
-        // Note: Call sites will show as the property name, which may not match
-        // the import alias (e.g., utils.foo() tracked as 'foo')
+        // Note: Call sites are tracked as the property name (e.g., utils.foo() → 'foo'),
+        // so namespace imports will correctly match when the call site uses the symbol.
+        // This could produce false positives if another symbol with the same name exists
+        // from a different module, but in practice this is rare.
         if (symbols.some(s => s.startsWith('* as '))) return true;
       }
     }

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -613,8 +613,11 @@ function extractSnippet(lines: string[], callLine: number, startLine: number, sy
   }
   
   // If direct line is blank, search for nearby non-blank context
+  // Limit search radius to 5 lines to ensure contextual relevance
+  const searchRadius = 5;
+  
   // Search backwards first (prefer earlier lines)
-  for (let i = lineIndex - 1; i >= 0; i--) {
+  for (let i = lineIndex - 1; i >= Math.max(0, lineIndex - searchRadius); i--) {
     const candidate = lines[i].trim();
     if (candidate) {
       return candidate;
@@ -622,7 +625,7 @@ function extractSnippet(lines: string[], callLine: number, startLine: number, sy
   }
   
   // Search forwards
-  for (let i = lineIndex + 1; i < lines.length; i++) {
+  for (let i = lineIndex + 1; i < Math.min(lines.length, lineIndex + searchRadius + 1); i++) {
     const candidate = lines[i].trim();
     if (candidate) {
       return candidate;

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -181,6 +181,19 @@ function buildDependentsList(
 /**
  * Validate that a symbol is exported from the target file.
  */
+/**
+ * Validate that the target file exports the requested symbol.
+ * 
+ * Design decision: This function only logs a warning and does NOT throw an error
+ * or return false to stop execution. This is intentional because:
+ * 
+ * 1. The export might be dynamic or conditional (not captured by static analysis)
+ * 2. False positives are better than false negatives (we want to show potential matches)
+ * 3. The user can see the warning and interpret results accordingly
+ * 
+ * The function continues to search for usages even if the symbol isn't found in exports,
+ * which may reveal re-exports, dynamic exports, or help diagnose indexing issues.
+ */
 function validateSymbolExport(
   allChunks: SearchResult[],
   normalizedTarget: string,

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -238,6 +238,12 @@ export async function findDependents(
     chunksByFile, symbol, normalizedTarget, normalizePathCached, allChunks, filepath, log
   );
 
+  // Sort dependents: production files first, then test files
+  dependents.sort((a, b) => {
+    if (a.isTestFile === b.isTestFile) return 0;
+    return a.isTestFile ? 1 : -1;
+  });
+
   // Calculate test/production split
   const testDependentCount = dependents.filter(f => f.isTestFile).length;
   const productionDependentCount = dependents.length - testDependentCount;

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -179,9 +179,6 @@ function buildDependentsList(
 }
 
 /**
- * Validate that a symbol is exported from the target file.
- */
-/**
  * Validate that the target file exports the requested symbol.
  * 
  * Design decision: This function only logs a warning and does NOT throw an error

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -556,6 +556,8 @@ function fileImportsSymbol(
         // so namespace imports will correctly match when the call site uses the symbol.
         // This could produce false positives if another symbol with the same name exists
         // from a different module, but in practice this is rare.
+        // TODO: Track namespace aliases at call sites (e.g., 'utils.foo' instead of just 'foo')
+        //       to enable more precise matching and further reduce these false positives.
         if (symbols.some(s => s.startsWith('* as '))) return true;
       }
     }
@@ -599,6 +601,8 @@ function extractSnippet(lines: string[], callLine: number, startLine: number, sy
   const placeholder = `${symbolName}(...)`;
   
   if (lineIndex < 0 || lineIndex >= lines.length) {
+    // This can happen when call site line is outside chunk boundaries (edge case)
+    // Not necessarily an error - could be chunk boundary misalignment
     return placeholder;
   }
   

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -547,12 +547,15 @@ function extractSymbolUsagesFromChunks(chunks: SearchResult[], targetSymbol: str
     const callSites = chunk.metadata.callSites;
     if (!callSites) continue;
     
+    // Split content once per chunk for efficiency (avoid repeated splits)
+    const lines = chunk.content.split('\n');
+    
     for (const call of callSites) {
       if (call.symbol === targetSymbol) {
         usages.push({
           callerSymbol: chunk.metadata.symbolName || 'unknown',
           line: call.line,
-          snippet: extractSnippet(chunk, call.line, targetSymbol),
+          snippet: extractSnippet(lines, call.line, chunk.metadata.startLine, targetSymbol),
         });
       }
     }
@@ -564,9 +567,8 @@ function extractSymbolUsagesFromChunks(chunks: SearchResult[], targetSymbol: str
 /**
  * Extract a code snippet for a call site with bounds checking.
  */
-function extractSnippet(chunk: SearchResult, callLine: number, symbolName: string): string {
-  const lines = chunk.content.split('\n');
-  const lineIndex = callLine - chunk.metadata.startLine;
+function extractSnippet(lines: string[], callLine: number, startLine: number, symbolName: string): string {
+  const lineIndex = callLine - startLine;
   
   if (lineIndex >= 0 && lineIndex < lines.length) {
     return lines[lineIndex].trim() || `${symbolName}(...)`;

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -722,7 +722,7 @@ describe('handleGetDependents', () => {
       );
 
       expect(mockLog).toHaveBeenCalledWith(
-        expect.stringContaining("Found 5 usages of 'myFunction' across 2 files")
+        expect.stringContaining("Found 5 tracked call sites across 2 files")
       );
     });
 

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -36,7 +36,11 @@ describe('handleGetDependents', () => {
 
   // Helper to create mock analysis result
   function createMockAnalysis(overrides: {
-    dependents?: Array<{ filepath: string; isTestFile: boolean }>;
+    dependents?: Array<{
+      filepath: string;
+      isTestFile: boolean;
+      usages?: Array<{ callerSymbol: string; line: number; snippet: string }>;
+    }>;
     hitLimit?: boolean;
     complexityMetrics?: {
       averageComplexity: number;
@@ -45,6 +49,7 @@ describe('handleGetDependents', () => {
       highComplexityDependents: Array<{ filepath: string; maxComplexity: number; avgComplexity: number }>;
       complexityRiskBoost: 'low' | 'medium' | 'high' | 'critical';
     };
+    totalUsageCount?: number;
   } = {}) {
     const dependents = overrides.dependents ?? [
       { filepath: 'src/consumer.ts', isTestFile: false },
@@ -67,6 +72,7 @@ describe('handleGetDependents', () => {
       },
       hitLimit: overrides.hitLimit ?? false,
       allChunks: [] as SearchResult[],
+      totalUsageCount: overrides.totalUsageCount,
     };
   }
 
@@ -126,7 +132,8 @@ describe('handleGetDependents', () => {
         mockVectorDB,
         'src/utils/helpers.ts',
         false, // crossRepo default
-        mockLog
+        mockLog,
+        undefined // symbol default
       );
     });
 
@@ -305,7 +312,8 @@ describe('handleGetDependents', () => {
         mockQdrantDB,
         'src/shared/utils.ts',
         true,
-        mockLog
+        mockLog,
+        undefined
       );
     });
 
@@ -384,7 +392,8 @@ describe('handleGetDependents', () => {
         mockVectorDB,
         'src/utils.ts',
         true,
-        mockLog
+        mockLog,
+        undefined
       );
     });
   });
@@ -595,6 +604,152 @@ describe('handleGetDependents', () => {
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.productionDependentCount).toBe(1);
       expect(parsed.riskLevel).toBe('critical');
+    });
+  });
+
+  describe('symbol-level usage tracking', () => {
+    it('should pass symbol parameter to findDependents', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents(
+        { filepath: 'src/utils/validate.ts', symbol: 'validateEmail' },
+        mockCtx
+      );
+
+      expect(findDependents).toHaveBeenCalledWith(
+        mockVectorDB,
+        'src/utils/validate.ts',
+        false,
+        mockLog,
+        'validateEmail'
+      );
+    });
+
+    it('should include symbol in response when provided', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis(),
+        totalUsageCount: 3,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils/validate.ts', symbol: 'validateEmail' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.symbol).toBe('validateEmail');
+      expect(parsed.totalUsageCount).toBe(3);
+    });
+
+    it('should include usages array in dependents when symbol usages found', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({
+          dependents: [
+            {
+              filepath: 'src/signup.ts',
+              isTestFile: false,
+              usages: [
+                { callerSymbol: 'signupUser', line: 45, snippet: 'validateEmail(input.email)' },
+              ],
+            },
+            {
+              filepath: 'src/profile.ts',
+              isTestFile: false,
+              usages: [
+                { callerSymbol: 'updateEmail', line: 89, snippet: 'if (!validateEmail(newEmail))' },
+              ],
+            },
+          ],
+        }),
+        totalUsageCount: 2,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils/validate.ts', symbol: 'validateEmail' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.totalUsageCount).toBe(2);
+      expect(parsed.dependents).toHaveLength(2);
+      expect(parsed.dependents[0].usages).toHaveLength(1);
+      expect(parsed.dependents[0].usages[0]).toEqual({
+        callerSymbol: 'signupUser',
+        line: 45,
+        snippet: 'validateEmail(input.email)',
+      });
+    });
+
+    it('should include dependents that import symbol but have no tracked call sites', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({
+          dependents: [
+            {
+              filepath: 'src/consumer.ts',
+              isTestFile: false,
+              usages: undefined, // Imports but no call sites tracked
+            },
+          ],
+        }),
+        totalUsageCount: 0,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils/validate.ts', symbol: 'validateEmail' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(1);
+      expect(parsed.totalUsageCount).toBe(0);
+      expect(parsed.dependents[0].usages).toBeUndefined();
+    });
+
+    it('should log usage count when symbol is provided', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({
+          dependents: [
+            { filepath: 'src/a.ts', isTestFile: false },
+            { filepath: 'src/b.ts', isTestFile: false },
+          ],
+        }),
+        totalUsageCount: 5,
+      });
+
+      await handleGetDependents(
+        { filepath: 'src/utils.ts', symbol: 'myFunction' },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("Found 5 usages of 'myFunction' across 2 files")
+      );
+    });
+
+    it('should indicate symbol in initial log message', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents(
+        { filepath: 'src/utils.ts', symbol: 'helper' },
+        mockCtx
+      );
+
+      expect(mockLog).toHaveBeenCalledWith(
+        'Finding dependents of: src/utils.ts (symbol: helper)'
+      );
+    });
+
+    it('should not include totalUsageCount when symbol not provided', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils.ts' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.symbol).toBeUndefined();
+      expect(parsed.totalUsageCount).toBeUndefined();
     });
   });
 });

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -73,18 +73,27 @@ function logRiskAssessment(
   symbol: string | undefined,
   log: (msg: string) => void
 ): void {
+  const prodTest = `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test)`;
+  
   if (symbol && analysis.totalUsageCount !== undefined) {
-    const usageInfo = analysis.totalUsageCount > 0
-      ? `Found ${analysis.totalUsageCount} tracked call sites`
-      : `Found ${analysis.dependents.length} files importing '${symbol}' (no call sites tracked)`;
-    log(
-      `${usageInfo} across ${analysis.dependents.length} files ` +
-      `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
-    );
+    if (analysis.totalUsageCount > 0) {
+      // Symbol tracking with call sites found
+      log(
+        `Found ${analysis.totalUsageCount} tracked call sites across ${analysis.dependents.length} files ` +
+        `${prodTest} - risk: ${riskLevel}`
+      );
+    } else {
+      // Files import the symbol but no call sites were tracked
+      // This happens when call site tracking isn't available for those chunks
+      log(
+        `Found ${analysis.dependents.length} files importing '${symbol}' (no call sites tracked) ` +
+        `${prodTest} - risk: ${riskLevel}`
+      );
+    }
   } else {
     log(
       `Found ${analysis.dependents.length} dependents ` +
-      `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
+      `${prodTest} - risk: ${riskLevel}`
     );
   }
 }

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -85,9 +85,10 @@ function logRiskAssessment(
     } else {
       // Files import the symbol but no call sites were tracked
       // This happens when call site tracking isn't available for those chunks
+      // (e.g., chunks without complexity analysis)
       log(
-        `Found ${analysis.dependents.length} files importing '${symbol}' (no call sites tracked) ` +
-        `${prodTest} - risk: ${riskLevel}`
+        `Found ${analysis.dependents.length} files importing '${symbol}' ` +
+        `${prodTest} - risk: ${riskLevel} (Note: Call site tracking unavailable for these chunks)`
       );
     }
   } else {

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -74,8 +74,11 @@ function logRiskAssessment(
   log: (msg: string) => void
 ): void {
   if (symbol && analysis.totalUsageCount !== undefined) {
+    const usageInfo = analysis.totalUsageCount > 0
+      ? `Found ${analysis.totalUsageCount} tracked call sites`
+      : `Found ${analysis.dependents.length} files importing '${symbol}' (no call sites tracked)`;
     log(
-      `Found ${analysis.totalUsageCount} usages of '${symbol}' across ${analysis.dependents.length} files ` +
+      `${usageInfo} across ${analysis.dependents.length} files ` +
       `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
     );
   } else {

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -1,13 +1,108 @@
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetDependentsSchema } from '../schemas/index.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
+import type { VectorDBInterface } from '@liendev/core';
 import { QdrantDB } from '@liendev/core';
 import {
   findDependents,
   calculateRiskLevel,
   groupDependentsByRepo,
+  type DependencyAnalysisResult,
 } from './dependency-analyzer.js';
 
+
+// Types for validated args and response building
+interface ValidatedArgs {
+  filepath: string;
+  symbol?: string;
+  crossRepo?: boolean;
+}
+
+interface IndexInfo {
+  indexVersion: number;
+  indexDate: string;
+}
+
+/**
+ * Check if cross-repo search is requested but not supported.
+ */
+function checkCrossRepoFallback(crossRepo: boolean | undefined, vectorDB: VectorDBInterface): boolean {
+  return Boolean(crossRepo && !(vectorDB instanceof QdrantDB));
+}
+
+/**
+ * Build warning notes for the response.
+ */
+function buildNotes(crossRepoFallback: boolean, hitLimit: boolean): string[] {
+  const notes: string[] = [];
+  if (crossRepoFallback) {
+    notes.push('Cross-repo search requires Qdrant backend. Fell back to single-repo search.');
+  }
+  if (hitLimit) {
+    notes.push('Scanned 10,000 chunks (limit reached). Results may be incomplete.');
+  }
+  return notes;
+}
+
+/**
+ * Log the analysis results with risk assessment.
+ */
+function logRiskAssessment(
+  analysis: DependencyAnalysisResult,
+  riskLevel: string,
+  symbol: string | undefined,
+  log: (msg: string) => void
+): void {
+  if (symbol && analysis.totalUsageCount !== undefined) {
+    log(
+      `Found ${analysis.totalUsageCount} usages of '${symbol}' across ${analysis.dependents.length} files ` +
+      `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
+    );
+  } else {
+    log(
+      `Found ${analysis.dependents.length} dependents ` +
+      `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
+    );
+  }
+}
+
+/**
+ * Build the response object from analysis results.
+ */
+function buildDependentsResponse(
+  analysis: DependencyAnalysisResult,
+  args: ValidatedArgs,
+  riskLevel: string,
+  indexInfo: IndexInfo,
+  notes: string[],
+  crossRepo: boolean | undefined,
+  vectorDB: VectorDBInterface
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+  const { symbol, filepath } = args;
+  
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response: any = {
+    indexInfo,
+    filepath,
+    ...(symbol && { symbol }),
+    dependentCount: analysis.dependents.length,
+    productionDependentCount: analysis.productionDependentCount,
+    testDependentCount: analysis.testDependentCount,
+    ...(analysis.totalUsageCount !== undefined && { totalUsageCount: analysis.totalUsageCount }),
+    riskLevel,
+    dependents: analysis.dependents,
+    complexityMetrics: analysis.complexityMetrics,
+    ...(notes.length > 0 && { note: notes.join(' ') }),
+  };
+
+  // Group by repo if cross-repo search with Qdrant
+  if (crossRepo && vectorDB instanceof QdrantDB) {
+    response.groupedByRepo = groupDependentsByRepo(analysis.dependents, analysis.allChunks);
+  }
+
+  return response;
+}
 
 /**
  * Handle get_dependents tool calls.
@@ -26,64 +121,40 @@ export async function handleGetDependents(
     GetDependentsSchema,
     async (validatedArgs) => {
       const { crossRepo, filepath, symbol } = validatedArgs;
+      
+      // Log initial request
       const symbolSuffix = symbol ? ` (symbol: ${symbol})` : '';
       const crossRepoSuffix = crossRepo ? ' (cross-repo)' : '';
       log(`Finding dependents of: ${filepath}${symbolSuffix}${crossRepoSuffix}`);
+      
       await checkAndReconnect();
 
-      // Find dependents using dependency analysis functions
+      // Analyze dependencies
       const analysis = await findDependents(vectorDB, filepath, crossRepo ?? false, log, symbol);
 
+      // Calculate risk level
       const riskLevel = calculateRiskLevel(
         analysis.dependents.length,
         analysis.complexityMetrics.complexityRiskBoost,
         analysis.productionDependentCount
       );
       
-      // Log message varies based on whether symbol-level analysis was done
-      if (symbol && analysis.totalUsageCount !== undefined) {
-        log(
-          `Found ${analysis.totalUsageCount} usages of '${symbol}' across ${analysis.dependents.length} files (${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
-        );
-      } else {
-        log(
-          `Found ${analysis.dependents.length} dependents (${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test) - risk: ${riskLevel}`
-        );
-      }
+      // Log results with risk assessment
+      logRiskAssessment(analysis, riskLevel, symbol, log);
 
-      // Build note(s) for warnings
-      const notes: string[] = [];
-      const crossRepoFallback = crossRepo && !(vectorDB instanceof QdrantDB);
+      // Build and return response
+      const crossRepoFallback = checkCrossRepoFallback(crossRepo, vectorDB);
+      const notes = buildNotes(crossRepoFallback, analysis.hitLimit);
       
-      if (crossRepoFallback) {
-        notes.push('Cross-repo search requires Qdrant backend. Fell back to single-repo search.');
-      }
-      if (analysis.hitLimit) {
-        notes.push('Scanned 10,000 chunks (limit reached). Results may be incomplete.');
-      }
-
-      // Build response
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: any = {
-        indexInfo: getIndexMetadata(),
-        filepath: validatedArgs.filepath,
-        ...(symbol && { symbol }),
-        dependentCount: analysis.dependents.length,
-        productionDependentCount: analysis.productionDependentCount,
-        testDependentCount: analysis.testDependentCount,
-        ...(analysis.totalUsageCount !== undefined && { totalUsageCount: analysis.totalUsageCount }),
+      return buildDependentsResponse(
+        analysis,
+        validatedArgs,
         riskLevel,
-        dependents: analysis.dependents,
-        complexityMetrics: analysis.complexityMetrics,
-        ...(notes.length > 0 && { note: notes.join(' ') }),
-      };
-
-      // Group by repo if cross-repo search
-      if (crossRepo && vectorDB instanceof QdrantDB) {
-        response.groupedByRepo = groupDependentsByRepo(analysis.dependents, analysis.allChunks);
-      }
-
-      return response;
+        getIndexMetadata(),
+        notes,
+        crossRepo,
+        vectorDB
+      );
     }
   )(args);
 }

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -6,6 +6,9 @@ import { z } from 'zod';
  * Validates file paths and options for finding reverse dependencies
  * (which files import/depend on a given file).
  * 
+ * When the optional `symbol` parameter is provided, returns specific call sites
+ * for that exported symbol instead of just file-level dependencies.
+ * 
  * Limitations:
  * - Scans up to 10,000 code chunks. For very large codebases (>1M lines),
  *   results may be incomplete. A warning is returned if the limit is reached.
@@ -19,6 +22,15 @@ export const GetDependentsSchema = z.object({
       "Returns all files that import or depend on this file.\n\n" +
       "Note: Scans up to 10,000 code chunks. For very large codebases,\n" +
       "results may be incomplete (a warning will be included if truncated)."
+    ),
+  
+  symbol: z.string()
+    .optional()
+    .describe(
+      "Optional: specific exported symbol to find usages of.\n\n" +
+      "When provided, returns call sites instead of just importing files.\n\n" +
+      "Example: 'validateEmail' to find where validateEmail() is called.\n\n" +
+      "Response includes 'usages' array showing which functions call this symbol."
     ),
     
   depth: z.number()

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -25,6 +25,7 @@ export const GetDependentsSchema = z.object({
     ),
   
   symbol: z.string()
+    .min(1, "Symbol cannot be an empty string")
     .optional()
     .describe(
       "Optional: specific exported symbol to find usages of.\n\n" +

--- a/packages/cli/src/mcp/server.matchesFile.test.ts
+++ b/packages/cli/src/mcp/server.matchesFile.test.ts
@@ -152,5 +152,32 @@ describe('matchesFile - Path Boundary Checking', () => {
       expect(testMatchesFile('src/auth.ts', 'src/auth.spec.ts')).toBe(false);
     });
   });
+
+  describe('PHP namespace matching', () => {
+    it('should match PHP namespace to file path', () => {
+      // PHP uses namespaces like App\Models\User which map to app/Models/User.php
+      expect(testMatchesFile('App\\Models\\User', 'app/Models/User.php')).toBe(true);
+      expect(testMatchesFile('App\\Models\\Collection', 'web/app/Models/Collection.php')).toBe(true);
+    });
+
+    it('should match nested PHP namespaces', () => {
+      expect(testMatchesFile('Domain\\Hobbii\\Collections\\Services\\CollectionManager', 'web/Domain/Hobbii/Collections/Services/CollectionManager.php')).toBe(true);
+    });
+
+    it('should match case-insensitively for App namespace', () => {
+      // Laravel convention: App namespace maps to app directory
+      expect(testMatchesFile('App\\Http\\Controllers\\UserController', 'app/Http/Controllers/UserController.php')).toBe(true);
+    });
+
+    it('should NOT match unrelated PHP namespaces', () => {
+      expect(testMatchesFile('App\\Models\\User', 'app/Models/Product.php')).toBe(false);
+      expect(testMatchesFile('App\\Services\\Auth', 'app/Models/User.php')).toBe(false);
+    });
+
+    it('should NOT apply PHP matching to non-namespace imports', () => {
+      // Regular file paths should not use PHP namespace matching
+      expect(testMatchesFile('src/models/user', 'src/models/product')).toBe(false);
+    });
+  });
 });
 

--- a/packages/cli/src/mcp/server.matchesFile.test.ts
+++ b/packages/cli/src/mcp/server.matchesFile.test.ts
@@ -179,5 +179,46 @@ describe('matchesFile - Path Boundary Checking', () => {
       expect(testMatchesFile('src/models/user', 'src/models/product')).toBe(false);
     });
   });
+
+  describe('Python module matching', () => {
+    it('should match Python dotted module to file path', () => {
+      // Python uses dotted paths like django.http which map to django/http/*.py
+      expect(testMatchesFile('django.http', 'django/http/response.py')).toBe(true);
+      expect(testMatchesFile('django.http', 'django/http/__init__.py')).toBe(true);
+    });
+
+    it('should match exact Python module path', () => {
+      expect(testMatchesFile('django.http.response', 'django/http/response.py')).toBe(true);
+      expect(testMatchesFile('django.views.generic.base', 'django/views/generic/base.py')).toBe(true);
+    });
+
+    it('should match Python module with prefix in target', () => {
+      // When target has extra prefix directories
+      expect(testMatchesFile('django.http', 'src/django/http/response.py')).toBe(true);
+      expect(testMatchesFile('myapp.models', 'project/myapp/models/__init__.py')).toBe(true);
+    });
+
+    it('should match parent package to child modules', () => {
+      // from django.http import HttpResponse - matches any module under django/http/
+      expect(testMatchesFile('django.http', 'django/http/request.py')).toBe(true);
+      expect(testMatchesFile('django.http', 'django/http/cookie.py')).toBe(true);
+    });
+
+    it('should NOT match unrelated Python modules', () => {
+      expect(testMatchesFile('django.http', 'django/views/generic.py')).toBe(false);
+      expect(testMatchesFile('django.db.models', 'django/http/response.py')).toBe(false);
+    });
+
+    it('should NOT apply Python matching to non-dotted imports', () => {
+      // Regular file paths should not use Python module matching
+      expect(testMatchesFile('src/models/user', 'src/models/product.py')).toBe(false);
+    });
+
+    it('should handle single-level Python modules', () => {
+      // Single module without dots should still work if it's part of the path
+      expect(testMatchesFile('django.utils', 'django/utils/__init__.py')).toBe(true);
+      expect(testMatchesFile('django.utils', 'django/utils/timezone.py')).toBe(true);
+    });
+  });
 });
 

--- a/packages/cli/src/mcp/utils/path-matching.ts
+++ b/packages/cli/src/mcp/utils/path-matching.ts
@@ -170,8 +170,9 @@ function matchesPythonModule(importPath: string, targetPath: string): boolean {
   if (moduleIndex >= 0) {
     const prefix = targetWithoutPy.substring(0, moduleIndex);
     // Prefix should be empty or a single directory (e.g., "src/")
+    // Also verify prefix ends with '/' or is empty to avoid partial matches like "foo/bardjango/http"
     const prefixSlashes = (prefix.match(/\//g) || []).length;
-    if (prefixSlashes <= 1) {
+    if (prefixSlashes <= 1 && (prefix === '' || prefix.endsWith('/'))) {
       // Also verify it's at a directory boundary
       if (moduleIndex === 0 || targetWithoutPy[moduleIndex - 1] === '/') {
         return true;

--- a/packages/cli/src/mcp/utils/path-matching.ts
+++ b/packages/cli/src/mcp/utils/path-matching.ts
@@ -114,18 +114,6 @@ export function matchesFile(normalizedImport: string, normalizedTarget: string):
 }
 
 /**
- * Checks if a Python dotted module path matches a file path.
- * 
- * Python imports use dotted paths like "django.http" which should match:
- * - django/http/__init__.py (package)
- * - django/http/response.py (module within package)
- * - django/http.py (direct module, less common)
- * 
- * @param importPath - The import path (may contain dots)
- * @param targetPath - The normalized file path
- * @returns True if the Python module matches the file path
- */
-/**
  * Check if target exactly matches the module path (handles __init__.py)
  */
 function matchesDirectPythonModule(moduleAsPath: string, targetWithoutPy: string): boolean {
@@ -169,6 +157,18 @@ function matchesWithSourcePrefix(moduleAsPath: string, targetWithoutPy: string):
   return false;
 }
 
+/**
+ * Checks if a Python dotted module path matches a file path.
+ * 
+ * Python imports use dotted paths like "django.http" which should match:
+ * - django/http/__init__.py (package)
+ * - django/http/response.py (module within package)
+ * - django/http.py (direct module, less common)
+ * 
+ * @param importPath - The import path (may contain dots)
+ * @param targetPath - The normalized file path
+ * @returns True if the Python module matches the file path
+ */
 function matchesPythonModule(importPath: string, targetPath: string): boolean {
   // Only apply if the import contains dots (Python module syntax)
   if (!importPath.includes('.')) {

--- a/packages/cli/src/mcp/utils/path-matching.ts
+++ b/packages/cli/src/mcp/utils/path-matching.ts
@@ -148,13 +148,10 @@ function matchesWithSourcePrefix(moduleAsPath: string, targetWithoutPy: string):
   const prefixSlashes = (prefix.match(/\//g) || []).length;
   
   // Prefix should be empty or a single directory (e.g., "src/")
-  // Also verify prefix ends with '/' or is empty to avoid partial matches
-  if (prefixSlashes <= 1 && (prefix === '' || prefix.endsWith('/'))) {
-    // Verify it's at a directory boundary
-    return moduleIndex === 0 || targetWithoutPy[moduleIndex - 1] === '/';
-  }
-  
-  return false;
+  // The check for prefix === '' || prefix.endsWith('/') ensures we're at a directory boundary:
+  // - If prefix is empty, moduleIndex is 0 (start of string)
+  // - If prefix ends with '/', then it's a valid directory separator
+  return prefixSlashes <= 1 && (prefix === '' || prefix.endsWith('/'));
 }
 
 /**

--- a/packages/core/src/frameworks/python/config.ts
+++ b/packages/core/src/frameworks/python/config.ts
@@ -1,0 +1,86 @@
+import { FrameworkConfig } from '../../config/schema.js';
+
+/**
+ * Generate Python framework configuration
+ */
+export async function generatePythonConfig(
+  _rootDir: string,
+  _relativePath: string
+): Promise<FrameworkConfig> {
+  return {
+    include: [
+      // Python source code - broad patterns
+      '**/*.py',
+      
+      // Documentation
+      '**/*.md',
+      '**/*.mdx',
+      'docs/**/*.md',
+      'README.md',
+      'CHANGELOG.md',
+    ],
+    exclude: [
+      // Virtual environments (CRITICAL)
+      '**/venv/**',
+      'venv/**',
+      '**/.venv/**',
+      '.venv/**',
+      '**/env/**',
+      'env/**',
+      '**/.env/**',
+      '.env/**',
+      '**/virtualenv/**',
+      'virtualenv/**',
+      
+      // Python build artifacts
+      '**/__pycache__/**',
+      '__pycache__/**',
+      '**/*.pyc',
+      '**/*.pyo',
+      '**/*.pyd',
+      '**/*.egg-info/**',
+      '*.egg-info/**',
+      '**/dist/**',
+      'dist/**',
+      '**/build/**',
+      'build/**',
+      '**/eggs/**',
+      'eggs/**',
+      '**/*.egg/**',
+      
+      // Test artifacts
+      '**/.tox/**',
+      '.tox/**',
+      '**/.pytest_cache/**',
+      '.pytest_cache/**',
+      '**/.coverage/**',
+      '.coverage/**',
+      '**/htmlcov/**',
+      'htmlcov/**',
+      '**/.mypy_cache/**',
+      '.mypy_cache/**',
+      
+      // Documentation build
+      '**/docs/_build/**',
+      'docs/_build/**',
+      
+      // Node.js dependencies (for mixed projects)
+      '**/node_modules/**',
+      'node_modules/**',
+      
+      // Vendor directories
+      '**/vendor/**',
+      'vendor/**',
+      
+      // IDE
+      '**/.idea/**',
+      '.idea/**',
+      '**/.vscode/**',
+      '.vscode/**',
+      
+      // Migrations (often auto-generated)
+      '**/migrations/**',
+    ],
+  };
+}
+

--- a/packages/core/src/frameworks/python/config.ts
+++ b/packages/core/src/frameworks/python/config.ts
@@ -27,8 +27,8 @@ export async function generatePythonConfig(
       '.venv/**',
       '**/env/**',
       'env/**',
-      '**/.env/**',
-      '.env/**',
+      '**/.env/**',    // .env directory (virtual environment)
+      '.env',          // .env file (environment variables)
       '**/virtualenv/**',
       'virtualenv/**',
       

--- a/packages/core/src/frameworks/python/detector.ts
+++ b/packages/core/src/frameworks/python/detector.ts
@@ -57,7 +57,7 @@ export const pythonDetector: FrameworkDetector = {
     const managePyPath = path.join(fullPath, 'manage.py');
     try {
       const content = await fs.readFile(managePyPath, 'utf-8');
-      if (content.includes('django') || content.includes('DJANGO')) {
+      if (content.includes('django.core.management') || content.includes('DJANGO_SETTINGS_MODULE')) {
         result.evidence.push('Django project detected (manage.py)');
       }
     } catch {

--- a/packages/core/src/frameworks/python/detector.ts
+++ b/packages/core/src/frameworks/python/detector.ts
@@ -1,0 +1,146 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { FrameworkDetector, DetectionResult } from '../types.js';
+import { generatePythonConfig } from './config.js';
+
+/**
+ * Python framework detector
+ * Detects Python projects via requirements.txt, pyproject.toml, setup.py, or Pipfile
+ */
+export const pythonDetector: FrameworkDetector = {
+  name: 'python',
+  priority: 50, // Generic, yields to specific frameworks like Django
+  
+  async detect(rootDir: string, relativePath: string): Promise<DetectionResult> {
+    const fullPath = path.join(rootDir, relativePath);
+    const result: DetectionResult = {
+      detected: false,
+      name: 'python',
+      path: relativePath,
+      confidence: 'low',
+      evidence: [],
+    };
+    
+    // Check for Python project indicators
+    const indicators = [
+      { file: 'requirements.txt', display: 'requirements.txt' },
+      { file: 'pyproject.toml', display: 'pyproject.toml' },
+      { file: 'setup.py', display: 'setup.py' },
+      { file: 'Pipfile', display: 'Pipfile' },
+      { file: 'setup.cfg', display: 'setup.cfg' },
+    ];
+    
+    let foundIndicator = false;
+    
+    for (const indicator of indicators) {
+      try {
+        const filePath = path.join(fullPath, indicator.file);
+        await fs.access(filePath);
+        result.evidence.push(`Found ${indicator.display}`);
+        foundIndicator = true;
+        break; // Found at least one indicator
+      } catch {
+        // File doesn't exist, continue checking
+      }
+    }
+    
+    if (!foundIndicator) {
+      // No Python project indicators found
+      return result;
+    }
+    
+    // At this point, we know it's a Python project
+    result.detected = true;
+    result.confidence = 'high';
+    
+    // Check for Django (manage.py is a strong indicator)
+    const managePyPath = path.join(fullPath, 'manage.py');
+    try {
+      const content = await fs.readFile(managePyPath, 'utf-8');
+      if (content.includes('django') || content.includes('DJANGO')) {
+        result.evidence.push('Django project detected (manage.py)');
+      }
+    } catch {
+      // No manage.py
+    }
+    
+    // Check for common Python directories
+    const pythonDirs = ['src', 'lib', 'app', 'tests', 'test'];
+    let foundDirs = 0;
+    
+    for (const dir of pythonDirs) {
+      try {
+        const dirPath = path.join(fullPath, dir);
+        const stats = await fs.stat(dirPath);
+        if (stats.isDirectory()) {
+          foundDirs++;
+        }
+      } catch {
+        // Directory doesn't exist
+      }
+    }
+    
+    if (foundDirs > 0) {
+      result.evidence.push(`Found Python project structure (${foundDirs} directories)`);
+    }
+    
+    // Try to detect Python version from pyproject.toml
+    try {
+      const pyprojectPath = path.join(fullPath, 'pyproject.toml');
+      const content = await fs.readFile(pyprojectPath, 'utf-8');
+      
+      // Look for python version requirement
+      const versionMatch = content.match(/python\s*[>=<]+\s*["']?(\d+\.\d+)/i);
+      if (versionMatch) {
+        result.version = versionMatch[1];
+        result.evidence.push(`Python ${versionMatch[1]}+`);
+      }
+    } catch {
+      // No pyproject.toml or couldn't parse
+    }
+    
+    // Check for testing frameworks in requirements.txt
+    try {
+      const requirementsPath = path.join(fullPath, 'requirements.txt');
+      const content = await fs.readFile(requirementsPath, 'utf-8');
+      
+      const testFrameworks = [
+        { pattern: /pytest/i, display: 'pytest' },
+        { pattern: /unittest/i, display: 'unittest' },
+        { pattern: /nose/i, display: 'nose' },
+      ];
+      
+      for (const framework of testFrameworks) {
+        if (framework.pattern.test(content)) {
+          result.evidence.push(`${framework.display} test framework detected`);
+          break;
+        }
+      }
+      
+      // Check for common frameworks
+      const frameworks = [
+        { pattern: /django/i, display: 'Django' },
+        { pattern: /flask/i, display: 'Flask' },
+        { pattern: /fastapi/i, display: 'FastAPI' },
+        { pattern: /tornado/i, display: 'Tornado' },
+        { pattern: /celery/i, display: 'Celery' },
+      ];
+      
+      for (const framework of frameworks) {
+        if (framework.pattern.test(content)) {
+          result.evidence.push(`${framework.display} detected`);
+          break;
+        }
+      }
+    } catch {
+      // No requirements.txt
+    }
+    
+    return result;
+  },
+  
+  async generateConfig(rootDir: string, relativePath: string) {
+    return generatePythonConfig(rootDir, relativePath);
+  },
+};
+

--- a/packages/core/src/frameworks/python/detector.ts
+++ b/packages/core/src/frameworks/python/detector.ts
@@ -32,13 +32,13 @@ export const pythonDetector: FrameworkDetector = {
     
     let foundIndicator = false;
     
+    // Check all indicators to provide complete evidence
     for (const indicator of indicators) {
       try {
         const filePath = path.join(fullPath, indicator.file);
         await fs.access(filePath);
         result.evidence.push(`Found ${indicator.display}`);
         foundIndicator = true;
-        break; // Found at least one indicator
       } catch {
         // File doesn't exist, continue checking
       }
@@ -117,7 +117,7 @@ export const pythonDetector: FrameworkDetector = {
         }
       }
       
-      // Check for common frameworks
+      // Check for common frameworks - collect all detected frameworks
       const frameworks = [
         { pattern: /django/i, display: 'Django' },
         { pattern: /flask/i, display: 'Flask' },
@@ -129,7 +129,6 @@ export const pythonDetector: FrameworkDetector = {
       for (const framework of frameworks) {
         if (framework.pattern.test(content)) {
           result.evidence.push(`${framework.display} detected`);
-          break;
         }
       }
     } catch {

--- a/packages/core/src/frameworks/registry.ts
+++ b/packages/core/src/frameworks/registry.ts
@@ -1,6 +1,7 @@
 import { FrameworkDetector } from './types.js';
 import { nodejsDetector } from './nodejs/detector.js';
 import { phpDetector } from './php/detector.js';
+import { pythonDetector } from './python/detector.js';
 import { laravelDetector } from './laravel/detector.js';
 import { shopifyDetector } from './shopify/detector.js';
 
@@ -10,12 +11,13 @@ import { shopifyDetector } from './shopify/detector.js';
  * 
  * Order doesn't matter for detection as priority system handles conflicts,
  * but listed here in order from generic to specific for clarity:
- * - Generic language detectors (Node.js, PHP)
+ * - Generic language detectors (Node.js, PHP, Python)
  * - Specific framework detectors (Laravel, Shopify)
  */
 export const frameworkDetectors: FrameworkDetector[] = [
   nodejsDetector,
   phpDetector,
+  pythonDetector,
   laravelDetector,
   shopifyDetector,
 ];

--- a/packages/core/src/indexer/ast/chunker.ts
+++ b/packages/core/src/indexer/ast/chunker.ts
@@ -342,6 +342,7 @@ function createChunk(
       // attach them to every chunk from the same file (including "uncovered" chunks).
       // This duplicates some metadata, but greatly simplifies dependency analysis,
       // since consumers can inspect a single chunk in isolation without additional lookups.
+      // This increases storage overhead but is acceptable given typical file sizes and chunk counts.
       ...(fileExports && fileExports.length > 0 && { exports: fileExports }),
       ...(importedSymbols && Object.keys(importedSymbols).length > 0 && { importedSymbols }),
       ...(callSites && callSites.length > 0 && { callSites }),

--- a/packages/core/src/indexer/ast/chunker.ts
+++ b/packages/core/src/indexer/ast/chunker.ts
@@ -338,6 +338,10 @@ function createChunk(
       signature: symbolInfo?.signature,
       imports,
       // Symbol-level dependency tracking
+      // NOTE: `exports` and `importedSymbols` are file-level concepts, but we deliberately
+      // attach them to every chunk from the same file (including "uncovered" chunks).
+      // This duplicates some metadata, but greatly simplifies dependency analysis,
+      // since consumers can inspect a single chunk in isolation without additional lookups.
       ...(fileExports && fileExports.length > 0 && { exports: fileExports }),
       ...(importedSymbols && Object.keys(importedSymbols).length > 0 && { importedSymbols }),
       ...(callSites && callSites.length > 0 && { callSites }),

--- a/packages/core/src/indexer/ast/symbols.test.ts
+++ b/packages/core/src/indexer/ast/symbols.test.ts
@@ -587,6 +587,47 @@ from json import loads, dumps
       expect(importedSymbols['json']).toContain('loads');
       expect(importedSymbols['json']).toContain('dumps');
     });
+
+    it('should extract Python regular imports', () => {
+      const content = `
+import os
+import sys
+import pathlib
+      `.trim();
+
+      const parseResult = parseAST(content, 'python');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(importedSymbols['os']).toContain('os');
+      expect(importedSymbols['sys']).toContain('sys');
+      expect(importedSymbols['pathlib']).toContain('pathlib');
+    });
+
+    it('should extract Python aliased regular imports', () => {
+      const content = `
+import numpy as np
+import pandas as pd
+      `.trim();
+
+      const parseResult = parseAST(content, 'python');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(importedSymbols['numpy']).toContain('np');
+      expect(importedSymbols['pandas']).toContain('pd');
+    });
+
+    it('should extract Python dotted module imports', () => {
+      const content = `
+import os.path
+import xml.etree.ElementTree
+      `.trim();
+
+      const parseResult = parseAST(content, 'python');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(importedSymbols['os.path']).toContain('os.path');
+      expect(importedSymbols['xml.etree.ElementTree']).toContain('xml.etree.ElementTree');
+    });
   });
 });
 

--- a/packages/core/src/indexer/ast/symbols.test.ts
+++ b/packages/core/src/indexer/ast/symbols.test.ts
@@ -209,6 +209,22 @@ const private = 42;
 
       expect(exports).toHaveLength(0);
     });
+
+    it('should extract re-exports from another module', () => {
+      const content = `
+export { validateEmail, validatePhone } from './validation';
+export { User as UserType } from './types';
+export { default as utils } from './utils';
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toContain('validateEmail');
+      expect(exports).toContain('validatePhone');
+      expect(exports).toContain('UserType'); // aliased export
+      expect(exports).toContain('utils');    // default re-export with alias
+    });
   });
 
   describe('extractCallSites', () => {

--- a/packages/core/src/indexer/ast/symbols.test.ts
+++ b/packages/core/src/indexer/ast/symbols.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect } from 'vitest';
+import { parseAST } from './parser.js';
+import {
+  extractImports,
+  extractImportedSymbols,
+  extractExports,
+  extractCallSites,
+} from './symbols.js';
+
+describe('Symbol Extraction', () => {
+  describe('extractImportedSymbols', () => {
+    it('should extract named imports', () => {
+      const content = `
+import { foo, bar } from './module';
+import { validateEmail } from '../utils/validate';
+
+function test() {}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(importedSymbols['./module']).toEqual(['foo', 'bar']);
+      expect(importedSymbols['../utils/validate']).toEqual(['validateEmail']);
+    });
+
+    it('should extract default imports', () => {
+      const content = `
+import React from 'react';
+import lodash from 'lodash';
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(importedSymbols['react']).toEqual(['React']);
+      expect(importedSymbols['lodash']).toEqual(['lodash']);
+    });
+
+    it('should extract namespace imports', () => {
+      const content = `
+import * as utils from './utils';
+import * as fs from 'fs';
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(importedSymbols['./utils']).toEqual(['* as utils']);
+      expect(importedSymbols['fs']).toEqual(['* as fs']);
+    });
+
+    it('should extract mixed import styles', () => {
+      const content = `
+import React, { useState, useEffect } from 'react';
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      // Should include both default and named imports
+      expect(importedSymbols['react']).toContain('React');
+      expect(importedSymbols['react']).toContain('useState');
+      expect(importedSymbols['react']).toContain('useEffect');
+    });
+
+    it('should handle aliased imports', () => {
+      const content = `
+import { foo as bar, baz as qux } from './module';
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      // Aliases should use the local name
+      expect(importedSymbols['./module']).toContain('bar');
+      expect(importedSymbols['./module']).toContain('qux');
+    });
+
+    it('should return empty object for files with no imports', () => {
+      const content = `
+function hello() {
+  console.log('hi');
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode);
+
+      expect(Object.keys(importedSymbols)).toHaveLength(0);
+    });
+  });
+
+  describe('extractExports', () => {
+    it('should extract named exports', () => {
+      const content = `
+export { foo, bar };
+export { baz };
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toContain('foo');
+      expect(exports).toContain('bar');
+      expect(exports).toContain('baz');
+    });
+
+    it('should extract exported function declarations', () => {
+      const content = `
+export function validateEmail(email: string): boolean {
+  return email.includes('@');
+}
+
+export async function fetchUser(id: string) {
+  return await fetch('/user/' + id);
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toContain('validateEmail');
+      expect(exports).toContain('fetchUser');
+    });
+
+    it('should extract exported const/let declarations', () => {
+      const content = `
+export const API_URL = 'https://api.example.com';
+export let counter = 0;
+export const helper = (x: number) => x * 2;
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toContain('API_URL');
+      expect(exports).toContain('counter');
+      expect(exports).toContain('helper');
+    });
+
+    it('should extract exported class and interface declarations', () => {
+      const content = `
+export class UserService {
+  getUser() {}
+}
+
+export interface User {
+  id: string;
+  name: string;
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toContain('UserService');
+      expect(exports).toContain('User');
+    });
+
+    it('should extract default exports', () => {
+      const content = `
+export default function main() {
+  console.log('main');
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toContain('default');
+    });
+
+    it('should extract renamed exports', () => {
+      const content = `
+const internalFoo = () => {};
+export { internalFoo as foo };
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      // Should use the exported name, not the internal name
+      expect(exports).toContain('foo');
+    });
+
+    it('should deduplicate exports', () => {
+      const content = `
+export function foo() {}
+export { foo };
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      // Should only appear once
+      const fooCount = exports.filter(e => e === 'foo').length;
+      expect(fooCount).toBe(1);
+    });
+
+    it('should return empty array for files with no exports', () => {
+      const content = `
+function internal() {}
+const private = 42;
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const exports = extractExports(parseResult.tree!.rootNode);
+
+      expect(exports).toHaveLength(0);
+    });
+  });
+
+  describe('extractCallSites', () => {
+    it('should extract direct function calls', () => {
+      const content = `
+function processUser(user) {
+  validateEmail(user.email);
+  validatePhone(user.phone);
+  return user;
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'validateEmail' })
+      );
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'validatePhone' })
+      );
+    });
+
+    it('should extract method calls', () => {
+      const content = `
+function saveUser(user) {
+  database.save(user);
+  logger.info('User saved');
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'save' })
+      );
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'info' })
+      );
+    });
+
+    it('should include line numbers for calls', () => {
+      const content = `function test() {
+  foo();
+  bar();
+}`.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      const fooCall = callSites.find(c => c.symbol === 'foo');
+      const barCall = callSites.find(c => c.symbol === 'bar');
+
+      expect(fooCall?.line).toBe(2);
+      expect(barCall?.line).toBe(3);
+    });
+
+    it('should handle nested function calls', () => {
+      const content = `
+function complex() {
+  const result = outer(inner(value));
+  return result;
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'outer' })
+      );
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'inner' })
+      );
+    });
+
+    it('should handle conditional and loop calls', () => {
+      const content = `
+function process(items) {
+  if (validate(items)) {
+    for (const item of items) {
+      transform(item);
+    }
+  }
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'validate' })
+      );
+      expect(callSites).toContainEqual(
+        expect.objectContaining({ symbol: 'transform' })
+      );
+    });
+
+    it('should deduplicate same-line calls', () => {
+      const content = `
+function test() {
+  foo(); foo();
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      // Multiple calls to same symbol on same line should be deduplicated
+      const fooCalls = callSites.filter(c => c.symbol === 'foo');
+      expect(fooCalls).toHaveLength(1);
+    });
+
+    it('should track same symbol on different lines separately', () => {
+      const content = `
+function test() {
+  foo();
+  bar();
+  foo();
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      const fooCalls = callSites.filter(c => c.symbol === 'foo');
+      expect(fooCalls).toHaveLength(2);
+      expect(fooCalls[0].line).not.toBe(fooCalls[1].line);
+    });
+
+    it('should return empty array for function with no calls', () => {
+      const content = `
+function simple() {
+  const x = 1 + 2;
+  return x;
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
+      const callSites = extractCallSites(funcNode);
+
+      expect(callSites).toHaveLength(0);
+    });
+  });
+
+  describe('extractImports (existing)', () => {
+    it('should extract import paths from TypeScript', () => {
+      const content = `
+import { foo } from './module';
+import bar from 'library';
+import * as utils from '../utils';
+      `.trim();
+
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(parseResult.tree!.rootNode);
+
+      expect(imports).toContain('./module');
+      expect(imports).toContain('library');
+      expect(imports).toContain('../utils');
+    });
+  });
+});
+

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -341,6 +341,9 @@ export function extractImports(rootNode: Parser.SyntaxNode): string[] {
  * - Named imports: import { foo, bar } from './module'
  * - Default imports: import foo from './module' 
  * - Namespace imports: import * as utils from './module'
+ *
+ * Note: Only top-level static import statements are processed. Dynamic imports
+ * (e.g., `await import('./module')`) and non-top-level imports are not tracked.
  */
 export function extractImportedSymbols(rootNode: Parser.SyntaxNode): Record<string, string[]> {
   const importedSymbols: Record<string, string[]> = {};
@@ -527,6 +530,11 @@ function extractExportStatementSymbols(node: Parser.SyntaxNode, addExport: (name
  * - Declaration exports: export function foo() {}, export const bar = ...
  * - Default exports: export default ...
  * - Re-exports: export { foo } from './module'
+ * 
+ * Limitations:
+ * - Only static, top-level export statements are processed (direct children of the root node).
+ * - Dynamic or conditional exports (e.g., inside if/for blocks, functions, or created programmatically)
+ *   are not detected and will not be included in the returned symbol list.
  */
 export function extractExports(rootNode: Parser.SyntaxNode): string[] {
   const exports: string[] = [];
@@ -623,9 +631,9 @@ function traverseForCallSites(
     }
   }
   
-  // Recurse into children
-  for (let i = 0; i < node.childCount; i++) {
-    const child = node.child(i);
+  // Recurse into named children to skip punctuation and other non-semantic nodes
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
     if (child) traverseForCallSites(child, callSites, seen);
   }
 }

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -360,16 +360,19 @@ export function extractImportedSymbols(rootNode: Parser.SyntaxNode): Record<stri
 }
 
 /**
- * Process a single import statement and extract its symbols.
+ * Extract the import path from an import statement.
  */
-function processImportStatement(node: Parser.SyntaxNode): { importPath: string; symbols: string[] } | null {
+function extractImportPath(node: Parser.SyntaxNode): string | null {
   const sourceNode = node.childForFieldName('source');
-  if (!sourceNode) return null;
-  
-  const importPath = sourceNode.text.replace(/['"]/g, '');
+  return sourceNode?.text.replace(/['"]/g, '') ?? null;
+}
+
+/**
+ * Extract all imported symbols from an import statement's children.
+ */
+function extractImportStatementSymbols(node: Parser.SyntaxNode): string[] {
   const symbols: string[] = [];
   
-  // Find import clause children
   for (let i = 0; i < node.namedChildCount; i++) {
     const child = node.namedChild(i);
     if (!child) continue;
@@ -392,6 +395,17 @@ function processImportStatement(node: Parser.SyntaxNode): { importPath: string; 
     }
   }
   
+  return symbols;
+}
+
+/**
+ * Process a single import statement and extract its symbols.
+ */
+function processImportStatement(node: Parser.SyntaxNode): { importPath: string; symbols: string[] } | null {
+  const importPath = extractImportPath(node);
+  if (!importPath) return null;
+  
+  const symbols = extractImportStatementSymbols(node);
   return symbols.length > 0 ? { importPath, symbols } : null;
 }
 

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -419,6 +419,13 @@ function extractImportClauseSymbols(node: Parser.SyntaxNode, symbols: string[]):
 
 /**
  * Extract namespace import symbol: import * as utils
+ * 
+ * Format: "* as {alias}" (e.g., "* as utils")
+ * 
+ * The "* as " prefix is intentionally included to distinguish namespace imports
+ * from regular named imports in the symbol matching logic. This allows us to
+ * identify when a file has access to all exports via a namespace, which is
+ * useful for dependency analysis even when we can't track specific call sites.
  */
 function extractNamespaceImportSymbol(node: Parser.SyntaxNode, symbols: string[]): void {
   // Find the identifier child (the alias name)
@@ -562,7 +569,7 @@ function extractExportClauseSymbols(node: Parser.SyntaxNode, addExport: (name: s
  * Extract call sites within a function/method body.
  * 
  * Returns array of function calls made within the node.
- * Only tracks direct function calls (not method calls on objects).
+ * Tracks direct function calls (e.g. foo()) and simple method calls on objects (e.g. foo.bar()).
  */
 export function extractCallSites(node: Parser.SyntaxNode): Array<{ symbol: string; line: number }> {
   const callSites: Array<{ symbol: string; line: number }> = [];

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -331,3 +331,283 @@ export function extractImports(rootNode: Parser.SyntaxNode): string[] {
   traverse(rootNode);
   return imports;
 }
+
+/**
+ * Extract imported symbols mapped to their source paths.
+ * 
+ * Returns a map like: { './validate': ['validateEmail', 'validatePhone'] }
+ * 
+ * Handles various import styles:
+ * - Named imports: import { foo, bar } from './module'
+ * - Default imports: import foo from './module' 
+ * - Namespace imports: import * as utils from './module'
+ */
+export function extractImportedSymbols(rootNode: Parser.SyntaxNode): Record<string, string[]> {
+  const importedSymbols: Record<string, string[]> = {};
+  
+  function traverse(node: Parser.SyntaxNode) {
+    if (node.type === 'import_statement') {
+      const sourceNode = node.childForFieldName('source');
+      if (!sourceNode) return;
+      
+      const importPath = sourceNode.text.replace(/['"]/g, '');
+      const symbols: string[] = [];
+      
+      // Find import clause children
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (!child) continue;
+        
+        // Default import: import foo from './module'
+        if (child.type === 'identifier') {
+          symbols.push(child.text);
+        }
+        // Import clause wraps both default import, named imports and namespace imports
+        else if (child.type === 'import_clause') {
+          extractImportClauseSymbols(child, symbols);
+        }
+        // Named imports: import { foo, bar } from './module'
+        else if (child.type === 'named_imports') {
+          extractNamedImportSymbols(child, symbols);
+        }
+        // Namespace import: import * as utils from './module'
+        else if (child.type === 'namespace_import') {
+          extractNamespaceImportSymbol(child, symbols);
+        }
+      }
+      
+      if (symbols.length > 0) {
+        importedSymbols[importPath] = symbols;
+      }
+    }
+    
+    // Only traverse top-level nodes
+    if (node === rootNode) {
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child) traverse(child);
+      }
+    }
+  }
+  
+  traverse(rootNode);
+  return importedSymbols;
+}
+
+/**
+ * Extract symbols from an import clause (handles default, named, and namespace imports)
+ */
+function extractImportClauseSymbols(node: Parser.SyntaxNode, symbols: string[]): void {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (!child) continue;
+    
+    // Default import identifier
+    if (child.type === 'identifier') {
+      symbols.push(child.text);
+    }
+    // Named imports
+    else if (child.type === 'named_imports') {
+      extractNamedImportSymbols(child, symbols);
+    }
+    // Namespace import
+    else if (child.type === 'namespace_import') {
+      extractNamespaceImportSymbol(child, symbols);
+    }
+  }
+}
+
+/**
+ * Extract namespace import symbol: import * as utils
+ */
+function extractNamespaceImportSymbol(node: Parser.SyntaxNode, symbols: string[]): void {
+  // Find the identifier child (the alias name)
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'identifier') {
+      symbols.push(`* as ${child.text}`);
+      return;
+    }
+  }
+}
+
+/**
+ * Helper to extract symbol names from named imports clause
+ */
+function extractNamedImportSymbols(node: Parser.SyntaxNode, symbols: string[]): void {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (!child) continue;
+    
+    if (child.type === 'import_specifier') {
+      // Get the imported name (or alias if renamed)
+      const aliasNode = child.childForFieldName('alias');
+      const nameNode = child.childForFieldName('name');
+      const symbol = aliasNode?.text || nameNode?.text || child.text;
+      if (symbol && !symbol.includes('{') && !symbol.includes('}')) {
+        symbols.push(symbol);
+      }
+    } else if (child.type === 'identifier') {
+      symbols.push(child.text);
+    } else if (child.type === 'named_imports') {
+      // Recurse into nested named_imports
+      extractNamedImportSymbols(child, symbols);
+    }
+  }
+}
+
+/**
+ * Extract exported symbols from a file.
+ * 
+ * Returns array of exported symbol names like: ['validateEmail', 'validatePhone', 'default']
+ * 
+ * Handles various export styles:
+ * - Named exports: export { foo, bar }
+ * - Declaration exports: export function foo() {}, export const bar = ...
+ * - Default exports: export default ...
+ * - Re-exports: export { foo } from './module'
+ */
+export function extractExports(rootNode: Parser.SyntaxNode): string[] {
+  const exports: string[] = [];
+  const seen = new Set<string>();
+  
+  const addExport = (name: string) => {
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      exports.push(name);
+    }
+  };
+  
+  function traverse(node: Parser.SyntaxNode) {
+    // Export statement: export { foo, bar } or export { foo } from './module'
+    if (node.type === 'export_statement') {
+      // Check for default export
+      const defaultKeyword = node.children.find(c => c.type === 'default');
+      if (defaultKeyword) {
+        addExport('default');
+      }
+      
+      // Check for declaration (export function/const/class)
+      const declaration = node.childForFieldName('declaration');
+      if (declaration) {
+        extractDeclarationExports(declaration, addExport);
+      }
+      
+      // Check for export clause (export { foo, bar })
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child?.type === 'export_clause') {
+          extractExportClauseSymbols(child, addExport);
+        }
+      }
+    }
+    
+    // Only traverse top-level nodes
+    if (node === rootNode) {
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child) traverse(child);
+      }
+    }
+  }
+  
+  traverse(rootNode);
+  return exports;
+}
+
+/**
+ * Extract exported names from a declaration (function, const, class, interface)
+ */
+function extractDeclarationExports(node: Parser.SyntaxNode, addExport: (name: string) => void): void {
+  // function/class/interface declaration
+  const nameNode = node.childForFieldName('name');
+  if (nameNode) {
+    addExport(nameNode.text);
+    return;
+  }
+  
+  // lexical_declaration: const/let declarations
+  if (node.type === 'lexical_declaration' || node.type === 'variable_declaration') {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child?.type === 'variable_declarator') {
+        const varName = child.childForFieldName('name');
+        if (varName) {
+          addExport(varName.text);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Extract symbol names from export clause: export { foo, bar as baz }
+ */
+function extractExportClauseSymbols(node: Parser.SyntaxNode, addExport: (name: string) => void): void {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'export_specifier') {
+      // Use alias if present, otherwise use the name
+      const aliasNode = child.childForFieldName('alias');
+      const nameNode = child.childForFieldName('name');
+      const exported = aliasNode?.text || nameNode?.text;
+      if (exported) {
+        addExport(exported);
+      }
+    }
+  }
+}
+
+/**
+ * Extract call sites within a function/method body.
+ * 
+ * Returns array of function calls made within the node.
+ * Only tracks direct function calls (not method calls on objects).
+ */
+export function extractCallSites(node: Parser.SyntaxNode): Array<{ symbol: string; line: number }> {
+  const callSites: Array<{ symbol: string; line: number }> = [];
+  const seen = new Set<string>();
+  
+  function traverse(n: Parser.SyntaxNode) {
+    // call_expression: foo() or foo.bar()
+    if (n.type === 'call_expression') {
+      const functionNode = n.childForFieldName('function');
+      if (functionNode) {
+        // Direct function call: foo()
+        if (functionNode.type === 'identifier') {
+          const key = `${functionNode.text}:${n.startPosition.row + 1}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            callSites.push({
+              symbol: functionNode.text,
+              line: n.startPosition.row + 1,
+            });
+          }
+        }
+        // Member expression: foo.bar() - extract 'bar' if it's a method call
+        else if (functionNode.type === 'member_expression') {
+          const propertyNode = functionNode.childForFieldName('property');
+          if (propertyNode?.type === 'property_identifier') {
+            const key = `${propertyNode.text}:${n.startPosition.row + 1}`;
+            if (!seen.has(key)) {
+              seen.add(key);
+              callSites.push({
+                symbol: propertyNode.text,
+                line: n.startPosition.row + 1,
+              });
+            }
+          }
+        }
+      }
+    }
+    
+    // Recurse into children
+    for (let i = 0; i < n.childCount; i++) {
+      const child = n.child(i);
+      if (child) traverse(child);
+    }
+  }
+  
+  traverse(node);
+  return callSites;
+}

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -502,12 +502,11 @@ function processPythonImport(node: Parser.SyntaxNode): { importPath: string; sym
     // Regular module import: "import os"
     if (child.type === 'dotted_name' || child.type === 'identifier') {
       const moduleName = child.text;
-      // For 'import foo.bar', 'foo' is the module, 'bar' is not a direct symbol
+      // For 'import foo.bar', track the full module path as the symbol
       // For 'import foo', 'foo' is both module and symbol
-      const parts = moduleName.split('.');
       return { 
         importPath: moduleName, 
-        symbols: [parts[0]]  // Only track the top-level module name
+        symbols: [moduleName]
       };
     }
     // Aliased import: "import os as system"

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -468,7 +468,8 @@ function extractPythonAliasedSymbol(node: Parser.SyntaxNode): string | undefined
 
   // If there's at least one identifier, it's the alias (after 'as')
   if (identifierChildren.length >= 1) {
-    return identifierChildren[identifierChildren.length - 1]?.text;
+    // Length check guarantees element exists, no optional chaining needed
+    return identifierChildren[identifierChildren.length - 1].text;
   }
   
   // No alias found, return the original symbol name

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -676,11 +676,13 @@ function extractImportClauseSymbols(node: Parser.SyntaxNode, symbols: string[]):
  */
 function extractNamespaceImportSymbol(node: Parser.SyntaxNode, symbols: string[]): void {
   // Find the identifier child (the alias name)
+  // Namespace imports have exactly one alias identifier, so we return after finding it.
+  // Example: "import * as utils from './module'" → identifier is "utils"
   for (let i = 0; i < node.namedChildCount; i++) {
     const child = node.namedChild(i);
     if (child?.type === 'identifier') {
       symbols.push(`* as ${child.text}`);
-      return;
+      return; // Early return - namespace imports have only one alias
     }
   }
 }

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -468,10 +468,17 @@ function processPythonFromImport(node: Parser.SyntaxNode): { importPath: string;
     // Aliased imports: "from module import foo as bar"
     else if (child.type === 'aliased_import') {
       const identifierChildren = child.namedChildren.filter(c => c.type === 'identifier');
-      // Use the alias name (last identifier, after 'as'), or fall back to the original name
-      const aliasIdentifier = identifierChildren[identifierChildren.length - 1];
       const dottedName = child.namedChildren.find(c => c.type === 'dotted_name');
-      const symbolName = aliasIdentifier?.text || dottedName?.text;
+      let symbolName: string | undefined;
+
+      if (identifierChildren.length >= 2) {
+        // When we have both original and alias identifiers, use the alias (last identifier, after 'as')
+        symbolName = identifierChildren[identifierChildren.length - 1]?.text;
+      } else {
+        // Fallback: prefer the dotted_name text, or the single identifier if present
+        symbolName = dottedName?.text || identifierChildren[0]?.text;
+      }
+
       if (symbolName) {
         symbols.push(symbolName);
       }

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -465,12 +465,16 @@ function processPythonFromImport(node: Parser.SyntaxNode): { importPath: string;
     else if (child.type === 'dotted_name' && foundModule) {
       symbols.push(child.text);
     }
-    // Aliased imports: "import foo as bar"
+    // Aliased imports: "from module import foo as bar"
     else if (child.type === 'aliased_import') {
-      const aliasIdentifier = child.namedChildren.find(c => c.type === 'identifier');
+      const identifierChildren = child.namedChildren.filter(c => c.type === 'identifier');
+      // Use the alias name (last identifier, after 'as'), or fall back to the original name
+      const aliasIdentifier = identifierChildren[identifierChildren.length - 1];
       const dottedName = child.namedChildren.find(c => c.type === 'dotted_name');
-      // Use the alias name, or fall back to the original name
-      symbols.push(aliasIdentifier?.text || dottedName?.text || '');
+      const symbolName = aliasIdentifier?.text || dottedName?.text;
+      if (symbolName) {
+        symbols.push(symbolName);
+      }
     }
   }
   

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -406,6 +406,9 @@ function extractPHPQualifiedName(clause: Parser.SyntaxNode): string | null {
  *
  * Note: Only top-level static import statements are processed. Dynamic imports
  * (e.g., `await import('./module')`) and non-top-level imports are not tracked.
+ * TypeScript/JavaScript side-effect imports without imported symbols (e.g.,
+ * `import './styles.css'`) are also not tracked and will not appear in
+ * `importedSymbols`.
  */
 export function extractImportedSymbols(rootNode: Parser.SyntaxNode): Record<string, string[]> {
   const importedSymbols: Record<string, string[]> = {};

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -455,14 +455,6 @@ export function extractImportedSymbols(rootNode: Parser.SyntaxNode): Record<stri
 }
 
 /**
- * Extract symbol name from Python aliased import node.
- * Handles "from module import foo as bar" by extracting the alias (bar).
- * 
- * AST structure for "from module import Optional as Opt":
- * - aliased_import contains: dotted_name('Optional') and identifier('Opt')
- * - The alias is always the last identifier child
- */
-/**
  * Extract the aliased symbol from a Python aliased_import node.
  * For "from typing import Optional as Opt", returns "Opt" (the alias).
  * 

--- a/packages/core/src/indexer/types.ts
+++ b/packages/core/src/indexer/types.ts
@@ -41,7 +41,7 @@ export interface ChunkMetadata {
   
   /**
    * Call sites within this chunk - symbols called and their locations.
-   * Only tracked for function/method chunks.
+   * Tracked for chunks whose symbolType supports complexity analysis (e.g. functions and methods).
    */
   callSites?: Array<{
     symbol: string;     // The called symbol name

--- a/packages/core/src/indexer/types.ts
+++ b/packages/core/src/indexer/types.ts
@@ -26,6 +26,28 @@ export interface ChunkMetadata {
   signature?: string;         // Full signature
   imports?: string[];         // File imports (for context)
   
+  // Symbol-level dependency tracking (v0.23.0)
+  /**
+   * Symbols exported by this file. Extracted from export statements.
+   * Example: ['validateEmail', 'validatePhone', 'ValidationError']
+   */
+  exports?: string[];
+  
+  /**
+   * Map of import paths to the symbols imported from them.
+   * Example: { './validate': ['validateEmail', 'validatePhone'] }
+   */
+  importedSymbols?: Record<string, string[]>;
+  
+  /**
+   * Call sites within this chunk - symbols called and their locations.
+   * Only tracked for function/method chunks.
+   */
+  callSites?: Array<{
+    symbol: string;     // The called symbol name
+    line: number;       // Line number of the call
+  }>;
+  
   // Halstead metrics (v0.19.0)
   halsteadVolume?: number;      // V = N × log₂(n) - size of implementation
   halsteadDifficulty?: number;  // D = (n1/2) × (N2/n2) - error-proneness

--- a/packages/core/src/vectordb/batch-insert.test.ts
+++ b/packages/core/src/vectordb/batch-insert.test.ts
@@ -183,6 +183,12 @@ describe('batch-insert', () => {
           halsteadDifficulty: 0,
           halsteadEffort: 0,
           halsteadBugs: 0,
+          // Symbol-level tracking (v0.23.0) - placeholders for missing data
+          exports: [''],
+          importedSymbolPaths: [''],
+          importedSymbolNames: [''],
+          callSiteSymbols: [''],
+          callSiteLines: [0],
         });
       });
 

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -86,7 +86,7 @@ function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
  * Note: Returns single-element arrays with placeholder values (empty string, 0)
  * for missing data. This is required for Arrow type inference - empty arrays cause
  * schema inference failures. The deserialization in query.ts filters out these
- * placeholders via hasValidArrayEntries() and the line > 0 check.
+ * placeholders via hasValidStringEntries() and the line > 0 check.
  */
 function serializeCallSites(callSites?: Array<{ symbol: string; line: number }>): {
   symbols: string[];

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -63,7 +63,7 @@ interface DatabaseRecord {
  * 
  * Note: Returns single-element arrays with empty strings for missing data.
  * This is required for Arrow type inference - empty arrays cause schema inference
- * failures. The deserialization in query.ts uses hasValidArrayEntries() to filter
+ * failures. The deserialization in query.ts uses hasValidStringEntries() to filter
  * out these placeholder values.
  */
 function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -60,6 +60,11 @@ interface DatabaseRecord {
  * Serialize importedSymbols map into parallel arrays for Arrow storage.
  * Returns { paths: string[], names: string[] } where names[i] is JSON-encoded array
  * of symbols imported from paths[i].
+ * 
+ * Note: Returns single-element arrays with empty strings for missing data.
+ * This is required for Arrow type inference - empty arrays cause schema inference
+ * failures. The deserialization in query.ts uses hasValidArrayEntries() to filter
+ * out these placeholder values.
  */
 function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
   paths: string[];
@@ -77,6 +82,11 @@ function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
 
 /**
  * Serialize callSites into parallel arrays for Arrow storage.
+ * 
+ * Note: Returns single-element arrays with placeholder values (empty string, 0)
+ * for missing data. This is required for Arrow type inference - empty arrays cause
+ * schema inference failures. The deserialization in query.ts filters out these
+ * placeholders via hasValidArrayEntries() and the line >= 0 check.
  */
 function serializeCallSites(callSites?: Array<{ symbol: string; line: number }>): {
   symbols: string[];

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -53,10 +53,6 @@ interface DatabaseRecord {
 }
 
 /**
- * Transform a chunk's data into a database record.
- * Handles missing/empty metadata by providing defaults for Arrow type inference.
- */
-/**
  * Serialize importedSymbols map into parallel arrays for Arrow storage.
  * Returns { paths: string[], names: string[] } where names[i] is JSON-encoded array
  * of symbols imported from paths[i].
@@ -101,6 +97,11 @@ function serializeCallSites(callSites?: Array<{ symbol: string; line: number }>)
   };
 }
 
+/**
+ * Transform a chunk's data into a database record.
+ * Serializes complex metadata fields and handles missing/empty data by providing
+ * placeholder values for Arrow type inference.
+ */
 function transformChunkToRecord(
   vector: Float32Array,
   content: string,

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -46,8 +46,8 @@ interface DatabaseRecord {
   halsteadBugs: number;
   // Symbol-level dependency tracking (v0.23.0)
   exports: string[];
-  importedSymbolPaths: string[];    // JSON-encoded import path -> symbols mapping keys
-  importedSymbolNames: string[];    // JSON-encoded import path -> symbols mapping values
+  importedSymbolPaths: string[];    // Import paths (keys from importedSymbols map)
+  importedSymbolNames: string[];    // JSON-encoded symbol arrays (values from importedSymbols map)
   callSiteSymbols: string[];        // Called symbol names
   callSiteLines: number[];          // Line numbers of calls (parallel array)
 }

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -53,21 +53,26 @@ interface DatabaseRecord {
 }
 
 /**
+ * Arrow type inference placeholder for empty string arrays.
+ * Used to prevent schema inference failures when no data is present.
+ * Filtered out during deserialization via hasValidStringEntries().
+ */
+const ARROW_EMPTY_STRING_PLACEHOLDER = [''];
+
+/**
  * Serialize importedSymbols map into parallel arrays for Arrow storage.
  * Returns { paths: string[], names: string[] } where names[i] is JSON-encoded array
  * of symbols imported from paths[i].
- * 
- * Note: For missing data, this function uses single-element placeholder arrays with
- * empty strings. This is required for Arrow type inference - empty arrays cause
- * schema inference failures. The deserialization in query.ts uses
- * hasValidStringEntries() to filter out these placeholder values.
+ *
+ * Note: For missing data, this function uses ARROW_EMPTY_STRING_PLACEHOLDER.
+ * This is required for Arrow type inference - empty arrays cause schema inference failures.
  */
 function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
   paths: string[];
   names: string[];
 } {
   if (!importedSymbols || Object.keys(importedSymbols).length === 0) {
-    return { paths: [''], names: [''] };
+    return { paths: ARROW_EMPTY_STRING_PLACEHOLDER, names: ARROW_EMPTY_STRING_PLACEHOLDER };
   }
   const entries = Object.entries(importedSymbols);
   return {
@@ -77,19 +82,25 @@ function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
 }
 
 /**
+ * Arrow type inference placeholder for empty number arrays.
+ * Used to prevent schema inference failures when no data is present.
+ * Filtered out during deserialization via hasValidNumberEntries().
+ */
+const ARROW_EMPTY_NUMBER_PLACEHOLDER = [0];
+
+/**
  * Serialize callSites into parallel arrays for Arrow storage.
  * 
- * Note: Returns single-element arrays with placeholder values (empty string, 0)
+ * Note: Uses ARROW_EMPTY_STRING_PLACEHOLDER and ARROW_EMPTY_NUMBER_PLACEHOLDER
  * for missing data. This is required for Arrow type inference - empty arrays cause
- * schema inference failures. The deserialization in query.ts filters out these
- * placeholders via hasValidStringEntries() and the line > 0 check.
+ * schema inference failures.
  */
 function serializeCallSites(callSites?: Array<{ symbol: string; line: number }>): {
   symbols: string[];
   lines: number[];
 } {
   if (!callSites || callSites.length === 0) {
-    return { symbols: [''], lines: [0] };
+    return { symbols: ARROW_EMPTY_STRING_PLACEHOLDER, lines: ARROW_EMPTY_NUMBER_PLACEHOLDER };
   }
   return {
     symbols: callSites.map(c => c.symbol),

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -61,10 +61,10 @@ interface DatabaseRecord {
  * Returns { paths: string[], names: string[] } where names[i] is JSON-encoded array
  * of symbols imported from paths[i].
  * 
- * Note: Returns single-element arrays with empty strings for missing data.
- * This is required for Arrow type inference - empty arrays cause schema inference
- * failures. The deserialization in query.ts uses hasValidStringEntries() to filter
- * out these placeholder values.
+ * Note: For missing data, this function uses single-element placeholder arrays with
+ * empty strings. This is required for Arrow type inference - empty arrays cause
+ * schema inference failures. The deserialization in query.ts uses
+ * hasValidStringEntries() to filter out these placeholder values.
  */
 function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
   paths: string[];

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -86,7 +86,7 @@ function serializeImportedSymbols(importedSymbols?: Record<string, string[]>): {
  * Note: Returns single-element arrays with placeholder values (empty string, 0)
  * for missing data. This is required for Arrow type inference - empty arrays cause
  * schema inference failures. The deserialization in query.ts filters out these
- * placeholders via hasValidArrayEntries() and the line >= 0 check.
+ * placeholders via hasValidArrayEntries() and the line > 0 check.
  */
 function serializeCallSites(callSites?: Array<{ symbol: string; line: number }>): {
   symbols: string[];

--- a/packages/core/src/vectordb/qdrant-payload-mapper.ts
+++ b/packages/core/src/vectordb/qdrant-payload-mapper.ts
@@ -31,6 +31,10 @@ export interface QdrantPayload {
   halsteadDifficulty: number;   // Always present (defaults to 0 if missing)
   halsteadEffort: number;       // Always present (defaults to 0 if missing)
   halsteadBugs: number;         // Always present (defaults to 0 if missing)
+  // Symbol-level dependency tracking (v0.23.0)
+  exports: string[];
+  importedSymbols: string;      // JSON-encoded Record<string, string[]>
+  callSites: string;            // JSON-encoded Array<{symbol, line}>
   // Multi-tenant fields
   orgId: string;
   repoId: string;
@@ -79,6 +83,10 @@ export class QdrantPayloadMapper {
       parameters: metadata.parameters ?? [],
       signature: metadata.signature ?? '',
       imports: metadata.imports ?? [],
+      // Symbol-level dependency tracking (v0.23.0)
+      exports: metadata.exports ?? [],
+      importedSymbols: metadata.importedSymbols ? JSON.stringify(metadata.importedSymbols) : '{}',
+      callSites: metadata.callSites ? JSON.stringify(metadata.callSites) : '[]',
     };
   }
 
@@ -150,6 +158,41 @@ export class QdrantPayloadMapper {
   }
 
   /**
+   * Parse JSON safely, returning undefined on error.
+   */
+  private safeJsonParse<T>(json: string | undefined, defaultValue: T): T {
+    if (!json || json === '{}' || json === '[]') {
+      return defaultValue;
+    }
+    try {
+      return JSON.parse(json);
+    } catch {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Extract symbol-level dependency tracking fields.
+   */
+  private extractDependencyTracking(payload: Record<string, any>) {
+    const exports = payload.exports?.length > 0 ? payload.exports : undefined;
+    const importedSymbols = this.safeJsonParse<Record<string, string[]>>(
+      payload.importedSymbols,
+      {}
+    );
+    const callSites = this.safeJsonParse<Array<{ symbol: string; line: number }>>(
+      payload.callSites,
+      []
+    );
+
+    return {
+      exports,
+      importedSymbols: Object.keys(importedSymbols).length > 0 ? importedSymbols : undefined,
+      callSites: callSites.length > 0 ? callSites : undefined,
+    };
+  }
+
+  /**
    * Transform Qdrant payload back to ChunkMetadata.
    */
   fromPayload(payload: Record<string, any>): ChunkMetadata {
@@ -168,6 +211,7 @@ export class QdrantPayloadMapper {
       imports: payload.imports ?? undefined,
       ...this.extractMetrics(payload),
       ...this.extractTrackingInfo(payload),
+      ...this.extractDependencyTracking(payload),
     };
   }
 }

--- a/packages/core/src/vectordb/qdrant-payload-mapper.ts
+++ b/packages/core/src/vectordb/qdrant-payload-mapper.ts
@@ -166,7 +166,8 @@ export class QdrantPayloadMapper {
     }
     try {
       return JSON.parse(json);
-    } catch {
+    } catch (err) {
+      console.warn(`QdrantPayloadMapper.safeJsonParse: failed to parse JSON. Returning default.`, err);
       return defaultValue;
     }
   }

--- a/packages/core/src/vectordb/qdrant-payload-mapper.ts
+++ b/packages/core/src/vectordb/qdrant-payload-mapper.ts
@@ -158,10 +158,10 @@ export class QdrantPayloadMapper {
   }
 
   /**
-   * Parse JSON safely, returning undefined on error.
+   * Parse JSON safely, returning default value on error or missing input.
    */
   private safeJsonParse<T>(json: string | undefined, defaultValue: T): T {
-    if (!json || json === '{}' || json === '[]') {
+    if (json == null) {
       return defaultValue;
     }
     try {

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -162,6 +162,10 @@ function deserializeImportedSymbols(
   if (!pathsArr || !namesArr || !hasValidStringEntries(pathsArr) || !hasValidStringEntries(namesArr)) {
     return undefined;
   }
+  // Warn if arrays are mismatched (could indicate data corruption)
+  if (pathsArr.length !== namesArr.length) {
+    console.warn(`deserializeImportedSymbols: array length mismatch (paths: ${pathsArr.length}, names: ${namesArr.length})`);
+  }
   const result: Record<string, string[]> = {};
   for (let i = 0; i < pathsArr.length && i < namesArr.length; i++) {
     const path = pathsArr[i];
@@ -189,6 +193,10 @@ function deserializeCallSites(
   
   if (!symbolsArr || !linesArr || !hasValidStringEntries(symbolsArr) || !hasValidNumberEntries(linesArr)) {
     return undefined;
+  }
+  // Warn if arrays are mismatched (could indicate data corruption)
+  if (symbolsArr.length !== linesArr.length) {
+    console.warn(`deserializeCallSites: array length mismatch (symbols: ${symbolsArr.length}, lines: ${linesArr.length})`);
   }
   const result: Array<{ symbol: string; line: number }> = [];
   for (let i = 0; i < symbolsArr.length && i < linesArr.length; i++) {

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -98,8 +98,9 @@ function isValidRecord(r: DBRecord): boolean {
 }
 
 /**
- * Check if a string array field has valid (non-empty) entries.
- * LanceDB stores empty arrays as [''] which we need to filter out.
+ * Check if a string array has valid (non-empty) entries.
+ * LanceDB stores empty string arrays as [''] which we need to filter out.
+ * This is specifically for string arrays (cf. hasValidNumberEntries for number arrays).
  */
 function hasValidStringEntries(arr: string[] | undefined): boolean {
   return Boolean(arr && arr.length > 0 && arr[0] !== '');
@@ -152,6 +153,10 @@ function toPlainArray<T>(arr: any): T[] | undefined {
 
 /**
  * Deserialize importedSymbols from parallel arrays stored in DB.
+ * 
+ * @param paths - Array of import paths (keys from importedSymbols map)
+ * @param names - Array of JSON-encoded symbol arrays (values from importedSymbols map)
+ * @returns Record mapping import paths to symbol arrays, or undefined if no valid data
  */
 function deserializeImportedSymbols(
   paths?: unknown,
@@ -188,6 +193,10 @@ function deserializeImportedSymbols(
 
 /**
  * Deserialize callSites from parallel arrays stored in DB.
+ * 
+ * @param symbols - Array of symbol names called at each site
+ * @param lines - Array of line numbers for each call site (parallel to symbols)
+ * @returns Array of call site objects with symbol and line, or undefined if no valid data
  */
 function deserializeCallSites(
   symbols?: unknown,

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -181,7 +181,7 @@ function deserializeImportedSymbols(
     );
   }
   const result: Record<string, string[]> = {};
-  for (let i = 0; i < pathsArr.length && i < namesArr.length; i++) {
+  for (let i = 0; i < pathsArr.length; i++) {
     const path = pathsArr[i];
     const namesJson = namesArr[i];
     if (path && namesJson) {
@@ -221,7 +221,7 @@ function deserializeCallSites(
     );
   }
   const result: Array<{ symbol: string; line: number }> = [];
-  for (let i = 0; i < symbolsArr.length && i < linesArr.length; i++) {
+  for (let i = 0; i < symbolsArr.length; i++) {
     const symbol = symbolsArr[i];
     const line = linesArr[i];
     // Note: line > 0 is intentional - we use 0 as a placeholder value for missing data

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -173,8 +173,8 @@ function deserializeImportedSymbols(
     if (path && namesJson) {
       try {
         result[path] = JSON.parse(namesJson);
-      } catch {
-        // Skip malformed entries
+      } catch (err) {
+        console.warn(`deserializeImportedSymbols: failed to parse JSON for path "${path}". Skipping entry.`, err);
       }
     }
   }

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -106,8 +106,9 @@ function hasValidStringEntries(arr: string[] | undefined): boolean {
 }
 
 /**
- * Check if a number array field has valid (non-zero) entries.
- * LanceDB stores empty arrays as [0] which we need to filter out.
+ * Check if a number array has valid entries (filters out placeholder values).
+ * When there's no data, serializeCallSites() returns [0] as a sentinel value.
+ * This function checks if the array contains real data (line numbers > 0).
  */
 function hasValidNumberEntries(arr: number[] | undefined): boolean {
   return Boolean(arr && arr.length > 0 && arr[0] !== 0);

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -164,7 +164,11 @@ function deserializeImportedSymbols(
   }
   // Warn if arrays are mismatched (could indicate data corruption)
   if (pathsArr.length !== namesArr.length) {
-    console.warn(`deserializeImportedSymbols: array length mismatch (paths: ${pathsArr.length}, names: ${namesArr.length})`);
+    const missingCount = Math.abs(pathsArr.length - namesArr.length);
+    console.warn(
+      `deserializeImportedSymbols: array length mismatch (paths: ${pathsArr.length}, names: ${namesArr.length}). ` +
+      `Proceeding with ${Math.min(pathsArr.length, namesArr.length)} entries; ${missingCount} entr${missingCount === 1 ? 'y' : 'ies'} will be skipped.`
+    );
   }
   const result: Record<string, string[]> = {};
   for (let i = 0; i < pathsArr.length && i < namesArr.length; i++) {
@@ -196,7 +200,11 @@ function deserializeCallSites(
   }
   // Warn if arrays are mismatched (could indicate data corruption)
   if (symbolsArr.length !== linesArr.length) {
-    console.warn(`deserializeCallSites: array length mismatch (symbols: ${symbolsArr.length}, lines: ${linesArr.length})`);
+    const missingCount = Math.abs(symbolsArr.length - linesArr.length);
+    console.warn(
+      `deserializeCallSites: array length mismatch (symbols: ${symbolsArr.length}, lines: ${linesArr.length}). ` +
+      `Proceeding with ${Math.min(symbolsArr.length, linesArr.length)} entries; ${missingCount} entr${missingCount === 1 ? 'y' : 'ies'} will be skipped.`
+    );
   }
   const result: Array<{ symbol: string; line: number }> = [];
   for (let i = 0; i < symbolsArr.length && i < linesArr.length; i++) {

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -190,7 +190,9 @@ function deserializeCallSites(
   for (let i = 0; i < symbolsArr.length && i < linesArr.length; i++) {
     const symbol = symbolsArr[i];
     const line = linesArr[i];
-    if (symbol && line > 0) {
+    // Note: line > 0 is intentional - we use 0 as a placeholder value for missing data
+    // in serializeCallSites(). Real line numbers are 1-indexed in source files.
+    if (symbol && typeof line === 'number' && line > 0) {
       result.push({ symbol, line });
     }
   }


### PR DESCRIPTION
Phase 2 of get_dependents enhancements. When an optional 'symbol' parameter is provided, returns specific call sites for that symbol instead of just file-level dependencies.

Changes:
- Add 'symbol' parameter to GetDependentsSchema
- Add 'exports' field to ChunkMetadata (symbols exported by file)
- Add 'importedSymbols' field (map of import paths to symbols)
- Add 'callSites' field (function calls within a chunk)
- Add extractImportedSymbols, extractExports, extractCallSites to symbols.ts
- Update chunker to extract and store new metadata during indexing
- Update findDependents to filter by symbol and return usages
- Add DependentInfo.usages array with caller, line, and snippet
- Add totalUsageCount to response when symbol is specified

API example:
  get_dependents({ filepath: 'validate.ts', symbol: 'validateEmail' }) → Returns files that import validateEmail with call site details

Tested with 23 new symbol extraction tests and 7 handler tests.

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Improved!** This PR reduces complexity by 2.

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 5 | +114 |
| ⏱️ time to understand | 1 | -116 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->