### PR TITLE
fix(indexer): track PHP and Python exports for symbol-level dependencies

### DIFF
--- a/.changeset/forty-suns-march.md
+++ b/.changeset/forty-suns-march.md
@@ -1,0 +1,24 @@
+---
+"@liendev/core": minor
+"@liendev/lien": minor
+---
+
+feat(indexer): add PHP and Python export tracking for symbol-level dependencies
+
+Extends symbol-level `get_dependents` support to PHP and Python codebases by implementing export tracking for these languages. The `extractExports()` function now identifies:
+
+**PHP:**
+
+- Classes, traits, interfaces (namespaced and global)
+- Top-level functions
+- All exportable declarations within namespace blocks
+
+**Python:**
+
+- Classes (including `@dataclass` and other decorated classes)
+- Functions and async functions
+- Decorated definitions (e.g., `@property`, `@staticmethod`)
+
+This enables accurate dependency analysis, impact assessment, and symbol usage tracking for PHP and Python projects. Previously, symbol-level `get_dependents` only worked for JavaScript/TypeScript.
+
+**Architecture:** Export extraction logic has been refactored into dedicated language-specific modules (`extractors/`), mirroring the existing `traversers/` pattern for improved modularity and maintainability.

--- a/packages/cli/test/benchmarks/performance.test.ts
+++ b/packages/cli/test/benchmarks/performance.test.ts
@@ -36,7 +36,7 @@ describe('Performance Benchmarks', () => {
 
     // Seed vector database with test data
     await seedTestData();
-  });
+  }, 60000); // 60 second timeout for CI (embedding model initialization is slow)
 
   afterAll(async () => {
     // Cleanup

--- a/packages/core/src/indexer/ast/chunker.ts
+++ b/packages/core/src/indexer/ast/chunker.ts
@@ -54,7 +54,7 @@ function prepareASTContext(
     lines: content.split('\n'),
     fileImports: extractImports(rootNode),
     importedSymbols: extractImportedSymbols(rootNode),
-    fileExports: extractExports(rootNode),
+    fileExports: extractExports(rootNode, language),
     traverser: getTraverser(language),
   };
 }

--- a/packages/core/src/indexer/ast/extractors/extractors.test.ts
+++ b/packages/core/src/indexer/ast/extractors/extractors.test.ts
@@ -136,5 +136,39 @@ async def fetch():
       
       expect(exports).toEqual(['User', 'helper', 'fetch']);
     });
+    
+    it('should extract decorated class exports', () => {
+      const code = `@dataclass
+class User:
+    pass`;
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['User']);
+    });
+    
+    it('should extract decorated function exports', () => {
+      const code = `@property
+def get_name():
+    pass`;
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['get_name']);
+    });
+    
+    it('should extract multiple decorators', () => {
+      const code = `@staticmethod
+@cache
+def compute():
+    pass`;
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['compute']);
+    });
   });
 });

--- a/packages/core/src/indexer/ast/extractors/extractors.test.ts
+++ b/packages/core/src/indexer/ast/extractors/extractors.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import TypeScript from 'tree-sitter-typescript';
+import PHP from 'tree-sitter-php';
+import Python from 'tree-sitter-python';
+import { getExtractor } from './index.js';
+
+describe('Export Extractors', () => {
+  describe('JavaScriptExportExtractor', () => {
+    const parser = new Parser();
+    parser.setLanguage(TypeScript.typescript);
+    
+    it('should extract named exports', () => {
+      const code = 'export { foo, bar };';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('javascript');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['foo', 'bar']);
+    });
+    
+    it('should extract function exports', () => {
+      const code = 'export function validateEmail() {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('typescript');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['validateEmail']);
+    });
+    
+    it('should extract default exports', () => {
+      const code = 'export default class App {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('javascript');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['default', 'App']);
+    });
+  });
+  
+  describe('PHPExportExtractor', () => {
+    const parser = new Parser();
+    parser.setLanguage(PHP.php);
+    
+    it('should extract class exports', () => {
+      const code = '<?php\nclass User {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('php');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['User']);
+    });
+    
+    it('should extract trait exports', () => {
+      const code = '<?php\ntrait HasTimestamps {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('php');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['HasTimestamps']);
+    });
+    
+    it('should extract interface exports', () => {
+      const code = '<?php\ninterface Repository {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('php');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['Repository']);
+    });
+    
+    it('should extract function exports', () => {
+      const code = '<?php\nfunction helper() {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('php');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['helper']);
+    });
+    
+    it('should extract namespaced exports', () => {
+      const code = '<?php\nnamespace App\\Models;\nclass User {}';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('php');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['User']);
+    });
+  });
+  
+  describe('PythonExportExtractor', () => {
+    const parser = new Parser();
+    parser.setLanguage(Python);
+    
+    it('should extract class exports', () => {
+      const code = 'class User:\n    pass';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['User']);
+    });
+    
+    it('should extract function exports', () => {
+      const code = 'def helper():\n    pass';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['helper']);
+    });
+    
+    it('should extract async function exports', () => {
+      const code = 'async def fetch_data():\n    pass';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['fetch_data']);
+    });
+    
+    it('should extract multiple exports', () => {
+      const code = `
+class User:
+    pass
+
+def helper():
+    pass
+
+async def fetch():
+    pass
+`;
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+      
+      expect(exports).toEqual(['User', 'helper', 'fetch']);
+    });
+  });
+});

--- a/packages/core/src/indexer/ast/extractors/index.ts
+++ b/packages/core/src/indexer/ast/extractors/index.ts
@@ -1,0 +1,50 @@
+import type { SupportedLanguage } from '../types.js';
+import type { LanguageExportExtractor } from './types.js';
+import { JavaScriptExportExtractor, TypeScriptExportExtractor } from './javascript.js';
+import { PHPExportExtractor } from './php.js';
+import { PythonExportExtractor } from './python.js';
+
+export type { LanguageExportExtractor } from './types.js';
+
+/**
+ * Registry of language export extractors
+ * 
+ * Maps each supported language to its export extractor implementation.
+ * When adding a new language:
+ * 1. Create a new extractor class implementing LanguageExportExtractor
+ * 2. Add it to this registry
+ * 3. Update SupportedLanguage type in ../types.ts
+ */
+const extractorRegistry: Record<SupportedLanguage, LanguageExportExtractor> = {
+  typescript: new TypeScriptExportExtractor(),
+  javascript: new JavaScriptExportExtractor(),
+  php: new PHPExportExtractor(),
+  python: new PythonExportExtractor(),
+};
+
+/**
+ * Get the export extractor for a specific language
+ * 
+ * @param language - Programming language
+ * @returns Language-specific export extractor
+ * @throws Error if language is not supported
+ */
+export function getExtractor(language: SupportedLanguage): LanguageExportExtractor {
+  const extractor = extractorRegistry[language];
+  
+  if (!extractor) {
+    throw new Error(`No export extractor available for language: ${language}`);
+  }
+  
+  return extractor;
+}
+
+/**
+ * Check if a language has an export extractor implementation
+ * 
+ * @param language - Programming language
+ * @returns True if extractor exists
+ */
+export function hasExtractor(language: SupportedLanguage): boolean {
+  return language in extractorRegistry;
+}

--- a/packages/core/src/indexer/ast/extractors/index.ts
+++ b/packages/core/src/indexer/ast/extractors/index.ts
@@ -27,11 +27,18 @@ const extractorRegistry: Record<SupportedLanguage, LanguageExportExtractor> = {
  * 
  * @param language - Programming language
  * @returns Language-specific export extractor
- * @throws Error if language is not supported
+ * @throws Error if language is not supported (defensive check for runtime safety)
+ * 
+ * Note: While TypeScript's type system guarantees all SupportedLanguage values
+ * have corresponding extractors, this runtime check provides defense against:
+ * - Type system bypasses (e.g., `as any` casting elsewhere)
+ * - JavaScript consumers without type checking
+ * - Future refactoring errors during registry modifications
  */
 export function getExtractor(language: SupportedLanguage): LanguageExportExtractor {
   const extractor = extractorRegistry[language];
   
+  // Defensive runtime check - see function documentation
   if (!extractor) {
     throw new Error(`No export extractor available for language: ${language}`);
   }

--- a/packages/core/src/indexer/ast/extractors/javascript.ts
+++ b/packages/core/src/indexer/ast/extractors/javascript.ts
@@ -1,0 +1,108 @@
+import type Parser from 'tree-sitter';
+import type { LanguageExportExtractor } from './types.js';
+
+/**
+ * JavaScript/TypeScript export extractor
+ * 
+ * Handles explicit export statements:
+ * - Named exports: export { foo, bar }
+ * - Declaration exports: export function foo() {}, export const bar = ...
+ * - Default exports: export default ...
+ * - Re-exports: export { foo } from './module'
+ */
+export class JavaScriptExportExtractor implements LanguageExportExtractor {
+  extractExports(rootNode: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const seen = new Set<string>();
+    
+    const addExport = (name: string) => {
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        exports.push(name);
+      }
+    };
+    
+    // Process only top-level export statements
+    for (let i = 0; i < rootNode.namedChildCount; i++) {
+      const child = rootNode.namedChild(i);
+      if (child?.type === 'export_statement') {
+        this.extractExportStatementSymbols(child, addExport);
+      }
+    }
+    
+    return exports;
+  }
+  
+  /**
+   * Extract symbols from a single export statement
+   */
+  private extractExportStatementSymbols(node: Parser.SyntaxNode, addExport: (name: string) => void): void {
+    // Check for default export
+    const defaultKeyword = node.children.find(c => c.type === 'default');
+    if (defaultKeyword) {
+      addExport('default');
+    }
+    
+    // Check for declaration (export function/const/class)
+    const declaration = node.childForFieldName('declaration');
+    if (declaration) {
+      this.extractDeclarationExports(declaration, addExport);
+    }
+    
+    // Check for export clause (export { foo, bar })
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child?.type === 'export_clause') {
+        this.extractExportClauseSymbols(child, addExport);
+      }
+    }
+  }
+  
+  /**
+   * Extract exported names from a declaration (function, const, class, interface)
+   */
+  private extractDeclarationExports(node: Parser.SyntaxNode, addExport: (name: string) => void): void {
+    // function/class/interface declaration
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) {
+      addExport(nameNode.text);
+      return;
+    }
+    
+    // lexical_declaration: const/let declarations
+    if (node.type === 'lexical_declaration' || node.type === 'variable_declaration') {
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const child = node.namedChild(i);
+        if (child?.type === 'variable_declarator') {
+          const varName = child.childForFieldName('name');
+          if (varName) {
+            addExport(varName.text);
+          }
+        }
+      }
+    }
+  }
+  
+  /**
+   * Extract symbol names from export clause: export { foo, bar as baz }
+   */
+  private extractExportClauseSymbols(node: Parser.SyntaxNode, addExport: (name: string) => void): void {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child?.type === 'export_specifier') {
+        // Use alias if present, otherwise use the name
+        const aliasNode = child.childForFieldName('alias');
+        const nameNode = child.childForFieldName('name');
+        const exported = aliasNode?.text || nameNode?.text;
+        if (exported) {
+          addExport(exported);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * TypeScript uses the same export extraction as JavaScript
+ */
+export class TypeScriptExportExtractor extends JavaScriptExportExtractor {}

--- a/packages/core/src/indexer/ast/extractors/php.ts
+++ b/packages/core/src/indexer/ast/extractors/php.ts
@@ -1,0 +1,90 @@
+import type Parser from 'tree-sitter';
+import type { LanguageExportExtractor } from './types.js';
+
+/**
+ * PHP export extractor
+ * 
+ * PHP doesn't have explicit export syntax. All top-level declarations are
+ * considered exported (accessible via `use` statements):
+ * - Classes: class User {}
+ * - Traits: trait HasTimestamps {}
+ * - Interfaces: interface Repository {}
+ * - Functions: function helper() {}
+ * - Namespaced declarations are also tracked
+ */
+export class PHPExportExtractor implements LanguageExportExtractor {
+  /**
+   * Node types that represent exportable PHP declarations
+   */
+  private readonly exportableTypes = new Set([
+    'class_declaration',
+    'trait_declaration',
+    'interface_declaration',
+    'function_definition',
+  ]);
+  
+  extractExports(rootNode: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const seen = new Set<string>();
+    
+    for (let i = 0; i < rootNode.namedChildCount; i++) {
+      const child = rootNode.namedChild(i);
+      if (!child) continue;
+      
+      const childExports = this.extractExportsFromNode(child);
+      childExports.forEach(exp => {
+        if (exp && !seen.has(exp)) {
+          seen.add(exp);
+          exports.push(exp);
+        }
+      });
+    }
+    
+    return exports;
+  }
+  
+  /**
+   * Extract PHP exports from a single AST node
+   * Handles both direct declarations and namespace definitions
+   */
+  private extractExportsFromNode(node: Parser.SyntaxNode): string[] {
+    if (node.type === 'namespace_definition') {
+      return this.extractExportsFromNamespace(node);
+    }
+    
+    const name = this.extractExportableDeclaration(node);
+    return name ? [name] : [];
+  }
+  
+  /**
+   * Extract exports from within a PHP namespace definition
+   */
+  private extractExportsFromNamespace(node: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const body = node.childForFieldName('body');
+    
+    if (body) {
+      for (let i = 0; i < body.namedChildCount; i++) {
+        const child = body.namedChild(i);
+        if (child) {
+          const name = this.extractExportableDeclaration(child);
+          if (name) exports.push(name);
+        }
+      }
+    }
+    
+    return exports;
+  }
+  
+  /**
+   * Extract the name from a PHP exportable declaration (class, trait, interface, function)
+   */
+  private extractExportableDeclaration(node: Parser.SyntaxNode): string | null {
+    if (this.exportableTypes.has(node.type)) {
+      const nameNode = node.childForFieldName('name');
+      return nameNode ? nameNode.text : null;
+    }
+    
+    return null;
+  }
+}

--- a/packages/core/src/indexer/ast/extractors/python.ts
+++ b/packages/core/src/indexer/ast/extractors/python.ts
@@ -1,0 +1,51 @@
+import type Parser from 'tree-sitter';
+import type { LanguageExportExtractor } from './types.js';
+
+/**
+ * Python export extractor
+ * 
+ * Python doesn't have explicit export syntax. All module-level (top-level)
+ * declarations are considered exported (importable by other modules):
+ * - Classes: class User: ...
+ * - Functions: def helper(): ...
+ * - Async functions: async def fetch_data(): ...
+ * 
+ * Note: Only top-level definitions are tracked. Nested functions/classes
+ * inside other functions are not considered exports.
+ */
+export class PythonExportExtractor implements LanguageExportExtractor {
+  /**
+   * Node types that represent exportable Python declarations
+   */
+  private readonly exportableTypes = new Set([
+    'class_definition',
+    'function_definition',
+    'async_function_definition',
+  ]);
+  
+  extractExports(rootNode: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const seen = new Set<string>();
+    
+    const addExport = (name: string) => {
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        exports.push(name);
+      }
+    };
+    
+    // Process only top-level nodes (module-level definitions)
+    for (let i = 0; i < rootNode.namedChildCount; i++) {
+      const child = rootNode.namedChild(i);
+      if (!child) continue;
+      
+      // Extract name from exportable node types
+      if (this.exportableTypes.has(child.type)) {
+        const nameNode = child.childForFieldName('name');
+        if (nameNode) addExport(nameNode.text);
+      }
+    }
+    
+    return exports;
+  }
+}

--- a/packages/core/src/indexer/ast/extractors/python.ts
+++ b/packages/core/src/indexer/ast/extractors/python.ts
@@ -39,6 +39,17 @@ export class PythonExportExtractor implements LanguageExportExtractor {
       const child = rootNode.namedChild(i);
       if (!child) continue;
       
+      // Handle decorated definitions (@dataclass, @property, etc.)
+      // Decorators wrap the actual definition in a 'decorated_definition' node
+      if (child.type === 'decorated_definition') {
+        const definition = child.childForFieldName('definition');
+        if (definition && this.exportableTypes.has(definition.type)) {
+          const nameNode = definition.childForFieldName('name');
+          if (nameNode) addExport(nameNode.text);
+        }
+        continue;
+      }
+      
       // Extract name from exportable node types
       if (this.exportableTypes.has(child.type)) {
         const nameNode = child.childForFieldName('name');

--- a/packages/core/src/indexer/ast/extractors/types.ts
+++ b/packages/core/src/indexer/ast/extractors/types.ts
@@ -1,0 +1,52 @@
+import type Parser from 'tree-sitter';
+
+/**
+ * Language-specific export extraction strategy
+ * 
+ * Each language has different export semantics:
+ * - JavaScript/TypeScript: Explicit export statements
+ * - PHP: All top-level declarations are implicitly exported
+ * - Python: All module-level declarations are implicitly exported
+ * 
+ * This interface allows us to implement language-specific export extraction
+ * while keeping the core symbol extraction logic language-agnostic.
+ * 
+ * @example JavaScript/TypeScript
+ * ```typescript
+ * export function validateEmail() {}  // Explicit export
+ * export { foo, bar }                 // Named exports
+ * export default App                  // Default export
+ * ```
+ * 
+ * @example PHP
+ * ```php
+ * class User {}        // Implicitly exported
+ * function helper() {} // Implicitly exported
+ * ```
+ * 
+ * @example Python
+ * ```python
+ * class User:          # Implicitly exported
+ *     pass
+ * def helper():        # Implicitly exported
+ *     pass
+ * ```
+ */
+export interface LanguageExportExtractor {
+  /**
+   * Extract exported symbol names from an AST root node
+   * 
+   * For JavaScript/TypeScript: Processes explicit export statements
+   * For PHP/Python: Processes top-level declarations (implicitly exported)
+   * 
+   * @param rootNode - AST root node (typically 'program' or similar)
+   * @returns Array of exported symbol names (deduplicated)
+   * 
+   * @example
+   * ```typescript
+   * // For: export { foo, bar }; export default App;
+   * extractExports(rootNode) // => ['foo', 'bar', 'default']
+   * ```
+   */
+  extractExports(rootNode: Parser.SyntaxNode): string[];
+}

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -756,18 +756,53 @@ function extractExportStatementSymbols(node: Parser.SyntaxNode, addExport: (name
  * 
  * Returns array of exported symbol names like: ['validateEmail', 'validatePhone', 'default']
  * 
- * Handles various export styles:
+ * Language-specific behavior:
+ * 
+ * **JavaScript/TypeScript:**
  * - Named exports: export { foo, bar }
  * - Declaration exports: export function foo() {}, export const bar = ...
  * - Default exports: export default ...
  * - Re-exports: export { foo } from './module'
  * 
+ * **PHP:**
+ * - All top-level classes, traits, interfaces, and functions are considered exported
+ * - PHP doesn't have explicit export syntax - all public declarations are accessible
+ * 
+ * **Python:**
+ * - All module-level classes and functions are considered exported
+ * - Python doesn't have explicit export syntax - module-level names are importable
+ * 
  * Limitations:
- * - Only static, top-level export statements are processed (direct children of the root node).
- * - Dynamic or conditional exports (e.g., inside if/for blocks, functions, or created programmatically)
- *   are not detected and will not be included in the returned symbol list.
+ * - Only static, top-level declarations are processed (direct children of the root node).
+ * - Dynamic or conditional exports/declarations are not detected.
+ * 
+ * @param rootNode - AST root node
+ * @param language - Programming language (required for PHP/Python)
+ * @returns Array of exported symbol names
  */
-export function extractExports(rootNode: Parser.SyntaxNode): string[] {
+export function extractExports(rootNode: Parser.SyntaxNode, language?: string): string[] {
+  // Dispatch to language-specific implementation
+  switch (language) {
+    case 'php':
+      return extractPHPExports(rootNode);
+    case 'python':
+      return extractPythonExports(rootNode);
+    default:
+      // JavaScript/TypeScript
+      return extractJSExports(rootNode);
+  }
+}
+
+/**
+ * Extract exports from JavaScript/TypeScript files.
+ * 
+ * Handles explicit export statements:
+ * - Named exports: export { foo, bar }
+ * - Declaration exports: export function foo() {}
+ * - Default exports: export default ...
+ * - Re-exports: export { foo } from './module'
+ */
+function extractJSExports(rootNode: Parser.SyntaxNode): string[] {
   const exports: string[] = [];
   const seen = new Set<string>();
   
@@ -783,6 +818,122 @@ export function extractExports(rootNode: Parser.SyntaxNode): string[] {
     const child = rootNode.namedChild(i);
     if (child?.type === 'export_statement') {
       extractExportStatementSymbols(child, addExport);
+    }
+  }
+  
+  return exports;
+}
+
+/**
+ * Extract exports from PHP files.
+ * 
+ * PHP doesn't have explicit export syntax. All top-level declarations are
+ * considered exported (accessible via `use` statements):
+ * - Classes: class User {}
+ * - Traits: trait HasTimestamps {}
+ * - Interfaces: interface Repository {}
+ * - Functions: function helper() {}
+ * - Namespaced declarations are also tracked
+ */
+function extractPHPExports(rootNode: Parser.SyntaxNode): string[] {
+  const exports: string[] = [];
+  const seen = new Set<string>();
+  
+  const addExport = (name: string) => {
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      exports.push(name);
+    }
+  };
+  
+  function traverse(node: Parser.SyntaxNode): void {
+    // Extract class declarations
+    if (node.type === 'class_declaration') {
+      const nameNode = node.childForFieldName('name');
+      if (nameNode) addExport(nameNode.text);
+    }
+    // Extract trait declarations
+    else if (node.type === 'trait_declaration') {
+      const nameNode = node.childForFieldName('name');
+      if (nameNode) addExport(nameNode.text);
+    }
+    // Extract interface declarations
+    else if (node.type === 'interface_declaration') {
+      const nameNode = node.childForFieldName('name');
+      if (nameNode) addExport(nameNode.text);
+    }
+    // Extract top-level function definitions
+    else if (node.type === 'function_definition') {
+      const nameNode = node.childForFieldName('name');
+      if (nameNode) addExport(nameNode.text);
+    }
+    // Recurse into namespace definitions
+    else if (node.type === 'namespace_definition') {
+      const body = node.childForFieldName('body');
+      if (body) {
+        for (let i = 0; i < body.namedChildCount; i++) {
+          const child = body.namedChild(i);
+          if (child) traverse(child);
+        }
+      }
+    }
+  }
+  
+  // Process top-level nodes
+  for (let i = 0; i < rootNode.namedChildCount; i++) {
+    const child = rootNode.namedChild(i);
+    if (child) traverse(child);
+  }
+  
+  return exports;
+}
+
+/**
+ * Extract exports from Python files.
+ * 
+ * Python doesn't have explicit export syntax. All module-level (top-level)
+ * declarations are considered exported (importable by other modules):
+ * - Classes: class User: ...
+ * - Functions: def helper(): ...
+ * - Async functions: async def fetch_data(): ...
+ * 
+ * Note: Only top-level definitions are tracked. Nested functions/classes
+ * inside other functions are not considered exports.
+ */
+function extractPythonExports(rootNode: Parser.SyntaxNode): string[] {
+  const exports: string[] = [];
+  const seen = new Set<string>();
+  
+  const addExport = (name: string) => {
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      exports.push(name);
+    }
+  };
+  
+  // Process only top-level nodes (module-level definitions)
+  for (let i = 0; i < rootNode.namedChildCount; i++) {
+    const child = rootNode.namedChild(i);
+    if (!child) continue;
+    
+    // Extract class definitions
+    if (child.type === 'class_definition') {
+      const nameNode = child.childForFieldName('name');
+      if (nameNode) addExport(nameNode.text);
+    }
+    // Extract function definitions
+    else if (child.type === 'function_definition') {
+      const nameNode = child.childForFieldName('name');
+      if (nameNode) addExport(nameNode.text);
+    }
+    // Extract async function definitions
+    else if (child.type === 'async_function_definition') {
+      // For async functions, the actual function_definition is nested
+      const funcDef = child.namedChildren.find(n => n.type === 'function_definition');
+      if (funcDef) {
+        const nameNode = funcDef.childForFieldName('name');
+        if (nameNode) addExport(nameNode.text);
+      }
     }
   }
   

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -753,12 +753,12 @@ function extractNamedImportSymbols(node: Parser.SyntaxNode, symbols: string[]): 
  * - Dynamic or conditional exports/declarations are not detected.
  * 
  * @param rootNode - AST root node
- * @param language - Programming language
+ * @param language - Programming language (defaults to 'javascript' for backwards compatibility)
  * @returns Array of exported symbol names
  */
-export function extractExports(rootNode: Parser.SyntaxNode, language?: string): string[] {
+export function extractExports(rootNode: Parser.SyntaxNode, language?: SupportedLanguage): string[] {
   // Default to JavaScript if no language specified (for backwards compatibility)
-  const lang = (language || 'javascript') as SupportedLanguage;
+  const lang: SupportedLanguage = language ?? 'javascript';
   const extractor = getExtractor(lang);
   return extractor.extractExports(rootNode);
 }

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -921,19 +921,10 @@ function extractPythonExports(rootNode: Parser.SyntaxNode): string[] {
       const nameNode = child.childForFieldName('name');
       if (nameNode) addExport(nameNode.text);
     }
-    // Extract function definitions
-    else if (child.type === 'function_definition') {
+    // Extract function definitions (including async functions)
+    else if (child.type === 'function_definition' || child.type === 'async_function_definition') {
       const nameNode = child.childForFieldName('name');
       if (nameNode) addExport(nameNode.text);
-    }
-    // Extract async function definitions
-    else if (child.type === 'async_function_definition') {
-      // For async functions, the actual function_definition is nested
-      const funcDef = child.namedChildren.find(n => n.type === 'function_definition');
-      if (funcDef) {
-        const nameNode = funcDef.childForFieldName('name');
-        if (nameNode) addExport(nameNode.text);
-      }
     }
   }
   


### PR DESCRIPTION
PHP and Python classes/functions were not being tracked as exports, causing symbol-level get_dependents to return zero results.

The extractExports() function only handled JavaScript/TypeScript export statements. Added language parameter and implemented:

- PHP: Track classes, traits, interfaces, functions as exports
- Python: Track classes, functions, async functions as exports

All top-level declarations in PHP/Python are considered exported since these languages don't have explicit export syntax like JS/TS.

Fixes: Symbol-level dependency tracking for PHP/Python
Tests: Manual testing with Laravel project confirms exports are tracked

---

<!-- lien-stats -->
### 👁️ Veille

⚠️ **Needs attention** - 1 new function is more complex than recommended.

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 6 | +20 |
| ⏱️ time to understand | 1 | +0 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->