### PR TITLE
Add few-shot comment examples for complexity metrics

### DIFF
--- a/packages/action/src/prompt.ts
+++ b/packages/action/src/prompt.ts
@@ -780,23 +780,17 @@ See inline comments below for specific suggestions.
 function getExampleForPrimaryMetric(violations: ComplexityViolation[]): string {
   if (violations.length === 0) return DEFAULT_EXAMPLE;
   
-  // Count metric types
-  const counts = new Map<string, number>();
-  for (const v of violations) {
-    const type = v.metricType || 'cyclomatic';
-    counts.set(type, (counts.get(type) || 0) + 1);
-  }
-  
-  // Find most common
-  let maxType = 'cyclomatic';
-  let maxCount = 0;
-  for (const [type, count] of counts) {
-    if (count > maxCount) {
-      maxType = type;
-      maxCount = count;
-    }
-  }
-  
+  const counts = collect(violations)
+    .countBy((v: ComplexityViolation) => v.metricType || 'cyclomatic')
+    .all() as Record<string, number>;
+
+  const maxType = Object.entries(counts)
+    .reduce(
+      (max, [type, count]) =>
+        count > max.count ? { type, count } : max,
+      { type: 'cyclomatic', count: 0 }
+    ).type;
+
   return COMMENT_EXAMPLES[maxType] || DEFAULT_EXAMPLE;
 }
 


### PR DESCRIPTION
Introduces COMMENT_EXAMPLES with tailored review comment samples for each complexity metric. Adds getExampleForPrimaryMetric to select the most relevant example for prompt generation, and updates the prompt to include a concrete example for better model guidance.

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |
| 🐛 estimated bugs | 1 | +0 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->