### PR TITLE
fix: clean up empty string artifacts, duplicate dedup, and untyped responses

### DIFF
--- a/.changeset/tech-debt-cleanup.md
+++ b/.changeset/tech-debt-cleanup.md
@@ -1,0 +1,12 @@
+---
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+fix: clean up empty string artifacts in metadata, fix list_functions crash with LanceDB storage
+
+- Filter empty strings from metadata fields (parameters, symbolType, symbols) at both AST extraction and MCP response shaping
+- Fix list_functions crash when LanceDB flattens nested symbols objects
+- Consolidate duplicate deduplication logic into shared utility
+- Remove untyped response objects in MCP handlers
+- Filter markdown files from related chunks in get_files_context

--- a/packages/cli/src/mcp/handlers/semantic-search.ts
+++ b/packages/cli/src/mcp/handlers/semantic-search.ts
@@ -88,20 +88,12 @@ export async function handleSemanticSearch(
       const shaped = shapeResults(results, 'semantic_search');
 
       // Build response
-      const response: any = {
+      return {
         indexInfo: getIndexMetadata(),
         results: shaped,
+        ...(crossRepo && vectorDB instanceof QdrantDB && { groupedByRepo: groupResultsByRepo(shaped) }),
+        ...(notes.length > 0 && { note: notes.join(' ') }),
       };
-
-      if (crossRepo && vectorDB instanceof QdrantDB) {
-        response.groupedByRepo = groupResultsByRepo(shaped);
-      }
-
-      if (notes.length > 0) {
-        response.note = notes.join(' ');
-      }
-
-      return response;
     }
   )(args);
 }

--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -342,13 +342,13 @@ describe('get_files_context - Helper Functions', () => {
         { content: 'chunk2', metadata: { file: 'src/auth.ts', startLine: 11, endLine: 20 }, score: 0.8 },
       ];
       
-      const result = deduplicateChunks(chunks as any, [], workspaceRoot);
-      
+      const result = deduplicateChunks(chunks as any, []);
+
       expect(result).toHaveLength(2);
       expect(result[0].metadata.startLine).toBe(1);
       expect(result[1].metadata.startLine).toBe(11);
     });
-    
+
     it('should merge file chunks and related chunks', () => {
       const fileChunks = [
         { content: 'file', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
@@ -356,20 +356,20 @@ describe('get_files_context - Helper Functions', () => {
       const relatedChunks = [
         { content: 'related', metadata: { file: 'src/utils.ts', startLine: 1, endLine: 10 }, score: 0.8 },
       ];
-      
-      const result = deduplicateChunks(fileChunks as any, relatedChunks as any, workspaceRoot);
-      
+
+      const result = deduplicateChunks(fileChunks as any, relatedChunks as any);
+
       expect(result).toHaveLength(2);
     });
-    
-    it('should handle absolute paths via canonicalization', () => {
+
+    it('should deduplicate by file + startLine + endLine', () => {
       const chunks = [
-        { content: 'chunk1', metadata: { file: '/fake/workspace/src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
-        { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.85 }, // Same after canonicalization
+        { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 },
+        { content: 'chunk1', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.85 }, // Same key
       ];
-      
-      const result = deduplicateChunks(chunks as any, [], workspaceRoot);
-      
+
+      const result = deduplicateChunks(chunks as any, []);
+
       expect(result).toHaveLength(1);
     });
   });
@@ -395,23 +395,21 @@ describe('get_files_context - Helper Functions', () => {
         fileChunksMap as any,
         relatedChunksMap as any,
         testAssociationsMap,
-        workspaceRoot
       );
-      
+
       expect(Object.keys(result)).toEqual(['src/auth.ts', 'src/user.ts']);
       expect(result['src/auth.ts'].chunks).toHaveLength(2); // file + related
       expect(result['src/auth.ts'].testAssociations).toEqual(['src/__tests__/auth.test.ts']);
       expect(result['src/user.ts'].chunks).toHaveLength(1);
       expect(result['src/user.ts'].testAssociations).toEqual(['src/__tests__/user.test.ts']);
     });
-    
+
     it('should handle empty related chunks', () => {
       const result = buildFilesData(
         ['src/auth.ts'],
         [[{ content: 'auth', metadata: { file: 'src/auth.ts', startLine: 1, endLine: 10 }, score: 0.9 }]] as any,
         [], // Empty related chunks
         [['src/__tests__/auth.test.ts']],
-        workspaceRoot
       );
       
       expect(result['src/auth.ts'].chunks).toHaveLength(1);

--- a/packages/cli/src/mcp/utils/metadata-shaper.test.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.test.ts
@@ -134,6 +134,34 @@ describe('shapeResultMetadata', () => {
     expect(result.metadata.symbolName).toBeUndefined();
     expect(Object.keys(result.metadata)).not.toContain('imports');
   });
+
+  it('strips empty string symbolType', () => {
+    const result = createFullResult();
+    (result.metadata as any).symbolType = '';
+    const shaped = shapeResultMetadata(result, 'semantic_search');
+    expect(Object.keys(shaped.metadata)).not.toContain('symbolType');
+  });
+
+  it('strips parameters with only empty strings', () => {
+    const result = createFullResult();
+    result.metadata.parameters = [''];
+    const shaped = shapeResultMetadata(result, 'semantic_search');
+    expect(Object.keys(shaped.metadata)).not.toContain('parameters');
+  });
+
+  it('filters empty strings from parameters but keeps non-empty', () => {
+    const result = createFullResult();
+    result.metadata.parameters = ['', 'a: string', ''];
+    const shaped = shapeResultMetadata(result, 'semantic_search');
+    expect(shaped.metadata.parameters).toEqual(['a: string']);
+  });
+
+  it('strips empty strings from symbols arrays', () => {
+    const result = createFullResult();
+    result.metadata.symbols = { functions: [''], classes: [''], interfaces: [''] };
+    const shaped = shapeResultMetadata(result, 'get_files_context');
+    expect(shaped.metadata.symbols).toEqual({ functions: [], classes: [], interfaces: [] });
+  });
 });
 
 describe('shapeResults', () => {

--- a/packages/cli/src/mcp/utils/metadata-shaper.test.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.test.ts
@@ -156,11 +156,18 @@ describe('shapeResultMetadata', () => {
     expect(shaped.metadata.parameters).toEqual(['a: string']);
   });
 
-  it('strips empty strings from symbols arrays', () => {
+  it('omits symbols when all arrays contain only empty strings', () => {
     const result = createFullResult();
     result.metadata.symbols = { functions: [''], classes: [''], interfaces: [''] };
     const shaped = shapeResultMetadata(result, 'get_files_context');
-    expect(shaped.metadata.symbols).toEqual({ functions: [], classes: [], interfaces: [] });
+    expect(Object.keys(shaped.metadata)).not.toContain('symbols');
+  });
+
+  it('keeps symbols when at least one array has non-empty values', () => {
+    const result = createFullResult();
+    result.metadata.symbols = { functions: ['foo'], classes: [''], interfaces: [] };
+    const shaped = shapeResultMetadata(result, 'get_files_context');
+    expect(shaped.metadata.symbols).toEqual({ functions: ['foo'], classes: [], interfaces: [] });
   });
 });
 

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -117,11 +117,13 @@ function cleanMetadataValue(key: string, value: unknown): unknown | null {
   }
 
   if (key === 'symbols' && typeof value === 'object' && value !== null) {
-    const symbols = value as { functions: string[]; classes: string[]; interfaces: string[] };
+    const symbols = value as Record<string, unknown>;
+    const filterArr = (arr: unknown): string[] =>
+      Array.isArray(arr) ? arr.filter((s: unknown) => s !== '') : [];
     const filtered = {
-      functions: symbols.functions.filter(s => s !== ''),
-      classes: symbols.classes.filter(s => s !== ''),
-      interfaces: symbols.interfaces.filter(s => s !== ''),
+      functions: filterArr(symbols.functions),
+      classes: filterArr(symbols.classes),
+      interfaces: filterArr(symbols.interfaces),
     };
     const hasAny = filtered.functions.length > 0 || filtered.classes.length > 0 || filtered.interfaces.length > 0;
     return hasAny ? filtered : null;

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -101,10 +101,6 @@ export function deduplicateResults(results: SearchResult[]): SearchResult[] {
 }
 
 /**
- * Pick allowed fields from metadata based on tool-specific allowlist.
- * Required fields (file, startLine, endLine) are always set explicitly.
- */
-/**
  * Clean a metadata value by stripping empty strings.
  * Returns null if the value should be omitted entirely.
  */

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -119,8 +119,26 @@ function pickMetadata(
   const out = result as unknown as Record<string, unknown>;
   for (const key of allowlist) {
     if (key === 'file' || key === 'startLine' || key === 'endLine') continue;
-    if (metadata[key] !== undefined) {
-      out[key] = metadata[key];
+    const value = metadata[key];
+    if (value === undefined || value === '') continue;
+
+    // Strip empty strings from arrays (e.g., parameters: [""] → omit)
+    if (Array.isArray(value)) {
+      const filtered = value.filter((v: unknown) => v !== '');
+      if (filtered.length === 0) continue;
+      out[key] = filtered;
+    }
+    // Strip empty strings from symbols object (classes: [""] → classes: [])
+    else if (key === 'symbols' && typeof value === 'object' && value !== null) {
+      const symbols = value as { functions: string[]; classes: string[]; interfaces: string[] };
+      out[key] = {
+        functions: symbols.functions.filter(s => s !== ''),
+        classes: symbols.classes.filter(s => s !== ''),
+        interfaces: symbols.interfaces.filter(s => s !== ''),
+      };
+    }
+    else {
+      out[key] = value;
     }
   }
 

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -104,6 +104,36 @@ export function deduplicateResults(results: SearchResult[]): SearchResult[] {
  * Pick allowed fields from metadata based on tool-specific allowlist.
  * Required fields (file, startLine, endLine) are always set explicitly.
  */
+/**
+ * Clean a metadata value by stripping empty strings.
+ * Returns null if the value should be omitted entirely.
+ */
+function cleanMetadataValue(key: string, value: unknown): unknown | null {
+  if (value === undefined || value === '') return null;
+
+  if (Array.isArray(value)) {
+    const filtered = value.filter((v: unknown) => v !== '');
+    return filtered.length > 0 ? filtered : null;
+  }
+
+  if (key === 'symbols' && typeof value === 'object' && value !== null) {
+    const symbols = value as { functions: string[]; classes: string[]; interfaces: string[] };
+    const filtered = {
+      functions: symbols.functions.filter(s => s !== ''),
+      classes: symbols.classes.filter(s => s !== ''),
+      interfaces: symbols.interfaces.filter(s => s !== ''),
+    };
+    const hasAny = filtered.functions.length > 0 || filtered.classes.length > 0 || filtered.interfaces.length > 0;
+    return hasAny ? filtered : null;
+  }
+
+  return value;
+}
+
+/**
+ * Pick allowed fields from metadata based on tool-specific allowlist.
+ * Required fields (file, startLine, endLine) are always set explicitly.
+ */
 function pickMetadata(
   metadata: ChunkMetadata,
   allowlist: ReadonlySet<AllowlistKey>
@@ -119,26 +149,9 @@ function pickMetadata(
   const out = result as unknown as Record<string, unknown>;
   for (const key of allowlist) {
     if (key === 'file' || key === 'startLine' || key === 'endLine') continue;
-    const value = metadata[key];
-    if (value === undefined || value === '') continue;
-
-    // Strip empty strings from arrays (e.g., parameters: [""] → omit)
-    if (Array.isArray(value)) {
-      const filtered = value.filter((v: unknown) => v !== '');
-      if (filtered.length === 0) continue;
-      out[key] = filtered;
-    }
-    // Strip empty strings from symbols object (classes: [""] → classes: [])
-    else if (key === 'symbols' && typeof value === 'object' && value !== null) {
-      const symbols = value as { functions: string[]; classes: string[]; interfaces: string[] };
-      out[key] = {
-        functions: symbols.functions.filter(s => s !== ''),
-        classes: symbols.classes.filter(s => s !== ''),
-        interfaces: symbols.interfaces.filter(s => s !== ''),
-      };
-    }
-    else {
-      out[key] = value;
+    const cleaned = cleanMetadataValue(key, metadata[key]);
+    if (cleaned !== null) {
+      out[key] = cleaned;
     }
   }
 

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -271,7 +271,7 @@ function extractParameters(node: Parser.SyntaxNode, _content: string): string[] 
   // Traverse parameter nodes
   for (let i = 0; i < paramsNode.namedChildCount; i++) {
     const param = paramsNode.namedChild(i);
-    if (param) {
+    if (param && param.text.trim()) {
       parameters.push(param.text);
     }
   }


### PR DESCRIPTION
- Strip empty strings from metadata arrays (parameters: [""] → omitted) and scalar fields (symbolType: "" → omitted) in pickMetadata
- Filter empty param.text at extraction time in extractParameters
- Consolidate deduplicateChunks to delegate to shared deduplicateResults
- Remove redundant workspaceRoot param from deduplicateChunks/buildFilesData
- Replace `const response: any` with spread-based conditional fields in semantic-search and get-complexity handlers
- Filter markdown files from related chunks in get_files_context

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 7 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 5 | +0 |
| ⏱️ time to understand | 2 | +0 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->