### PR TITLE
feat(mcp): add symbolType filter to list_functions tool

### DIFF
--- a/.changeset/list-functions-symboltype-filter.md
+++ b/.changeset/list-functions-symboltype-filter.md
@@ -1,6 +1,6 @@
 ---
-'@liendev/lien': patch
-'@liendev/core': patch
+'@liendev/lien': minor
+'@liendev/core': minor
 ---
 
 feat(mcp): add symbolType filter to list_functions tool

--- a/.changeset/list-functions-symboltype-filter.md
+++ b/.changeset/list-functions-symboltype-filter.md
@@ -1,5 +1,11 @@
 ---
 '@liendev/lien': patch
+'@liendev/core': patch
 ---
 
 feat(mcp): add symbolType filter to list_functions tool
+
+Adds an optional `symbolType` parameter to the `list_functions` MCP tool,
+allowing callers to filter results by symbol kind: function, method, class,
+or interface. The `function` filter includes methods for backward compatibility;
+use `method` to target only class/object methods.

--- a/.changeset/list-functions-symboltype-filter.md
+++ b/.changeset/list-functions-symboltype-filter.md
@@ -1,0 +1,5 @@
+---
+'@liendev/lien': patch
+---
+
+feat(mcp): add symbolType filter to list_functions tool

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -122,6 +122,42 @@ describe('handleListFunctions', () => {
       expect(parsed.results).toHaveLength(1);
     });
 
+    it('should filter by symbolType method in content scan fallback', async () => {
+      mockVectorDB.querySymbols.mockResolvedValue([]);
+      mockVectorDB.scanWithFilter.mockResolvedValue([
+        {
+          content: 'function standalone() {}',
+          metadata: {
+            file: 'src/utils.ts',
+            symbolName: 'standalone',
+            symbolType: 'function',
+          },
+          score: 0,
+          relevance: 'highly_relevant',
+        },
+        {
+          content: 'getName() { return this.name; }',
+          metadata: {
+            file: 'src/user.ts',
+            symbolName: 'getName',
+            symbolType: 'method',
+          },
+          score: 0,
+          relevance: 'highly_relevant',
+        },
+      ]);
+
+      const result = await handleListFunctions(
+        { symbolType: 'method' },
+        mockCtx
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.results[0].metadata.symbolName).toBe('getName');
+      expect(parsed.results[0].metadata.symbolType).toBe('method');
+    });
+
     it('should return all types when symbolType is omitted', async () => {
       mockVectorDB.querySymbols.mockResolvedValue([
         {

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -63,6 +63,7 @@ export async function handleListFunctions(
         const results = await vectorDB.querySymbols({
           language: validatedArgs.language,
           pattern: validatedArgs.pattern,
+          symbolType: validatedArgs.symbolType,
           limit: 50,
         });
 

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -1,16 +1,10 @@
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { ListFunctionsSchema } from '../schemas/index.js';
+import type { ListFunctionsInput } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
+import { SYMBOL_TYPE_MATCHES } from '@liendev/core';
 import type { VectorDBInterface, SearchResult } from '@liendev/core';
-
-/** Maps symbolType filter values to the set of matching record types */
-const SYMBOL_TYPE_MATCHES: Record<string, Set<string>> = {
-  function: new Set(['function', 'method']),
-  method: new Set(['method']),
-  class: new Set(['class']),
-  interface: new Set(['interface']),
-};
 
 interface QueryResult {
   results: SearchResult[];
@@ -23,7 +17,7 @@ interface QueryResult {
  */
 async function performContentScan(
   vectorDB: VectorDBInterface,
-  args: { language?: string; pattern?: string; symbolType?: string },
+  args: ListFunctionsInput,
   log: LogFn
 ): Promise<QueryResult> {
   log('Falling back to content scan...');

--- a/packages/cli/src/mcp/schemas/symbols.schema.ts
+++ b/packages/cli/src/mcp/schemas/symbols.schema.ts
@@ -24,6 +24,10 @@ export const ListFunctionsSchema = z.object({
       "Examples: 'typescript', 'python', 'javascript', 'php'\n\n" +
       "If omitted, searches all languages."
     ),
+
+  symbolType: z.enum(['function', 'method', 'class', 'interface'])
+    .optional()
+    .describe("Filter by symbol type. If omitted, returns all types."),
 });
 
 /**

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -98,6 +98,8 @@ Batch calls are more efficient than multiple single-file calls.`
 Examples:
 - "Show all controllers" → list_functions({ pattern: ".*Controller.*" })
 - "Find service classes" → list_functions({ pattern: ".*Service$" })
+- "List all class methods" → list_functions({ symbolType: "method" })
+- "Find standalone functions" → list_functions({ symbolType: "function" })
 
 Filter by symbol type (function, method, class, interface) to narrow results.
 

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -99,6 +99,8 @@ Examples:
 - "Show all controllers" → list_functions({ pattern: ".*Controller.*" })
 - "Find service classes" → list_functions({ pattern: ".*Service$" })
 
+Filter by symbol type (function, method, class, interface) to narrow results.
+
 10x faster than semantic_search for structural/architectural queries. Use semantic_search instead when searching by what code DOES.`
   ),
   toMCPToolSchema(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export { VectorDB } from './vectordb/lancedb.js';
 export { QdrantDB } from './vectordb/qdrant.js';
 export { createVectorDB } from './vectordb/factory.js';
 export type { VectorDBInterface, SearchResult } from './vectordb/types.js';
+export { SYMBOL_TYPE_MATCHES } from './vectordb/types.js';
 export { calculateRelevance } from './vectordb/relevance.js';
 export type { RelevanceCategory } from './vectordb/relevance.js';
 export { readVersionFile, writeVersionFile } from './vectordb/version.js';

--- a/packages/core/src/vectordb/lancedb.ts
+++ b/packages/core/src/vectordb/lancedb.ts
@@ -149,7 +149,7 @@ export class VectorDB implements VectorDBInterface {
   async querySymbols(options: {
     language?: string;
     pattern?: string;
-    symbolType?: 'function' | 'class' | 'interface';
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
   }): Promise<SearchResult[]> {
     if (!this.table) {

--- a/packages/core/src/vectordb/qdrant.ts
+++ b/packages/core/src/vectordb/qdrant.ts
@@ -98,6 +98,17 @@ class QdrantFilterBuilder {
     return this;
   }
 
+  addSymbolTypes(symbolTypes: string[]): this {
+    const cleaned = symbolTypes.map(s => s.trim()).filter(s => s.length > 0);
+    if (cleaned.length === 0) {
+      throw new Error(
+        'Invalid symbolTypes: at least one non-empty, non-whitespace string is required.'
+      );
+    }
+    this.filter.must.push({ key: 'symbolType', match: { any: cleaned } });
+    return this;
+  }
+
   addPattern(pattern: string, key: 'file' | 'symbolName' = 'file'): this {
     const cleanedPattern = pattern.trim();
     if (cleanedPattern.length === 0) {
@@ -317,7 +328,12 @@ export class QdrantDB implements VectorDBInterface {
 
     // Validate symbolType is non-empty if explicitly provided (even if empty string)
     if (options.symbolType !== undefined) {
-      builder.addSymbolType(options.symbolType);
+      if (options.symbolType === 'function') {
+        // Match both functions and methods for backward compatibility
+        builder.addSymbolTypes(['function', 'method']);
+      } else {
+        builder.addSymbolType(options.symbolType);
+      }
     }
 
     // Validate pattern is non-empty if explicitly provided (even if empty string)

--- a/packages/core/src/vectordb/qdrant.ts
+++ b/packages/core/src/vectordb/qdrant.ts
@@ -287,7 +287,7 @@ export class QdrantDB implements VectorDBInterface {
   private buildBaseFilter(options: {
     language?: string;
     pattern?: string;
-    symbolType?: 'function' | 'class' | 'interface';
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
     repoIds?: string[];
     branch?: string;
     includeCurrentRepo?: boolean;
@@ -649,7 +649,7 @@ export class QdrantDB implements VectorDBInterface {
   async querySymbols(options: {
     language?: string;
     pattern?: string;
-    symbolType?: 'function' | 'class' | 'interface';
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
   }): Promise<SearchResult[]> {
     const filter = this.buildBaseFilter({

--- a/packages/core/src/vectordb/query.test.ts
+++ b/packages/core/src/vectordb/query.test.ts
@@ -368,6 +368,95 @@ describe('VectorDB Query Operations', () => {
       expect(results[0].metadata.symbolType).toBe('interface');
     });
 
+    it('should filter by symbolType (method)', async () => {
+      const mockTable = {
+        countRows: vi.fn().mockResolvedValue(10),
+        search: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          toArray: vi.fn().mockResolvedValue([
+            {
+              content: 'function standalone() {}',
+              file: 'src/test.ts',
+              startLine: 1,
+              endLine: 3,
+              type: 'function',
+              language: 'typescript',
+              symbolName: 'standalone',
+              symbolType: 'function',
+              functionNames: ['standalone'],
+            },
+            {
+              content: 'getName() { return this.name; }',
+              file: 'src/test.ts',
+              startLine: 5,
+              endLine: 7,
+              type: 'function',
+              language: 'typescript',
+              symbolName: 'getName',
+              symbolType: 'method',
+              functionNames: ['getName'],
+            },
+          ]),
+        }),
+      };
+
+      const results = await querySymbols(mockTable, { symbolType: 'method', limit: 10 });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].metadata.symbolType).toBe('method');
+    });
+
+    it('should include methods when filtering by symbolType function', async () => {
+      const mockTable = {
+        countRows: vi.fn().mockResolvedValue(10),
+        search: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          toArray: vi.fn().mockResolvedValue([
+            {
+              content: 'function standalone() {}',
+              file: 'src/test.ts',
+              startLine: 1,
+              endLine: 3,
+              type: 'function',
+              language: 'typescript',
+              symbolName: 'standalone',
+              symbolType: 'function',
+              functionNames: ['standalone'],
+            },
+            {
+              content: 'getName() { return this.name; }',
+              file: 'src/test.ts',
+              startLine: 5,
+              endLine: 7,
+              type: 'function',
+              language: 'typescript',
+              symbolName: 'getName',
+              symbolType: 'method',
+              functionNames: ['getName'],
+            },
+            {
+              content: 'class TestClass {}',
+              file: 'src/test.ts',
+              startLine: 9,
+              endLine: 11,
+              type: 'class',
+              language: 'typescript',
+              symbolName: 'TestClass',
+              symbolType: 'class',
+              classNames: ['TestClass'],
+            },
+          ]),
+        }),
+      };
+
+      const results = await querySymbols(mockTable, { symbolType: 'function', limit: 10 });
+
+      expect(results).toHaveLength(2);
+      expect(results.map(r => r.metadata.symbolType)).toEqual(['function', 'method']);
+    });
+
     it('should filter by pattern', async () => {
       const mockTable = {
         countRows: vi.fn().mockResolvedValue(10),

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -405,7 +405,7 @@ export async function scanWithFilter(
  */
 /** Maps query symbolType to acceptable AST symbolType values */
 const SYMBOL_TYPE_MATCHES: Record<string, Set<string>> = {
-  function: new Set(['function']),
+  function: new Set(['function', 'method']),
   method: new Set(['method']),
   class: new Set(['class']),
   interface: new Set(['interface']),

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -1,4 +1,4 @@
-import { SearchResult } from './types.js';
+import { SearchResult, SYMBOL_TYPE_MATCHES } from './types.js';
 import { EMBEDDING_DIMENSION } from '../embeddings/types.js';
 import { DatabaseError, wrapError } from '../errors/index.js';
 import { calculateRelevance } from './relevance.js';
@@ -403,14 +403,6 @@ export async function scanWithFilter(
 /**
  * Helper to check if a record matches the requested symbol type
  */
-/** Maps query symbolType to acceptable AST symbolType values */
-const SYMBOL_TYPE_MATCHES: Record<string, Set<string>> = {
-  function: new Set(['function', 'method']),
-  method: new Set(['method']),
-  class: new Set(['class']),
-  interface: new Set(['interface']),
-};
-
 function matchesSymbolType(
   record: DBRecord,
   symbolType: 'function' | 'method' | 'class' | 'interface',

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -124,10 +124,10 @@ function hasValidNumberEntries(arr: number[] | undefined): boolean {
  * Consolidates the symbol extraction logic used across query functions.
  */
 function getSymbolsForType(
-  r: DBRecord, 
-  symbolType?: 'function' | 'class' | 'interface'
+  r: DBRecord,
+  symbolType?: 'function' | 'method' | 'class' | 'interface'
 ): string[] {
-  if (symbolType === 'function') return r.functionNames || [];
+  if (symbolType === 'function' || symbolType === 'method') return r.functionNames || [];
   if (symbolType === 'class') return r.classNames || [];
   if (symbolType === 'interface') return r.interfaceNames || [];
   return [
@@ -405,14 +405,15 @@ export async function scanWithFilter(
  */
 /** Maps query symbolType to acceptable AST symbolType values */
 const SYMBOL_TYPE_MATCHES: Record<string, Set<string>> = {
-  function: new Set(['function', 'method']),
+  function: new Set(['function']),
+  method: new Set(['method']),
   class: new Set(['class']),
   interface: new Set(['interface']),
 };
 
 function matchesSymbolType(
   record: DBRecord,
-  symbolType: 'function' | 'class' | 'interface',
+  symbolType: 'function' | 'method' | 'class' | 'interface',
   symbols: string[]
 ): boolean {
   // If AST-based symbolType exists, use lookup table
@@ -427,7 +428,7 @@ function matchesSymbolType(
 interface SymbolQueryOptions {
   language?: string;
   pattern?: string;
-  symbolType?: 'function' | 'class' | 'interface';
+  symbolType?: 'function' | 'method' | 'class' | 'interface';
 }
 
 /**
@@ -486,7 +487,7 @@ export async function querySymbols(
   options: {
     language?: string;
     pattern?: string;
-    symbolType?: 'function' | 'class' | 'interface';
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
   }
 ): Promise<SearchResult[]> {

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -23,6 +23,14 @@ export interface SearchResult {
   relevance: RelevanceCategory;
 }
 
+/** Maps symbolType filter values to the set of matching record types */
+export const SYMBOL_TYPE_MATCHES: Record<string, Set<string>> = {
+  function: new Set(['function', 'method']),
+  method: new Set(['method']),
+  class: new Set(['class']),
+  interface: new Set(['interface']),
+};
+
 export interface VectorDBInterface {
   /** Path to local storage (used for manifest and version files, even with remote backends like Qdrant) */
   readonly dbPath: string;

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -41,7 +41,7 @@ export interface VectorDBInterface {
   querySymbols(options: {
     language?: string;
     pattern?: string;
-    symbolType?: 'function' | 'class' | 'interface';
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
   }): Promise<SearchResult[]>;
   clear(): Promise<void>;


### PR DESCRIPTION
Expose the existing DB-level symbolType filter through the MCP schema and handler so callers can narrow results to specific symbol kinds (function, method, class, interface) without post-filtering.

Also adds 'method' as a distinct filter value across the DB layer, separating it from 'function' which previously matched both.

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->