### PR TITLE
fix(core): emit class chunks in AST chunker

### DIFF
--- a/packages/cli/test/integration/python-ast.test.ts
+++ b/packages/cli/test/integration/python-ast.test.ts
@@ -90,15 +90,17 @@ describe('Python AST Integration', () => {
     const chunks = await chunkFile(filepath, content, { useAST: true });
     
     // Check that line numbers are sequential and non-overlapping
-    const sortedChunks = [...chunks].sort((a, b) => a.metadata.startLine - b.metadata.startLine);
-    
+    // Class chunks intentionally encompass their child method chunks, so exclude them
+    const nonClassChunks = chunks.filter(c => c.metadata.symbolType !== 'class');
+    const sortedChunks = [...nonClassChunks].sort((a, b) => a.metadata.startLine - b.metadata.startLine);
+
     for (let i = 0; i < sortedChunks.length - 1; i++) {
       const current = sortedChunks[i];
       const next = sortedChunks[i + 1];
-      
+
       // Single-line functions/methods are valid (e.g., "def add(a, b): return a + b")
       expect(current.metadata.startLine).toBeLessThanOrEqual(current.metadata.endLine);
-      
+
       // Chunks must not overlap - next chunk must start AFTER current ends
       // Using strict > ensures no two chunks share the same line
       expect(next.metadata.startLine).toBeGreaterThan(current.metadata.endLine);

--- a/packages/core/src/indexer/ast/chunker.test.ts
+++ b/packages/core/src/indexer/ast/chunker.test.ts
@@ -67,20 +67,25 @@ class Calculator {
 
       const chunks = chunkByAST('test.ts', content);
       
-      // Should have chunks for each method (not the class itself)
+      // Should have a class chunk and chunks for each method
+      const classChunk = chunks.find(c => c.metadata.symbolName === 'Calculator');
       const addMethod = chunks.find(c => c.metadata.symbolName === 'add');
       const subtractMethod = chunks.find(c => c.metadata.symbolName === 'subtract');
-      
+
+      expect(classChunk).toBeDefined();
+      expect(classChunk?.metadata.symbolType).toBe('class');
+      expect(classChunk?.metadata.type).toBe('class');
+
       expect(addMethod).toBeDefined();
       expect(addMethod?.metadata.symbolType).toBe('method');
       expect(addMethod?.metadata.parentClass).toBe('Calculator');
-      
+
       expect(subtractMethod).toBeDefined();
       expect(subtractMethod?.metadata.symbolType).toBe('method');
       expect(subtractMethod?.metadata.parentClass).toBe('Calculator');
-      
-      // Should have 2 method chunks (no class chunk)
-      expect(chunks.length).toBe(2);
+
+      // Should have 1 class chunk + 2 method chunks
+      expect(chunks.length).toBe(3);
     });
 
     it('should extract function metadata', () => {
@@ -313,18 +318,23 @@ class UserController {
 ?>`;
 
       const chunks = chunkByAST('test.php', content);
-      
+
+      // Should have a class chunk
+      const classChunk = chunks.find(c => c.metadata.symbolName === 'UserController');
+      expect(classChunk).toBeDefined();
+      expect(classChunk?.metadata.symbolType).toBe('class');
+
       // Should have chunks for each method
       const constructorChunk = chunks.find(c => c.metadata.symbolName === '__construct');
       expect(constructorChunk).toBeDefined();
       expect(constructorChunk?.metadata.symbolType).toBe('method');
       expect(constructorChunk?.metadata.parentClass).toBe('UserController');
-      
+
       const getByIdChunk = chunks.find(c => c.metadata.symbolName === 'getUserById');
       expect(getByIdChunk).toBeDefined();
       expect(getByIdChunk?.metadata.symbolType).toBe('method');
       expect(getByIdChunk?.metadata.parentClass).toBe('UserController');
-      
+
       const createChunk = chunks.find(c => c.metadata.symbolName === 'createUser');
       expect(createChunk).toBeDefined();
       expect(createChunk?.metadata.symbolType).toBe('method');

--- a/packages/core/src/indexer/ast/chunker.ts
+++ b/packages/core/src/indexer/ast/chunker.ts
@@ -222,8 +222,9 @@ function findTopLevelNodes(
       return;
     }
     
-    // Handle containers - traverse body at increased depth
+    // Handle containers - emit the container itself AND traverse body for children
     if (traverser.shouldExtractChildren(node)) {
+      nodes.push(node);
       const body = traverser.getContainerBody(node);
       if (body) traverse(body, depth + 1);
       return;

--- a/packages/core/src/indexer/ast/python.test.ts
+++ b/packages/core/src/indexer/ast/python.test.ts
@@ -31,14 +31,22 @@ class Calculator:
 `;
     
     const chunks = chunkByAST('test.py', content.trim());
-    
-    expect(chunks).toHaveLength(2);
-    expect(chunks[0].metadata.symbolName).toBe('add');
-    expect(chunks[0].metadata.symbolType).toBe('method');
-    expect(chunks[0].metadata.parentClass).toBe('Calculator');
-    expect(chunks[1].metadata.symbolName).toBe('subtract');
-    expect(chunks[1].metadata.symbolType).toBe('method');
-    expect(chunks[1].metadata.parentClass).toBe('Calculator');
+
+    expect(chunks).toHaveLength(3);
+
+    const classChunk = chunks.find(c => c.metadata.symbolName === 'Calculator');
+    expect(classChunk).toBeDefined();
+    expect(classChunk?.metadata.symbolType).toBe('class');
+
+    const addMethod = chunks.find(c => c.metadata.symbolName === 'add');
+    expect(addMethod).toBeDefined();
+    expect(addMethod?.metadata.symbolType).toBe('method');
+    expect(addMethod?.metadata.parentClass).toBe('Calculator');
+
+    const subtractMethod = chunks.find(c => c.metadata.symbolName === 'subtract');
+    expect(subtractMethod).toBeDefined();
+    expect(subtractMethod?.metadata.symbolType).toBe('method');
+    expect(subtractMethod?.metadata.parentClass).toBe('Calculator');
   });
   
   it('should handle async functions', () => {
@@ -119,7 +127,12 @@ class Person:
     
     const chunks = chunkByAST('test.py', content.trim());
     
-    expect(chunks).toHaveLength(2);
+    expect(chunks).toHaveLength(3);
+
+    const classChunk = chunks.find(c => c.metadata.symbolName === 'Person');
+    expect(classChunk).toBeDefined();
+    expect(classChunk?.metadata.symbolType).toBe('class');
+
     const initMethod = chunks.find(c => c.metadata.symbolName === '__init__');
     expect(initMethod).toBeDefined();
     expect(initMethod?.metadata.symbolType).toBe('method');


### PR DESCRIPTION
## Summary

- Fix `symbolType: 'class'` queries returning 0 results by emitting a chunk for class declarations alongside their child method chunks
- The AST chunker previously treated classes as containers only — extracting methods but skipping the class node itself
- One-line fix in `findTopLevelNodes`: push the container node before traversing its children
- Affects all languages: TypeScript/JavaScript, Python, and PHP

## Test plan

- [x] Updated TS class chunking test to assert class chunk is emitted (`chunker.test.ts`)
- [x] Updated Python class chunking tests to assert class chunk is emitted (`python.test.ts`)
- [x] Added PHP class chunk assertion (`chunker.test.ts`)
- [x] Updated integration overlap test to account for class chunks encompassing methods (`python-ast.test.ts`)
- [x] All 1249 tests pass, typecheck clean

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->