### PR TITLE
chore: add changeset for v0.31.0 release

### DIFF
--- a/.changeset/class-chunks-and-symbol-filter.md
+++ b/.changeset/class-chunks-and-symbol-filter.md
@@ -1,0 +1,11 @@
+---
+"@liendev/core": minor
+"@liendev/lien": minor
+---
+
+feat(core): add symbolType filtering to scanWithFilter in VectorDB
+
+fix(core): emit class chunks alongside method chunks in AST chunker
+fix(core): add missing chalk dependency
+fix(core): resolve file paths relative to rootDir in indexer
+fix(core): log per-file indexing errors instead of swallowing silently


### PR DESCRIPTION
## Summary
- Adds changeset for the next minor release covering all changes since v0.30.0

### Included changes
- **feat(core):** add symbolType filtering to scanWithFilter in VectorDB
- **fix(core):** emit class chunks alongside method chunks in AST chunker
- **fix(core):** add missing chalk dependency
- **fix(core):** resolve file paths relative to rootDir in indexer
- **fix(core):** log per-file indexing errors instead of swallowing silently