### PR TITLE
fix(ci): remove changeset gate from release workflow

### DIFF
--- a/.changeset/class-chunks-and-symbol-filter.md
+++ b/.changeset/class-chunks-and-symbol-filter.md
@@ -1,0 +1,11 @@
+---
+"@liendev/core": minor
+"@liendev/lien": minor
+---
+
+feat(core): add symbolType filtering to scanWithFilter in VectorDB
+
+fix(core): emit class chunks alongside method chunks in AST chunker
+fix(core): add missing chalk dependency
+fix(core): resolve file paths relative to rootDir in indexer
+fix(core): log per-file indexing errors instead of swallowing silently

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,29 +9,9 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  check-changeset:
-    name: Check for changesets
-    runs-on: ubuntu-latest
-    outputs:
-      has-changesets: ${{ github.event_name == 'workflow_dispatch' || steps.check.outputs.has-changesets }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Check for changeset files
-        id: check
-        run: |
-          # Look for any .md files in .changeset/ besides README.md
-          if find .changeset -name '*.md' ! -name 'README.md' | grep -q .; then
-            echo "has-changesets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-changesets=false" >> "$GITHUB_OUTPUT"
-          fi
-
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: check-changeset
-    if: needs.check-changeset.outputs.has-changesets == 'true'
     permissions:
       contents: write       # Create releases
       pull-requests: write  # Create "Version Packages" PR


### PR DESCRIPTION
## Summary
- Removes the `check-changeset` job that gated the release job
- `changesets/action` handles this logic internally: creates a version PR when changesets exist, publishes when they don't
- This was preventing the publish step from running after the version PR merged (no changeset files remain at that point)

The v0.31.0 publish should trigger automatically once this merges.