### PR TITLE
docs(mcp): document symbol tracking limitation for re-exports

### DIFF
--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -510,11 +510,18 @@ export function groupDependentsByRepo(
 
 /**
  * Find usages of a specific symbol in dependent files.
- * 
+ *
  * Looks for:
  * 1. Files that import the symbol from the target file (direct or namespace import)
  * 2. Chunks within those files that have call sites for the symbol
- * 
+ *
+ * **Known Limitation - Direct Imports Only:**
+ * Symbol tracking only works for files that import directly from the target file path.
+ * Symbols accessed through re-export chains (e.g., `import { Foo } from '@scope/pkg'`
+ * where the package barrel file re-exports from the target) are not tracked. These files
+ * will still appear in file-level dependents (without the `symbol` parameter) but won't
+ * be included in symbol-specific usage counts.
+ *
  * **Known Limitation - Namespace Imports:**
  * Files with namespace imports (e.g., `import * as utils from './module'`) are included
  * in results if they have call sites matching the symbol name. However, call sites are

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -149,6 +149,9 @@ function buildDependentsResponse(
  * 
  * When the optional `symbol` parameter is provided, returns specific call sites
  * for that exported symbol instead of just file-level dependencies.
+ *
+ * Note: Symbol tracking only works for direct imports from the target file.
+ * Re-exported symbols (e.g., via barrel files or package entry points) are not tracked.
  */
 export async function handleGetDependents(
   args: unknown,


### PR DESCRIPTION
## Summary
- Documents that `symbol` tracking in `get_dependents` only works for direct imports
- Re-exported symbols (via barrel files or package entry points) are not tracked
- This is accepted as a known limitation — the usage count is informational and agents read the code directly for full context

Replaces #89 which added ~700 lines of re-export chain resolution for minimal practical value.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->