### PR TITLE
fix(indexer): index barrel/re-export files that produced zero chunks

### DIFF
--- a/packages/core/src/indexer/ast/chunker.test.ts
+++ b/packages/core/src/indexer/ast/chunker.test.ts
@@ -461,6 +461,32 @@ function third() {
     });
   });
 
+  describe('barrel/re-export files', () => {
+    it('should produce at least one chunk for barrel files with only re-exports', () => {
+      const content = `export { foo } from './foo';
+export { bar, baz } from './bar';
+export { default as qux } from './qux';`;
+
+      const chunks = chunkByAST('index.ts', content);
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks[0].metadata.type).toBe('block');
+      expect(chunks[0].metadata.exports).toBeDefined();
+      expect(chunks[0].metadata.exports!.length).toBeGreaterThan(0);
+      expect(chunks[0].content).toContain('export');
+    });
+
+    it('should produce a chunk for a single re-export', () => {
+      const content = `export { foo } from './foo';`;
+
+      const chunks = chunkByAST('index.ts', content);
+
+      expect(chunks.length).toBe(1);
+      expect(chunks[0].metadata.exports).toBeDefined();
+      expect(chunks[0].content).toBe("export { foo } from './foo';");
+    });
+  });
+
   describe('error handling', () => {
     it('should throw error for unsupported language', () => {
       const content = 'puts "Hello"';

--- a/packages/core/src/indexer/ast/chunker.ts
+++ b/packages/core/src/indexer/ast/chunker.ts
@@ -464,9 +464,11 @@ function extractUncoveredCode(
 ): ASTChunk[] {
   const uncoveredRanges = findUncoveredRanges(coveredRanges, lines.length);
   
+  const hasExports = fileExports && fileExports.length > 0;
+
   return uncoveredRanges
     .map(range => createChunkFromRange(range, lines, filepath, language, imports, tenantContext, fileExports, importedSymbols))
-    .filter(chunk => isValidChunk(chunk, minChunkSize));
+    .filter(chunk => hasExports ? chunk.content.length > 0 : isValidChunk(chunk, minChunkSize));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Barrel files (e.g. `index.ts` with only `export { x } from './x'` statements) were producing zero chunks because `export_statement` isn't a target node type, and the uncovered code was rejected by `minChunkSize`
- Bypass `minChunkSize` filter when the file has exports — only require non-empty content
- Added tests for barrel files with single and multiple re-exports

Closes #90

## Test plan
- [x] Added test: barrel file with multiple re-exports produces chunk with correct exports metadata
- [x] Added test: single re-export produces exactly one chunk
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] All 476 tests pass (29/29 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->