### PR TITLE
fix(mcp): convert Arrow Vectors in querySymbols to fix symbolType filtering

### DIFF
--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -127,13 +127,13 @@ function getSymbolsForType(
   r: DBRecord,
   symbolType?: 'function' | 'method' | 'class' | 'interface'
 ): string[] {
-  if (symbolType === 'function' || symbolType === 'method') return r.functionNames || [];
-  if (symbolType === 'class') return r.classNames || [];
-  if (symbolType === 'interface') return r.interfaceNames || [];
+  if (symbolType === 'function' || symbolType === 'method') return toPlainArray<string>(r.functionNames) || [];
+  if (symbolType === 'class') return toPlainArray<string>(r.classNames) || [];
+  if (symbolType === 'interface') return toPlainArray<string>(r.interfaceNames) || [];
   return [
-    ...(r.functionNames || []),
-    ...(r.classNames || []),
-    ...(r.interfaceNames || []),
+    ...(toPlainArray<string>(r.functionNames) || []),
+    ...(toPlainArray<string>(r.classNames) || []),
+    ...(toPlainArray<string>(r.interfaceNames) || []),
   ];
 }
 
@@ -498,10 +498,13 @@ function matchesSymbolFilter(
  * Build legacy symbols object for backwards compatibility.
  */
 function buildLegacySymbols(r: DBRecord) {
+  const functions = toPlainArray<string>(r.functionNames);
+  const classes = toPlainArray<string>(r.classNames);
+  const interfaces = toPlainArray<string>(r.interfaceNames);
   return {
-    functions: hasValidStringEntries(r.functionNames) ? r.functionNames : [],
-    classes: hasValidStringEntries(r.classNames) ? r.classNames : [],
-    interfaces: hasValidStringEntries(r.interfaceNames) ? r.interfaceNames : [],
+    functions: hasValidStringEntries(functions) ? functions! : [],
+    classes: hasValidStringEntries(classes) ? classes! : [],
+    interfaces: hasValidStringEntries(interfaces) ? interfaces! : [],
   };
 }
 


### PR DESCRIPTION
## Summary

- `getSymbolsForType()` and `buildLegacySymbols()` accessed LanceDB array columns (`functionNames`, `classNames`, `interfaceNames`) directly without converting Arrow Vectors to plain arrays via `toPlainArray()`
- Arrow Vectors lack `.some()` and other standard array methods, causing `querySymbols` to throw when iterating records with empty `symbolType` placeholders
- `queryWithFallback` silently caught the error and fell back to content scan, making `list_functions({ symbolType: "class" })` always report `method: "content"`
- Added regression test simulating Arrow Vector objects to verify the fix

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] All query tests pass (23/23)
- [ ] Manual verification: `list_functions({ symbolType: "class" })` returns `method: "symbols"`

Closes #96

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->