### PR TITLE
feat(mcp): derive enclosingSymbol in tool response metadata

### DIFF
--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -557,14 +557,14 @@ describe('handleListFunctions', () => {
   describe('pagination', () => {
     function makeResults(count: number): SearchResult[] {
       return Array.from({ length: count }, (_, i) => ({
-        content: `function func${i}() {}`,
+        content: `f${i}(){}`,
         metadata: {
-          file: `src/file${i}.ts`,
+          file: `s/${i}.ts`,
           startLine: 1,
           endLine: 5,
           type: 'function' as const,
           language: 'typescript',
-          symbolName: `func${i}`,
+          symbolName: `f${i}`,
           symbolType: 'function',
         },
         score: 1,
@@ -613,9 +613,9 @@ describe('handleListFunctions', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(5);
-      // Results should start from offset 10 (func10..func14)
-      expect(parsed.results[0].metadata.symbolName).toBe('func10');
-      expect(parsed.results[4].metadata.symbolName).toBe('func14');
+      // Results should start from offset 10 (f10..f14)
+      expect(parsed.results[0].metadata.symbolName).toBe('f10');
+      expect(parsed.results[4].metadata.symbolName).toBe('f14');
 
       expect(parsed.hasMore).toBe(true);
       expect(parsed.nextOffset).toBe(15);

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -29,7 +29,8 @@ IMPORTANT: Phrase queries as full questions starting with "How", "Where", "What"
 Use natural language describing what the code DOES, not function names. For exact string matching, use grep instead.
 
 Returns:
-- results[]: { content, score, relevance, metadata: { file, startLine, endLine, language?, symbolName?, symbolType?, signature? } }
+- results[]: { content, score, relevance, metadata: { file, startLine, endLine, language?, symbolName?, symbolType?, signature?, enclosingSymbol? } }
+- enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - relevance: "highly_relevant" | "relevant" | "loosely_related" (not_relevant auto-filtered)
 - groupedByRepo?: Record<repoId, results[]> (when crossRepo=true)`
   ),
@@ -50,7 +51,8 @@ Optional filters:
 Low-relevance results (not_relevant) are automatically pruned.
 
 Returns:
-- results[]: { content, score, relevance, metadata: { file, startLine, endLine, language?, symbolName?, signature? } }
+- results[]: { content, score, relevance, metadata: { file, startLine, endLine, language?, symbolName?, signature?, enclosingSymbol? } }
+- enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - relevance: "highly_relevant" | "relevant" | "loosely_related" (not_relevant auto-filtered)
 - filtersApplied?: { language?, pathHint?, prunedLowRelevance: number }`
   ),
@@ -116,7 +118,8 @@ Filter by symbol type (function, method, class, interface) to narrow results.
 Results are paginated (default: 50, max: 200). Use \`offset\` to page through large result sets.
 
 Returns:
-- results[]: { content, metadata: { file, startLine, endLine, language?, symbolName?, symbolType?, signature? } }
+- results[]: { content, metadata: { file, startLine, endLine, language?, symbolName?, symbolType?, signature?, enclosingSymbol? } }
+- enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - method: "symbols" | "content" (query method used)
 - hasMore: boolean (more results available)
 - nextOffset?: number (offset for next page, when hasMore=true)`

--- a/packages/cli/src/mcp/utils/metadata-shaper.test.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.test.ts
@@ -169,6 +169,36 @@ describe('shapeResultMetadata', () => {
     const shaped = shapeResultMetadata(result, 'get_files_context');
     expect(shaped.metadata.symbols).toEqual({ functions: ['foo'], classes: [], interfaces: [] });
   });
+
+  it('derives enclosingSymbol as parentClass.symbolName for methods', () => {
+    const result = createFullResult();
+    const shaped = shapeResultMetadata(result, 'semantic_search');
+    expect(shaped.metadata.enclosingSymbol).toBe('ExampleClass.example');
+  });
+
+  it('derives enclosingSymbol as symbolName for standalone functions', () => {
+    const result = createFullResult();
+    delete (result.metadata as any).parentClass;
+    const shaped = shapeResultMetadata(result, 'semantic_search');
+    expect(shaped.metadata.enclosingSymbol).toBe('example');
+  });
+
+  it('omits enclosingSymbol for block chunks without symbolName', () => {
+    const sparse: SearchResult = {
+      content: 'const x = 1;',
+      metadata: {
+        file: 'src/x.ts',
+        startLine: 1,
+        endLine: 1,
+        type: 'block',
+        language: 'typescript',
+      },
+      score: 0.8,
+      relevance: 'loosely_related',
+    };
+    const shaped = shapeResultMetadata(sparse, 'semantic_search');
+    expect(Object.keys(shaped.metadata)).not.toContain('enclosingSymbol');
+  });
 });
 
 describe('shapeResults', () => {

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -33,6 +33,7 @@ export interface ToolResultMetadata {
   callSites?: Array<{ symbol: string; line: number }>;
   symbols?: { functions: string[]; classes: string[]; interfaces: string[] };
   repoId?: string;
+  enclosingSymbol?: string;
 }
 
 /**
@@ -151,6 +152,13 @@ function pickMetadata(
     if (cleaned !== null) {
       out[key] = cleaned;
     }
+  }
+
+  // Derive enclosingSymbol from parentClass + symbolName
+  if (metadata.symbolName) {
+    out['enclosingSymbol'] = metadata.parentClass
+      ? `${metadata.parentClass}.${metadata.symbolName}`
+      : metadata.symbolName;
   }
 
   return result;


### PR DESCRIPTION
Closes #101

## Summary

- Derive `enclosingSymbol` field in MCP tool response metadata by composing `parentClass` + `symbolName` (e.g. `"AuthService.validateToken"`)
- Computed at response time in the metadata shaper — no DB changes, no re-index required
- Field is omitted for block chunks (no `symbolName`)

| Input | Output |
|-------|--------|
| `parentClass: "AuthService"`, `symbolName: "validateToken"` | `"AuthService.validateToken"` |
| `symbolName: "validateEmail"` (no class) | `"validateEmail"` |
| No `symbolName` (block chunk) | Field omitted |

## Changes

- `metadata-shaper.ts`: Add `enclosingSymbol` to `ToolResultMetadata`, compute in `pickMetadata()`
- `metadata-shaper.test.ts`: Add 3 test cases (method, standalone function, block chunk)
- `tools.ts`: Document `enclosingSymbol` in Returns for `semantic_search`, `find_similar`, `list_functions`
- `list-functions.test.ts`: Shrink pagination mock data to stay within response budget

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` compiles
- [x] `npm test` — all 536 tests pass
- [x] Dogfooded: `semantic_search`, `list_functions` via MCP — `enclosingSymbol` appears for functions/methods, absent for block chunks

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->