### PR TITLE
fix(ast): return alias instead of original name for Python aliased imports

### DIFF
--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -461,7 +461,7 @@ export function extractImportedSymbols(rootNode: Parser.SyntaxNode): Record<stri
  * For "from typing import Optional as Opt", returns "Opt" (the alias).
  * 
  * The alias is always the last identifier child when there are at least two identifiers
- * (original name + alias). If fewer identifiers exist, falls back to dotted_name or first identifier.
+ * (original name + alias). If fewer identifiers exist, falls back to first identifier then dotted_name.
  */
 function extractPythonAliasedSymbol(node: Parser.SyntaxNode): string | undefined {
   const identifierChildren = node.namedChildren.filter(c => c.type === 'identifier');


### PR DESCRIPTION
Fixes #121

## Summary
- Fix `extractPythonAliasedSymbol` fallback logic that returned the original name (`Optional`) instead of the alias (`Opt`) for `from typing import Optional as Opt`
- Swap preference to check the direct `identifier` child (alias) before `dotted_name` (original name)

## Test plan
- [x] Specific test passes: `should handle Python aliased imports`
- [x] All 66 symbol tests pass
- [x] Typecheck clean

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 6 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 5 | +0 |
| ⏱️ time to understand | 1 | +0 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->