### PR TITLE
feat(ast): consolidate symbol extraction into per-language files

### DIFF
--- a/packages/core/src/indexer/ast/chunker.ts
+++ b/packages/core/src/indexer/ast/chunker.ts
@@ -318,7 +318,7 @@ function createChunk(
   
   // Extract call sites for functions and methods
   const callSites = shouldCalcComplexity
-    ? extractCallSites(node)
+    ? extractCallSites(node, language)
     : undefined;
   
   return {

--- a/packages/core/src/indexer/ast/extractors/index.ts
+++ b/packages/core/src/indexer/ast/extractors/index.ts
@@ -1,8 +1,8 @@
 import type { SupportedLanguage } from '../types.js';
-import type { LanguageExportExtractor, LanguageImportExtractor } from './types.js';
+import type { LanguageExportExtractor, LanguageImportExtractor, LanguageSymbolExtractor } from './types.js';
 import { getLanguage, languageExists } from '../languages/registry.js';
 
-export type { LanguageExportExtractor, LanguageImportExtractor } from './types.js';
+export type { LanguageExportExtractor, LanguageImportExtractor, LanguageSymbolExtractor } from './types.js';
 
 /**
  * Get the export extractor for a specific language.
@@ -24,6 +24,17 @@ export function getExtractor(language: SupportedLanguage): LanguageExportExtract
  */
 export function getImportExtractor(language: SupportedLanguage): LanguageImportExtractor | undefined {
   return getLanguage(language).importExtractor;
+}
+
+/**
+ * Get the symbol extractor for a specific language.
+ * Delegates to the language registry.
+ *
+ * @param language - Programming language
+ * @returns Language-specific symbol extractor, or undefined if not implemented
+ */
+export function getSymbolExtractor(language: SupportedLanguage): LanguageSymbolExtractor | undefined {
+  return getLanguage(language).symbolExtractor;
 }
 
 /**

--- a/packages/core/src/indexer/ast/extractors/symbol-helpers.ts
+++ b/packages/core/src/indexer/ast/extractors/symbol-helpers.ts
@@ -1,0 +1,65 @@
+import type Parser from 'tree-sitter';
+
+/**
+ * Extract function/method signature
+ */
+export function extractSignature(node: Parser.SyntaxNode, content: string): string {
+  // Get the first line of the function (up to opening brace or arrow)
+  const startLine = node.startPosition.row;
+  const lines = content.split('\n');
+  let signature = lines[startLine] || '';
+
+  // If signature spans multiple lines, try to get up to the opening brace
+  let currentLine = startLine;
+  while (currentLine < node.endPosition.row && !signature.includes('{') && !signature.includes('=>')) {
+    currentLine++;
+    signature += ' ' + (lines[currentLine] || '');
+  }
+
+  // Clean up signature
+  signature = signature.split('{')[0].split('=>')[0].trim();
+
+  // Limit length
+  if (signature.length > 200) {
+    signature = signature.substring(0, 197) + '...';
+  }
+
+  return signature;
+}
+
+/**
+ * Extract parameter list from function node
+ *
+ * Note: The `_content` parameter is unused in this function, but is kept for API consistency
+ * with other extract functions (e.g., extractSignature).
+ */
+export function extractParameters(node: Parser.SyntaxNode, _content: string): string[] {
+  const parameters: string[] = [];
+
+  // Find parameters node
+  const paramsNode = node.childForFieldName('parameters');
+  if (!paramsNode) return parameters;
+
+  // Traverse parameter nodes
+  for (let i = 0; i < paramsNode.namedChildCount; i++) {
+    const param = paramsNode.namedChild(i);
+    if (param && param.text.trim()) {
+      parameters.push(param.text);
+    }
+  }
+
+  return parameters;
+}
+
+/**
+ * Extract return type from function node (TypeScript)
+ *
+ * Note: The `_content` parameter is unused in this function, but is kept for API consistency
+ * with other extract functions (e.g., extractSignature).
+ */
+export function extractReturnType(node: Parser.SyntaxNode, _content: string): string | undefined {
+  const returnTypeNode = node.childForFieldName('return_type');
+  if (!returnTypeNode) return undefined;
+
+  return returnTypeNode.text;
+}

--- a/packages/core/src/indexer/ast/extractors/types.ts
+++ b/packages/core/src/indexer/ast/extractors/types.ts
@@ -1,4 +1,29 @@
 import type Parser from 'tree-sitter';
+import type { SymbolInfo } from '../types.js';
+
+/**
+ * Language-specific symbol extraction strategy
+ *
+ * Each language has different AST node types for functions, classes, and methods.
+ * This interface allows language-specific symbol extraction while keeping the
+ * core chunking logic language-agnostic.
+ */
+export interface LanguageSymbolExtractor {
+  /** AST node types this extractor can handle for symbol extraction */
+  readonly symbolNodeTypes: string[];
+
+  /** Extract symbol info (name, type, signature, etc.) from an AST node */
+  extractSymbol(
+    node: Parser.SyntaxNode,
+    content: string,
+    parentClass?: string
+  ): SymbolInfo | null;
+
+  /** Extract symbol name and line from a call expression node */
+  extractCallSite(
+    node: Parser.SyntaxNode
+  ): { symbol: string; line: number; key: string } | null;
+}
 
 /**
  * Language-specific export extraction strategy

--- a/packages/core/src/indexer/ast/languages/types.ts
+++ b/packages/core/src/indexer/ast/languages/types.ts
@@ -1,5 +1,5 @@
 import type { LanguageTraverser } from '../traversers/types.js';
-import type { LanguageExportExtractor, LanguageImportExtractor } from '../extractors/types.js';
+import type { LanguageExportExtractor, LanguageImportExtractor, LanguageSymbolExtractor } from '../extractors/types.js';
 import type { SupportedLanguage } from './registry.js';
 
 /**
@@ -34,6 +34,9 @@ export interface LanguageDefinition {
 
   /** Language-specific import extractor instance (optional for backwards compatibility) */
   importExtractor?: LanguageImportExtractor;
+
+  /** Language-specific symbol extractor instance (optional for backwards compatibility) */
+  symbolExtractor?: LanguageSymbolExtractor;
 
   /** Complexity metric configuration */
   complexity: {

--- a/packages/core/src/indexer/ast/languages/typescript.ts
+++ b/packages/core/src/indexer/ast/languages/typescript.ts
@@ -1,6 +1,6 @@
 import TypeScript from 'tree-sitter-typescript';
 import type { LanguageDefinition } from './types.js';
-import { TypeScriptTraverser, TypeScriptExportExtractor, TypeScriptImportExtractor } from './javascript.js';
+import { TypeScriptTraverser, TypeScriptExportExtractor, TypeScriptImportExtractor, TypeScriptSymbolExtractor } from './javascript.js';
 
 export const typescriptDefinition: LanguageDefinition = {
   id: 'typescript',
@@ -9,6 +9,7 @@ export const typescriptDefinition: LanguageDefinition = {
   traverser: new TypeScriptTraverser(),
   exportExtractor: new TypeScriptExportExtractor(),
   importExtractor: new TypeScriptImportExtractor(),
+  symbolExtractor: new TypeScriptSymbolExtractor(),
 
   complexity: {
     decisionPoints: [

--- a/packages/core/src/indexer/ast/symbols.test.ts
+++ b/packages/core/src/indexer/ast/symbols.test.ts
@@ -304,7 +304,7 @@ function processUser(user) {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toContainEqual(
         expect.objectContaining({ symbol: 'validateEmail' })
@@ -324,7 +324,7 @@ function saveUser(user) {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toContainEqual(
         expect.objectContaining({ symbol: 'save' })
@@ -342,7 +342,7 @@ function saveUser(user) {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       const fooCall = callSites.find(c => c.symbol === 'foo');
       const barCall = callSites.find(c => c.symbol === 'bar');
@@ -361,7 +361,7 @@ function complex() {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toContainEqual(
         expect.objectContaining({ symbol: 'outer' })
@@ -384,7 +384,7 @@ function process(items) {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toContainEqual(
         expect.objectContaining({ symbol: 'validate' })
@@ -403,7 +403,7 @@ function test() {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       // Multiple calls to same symbol on same line should be deduplicated
       const fooCalls = callSites.filter(c => c.symbol === 'foo');
@@ -421,7 +421,7 @@ function test() {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       const fooCalls = callSites.filter(c => c.symbol === 'foo');
       expect(fooCalls).toHaveLength(2);
@@ -438,7 +438,7 @@ function simple() {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toHaveLength(0);
     });
@@ -452,7 +452,7 @@ function simple() {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toContainEqual(
         expect.objectContaining({ symbol: 'VectorDB', line: 2 })
@@ -472,7 +472,7 @@ function create() {
 
       const parseResult = parseAST(content, 'typescript');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'typescript');
 
       expect(callSites).toContainEqual(
         expect.objectContaining({ symbol: 'MyClass' })
@@ -491,7 +491,7 @@ function process() {
 
       const parseResult = parseAST(content, 'php');
       const funcNode = parseResult.tree!.rootNode.namedChild(1)!; // Skip php_tag
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'php');
 
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'helper_function' }));
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'another_call' }));
@@ -509,7 +509,7 @@ class Controller {
 
       const parseResult = parseAST(content, 'php');
       const classNode = parseResult.tree!.rootNode.namedChild(1)!;
-      const callSites = extractCallSites(classNode);
+      const callSites = extractCallSites(classNode, 'php');
 
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'validate' }));
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'save' }));
@@ -525,7 +525,7 @@ function getData() {
 
       const parseResult = parseAST(content, 'php');
       const funcNode = parseResult.tree!.rootNode.namedChild(1)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'php');
 
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'find' }));
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'where' }));
@@ -543,7 +543,7 @@ def process():
 
       const parseResult = parseAST(content, 'python');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'python');
 
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'helper_function' }));
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'another_call' }));
@@ -558,7 +558,7 @@ def process(user):
 
       const parseResult = parseAST(content, 'python');
       const funcNode = parseResult.tree!.rootNode.namedChild(0)!;
-      const callSites = extractCallSites(funcNode);
+      const callSites = extractCallSites(funcNode, 'python');
 
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'save' }));
       expect(callSites).toContainEqual(expect.objectContaining({ symbol: 'validate' }));

--- a/packages/core/src/indexer/ast/symbols.ts
+++ b/packages/core/src/indexer/ast/symbols.ts
@@ -1,216 +1,16 @@
 import type Parser from 'tree-sitter';
 import type { SymbolInfo, SupportedLanguage } from './types.js';
-import { calculateComplexity } from './complexity/index.js';
-import { getExtractor, getImportExtractor } from './extractors/index.js';
-import { getAllLanguages } from './languages/registry.js';
+import type { LanguageSymbolExtractor } from './extractors/types.js';
+import { getExtractor, getImportExtractor, getSymbolExtractor } from './extractors/index.js';
+import { getLanguage } from './languages/registry.js';
 
 /**
- * Type for symbol extractor functions
- */
-type SymbolExtractor = (
-  node: Parser.SyntaxNode,
-  content: string,
-  parentClass?: string
-) => SymbolInfo | null;
-
-/**
- * Extract function declaration info (function_declaration, function)
- */
-function extractFunctionInfo(
-  node: Parser.SyntaxNode,
-  content: string,
-  parentClass?: string
-): SymbolInfo | null {
-    const nameNode = node.childForFieldName('name');
-    if (!nameNode) return null;
-
-    return {
-      name: nameNode.text,
-      type: parentClass ? 'method' : 'function',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      parentClass,
-      signature: extractSignature(node, content),
-      parameters: extractParameters(node, content),
-      returnType: extractReturnType(node, content),
-      complexity: calculateComplexity(node),
-    };
-  }
-
-/**
- * Extract arrow function or function expression info
- */
-function extractArrowFunctionInfo(
-  node: Parser.SyntaxNode,
-  content: string,
-  parentClass?: string
-): SymbolInfo | null {
-    // Try to find variable name for arrow functions
-    const parent = node.parent;
-    let name = 'anonymous';
-
-    if (parent?.type === 'variable_declarator') {
-      const nameNode = parent.childForFieldName('name');
-      name = nameNode?.text || 'anonymous';
-    }
-
-    return {
-      name,
-      type: parentClass ? 'method' : 'function',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      parentClass,
-      signature: extractSignature(node, content),
-      parameters: extractParameters(node, content),
-      complexity: calculateComplexity(node),
-    };
-  }
-
-/**
- * Extract method definition info
- */
-function extractMethodInfo(
-  node: Parser.SyntaxNode,
-  content: string,
-  parentClass?: string
-): SymbolInfo | null {
-    const nameNode = node.childForFieldName('name');
-    if (!nameNode) return null;
-
-    return {
-      name: nameNode.text,
-      type: 'method',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      parentClass,
-      signature: extractSignature(node, content),
-      parameters: extractParameters(node, content),
-      returnType: extractReturnType(node, content),
-      complexity: calculateComplexity(node),
-    };
-  }
-
-/**
- * Extract class declaration info
- */
-function extractClassInfo(
-  node: Parser.SyntaxNode,
-  _content: string,
-  _parentClass?: string
-): SymbolInfo | null {
-    const nameNode = node.childForFieldName('name');
-    if (!nameNode) return null;
-
-    return {
-      name: nameNode.text,
-      type: 'class',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      signature: `class ${nameNode.text}`,
-    };
-  }
-
-/**
- * Extract interface declaration info (TypeScript)
- */
-function extractInterfaceInfo(
-  node: Parser.SyntaxNode,
-  _content: string,
-  _parentClass?: string
-): SymbolInfo | null {
-    const nameNode = node.childForFieldName('name');
-    if (!nameNode) return null;
-
-    return {
-      name: nameNode.text,
-      type: 'interface',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      signature: `interface ${nameNode.text}`,
-    };
-  }
-
-/**
- * Extract Python function info (def and async def)
- */
-function extractPythonFunctionInfo(
-  node: Parser.SyntaxNode,
-  content: string,
-  parentClass?: string
-): SymbolInfo | null {
-    const nameNode = node.childForFieldName('name');
-    if (!nameNode) return null;
-
-    return {
-      name: nameNode.text,
-      type: parentClass ? 'method' : 'function',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      parentClass,
-      signature: extractSignature(node, content),
-      parameters: extractParameters(node, content),
-      complexity: calculateComplexity(node),
-    };
-  }
-
-/**
- * Extract Python class info
- */
-function extractPythonClassInfo(
-  node: Parser.SyntaxNode,
-  _content: string,
-  _parentClass?: string
-): SymbolInfo | null {
-    const nameNode = node.childForFieldName('name');
-    if (!nameNode) return null;
-
-    return {
-      name: nameNode.text,
-      type: 'class',
-      startLine: node.startPosition.row + 1,
-      endLine: node.endPosition.row + 1,
-      signature: `class ${nameNode.text}`,
-    };
-  }
-
-/**
- * Map of AST node types to their specialized extractors
- *
- * Note: There is intentional overlap in node type names across languages:
- * - 'function_definition': Used by both PHP and Python
- * - 'class_declaration': Used by TypeScript/JavaScript
- * - 'class_definition': Used by Python
- *
- * This is handled correctly because each file is parsed with its specific language parser.
- */
-const symbolExtractors: Record<string, SymbolExtractor> = {
-  // TypeScript/JavaScript
-  'function_declaration': extractFunctionInfo,
-  'function': extractFunctionInfo,
-  'arrow_function': extractArrowFunctionInfo,
-  'function_expression': extractArrowFunctionInfo,
-  'method_definition': extractMethodInfo,
-  'class_declaration': extractClassInfo,
-  'interface_declaration': extractInterfaceInfo,
-
-  // PHP
-  'function_definition': extractFunctionInfo,   // PHP functions (Python handled via language check in extractSymbolInfo)
-  'method_declaration': extractMethodInfo,       // PHP methods
-
-  // Python
-  'async_function_definition': extractPythonFunctionInfo,  // Python async functions
-  'class_definition': extractPythonClassInfo,              // Python classes
-  // Note: Python regular functions use 'function_definition' (same as PHP)
-  // They are dispatched to extractPythonFunctionInfo via language check in extractSymbolInfo()
-};
-
-/**
- * Extract symbol information from an AST node using specialized extractors
+ * Extract symbol information from an AST node using language-specific extractors.
  *
  * @param node - AST node to extract info from
  * @param content - Source code content
  * @param parentClass - Parent class name if this is a method
- * @param language - Programming language (for disambiguating shared node types)
+ * @param language - Programming language
  * @returns Symbol information or null
  */
 export function extractSymbolInfo(
@@ -219,78 +19,13 @@ export function extractSymbolInfo(
   parentClass?: string,
   language?: string
 ): SymbolInfo | null {
-  // Handle ambiguous node types that are shared between languages
-  // PHP and Python both use 'function_definition', but need different extractors
-  if (node.type === 'function_definition' && language === 'python') {
-    return extractPythonFunctionInfo(node, content, parentClass);
-  }
-
-  const extractor = symbolExtractors[node.type];
-  return extractor ? extractor(node, content, parentClass) : null;
-}
-
-/**
- * Extract function/method signature
- */
-function extractSignature(node: Parser.SyntaxNode, content: string): string {
-  // Get the first line of the function (up to opening brace or arrow)
-  const startLine = node.startPosition.row;
-  const lines = content.split('\n');
-  let signature = lines[startLine] || '';
-
-  // If signature spans multiple lines, try to get up to the opening brace
-  let currentLine = startLine;
-  while (currentLine < node.endPosition.row && !signature.includes('{') && !signature.includes('=>')) {
-    currentLine++;
-    signature += ' ' + (lines[currentLine] || '');
-  }
-
-  // Clean up signature
-  signature = signature.split('{')[0].split('=>')[0].trim();
-
-  // Limit length
-  if (signature.length > 200) {
-    signature = signature.substring(0, 197) + '...';
-  }
-
-  return signature;
-}
-
-/**
- * Extract parameter list from function node
- *
- * Note: The `_content` parameter is unused in this function, but is kept for API consistency
- * with other extract functions (e.g., extractSignature).
- */
-function extractParameters(node: Parser.SyntaxNode, _content: string): string[] {
-  const parameters: string[] = [];
-
-  // Find parameters node
-  const paramsNode = node.childForFieldName('parameters');
-  if (!paramsNode) return parameters;
-
-  // Traverse parameter nodes
-  for (let i = 0; i < paramsNode.namedChildCount; i++) {
-    const param = paramsNode.namedChild(i);
-    if (param && param.text.trim()) {
-      parameters.push(param.text);
+  if (language) {
+    const extractor = getSymbolExtractor(language as SupportedLanguage);
+    if (extractor) {
+      return extractor.extractSymbol(node, content, parentClass);
     }
   }
-
-  return parameters;
-}
-
-/**
- * Extract return type from function node (TypeScript)
- *
- * Note: The `_content` parameter is unused in this function, but is kept for API consistency
- * with other extract functions (e.g., extractSignature).
- */
-function extractReturnType(node: Parser.SyntaxNode, _content: string): string | undefined {
-  const returnTypeNode = node.childForFieldName('return_type');
-  if (!returnTypeNode) return undefined;
-
-  return returnTypeNode.text;
+  return null;
 }
 
 /**
@@ -426,32 +161,24 @@ export function extractExports(rootNode: Parser.SyntaxNode, language?: Supported
  * - TypeScript/JavaScript: call_expression (foo(), obj.method()), new_expression (new Foo())
  * - PHP: function_call_expression, member_call_expression, scoped_call_expression
  * - Python: call (similar to JS call_expression)
+ * - Rust: call_expression (foo(), obj.method()), macro_invocation (println!())
  */
-export function extractCallSites(node: Parser.SyntaxNode): Array<{ symbol: string; line: number }> {
+export function extractCallSites(
+  node: Parser.SyntaxNode,
+  language?: SupportedLanguage
+): Array<{ symbol: string; line: number }> {
+  if (!language) return [];
+
+  const langDef = getLanguage(language);
+  const extractor = langDef.symbolExtractor;
+  if (!extractor) return [];
+
+  const callExprTypes = new Set(langDef.symbols.callExpressionTypes);
   const callSites: Array<{ symbol: string; line: number }> = [];
   const seen = new Set<string>();
-  const callExprTypes = getCallExpressionTypes();
 
-  traverseForCallSites(node, callSites, seen, callExprTypes);
+  traverseForCallSites(node, callSites, seen, callExprTypes, extractor);
   return callSites;
-}
-
-/**
- * Call expression node types, built from all language definitions.
- * Lazily initialized on first use.
- */
-let callExpressionTypesCache: Set<string> | null = null;
-
-function getCallExpressionTypes(): Set<string> {
-  if (!callExpressionTypesCache) {
-    callExpressionTypesCache = new Set<string>();
-    for (const lang of getAllLanguages()) {
-      for (const type of lang.symbols.callExpressionTypes) {
-        callExpressionTypesCache.add(type);
-      }
-    }
-  }
-  return callExpressionTypesCache;
 }
 
 /**
@@ -461,10 +188,11 @@ function traverseForCallSites(
   node: Parser.SyntaxNode,
   callSites: Array<{ symbol: string; line: number }>,
   seen: Set<string>,
-  callExprTypes: Set<string>
+  callExprTypes: Set<string>,
+  extractor: LanguageSymbolExtractor
 ): void {
   if (callExprTypes.has(node.type)) {
-    const callSite = extractCallSiteFromExpression(node);
+    const callSite = extractor.extractCallSite(node);
     if (callSite && !seen.has(callSite.key)) {
       seen.add(callSite.key);
       callSites.push({ symbol: callSite.symbol, line: callSite.line });
@@ -474,110 +202,6 @@ function traverseForCallSites(
   // Recurse into named children to skip punctuation and other non-semantic nodes
   for (let i = 0; i < node.namedChildCount; i++) {
     const child = node.namedChild(i);
-    if (child) traverseForCallSites(child, callSites, seen, callExprTypes);
+    if (child) traverseForCallSites(child, callSites, seen, callExprTypes, extractor);
   }
-}
-
-/**
- * Extract symbol and line from a call expression.
- * Handles multiple languages with different AST structures.
- */
-function extractCallSiteFromExpression(node: Parser.SyntaxNode): { symbol: string; line: number; key: string } | null {
-  const line = node.startPosition.row + 1;
-
-  // TypeScript/JavaScript: call_expression
-  if (node.type === 'call_expression') {
-    return extractJSCallSite(node, line);
-  }
-
-  // TypeScript/JavaScript: new_expression (new Foo(), new ns.Bar())
-  if (node.type === 'new_expression') {
-    return extractNewExpressionCallSite(node, line);
-  }
-
-  // Python: call
-  if (node.type === 'call') {
-    return extractPythonCallSite(node, line);
-  }
-
-  // PHP: function_call_expression - helper_function()
-  if (node.type === 'function_call_expression') {
-    const funcNode = node.childForFieldName('function');
-    if (funcNode?.type === 'name') {
-      return { symbol: funcNode.text, line, key: `${funcNode.text}:${line}` };
-    }
-  }
-
-  // PHP: member_call_expression - $this->method() or $obj->method()
-  if (node.type === 'member_call_expression') {
-    const nameNode = node.childForFieldName('name');
-    if (nameNode?.type === 'name') {
-      return { symbol: nameNode.text, line, key: `${nameNode.text}:${line}` };
-    }
-  }
-
-  // PHP: scoped_call_expression - User::find() or static::method()
-  if (node.type === 'scoped_call_expression') {
-    const nameNode = node.childForFieldName('name');
-    if (nameNode?.type === 'name') {
-      return { symbol: nameNode.text, line, key: `${nameNode.text}:${line}` };
-    }
-  }
-
-  return null;
-}
-
-/**
- * Resolve a JS/TS node (identifier or member_expression) to a symbol name.
- */
-function resolveJSSymbol(node: Parser.SyntaxNode): string | null {
-  if (node.type === 'identifier') return node.text;
-  if (node.type === 'member_expression') {
-    const propertyNode = node.childForFieldName('property');
-    if (propertyNode?.type === 'property_identifier') return propertyNode.text;
-  }
-  return null;
-}
-
-/**
- * Extract call site from JavaScript/TypeScript call_expression.
- */
-function extractJSCallSite(node: Parser.SyntaxNode, line: number): { symbol: string; line: number; key: string } | null {
-  const functionNode = node.childForFieldName('function');
-  if (!functionNode) return null;
-  const symbol = resolveJSSymbol(functionNode);
-  return symbol ? { symbol, line, key: `${symbol}:${line}` } : null;
-}
-
-/**
- * Extract call site from JavaScript/TypeScript new_expression.
- */
-function extractNewExpressionCallSite(node: Parser.SyntaxNode, line: number): { symbol: string; line: number; key: string } | null {
-  const ctorNode = node.childForFieldName('constructor');
-  if (!ctorNode) return null;
-  const symbol = resolveJSSymbol(ctorNode);
-  return symbol ? { symbol, line, key: `${symbol}:${line}` } : null;
-}
-
-/**
- * Extract call site from Python call expression.
- */
-function extractPythonCallSite(node: Parser.SyntaxNode, line: number): { symbol: string; line: number; key: string } | null {
-  const funcNode = node.childForFieldName('function');
-  if (!funcNode) return null;
-
-  // Direct function call: foo()
-  if (funcNode.type === 'identifier') {
-    return { symbol: funcNode.text, line, key: `${funcNode.text}:${line}` };
-  }
-
-  // Attribute access: obj.method() - extract 'method'
-  if (funcNode.type === 'attribute') {
-    const attrNode = funcNode.childForFieldName('attribute');
-    if (attrNode?.type === 'identifier') {
-      return { symbol: attrNode.text, line, key: `${attrNode.text}:${line}` };
-    }
-  }
-
-  return null;
 }


### PR DESCRIPTION
## Summary

- Moves symbol extraction logic (`extractSymbolInfo`, `extractCallSiteFromExpression`) from the shared `symbols.ts` into per-language files, following the established pattern for traversers, export extractors, and import extractors
- Adds `LanguageSymbolExtractor` interface and per-language implementations (JS/TS, Python, PHP, Rust)
- Adds **Rust symbol extraction** (previously missing — `extractSymbolInfo` returned `null` for all Rust nodes)
- Eliminates the Python/PHP `function_definition` ambiguity hack — each language now has its own extractor
- Removes ~280 lines from `symbols.ts`, creates 1 new file (`extractors/symbol-helpers.ts`)

## Changes

| File | Action | Description |
|------|--------|-------------|
| `extractors/symbol-helpers.ts` | **New** | Shared `extractSignature`, `extractParameters`, `extractReturnType` helpers |
| `extractors/types.ts` | Modified | Added `LanguageSymbolExtractor` interface |
| `extractors/index.ts` | Modified | Added `getSymbolExtractor()` |
| `languages/types.ts` | Modified | Added `symbolExtractor?` to `LanguageDefinition` |
| `languages/javascript.ts` | Modified | Added `JavaScriptSymbolExtractor` + `TypeScriptSymbolExtractor` |
| `languages/typescript.ts` | Modified | Wired `TypeScriptSymbolExtractor` |
| `languages/python.ts` | Modified | Added `PythonSymbolExtractor` |
| `languages/php.ts` | Modified | Added `PHPSymbolExtractor` |
| `languages/rust.ts` | Modified | Added `RustSymbolExtractor` (NEW functionality) |
| `symbols.ts` | Modified | Removed ~280 lines, delegates to per-language extractors |
| `chunker.ts` | Modified | Passes `language` to `extractCallSites()` |
| `symbols.test.ts` | Modified | Updated `extractCallSites()` calls to pass language parameter |

## Test plan

- [x] `npm run typecheck` passes with 0 errors
- [x] `npm run build` compiles successfully
- [x] `symbols.test.ts` — 88 tests pass (symbol extraction, call sites for JS/TS/PHP/Python)
- [x] `chunker.test.ts` — 28 tests pass (end-to-end chunking with symbolName/symbolType)
- [x] `python.test.ts` — 10 tests pass (Python-specific chunking)

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->