### PR TITLE
feat(ast): support Python __init__.py re-exports for dependency tracking

### DIFF
--- a/packages/core/src/indexer/ast/extractors/extractors.test.ts
+++ b/packages/core/src/indexer/ast/extractors/extractors.test.ts
@@ -201,6 +201,33 @@ class UserController:
       expect(exports).toEqual(['AuthService', 'UserController']);
     });
 
+    it('should extract re-exports from absolute imports', () => {
+      const code = 'from utils import helper';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+
+      expect(exports).toEqual(['helper']);
+    });
+
+    it('should extract re-exports from current package import', () => {
+      const code = 'from . import symbol';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+
+      expect(exports).toEqual(['symbol']);
+    });
+
+    it('should ignore wildcard imports', () => {
+      const code = 'from .module import *';
+      const tree = parser.parse(code);
+      const extractor = getExtractor('python');
+      const exports = extractor.extractExports(tree.rootNode);
+
+      expect(exports).toEqual([]);
+    });
+
     it('should deduplicate re-exports and declarations', () => {
       const code = `from .base import Helper
 


### PR DESCRIPTION
## Summary

Closes #129.

- Add re-export detection to `PythonExportExtractor` so that `from .module import Symbol` populates the `exports` metadata array
- Handles both relative (`from .auth import X`) and absolute (`from utils import X`) imports, including aliased re-exports (`from .auth import X as Y`)
- The dependency analyzer already resolves re-export chains via `fileIsReExporter` — it just needed the `exports` array populated correctly

## Test plan

- [x] Added 4 new test cases: multi-symbol re-exports, aliased re-exports, combined declarations + re-exports, deduplication
- [x] All existing extractor, symbol, and chunker tests pass
- [x] Typecheck and build pass

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->