### PR TITLE
fix(mcp): add checkAndReconnect guard to background git reindex paths

### DIFF
--- a/packages/cli/src/mcp/server.reconnect-guard.test.ts
+++ b/packages/cli/src/mcp/server.reconnect-guard.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createReindexStateManager } from './reindex-state-manager.js';
+import type { LogFn } from './types.js';
+
+// Track call order across mocks
+let callOrder: string[];
+
+// Mock @liendev/core
+vi.mock('@liendev/core', async () => {
+  const actual = await vi.importActual<typeof import('@liendev/core')>('@liendev/core');
+  return {
+    ...actual,
+    indexMultipleFiles: vi.fn(async () => {
+      callOrder.push('indexMultipleFiles');
+      return 1;
+    }),
+    createGitignoreFilter: vi.fn(async () => () => false),
+    DEFAULT_GIT_POLL_INTERVAL_MS: 1000,
+  };
+});
+
+// Mock fs/promises (used by filterGitChangedFiles → fs.access)
+vi.mock('fs/promises', () => ({
+  default: {
+    access: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn(),
+  },
+}));
+
+import { _testing } from './server.js';
+import { indexMultipleFiles } from '@liendev/core';
+
+const { handleGitStartup, createGitPollInterval, createGitChangeHandler } = _testing;
+
+function createMockGitTracker(changedFiles: string[] | null = ['/project/src/file.ts']) {
+  return {
+    initialize: vi.fn().mockResolvedValue(changedFiles),
+    detectChanges: vi.fn().mockResolvedValue(changedFiles),
+    getDbPath: vi.fn().mockReturnValue('/project/.lien/indices/abc'),
+  } as any;
+}
+
+function createMockVectorDB() {
+  return {
+    dbPath: '/project/.lien/indices/abc',
+    hasData: vi.fn().mockResolvedValue(true),
+  } as any;
+}
+
+function createMockEmbeddings() {
+  return {} as any;
+}
+
+describe('Background git reindex reconnect guard', () => {
+  let checkAndReconnect: () => Promise<void>;
+  let log: LogFn;
+  let reindexStateManager: ReturnType<typeof createReindexStateManager>;
+
+  beforeEach(() => {
+    callOrder = [];
+    checkAndReconnect = vi.fn<() => Promise<void>>(async () => {
+      callOrder.push('checkAndReconnect');
+    });
+    log = vi.fn<LogFn>();
+    reindexStateManager = createReindexStateManager();
+    vi.mocked(indexMultipleFiles).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('handleGitStartup', () => {
+    it('should call checkAndReconnect before indexMultipleFiles', async () => {
+      const gitTracker = createMockGitTracker();
+
+      await handleGitStartup(
+        '/project',
+        gitTracker,
+        createMockVectorDB(),
+        createMockEmbeddings(),
+        false,
+        log,
+        reindexStateManager,
+        checkAndReconnect
+      );
+
+      expect(checkAndReconnect).toHaveBeenCalledOnce();
+      expect(indexMultipleFiles).toHaveBeenCalledOnce();
+      expect(callOrder).toEqual(['checkAndReconnect', 'indexMultipleFiles']);
+    });
+
+    it('should not call checkAndReconnect when no changes detected', async () => {
+      const gitTracker = createMockGitTracker(null);
+
+      await handleGitStartup(
+        '/project',
+        gitTracker,
+        createMockVectorDB(),
+        createMockEmbeddings(),
+        false,
+        log,
+        reindexStateManager,
+        checkAndReconnect
+      );
+
+      expect(checkAndReconnect).not.toHaveBeenCalled();
+      expect(indexMultipleFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createGitPollInterval', () => {
+    it('should call checkAndReconnect before indexMultipleFiles', async () => {
+      vi.useFakeTimers();
+      const gitTracker = createMockGitTracker();
+
+      createGitPollInterval(
+        '/project',
+        gitTracker,
+        createMockVectorDB(),
+        createMockEmbeddings(),
+        false,
+        log,
+        reindexStateManager,
+        checkAndReconnect
+      );
+
+      // Advance past the poll interval
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(checkAndReconnect).toHaveBeenCalledOnce();
+      expect(indexMultipleFiles).toHaveBeenCalledOnce();
+      expect(callOrder).toEqual(['checkAndReconnect', 'indexMultipleFiles']);
+    });
+  });
+
+  describe('createGitChangeHandler', () => {
+    it('should call checkAndReconnect before indexMultipleFiles', async () => {
+      const gitTracker = createMockGitTracker();
+
+      const handler = createGitChangeHandler(
+        '/project',
+        gitTracker,
+        createMockVectorDB(),
+        createMockEmbeddings(),
+        false,
+        log,
+        reindexStateManager,
+        checkAndReconnect
+      );
+
+      await handler();
+
+      expect(checkAndReconnect).toHaveBeenCalledOnce();
+      expect(indexMultipleFiles).toHaveBeenCalledOnce();
+      expect(callOrder).toEqual(['checkAndReconnect', 'indexMultipleFiles']);
+    });
+
+    it('should not call checkAndReconnect when no changes detected', async () => {
+      const gitTracker = createMockGitTracker(null);
+
+      const handler = createGitChangeHandler(
+        '/project',
+        gitTracker,
+        createMockVectorDB(),
+        createMockEmbeddings(),
+        false,
+        log,
+        reindexStateManager,
+        checkAndReconnect
+      );
+
+      await handler();
+
+      expect(checkAndReconnect).not.toHaveBeenCalled();
+      expect(indexMultipleFiles).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1037,3 +1037,6 @@ export async function startMCPServer(options: MCPServerOptions): Promise<void> {
 
   await setupAndConnectServer(server, toolContext, log, versionCheckInterval, reindexStateManager, { rootDir, verbose, watch });
 }
+
+/** @internal — exported for testing only */
+export const _testing = { handleGitStartup, createGitPollInterval, createGitChangeHandler };


### PR DESCRIPTION
## Summary

- Adds `checkAndReconnect()` calls before `indexMultipleFiles` in all three background git reindex paths (`handleGitStartup`, `createGitPollInterval`, `createGitChangeHandler`)
- Threads `checkAndReconnect` from `ToolContext` through `setupGitDetection` into the affected functions
- Prevents stale DB connections when the index is rebuilt externally between reindex intervals

Closes #143

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] All non-qdrant tests pass (qdrant failures expected without running server)
- [ ] Manual: verify MCP server starts correctly and git reindex works after external index rebuild

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->