### PR TITLE
feat(core): add persistent embedding cache for faster reindexing

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -3,34 +3,88 @@ name: Veille Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches: [main]
 
-# Cancel previous runs on same PR to save resources
+# Cancel previous runs on same PR/branch to save resources
 concurrency:
-  group: veille-review-${{ github.event.pull_request.number }}
+  group: veille-review-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  review:
+  # Warm the Lien index cache on main so PR runs can restore it
+  warm-cache:
     runs-on: ubuntu-latest
-    # Only run if PR is not from a fork (secrets not available in forks)
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    
+    if: github.event_name == 'push'
+
     permissions:
       contents: read
-      pull-requests: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Need full history for delta tracking
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
-      
+
+      - name: Cache builds
+        id: cache-build
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/core/dist
+            node_modules
+            packages/*/node_modules
+          key: lien-build-v5-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/*/package.json', 'packages/*/tsconfig.json', 'packages/core/src/**/*', 'packages/review/src/**/*', 'packages/action/src/**/*') }}
+
+      - name: Cache Lien index
+        uses: actions/cache@v4
+        with:
+          path: .lien
+          key: lien-index-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            lien-index-${{ runner.os }}-
+
+      - name: Install dependencies
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build Core
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: npm run build -w @liendev/core
+
+      - name: Build and run indexer
+        run: |
+          node --input-type=module -e "
+            import { indexCodebase } from '@liendev/core';
+            const result = await indexCodebase({ rootDir: process.cwd() });
+            console.log('Index result:', JSON.stringify(result, null, 2));
+          "
+
+  review:
+    runs-on: ubuntu-latest
+    # Only run on PRs, not on push to main
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for delta tracking
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
       # Cache node_modules and built packages
       - name: Cache builds
         id: cache-build
@@ -43,12 +97,21 @@ jobs:
             node_modules
             packages/*/node_modules
           key: lien-build-v5-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/*/package.json', 'packages/*/tsconfig.json', 'packages/core/src/**/*', 'packages/review/src/**/*', 'packages/action/src/**/*') }}
-      
+
+      # Cache Lien index and embedding cache across runs
+      - name: Cache Lien index
+        uses: actions/cache@v4
+        with:
+          path: .lien
+          key: lien-index-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            lien-index-${{ runner.os }}-
+
       # Always install deps if not cached - native modules need to be present
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: npm ci
-      
+
       - name: Build Core (required by Review)
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: npm run build -w @liendev/core
@@ -60,12 +123,12 @@ jobs:
       - name: Build Action
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: npm run build -w @liendev/action
-      
+
       - name: Ensure dist/package.json is ESM
         run: |
           echo '{"type":"module"}' > packages/action/dist/package.json
           cat packages/action/dist/package.json
-      
+
       # Install @liendev/core into node_modules so action can import it
       # This is how CLI works - core is a dependency installed via npm
       - name: Install @liendev/core for action
@@ -73,7 +136,7 @@ jobs:
           npm install ./packages/core
           # Verify it works with ESM import (not just require)
           node --input-type=module -e "import * as c from '@liendev/core'; console.log('Core ESM import works! Exports:', Object.keys(c).slice(0,5).join(', '), '...')"
-      
+
       - name: Run AI Code Review
         env:
           ACTIONS_STEP_DEBUG: true
@@ -85,4 +148,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           enable_delta_tracking: true  # Automatic base vs head comparison
           review_style: 'summary'
-

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -53,3 +53,7 @@ export const MAX_CHUNKS_PER_FILE = 100;
 // v3: Added cognitiveComplexity field to schema
 // v4: Added Halstead metrics (volume, difficulty, effort, bugs)
 export const INDEX_FORMAT_VERSION = 4;
+
+// Persistent embedding cache
+// At 384 dimensions (Float32), 50K entries ≈ 73 MB buffer + ~4 MB JSON index
+export const DEFAULT_EMBEDDING_CACHE_MAX_ENTRIES = 50_000;

--- a/packages/core/src/embeddings/persistent-cache.test.ts
+++ b/packages/core/src/embeddings/persistent-cache.test.ts
@@ -1,0 +1,549 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { writeFile } from 'fs/promises';
+import { PersistentEmbeddingCache, embedBatchWithCache, computeEmbeddingHash } from './persistent-cache.js';
+import { EmbeddingService } from './types.js';
+
+class MockEmbeddingService implements EmbeddingService {
+  embedCallCount = 0;
+  embedBatchCallCount = 0;
+
+  async initialize(): Promise<void> {
+    // No-op
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    this.embedCallCount++;
+    const embedding = new Float32Array(384);
+    embedding.fill(text.length / 1000);
+    return embedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    this.embedBatchCallCount++;
+    return Promise.all(texts.map(text => this.embed(text)));
+  }
+
+  async dispose(): Promise<void> {
+    // No-op
+  }
+}
+
+describe('PersistentEmbeddingCache', () => {
+  let tmpDir: string;
+  let cachePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'lien-cache-test-'));
+    cachePath = path.join(tmpDir, 'embedding-cache');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeVector(value: number, dimensions = 384): Float32Array {
+    const vec = new Float32Array(dimensions);
+    vec.fill(value);
+    return vec;
+  }
+
+  describe('computeEmbeddingHash', () => {
+    it('should return consistent hash for same input', () => {
+      const hash1 = computeEmbeddingHash('hello world');
+      const hash2 = computeEmbeddingHash('hello world');
+      expect(hash1).toBe(hash2);
+    });
+
+    it('should return different hashes for different inputs', () => {
+      const hash1 = computeEmbeddingHash('hello world');
+      const hash2 = computeEmbeddingHash('goodbye world');
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('should return 16 character hex string', () => {
+      const hash = computeEmbeddingHash('test');
+      expect(hash).toHaveLength(16);
+      expect(hash).toMatch(/^[0-9a-f]{16}$/);
+    });
+  });
+
+  describe('get/set', () => {
+    it('should return undefined on cache miss', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      const result = cache.get('nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return correct vector on cache hit', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      const vec = makeVector(0.5);
+      const hash = computeEmbeddingHash('test text');
+      cache.set(hash, vec);
+
+      const result = cache.get(hash);
+      expect(result).toBeDefined();
+      expect(result!.length).toBe(384);
+      for (let i = 0; i < 384; i++) {
+        expect(result![i]).toBeCloseTo(0.5);
+      }
+    });
+
+    it('should track hit and miss counts', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      const hash = computeEmbeddingHash('test');
+      cache.set(hash, makeVector(1.0));
+
+      expect(cache.hitCount).toBe(0);
+      expect(cache.missCount).toBe(0);
+
+      cache.get('nonexistent');
+      expect(cache.missCount).toBe(1);
+
+      cache.get(hash);
+      expect(cache.hitCount).toBe(1);
+
+      cache.get(hash);
+      expect(cache.hitCount).toBe(2);
+      expect(cache.missCount).toBe(1);
+    });
+
+    it('should update existing entry on set', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      const hash = computeEmbeddingHash('test');
+      cache.set(hash, makeVector(1.0));
+      cache.set(hash, makeVector(2.0));
+
+      expect(cache.size).toBe(1);
+      const result = cache.get(hash);
+      expect(result![0]).toBeCloseTo(2.0);
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('should evict oldest entry when at capacity', async () => {
+      const cache = new PersistentEmbeddingCache({
+        cachePath,
+        maxEntries: 5,
+      });
+      await cache.initialize();
+
+      // Fill cache with 5 entries
+      for (let i = 0; i < 5; i++) {
+        cache.set(`hash${i}`, makeVector(i));
+      }
+      expect(cache.size).toBe(5);
+
+      // Adding 6th should evict hash0 (oldest)
+      cache.set('hash5', makeVector(5));
+      expect(cache.size).toBe(5);
+
+      // hash0 should be gone
+      const evicted = cache.get('hash0');
+      expect(evicted).toBeUndefined();
+
+      // hash5 should exist
+      const newest = cache.get('hash5');
+      expect(newest).toBeDefined();
+      expect(newest![0]).toBeCloseTo(5);
+    });
+
+    it('should keep recently accessed entries', async () => {
+      const cache = new PersistentEmbeddingCache({
+        cachePath,
+        maxEntries: 5,
+      });
+      await cache.initialize();
+
+      // Fill cache
+      for (let i = 0; i < 5; i++) {
+        cache.set(`hash${i}`, makeVector(i));
+      }
+
+      // Access hash0 to make it recently used
+      cache.get('hash0');
+
+      // Add new entry — should evict hash1 (oldest non-accessed)
+      cache.set('hash5', makeVector(5));
+      expect(cache.size).toBe(5);
+
+      // hash0 should still be there (recently accessed)
+      expect(cache.get('hash0')).toBeDefined();
+
+      // hash1 should be evicted
+      expect(cache.get('hash1')).toBeUndefined();
+    });
+  });
+
+  describe('embedBatchWithCache', () => {
+    it('should only embed uncached texts', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+      const mockService = new MockEmbeddingService();
+
+      // Pre-cache some texts
+      const hash1 = computeEmbeddingHash('cached text 1');
+      const hash2 = computeEmbeddingHash('cached text 2');
+      cache.set(hash1, makeVector(0.1));
+      cache.set(hash2, makeVector(0.2));
+
+      // Embed a batch with mix of cached and uncached
+      const results = await embedBatchWithCache(
+        ['cached text 1', 'new text', 'cached text 2', 'another new text'],
+        mockService,
+        cache,
+      );
+
+      expect(results).toHaveLength(4);
+      // Only 2 uncached texts should have been embedded
+      expect(mockService.embedBatchCallCount).toBe(1);
+      expect(mockService.embedCallCount).toBe(2); // embedBatch calls embed internally
+
+      // Cached results should be returned correctly
+      expect(results[0][0]).toBeCloseTo(0.1);
+      expect(results[2][0]).toBeCloseTo(0.2);
+    });
+
+    it('should cache newly embedded texts', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+      const mockService = new MockEmbeddingService();
+
+      await embedBatchWithCache(['text1', 'text2'], mockService, cache);
+      expect(cache.size).toBe(2);
+
+      // Second batch with same texts should all be cached
+      mockService.embedCallCount = 0;
+      mockService.embedBatchCallCount = 0;
+      await embedBatchWithCache(['text1', 'text2'], mockService, cache);
+      expect(mockService.embedBatchCallCount).toBe(0);
+    });
+
+    it('should handle all cached', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+      const mockService = new MockEmbeddingService();
+
+      // Pre-cache everything
+      const hash = computeEmbeddingHash('only text');
+      cache.set(hash, makeVector(0.42));
+
+      const results = await embedBatchWithCache(['only text'], mockService, cache);
+      expect(results).toHaveLength(1);
+      expect(results[0][0]).toBeCloseTo(0.42);
+      expect(mockService.embedBatchCallCount).toBe(0);
+    });
+  });
+
+  describe('flush/reload', () => {
+    it('should persist and reload entries', async () => {
+      // Create cache, add entries, flush
+      const cache1 = new PersistentEmbeddingCache({ cachePath });
+      await cache1.initialize();
+
+      const hash1 = computeEmbeddingHash('text1');
+      const hash2 = computeEmbeddingHash('text2');
+      cache1.set(hash1, makeVector(1.0));
+      cache1.set(hash2, makeVector(2.0));
+      await cache1.flush();
+
+      // Create new cache from same path, initialize
+      const cache2 = new PersistentEmbeddingCache({ cachePath });
+      await cache2.initialize();
+
+      expect(cache2.size).toBe(2);
+      const result1 = cache2.get(hash1);
+      expect(result1).toBeDefined();
+      expect(result1![0]).toBeCloseTo(1.0);
+
+      const result2 = cache2.get(hash2);
+      expect(result2).toBeDefined();
+      expect(result2![0]).toBeCloseTo(2.0);
+    });
+
+    it('should preserve slot allocation after reload', async () => {
+      const cache1 = new PersistentEmbeddingCache({ cachePath, maxEntries: 10 });
+      await cache1.initialize();
+
+      for (let i = 0; i < 5; i++) {
+        cache1.set(`h${i}`, makeVector(i));
+      }
+      await cache1.flush();
+
+      const cache2 = new PersistentEmbeddingCache({ cachePath, maxEntries: 10 });
+      await cache2.initialize();
+
+      // Add more entries — should not collide with existing slots
+      cache2.set('h5', makeVector(5));
+      expect(cache2.size).toBe(6);
+
+      // All entries should be valid
+      for (let i = 0; i <= 5; i++) {
+        const result = cache2.get(`h${i}`);
+        expect(result).toBeDefined();
+        expect(result![0]).toBeCloseTo(i);
+      }
+    });
+  });
+
+  describe('model mismatch', () => {
+    it('should clear cache when model name mismatches', async () => {
+      // Create cache with model A
+      const cache1 = new PersistentEmbeddingCache({
+        cachePath,
+        modelName: 'model-A',
+      });
+      await cache1.initialize();
+      cache1.set(computeEmbeddingHash('test'), makeVector(1.0));
+      await cache1.flush();
+
+      // Re-initialize with model B
+      const cache2 = new PersistentEmbeddingCache({
+        cachePath,
+        modelName: 'model-B',
+      });
+      await cache2.initialize();
+
+      expect(cache2.size).toBe(0);
+      expect(cache2.get(computeEmbeddingHash('test'))).toBeUndefined();
+    });
+
+    it('should keep cache when model name matches', async () => {
+      const cache1 = new PersistentEmbeddingCache({
+        cachePath,
+        modelName: 'model-A',
+      });
+      await cache1.initialize();
+      const hash = computeEmbeddingHash('test');
+      cache1.set(hash, makeVector(1.0));
+      await cache1.flush();
+
+      const cache2 = new PersistentEmbeddingCache({
+        cachePath,
+        modelName: 'model-A',
+      });
+      await cache2.initialize();
+
+      expect(cache2.size).toBe(1);
+      expect(cache2.get(hash)).toBeDefined();
+    });
+  });
+
+  describe('empty cache', () => {
+    it('should return undefined for get on empty cache', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      expect(cache.get('anything')).toBeUndefined();
+      expect(cache.size).toBe(0);
+    });
+
+    it('should not error on flush of empty cache', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      await expect(cache.flush()).resolves.not.toThrow();
+    });
+
+    it('should not error on dispose of empty cache', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      await expect(cache.dispose()).resolves.not.toThrow();
+    });
+  });
+
+  describe('dispose', () => {
+    it('should clear all state after dispose', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      cache.set(computeEmbeddingHash('test'), makeVector(1.0));
+      expect(cache.size).toBe(1);
+
+      await cache.dispose();
+      expect(cache.size).toBe(0);
+    });
+
+    it('should not error on flush after dispose', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      cache.set(computeEmbeddingHash('test'), makeVector(1.0));
+      await cache.dispose();
+
+      // Flush after dispose should be idempotent
+      await expect(cache.flush()).resolves.not.toThrow();
+    });
+  });
+
+  describe('dimension validation', () => {
+    it('should throw on dimension mismatch in set()', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath, dimensions: 384 });
+      await cache.initialize();
+
+      const wrongDims = new Float32Array(128);
+      wrongDims.fill(1.0);
+
+      expect(() => cache.set('hash1', wrongDims)).toThrow('Embedding dimension mismatch: expected 384, got 128');
+    });
+  });
+
+  describe('corrupt file recovery', () => {
+    it('should recover from truncated .bin file', async () => {
+      // Create a valid cache and flush
+      const cache1 = new PersistentEmbeddingCache({ cachePath });
+      await cache1.initialize();
+      cache1.set(computeEmbeddingHash('text1'), makeVector(1.0));
+      cache1.set(computeEmbeddingHash('text2'), makeVector(2.0));
+      await cache1.flush();
+
+      // Truncate the .bin file
+      await writeFile(cachePath + '.bin', Buffer.alloc(10));
+
+      // Should recover gracefully (fall back to empty cache)
+      const cache2 = new PersistentEmbeddingCache({ cachePath });
+      await cache2.initialize();
+      expect(cache2.size).toBe(0);
+    });
+
+    it('should recover from corrupt .json file', async () => {
+      // Write garbage JSON
+      await writeFile(cachePath + '.json', 'not valid json', 'utf-8');
+      await writeFile(cachePath + '.bin', Buffer.alloc(100));
+
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+      expect(cache.size).toBe(0);
+    });
+
+    it('should recover from missing .bin file with valid .json', async () => {
+      // Write valid JSON but no .bin file
+      const index = {
+        version: 1,
+        modelName: 'default',
+        dimensions: 384,
+        entries: { 'abc123': { slot: 0, lastAccess: 1 } },
+        nextSlot: 1,
+        freeSlots: [],
+      };
+      await writeFile(cachePath + '.json', JSON.stringify(index), 'utf-8');
+
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  describe('buffer growth', () => {
+    it('should grow buffer beyond initial allocation', async () => {
+      // INITIAL_ALLOCATED_SLOTS is 1000, so adding 1001+ entries triggers growth
+      // Use small dimensions to keep test fast
+      const cache = new PersistentEmbeddingCache({
+        cachePath,
+        maxEntries: 2000,
+        dimensions: 4,
+      });
+      await cache.initialize();
+
+      // Add more entries than initial allocation
+      for (let i = 0; i < 1100; i++) {
+        const vec = new Float32Array(4);
+        vec.fill(i / 1000);
+        cache.set(`h${i}`, vec);
+      }
+
+      expect(cache.size).toBe(1100);
+
+      // Verify first and last entries are valid
+      const first = cache.get('h0');
+      expect(first).toBeDefined();
+      expect(first![0]).toBeCloseTo(0);
+
+      const last = cache.get('h1099');
+      expect(last).toBeDefined();
+      expect(last![0]).toBeCloseTo(1.099);
+    });
+  });
+
+  describe('free slot reuse', () => {
+    it('should reuse evicted slots for new entries', async () => {
+      const cache = new PersistentEmbeddingCache({
+        cachePath,
+        maxEntries: 3,
+        dimensions: 4,
+      });
+      await cache.initialize();
+
+      // Fill cache
+      for (let i = 0; i < 3; i++) {
+        const vec = new Float32Array(4);
+        vec.fill(i + 1);
+        cache.set(`h${i}`, vec);
+      }
+      expect(cache.size).toBe(3);
+
+      // Evict h0 by adding h3
+      const vec3 = new Float32Array(4);
+      vec3.fill(10);
+      cache.set('h3', vec3);
+      expect(cache.size).toBe(3);
+      expect(cache.get('h0')).toBeUndefined();
+
+      // h3 should have reused h0's slot — verify it reads correctly
+      const result = cache.get('h3');
+      expect(result).toBeDefined();
+      expect(result![0]).toBeCloseTo(10);
+
+      // Flush and reload to verify slot reuse persists
+      await cache.flush();
+      const cache2 = new PersistentEmbeddingCache({
+        cachePath,
+        maxEntries: 3,
+        dimensions: 4,
+      });
+      await cache2.initialize();
+      expect(cache2.size).toBe(3);
+
+      const reloaded = cache2.get('h3');
+      expect(reloaded).toBeDefined();
+      expect(reloaded![0]).toBeCloseTo(10);
+    });
+  });
+
+  describe('flush optimization', () => {
+    it('should not write .bin on read-only access', async () => {
+      const cache = new PersistentEmbeddingCache({ cachePath });
+      await cache.initialize();
+
+      // Write data and flush
+      cache.set(computeEmbeddingHash('test'), makeVector(1.0));
+      await cache.flush();
+
+      // Record .bin modification time
+      const { stat } = await import('fs/promises');
+      const binStatBefore = await stat(cachePath + '.bin');
+
+      // Wait a bit to ensure mtime would differ
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Read-only access (only updates access counters)
+      cache.get(computeEmbeddingHash('test'));
+      await cache.flush();
+
+      // .bin should NOT have been rewritten
+      const binStatAfter = await stat(cachePath + '.bin');
+      expect(binStatAfter.mtimeMs).toBe(binStatBefore.mtimeMs);
+    });
+  });
+});

--- a/packages/core/src/embeddings/persistent-cache.ts
+++ b/packages/core/src/embeddings/persistent-cache.ts
@@ -1,0 +1,353 @@
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import { EmbeddingService } from './types.js';
+import { EMBEDDING_DIMENSIONS } from '../constants.js';
+
+export interface PersistentCacheOptions {
+  /** Base path for cache files (without extension). Files created: {cachePath}.json and {cachePath}.bin */
+  cachePath: string;
+  /** Maximum number of entries (default: 50000) */
+  maxEntries?: number;
+  /** Embedding dimensions (default: EMBEDDING_DIMENSIONS = 384) */
+  dimensions?: number;
+  /** Model name for cache invalidation */
+  modelName?: string;
+}
+
+interface CacheIndex {
+  version: 1;
+  modelName: string;
+  dimensions: number;
+  entries: Record<string, { slot: number; lastAccess: number }>;
+  nextSlot: number;
+  freeSlots: number[];
+}
+
+const DEFAULT_MAX_ENTRIES = 50000;
+const INITIAL_ALLOCATED_SLOTS = 1000;
+
+/**
+ * Compute a content hash for embedding cache lookup.
+ * Uses SHA-256 truncated to 16 hex chars (64 bits) — collision probability
+ * is negligible at 50K entries (~7e-11).
+ */
+export function computeEmbeddingHash(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex').slice(0, 16);
+}
+
+export class PersistentEmbeddingCache {
+  private entries: Map<string, { slot: number; lastAccess: number }>;
+  private accessCounter: number;
+  private data: Buffer;
+  private freeSlots: number[];
+  private nextSlot: number;
+  private dataDirty: boolean;  // Vectors written — need to flush .bin
+  private metaDirty: boolean;  // Access counters changed — need to flush .json only
+  private _hitCount: number;
+  private _missCount: number;
+  private allocatedSlots: number;
+
+  private readonly cachePath: string;
+  private readonly maxEntries: number;
+  private readonly dimensions: number;
+  private readonly modelName: string;
+  private readonly bytesPerVector: number;
+
+  constructor(options: PersistentCacheOptions) {
+    this.cachePath = options.cachePath;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.dimensions = options.dimensions ?? EMBEDDING_DIMENSIONS;
+    this.modelName = options.modelName ?? 'default';
+    this.bytesPerVector = this.dimensions * 4; // Float32 = 4 bytes
+
+    this.entries = new Map();
+    this.accessCounter = 0;
+    this.freeSlots = [];
+    this.nextSlot = 0;
+    this.dataDirty = false;
+    this.metaDirty = false;
+    this._hitCount = 0;
+    this._missCount = 0;
+    this.allocatedSlots = Math.min(INITIAL_ALLOCATED_SLOTS, this.maxEntries);
+    this.data = Buffer.alloc(this.allocatedSlots * this.bytesPerVector);
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      const { index, binData } = await this.loadCacheFiles();
+
+      if (!this.isValidCache(index)) {
+        await this.resetCache();
+        return;
+      }
+
+      this.restoreFromDisk(index, binData);
+    } catch {
+      await this.resetCache();
+    }
+  }
+
+  private async loadCacheFiles(): Promise<{ index: CacheIndex; binData: Buffer }> {
+    const [indexData, binData] = await Promise.all([
+      fs.readFile(this.cachePath + '.json', 'utf-8'),
+      fs.readFile(this.cachePath + '.bin'),
+    ]);
+    return { index: JSON.parse(indexData), binData };
+  }
+
+  private isValidCache(index: CacheIndex): boolean {
+    return index.version === 1 &&
+      index.modelName === this.modelName &&
+      index.dimensions === this.dimensions;
+  }
+
+  private restoreFromDisk(index: CacheIndex, binData: Buffer): void {
+    // Validate bin file isn't truncated — a truncated file would serve garbage vectors
+    const requiredBytes = index.nextSlot * this.bytesPerVector;
+    if (binData.length < requiredBytes) {
+      throw new Error(`Cache data file truncated: expected ${requiredBytes} bytes, got ${binData.length}`);
+    }
+
+    this.entries = new Map(Object.entries(index.entries));
+    this.nextSlot = index.nextSlot;
+    this.freeSlots = index.freeSlots;
+
+    // Resume access counter from highest stored value
+    this.accessCounter = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.lastAccess > this.accessCounter) {
+        this.accessCounter = entry.lastAccess;
+      }
+    }
+
+    // Allocate buffer and copy stored vectors (cap at maxEntries like constructor/clear)
+    this.allocatedSlots = Math.min(
+      Math.max(INITIAL_ALLOCATED_SLOTS, this.nextSlot, this.entries.size),
+      this.maxEntries
+    );
+    while (this.allocatedSlots < this.nextSlot) {
+      this.allocatedSlots = Math.min(this.allocatedSlots * 2, this.maxEntries);
+      if (this.allocatedSlots < this.nextSlot) {
+        this.allocatedSlots = this.nextSlot;
+        break;
+      }
+    }
+    this.data = Buffer.alloc(this.allocatedSlots * this.bytesPerVector);
+    binData.copy(this.data, 0, 0, requiredBytes);
+
+    this.dataDirty = false;
+    this.metaDirty = false;
+  }
+
+  private async resetCache(): Promise<void> {
+    await this.deleteFiles();
+    this.clear();
+  }
+
+  get(hash: string): Float32Array | undefined {
+    const entry = this.entries.get(hash);
+    if (!entry) {
+      this._missCount++;
+      return undefined;
+    }
+
+    this._hitCount++;
+    entry.lastAccess = ++this.accessCounter;
+    this.metaDirty = true;
+
+    // Read via Float32Array view over the buffer, then copy for immutability
+    const offset = entry.slot * this.bytesPerVector;
+    const view = new Float32Array(this.data.buffer, this.data.byteOffset + offset, this.dimensions);
+    return new Float32Array(view);
+  }
+
+  set(hash: string, embedding: Float32Array): void {
+    if (embedding.length !== this.dimensions) {
+      throw new Error(`Embedding dimension mismatch: expected ${this.dimensions}, got ${embedding.length}`);
+    }
+
+    // If already exists, update in place
+    const existing = this.entries.get(hash);
+    if (existing) {
+      existing.lastAccess = ++this.accessCounter;
+      this.writeVector(existing.slot, embedding);
+      this.dataDirty = true;
+      return;
+    }
+
+    // Evict if at capacity
+    if (this.entries.size >= this.maxEntries) {
+      this.evictOldest();
+    }
+
+    // Allocate a slot
+    let slot: number;
+    if (this.freeSlots.length > 0) {
+      slot = this.freeSlots.pop()!;
+    } else {
+      slot = this.nextSlot++;
+    }
+
+    // Grow buffer if needed
+    this.ensureCapacity(slot);
+
+    this.entries.set(hash, { slot, lastAccess: ++this.accessCounter });
+    this.writeVector(slot, embedding);
+    this.dataDirty = true;
+  }
+
+  async flush(): Promise<void> {
+    if (!this.dataDirty && !this.metaDirty) {
+      return;
+    }
+
+    // Ensure directory exists
+    const dir = path.dirname(this.cachePath);
+    await fs.mkdir(dir, { recursive: true });
+
+    const indexPath = this.cachePath + '.json';
+    const dataPath = this.cachePath + '.bin';
+
+    // Only write .bin when vector data changed (not on read-only access updates)
+    if (this.dataDirty) {
+      const dataTmp = dataPath + '.tmp';
+      const usedBytes = this.nextSlot * this.bytesPerVector;
+      await fs.writeFile(dataTmp, this.data.subarray(0, usedBytes));
+      await fs.rename(dataTmp, dataPath);
+    }
+
+    // Always write .json when anything changed (access counters or entries)
+    const index: CacheIndex = {
+      version: 1,
+      modelName: this.modelName,
+      dimensions: this.dimensions,
+      entries: Object.fromEntries(this.entries),
+      nextSlot: this.nextSlot,
+      freeSlots: this.freeSlots,
+    };
+    const indexTmp = indexPath + '.tmp';
+    await fs.writeFile(indexTmp, JSON.stringify(index), 'utf-8');
+    await fs.rename(indexTmp, indexPath);
+
+    this.dataDirty = false;
+    this.metaDirty = false;
+  }
+
+  async dispose(): Promise<void> {
+    await this.flush();
+    this.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get hitCount(): number {
+    return this._hitCount;
+  }
+
+  get missCount(): number {
+    return this._missCount;
+  }
+
+  private clear(): void {
+    this.entries = new Map();
+    this.accessCounter = 0;
+    this.freeSlots = [];
+    this.nextSlot = 0;
+    this.dataDirty = false;
+    this.metaDirty = false;
+    this.allocatedSlots = Math.min(INITIAL_ALLOCATED_SLOTS, this.maxEntries);
+    this.data = Buffer.alloc(this.allocatedSlots * this.bytesPerVector);
+  }
+
+  private async deleteFiles(): Promise<void> {
+    try { await fs.unlink(this.cachePath + '.json'); } catch { /* ignore */ }
+    try { await fs.unlink(this.cachePath + '.bin'); } catch { /* ignore */ }
+  }
+
+  private writeVector(slot: number, embedding: Float32Array): void {
+    const offset = slot * this.bytesPerVector;
+    for (let i = 0; i < this.dimensions; i++) {
+      this.data.writeFloatLE(embedding[i], offset + i * 4);
+    }
+  }
+
+  private ensureCapacity(slot: number): void {
+    if (slot < this.allocatedSlots) {
+      return;
+    }
+
+    // Double until we can fit the slot
+    let newAllocated = this.allocatedSlots;
+    while (newAllocated <= slot) {
+      newAllocated = Math.min(newAllocated * 2, this.maxEntries);
+      if (newAllocated <= slot) {
+        // If doubling capped at maxEntries isn't enough, just use slot + 1
+        newAllocated = slot + 1;
+        break;
+      }
+    }
+
+    const newBuffer = Buffer.alloc(newAllocated * this.bytesPerVector);
+    this.data.copy(newBuffer, 0, 0, this.data.length);
+    this.data = newBuffer;
+    this.allocatedSlots = newAllocated;
+  }
+
+  private evictOldest(): void {
+    let oldestHash: string | undefined;
+    let oldestAccess = Infinity;
+
+    for (const [hash, entry] of this.entries) {
+      if (entry.lastAccess < oldestAccess) {
+        oldestAccess = entry.lastAccess;
+        oldestHash = hash;
+      }
+    }
+
+    if (oldestHash) {
+      const entry = this.entries.get(oldestHash)!;
+      this.freeSlots.push(entry.slot);
+      this.entries.delete(oldestHash);
+    }
+  }
+}
+
+/**
+ * Embed texts with persistent cache lookup.
+ * Computes hashes, checks cache, only embeds misses, stores results.
+ */
+export async function embedBatchWithCache(
+  texts: string[],
+  embeddings: EmbeddingService,
+  cache: PersistentEmbeddingCache,
+): Promise<Float32Array[]> {
+  const results: Float32Array[] = new Array(texts.length);
+  const uncachedTexts: string[] = [];
+  const uncachedIndices: number[] = [];
+  const hashes = texts.map(t => computeEmbeddingHash(t));
+
+  // Check cache
+  for (let i = 0; i < texts.length; i++) {
+    const cached = cache.get(hashes[i]);
+    if (cached) {
+      results[i] = cached;
+    } else {
+      uncachedTexts.push(texts[i]);
+      uncachedIndices.push(i);
+    }
+  }
+
+  // Embed misses
+  if (uncachedTexts.length > 0) {
+    const newEmbeddings = await embeddings.embedBatch(uncachedTexts);
+    for (let i = 0; i < newEmbeddings.length; i++) {
+      results[uncachedIndices[i]] = newEmbeddings[i];
+      cache.set(hashes[uncachedIndices[i]], newEmbeddings[i]);
+    }
+  }
+
+  return results;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,7 @@ export type { EcosystemPreset } from './indexer/ecosystem-presets.js';
 export { LocalEmbeddings } from './embeddings/local.js';
 export { WorkerEmbeddings } from './embeddings/worker-embeddings.js';
 export { CachedEmbeddings } from './embeddings/cache.js';
+export { PersistentEmbeddingCache, embedBatchWithCache, computeEmbeddingHash } from './embeddings/persistent-cache.js';
 export type { EmbeddingService } from './embeddings/types.js';
 export { EMBEDDING_DIMENSION, EMBEDDING_DIMENSIONS } from './embeddings/types.js';
 
@@ -202,6 +203,7 @@ export {
   DEFAULT_DEBOUNCE_MS,
   INDEX_FORMAT_VERSION,
   MAX_CHUNKS_PER_FILE,
+  DEFAULT_EMBEDDING_CACHE_MAX_ENTRIES,
 } from './constants.js';
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Persistent disk-backed cache for embedding vectors that survives across indexing runs. On incremental reindex, unchanged chunks hit the cache instead of re-computing embeddings, significantly reducing indexing time.

**Depends on:** #158 (refactor/indexer-decomposition)

### New files
- `packages/core/src/embeddings/persistent-cache.ts` — `PersistentEmbeddingCache` with LRU eviction, binary storage, atomic writes
- `packages/core/src/embeddings/persistent-cache.test.ts` — 28 tests covering get/set, eviction, persistence, corruption recovery, buffer growth

### Changes
- **`index.ts`**: `withEmbeddings` → `withIndexingServices` (adds cache lifecycle + hit rate logging)
- **`incremental.ts`**: Thread `cache?` through `processFileContent`, `processSingleFileForIndexing`, `indexMultipleFiles`
- **`chunk-batch-processor.ts`**: Thread `cache?` through constructor and `processEmbeddingMicroBatches`
- **`constants.ts`**: Add `DEFAULT_EMBEDDING_CACHE_MAX_ENTRIES` (50K entries ≈ 73 MB)
- **`core/index.ts`**: Export `PersistentEmbeddingCache`, `embedBatchWithCache`, `computeEmbeddingHash`, `DEFAULT_EMBEDDING_CACHE_MAX_ENTRIES`
- **`.github/workflows/ai-review.yml`**: Add `warm-cache` job on push to main; add Lien index caching for PR review runs

## Test plan
- [x] `npm run typecheck` passes with 0 errors
- [x] `npm run build` compiles successfully
- [x] All 804 non-Qdrant tests pass (28 new persistent cache tests included)
- [ ] Manual verification: run `lien index` twice, check verbose output for cache hit rate

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +9 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->