### PR TITLE
refactor(core): derive SupportedLanguage type from LANGUAGE_IDS array

### DIFF
--- a/packages/core/src/indexer/ast/languages/registry.ts
+++ b/packages/core/src/indexer/ast/languages/registry.ts
@@ -48,7 +48,7 @@ for (const def of definitions) {
 
 // Validate LANGUAGE_IDS has no duplicates and every ID has a definition
 if (new Set(LANGUAGE_IDS).size !== LANGUAGE_IDS.length) {
-  const dupes = LANGUAGE_IDS.filter((id, i) => LANGUAGE_IDS.indexOf(id) !== i);
+  const dupes = [...new Set(LANGUAGE_IDS.filter((id, i) => LANGUAGE_IDS.indexOf(id) !== i))];
   throw new Error(`LANGUAGE_IDS contains duplicate entries: ${dupes.join(', ')}`);
 }
 for (const id of LANGUAGE_IDS) {


### PR DESCRIPTION
## Summary

- Replace the manually maintained `SupportedLanguage` union type with a `LANGUAGE_IDS` const array and derived type, creating a single source of truth
- Add runtime validation that every ID in `LANGUAGE_IDS` has a corresponding definition in the registry (the reverse is already caught by TypeScript)
- `LANGUAGE_IDS` is exported for internal use (type derivation, validation, tests via deep import) — not re-exported from the public API

## Test plan

- [x] `npm run typecheck` passes (both packages)
- [x] `npm run build` passes (both packages)
- [x] All 15 registry tests pass
- [ ] Verify IDE autocomplete still works for `SupportedLanguage` values

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->