### PR TITLE
feat(core): add skipEmbeddings option to indexCodebase

### DIFF
--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -658,8 +658,8 @@ async function performChunkOnlyIndex(
   await Promise.all(
     files.map(file =>
       limit(async () => {
-        const processed = await chunkFileForCollection(file, rootDir, indexConfig, allChunks);
-        if (processed) filesProcessed++;
+        await chunkFileForCollection(file, rootDir, indexConfig, allChunks);
+        filesProcessed++;
         options.onProgress?.({
           phase: 'indexing',
           message: 'Processing files...',

--- a/packages/core/src/insights/complexity-analyzer.test.ts
+++ b/packages/core/src/insights/complexity-analyzer.test.ts
@@ -760,8 +760,7 @@ describe('ComplexityAnalyzer', () => {
         },
       ];
 
-      const analyzer = new ComplexityAnalyzer();
-      const report = analyzer.analyzeFromChunks(chunks);
+      const report = ComplexityAnalyzer.analyzeFromChunks(chunks);
 
       expect(report.summary.totalViolations).toBe(1);
       expect(report.summary.filesAnalyzed).toBe(1);
@@ -799,8 +798,7 @@ describe('ComplexityAnalyzer', () => {
         },
       ];
 
-      const analyzer = new ComplexityAnalyzer();
-      const report = analyzer.analyzeFromChunks(chunks, ['src/file1.ts']);
+      const report = ComplexityAnalyzer.analyzeFromChunks(chunks, ['src/file1.ts']);
 
       expect(report.summary.filesAnalyzed).toBe(1);
       expect(report.files['src/file1.ts']).toBeDefined();
@@ -808,8 +806,7 @@ describe('ComplexityAnalyzer', () => {
     });
 
     it('should handle empty chunks', () => {
-      const analyzer = new ComplexityAnalyzer();
-      const report = analyzer.analyzeFromChunks([]);
+      const report = ComplexityAnalyzer.analyzeFromChunks([]);
 
       expect(report.summary.totalViolations).toBe(0);
       expect(report.summary.filesAnalyzed).toBe(0);

--- a/packages/review/src/review-engine.ts
+++ b/packages/review/src/review-engine.ts
@@ -159,8 +159,7 @@ export async function runComplexityAnalysis(
 
     // Run complexity analysis from in-memory chunks (no VectorDB needed)
     logger.info('Analyzing complexity...');
-    const analyzer = new ComplexityAnalyzer();
-    const report = analyzer.analyzeFromChunks(indexResult.chunks, files);
+    const report = ComplexityAnalyzer.analyzeFromChunks(indexResult.chunks, files);
     logger.info(`Found ${report.summary.totalViolations} violations`);
 
     return report;


### PR DESCRIPTION
## Summary

- Adds `skipEmbeddings: true` option to `indexCodebase()` that short-circuits after AST chunking, returning chunks in-memory without embedding generation or VectorDB writes
- Adds `ComplexityAnalyzer.analyzeFromChunks()` for running complexity analysis directly on in-memory chunks
- Updates the review engine (`packages/review`) to use the new chunk-only path, eliminating VectorDB setup for complexity-only workflows

Closes #206

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` compiles successfully
- [x] All 984 non-Qdrant tests pass (Qdrant tests require running server)
- [x] 3 new unit tests for `analyzeFromChunks` (violations, file filtering, empty input)
- [x] Manual test: run veille action on a PR to verify faster execution

---

<!-- lien-stats -->
### 👁️ Veille

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +0 |

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->