### PR TITLE
fix(core): use effort-based Halstead bugs formula

### DIFF
--- a/packages/cli/.cursor/rules/lien.mdc
+++ b/packages/cli/.cursor/rules/lien.mdc
@@ -67,7 +67,7 @@ REQUIRED sequence:
   - **Test paths**: Number of test cases needed for full coverage (cyclomatic)
   - **Mental load**: How hard to follow - penalizes nesting (cognitive)
   - **Time to understand**: Estimated reading time (Halstead effort)
-  - **Estimated bugs**: Predicted bug count (Halstead volume / 3000)
+  - **Estimated bugs**: Predicted bug count (Halstead effort-based)
 - Use for tech debt analysis and refactoring prioritization
 - Returns `metricType` ('cyclomatic', 'cognitive', 'halstead_effort', or 'halstead_bugs')
 - Human-readable output: "23 (needs ~23 tests)", "🧠 45", "~2h 30m", "2.27 bugs"

--- a/packages/core/src/indexer/ast/complexity/halstead.ts
+++ b/packages/core/src/indexer/ast/complexity/halstead.ts
@@ -26,7 +26,7 @@ export interface HalsteadMetrics {
   difficulty: number; // D = (n1/2) × (N2/n2)
   effort: number; // E = D × V
   time: number; // T = E / 18 (seconds to understand)
-  bugs: number; // B = V / 3000 (estimated delivered bugs)
+  bugs: number; // B = E^(2/3) / 3000 (estimated delivered bugs)
 }
 
 /**
@@ -208,7 +208,7 @@ export function countHalstead(
  * - Difficulty (D) = (n1/2) × (N2/n2) - error-proneness
  * - Effort (E) = D × V - mental effort required
  * - Time (T) = E / 18 - seconds to understand (Stroud number)
- * - Bugs (B) = V / 3000 - estimated delivered bugs
+ * - Bugs (B) = E^(2/3) / 3000 - estimated delivered bugs (effort-based variant)
  *
  * @param counts - Raw Halstead counts from countHalstead()
  * @returns Calculated HalsteadMetrics
@@ -224,7 +224,7 @@ export function calculateHalsteadMetrics(counts: HalsteadCounts): HalsteadMetric
   const difficulty = n2 > 0 ? (n1 / 2) * (N2 / n2) : 0;
   const effort = difficulty * volume;
   const time = effort / 18; // Stroud number (18 mental discriminations per second)
-  const bugs = volume / 3000;
+  const bugs = Math.pow(effort, 2 / 3) / 3000;
 
   return {
     vocabulary: Math.round(vocabulary),

--- a/packages/core/src/indexer/types.ts
+++ b/packages/core/src/indexer/types.ts
@@ -61,7 +61,7 @@ export interface ChunkMetadata {
   halsteadVolume?: number; // V = N × log₂(n) - size of implementation
   halsteadDifficulty?: number; // D = (n1/2) × (N2/n2) - error-proneness
   halsteadEffort?: number; // E = D × V - mental effort required
-  halsteadBugs?: number; // B = V / 3000 - estimated delivered bugs
+  halsteadBugs?: number; // B = E^(2/3) / 3000 - estimated delivered bugs
 
   // Multi-tenant fields (optional for backward compatibility)
   /**

--- a/packages/site/docs/guide/cli-commands.md
+++ b/packages/site/docs/guide/cli-commands.md
@@ -398,7 +398,7 @@ Based on Halstead's software science metrics. Estimates reading time:
 
 #### Halstead Bugs (Estimated Bugs)
 Predicted bug count based on code complexity:
-- Formula: `Bugs = Volume / 3000`
+- Formula: `Bugs = Effort^(2/3) / 3000`
 - Default threshold: 1.5 (functions likely to have >1.5 bugs)
 
 | Complexity | Severity | Interpretation |

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -357,7 +357,7 @@ Analyze code complexity for tech debt identification and refactoring prioritizat
 - **Test paths**: Number of test cases needed (cyclomatic complexity)
 - **Mental load**: How hard to follow (penalizes nesting)
 - **Time to understand**: Estimated reading time (Halstead effort)
-- **Estimated bugs**: Predicted bug count (Halstead volume / 3000)
+- **Estimated bugs**: Predicted bug count (Halstead effort-based)
 
 ### Parameters
 
@@ -442,7 +442,7 @@ Analyze complexity of src/api/
 | `cyclomatic` | Test cases needed for full branch coverage |
 | `cognitive` | Mental load - how hard to follow (penalizes nesting) |
 | `halstead_effort` | Time to understand (shown as human-readable duration) |
-| `halstead_bugs` | Estimated bug count (Volume / 3000) |
+| `halstead_bugs` | Estimated bug count (Effort^(2/3) / 3000) |
 
 ::: tip Halstead Metrics
 Both Halstead metrics use intuitive thresholds:

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -90,7 +90,7 @@ Lien tracks four complementary complexity metrics:
 | **Cyclomatic** | Decision paths (if, for, switch) | Testability - how many tests needed? |
 | **Cognitive** | Mental effort (nesting depth, breaks) | Understandability - how hard to read? |
 | **Halstead Effort** | Reading time based on operators/operands | Learning curve - how long to understand? |
-| **Halstead Bugs** | Predicted bug count (Volume / 3000) | Reliability - how bug-prone is this? |
+| **Halstead Bugs** | Predicted bug count (Effort^(2/3) / 3000) | Reliability - how bug-prone is this? |
 
 All metrics are calculated during indexing using Tree-sitter AST parsing. Cognitive complexity is based on [SonarSource's specification](https://www.sonarsource.com/docs/CognitiveComplexity.pdf), Halstead metrics are based on Maurice Halstead's "Elements of Software Science" (1977).
 


### PR DESCRIPTION
## Summary

- Change `halstead_bugs` formula from `V / 3000` to `E^(2/3) / 3000` (effort-based Halstead bug prediction)
- High-difficulty functions with moderate volume now correctly trigger bug warnings
- Add regression test for the scenario described in #258

Closes #258

## Context

A 197-line function with cyclomatic 44, cognitive 105, and ~10h halstead_effort did **not** trigger a `halstead_bugs` violation. The old `V / 3000` formula only measures implementation size — for "pipeline" functions that reuse variables across many operations, difficulty is very high but volume stays moderate.

The effort-based variant `E^(2/3) / 3000` incorporates difficulty through the effort metric, providing better correlation with actual defect rates.

| Scenario | Old bugs | New bugs | Status |
|----------|----------|----------|--------|
| Trivial function | 0.02 | 0.01 | OK |
| ~10h effort (issue case) | ~1.0 | ~2.50 | **Fixed** |

## Test plan

- [x] Updated formula test to verify `E^(2/3) / 3000`
- [x] Added regression test: high difficulty + moderate volume triggers warning
- [x] All existing Halstead tests pass
- [x] `npm run typecheck` passes
- [x] `npm run lint` — 0 errors
- [x] `npm run build` succeeds

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->