### PR TITLE
fix(review): use language registry for analyzable file extensions

### DIFF
--- a/packages/review/src/review-engine.ts
+++ b/packages/review/src/review-engine.ts
@@ -10,6 +10,7 @@ import {
   indexCodebase,
   ComplexityAnalyzer,
   RISK_ORDER,
+  getSupportedExtensions,
   type ComplexityReport,
   type ComplexityViolation,
   type CodeChunk,
@@ -94,7 +95,7 @@ export interface ReviewSetup {
  * (excludes non-code files, vendor, node_modules, etc.)
  */
 export function filterAnalyzableFiles(files: string[]): string[] {
-  const codeExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.py', '.php']);
+  const codeExtensions = new Set(getSupportedExtensions().map(ext => `.${ext}`));
 
   const excludePatterns = [
     /node_modules\//,


### PR DESCRIPTION
## Summary

- Replace hardcoded extension list (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.php`) with `getSupportedExtensions()` from the core language registry
- Adds Rust (`.rs`) support that was missing from the review pipeline
- New languages added to core are automatically picked up — no more manual sync

## Test plan

- [x] All 40 review-engine tests pass
- [x] Typecheck passes

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->