### PR TITLE
chore: add changeset for v0.39.0

### DIFF
--- a/.changeset/v0-39-0.md
+++ b/.changeset/v0-39-0.md
@@ -1,0 +1,24 @@
+---
+"@liendev/core": minor
+"@liendev/lien": minor
+---
+
+### Features
+- Add `--editor` flag to `lien init` for multi-editor support (#272)
+- Add `metricType` filter to `get_complexity` MCP tool (#270)
+- Detect KISS violations via per-file simplicity signals in Veille reviews (#263)
+- Architectural review with codebase fingerprint (#251)
+- AST-powered logic review with GitHub suggestion diffs (#249)
+- Veille review system improvements (#248)
+
+### Fixes
+- Use language registry for analyzable file extensions in reviews (#269)
+- Tighten marginal violation threshold from 15% to 5% (#267)
+- Remove hard violation cap, add token-budget-aware fallback (#265)
+- Use effort-based Halstead bugs formula (#262)
+- Improve dedup note with severity, grouped metrics, and comment links (#261)
+- Skip unchecked_return for void-returning functions (#260)
+- Deduplicate Veille review comments across push rounds (#253)
+
+### Refactors
+- Reduce formatTextReport complexity (#254)


### PR DESCRIPTION
## Summary
- Adds changeset for v0.39.0 release covering 14 commits since v0.38.1
- Includes 6 features, 7 fixes, and 1 refactor
- Minor bump for both `@liendev/core` and `@liendev/lien`

## Test plan
- [ ] Verify changeset file format is correct
- [ ] CI passes