### PR TITLE
refactor(mcp): align response type interfaces with shapeResults output

### DIFF
--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -29,14 +29,7 @@ export interface ToolContext {
   /** Check if index has been updated and reconnect if needed */
   checkAndReconnect: () => Promise<void>;
   /** Get current index metadata for responses */
-  getIndexMetadata: () => {
-    indexVersion: number;
-    indexDate: string;
-    reindexInProgress?: boolean;
-    pendingFileCount?: number;
-    lastReindexDurationMs?: number | null;
-    msSinceLastReindex?: number | null;
-  };
+  getIndexMetadata: () => IndexMetadata;
   /** Get current reindex state */
   getReindexState: () => ReindexState;
 }
@@ -56,13 +49,11 @@ export interface MCPToolResult {
 export type ToolHandler = (args: unknown, ctx: ToolContext) => Promise<MCPToolResult>;
 
 /**
- * Metadata about the index state
+ * Metadata about the index state, returned by getIndexMetadata().
  */
 export interface IndexMetadata {
-  lastIndexed: string | null;
-  version: number;
-  hasData: boolean;
-  // Reindex status fields
+  indexVersion: number;
+  indexDate: string;
   reindexInProgress?: boolean;
   pendingFileCount?: number;
   lastReindexDurationMs?: number | null;
@@ -134,19 +125,4 @@ export interface SymbolListResponse {
   hasMore: boolean;
   nextOffset?: number;
   note?: string;
-}
-
-/**
- * Helper to create index metadata
- */
-export function createIndexMetadata(
-  lastIndexed: string | null,
-  version: number,
-  hasData: boolean,
-): IndexMetadata {
-  return {
-    lastIndexed,
-    version,
-    hasData,
-  };
 }


### PR DESCRIPTION
## Summary

- Replace `SearchResult[]` with `ToolResult[]` in all MCP response interfaces (`SearchResultResponse`, `SimilarCodeResponse`, `FilesContextResponse`, `FilesContextMultiResponse`, `SymbolListResponse`) to match what handlers actually return after `shapeResults()` processing
- Remove dead `SymbolInfo` interface (zero usages — the core `SymbolInfo` in `packages/core/src/indexer/ast/types.ts` is unrelated)
- Remove unused `SearchResult` import from `types.ts`
- Add missing fields to interfaces that handlers return but interfaces omitted: `groupedByRepo` on `SearchResultResponse`, `filtersApplied` on `SimilarCodeResponse`, `hasMore`/`nextOffset` on `SymbolListResponse`
- Fix `SymbolListResponse` field name from `symbols` to `results` to match handler output

Closes #113

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` succeeds
- [x] `npm run format:check` passes
- [x] All CLI tests pass (619/619)
- [x] All core tests pass (qdrant failures are pre-existing — no running server)

---

<!-- lien-stats -->
### 👁️ Veille

✅ **Good** - No complexity issues found.

*[Veille](https://lien.dev) by Lien*
<!-- /lien-stats -->