### PR TITLE
fix(changeset): remove deleted @liendev/action from ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@liendev/action"]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary
- Removes `@liendev/action` from the changeset `ignore` list — the package was deleted in #277 but the config entry was left behind, causing `changeset version` to fail with a `ValidationError`

## Test plan
- [x] Changeset release workflow succeeds after merge