### PR TITLE
refactor: replace remaining manual index loops with array methods

### DIFF
--- a/packages/cli/src/mcp/utils/response-budget.test.ts
+++ b/packages/cli/src/mcp/utils/response-budget.test.ts
@@ -26,22 +26,18 @@ function makeResultsResponse(count: number, contentSize: number) {
 
 /** Create a get_files_context multi-file response. */
 function makeFilesResponse(fileCount: number, chunksPerFile: number, contentSize: number) {
-  const files: Record<
-    string,
-    {
-      chunks: Array<{ content: string; metadata: Record<string, unknown> }>;
-      testAssociations: string[];
-    }
-  > = {};
-  for (let f = 0; f < fileCount; f++) {
-    files[`src/file-${f}.ts`] = {
-      chunks: Array.from({ length: chunksPerFile }, (_, i) => ({
-        content: bigContent(contentSize),
-        metadata: { file: `src/file-${f}.ts`, startLine: i * 50, endLine: (i + 1) * 50 },
-      })),
-      testAssociations: [`src/__tests__/file-${f}.test.ts`],
-    };
-  }
+  const files = Object.fromEntries(
+    Array.from({ length: fileCount }, (_, f) => [
+      `src/file-${f}.ts`,
+      {
+        chunks: Array.from({ length: chunksPerFile }, (_, i) => ({
+          content: bigContent(contentSize),
+          metadata: { file: `src/file-${f}.ts`, startLine: i * 50, endLine: (i + 1) * 50 },
+        })),
+        testAssociations: [`src/__tests__/file-${f}.test.ts`],
+      },
+    ]),
+  );
   return { indexInfo: { indexVersion: 1, indexDate: '2025-01-01' }, files };
 }
 

--- a/packages/core/src/embeddings/cache.test.ts
+++ b/packages/core/src/embeddings/cache.test.ts
@@ -198,7 +198,7 @@ describe('CachedEmbeddings', () => {
     it('should work with large max size', async () => {
       const largeCache = new CachedEmbeddings(mockService, 10000);
 
-      for (let i = 0; i < 100; i++) {
+      for (const i of Array.from({ length: 100 }, (_, idx) => idx)) {
         await largeCache.embed(`query${i}`);
       }
 

--- a/packages/core/src/embeddings/cache.ts
+++ b/packages/core/src/embeddings/cache.ts
@@ -57,24 +57,23 @@ export class CachedEmbeddings implements EmbeddingService {
     const uncachedIndices: number[] = [];
 
     // Check cache for each text
-    for (let i = 0; i < texts.length; i++) {
-      const cached = this.cache.get(texts[i]);
+    texts.forEach((text, i) => {
+      const cached = this.cache.get(text);
       if (cached) {
         results[i] = cached;
       } else {
-        uncachedTexts.push(texts[i]);
+        uncachedTexts.push(text);
         uncachedIndices.push(i);
       }
-    }
+    });
 
     // Generate embeddings for uncached texts
     if (uncachedTexts.length > 0) {
       const newEmbeddings = await this.underlying.embedBatch(uncachedTexts);
 
       // Store in cache and results
-      for (let i = 0; i < newEmbeddings.length; i++) {
+      newEmbeddings.forEach((embedding, i) => {
         const text = uncachedTexts[i];
-        const embedding = newEmbeddings[i];
         const resultIndex = uncachedIndices[i];
 
         // Add to cache with LRU eviction
@@ -87,7 +86,7 @@ export class CachedEmbeddings implements EmbeddingService {
 
         this.cache.set(text, embedding);
         results[resultIndex] = embedding;
-      }
+      });
     }
 
     return results;

--- a/packages/core/src/embeddings/local.test.ts
+++ b/packages/core/src/embeddings/local.test.ts
@@ -127,10 +127,7 @@ describe('LocalEmbeddings', () => {
       const embedding = await embeddings.embed('test normalization');
 
       // Calculate L2 norm - should be close to 1.0 (normalized)
-      let sumSquares = 0;
-      for (let i = 0; i < embedding.length; i++) {
-        sumSquares += embedding[i] * embedding[i];
-      }
+      const sumSquares = Array.from(embedding).reduce((sum, val) => sum + val * val, 0);
       const norm = Math.sqrt(sumSquares);
 
       expect(norm).toBeCloseTo(1.0, 5);
@@ -217,15 +214,10 @@ describe('LocalEmbeddings', () => {
 
 // Helper function to calculate cosine similarity
 function cosineSimilarity(a: Float32Array, b: Float32Array): number {
-  let dotProduct = 0;
-  let normA = 0;
-  let normB = 0;
-
-  for (let i = 0; i < a.length; i++) {
-    dotProduct += a[i] * b[i];
-    normA += a[i] * a[i];
-    normB += b[i] * b[i];
-  }
+  const aArr = Array.from(a);
+  const dotProduct = aArr.reduce((sum, val, i) => sum + val * b[i], 0);
+  const normA = aArr.reduce((sum, val) => sum + val * val, 0);
+  const normB = Array.from(b).reduce((sum, val) => sum + val * val, 0);
 
   return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
 }

--- a/packages/core/src/embeddings/worker-embeddings.test.ts
+++ b/packages/core/src/embeddings/worker-embeddings.test.ts
@@ -84,10 +84,7 @@ describe('WorkerEmbeddings', () => {
     it('should produce normalized embeddings', async () => {
       const embedding = await embeddings.embed('test normalization');
 
-      let sumSquares = 0;
-      for (let i = 0; i < embedding.length; i++) {
-        sumSquares += embedding[i] * embedding[i];
-      }
+      const sumSquares = Array.from(embedding).reduce((sum, val) => sum + val * val, 0);
       const norm = Math.sqrt(sumSquares);
 
       expect(norm).toBeCloseTo(1.0, 5);
@@ -138,9 +135,9 @@ describe('WorkerEmbeddings', () => {
       const localResult = await local.embed(text);
 
       expect(workerResult.length).toBe(localResult.length);
-      for (let i = 0; i < workerResult.length; i++) {
-        expect(workerResult[i]).toBeCloseTo(localResult[i], 4);
-      }
+      Array.from(workerResult).forEach((val, i) => {
+        expect(val).toBeCloseTo(localResult[i], 4);
+      });
     });
   });
 

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CONCURRENCY,
   EMBEDDING_MICRO_BATCH_SIZE,
 } from '../constants.js';
+import { chunkArray } from '../utils/chunk-array.js';
 import { ManifestManager } from './manifest.js';
 import type { Result } from '../utils/result.js';
 import { Ok, Err, isOk } from '../utils/result.js';
@@ -125,8 +126,7 @@ async function processFileContent(
   const texts = chunks.map(c => c.content);
   const vectors: Float32Array[] = [];
 
-  for (let j = 0; j < texts.length; j += EMBEDDING_MICRO_BATCH_SIZE) {
-    const microBatch = texts.slice(j, Math.min(j + EMBEDDING_MICRO_BATCH_SIZE, texts.length));
+  for (const microBatch of chunkArray(texts, EMBEDDING_MICRO_BATCH_SIZE)) {
     const microResults = await embeddings.embedBatch(microBatch);
     vectors.push(...microResults);
 

--- a/packages/core/src/indexer/progress-tracker.test.ts
+++ b/packages/core/src/indexer/progress-tracker.test.ts
@@ -151,9 +151,9 @@ describe('IndexingProgressTracker', () => {
       tracker.start();
 
       // Simulate processing files
-      for (let i = 0; i < totalFiles; i++) {
+      Array.from({ length: totalFiles }).forEach(() => {
         tracker.incrementFiles();
-      }
+      });
 
       // Change message for final phase
       tracker.setMessage('Saving manifest...');

--- a/packages/core/src/utils/chunk-array.test.ts
+++ b/packages/core/src/utils/chunk-array.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { chunkArray } from './chunk-array.js';
+
+describe('chunkArray', () => {
+  it('should split array into chunks of given size', () => {
+    expect(chunkArray([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('should return single chunk when array fits', () => {
+    expect(chunkArray([1, 2, 3], 5)).toEqual([[1, 2, 3]]);
+  });
+
+  it('should return exact chunks when evenly divisible', () => {
+    expect(chunkArray([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('should return empty array for empty input', () => {
+    expect(chunkArray([], 3)).toEqual([]);
+  });
+
+  it('should handle chunk size of 1', () => {
+    expect(chunkArray([1, 2, 3], 1)).toEqual([[1], [2], [3]]);
+  });
+
+  it('should throw RangeError for size <= 0', () => {
+    expect(() => chunkArray([1], 0)).toThrow(RangeError);
+    expect(() => chunkArray([1], -1)).toThrow(RangeError);
+  });
+
+  it('should work with non-number types', () => {
+    expect(chunkArray(['a', 'b', 'c'], 2)).toEqual([['a', 'b'], ['c']]);
+  });
+});

--- a/packages/core/src/utils/chunk-array.ts
+++ b/packages/core/src/utils/chunk-array.ts
@@ -1,0 +1,17 @@
+/**
+ * Split an array into chunks of the given size.
+ *
+ * @param arr - Array to split
+ * @param size - Maximum chunk size (must be > 0)
+ * @returns Array of chunks (sub-arrays)
+ */
+export function chunkArray<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) throw new RangeError('chunkArray: size must be greater than 0');
+  if (arr.length === 0) return [];
+
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}

--- a/packages/core/src/vectordb/batch-insert.test.ts
+++ b/packages/core/src/vectordb/batch-insert.test.ts
@@ -36,11 +36,11 @@ function createTestData(count: number) {
   const metadatas: ChunkMetadata[] = [];
   const contents: string[] = [];
 
-  for (let i = 0; i < count; i++) {
+  Array.from({ length: count }).forEach((_, i) => {
     vectors.push(new Float32Array([i, i + 1, i + 2]));
     metadatas.push(createMockMetadata(`file${i}.ts`, i * 10));
     contents.push(`content ${i}`);
-  }
+  });
 
   return { vectors, metadatas, contents };
 }

--- a/packages/core/src/vectordb/batch-insert.ts
+++ b/packages/core/src/vectordb/batch-insert.ts
@@ -2,6 +2,7 @@ import type { LanceDBConnection, LanceDBTable } from './lancedb-types.js';
 import type { ChunkMetadata } from '@liendev/parser';
 import { DatabaseError } from '../errors/index.js';
 import { VECTOR_DB_MAX_BATCH_SIZE, VECTOR_DB_MIN_BATCH_SIZE } from '../constants.js';
+import { chunkArray } from '../utils/chunk-array.js';
 
 /**
  * Batch of data to be inserted into the vector database
@@ -223,12 +224,11 @@ function chunkIntoBatches(
     return [[vectors, metadatas, contents]];
   }
 
-  const batches: Array<[Float32Array[], ChunkMetadata[], string[]]> = [];
-  for (let i = 0; i < vectors.length; i += batchSize) {
-    const end = Math.min(i + batchSize, vectors.length);
-    batches.push([vectors.slice(i, end), metadatas.slice(i, end), contents.slice(i, end)]);
-  }
-  return batches;
+  const vectorChunks = chunkArray(vectors, batchSize);
+  const metadataChunks = chunkArray(metadatas, batchSize);
+  const contentChunks = chunkArray(contents, batchSize);
+
+  return vectorChunks.map((v, i) => [v, metadataChunks[i], contentChunks[i]]);
 }
 
 /**

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -186,8 +186,7 @@ function deserializeImportedSymbols(
     );
   }
   const result: Record<string, string[]> = {};
-  for (let i = 0; i < pathsArr.length; i++) {
-    const path = pathsArr[i];
+  pathsArr.forEach((path, i) => {
     const namesJson = namesArr[i];
     if (path && namesJson) {
       try {
@@ -199,7 +198,7 @@ function deserializeImportedSymbols(
         );
       }
     }
-  }
+  });
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
@@ -233,16 +232,11 @@ function deserializeCallSites(
         `This indicates data corruption. Refusing to deserialize to avoid silent data loss.`,
     );
   }
-  const result: Array<{ symbol: string; line: number }> = [];
-  for (let i = 0; i < symbolsArr.length; i++) {
-    const symbol = symbolsArr[i];
-    const line = linesArr[i];
+  const result = symbolsArr
+    .map((symbol, i) => ({ symbol, line: linesArr[i] }))
     // Note: line > 0 is intentional - we use 0 as a placeholder value for missing data
     // in serializeCallSites(). Real line numbers are 1-indexed in source files.
-    if (symbol && typeof line === 'number' && line > 0) {
-      result.push({ symbol, line });
-    }
-  }
+    .filter(({ symbol, line }) => symbol && typeof line === 'number' && line > 0);
   return result.length > 0 ? result : undefined;
 }
 

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -239,9 +239,8 @@ function findTopLevelNodes(
 
     // Traverse children of traversable nodes
     if (!traverser.shouldTraverseChildren(node)) return;
-    for (let i = 0; i < node.namedChildCount; i++) {
-      const child = node.namedChild(i);
-      if (child) traverse(child, depth);
+    for (const child of node.namedChildren) {
+      traverse(child, depth);
     }
   }
 

--- a/packages/parser/src/ast/cognitive-complexity.test.ts
+++ b/packages/parser/src/ast/cognitive-complexity.test.ts
@@ -18,12 +18,9 @@ function getCognitiveComplexity(code: string): number {
     ) {
       return node;
     }
-    for (let i = 0; i < node.namedChildCount; i++) {
-      const child = node.namedChild(i);
-      if (child) {
-        const found = findFunction(child);
-        if (found) return found;
-      }
+    for (const child of node.namedChildren) {
+      const found = findFunction(child);
+      if (found) return found;
     }
     return null;
   };

--- a/packages/parser/src/ast/complexity/cognitive.ts
+++ b/packages/parser/src/ast/complexity/cognitive.ts
@@ -97,9 +97,8 @@ function traverseLogicalChildren(
   ctx: TraversalContext,
 ): void {
   const operator = n.childForFieldName('operator');
-  for (let i = 0; i < n.namedChildCount; i++) {
-    const child = n.namedChild(i);
-    if (child && child !== operator) ctx.traverse(child, level, op);
+  for (const child of n.namedChildren) {
+    if (child !== operator) ctx.traverse(child, level, op);
   }
 }
 
@@ -110,17 +109,15 @@ function traverseNestingChildren(
   nonNestingTypes: Set<string>,
   ctx: TraversalContext,
 ): void {
-  for (let i = 0; i < n.namedChildCount; i++) {
-    const child = n.namedChild(i);
-    if (child) ctx.traverse(child, getChildNestingLevel(n, child, level, nonNestingTypes), null);
+  for (const child of n.namedChildren) {
+    ctx.traverse(child, getChildNestingLevel(n, child, level, nonNestingTypes), null);
   }
 }
 
 /** Traverse all children at specified level */
 function traverseAllChildren(n: Parser.SyntaxNode, level: number, ctx: TraversalContext): void {
-  for (let i = 0; i < n.namedChildCount; i++) {
-    const child = n.namedChild(i);
-    if (child) ctx.traverse(child, level, null);
+  for (const child of n.namedChildren) {
+    ctx.traverse(child, level, null);
   }
 }
 

--- a/packages/parser/src/ast/complexity/cyclomatic.ts
+++ b/packages/parser/src/ast/complexity/cyclomatic.ts
@@ -47,9 +47,8 @@ export function calculateComplexity(node: Parser.SyntaxNode): number {
     }
 
     // Traverse children
-    for (let i = 0; i < n.namedChildCount; i++) {
-      const child = n.namedChild(i);
-      if (child) traverse(child);
+    for (const child of n.namedChildren) {
+      traverse(child);
     }
   }
 

--- a/packages/parser/src/ast/extractors/symbol-helpers.ts
+++ b/packages/parser/src/ast/extractors/symbol-helpers.ts
@@ -45,9 +45,8 @@ export function extractParameters(node: Parser.SyntaxNode, _content: string): st
   if (!paramsNode) return parameters;
 
   // Traverse parameter nodes
-  for (let i = 0; i < paramsNode.namedChildCount; i++) {
-    const param = paramsNode.namedChild(i);
-    if (param && param.text.trim()) {
+  for (const param of paramsNode.namedChildren) {
+    if (param.text.trim()) {
       parameters.push(param.text);
     }
   }

--- a/packages/parser/src/ast/halstead.test.ts
+++ b/packages/parser/src/ast/halstead.test.ts
@@ -21,12 +21,9 @@ function getHalstead(code: string, language: SupportedLanguage = 'typescript') {
     ) {
       return node;
     }
-    for (let i = 0; i < node.namedChildCount; i++) {
-      const child = node.namedChild(i);
-      if (child) {
-        const found = findFunction(child);
-        if (found) return found;
-      }
+    for (const child of node.namedChildren) {
+      const found = findFunction(child);
+      if (found) return found;
     }
     return null;
   };
@@ -53,12 +50,9 @@ function getHalsteadCounts(code: string, language: SupportedLanguage = 'typescri
     ) {
       return node;
     }
-    for (let i = 0; i < node.namedChildCount; i++) {
-      const child = node.namedChild(i);
-      if (child) {
-        const found = findFunction(child);
-        if (found) return found;
-      }
+    for (const child of node.namedChildren) {
+      const found = findFunction(child);
+      if (found) return found;
     }
     return null;
   };

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -40,9 +40,8 @@ function extractImportPaths(
   const imports: string[] = [];
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
-  for (let i = 0; i < rootNode.namedChildCount; i++) {
-    const child = rootNode.namedChild(i);
-    if (!child || !nodeTypeSet.has(child.type)) continue;
+  for (const child of rootNode.namedChildren) {
+    if (!nodeTypeSet.has(child.type)) continue;
 
     const result = importExtractor.extractImportPath(child);
     if (result) imports.push(result);
@@ -93,9 +92,8 @@ function extractSymbolsWithExtractor(
   const importedSymbols: Record<string, string[]> = {};
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
-  for (let i = 0; i < rootNode.namedChildCount; i++) {
-    const node = rootNode.namedChild(i);
-    if (!node || !nodeTypeSet.has(node.type)) continue;
+  for (const node of rootNode.namedChildren) {
+    if (!nodeTypeSet.has(node.type)) continue;
 
     const result = importExtractor.processImportSymbols(node);
     if (result) {
@@ -209,8 +207,7 @@ function traverseForCallSites(
   }
 
   // Recurse into named children to skip punctuation and other non-semantic nodes
-  for (let i = 0; i < node.namedChildCount; i++) {
-    const child = node.namedChild(i);
-    if (child) traverseForCallSites(child, callSites, seen, callExprTypes, extractor);
+  for (const child of node.namedChildren) {
+    traverseForCallSites(child, callSites, seen, callExprTypes, extractor);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #307 — replaces **~31 remaining manual index loops** across `packages/core`, `packages/parser`, and `packages/cli` with idiomatic array methods.

**Category A — Tree-sitter `namedChildCount` loops (12 loops, 7 files)**
- `for (let i = 0; i < node.namedChildCount; i++) { node.namedChild(i) }` → `for (const child of node.namedChildren)`
- Files: `symbols.ts`, `cognitive.ts`, `cyclomatic.ts`, `symbol-helpers.ts`, `chunker.ts`, and 2 test files

**Category B — Batch/stride loops → `chunkArray` utility (5 loops, 5 files)**
- Extracted shared `chunkArray<T>(arr, size): T[][]` utility in `packages/core/src/utils/chunk-array.ts`
- Replaced `for (let i = 0; i < arr.length; i += batchSize) { arr.slice(i, i + batchSize) }` pattern
- Files: `chunk-batch-processor.ts`, `batch-insert.ts`, `qdrant-batch-insert.ts`, `incremental.ts`

**Category C — Parallel-array / simple iterations (12 loops, 8 files)**
- `.forEach((val, i) => ...)`, `Array.from().reduce()`, `Object.fromEntries(Array.from(...))`
- Files: `cache.ts`, `query.ts`, and 6 test files

**Explicitly skipped** loops with overlap-aware strides, pairwise `[i+1]` access, `Float32Array` indexed writes, and sequential async timing — these are clearer with manual indexing.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — passes
- [x] `npm test -w @liendev/parser` — 713/713 pass
- [x] `npm test -w @liendev/core` — 452/452 pass (excluding pre-existing qdrant/worker-embeddings failures)
- [x] `npm test -w @liendev/lien` — 619/619 pass
- [x] Grep confirms no `namedChildCount` loops remain in modified files

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->