### PR TITLE
fix(review): use non-greedy regex in JSON code block extraction

### DIFF
--- a/packages/review/src/llm-client.ts
+++ b/packages/review/src/llm-client.ts
@@ -224,7 +224,7 @@ function filterStringValues(parsed: unknown): Record<string, string> {
  * Returns the trimmed content inside the first code block, or the original content if none found.
  */
 export function extractJSONFromCodeBlock(content: string): string {
-  const codeBlockMatch = content.match(/```(?:json)?\s*([\s\S]*)```/);
+  const codeBlockMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
   return (codeBlockMatch ? codeBlockMatch[1] : content).trim();
 }
 

--- a/packages/review/test/llm-client.test.ts
+++ b/packages/review/test/llm-client.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { extractJSONFromCodeBlock } from '../src/llm-client.js';
+
+describe('extractJSONFromCodeBlock', () => {
+  it('extracts JSON from a simple code block', () => {
+    const input = '```json\n{"key": "value"}\n```';
+    expect(extractJSONFromCodeBlock(input)).toBe('{"key": "value"}');
+  });
+
+  it('extracts JSON from a code block without json tag', () => {
+    const input = '```\n{"key": "value"}\n```';
+    expect(extractJSONFromCodeBlock(input)).toBe('{"key": "value"}');
+  });
+
+  it('returns original content when no code block is present', () => {
+    const input = '{"key": "value"}';
+    expect(extractJSONFromCodeBlock(input)).toBe('{"key": "value"}');
+  });
+
+  it('stops at the first closing fence when multiple code blocks exist', () => {
+    const input = [
+      '```json',
+      '{"comments": {"file.ts::10": "bad code"}}',
+      '```',
+      '',
+      'Here is the suggested fix:',
+      '```typescript',
+      'const x = 1;',
+      '```',
+    ].join('\n');
+
+    const result = extractJSONFromCodeBlock(input);
+    expect(() => JSON.parse(result)).not.toThrow();
+    expect(JSON.parse(result)).toEqual({ comments: { 'file.ts::10': 'bad code' } });
+  });
+
+  it('trims whitespace from extracted content', () => {
+    const input = '```json\n  {"key": "value"}  \n```';
+    expect(extractJSONFromCodeBlock(input)).toBe('{"key": "value"}');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix greedy `[\s\S]*` regex in `extractJSONFromCodeBlock` that matched past the intended closing fence when LLM responses contained multiple code blocks, causing JSON parse failures
- Add test coverage for `extractJSONFromCodeBlock` (5 cases including the multi-block regression)

## Details

The regex `/```(?:json)?\s*([\s\S]*)```/` greedily captured from the first opening fence to the **last** closing fence in the response. When an LLM included additional code blocks after the JSON block (e.g., code suggestions), the extracted content included non-JSON text and `JSON.parse()` failed.

Changing to the lazy quantifier `[\s\S]*?` makes it stop at the **first** closing fence, correctly isolating the JSON.

**Note:** The `{[\s\S]*}` fallback regex in the aggressive retry paths was also flagged in #285 but is intentionally left greedy — making it lazy would break extraction of nested JSON objects.

## Test plan

- [x] New `llm-client.test.ts` covers: simple code block, no-tag block, no block, multi-block regression, whitespace trimming
- [x] All 312 review package tests pass

Fixes #285

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +0 |

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->