### PR TITLE
refactor(review): extract JSON parsing utils from llm-client

### DIFF
--- a/packages/review/src/architectural-review.ts
+++ b/packages/review/src/architectural-review.ts
@@ -18,7 +18,7 @@ import {
 } from './openrouter.js';
 import { computeFingerprint, serializeFingerprint } from './fingerprint.js';
 import { assembleDependentContext } from './dependent-context.js';
-import { extractJSONFromCodeBlock } from './llm-client.js';
+import { extractJSONFromCodeBlock } from './json-utils.js';
 import { computeSimplicitySignals, serializeSimplicitySignals } from './simplicity-signals.js';
 
 import type { AnalysisResult } from './review-engine.js';

--- a/packages/review/src/json-utils.ts
+++ b/packages/review/src/json-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure JSON / string-processing helpers shared across the review package.
+ * Extracted from llm-client.ts to decouple string utilities from the HTTP client.
+ */
+
+/**
+ * Extract JSON content from an LLM response that may be wrapped in markdown code blocks.
+ * Returns the trimmed content inside the first code block, or the original content if none found.
+ */
+export function extractJSONFromCodeBlock(content: string): string {
+  const codeBlockMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+  return (codeBlockMatch ? codeBlockMatch[1] : content).trim();
+}
+
+/**
+ * Estimate prompt token count using ~4 chars/token heuristic.
+ */
+export function estimatePromptTokens(prompt: string): number {
+  return Math.ceil(prompt.length / 4);
+}

--- a/packages/review/src/llm-client.ts
+++ b/packages/review/src/llm-client.ts
@@ -6,7 +6,6 @@
  * - Per-instance token usage tracking (no global state)
  * - Per-call timeout via AbortSignal
  * - Per-instance token budget enforcement
- * - JSON response parsing with retry
  */
 
 import type { LLMClient, LLMOptions, LLMResponse } from './plugin-types.js';
@@ -163,74 +162,4 @@ export class OpenRouterLLMClient implements LLMClient {
   getUsage() {
     return { ...this.usage };
   }
-}
-
-// ---------------------------------------------------------------------------
-// JSON parsing helpers (migrated from openrouter.ts)
-// ---------------------------------------------------------------------------
-
-/**
- * Parse JSON comments response from LLM, handling markdown code blocks.
- * Returns null if parsing fails.
- */
-export function parseJSONResponse(content: string, logger: Logger): Record<string, string> | null {
-  const jsonStr = extractJSONFromCodeBlock(content);
-
-  try {
-    const parsed = JSON.parse(jsonStr);
-    const filtered = filterStringValues(parsed);
-    logger.info(`Successfully parsed ${Object.keys(filtered).length} entries`);
-    return filtered;
-  } catch {
-    // Aggressive retry: extract any JSON object from response
-    const objectMatch = content.match(/\{[\s\S]*\}/);
-    if (objectMatch) {
-      try {
-        const parsed = JSON.parse(objectMatch[0]);
-        const filtered = filterStringValues(parsed);
-        logger.info(
-          `Recovered JSON with aggressive parsing: ${Object.keys(filtered).length} entries`,
-        );
-        return filtered;
-      } catch {
-        // Total failure
-      }
-    }
-  }
-
-  logger.warning('Failed to parse LLM JSON response');
-  return null;
-}
-
-/**
- * Filter a parsed JSON object to only include string values.
- * Non-string values (arrays, objects, numbers) are dropped.
- */
-function filterStringValues(parsed: unknown): Record<string, string> {
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    return {};
-  }
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value === 'string') {
-      result[key] = value;
-    }
-  }
-  return result;
-}
-
-/**
- * Extract JSON content from an LLM response that may be wrapped in markdown code blocks.
- * Returns the trimmed content inside the first code block, or the original content if none found.
- */
-export function extractJSONFromCodeBlock(content: string): string {
-  const codeBlockMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
-  return (codeBlockMatch ? codeBlockMatch[1] : content).trim();
-}
-
-/**
- * Estimate prompt token count using ~4 chars/token heuristic.
- */
-export function estimatePromptTokens(prompt: string): number {
-  return Math.ceil(prompt.length / 4);
 }

--- a/packages/review/src/logic-response.ts
+++ b/packages/review/src/logic-response.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import type { Logger } from './logger.js';
-import { extractJSONFromCodeBlock } from './llm-client.js';
+import { extractJSONFromCodeBlock } from './json-utils.js';
 
 /**
  * Schema for a single logic review response entry

--- a/packages/review/src/openrouter.ts
+++ b/packages/review/src/openrouter.ts
@@ -8,7 +8,7 @@ import type { Logger } from './logger.js';
 import { buildBatchedCommentsPrompt } from './prompt.js';
 import { buildLogicReviewPrompt } from './logic-prompt.js';
 import { parseLogicReviewResponse } from './logic-response.js';
-import { extractJSONFromCodeBlock } from './llm-client.js';
+import { extractJSONFromCodeBlock, estimatePromptTokens } from './json-utils.js';
 import { LOGIC_MARKER_PREFIX } from './github-api.js';
 
 /**
@@ -126,14 +126,6 @@ export function parseCommentsResponse(
 
   logger.warning(`Full response content:\n${content}`);
   return null;
-}
-
-/**
- * Estimate prompt token count using ~4 chars/token heuristic.
- * Exported for testing.
- */
-export function estimatePromptTokens(prompt: string): number {
-  return Math.ceil(prompt.length / 4);
 }
 
 /** Max tokens to reserve for the prompt (leaves room for output within 128K context) */

--- a/packages/review/src/plugins/architectural.ts
+++ b/packages/review/src/plugins/architectural.ts
@@ -15,7 +15,7 @@ import type {
   ArchitecturalFindingMetadata,
   PresentContext,
 } from '../plugin-types.js';
-import { extractJSONFromCodeBlock } from '../llm-client.js';
+import { extractJSONFromCodeBlock } from '../json-utils.js';
 import type { Logger } from '../logger.js';
 
 export const architecturalConfigSchema = z.object({

--- a/packages/review/test/json-utils.test.ts
+++ b/packages/review/test/json-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractJSONFromCodeBlock } from '../src/llm-client.js';
+import { extractJSONFromCodeBlock, estimatePromptTokens } from '../src/json-utils.js';
 
 describe('extractJSONFromCodeBlock', () => {
   it('extracts JSON from a simple code block', () => {
@@ -37,5 +37,22 @@ describe('extractJSONFromCodeBlock', () => {
   it('trims whitespace from extracted content', () => {
     const input = '```json\n  {"key": "value"}  \n```';
     expect(extractJSONFromCodeBlock(input)).toBe('{"key": "value"}');
+  });
+});
+
+describe('estimatePromptTokens', () => {
+  it('estimates tokens at ~4 chars per token', () => {
+    expect(estimatePromptTokens('abcd')).toBe(1);
+    expect(estimatePromptTokens('abcde')).toBe(2);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(estimatePromptTokens('')).toBe(0);
+  });
+
+  it('rounds up partial tokens', () => {
+    expect(estimatePromptTokens('ab')).toBe(1); // 2/4 = 0.5 → ceil = 1
+    expect(estimatePromptTokens('abcdefgh')).toBe(2); // 8/4 = 2 exact
+    expect(estimatePromptTokens('abcdefghi')).toBe(3); // 9/4 = 2.25 → ceil = 3
   });
 });


### PR DESCRIPTION
## Summary

- Extract `extractJSONFromCodeBlock` and `estimatePromptTokens` from `llm-client.ts` into a new `json-utils.ts` module, decoupling pure string helpers from the HTTP client class
- Delete dead code: `parseJSONResponse` and `filterStringValues` (exported but never imported anywhere)
- Remove duplicate `estimatePromptTokens` from `openrouter.ts` (was defined in both files)
- Rename test file to `json-utils.test.ts` and add `estimatePromptTokens` test coverage

Closes #292

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format:check` passes
- [x] `npm test -w @liendev/review -- --run` — all 315 tests pass