### PR TITLE
fix(runner): add Accept: application/json header to API client

### DIFF
--- a/packages/runner/src/api-client.ts
+++ b/packages/runner/src/api-client.ts
@@ -31,6 +31,7 @@ export async function postReviewRunResult(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Accept: 'application/json',
           Authorization: `Bearer ${serviceToken}`,
           'Idempotency-Key': result.idempotency_key,
         },


### PR DESCRIPTION
## Summary

- Adds `Accept: application/json` to the `postReviewRunResult` fetch call in `api-client.ts`

Without this header, Laravel responds to validation errors with a `302` redirect instead of a `422` JSON response. Node's `fetch()` follows the redirect automatically (changing `POST` to `GET`), hits the homepage, gets a `200 OK`, and logs a false success — meaning the runner never knows the request failed.

## Test plan

- [x] Trigger a review run and verify errors return `422` JSON (not a redirect) when validation fails
- [x] Verify successful posts still return `201`

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +2 |

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->