### PR TITLE
feat(runner): send committed_at timestamp with review run results

### DIFF
--- a/packages/runner/src/clone.ts
+++ b/packages/runner/src/clone.ts
@@ -151,3 +151,15 @@ export async function resolveHeadSha(dir: string): Promise<string> {
   });
   return stdout.trim();
 }
+
+/**
+ * Resolve the HEAD commit timestamp (ISO 8601) of a cloned directory.
+ */
+export async function resolveCommitTimestamp(dir: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['-C', dir, 'log', '-1', '--format=%aI'],
+    { timeout: 10_000, env: GIT_ENV },
+  );
+  return stdout.trim();
+}

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -98,6 +98,7 @@ export interface ReviewRunResult {
   repo_id: number;
   pr_number: number | null;
   head_sha: string;
+  committed_at: string | null;
   base_sha: string | null;
   started_at: string;
   completed_at: string;


### PR DESCRIPTION
## Summary
- Adds `resolveCommitTimestamp()` to `clone.ts` — runs `git log -1 --format=%aI` on the cloned repo
- Sends `committed_at` in the POST to `/api/v1/review-runs` from both baseline and PR review handlers
- Platform uses this to graph complexity trends by commit time instead of review run completion time

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit -p packages/runner/tsconfig.json`)
- [ ] Deploy and verify `committed_at` appears in review run results

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 5 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 2 | +21 |
| 🐛 estimated bugs | 1 | +0.041 |

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->