### PR TITLE
fix(runner): report completed for repos with no supported files

### DIFF
--- a/packages/runner/src/handlers/baseline.ts
+++ b/packages/runner/src/handlers/baseline.ts
@@ -53,13 +53,31 @@ export async function handleBaseline(
     logger.info('Running chunk-only index on full repo...');
     const indexResult = await performChunkOnlyIndex(clone.dir);
 
-    if (!indexResult.success || !indexResult.chunks || indexResult.chunks.length === 0) {
-      logger.warning('Indexing produced no chunks');
+    if (!indexResult.success) {
+      logger.error('Indexing failed');
       await postBaselineResult(
         config,
         payload,
         startedAt,
         'failed',
+        sha ?? null,
+        sha ? (payload.committed_at ?? null) : null,
+        0,
+        0,
+        0,
+        [],
+        logger,
+      );
+      return;
+    }
+
+    if (!indexResult.chunks || indexResult.chunks.length === 0) {
+      logger.info('No supported files found — marking as completed with zero complexity');
+      await postBaselineResult(
+        config,
+        payload,
+        startedAt,
+        'completed',
         sha ?? null,
         sha ? (payload.committed_at ?? null) : null,
         0,


### PR DESCRIPTION
## Summary
- Repos with no parseable code (e.g. Terraform/YAML/shell) were marked as `failed` when indexing produced zero chunks
- Split the condition: indexing failure → `failed`, no supported files → `completed` with zero complexity
- Allows the UI to distinguish "unsupported repo" from "scan broke"

## Test plan
- [ ] Deploy and verify `lien-infrastructure` baselines would now be `completed`
- [ ] Verify repos with supported files still report correctly

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +1 |
| 🧠 mental load | 1 | +2 |
| ⏱️ time to understand | 1 | +30 |

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->