### PR TITLE
feat(review): add PR summary plugin with risk assessment

### DIFF
--- a/packages/review/src/config.ts
+++ b/packages/review/src/config.ts
@@ -37,7 +37,7 @@ const pluginEntrySchema = z.union([
 ]);
 
 const reviewConfigSchema = z.object({
-  plugins: z.array(pluginEntrySchema).default(['complexity', 'architectural']),
+  plugins: z.array(pluginEntrySchema).default(['complexity', 'architectural', 'summary']),
   llm: llmConfigSchema,
 });
 
@@ -201,6 +201,10 @@ const BUILTIN_PLUGINS: Record<string, () => Promise<ReviewPlugin>> = {
   architectural: async () => {
     const { ArchitecturalPlugin } = await import('./plugins/architectural.js');
     return new ArchitecturalPlugin();
+  },
+  summary: async () => {
+    const { SummaryPlugin } = await import('./plugins/summary.js');
+    return new SummaryPlugin();
   },
 };
 

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -308,7 +308,8 @@ function buildPresentContext(
     appendSummary: (markdown: string) => summarySections.push(markdown),
     updateDescription:
       octokit && pr
-        ? (markdown: string) => updatePRDescription(octokit, pr, markdown, logger)
+        ? (markdown: string, sectionId?: string) =>
+            updatePRDescription(octokit, pr, markdown, logger, sectionId)
         : undefined,
     postInlineComments:
       octokit && pr

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -24,6 +24,7 @@ export type {
   ReviewSetup,
   ComplexityFindingMetadata,
   ArchitecturalFindingMetadata,
+  SummaryFindingMetadata,
   BuiltinFindingMetadata,
 } from './plugin-types.js';
 
@@ -36,6 +37,7 @@ export { OpenRouterLLMClient, type OpenRouterLLMClientOptions } from './llm-clie
 // Built-in plugins
 export { ComplexityPlugin } from './plugins/complexity.js';
 export { ArchitecturalPlugin } from './plugins/architectural.js';
+export { SummaryPlugin } from './plugins/summary.js';
 
 // Output adapters
 export { TerminalAdapter } from './adapters/terminal.js';

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -110,7 +110,18 @@ export interface ArchitecturalFindingMetadata {
   scope: string;
 }
 
-export type BuiltinFindingMetadata = ComplexityFindingMetadata | ArchitecturalFindingMetadata;
+export interface SummaryFindingMetadata {
+  pluginType: 'summary';
+  riskLevel: 'low' | 'medium' | 'high' | 'critical';
+  confidence: 'low' | 'medium' | 'high';
+  overview: string;
+  keyChanges: string[];
+}
+
+export type BuiltinFindingMetadata =
+  | ComplexityFindingMetadata
+  | ArchitecturalFindingMetadata
+  | SummaryFindingMetadata;
 
 /**
  * The universal output of a review plugin.
@@ -189,8 +200,10 @@ export interface PresentContext {
   /**
    * Update the PR description with a badge or stats block.
    * Only available in GitHub App context (pr + octokit present).
+   * @param sectionId - Optional section identifier for per-plugin markers (e.g., 'summary').
+   *   When omitted, uses the default `<!-- lien-stats -->` markers.
    */
-  updateDescription?(markdown: string): Promise<void>;
+  updateDescription?(markdown: string, sectionId?: string): Promise<void>;
 
   /**
    * Post findings as inline PR review comments.

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -1,0 +1,394 @@
+/**
+ * PR Summary plugin.
+ *
+ * Generates a human-readable PR summary with risk assessment,
+ * posted to the PR description. Leverages deterministic risk signals
+ * from ReviewContext and LLM for natural-language synthesis.
+ */
+
+import type { CodeChunk, ComplexityReport } from '@liendev/parser';
+import type {
+  ReviewPlugin,
+  ReviewContext,
+  ReviewFinding,
+  SummaryFindingMetadata,
+  PresentContext,
+} from '../plugin-types.js';
+import { extractJSONFromCodeBlock } from '../json-utils.js';
+import type { Logger } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Risk Signal Computation (deterministic)
+// ---------------------------------------------------------------------------
+
+type FileCategory = 'infra' | 'config' | 'db' | 'test' | 'docs' | 'source';
+
+const CATEGORY_PATTERNS: [RegExp, FileCategory][] = [
+  [/(?:cloudformation|terraform|cdk|pulumi|docker|k8s|kubernetes|helm)/i, 'infra'],
+  [/(?:migration|schema|seed|\.sql)/i, 'db'],
+  [/(?:\.test\.|\.spec\.|__tests__|test\/|tests\/)/i, 'test'],
+  [/(?:\.md|\.txt|\.rst|docs\/|README)/i, 'docs'],
+  [/\.(ya?ml|json|toml|ini|env)$/i, 'config'],
+];
+
+function categorizeFile(filepath: string): FileCategory {
+  for (const [pattern, category] of CATEGORY_PATTERNS) {
+    if (pattern.test(filepath)) return category;
+  }
+  return 'source';
+}
+
+export interface RiskSignals {
+  totalFiles: number;
+  categories: Record<FileCategory, number>;
+  languages: string[];
+  newViolations: number;
+  improvedViolations: number;
+  highRiskFileCount: number;
+  hasExportChanges: boolean;
+}
+
+export function computeRiskSignals(context: ReviewContext): RiskSignals {
+  const categories: Record<FileCategory, number> = {
+    infra: 0,
+    config: 0,
+    db: 0,
+    test: 0,
+    docs: 0,
+    source: 0,
+  };
+
+  for (const file of context.changedFiles) {
+    categories[categorizeFile(file)]++;
+  }
+
+  // Languages from chunks
+  const langSet = new Set<string>();
+  for (const chunk of context.chunks) {
+    if (chunk.metadata.language) langSet.add(chunk.metadata.language);
+  }
+
+  // Complexity delta summary
+  let newViolations = 0;
+  let improvedViolations = 0;
+  if (context.deltas) {
+    for (const delta of context.deltas) {
+      if (delta.severity === 'new' || delta.severity === 'error' || delta.severity === 'warning')
+        newViolations++;
+      if (delta.severity === 'improved' || delta.severity === 'deleted') improvedViolations++;
+    }
+  }
+
+  // High-risk files (files with many dependents)
+  let highRiskFileCount = 0;
+  for (const file of context.changedFiles) {
+    const fileData = context.complexityReport.files[file];
+    if (fileData && (fileData.dependentCount ?? 0) > 0) highRiskFileCount++;
+  }
+
+  // Export changes
+  const hasExportChanges = detectExportChanges(context);
+
+  return {
+    totalFiles: context.changedFiles.length,
+    categories,
+    languages: [...langSet].sort(),
+    newViolations,
+    improvedViolations,
+    highRiskFileCount,
+    hasExportChanges,
+  };
+}
+
+function detectExportChanges(context: ReviewContext): boolean {
+  if (!context.baselineReport) return false;
+
+  for (const chunk of context.chunks) {
+    if (chunk.metadata.exports && chunk.metadata.exports.length > 0) {
+      if (!context.baselineReport.files[chunk.metadata.file]) return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Code Context Assembly (same pattern as ArchitecturalPlugin)
+// ---------------------------------------------------------------------------
+
+const MAX_TOTAL_CHARS = 30_000;
+
+function buildCodeContext(
+  chunks: CodeChunk[],
+  report: ComplexityReport,
+  changedFiles: string[],
+): string {
+  const changedFilesSet = new Set(changedFiles);
+  const chunksByFile = new Map<string, CodeChunk[]>();
+
+  for (const chunk of chunks) {
+    const file = chunk.metadata.file;
+    if (!changedFilesSet.has(file)) continue;
+    if (chunk.metadata.symbolType === 'method') continue;
+    if (chunk.metadata.type === 'block' && !chunk.metadata.symbolName) continue;
+    const existing = chunksByFile.get(file) ?? [];
+    existing.push(chunk);
+    chunksByFile.set(file, existing);
+  }
+
+  // Sort files by dependentCount descending
+  const sortedFiles = [...chunksByFile.keys()].sort((a, b) => {
+    const depA = report.files[a]?.dependentCount ?? 0;
+    const depB = report.files[b]?.dependentCount ?? 0;
+    return depB - depA;
+  });
+
+  const sections: string[] = [];
+  let totalChars = 0;
+
+  for (const file of sortedFiles) {
+    const fileChunks = chunksByFile.get(file)!;
+    const fileCode = fileChunks.map(c => c.content).join('\n\n');
+    if (totalChars + fileCode.length > MAX_TOTAL_CHARS) continue;
+
+    const dependentCount = report.files[file]?.dependentCount ?? 0;
+    const header =
+      dependentCount > 0 ? `### ${file} (${dependentCount} dependents)` : `### ${file}`;
+    sections.push(`${header}\n\`\`\`\n${fileCode}\n\`\`\``);
+    totalChars += fileCode.length;
+  }
+
+  return sections.join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Building
+// ---------------------------------------------------------------------------
+
+function formatRiskSignals(signals: RiskSignals): string {
+  const parts: string[] = [];
+  parts.push(`Files changed: ${signals.totalFiles}`);
+
+  const nonZeroCategories = Object.entries(signals.categories)
+    .filter(([, count]) => count > 0)
+    .map(([cat, count]) => `${cat}: ${count}`);
+  if (nonZeroCategories.length > 0) {
+    parts.push(`Categories: ${nonZeroCategories.join(', ')}`);
+  }
+
+  if (signals.languages.length > 0) {
+    parts.push(`Languages: ${signals.languages.join(', ')}`);
+  }
+
+  if (signals.newViolations > 0) parts.push(`New complexity violations: ${signals.newViolations}`);
+  if (signals.improvedViolations > 0)
+    parts.push(`Improved/resolved: ${signals.improvedViolations}`);
+  if (signals.highRiskFileCount > 0)
+    parts.push(`High-impact files (with dependents): ${signals.highRiskFileCount}`);
+  if (signals.hasExportChanges) parts.push(`Export/interface changes detected`);
+
+  return parts.join('\n');
+}
+
+export function buildSummaryPrompt(
+  signals: RiskSignals,
+  codeContext: string,
+  context: ReviewContext,
+): string {
+  const body = context.pr?.body ? context.pr.body.slice(0, 2000) : undefined;
+  const prHeader = context.pr ? `## PR: ${context.pr.title}${body ? `\n\n${body}` : ''}\n\n` : '';
+
+  return `You are a senior engineer writing a concise PR summary with risk assessment.
+
+${prHeader}## Risk Signals
+
+${formatRiskSignals(signals)}
+
+## Changed Code
+
+${codeContext}
+
+## Instructions
+
+Write a brief PR summary. Respond with ONLY valid JSON:
+
+\`\`\`json
+{
+  "risk_level": "low | medium | high | critical",
+  "confidence": "low | medium | high",
+  "risk_explanation": "1-2 sentences explaining the risk level",
+  "overview": "1-2 sentence summary of what this PR does",
+  "key_changes": ["change 1", "change 2", "change 3"]
+}
+\`\`\`
+
+Guidelines:
+- **risk_level**: "low" for docs/tests/config-only, "medium" for source changes with moderate scope, "high" for infra/db/many dependents/export changes, "critical" for breaking changes to widely-used interfaces
+- **confidence**: "high" when the code context is clear and complete, "medium" when some files were truncated or the scope is ambiguous, "low" when the context is very limited
+- **overview**: Focus on intent, not implementation details
+- **key_changes**: 2-5 bullets, each under 100 characters
+- Be factual and specific — avoid vague language`;
+}
+
+// ---------------------------------------------------------------------------
+// Response Parsing
+// ---------------------------------------------------------------------------
+
+interface SummaryResponse {
+  risk_level: 'low' | 'medium' | 'high' | 'critical';
+  confidence: 'low' | 'medium' | 'high';
+  risk_explanation: string;
+  overview: string;
+  key_changes: string[];
+}
+
+const VALID_RISK_LEVELS = new Set(['low', 'medium', 'high', 'critical']);
+const VALID_CONFIDENCE_LEVELS = new Set(['low', 'medium', 'high']);
+
+function isValidSummaryResponse(parsed: unknown): parsed is SummaryResponse {
+  if (!parsed || typeof parsed !== 'object') return false;
+  const p = parsed as Record<string, unknown>;
+  return (
+    typeof p.risk_level === 'string' &&
+    VALID_RISK_LEVELS.has(p.risk_level) &&
+    typeof p.confidence === 'string' &&
+    VALID_CONFIDENCE_LEVELS.has(p.confidence) &&
+    typeof p.risk_explanation === 'string' &&
+    typeof p.overview === 'string' &&
+    Array.isArray(p.key_changes) &&
+    p.key_changes.length > 0 &&
+    p.key_changes.every((c: unknown) => typeof c === 'string')
+  );
+}
+
+export function parseSummaryResponse(content: string, logger: Logger): SummaryResponse | null {
+  const jsonStr = extractJSONFromCodeBlock(content);
+
+  try {
+    const parsed = JSON.parse(jsonStr);
+    if (isValidSummaryResponse(parsed)) return parsed;
+  } catch {
+    // Fall through to retry
+  }
+
+  // Aggressive retry: find outermost JSON object
+  const objectMatch = content.match(/\{[\s\S]*\}/);
+  if (objectMatch) {
+    try {
+      const parsed = JSON.parse(objectMatch[0]);
+      if (isValidSummaryResponse(parsed)) {
+        logger.info('Recovered summary response with retry parsing');
+        return parsed;
+      }
+    } catch {
+      // Total failure
+    }
+  }
+
+  logger.warning('Failed to parse summary LLM response');
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown Formatting
+// ---------------------------------------------------------------------------
+
+function capitalizeFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function formatSummaryMarkdown(response: SummaryResponse): string {
+  const riskLabel = capitalizeFirst(response.risk_level);
+  const confidenceLabel = capitalizeFirst(response.confidence);
+  const keyChanges = response.key_changes.map(c => `- ${c}`).join('\n');
+
+  return `### Lien Summary
+
+> **${riskLabel} Risk** · ${confidenceLabel} Confidence
+>
+> ${response.risk_explanation}
+
+**Overview** — ${response.overview}
+
+**Key Changes**
+${keyChanges}
+
+*[Lien Review](https://lien.dev)*`;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin Implementation
+// ---------------------------------------------------------------------------
+
+export class SummaryPlugin implements ReviewPlugin {
+  id = 'summary';
+  name = 'PR Summary';
+  description = 'Human-readable PR summary with risk assessment';
+  requiresLLM = true;
+
+  shouldActivate(context: ReviewContext): boolean {
+    return !!context.pr;
+  }
+
+  async analyze(context: ReviewContext): Promise<ReviewFinding[]> {
+    if (!context.llm) return [];
+
+    const { chunks, complexityReport, changedFiles, logger } = context;
+
+    logger.info('Computing risk signals for summary...');
+    const signals = computeRiskSignals(context);
+
+    const codeContext = buildCodeContext(chunks, complexityReport, changedFiles);
+    const prompt = buildSummaryPrompt(signals, codeContext, context);
+    const response = await context.llm.complete(prompt);
+
+    const parsed = parseSummaryResponse(response.content, logger);
+    if (!parsed) return [];
+
+    const metadata: SummaryFindingMetadata = {
+      pluginType: 'summary',
+      riskLevel: parsed.risk_level,
+      confidence: parsed.confidence,
+      overview: parsed.overview,
+      keyChanges: parsed.key_changes,
+    };
+
+    return [
+      {
+        pluginId: 'summary',
+        filepath: '',
+        line: 0,
+        severity: 'info',
+        category: 'summary',
+        message: parsed.overview,
+        evidence: parsed.risk_explanation,
+        metadata,
+      },
+    ];
+  }
+
+  async present(findings: ReviewFinding[], context: PresentContext): Promise<void> {
+    if (findings.length === 0) return;
+
+    const finding = findings[0];
+    const meta = finding.metadata as SummaryFindingMetadata | undefined;
+    if (!meta || meta.pluginType !== 'summary') return;
+
+    const response: SummaryResponse = {
+      risk_level: meta.riskLevel,
+      confidence: meta.confidence,
+      risk_explanation: finding.evidence ?? '',
+      overview: meta.overview,
+      key_changes: meta.keyChanges,
+    };
+
+    const markdown = formatSummaryMarkdown(response);
+
+    // Update PR description with dedicated section markers
+    if (context.updateDescription) {
+      await context.updateDescription(markdown, 'summary');
+    }
+
+    // Append to check run summary
+    context.appendSummary(markdown);
+  }
+}

--- a/packages/review/test/config.test.ts
+++ b/packages/review/test/config.test.ts
@@ -29,7 +29,7 @@ describe('loadConfig', () => {
   it('returns defaults when no config file exists', () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
     const config = loadConfig('/fake/root');
-    expect(config.plugins).toEqual(['complexity', 'architectural']);
+    expect(config.plugins).toEqual(['complexity', 'architectural', 'summary']);
     expect(config.llm.provider).toBe('openrouter');
     expect(config.llm.model).toBe('minimax/minimax-m2.5');
     expect(config.settings).toEqual({});
@@ -39,7 +39,7 @@ describe('loadConfig', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('null');
     const config = loadConfig('/fake/root');
-    expect(config.plugins).toEqual(['complexity', 'architectural']);
+    expect(config.plugins).toEqual(['complexity', 'architectural', 'summary']);
   });
 
   it('parses valid YAML config with string plugin list', () => {

--- a/packages/review/test/plugins-summary.test.ts
+++ b/packages/review/test/plugins-summary.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SummaryPlugin } from '../src/plugins/summary.js';
+import {
+  computeRiskSignals,
+  buildSummaryPrompt,
+  parseSummaryResponse,
+  formatSummaryMarkdown,
+} from '../src/plugins/summary.js';
+import type { ReviewContext, PresentContext, SummaryFindingMetadata } from '../src/plugin-types.js';
+import {
+  createTestContext,
+  createTestChunk,
+  createTestReport,
+  createMockLLMClient,
+  silentLogger,
+} from '../src/test-helpers.js';
+
+function makeSummaryLLMResponse(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    risk_level: 'medium',
+    confidence: 'high',
+    risk_explanation: 'Touches deployment flow; mistakes could leave stacks stuck.',
+    overview: 'Adds a two-phase CloudFormation rollout to safely remove legacy RDS resources.',
+    key_changes: [
+      'Modified CloudFormation templates',
+      'New deployment script',
+      'Updated integration tests',
+    ],
+    ...overrides,
+  });
+}
+
+describe('SummaryPlugin', () => {
+  const plugin = new SummaryPlugin();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('metadata', () => {
+    it('has correct id and requiresLLM', () => {
+      expect(plugin.id).toBe('summary');
+      expect(plugin.requiresLLM).toBe(true);
+    });
+  });
+
+  describe('shouldActivate', () => {
+    it('activates when PR context is present', () => {
+      const context = createTestContext({
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'test PR',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+      expect(plugin.shouldActivate(context)).toBe(true);
+    });
+
+    it('does not activate without PR context', () => {
+      const context = createTestContext();
+      expect(plugin.shouldActivate(context)).toBe(false);
+    });
+  });
+
+  describe('computeRiskSignals', () => {
+    it('categorizes files by path patterns', () => {
+      const context = createTestContext({
+        changedFiles: [
+          'cloudformation/stack.yml',
+          'src/app.ts',
+          'test/app.test.ts',
+          'README.md',
+          'config.json',
+          'db/migrations/001.sql',
+        ],
+      });
+
+      const signals = computeRiskSignals(context);
+      expect(signals.totalFiles).toBe(6);
+      expect(signals.categories.infra).toBe(1);
+      expect(signals.categories.source).toBe(1);
+      expect(signals.categories.test).toBe(1);
+      expect(signals.categories.docs).toBe(1);
+      expect(signals.categories.config).toBe(1);
+      expect(signals.categories.db).toBe(1);
+    });
+
+    it('counts new and improved violations from deltas', () => {
+      const context = createTestContext({
+        changedFiles: ['src/a.ts'],
+        deltas: [
+          {
+            filepath: 'src/a.ts',
+            symbolName: 'foo',
+            symbolType: 'function',
+            startLine: 1,
+            metricType: 'cyclomatic',
+            baseComplexity: null,
+            headComplexity: 20,
+            delta: 20,
+            threshold: 15,
+            severity: 'new',
+          },
+          {
+            filepath: 'src/a.ts',
+            symbolName: 'bar',
+            symbolType: 'function',
+            startLine: 10,
+            metricType: 'cyclomatic',
+            baseComplexity: 18,
+            headComplexity: 12,
+            delta: -6,
+            threshold: 15,
+            severity: 'improved',
+          },
+        ],
+      });
+
+      const signals = computeRiskSignals(context);
+      expect(signals.newViolations).toBe(1);
+      expect(signals.improvedViolations).toBe(1);
+    });
+
+    it('counts high-risk files with dependents', () => {
+      const report = createTestReport([{ filepath: 'src/core.ts' }]);
+      report.files['src/core.ts'].dependentCount = 5;
+
+      const context = createTestContext({
+        changedFiles: ['src/core.ts', 'src/util.ts'],
+        complexityReport: report,
+      });
+
+      const signals = computeRiskSignals(context);
+      expect(signals.highRiskFileCount).toBe(1);
+    });
+
+    it('extracts languages from chunks', () => {
+      const context = createTestContext({
+        changedFiles: ['src/a.ts', 'src/b.py'],
+        chunks: [
+          createTestChunk({ metadata: { language: 'typescript', file: 'src/a.ts' } }),
+          createTestChunk({ metadata: { language: 'python', file: 'src/b.py' } }),
+        ],
+      });
+
+      const signals = computeRiskSignals(context);
+      expect(signals.languages).toEqual(['python', 'typescript']);
+    });
+  });
+
+  describe('analyze', () => {
+    it('returns empty when no LLM available', async () => {
+      const context = createTestContext({
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'test',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+      const findings = await plugin.analyze(context);
+      expect(findings).toEqual([]);
+    });
+
+    it('sends prompt to LLM and returns finding', async () => {
+      const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+      const context = createTestContext({
+        changedFiles: ['src/deploy.ts'],
+        chunks: [
+          createTestChunk({
+            content: 'function deploy() { /* ... */ }',
+            metadata: { file: 'src/deploy.ts', symbolName: 'deploy', language: 'typescript' },
+          }),
+        ],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'Add CloudFormation rollout',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      const findings = await plugin.analyze(context);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].pluginId).toBe('summary');
+      expect(findings[0].category).toBe('summary');
+      expect(findings[0].severity).toBe('info');
+
+      const meta = findings[0].metadata as SummaryFindingMetadata;
+      expect(meta.pluginType).toBe('summary');
+      expect(meta.riskLevel).toBe('medium');
+      expect(meta.confidence).toBe('high');
+      expect(meta.keyChanges).toHaveLength(3);
+    });
+
+    it('includes PR title in LLM prompt', async () => {
+      const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+      const context = createTestContext({
+        changedFiles: ['src/a.ts'],
+        chunks: [createTestChunk({ metadata: { file: 'src/a.ts' } })],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'My Special PR Title',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      await plugin.analyze(context);
+      expect(llm.calls[0].prompt).toContain('My Special PR Title');
+    });
+
+    it('returns empty on unparseable LLM response', async () => {
+      const llm = createMockLLMClient(['not valid json at all']);
+      const context = createTestContext({
+        changedFiles: ['src/a.ts'],
+        chunks: [createTestChunk({ metadata: { file: 'src/a.ts' } })],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'test',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      const findings = await plugin.analyze(context);
+      expect(findings).toEqual([]);
+    });
+  });
+
+  describe('parseSummaryResponse', () => {
+    it('parses valid JSON response', () => {
+      const result = parseSummaryResponse(makeSummaryLLMResponse(), silentLogger);
+      expect(result).not.toBeNull();
+      expect(result!.risk_level).toBe('medium');
+      expect(result!.confidence).toBe('high');
+      expect(result!.key_changes).toHaveLength(3);
+    });
+
+    it('parses response wrapped in code block', () => {
+      const wrapped = '```json\n' + makeSummaryLLMResponse() + '\n```';
+      const result = parseSummaryResponse(wrapped, silentLogger);
+      expect(result).not.toBeNull();
+      expect(result!.risk_level).toBe('medium');
+    });
+
+    it('recovers JSON embedded in text', () => {
+      const content = 'Here is my analysis:\n' + makeSummaryLLMResponse() + '\nHope that helps!';
+      const result = parseSummaryResponse(content, silentLogger);
+      expect(result).not.toBeNull();
+      expect(result!.overview).toContain('CloudFormation');
+    });
+
+    it('returns null for completely invalid content', () => {
+      const result = parseSummaryResponse('just some text with no json', silentLogger);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when required fields are missing', () => {
+      const incomplete = JSON.stringify({
+        risk_level: 'medium',
+        // missing confidence, overview, key_changes, risk_explanation
+      });
+      const result = parseSummaryResponse(incomplete, silentLogger);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid risk_level', () => {
+      const result = parseSummaryResponse(
+        makeSummaryLLMResponse({ risk_level: 'extreme' }),
+        silentLogger,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty key_changes', () => {
+      const result = parseSummaryResponse(
+        makeSummaryLLMResponse({ key_changes: [] }),
+        silentLogger,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('formatSummaryMarkdown', () => {
+    it('formats markdown with risk badge and key changes', () => {
+      const md = formatSummaryMarkdown({
+        risk_level: 'high',
+        confidence: 'medium',
+        risk_explanation: 'Touches critical infrastructure.',
+        overview: 'Refactors deployment pipeline.',
+        key_changes: ['Updated CI config', 'New rollback logic'],
+      });
+
+      expect(md).toContain('### Lien Summary');
+      expect(md).toContain('**High Risk**');
+      expect(md).toContain('Medium Confidence');
+      expect(md).toContain('Touches critical infrastructure.');
+      expect(md).toContain('**Overview** — Refactors deployment pipeline.');
+      expect(md).toContain('- Updated CI config');
+      expect(md).toContain('- New rollback logic');
+      expect(md).toContain('*[Lien Review](https://lien.dev)*');
+    });
+  });
+
+  describe('present', () => {
+    function makePresentContext(overrides?: Partial<PresentContext>): PresentContext {
+      return {
+        complexityReport: createTestReport().complexityReport ?? createTestReport(),
+        baselineReport: null,
+        deltas: null,
+        deltaSummary: null,
+        logger: silentLogger,
+        addAnnotations: vi.fn(),
+        appendSummary: vi.fn(),
+        updateDescription: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+      } as unknown as PresentContext;
+    }
+
+    it('does nothing with no findings', async () => {
+      const ctx = makePresentContext();
+      await plugin.present!([], ctx);
+      expect(ctx.appendSummary).not.toHaveBeenCalled();
+    });
+
+    it('updates PR description with summary section marker', async () => {
+      const ctx = makePresentContext();
+      const finding = {
+        pluginId: 'summary',
+        filepath: '',
+        line: 0,
+        severity: 'info' as const,
+        category: 'summary',
+        message: 'Adds two-phase rollout.',
+        evidence: 'Touches deployment flow.',
+        metadata: {
+          pluginType: 'summary' as const,
+          riskLevel: 'medium' as const,
+          confidence: 'high' as const,
+          overview: 'Adds two-phase rollout.',
+          keyChanges: ['Updated templates', 'New script'],
+        },
+      };
+
+      await plugin.present!([finding], ctx);
+
+      expect(ctx.updateDescription).toHaveBeenCalledTimes(1);
+      const [markdown, sectionId] = (ctx.updateDescription as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      expect(sectionId).toBe('summary');
+      expect(markdown).toContain('### Lien Summary');
+      expect(markdown).toContain('**Medium Risk**');
+    });
+
+    it('appends summary to check run output', async () => {
+      const ctx = makePresentContext();
+      const finding = {
+        pluginId: 'summary',
+        filepath: '',
+        line: 0,
+        severity: 'info' as const,
+        category: 'summary',
+        message: 'Overview text.',
+        evidence: 'Risk explanation.',
+        metadata: {
+          pluginType: 'summary' as const,
+          riskLevel: 'low' as const,
+          confidence: 'high' as const,
+          overview: 'Overview text.',
+          keyChanges: ['Change 1'],
+        },
+      };
+
+      await plugin.present!([finding], ctx);
+      expect(ctx.appendSummary).toHaveBeenCalledTimes(1);
+      const summary = (ctx.appendSummary as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(summary).toContain('### Lien Summary');
+    });
+
+    it('works when updateDescription is not available', async () => {
+      const ctx = makePresentContext({ updateDescription: undefined });
+      const finding = {
+        pluginId: 'summary',
+        filepath: '',
+        line: 0,
+        severity: 'info' as const,
+        category: 'summary',
+        message: 'Overview.',
+        evidence: 'Risk.',
+        metadata: {
+          pluginType: 'summary' as const,
+          riskLevel: 'low' as const,
+          confidence: 'high' as const,
+          overview: 'Overview.',
+          keyChanges: ['Change 1'],
+        },
+      };
+
+      // Should not throw
+      await plugin.present!([finding], ctx);
+      expect(ctx.appendSummary).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('buildSummaryPrompt', () => {
+    it('includes risk signals and PR context', () => {
+      const signals = computeRiskSignals(
+        createTestContext({
+          changedFiles: ['src/a.ts', 'test/a.test.ts'],
+          chunks: [createTestChunk({ metadata: { language: 'typescript', file: 'src/a.ts' } })],
+        }),
+      );
+
+      const prompt = buildSummaryPrompt(signals, '### src/a.ts\n```\ncode\n```', {
+        ...createTestContext(),
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'My PR',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      expect(prompt).toContain('My PR');
+      expect(prompt).toContain('Files changed: 2');
+      expect(prompt).toContain('### src/a.ts');
+      expect(prompt).toContain('risk_level');
+      expect(prompt).toContain('confidence');
+    });
+  });
+});

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -22,6 +22,7 @@ import {
   ReviewEngine,
   ComplexityPlugin,
   ArchitecturalPlugin,
+  SummaryPlugin,
   OpenRouterLLMClient,
 } from '@liendev/review';
 
@@ -242,6 +243,7 @@ export async function handlePRReview(
     const engine = new ReviewEngine();
     if (payload.config.review_types.complexity) engine.register(new ComplexityPlugin());
     if (payload.config.review_types.architectural) engine.register(new ArchitecturalPlugin());
+    if (payload.config.review_types.summary) engine.register(new SummaryPlugin());
 
     // Build LLM client
     const llm = reviewConfig.openrouterApiKey

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -27,6 +27,7 @@ export interface PRJobPayload {
     review_types: {
       complexity: boolean;
       architectural: boolean;
+      summary?: boolean;
     };
     block_on_new_errors: boolean;
     architectural_mode: 'auto' | 'always' | 'off';


### PR DESCRIPTION
Add SummaryPlugin that generates human-readable PR summaries with risk assessment and confidence levels, posted to the PR description using per-plugin section markers.

The plugin computes deterministic risk signals (file categories, complexity deltas, dependency impact), sends a structured prompt to the LLM, parses the JSON response, and formats markdown with a risk badge. It integrates seamlessly with the existing plugin architecture and includes 24 comprehensive tests.

Key features: per-plugin PR description section markers (backward compatible), risk signal computation (infra/db/config/test/docs/source categorization), LLM-powered risk synthesis, and confidence-level reporting.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 2 new functions are too complex.
🔗 **Impact**: 1 high-risk file(s) with 6 total dependents

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +1 |
| 🧠 mental load | 3 | +20 |
| ⏱️ time to understand | 5 | +101 |
| 🐛 estimated bugs | 1 | +0.042 |

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->