### PR TITLE
fix(runner): decouple summary plugin from analyzable files gate

### DIFF
--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -64,7 +64,8 @@ export interface LLMClient {
  * The world every plugin receives. Built by the engine before running plugins.
  *
  * @property chunks - AST-parsed code chunks for all changed files. Always present.
- * @property changedFiles - List of file paths changed in this review scope.
+ * @property changedFiles - List of file paths changed in this review scope (code files eligible for analysis).
+ * @property allChangedFiles - All files changed in the PR including non-code files (docs, config, etc.). Falls back to changedFiles when not provided.
  * @property complexityReport - Complexity analysis of the current code. Always present (the parser always runs).
  * @property baselineReport - Complexity analysis of the base branch. Null when no baseline is available (CLI without git, first PR).
  * @property deltas - Computed complexity deltas between baseline and current. Null when no baseline.
@@ -77,6 +78,8 @@ export interface LLMClient {
 export interface ReviewContext {
   chunks: CodeChunk[];
   changedFiles: string[];
+  /** All files changed in the PR, including non-code files. Used by summary plugin for full file categorization. */
+  allChangedFiles?: string[];
   complexityReport: ComplexityReport;
   baselineReport: ComplexityReport | null;
   deltas: ComplexityDelta[] | null;

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -49,6 +49,9 @@ export interface RiskSignals {
 }
 
 export function computeRiskSignals(context: ReviewContext): RiskSignals {
+  // Use allChangedFiles for categorization so we capture docs/config/infra files
+  const allFiles = context.allChangedFiles ?? context.changedFiles;
+
   const categories: Record<FileCategory, number> = {
     infra: 0,
     config: 0,
@@ -58,7 +61,7 @@ export function computeRiskSignals(context: ReviewContext): RiskSignals {
     source: 0,
   };
 
-  for (const file of context.changedFiles) {
+  for (const file of allFiles) {
     categories[categorizeFile(file)]++;
   }
 
@@ -81,7 +84,7 @@ export function computeRiskSignals(context: ReviewContext): RiskSignals {
 
   // High-risk files (files with many dependents)
   let highRiskFileCount = 0;
-  for (const file of context.changedFiles) {
+  for (const file of allFiles) {
     const fileData = context.complexityReport.files[file];
     if (fileData && (fileData.dependentCount ?? 0) > 0) highRiskFileCount++;
   }
@@ -90,7 +93,7 @@ export function computeRiskSignals(context: ReviewContext): RiskSignals {
   const hasExportChanges = detectExportChanges(context);
 
   return {
-    totalFiles: context.changedFiles.length,
+    totalFiles: allFiles.length,
     categories,
     languages: [...langSet].sort(),
     newViolations,

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -280,10 +280,11 @@ export async function handlePRReview(
         })
       : undefined;
 
-    // Run engine — pass allChangedFiles so summary plugin can categorize all files
+    // Run engine
     findings = await engine.run({
       chunks,
-      changedFiles: allChangedFiles,
+      changedFiles: filesToAnalyze,
+      allChangedFiles,
       complexityReport: currentReport,
       baselineReport,
       deltas,


### PR DESCRIPTION
## Summary
Fixed a bug where the summary plugin wouldn't run on PRs containing only files not eligible for complexity analysis (e.g., `.vue`, `.md`, config-only changes). The handler was exiting before the ReviewEngine was instantiated.

## Changes
- Only skip engine execution when both no analyzable files exist AND summary plugin is disabled
- Create an empty complexity report for summary-only analysis path  
- Pass all changed files to the engine so summary plugin can properly categorize files (not just code)

## Impact
Summary plugin now reliably triggers on all PRs with LLM configured, regardless of file types changed.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 6 pre-existing issues in touched files (none introduced).

| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +2 |
| 🧠 mental load | 2 | +5 |
| ⏱️ time to understand | 2 | +97 |
| 🐛 estimated bugs | 1 | +0.245 |

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->

---

<!-- lien:summary -->
### Lien Summary

> **Low Risk** · High Confidence
>
> Bug fix that adds a new code path for summary-only analysis with defensive empty report creation. Changes are contained to one file with no breaking changes to existing behavior.

**Overview** — Fixes bug where summary plugin wouldn't run on PRs with only non-code files by creating empty complexity report and continuing to engine when summary is enabled.

**Key Changes**
- Changed early exit to only skip when no analyzable files AND summary disabled
- Create empty complexity report for summary-only analysis path
- Pass allChangedFiles to engine for proper file categorization

*[Lien Review](https://lien.dev)*
<!-- /lien:summary -->