### PR TITLE
fix(runner): post terminal status to platform after review completes

### DIFF
--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -566,4 +566,15 @@ async function postResult(
       );
     }
   }
+
+  // Transition platform review run to terminal state (running → completed/failed)
+  if (reviewRunId != null) {
+    await postReviewRunStatus(
+      config.laravelApiUrl,
+      payload.auth.service_token,
+      reviewRunId,
+      status,
+      logger,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- The runner called `postReviewRunStatus('running')` on job pickup but never posted the terminal state (`completed`/`failed`) via the same endpoint
- It relied on `postReviewRunResult()` (a different endpoint: `POST /api/v1/review-runs`) to convey the final status, but the platform's dedicated status transition endpoint (`POST /api/v1/review-runs/{id}/status`) was never hit for terminal states
- This left review runs stuck as `running` on the platform even though the GitHub check run completed normally

Adds a `postReviewRunStatus(status)` call at the end of `postResult()`, which all code paths (success, failure, early returns) funnel through.

## Test plan

- [ ] Deploy and trigger a PR review — verify the platform review run transitions to `completed`
- [ ] Trigger a review that fails — verify the platform review run transitions to `failed`
- [ ] Verify standalone runs (no `review_run_id`) are unaffected (the call is guarded by `reviewRunId != null`)

---

<!-- lien-stats -->
### Lien Review

**Medium Risk** · High Confidence — A focused bug fix that adds a single API call to post terminal status. The change is properly guarded with null checks and only affects review runs with a platform ID, leaving standalone runs untouched.

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |
| 🐛 estimated bugs | 1 | +0 |


*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->