### PR TITLE
feat(site): purple brand redesign for documentation site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,12 @@ These live in project root and are tracked in git:
 
 ---
 
+## Style Guide
+
+**Read `STYLE_GUIDE.md` before making any UI or frontend changes.** It defines the design identity: typography (Satoshi/JetBrains Mono), color system (dark-first, zinc neutrals, purple accent), surface hierarchy, component patterns, motion, and accessibility requirements. All frontend work must conform to the style guide.
+
+---
+
 ## Core Principles
 
 ### KISS (Keep It Simple, Stupid)

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,158 @@
+# Lien Brand Style Guide
+
+Design identity for all Lien properties (documentation site, platform app).
+
+---
+
+## Typography
+
+### Typefaces
+
+| Role | Family | Weights | Usage |
+|------|--------|---------|-------|
+| UI / body | **Satoshi** | 400, 500 | All prose, labels, nav, buttons |
+| Code / mono | **JetBrains Mono** | 400, 500 | Code blocks, inline code, terminal output |
+
+- Satoshi is served from [fontshare.com](https://api.fontshare.com/v2/css?f[]=satoshi@400,500&display=swap)
+- JetBrains Mono is served from [Google Fonts](https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap)
+
+### Weight Scale
+
+| Token | Value | Use |
+|-------|-------|-----|
+| Regular | 400 | Body text, descriptions |
+| Medium | 500 | Labels, nav items, code |
+| **No bold (600+)** | — | Avoid — disrupts visual rhythm |
+
+### CSS Variables (VitePress)
+
+```css
+--vp-font-family-base: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
+--vp-font-family-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+```
+
+---
+
+## Color System
+
+### Philosophy
+
+- **Dark-first** — dark mode is the primary design target
+- **Zinc neutrals** — surfaces use zinc/gray scale, not blue-gray
+- **Purple accent** — single accent color, no secondary hues
+
+### Accent Scale (Purple)
+
+| Token | Hex | Tailwind | Use |
+|-------|-----|----------|-----|
+| brand-300 | `#c084fc` | purple-400 | Dark mode interactive highlights |
+| brand-500 | `#a855f7` | purple-500 | Primary accent (links, active states) |
+| brand-600 | `#9333ea` | purple-600 | Buttons, CTAs, logo gradient start |
+| brand-soft | `rgba(168,85,247,0.14)` | — | Subtle tints, badges |
+
+### VitePress CSS Variables
+
+```css
+/* Light + default */
+:root {
+  --vp-c-brand-1: #a855f7;   /* interactive elements */
+  --vp-c-brand-2: #9333ea;   /* hover states */
+  --vp-c-brand-3: #c084fc;   /* softer accents */
+  --vp-c-brand-soft: rgba(168, 85, 247, 0.14);
+}
+
+/* Dark mode */
+.dark {
+  --vp-c-brand-1: #a855f7;
+  --vp-c-brand-2: #c084fc;   /* lighter in dark for readability */
+  --vp-c-brand-3: #9333ea;
+  --vp-c-brand-soft: rgba(168, 85, 247, 0.16);
+}
+```
+
+### Neutrals
+
+Use VitePress `--vp-c-*` surface tokens. Do not hardcode neutral grays — they adapt between light/dark automatically.
+
+### What Not to Use
+
+- `#646cff` — old indigo brand color (replaced)
+- `#4a9eff` — old sky blue (replaced)
+- `rgba(99,102,241,*)` — indigo RGBA (replaced)
+- `rgba(74,158,255,*)` — sky blue RGBA (replaced)
+
+---
+
+## Surfaces & Elevation
+
+| Level | Token / value | Use |
+|-------|---------------|-----|
+| Base | `--vp-c-bg` | Page background |
+| Raised | `--vp-c-bg-soft` | Cards, sidebars |
+| Overlay | `--vp-c-bg-elv` | Dropdowns, modals |
+| Border | `--vp-c-divider` | Dividers, card outlines |
+
+---
+
+## Logo & Favicon
+
+### Logo (logo.svg)
+
+- Chain-link icon with linear gradient: `#9333ea` (brand-600) → `#a855f7` (brand-500), top-left to bottom-right
+- No stroke, opacity 0.9 on top link element
+
+### Favicon (favicon.svg)
+
+- 32×32 rounded rect, `rx=6`, fill `#9333ea`
+- Letter "L" centered, `font-weight="500"`, `fill="white"`
+
+---
+
+## Component Patterns
+
+### Interactive Background (documentation homepage)
+
+Floating language logos behind the hero section.
+
+- Default opacity: `0.25` (mobile: `0.15`)
+- Hover glow — light: `drop-shadow(0 0 20px rgba(168, 85, 247, 0.6))`
+- Hover glow — dark: `drop-shadow(0 0 25px rgba(192, 132, 252, 0.7))`
+- Pulse radial — light: `rgba(168, 85, 247, 0.2)`
+- Pulse radial — dark: `rgba(192, 132, 252, 0.2)`
+- Logo name label: `font-weight: 500`
+
+---
+
+## Mermaid Diagrams
+
+Theme: `dark`. Accent lines and borders use brand-500:
+
+```js
+themeVariables: {
+  primaryBorderColor: '#a855f7',
+  lineColor: '#a855f7',
+  border1: '#a855f7',
+  border2: '#a855f7',
+}
+```
+
+Dark-mode CSS overrides also use `#a855f7` for strokes.
+
+---
+
+## Motion
+
+| Property | Value | Rationale |
+|----------|-------|-----------|
+| Easing | `cubic-bezier(0.4, 0, 0.2, 1)` | Material-style ease-in-out |
+| Duration (micro) | `0.4s` | Hover/fade transitions |
+| Reduce-motion | `opacity: 0.4`, no animation | Respect `prefers-reduced-motion` |
+
+---
+
+## Accessibility
+
+- All interactive text must meet **WCAG AA** contrast (4.5:1 for normal text, 3:1 for large/bold)
+- `brand-500` (`#a855f7`) on a dark background (`#1a1a1a`) passes AA at normal size
+- Never convey information by color alone — pair with icons or labels
+- Respect `prefers-reduced-motion` — wrap animations in the media query

--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -11,7 +11,9 @@ export default withMermaid(
     
     head: [
       ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
-      ['meta', { name: 'theme-color', content: '#646cff' }],
+      ['link', { rel: 'stylesheet', href: 'https://api.fontshare.com/v2/css?f[]=satoshi@400,500&display=swap' }],
+      ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap' }],
+      ['meta', { name: 'theme-color', content: '#9333ea' }],
       ['meta', { name: 'og:type', content: 'website' }],
       ['meta', { name: 'og:locale', content: 'en' }],
       ['meta', { name: 'og:site_name', content: 'Lien' }],
@@ -81,8 +83,8 @@ export default withMermaid(
         darkMode: true,
         primaryColor: '#2d2d2d',
         primaryTextColor: '#e0e0e0',
-        primaryBorderColor: '#4a9eff',
-        lineColor: '#4a9eff',
+        primaryBorderColor: '#a855f7',
+        lineColor: '#a855f7',
         secondaryColor: '#3d3d3d',
         tertiaryColor: '#1e1e1e',
         background: '#1a1a1a',
@@ -90,8 +92,8 @@ export default withMermaid(
         secondBkg: '#3d3d3d',
         mainContrastColor: '#e0e0e0',
         darkTextColor: '#e0e0e0',
-        border1: '#4a9eff',
-        border2: '#4a9eff',
+        border1: '#a855f7',
+        border2: '#a855f7',
         fontSize: '16px'
       },
       flowchart: {

--- a/packages/site/docs/.vitepress/theme/components/InteractiveBackground.vue
+++ b/packages/site/docs/.vitepress/theme/components/InteractiveBackground.vue
@@ -225,7 +225,7 @@ onUnmounted(() => {
 
 .logo-name {
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
   color: var(--vp-c-text-2);
   opacity: 0;
   transform: translateY(-5px);
@@ -242,14 +242,14 @@ onUnmounted(() => {
 
 .floating-logo:hover .logo-icon,
 .floating-logo.is-hovered .logo-icon {
-  filter: grayscale(0) drop-shadow(0 0 20px rgba(99, 102, 241, 0.6));
+  filter: grayscale(0) drop-shadow(0 0 20px rgba(168, 85, 247, 0.6));
   width: 3.5rem;
   height: 3.5rem;
 }
 
 .dark .floating-logo:hover .logo-icon,
 .dark .floating-logo.is-hovered .logo-icon {
-  filter: grayscale(0) drop-shadow(0 0 25px rgba(74, 158, 255, 0.7));
+  filter: grayscale(0) drop-shadow(0 0 25px rgba(192, 132, 252, 0.7));
 }
 
 .floating-logo:hover .logo-name,
@@ -268,7 +268,7 @@ onUnmounted(() => {
   transform: translate(-50%, -50%);
   width: 80px;
   height: 80px;
-  background: radial-gradient(circle, rgba(99, 102, 241, 0.2), transparent 70%);
+  background: radial-gradient(circle, rgba(168, 85, 247, 0.2), transparent 70%);
   border-radius: 50%;
   animation: pulse 1.5s ease-out infinite;
   pointer-events: none;
@@ -276,7 +276,7 @@ onUnmounted(() => {
 
 .dark .floating-logo:hover::before,
 .dark .floating-logo.is-hovered::before {
-  background: radial-gradient(circle, rgba(74, 158, 255, 0.2), transparent 70%);
+  background: radial-gradient(circle, rgba(192, 132, 252, 0.2), transparent 70%);
 }
 
 @keyframes pulse {

--- a/packages/site/docs/.vitepress/theme/custom.css
+++ b/packages/site/docs/.vitepress/theme/custom.css
@@ -1,3 +1,24 @@
+/* ─── Typography ─────────────────────────────────────────── */
+:root {
+  --vp-font-family-base: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
+  --vp-font-family-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+}
+
+/* ─── Brand color overrides (purple scale) ───────────────── */
+:root {
+  --vp-c-brand-1: #a855f7;
+  --vp-c-brand-2: #9333ea;
+  --vp-c-brand-3: #c084fc;
+  --vp-c-brand-soft: rgba(168, 85, 247, 0.14);
+}
+
+.dark {
+  --vp-c-brand-1: #a855f7;
+  --vp-c-brand-2: #c084fc;
+  --vp-c-brand-3: #9333ea;
+  --vp-c-brand-soft: rgba(168, 85, 247, 0.16);
+}
+
 /* Custom styles for Mermaid diagrams */
 
 /* Make Mermaid diagrams larger and more readable */
@@ -46,7 +67,7 @@
 .dark .mermaid rect,
 .dark .mermaid polygon {
   fill: #1e1e1e !important;
-  stroke: #4a9eff !important;
+  stroke: #a855f7 !important;
   stroke-width: 2px !important;
 }
 
@@ -58,7 +79,7 @@
 .dark .mermaid .node polygon,
 .dark .mermaid .node circle {
   fill: #2d2d2d !important;
-  stroke: #4a9eff !important;
+  stroke: #a855f7 !important;
 }
 
 .dark .mermaid .edgeLabel {
@@ -68,7 +89,7 @@
 
 .dark .mermaid line,
 .dark .mermaid path {
-  stroke: #4a9eff !important;
+  stroke: #a855f7 !important;
 }
 
 /* Add some spacing around diagrams */

--- a/packages/site/docs/public/favicon.svg
+++ b/packages/site/docs/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#646cff"/>
-  <text x="16" y="24" font-family="system-ui, sans-serif" font-size="20" font-weight="bold" text-anchor="middle" fill="white">L</text>
+  <rect width="32" height="32" rx="6" fill="#9333ea"/>
+  <text x="16" y="24" font-family="system-ui, sans-serif" font-size="20" font-weight="500" text-anchor="middle" fill="white">L</text>
 </svg>
 

--- a/packages/site/docs/public/logo.svg
+++ b/packages/site/docs/public/logo.svg
@@ -2,8 +2,8 @@
   <!-- Modern link/chain icon representing "Lien" (link in French) -->
   <defs>
     <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#646cff;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#4a9eff;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#9333ea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#a855f7;stop-opacity:1" />
     </linearGradient>
   </defs>
   


### PR DESCRIPTION
## Summary

- Replaces old indigo/sky-blue accent (`#646cff`, `#4a9eff`) with the purple scale used on app.lien.dev (`#9333ea` / `#a855f7`)
- Adds Satoshi (UI) and JetBrains Mono (code) font loading via `<link>` tags and `--vp-font-family-*` overrides
- Updates logo gradient, favicon fill, Mermaid diagram stroke colours, and `InteractiveBackground.vue` hover glows to match
- Adds `STYLE_GUIDE.md` as the canonical brand reference, referenced from `CLAUDE.md`

## Changed files

| File | Change |
|------|--------|
| `STYLE_GUIDE.md` | New — full brand guide (typography, colours, components, motion, a11y) |
| `CLAUDE.md` | Added Style Guide section pointing to `STYLE_GUIDE.md` |
| `packages/site/docs/.vitepress/config.ts` | Font `<link>` tags, `theme-color` → `#9333ea`, Mermaid accent → `#a855f7` |
| `packages/site/docs/.vitepress/theme/custom.css` | Typography + brand CSS variable overrides; Mermaid dark-mode strokes |
| `packages/site/docs/public/logo.svg` | Gradient stops updated to purple |
| `packages/site/docs/public/favicon.svg` | Fill → `#9333ea`, `font-weight` → `500` |
| `packages/site/docs/.vitepress/theme/components/InteractiveBackground.vue` | Hover glows + pulse radials → purple; `.logo-name` weight → `500` |

## Test plan

- [ ] `npm run docs:build` compiles clean (verified locally)
- [ ] `npm run docs:dev` — logo and favicon render purple
- [ ] Nav link hover / active states are purple
- [ ] Hero "Get Started" button is purple
- [ ] No `#646cff`, `#4a9eff`, `rgba(99, 102, 241`, `rgba(74, 158, 255` remain in site files

---

<!-- lien-stats -->
### Lien Review

**Low Risk** · High Confidence — This PR modifies only documentation site assets (CSS, Vue components, VitePress config, and static files). No production code, infrastructure, or database changes. The visual-only changes cannot cause runtime errors.

**Overview** — Aligns the docs site branding with app.lien.dev by adopting the purple color scale, creating a consistent visual identity across both properties. The new STYLE_GUIDE.md codifies these standards for future contributions.

✅ **Good** - No complexity issues found.

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->