### PR TITLE
fix(summary): scope chunk content to changed functions when file exceeds budget

### DIFF
--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -155,32 +155,54 @@ function groupChunksByFile(
   return map;
 }
 
-function appendPatchSections(
-  sections: string[],
-  notShownFiles: string[],
-  prPatches: Map<string, string> | undefined,
-  totalChars: number,
-): void {
-  const listedOnly: string[] = [];
+function buildFileStats(file: string, report: ComplexityReport): string {
+  const fileData = report.files[file];
+  if (!fileData) return '';
 
-  for (const file of notShownFiles) {
-    const patch = prPatches?.get(file);
-    if (patch) {
-      const section = `### ${file}\n\`\`\`diff\n${patch}\n\`\`\``;
-      if (totalChars + section.length <= MAX_TOTAL_CHARS) {
-        sections.push(section);
-        totalChars += section.length;
-        continue;
-      }
+  const stats: string[] = [];
+
+  if ((fileData.dependentCount ?? 0) > 0) stats.push(`dependents: ${fileData.dependentCount}`);
+
+  if (fileData.violations.length > 0) {
+    const errors = fileData.violations.filter(v => v.severity === 'error').length;
+    const warnings = fileData.violations.filter(v => v.severity === 'warning').length;
+    const parts: string[] = [];
+    if (errors > 0) parts.push(`${errors} error${errors > 1 ? 's' : ''}`);
+    if (warnings > 0) parts.push(`${warnings} warning${warnings > 1 ? 's' : ''}`);
+    stats.push(`violations: ${parts.join(', ')}`);
+  }
+
+  if (fileData.testAssociations.length > 0) {
+    stats.push(`covered by: ${fileData.testAssociations.join(', ')}`);
+  } else if (categorizeFile(file) === 'source') {
+    stats.push('no test coverage');
+  }
+
+  return stats.length > 0 ? `*${stats.join(' · ')}*` : '';
+}
+
+function buildFileSection(
+  file: string,
+  report: ComplexityReport,
+  fileChunks: CodeChunk[] | undefined,
+  patch: string | undefined,
+  remainingBudget: number,
+): { text: string; contentChars: number } {
+  const stats = buildFileStats(file, report);
+  const header = stats ? `### ${file}\n${stats}` : `### ${file}`;
+
+  if (fileChunks) {
+    const code = fileChunks.map(c => c.content).join('\n\n');
+    if (code.length <= remainingBudget) {
+      return { text: `${header}\n\`\`\`\n${code}\n\`\`\``, contentChars: code.length };
     }
-    listedOnly.push(file);
   }
 
-  if (listedOnly.length > 0) {
-    sections.push(
-      `### Files changed (content not available)\n${listedOnly.map(f => `- ${f}`).join('\n')}`,
-    );
+  if (patch && patch.length <= remainingBudget) {
+    return { text: `${header}\n\`\`\`diff\n${patch}\n\`\`\``, contentChars: patch.length };
   }
+
+  return { text: `${header}\n*(content not available)*`, contentChars: 0 };
 }
 
 function buildCodeContext(
@@ -190,11 +212,9 @@ function buildCodeContext(
   allChangedFiles: string[],
   prPatches?: Map<string, string>,
 ): string {
-  const changedFilesSet = new Set(changedFiles);
-  const chunksByFile = groupChunksByFile(chunks, changedFilesSet);
+  const chunksByFile = groupChunksByFile(chunks, new Set(changedFiles));
 
-  // Sort files by dependentCount descending
-  const sortedFiles = [...chunksByFile.keys()].sort((a, b) => {
+  const sortedFiles = [...allChangedFiles].sort((a, b) => {
     const depA = report.files[a]?.dependentCount ?? 0;
     const depB = report.files[b]?.dependentCount ?? 0;
     return depB - depA;
@@ -202,23 +222,18 @@ function buildCodeContext(
 
   const sections: string[] = [];
   let totalChars = 0;
-  const shownFiles = new Set<string>();
 
   for (const file of sortedFiles) {
-    const fileChunks = chunksByFile.get(file)!;
-    const fileCode = fileChunks.map(c => c.content).join('\n\n');
-    if (totalChars + fileCode.length > MAX_TOTAL_CHARS) continue;
-
-    const dependentCount = report.files[file]?.dependentCount ?? 0;
-    const header =
-      dependentCount > 0 ? `### ${file} (${dependentCount} dependents)` : `### ${file}`;
-    sections.push(`${header}\n\`\`\`\n${fileCode}\n\`\`\``);
-    totalChars += fileCode.length;
-    shownFiles.add(file);
+    const { text, contentChars } = buildFileSection(
+      file,
+      report,
+      chunksByFile.get(file),
+      prPatches?.get(file),
+      MAX_TOTAL_CHARS - totalChars,
+    );
+    sections.push(text);
+    totalChars += contentChars;
   }
-
-  const notShownFiles = allChangedFiles.filter(f => !shownFiles.has(f));
-  appendPatchSections(sections, notShownFiles, prPatches, totalChars);
 
   return sections.join('\n\n');
 }
@@ -245,13 +260,7 @@ function formatRiskSignals(signals: RiskSignals): string {
   if (signals.newViolations > 0) parts.push(`New complexity violations: ${signals.newViolations}`);
   if (signals.improvedViolations > 0)
     parts.push(`Improved/resolved: ${signals.improvedViolations}`);
-  if (signals.highRiskFileCount > 0)
-    parts.push(`High-impact files (with dependents): ${signals.highRiskFileCount}`);
   if (signals.hasExportChanges) parts.push(`Export/interface changes detected`);
-  if (signals.uncoveredSourceFileCount > 0)
-    parts.push(
-      `Source files without test coverage: ${signals.uncoveredSourceFileCount}/${signals.categories.source}`,
-    );
 
   return parts.join('\n');
 }

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -207,9 +207,9 @@ function buildFileStats(
       stats.push(`depended on by: ${fileData.dependents.join(', ')}`);
 
     if (fileData.testAssociations.length > 0) {
-      stats.push(`covered by: ${fileData.testAssociations.join(', ')}`);
+      stats.push(`tests: ${fileData.testAssociations.join(', ')}`);
     } else if (categorizeFile(file) === 'source') {
-      stats.push('no test coverage');
+      stats.push('tests: none');
     }
   }
 

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -200,20 +200,17 @@ function buildFileStats(
 ): string {
   const fileData = report.files[file];
   const lines: string[] = [];
-  const stats: string[] = [];
 
   if (fileData) {
     if (fileData.dependents.length > 0)
-      stats.push(`depended on by: ${fileData.dependents.join(', ')}`);
+      lines.push(`*depended on by: ${fileData.dependents.join(', ')}*`);
 
     if (fileData.testAssociations.length > 0) {
-      stats.push(`tests: ${fileData.testAssociations.join(', ')}`);
+      lines.push(`*tests: ${fileData.testAssociations.join(', ')}*`);
     } else if (categorizeFile(file) === 'source') {
-      stats.push('tests: none');
+      lines.push('*tests: none*');
     }
   }
-
-  if (stats.length > 0) lines.push(`*${stats.join(' · ')}*`);
 
   if (changedFunctions.size > 0) {
     lines.push(`*changed: ${[...changedFunctions].join(', ')}*`);

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -248,9 +248,28 @@ function buildFileSection(
   const header = stats ? `### ${file}\n${stats}` : `### ${file}`;
 
   if (fileChunks) {
-    const code = fileChunks.map(c => c.content).join('\n\n');
-    if (code.length <= remainingBudget) {
-      return { text: `${header}\n\`\`\`\n${code}\n\`\`\``, contentChars: code.length };
+    const allCode = fileChunks.map(c => c.content).join('\n\n');
+
+    // 1. Full file fits → include it (full context is valuable for risk assessment)
+    if (allCode.length <= remainingBudget) {
+      return { text: `${header}\n\`\`\`\n${allCode}\n\`\`\``, contentChars: allCode.length };
+    }
+
+    // 2. Doesn't fit → fallback to changed chunks only
+    const fileDiffLines = diffLines?.get(file);
+    if (fileDiffLines && fileDiffLines.size > 0) {
+      const changedChunks = fileChunks.filter(c =>
+        [...fileDiffLines].some(line => line >= c.metadata.startLine && line <= c.metadata.endLine),
+      );
+      if (changedChunks.length > 0) {
+        const changedCode = changedChunks.map(c => c.content).join('\n\n');
+        if (changedCode.length <= remainingBudget) {
+          return {
+            text: `${header}\n\`\`\`\n${changedCode}\n\`\`\``,
+            contentChars: changedCode.length,
+          };
+        }
+      }
     }
   }
 

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -73,7 +73,7 @@ function countViolationDeltas(deltas: ReviewContext['deltas']): {
 }
 
 function countHighRiskFiles(files: string[], report: ComplexityReport): number {
-  return files.filter(f => (report.files[f]?.dependentCount ?? 0) > 0).length;
+  return files.filter(f => (report.files[f]?.dependents.length ?? 0) > 0).length;
 }
 
 export function computeRiskSignals(context: ReviewContext): RiskSignals {
@@ -203,7 +203,8 @@ function buildFileStats(
   const stats: string[] = [];
 
   if (fileData) {
-    if ((fileData.dependentCount ?? 0) > 0) stats.push(`dependents: ${fileData.dependentCount}`);
+    if (fileData.dependents.length > 0)
+      stats.push(`depended on by: ${fileData.dependents.join(', ')}`);
 
     if (fileData.testAssociations.length > 0) {
       stats.push(`covered by: ${fileData.testAssociations.join(', ')}`);

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -122,7 +122,7 @@ function detectExportChanges(context: ReviewContext): boolean {
 // Code Context Assembly (same pattern as ArchitecturalPlugin)
 // ---------------------------------------------------------------------------
 
-const MAX_TOTAL_CHARS = 30_000;
+const MAX_TOTAL_CHARS = 50_000;
 
 function groupChunksByFile(
   chunks: CodeChunk[],

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -137,15 +137,29 @@ function groupChunksByFile(
   changedFilesSet: Set<string>,
 ): Map<string, CodeChunk[]> {
   const map = new Map<string, CodeChunk[]>();
+  // Separate method chunks as fallback for files with no class/function-level chunks
+  const methodFallback = new Map<string, CodeChunk[]>();
+
   for (const chunk of chunks) {
     const file = chunk.metadata.file;
     if (!changedFilesSet.has(file)) continue;
-    if (chunk.metadata.symbolType === 'method') continue;
+    if (chunk.metadata.symbolType === 'method') {
+      const existing = methodFallback.get(file) ?? [];
+      existing.push(chunk);
+      methodFallback.set(file, existing);
+      continue;
+    }
     if (chunk.metadata.type === 'block' && !chunk.metadata.symbolName) continue;
     const existing = map.get(file) ?? [];
     existing.push(chunk);
     map.set(file, existing);
   }
+
+  // Use method chunks for files that produced no primary chunks (e.g. migrations)
+  for (const [file, fallbackChunks] of methodFallback) {
+    if (!map.has(file)) map.set(file, fallbackChunks);
+  }
+
   return map;
 }
 
@@ -153,6 +167,7 @@ function buildCodeContext(
   chunks: CodeChunk[],
   report: ComplexityReport,
   changedFiles: string[],
+  allChangedFiles: string[],
 ): string {
   const changedFilesSet = new Set(changedFiles);
   const chunksByFile = groupChunksByFile(chunks, changedFilesSet);
@@ -166,6 +181,7 @@ function buildCodeContext(
 
   const sections: string[] = [];
   let totalChars = 0;
+  const shownFiles = new Set<string>();
 
   for (const file of sortedFiles) {
     const fileChunks = chunksByFile.get(file)!;
@@ -177,6 +193,15 @@ function buildCodeContext(
       dependentCount > 0 ? `### ${file} (${dependentCount} dependents)` : `### ${file}`;
     sections.push(`${header}\n\`\`\`\n${fileCode}\n\`\`\``);
     totalChars += fileCode.length;
+    shownFiles.add(file);
+  }
+
+  // List any changed files not represented in the code sections above
+  const notShown = allChangedFiles.filter(f => !shownFiles.has(f));
+  if (notShown.length > 0) {
+    sections.push(
+      `### Files changed (content not available)\n${notShown.map(f => `- ${f}`).join('\n')}`,
+    );
   }
 
   return sections.join('\n\n');
@@ -367,11 +392,12 @@ export class SummaryPlugin implements ReviewPlugin {
     if (!context.llm) return [];
 
     const { chunks, complexityReport, changedFiles, logger } = context;
+    const allChangedFiles = context.allChangedFiles ?? changedFiles;
 
     logger.info('Computing risk signals for summary...');
     const signals = computeRiskSignals(context);
 
-    const codeContext = buildCodeContext(chunks, complexityReport, changedFiles);
+    const codeContext = buildCodeContext(chunks, complexityReport, changedFiles, allChangedFiles);
     const prompt = buildSummaryPrompt(signals, codeContext, context);
     const response = await context.llm.complete(prompt);
 

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -14,6 +14,7 @@ import type {
   SummaryFindingMetadata,
   PresentContext,
 } from '../plugin-types.js';
+import type { ComplexityDelta } from '../delta.js';
 import { extractJSONFromCodeBlock } from '../json-utils.js';
 import type { Logger } from '../logger.js';
 
@@ -155,27 +156,79 @@ function groupChunksByFile(
   return map;
 }
 
-function buildFileStats(file: string, report: ComplexityReport): string {
-  const fileData = report.files[file];
-  if (!fileData) return '';
+type FileDeltaMap = Map<string, ComplexityDelta>;
 
+function buildDeltaMap(deltas: ComplexityDelta[] | null): Map<string, FileDeltaMap> {
+  const map = new Map<string, FileDeltaMap>();
+  for (const delta of deltas ?? []) {
+    const fileMap = map.get(delta.filepath) ?? new Map<string, ComplexityDelta>();
+    fileMap.set(`${delta.symbolName}:${delta.metricType}`, delta);
+    map.set(delta.filepath, fileMap);
+  }
+  return map;
+}
+
+function computeChangedFunctions(
+  file: string,
+  fileChunks: CodeChunk[] | undefined,
+  diffLines: Map<string, Set<number>> | undefined,
+): Set<string> {
+  const changed = new Set<string>();
+  if (!fileChunks || !diffLines) return changed;
+
+  const fileDiffLines = diffLines.get(file);
+  if (!fileDiffLines || fileDiffLines.size === 0) return changed;
+
+  for (const chunk of fileChunks) {
+    const name = chunk.metadata.symbolName;
+    if (!name) continue;
+    for (const line of fileDiffLines) {
+      if (line >= chunk.metadata.startLine && line <= chunk.metadata.endLine) {
+        changed.add(name);
+        break;
+      }
+    }
+  }
+  return changed;
+}
+
+function buildFileStats(
+  file: string,
+  report: ComplexityReport,
+  fileDeltaMap: FileDeltaMap | undefined,
+  changedFunctions: Set<string>,
+): string {
+  const fileData = report.files[file];
   const lines: string[] = [];
   const stats: string[] = [];
 
-  if ((fileData.dependentCount ?? 0) > 0) stats.push(`dependents: ${fileData.dependentCount}`);
+  if (fileData) {
+    if ((fileData.dependentCount ?? 0) > 0) stats.push(`dependents: ${fileData.dependentCount}`);
 
-  if (fileData.testAssociations.length > 0) {
-    stats.push(`covered by: ${fileData.testAssociations.join(', ')}`);
-  } else if (categorizeFile(file) === 'source') {
-    stats.push('no test coverage');
+    if (fileData.testAssociations.length > 0) {
+      stats.push(`covered by: ${fileData.testAssociations.join(', ')}`);
+    } else if (categorizeFile(file) === 'source') {
+      stats.push('no test coverage');
+    }
   }
 
   if (stats.length > 0) lines.push(`*${stats.join(' · ')}*`);
 
-  if (fileData.violations.length > 0) {
+  if (changedFunctions.size > 0) {
+    lines.push(`*changed: ${[...changedFunctions].join(', ')}*`);
+  }
+
+  if (fileData?.violations && fileData.violations.length > 0) {
     const formatted = fileData.violations.map(v => {
       const icon = v.severity === 'error' ? '🔴' : '🟡';
-      return `${v.symbolName} (${v.metricType} ${v.complexity}/${v.threshold} ${icon})`;
+      const delta = fileDeltaMap?.get(`${v.symbolName}:${v.metricType}`);
+      let deltaStr = '';
+      if (delta) {
+        if (delta.severity === 'new') deltaStr = ' new';
+        else if (delta.delta > 0) deltaStr = ` +${delta.delta}`;
+        else if (delta.delta < 0) deltaStr = ` ${delta.delta}`;
+      }
+      return `${v.symbolName} (${v.metricType} ${v.complexity}/${v.threshold} ${icon}${deltaStr})`;
     });
     lines.push(`*violations: ${formatted.join(', ')}*`);
   }
@@ -189,8 +242,11 @@ function buildFileSection(
   fileChunks: CodeChunk[] | undefined,
   patch: string | undefined,
   remainingBudget: number,
+  fileDeltaMap: FileDeltaMap | undefined,
+  diffLines: Map<string, Set<number>> | undefined,
 ): { text: string; contentChars: number } {
-  const stats = buildFileStats(file, report);
+  const changedFunctions = computeChangedFunctions(file, fileChunks, diffLines);
+  const stats = buildFileStats(file, report, fileDeltaMap, changedFunctions);
   const header = stats ? `### ${file}\n${stats}` : `### ${file}`;
 
   if (fileChunks) {
@@ -213,8 +269,11 @@ function buildCodeContext(
   changedFiles: string[],
   allChangedFiles: string[],
   prPatches?: Map<string, string>,
+  deltas?: ComplexityDelta[] | null,
+  diffLines?: Map<string, Set<number>>,
 ): string {
   const chunksByFile = groupChunksByFile(chunks, new Set(changedFiles));
+  const deltaMap = buildDeltaMap(deltas ?? null);
 
   const sortedFiles = [...allChangedFiles].sort((a, b) => {
     const depA = report.files[a]?.dependentCount ?? 0;
@@ -232,6 +291,8 @@ function buildCodeContext(
       chunksByFile.get(file),
       prPatches?.get(file),
       MAX_TOTAL_CHARS - totalChars,
+      deltaMap.get(file),
+      diffLines,
     );
     sections.push(text);
     totalChars += contentChars;
@@ -430,6 +491,8 @@ export class SummaryPlugin implements ReviewPlugin {
       changedFiles,
       allChangedFiles,
       context.pr?.patches,
+      context.deltas,
+      context.pr?.diffLines,
     );
     const prompt = buildSummaryPrompt(signals, codeContext, context);
     const response = await context.llm.complete(prompt);

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -57,6 +57,24 @@ function countUncoveredSourceFiles(files: string[], report: ComplexityReport): n
   }).length;
 }
 
+function countViolationDeltas(deltas: ReviewContext['deltas']): {
+  newViolations: number;
+  improvedViolations: number;
+} {
+  let newViolations = 0;
+  let improvedViolations = 0;
+  for (const delta of deltas ?? []) {
+    if (delta.severity === 'new' || delta.severity === 'error' || delta.severity === 'warning')
+      newViolations++;
+    if (delta.severity === 'improved' || delta.severity === 'deleted') improvedViolations++;
+  }
+  return { newViolations, improvedViolations };
+}
+
+function countHighRiskFiles(files: string[], report: ComplexityReport): number {
+  return files.filter(f => (report.files[f]?.dependentCount ?? 0) > 0).length;
+}
+
 export function computeRiskSignals(context: ReviewContext): RiskSignals {
   // Use allChangedFiles for categorization so we capture docs/config/infra files
   const allFiles = context.allChangedFiles ?? context.changedFiles;
@@ -69,49 +87,23 @@ export function computeRiskSignals(context: ReviewContext): RiskSignals {
     docs: 0,
     source: 0,
   };
+  for (const file of allFiles) categories[categorizeFile(file)]++;
 
-  for (const file of allFiles) {
-    categories[categorizeFile(file)]++;
-  }
+  const languages = [
+    ...new Set(context.chunks.map(c => c.metadata.language).filter(Boolean)),
+  ].sort() as string[];
 
-  // Languages from chunks
-  const langSet = new Set<string>();
-  for (const chunk of context.chunks) {
-    if (chunk.metadata.language) langSet.add(chunk.metadata.language);
-  }
-
-  // Complexity delta summary
-  let newViolations = 0;
-  let improvedViolations = 0;
-  if (context.deltas) {
-    for (const delta of context.deltas) {
-      if (delta.severity === 'new' || delta.severity === 'error' || delta.severity === 'warning')
-        newViolations++;
-      if (delta.severity === 'improved' || delta.severity === 'deleted') improvedViolations++;
-    }
-  }
-
-  // High-risk files (files with many dependents)
-  let highRiskFileCount = 0;
-  for (const file of allFiles) {
-    const fileData = context.complexityReport.files[file];
-    if (fileData && (fileData.dependentCount ?? 0) > 0) highRiskFileCount++;
-  }
-
-  // Export changes
-  const hasExportChanges = detectExportChanges(context);
-
-  const uncoveredSourceFileCount = countUncoveredSourceFiles(allFiles, context.complexityReport);
+  const { newViolations, improvedViolations } = countViolationDeltas(context.deltas);
 
   return {
     totalFiles: allFiles.length,
     categories,
-    languages: [...langSet].sort(),
+    languages,
     newViolations,
     improvedViolations,
-    highRiskFileCount,
-    hasExportChanges,
-    uncoveredSourceFileCount,
+    highRiskFileCount: countHighRiskFiles(allFiles, context.complexityReport),
+    hasExportChanges: detectExportChanges(context),
+    uncoveredSourceFileCount: countUncoveredSourceFiles(allFiles, context.complexityReport),
   };
 }
 
@@ -163,6 +155,19 @@ function groupChunksByFile(
   return map;
 }
 
+function appendNotShownSection(
+  sections: string[],
+  allChangedFiles: string[],
+  shownFiles: Set<string>,
+): void {
+  const notShown = allChangedFiles.filter(f => !shownFiles.has(f));
+  if (notShown.length > 0) {
+    sections.push(
+      `### Files changed (content not available)\n${notShown.map(f => `- ${f}`).join('\n')}`,
+    );
+  }
+}
+
 function buildCodeContext(
   chunks: CodeChunk[],
   report: ComplexityReport,
@@ -196,13 +201,7 @@ function buildCodeContext(
     shownFiles.add(file);
   }
 
-  // List any changed files not represented in the code sections above
-  const notShown = allChangedFiles.filter(f => !shownFiles.has(f));
-  if (notShown.length > 0) {
-    sections.push(
-      `### Files changed (content not available)\n${notShown.map(f => `- ${f}`).join('\n')}`,
-    );
-  }
+  appendNotShownSection(sections, allChangedFiles, shownFiles);
 
   return sections.join('\n\n');
 }

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -155,24 +155,12 @@ function groupChunksByFile(
   return map;
 }
 
-function appendNotShownSection(
-  sections: string[],
-  allChangedFiles: string[],
-  shownFiles: Set<string>,
-): void {
-  const notShown = allChangedFiles.filter(f => !shownFiles.has(f));
-  if (notShown.length > 0) {
-    sections.push(
-      `### Files changed (content not available)\n${notShown.map(f => `- ${f}`).join('\n')}`,
-    );
-  }
-}
-
 function buildCodeContext(
   chunks: CodeChunk[],
   report: ComplexityReport,
   changedFiles: string[],
   allChangedFiles: string[],
+  prPatches?: Map<string, string>,
 ): string {
   const changedFilesSet = new Set(changedFiles);
   const chunksByFile = groupChunksByFile(chunks, changedFilesSet);
@@ -201,7 +189,28 @@ function buildCodeContext(
     shownFiles.add(file);
   }
 
-  appendNotShownSection(sections, allChangedFiles, shownFiles);
+  // For files not covered by chunks: fill remaining budget with raw diff patches
+  const notShownFiles = allChangedFiles.filter(f => !shownFiles.has(f));
+  const listedOnly: string[] = [];
+
+  for (const file of notShownFiles) {
+    const patch = prPatches?.get(file);
+    if (patch) {
+      const section = `### ${file}\n\`\`\`diff\n${patch}\n\`\`\``;
+      if (totalChars + section.length <= MAX_TOTAL_CHARS) {
+        sections.push(section);
+        totalChars += section.length;
+        continue;
+      }
+    }
+    listedOnly.push(file);
+  }
+
+  if (listedOnly.length > 0) {
+    sections.push(
+      `### Files changed (content not available)\n${listedOnly.map(f => `- ${f}`).join('\n')}`,
+    );
+  }
 
   return sections.join('\n\n');
 }
@@ -396,7 +405,13 @@ export class SummaryPlugin implements ReviewPlugin {
     logger.info('Computing risk signals for summary...');
     const signals = computeRiskSignals(context);
 
-    const codeContext = buildCodeContext(chunks, complexityReport, changedFiles, allChangedFiles);
+    const codeContext = buildCodeContext(
+      chunks,
+      complexityReport,
+      changedFiles,
+      allChangedFiles,
+      context.pr?.patches,
+    );
     const prompt = buildSummaryPrompt(signals, codeContext, context);
     const response = await context.llm.complete(prompt);
 

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -274,8 +274,8 @@ function buildCodeContext(
   const deltaMap = buildDeltaMap(deltas ?? null);
 
   const sortedFiles = [...allChangedFiles].sort((a, b) => {
-    const depA = report.files[a]?.dependentCount ?? 0;
-    const depB = report.files[b]?.dependentCount ?? 0;
+    const depA = report.files[a]?.dependents.length ?? 0;
+    const depB = report.files[b]?.dependents.length ?? 0;
     return depB - depA;
   });
 

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -159,18 +159,10 @@ function buildFileStats(file: string, report: ComplexityReport): string {
   const fileData = report.files[file];
   if (!fileData) return '';
 
+  const lines: string[] = [];
   const stats: string[] = [];
 
   if ((fileData.dependentCount ?? 0) > 0) stats.push(`dependents: ${fileData.dependentCount}`);
-
-  if (fileData.violations.length > 0) {
-    const errors = fileData.violations.filter(v => v.severity === 'error').length;
-    const warnings = fileData.violations.filter(v => v.severity === 'warning').length;
-    const parts: string[] = [];
-    if (errors > 0) parts.push(`${errors} error${errors > 1 ? 's' : ''}`);
-    if (warnings > 0) parts.push(`${warnings} warning${warnings > 1 ? 's' : ''}`);
-    stats.push(`violations: ${parts.join(', ')}`);
-  }
 
   if (fileData.testAssociations.length > 0) {
     stats.push(`covered by: ${fileData.testAssociations.join(', ')}`);
@@ -178,7 +170,17 @@ function buildFileStats(file: string, report: ComplexityReport): string {
     stats.push('no test coverage');
   }
 
-  return stats.length > 0 ? `*${stats.join(' · ')}*` : '';
+  if (stats.length > 0) lines.push(`*${stats.join(' · ')}*`);
+
+  if (fileData.violations.length > 0) {
+    const formatted = fileData.violations.map(v => {
+      const icon = v.severity === 'error' ? '🔴' : '🟡';
+      return `${v.symbolName} (${v.metricType} ${v.complexity}/${v.threshold} ${icon})`;
+    });
+    lines.push(`*violations: ${formatted.join(', ')}*`);
+  }
+
+  return lines.join('\n');
 }
 
 function buildFileSection(

--- a/packages/review/src/plugins/summary.ts
+++ b/packages/review/src/plugins/summary.ts
@@ -155,6 +155,34 @@ function groupChunksByFile(
   return map;
 }
 
+function appendPatchSections(
+  sections: string[],
+  notShownFiles: string[],
+  prPatches: Map<string, string> | undefined,
+  totalChars: number,
+): void {
+  const listedOnly: string[] = [];
+
+  for (const file of notShownFiles) {
+    const patch = prPatches?.get(file);
+    if (patch) {
+      const section = `### ${file}\n\`\`\`diff\n${patch}\n\`\`\``;
+      if (totalChars + section.length <= MAX_TOTAL_CHARS) {
+        sections.push(section);
+        totalChars += section.length;
+        continue;
+      }
+    }
+    listedOnly.push(file);
+  }
+
+  if (listedOnly.length > 0) {
+    sections.push(
+      `### Files changed (content not available)\n${listedOnly.map(f => `- ${f}`).join('\n')}`,
+    );
+  }
+}
+
 function buildCodeContext(
   chunks: CodeChunk[],
   report: ComplexityReport,
@@ -189,28 +217,8 @@ function buildCodeContext(
     shownFiles.add(file);
   }
 
-  // For files not covered by chunks: fill remaining budget with raw diff patches
   const notShownFiles = allChangedFiles.filter(f => !shownFiles.has(f));
-  const listedOnly: string[] = [];
-
-  for (const file of notShownFiles) {
-    const patch = prPatches?.get(file);
-    if (patch) {
-      const section = `### ${file}\n\`\`\`diff\n${patch}\n\`\`\``;
-      if (totalChars + section.length <= MAX_TOTAL_CHARS) {
-        sections.push(section);
-        totalChars += section.length;
-        continue;
-      }
-    }
-    listedOnly.push(file);
-  }
-
-  if (listedOnly.length > 0) {
-    sections.push(
-      `### Files changed (content not available)\n${listedOnly.map(f => `- ${f}`).join('\n')}`,
-    );
-  }
+  appendPatchSections(sections, notShownFiles, prPatches, totalChars);
 
   return sections.join('\n\n');
 }

--- a/packages/review/src/types.ts
+++ b/packages/review/src/types.ts
@@ -16,6 +16,8 @@ export interface PRContext {
   body?: string;
   baseSha: string;
   headSha: string;
+  /** Raw unified diff patches keyed by filename. Populated by the runner when available. */
+  patches?: Map<string, string>;
 }
 
 /**

--- a/packages/review/src/types.ts
+++ b/packages/review/src/types.ts
@@ -18,6 +18,8 @@ export interface PRContext {
   headSha: string;
   /** Raw unified diff patches keyed by filename. Populated by the runner when available. */
   patches?: Map<string, string>;
+  /** Changed line numbers per filename, derived from the unified diff. Populated by the runner when available. */
+  diffLines?: Map<string, Set<number>>;
 }
 
 /**

--- a/packages/review/test/plugins-summary.test.ts
+++ b/packages/review/test/plugins-summary.test.ts
@@ -405,6 +405,113 @@ describe('SummaryPlugin', () => {
       expect(prompt).not.toContain('content not available');
     });
 
+    describe('buildCodeContext chunk scoping', () => {
+      // Each chunk is ~17.6k chars; 3 chunks total ~52.9k > 50k budget
+      const bigBody = '// padding\n'.repeat(1600);
+
+      it('includes all chunks when full file fits in budget', async () => {
+        const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+        const context = createTestContext({
+          changedFiles: ['src/app.ts'],
+          chunks: [
+            createTestChunk({
+              content: 'function small_a() { return 1; }',
+              metadata: { file: 'src/app.ts', symbolName: 'small_a', startLine: 1, endLine: 3 },
+            }),
+            createTestChunk({
+              content: 'function small_b() { return 2; }',
+              metadata: { file: 'src/app.ts', symbolName: 'small_b', startLine: 5, endLine: 7 },
+            }),
+          ],
+          llm,
+          pr: {
+            owner: 'test',
+            repo: 'repo',
+            pullNumber: 1,
+            title: 'test',
+            headSha: 'abc',
+            baseSha: 'def',
+            diffLines: new Map([['src/app.ts', new Set([2])]]),
+          },
+        });
+        await plugin.analyze(context);
+        const prompt = llm.calls[0].prompt;
+        expect(prompt).toContain('small_a');
+        expect(prompt).toContain('small_b');
+      });
+
+      it('scopes to changed chunks only when full file exceeds budget', async () => {
+        const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+        const context = createTestContext({
+          changedFiles: ['src/app.ts'],
+          chunks: [
+            createTestChunk({
+              content: `function chunk_a() {\n${bigBody}}`,
+              metadata: { file: 'src/app.ts', symbolName: 'chunk_a', startLine: 1, endLine: 100 },
+            }),
+            createTestChunk({
+              content: `function chunk_b() {\n${bigBody}}`,
+              metadata: { file: 'src/app.ts', symbolName: 'chunk_b', startLine: 101, endLine: 200 },
+            }),
+            createTestChunk({
+              content: `function chunk_c() {\n${bigBody}}`,
+              metadata: { file: 'src/app.ts', symbolName: 'chunk_c', startLine: 201, endLine: 300 },
+            }),
+          ],
+          llm,
+          pr: {
+            owner: 'test',
+            repo: 'repo',
+            pullNumber: 1,
+            title: 'test',
+            headSha: 'abc',
+            baseSha: 'def',
+            diffLines: new Map([['src/app.ts', new Set([150])]]),
+          },
+        });
+        await plugin.analyze(context);
+        const prompt = llm.calls[0].prompt;
+        expect(prompt).toContain('chunk_b');
+        expect(prompt).not.toContain('chunk_a');
+        expect(prompt).not.toContain('chunk_c');
+      });
+
+      it('falls through to patch when full file exceeds budget and diffLines is absent', async () => {
+        const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+        const context = createTestContext({
+          changedFiles: ['src/app.ts'],
+          chunks: [
+            createTestChunk({
+              content: `function chunk_a() {\n${bigBody}}`,
+              metadata: { file: 'src/app.ts', symbolName: 'chunk_a', startLine: 1, endLine: 100 },
+            }),
+            createTestChunk({
+              content: `function chunk_b() {\n${bigBody}}`,
+              metadata: { file: 'src/app.ts', symbolName: 'chunk_b', startLine: 101, endLine: 200 },
+            }),
+            createTestChunk({
+              content: `function chunk_c() {\n${bigBody}}`,
+              metadata: { file: 'src/app.ts', symbolName: 'chunk_c', startLine: 201, endLine: 300 },
+            }),
+          ],
+          llm,
+          pr: {
+            owner: 'test',
+            repo: 'repo',
+            pullNumber: 1,
+            title: 'test',
+            headSha: 'abc',
+            baseSha: 'def',
+            patches: new Map([['src/app.ts', '+function chunk_b() { /* changed */ }']]),
+          },
+        });
+        await plugin.analyze(context);
+        const prompt = llm.calls[0].prompt;
+        expect(prompt).toContain('```diff');
+        expect(prompt).toContain('+function chunk_b');
+      });
+    });
+
     it('returns empty on unparseable LLM response', async () => {
       const llm = createMockLLMClient(['not valid json at all']);
       const context = createTestContext({

--- a/packages/review/test/plugins-summary.test.ts
+++ b/packages/review/test/plugins-summary.test.ts
@@ -275,6 +275,95 @@ describe('SummaryPlugin', () => {
       expect(llm.calls[0].prompt).toContain('My Special PR Title');
     });
 
+    it('includes method-only files (e.g. migrations) via fallback chunks', async () => {
+      const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+      const context = createTestContext({
+        changedFiles: ['database/migrations/add_pr_title.php'],
+        chunks: [
+          // Only method chunks — no class/function-level chunks
+          createTestChunk({
+            content: 'public function up() { Schema::table(...); }',
+            metadata: {
+              file: 'database/migrations/add_pr_title.php',
+              symbolName: 'up',
+              symbolType: 'method',
+              type: 'function',
+              language: 'php',
+            },
+          }),
+        ],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'Add pr_title column',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      await plugin.analyze(context);
+      const prompt = llm.calls[0].prompt;
+      expect(prompt).toContain('database/migrations/add_pr_title.php');
+      expect(prompt).toContain('Schema::table');
+    });
+
+    it('lists allChangedFiles not in code context under "content not available"', async () => {
+      const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+      const context = createTestContext({
+        changedFiles: ['src/app.ts'],
+        allChangedFiles: ['src/app.ts', 'database/migrations/add_pr_title.php'],
+        chunks: [
+          createTestChunk({
+            content: 'function app() {}',
+            metadata: { file: 'src/app.ts', symbolName: 'app', language: 'typescript' },
+          }),
+        ],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'Add pr_title column',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      await plugin.analyze(context);
+      const prompt = llm.calls[0].prompt;
+      expect(prompt).toContain('Files changed (content not available)');
+      expect(prompt).toContain('database/migrations/add_pr_title.php');
+    });
+
+    it('does not add "content not available" section when all files are shown', async () => {
+      const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+      const context = createTestContext({
+        changedFiles: ['src/app.ts'],
+        allChangedFiles: ['src/app.ts'],
+        chunks: [
+          createTestChunk({
+            content: 'function app() {}',
+            metadata: { file: 'src/app.ts', symbolName: 'app', language: 'typescript' },
+          }),
+        ],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'test',
+          headSha: 'abc',
+          baseSha: 'def',
+        },
+      });
+
+      await plugin.analyze(context);
+      const prompt = llm.calls[0].prompt;
+      expect(prompt).not.toContain('content not available');
+    });
+
     it('returns empty on unparseable LLM response', async () => {
       const llm = createMockLLMClient(['not valid json at all']);
       const context = createTestContext({

--- a/packages/review/test/plugins-summary.test.ts
+++ b/packages/review/test/plugins-summary.test.ts
@@ -126,7 +126,13 @@ describe('SummaryPlugin', () => {
 
     it('counts high-risk files with dependents', () => {
       const report = createTestReport([{ filepath: 'src/core.ts' }]);
-      report.files['src/core.ts'].dependentCount = 5;
+      report.files['src/core.ts'].dependents = [
+        'src/a.ts',
+        'src/b.ts',
+        'src/c.ts',
+        'src/d.ts',
+        'src/e.ts',
+      ];
 
       const context = createTestContext({
         changedFiles: ['src/core.ts', 'src/util.ts'],

--- a/packages/review/test/plugins-summary.test.ts
+++ b/packages/review/test/plugins-summary.test.ts
@@ -315,6 +315,41 @@ describe('SummaryPlugin', () => {
       expect(prompt).toContain('Schema::table');
     });
 
+    it('includes raw diff patch for unparseable files with no AST chunks', async () => {
+      const llm = createMockLLMClient([makeSummaryLLMResponse()]);
+      const context = createTestContext({
+        changedFiles: ['src/app.ts'],
+        allChangedFiles: ['src/app.ts', 'database/migrations/add_reset_tokens.sql'],
+        chunks: [
+          createTestChunk({
+            content: 'function app() {}',
+            metadata: { file: 'src/app.ts', symbolName: 'app', language: 'typescript' },
+          }),
+        ],
+        llm,
+        pr: {
+          owner: 'test',
+          repo: 'repo',
+          pullNumber: 1,
+          title: 'Add reset tokens',
+          headSha: 'abc',
+          baseSha: 'def',
+          patches: new Map([
+            [
+              'database/migrations/add_reset_tokens.sql',
+              '+CREATE TABLE reset_tokens (\n+  id BIGINT PRIMARY KEY\n+);',
+            ],
+          ]),
+        },
+      });
+
+      await plugin.analyze(context);
+      const prompt = llm.calls[0].prompt;
+      expect(prompt).toContain('### database/migrations/add_reset_tokens.sql');
+      expect(prompt).toContain('```diff');
+      expect(prompt).toContain('+CREATE TABLE reset_tokens');
+    });
+
     it('shows per-file "content not available" for files without chunks or patches', async () => {
       const llm = createMockLLMClient([makeSummaryLLMResponse()]);
       const context = createTestContext({

--- a/packages/review/test/plugins-summary.test.ts
+++ b/packages/review/test/plugins-summary.test.ts
@@ -309,7 +309,7 @@ describe('SummaryPlugin', () => {
       expect(prompt).toContain('Schema::table');
     });
 
-    it('lists allChangedFiles not in code context under "content not available"', async () => {
+    it('shows per-file "content not available" for files without chunks or patches', async () => {
       const llm = createMockLLMClient([makeSummaryLLMResponse()]);
       const context = createTestContext({
         changedFiles: ['src/app.ts'],
@@ -333,8 +333,8 @@ describe('SummaryPlugin', () => {
 
       await plugin.analyze(context);
       const prompt = llm.calls[0].prompt;
-      expect(prompt).toContain('Files changed (content not available)');
-      expect(prompt).toContain('database/migrations/add_pr_title.php');
+      expect(prompt).toContain('### database/migrations/add_pr_title.php');
+      expect(prompt).toContain('*(content not available)*');
     });
 
     it('does not add "content not available" section when all files are shown', async () => {

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -412,6 +412,7 @@ async function tryFetchPRPatches(
 ): Promise<void> {
   const patchData = await getPRPatchData(octokit, prContext);
   prContext.patches = patchData.patches;
+  prContext.diffLines = patchData.diffLines;
 }
 
 async function tryEnrichTestAssociations(

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -20,6 +20,7 @@ import {
   filterAnalyzableFiles,
   enrichWithTestAssociations,
   getPRChangedFiles,
+  getPRPatchData,
   calculateDeltas,
   calculateDeltaSummary,
   ReviewEngine,
@@ -128,6 +129,10 @@ export async function handlePRReview(
     );
 
     const summaryEnabled = !!payload.config.review_types.summary;
+    if (summaryEnabled) {
+      const patchData = await getPRPatchData(octokit, prContext);
+      prContext.patches = patchData.patches;
+    }
 
     if (filesToAnalyze.length === 0 && !summaryEnabled) {
       logger.info('No analyzable files, skipping');

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -129,7 +129,7 @@ export async function handlePRReview(
     );
 
     const summaryEnabled = !!payload.config.review_types.summary;
-    if (summaryEnabled) await tryFetchPRPatches(octokit, prContext);
+    if (summaryEnabled) await tryFetchPRPatches(octokit, prContext, logger);
 
     if (filesToAnalyze.length === 0 && !summaryEnabled) {
       logger.info('No analyzable files, skipping');
@@ -409,10 +409,17 @@ export async function handlePRReview(
 async function tryFetchPRPatches(
   octokit: ReturnType<typeof createOctokit>,
   prContext: PRContext,
+  logger: Logger,
 ): Promise<void> {
-  const patchData = await getPRPatchData(octokit, prContext);
-  prContext.patches = patchData.patches;
-  prContext.diffLines = patchData.diffLines;
+  try {
+    const patchData = await getPRPatchData(octokit, prContext);
+    prContext.patches = patchData.patches;
+    prContext.diffLines = patchData.diffLines;
+  } catch (error) {
+    logger.warning(
+      `Failed to fetch PR patch data: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 async function tryEnrichTestAssociations(

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -129,10 +129,7 @@ export async function handlePRReview(
     );
 
     const summaryEnabled = !!payload.config.review_types.summary;
-    if (summaryEnabled) {
-      const patchData = await getPRPatchData(octokit, prContext);
-      prContext.patches = patchData.patches;
-    }
+    if (summaryEnabled) await tryFetchPRPatches(octokit, prContext);
 
     if (filesToAnalyze.length === 0 && !summaryEnabled) {
       logger.info('No analyzable files, skipping');
@@ -408,6 +405,14 @@ export async function handlePRReview(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+async function tryFetchPRPatches(
+  octokit: ReturnType<typeof createOctokit>,
+  prContext: PRContext,
+): Promise<void> {
+  const patchData = await getPRPatchData(octokit, prContext);
+  prContext.patches = patchData.patches;
+}
 
 async function tryEnrichTestAssociations(
   report: ComplexityReport,


### PR DESCRIPTION
## Summary

- When a file's full AST chunks exceed the remaining character budget, fall back to including only the chunks whose line ranges overlap with the diff
- Full file is still preferred when it fits (preserving full context for risk assessment)
- Falls through to patch/unavailable as before when changed chunks also don't fit or diff lines are unavailable

Fixes #341.

## Test plan

- [ ] Existing tests all pass (no regressions)
- [ ] New test: small file → all chunks included regardless of which lines changed
- [ ] New test: large file (3×17.6k > 50k budget) with `diffLines` → only the changed chunk appears in prompt
- [ ] New test: large file without `diffLines` → falls through to raw diff patch

---

<!-- lien-stats -->
### Lien Review

**Low Risk** · High Confidence — This is a targeted bug fix to the summary generation logic that improves context selection for large files. Changes are isolated to the review plugin and runner with no impact on core business logic or data persistence.

**Overview** — Improves PR summary generation by scoping chunk content to changed functions when files exceed the character budget, falling back to partial content instead of truncating entirely.

**Key Changes**
- Added diffLines field to PRContext for tracking changed line numbers per file
- Modified buildFileSection to try full file first, then changed chunks only, then raw patch
- Added computeChangedFunctions helper to identify functions matching diff lines
- Updated pr-review handler to fetch and populate diffLines data

🔴 **Review required** - 2 new functions are too complex.
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 3 | +21 |
| ⏱️ time to understand | 3 | +70 |
| 🐛 estimated bugs | 1 | +0 |


*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->