### PR TITLE
feat(review): add truncateToTokenBudget util, raise over-abstraction threshold

### DIFF
--- a/packages/review/src/json-utils.ts
+++ b/packages/review/src/json-utils.ts
@@ -18,3 +18,20 @@ export function extractJSONFromCodeBlock(content: string): string {
 export function estimatePromptTokens(prompt: string): number {
   return Math.ceil(prompt.length / 4);
 }
+
+/**
+ * Truncate a string to fit within a token budget, preserving whole lines where possible.
+ * Returns the truncated string with an optional suffix appended when truncation occurs.
+ */
+export function truncateToTokenBudget(
+  text: string,
+  maxTokens: number,
+  suffix = '... (truncated)',
+): string {
+  const maxChars = maxTokens * 4;
+  if (text.length <= maxChars) return text;
+
+  const truncated = text.slice(0, maxChars - suffix.length);
+  const lastNewline = truncated.lastIndexOf('\n');
+  return (lastNewline > maxChars * 0.8 ? truncated.slice(0, lastNewline) : truncated) + suffix;
+}

--- a/packages/review/src/simplicity-signals.ts
+++ b/packages/review/src/simplicity-signals.ts
@@ -23,11 +23,11 @@ export interface FileSimplicitySignal {
 /** Minimum classes to emit a signal (even if not flagged) */
 const SIGNAL_CLASS_THRESHOLD = 2;
 /** Minimum classes to consider flagging as over-abstraction */
-const OVER_ABSTRACTION_CLASSES = 3;
+const OVER_ABSTRACTION_CLASSES = 4;
 /** Max avg method complexity to be considered "trivial" */
 const TRIVIAL_COMPLEXITY = 2;
 /** Max avg method lines to be considered "trivial" */
-const TRIVIAL_METHOD_LINES = 5;
+const TRIVIAL_METHOD_LINES = 8;
 
 /**
  * Group chunks by file path (same pattern as fingerprint.ts).
@@ -112,7 +112,7 @@ export function computeSimplicitySignals(
       avgMethodLines <= TRIVIAL_METHOD_LINES;
 
     const reason = flagged
-      ? `${classCount} classes with avg method complexity ${avgMethodComplexity.toFixed(1)} and avg ${Math.round(avgMethodLines)} lines — possible over-abstraction`
+      ? `${classCount} classes with avg complexity ${avgMethodComplexity.toFixed(1)} and avg ${Math.round(avgMethodLines)} lines/method — possible over-abstraction`
       : '';
 
     if (classCount >= SIGNAL_CLASS_THRESHOLD || flagged) {

--- a/packages/review/test/simplicity-signals.test.ts
+++ b/packages/review/test/simplicity-signals.test.ts
@@ -33,11 +33,12 @@ describe('computeSimplicitySignals', () => {
     expect(signals).toEqual([]);
   });
 
-  it('flags file with 3 trivial classes', () => {
+  it('flags file with 4 trivial classes', () => {
     const chunks = [
       makeChunk({ file: 'a.ts', symbolType: 'class', symbolName: 'A' }),
       makeChunk({ file: 'a.ts', symbolType: 'class', symbolName: 'B' }),
       makeChunk({ file: 'a.ts', symbolType: 'class', symbolName: 'C' }),
+      makeChunk({ file: 'a.ts', symbolType: 'class', symbolName: 'D' }),
       makeChunk({
         file: 'a.ts',
         symbolType: 'method',
@@ -66,7 +67,7 @@ describe('computeSimplicitySignals', () => {
     const signals = computeSimplicitySignals(chunks, ['a.ts']);
     expect(signals).toHaveLength(1);
     expect(signals[0].flagged).toBe(true);
-    expect(signals[0].classCount).toBe(3);
+    expect(signals[0].classCount).toBe(4);
     expect(signals[0].reason).toContain('possible over-abstraction');
   });
 
@@ -236,6 +237,7 @@ describe('serializeSimplicitySignals', () => {
         makeChunk({ file: 'src/kiss-violations.ts', symbolType: 'class', symbolName: 'A' }),
         makeChunk({ file: 'src/kiss-violations.ts', symbolType: 'class', symbolName: 'B' }),
         makeChunk({ file: 'src/kiss-violations.ts', symbolType: 'class', symbolName: 'C' }),
+        makeChunk({ file: 'src/kiss-violations.ts', symbolType: 'class', symbolName: 'D' }),
         makeChunk({ file: 'src/kiss-violations.ts', symbolType: 'function', symbolName: 'create' }),
         makeChunk({
           file: 'src/kiss-violations.ts',
@@ -260,10 +262,10 @@ describe('serializeSimplicitySignals', () => {
     const output = serializeSimplicitySignals(signals);
     expect(output).toContain('## File Structure Signals');
     expect(output).toContain('kiss-violations.ts');
-    expect(output).toContain('3 classes');
+    expect(output).toContain('4 classes');
     expect(output).toContain('1 functions');
     expect(output).toContain('2 methods');
-    expect(output).toContain('avg method complexity');
+    expect(output).toContain('avg complexity');
     expect(output).toContain('⚠️');
     expect(output).toContain('possible over-abstraction');
   });


### PR DESCRIPTION
Testing Lien review quality. The correct key changes for this PR are:

1. Added `truncateToTokenBudget()` to `json-utils.ts` — truncates text to a token budget while preserving whole lines
2. Raised `OVER_ABSTRACTION_CLASSES` from 3 → 4 in `simplicity-signals.ts`
3. Raised `TRIVIAL_METHOD_LINES` from 5 → 8 in `simplicity-signals.ts`
4. Changed flagged reason string from "avg method complexity" → "avg complexity ... lines/method"
5. Updated tests to match new thresholds

---

<!-- lien-stats -->
### Lien Review

**Low Risk** · High Confidence — This PR adds a new utility function and adjusts configuration thresholds for an existing lint signal. All changes are localized to the review package with no external API or dependent changes.

**Overview** — Adds a token-budget-aware text truncation utility for prompt handling, and recalibrates the over-abstraction detection thresholds to reduce false positives in the review signal system.

✅ **Good** - No complexity issues found.

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->