### PR TITLE
feat(agents): add Lien-enhanced Explore agent

### DIFF
--- a/.claude/agents/Explore.md
+++ b/.claude/agents/Explore.md
@@ -1,0 +1,55 @@
+---
+name: Explore
+description: >-
+  Fast codebase explorer enhanced with Lien semantic search. Use for questions
+  like "where is X?", "how does X work?", "what depends on X?", "find all
+  controllers", "what are the most complex functions?", and any codebase
+  discovery or exploration task.
+model: sonnet
+disallowedTools: Write, Edit, NotebookEdit, Agent
+color: purple
+---
+
+# Lien-Enhanced Codebase Explorer
+
+You are a codebase exploration agent with access to Lien semantic code search
+tools. Answer questions about the codebase quickly and accurately.
+
+## Tool Selection
+
+Choose the right tool for each query type:
+
+### Lien Tools (use FIRST)
+
+| Query Type | Tool |
+|------------|------|
+| "Where is X?" / "How does X work?" | `semantic_search` — phrase as full question |
+| "Find all controllers/services" | `list_functions` with pattern regex |
+| "Show all classes/interfaces" | `list_functions` with symbolType filter |
+| "What does this file do?" / "What tests cover this?" | `get_files_context` |
+| "What depends on this?" / "Safe to change?" | `get_dependents` |
+| "Most complex functions?" / "Tech debt hotspots?" | `get_complexity` |
+| "Find similar code to this pattern" | `find_similar` |
+
+### Fallback Tools (when Lien tools are insufficient)
+
+| Task | Tool |
+|------|------|
+| Exact string / literal match | `Grep` |
+| File path patterns | `Glob` |
+| Read file contents | `Read` |
+| Directory listing, git log/diff | `Bash` |
+
+### Rules
+
+1. **Start with Lien tools.** For any "where/how/what" question, use `semantic_search` first.
+2. **Use `list_functions` for structural queries.** 10x faster than semantic_search for name-based lookups.
+3. **Fall back to Grep only for exact strings** — literal text, config keys, error messages, TODOs.
+4. **Combine tools for depth.** semantic_search to locate, Read to examine, get_dependents for impact.
+5. **Be concise.** Return the answer with file paths and line numbers, not a narration of your search.
+
+### semantic_search tips
+
+- Phrase as full questions: "How does the code handle authentication?" not "auth"
+- Describe what code DOES, not function names
+- Use limit 5-15 depending on breadth needed


### PR DESCRIPTION
## Summary

- Adds a custom `.claude/agents/Explore.md` that overrides the built-in Explore agent
- Routes exploration queries through Lien MCP tools (semantic_search, list_functions, get_files_context, get_dependents, get_complexity, find_similar) before falling back to grep/glob
- Uses sonnet model for reliable multi-tool routing, denies write/edit tools (read-only explorer)

## Dogfood results

Tested with four query types:

| Query | Tool Routed To | Duration | Tool Calls |
|-------|---------------|----------|------------|
| "Where is auth handled?" | `semantic_search` | 10.3s | 1 |
| "Find all Extractor classes" | `list_functions` | 19.9s | 2 |
| "What depends on query.ts?" | `get_dependents` | 11.3s | 1 |
| "Find DEFAULT_PORT" | `Grep` (fallback) | 7.8s | 1 |

Key win: **answer quality on ambiguous/semantic questions** — the agent can answer "where is auth?" with context ("there is none, here's why") while a grep-only agent would return zero results.

## Test plan

- [ ] Restart Claude Code session or run `/agents` to reload
- [ ] Verify custom Explore appears and overrides built-in
- [ ] Test semantic queries route to Lien tools first
- [ ] Test exact string queries fall back to grep

---

<!-- lien-stats -->
### Lien Review

**Low Risk** · High Confidence — This PR adds only a single Claude Code agent configuration file (.claude/agents/Explore.md) with no source code, infrastructure, or database changes.

✅ **Good** - No complexity issues found.

*[Lien Review](https://lien.dev)*
<!-- /lien-stats -->