### PR TITLE
feat(billing): add credit-based billing system

### DIFF
--- a/platform/app/Enums/BillingMode.php
+++ b/platform/app/Enums/BillingMode.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum BillingMode: string
+{
+    case Credits = 'credits';
+    case Byok = 'byok';
+}

--- a/platform/app/Enums/CreditPackage.php
+++ b/platform/app/Enums/CreditPackage.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Enums;
+
+enum CreditPackage: string
+{
+    case Starter = 'starter';
+    case Growth = 'growth';
+    case Scale = 'scale';
+
+    public function credits(): int
+    {
+        return match ($this) {
+            self::Starter => 100,
+            self::Growth => 500,
+            self::Scale => 2_000,
+        };
+    }
+
+    public function priceInCents(): int
+    {
+        return match ($this) {
+            self::Starter => 500,
+            self::Growth => 2_000,
+            self::Scale => 6_000,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Starter => 'Starter',
+            self::Growth => 'Growth',
+            self::Scale => 'Scale',
+        };
+    }
+
+    public function priceFormatted(): string
+    {
+        return '$'.number_format($this->priceInCents() / 100, 0);
+    }
+
+    public function perCreditFormatted(): string
+    {
+        return '$'.number_format($this->priceInCents() / 100 / $this->credits(), 2);
+    }
+}

--- a/platform/app/Enums/CreditTransactionType.php
+++ b/platform/app/Enums/CreditTransactionType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum CreditTransactionType: string
+{
+    case InitialGrant = 'initial_grant';
+    case Purchase = 'purchase';
+    case Deduction = 'deduction';
+}

--- a/platform/app/Enums/ReviewRunStatus.php
+++ b/platform/app/Enums/ReviewRunStatus.php
@@ -8,4 +8,5 @@ enum ReviewRunStatus: string
     case Running = 'running';
     case Completed = 'completed';
     case Failed = 'failed';
+    case Skipped = 'skipped';
 }

--- a/platform/app/Exceptions/InsufficientCreditsException.php
+++ b/platform/app/Exceptions/InsufficientCreditsException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class InsufficientCreditsException extends RuntimeException
+{
+    public function __construct(int $organizationId)
+    {
+        parent::__construct("Organization {$organizationId} has insufficient credits to run a review.");
+    }
+}

--- a/platform/app/Jobs/ProcessPullRequestWebhook.php
+++ b/platform/app/Jobs/ProcessPullRequestWebhook.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\DataTransferObjects\ReviewJobPayload;
 use App\Enums\ReviewRunStatus;
 use App\Enums\ReviewRunType;
+use App\Models\Organization;
 use App\Models\Repository;
 use App\Models\ReviewRun;
 use App\Services\GitHubAppService;
@@ -61,8 +62,32 @@ class ProcessPullRequestWebhook implements ShouldQueue
         $repository->organization()
             ->update(['github_installation_id' => $installationId]);
 
+        $org = $repository->organization;
         $token = $gitHubApp->getInstallationToken($installationId);
 
+        $reviewRun = $this->findOrCreateReviewRun($repository, $fullName);
+
+        if (! $reviewRun) {
+            return;
+        }
+
+        if (! $reviewRun->github_check_run_id) {
+            $checkRunId = $checkService->createCheckRun($reviewRun, $token);
+
+            if ($checkRunId) {
+                $reviewRun->update(['github_check_run_id' => $checkRunId]);
+            }
+        }
+
+        if (! $this->hasCredits($org, $reviewRun, $checkService, $token)) {
+            return;
+        }
+
+        $this->dispatchToNats($repository, $reviewRun, $configService, $nats, $tokenService, $token);
+    }
+
+    private function findOrCreateReviewRun(Repository $repository, ?string $fullName): ?ReviewRun
+    {
         $pr = $this->payload['pull_request'];
         $headSha = $pr['head']['sha'];
         $prNumber = $pr['number'];
@@ -92,17 +117,52 @@ class ProcessPullRequestWebhook implements ShouldQueue
                 'status' => $reviewRun->status->value,
             ]);
 
-            return;
+            return null;
         }
 
-        if (! $reviewRun->github_check_run_id) {
-            $checkRunId = $checkService->createCheckRun($reviewRun, $token);
+        return $reviewRun;
+    }
 
-            if ($checkRunId) {
-                $reviewRun->update(['github_check_run_id' => $checkRunId]);
-            }
+    private function hasCredits(
+        Organization $org,
+        ReviewRun $reviewRun,
+        GitHubCheckService $checkService,
+        string $token,
+    ): bool {
+        if ($org->canRunReview()) {
+            return true;
         }
 
+        Log::info('Insufficient credits, skipping review', [
+            'repo' => $reviewRun->repository->full_name,
+            'pr' => $reviewRun->pr_number,
+            'organization_id' => $org->id,
+        ]);
+
+        $reviewRun->update(['status' => ReviewRunStatus::Skipped]);
+
+        if ($reviewRun->github_check_run_id) {
+            $checkService->completeCheckRun(
+                reviewRun: $reviewRun,
+                checkRunId: $reviewRun->github_check_run_id,
+                installationToken: $token,
+                conclusion: 'neutral',
+                title: 'No credits remaining',
+                summary: 'This review was skipped because your organization has no credits remaining. [Purchase credits](https://lien.dev/billing) to continue receiving AI-powered reviews.',
+            );
+        }
+
+        return false;
+    }
+
+    private function dispatchToNats(
+        Repository $repository,
+        ReviewRun $reviewRun,
+        RepoConfigService $configService,
+        NatsService $nats,
+        RunnerTokenService $tokenService,
+        string $token,
+    ): void {
         $config = $configService->getRunnerConfig($repository);
 
         $payload = ReviewJobPayload::fromWebhook(
@@ -118,8 +178,8 @@ class ProcessPullRequestWebhook implements ShouldQueue
         $nats->publish('reviews.pr', $payload->toArray());
 
         Log::info('Dispatched PR review to NATS', [
-            'repo' => $fullName,
-            'pr' => $prNumber,
+            'repo' => $repository->full_name,
+            'pr' => $reviewRun->pr_number,
             'review_run_id' => $reviewRun->id,
             'check_run_id' => $reviewRun->github_check_run_id,
         ]);

--- a/platform/app/Models/CreditTransaction.php
+++ b/platform/app/Models/CreditTransaction.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\CreditTransactionType;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CreditTransaction extends Model
+{
+    /** @use HasFactory<\Database\Factories\CreditTransactionFactory> */
+    use HasFactory;
+
+    const UPDATED_AT = null;
+
+    protected $fillable = [
+        'organization_id',
+        'type',
+        'amount',
+        'balance_after',
+        'description',
+        'review_run_id',
+        'stripe_payment_intent_id',
+        'created_by_user_id',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'type' => CreditTransactionType::class,
+            'amount' => 'integer',
+            'balance_after' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Organization, $this>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    /**
+     * @return BelongsTo<ReviewRun, $this>
+     */
+    public function reviewRun(): BelongsTo
+    {
+        return $this->belongsTo(ReviewRun::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+}

--- a/platform/app/Models/Organization.php
+++ b/platform/app/Models/Organization.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\BillingMode;
 use App\Enums\PlanTier;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -21,6 +22,12 @@ class Organization extends Model
         'slug',
         'avatar_url',
         'plan_tier',
+        'credit_balance',
+        'billing_mode',
+        'stripe_customer_id',
+        'stripe_subscription_id',
+        'byok_api_key',
+        'byok_provider',
         'settings',
     ];
 
@@ -31,6 +38,9 @@ class Organization extends Model
     {
         return [
             'plan_tier' => PlanTier::class,
+            'billing_mode' => BillingMode::class,
+            'credit_balance' => 'integer',
+            'byok_api_key' => 'encrypted',
             'settings' => 'array',
         ];
     }
@@ -51,5 +61,28 @@ class Organization extends Model
     public function repositories(): HasMany
     {
         return $this->hasMany(Repository::class);
+    }
+
+    /**
+     * @return HasMany<CreditTransaction, $this>
+     */
+    public function creditTransactions(): HasMany
+    {
+        return $this->hasMany(CreditTransaction::class);
+    }
+
+    public function hasCredits(): bool
+    {
+        return $this->credit_balance > 0;
+    }
+
+    public function isByok(): bool
+    {
+        return $this->billing_mode === BillingMode::Byok;
+    }
+
+    public function canRunReview(): bool
+    {
+        return $this->isByok() || $this->hasCredits();
     }
 }

--- a/platform/app/Services/CreditService.php
+++ b/platform/app/Services/CreditService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\CreditPackage;
+use App\Enums\CreditTransactionType;
+use App\Models\CreditTransaction;
+use App\Models\Organization;
+use App\Models\ReviewRun;
+use Illuminate\Support\Facades\DB;
+
+class CreditService
+{
+    public function grantInitialCredits(Organization $org): ?CreditTransaction
+    {
+        return DB::transaction(function () use ($org) {
+            $org = Organization::lockForUpdate()->find($org->id);
+
+            $alreadyGranted = CreditTransaction::query()
+                ->where('organization_id', $org->id)
+                ->where('type', CreditTransactionType::InitialGrant)
+                ->exists();
+
+            if ($alreadyGranted) {
+                return null;
+            }
+
+            $org->increment('credit_balance', 5);
+
+            return CreditTransaction::create([
+                'organization_id' => $org->id,
+                'type' => CreditTransactionType::InitialGrant,
+                'amount' => 5,
+                'balance_after' => $org->fresh()->credit_balance,
+                'description' => 'Welcome credits',
+            ]);
+        });
+    }
+
+    public function deductCredit(Organization $org, ReviewRun $reviewRun): CreditTransaction
+    {
+        return DB::transaction(function () use ($org, $reviewRun) {
+            $org = Organization::lockForUpdate()->find($org->id);
+
+            $alreadyDeducted = CreditTransaction::query()
+                ->where('organization_id', $org->id)
+                ->where('review_run_id', $reviewRun->id)
+                ->where('type', CreditTransactionType::Deduction)
+                ->exists();
+
+            if ($alreadyDeducted) {
+                return CreditTransaction::query()
+                    ->where('organization_id', $org->id)
+                    ->where('review_run_id', $reviewRun->id)
+                    ->where('type', CreditTransactionType::Deduction)
+                    ->first();
+            }
+
+            $org->decrement('credit_balance');
+
+            return CreditTransaction::create([
+                'organization_id' => $org->id,
+                'type' => CreditTransactionType::Deduction,
+                'amount' => -1,
+                'balance_after' => $org->fresh()->credit_balance,
+                'description' => "Review run #{$reviewRun->id}",
+                'review_run_id' => $reviewRun->id,
+            ]);
+        });
+    }
+
+    public function purchaseCredits(Organization $org, CreditPackage $package, string $stripePaymentIntentId): ?CreditTransaction
+    {
+        return DB::transaction(function () use ($org, $package, $stripePaymentIntentId) {
+            $org = Organization::lockForUpdate()->find($org->id);
+
+            $alreadyProcessed = CreditTransaction::query()
+                ->where('stripe_payment_intent_id', $stripePaymentIntentId)
+                ->exists();
+
+            if ($alreadyProcessed) {
+                return null;
+            }
+
+            $org->increment('credit_balance', $package->credits());
+
+            return CreditTransaction::create([
+                'organization_id' => $org->id,
+                'type' => CreditTransactionType::Purchase,
+                'amount' => $package->credits(),
+                'balance_after' => $org->fresh()->credit_balance,
+                'description' => "{$package->label()} pack ({$package->credits()} credits)",
+                'stripe_payment_intent_id' => $stripePaymentIntentId,
+            ]);
+        });
+    }
+}

--- a/platform/app/Services/GitHubCheckService.php
+++ b/platform/app/Services/GitHubCheckService.php
@@ -80,12 +80,46 @@ class GitHubCheckService
         }
     }
 
+    /**
+     * Complete a GitHub Check Run with a custom conclusion and output.
+     */
+    public function completeCheckRun(
+        ReviewRun $reviewRun,
+        int $checkRunId,
+        string $installationToken,
+        string $conclusion,
+        string $title,
+        string $summary,
+    ): void {
+        $repository = $reviewRun->repository;
+
+        $response = Http::withToken($installationToken)
+            ->acceptJson()
+            ->patch("https://api.github.com/repos/{$repository->full_name}/check-runs/{$checkRunId}", [
+                'status' => 'completed',
+                'conclusion' => $conclusion,
+                'completed_at' => now()->toIso8601String(),
+                'output' => [
+                    'title' => $title,
+                    'summary' => $summary,
+                ],
+            ]);
+
+        if (! $response->successful()) {
+            Log::warning('Failed to complete GitHub check run', [
+                'review_run_id' => $reviewRun->id,
+                'check_run_id' => $checkRunId,
+                'response' => $response->body(),
+            ]);
+        }
+    }
+
     private function mapStatus(ReviewRunStatus $status): string
     {
         return match ($status) {
             ReviewRunStatus::Pending => 'queued',
             ReviewRunStatus::Running => 'in_progress',
-            ReviewRunStatus::Completed, ReviewRunStatus::Failed => 'completed',
+            ReviewRunStatus::Completed, ReviewRunStatus::Failed, ReviewRunStatus::Skipped => 'completed',
         };
     }
 }

--- a/platform/app/Services/RepoConfigService.php
+++ b/platform/app/Services/RepoConfigService.php
@@ -2,7 +2,6 @@
 
 namespace App\Services;
 
-use App\Enums\PlanTier;
 use App\Models\Repository;
 
 class RepoConfigService
@@ -13,11 +12,12 @@ class RepoConfigService
     public function getMergedConfig(Repository $repository): array
     {
         $org = $repository->organization;
-        $planDefaults = $this->getPlanDefaults($org->plan_tier);
         $repoOverrides = $repository->review_config ?? [];
 
         return [
             'plan' => $org->plan_tier->value,
+            'billingMode' => $org->billing_mode->value,
+            'creditBalance' => $org->credit_balance,
             'reviewTypes' => [
                 'complexity' => [
                     'enabled' => data_get($repoOverrides, 'complexity.enabled', true),
@@ -25,19 +25,23 @@ class RepoConfigService
                     'deltaTracking' => data_get($repoOverrides, 'complexity.deltaTracking', true),
                 ],
                 'architectural' => [
-                    'enabled' => data_get($repoOverrides, 'architectural.enabled', $planDefaults['architectural_default']),
+                    'enabled' => data_get($repoOverrides, 'architectural.enabled', 'auto'),
                 ],
                 'summary' => [
                     'enabled' => data_get($repoOverrides, 'summary.enabled', true),
                 ],
                 'bugs' => [
-                    'enabled' => data_get($repoOverrides, 'bugs.enabled', $planDefaults['bugs_default'] ?? false),
+                    'enabled' => data_get($repoOverrides, 'bugs.enabled', true),
                 ],
             ],
             'complexityReviewsRemaining' => null,
-            'managedLlmReviewsRemaining' => $planDefaults['managed_llm_reviews'],
-            'llmSource' => $planDefaults['llm_source'],
-            'features' => $planDefaults['features'],
+            'managedLlmReviewsRemaining' => $org->isByok() ? null : $org->credit_balance,
+            'llmSource' => $org->isByok() ? 'byok' : 'managed',
+            'features' => [
+                'orgManagement' => true,
+                'customRules' => true,
+                'trendRetentionDays' => null,
+            ],
         ];
     }
 
@@ -48,11 +52,9 @@ class RepoConfigService
      */
     public function getRunnerConfig(Repository $repository): array
     {
-        $org = $repository->organization;
-        $planDefault = $this->getPlanDefaults($org->plan_tier)['architectural_default'];
         $overrides = $repository->review_config ?? [];
 
-        $rawArchMode = data_get($overrides, 'architectural.enabled', $planDefault);
+        $rawArchMode = data_get($overrides, 'architectural.enabled', 'auto');
         $architecturalMode = $rawArchMode === 'disabled' ? 'off' : $rawArchMode;
 
         return [
@@ -61,85 +63,10 @@ class RepoConfigService
                 'complexity' => (bool) data_get($overrides, 'complexity.enabled', true),
                 'architectural' => $architecturalMode !== 'off',
                 'summary' => (bool) data_get($overrides, 'summary.enabled', true),
-                'bugs' => (bool) data_get($overrides, 'bugs.enabled', $this->getPlanDefaults($org->plan_tier)['bugs_default'] ?? false),
+                'bugs' => (bool) data_get($overrides, 'bugs.enabled', true),
             ],
             'block_on_new_errors' => false,
             'architectural_mode' => $architecturalMode,
         ];
-    }
-
-    /**
-     * @return array{managed_llm_reviews: int|null, llm_source: string, architectural_default: string, features: array<string, mixed>}
-     */
-    private function getPlanDefaults(PlanTier $tier): array
-    {
-        return match ($tier) {
-            PlanTier::Free => [
-                'managed_llm_reviews' => 5,
-                'llm_source' => 'managed',
-                'architectural_default' => 'disabled',
-                'bugs_default' => false,
-                'features' => [
-                    'orgManagement' => false,
-                    'customRules' => false,
-                    'trendRetentionDays' => 30,
-                ],
-            ],
-            PlanTier::Solo => [
-                'managed_llm_reviews' => 25,
-                'llm_source' => 'managed',
-                'architectural_default' => 'auto',
-                'bugs_default' => false,
-                'features' => [
-                    'orgManagement' => false,
-                    'customRules' => false,
-                    'trendRetentionDays' => 90,
-                ],
-            ],
-            PlanTier::Team => [
-                'managed_llm_reviews' => 100,
-                'llm_source' => 'managed',
-                'architectural_default' => 'auto',
-                'bugs_default' => true,
-                'features' => [
-                    'orgManagement' => true,
-                    'customRules' => false,
-                    'trendRetentionDays' => 90,
-                ],
-            ],
-            PlanTier::Business => [
-                'managed_llm_reviews' => 200,
-                'llm_source' => 'managed',
-                'architectural_default' => 'auto',
-                'bugs_default' => true,
-                'features' => [
-                    'orgManagement' => true,
-                    'customRules' => true,
-                    'trendRetentionDays' => null,
-                ],
-            ],
-            PlanTier::BusinessPlus => [
-                'managed_llm_reviews' => 500,
-                'llm_source' => 'managed',
-                'architectural_default' => 'auto',
-                'bugs_default' => true,
-                'features' => [
-                    'orgManagement' => true,
-                    'customRules' => true,
-                    'trendRetentionDays' => null,
-                ],
-            ],
-            PlanTier::Enterprise => [
-                'managed_llm_reviews' => null,
-                'llm_source' => 'managed',
-                'architectural_default' => 'auto',
-                'bugs_default' => true,
-                'features' => [
-                    'orgManagement' => true,
-                    'customRules' => true,
-                    'trendRetentionDays' => null,
-                ],
-            ],
-        };
     }
 }

--- a/platform/app/Services/ReviewRunService.php
+++ b/platform/app/Services/ReviewRunService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\BillingMode;
 use App\Enums\CommentResolution;
 use App\Enums\ReviewRunStatus;
 use App\Enums\ReviewRunType;
@@ -185,6 +186,21 @@ class ReviewRunService
 
         $reviewRun->update($updates);
 
+        if ($status === ReviewRunStatus::Completed) {
+            $this->deductCreditOnCompletion($reviewRun);
+        }
+
         return $reviewRun;
+    }
+
+    private function deductCreditOnCompletion(ReviewRun $reviewRun): void
+    {
+        $org = $reviewRun->repository->organization;
+
+        if ($org->billing_mode === BillingMode::Byok) {
+            return;
+        }
+
+        app(CreditService::class)->deductCredit($org, $reviewRun);
     }
 }

--- a/platform/database/factories/CreditTransactionFactory.php
+++ b/platform/database/factories/CreditTransactionFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CreditTransactionType;
+use App\Models\CreditTransaction;
+use App\Models\Organization;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CreditTransaction>
+ */
+class CreditTransactionFactory extends Factory
+{
+    protected $model = CreditTransaction::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organization_id' => Organization::factory(),
+            'type' => CreditTransactionType::Purchase,
+            'amount' => 100,
+            'balance_after' => 100,
+            'description' => null,
+            'review_run_id' => null,
+            'stripe_payment_intent_id' => null,
+            'created_by_user_id' => null,
+        ];
+    }
+
+    public function initialGrant(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => CreditTransactionType::InitialGrant,
+            'amount' => 5,
+            'balance_after' => 5,
+            'description' => 'Welcome credits',
+        ]);
+    }
+
+    public function purchase(int $amount = 100): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => CreditTransactionType::Purchase,
+            'amount' => $amount,
+            'stripe_payment_intent_id' => 'pi_'.fake()->unique()->regexify('[a-zA-Z0-9]{24}'),
+        ]);
+    }
+
+    public function deduction(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => CreditTransactionType::Deduction,
+            'amount' => -1,
+            'description' => 'Review run',
+        ]);
+    }
+}

--- a/platform/database/factories/OrganizationFactory.php
+++ b/platform/database/factories/OrganizationFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\BillingMode;
 use App\Enums\PlanTier;
 use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -52,6 +53,23 @@ class OrganizationFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'plan_tier' => PlanTier::Enterprise,
+        ]);
+    }
+
+    public function withCredits(int $amount = 5): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'credit_balance' => $amount,
+            'billing_mode' => BillingMode::Credits,
+        ]);
+    }
+
+    public function byok(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'billing_mode' => BillingMode::Byok,
+            'byok_provider' => 'openrouter',
+            'byok_api_key' => 'sk-test-byok-key-'.fake()->regexify('[a-zA-Z0-9]{24}'),
         ]);
     }
 }

--- a/platform/database/migrations/2026_03_27_000001_add_billing_fields_to_organizations_table.php
+++ b/platform/database/migrations/2026_03_27_000001_add_billing_fields_to_organizations_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->unsignedInteger('credit_balance')->default(0)->after('plan_tier');
+            $table->string('billing_mode')->default('credits')->after('credit_balance');
+            $table->string('stripe_customer_id')->nullable()->unique()->after('billing_mode');
+            $table->string('stripe_subscription_id')->nullable()->after('stripe_customer_id');
+            $table->text('byok_api_key')->nullable()->after('stripe_subscription_id');
+            $table->string('byok_provider')->nullable()->after('byok_api_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropUnique(['stripe_customer_id']);
+            $table->dropColumn([
+                'credit_balance',
+                'billing_mode',
+                'stripe_customer_id',
+                'stripe_subscription_id',
+                'byok_api_key',
+                'byok_provider',
+            ]);
+        });
+    }
+};

--- a/platform/database/migrations/2026_03_27_000002_create_credit_transactions_table.php
+++ b/platform/database/migrations/2026_03_27_000002_create_credit_transactions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('credit_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->integer('amount');
+            $table->integer('balance_after');
+            $table->string('description')->nullable();
+            $table->foreignId('review_run_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('stripe_payment_intent_id')->nullable();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('created_at');
+
+            $table->index(['organization_id', 'created_at']);
+            $table->index('review_run_id');
+            $table->index('stripe_payment_intent_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('credit_transactions');
+    }
+};

--- a/platform/database/migrations/2026_03_27_000003_backfill_billing_mode_and_credits.php
+++ b/platform/database/migrations/2026_03_27_000003_backfill_billing_mode_and_credits.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('organizations')
+            ->whereNull('billing_mode')
+            ->orWhere('billing_mode', '')
+            ->update(['billing_mode' => 'credits']);
+
+        $orgs = DB::table('organizations')
+            ->where('credit_balance', 0)
+            ->get(['id']);
+
+        foreach ($orgs as $org) {
+            $alreadyGranted = DB::table('credit_transactions')
+                ->where('organization_id', $org->id)
+                ->where('type', 'initial_grant')
+                ->exists();
+
+            if (! $alreadyGranted) {
+                DB::table('organizations')
+                    ->where('id', $org->id)
+                    ->update(['credit_balance' => 5]);
+
+                DB::table('credit_transactions')->insert([
+                    'organization_id' => $org->id,
+                    'type' => 'initial_grant',
+                    'amount' => 5,
+                    'balance_after' => 5,
+                    'description' => 'Welcome credits',
+                    'created_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('credit_transactions')
+            ->where('type', 'initial_grant')
+            ->where('description', 'Welcome credits')
+            ->delete();
+
+        DB::table('organizations')->update(['credit_balance' => 0]);
+    }
+};

--- a/platform/database/migrations/2026_03_27_000004_allow_negative_credit_balance.php
+++ b/platform/database/migrations/2026_03_27_000004_allow_negative_credit_balance.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->integer('credit_balance')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->unsignedInteger('credit_balance')->default(0)->change();
+        });
+    }
+};

--- a/platform/tests/Feature/Api/V1/RepoConfigTest.php
+++ b/platform/tests/Feature/Api/V1/RepoConfigTest.php
@@ -21,7 +21,7 @@ class RepoConfigTest extends TestCase
 
     public function test_get_repo_config(): void
     {
-        $org = Organization::factory()->team()->create();
+        $org = Organization::factory()->team()->withCredits(100)->create();
         $repo = Repository::factory()->create(['organization_id' => $org->id]);
 
         $response = $this->getJson(
@@ -32,6 +32,8 @@ class RepoConfigTest extends TestCase
         $response->assertOk();
         $response->assertJsonStructure([
             'plan',
+            'billingMode',
+            'creditBalance',
             'reviewTypes' => [
                 'complexity' => ['enabled', 'threshold', 'deltaTracking'],
                 'architectural' => ['enabled'],
@@ -41,7 +43,12 @@ class RepoConfigTest extends TestCase
             'llmSource',
             'features' => ['orgManagement', 'customRules', 'trendRetentionDays'],
         ]);
-        $response->assertJson(['plan' => 'team', 'managedLlmReviewsRemaining' => 100]);
+        $response->assertJson([
+            'plan' => 'team',
+            'billingMode' => 'credits',
+            'creditBalance' => 100,
+            'managedLlmReviewsRemaining' => 100,
+        ]);
     }
 
     public function test_get_repo_config_with_overrides(): void

--- a/platform/tests/Feature/Api/Webhooks/ProcessPullRequestWebhookTest.php
+++ b/platform/tests/Feature/Api/Webhooks/ProcessPullRequestWebhookTest.php
@@ -10,6 +10,7 @@ use App\Models\ReviewRun;
 use App\Services\GitHubAppService;
 use App\Services\GitHubCheckService;
 use App\Services\NatsService;
+use App\Services\RepoConfigService;
 use App\Services\RunnerTokenService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -26,12 +27,13 @@ class ProcessPullRequestWebhookTest extends TestCase
         config(['services.lien.service_token' => 'test-signing-key-that-is-at-least-32-bytes-long']);
         Http::fake([
             'api.github.com/repos/*/check-runs' => Http::response(['id' => 99999], 201),
+            'api.github.com/repos/*/check-runs/*' => Http::response([], 200),
         ]);
     }
 
     public function test_happy_path_publishes_to_nats(): void
     {
-        $org = Organization::factory()->create(['login' => 'test-org']);
+        $org = Organization::factory()->withCredits(10)->create(['login' => 'test-org']);
         $repo = Repository::factory()->create([
             'organization_id' => $org->id,
             'full_name' => 'test-org/test-repo',
@@ -67,20 +69,17 @@ class ProcessPullRequestWebhookTest extends TestCase
                 });
         });
 
-        $job = new ProcessPullRequestWebhook($this->webhookPayload());
-        $job->handle(
-            app(GitHubAppService::class),
-            app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
-            app(NatsService::class),
-            app(RunnerTokenService::class),
-        );
+        $this->dispatchJob($this->webhookPayload());
 
         $this->assertDatabaseHas('review_runs', [
             'repository_id' => $repo->id,
             'pr_number' => 42,
             'status' => 'pending',
         ]);
+
+        // Credits are NOT deducted at dispatch — only on completion
+        $org->refresh();
+        $this->assertEquals(10, $org->credit_balance);
     }
 
     public function test_ignores_unknown_repo(): void
@@ -89,19 +88,12 @@ class ProcessPullRequestWebhookTest extends TestCase
             $mock->shouldNotReceive('publish');
         });
 
-        $job = new ProcessPullRequestWebhook($this->webhookPayload());
-        $job->handle(
-            app(GitHubAppService::class),
-            app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
-            app(NatsService::class),
-            app(RunnerTokenService::class),
-        );
+        $this->dispatchJob($this->webhookPayload());
     }
 
     public function test_ignores_inactive_repo(): void
     {
-        $org = Organization::factory()->create(['login' => 'test-org']);
+        $org = Organization::factory()->withCredits(5)->create(['login' => 'test-org']);
         Repository::factory()->create([
             'organization_id' => $org->id,
             'full_name' => 'test-org/test-repo',
@@ -112,19 +104,12 @@ class ProcessPullRequestWebhookTest extends TestCase
             $mock->shouldNotReceive('publish');
         });
 
-        $job = new ProcessPullRequestWebhook($this->webhookPayload());
-        $job->handle(
-            app(GitHubAppService::class),
-            app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
-            app(NatsService::class),
-            app(RunnerTokenService::class),
-        );
+        $this->dispatchJob($this->webhookPayload());
     }
 
     public function test_stores_installation_id_on_organization(): void
     {
-        $org = Organization::factory()->create([
+        $org = Organization::factory()->withCredits(5)->create([
             'login' => 'test-org',
             'github_installation_id' => null,
         ]);
@@ -142,14 +127,7 @@ class ProcessPullRequestWebhookTest extends TestCase
             $mock->shouldReceive('publish')->once();
         });
 
-        $job = new ProcessPullRequestWebhook($this->webhookPayload());
-        $job->handle(
-            app(GitHubAppService::class),
-            app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
-            app(NatsService::class),
-            app(RunnerTokenService::class),
-        );
+        $this->dispatchJob($this->webhookPayload());
 
         $this->assertDatabaseHas('organizations', [
             'id' => $org->id,
@@ -159,7 +137,7 @@ class ProcessPullRequestWebhookTest extends TestCase
 
     public function test_overwrites_existing_installation_id(): void
     {
-        $org = Organization::factory()->create([
+        $org = Organization::factory()->withCredits(5)->create([
             'login' => 'test-org',
             'github_installation_id' => 11111,
         ]);
@@ -177,14 +155,7 @@ class ProcessPullRequestWebhookTest extends TestCase
             $mock->shouldReceive('publish')->once();
         });
 
-        $job = new ProcessPullRequestWebhook($this->webhookPayload());
-        $job->handle(
-            app(GitHubAppService::class),
-            app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
-            app(NatsService::class),
-            app(RunnerTokenService::class),
-        );
+        $this->dispatchJob($this->webhookPayload());
 
         $this->assertDatabaseHas('organizations', [
             'id' => $org->id,
@@ -194,7 +165,7 @@ class ProcessPullRequestWebhookTest extends TestCase
 
     public function test_skips_duplicate_dispatch_for_existing_review_run(): void
     {
-        $org = Organization::factory()->create(['login' => 'test-org']);
+        $org = Organization::factory()->withCredits(5)->create(['login' => 'test-org']);
         $repo = Repository::factory()->create([
             'organization_id' => $org->id,
             'full_name' => 'test-org/test-repo',
@@ -215,14 +186,7 @@ class ProcessPullRequestWebhookTest extends TestCase
             $mock->shouldNotReceive('publish');
         });
 
-        $job = new ProcessPullRequestWebhook($this->webhookPayload());
-        $job->handle(
-            app(GitHubAppService::class),
-            app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
-            app(NatsService::class),
-            app(RunnerTokenService::class),
-        );
+        $this->dispatchJob($this->webhookPayload());
 
         $existingRun->refresh();
         $this->assertEquals(ReviewRunStatus::Running, $existingRun->status);
@@ -230,7 +194,7 @@ class ProcessPullRequestWebhookTest extends TestCase
 
     public function test_skips_processing_when_installation_id_missing(): void
     {
-        $org = Organization::factory()->create(['login' => 'test-org']);
+        $org = Organization::factory()->withCredits(5)->create(['login' => 'test-org']);
         Repository::factory()->create([
             'organization_id' => $org->id,
             'full_name' => 'test-org/test-repo',
@@ -244,11 +208,67 @@ class ProcessPullRequestWebhookTest extends TestCase
         $payload = $this->webhookPayload();
         unset($payload['installation']);
 
+        $this->dispatchJob($payload);
+    }
+
+    public function test_skips_review_on_zero_credits(): void
+    {
+        $org = Organization::factory()->withCredits(0)->create(['login' => 'test-org']);
+        $repo = Repository::factory()->create([
+            'organization_id' => $org->id,
+            'full_name' => 'test-org/test-repo',
+            'is_active' => true,
+        ]);
+
+        $this->mock(GitHubAppService::class, function (MockInterface $mock) {
+            $mock->shouldReceive('getInstallationToken')->andReturn('ghs_test_token');
+        });
+
+        $this->mock(NatsService::class, function (MockInterface $mock) {
+            $mock->shouldNotReceive('publish');
+        });
+
+        $this->dispatchJob($this->webhookPayload());
+
+        $this->assertDatabaseHas('review_runs', [
+            'repository_id' => $repo->id,
+            'pr_number' => 42,
+            'status' => 'skipped',
+        ]);
+    }
+
+    public function test_byok_org_dispatches_with_zero_credits(): void
+    {
+        $org = Organization::factory()->withCredits(0)->byok()->create(['login' => 'test-org']);
+        Repository::factory()->create([
+            'organization_id' => $org->id,
+            'full_name' => 'test-org/test-repo',
+            'is_active' => true,
+        ]);
+
+        $this->mock(GitHubAppService::class, function (MockInterface $mock) {
+            $mock->shouldReceive('getInstallationToken')->andReturn('ghs_test_token');
+        });
+
+        $this->mock(NatsService::class, function (MockInterface $mock) {
+            $mock->shouldReceive('publish')->once();
+        });
+
+        $this->dispatchJob($this->webhookPayload());
+
+        $this->assertDatabaseHas('review_runs', [
+            'pr_number' => 42,
+            'status' => 'pending',
+        ]);
+    }
+
+    private function dispatchJob(array $payload): void
+    {
         $job = new ProcessPullRequestWebhook($payload);
         $job->handle(
             app(GitHubAppService::class),
             app(GitHubCheckService::class),
-            app(\App\Services\RepoConfigService::class),
+            app(RepoConfigService::class),
             app(NatsService::class),
             app(RunnerTokenService::class),
         );

--- a/platform/tests/Feature/Services/ReviewRunServiceTest.php
+++ b/platform/tests/Feature/Services/ReviewRunServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Services;
 use App\Enums\CommentResolution;
 use App\Enums\ReviewRunStatus;
 use App\Enums\ReviewRunType;
+use App\Models\Organization;
 use App\Models\Repository;
 use App\Models\ReviewComment;
 use App\Models\ReviewRun;
@@ -512,6 +513,58 @@ class ReviewRunServiceTest extends TestCase
         $expected = hash('sha256', 'bugs:src/a.ts:funcA:null_check');
 
         $this->assertEquals($expected, $comment->fingerprint);
+    }
+
+    public function test_deducts_credit_on_completion(): void
+    {
+        $org = Organization::factory()->withCredits(10)->create();
+        $repo = Repository::factory()->create(['organization_id' => $org->id]);
+        $run = ReviewRun::factory()->running()->create(['repository_id' => $repo->id]);
+
+        $this->service->updateStatus($run, ReviewRunStatus::Completed);
+
+        $org->refresh();
+        $this->assertEquals(9, $org->credit_balance);
+
+        $this->assertDatabaseHas('credit_transactions', [
+            'organization_id' => $org->id,
+            'review_run_id' => $run->id,
+            'type' => 'deduction',
+            'amount' => -1,
+        ]);
+    }
+
+    public function test_does_not_deduct_credit_on_failure(): void
+    {
+        $org = Organization::factory()->withCredits(10)->create();
+        $repo = Repository::factory()->create(['organization_id' => $org->id]);
+        $run = ReviewRun::factory()->running()->create(['repository_id' => $repo->id]);
+
+        $this->service->updateStatus($run, ReviewRunStatus::Failed);
+
+        $org->refresh();
+        $this->assertEquals(10, $org->credit_balance);
+
+        $this->assertDatabaseMissing('credit_transactions', [
+            'organization_id' => $org->id,
+            'review_run_id' => $run->id,
+        ]);
+    }
+
+    public function test_does_not_deduct_credit_for_byok_org(): void
+    {
+        $org = Organization::factory()->withCredits(0)->byok()->create();
+        $repo = Repository::factory()->create(['organization_id' => $org->id]);
+        $run = ReviewRun::factory()->running()->create(['repository_id' => $repo->id]);
+
+        $this->service->updateStatus($run, ReviewRunStatus::Completed);
+
+        $org->refresh();
+        $this->assertEquals(0, $org->credit_balance);
+
+        $this->assertDatabaseMissing('credit_transactions', [
+            'organization_id' => $org->id,
+        ]);
     }
 
     /**

--- a/platform/tests/Unit/Services/CreditServiceTest.php
+++ b/platform/tests/Unit/Services/CreditServiceTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Enums\CreditPackage;
+use App\Enums\CreditTransactionType;
+use App\Models\CreditTransaction;
+use App\Models\Organization;
+use App\Models\Repository;
+use App\Models\ReviewRun;
+use App\Services\CreditService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CreditServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CreditService $creditService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->creditService = new CreditService;
+    }
+
+    public function test_grants_initial_credits_to_new_org(): void
+    {
+        $org = Organization::factory()->withCredits(0)->create();
+
+        $tx = $this->creditService->grantInitialCredits($org);
+
+        $this->assertNotNull($tx);
+        $this->assertEquals(CreditTransactionType::InitialGrant, $tx->type);
+        $this->assertEquals(5, $tx->amount);
+        $this->assertEquals(5, $tx->balance_after);
+
+        $org->refresh();
+        $this->assertEquals(5, $org->credit_balance);
+    }
+
+    public function test_initial_grant_is_idempotent(): void
+    {
+        $org = Organization::factory()->withCredits(0)->create();
+
+        $tx1 = $this->creditService->grantInitialCredits($org);
+        $tx2 = $this->creditService->grantInitialCredits($org);
+
+        $this->assertNotNull($tx1);
+        $this->assertNull($tx2);
+
+        $org->refresh();
+        $this->assertEquals(5, $org->credit_balance);
+
+        $this->assertEquals(1, CreditTransaction::where('organization_id', $org->id)
+            ->where('type', CreditTransactionType::InitialGrant)
+            ->count());
+    }
+
+    public function test_deducts_credit_and_records_transaction(): void
+    {
+        $org = Organization::factory()->withCredits(10)->create();
+        $repo = Repository::factory()->create(['organization_id' => $org->id]);
+        $run = ReviewRun::factory()->create(['repository_id' => $repo->id]);
+
+        $tx = $this->creditService->deductCredit($org, $run);
+
+        $this->assertEquals(CreditTransactionType::Deduction, $tx->type);
+        $this->assertEquals(-1, $tx->amount);
+        $this->assertEquals(9, $tx->balance_after);
+        $this->assertEquals($run->id, $tx->review_run_id);
+
+        $org->refresh();
+        $this->assertEquals(9, $org->credit_balance);
+    }
+
+    public function test_deduction_allows_negative_balance(): void
+    {
+        $org = Organization::factory()->withCredits(0)->create();
+        $repo = Repository::factory()->create(['organization_id' => $org->id]);
+        $run = ReviewRun::factory()->create(['repository_id' => $repo->id]);
+
+        $tx = $this->creditService->deductCredit($org, $run);
+
+        $this->assertEquals(-1, $tx->amount);
+        $this->assertEquals(-1, $tx->balance_after);
+
+        $org->refresh();
+        $this->assertEquals(-1, $org->credit_balance);
+    }
+
+    public function test_deduction_is_idempotent_per_review_run(): void
+    {
+        $org = Organization::factory()->withCredits(10)->create();
+        $repo = Repository::factory()->create(['organization_id' => $org->id]);
+        $run = ReviewRun::factory()->create(['repository_id' => $repo->id]);
+
+        $tx1 = $this->creditService->deductCredit($org, $run);
+        $tx2 = $this->creditService->deductCredit($org, $run);
+
+        $this->assertEquals($tx1->id, $tx2->id);
+
+        $org->refresh();
+        $this->assertEquals(9, $org->credit_balance);
+
+        $this->assertEquals(1, CreditTransaction::where('organization_id', $org->id)
+            ->where('review_run_id', $run->id)
+            ->where('type', CreditTransactionType::Deduction)
+            ->count());
+    }
+
+    public function test_purchase_increments_balance_and_records_transaction(): void
+    {
+        $org = Organization::factory()->withCredits(5)->create();
+
+        $tx = $this->creditService->purchaseCredits(
+            $org,
+            CreditPackage::Starter,
+            'pi_test_abc123',
+        );
+
+        $this->assertNotNull($tx);
+        $this->assertEquals(CreditTransactionType::Purchase, $tx->type);
+        $this->assertEquals(100, $tx->amount);
+        $this->assertEquals(105, $tx->balance_after);
+        $this->assertEquals('pi_test_abc123', $tx->stripe_payment_intent_id);
+
+        $org->refresh();
+        $this->assertEquals(105, $org->credit_balance);
+    }
+
+    public function test_purchase_is_idempotent_on_stripe_payment_intent(): void
+    {
+        $org = Organization::factory()->withCredits(5)->create();
+
+        $tx1 = $this->creditService->purchaseCredits(
+            $org,
+            CreditPackage::Starter,
+            'pi_test_duplicate',
+        );
+        $tx2 = $this->creditService->purchaseCredits(
+            $org,
+            CreditPackage::Starter,
+            'pi_test_duplicate',
+        );
+
+        $this->assertNotNull($tx1);
+        $this->assertNull($tx2);
+
+        $org->refresh();
+        $this->assertEquals(105, $org->credit_balance);
+    }
+
+    public function test_purchase_growth_pack(): void
+    {
+        $org = Organization::factory()->withCredits(0)->create();
+
+        $tx = $this->creditService->purchaseCredits(
+            $org,
+            CreditPackage::Growth,
+            'pi_test_growth',
+        );
+
+        $this->assertEquals(500, $tx->amount);
+        $this->assertEquals(500, $tx->balance_after);
+
+        $org->refresh();
+        $this->assertEquals(500, $org->credit_balance);
+    }
+
+    public function test_purchase_scale_pack(): void
+    {
+        $org = Organization::factory()->withCredits(0)->create();
+
+        $tx = $this->creditService->purchaseCredits(
+            $org,
+            CreditPackage::Scale,
+            'pi_test_scale',
+        );
+
+        $this->assertEquals(2000, $tx->amount);
+        $this->assertEquals(2000, $tx->balance_after);
+
+        $org->refresh();
+        $this->assertEquals(2000, $org->credit_balance);
+    }
+
+    public function test_purchase_recovers_negative_balance(): void
+    {
+        $org = Organization::factory()->withCredits(-3)->create();
+
+        $tx = $this->creditService->purchaseCredits(
+            $org,
+            CreditPackage::Starter,
+            'pi_test_recovery',
+        );
+
+        $this->assertEquals(100, $tx->amount);
+        $this->assertEquals(97, $tx->balance_after);
+
+        $org->refresh();
+        $this->assertEquals(97, $org->credit_balance);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a credit-based billing system for Lien Review monetization. 1 credit = 1 completed review run. Credits are deducted on completion, not dispatch — users are never charged for failed runs.

**Billing model:**
| Package | Credits | Price |
|---------|---------|-------|
| Free | 5 | $0 (on signup) |
| Starter | 100 | $5 |
| Growth | 500 | $20 |
| Scale | 2,000 | $60 |
| BYOK | Unlimited | $10/mo |

**How it works:**
- **Dispatch**: soft gate via `canRunReview()` — blocks if balance <= 0 (BYOK always passes)
- **Completion**: `CreditService::deductCredit()` when `ReviewRunService` transitions status to `Completed`
- **Concurrent runs**: balance can go negative, recovers on next credit purchase
- **All features unlocked** for all users — no tier-based feature gating, you pay for quantity not capability

**Key design decisions:**
- `lockForUpdate` on org row with idempotency checks *inside* the lock to prevent TOCTOU races
- `deductCredit` is idempotent per review run (safe for job retries)
- No refund concept — a run is a run, even trivial PRs still get a summary
- `InsufficientCreditsException` kept for the dispatch soft-gate check run message

### New files
- 3 enums: `BillingMode`, `CreditTransactionType`, `CreditPackage`
- `CreditTransaction` model + factory
- `CreditService` (grant/deduct/purchase, all idempotent)
- `InsufficientCreditsException`
- 4 database migrations
- `CreditServiceTest` (11 unit tests)

### Modified files
- `Organization`: billing fields, encrypted BYOK key, `hasCredits()`, `isByok()`, `canRunReview()`
- `ProcessPullRequestWebhook`: credit soft-gate at dispatch
- `ReviewRunService`: credit deduction on completion, BYOK bypass
- `GitHubCheckService`: `completeCheckRun()` for skip scenario
- `RepoConfigService`: uniform defaults, `creditBalance`/`billingMode` in config

## Test plan
- [x] 221 tests pass (1170 assertions)
- [x] Pint code style passes
- [ ] Run `php artisan migrate` on staging
- [ ] Verify backfill grants 5 welcome credits to existing orgs
- [ ] Trigger PR → verify run dispatches without deduction
- [ ] Complete run → verify credit deducted
- [ ] Failed run → verify no deduction
- [ ] Set balance to 0 → verify next PR is skipped with neutral check run
- [ ] BYOK org → verify runs dispatch and complete without any credit activity

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** This PR reduces complexity by 74.

> [!WARNING]
> **1 issue found** · High Risk
>
> This PR introduces a credit-based billing system, allowing organizations to consume credits for review runs or use their own API keys (BYOK). It includes new enums, models, a CreditService for managing transactions, and updates to existing services to integrate credit checks and deductions. The core credit management and idempotency logic in `CreditService` appears robust, utilizing `lockForUpdate` and idempotency checks effectively. However, a significant change in `RepoConfigService` alters the default enablement of 'architectural' and 'bugs' review types. This change will cause these features to be enabled by default for organizations on lower plan tiers that previously had them disabled, leading to unexpected credit deductions for existing users. This is a high-risk breaking change in user experience and billing behavior.
>
> - Introduced credit-based billing with `CreditService` for managing transactions.
> - Implemented soft-gating for review runs based on credit balance or BYOK status.
> - Added `Skipped` status for review runs when credits are insufficient.
> - Changed default enablement of 'architectural' and 'bugs' review types in `RepoConfigService`, potentially leading to unexpected credit consumption for existing users.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2fc8e7d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credit-based billing system with two modes: Credits and BYOK (Bring Your Own Key)
  * Introduced credit packages (Starter, Growth, Scale) available for purchase
  * Organizations receive 5 starter credits; reviews cost 1 credit each
  * Reviews automatically skip if insufficient credits in Credits billing mode
  * BYOK organizations bypass credit requirements for unlimited reviews
  * API responses now include billing mode and credit balance information

* **Tests**
  * Added comprehensive test coverage for credit lifecycle and billing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->