### PR TITLE
feat(mcp): add server instructions for LLM guidance

### DIFF
--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -1,0 +1,36 @@
+/**
+ * MCP server instructions returned on `initialize`.
+ *
+ * Every connecting MCP client receives this string as always-on guidance
+ * for how to use Lien's tools. Keep it tight — it travels with every turn.
+ */
+export const SERVER_INSTRUCTIONS = `Lien provides semantic code search and dependency analysis over this codebase.
+Use Lien tools proactively — they complement grep/glob rather than replace each
+other. Prefer Lien for meaning-based queries and structural impact; use grep
+only for exact literals (error strings, config keys, TODOs).
+
+REQUIRED before Edit/Write on any file:
+  get_files_context({ filepaths }) — returns imports, callSites, and test
+  associations. Batch form: { filepaths: [...] } for multi-file edits.
+  Always check testAssociations and run those tests after changes.
+
+REQUIRED before renaming, removing, or changing the signature of any exported
+symbol:
+  get_dependents({ filepath, symbol }) — check dependentCount and riskLevel.
+  If riskLevel is "high" or "critical", list affected dependents to the user
+  before editing.
+
+For discovery ("where is X?", "how does Y work?"), call semantic_search FIRST.
+Phrase queries as full questions ("How does the code handle auth?") — natural
+questions score ~2x higher than keyword phrases.
+
+Tool selection:
+  semantic_search   — discovery by meaning
+  list_functions    — by-name/pattern lookup; 10x faster for structural queries
+  find_similar      — before adding new code, check for existing patterns
+  get_complexity    — before refactoring; identify real hotspots
+  get_files_context — before editing (MANDATORY)
+  get_dependents    — before symbol changes (MANDATORY)
+
+Batch when possible — batched calls are materially cheaper than sequential
+singletons.`;

--- a/packages/cli/src/mcp/server-config.test.ts
+++ b/packages/cli/src/mcp/server-config.test.ts
@@ -25,6 +25,15 @@ describe('createMCPServerConfig', () => {
     expect(config.name).toBe('custom-server');
     expect(config.version).toBe('2.5.3-beta');
   });
+
+  it('should include instructions text for LLM guidance', () => {
+    const config = createMCPServerConfig('lien', '1.0.0');
+    expect(config.instructions).toBeDefined();
+    expect(typeof config.instructions).toBe('string');
+    expect(config.instructions.length).toBeGreaterThan(0);
+    expect(config.instructions).toContain('get_files_context');
+    expect(config.instructions).toContain('get_dependents');
+  });
 });
 
 describe('registerMCPHandlers', () => {

--- a/packages/cli/src/mcp/server-config.ts
+++ b/packages/cli/src/mcp/server-config.ts
@@ -2,6 +2,7 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { tools } from './tools.js';
 import { toolHandlers } from './handlers/index.js';
+import { SERVER_INSTRUCTIONS } from './instructions.js';
 import type { ToolContext, LogFn } from './types.js';
 import { LienError, LienErrorCode } from '@liendev/core';
 
@@ -11,6 +12,7 @@ import { LienError, LienErrorCode } from '@liendev/core';
 export interface MCPServerConfig {
   name: string;
   version: string;
+  instructions: string;
   capabilities: {
     tools: Record<string, unknown>;
     logging?: Record<string, unknown>;
@@ -24,6 +26,7 @@ export function createMCPServerConfig(name: string, version: string): MCPServerC
   return {
     name,
     version,
+    instructions: SERVER_INSTRUCTIONS,
     capabilities: {
       tools: {},
       logging: {},

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -261,7 +261,10 @@ function createMCPServer(): Server {
   const serverConfig = createMCPServerConfig('lien', packageJson.version);
   return new Server(
     { name: serverConfig.name, version: serverConfig.version },
-    { capabilities: serverConfig.capabilities },
+    {
+      capabilities: serverConfig.capabilities,
+      instructions: serverConfig.instructions,
+    },
   );
 }
 


### PR DESCRIPTION
## Summary

- Attaches an always-on `instructions` string to the MCP server so every connecting client receives Lien's workflow guidance on the `initialize` response — no user action (slash command, skill, etc.) required.
- Moves the "call `get_files_context` before Edit" and "call `get_dependents` before symbol changes" rules from CLAUDE.md (agent-visible only) into a portable surface every MCP client sees (Claude Code, Cursor, Windsurf, Zed, etc.).
- New `packages/cli/src/mcp/instructions.ts` keeps the copy diff-reviewable independently from the plumbing.

## Why

CLAUDE.md rules only reach agents that happen to read that file. MCP server instructions fire on every connection and are part of the protocol — this is the highest-leverage place to put always-on guidance for Lien's tools. User-invoked slash commands and MCP prompts have poor adoption; server instructions don't require the user to remember anything.

## Test plan

- [x] `npm run format:check` — passes
- [x] `npm run lint` — 0 errors (pre-existing warnings untouched)
- [x] `npm run typecheck` — 0 errors across all packages
- [x] `npm run build` — succeeds
- [x] `npm test` — 20/20 pass on `server.test.ts` + `server-config.test.ts`, including new assertion that `instructions` is populated and names the mandatory tools
- [x] Manual verification: reconnected local MCP server; Claude Code surfaced the full instructions string under `## lien` in the initialize system reminder

## Follow-ups worth considering (not in this PR)

- Audit tool descriptions in `tools.ts` to add cross-tool workflow hints (e.g. `get_dependents` could recommend `get_files_context` in the same turn if the caller will also edit)
- Ship an optional hooks template (`lien install --with-hooks`) for Claude Code users who want hard enforcement of the mandatory rules on top of the advisory instructions

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR introduces a new constant `SERVER_INSTRUCTIONS` which provides guidance for LLMs on how to use Lien's tools. This instruction string is integrated into the MCP server configuration and passed to the Model Context Protocol (MCP) server during initialization. A new test case has been added to verify that the instructions are correctly populated and contain the expected mandatory tool mentions. The changes are well-contained and primarily involve adding a new configuration field and its value.
>
> - Added `packages/cli/src/mcp/instructions.ts` exporting `SERVER_INSTRUCTIONS`.
> - Modified `packages/cli/src/mcp/server-config.ts` to include `instructions` in `MCPServerConfig` and populate it.
> - Modified `packages/cli/src/mcp/server.ts` to pass the `instructions` to the MCP `Server` constructor.
> - Added a test in `packages/cli/src/mcp/server-config.test.ts` to verify the presence and content of the instructions.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5d035ec. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server now includes comprehensive built-in guidance for AI clients, covering tool usage best practices, required safety checks before modifications, dependency analysis, and efficient batch operation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->