### PR TITLE
feat(core): add blast-radius risk scoring helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,13 @@ export type { GitState } from './git/tracker.js';
 // Use detectEcosystems() and getEcosystemExcludePatterns() instead.
 
 // =============================================================================
+// RISK ANALYSIS
+// =============================================================================
+
+export { computeBlastRadiusRisk } from './risk/blast-radius-risk.js';
+export type { BlastRadiusRiskInput, BlastRadiusRisk } from './risk/blast-radius-risk.js';
+
+// =============================================================================
 // ERRORS
 // =============================================================================
 

--- a/packages/core/src/risk/blast-radius-risk.test.ts
+++ b/packages/core/src/risk/blast-radius-risk.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { computeBlastRadiusRisk } from './blast-radius-risk.js';
+
+describe('computeBlastRadiusRisk', () => {
+  it('returns low with no reasoning when nothing is at risk', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 0,
+      uncoveredDependents: 0,
+    });
+    expect(result.level).toBe('low');
+    expect(result.reasoning).toEqual([]);
+  });
+
+  it('stays low for small, fully tested blast radius', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 0,
+      maxDependentComplexity: 4,
+    });
+    expect(result.level).toBe('low');
+    expect(result.reasoning).toContain('3 callers');
+    expect(result.reasoning).toContain('max complexity 4');
+  });
+
+  it('escalates to medium when any dependent is untested', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 1,
+    });
+    expect(result.level).toBe('medium');
+    expect(result.reasoning).toContain('1 untested');
+  });
+
+  it('escalates to medium based on caller count', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 7,
+      uncoveredDependents: 0,
+    });
+    expect(result.level).toBe('medium');
+    expect(result.reasoning).toContain('7 callers');
+  });
+
+  it('escalates to high when caller count exceeds 20', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 25,
+      uncoveredDependents: 0,
+    });
+    expect(result.level).toBe('high');
+  });
+
+  it('escalates to high when an untested dependent has high complexity', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 1,
+      hasHighComplexityUncovered: true,
+    });
+    expect(result.level).toBe('high');
+  });
+
+  it('escalates to critical on very large blast radius', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 60,
+      uncoveredDependents: 10,
+    });
+    expect(result.level).toBe('critical');
+  });
+
+  it('escalates to critical when high-complexity uncovered combines with large radius', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 25,
+      uncoveredDependents: 5,
+      hasHighComplexityUncovered: true,
+    });
+    expect(result.level).toBe('critical');
+  });
+
+  it('uses singular "caller" phrasing when dependentCount is 1', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 1,
+      uncoveredDependents: 0,
+    });
+    expect(result.reasoning).toContain('1 caller');
+    expect(result.reasoning).not.toContain('1 callers');
+  });
+
+  it('omits max complexity phrase when value is zero or missing', () => {
+    const zero = computeBlastRadiusRisk({
+      dependentCount: 2,
+      uncoveredDependents: 0,
+      maxDependentComplexity: 0,
+    });
+    expect(zero.reasoning.some(r => r.startsWith('max complexity'))).toBe(false);
+
+    const missing = computeBlastRadiusRisk({
+      dependentCount: 2,
+      uncoveredDependents: 0,
+    });
+    expect(missing.reasoning.some(r => r.startsWith('max complexity'))).toBe(false);
+  });
+});

--- a/packages/core/src/risk/blast-radius-risk.ts
+++ b/packages/core/src/risk/blast-radius-risk.ts
@@ -1,0 +1,75 @@
+/**
+ * Blast-radius risk scoring.
+ *
+ * Composes three signals — dependency breadth, test coverage of dependents,
+ * and complexity of dependents — into a single RiskLevel. Intended as a
+ * shared primitive for both the MCP `get_dependents` response and the
+ * review-side blast-radius injection.
+ */
+
+import type { RiskLevel } from '@liendev/parser';
+
+export interface BlastRadiusRiskInput {
+  /** Distinct dependents across all hops. */
+  dependentCount: number;
+  /** Dependents with no associated test file. */
+  uncoveredDependents: number;
+  /** Max complexity (cyclomatic or cognitive) among dependents. Optional. */
+  maxDependentComplexity?: number;
+  /**
+   * True when at least one untested dependent has high complexity.
+   * Supplied by the caller to keep this helper independent of any
+   * specific complexity-report shape.
+   */
+  hasHighComplexityUncovered?: boolean;
+}
+
+export interface BlastRadiusRisk {
+  level: RiskLevel;
+  /**
+   * Short phrases describing why the level was assigned, in the order they
+   * contributed. Used verbatim by renderers (e.g. "14 callers, 3 untested,
+   * max cognitive complexity 18").
+   */
+  reasoning: string[];
+}
+
+/**
+ * Compute a consolidated risk level for a blast radius.
+ *
+ * Thresholds are deliberately conservative — the goal is to surface risk, not
+ * to be statistically rigorous. Callers that want finer control should consume
+ * the raw input fields directly.
+ */
+export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadiusRisk {
+  const {
+    dependentCount,
+    uncoveredDependents,
+    maxDependentComplexity,
+    hasHighComplexityUncovered = false,
+  } = input;
+
+  const reasoning: string[] = [];
+  if (dependentCount > 0) {
+    reasoning.push(`${dependentCount} ${dependentCount === 1 ? 'caller' : 'callers'}`);
+  }
+  if (uncoveredDependents > 0) {
+    reasoning.push(`${uncoveredDependents} untested`);
+  }
+  if (typeof maxDependentComplexity === 'number' && maxDependentComplexity > 0) {
+    reasoning.push(`max complexity ${maxDependentComplexity}`);
+  }
+
+  let level: RiskLevel;
+  if (dependentCount > 50 || (hasHighComplexityUncovered && dependentCount > 20)) {
+    level = 'critical';
+  } else if (dependentCount > 20 || hasHighComplexityUncovered) {
+    level = 'high';
+  } else if (dependentCount > 5 || uncoveredDependents > 0) {
+    level = 'medium';
+  } else {
+    level = 'low';
+  }
+
+  return { level, reasoning };
+}


### PR DESCRIPTION
## Summary

Shared risk primitive for blast-radius analysis. Composes dependency breadth, test coverage of dependents, and complexity into a single `RiskLevel`. Pure addition — no existing consumers yet. First commit of the workstream planned in [\`.wip/plan-workstream-a-blast-radius.md\`](.wip/plan-workstream-a-blast-radius.md).

## Why

Both the review pipeline and the MCP \`get_dependents\` tool want a consolidated "how risky is this change?" answer, but today they compute risk ad-hoc in different places with different rules. Centralising the logic here means:

- Review-side blast-radius injection (next workstream commit) can call it.
- Future MCP \`get_dependents\` depth extension (Workstream B) reuses the same scoring.
- Thresholds are tweakable in one place if the defaults miss.

## Thresholds

Aligned with the existing 4-tier \`RiskLevel\` scheme in \`@liendev/parser\`:

| Level | Condition |
|---|---|
| critical | \>50 dependents, or (high-complexity uncovered AND \>20 dependents) |
| high | \>20 dependents, or any high-complexity uncovered |
| medium | \>5 dependents, or any uncovered dependent |
| low | otherwise |

Reasoning strings ("14 callers", "3 untested", "max complexity 18") are returned alongside so renderers can show the driving signals verbatim.

## Test plan

- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` — 0 errors (pre-existing warnings untouched)
- [x] \`npm run typecheck\` — 0 errors across all packages
- [x] \`npm run build\` succeeds
- [x] 10 new unit tests pass, covering all threshold edges, singular/plural phrasing, optional-field handling
- [x] No existing consumers yet, so no regression surface in core/review

## Follow-up

Subsequent commits in the workstream will add \`getCallersTransitive\` to the review \`DependencyGraph\`, a computation module that calls this helper, a renderer, and agent wiring. See the plan doc for detail.

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 1 new function is more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +18 |


> [!NOTE]
> **Low Risk**
>
> This PR introduces a new utility function `computeBlastRadiusRisk` and its associated types and tests. This function centralizes the logic for calculating a risk level based on dependent count, test coverage, and complexity. It's a pure addition with no existing consumers, meaning it introduces no immediate breaking changes or regressions. The implementation correctly applies the specified risk thresholds and generates descriptive reasoning strings. All edge cases and input variations appear to be handled correctly and are well-covered by the new unit tests.
>
> - Added `computeBlastRadiusRisk` function to calculate a consolidated risk level.
> - Introduced `BlastRadiusRiskInput` and `BlastRadiusRisk` types.
> - Exported new function and types from `packages/core/src/index.ts`.
> - Added comprehensive unit tests covering all threshold conditions and reasoning string generation.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bade569. Updates automatically on new commits.</sup>
<!-- /lien-stats -->