### PR TITLE
feat(review): add getCallersTransitive to DependencyGraph

### DIFF
--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -24,9 +24,41 @@ export interface CallerEdge {
   callSiteLine: number;
 }
 
+export interface TransitiveCallerEdge extends CallerEdge {
+  /** Distance from the seed symbol. Direct callers are 1, callers-of-callers are 2. */
+  hops: number;
+  /** The symbol on the call chain this caller resolved through. Equals the seed for hops=1. */
+  viaSymbol: string;
+}
+
+export interface TransitiveResult {
+  callers: TransitiveCallerEdge[];
+  /** True if BFS stopped because it hit maxNodes before exploring the full graph. */
+  truncated: boolean;
+  /** Count of distinct symbols whose callers were expanded (for diagnostics). */
+  visitedSymbols: number;
+}
+
+export interface TransitiveOptions {
+  /** Max hop distance from the seed. Default 2. */
+  depth?: number;
+  /** Max edges to emit. Default 30. */
+  maxNodes?: number;
+}
+
 export interface DependencyGraph {
   /** Find all chunks that call a given exported symbol. */
   getCallers(filepath: string, symbolName: string): CallerEdge[];
+  /**
+   * BFS-walk callers up to `depth` hops. Each caller is emitted exactly once,
+   * at its shortest hop distance from the seed. Stops when `maxNodes` edges
+   * have been emitted (sets `truncated=true`).
+   */
+  getCallersTransitive(
+    filepath: string,
+    symbolName: string,
+    opts?: TransitiveOptions,
+  ): TransitiveResult;
 }
 
 // ---------------------------------------------------------------------------
@@ -96,11 +128,76 @@ export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
   const chunkImportMaps = resolveChunkImports(chunks, fileSet);
   const callerEdges = buildCallerEdges(chunks, chunkImportMaps, exportIndex);
 
-  return {
-    getCallers(filepath: string, symbolName: string): CallerEdge[] {
-      return callerEdges.get(`${filepath}::${symbolName}`) ?? [];
-    },
+  const getCallers = (filepath: string, symbolName: string): CallerEdge[] => {
+    return callerEdges.get(`${filepath}::${symbolName}`) ?? [];
   };
+
+  const getCallersTransitive = (
+    filepath: string,
+    symbolName: string,
+    opts: TransitiveOptions = {},
+  ): TransitiveResult => {
+    const depth = opts.depth ?? 2;
+    const maxNodes = opts.maxNodes ?? 30;
+
+    if (depth < 1 || maxNodes < 1) {
+      return { callers: [], truncated: false, visitedSymbols: 0 };
+    }
+
+    const seedKey = `${filepath}::${symbolName}`;
+    const expandedSymbols = new Set<string>();
+    const emittedCallers = new Set<string>();
+    // Never emit the seed as its own caller — guards against cycles that
+    // would otherwise produce meaningless "X calls X" edges.
+    emittedCallers.add(seedKey);
+
+    const result: TransitiveCallerEdge[] = [];
+    const queue: Array<{ filepath: string; symbolName: string; hops: number }> = [
+      { filepath, symbolName, hops: 0 },
+    ];
+
+    let truncated = false;
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current) break;
+      const currentKey = `${current.filepath}::${current.symbolName}`;
+      if (expandedSymbols.has(currentKey)) continue;
+      expandedSymbols.add(currentKey);
+
+      const directCallers = getCallers(current.filepath, current.symbolName);
+      for (const edge of directCallers) {
+        const callerKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
+        if (emittedCallers.has(callerKey)) continue;
+
+        if (result.length >= maxNodes) {
+          truncated = true;
+          break;
+        }
+
+        emittedCallers.add(callerKey);
+        const hops = current.hops + 1;
+        result.push({
+          caller: edge.caller,
+          callSiteLine: edge.callSiteLine,
+          hops,
+          viaSymbol: current.symbolName,
+        });
+
+        if (hops < depth) {
+          queue.push({
+            filepath: edge.caller.filepath,
+            symbolName: edge.caller.symbolName,
+            hops,
+          });
+        }
+      }
+      if (truncated) break;
+    }
+
+    return { callers: result, truncated, visitedSymbols: expandedSymbols.size };
+  };
+
+  return { getCallers, getCallersTransitive };
 }
 
 type ExportEntry = { filepath: string; chunk: CodeChunk };

--- a/packages/review/test/dependency-graph.test.ts
+++ b/packages/review/test/dependency-graph.test.ts
@@ -593,3 +593,234 @@ describe('buildDependencyGraph — cross-package fallback', () => {
     expect(graph.getCallers('src/utils.ts', 'helper')).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// getCallersTransitive
+// ---------------------------------------------------------------------------
+
+describe('getCallersTransitive', () => {
+  /**
+   * Two-level chain: seed <- bLevel1 <- cLevel2
+   * `bLevel1` directly calls the seed; `cLevel2` calls `bLevel1`.
+   */
+  function buildTwoLevelChain() {
+    const seed = createTestChunk({
+      metadata: {
+        file: 'src/seed.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'seed',
+        language: 'typescript',
+        exports: ['seed'],
+      },
+    });
+
+    const bLevel1 = createTestChunk({
+      metadata: {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'bLevel1',
+        language: 'typescript',
+        exports: ['bLevel1'],
+        importedSymbols: { './seed': ['seed'] },
+        callSites: [{ symbol: 'seed', line: 5 }],
+      },
+    });
+
+    const cLevel2 = createTestChunk({
+      metadata: {
+        file: 'src/c.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'cLevel2',
+        language: 'typescript',
+        exports: ['cLevel2'],
+        importedSymbols: { './b': ['bLevel1'] },
+        callSites: [{ symbol: 'bLevel1', line: 5 }],
+      },
+    });
+
+    return { seed, bLevel1, cLevel2 };
+  }
+
+  it('walks two hops outward and labels each caller with its shortest hop', () => {
+    const { seed, bLevel1, cLevel2 } = buildTwoLevelChain();
+    const graph = buildDependencyGraph([seed, bLevel1, cLevel2]);
+
+    const result = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 2 });
+
+    expect(result.callers).toHaveLength(2);
+    const b = result.callers.find(e => e.caller.symbolName === 'bLevel1');
+    const c = result.callers.find(e => e.caller.symbolName === 'cLevel2');
+    expect(b?.hops).toBe(1);
+    expect(b?.viaSymbol).toBe('seed');
+    expect(c?.hops).toBe(2);
+    expect(c?.viaSymbol).toBe('bLevel1');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('depth=1 matches the one-hop getCallers set', () => {
+    const { seed, bLevel1, cLevel2 } = buildTwoLevelChain();
+    const graph = buildDependencyGraph([seed, bLevel1, cLevel2]);
+
+    const oneHop = graph.getCallers('src/seed.ts', 'seed');
+    const transitive = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 1 });
+
+    expect(transitive.callers).toHaveLength(oneHop.length);
+    expect(transitive.callers.map(e => e.caller.symbolName).sort()).toEqual(
+      oneHop.map(e => e.caller.symbolName).sort(),
+    );
+    expect(transitive.callers.every(e => e.hops === 1)).toBe(true);
+  });
+
+  it('terminates cleanly when a cycle is present', () => {
+    // a <-> b mutual recursion at the symbol level
+    const a = createTestChunk({
+      metadata: {
+        file: 'src/a.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'a',
+        language: 'typescript',
+        exports: ['a'],
+        importedSymbols: { './b': ['b'] },
+        callSites: [{ symbol: 'b', line: 5 }],
+      },
+    });
+    const b = createTestChunk({
+      metadata: {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'b',
+        language: 'typescript',
+        exports: ['b'],
+        importedSymbols: { './a': ['a'] },
+        callSites: [{ symbol: 'a', line: 5 }],
+      },
+    });
+    const graph = buildDependencyGraph([a, b]);
+
+    const result = graph.getCallersTransitive('src/a.ts', 'a', { depth: 5 });
+
+    // Only b is emitted; the seed a must never appear as its own caller.
+    expect(result.callers).toHaveLength(1);
+    expect(result.callers[0].caller.symbolName).toBe('b');
+    expect(result.callers[0].hops).toBe(1);
+  });
+
+  it('deduplicates callers that reach the seed via multiple paths', () => {
+    // Diamond: a calls seed, a calls b, b calls seed. "a" has two paths to seed.
+    const seed = createTestChunk({
+      metadata: {
+        file: 'src/seed.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'seed',
+        language: 'typescript',
+        exports: ['seed'],
+      },
+    });
+    const b = createTestChunk({
+      metadata: {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'b',
+        language: 'typescript',
+        exports: ['b'],
+        importedSymbols: { './seed': ['seed'] },
+        callSites: [{ symbol: 'seed', line: 5 }],
+      },
+    });
+    const a = createTestChunk({
+      metadata: {
+        file: 'src/a.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'a',
+        language: 'typescript',
+        exports: ['a'],
+        importedSymbols: { './seed': ['seed'], './b': ['b'] },
+        callSites: [
+          { symbol: 'seed', line: 5 },
+          { symbol: 'b', line: 6 },
+        ],
+      },
+    });
+
+    const graph = buildDependencyGraph([seed, b, a]);
+    const result = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 3 });
+
+    // a and b are both callers. a must appear only once, at its shortest hop (1).
+    const aEdges = result.callers.filter(e => e.caller.symbolName === 'a');
+    expect(aEdges).toHaveLength(1);
+    expect(aEdges[0].hops).toBe(1);
+    expect(result.callers).toHaveLength(2);
+  });
+
+  it('truncates when maxNodes is exceeded', () => {
+    const seed = createTestChunk({
+      metadata: {
+        file: 'src/seed.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'seed',
+        language: 'typescript',
+        exports: ['seed'],
+      },
+    });
+    const callers = Array.from({ length: 5 }, (_, i) =>
+      createTestChunk({
+        metadata: {
+          file: `src/caller${i}.ts`,
+          startLine: 1,
+          endLine: 10,
+          type: 'function',
+          symbolName: `caller${i}`,
+          language: 'typescript',
+          importedSymbols: { './seed': ['seed'] },
+          callSites: [{ symbol: 'seed', line: 5 }],
+        },
+      }),
+    );
+
+    const graph = buildDependencyGraph([seed, ...callers]);
+    const result = graph.getCallersTransitive('src/seed.ts', 'seed', {
+      depth: 2,
+      maxNodes: 2,
+    });
+
+    expect(result.callers).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('returns an empty result for depth < 1 or maxNodes < 1', () => {
+    const { seed, bLevel1 } = buildTwoLevelChain();
+    const graph = buildDependencyGraph([seed, bLevel1]);
+
+    const zeroDepth = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 0 });
+    expect(zeroDepth.callers).toEqual([]);
+    expect(zeroDepth.visitedSymbols).toBe(0);
+
+    const zeroNodes = graph.getCallersTransitive('src/seed.ts', 'seed', { maxNodes: 0 });
+    expect(zeroNodes.callers).toEqual([]);
+  });
+
+  it('returns an empty result for an unknown seed', () => {
+    const graph = buildDependencyGraph([]);
+    const result = graph.getCallersTransitive('nonexistent.ts', 'noSuchSymbol', { depth: 2 });
+    expect(result.callers).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Multi-hop BFS walk over the existing one-hop \`getCallers\`. Defaults: \`depth=2\`, \`maxNodes=30\`. Pure addition — no existing consumer yet.

Second commit of the workstream planned in [\`.wip/plan-workstream-a-blast-radius.md\`](.wip/plan-workstream-a-blast-radius.md). Independent of [#515](https://github.com/getlien/lien/pull/515) — can merge in either order.

## Why

\`getCallers\` is one-hop only. For blast-radius analysis (the upcoming \`computeBlastRadius\` in the review package) we need to walk out N hops from a changed symbol to find the callers-of-callers most likely to regress. Doing that BFS inside the graph module keeps it reusable and puts the dedup/cycle/truncation logic in one place.

## Design decisions

- **Each caller emitted once** at its shortest hop distance. A diamond where \`A\` reaches the seed via two paths still produces one \`A\` edge at hops=1.
- **Seed never emitted as its own caller.** Guards against cycles that would otherwise produce meaningless "X calls X" edges.
- **Truncation signal.** When BFS hits \`maxNodes\` before exhausting the graph, \`truncated=true\` tells the caller there's more to drill into.
- **Return type extends \`CallerEdge\`** with \`hops\` and \`viaSymbol\`, so downstream renderers get provenance for each row without extra lookups.

## Test plan

- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` — 0 errors (pre-existing warnings untouched)
- [x] \`npm run typecheck\` — 0 errors across all packages
- [x] 7 new unit tests pass (plus 23 existing \`DependencyGraph\` tests untouched):
  - two-hop chain labelled with correct hops and \`viaSymbol\`
  - \`depth=1\` result matches the one-hop \`getCallers\` set
  - cycle terminates cleanly (seed never re-emitted)
  - diamond dedup at shortest hop
  - \`maxNodes\` truncation sets \`truncated=true\`
  - \`depth<1\` or \`maxNodes<1\` return empty
  - unknown seed returns empty

## Follow-up

Next commit wires this into a \`computeBlastRadius\` module that overlays test coverage and complexity, and calls the risk helper from #515. See the plan doc for the full sequencing.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 2 new functions are too complex.
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +20 |
| ⏱️ time to understand | 2 | +141 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit cd48852. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transitive caller discovery to identify callers across multiple hops with configurable depth and node limits
  * Caller results now include hop distance and seed symbol information
  * Includes truncation reporting when search limits are reached

<!-- end of auto-generated comment: release notes by coderabbit.ai -->