### PR TITLE
feat(review): inject transitive blast radius into agent context

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -141,3 +141,10 @@ export { analyzeComplexityFromChunks } from './insights/chunk-complexity.js';
 
 export { performChunkOnlyIndex } from './chunk-only-index.js';
 export type { ChunkOnlyOptions, ChunkOnlyResult } from './chunk-only-index.js';
+
+// =============================================================================
+// RISK ANALYSIS
+// =============================================================================
+
+export { computeBlastRadiusRisk } from './risk/blast-radius-risk.js';
+export type { BlastRadiusRiskInput, BlastRadiusRisk } from './risk/blast-radius-risk.js';

--- a/packages/parser/src/risk/blast-radius-risk.test.ts
+++ b/packages/parser/src/risk/blast-radius-risk.test.ts
@@ -55,6 +55,9 @@ describe('computeBlastRadiusRisk', () => {
       hasHighComplexityUncovered: true,
     });
     expect(result.level).toBe('high');
+    // The escalation driver must be visible in reasoning; otherwise a caller
+    // sees only "3 callers, 1 untested" and can't tell why it isn't medium.
+    expect(result.reasoning).toContain('untested high-complexity dependent');
   });
 
   it('escalates to critical on very large blast radius', () => {

--- a/packages/parser/src/risk/blast-radius-risk.test.ts
+++ b/packages/parser/src/risk/blast-radius-risk.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { computeBlastRadiusRisk } from './blast-radius-risk.js';
+
+describe('computeBlastRadiusRisk', () => {
+  it('returns low with no reasoning when nothing is at risk', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 0,
+      uncoveredDependents: 0,
+    });
+    expect(result.level).toBe('low');
+    expect(result.reasoning).toEqual([]);
+  });
+
+  it('stays low for small, fully tested blast radius', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 0,
+      maxDependentComplexity: 4,
+    });
+    expect(result.level).toBe('low');
+    expect(result.reasoning).toContain('3 callers');
+    expect(result.reasoning).toContain('max complexity 4');
+  });
+
+  it('escalates to medium when any dependent is untested', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 1,
+    });
+    expect(result.level).toBe('medium');
+    expect(result.reasoning).toContain('1 untested');
+  });
+
+  it('escalates to medium based on caller count', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 7,
+      uncoveredDependents: 0,
+    });
+    expect(result.level).toBe('medium');
+    expect(result.reasoning).toContain('7 callers');
+  });
+
+  it('escalates to high when caller count exceeds 20', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 25,
+      uncoveredDependents: 0,
+    });
+    expect(result.level).toBe('high');
+  });
+
+  it('escalates to high when an untested dependent has high complexity', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 1,
+      hasHighComplexityUncovered: true,
+    });
+    expect(result.level).toBe('high');
+  });
+
+  it('escalates to critical on very large blast radius', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 60,
+      uncoveredDependents: 10,
+    });
+    expect(result.level).toBe('critical');
+  });
+
+  it('escalates to critical when high-complexity uncovered combines with large radius', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 25,
+      uncoveredDependents: 5,
+      hasHighComplexityUncovered: true,
+    });
+    expect(result.level).toBe('critical');
+  });
+
+  it('uses singular "caller" phrasing when dependentCount is 1', () => {
+    const result = computeBlastRadiusRisk({
+      dependentCount: 1,
+      uncoveredDependents: 0,
+    });
+    expect(result.reasoning).toContain('1 caller');
+    expect(result.reasoning).not.toContain('1 callers');
+  });
+
+  it('omits max complexity phrase when value is zero or missing', () => {
+    const zero = computeBlastRadiusRisk({
+      dependentCount: 2,
+      uncoveredDependents: 0,
+      maxDependentComplexity: 0,
+    });
+    expect(zero.reasoning.some(r => r.startsWith('max complexity'))).toBe(false);
+
+    const missing = computeBlastRadiusRisk({
+      dependentCount: 2,
+      uncoveredDependents: 0,
+    });
+    expect(missing.reasoning.some(r => r.startsWith('max complexity'))).toBe(false);
+  });
+});

--- a/packages/parser/src/risk/blast-radius-risk.ts
+++ b/packages/parser/src/risk/blast-radius-risk.ts
@@ -1,0 +1,75 @@
+/**
+ * Blast-radius risk scoring.
+ *
+ * Composes three signals — dependency breadth, test coverage of dependents,
+ * and complexity of dependents — into a single RiskLevel. Intended as a
+ * shared primitive for both the MCP `get_dependents` response and the
+ * review-side blast-radius injection.
+ */
+
+import type { RiskLevel } from '../insights/types.js';
+
+export interface BlastRadiusRiskInput {
+  /** Distinct dependents across all hops. */
+  dependentCount: number;
+  /** Dependents with no associated test file. */
+  uncoveredDependents: number;
+  /** Max complexity (cyclomatic or cognitive) among dependents. Optional. */
+  maxDependentComplexity?: number;
+  /**
+   * True when at least one untested dependent has high complexity.
+   * Supplied by the caller to keep this helper independent of any
+   * specific complexity-report shape.
+   */
+  hasHighComplexityUncovered?: boolean;
+}
+
+export interface BlastRadiusRisk {
+  level: RiskLevel;
+  /**
+   * Short phrases describing why the level was assigned, in the order they
+   * contributed. Used verbatim by renderers (e.g. "14 callers, 3 untested,
+   * max cognitive complexity 18").
+   */
+  reasoning: string[];
+}
+
+/**
+ * Compute a consolidated risk level for a blast radius.
+ *
+ * Thresholds are deliberately conservative — the goal is to surface risk, not
+ * to be statistically rigorous. Callers that want finer control should consume
+ * the raw input fields directly.
+ */
+export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadiusRisk {
+  const {
+    dependentCount,
+    uncoveredDependents,
+    maxDependentComplexity,
+    hasHighComplexityUncovered = false,
+  } = input;
+
+  const reasoning: string[] = [];
+  if (dependentCount > 0) {
+    reasoning.push(`${dependentCount} ${dependentCount === 1 ? 'caller' : 'callers'}`);
+  }
+  if (uncoveredDependents > 0) {
+    reasoning.push(`${uncoveredDependents} untested`);
+  }
+  if (typeof maxDependentComplexity === 'number' && maxDependentComplexity > 0) {
+    reasoning.push(`max complexity ${maxDependentComplexity}`);
+  }
+
+  let level: RiskLevel;
+  if (dependentCount > 50 || (hasHighComplexityUncovered && dependentCount > 20)) {
+    level = 'critical';
+  } else if (dependentCount > 20 || hasHighComplexityUncovered) {
+    level = 'high';
+  } else if (dependentCount > 5 || uncoveredDependents > 0) {
+    level = 'medium';
+  } else {
+    level = 'low';
+  }
+
+  return { level, reasoning };
+}

--- a/packages/parser/src/risk/blast-radius-risk.ts
+++ b/packages/parser/src/risk/blast-radius-risk.ts
@@ -29,13 +29,18 @@ export interface BlastRadiusRisk {
   /**
    * Short phrases describing why the level was assigned, in the order they
    * contributed. Used verbatim by renderers (e.g. "14 callers, 3 untested,
-   * max cognitive complexity 18").
+   * max complexity 18, untested high-complexity dependent").
    */
   reasoning: string[];
 }
 
 function buildReasoning(input: BlastRadiusRiskInput): string[] {
-  const { dependentCount, uncoveredDependents, maxDependentComplexity } = input;
+  const {
+    dependentCount,
+    uncoveredDependents,
+    maxDependentComplexity,
+    hasHighComplexityUncovered = false,
+  } = input;
   const reasoning: string[] = [];
   if (dependentCount > 0) {
     reasoning.push(`${dependentCount} ${dependentCount === 1 ? 'caller' : 'callers'}`);
@@ -45,6 +50,11 @@ function buildReasoning(input: BlastRadiusRiskInput): string[] {
   }
   if (typeof maxDependentComplexity === 'number' && maxDependentComplexity > 0) {
     reasoning.push(`max complexity ${maxDependentComplexity}`);
+  }
+  // Surface the escalation driver explicitly — otherwise a caller with only
+  // "3 callers, 1 untested" can't tell why the level came back as 'high'.
+  if (hasHighComplexityUncovered) {
+    reasoning.push('untested high-complexity dependent');
   }
   return reasoning;
 }

--- a/packages/parser/src/risk/blast-radius-risk.ts
+++ b/packages/parser/src/risk/blast-radius-risk.ts
@@ -34,21 +34,8 @@ export interface BlastRadiusRisk {
   reasoning: string[];
 }
 
-/**
- * Compute a consolidated risk level for a blast radius.
- *
- * Thresholds are deliberately conservative — the goal is to surface risk, not
- * to be statistically rigorous. Callers that want finer control should consume
- * the raw input fields directly.
- */
-export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadiusRisk {
-  const {
-    dependentCount,
-    uncoveredDependents,
-    maxDependentComplexity,
-    hasHighComplexityUncovered = false,
-  } = input;
-
+function buildReasoning(input: BlastRadiusRiskInput): string[] {
+  const { dependentCount, uncoveredDependents, maxDependentComplexity } = input;
   const reasoning: string[] = [];
   if (dependentCount > 0) {
     reasoning.push(`${dependentCount} ${dependentCount === 1 ? 'caller' : 'callers'}`);
@@ -59,17 +46,27 @@ export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadius
   if (typeof maxDependentComplexity === 'number' && maxDependentComplexity > 0) {
     reasoning.push(`max complexity ${maxDependentComplexity}`);
   }
+  return reasoning;
+}
 
-  let level: RiskLevel;
-  if (dependentCount > 50 || (hasHighComplexityUncovered && dependentCount > 20)) {
-    level = 'critical';
-  } else if (dependentCount > 20 || hasHighComplexityUncovered) {
-    level = 'high';
-  } else if (dependentCount > 5 || uncoveredDependents > 0) {
-    level = 'medium';
-  } else {
-    level = 'low';
-  }
+function classifyLevel(input: BlastRadiusRiskInput): RiskLevel {
+  const { dependentCount, uncoveredDependents, hasHighComplexityUncovered = false } = input;
+  if (dependentCount > 50) return 'critical';
+  if (hasHighComplexityUncovered && dependentCount > 20) return 'critical';
+  if (dependentCount > 20) return 'high';
+  if (hasHighComplexityUncovered) return 'high';
+  if (dependentCount > 5) return 'medium';
+  if (uncoveredDependents > 0) return 'medium';
+  return 'low';
+}
 
-  return { level, reasoning };
+/**
+ * Compute a consolidated risk level for a blast radius.
+ *
+ * Thresholds are deliberately conservative — the goal is to surface risk, not
+ * to be statistically rigorous. Callers that want finer control should consume
+ * the raw input fields directly.
+ */
+export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadiusRisk {
+  return { level: classifyLevel(input), reasoning: buildReasoning(input) };
 }

--- a/packages/review/src/blast-radius-render.ts
+++ b/packages/review/src/blast-radius-render.ts
@@ -1,0 +1,85 @@
+/**
+ * Markdown rendering for BlastRadiusReport.
+ *
+ * Kept separate from computeBlastRadius so the prompt format can evolve
+ * without touching compute logic.
+ */
+
+import type { BlastRadiusReport, BlastRadiusEntry, BlastRadiusDependent } from './blast-radius.js';
+
+const LEVEL_LABEL: Record<string, string> = {
+  low: 'LOW',
+  medium: 'MEDIUM',
+  high: 'HIGH',
+  critical: 'CRITICAL',
+};
+
+/**
+ * Render a blast-radius report as markdown wrapped in a `<blast_radius>` XML tag.
+ * Returns an empty string when the report has no entries, so callers can
+ * unconditionally append without an emptiness check.
+ */
+export function renderBlastRadiusMarkdown(report: BlastRadiusReport): string {
+  if (report.entries.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('<blast_radius>');
+  lines.push(renderSummary(report));
+  lines.push('');
+  lines.push(...renderTable(report.entries));
+
+  if (report.truncated) {
+    const shown = report.entries.reduce((n, e) => n + e.dependents.length, 0);
+    lines.push('');
+    lines.push(
+      `[truncated — showing ${shown} dependents across ${report.entries.length} seed(s); more exist]`,
+    );
+  }
+
+  lines.push('</blast_radius>');
+  return lines.join('\n');
+}
+
+function renderSummary(report: BlastRadiusReport): string {
+  const level = LEVEL_LABEL[report.globalRisk.level] ?? report.globalRisk.level.toUpperCase();
+  const reasoning = report.globalRisk.reasoning.join(', ');
+  const base = `Global risk: ${level}`;
+  if (reasoning.length > 0) {
+    return `${base} — ${report.totalDistinctDependents} distinct dependents (${reasoning}).`;
+  }
+  return `${base} — ${report.totalDistinctDependents} distinct dependents.`;
+}
+
+function renderTable(entries: BlastRadiusEntry[]): string[] {
+  const rows: string[] = [];
+  rows.push('| Seed (changed) | Hops | Dependent | Tests | Complexity |');
+  rows.push('|---|---|---|---|---|');
+
+  for (const entry of entries) {
+    const seedLabel = formatSeed(entry);
+    // Intra-entry sort: shorter hops first, then alphabetical
+    const deps = [...entry.dependents].sort((a, b) => {
+      if (a.hops !== b.hops) return a.hops - b.hops;
+      return a.filepath.localeCompare(b.filepath);
+    });
+    for (const dep of deps) {
+      rows.push(
+        `| \`${seedLabel}\` | ${dep.hops} | ${formatDependent(dep)} | ${dep.hasTestCoverage ? '✓' : '✗'} | ${formatComplexity(dep)} |`,
+      );
+    }
+  }
+
+  return rows;
+}
+
+function formatSeed(entry: BlastRadiusEntry): string {
+  return `${entry.seed.filepath}:${entry.seed.symbolName}`;
+}
+
+function formatDependent(dep: BlastRadiusDependent): string {
+  return `\`${dep.filepath}:${dep.symbolName}\` (L${dep.callSiteLine})`;
+}
+
+function formatComplexity(dep: BlastRadiusDependent): string {
+  return typeof dep.complexity === 'number' ? String(dep.complexity) : '—';
+}

--- a/packages/review/src/blast-radius.ts
+++ b/packages/review/src/blast-radius.ts
@@ -161,6 +161,116 @@ function computeTestCoverage(
 }
 
 // ---------------------------------------------------------------------------
+// Per-entry enrichment
+// ---------------------------------------------------------------------------
+
+interface RawSeedResult {
+  seed: BlastRadiusSeed;
+  result: ReturnType<DependencyGraph['getCallersTransitive']>;
+}
+
+function buildDependent(
+  edge: RawSeedResult['result']['callers'][number],
+  chunkIndex: Map<string, CodeChunk>,
+  coveredFiles: Set<string>,
+): BlastRadiusDependent {
+  const chunkKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
+  const dependentChunk = chunkIndex.get(chunkKey);
+  const complexity = dependentChunk ? chunkComplexity(dependentChunk) : undefined;
+  return {
+    filepath: edge.caller.filepath,
+    symbolName: edge.caller.symbolName,
+    hops: edge.hops,
+    callSiteLine: edge.callSiteLine,
+    complexity: complexity && complexity > 0 ? complexity : undefined,
+    hasTestCoverage: coveredFiles.has(edge.caller.filepath),
+  };
+}
+
+function buildEntry(
+  raw: RawSeedResult,
+  chunkIndex: Map<string, CodeChunk>,
+  coveredFiles: Set<string>,
+  highComplexityThreshold: number,
+): BlastRadiusEntry {
+  const dependents = raw.result.callers.map(edge => buildDependent(edge, chunkIndex, coveredFiles));
+  const uncovered = dependents.filter(d => !d.hasTestCoverage);
+  const maxDependentComplexity = dependents.reduce((acc, d) => Math.max(acc, d.complexity ?? 0), 0);
+  const hasHighComplexityUncovered = uncovered.some(
+    d => (d.complexity ?? 0) >= highComplexityThreshold,
+  );
+
+  const risk = computeBlastRadiusRisk({
+    dependentCount: dependents.length,
+    uncoveredDependents: uncovered.length,
+    maxDependentComplexity: maxDependentComplexity > 0 ? maxDependentComplexity : undefined,
+    hasHighComplexityUncovered,
+  });
+
+  return { seed: raw.seed, dependents, risk, truncated: raw.result.truncated };
+}
+
+function sortEntries(entries: BlastRadiusEntry[]): void {
+  entries.sort((a, b) => {
+    const levelDelta = RISK_RANK[b.risk.level] - RISK_RANK[a.risk.level];
+    if (levelDelta !== 0) return levelDelta;
+    return b.dependents.length - a.dependents.length;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Global aggregation
+// ---------------------------------------------------------------------------
+
+interface GlobalAccumulator {
+  seen: Set<string>;
+  uncovered: number;
+  maxComplexity: number;
+  hasHighUncovered: boolean;
+}
+
+function accumulateDependent(
+  acc: GlobalAccumulator,
+  d: BlastRadiusDependent,
+  highComplexityThreshold: number,
+): void {
+  const key = `${d.filepath}::${d.symbolName}`;
+  if (acc.seen.has(key)) return;
+  acc.seen.add(key);
+  if (!d.hasTestCoverage) acc.uncovered += 1;
+  if (typeof d.complexity === 'number' && d.complexity > acc.maxComplexity) {
+    acc.maxComplexity = d.complexity;
+  }
+  if (!d.hasTestCoverage && (d.complexity ?? 0) >= highComplexityThreshold) {
+    acc.hasHighUncovered = true;
+  }
+}
+
+function computeGlobalRisk(
+  entries: BlastRadiusEntry[],
+  highComplexityThreshold: number,
+): { risk: BlastRadiusReport['globalRisk']; distinctCount: number } {
+  const acc: GlobalAccumulator = {
+    seen: new Set(),
+    uncovered: 0,
+    maxComplexity: 0,
+    hasHighUncovered: false,
+  };
+  for (const entry of entries) {
+    for (const d of entry.dependents) {
+      accumulateDependent(acc, d, highComplexityThreshold);
+    }
+  }
+  const risk = computeBlastRadiusRisk({
+    dependentCount: acc.seen.size,
+    uncoveredDependents: acc.uncovered,
+    maxDependentComplexity: acc.maxComplexity > 0 ? acc.maxComplexity : undefined,
+    hasHighComplexityUncovered: acc.hasHighUncovered,
+  });
+  return { risk, distinctCount: acc.seen.size };
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -176,105 +286,40 @@ export function computeBlastRadius(
   const highComplexityThreshold = opts.highComplexityThreshold ?? DEFAULT_HIGH_COMPLEXITY_THRESHOLD;
 
   const seeds = selectSeeds(changedChunks, maxSeeds);
-  if (seeds.length === 0) {
-    return emptyReport();
-  }
+  if (seeds.length === 0) return emptyReport();
 
   const chunkIndex = buildChunkIndex(repoChunks);
+  const rawPerSeed: RawSeedResult[] = seeds.map(seed => ({
+    seed,
+    result: graph.getCallersTransitive(seed.filepath, seed.symbolName, { depth, maxNodes }),
+  }));
 
-  // First pass: BFS per seed, collect raw edges. We'll overlay tests/complexity after,
-  // because test-association lookup over the full repo should be done once.
-  const rawPerSeed = seeds.map(seed => {
-    const result = graph.getCallersTransitive(seed.filepath, seed.symbolName, {
-      depth,
-      maxNodes,
-    });
-    return { seed, result };
-  });
-
-  const dependentFiles = new Set<string>();
-  for (const { result } of rawPerSeed) {
-    for (const edge of result.callers) {
-      dependentFiles.add(edge.caller.filepath);
-    }
-  }
+  const dependentFiles = collectDependentFiles(rawPerSeed);
   const coveredFiles = computeTestCoverage(dependentFiles, repoChunks, opts.workspaceRoot);
 
-  // Second pass: enrich + score per seed.
-  const entries: BlastRadiusEntry[] = rawPerSeed.map(({ seed, result }) => {
-    const dependents: BlastRadiusDependent[] = result.callers.map(edge => {
-      const chunkKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
-      const dependentChunk = chunkIndex.get(chunkKey);
-      const complexity = dependentChunk ? chunkComplexity(dependentChunk) : undefined;
-      return {
-        filepath: edge.caller.filepath,
-        symbolName: edge.caller.symbolName,
-        hops: edge.hops,
-        callSiteLine: edge.callSiteLine,
-        complexity: complexity && complexity > 0 ? complexity : undefined,
-        hasTestCoverage: coveredFiles.has(edge.caller.filepath),
-      };
-    });
+  const entries = rawPerSeed.map(raw =>
+    buildEntry(raw, chunkIndex, coveredFiles, highComplexityThreshold),
+  );
+  sortEntries(entries);
 
-    const uncovered = dependents.filter(d => !d.hasTestCoverage);
-    const maxDependentComplexity = dependents.reduce(
-      (acc, d) => Math.max(acc, d.complexity ?? 0),
-      0,
-    );
-    const hasHighComplexityUncovered = uncovered.some(
-      d => (d.complexity ?? 0) >= highComplexityThreshold,
-    );
-
-    const risk = computeBlastRadiusRisk({
-      dependentCount: dependents.length,
-      uncoveredDependents: uncovered.length,
-      maxDependentComplexity: maxDependentComplexity > 0 ? maxDependentComplexity : undefined,
-      hasHighComplexityUncovered,
-    });
-
-    return { seed, dependents, risk, truncated: result.truncated };
-  });
-
-  entries.sort((a, b) => {
-    const levelDelta = RISK_RANK[b.risk.level] - RISK_RANK[a.risk.level];
-    if (levelDelta !== 0) return levelDelta;
-    return b.dependents.length - a.dependents.length;
-  });
-
-  // Global aggregation
-  const distinct = new Set<string>();
-  let globalUncovered = 0;
-  let globalMaxComplexity = 0;
-  let globalHasHighUncovered = false;
-  for (const entry of entries) {
-    for (const d of entry.dependents) {
-      const key = `${d.filepath}::${d.symbolName}`;
-      if (!distinct.has(key)) {
-        distinct.add(key);
-        if (!d.hasTestCoverage) globalUncovered += 1;
-        if (typeof d.complexity === 'number' && d.complexity > globalMaxComplexity) {
-          globalMaxComplexity = d.complexity;
-        }
-        if (!d.hasTestCoverage && (d.complexity ?? 0) >= highComplexityThreshold) {
-          globalHasHighUncovered = true;
-        }
-      }
-    }
-  }
-
-  const globalRisk = computeBlastRadiusRisk({
-    dependentCount: distinct.size,
-    uncoveredDependents: globalUncovered,
-    maxDependentComplexity: globalMaxComplexity > 0 ? globalMaxComplexity : undefined,
-    hasHighComplexityUncovered: globalHasHighUncovered,
-  });
+  const { risk: globalRisk, distinctCount } = computeGlobalRisk(entries, highComplexityThreshold);
 
   return {
     entries,
-    totalDistinctDependents: distinct.size,
+    totalDistinctDependents: distinctCount,
     globalRisk,
     truncated: entries.some(e => e.truncated),
   };
+}
+
+function collectDependentFiles(rawPerSeed: RawSeedResult[]): Set<string> {
+  const files = new Set<string>();
+  for (const { result } of rawPerSeed) {
+    for (const edge of result.callers) {
+      files.add(edge.caller.filepath);
+    }
+  }
+  return files;
 }
 
 function emptyReport(): BlastRadiusReport {

--- a/packages/review/src/blast-radius.ts
+++ b/packages/review/src/blast-radius.ts
@@ -1,0 +1,287 @@
+/**
+ * Blast-radius computation for PR reviews.
+ *
+ * Given the set of changed chunks, walks the dependency graph outward to find
+ * transitive dependents, overlays test coverage + complexity, and produces a
+ * risk-scored report ready for rendering into the agent's initial message.
+ */
+
+import type { CodeChunk, RiskLevel, BlastRadiusRisk } from '@liendev/parser';
+import { findTestAssociationsFromChunks, computeBlastRadiusRisk } from '@liendev/parser';
+import type { DependencyGraph } from './dependency-graph.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BlastRadiusSeed {
+  filepath: string;
+  symbolName: string;
+  /** The exporting chunk's symbolType, e.g. 'function' | 'method' | 'class'. */
+  symbolType: string;
+  /** Complexity of the seed chunk itself, for ranking. */
+  complexity: number;
+}
+
+export interface BlastRadiusDependent {
+  filepath: string;
+  symbolName: string;
+  /** Distance from the seed: 1 = direct caller, 2 = caller-of-caller, etc. */
+  hops: number;
+  /** Line in the dependent where the call occurs. */
+  callSiteLine: number;
+  /** Complexity of the dependent (cognitive preferred, else cyclomatic). Absent when unknown. */
+  complexity?: number;
+  /** True when a test file imports the dependent's source file. */
+  hasTestCoverage: boolean;
+}
+
+export interface BlastRadiusEntry {
+  seed: BlastRadiusSeed;
+  dependents: BlastRadiusDependent[];
+  risk: BlastRadiusRisk;
+  /** True when BFS truncated before exploring the full reachable set for this seed. */
+  truncated: boolean;
+}
+
+export interface BlastRadiusReport {
+  /** Sorted: highest-risk first, then most-dependent first. */
+  entries: BlastRadiusEntry[];
+  /** Count of distinct dependents across all entries. */
+  totalDistinctDependents: number;
+  /** Aggregated risk across all seeds (max level, union of reasoning). */
+  globalRisk: BlastRadiusRisk;
+  /** True if any entry was truncated. */
+  truncated: boolean;
+}
+
+export interface ComputeBlastRadiusOptions {
+  /** Max hop distance per seed. Default 2. */
+  depth?: number;
+  /** Max dependents emitted per seed. Default 30. */
+  maxNodes?: number;
+  /** Max seeds considered. Default 8. */
+  maxSeeds?: number;
+  /** Complexity threshold above which an uncovered dependent is "high-complexity". Default 15. */
+  highComplexityThreshold?: number;
+  /** Workspace root for path normalization in test-association lookup. */
+  workspaceRoot?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_DEPTH = 2;
+const DEFAULT_MAX_NODES = 30;
+const DEFAULT_MAX_SEEDS = 8;
+const DEFAULT_HIGH_COMPLEXITY_THRESHOLD = 15;
+
+const SEED_SYMBOL_TYPES = new Set(['function', 'method', 'class']);
+
+const RISK_RANK: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2, critical: 3 };
+
+// ---------------------------------------------------------------------------
+// Seed selection
+// ---------------------------------------------------------------------------
+
+function isSeedCandidate(chunk: CodeChunk): boolean {
+  const { symbolName, symbolType, exports } = chunk.metadata;
+  if (!symbolName || !symbolType) return false;
+  if (!SEED_SYMBOL_TYPES.has(symbolType)) return false;
+
+  // Either the file explicitly exports the symbol, or it's a top-level function/class
+  // that's a valid target for cross-file calls. Treat "exports contains symbol" as
+  // the primary signal; fall back to top-level (no parentClass) for classes/functions.
+  const isExported = exports?.includes(symbolName) ?? false;
+  if (isExported) return true;
+
+  if (symbolType === 'method') return false; // methods require their class to be exported
+  return !chunk.metadata.parentClass;
+}
+
+function chunkComplexity(chunk: CodeChunk): number {
+  return chunk.metadata.cognitiveComplexity ?? chunk.metadata.complexity ?? 0;
+}
+
+function selectSeeds(changedChunks: CodeChunk[], maxSeeds: number): BlastRadiusSeed[] {
+  return changedChunks
+    .filter(isSeedCandidate)
+    .map(chunk => ({
+      filepath: chunk.metadata.file,
+      symbolName: chunk.metadata.symbolName!,
+      symbolType: chunk.metadata.symbolType!,
+      complexity: chunkComplexity(chunk),
+      isExported: chunk.metadata.exports?.includes(chunk.metadata.symbolName!) ?? false,
+    }))
+    .sort((a, b) => {
+      // Exported first, then higher complexity first.
+      if (a.isExported !== b.isExported) return a.isExported ? -1 : 1;
+      return b.complexity - a.complexity;
+    })
+    .slice(0, maxSeeds)
+    .map(({ filepath, symbolName, symbolType, complexity }) => ({
+      filepath,
+      symbolName,
+      symbolType,
+      complexity,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Overlay helpers
+// ---------------------------------------------------------------------------
+
+function buildChunkIndex(chunks: CodeChunk[]): Map<string, CodeChunk> {
+  const index = new Map<string, CodeChunk>();
+  for (const chunk of chunks) {
+    const key = `${chunk.metadata.file}::${chunk.metadata.symbolName ?? ''}`;
+    // Keep the highest-complexity chunk if multiple chunks share the same key
+    // (rare but possible with overloads / partial classes).
+    const existing = index.get(key);
+    if (!existing || chunkComplexity(chunk) > chunkComplexity(existing)) {
+      index.set(key, chunk);
+    }
+  }
+  return index;
+}
+
+function computeTestCoverage(
+  dependentFiles: Set<string>,
+  repoChunks: CodeChunk[],
+  workspaceRoot: string | undefined,
+): Set<string> {
+  if (dependentFiles.size === 0) return new Set();
+  const map = findTestAssociationsFromChunks(Array.from(dependentFiles), repoChunks, workspaceRoot);
+  const covered = new Set<string>();
+  for (const [filepath, tests] of map.entries()) {
+    if (tests.length > 0) covered.add(filepath);
+  }
+  return covered;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export function computeBlastRadius(
+  changedChunks: CodeChunk[],
+  graph: DependencyGraph,
+  repoChunks: CodeChunk[],
+  opts: ComputeBlastRadiusOptions = {},
+): BlastRadiusReport {
+  const depth = opts.depth ?? DEFAULT_DEPTH;
+  const maxNodes = opts.maxNodes ?? DEFAULT_MAX_NODES;
+  const maxSeeds = opts.maxSeeds ?? DEFAULT_MAX_SEEDS;
+  const highComplexityThreshold = opts.highComplexityThreshold ?? DEFAULT_HIGH_COMPLEXITY_THRESHOLD;
+
+  const seeds = selectSeeds(changedChunks, maxSeeds);
+  if (seeds.length === 0) {
+    return emptyReport();
+  }
+
+  const chunkIndex = buildChunkIndex(repoChunks);
+
+  // First pass: BFS per seed, collect raw edges. We'll overlay tests/complexity after,
+  // because test-association lookup over the full repo should be done once.
+  const rawPerSeed = seeds.map(seed => {
+    const result = graph.getCallersTransitive(seed.filepath, seed.symbolName, {
+      depth,
+      maxNodes,
+    });
+    return { seed, result };
+  });
+
+  const dependentFiles = new Set<string>();
+  for (const { result } of rawPerSeed) {
+    for (const edge of result.callers) {
+      dependentFiles.add(edge.caller.filepath);
+    }
+  }
+  const coveredFiles = computeTestCoverage(dependentFiles, repoChunks, opts.workspaceRoot);
+
+  // Second pass: enrich + score per seed.
+  const entries: BlastRadiusEntry[] = rawPerSeed.map(({ seed, result }) => {
+    const dependents: BlastRadiusDependent[] = result.callers.map(edge => {
+      const chunkKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
+      const dependentChunk = chunkIndex.get(chunkKey);
+      const complexity = dependentChunk ? chunkComplexity(dependentChunk) : undefined;
+      return {
+        filepath: edge.caller.filepath,
+        symbolName: edge.caller.symbolName,
+        hops: edge.hops,
+        callSiteLine: edge.callSiteLine,
+        complexity: complexity && complexity > 0 ? complexity : undefined,
+        hasTestCoverage: coveredFiles.has(edge.caller.filepath),
+      };
+    });
+
+    const uncovered = dependents.filter(d => !d.hasTestCoverage);
+    const maxDependentComplexity = dependents.reduce(
+      (acc, d) => Math.max(acc, d.complexity ?? 0),
+      0,
+    );
+    const hasHighComplexityUncovered = uncovered.some(
+      d => (d.complexity ?? 0) >= highComplexityThreshold,
+    );
+
+    const risk = computeBlastRadiusRisk({
+      dependentCount: dependents.length,
+      uncoveredDependents: uncovered.length,
+      maxDependentComplexity: maxDependentComplexity > 0 ? maxDependentComplexity : undefined,
+      hasHighComplexityUncovered,
+    });
+
+    return { seed, dependents, risk, truncated: result.truncated };
+  });
+
+  entries.sort((a, b) => {
+    const levelDelta = RISK_RANK[b.risk.level] - RISK_RANK[a.risk.level];
+    if (levelDelta !== 0) return levelDelta;
+    return b.dependents.length - a.dependents.length;
+  });
+
+  // Global aggregation
+  const distinct = new Set<string>();
+  let globalUncovered = 0;
+  let globalMaxComplexity = 0;
+  let globalHasHighUncovered = false;
+  for (const entry of entries) {
+    for (const d of entry.dependents) {
+      const key = `${d.filepath}::${d.symbolName}`;
+      if (!distinct.has(key)) {
+        distinct.add(key);
+        if (!d.hasTestCoverage) globalUncovered += 1;
+        if (typeof d.complexity === 'number' && d.complexity > globalMaxComplexity) {
+          globalMaxComplexity = d.complexity;
+        }
+        if (!d.hasTestCoverage && (d.complexity ?? 0) >= highComplexityThreshold) {
+          globalHasHighUncovered = true;
+        }
+      }
+    }
+  }
+
+  const globalRisk = computeBlastRadiusRisk({
+    dependentCount: distinct.size,
+    uncoveredDependents: globalUncovered,
+    maxDependentComplexity: globalMaxComplexity > 0 ? globalMaxComplexity : undefined,
+    hasHighComplexityUncovered: globalHasHighUncovered,
+  });
+
+  return {
+    entries,
+    totalDistinctDependents: distinct.size,
+    globalRisk,
+    truncated: entries.some(e => e.truncated),
+  };
+}
+
+function emptyReport(): BlastRadiusReport {
+  return {
+    entries: [],
+    totalDistinctDependents: 0,
+    globalRisk: { level: 'low', reasoning: [] },
+    truncated: false,
+  };
+}

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -164,6 +164,12 @@ export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
       if (expandedSymbols.has(currentKey)) continue;
       expandedSymbols.add(currentKey);
 
+      // Truncation is deterministic but ordering-dependent: when maxNodes is
+      // hit mid-expansion, the remaining callers of the current symbol (and
+      // any deeper symbols still in the queue) are dropped silently. Which
+      // callers survive therefore depends on the iteration order of
+      // directCallers — consumers should not rely on any particular subset
+      // appearing in a truncated result.
       const directCallers = getCallers(current.filepath, current.symbolName);
       for (const edge of directCallers) {
         const callerKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -24,9 +24,41 @@ export interface CallerEdge {
   callSiteLine: number;
 }
 
+export interface TransitiveCallerEdge extends CallerEdge {
+  /** Distance from the seed symbol. Direct callers are 1, callers-of-callers are 2. */
+  hops: number;
+  /** The symbol on the call chain this caller resolved through. Equals the seed for hops=1. */
+  viaSymbol: string;
+}
+
+export interface TransitiveResult {
+  callers: TransitiveCallerEdge[];
+  /** True if BFS stopped because it hit maxNodes before exploring the full graph. */
+  truncated: boolean;
+  /** Count of distinct symbols whose callers were expanded (for diagnostics). */
+  visitedSymbols: number;
+}
+
+export interface TransitiveOptions {
+  /** Max hop distance from the seed. Default 2. */
+  depth?: number;
+  /** Max edges to emit. Default 30. */
+  maxNodes?: number;
+}
+
 export interface DependencyGraph {
   /** Find all chunks that call a given exported symbol. */
   getCallers(filepath: string, symbolName: string): CallerEdge[];
+  /**
+   * BFS-walk callers up to `depth` hops. Each caller is emitted exactly once,
+   * at its shortest hop distance from the seed. Stops when `maxNodes` edges
+   * have been emitted (sets `truncated=true`).
+   */
+  getCallersTransitive(
+    filepath: string,
+    symbolName: string,
+    opts?: TransitiveOptions,
+  ): TransitiveResult;
 }
 
 // ---------------------------------------------------------------------------
@@ -96,11 +128,76 @@ export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
   const chunkImportMaps = resolveChunkImports(chunks, fileSet);
   const callerEdges = buildCallerEdges(chunks, chunkImportMaps, exportIndex);
 
-  return {
-    getCallers(filepath: string, symbolName: string): CallerEdge[] {
-      return callerEdges.get(`${filepath}::${symbolName}`) ?? [];
-    },
+  const getCallers = (filepath: string, symbolName: string): CallerEdge[] => {
+    return callerEdges.get(`${filepath}::${symbolName}`) ?? [];
   };
+
+  const getCallersTransitive = (
+    filepath: string,
+    symbolName: string,
+    opts: TransitiveOptions = {},
+  ): TransitiveResult => {
+    const depth = opts.depth ?? 2;
+    const maxNodes = opts.maxNodes ?? 30;
+
+    if (depth < 1 || maxNodes < 1) {
+      return { callers: [], truncated: false, visitedSymbols: 0 };
+    }
+
+    const seedKey = `${filepath}::${symbolName}`;
+    const expandedSymbols = new Set<string>();
+    const emittedCallers = new Set<string>();
+    // Never emit the seed as its own caller — guards against cycles that
+    // would otherwise produce meaningless "X calls X" edges.
+    emittedCallers.add(seedKey);
+
+    const result: TransitiveCallerEdge[] = [];
+    const queue: Array<{ filepath: string; symbolName: string; hops: number }> = [
+      { filepath, symbolName, hops: 0 },
+    ];
+
+    let truncated = false;
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current) break;
+      const currentKey = `${current.filepath}::${current.symbolName}`;
+      if (expandedSymbols.has(currentKey)) continue;
+      expandedSymbols.add(currentKey);
+
+      const directCallers = getCallers(current.filepath, current.symbolName);
+      for (const edge of directCallers) {
+        const callerKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
+        if (emittedCallers.has(callerKey)) continue;
+
+        if (result.length >= maxNodes) {
+          truncated = true;
+          break;
+        }
+
+        emittedCallers.add(callerKey);
+        const hops = current.hops + 1;
+        result.push({
+          caller: edge.caller,
+          callSiteLine: edge.callSiteLine,
+          hops,
+          viaSymbol: current.symbolName,
+        });
+
+        if (hops < depth) {
+          queue.push({
+            filepath: edge.caller.filepath,
+            symbolName: edge.caller.symbolName,
+            hops,
+          });
+        }
+      }
+      if (truncated) break;
+    }
+
+    return { callers: result, truncated, visitedSymbols: expandedSymbols.size };
+  };
+
+  return { getCallers, getCallersTransitive };
 }
 
 type ExportEntry = { filepath: string; chunk: CodeChunk };

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -128,82 +128,111 @@ export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
   const chunkImportMaps = resolveChunkImports(chunks, fileSet);
   const callerEdges = buildCallerEdges(chunks, chunkImportMaps, exportIndex);
 
-  const getCallers = (filepath: string, symbolName: string): CallerEdge[] => {
-    return callerEdges.get(`${filepath}::${symbolName}`) ?? [];
+  const getCallers = (filepath: string, symbolName: string): CallerEdge[] =>
+    callerEdges.get(`${filepath}::${symbolName}`) ?? [];
+
+  return {
+    getCallers,
+    getCallersTransitive: (filepath, symbolName, opts = {}) =>
+      bfsTransitiveCallers(getCallers, filepath, symbolName, opts),
   };
+}
 
-  const getCallersTransitive = (
-    filepath: string,
-    symbolName: string,
-    opts: TransitiveOptions = {},
-  ): TransitiveResult => {
-    const depth = opts.depth ?? 2;
-    const maxNodes = opts.maxNodes ?? 30;
+// ---------------------------------------------------------------------------
+// Transitive BFS — extracted so buildDependencyGraph stays a thin wire-up.
+// ---------------------------------------------------------------------------
 
-    if (depth < 1 || maxNodes < 1) {
-      return { callers: [], truncated: false, visitedSymbols: 0 };
+const DEFAULT_TRANSITIVE_DEPTH = 2;
+const DEFAULT_TRANSITIVE_MAX_NODES = 30;
+
+interface BfsQueueItem {
+  filepath: string;
+  symbolName: string;
+  hops: number;
+}
+
+function bfsTransitiveCallers(
+  getCallers: (filepath: string, symbolName: string) => CallerEdge[],
+  filepath: string,
+  symbolName: string,
+  opts: TransitiveOptions,
+): TransitiveResult {
+  const depth = opts.depth ?? DEFAULT_TRANSITIVE_DEPTH;
+  const maxNodes = opts.maxNodes ?? DEFAULT_TRANSITIVE_MAX_NODES;
+
+  if (depth < 1 || maxNodes < 1) {
+    return { callers: [], truncated: false, visitedSymbols: 0 };
+  }
+
+  // Seed in emittedCallers ensures cycles can never re-emit the seed.
+  const emittedCallers = new Set<string>([`${filepath}::${symbolName}`]);
+  const expandedSymbols = new Set<string>();
+  const result: TransitiveCallerEdge[] = [];
+  const queue: BfsQueueItem[] = [{ filepath, symbolName, hops: 0 }];
+  const state = { truncated: false };
+
+  while (queue.length > 0 && !state.truncated) {
+    const current = queue.shift();
+    if (!current) break;
+    const currentKey = `${current.filepath}::${current.symbolName}`;
+    if (expandedSymbols.has(currentKey)) continue;
+    expandedSymbols.add(currentKey);
+    expandFrontier(current, getCallers, { depth, maxNodes }, emittedCallers, result, queue, state);
+  }
+
+  return { callers: result, truncated: state.truncated, visitedSymbols: expandedSymbols.size };
+}
+
+interface ExpandLimits {
+  depth: number;
+  maxNodes: number;
+}
+
+/**
+ * Process the direct callers of a single frontier symbol.
+ *
+ * Truncation is deterministic but ordering-dependent: when maxNodes is hit
+ * mid-expansion, the remaining callers of the current symbol (and any deeper
+ * symbols still in the queue) are dropped silently. Which callers survive
+ * therefore depends on the iteration order of getCallers — consumers should
+ * not rely on any particular subset appearing in a truncated result.
+ */
+function expandFrontier(
+  current: BfsQueueItem,
+  getCallers: (filepath: string, symbolName: string) => CallerEdge[],
+  limits: ExpandLimits,
+  emittedCallers: Set<string>,
+  result: TransitiveCallerEdge[],
+  queue: BfsQueueItem[],
+  state: { truncated: boolean },
+): void {
+  const directCallers = getCallers(current.filepath, current.symbolName);
+  for (const edge of directCallers) {
+    const callerKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
+    if (emittedCallers.has(callerKey)) continue;
+
+    if (result.length >= limits.maxNodes) {
+      state.truncated = true;
+      return;
     }
 
-    const seedKey = `${filepath}::${symbolName}`;
-    const expandedSymbols = new Set<string>();
-    const emittedCallers = new Set<string>();
-    // Never emit the seed as its own caller — guards against cycles that
-    // would otherwise produce meaningless "X calls X" edges.
-    emittedCallers.add(seedKey);
+    emittedCallers.add(callerKey);
+    const hops = current.hops + 1;
+    result.push({
+      caller: edge.caller,
+      callSiteLine: edge.callSiteLine,
+      hops,
+      viaSymbol: current.symbolName,
+    });
 
-    const result: TransitiveCallerEdge[] = [];
-    const queue: Array<{ filepath: string; symbolName: string; hops: number }> = [
-      { filepath, symbolName, hops: 0 },
-    ];
-
-    let truncated = false;
-    while (queue.length > 0) {
-      const current = queue.shift();
-      if (!current) break;
-      const currentKey = `${current.filepath}::${current.symbolName}`;
-      if (expandedSymbols.has(currentKey)) continue;
-      expandedSymbols.add(currentKey);
-
-      // Truncation is deterministic but ordering-dependent: when maxNodes is
-      // hit mid-expansion, the remaining callers of the current symbol (and
-      // any deeper symbols still in the queue) are dropped silently. Which
-      // callers survive therefore depends on the iteration order of
-      // directCallers — consumers should not rely on any particular subset
-      // appearing in a truncated result.
-      const directCallers = getCallers(current.filepath, current.symbolName);
-      for (const edge of directCallers) {
-        const callerKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
-        if (emittedCallers.has(callerKey)) continue;
-
-        if (result.length >= maxNodes) {
-          truncated = true;
-          break;
-        }
-
-        emittedCallers.add(callerKey);
-        const hops = current.hops + 1;
-        result.push({
-          caller: edge.caller,
-          callSiteLine: edge.callSiteLine,
-          hops,
-          viaSymbol: current.symbolName,
-        });
-
-        if (hops < depth) {
-          queue.push({
-            filepath: edge.caller.filepath,
-            symbolName: edge.caller.symbolName,
-            hops,
-          });
-        }
-      }
-      if (truncated) break;
+    if (hops < limits.depth) {
+      queue.push({
+        filepath: edge.caller.filepath,
+        symbolName: edge.caller.symbolName,
+        hops,
+      });
     }
-
-    return { callers: result, truncated, visitedSymbols: expandedSymbols.size };
-  };
-
-  return { getCallers, getCallersTransitive };
+  }
 }
 
 type ExportEntry = { filepath: string; chunk: CodeChunk };

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -15,6 +15,7 @@ import type {
   PresentContext,
 } from '../../plugin-types.js';
 import { buildDependencyGraph } from '../../dependency-graph.js';
+import { computeBlastRadius } from '../../blast-radius.js';
 import type { Logger } from '../../logger.js';
 
 import type { AgentConfig, AgentFinding, AgentResult } from './types.js';
@@ -36,6 +37,14 @@ const configSchema = z.object({
   maxTokenBudget: z.number().int().default(100_000),
   // Legacy — maps to apiKey
   anthropicApiKey: z.string().optional(),
+  blastRadius: z
+    .object({
+      enabled: z.boolean().default(true),
+      depth: z.number().int().min(1).max(4).default(2),
+      maxNodes: z.number().int().min(5).max(200).default(30),
+      maxSeeds: z.number().int().min(1).max(20).default(8),
+    })
+    .optional(),
 });
 
 export interface AgentReviewPluginOptions {
@@ -86,8 +95,26 @@ export class AgentReviewPlugin implements ReviewPlugin {
       `[${this.id}] Rules: ${rules.active.map(r => r.id).join(', ')} (skipped: ${rules.skipped.join(', ') || 'none'})`,
     );
 
+    // Pre-compute transitive blast radius so the agent sees it in the initial
+    // message instead of having to decide to call get_dependents itself.
+    const blastRadiusConfig = config.blastRadius ?? {};
+    const blastRadius =
+      blastRadiusConfig.enabled !== false
+        ? computeBlastRadius(context.chunks, graph, context.repoChunks!, {
+            depth: blastRadiusConfig.depth,
+            maxNodes: blastRadiusConfig.maxNodes,
+            maxSeeds: blastRadiusConfig.maxSeeds,
+            workspaceRoot: context.repoRootDir,
+          })
+        : null;
+    if (blastRadius) {
+      logger.info(
+        `[${this.id}] Blast radius: ${blastRadius.totalDistinctDependents} deps, risk=${blastRadius.globalRisk.level}${blastRadius.truncated ? ' (truncated)' : ''}`,
+      );
+    }
+
     const systemPrompt = buildSystemPrompt(rules);
-    const initialMessage = buildInitialMessage(context);
+    const initialMessage = buildInitialMessage(context, { blastRadius });
     const result = await runAgentClient(
       provider,
       config,

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -13,6 +13,8 @@
  */
 
 import type { ReviewContext } from '../../plugin-types.js';
+import type { BlastRadiusReport } from '../../blast-radius.js';
+import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -29,6 +31,8 @@ You have these tools to investigate the codebase:
 - grep_codebase: Search the entire repository for a text pattern (regex). Use to find all files that reference a symbol, including cross-package imports within this monorepo.
 - get_complexity: Get complexity metrics for files
 - read_file: Read file contents from the repo
+
+A <blast_radius> section may be present in your initial message. It lists pre-computed transitive dependents of the changed symbols, with test coverage and complexity overlay. Use it as your starting map. Call get_dependents only for drill-down on specific symbols not already covered there.
 </tools>`;
 
 const SELF_REVIEW = `### Self-Review
@@ -143,13 +147,22 @@ ${OUTPUT_FORMAT}`;
 /** Max characters for the diff section before truncation. */
 const MAX_DIFF_CHARS = 50_000;
 
+/** Options for initial-message assembly. */
+export interface BuildInitialMessageOptions {
+  /** Pre-computed blast-radius report to inject as a `<blast_radius>` block. */
+  blastRadius?: BlastRadiusReport | null;
+}
+
 /**
  * Build the initial user message from the review context.
  *
  * Uses XML tags to separate context sections (structured input technique
  * from aisnacks.io — reduces misinterpretation between instructions and data).
  */
-export function buildInitialMessage(context: ReviewContext): string {
+export function buildInitialMessage(
+  context: ReviewContext,
+  opts: BuildInitialMessageOptions = {},
+): string {
   const sections: string[] = [];
 
   // PR metadata
@@ -202,6 +215,14 @@ Title: ${context.pr.title}${context.pr.body ? `\nDescription: ${context.pr.body}
       return `- \`${sig}\` at ${loc}`;
     });
     sections.push(`<changed_functions>\n${lines.join('\n')}\n</changed_functions>`);
+  }
+
+  // Blast radius — pre-computed transitive dependents, test coverage, risk score.
+  if (opts.blastRadius) {
+    const rendered = renderBlastRadiusMarkdown(opts.blastRadius);
+    if (rendered.length > 0) {
+      sections.push(rendered);
+    }
   }
 
   // Detect deleted exports from diff — critical for finding breaking changes

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -164,82 +164,87 @@ export function buildInitialMessage(
   opts: BuildInitialMessageOptions = {},
 ): string {
   const sections: string[] = [];
-
-  // PR metadata
-  if (context.pr) {
-    sections.push(`<pr_metadata>
-Title: ${context.pr.title}${context.pr.body ? `\nDescription: ${context.pr.body}` : ''}
-</pr_metadata>`);
-  }
-
-  // Changed files
-  sections.push(
-    `<changed_files>\n${context.changedFiles.map(f => `- ${f}`).join('\n')}\n</changed_files>`,
-  );
-
-  // Diff patches
-  if (context.pr?.patches && context.pr.patches.size > 0) {
-    let diffText = '';
-    for (const [file, patch] of context.pr.patches) {
-      diffText += `### ${file}\n\`\`\`diff\n${patch}\n\`\`\`\n\n`;
-    }
-
-    if (diffText.length > MAX_DIFF_CHARS) {
-      diffText = diffText.slice(0, MAX_DIFF_CHARS);
-      diffText += '\n\n[Diff truncated — use read_file to see full contents of specific files]';
-    }
-
-    sections.push(`<diff>\n${diffText}</diff>`);
-  }
-
-  // Complexity regressions (positive deltas only)
-  if (context.deltas && context.deltas.length > 0) {
-    const regressions = context.deltas.filter(d => d.delta > 0);
-    if (regressions.length > 0) {
-      const lines = regressions.map(
-        d =>
-          `- ${d.filepath} \`${d.symbolName ?? 'file'}\`: ${d.metricType} ${d.baseComplexity} -> ${d.headComplexity} (+${d.delta})`,
-      );
-      sections.push(`<complexity_regressions>\n${lines.join('\n')}\n</complexity_regressions>`);
-    }
-  }
-
-  // Changed function signatures
-  const functionChunks = context.chunks.filter(
-    c => c.metadata.symbolType === 'function' || c.metadata.symbolType === 'method',
-  );
-  if (functionChunks.length > 0) {
-    const lines = functionChunks.map(c => {
-      const sig = c.metadata.signature ?? c.metadata.symbolName ?? 'unknown';
-      const loc = `${c.metadata.file}:${c.metadata.startLine}`;
-      return `- \`${sig}\` at ${loc}`;
-    });
-    sections.push(`<changed_functions>\n${lines.join('\n')}\n</changed_functions>`);
-  }
-
-  // Blast radius — pre-computed transitive dependents, test coverage, risk score.
-  if (opts.blastRadius) {
-    const rendered = renderBlastRadiusMarkdown(opts.blastRadius);
-    if (rendered.length > 0) {
-      sections.push(rendered);
-    }
-  }
-
-  // Detect deleted exports from diff — critical for finding breaking changes
-  if (context.pr?.patches) {
-    const deletedExports = extractDeletedExports(context.pr.patches);
-    if (deletedExports.length > 0) {
-      sections.push(
-        `<deleted_exports>\nThese exports were REMOVED in this PR. Use grep_codebase to check if any file still imports them. After checking deleted exports, continue with the rest of your investigation (edge case sweep on new/changed functions, self-review).\n${deletedExports.map(e => `- ${e}`).join('\n')}\n</deleted_exports>`,
-      );
-    }
-  }
-
+  appendIfPresent(sections, renderPrMetadata(context));
+  sections.push(renderChangedFiles(context));
+  appendIfPresent(sections, renderDiff(context));
+  appendIfPresent(sections, renderComplexityRegressions(context));
+  appendIfPresent(sections, renderChangedFunctions(context));
+  appendIfPresent(sections, renderBlastRadius(opts));
+  appendIfPresent(sections, renderDeletedExports(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );
-
   return sections.join('\n\n');
+}
+
+function appendIfPresent(sections: string[], value: string | null): void {
+  if (value) sections.push(value);
+}
+
+function renderPrMetadata(context: ReviewContext): string | null {
+  if (!context.pr) return null;
+  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
+  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
+}
+
+function renderChangedFiles(context: ReviewContext): string {
+  const list = context.changedFiles.map(f => `- ${f}`).join('\n');
+  return `<changed_files>\n${list}\n</changed_files>`;
+}
+
+function renderDiff(context: ReviewContext): string | null {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return null;
+  let diffText = '';
+  for (const [file, patch] of patches) {
+    diffText += `### ${file}\n\`\`\`diff\n${patch}\n\`\`\`\n\n`;
+  }
+  if (diffText.length > MAX_DIFF_CHARS) {
+    diffText =
+      diffText.slice(0, MAX_DIFF_CHARS) +
+      '\n\n[Diff truncated — use read_file to see full contents of specific files]';
+  }
+  return `<diff>\n${diffText}</diff>`;
+}
+
+function renderComplexityRegressions(context: ReviewContext): string | null {
+  const deltas = context.deltas;
+  if (!deltas || deltas.length === 0) return null;
+  const regressions = deltas.filter(d => d.delta > 0);
+  if (regressions.length === 0) return null;
+  const lines = regressions.map(
+    d =>
+      `- ${d.filepath} \`${d.symbolName ?? 'file'}\`: ${d.metricType} ${d.baseComplexity} -> ${d.headComplexity} (+${d.delta})`,
+  );
+  return `<complexity_regressions>\n${lines.join('\n')}\n</complexity_regressions>`;
+}
+
+function renderChangedFunctions(context: ReviewContext): string | null {
+  const functionChunks = context.chunks.filter(
+    c => c.metadata.symbolType === 'function' || c.metadata.symbolType === 'method',
+  );
+  if (functionChunks.length === 0) return null;
+  const lines = functionChunks.map(c => {
+    const sig = c.metadata.signature ?? c.metadata.symbolName ?? 'unknown';
+    const loc = `${c.metadata.file}:${c.metadata.startLine}`;
+    return `- \`${sig}\` at ${loc}`;
+  });
+  return `<changed_functions>\n${lines.join('\n')}\n</changed_functions>`;
+}
+
+function renderBlastRadius(opts: BuildInitialMessageOptions): string | null {
+  if (!opts.blastRadius) return null;
+  const rendered = renderBlastRadiusMarkdown(opts.blastRadius);
+  return rendered.length > 0 ? rendered : null;
+}
+
+function renderDeletedExports(context: ReviewContext): string | null {
+  const patches = context.pr?.patches;
+  if (!patches) return null;
+  const deletedExports = extractDeletedExports(patches);
+  if (deletedExports.length === 0) return null;
+  const list = deletedExports.map(e => `- ${e}`).join('\n');
+  return `<deleted_exports>\nThese exports were REMOVED in this PR. Use grep_codebase to check if any file still imports them. After checking deleted exports, continue with the rest of your investigation (edge case sweep on new/changed functions, self-review).\n${list}\n</deleted_exports>`;
 }
 
 /**

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -9,6 +9,18 @@ import type { CodeChunk } from '@liendev/parser';
 import type { DependencyGraph } from '../../dependency-graph.js';
 import type { Logger } from '../../logger.js';
 
+/** Configuration for the blast-radius context injection. */
+export interface BlastRadiusConfig {
+  /** Master switch. Default true. */
+  enabled?: boolean;
+  /** Max hop distance per seed. Default 2. */
+  depth?: number;
+  /** Max dependents emitted per seed. Default 30. */
+  maxNodes?: number;
+  /** Max seeds considered. Default 8. */
+  maxSeeds?: number;
+}
+
 /** Configuration for the agent review plugin. */
 export interface AgentConfig {
   /** API key (OpenRouter or Anthropic) */
@@ -24,6 +36,8 @@ export interface AgentConfig {
   outputCostPerMTok?: number;
   maxTurns: number;
   maxTokenBudget: number;
+  /** Inject transitive blast radius into the agent's initial message. */
+  blastRadius?: BlastRadiusConfig;
 }
 
 /** A single finding produced by the agent during review. */

--- a/packages/review/test/blast-radius-render.test.ts
+++ b/packages/review/test/blast-radius-render.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { renderBlastRadiusMarkdown } from '../src/blast-radius-render.js';
+import type { BlastRadiusReport, BlastRadiusEntry } from '../src/blast-radius.js';
+
+function makeEntry(overrides?: Partial<BlastRadiusEntry>): BlastRadiusEntry {
+  return {
+    seed: {
+      filepath: 'src/seed.ts',
+      symbolName: 'seed',
+      symbolType: 'function',
+      complexity: 0,
+    },
+    dependents: [
+      {
+        filepath: 'src/caller.ts',
+        symbolName: 'caller',
+        hops: 1,
+        callSiteLine: 10,
+        complexity: 8,
+        hasTestCoverage: true,
+      },
+    ],
+    risk: { level: 'low', reasoning: ['1 caller'] },
+    truncated: false,
+    ...overrides,
+  };
+}
+
+function makeReport(overrides?: Partial<BlastRadiusReport>): BlastRadiusReport {
+  return {
+    entries: [makeEntry()],
+    totalDistinctDependents: 1,
+    globalRisk: { level: 'low', reasoning: ['1 caller'] },
+    truncated: false,
+    ...overrides,
+  };
+}
+
+describe('renderBlastRadiusMarkdown', () => {
+  it('returns an empty string when the report has no entries', () => {
+    const empty: BlastRadiusReport = {
+      entries: [],
+      totalDistinctDependents: 0,
+      globalRisk: { level: 'low', reasoning: [] },
+      truncated: false,
+    };
+    expect(renderBlastRadiusMarkdown(empty)).toBe('');
+  });
+
+  it('wraps the output in <blast_radius> XML tags', () => {
+    const out = renderBlastRadiusMarkdown(makeReport());
+    expect(out.startsWith('<blast_radius>')).toBe(true);
+    expect(out.endsWith('</blast_radius>')).toBe(true);
+  });
+
+  it('shows level uppercased in the summary line', () => {
+    const out = renderBlastRadiusMarkdown(
+      makeReport({ globalRisk: { level: 'high', reasoning: ['25 callers', '5 untested'] } }),
+    );
+    expect(out).toContain('Global risk: HIGH');
+    expect(out).toContain('25 callers');
+    expect(out).toContain('5 untested');
+  });
+
+  it('renders tested/untested markers correctly', () => {
+    const out = renderBlastRadiusMarkdown(
+      makeReport({
+        entries: [
+          makeEntry({
+            dependents: [
+              {
+                filepath: 'src/a.ts',
+                symbolName: 'a',
+                hops: 1,
+                callSiteLine: 3,
+                complexity: 5,
+                hasTestCoverage: true,
+              },
+              {
+                filepath: 'src/b.ts',
+                symbolName: 'b',
+                hops: 1,
+                callSiteLine: 7,
+                complexity: 12,
+                hasTestCoverage: false,
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(out).toContain('| ✓ |');
+    expect(out).toContain('| ✗ |');
+  });
+
+  it('shows complexity as em-dash when absent', () => {
+    const out = renderBlastRadiusMarkdown(
+      makeReport({
+        entries: [
+          makeEntry({
+            dependents: [
+              {
+                filepath: 'src/a.ts',
+                symbolName: 'a',
+                hops: 1,
+                callSiteLine: 3,
+                hasTestCoverage: true,
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(out).toMatch(/\|\s*—\s*\|/);
+  });
+
+  it('sorts dependents within an entry by hops then filepath', () => {
+    const out = renderBlastRadiusMarkdown(
+      makeReport({
+        entries: [
+          makeEntry({
+            dependents: [
+              {
+                filepath: 'src/z.ts',
+                symbolName: 'z',
+                hops: 2,
+                callSiteLine: 1,
+                hasTestCoverage: true,
+              },
+              {
+                filepath: 'src/a.ts',
+                symbolName: 'a',
+                hops: 1,
+                callSiteLine: 1,
+                hasTestCoverage: true,
+              },
+              {
+                filepath: 'src/b.ts',
+                symbolName: 'b',
+                hops: 1,
+                callSiteLine: 1,
+                hasTestCoverage: true,
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    const aIdx = out.indexOf('src/a.ts:a');
+    const bIdx = out.indexOf('src/b.ts:b');
+    const zIdx = out.indexOf('src/z.ts:z');
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBeLessThan(bIdx); // alpha within same hop
+    expect(bIdx).toBeLessThan(zIdx); // hop-1 before hop-2
+  });
+
+  it('appends a truncation footer when the report is truncated', () => {
+    const out = renderBlastRadiusMarkdown(makeReport({ truncated: true }));
+    expect(out).toContain('[truncated');
+    expect(out).toContain('more exist');
+  });
+
+  it('omits the truncation footer when not truncated', () => {
+    const out = renderBlastRadiusMarkdown(makeReport());
+    expect(out.includes('[truncated')).toBe(false);
+  });
+});

--- a/packages/review/test/blast-radius.test.ts
+++ b/packages/review/test/blast-radius.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { computeBlastRadius } from '../src/blast-radius.js';
+import { createTestChunk } from '../src/test-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function exportChunk(file: string, symbol: string, complexity = 4): CodeChunk {
+  return createTestChunk({
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: 10,
+      type: 'function',
+      symbolName: symbol,
+      symbolType: 'function',
+      language: 'typescript',
+      exports: [symbol],
+      complexity,
+      cognitiveComplexity: complexity,
+    },
+  });
+}
+
+function callerChunk(
+  file: string,
+  symbol: string,
+  target: { file: string; symbol: string; importPath: string },
+  opts: { complexity?: number } = {},
+): CodeChunk {
+  return createTestChunk({
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: 10,
+      type: 'function',
+      symbolName: symbol,
+      symbolType: 'function',
+      language: 'typescript',
+      exports: [symbol],
+      importedSymbols: { [target.importPath]: [target.symbol] },
+      callSites: [{ symbol: target.symbol, line: 5 }],
+      complexity: opts.complexity,
+      cognitiveComplexity: opts.complexity,
+    },
+  });
+}
+
+function testChunkFor(testFile: string, importedSrc: string): CodeChunk {
+  return createTestChunk({
+    content: `import { x } from '${importedSrc}';\ntest("x", () => {});`,
+    metadata: {
+      file: testFile,
+      startLine: 1,
+      endLine: 5,
+      type: 'block',
+      language: 'typescript',
+      imports: [importedSrc],
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('computeBlastRadius', () => {
+  it('returns an empty report when no seed candidates are changed', () => {
+    const repoChunks: CodeChunk[] = [];
+    const graph = buildDependencyGraph(repoChunks);
+
+    const report = computeBlastRadius([], graph, repoChunks);
+
+    expect(report.entries).toEqual([]);
+    expect(report.totalDistinctDependents).toBe(0);
+    expect(report.globalRisk.level).toBe('low');
+    expect(report.truncated).toBe(false);
+  });
+
+  it('skips non-exported non-top-level symbols (like methods) as seeds', () => {
+    const methodChunk = createTestChunk({
+      metadata: {
+        file: 'src/order.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'privateHelper',
+        symbolType: 'method',
+        parentClass: 'Order',
+        language: 'typescript',
+      },
+    });
+    const graph = buildDependencyGraph([methodChunk]);
+    const report = computeBlastRadius([methodChunk], graph, [methodChunk]);
+    expect(report.entries).toEqual([]);
+  });
+
+  it('finds transitive dependents, labels hops, overlays test coverage', () => {
+    const seed = exportChunk('src/seed.ts', 'seed');
+    const b = callerChunk('src/b.ts', 'b', {
+      file: 'src/seed.ts',
+      symbol: 'seed',
+      importPath: './seed',
+    });
+    const c = callerChunk('src/c.ts', 'c', {
+      file: 'src/b.ts',
+      symbol: 'b',
+      importPath: './b',
+    });
+    const bTest = testChunkFor('src/b.test.ts', './b'); // b is covered by a test
+    const repoChunks = [seed, b, c, bTest];
+    const graph = buildDependencyGraph(repoChunks);
+
+    const report = computeBlastRadius([seed], graph, repoChunks, { depth: 2 });
+
+    expect(report.entries).toHaveLength(1);
+    const entry = report.entries[0];
+    expect(entry.seed.symbolName).toBe('seed');
+    expect(entry.dependents).toHaveLength(2);
+
+    const bDep = entry.dependents.find(d => d.symbolName === 'b')!;
+    const cDep = entry.dependents.find(d => d.symbolName === 'c')!;
+    expect(bDep.hops).toBe(1);
+    expect(bDep.hasTestCoverage).toBe(true);
+    expect(cDep.hops).toBe(2);
+    expect(cDep.hasTestCoverage).toBe(false);
+
+    expect(report.totalDistinctDependents).toBe(2);
+    // b is covered but c is not — global risk should reflect that.
+    expect(['medium', 'high', 'critical']).toContain(report.globalRisk.level);
+  });
+
+  it('picks cognitiveComplexity over cyclomatic when overlaying complexity', () => {
+    const seed = exportChunk('src/seed.ts', 'seed');
+    const caller = callerChunk(
+      'src/caller.ts',
+      'caller',
+      { file: 'src/seed.ts', symbol: 'seed', importPath: './seed' },
+      { complexity: 12 },
+    );
+    // Force cognitive to a different value than the default (setting cognitive via helper's complexity option).
+    caller.metadata.cognitiveComplexity = 9;
+    caller.metadata.complexity = 12;
+
+    const repoChunks = [seed, caller];
+    const graph = buildDependencyGraph(repoChunks);
+    const report = computeBlastRadius([seed], graph, repoChunks);
+
+    const dep = report.entries[0].dependents[0];
+    // Cognitive preferred
+    expect(dep.complexity).toBe(9);
+  });
+
+  it('sorts entries by risk level then by dependent count', () => {
+    // Two seeds:
+    //   - "cold" with 1 tested dependent → low
+    //   - "hot" with 3 untested dependents → medium
+    const cold = exportChunk('src/cold.ts', 'cold');
+    const coldCaller = callerChunk('src/usesCold.ts', 'usesCold', {
+      file: 'src/cold.ts',
+      symbol: 'cold',
+      importPath: './cold',
+    });
+    const coldCallerTest = testChunkFor('src/usesCold.test.ts', './usesCold');
+
+    const hot = exportChunk('src/hot.ts', 'hot');
+    const hotCallers = Array.from({ length: 3 }, (_, i) =>
+      callerChunk(`src/usesHot${i}.ts`, `usesHot${i}`, {
+        file: 'src/hot.ts',
+        symbol: 'hot',
+        importPath: './hot',
+      }),
+    );
+
+    const repoChunks = [cold, coldCaller, coldCallerTest, hot, ...hotCallers];
+    const graph = buildDependencyGraph(repoChunks);
+    const report = computeBlastRadius([cold, hot], graph, repoChunks);
+
+    expect(report.entries).toHaveLength(2);
+    expect(report.entries[0].seed.symbolName).toBe('hot');
+    expect(report.entries[1].seed.symbolName).toBe('cold');
+  });
+
+  it('clips seeds to maxSeeds, ranking exported + higher complexity first', () => {
+    const chunks = Array.from(
+      { length: 5 },
+      (_, i) => exportChunk(`src/s${i}.ts`, `s${i}`, i), // increasing complexity with index
+    );
+    const graph = buildDependencyGraph(chunks);
+    const report = computeBlastRadius(chunks, graph, chunks, { maxSeeds: 2 });
+
+    expect(report.entries).toHaveLength(2);
+    // Highest complexity wins (4 and 3).
+    expect(report.entries.map(e => e.seed.symbolName).sort()).toEqual(['s3', 's4']);
+  });
+
+  it('propagates per-entry truncation into the report', () => {
+    const seed = exportChunk('src/seed.ts', 'seed');
+    const callers = Array.from({ length: 5 }, (_, i) =>
+      callerChunk(`src/c${i}.ts`, `c${i}`, {
+        file: 'src/seed.ts',
+        symbol: 'seed',
+        importPath: './seed',
+      }),
+    );
+    const repoChunks = [seed, ...callers];
+    const graph = buildDependencyGraph(repoChunks);
+    const report = computeBlastRadius([seed], graph, repoChunks, { maxNodes: 2 });
+
+    expect(report.entries[0].truncated).toBe(true);
+    expect(report.truncated).toBe(true);
+    expect(report.entries[0].dependents).toHaveLength(2);
+  });
+});

--- a/packages/review/test/dependency-graph.test.ts
+++ b/packages/review/test/dependency-graph.test.ts
@@ -593,3 +593,234 @@ describe('buildDependencyGraph — cross-package fallback', () => {
     expect(graph.getCallers('src/utils.ts', 'helper')).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// getCallersTransitive
+// ---------------------------------------------------------------------------
+
+describe('getCallersTransitive', () => {
+  /**
+   * Two-level chain: seed <- bLevel1 <- cLevel2
+   * `bLevel1` directly calls the seed; `cLevel2` calls `bLevel1`.
+   */
+  function buildTwoLevelChain() {
+    const seed = createTestChunk({
+      metadata: {
+        file: 'src/seed.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'seed',
+        language: 'typescript',
+        exports: ['seed'],
+      },
+    });
+
+    const bLevel1 = createTestChunk({
+      metadata: {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'bLevel1',
+        language: 'typescript',
+        exports: ['bLevel1'],
+        importedSymbols: { './seed': ['seed'] },
+        callSites: [{ symbol: 'seed', line: 5 }],
+      },
+    });
+
+    const cLevel2 = createTestChunk({
+      metadata: {
+        file: 'src/c.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'cLevel2',
+        language: 'typescript',
+        exports: ['cLevel2'],
+        importedSymbols: { './b': ['bLevel1'] },
+        callSites: [{ symbol: 'bLevel1', line: 5 }],
+      },
+    });
+
+    return { seed, bLevel1, cLevel2 };
+  }
+
+  it('walks two hops outward and labels each caller with its shortest hop', () => {
+    const { seed, bLevel1, cLevel2 } = buildTwoLevelChain();
+    const graph = buildDependencyGraph([seed, bLevel1, cLevel2]);
+
+    const result = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 2 });
+
+    expect(result.callers).toHaveLength(2);
+    const b = result.callers.find(e => e.caller.symbolName === 'bLevel1');
+    const c = result.callers.find(e => e.caller.symbolName === 'cLevel2');
+    expect(b?.hops).toBe(1);
+    expect(b?.viaSymbol).toBe('seed');
+    expect(c?.hops).toBe(2);
+    expect(c?.viaSymbol).toBe('bLevel1');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('depth=1 matches the one-hop getCallers set', () => {
+    const { seed, bLevel1, cLevel2 } = buildTwoLevelChain();
+    const graph = buildDependencyGraph([seed, bLevel1, cLevel2]);
+
+    const oneHop = graph.getCallers('src/seed.ts', 'seed');
+    const transitive = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 1 });
+
+    expect(transitive.callers).toHaveLength(oneHop.length);
+    expect(transitive.callers.map(e => e.caller.symbolName).sort()).toEqual(
+      oneHop.map(e => e.caller.symbolName).sort(),
+    );
+    expect(transitive.callers.every(e => e.hops === 1)).toBe(true);
+  });
+
+  it('terminates cleanly when a cycle is present', () => {
+    // a <-> b mutual recursion at the symbol level
+    const a = createTestChunk({
+      metadata: {
+        file: 'src/a.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'a',
+        language: 'typescript',
+        exports: ['a'],
+        importedSymbols: { './b': ['b'] },
+        callSites: [{ symbol: 'b', line: 5 }],
+      },
+    });
+    const b = createTestChunk({
+      metadata: {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'b',
+        language: 'typescript',
+        exports: ['b'],
+        importedSymbols: { './a': ['a'] },
+        callSites: [{ symbol: 'a', line: 5 }],
+      },
+    });
+    const graph = buildDependencyGraph([a, b]);
+
+    const result = graph.getCallersTransitive('src/a.ts', 'a', { depth: 5 });
+
+    // Only b is emitted; the seed a must never appear as its own caller.
+    expect(result.callers).toHaveLength(1);
+    expect(result.callers[0].caller.symbolName).toBe('b');
+    expect(result.callers[0].hops).toBe(1);
+  });
+
+  it('deduplicates callers that reach the seed via multiple paths', () => {
+    // Diamond: a calls seed, a calls b, b calls seed. "a" has two paths to seed.
+    const seed = createTestChunk({
+      metadata: {
+        file: 'src/seed.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'seed',
+        language: 'typescript',
+        exports: ['seed'],
+      },
+    });
+    const b = createTestChunk({
+      metadata: {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'b',
+        language: 'typescript',
+        exports: ['b'],
+        importedSymbols: { './seed': ['seed'] },
+        callSites: [{ symbol: 'seed', line: 5 }],
+      },
+    });
+    const a = createTestChunk({
+      metadata: {
+        file: 'src/a.ts',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'a',
+        language: 'typescript',
+        exports: ['a'],
+        importedSymbols: { './seed': ['seed'], './b': ['b'] },
+        callSites: [
+          { symbol: 'seed', line: 5 },
+          { symbol: 'b', line: 6 },
+        ],
+      },
+    });
+
+    const graph = buildDependencyGraph([seed, b, a]);
+    const result = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 3 });
+
+    // a and b are both callers. a must appear only once, at its shortest hop (1).
+    const aEdges = result.callers.filter(e => e.caller.symbolName === 'a');
+    expect(aEdges).toHaveLength(1);
+    expect(aEdges[0].hops).toBe(1);
+    expect(result.callers).toHaveLength(2);
+  });
+
+  it('truncates when maxNodes is exceeded', () => {
+    const seed = createTestChunk({
+      metadata: {
+        file: 'src/seed.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'seed',
+        language: 'typescript',
+        exports: ['seed'],
+      },
+    });
+    const callers = Array.from({ length: 5 }, (_, i) =>
+      createTestChunk({
+        metadata: {
+          file: `src/caller${i}.ts`,
+          startLine: 1,
+          endLine: 10,
+          type: 'function',
+          symbolName: `caller${i}`,
+          language: 'typescript',
+          importedSymbols: { './seed': ['seed'] },
+          callSites: [{ symbol: 'seed', line: 5 }],
+        },
+      }),
+    );
+
+    const graph = buildDependencyGraph([seed, ...callers]);
+    const result = graph.getCallersTransitive('src/seed.ts', 'seed', {
+      depth: 2,
+      maxNodes: 2,
+    });
+
+    expect(result.callers).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('returns an empty result for depth < 1 or maxNodes < 1', () => {
+    const { seed, bLevel1 } = buildTwoLevelChain();
+    const graph = buildDependencyGraph([seed, bLevel1]);
+
+    const zeroDepth = graph.getCallersTransitive('src/seed.ts', 'seed', { depth: 0 });
+    expect(zeroDepth.callers).toEqual([]);
+    expect(zeroDepth.visitedSymbols).toBe(0);
+
+    const zeroNodes = graph.getCallersTransitive('src/seed.ts', 'seed', { maxNodes: 0 });
+    expect(zeroNodes.callers).toEqual([]);
+  });
+
+  it('returns an empty result for an unknown seed', () => {
+    const graph = buildDependencyGraph([]);
+    const result = graph.getCallersTransitive('nonexistent.ts', 'noSuchSymbol', { depth: 2 });
+    expect(result.callers).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+});

--- a/packages/review/test/plugins-agent-blast-radius.test.ts
+++ b/packages/review/test/plugins-agent-blast-radius.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { createTestContext } from '../src/test-helpers.js';
+import type { BlastRadiusReport } from '../src/blast-radius.js';
+
+function sampleReport(): BlastRadiusReport {
+  return {
+    entries: [
+      {
+        seed: {
+          filepath: 'src/auth/validate.ts',
+          symbolName: 'validateToken',
+          symbolType: 'function',
+          complexity: 8,
+        },
+        dependents: [
+          {
+            filepath: 'src/middleware/auth.ts',
+            symbolName: 'requireAuth',
+            hops: 1,
+            callSiteLine: 42,
+            complexity: 6,
+            hasTestCoverage: true,
+          },
+          {
+            filepath: 'src/routes/oauth.ts',
+            symbolName: 'oauthHandler',
+            hops: 2,
+            callSiteLine: 18,
+            complexity: 18,
+            hasTestCoverage: false,
+          },
+        ],
+        risk: { level: 'medium', reasoning: ['2 callers', '1 untested'] },
+        truncated: false,
+      },
+    ],
+    totalDistinctDependents: 2,
+    globalRisk: { level: 'medium', reasoning: ['2 callers', '1 untested'] },
+    truncated: false,
+  };
+}
+
+describe('buildInitialMessage with blast-radius injection', () => {
+  it('includes a <blast_radius> block when a report is provided', () => {
+    const context = createTestContext({ changedFiles: ['src/auth/validate.ts'] });
+    const message = buildInitialMessage(context, { blastRadius: sampleReport() });
+
+    expect(message).toContain('<blast_radius>');
+    expect(message).toContain('</blast_radius>');
+    expect(message).toContain('Global risk: MEDIUM');
+    expect(message).toContain('src/middleware/auth.ts:requireAuth');
+    expect(message).toContain('src/routes/oauth.ts:oauthHandler');
+  });
+
+  it('omits the <blast_radius> block when no report is provided', () => {
+    const context = createTestContext({ changedFiles: ['src/auth/validate.ts'] });
+    const noOpts = buildInitialMessage(context);
+    const nullReport = buildInitialMessage(context, { blastRadius: null });
+
+    expect(noOpts).not.toContain('<blast_radius>');
+    expect(nullReport).not.toContain('<blast_radius>');
+  });
+
+  it('omits the <blast_radius> block when the report has no entries', () => {
+    const context = createTestContext({ changedFiles: ['src/auth/validate.ts'] });
+    const message = buildInitialMessage(context, {
+      blastRadius: {
+        entries: [],
+        totalDistinctDependents: 0,
+        globalRisk: { level: 'low', reasoning: [] },
+        truncated: false,
+      },
+    });
+
+    expect(message).not.toContain('<blast_radius>');
+  });
+
+  it('places <blast_radius> after <changed_files> and before <deleted_exports>', () => {
+    const context = createTestContext({
+      changedFiles: ['src/auth/validate.ts'],
+      pr: {
+        title: 'Refactor auth',
+        body: '',
+        number: 1,
+        baseSha: 'base',
+        headSha: 'head',
+        patches: new Map([['src/auth/validate.ts', '-export { something } from "./x";']]),
+      } as unknown as ReturnType<typeof createTestContext>['pr'],
+    });
+    const message = buildInitialMessage(context, { blastRadius: sampleReport() });
+
+    const changedFilesIdx = message.indexOf('<changed_files>');
+    const blastIdx = message.indexOf('<blast_radius>');
+    const deletedIdx = message.indexOf('<deleted_exports>');
+
+    expect(changedFilesIdx).toBeGreaterThan(-1);
+    expect(blastIdx).toBeGreaterThan(changedFilesIdx);
+    if (deletedIdx > -1) {
+      expect(blastIdx).toBeLessThan(deletedIdx);
+    }
+  });
+});

--- a/packages/review/test/plugins-agent-blast-radius.test.ts
+++ b/packages/review/test/plugins-agent-blast-radius.test.ts
@@ -94,10 +94,12 @@ describe('buildInitialMessage with blast-radius injection', () => {
     const blastIdx = message.indexOf('<blast_radius>');
     const deletedIdx = message.indexOf('<deleted_exports>');
 
+    // All three blocks must be present — otherwise the ordering assertion
+    // silently no-ops and this test loses its point.
     expect(changedFilesIdx).toBeGreaterThan(-1);
+    expect(blastIdx).toBeGreaterThan(-1);
+    expect(deletedIdx).toBeGreaterThan(-1);
     expect(blastIdx).toBeGreaterThan(changedFilesIdx);
-    if (deletedIdx > -1) {
-      expect(blastIdx).toBeLessThan(deletedIdx);
-    }
+    expect(blastIdx).toBeLessThan(deletedIdx);
   });
 });


### PR DESCRIPTION
## Summary

Pre-compute transitive dependents of changed symbols and inject them as structured context into the review agent's initial message. The agent now **sees** the blast radius up-front instead of having to decide to call \`get_dependents\` mid-conversation.

Implements Workstream A from [\`.wip/plan-workstream-a-blast-radius.md\`](.wip/plan-workstream-a-blast-radius.md). Replaces the two superseded PRs #515 and #516.

## Why

- \`get_dependents\` is one-hop; a change's real regression surface extends further.
- The review agent gets the diff up-front but only explores blast radius if it *chooses* to. In practice many reviews skip it.
- The fix isn't "make the tool better" — it's "make the context better." Compute once at review start, render as a table the agent can scan, let it drill into specific symbols via \`get_dependents\` only when needed.

## What's in the block

\`\`\`
<blast_radius>
Global risk: MEDIUM — 14 distinct dependents (14 callers, 3 untested, max complexity 18).

| Seed (changed) | Hops | Dependent | Tests | Complexity |
|---|---|---|---|---|
| \`src/auth/validate.ts:validateToken\` | 1 | \`src/middleware/auth.ts:requireAuth\` (L42) | ✓ | 6 |
| \`src/auth/validate.ts:validateToken\` | 2 | \`src/routes/oauth.ts:oauthHandler\` (L18) | ✗ | 18 |
...
</blast_radius>
\`\`\`

## Commit structure (5 logical commits)

| # | Commit | Behaviour change |
|---|---|---|
| 1 | \`feat(parser)\`: risk scoring helper | none |
| 2 | \`feat(review)\`: getCallersTransitive on DependencyGraph | none |
| 3 | \`feat(review)\`: computeBlastRadius module | none |
| 4 | \`feat(review)\`: markdown renderer | none |
| 5 | \`feat(review)\`: inject into agent's initial message | **yes — this is the rollback target** |

Kill switch: \`config.blastRadius.enabled=false\`. Rollback is commit 5 only — commits 1-4 are pure library additions and harmless if left in place.

## Key design choices

- **Seed selection**: function/method/class symbols from changed chunks, ranked exported-first then by cognitive complexity. Capped at \`maxSeeds\` (default 8).
- **Defaults**: depth=2, maxNodes=30 per seed, maxSeeds=8. All config-overridable.
- **Risk scoring**: 4-tier (\`low|medium|high|critical\`) combining breadth + uncovered dependents + max complexity. Reasoning strings emitted alongside.
- **Test-coverage overlay**: hard ✓/✗ markers to drive attention to uncovered dependents.
- **Placement**: risk helper lives in \`@liendev/parser\`, not \`@liendev/core\`, so review doesn't pull in VectorDB/LanceDB bindings at bundle time.
- **Dedup on shortest hop**: a caller reachable via multiple paths appears once, at its shortest distance.

## Test plan

- [x] \`npm run format:check\` — passes
- [x] \`npm run lint\` — 0 errors (27 pre-existing warnings untouched)
- [x] \`npm run typecheck\` — 0 errors across all packages
- [x] \`npm run build\` — succeeds (all five packages)
- [x] Full review suite passes: 285/285
- [x] Parser risk tests: 10/10
- [x] New blast-radius tests: 7/7
- [x] New renderer tests: 8/8
- [x] New agent-wiring tests: 4/4
- [x] DependencyGraph tests still pass (now 30, was 23)

## What's intentionally deferred

- **Fixture harness + dev runner script** for local iteration against the real LLM. Best added in a follow-up once the core behaviour is validated.
- **MCP \`get_dependents\` depth extension** (Workstream B) — reuses the same risk helper when we're ready to ship it.
- **Call-graph edge confidence tiers** (EXTRACTED / INFERRED / AMBIGUOUS). Noise reduction for depth ≥ 3; not needed at depth 2.
- **Non-agent plugins.** Agent-only in v1; easy to lift to shared prompt path later.

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 113. 9 pre-existing issues remain in touched files.
🔗 **Impact**: 1 high-risk file(s) with 12 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 3 | -21 |
| ⏱️ time to understand | 5 | -92 |


> [!NOTE]
> **Low Risk**
>
> This PR introduces a new feature to pre-compute and inject a 'blast radius' report into the review agent's initial message. This report details transitive dependents of changed symbols, their test coverage, and complexity, along with an aggregated risk score. The implementation involves extending the dependency graph traversal, adding risk scoring logic, and rendering the report in Markdown. The core logic for identifying seeds, traversing the dependency graph, overlaying test coverage and complexity, and computing risk appears robust and handles various edge cases like truncation and empty inputs. The integration into the agent's system prompt is well-handled, providing clear instructions for the agent on how to use this new context. While the `buildDependencyGraph` function's complexity has increased, this is a direct consequence of adding a sophisticated BFS algorithm for transitive dependency analysis, and the implementation appears correct and robust.
>
> - Added `computeBlastRadiusRisk` for scoring the blast radius based on dependent count, test coverage, and complexity.
> - Extended `DependencyGraph` with `getCallersTransitive` for BFS-based traversal of callers, handling depth, max nodes, and cycles.
> - Implemented `computeBlastRadius` to orchestrate seed selection, transitive caller discovery, test coverage overlay, and risk calculation.
> - Added `renderBlastRadiusMarkdown` to format the blast radius report for agent consumption.
> - Integrated the blast radius computation and rendering into the agent's initial message, with configurable options and a kill switch.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a7b77ea. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blast-radius risk analysis to assess the impact scope of code changes by identifying and scoring transitive dependent relationships.
  * Displays risk levels (low, medium, high, critical) with reasoning for affected dependencies, including test coverage status and complexity metrics.
  * Integrated into the review agent with configurable depth and node limits for transitive dependency discovery.

* **Tests**
  * Added comprehensive test suites for blast-radius computation, rendering, and risk scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->