### PR TITLE
fix(infra): bump DOKS k8s_version prefix 1.32 → 1.33

### DIFF
--- a/platform/.infra/terraform/variables.tf
+++ b/platform/.infra/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "region" {
 variable "k8s_version" {
   description = "DOKS Kubernetes version prefix"
   type        = string
-  default     = "1.32"
+  default     = "1.33"
 }
 
 variable "node_size" {


### PR DESCRIPTION
## Summary

Unblocks the Deploy workflow by bumping the k8s version prefix to one DigitalOcean still supports. One-line change in \`platform/.infra/terraform/variables.tf\`.

## Why

The [last Deploy run](https://github.com/getlien/lien/actions/runs/24534992798) failed with:

\`\`\`
Error: Missing required argument
  with module.doks.digitalocean_kubernetes_cluster.this,
  on modules/doks/main.tf line 21:
  version = data.digitalocean_kubernetes_versions.this.latest_version
The argument "version" is required, but no definition was found.
\`\`\`

DO retired 1.32 from the supported-versions API after the last successful deploy (2026-03-30). \`doctl kubernetes options versions\` now returns only 1.33.9, 1.34.5, and 1.35.1. With \`version_prefix = "1.32."\`, the data source yields an empty set → \`latest_version\` is undefined → plan validation fails.

## Risk assessment

- **Deploy workflow is read-only on Terraform** — runs \`terraform refresh -target=module.databases\`, never \`terraform apply\`. This change unblocks the refresh but does NOT mutate the cluster during deploy.
- **Next full \`terraform apply\`** will propose an in-place upgrade from \`1.32.13-do.2\` → \`1.33.9-do.2\`. The \`version\` attribute on \`digitalocean_kubernetes_cluster\` is NOT \`ForceNew\` — upgrade is in-place, no cluster replacement, no data loss.
- **\`auto_upgrade = true\`** on the cluster means DO was supposed to handle this transparently and hasn't. The cluster is overdue regardless.
- **DO enforces one-minor-version-at-a-time upgrades** — 1.33 is the correct target. A future bump to 1.34 can follow.

## Verification

\`\`\`
$ doctl kubernetes options versions
Slug           Kubernetes Version    Supported Features
1.35.1-do.2    1.35.1                cluster-autoscaler, docr-integration, ha-control-plane
1.34.5-do.2    1.34.5                cluster-autoscaler, docr-integration, ha-control-plane
1.33.9-do.2    1.33.9                cluster-autoscaler, docr-integration, ha-control-plane

$ doctl kubernetes cluster list --format Name,Version,AutoUpgrade
Name        Version         Auto Upgrade
lien-k8s    1.32.13-do.2    true
\`\`\`

## Test plan

- [x] Change compiles (single variable default, no dependent code)
- [ ] Post-merge: re-run Deploy workflow; confirm the "Read Terraform outputs" step succeeds and deploy proceeds through to kustomize/rollout

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 78 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 21 high-risk file(s) with 2717 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 20 | — |
| ⏱️ time to understand | 44 | — |
| 🐛 estimated bugs | 3 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fd84dd3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->