### PR TITLE
docs(parser): add @example to computeBlastRadiusRisk (test PR)

### DIFF
--- a/packages/parser/src/risk/blast-radius-risk.ts
+++ b/packages/parser/src/risk/blast-radius-risk.ts
@@ -76,6 +76,19 @@ function classifyLevel(input: BlastRadiusRiskInput): RiskLevel {
  * Thresholds are deliberately conservative — the goal is to surface risk, not
  * to be statistically rigorous. Callers that want finer control should consume
  * the raw input fields directly.
+ *
+ * @example
+ * const risk = computeBlastRadiusRisk({
+ *   dependentCount: 14,
+ *   uncoveredDependents: 3,
+ *   maxDependentComplexity: 18,
+ *   hasHighComplexityUncovered: true,
+ * });
+ * // risk.level === 'high'
+ * // risk.reasoning === [
+ * //   '14 callers', '3 untested', 'max complexity 18',
+ * //   'untested high-complexity dependent',
+ * // ]
  */
 export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadiusRisk {
   return { level: classifyLevel(input), reasoning: buildReasoning(input) };


### PR DESCRIPTION
## Summary

**This is a test PR** for validating the transitive blast-radius injection shipped in #517 and deployed today.

Change is docs-only: one \`@example\` block on \`computeBlastRadiusRisk\` showing how inputs map to level + reasoning.

## What we expect the review agent to see

\`computeBlastRadiusRisk\` is called from \`packages/review/src/blast-radius.ts\` — specifically \`buildEntry\` and \`computeGlobalRisk\` (hop 1), each of which is called by \`computeBlastRadius\` (hop 2). With default \`depth=2\`, the \`<blast_radius>\` block should contain ~2-3 rows and the runner log should show the \`[agent-review] Blast radius: ...\` line.

## Safe to close without merging

The code change is valuable enough to keep if you want (legit docs improvement), but the PR's primary purpose is verifying the deployed feature. Feel free to close once we've confirmed it worked.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This pull request introduces a documentation-only change by adding an `@example` block to the JSDoc of the `computeBlastRadiusRisk` function. This change clarifies the function's usage and expected output without altering any runtime logic, dependencies, or external interactions. The blast radius analysis confirms that all direct and indirect dependents of the modified functions are covered by tests, and the change itself is purely descriptive.
>
> - Added an `@example` block to the JSDoc of `computeBlastRadiusRisk` in `packages/parser/src/risk/blast-radius-risk.ts`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2c4950b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example usage documentation with sample inputs and expected outputs for risk assessment calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->