### PR TITLE
fix(parser): include 5-dependent blast radius in medium threshold

### DIFF
--- a/packages/parser/src/risk/blast-radius-risk.ts
+++ b/packages/parser/src/risk/blast-radius-risk.ts
@@ -65,7 +65,7 @@ function classifyLevel(input: BlastRadiusRiskInput): RiskLevel {
   if (hasHighComplexityUncovered && dependentCount > 20) return 'critical';
   if (dependentCount > 20) return 'high';
   if (hasHighComplexityUncovered) return 'high';
-  if (dependentCount > 5) return 'medium';
+  if (dependentCount >= 5) return 'medium';
   if (uncoveredDependents > 0) return 'medium';
   return 'low';
 }


### PR DESCRIPTION
A blast radius with exactly 5 dependents was being classified as \`low\` while 6+ is \`medium\`. Off-by-one at the boundary — shifting the medium check to include 5 so the escalation kicks in one dependent earlier.

Ship it?

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR modifies the risk classification logic for blast radius by changing a threshold from exclusive to inclusive. Specifically, it reclassifies projects with exactly 5 dependents from 'low' to 'medium' risk. While the change itself is small, the lack of a specific test case for this new boundary condition means the intended behavior for `dependentCount = 5` is not explicitly verified by the existing test suite. This could lead to an unvalidated shift in risk assessment for certain PRs.
>
> - Changed `dependentCount > 5` to `dependentCount >= 5` in `classifyLevel` function.
> - Reclassifies `dependentCount = 5` from 'low' to 'medium' risk.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bb9959d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated blast-radius risk classification threshold for improved accuracy in determining medium-risk dependency levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->