### PR TITLE
feat(review): rule-gate blast-radius compute, add boundary-change rule

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -97,16 +97,19 @@ export class AgentReviewPlugin implements ReviewPlugin {
 
     // Pre-compute transitive blast radius so the agent sees it in the initial
     // message instead of having to decide to call get_dependents itself.
+    // Gated on an active rule opting in — saves compute on PRs where no
+    // pattern-specific rule needs dependency context (docs, formatting, etc.).
     const blastRadiusConfig = config.blastRadius ?? {};
-    const blastRadius =
-      blastRadiusConfig.enabled !== false
-        ? computeBlastRadius(context.chunks, graph, context.repoChunks!, {
-            depth: blastRadiusConfig.depth,
-            maxNodes: blastRadiusConfig.maxNodes,
-            maxSeeds: blastRadiusConfig.maxSeeds,
-            workspaceRoot: context.repoRootDir,
-          })
-        : null;
+    const needsBlastRadius =
+      blastRadiusConfig.enabled !== false && rules.active.some(r => r.requiresBlastRadius === true);
+    const blastRadius = needsBlastRadius
+      ? computeBlastRadius(context.chunks, graph, context.repoChunks!, {
+          depth: blastRadiusConfig.depth,
+          maxNodes: blastRadiusConfig.maxNodes,
+          maxSeeds: blastRadiusConfig.maxSeeds,
+          workspaceRoot: context.repoRootDir,
+        })
+      : null;
     if (blastRadius) {
       logger.info(
         `[${this.id}] Blast radius: ${blastRadius.totalDistinctDependents} deps, risk=${blastRadius.globalRisk.level}${blastRadius.truncated ? ' (truncated)' : ''}`,

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -379,27 +379,31 @@ a numeric threshold, or a classification cutoff in an exported function:
 }`,
   triggers: {
     keywords: [
-      // Comparison operators in threshold-like diffs. Cover negative and
-      // float literals and include the equality operators the rule prompt
-      // explicitly mentions. Lien Review (PR #521) caught the earlier
-      // version missing === / !== and negatives.
-      //
-      // Note: character class [\d.]+ is a trigger heuristic — not a strict
-      // numeric parser — because nested-quantifier groups like \d+(\.\d+)?
-      // trip the local REDOS_PATTERN in safeRegex (rules.ts:16) and would
-      // be silently dropped.
+      // Comparison operators in threshold-like diffs. Two rounds of review
+      // feedback landed here:
+      // - Lien Review (PR #521): the original missed === / !== operators and
+      //   negative/float literals. Widened to [-+]?[\d.]+ (heuristic — strict
+      //   \d+(\.\d+)? trips the local REDOS_PATTERN in safeRegex).
+      // - CodeRabbit (same PR): bare '>'/'<' patterns match arrow-function
+      //   returns like `() => 5` or `.map(x => x.length)`, which are
+      //   pervasive in TS. Anchor those to a LHS identifier/closing bracket
+      //   so only real comparisons trigger. Multi-char operators (>=, <=,
+      //   ===, !==) don't appear in arrow contexts and stay unanchored.
       '>=\\s*[-+]?[\\d.]+',
       '<=\\s*[-+]?[\\d.]+',
-      '>\\s*[-+]?[\\d.]+',
-      '<\\s*[-+]?[\\d.]+',
-      '===\\s*[-+]?[\\d.]+',
-      '!==\\s*[-+]?[\\d.]+',
-      // Semantic markers common in threshold/classification code
+      '[\\w)\\]]\\s*>\\s*[-+]?[\\d.]+',
+      '[\\w)\\]]\\s*<\\s*[-+]?[\\d.]+',
+      '===?\\s*[-+]?[\\d.]+',
+      '!==?\\s*[-+]?[\\d.]+',
+      // Semantic markers common in threshold/classification code.
+      // `severity` is narrowed to assignment/label context (severity: or
+      // severity =) — bare 'severity' matches every ReviewFinding and
+      // logger call in this codebase.
       '\\bthreshold\\b',
       '\\bboundary\\b',
       '\\bcutoff\\b',
       'classify\\w*',
-      'severity',
+      'severity\\s*[:=]',
     ],
   },
   requiresBlastRadius: true,

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -379,11 +379,21 @@ a numeric threshold, or a classification cutoff in an exported function:
 }`,
   triggers: {
     keywords: [
-      // Comparison operators in threshold-like diffs
-      '>=\\s*\\d',
-      '<=\\s*\\d',
-      '>\\s*\\d',
-      '<\\s*\\d',
+      // Comparison operators in threshold-like diffs. Cover negative and
+      // float literals and include the equality operators the rule prompt
+      // explicitly mentions. Lien Review (PR #521) caught the earlier
+      // version missing === / !== and negatives.
+      //
+      // Note: character class [\d.]+ is a trigger heuristic — not a strict
+      // numeric parser — because nested-quantifier groups like \d+(\.\d+)?
+      // trip the local REDOS_PATTERN in safeRegex (rules.ts:16) and would
+      // be silently dropped.
+      '>=\\s*[-+]?[\\d.]+',
+      '<=\\s*[-+]?[\\d.]+',
+      '>\\s*[-+]?[\\d.]+',
+      '<\\s*[-+]?[\\d.]+',
+      '===\\s*[-+]?[\\d.]+',
+      '!==\\s*[-+]?[\\d.]+',
       // Semantic markers common in threshold/classification code
       '\\bthreshold\\b',
       '\\bboundary\\b',

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -345,6 +345,60 @@ The key question: if this operation fails, will the caller know? If the answer i
   source: 'builtin',
 };
 
+const BOUNDARY_CHANGE: ReviewRule = {
+  id: 'boundary-change',
+  name: 'Threshold / Boundary Condition Change',
+  description:
+    'Flag diffs that shift comparison boundaries, threshold constants, or classification cutoffs without caller impact analysis',
+  prompt: `### Threshold / Boundary Change Check
+When the diff modifies a comparison operator (>, <, >=, <=, ===, !==),
+a numeric threshold, or a classification cutoff in an exported function:
+
+1. Do NOT accept the author's framing at face value. "Off-by-one fix"
+   and "minor correction" are claims to verify, not conclusions.
+2. Consult the <blast_radius> section — every listed dependent is a
+   caller whose behavior now shifts at the new boundary value.
+3. Check whether any test covers the new boundary value. If no test
+   exercises the exact input at which behavior now differs, flag it:
+   a passing test suite after a threshold change means the boundary
+   was untested, not that the change is safe.
+4. For each uncovered dependent (✗ in the blast_radius table), name
+   the specific input where old and new semantics diverge and the
+   downstream cascade into that dependent.`,
+  example: `### Good finding — threshold drift with uncovered boundary:
+{
+  "filepath": "packages/parser/src/risk/blast-radius-risk.ts",
+  "line": 68,
+  "symbolName": "classifyLevel",
+  "severity": "warning",
+  "category": "logic_error",
+  "ruleId": "boundary-change",
+  "message": "Changing \`> 5\` to \`>= 5\` silently reclassifies dependentCount === 5 from 'low' to 'medium'. No existing test covers the boundary value 5, so the passing suite does not validate the new behavior. Per <blast_radius>, both buildEntry and computeGlobalRisk call classifyLevel via computeBlastRadiusRisk, and both cascade into the agent's global risk score — a 5-dependent PR now surfaces 'medium risk' instead of 'low'.",
+  "suggestion": "Add a test case for dependentCount === 5 covering the intended behavior, then decide whether the shift is actually desired. If it is, note the behavior change in the commit and update any call-site thresholds that depend on 'low at 5'.",
+  "evidence": "Boundary-change check — operator shift with no test at the new boundary value"
+}`,
+  triggers: {
+    keywords: [
+      // Comparison operators in threshold-like diffs
+      '>=\\s*\\d',
+      '<=\\s*\\d',
+      '>\\s*\\d',
+      '<\\s*\\d',
+      // Semantic markers common in threshold/classification code
+      '\\bthreshold\\b',
+      '\\bboundary\\b',
+      '\\bcutoff\\b',
+      'classify\\w*',
+      'severity',
+    ],
+  },
+  requiresBlastRadius: true,
+  severity: 'warning',
+  category: 'logic_error',
+  enabled: true,
+  source: 'builtin',
+};
+
 /** All built-in review rules. */
 export const BUILTIN_RULES: ReviewRule[] = [
   STRUCTURAL_ANALYSIS,
@@ -352,4 +406,5 @@ export const BUILTIN_RULES: ReviewRule[] = [
   CONCURRENCY_RACE,
   INCOMPLETE_HANDLING,
   ERROR_SWALLOWING,
+  BOUNDARY_CHANGE,
 ];

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -93,6 +93,12 @@ export interface ReviewRule {
   enabled: boolean;
   /** 'builtin' for extracted rules, 'custom' for user-defined rules. */
   source: 'builtin' | 'custom';
+  /**
+   * When true, an active instance of this rule causes the agent to receive
+   * the pre-computed <blast_radius> block in the initial message. The rule's
+   * prompt should tell the agent how to act on it.
+   */
+  requiresBlastRadius?: boolean;
 }
 
 /** Resolved set of rules for a specific review run. */

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -512,6 +512,25 @@ describe('boundary-change rule', () => {
     expect(active).toContain('boundary-change');
   });
 
+  it('activates on strict-equality comparisons with numeric literals', () => {
+    const ctx = makeTriggerContext({
+      diffText: '-  if (status === 0) throw;\n+  if (status !== 0) throw;',
+    });
+    const active = selectRules(BUILTIN_RULES, ctx).active.map(r => r.id);
+    expect(active).toContain('boundary-change');
+  });
+
+  it('activates on comparisons against negative and float literals', () => {
+    const negCtx = makeTriggerContext({
+      diffText: '+  if (temperature > -10) alert();',
+    });
+    const floatCtx = makeTriggerContext({
+      diffText: '+  if (ratio <= 0.95) retry();',
+    });
+    expect(selectRules(BUILTIN_RULES, negCtx).active.map(r => r.id)).toContain('boundary-change');
+    expect(selectRules(BUILTIN_RULES, floatCtx).active.map(r => r.id)).toContain('boundary-change');
+  });
+
   it('is skipped on a diff with no operators, digits, or threshold markers', () => {
     const ctx = makeTriggerContext({
       diffText: '-// old comment\n+// new comment describing the function',

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -531,6 +531,31 @@ describe('boundary-change rule', () => {
     expect(selectRules(BUILTIN_RULES, floatCtx).active.map(r => r.id)).toContain('boundary-change');
   });
 
+  // CodeRabbit (PR #521) flagged false-positive cases these tests pin down:
+  // arrow-function returns and bare uses of the word "severity" must not
+  // activate the rule.
+
+  it('does not activate on arrow-function returns like `() => 5`', () => {
+    const ctx = makeTriggerContext({
+      diffText: '+  const items = arr.map(x => 5);\n+  const fn = () => 42;',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
+  });
+
+  it('does not activate on bare "severity" references in logger/finding code', () => {
+    const ctx = makeTriggerContext({
+      diffText: '+  logger.info(`severity is ${finding.severity}`);',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
+  });
+
+  it('does activate on severity in assignment/label context', () => {
+    const ctx = makeTriggerContext({
+      diffText: "+  const newRule = { severity: 'warning' };",
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).active.map(r => r.id)).toContain('boundary-change');
+  });
+
   it('is skipped on a diff with no operators, digits, or threshold markers', () => {
     const ctx = makeTriggerContext({
       diffText: '-// old comment\n+// new comment describing the function',

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -489,3 +489,47 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('"ruleId": "error-swallowing"');
   });
 });
+
+// ---------------------------------------------------------------------------
+// boundary-change rule + blast-radius gate
+// ---------------------------------------------------------------------------
+
+describe('boundary-change rule', () => {
+  it('activates on operator shifts in the diff', () => {
+    const ctx = makeTriggerContext({
+      diffText:
+        '-  if (dependentCount > 5) return "medium";\n+  if (dependentCount >= 5) return "medium";',
+    });
+    const active = selectRules(BUILTIN_RULES, ctx).active.map(r => r.id);
+    expect(active).toContain('boundary-change');
+  });
+
+  it('activates when the diff contains threshold-related vocabulary', () => {
+    const ctx = makeTriggerContext({
+      diffText: '+  const threshold = calculateCutoff(x);',
+    });
+    const active = selectRules(BUILTIN_RULES, ctx).active.map(r => r.id);
+    expect(active).toContain('boundary-change');
+  });
+
+  it('is skipped on a diff with no operators, digits, or threshold markers', () => {
+    const ctx = makeTriggerContext({
+      diffText: '-// old comment\n+// new comment describing the function',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
+  });
+
+  it('carries requiresBlastRadius=true so the agent gate can detect it', () => {
+    const ctx = makeTriggerContext({
+      diffText: '+  if (dependentCount >= 5) return "medium";',
+    });
+    const { active } = selectRules(BUILTIN_RULES, ctx);
+    expect(active.some(r => r.requiresBlastRadius === true)).toBe(true);
+  });
+
+  it('does not cause other existing rules to require blast radius', () => {
+    // Sanity check: only boundary-change opts in via requiresBlastRadius.
+    const requiring = BUILTIN_RULES.filter(r => r.requiresBlastRadius === true).map(r => r.id);
+    expect(requiring).toEqual(['boundary-change']);
+  });
+});


### PR DESCRIPTION
## Summary

Blast-radius compute is now opt-in per rule, not always-on. Adds a \`boundary-change\` rule that activates on comparison-operator shifts and threshold/classification vocabulary, and whose prompt explicitly instructs the agent to walk \`<blast_radius>\` to verify callers tolerate the new semantics.

Follow-up to #517 based on live testing against #519 (docs-only) and #520 (planted \`> 5\` → \`>= 5\` regression): the feature pipeline fired on every PR but the agent accepted the regression's framing at face value. Root cause was architectural — every review received the block with only generic \`<tools>\` guidance.

## What changes

| File | Change |
|---|---|
| \`packages/review/src/plugins/agent/types.ts\` | Add optional \`requiresBlastRadius?: boolean\` to \`ReviewRule\` |
| \`packages/review/src/plugins/agent/rules.ts\` | Add \`BOUNDARY_CHANGE\` rule; register in \`BUILTIN_RULES\` |
| \`packages/review/src/plugins/agent/index.ts\` | Gate \`computeBlastRadius\` on \`rules.active.some(r => r.requiresBlastRadius)\` |
| \`packages/review/test/plugins-agent-rules.test.ts\` | 5 new assertions |

## Effects

- **Compute skipped** on docs / formatting / non-threshold PRs. Saves BFS cycles and prompt tokens for the majority of reviews.
- **Rule-specific prompt** when \`boundary-change\` fires. Tells the agent to:
  1. Not accept "off-by-one fix" or "minor correction" framings at face value
  2. Use \`<blast_radius>\` to enumerate callers impacted by the new boundary
  3. Flag the change if no test covers the new boundary value
  4. Name each uncovered dependent's specific cascade
- **Architectural consistency**: blast-radius now activates the same way rules like \`concurrency-race\` and \`error-swallowing\` do.

## Test plan

Pre-commit:
- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` — 0 errors (27 pre-existing warnings)
- [x] \`npm run typecheck\` — 0 errors across all packages
- [x] Full review test suite: **290/290 pass** (was 285; +5 new)
- [x] New tests: boundary-change activates on operator shifts, activates on threshold vocabulary, skipped on non-threshold diffs, carries the \`requiresBlastRadius\` flag, and is the only rule currently opting in

Post-deploy retest (see plan doc):
- Push empty commits to \`test/blast-radius-fake-pr\` (#519) and \`test/blast-radius-planted-regression\` (#520).
- **#519 expected**: no \`Blast radius:\` log line, clean review.
- **#520 expected**: \`Blast radius:\` log line fires AND the agent posts a boundary-change finding citing the table.

## Rollback

- First-line: tighten \`BOUNDARY_CHANGE.triggers.keywords\`, redeploy.
- Second-line: \`enabled: false\` on \`BOUNDARY_CHANGE\`. Rule stays in code, blast-radius compute also stops (no opt-in rule), review falls back to pre-Workstream-A behavior.
- Nuclear: revert this PR. Underlying \`computeBlastRadius\` / \`renderBlastRadiusMarkdown\` from #517 stay intact.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 5 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 4 | +13 |


> [!NOTE]
> **Low Risk**
>
> This pull request introduces a new review rule, `boundary-change`, designed to flag modifications to comparison operators, numeric thresholds, or classification cutoffs. It also optimizes the blast radius computation by making it opt-in for rules that explicitly require it, saving computational resources and prompt tokens for reviews where dependency context is not needed. The changes include adding a `requiresBlastRadius` field to the `ReviewRule` interface, updating the `AgentReviewPlugin` to conditionally compute the blast radius, and defining the new `BOUNDARY_CHANGE` rule with specific trigger patterns and agent instructions. Comprehensive tests have been added to validate the new rule's behavior. The overall change improves the efficiency and targeting of the review agent.
>
> - Introduced `requiresBlastRadius` field to `ReviewRule` interface.
> - Modified `AgentReviewPlugin` to compute blast radius only if an active rule requires it.
> - Added `BOUNDARY_CHANGE` rule to detect shifts in comparison operators or numeric thresholds.
> - Expanded test coverage for rule activation logic, including edge cases for the new `boundary-change` rule.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 524232f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "boundary-change" review rule that flags code changes altering comparison boundaries, numeric thresholds, or classification cutoffs in exported functions.
  * Optimized blast radius computation to activate only when required by active rules, improving performance.

* **Tests**
  * Added comprehensive tests for boundary-change rule detection based on diff content patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->