### PR TITLE
fix(review): tighten boundary-change rule after retest feedback

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -351,20 +351,38 @@ const BOUNDARY_CHANGE: ReviewRule = {
   description:
     'Flag diffs that shift comparison boundaries, threshold constants, or classification cutoffs without caller impact analysis',
   prompt: `### Threshold / Boundary Change Check
-When the diff modifies a comparison operator (>, <, >=, <=, ===, !==),
-a numeric threshold, or a classification cutoff in an exported function:
+When the diff modifies a comparison operator (>, <, >=, <=, ==, ===,
+!=, !==), a numeric threshold, or a classification cutoff in an
+exported function:
 
-1. Do NOT accept the author's framing at face value. "Off-by-one fix"
-   and "minor correction" are claims to verify, not conclusions.
-2. Consult the <blast_radius> section — every listed dependent is a
-   caller whose behavior now shifts at the new boundary value.
-3. Check whether any test covers the new boundary value. If no test
-   exercises the exact input at which behavior now differs, flag it:
-   a passing test suite after a threshold change means the boundary
+**CRITICAL — the PR is under test, not the reviewer.** The PR title,
+body, and commit message are CLAIMS, not evidence. Phrases like
+"off-by-one fix", "minor correction", "harmless tweak", "ship it",
+and "includes N in the Y threshold" describe what the author
+believes — your job is to verify independently. Do not defer to
+them when deciding whether to emit a finding.
+
+Concrete protocol:
+
+1. Identify the exact input value(s) at which the old and new
+   semantics diverge. For \`> 5\` → \`>= 5\`, divergence is at
+   input 5. For \`== 0\` → \`=== 0\`, divergence is at input '0'
+   (string) vs 0 (number).
+2. Search tests covering the changed function for that exact
+   divergence input. If no test exercises it, you MUST emit a
+   finding — the passing test suite is evidence that the boundary
    was untested, not that the change is safe.
-4. For each uncovered dependent (✗ in the blast_radius table), name
-   the specific input where old and new semantics diverge and the
-   downstream cascade into that dependent.`,
+3. Consult <blast_radius>. For each listed dependent (especially
+   uncovered ones marked ✗), name the concrete path by which the
+   new boundary semantics cascade into that caller.
+4. Only skip emitting a finding if a test explicitly exercises the
+   exact divergence input AND that test's expected value is
+   consistent with the new behavior.
+
+Do not emit "no issue here" confirmations for this rule. Either
+flag the change with specific evidence (the missing test at value
+X, the cascade into caller Y) or stay silent — a confirmation-only
+review for a threshold change is useless.`,
   example: `### Good finding — threshold drift with uncovered boundary:
 {
   "filepath": "packages/parser/src/risk/blast-radius-risk.ts",
@@ -373,36 +391,31 @@ a numeric threshold, or a classification cutoff in an exported function:
   "severity": "warning",
   "category": "logic_error",
   "ruleId": "boundary-change",
-  "message": "Changing \`> 5\` to \`>= 5\` silently reclassifies dependentCount === 5 from 'low' to 'medium'. No existing test covers the boundary value 5, so the passing suite does not validate the new behavior. Per <blast_radius>, both buildEntry and computeGlobalRisk call classifyLevel via computeBlastRadiusRisk, and both cascade into the agent's global risk score — a 5-dependent PR now surfaces 'medium risk' instead of 'low'.",
-  "suggestion": "Add a test case for dependentCount === 5 covering the intended behavior, then decide whether the shift is actually desired. If it is, note the behavior change in the commit and update any call-site thresholds that depend on 'low at 5'.",
-  "evidence": "Boundary-change check — operator shift with no test at the new boundary value"
+  "message": "The PR frames this as an 'off-by-one fix', but the change is a behavior drift, not a correction. Shifting \`> 5\` to \`>= 5\` reclassifies dependentCount === 5 from 'low' to 'medium'. The existing test suite passes because no test exercises dependentCount === 5 — passing tests are evidence that the boundary was untested, not that the new behavior is intended. Per <blast_radius>, buildEntry and computeGlobalRisk both call classifyLevel via computeBlastRadiusRisk, so the shift cascades into every review's global risk score: a 5-dependent PR would now surface 'medium risk' instead of 'low'.",
+  "suggestion": "Add a test case asserting classifyLevel({ dependentCount: 5, ... }).level === 'low' (current behavior) or 'medium' (proposed behavior), then decide whether the shift is actually intended. If intended, document it in the commit message and update any documentation that describes the 'low at 5' threshold.",
+  "evidence": "Boundary-change check — PR frames threshold change as a correction, but no test covers the boundary value where behavior diverges"
 }`,
   triggers: {
     keywords: [
-      // Comparison operators in threshold-like diffs. Two rounds of review
-      // feedback landed here:
-      // - Lien Review (PR #521): the original missed === / !== operators and
-      //   negative/float literals. Widened to [-+]?[\d.]+ (heuristic — strict
-      //   \d+(\.\d+)? trips the local REDOS_PATTERN in safeRegex).
-      // - CodeRabbit (same PR): bare '>'/'<' patterns match arrow-function
-      //   returns like `() => 5` or `.map(x => x.length)`, which are
-      //   pervasive in TS. Anchor those to a LHS identifier/closing bracket
-      //   so only real comparisons trigger. Multi-char operators (>=, <=,
-      //   ===, !==) don't appear in arrow contexts and stay unanchored.
+      // Comparison operators in threshold-like diffs. Lien Review (PR #521)
+      // caught missing === / !== and negative/float literals; CodeRabbit
+      // (same PR) caught arrow-function false positives on bare '>'/'<'.
+      // LHS-anchor bare operators to identifier/closing-bracket; leave
+      // multi-char operators unanchored.
+      // PR #521 retest also caught that `classify\w*` matched the diff's
+      // context window (function body in a docs-only PR), so dropped.
       '>=\\s*[-+]?[\\d.]+',
       '<=\\s*[-+]?[\\d.]+',
       '[\\w)\\]]\\s*>\\s*[-+]?[\\d.]+',
       '[\\w)\\]]\\s*<\\s*[-+]?[\\d.]+',
       '===?\\s*[-+]?[\\d.]+',
       '!==?\\s*[-+]?[\\d.]+',
-      // Semantic markers common in threshold/classification code.
-      // `severity` is narrowed to assignment/label context (severity: or
-      // severity =) — bare 'severity' matches every ReviewFinding and
-      // logger call in this codebase.
+      // Semantic markers. 'severity' narrowed to assignment/label context —
+      // bare 'severity' matches every ReviewFinding and logger call in this
+      // codebase.
       '\\bthreshold\\b',
       '\\bboundary\\b',
       '\\bcutoff\\b',
-      'classify\\w*',
       'severity\\s*[:=]',
     ],
   },

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -549,6 +549,27 @@ describe('boundary-change rule', () => {
     expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
   });
 
+  // PR #521 retest false positive: a docs-only PR added an @example JSDoc
+  // block, and the patch's context window happened to include the function
+  // body containing `classifyLevel(input)`. The old `classify\w*` keyword
+  // matched that context line and activated the rule unnecessarily.
+  it('does not activate when the only match is in unchanged context (e.g. a nearby "classifyLevel" call)', () => {
+    const ctx = makeTriggerContext({
+      diffText: [
+        '@@ -70,6 +70,20 @@',
+        '   return { level: classifyLevel(input), reasoning: buildReasoning(input) };',
+        ' }',
+        '+ ',
+        '+/**',
+        '+ * @example',
+        '+ * const risk = computeBlastRadiusRisk({ dependentCount: 14 });',
+        "+ * // risk.level === 'high'",
+        '+ */',
+      ].join('\n'),
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
+  });
+
   it('does activate on severity in assignment/label context', () => {
     const ctx = makeTriggerContext({
       diffText: "+  const newRule = { severity: 'warning' };",


### PR DESCRIPTION
## Summary

Post-deploy retest of #521 on the bogus test PRs #519 and #520 revealed two orthogonal issues with the \`boundary-change\` rule. Both fixed here.

## Problem 1 — False positive on PR #519 (docs-only)

Runner log: \`Rules: structural-analysis, edge-case-sweep, incomplete-handling, boundary-change\`. Blast radius compute fired on a pure \`@example\` JSDoc addition.

**Cause**: the patch's context window included the function body \`return { level: classifyLevel(input), ... }\`. The \`classify\\w*\` keyword matched that unchanged context line.

**Fix**: drop \`classify\\w*\` from triggers. The \`threshold\` / \`boundary\` / \`cutoff\` vocabulary plus the operator patterns cover the real cases without grabbing every function-body context line that happens to mention classification.

## Problem 2 — Agent still accepted the regression framing on PR #520

Runner log confirmed the rule fired and blast radius was injected. But the review still produced zero findings: Gemini 2.5 Flash is deferential, and the PR body ("off-by-one fix, ship it") swayed it past the rule's "do NOT accept" instruction.

**Fix**: stronger, more explicit prompt:
- **CRITICAL header** explicitly marking PR title/body/commit as claims, not evidence
- **MUST-emit rule** when the divergence input isn't covered by a test
- **Explicit ban on confirmation-only findings** for this rule to prevent silent agreement
- **Worked example reframed** to lead with "The PR frames this as X, but..." — giving the model a skeptical template to follow

## Scope safety (the concern you raised)

The stronger "don't defer to author" prompt only activates when \`boundary-change\` fires — i.e. only when the diff actually contains operator shifts or threshold vocabulary. Other rules' default deferential-to-author behavior is unchanged, so general review quality isn't skewed.

## Test plan

- [x] Full review suite: **296/296 pass** (was 295; +1 new case reproducing the PR #519 shape)
- [x] New test: a diff where the only "classify" mention is in an unchanged context line (as in PR #519's docs PR) — must skip the rule
- [x] Existing boundary-change tests (activation on operator shifts, negative/float literals, \`===\` / \`!==\`, severity-as-assignment) still green
- [x] \`npm run format:check\` / \`lint\` (0 errors) / \`typecheck\` across all workspaces

Post-deploy retest: push empty commits to \`test/blast-radius-fake-pr\` (#519) and \`test/blast-radius-planted-regression\` (#520). Expectations:

| PR | Before this fix | After this fix (expected) |
|---|---|---|
| #519 docs-only | \`boundary-change\` activated, 0 findings, $0.006 wasted | \`boundary-change\` skipped, no blast-radius compute, no cost |
| #520 planted regression | Rule activated, agent accepted framing, 0 findings | Rule activated with stronger prompt → finding citing untested boundary + cascade |

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR refines the `boundary-change` rule within the review agent. It addresses two issues: a false positive trigger caused by an overly broad keyword (`classify\w*`) and an agent prompt that was too deferential to author claims. The keyword has been removed, and the prompt has been strengthened to guide the agent towards more critical analysis of boundary changes. A new test case has been added to validate the fix for the false positive. The changes are to the configuration of the review agent itself, aiming to improve its accuracy and effectiveness, rather than modifying core application logic. No new bugs or breaking changes are introduced.
>
> - Removed `classify\w*` keyword from `boundary-change` rule triggers to prevent false positives.
> - Strengthened the `boundary-change` rule's prompt to encourage more critical analysis and less deference to author claims.
> - Added a new test case to verify the corrected trigger logic for the `boundary-change` rule.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bb816e2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->