### PR TITLE
fix(review): force boundary-change to investigate before silence

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -351,38 +351,45 @@ const BOUNDARY_CHANGE: ReviewRule = {
   description:
     'Flag diffs that shift comparison boundaries, threshold constants, or classification cutoffs without caller impact analysis',
   prompt: `### Threshold / Boundary Change Check
-When the diff modifies a comparison operator (>, <, >=, <=, ==, ===,
-!=, !==), a numeric threshold, or a classification cutoff in an
-exported function:
 
-**CRITICAL — the PR is under test, not the reviewer.** The PR title,
-body, and commit message are CLAIMS, not evidence. Phrases like
-"off-by-one fix", "minor correction", "harmless tweak", "ship it",
-and "includes N in the Y threshold" describe what the author
-believes — your job is to verify independently. Do not defer to
-them when deciding whether to emit a finding.
+**This rule is an exception to the general "silence means approval"
+policy.** For threshold/boundary diffs, verifying the change requires
+active investigation; producing empty findings without investigating
+is a failure of this rule, NOT a safe default. Do not fall back to
+silence if you cannot immediately confirm a problem — investigate
+first.
 
-Concrete protocol:
+The PR title, body, and commit message are CLAIMS, not evidence.
+Phrases like "off-by-one fix", "minor correction", "harmless tweak",
+"ship it", and "includes N in the Y threshold" describe what the
+author believes — your job is to verify independently.
+
+MANDATORY protocol when this rule is active:
 
 1. Identify the exact input value(s) at which the old and new
    semantics diverge. For \`> 5\` → \`>= 5\`, divergence is at
    input 5. For \`== 0\` → \`=== 0\`, divergence is at input '0'
    (string) vs 0 (number).
-2. Search tests covering the changed function for that exact
-   divergence input. If no test exercises it, you MUST emit a
-   finding — the passing test suite is evidence that the boundary
-   was untested, not that the change is safe.
-3. Consult <blast_radius>. For each listed dependent (especially
+2. **You MUST call \`get_files_context\` on the changed file** to
+   locate its test associations. Then inspect those test files (via
+   \`read_file\` or \`grep_codebase\`) for any assertion that
+   exercises the exact divergence input identified in step 1.
+3. **Emit a finding** unless step 2 locates a concrete test that
+   (a) calls the function with the exact divergence input AND
+   (b) asserts an expected result consistent with the NEW behavior.
+   Any other outcome — test absent, test exists but covers a
+   different input, test exists but asserts the OLD behavior — is
+   a finding. Cite the test file and line you inspected (or note
+   its absence) in \`evidence\`.
+4. Consult <blast_radius>. For each listed dependent (especially
    uncovered ones marked ✗), name the concrete path by which the
-   new boundary semantics cascade into that caller.
-4. Only skip emitting a finding if a test explicitly exercises the
-   exact divergence input AND that test's expected value is
-   consistent with the new behavior.
+   new boundary semantics cascade into that caller. This is
+   additional evidence for the finding, not a replacement for the
+   test-coverage check.
 
-Do not emit "no issue here" confirmations for this rule. Either
-flag the change with specific evidence (the missing test at value
-X, the cascade into caller Y) or stay silent — a confirmation-only
-review for a threshold change is useless.`,
+Do not finalize a response for this rule with zero findings unless
+step 2 found a qualifying test. "I could not find an obvious bug"
+is not a qualifying test; an actual test file + line is.`,
   example: `### Good finding — threshold drift with uncovered boundary:
 {
   "filepath": "packages/parser/src/risk/blast-radius-risk.ts",


### PR DESCRIPTION
## What the retest logs revealed

The runner log line \`[agent] Turn 1: finish_reason=stop, tokens=5470\` told us something the higher-level logs didn't: the model **voluntarily** stopped after one turn without calling any tools. It read the 5470-token prompt, couldn't immediately confirm a problem from the diff alone, and chose silence.

That made sense once I traced the prompt stack:

| Source | Instruction |
|---|---|
| System \`RULES_SECTION\` | "silence means approval" |
| System \`<output_format>\` | "empty findings with low-risk summary is fine" |
| boundary-change rule (previous) | "flag with specific evidence **or stay silent**" |

Three votes for silence, one for emitting. My own rule gave the model the escape hatch. Fix.

## Changes

1. **Remove the "or stay silent" escape.** Replace with an explicit carve-out: boundary-change is an exception to the system-level "silence = approval" policy. Empty findings without investigation is a failure of the rule, not a safe default.

2. **Require tool usage before concluding.** The rule now mandates calling \`get_files_context\` on the changed file, locating its test associations, and inspecting those test files for a concrete assertion that exercises the exact divergence input with an expected result consistent with the new behavior. "I could not find an obvious bug" is not a qualifying test — an actual file + line is.

## Scope safety

Only the \`boundary-change\` rule prompt changed. It's gated on the existing keyword triggers (operator shifts, threshold vocabulary), so the "don't stay silent, investigate" carve-out only applies when the diff actually contains one of those patterns. Other rules retain their default deferential behavior.

## Test plan

- [x] Full review suite passes (prompt-only change, no behavior change for tests)
- [x] Format / lint / typecheck clean

Post-deploy retest: push empty commit to #520. Expected:
- Runner log: \`Turn 1\` → **tool call** → \`Turn 2+\` with investigation → either a cited test or a finding
- If the model now investigates and finds no test, it should emit a finding with \`evidence\` naming the inspected test file
- If it still emits zero findings without calling tools, the model is ignoring the prompt and we're at the model ceiling

#519 should still skip \`boundary-change\` (unchanged triggers).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This pull request modifies the `prompt` string literal within the `BOUNDARY_CHANGE` rule definition in `packages/review/src/plugins/agent/rules.ts`. The change updates the instructions provided to the review agent regarding how to handle threshold/boundary change checks, specifically removing the 'or stay silent' escape clause and mandating tool usage for investigation. Since the change is confined to a string literal that serves as configuration/instruction for an external system (the LLM agent), it does not introduce any functional bugs, breaking changes, or logical errors within the `rules.ts` file or its direct callers. Callers will simply receive the updated prompt string, which is the intended behavior.
>
> - Updated the `prompt` string for the `BOUNDARY_CHANGE` rule to mandate investigation and tool usage for boundary change checks.
> - Removed the 'or stay silent' clause from the `BOUNDARY_CHANGE` rule's instructions.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9854e24. Updates automatically on new commits.</sup>
<!-- /lien-stats -->