### PR TITLE
test(review): assert every BUILTIN_RULES keyword compiles via safeRegex

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -16,8 +16,15 @@ import type { ReviewRule, ResolvedRules } from './types.js';
 /** Reject patterns with nested quantifiers that cause catastrophic backtracking. */
 const REDOS_PATTERN = /\([^)]*(?:[+*?]|\{)\)\s*(?:[+*?]|\{)/;
 
-/** Compile a regex pattern, returning null for invalid syntax or ReDoS-prone patterns. */
-function safeRegex(pattern: string): RegExp | null {
+/**
+ * Compile a regex pattern, returning null for invalid syntax or ReDoS-prone patterns.
+ *
+ * Exported for test-only usage: `plugins-agent-rules.test.ts` walks every
+ * keyword in every BUILTIN_RULES rule and asserts this function returns a
+ * RegExp. A null here silently disables a keyword at runtime, which is the
+ * kind of bug that's invisible at authoring time.
+ */
+export function safeRegex(pattern: string): RegExp | null {
   if (REDOS_PATTERN.test(pattern)) return null;
   try {
     return new RegExp(pattern, 'i');

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -5,6 +5,7 @@ import {
   BUILTIN_RULES,
   buildTriggerContext,
   globToRegex,
+  safeRegex,
   selectRules,
   type TriggerContext,
 } from '../src/plugins/agent/rules.js';
@@ -597,4 +598,43 @@ describe('boundary-change rule', () => {
     const requiring = BUILTIN_RULES.filter(r => r.requiresBlastRadius === true).map(r => r.id);
     expect(requiring).toEqual(['boundary-change']);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Keyword sanity invariant
+//
+// Rules use `safeRegex` (which rejects invalid syntax AND ReDoS-prone nested
+// quantifier groups) to compile keyword triggers. If a keyword fails to
+// compile, it's silently dropped at runtime — the rule stays registered but
+// the keyword never matches anything, and there's no diagnostic path. This
+// class of bug hit boundary-change during PR #521 iteration when the
+// `\d+(\.\d+)?` pattern tripped REDOS_PATTERN.
+//
+// This invariant catches the same failure at test time, with a message that
+// tells the next rule author exactly what went wrong.
+// ---------------------------------------------------------------------------
+
+describe('BUILTIN_RULES keyword sanity', () => {
+  for (const rule of BUILTIN_RULES) {
+    const keywords = rule.triggers.keywords;
+    if (!keywords || keywords.length === 0) continue;
+
+    describe(`${rule.id}`, () => {
+      for (const kw of keywords) {
+        it(`keyword "${kw}" compiles via safeRegex`, () => {
+          const compiled = safeRegex(kw);
+          if (compiled === null) {
+            throw new Error(
+              `Keyword ${JSON.stringify(kw)} in rule '${rule.id}' cannot be compiled by safeRegex. ` +
+                `It is either invalid regex syntax OR matches the ReDoS heuristic ` +
+                `(nested quantifier groups like \\(\\w+\\)+). ` +
+                `At runtime this keyword silently fails to match anything. ` +
+                `See rules.ts:safeRegex for the rejection rules.`,
+            );
+          }
+          expect(compiled).toBeInstanceOf(RegExp);
+        });
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Why

During PR #521 iteration, the boundary-change rule used the keyword \`\\d+(\\.\\d+)?\` for numeric literals. That pattern matches the local \`REDOS_PATTERN\` heuristic (nested quantifier group), so \`safeRegex\` returned null, so the keyword compiled to nothing and silently failed to match at runtime. The rule stayed registered, all tests passed, but the keyword did nothing. Only way to notice was "my new rule never fires" with no diagnostic path.

This invariant catches the same failure at test time with a message that names the bad keyword + rule and points the reader at \`rules.ts:safeRegex\`.

## What changes

- Export \`safeRegex\` from \`rules.ts\` (previously module-local). Keeps the REDOS heuristic where it lives; just opens it up for test access.
- New test block \`BUILTIN_RULES keyword sanity\` in \`plugins-agent-rules.test.ts\`. Walks every keyword in every built-in rule's \`triggers.keywords\`, asserts \`safeRegex\` returns a \`RegExp\`. Test-per-keyword-per-rule so a failure points at the exact offender.

## Test plan

- [x] Full review suite: **330/330** pass (was 296; +34 keyword-compile assertions auto-generated from \`BUILTIN_RULES\`)
- [x] format / lint (0 errors) / typecheck across all workspaces
- [x] Manually confirmed the REDOS heuristic still rejects the \`\\d+(\\.\\d+)?\` pattern that bit us during #521 — so a future rule author writing a similar pattern will trip this invariant

## Follow-up not-in-this-PR

Documented in \`.wip/retro-blast-radius.md\` §4.5. That note still stands even after this PR — some authors may prefer a warning log over a test failure for rapid iteration. Ship this as the primary guardrail; log-on-null can come later if we want it.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR exports the `safeRegex` utility function from `rules.ts` and adds a comprehensive test suite to ensure that all keywords used in built-in review rules can be successfully compiled by `safeRegex`. This addresses a previous issue where a ReDoS-prone regex pattern silently failed to compile, leading to a rule keyword that never matched. The changes improve the robustness and testability of the rules engine without altering existing logic or introducing breaking changes.
>
> - Exported `safeRegex` from `packages/review/src/plugins/agent/rules.ts` for direct test access.
> - Added new test cases in `plugins-agent-rules.test.ts` to validate that all built-in rule keywords compile correctly via `safeRegex`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e672820. Updates automatically on new commits.</sup>
<!-- /lien-stats -->