### PR TITLE
feat(mcp): add depth + maxNodes to get_dependents with shared risk helper

### DIFF
--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -614,6 +614,10 @@ describe('findDependents', () => {
 
       // At depth 1 for symbol fnA, only src/b.ts imports the symbol directly.
       expect(result.dependents.map(d => d.filepath)).toEqual(['src/b.ts']);
+      // And the caller is warned that depth > 1 was ignored.
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining('depth > 1 is ignored for symbol-level queries'),
+      );
     });
   });
 

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -399,6 +399,255 @@ describe('findDependents', () => {
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/b.ts');
     });
+
+    it('should not revisit the target when BFS loops back at depth 2', async () => {
+      // A <- B, B <- A cycle (via importedSymbols so B isn't flagged as a re-exporter).
+      // From A, depth 1 finds B; depth 2 would revisit A via B's importer list —
+      // the walk must exclude the original target.
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', {
+            importedSymbols: { 'src/b': ['fnB'] },
+            exports: ['fnA'],
+          }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/a.ts',
+        false,
+        mockLog,
+        undefined,
+        undefined,
+        3,
+      );
+
+      expect(result.dependents.map(d => d.filepath)).toEqual(['src/b.ts']);
+      expect(result.dependents[0].hops).toBe(1);
+    });
+  });
+
+  describe('BFS over depth', () => {
+    // These tests use importedSymbols-only (no `imports` array) so chunks
+    // don't trip the '*' wildcard re-export sentinel that would otherwise
+    // pull transitive dependents in via the barrel-file walk at depth 1.
+
+    it('should stay at depth 1 by default (backwards compatible)', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          createChunk('src/c.ts', {
+            importedSymbols: { 'src/b': ['fnB'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(mockDB as any, 'src/a.ts', false, mockLog);
+
+      expect(result.dependents.map(d => d.filepath)).toEqual(['src/b.ts']);
+      expect(result.dependents[0].hops).toBe(1);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('should discover depth-2 dependents and tag them with hops=2', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          createChunk('src/c.ts', {
+            importedSymbols: { 'src/b': ['fnB'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/a.ts',
+        false,
+        mockLog,
+        undefined,
+        undefined,
+        2,
+      );
+
+      const byFile = new Map(result.dependents.map(d => [d.filepath, d.hops]));
+      expect(byFile.get('src/b.ts')).toBe(1);
+      expect(byFile.get('src/c.ts')).toBe(2);
+      expect(result.dependents).toHaveLength(2);
+    });
+
+    it('should discover depth-3 dependents', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          createChunk('src/c.ts', {
+            importedSymbols: { 'src/b': ['fnB'] },
+            exports: ['fnC'],
+          }),
+          createChunk('src/d.ts', {
+            importedSymbols: { 'src/c': ['fnC'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/a.ts',
+        false,
+        mockLog,
+        undefined,
+        undefined,
+        3,
+      );
+
+      const byFile = new Map(result.dependents.map(d => [d.filepath, d.hops]));
+      expect(byFile.get('src/b.ts')).toBe(1);
+      expect(byFile.get('src/c.ts')).toBe(2);
+      expect(byFile.get('src/d.ts')).toBe(3);
+    });
+
+    it('should record the minimum hop for diamond-shaped graphs', async () => {
+      // A <- B (hop 1), A <- C (hop 1), D imports both B and C (hop 2 via either).
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          createChunk('src/c.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnC'],
+          }),
+          createChunk('src/d.ts', {
+            importedSymbols: { 'src/b': ['fnB'], 'src/c': ['fnC'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/a.ts',
+        false,
+        mockLog,
+        undefined,
+        undefined,
+        2,
+      );
+
+      const byFile = new Map(result.dependents.map(d => [d.filepath, d.hops]));
+      expect(byFile.get('src/d.ts')).toBe(2);
+    });
+
+    it('should truncate when maxNodes is hit and set truncated=true', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          createChunk('src/c.ts', {
+            importedSymbols: { 'src/b': ['fnB'] },
+            exports: ['fnC'],
+          }),
+          createChunk('src/d.ts', {
+            importedSymbols: { 'src/c': ['fnC'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/a.ts',
+        false,
+        mockLog,
+        undefined,
+        undefined,
+        3,
+        1,
+      );
+
+      expect(result.dependents).toHaveLength(1);
+      expect(result.truncated).toBe(true);
+    });
+
+    it('should ignore depth > 1 for symbol-level queries', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          createChunk('src/b.ts', {
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          createChunk('src/c.ts', {
+            importedSymbols: { 'src/b': ['fnB'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/a.ts',
+        false,
+        mockLog,
+        'fnA',
+        undefined,
+        3,
+      );
+
+      // At depth 1 for symbol fnA, only src/b.ts imports the symbol directly.
+      expect(result.dependents.map(d => d.filepath)).toEqual(['src/b.ts']);
+    });
+  });
+
+  describe('uncovered production dependents', () => {
+    it('should count production dependents with no importing test file', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/target.ts', { exports: ['util'] }),
+          createChunk('src/covered.ts', { imports: ['src/target.ts'], exports: ['foo'] }),
+          createChunk('src/covered.test.ts', { imports: ['src/covered.ts'] }),
+          createChunk('src/uncovered.ts', { imports: ['src/target.ts'] }),
+        ]),
+      );
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+
+      expect(result.productionDependentCount).toBe(2);
+      expect(result.uncoveredProductionDependents).toBe(1);
+    });
+
+    it('should treat production dependents as covered if any test file imports them', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          createChunk('src/target.ts', { exports: ['util'] }),
+          createChunk('src/a.ts', { imports: ['src/target.ts'], exports: ['a'] }),
+          createChunk('src/a.test.ts', { imports: ['src/a.ts'] }),
+        ]),
+      );
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+
+      expect(result.productionDependentCount).toBe(1);
+      expect(result.uncoveredProductionDependents).toBe(0);
+    });
   });
 
   describe('files with no imports or exports', () => {

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -597,6 +597,17 @@ function resolveTransitiveDependents(
  * Symbol-level queries (`symbol` set) always behave as depth=1 — transitive
  * symbol tracking through re-renaming chains is out of scope for this tool.
  */
+/**
+ * Shared context for a single findDependents call. These values always travel
+ * together, so grouping them removes parameter noise from helpers.
+ */
+interface ScanContext {
+  importIndex: Map<string, SearchResult[]>;
+  allChunksByFile: Map<string, SearchResult[]>;
+  normalizePathCached: (p: string) => string;
+  log: (message: string, level?: 'warning') => void;
+}
+
 export async function findDependents(
   vectorDB: VectorDBInterface,
   filepath: string,
@@ -617,50 +628,27 @@ export async function findDependents(
     normalizePathCached,
     indexVersion,
   );
+  const ctx: ScanContext = { importIndex, allChunksByFile, normalizePathCached, log };
 
-  // Find dependent chunks and group by file
-  const dependentChunks = findDependentChunks(importIndex, normalizedTarget);
-  const chunksByFile = groupChunksByFile(dependentChunks);
+  const { chunksByFile, reExporterPaths } = seedDepth1Dependents(ctx, normalizedTarget);
 
-  // Find transitive dependents through re-export chains (barrel files)
-  const reExporters = resolveTransitiveDependents(
-    allChunksByFile,
-    normalizedTarget,
-    normalizePathCached,
-    importIndex,
-    chunksByFile,
-    log,
-  );
-
-  // Depth-1 hops — every file discovered so far.
+  // Stamp depth-1 files, then BFS outward if requested.
   const hopsByFile = new Map<string, number>();
   for (const file of chunksByFile.keys()) hopsByFile.set(file, 1);
-
-  // BFS for depth > 1 (file-level only; symbol queries stay at depth 1).
-  const effectiveDepth = symbol ? 1 : depth;
-  if (effectiveDepth > 1 && depth > 1 && symbol) {
-    log(`Note: depth > 1 is ignored for symbol-level queries (symbol=${symbol})`);
-  }
-  const bfsResult = expandBfsDependents({
+  const { truncated } = runBfsIfRequested({
+    ctx,
     chunksByFile,
     hopsByFile,
     normalizedTarget,
-    importIndex,
-    allChunksByFile,
-    normalizePathCached,
-    log,
-    depth: effectiveDepth,
+    symbol,
+    depth,
     maxNodes,
   });
 
-  // Calculate metrics
   const fileComplexities = calculateFileComplexities(chunksByFile);
   const complexityMetrics = calculateOverallComplexityMetrics(fileComplexities);
 
-  // Build dependents list (file-level or symbol-level)
-  // Only need target file chunks for symbol export validation — avoid flattening all chunks
   const targetFileChunks = symbol ? (allChunksByFile.get(normalizedTarget) ?? []) : [];
-  const reExporterPaths = reExporters.map(re => re.filepath);
   const { dependents, totalUsageCount } = buildDependentsList(
     chunksByFile,
     symbol,
@@ -671,31 +659,13 @@ export async function findDependents(
     log,
     reExporterPaths,
   );
+  stampHopsAndSort(dependents, hopsByFile);
 
-  // Stamp hops on each dependent from the BFS map.
-  for (const d of dependents) {
-    d.hops = hopsByFile.get(d.filepath) ?? 1;
-  }
-
-  // Sort dependents: shallower first, then production before test, stable otherwise.
-  dependents.sort((a, b) => {
-    const hopDelta = (a.hops ?? 1) - (b.hops ?? 1);
-    if (hopDelta !== 0) return hopDelta;
-    if (a.isTestFile === b.isTestFile) return 0;
-    return a.isTestFile ? 1 : -1;
-  });
-
-  // Calculate test/production split
   const testDependentCount = dependents.filter(f => f.isTestFile).length;
   const productionDependentCount = dependents.length - testDependentCount;
+  const uncoveredProductionDependents = countUncoveredProductionDependents(dependents, ctx);
 
-  const uncoveredProductionDependents = countUncoveredProductionDependents(
-    dependents,
-    importIndex,
-    normalizePathCached,
-  );
-
-  // Only flatten all chunks when needed for cross-repo grouping (groupDependentsByRepo)
+  // Only flatten all chunks when needed for cross-repo grouping (groupDependentsByRepo).
   const allChunks = crossRepo ? Array.from(allChunksByFile.values()).flat() : [];
 
   return {
@@ -708,119 +678,239 @@ export async function findDependents(
     hitLimit,
     allChunks,
     totalUsageCount,
-    truncated: bfsResult.truncated,
+    truncated,
     uncoveredProductionDependents,
   };
 }
 
+/** Depth-1 seed: direct importers plus barrel re-exporters. */
+function seedDepth1Dependents(
+  ctx: ScanContext,
+  normalizedTarget: string,
+): { chunksByFile: Map<string, SearchResult[]>; reExporterPaths: string[] } {
+  const { importIndex, allChunksByFile, normalizePathCached, log } = ctx;
+  const dependentChunks = findDependentChunks(importIndex, normalizedTarget);
+  const chunksByFile = groupChunksByFile(dependentChunks);
+  const reExporters = resolveTransitiveDependents(
+    allChunksByFile,
+    normalizedTarget,
+    normalizePathCached,
+    importIndex,
+    chunksByFile,
+    log,
+  );
+  return { chunksByFile, reExporterPaths: reExporters.map(re => re.filepath) };
+}
+
 /**
- * BFS over the import graph starting from the already-populated depth-1
- * frontier in `chunksByFile`. Mutates `chunksByFile` and `hopsByFile` in place
- * with newly discovered files and their hop counts.
+ * Apply the symbol-vs-depth policy and run BFS if applicable. Symbol queries
+ * stay at depth 1 — transitive symbol-renaming chains are out of scope.
  */
-function expandBfsDependents(args: {
+function runBfsIfRequested(args: {
+  ctx: ScanContext;
   chunksByFile: Map<string, SearchResult[]>;
   hopsByFile: Map<string, number>;
   normalizedTarget: string;
-  importIndex: Map<string, SearchResult[]>;
-  allChunksByFile: Map<string, SearchResult[]>;
-  normalizePathCached: (p: string) => string;
-  log: (message: string, level?: 'warning') => void;
+  symbol: string | undefined;
   depth: number;
   maxNodes: number;
 }): { truncated: boolean } {
-  const {
-    chunksByFile,
-    hopsByFile,
-    normalizedTarget,
-    importIndex,
-    allChunksByFile,
-    normalizePathCached,
-    log,
-    depth,
-    maxNodes,
-  } = args;
+  const { ctx, chunksByFile, hopsByFile, normalizedTarget, symbol, depth, maxNodes } = args;
+  if (symbol && depth > 1) {
+    ctx.log(`Note: depth > 1 is ignored for symbol-level queries (symbol=${symbol})`);
+    return { truncated: false };
+  }
+  return expandBfsDependents(ctx, chunksByFile, hopsByFile, normalizedTarget, depth, maxNodes);
+}
 
-  // `truncated` means "BFS was aborted mid-expansion because of maxNodes".
-  // If depth<=1, no BFS runs and the flag stays false regardless of size.
+/** Fill in `hops` on each dependent and sort shallower-first, prod-before-test. */
+function stampHopsAndSort(dependents: DependentInfo[], hopsByFile: Map<string, number>): void {
+  for (const d of dependents) {
+    d.hops = hopsByFile.get(d.filepath) ?? 1;
+  }
+  dependents.sort((a, b) => {
+    const hopDelta = (a.hops ?? 1) - (b.hops ?? 1);
+    if (hopDelta !== 0) return hopDelta;
+    if (a.isTestFile === b.isTestFile) return 0;
+    return a.isTestFile ? 1 : -1;
+  });
+}
+
+/**
+ * BFS outward from depth-1 frontier. Mutates `chunksByFile` and `hopsByFile`
+ * with newly discovered files. `truncated` means the walk was cut short by
+ * `maxNodes`; it stays false when no BFS runs.
+ */
+function expandBfsDependents(
+  ctx: ScanContext,
+  chunksByFile: Map<string, SearchResult[]>,
+  hopsByFile: Map<string, number>,
+  normalizedTarget: string,
+  depth: number,
+  maxNodes: number,
+): { truncated: boolean } {
   if (depth <= 1) return { truncated: false };
 
   let truncated = false;
-  let currentFrontier: Set<string> = new Set(chunksByFile.keys());
+  let frontier: Set<string> = new Set(chunksByFile.keys());
 
-  for (let level = 2; level <= depth; level++) {
-    if (truncated || currentFrontier.size === 0) break;
-
-    const nextFrontier = new Set<string>();
-
-    for (const frontierFile of currentFrontier) {
-      if (chunksByFile.size >= maxNodes) {
+  for (let level = 2; level <= depth && !truncated && frontier.size > 0; level++) {
+    frontier = advanceOneHop({
+      ctx,
+      chunksByFile,
+      hopsByFile,
+      normalizedTarget,
+      frontier,
+      level,
+      maxNodes,
+      onTruncated: () => {
         truncated = true;
-        break;
-      }
-      const normalizedFrontier = normalizePathCached(frontierFile);
-      if (normalizedFrontier === normalizedTarget) continue;
-
-      const dependentChunks = findDependentChunks(importIndex, normalizedFrontier);
-      if (dependentChunks.length === 0) continue;
-
-      const localChunksByFile = groupChunksByFile(dependentChunks);
-      // Extend via barrel re-exports for this frontier file too.
-      resolveTransitiveDependents(
-        allChunksByFile,
-        normalizedFrontier,
-        normalizePathCached,
-        importIndex,
-        localChunksByFile,
-        log,
-      );
-
-      for (const [file, chunks] of localChunksByFile.entries()) {
-        // `file` uses getCanonicalPath; target/frontier use normalizePath.
-        // Normalize both sides before comparing.
-        const normalizedFile = normalizePathCached(file);
-        if (normalizedFile === normalizedTarget) continue;
-        if (normalizedFile === normalizedFrontier) continue;
-        if (chunksByFile.has(file)) continue;
-        if (chunksByFile.size >= maxNodes) {
-          truncated = true;
-          break;
-        }
-        chunksByFile.set(file, chunks);
-        hopsByFile.set(file, level);
-        nextFrontier.add(file);
-      }
-      if (truncated) break;
-    }
-
-    currentFrontier = nextFrontier;
+      },
+    });
   }
 
-  if (truncated) {
-    log(`BFS stopped at maxNodes=${maxNodes} (dependents truncated)`);
-  }
+  if (truncated) ctx.log(`BFS stopped at maxNodes=${maxNodes} (dependents truncated)`);
   return { truncated };
+}
+
+/**
+ * Advance the BFS by one level: for every file in `frontier`, find its
+ * dependents and merge any newly-discovered files into `chunksByFile` /
+ * `hopsByFile`. Returns the next frontier.
+ */
+function advanceOneHop(args: {
+  ctx: ScanContext;
+  chunksByFile: Map<string, SearchResult[]>;
+  hopsByFile: Map<string, number>;
+  normalizedTarget: string;
+  frontier: Set<string>;
+  level: number;
+  maxNodes: number;
+  onTruncated: () => void;
+}): Set<string> {
+  const {
+    ctx,
+    chunksByFile,
+    hopsByFile,
+    normalizedTarget,
+    frontier,
+    level,
+    maxNodes,
+    onTruncated,
+  } = args;
+  const next = new Set<string>();
+
+  for (const frontierFile of frontier) {
+    if (chunksByFile.size >= maxNodes) {
+      onTruncated();
+      return next;
+    }
+    const normalizedFrontier = ctx.normalizePathCached(frontierFile);
+    if (normalizedFrontier === normalizedTarget) continue;
+
+    const discovered = discoverFrontierDependents(ctx, normalizedFrontier);
+    const stoppedEarly = mergeDiscovered({
+      discovered,
+      chunksByFile,
+      hopsByFile,
+      normalizedTarget,
+      normalizedFrontier,
+      normalizePathCached: ctx.normalizePathCached,
+      level,
+      maxNodes,
+      next,
+    });
+    if (stoppedEarly) {
+      onTruncated();
+      return next;
+    }
+  }
+  return next;
+}
+
+/**
+ * Direct importers of `normalizedFrontier` plus its barrel re-exporters,
+ * grouped by file. No new scan — reuses `importIndex` / `allChunksByFile`.
+ */
+function discoverFrontierDependents(
+  ctx: ScanContext,
+  normalizedFrontier: string,
+): Map<string, SearchResult[]> {
+  const dependentChunks = findDependentChunks(ctx.importIndex, normalizedFrontier);
+  if (dependentChunks.length === 0) return new Map();
+  const grouped = groupChunksByFile(dependentChunks);
+  resolveTransitiveDependents(
+    ctx.allChunksByFile,
+    normalizedFrontier,
+    ctx.normalizePathCached,
+    ctx.importIndex,
+    grouped,
+    ctx.log,
+  );
+  return grouped;
+}
+
+/**
+ * Merge discovered files into `chunksByFile` / `hopsByFile` / `next`,
+ * skipping the target, the current frontier file, and already-seen files.
+ * Returns true if the merge hit the maxNodes cap and stopped early.
+ */
+function mergeDiscovered(args: {
+  discovered: Map<string, SearchResult[]>;
+  chunksByFile: Map<string, SearchResult[]>;
+  hopsByFile: Map<string, number>;
+  normalizedTarget: string;
+  normalizedFrontier: string;
+  normalizePathCached: (p: string) => string;
+  level: number;
+  maxNodes: number;
+  next: Set<string>;
+}): boolean {
+  const {
+    discovered,
+    chunksByFile,
+    hopsByFile,
+    normalizedTarget,
+    normalizedFrontier,
+    normalizePathCached,
+    level,
+    maxNodes,
+    next,
+  } = args;
+
+  for (const [file, chunks] of discovered.entries()) {
+    // `file` uses getCanonicalPath; target/frontier use normalizePath — normalize both.
+    const normalizedFile = normalizePathCached(file);
+    if (normalizedFile === normalizedTarget) continue;
+    if (normalizedFile === normalizedFrontier) continue;
+    if (chunksByFile.has(file)) continue;
+    if (chunksByFile.size >= maxNodes) return true;
+    chunksByFile.set(file, chunks);
+    hopsByFile.set(file, level);
+    next.add(file);
+  }
+  return false;
 }
 
 /**
  * For each production dependent, check whether any test file imports it.
  * Reuses the existing `importIndex` — no fresh scan.
  */
-function countUncoveredProductionDependents(
-  dependents: DependentInfo[],
-  importIndex: Map<string, SearchResult[]>,
-  normalizePathCached: (p: string) => string,
-): number {
+function countUncoveredProductionDependents(dependents: DependentInfo[], ctx: ScanContext): number {
   let uncovered = 0;
   for (const d of dependents) {
     if (d.isTestFile) continue;
-    const normalized = normalizePathCached(d.filepath);
-    const importers = findDependentChunks(importIndex, normalized);
-    const importerFiles = new Set(importers.map(c => c.metadata.file));
-    const hasTestImporter = Array.from(importerFiles).some(f => isTestFile(f));
-    if (!hasTestImporter) uncovered += 1;
+    if (!hasTestImporter(d.filepath, ctx)) uncovered += 1;
   }
   return uncovered;
+}
+
+function hasTestImporter(filepath: string, ctx: ScanContext): boolean {
+  const importers = findDependentChunks(ctx.importIndex, ctx.normalizePathCached(filepath));
+  for (const chunk of importers) {
+    if (isTestFile(chunk.metadata.file)) return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -89,6 +89,8 @@ export interface DependentInfo {
   isTestFile: boolean;
   /** Only present when symbol parameter is provided */
   usages?: SymbolUsage[];
+  /** Depth at which this dependent was first discovered (1 = direct). */
+  hops?: number;
 }
 
 /**
@@ -105,6 +107,10 @@ export interface DependencyAnalysisResult {
   allChunks: SearchResult[];
   /** Total count of usages across all files (when symbol is specified) */
   totalUsageCount?: number;
+  /** True when BFS stopped because it hit the maxNodes cap. */
+  truncated: boolean;
+  /** Count of production dependents that are NOT imported by any test file. */
+  uncoveredProductionDependents: number;
 }
 
 /**
@@ -582,6 +588,14 @@ function resolveTransitiveDependents(
 /**
  * Find all files that depend on a target file, including transitive dependents
  * through re-export chains. Optionally tracks usages of a specific symbol.
+ *
+ * When `depth > 1`, the walk continues outward (BFS) over the import graph
+ * using the same in-memory `importIndex`. Each newly discovered file is
+ * tagged with the depth (hops) at which it was first reached. BFS stops when
+ * `depth` is reached or `chunksByFile.size >= maxNodes` (sets `truncated`).
+ *
+ * Symbol-level queries (`symbol` set) always behave as depth=1 — transitive
+ * symbol tracking through re-renaming chains is out of scope for this tool.
  */
 export async function findDependents(
   vectorDB: VectorDBInterface,
@@ -590,6 +604,8 @@ export async function findDependents(
   log: (message: string, level?: 'warning') => void,
   symbol?: string,
   indexVersion?: number,
+  depth: number = 1,
+  maxNodes: number = 500,
 ): Promise<DependencyAnalysisResult> {
   const normalizePathCached = createPathNormalizer();
   const normalizedTarget = normalizePathCached(filepath);
@@ -616,6 +632,27 @@ export async function findDependents(
     log,
   );
 
+  // Depth-1 hops — every file discovered so far.
+  const hopsByFile = new Map<string, number>();
+  for (const file of chunksByFile.keys()) hopsByFile.set(file, 1);
+
+  // BFS for depth > 1 (file-level only; symbol queries stay at depth 1).
+  const effectiveDepth = symbol ? 1 : depth;
+  if (effectiveDepth > 1 && depth > 1 && symbol) {
+    log(`Note: depth > 1 is ignored for symbol-level queries (symbol=${symbol})`);
+  }
+  const bfsResult = expandBfsDependents({
+    chunksByFile,
+    hopsByFile,
+    normalizedTarget,
+    importIndex,
+    allChunksByFile,
+    normalizePathCached,
+    log,
+    depth: effectiveDepth,
+    maxNodes,
+  });
+
   // Calculate metrics
   const fileComplexities = calculateFileComplexities(chunksByFile);
   const complexityMetrics = calculateOverallComplexityMetrics(fileComplexities);
@@ -635,8 +672,15 @@ export async function findDependents(
     reExporterPaths,
   );
 
-  // Sort dependents: production files first, then test files
+  // Stamp hops on each dependent from the BFS map.
+  for (const d of dependents) {
+    d.hops = hopsByFile.get(d.filepath) ?? 1;
+  }
+
+  // Sort dependents: shallower first, then production before test, stable otherwise.
   dependents.sort((a, b) => {
+    const hopDelta = (a.hops ?? 1) - (b.hops ?? 1);
+    if (hopDelta !== 0) return hopDelta;
     if (a.isTestFile === b.isTestFile) return 0;
     return a.isTestFile ? 1 : -1;
   });
@@ -644,6 +688,12 @@ export async function findDependents(
   // Calculate test/production split
   const testDependentCount = dependents.filter(f => f.isTestFile).length;
   const productionDependentCount = dependents.length - testDependentCount;
+
+  const uncoveredProductionDependents = countUncoveredProductionDependents(
+    dependents,
+    importIndex,
+    normalizePathCached,
+  );
 
   // Only flatten all chunks when needed for cross-repo grouping (groupDependentsByRepo)
   const allChunks = crossRepo ? Array.from(allChunksByFile.values()).flat() : [];
@@ -658,7 +708,119 @@ export async function findDependents(
     hitLimit,
     allChunks,
     totalUsageCount,
+    truncated: bfsResult.truncated,
+    uncoveredProductionDependents,
   };
+}
+
+/**
+ * BFS over the import graph starting from the already-populated depth-1
+ * frontier in `chunksByFile`. Mutates `chunksByFile` and `hopsByFile` in place
+ * with newly discovered files and their hop counts.
+ */
+function expandBfsDependents(args: {
+  chunksByFile: Map<string, SearchResult[]>;
+  hopsByFile: Map<string, number>;
+  normalizedTarget: string;
+  importIndex: Map<string, SearchResult[]>;
+  allChunksByFile: Map<string, SearchResult[]>;
+  normalizePathCached: (p: string) => string;
+  log: (message: string, level?: 'warning') => void;
+  depth: number;
+  maxNodes: number;
+}): { truncated: boolean } {
+  const {
+    chunksByFile,
+    hopsByFile,
+    normalizedTarget,
+    importIndex,
+    allChunksByFile,
+    normalizePathCached,
+    log,
+    depth,
+    maxNodes,
+  } = args;
+
+  // `truncated` means "BFS was aborted mid-expansion because of maxNodes".
+  // If depth<=1, no BFS runs and the flag stays false regardless of size.
+  if (depth <= 1) return { truncated: false };
+
+  let truncated = false;
+  let currentFrontier: Set<string> = new Set(chunksByFile.keys());
+
+  for (let level = 2; level <= depth; level++) {
+    if (truncated || currentFrontier.size === 0) break;
+
+    const nextFrontier = new Set<string>();
+
+    for (const frontierFile of currentFrontier) {
+      if (chunksByFile.size >= maxNodes) {
+        truncated = true;
+        break;
+      }
+      const normalizedFrontier = normalizePathCached(frontierFile);
+      if (normalizedFrontier === normalizedTarget) continue;
+
+      const dependentChunks = findDependentChunks(importIndex, normalizedFrontier);
+      if (dependentChunks.length === 0) continue;
+
+      const localChunksByFile = groupChunksByFile(dependentChunks);
+      // Extend via barrel re-exports for this frontier file too.
+      resolveTransitiveDependents(
+        allChunksByFile,
+        normalizedFrontier,
+        normalizePathCached,
+        importIndex,
+        localChunksByFile,
+        log,
+      );
+
+      for (const [file, chunks] of localChunksByFile.entries()) {
+        // `file` uses getCanonicalPath; target/frontier use normalizePath.
+        // Normalize both sides before comparing.
+        const normalizedFile = normalizePathCached(file);
+        if (normalizedFile === normalizedTarget) continue;
+        if (normalizedFile === normalizedFrontier) continue;
+        if (chunksByFile.has(file)) continue;
+        if (chunksByFile.size >= maxNodes) {
+          truncated = true;
+          break;
+        }
+        chunksByFile.set(file, chunks);
+        hopsByFile.set(file, level);
+        nextFrontier.add(file);
+      }
+      if (truncated) break;
+    }
+
+    currentFrontier = nextFrontier;
+  }
+
+  if (truncated) {
+    log(`BFS stopped at maxNodes=${maxNodes} (dependents truncated)`);
+  }
+  return { truncated };
+}
+
+/**
+ * For each production dependent, check whether any test file imports it.
+ * Reuses the existing `importIndex` — no fresh scan.
+ */
+function countUncoveredProductionDependents(
+  dependents: DependentInfo[],
+  importIndex: Map<string, SearchResult[]>,
+  normalizePathCached: (p: string) => string,
+): number {
+  let uncovered = 0;
+  for (const d of dependents) {
+    if (d.isTestFile) continue;
+    const normalized = normalizePathCached(d.filepath);
+    const importers = findDependentChunks(importIndex, normalized);
+    const importerFiles = new Set(importers.map(c => c.metadata.file));
+    const hasTestImporter = Array.from(importerFiles).some(f => isTestFile(f));
+    if (!hasTestImporter) uncovered += 1;
+  }
+  return uncovered;
 }
 
 /**
@@ -787,48 +949,6 @@ function calculateComplexityRiskBoost(avgComplexity: number, maxComplexity: numb
     return 'medium';
   }
   return 'low';
-}
-
-/**
- * Calculate risk level based on dependent count and complexity.
- * @param dependentCount Total number of dependent files
- * @param complexityRiskBoost Risk boost from complexity analysis
- * @param productionDependentCount Optional: if provided, use this for risk calculation instead of dependentCount
- */
-export function calculateRiskLevel(
-  dependentCount: number,
-  complexityRiskBoost: 'low' | 'medium' | 'high' | 'critical',
-  productionDependentCount?: number,
-): 'low' | 'medium' | 'high' | 'critical' {
-  const DEPENDENT_COUNT_THRESHOLDS = {
-    LOW: 5,
-    MEDIUM: 15,
-    HIGH: 30,
-  } as const;
-
-  const RISK_ORDER = { low: 0, medium: 1, high: 2, critical: 3 } as const;
-  type RiskLevel = keyof typeof RISK_ORDER;
-
-  // Use production count if provided, otherwise fall back to total
-  const effectiveCount = productionDependentCount ?? dependentCount;
-
-  let riskLevel: RiskLevel =
-    effectiveCount === 0
-      ? 'low'
-      : effectiveCount <= DEPENDENT_COUNT_THRESHOLDS.LOW
-        ? 'low'
-        : effectiveCount <= DEPENDENT_COUNT_THRESHOLDS.MEDIUM
-          ? 'medium'
-          : effectiveCount <= DEPENDENT_COUNT_THRESHOLDS.HIGH
-            ? 'high'
-            : 'critical';
-
-  // Boost if complexity risk is higher
-  if (RISK_ORDER[complexityRiskBoost] > RISK_ORDER[riskLevel]) {
-    riskLevel = complexityRiskBoost;
-  }
-
-  return riskLevel;
 }
 
 /**

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -12,7 +12,7 @@ vi.mock('./dependency-analyzer.js', async importOriginal => {
   };
 });
 
-import { findDependents, calculateRiskLevel } from './dependency-analyzer.js';
+import { findDependents } from './dependency-analyzer.js';
 
 describe('handleGetDependents', () => {
   const mockLog = vi.fn();
@@ -41,6 +41,7 @@ describe('handleGetDependents', () => {
         filepath: string;
         isTestFile: boolean;
         usages?: Array<{ callerSymbol: string; line: number; snippet: string }>;
+        hops?: number;
       }>;
       hitLimit?: boolean;
       complexityMetrics?: {
@@ -55,6 +56,8 @@ describe('handleGetDependents', () => {
         complexityRiskBoost: 'low' | 'medium' | 'high' | 'critical';
       };
       totalUsageCount?: number;
+      truncated?: boolean;
+      uncoveredProductionDependents?: number;
     } = {},
   ) {
     const dependents = overrides.dependents ?? [{ filepath: 'src/consumer.ts', isTestFile: false }];
@@ -77,6 +80,8 @@ describe('handleGetDependents', () => {
       hitLimit: overrides.hitLimit ?? false,
       allChunks: [] as SearchResult[],
       totalUsageCount: overrides.totalUsageCount,
+      truncated: overrides.truncated ?? false,
+      uncoveredProductionDependents: overrides.uncoveredProductionDependents ?? 0,
     };
   }
 
@@ -140,6 +145,8 @@ describe('handleGetDependents', () => {
         mockLog,
         undefined, // symbol default
         1234567890, // indexVersion from mock
+        1, // depth default
+        500, // maxNodes default
       );
     });
 
@@ -218,10 +225,13 @@ describe('handleGetDependents', () => {
       expect(parsed.complexityMetrics).toEqual(complexityMetrics);
     });
 
-    it('should boost risk level when complexity is high', async () => {
+    it('should escalate to high when an untested dependent is highly complex', async () => {
+      // computeBlastRadiusRisk: hasHighComplexityUncovered (maxComplexity >= 15 with uncovered > 0)
+      // → high regardless of dependent count.
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({
           dependents: [{ filepath: 'src/a.ts', isTestFile: false }],
+          uncoveredProductionDependents: 1,
           complexityMetrics: {
             averageComplexity: 20,
             maxComplexity: 30,
@@ -237,8 +247,34 @@ describe('handleGetDependents', () => {
       const result = await handleGetDependents({ filepath: 'src/utils.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
-      // Even with 1 dependent, complexity can boost the risk
-      expect(['high', 'critical']).toContain(parsed.riskLevel);
+      expect(parsed.riskLevel).toBe('high');
+      expect(parsed.riskReasoning).toEqual(
+        expect.arrayContaining(['untested high-complexity dependent']),
+      );
+    });
+
+    it('should keep risk low when complexity is high but all dependents are tested', async () => {
+      // hasHighComplexityUncovered only fires when uncovered > 0.
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: [{ filepath: 'src/a.ts', isTestFile: false }],
+          uncoveredProductionDependents: 0,
+          complexityMetrics: {
+            averageComplexity: 20,
+            maxComplexity: 30,
+            filesWithComplexityData: 1,
+            highComplexityDependents: [
+              { filepath: 'src/a.ts', maxComplexity: 30, avgComplexity: 20 },
+            ],
+            complexityRiskBoost: 'critical',
+          },
+        }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'src/utils.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.riskLevel).toBe('low');
     });
   });
 
@@ -316,6 +352,8 @@ describe('handleGetDependents', () => {
         mockLog,
         undefined,
         1234567890,
+        1,
+        500,
       );
     });
 
@@ -394,6 +432,8 @@ describe('handleGetDependents', () => {
         mockLog,
         undefined,
         1234567890,
+        1,
+        500,
       );
     });
   });
@@ -556,10 +596,13 @@ describe('handleGetDependents', () => {
       expect(parsed.riskLevel).toBe('low');
     });
 
-    it('should still boost risk level for high complexity even with few production dependents', async () => {
+    it('should escalate to high for an untested high-complexity dependent', async () => {
+      // Under computeBlastRadiusRisk, hasHighComplexityUncovered caps at "high"
+      // unless dependentCount also exceeds 20.
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({
           dependents: [{ filepath: 'src/complex.ts', isTestFile: false }],
+          uncoveredProductionDependents: 1,
           complexityMetrics: {
             averageComplexity: 30,
             maxComplexity: 50,
@@ -576,7 +619,7 @@ describe('handleGetDependents', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.productionDependentCount).toBe(1);
-      expect(parsed.riskLevel).toBe('critical');
+      expect(parsed.riskLevel).toBe('high');
     });
   });
 
@@ -596,6 +639,8 @@ describe('handleGetDependents', () => {
         mockLog,
         'validateEmail',
         1234567890,
+        1,
+        500,
       );
     });
 
@@ -715,71 +760,98 @@ describe('handleGetDependents', () => {
       expect(parsed.totalUsageCount).toBeUndefined();
     });
   });
-});
 
-describe('calculateRiskLevel (unit tests)', () => {
-  it('should return low for 0 dependents', () => {
-    expect(calculateRiskLevel(0, 'low')).toBe('low');
-  });
+  describe('depth / maxNodes / transitive response fields', () => {
+    it('should thread depth and maxNodes through to findDependents', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
 
-  it('should return low for 1-5 dependents with low complexity', () => {
-    expect(calculateRiskLevel(1, 'low')).toBe('low');
-    expect(calculateRiskLevel(5, 'low')).toBe('low');
-  });
+      await handleGetDependents({ filepath: 'src/target.ts', depth: 3, maxNodes: 50 }, mockCtx);
 
-  it('should return medium for 6-15 dependents with low complexity', () => {
-    expect(calculateRiskLevel(6, 'low')).toBe('medium');
-    expect(calculateRiskLevel(15, 'low')).toBe('medium');
-  });
-
-  it('should return high for 16-30 dependents with low complexity', () => {
-    expect(calculateRiskLevel(16, 'low')).toBe('high');
-    expect(calculateRiskLevel(30, 'low')).toBe('high');
-  });
-
-  it('should return critical for 31+ dependents', () => {
-    expect(calculateRiskLevel(31, 'low')).toBe('critical');
-    expect(calculateRiskLevel(100, 'low')).toBe('critical');
-  });
-
-  it('should boost risk level when complexity is higher', () => {
-    // Low dependent count but high complexity should boost to high
-    expect(calculateRiskLevel(2, 'high')).toBe('high');
-    expect(calculateRiskLevel(2, 'critical')).toBe('critical');
-  });
-
-  it('should not downgrade risk level from complexity', () => {
-    // High dependent count should not be reduced by low complexity
-    expect(calculateRiskLevel(50, 'low')).toBe('critical');
-  });
-
-  describe('with productionDependentCount', () => {
-    it('should use productionDependentCount for risk when provided', () => {
-      // 20 total dependents would be "high" risk
-      // But only 3 production dependents = "low" risk
-      expect(calculateRiskLevel(20, 'low', 3)).toBe('low');
+      expect(findDependents).toHaveBeenCalledWith(
+        mockVectorDB,
+        'src/target.ts',
+        false,
+        mockLog,
+        undefined,
+        1234567890,
+        3,
+        50,
+      );
     });
 
-    it('should return low risk when productionDependentCount is 0', () => {
-      // Even with many total dependents, 0 production = low risk
-      expect(calculateRiskLevel(50, 'low', 0)).toBe('low');
+    it('should echo the requested depth in the response', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents({ filepath: 'src/target.ts', depth: 2 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.depth).toBe(2);
     });
 
-    it('should return medium risk for 6-15 production dependents', () => {
-      expect(calculateRiskLevel(50, 'low', 10)).toBe('medium');
+    it('should surface truncated and totalImpacted in the response', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: [
+            { filepath: 'src/a.ts', isTestFile: false, hops: 1 },
+            { filepath: 'src/b.ts', isTestFile: false, hops: 2 },
+          ],
+          truncated: true,
+        }),
+      );
+
+      const result = await handleGetDependents(
+        { filepath: 'src/target.ts', depth: 2, maxNodes: 2 },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.truncated).toBe(true);
+      expect(parsed.totalImpacted).toBe(2);
+      expect(parsed.dependents[0].hops).toBe(1);
+      expect(parsed.dependents[1].hops).toBe(2);
     });
 
-    it('should return high risk for 16-30 production dependents', () => {
-      expect(calculateRiskLevel(100, 'low', 20)).toBe('high');
+    it('should include riskReasoning from computeBlastRadiusRisk', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: Array.from({ length: 8 }, (_, i) => ({
+            filepath: `src/f${i}.ts`,
+            isTestFile: false,
+          })),
+          uncoveredProductionDependents: 3,
+          complexityMetrics: {
+            averageComplexity: 6,
+            maxComplexity: 12,
+            filesWithComplexityData: 8,
+            highComplexityDependents: [],
+            complexityRiskBoost: 'medium',
+          },
+        }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'src/utils.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.riskLevel).toBe('medium');
+      expect(parsed.riskReasoning).toEqual(
+        expect.arrayContaining(['8 callers', '3 untested', 'max complexity 12']),
+      );
     });
 
-    it('should still boost from complexity even with low production count', () => {
-      expect(calculateRiskLevel(50, 'critical', 1)).toBe('critical');
+    it('should log transitive depth in the initial request line', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      await handleGetDependents({ filepath: 'src/target.ts', depth: 2 }, mockCtx);
+
+      expect(mockLog).toHaveBeenCalledWith('Finding dependents of: src/target.ts (depth: 2)');
     });
 
-    it('should fall back to dependentCount when productionDependentCount is undefined', () => {
-      // Backwards compatibility: undefined should use total count
-      expect(calculateRiskLevel(20, 'low', undefined)).toBe('high');
+    it('should reject depth above schema max', async () => {
+      const result = await handleGetDependents({ filepath: 'src/target.ts', depth: 99 }, mockCtx);
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.error).toBe('Invalid parameters');
     });
   });
 });

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -1,3 +1,4 @@
+import type { z } from 'zod';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetDependentsSchema } from '../schemas/index.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
@@ -15,14 +16,9 @@ import {
 // Matches the review-side blast-radius default (DEFAULT_HIGH_COMPLEXITY_THRESHOLD).
 const HIGH_COMPLEXITY_THRESHOLD = 15;
 
-// Types for validated args and response building
-interface ValidatedArgs {
-  filepath: string;
-  symbol?: string;
-  crossRepo?: boolean;
-  depth?: number;
-  maxNodes?: number;
-}
+// Validated args mirror the schema exactly — `depth` and `maxNodes` are
+// always present post-parse thanks to Zod `.default(...)`.
+type ValidatedArgs = z.infer<typeof GetDependentsSchema>;
 
 interface IndexInfo {
   indexVersion: number;
@@ -151,7 +147,7 @@ function buildDependentsResponse(
   const response: DependentsResponse = {
     indexInfo,
     filepath,
-    depth: depth ?? 1,
+    depth,
     dependentCount: analysis.dependents.length,
     productionDependentCount: analysis.productionDependentCount,
     testDependentCount: analysis.testDependentCount,
@@ -195,13 +191,17 @@ function buildDependentsResponse(
 export async function handleGetDependents(args: unknown, ctx: ToolContext): Promise<MCPToolResult> {
   const { vectorDB, log, checkAndReconnect, getIndexMetadata } = ctx;
 
-  return await wrapToolHandler(GetDependentsSchema, async validatedArgs => {
+  return await wrapToolHandler(GetDependentsSchema, async raw => {
+    // `wrapToolHandler`'s generic loses Zod's input-vs-output distinction, so
+    // defaults aren't reflected in `raw`'s type. At runtime Zod has already
+    // applied them, so the cast is sound.
+    const validatedArgs = raw as ValidatedArgs;
     const { crossRepo, filepath, symbol, depth, maxNodes } = validatedArgs;
 
     // Log initial request
     const symbolSuffix = symbol ? ` (symbol: ${symbol})` : '';
     const crossRepoSuffix = crossRepo ? ' (cross-repo)' : '';
-    const depthSuffix = depth && depth > 1 ? ` (depth: ${depth})` : '';
+    const depthSuffix = depth > 1 ? ` (depth: ${depth})` : '';
     log(`Finding dependents of: ${filepath}${symbolSuffix}${crossRepoSuffix}${depthSuffix}`);
 
     await checkAndReconnect();

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -2,20 +2,26 @@ import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetDependentsSchema } from '../schemas/index.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
 import type { VectorDBInterface } from '@liendev/core';
+import { computeBlastRadiusRisk, type BlastRadiusRisk } from '@liendev/parser';
 import {
   findDependents,
-  calculateRiskLevel,
   groupDependentsByRepo,
   type DependencyAnalysisResult,
   type DependentInfo,
   type ComplexityMetrics,
 } from './dependency-analyzer.js';
 
+// Complexity threshold above which an uncovered dependent escalates risk.
+// Matches the review-side blast-radius default (DEFAULT_HIGH_COMPLEXITY_THRESHOLD).
+const HIGH_COMPLEXITY_THRESHOLD = 15;
+
 // Types for validated args and response building
 interface ValidatedArgs {
   filepath: string;
   symbol?: string;
   crossRepo?: boolean;
+  depth?: number;
+  maxNodes?: number;
 }
 
 interface IndexInfo {
@@ -30,11 +36,18 @@ interface DependentsResponse {
   indexInfo: IndexInfo;
   filepath: string;
   symbol?: string;
+  depth: number;
   dependentCount: number;
   productionDependentCount: number;
   testDependentCount: number;
   totalUsageCount?: number;
+  /** Alias for dependentCount following the CRG naming convention. */
+  totalImpacted: number;
+  /** True when BFS stopped at the maxNodes cap. */
+  truncated: boolean;
   riskLevel: string;
+  /** Short phrases explaining why the risk level was assigned. */
+  riskReasoning: string[];
   dependents: DependentInfo[];
   complexityMetrics: ComplexityMetrics;
   note?: string;
@@ -77,13 +90,14 @@ function logRiskAssessment(
   log: (msg: string) => void,
 ): void {
   const prodTest = `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test)`;
+  const truncatedSuffix = analysis.truncated ? ' [truncated]' : '';
 
   if (symbol && analysis.totalUsageCount !== undefined) {
     if (analysis.totalUsageCount > 0) {
       // Symbol tracking with call sites found
       log(
         `Found ${analysis.totalUsageCount} tracked call sites across ${analysis.dependents.length} files ` +
-          `${prodTest} - risk: ${riskLevel}`,
+          `${prodTest} - risk: ${riskLevel}${truncatedSuffix}`,
       );
     } else {
       // Files import the symbol but no call sites were tracked
@@ -91,12 +105,33 @@ function logRiskAssessment(
       // (e.g., chunks without complexity analysis)
       log(
         `Found ${analysis.dependents.length} files importing '${symbol}' ` +
-          `${prodTest} - risk: ${riskLevel} (Note: Call site tracking unavailable for these chunks)`,
+          `${prodTest} - risk: ${riskLevel}${truncatedSuffix} (Note: Call site tracking unavailable for these chunks)`,
       );
     }
   } else {
-    log(`Found ${analysis.dependents.length} dependents ` + `${prodTest} - risk: ${riskLevel}`);
+    log(
+      `Found ${analysis.dependents.length} dependents ` +
+        `${prodTest} - risk: ${riskLevel}${truncatedSuffix}`,
+    );
   }
+}
+
+/**
+ * Compose blast-radius risk inputs from analysis results and compute the
+ * shared risk level via the parser primitive.
+ */
+function computeRisk(analysis: DependencyAnalysisResult): BlastRadiusRisk {
+  const { productionDependentCount, uncoveredProductionDependents, complexityMetrics } = analysis;
+  const maxComplexity = complexityMetrics.maxComplexity;
+  // Any high-complexity dependent that is also untested escalates risk.
+  const hasHighComplexityUncovered =
+    uncoveredProductionDependents > 0 && maxComplexity >= HIGH_COMPLEXITY_THRESHOLD;
+  return computeBlastRadiusRisk({
+    dependentCount: productionDependentCount,
+    uncoveredDependents: uncoveredProductionDependents,
+    maxDependentComplexity: maxComplexity > 0 ? maxComplexity : undefined,
+    hasHighComplexityUncovered,
+  });
 }
 
 /**
@@ -105,21 +140,25 @@ function logRiskAssessment(
 function buildDependentsResponse(
   analysis: DependencyAnalysisResult,
   args: ValidatedArgs,
-  riskLevel: string,
+  risk: BlastRadiusRisk,
   indexInfo: IndexInfo,
   notes: string[],
   crossRepo: boolean | undefined,
   vectorDB: VectorDBInterface,
 ): DependentsResponse {
-  const { symbol, filepath } = args;
+  const { symbol, filepath, depth } = args;
 
   const response: DependentsResponse = {
     indexInfo,
     filepath,
+    depth: depth ?? 1,
     dependentCount: analysis.dependents.length,
     productionDependentCount: analysis.productionDependentCount,
     testDependentCount: analysis.testDependentCount,
-    riskLevel,
+    totalImpacted: analysis.dependents.length,
+    truncated: analysis.truncated,
+    riskLevel: risk.level,
+    riskReasoning: risk.reasoning,
     dependents: analysis.dependents,
     complexityMetrics: analysis.complexityMetrics,
   };
@@ -157,12 +196,13 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
   const { vectorDB, log, checkAndReconnect, getIndexMetadata } = ctx;
 
   return await wrapToolHandler(GetDependentsSchema, async validatedArgs => {
-    const { crossRepo, filepath, symbol } = validatedArgs;
+    const { crossRepo, filepath, symbol, depth, maxNodes } = validatedArgs;
 
     // Log initial request
     const symbolSuffix = symbol ? ` (symbol: ${symbol})` : '';
     const crossRepoSuffix = crossRepo ? ' (cross-repo)' : '';
-    log(`Finding dependents of: ${filepath}${symbolSuffix}${crossRepoSuffix}`);
+    const depthSuffix = depth && depth > 1 ? ` (depth: ${depth})` : '';
+    log(`Finding dependents of: ${filepath}${symbolSuffix}${crossRepoSuffix}${depthSuffix}`);
 
     await checkAndReconnect();
 
@@ -177,17 +217,15 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
       log,
       symbol,
       indexInfo.indexVersion,
+      depth,
+      maxNodes,
     );
 
-    // Calculate risk level
-    const riskLevel = calculateRiskLevel(
-      analysis.dependents.length,
-      analysis.complexityMetrics.complexityRiskBoost,
-      analysis.productionDependentCount,
-    );
+    // Compose risk via the shared parser primitive.
+    const risk = computeRisk(analysis);
 
     // Log results with risk assessment
-    logRiskAssessment(analysis, riskLevel, symbol, log);
+    logRiskAssessment(analysis, risk.level, symbol, log);
 
     // Build and return response
     const crossRepoFallback = checkCrossRepoFallback(crossRepo, vectorDB);
@@ -196,7 +234,7 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
     return buildDependentsResponse(
       analysis,
       validatedArgs,
-      riskLevel,
+      risk,
       indexInfo,
       notes,
       crossRepo,

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -18,7 +18,13 @@ REQUIRED before renaming, removing, or changing the signature of any exported
 symbol:
   get_dependents({ filepath, symbol }) — check dependentCount and riskLevel.
   If riskLevel is "high" or "critical", list affected dependents to the user
-  before editing.
+  before editing. Read riskReasoning for the "why" (e.g. "14 callers, 3
+  untested, max complexity 18") before deciding how cautious to be.
+
+  For "what else could break?" impact analysis, pass depth: 2 (or up to 5) to
+  walk the import graph transitively. Each dependent carries a 'hops' field;
+  'truncated: true' means the BFS stopped at 'maxNodes' (default 500).
+  Symbol-level queries stay at depth 1 — pass depth only for file-level.
 
 For discovery ("where is X?", "how does Y work?"), call semantic_search FIRST.
 Phrase queries as full questions ("How does the code handle auth?") — natural

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -47,11 +47,27 @@ export const GetDependentsSchema = z.object({
     .number()
     .int()
     .min(1)
-    .max(1)
+    .max(5)
     .default(1)
     .describe(
-      'Depth of transitive dependencies. Only depth=1 (direct dependents) is currently supported.\n\n' +
-        '1 = Direct dependents only',
+      'Depth of transitive dependency walk (BFS over the import graph).\n\n' +
+        '1 = Direct dependents only (default; matches prior behavior).\n' +
+        '2 = Direct dependents + their dependents.\n' +
+        'Up to 5. Each dependent carries a `hops` field indicating the depth\n' +
+        'at which it was first discovered. Ignored for symbol-level queries\n' +
+        '(when `symbol` is set, only direct callers are returned).',
+    ),
+
+  maxNodes: z
+    .number()
+    .int()
+    .min(1)
+    .max(5000)
+    .default(500)
+    .describe(
+      'Maximum number of distinct dependent files to return.\n\n' +
+        'Acts as a guardrail for deep BFS on large repos. When the cap is\n' +
+        'hit, the response includes `truncated: true`.',
     ),
 
   crossRepo: z

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -65,9 +65,14 @@ export const GetDependentsSchema = z.object({
     .max(5000)
     .default(500)
     .describe(
-      'Maximum number of distinct dependent files to return.\n\n' +
-        'Acts as a guardrail for deep BFS on large repos. When the cap is\n' +
-        'hit, the response includes `truncated: true`.',
+      'Guardrail on BFS expansion (applies at depth >= 2).\n\n' +
+        'Caps the number of dependents discovered via the transitive walk\n' +
+        'performed by `expandBfsDependents` in `dependency-analyzer.ts`.\n' +
+        'Does NOT truncate the depth-1 frontier — direct importers and barrel\n' +
+        're-exporters are always returned in full (their only overall ceiling\n' +
+        'is the scan-level `hitLimit`). A `depth=1` response can therefore\n' +
+        'exceed `maxNodes` with `truncated: false`. When the BFS walk itself\n' +
+        'hits the cap mid-expansion, `truncated: true` is set.',
     ),
 
   crossRepo: z

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -377,6 +377,11 @@ describe('GetDependentsSchema', () => {
     expect(() => GetDependentsSchema.parse({ filepath: 'test.ts', maxNodes: 999999 })).toThrow();
   });
 
+  it('should accept maxNodes at the upper bound (5000)', () => {
+    const result = GetDependentsSchema.parse({ filepath: 'test.ts', maxNodes: 5000 });
+    expect(result.maxNodes).toBe(5000);
+  });
+
   it('should accept various filepath formats', () => {
     const paths = [
       'src/index.ts',

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -349,21 +349,32 @@ describe('GetDependentsSchema', () => {
     ).toThrow();
   });
 
-  it('should reject depth greater than 1', () => {
+  it('should reject depth greater than 5', () => {
     expect(() =>
       GetDependentsSchema.parse({
         filepath: 'src/test.ts',
-        depth: 2,
+        depth: 6,
       }),
     ).toThrow();
   });
 
-  it('should accept only depth=1', () => {
-    const result = GetDependentsSchema.parse({
-      filepath: 'test.ts',
-      depth: 1,
-    });
-    expect(result.depth).toBe(1);
+  it('should accept depth in [1, 5]', () => {
+    for (const d of [1, 2, 3, 5]) {
+      const result = GetDependentsSchema.parse({
+        filepath: 'test.ts',
+        depth: d,
+      });
+      expect(result.depth).toBe(d);
+    }
+  });
+
+  it('should default maxNodes to 500', () => {
+    const result = GetDependentsSchema.parse({ filepath: 'test.ts' });
+    expect(result.maxNodes).toBe(500);
+  });
+
+  it('should reject maxNodes above the cap', () => {
+    expect(() => GetDependentsSchema.parse({ filepath: 'test.ts', maxNodes: 999999 })).toThrow();
   });
 
   it('should accept various filepath formats', () => {

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -192,7 +192,15 @@ describe('MCP Tools Schema', () => {
       const tool = tools.find(t => t.name === 'get_dependents');
       const schema = tool?.inputSchema as any;
       expect(schema.properties.depth?.minimum).toBe(1);
-      expect(schema.properties.depth?.maximum).toBe(1);
+      expect(schema.properties.depth?.maximum).toBe(5);
+    });
+
+    it('should expose maxNodes with a default and cap', () => {
+      const tool = tools.find(t => t.name === 'get_dependents');
+      const schema = tool?.inputSchema as any;
+      expect(schema.properties.maxNodes?.default).toBe(500);
+      expect(schema.properties.maxNodes?.minimum).toBe(1);
+      expect(schema.properties.maxNodes?.maximum).toBe(5000);
     });
   });
 
@@ -400,14 +408,24 @@ describe('MCP Tools Schema', () => {
         expect(invalid.success).toBe(false);
       });
 
-      it('should reject depth > 1', () => {
+      it('should accept depth up to 5', () => {
+        for (const d of [1, 2, 3, 5]) {
+          const parsed = GetDependentsSchema.safeParse({
+            filepath: 'src/test.ts',
+            depth: d,
+          });
+          expect(parsed.success).toBe(true);
+        }
+      });
+
+      it('should reject depth > 5', () => {
         const invalid = GetDependentsSchema.safeParse({
           filepath: 'src/test.ts',
-          depth: 2,
+          depth: 6,
         });
         expect(invalid.success).toBe(false);
         if (!invalid.success) {
-          expect(invalid.error.issues[0].message).toContain('less than or equal to 1');
+          expect(invalid.error.issues[0].message).toContain('less than or equal to 5');
         }
       });
 


### PR DESCRIPTION
## Summary

- Extends the MCP `get_dependents` tool with transitive dependency walking (BFS over the existing in-memory `importIndex`) gated by a new `depth` (1–5, default 1) and `maxNodes` (default 500, cap 5000) parameter.
- Swaps the handler's local `calculateRiskLevel` heuristic for the shared `computeBlastRadiusRisk` primitive in `@liendev/parser` introduced by Workstream A.
- Response gains `dependents[].hops`, `truncated`, `totalImpacted`, `riskReasoning` while keeping existing fields. `truncated` fires only when the BFS loop is actually cut short — not when no BFS happened.
- Symbol-level queries (`symbol` set) remain depth-1 only; transitive symbol-renaming chains are out of scope.
- `uncoveredProductionDependents` is derived by reusing `findDependentChunks` against the same `importIndex` — no fresh scan.

Backwards-compatible in shape at `depth=1`; only `riskLevel` semantics shift (now sourced from `computeBlastRadiusRisk` — Workstream A's shared primitive — which considers test coverage and dependent complexity, not just count + a complexity boost).

Closes Workstream B from `.wip/retro-blast-radius.md` §4.6.

## Dogfood against this repo

```
get_dependents({ filepath: "packages/cli/src/mcp/utils/response-budget.ts", depth: 2 })
→ 117 deps total; 5 new at hops=2; truncated: false

get_dependents({ filepath: "packages/cli/src/mcp/utils/response-budget.ts", depth: 3, maxNodes: 2 })
→ 112 deps at hops=1; truncated: true (BFS correctly aborted)
```

## Related findings filed separately

Surfaced while dogfooding — each deserves its own fix, not part of this PR:

- #525 — `matchesFile` cross-package basename collisions pollute `get_dependents` responses
- #526 — Re-export walk's `*` sentinel falsely flags non-re-exporters, poisoning the depth-1 seed
- #527 — Stale \"10,000 chunks\" limit text (single-repo scan has no cap in reality)

## Test plan

- [x] `npm run typecheck` (0 errors)
- [x] `npm run lint` (0 errors — existing warnings only)
- [x] `npm run format:check`
- [x] `npm run build` — full monorepo
- [x] `npm run test --workspaces` — 630 CLI tests + 24 runner tests pass
- [x] New unit tests cover: depth=2/3 BFS, cycle handling, diamond graphs (min-hop), maxNodes truncation, symbol+depth interaction, uncovered-dependents counting, risk reasoning composition
- [x] Dogfooded via reloaded MCP (see above)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This pull request significantly enhances the `get_dependents` tool by introducing transitive dependency analysis (BFS) with configurable depth and maximum nodes. It also refactors the risk assessment logic to use a shared primitive, `computeBlastRadiusRisk`, which provides a more nuanced evaluation based on test coverage and dependent complexity. The implementation of the BFS algorithm correctly handles cycles and ensures that each dependent is reported with its minimum hop count. The new risk calculation is well-integrated and tested, particularly for scenarios involving high complexity and uncovered production dependents. The new parameters are properly validated, and the tool's logging and response structure have been updated to reflect the added functionality. No critical bugs or unintended breaking changes were identified.
>
> - Added `depth` and `maxNodes` parameters to `get_dependents` for transitive dependency analysis.
> - Replaced local risk calculation with `computeBlastRadiusRisk` from `@liendev/parser` for more robust risk assessment.
> - Introduced new response fields: `hops`, `truncated`, `totalImpacted`, and `riskReasoning`.
> - Implemented BFS logic for multi-depth dependency traversal, including cycle detection and truncation.
> - Added logic to count `uncoveredProductionDependents` for improved risk assessment.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit c5dd1cc. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dependency analysis now supports multi-depth traversal up to 5 levels, enabling discovery of transitive relationships beyond direct dependents
  * Added configurable `maxNodes` parameter to control analysis scope with automatic truncation when limit is exceeded
  * Enhanced risk assessment metrics with uncovered production dependents tracking
  * Dependencies now include hop-distance information for improved visibility into relationship depths

* **Tests**
  * Comprehensive test coverage for multi-depth traversal, edge cases, and risk scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->