### PR TITLE
fix(ci): drop broken npm self-upgrade step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # Create releases
-      pull-requests: write  # Create "Version Packages" PR
-      id-token: write       # OIDC for npm provenance
+      contents: write # Create releases
+      pull-requests: write # Create "Version Packages" PR
+      id-token: write # OIDC for npm provenance
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,8 +24,10 @@ jobs:
           cache: 'npm'
           # Don't set registry-url - npm will use OIDC automatically with publishConfig.provenance
 
-      - name: Ensure npm version supports OIDC
-        run: npm install -g npm@latest
+      # Node 22's bundled npm (10.9+) supports --provenance natively, so we
+      # no longer self-upgrade. The previous `npm install -g npm@latest` step
+      # hit a recurring self-upgrade crash (`Cannot find module 'promise-retry'`
+      # from inside @npmcli/arborist), blocking releases.
 
       - name: Configure npm scope
         run: |
@@ -39,8 +41,8 @@ jobs:
         with:
           publish: npm run release
           version: npm run version
-          title: "chore: version packages"
-          commit: "chore: version packages"
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No NPM_TOKEN needed - uses OIDC provenance


### PR DESCRIPTION
## Summary

Drops the \`Ensure npm version supports OIDC\` step from \`release.yml\`. Node 22's bundled npm 10.9+ supports \`--provenance\` natively, which is all this workflow needs.

## Why

The release workflow started failing after #528 merged — but not because of that PR. The npm self-upgrade step (\`npm install -g npm@latest\`) hits a recurring npm bug that leaves arborist in a half-broken state:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

Confirmed not transient — re-running the failed job produced the same error. See run [24562688643](https://github.com/getlien/lien/actions/runs/24562688643).

The step was added 2025-12-18 (40d80e4) when the bundled npm was older and lacked OIDC support. That's no longer the case.

## If we later need a newer npm

Pin to a specific version (e.g. \`npm install -g npm@11.2.0\`) rather than \`@latest\` to avoid the self-upgrade race.

## Test plan

- [x] Workflow YAML parses (no syntax errors)
- [ ] Merge will trigger the Release workflow — it should now reach the \`changesets/action\` step without crashing

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 77 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 21 high-risk file(s) with 2710 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 19 | — |
| ⏱️ time to understand | 44 | — |
| 🐛 estimated bugs | 3 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit c286ec4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->