### PR TITLE
fix(parser): resolve relative imports at index time (#525)

### DIFF
--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -432,6 +432,46 @@ describe('findDependents', () => {
     });
   });
 
+  describe('cross-package basename collisions (#525)', () => {
+    // Pre-fix, two files with the same basename in different packages would
+    // collide because relative specifiers were stored as bare basenames.
+    // With index-time resolution, importIndex keys are workspace-relative,
+    // and the collision no longer happens.
+    it('should not treat a same-basename file in another package as a dependent', async () => {
+      // Simulate what the indexer now stores: resolved workspace-relative
+      // paths in importedSymbols keys.
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          // The query target — no dependents in this test setup.
+          createChunk('packages/cli/src/mcp/handlers/dependency-analyzer.ts', {
+            exports: ['findDependents'],
+          }),
+          // A different file with the SAME basename in a different package.
+          createChunk('packages/parser/src/dependency-analyzer.ts', {
+            exports: ['chunkImportsFrom'],
+          }),
+          // Parser-side consumer imports the PARSER's dependency-analyzer.
+          // Its importedSymbols key is now a resolved workspace-relative path.
+          createChunk('packages/parser/src/ast/chunker.ts', {
+            importedSymbols: { 'packages/parser/src/dependency-analyzer': ['chunkImportsFrom'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(
+        mockDB as any,
+        'packages/cli/src/mcp/handlers/dependency-analyzer.ts',
+        false,
+        mockLog,
+      );
+
+      // The parser-side consumer must NOT appear as a dependent of the CLI file.
+      expect(result.dependents.map(d => d.filepath)).not.toContain(
+        'packages/parser/src/ast/chunker.ts',
+      );
+    });
+  });
+
   describe('BFS over depth', () => {
     // These tests use importedSymbols-only (no `imports` array) so chunks
     // don't trip the '*' wildcard re-export sentinel that would otherwise

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -45,4 +45,5 @@ export const DEFAULT_DEBOUNCE_MS = 1000;
 // v2: AST-based chunking + enhanced metadata (symbolName, complexity, etc.)
 // v3: Added cognitiveComplexity field to schema
 // v4: Added Halstead metrics (volume, difficulty, effort, bugs)
-export const INDEX_FORMAT_VERSION = 4;
+// v5: Resolved relative imports to workspace-relative paths in chunk metadata (#525)
+export const INDEX_FORMAT_VERSION = 5;

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -156,6 +156,36 @@ function test() {
       // '../lib/bar' → 'src/lib/bar'
       expect(funcChunk?.metadata.imports).toContain('src/consumer/foo');
       expect(funcChunk?.metadata.imports).toContain('src/lib/bar');
+
+      // Same resolution must apply to importedSymbols keys — dependency
+      // analysis matches symbol-level via this map, not just `imports`.
+      expect(funcChunk?.metadata.importedSymbols).toMatchObject({
+        'src/consumer/foo': ['foo'],
+        'src/lib/bar': ['bar'],
+      });
+    });
+
+    it('should NOT resolve relative-looking specifiers for non-JS/TS languages (#525 scope)', () => {
+      // Rust's extractor rewrites `super::utils::helper` as `../utils/helper`
+      // as an internal storage convention, not as a filesystem path. Resolving
+      // that against the chunk's directory would produce incorrect keys, so
+      // the gate in prepareASTContext must keep Rust imports untouched.
+      const rustContent = `
+use super::utils::helper;
+
+pub fn run() {
+    helper();
+}
+      `.trim();
+
+      const chunks = chunkByAST('crates/app/src/foo.rs', rustContent);
+      const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
+
+      expect(funcChunk?.metadata.imports).toBeDefined();
+      // The Rust extractor's normalized form stays exactly as-is.
+      expect(funcChunk?.metadata.imports).toContain('../utils/helper');
+      // Explicitly NOT resolved against crates/app/src/foo.rs.
+      expect(funcChunk?.metadata.imports).not.toContain('crates/app/utils/helper');
     });
 
     it('should calculate cyclomatic complexity', () => {

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -138,22 +138,24 @@ interface User {
       expect(interfaceChunk?.metadata.symbolType).toBe('interface');
     });
 
-    it('should extract imports', () => {
+    it('should extract imports and resolve relative specifiers against the file path', () => {
       const content = `
 import { foo } from './foo';
-import { bar } from './bar';
+import { bar } from '../lib/bar';
 
 function test() {
   return foo() + bar();
 }
       `.trim();
 
-      const chunks = chunkByAST('test.ts', content);
+      const chunks = chunkByAST('src/consumer/test.ts', content);
       const funcChunk = chunks.find(c => c.metadata.symbolName === 'test');
 
       expect(funcChunk?.metadata.imports).toBeDefined();
-      expect(funcChunk?.metadata.imports).toContain('./foo');
-      expect(funcChunk?.metadata.imports).toContain('./bar');
+      // './foo' relative to 'src/consumer/test.ts' → 'src/consumer/foo'
+      // '../lib/bar' → 'src/lib/bar'
+      expect(funcChunk?.metadata.imports).toContain('src/consumer/foo');
+      expect(funcChunk?.metadata.imports).toContain('src/lib/bar');
     });
 
     it('should calculate cyclomatic complexity', () => {

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -50,16 +50,22 @@ function parseAndValidate(filepath: string, content: string) {
 
 /**
  * Prepare AST context by extracting imports, exports, and symbols.
+ *
+ * `filepath` is threaded into the import extractors so that relative
+ * specifiers (`./foo`, `../bar`) are resolved to workspace-relative paths
+ * at index time. This prevents cross-package basename collisions in the
+ * downstream dependency analysis (see #525).
  */
 function prepareASTContext(
   content: string,
   rootNode: Parser.SyntaxNode,
   language: SupportedLanguage,
+  filepath: string,
 ): ASTContext {
   return {
     lines: content.split('\n'),
-    fileImports: extractImports(rootNode, language),
-    importedSymbols: extractImportedSymbols(rootNode, language),
+    fileImports: extractImports(rootNode, language, filepath),
+    importedSymbols: extractImportedSymbols(rootNode, language, filepath),
     fileExports: extractExports(rootNode, language),
     traverser: getTraverser(language),
   };
@@ -150,7 +156,7 @@ export function chunkByAST(
   const { language, rootNode } = parseAndValidate(filepath, content);
 
   // Prepare context
-  const context = prepareASTContext(content, rootNode, language);
+  const context = prepareASTContext(content, rootNode, language, filepath);
 
   // Find and process top-level nodes
   const topLevelNodes = findTopLevelNodes(rootNode, context.traverser);

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -53,10 +53,14 @@ function parseAndValidate(filepath: string, content: string) {
  * resolving relative imports against the importer's path produces the correct
  * workspace-relative target.
  *
- * Deliberately excludes Rust, whose extractor rewrites `super::x` to `../x`
- * as a normalized storage format — but Rust module paths don't map to parent
- * filesystem directories, so resolving them here would produce wrong keys.
- * Python's `from . import x` also passes through as-is (different mechanics).
+ * Deliberately excludes Rust: its extractor emits `../x` as an internal
+ * storage convention for `super::x`, but that string does not describe the
+ * actual filesystem target. `super::x` from `src/foo.rs` resolves to the
+ * sibling module `src/x`, not to `src/../x` — so applying filesystem-style
+ * `..` resolution here would produce wrong keys.
+ *
+ * Python's `from . import x` passes through as-is (different mechanics: dot
+ * counting rather than path joining).
  */
 const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
   'javascript',

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -49,12 +49,27 @@ function parseAndValidate(filepath: string, content: string) {
 }
 
 /**
+ * Languages that use `./` / `../` specifiers with filesystem semantics, where
+ * resolving relative imports against the importer's path produces the correct
+ * workspace-relative target.
+ *
+ * Deliberately excludes Rust, whose extractor rewrites `super::x` to `../x`
+ * as a normalized storage format — but Rust module paths don't map to parent
+ * filesystem directories, so resolving them here would produce wrong keys.
+ * Python's `from . import x` also passes through as-is (different mechanics).
+ */
+const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
+  'javascript',
+  'typescript',
+]);
+
+/**
  * Prepare AST context by extracting imports, exports, and symbols.
  *
- * `filepath` is threaded into the import extractors so that relative
- * specifiers (`./foo`, `../bar`) are resolved to workspace-relative paths
- * at index time. This prevents cross-package basename collisions in the
- * downstream dependency analysis (see #525).
+ * For JS/TS, `filepath` is threaded into the import extractors so that relative
+ * specifiers (`./foo`, `../bar`) are resolved to workspace-relative paths at
+ * index time. This prevents cross-package basename collisions in the downstream
+ * dependency analysis (see #525).
  */
 function prepareASTContext(
   content: string,
@@ -62,10 +77,11 @@ function prepareASTContext(
   language: SupportedLanguage,
   filepath: string,
 ): ASTContext {
+  const resolutionPath = RESOLVE_RELATIVE_IMPORTS.has(language) ? filepath : undefined;
   return {
     lines: content.split('\n'),
-    fileImports: extractImports(rootNode, language, filepath),
-    importedSymbols: extractImportedSymbols(rootNode, language, filepath),
+    fileImports: extractImports(rootNode, language, resolutionPath),
+    importedSymbols: extractImportedSymbols(rootNode, language, resolutionPath),
     fileExports: extractExports(rootNode, language),
     traverser: getTraverser(language),
   };

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -3,6 +3,7 @@ import type { SymbolInfo, SupportedLanguage } from './types.js';
 import type { LanguageSymbolExtractor } from './extractors/types.js';
 import { getExtractor, getImportExtractor, getSymbolExtractor } from './extractors/index.js';
 import { getLanguage } from './languages/registry.js';
+
 import { resolveRelativeImport } from '../utils/path-matching.js';
 
 /**

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -3,6 +3,7 @@ import type { SymbolInfo, SupportedLanguage } from './types.js';
 import type { LanguageSymbolExtractor } from './extractors/types.js';
 import { getExtractor, getImportExtractor, getSymbolExtractor } from './extractors/index.js';
 import { getLanguage } from './languages/registry.js';
+import { resolveRelativeImport } from '../utils/path-matching.js';
 
 /**
  * Extract symbol information from an AST node using language-specific extractors.
@@ -30,10 +31,16 @@ export function extractSymbolInfo(
 
 /**
  * Extract import paths using the language-specific extractor.
+ *
+ * When `filepath` is provided, relative specifiers (`./foo`, `../bar`) are
+ * resolved against the importer's directory so that cross-package files with
+ * the same basename don't collide downstream. Non-relative specifiers pass
+ * through unchanged.
  */
 function extractImportPaths(
   rootNode: Parser.SyntaxNode,
   importExtractor: ReturnType<typeof getImportExtractor>,
+  filepath?: string,
 ): string[] {
   if (!importExtractor) return [];
 
@@ -44,7 +51,7 @@ function extractImportPaths(
     if (!nodeTypeSet.has(child.type)) continue;
 
     const result = importExtractor.extractImportPath(child);
-    if (result) imports.push(result);
+    if (result) imports.push(filepath ? resolveRelativeImport(filepath, result) : result);
   }
 
   return imports;
@@ -55,13 +62,18 @@ function extractImportPaths(
  *
  * When a language is provided, uses the language-specific import extractor.
  * Falls back to legacy behavior for backwards compatibility.
+ *
+ * @param filepath - Optional path of the file being chunked. Enables resolution
+ *   of `./` / `../` specifiers so they store workspace-relative paths instead
+ *   of bare basenames.
  */
 export function extractImports(
   rootNode: Parser.SyntaxNode,
   language?: SupportedLanguage,
+  filepath?: string,
 ): string[] {
   if (!language) return [];
-  return extractImportPaths(rootNode, getImportExtractor(language));
+  return extractImportPaths(rootNode, getImportExtractor(language), filepath);
 }
 
 /**
@@ -82,10 +94,14 @@ function addSymbolsToMap(
 
 /**
  * Extract symbols using the language-specific extractor.
+ *
+ * When `filepath` is provided, relative import paths in the returned map's
+ * keys are resolved to workspace-relative paths via `resolveRelativeImport`.
  */
 function extractSymbolsWithExtractor(
   rootNode: Parser.SyntaxNode,
   importExtractor: ReturnType<typeof getImportExtractor>,
+  filepath?: string,
 ): Record<string, string[]> {
   if (!importExtractor) return {};
 
@@ -97,7 +113,8 @@ function extractSymbolsWithExtractor(
 
     const result = importExtractor.processImportSymbols(node);
     if (result) {
-      addSymbolsToMap(importedSymbols, result.importPath, result.symbols);
+      const key = filepath ? resolveRelativeImport(filepath, result.importPath) : result.importPath;
+      addSymbolsToMap(importedSymbols, key, result.symbols);
     }
   }
 
@@ -107,17 +124,20 @@ function extractSymbolsWithExtractor(
 /**
  * Extract imported symbols mapped to their source paths.
  *
- * Returns a map like: { './validate': ['validateEmail', 'validatePhone'] }
+ * Returns a map like: { 'packages/parser/src/validate': ['validateEmail'] }
+ * when `filepath` is provided, or { './validate': ['validateEmail'] } for
+ * legacy callers that don't pass it.
  *
- * When a language is provided, uses the language-specific import extractor.
- * Falls back to legacy behavior for backwards compatibility.
+ * @param filepath - Optional path of the file being chunked. Enables resolution
+ *   of `./` / `../` specifiers into workspace-relative keys.
  */
 export function extractImportedSymbols(
   rootNode: Parser.SyntaxNode,
   language?: SupportedLanguage,
+  filepath?: string,
 ): Record<string, string[]> {
   if (!language) return {};
-  return extractSymbolsWithExtractor(rootNode, getImportExtractor(language));
+  return extractSymbolsWithExtractor(rootNode, getImportExtractor(language), filepath);
 }
 
 /**

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -416,6 +416,16 @@ describe('resolveRelativeImport', () => {
     expect(resolveRelativeImport('packages/x/src/a.py', '..pkg.thing')).toBe('..pkg.thing');
   });
 
+  it('lets specifiers that escape the workspace stay as relative paths', () => {
+    // Importer is 3 segments deep; the specifier climbs 4 levels out. The
+    // resolver collapses what it can and keeps a leading `..` — downstream
+    // matchesFile then treats it as a boundary-matched path without producing
+    // false positives for unrelated in-workspace files.
+    expect(resolveRelativeImport('packages/a/src/x.ts', '../../../../outside/thing')).toBe(
+      '../outside/thing',
+    );
+  });
+
   it('prevents cross-package basename collisions (#525)', () => {
     // The scenario that motivated this fix: two files share a basename in different
     // packages. After resolution, their specifiers are distinct workspace-relative

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizePath, matchesFile, isTestFile } from './path-matching.js';
+import { normalizePath, matchesFile, isTestFile, resolveRelativeImport } from './path-matching.js';
 
 /**
  * Test cases for path matching logic in get_dependents tool.
@@ -367,5 +367,66 @@ describe('isTestFile - Precise Test Detection', () => {
       expect(isTestFile('src/test\\helper.ts')).toBe(true);
       expect(isTestFile('src\\auth.test.ts')).toBe(true);
     });
+  });
+});
+
+describe('resolveRelativeImport', () => {
+  it('resolves ./ against the importer directory', () => {
+    expect(resolveRelativeImport('packages/parser/src/chunker.ts', './symbols')).toBe(
+      'packages/parser/src/symbols',
+    );
+  });
+
+  it('resolves ../ and collapses segments', () => {
+    expect(resolveRelativeImport('packages/parser/src/ast/chunker.ts', '../utils/helpers')).toBe(
+      'packages/parser/src/utils/helpers',
+    );
+  });
+
+  it('resolves extensions through as-is (normalization happens later)', () => {
+    expect(resolveRelativeImport('packages/parser/src/foo.ts', './bar.js')).toBe(
+      'packages/parser/src/bar.js',
+    );
+  });
+
+  it('handles absolute importer paths', () => {
+    expect(resolveRelativeImport('/abs/repo/packages/a/src/x.ts', './y')).toBe(
+      '/abs/repo/packages/a/src/y',
+    );
+  });
+
+  it('normalizes Windows-style separators in the importer', () => {
+    expect(resolveRelativeImport('packages\\parser\\src\\chunker.ts', './foo')).toBe(
+      'packages/parser/src/foo',
+    );
+  });
+
+  it('passes package specifiers through unchanged', () => {
+    expect(resolveRelativeImport('packages/x/src/a.ts', '@liendev/core')).toBe('@liendev/core');
+    expect(resolveRelativeImport('packages/x/src/a.ts', 'lodash')).toBe('lodash');
+  });
+
+  it('passes absolute specifiers through unchanged', () => {
+    expect(resolveRelativeImport('packages/x/src/a.ts', '/abs/path')).toBe('/abs/path');
+  });
+
+  it('passes dotted Python-style imports through unchanged', () => {
+    // `.module` does not start with `./` — Python relative imports are out of scope.
+    expect(resolveRelativeImport('packages/x/src/a.py', '.module')).toBe('.module');
+    expect(resolveRelativeImport('packages/x/src/a.py', '..pkg.thing')).toBe('..pkg.thing');
+  });
+
+  it('prevents cross-package basename collisions (#525)', () => {
+    // The scenario that motivated this fix: two files share a basename in different
+    // packages. After resolution, their specifiers are distinct workspace-relative
+    // paths — matchesFile no longer conflates them.
+    const aResolved = resolveRelativeImport(
+      'packages/cli/src/mcp/handlers/foo.ts',
+      './dependency-analyzer',
+    );
+    const bResolved = resolveRelativeImport('packages/parser/src/bar.ts', './dependency-analyzer');
+    expect(aResolved).toBe('packages/cli/src/mcp/handlers/dependency-analyzer');
+    expect(bResolved).toBe('packages/parser/src/dependency-analyzer');
+    expect(aResolved).not.toBe(bResolved);
   });
 });

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -5,6 +5,8 @@
  * the get_dependents tool to find reverse dependencies.
  */
 
+import * as path from 'node:path';
+
 import { getSupportedExtensions } from '../ast/languages/registry.js';
 
 /**
@@ -258,6 +260,30 @@ function matchesPHPNamespace(importPath: string, targetPath: string): boolean {
   // All import components must match (from the end)
   // This ensures App/Models/User matches web/app/Models/User but not app/Services/User
   return matched === importComponents.length;
+}
+
+/**
+ * Resolve a relative import specifier against its importer's file path.
+ *
+ * Only acts on specifiers starting with `./` or `../`. Package specifiers
+ * (e.g. `@liendev/core`, `lodash`), dotted Python-style imports, and absolute
+ * paths pass through unchanged.
+ *
+ * Returns the resolved path in the same form as `importerFile` — relative when
+ * `importerFile` is relative, absolute when absolute. The caller's downstream
+ * normalization (`normalizePath`) is what ultimately strips extensions and the
+ * workspace-root prefix, so no extra work is needed here.
+ *
+ * @param importerFile - File path of the chunk doing the importing
+ * @param specifier - The raw import specifier from source code
+ * @returns Resolved path for relative specifiers; the original string otherwise
+ */
+export function resolveRelativeImport(importerFile: string, specifier: string): string {
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return specifier;
+  }
+  const importerDir = path.posix.dirname(importerFile.replace(/\\/g, '/'));
+  return path.posix.normalize(path.posix.join(importerDir, specifier));
 }
 
 /**


### PR DESCRIPTION
## Summary

JS/TS chunks stored raw import specifiers like `./dependency-analyzer.js` in `chunk.metadata.imports` / `importedSymbols`. Normalization then stripped these to bare basenames (`dependency-analyzer`), losing the directory context needed to distinguish cross-package namesakes. `matchesFile`'s fuzzy boundary-match would then conflate them, producing false-positive dependents.

This PR resolves `./` / `../` specifiers at extraction time by joining them against the chunk's own file path, so stored keys are workspace-relative paths. Downstream consumers already normalize before comparing — they get accurate matches for free. `matchesFile` itself is untouched.

## Scope

- **JS/TS/JSX/TSX only.** The only languages with `./`-style specifiers that lose directory context. Go/Rust/PHP/C#/Java use namespace-style imports that don't collide.
- **Python relative imports** (`from . import x`) are a separate follow-up — different mechanics (dot-counting, not path-joining).

## Breaking change

Bumps `INDEX_FORMAT_VERSION` 4 → 5. Existing indexes rebuild automatically on next `lien serve` / `lien index`.

## Dogfood verification on this repo (post-reindex)

| Query | Pre-fix | Post-fix |
|---|---|---|
| `get_dependents({ filepath: "packages/cli/src/mcp/handlers/dependency-analyzer.ts" })` | 17 deps, **mostly parser-side pollution** (cross-package basename collision with `packages/parser/src/dependency-analyzer.ts`) | **8 deps, all in `packages/cli/`** ✓ |
| `get_dependents({ filepath: "packages/cli/src/mcp/utils/response-budget.ts", depth: 2 })` | 112 deps (cross-package noise amplified by BFS), +5 at hops=2 | **23 deps, all CLI-side**; 3 legitimate hops=2 files (`server.ts`, `cli/serve.ts`, `cli/index.ts`) — real blast radius surfaces instead of noise ✓ |

The reduction reflects the true blast radius. Workstream B's `depth > 1` walk now rides on a clean seed.

## Changes

- `packages/parser/src/utils/path-matching.ts` — new exported `resolveRelativeImport(importerFile, specifier)` helper. Passes non-relative specifiers through unchanged (package names, absolute paths, Python dotted imports).
- `packages/parser/src/ast/symbols.ts` — `extractImports` / `extractImportedSymbols` take an optional `filepath` and resolve relative specifiers when provided. Backwards-compatible when filepath is absent.
- `packages/parser/src/ast/chunker.ts` — `prepareASTContext` threads `filepath` into the extractors.
- `packages/core/src/constants.ts` — `INDEX_FORMAT_VERSION` 4 → 5 with changelog comment.
- Tests: new unit tests for `resolveRelativeImport` (including the exact #525 repro); regression test in `packages/cli/src/mcp/handlers/dependency-analyzer.test.ts` asserting cross-package same-basename files don't cross-match; updated the JS/TS chunker import-extraction fixture.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm test --workspaces` — parser 733, review 330, CLI 632, runner 24 all pass. Core qdrant tests fail as expected without a running Qdrant server (documented pre-existing behavior).
- [x] Manual dogfood via reloaded MCP after reindex — see table above.

## Follow-ups (filed separately)

- #526 — `*` sentinel still false-flags non-re-exporters. Unrelated to this fix, still gates the Workstream B release.
- Python `from . import x` relative-import resolution — separate PR if we want parity across languages.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This pull request successfully addresses a long-standing issue of false positives in dependency analysis by correctly resolving relative import specifiers to workspace-relative paths at index time for JavaScript and TypeScript files. The changes are well-contained within the parser and path-matching utilities, with appropriate threading of file paths through the AST chunking process. The increment of `INDEX_FORMAT_VERSION` ensures that existing indexes are rebuilt, preventing data inconsistencies. Comprehensive unit and regression tests have been added, demonstrating the fix for cross-package basename collisions. The explicit exclusion of Rust and Python from this resolution mechanism aligns with their distinct import semantics, indicating a thoughtful and targeted solution.
>
> - Introduced `resolveRelativeImport` to convert relative import specifiers (e.g., `./foo`, `../bar`) into workspace-relative paths.
> - Integrated `resolveRelativeImport` into `extractImports` and `extractImportedSymbols` functions in `packages/parser/src/ast/symbols.ts`.
> - Modified `prepareASTContext` in `packages/parser/src/ast/chunker.ts` to pass the `filepath` to import extractors, enabling relative import resolution for JavaScript and TypeScript.
> - Bumped `INDEX_FORMAT_VERSION` from 4 to 5 in `packages/core/src/constants.ts` to trigger automatic reindexing.
> - Added new unit tests for `resolveRelativeImport` and a regression test in `dependency-analyzer.test.ts` to verify the fix for cross-package basename collisions.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8fdc5b0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved cross-package basename collisions in dependency tracking by normalizing import paths to workspace-relative format.

* **Tests**
  * Added test coverage for dependency analysis with duplicate basenames across packages.

* **Chores**
  * Incremented index format version to reflect workspace-relative path changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->