### PR TITLE
fix(mcp): require named imports for re-export detection (#526)

### DIFF
--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -472,10 +472,42 @@ describe('findDependents', () => {
     });
   });
 
+  describe('re-export walk: named-import requirement (#526)', () => {
+    // Pre-fix, a file that raw-imported the target AND exported anything at
+    // all was flagged as a re-exporter of everything the target exported.
+    // Then chains through that false re-exporter polluted depth-1 results.
+    it('should not treat "imports target + exports unrelated" as a re-exporter', async () => {
+      mockDB.scanPaginated.mockReturnValue(
+        mockAsyncGenerator([
+          // a.ts — the target
+          createChunk('src/a.ts', { exports: ['fnA'] }),
+          // b.ts — imports fnA from a, exports fnB (NOT a re-export of fnA)
+          createChunk('src/b.ts', {
+            imports: ['src/a.ts'],
+            importedSymbols: { 'src/a': ['fnA'] },
+            exports: ['fnB'],
+          }),
+          // c.ts — imports fnB from b. Must NOT be a transitive dependent of a.
+          createChunk('src/c.ts', {
+            imports: ['src/b.ts'],
+            importedSymbols: { 'src/b': ['fnB'] },
+          }),
+        ]),
+      );
+
+      const result = await findDependents(mockDB as any, 'src/a.ts', false, mockLog);
+
+      const filepaths = result.dependents.map(d => d.filepath);
+      // b is a direct dependent of a — correct.
+      expect(filepaths).toContain('src/b.ts');
+      // c only imports b, not a. Must not be pulled in via the re-export walk.
+      expect(filepaths).not.toContain('src/c.ts');
+    });
+  });
+
   describe('BFS over depth', () => {
-    // These tests use importedSymbols-only (no `imports` array) so chunks
-    // don't trip the '*' wildcard re-export sentinel that would otherwise
-    // pull transitive dependents in via the barrel-file walk at depth 1.
+    // Post-#526, chunks with raw `imports` no longer trip a '*' wildcard
+    // re-export sentinel — importedSymbols is the authoritative signal.
 
     it('should stay at depth 1 by default (backwards compatible)', async () => {
       mockDB.scanPaginated.mockReturnValue(

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -140,38 +140,19 @@ function collectNamedSymbolsFromChunk(
 }
 
 /**
- * Check if a chunk has raw imports matching the target path (adds '*' sentinel).
- */
-function collectRawImportSentinel(
-  chunk: SearchResult,
-  normalizedTarget: string,
-  normalizePathCached: (path: string) => string,
-  symbols: Set<string>,
-): void {
-  const imports = chunk.metadata.imports || [];
-  for (const imp of imports) {
-    if (matchesFile(normalizePathCached(imp), normalizedTarget)) symbols.add('*');
-  }
-}
-
-/**
- * Collect symbols from a single chunk that are imported from the target path.
- * Adds named symbols from importedSymbols and '*' sentinel for raw imports.
- */
-function collectSymbolsFromChunk(
-  chunk: SearchResult,
-  normalizedTarget: string,
-  normalizePathCached: (path: string) => string,
-  symbols: Set<string>,
-): void {
-  collectNamedSymbolsFromChunk(chunk, normalizedTarget, normalizePathCached, symbols);
-  collectRawImportSentinel(chunk, normalizedTarget, normalizePathCached, symbols);
-}
-
-/**
- * Collect symbols imported from a target path across all chunks of a file.
- * Returns a set of symbol names. Includes '*' sentinel for raw imports
- * where specific symbols are unknown.
+ * Collect symbols imported from a target path across all chunks of a file,
+ * sourced exclusively from `importedSymbols`.
+ *
+ * We deliberately do NOT fall back to the raw `imports` array to synthesize a
+ * `'*'` sentinel. Doing so flagged any file that raw-imports the target AND
+ * exports anything as a re-exporter of *all* the target's exports — even when
+ * the file had precise named imports (e.g. `import { x } from './a'`
+ * populates both `imports` and `importedSymbols['./a'] = ['x']`, so the
+ * sentinel would always fire). See #526.
+ *
+ * Legitimate wildcard cases (`import * as x` in JS, `use foo::*` in Rust)
+ * are already represented in `importedSymbols` as `'* as x'` or `'*'`, so
+ * `findReExportedSymbols` still handles them correctly.
  */
 function collectImportedSymbolsFromTarget(
   chunks: SearchResult[],
@@ -180,7 +161,7 @@ function collectImportedSymbolsFromTarget(
 ): Set<string> {
   const symbols = new Set<string>();
   for (const chunk of chunks) {
-    collectSymbolsFromChunk(chunk, normalizedTarget, normalizePathCached, symbols);
+    collectNamedSymbolsFromChunk(chunk, normalizedTarget, normalizePathCached, symbols);
   }
   return symbols;
 }

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -249,6 +249,28 @@ describe('analyzeDependencies', () => {
   });
 
   describe('barrel re-export tracking', () => {
+    it('should not flag "imports target + exports unrelated" as a re-exporter (#526)', () => {
+      // a.ts is the target. b.ts uses fnA from a but exports a different symbol
+      // (fnB). Pre-fix, b was wrongly flagged as a re-exporter — any consumer of
+      // b (like c.ts) would then be pulled in as a transitive dependent of a.
+      const chunks: CodeChunk[] = [
+        createChunk('src/a.ts', [], undefined, { exports: ['fnA'] }),
+        createChunk('src/b.ts', ['src/a.ts'], undefined, {
+          exports: ['fnB'],
+          importedSymbols: { './a': ['fnA'] },
+        }),
+        createChunk('src/c.ts', ['src/b.ts'], undefined, {
+          importedSymbols: { './b': ['fnB'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('src/a.ts', chunks, workspaceRoot);
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).toContain('src/b.ts'); // direct, correct
+      expect(dependentPaths).not.toContain('src/c.ts'); // must not leak through b
+    });
+
     it('should find transitive dependents through barrel files', () => {
       // auth.ts → index.ts (re-exports) → handler.ts (imports from index)
       const chunks: CodeChunk[] = [
@@ -308,18 +330,20 @@ describe('analyzeDependencies', () => {
     });
 
     it('should handle circular re-exports without infinite loops', () => {
-      // a.ts → b.ts → a.ts (circular) → c.ts imports from b.ts
+      // a.ts ↔ b.ts (circular). b genuinely re-exports foo from a, and c
+      // imports foo via b — so c is a transitive dependent of a.
       const chunks: CodeChunk[] = [
         createChunk('src/a.ts', ['src/b.ts'], undefined, {
           exports: ['foo'],
           importedSymbols: { './b': ['bar'] },
         }),
         createChunk('src/b.ts', ['src/a.ts'], undefined, {
-          exports: ['bar'],
+          // b re-exports foo (imported from a AND listed in exports).
+          exports: ['foo', 'bar'],
           importedSymbols: { './a': ['foo'] },
         }),
         createChunk('src/c.ts', ['src/b.ts'], undefined, {
-          importedSymbols: { './b': ['bar'] },
+          importedSymbols: { './b': ['foo'] },
         }),
       ];
 

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -271,6 +271,50 @@ describe('analyzeDependencies', () => {
       expect(dependentPaths).not.toContain('src/c.ts'); // must not leak through b
     });
 
+    it('should short-circuit on a Rust-style "*" wildcard glob import', () => {
+      // Rust `use foo::*` writes a '*' marker into importedSymbols. A file
+      // that glob-imports the target AND exports anything counts as re-
+      // exporting everything the target exports.
+      const chunks: CodeChunk[] = [
+        createChunk('src/a.ts', [], undefined, { exports: ['fnA'] }),
+        createChunk('src/b.ts', ['src/a.ts'], undefined, {
+          importedSymbols: { './a': ['*'] },
+          exports: ['fnA'],
+        }),
+        createChunk('src/c.ts', ['src/b.ts'], undefined, {
+          importedSymbols: { './b': ['fnA'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('src/a.ts', chunks, workspaceRoot);
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).toContain('src/b.ts'); // direct
+      expect(dependentPaths).toContain('src/c.ts'); // transitive via glob re-export
+    });
+
+    it('should short-circuit on a JS-style "* as ns" namespace import', () => {
+      // `import * as ns from './a'; export { ns };` → importedSymbols stores
+      // '* as ns' and exports lists 'ns'. b counts as a re-exporter because
+      // the namespace import pulls in everything.
+      const chunks: CodeChunk[] = [
+        createChunk('src/a.ts', [], undefined, { exports: ['fnA'] }),
+        createChunk('src/b.ts', ['src/a.ts'], undefined, {
+          importedSymbols: { './a': ['* as ns'] },
+          exports: ['ns'],
+        }),
+        createChunk('src/c.ts', ['src/b.ts'], undefined, {
+          importedSymbols: { './b': ['ns'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('src/a.ts', chunks, workspaceRoot);
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).toContain('src/b.ts');
+      expect(dependentPaths).toContain('src/c.ts');
+    });
+
     it('should find transitive dependents through barrel files', () => {
       // auth.ts → index.ts (re-exports) → handler.ts (imports from index)
       const chunks: CodeChunk[] = [
@@ -329,9 +373,10 @@ describe('analyzeDependencies', () => {
       expect(result.dependentCount).toBe(3);
     });
 
-    it('should handle circular re-exports without infinite loops', () => {
-      // a.ts ↔ b.ts (circular). b genuinely re-exports foo from a, and c
-      // imports foo via b — so c is a transitive dependent of a.
+    it('should handle cyclic import graphs with re-exports without infinite loops', () => {
+      // a.ts and b.ts import from each other (cyclic import graph). b genuinely
+      // re-exports foo from a, and c imports foo via b — so c is a transitive
+      // dependent of a. The BFS must terminate despite the cycle.
       const chunks: CodeChunk[] = [
         createChunk('src/a.ts', ['src/b.ts'], undefined, {
           exports: ['foo'],

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -322,13 +322,6 @@ export function chunkImportsFrom(
 }
 
 /**
- * Check if a chunk has any exports.
- */
-function chunkHasExports(chunk: CodeChunk): boolean {
-  return chunk.metadata.exports != null && chunk.metadata.exports.length > 0;
-}
-
-/**
  * Group chunks by their normalized file path.
  */
 export function groupChunksByNormalizedPath(
@@ -349,24 +342,77 @@ export function groupChunksByNormalizedPath(
 }
 
 /**
- * Check if a file (given its chunks) is a re-exporter from a source path.
- * A re-exporter has both imports from the source and exports.
+ * Collect the symbols a file imports from a given source path, sourced
+ * exclusively from `importedSymbols`. Mirrors the CLI-side approach in
+ * `packages/cli/src/mcp/handlers/dependency-analyzer.ts`.
+ *
+ * Deliberately ignores the raw `imports` array — a raw-only match means the
+ * file imports for side effect or does `export * from`, neither of which
+ * should qualify it as a re-exporter on its own (#526).
+ */
+function collectImportedSymbolsFromSource(
+  chunks: CodeChunk[],
+  sourcePath: string,
+  normalizePathCached: (path: string) => string,
+): Set<string> {
+  const symbols = new Set<string>();
+  for (const chunk of chunks) {
+    const importedSymbols = chunk.metadata.importedSymbols;
+    if (!importedSymbols || typeof importedSymbols !== 'object') continue;
+    for (const [importPath, syms] of Object.entries(importedSymbols)) {
+      if (matchesFile(normalizePathCached(importPath), sourcePath)) {
+        for (const sym of syms) symbols.add(sym);
+      }
+    }
+  }
+  return symbols;
+}
+
+/**
+ * Collect all symbols the file exports across its chunks.
+ */
+function collectExportsFromChunks(chunks: CodeChunk[]): Set<string> {
+  const allExports = new Set<string>();
+  for (const chunk of chunks) {
+    for (const exp of chunk.metadata.exports || []) allExports.add(exp);
+  }
+  return allExports;
+}
+
+/**
+ * Check if a file (given its chunks) genuinely re-exports symbols from a
+ * source path.
+ *
+ * Requires a non-empty intersection between (a) symbols the file imports from
+ * the source and (b) symbols the file exports. A plain named import (`import
+ * { x } from './a'`) paired with an unrelated own export (`export function y`)
+ * is no longer a re-exporter — closing the #526 false positive.
+ *
+ * Wildcard markers (`'*'` from Rust `use foo::*`, `'* as x'` from JS
+ * namespace imports) still trigger re-export detection: both mean "we pulled
+ * in everything the source exports," so intersection against the file's own
+ * export list is the right signal.
  */
 export function fileIsReExporter(
   chunks: CodeChunk[],
   sourcePath: string,
   normalizePathCached: (path: string) => string,
 ): boolean {
-  let importsFromSource = false;
-  let hasExports = false;
-  for (const chunk of chunks) {
-    if (!importsFromSource && chunkImportsFrom(chunk, sourcePath, normalizePathCached)) {
-      importsFromSource = true;
-    }
-    if (!hasExports && chunkHasExports(chunk)) {
-      hasExports = true;
-    }
-    if (importsFromSource && hasExports) return true;
+  const importsFromSource = collectImportedSymbolsFromSource(
+    chunks,
+    sourcePath,
+    normalizePathCached,
+  );
+  if (importsFromSource.size === 0) return false;
+
+  const allExports = collectExportsFromChunks(chunks);
+  if (allExports.size === 0) return false;
+
+  // Wildcards mean "imported everything"; any own export then counts.
+  if (importsFromSource.has('*')) return true;
+  for (const sym of importsFromSource) {
+    if (sym.startsWith('* as ')) return true;
+    if (allExports.has(sym)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

The re-export walk that feeds `get_dependents` was flagging any file that raw-imports the target AND exports anything at all as a re-exporter of the entire target — then chaining that file's own dependents into the depth-1 result. A plain named import like \`import { fnA } from './a'\` populates both \`chunk.metadata.imports\` and \`chunk.metadata.importedSymbols['./a'] = ['fnA']\`, so the \`*\` raw-imports sentinel fired even when we had precise symbol info.

This PR requires that a file actually has `importedSymbols` pointing at the target before it can be considered a re-exporter, and on the parser side additionally requires a symbol intersection with the file's own exports. Both were already supposed to be the semantics of a "re-exporter" — the code just had shortcuts that were fundamentally permissive.

## Dogfood on this repo (no reindex — query-time logic only)

| Query | Post-#525 | Post-#526 |
|---|---|---|
| \`get_dependents({ filepath: "packages/cli/src/mcp/utils/response-budget.ts", depth: 2 })\` | 23 deps | **8 deps** (`tool-wrapper` + 6 handlers that use it transitively + test) |
| \`get_dependents({ filepath: "packages/parser/src/risk/blast-radius-risk.ts" })\` | 7 deps (incl. 3 false-positive Rust files) | **4 deps** (parser barrel, 2 genuine Rust consumers, test) |
| \`get_dependents({ filepath: "packages/cli/src/mcp/handlers/dependency-analyzer.ts" })\` | 8 deps | **4 deps** (`get-dependents.ts` handler + 3 tests) |

Each reduction is the false re-export chain collapsing. The legitimate barrel (`packages/parser/src/index.ts`) and real transitive callers are still present. Workstream B's \`depth: 2\` now surfaces the true blast radius.

## Changes

### CLI side — \`packages/cli/src/mcp/handlers/dependency-analyzer.ts\`

- Delete \`collectRawImportSentinel\`.
- Simplify \`collectSymbolsFromChunk\` (now \`collectImportedSymbolsFromTarget\` does the work directly via \`collectNamedSymbolsFromChunk\`).
- \`findReExportedSymbols\` is **untouched**: its \`'*'\` and \`'* as '\` branches still serve Rust \`use foo::*\` and JS \`import * as x\` — both write into \`importedSymbols\` directly, not via the raw-imports path.

### Parser side — \`packages/parser/src/dependency-analyzer.ts\`

The parser had the same issue but structurally worse: \`fileIsReExporter\` didn't do any symbol intersection. Replaced with a proper check that:

1. Collects symbols the file imports from the source (\`importedSymbols\` only).
2. Collects the file's own exports.
3. Requires a non-empty intersection. Wildcards (\`'*'\`, \`'* as x'\`) short-circuit as "all exports count."

The public \`chunkImportsFrom\` helper is **untouched** — it has legitimate broader "does this chunk import X at all?" semantics and is used by other callers.

## Tests

- **CLI regression** (\`packages/cli/src/mcp/handlers/dependency-analyzer.test.ts\`): the exact #526 scenario — \`b\` imports \`fnA\` from \`a\` and exports an unrelated \`fnB\`; \`c\` imports \`fnB\` from \`b\`. Asserts \`findDependents(a)\` returns only \`b\`, not \`c\`.
- **Parser regression** (\`packages/parser/src/dependency-analyzer.test.ts\`): same shape at the \`analyzeDependencies\` level.
- **Updated existing test** — the "circular re-exports" parser test was asserting the buggy pre-fix behavior (c was a dependent of a). Reshaped the input so \`b\` genuinely re-exports \`foo\`, preserving the loop-protection assertion.

## Non-goals

- No \`INDEX_FORMAT_VERSION\` bump — this is pure query-time logic.
- \`export * from './a'\` detection is not restored (it was already broken pre-fix — the sentinel returned the barrel's OWN exports, not the target's). Proper support needs a dedicated \`reExports\` metadata field in the parser; out of scope.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test --workspaces\` — parser 745, review 330, CLI 633, runner 24 all pass (core qdrant tests fail as expected without a live Qdrant server — documented pre-existing behavior)
- [x] Manual dogfood via reloaded MCP — see table above

## Follow-ups

- Close #527 (stale "10,000 chunks" text) — cosmetic, can ride along or separately.
- After #526 merges: add a changeset and cut the Workstream B npm release.

Closes #526.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This pull request successfully addresses a critical logical flaw in the dependency analysis system's re-export detection. Previously, the system would incorrectly flag a file as a re-exporter if it merely imported anything from a target file and also exported anything itself, leading to an inflated and inaccurate blast radius. The changes introduce a more precise definition of a re-exporter, requiring an actual intersection between symbols imported from the target and symbols explicitly exported by the file itself. This correction is implemented consistently across both the CLI and parser components, with comprehensive new and updated tests validating the intended behavior. The PR effectively reduces false positives in dependency tracking, resulting in significantly more accurate blast radius calculations without introducing new regressions or breaking existing functionality.
>
> - Removed `collectRawImportSentinel` and simplified `collectSymbolsFromChunk` on the CLI side to prevent false re-export detection based on raw imports.
> - Rewrote `fileIsReExporter` on the parser side to require an intersection between imported and exported symbols for re-export qualification, correctly handling named and wildcard imports.
> - Added new test cases to both CLI and parser to specifically validate the corrected re-export logic, including scenarios for named imports and wildcard imports.
> - Updated an existing circular re-export test to reflect the new, correct behavior, ensuring cyclic import graphs are handled without infinite loops.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8ed4787. Updates automatically on new commits.</sup>
<!-- /lien-stats -->