### PR TITLE
fix(mcp): correct scan-limit docs + changeset for Workstream B (#527)

### DIFF
--- a/.changeset/workstream-b-get-dependents-depth.md
+++ b/.changeset/workstream-b-get-dependents-depth.md
@@ -1,0 +1,20 @@
+---
+'@liendev/lien': minor
+'@liendev/parser': minor
+'@liendev/core': minor
+---
+
+Transitive dependency walks and cleaner re-export detection for `get_dependents` (Workstream B).
+
+**Features**
+
+- `get_dependents` MCP tool gains `depth` (1–5, default 1) and `maxNodes` (default 500) parameters. At `depth > 1`, the tool walks the import graph outward via BFS. Each dependent carries a `hops` field indicating the depth at which it was discovered. `truncated: true` is set when the BFS stops at the `maxNodes` cap. Symbol-level queries (`symbol` set) remain depth-1 only.
+- Response gains `totalImpacted` (= `dependents.length`, for CRG-naming parity) and `riskReasoning` (short phrases explaining why a `riskLevel` was assigned, e.g. `["14 callers", "3 untested", "max complexity 18"]`).
+- `riskLevel` is now sourced from the shared `computeBlastRadiusRisk` primitive in `@liendev/parser`, unifying the heuristic across the MCP tool and the Lien Review pipeline. Thresholds consider dependent breadth, test coverage, and dependent complexity — not just count + a complexity boost.
+- The MCP server's initialize instructions now tell clients about `depth`, `hops`, `truncated`, and `riskReasoning`, so Claude Code / Cursor / etc. know transitive impact is available.
+
+**Fixes**
+
+- JS/TS relative import specifiers (`./foo`, `../bar`) are now resolved against the chunk's file path at index time, so `chunk.metadata.imports` and `importedSymbols` keys store workspace-relative paths instead of bare basenames. This eliminates cross-package basename-collision false positives in `get_dependents`. Bumps `INDEX_FORMAT_VERSION` 4 → 5; existing indexes reindex automatically on next `lien serve` / `lien index`.
+- Re-export detection now requires a symbol intersection between what a file imports from the target and what it exports. Previously, any file that imported the target and happened to export anything was flagged as re-exporting the entire target, polluting depth-1 results with its unrelated dependents.
+- Corrects the schema description and `hitLimit` warning message on `get_dependents`: single-repo scans have no chunk cap; the actual 100,000-chunk cap only applies to cross-repo scans.

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -295,8 +295,8 @@ describe('handleGetDependents', () => {
       const result = await handleGetDependents({ filepath: 'src/widely-used.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.note).toContain('10,000');
-      expect(parsed.note).toContain('limit reached');
+      expect(parsed.note).toContain('100,000');
+      expect(parsed.note).toContain('Cross-repo');
       expect(parsed.note).toContain('incomplete');
     });
 

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -71,7 +71,8 @@ function buildNotes(crossRepoFallback: boolean, hitLimit: boolean): string[] {
     );
   }
   if (hitLimit) {
-    notes.push('Scanned 10,000 chunks (limit reached). Results may be incomplete.');
+    // Only set by the cross-repo scan path (single-repo pagination is unbounded).
+    notes.push('Cross-repo scan reached its 100,000-chunk limit. Results may be incomplete.');
   }
   return notes;
 }

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -11,8 +11,9 @@ import path from 'path';
  * for that exported symbol instead of just file-level dependencies.
  *
  * Limitations:
- * - Scans up to 10,000 code chunks. For very large codebases (>1M lines),
- *   results may be incomplete. A warning is returned if the limit is reached.
+ * - Single-repo scans iterate every indexed chunk with no chunk-count cap.
+ * - Cross-repo scans (`crossRepo: true`) cap at 100,000 chunks; if that cap is
+ *   reached, a warning is returned in the response `note`.
  */
 export const GetDependentsSchema = z.object({
   filepath: z
@@ -27,8 +28,9 @@ export const GetDependentsSchema = z.object({
       'Path to file to find dependents for (relative to workspace root).\n\n' +
         "Example: 'src/utils/validate.ts'\n\n" +
         'Returns all files that import or depend on this file.\n\n' +
-        'Note: Scans up to 10,000 code chunks. For very large codebases,\n' +
-        'results may be incomplete (a warning will be included if truncated).',
+        'Single-repo scans are unbounded. Cross-repo scans cap at 100,000\n' +
+        'chunks — a warning is included in the response `note` if the cap\n' +
+        'is reached.',
     ),
 
   symbol: z


### PR DESCRIPTION
## Summary

Two small things bundled:

1. **Fixes #527** — the `get_dependents` schema description and `hitLimit` warning both said \"Scanned up to 10,000 code chunks.\" That's been wrong for a while:
   - Single-repo \`scanPaginated\` iterates to exhaustion with no chunk cap; \`hitLimit\` is never true on that path.
   - Cross-repo \`scanCrossRepo\` caps at 100,000 chunks. When \`hitLimit\` is true, *that's* the cap that was hit.
   
   Schema description now documents both scan modes accurately. Warning text names the correct 100,000 cross-repo cap. Test expectation updated.

2. **Changeset for Workstream B.** Linked minor bump for \`@liendev/lien\`, \`@liendev/parser\`, and \`@liendev/core\` covering everything shipped in this cycle:
   - #528 — MCP \`get_dependents\` depth + maxNodes BFS
   - #525 — JS/TS relative-import resolution at index time (bumps INDEX_FORMAT_VERSION 4 → 5)
   - #526 — re-export intersection requirement
   - #527 — this PR
   
   Release notes emphasize the new parameters (\`depth\`, \`maxNodes\`), new response fields (\`hops\`, \`truncated\`, \`totalImpacted\`, \`riskReasoning\`), the shared \`computeBlastRadiusRisk\` primitive, and the reindex-on-upgrade behavior.

## Scope

- \`get-files-context.ts\`'s \"10,000 chunks\" text is **not** changed — it has a real \`SCAN_LIMIT = 10000\` constant backing it. Only the \`get-dependents\` copy was wrong.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check\` — clean
- [x] \`npm test -w @liendev/lien\` — 633 tests pass
- [x] \`npm run build\` — clean

Closes #527.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This pull request primarily updates the documentation and warning messages related to the `get_dependents` tool's scan limits. It clarifies that single-repo scans are unbounded, while cross-repo scans have a 100,000-chunk limit. The warning message displayed when this limit is hit has been updated accordingly, and the corresponding test case has been adjusted. The PR also includes a changeset detailing other features and fixes for Workstream B, but these are not part of the provided diff for review. The changes in the diff are straightforward documentation and string literal updates, posing a low risk of introducing new bugs.
>
> - Updated `get_dependents` schema description to accurately reflect scan limits for single-repo (unbounded) and cross-repo (100,000 chunks) scans.
> - Modified the `buildNotes` function to change the `hitLimit` warning message from '10,000 chunks' to '100,000-chunk limit' and specify 'Cross-repo scan'.
> - Updated the test expectation in `get-dependents.test.ts` to match the new warning message.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8c481aa. Updates automatically on new commits.</sup>
<!-- /lien-stats -->