### PR TITLE
fix(ci): sign release commits via GitHub API (commitMode)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
           version: npm run version
           title: 'chore: version packages'
           commit: 'chore: version packages'
+          # Push via the GitHub Contents API so commits/tags are auto-signed
+          # by the GITHUB_TOKEN's owner. Required by the main-branch
+          # `required_signatures` ruleset — without this, the auto-opened
+          # Version Packages PR lands with unsigned commits and can't merge.
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No NPM_TOKEN needed - uses OIDC provenance


### PR DESCRIPTION
## Summary

Adds \`commitMode: github-api\` to the \`changesets/action\` step so the auto-opened \"Version Packages\" PR lands with signed commits.

## Why

The main-branch ruleset requires signed commits. \`changesets/action\` defaults to \`commitMode: git-cli\`, which pushes unsigned commits from the \`github-actions\` bot — so PR #534 landed \`BLOCKED\` despite all checks green, because every commit on \`changeset-release/main\` was \`reason: unsigned\`.

\`commitMode: github-api\` pushes via the GitHub Contents API, which auto-signs commits/tags with the \`GITHUB_TOKEN\`'s owner key. Satisfies \`required_signatures\` without loosening the rule.

## Scope

- One-liner workflow change.
- \`#534\` was bypass-merged as a one-off; future cycles land signed automatically.

## Test plan

- [x] YAML syntax valid (workflow parses; dry-run via push event triggers on merge).
- [ ] Next release cycle will verify end-to-end: a push to main with changesets pending should produce a signed \"Version Packages\" PR. Expected commit \`verification.verified: true\`.

Ref: https://github.com/changesets/action#inputs

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 77 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 21 high-risk file(s) with 2710 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 19 | — |
| ⏱️ time to understand | 44 | — |
| 🐛 estimated bugs | 3 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b47381e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to use GitHub API for creating versioning commits, improving compatibility with token-based authentication during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->