### PR TITLE
fix(ci): pin npm 11.5.1 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,13 @@ jobs:
           cache: 'npm'
           # Don't set registry-url - npm will use OIDC automatically with publishConfig.provenance
 
-      # Node 22's bundled npm (10.9+) supports --provenance natively, so we
-      # no longer self-upgrade. The previous `npm install -g npm@latest` step
-      # hit a recurring self-upgrade crash (`Cannot find module 'promise-retry'`
-      # from inside @npmcli/arborist), blocking releases.
+      # OIDC trusted publishing requires npm 11.5.1+ (the runner's Node 22
+      # bundled npm is 10.9.x). Pin to a specific 11.x rather than @latest —
+      # plain `npm install -g npm@latest` has hit a self-upgrade crash on the
+      # hosted runner image (`Cannot find module 'promise-retry'` from inside
+      # @npmcli/arborist), and pinning makes the install deterministic.
+      - name: Install npm 11.x for OIDC trusted publishing
+        run: npm install -g npm@11.5.1
 
       - name: Configure npm scope
         run: |


### PR DESCRIPTION
## Summary

Re-adds the pre-#529 npm upgrade step, pinned to \`npm@11.5.1\`. This restores OIDC trusted publishing capability that was inadvertently removed in #529.

## What happened

Before #529, the workflow ran \`npm install -g npm@latest\`, which upgraded the runner's Node-22-bundled npm 10.9 → 11.x. That was what provided the OIDC publish client.

#529 dropped that step after a recurring self-upgrade crash (\`Cannot find module 'promise-retry'\` from @npmcli/arborist). My reasoning in that PR was \"Node 22's bundled npm already supports \`--provenance\`\" — true for *build attestation*, but I conflated it with *OIDC auth*. **The OIDC publish client only shipped in npm 11.5.1+.**

Post-#529, publish falls back to classic auth, finds no \`NPM_TOKEN\` (we removed that too when moving to OIDC), and exits with \`ENEEDAUTH\`. See run 24638211301.

## Fix

\`\`\`yaml
- name: Install npm 11.x for OIDC trusted publishing
  run: npm install -g npm@11.5.1
\`\`\`

Pinning to a specific version sidesteps the self-upgrade race that caused the original crash (\`@latest\` may be mid-publish or transiently broken on the runner image). 11.5.1 is the first version with OIDC trusted-publishing client support.

## Verification

- Once merged, the next release cycle should publish \`@liendev/lien\`, \`@liendev/core\`, \`@liendev/parser\` at their pending 0.44.0 versions to npm with no token.
- Can re-run the failed publish directly via \`workflow_dispatch\` from the Actions tab to verify, OR just wait for the next PR merge to trigger it organically.

## Scope

- One-line workflow change.
- OIDC trusted publishers for all three packages are already configured on npmjs (per user confirmation).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 77 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 21 high-risk file(s) with 2710 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 19 | — |
| ⏱️ time to understand | 44 | — |
| 🐛 estimated bugs | 3 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 48fdca6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to ensure consistent and reliable release process execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->