### PR TITLE
feat(agent): bump default model to google/gemini-3-flash-preview

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -27,7 +27,7 @@ import { AGENT_TOOLS, dispatchTool } from './tools.js';
 
 const configSchema = z.object({
   apiKey: z.string().min(1),
-  model: z.string().default('google/gemini-2.5-flash'),
+  model: z.string().default('google/gemini-3-flash-preview'),
   /** 'openai' for OpenRouter/Gemini/DeepSeek, 'anthropic' for Claude */
   provider: z.enum(['openai', 'anthropic']).default('openai'),
   baseUrl: z.string().default('https://openrouter.ai/api/v1'),

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -256,9 +256,7 @@ export async function handlePRReview(
     // Selected model — used for both the agent-review plugin config and the
     // adapterContext below so cost/metadata reporting stays consistent across
     // the two providers we support.
-    const selectedModel = config.openrouterApiKey
-      ? 'google/gemini-3-flash-preview'
-      : 'claude-sonnet-4-6';
+    const selectedModel = selectAgentModel(!!config.openrouterApiKey);
 
     // Run engine
     findings = await engine.run({
@@ -387,6 +385,16 @@ export async function handlePRReview(
 
 // ---------------------------------------------------------------------------
 // Helpers
+
+/**
+ * Pick the agent-review model based on which provider key is configured.
+ * Extracted so the conditional doesn't add cyclomatic weight to the (large)
+ * handlePRReview body — and so the same value can be reused for the
+ * adapterContext metadata.
+ */
+function selectAgentModel(useOpenRouter: boolean): string {
+  return useOpenRouter ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6';
+}
 
 /**
  * Scale agent turn count and token budget dynamically.

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -253,6 +253,13 @@ export async function handlePRReview(
     // Track agent usage separately (reported via callback since it bypasses LLMClient)
     let agentUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 };
 
+    // Selected model — used for both the agent-review plugin config and the
+    // adapterContext below so cost/metadata reporting stays consistent across
+    // the two providers we support.
+    const selectedModel = config.openrouterApiKey
+      ? 'google/gemini-3-flash-preview'
+      : 'claude-sonnet-4-6';
+
     // Run engine
     findings = await engine.run({
       chunks,
@@ -269,7 +276,7 @@ export async function handlePRReview(
         'agent-review': {
           apiKey: config.openrouterApiKey || config.anthropicApiKey,
           provider: config.openrouterApiKey ? 'openai' : 'anthropic',
-          model: config.openrouterApiKey ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6',
+          model: selectedModel,
           baseUrl: config.openrouterApiKey ? 'https://openrouter.ai/api/v1' : undefined,
           inputCostPerMTok: config.openrouterApiKey ? 0.5 : 3,
           outputCostPerMTok: config.openrouterApiKey ? 3 : 15,
@@ -297,7 +304,7 @@ export async function handlePRReview(
       octokit,
       logger,
       llmUsage: agentUsage.totalTokens > 0 ? agentUsage : undefined,
-      model: 'claude-sonnet-4-6',
+      model: selectedModel,
       blockOnNewErrors: reviewConfig.blockOnNewErrors,
     };
 

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -269,10 +269,10 @@ export async function handlePRReview(
         'agent-review': {
           apiKey: config.openrouterApiKey || config.anthropicApiKey,
           provider: config.openrouterApiKey ? 'openai' : 'anthropic',
-          model: config.openrouterApiKey ? 'google/gemini-2.5-flash' : 'claude-sonnet-4-6',
+          model: config.openrouterApiKey ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6',
           baseUrl: config.openrouterApiKey ? 'https://openrouter.ai/api/v1' : undefined,
-          inputCostPerMTok: config.openrouterApiKey ? 0.3 : 3,
-          outputCostPerMTok: config.openrouterApiKey ? 2.5 : 15,
+          inputCostPerMTok: config.openrouterApiKey ? 0.5 : 3,
+          outputCostPerMTok: config.openrouterApiKey ? 3 : 15,
           ...scaleAgentBudget(filesToAnalyze.length, chunks),
         },
       },


### PR DESCRIPTION
## Summary

- Bump the agent-review plugin's default model from `google/gemini-2.5-flash` to `google/gemini-3-flash-preview` in both the runner config and the plugin's configSchema default.
- Update the cost-tracking constants ($0.30/$2.50 → $0.50/$3.00 per Mtok in/out) so per-review cost reporting stays accurate.

## Why now

Built a multi-fixture canary corpus (#538, follow-up PR) — one fixture per `BUILTIN_RULES` rule, captured from closed planted-regression test PRs. The `--calibrate 10` sweep against the corpus showed:

| rule | gemini-2.5-flash | **gemini-3-flash-preview** |
|---|:---:|:---:|
| structural-analysis | 9/10 ✓ | **10/10** ✓ |
| edge-case-sweep | 7/10 ✗ | **10/10** ✓ |
| incomplete-handling | 3/10 ✗ | **10/10** ✓ |
| error-swallowing | 7/10 ✗ | **10/10** ✓ |
| concurrency-race | 8/10 ✗ | **10/10** ✓ |
| boundary-change (Tier 1) | 9/10 ✓ | **10/10** ✓ |
| boundary-change (§4.3 test-pair vocab, Tier 2) | 0/10 ✗ | **10/10** ✓ |

The current production model misses the 9/10 reliability bar on **4 of 6** rules. The new model is a strict upgrade.

Bonus: unblocks `.wip/retro-blast-radius.md` §4.3 ("test pair covering both sides of the divergence") with no prompt change — the suggestion language emerges naturally on gemini-3-flash-preview.

Compared candidates included `gemini-2.5-flash-lite` (worse: 3/10 on structural), `deepseek-chat-v3.1` (no §4.3 vocab), `claude-haiku-4.5` (works but ~50% pricier), and `kimi-k2.6` (matched on quality where it worked but had OpenRouter "terminated" reliability issues at parallel concurrency).

Total eval spend: ~$6 across all calibrations.

## Cost impact

Pricing per Mtok rises from $0.30/$2.50 to $0.50/$3.00 (in/out). Empirical per-call cost:

- **boundary-change**: $0.022 → $0.023 (~+5%)
- **rules where current model was bailing early without producing findings**: roughly 2-3x per call

Net cost-per-genuine-finding is comparable, possibly favorable — gemini-2.5-flash's "low cost" was largely silence-mode bails that didn't actually catch the bugs the rules are meant to find.

## Risks

- `gemini-3-flash-preview` is in **preview** status. Behavior or pricing could change. The harness lets us re-validate on demand and rollback is a 1-line revert.
- Eval was on a single calibration per fixture. `kimi-k2.6` is queued for a re-eval once OpenRouter's Kimi reliability stabilises — could displace gemini-3 if it turns out qualitatively better, but on the current corpus there's no headroom (gemini-3 is at 10/10 ceiling).

## Test plan

- [ ] CI green on this PR
- [ ] Deploy + observe one review on a real PR; confirm finding quality holds
- [ ] After deploy, open follow-up PR for the offline harness (#538) so future prompt + model changes can be regression-tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default language model to the latest version for enhanced performance
  * Adjusted per-token cost estimates to reflect current pricing in cost analysis calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 10 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | -1 |
| 🧠 mental load | 2 | -1 |
| ⏱️ time to understand | 6 | +8 |
| 🐛 estimated bugs | 1 | +0.022 |


> [!NOTE]
> **Low Risk**
>
> This PR updates the default language model used by the agent-review plugin to `google/gemini-3-flash-preview` and adjusts the associated cost-tracking constants to reflect new pricing. The changes ensure that the agent plugin utilizes the improved model and that cost reporting remains accurate. The model selection logic is consistent across the plugin configuration and the adapter context.
>
> - Default agent model updated to `google/gemini-3-flash-preview` in `packages/review/src/plugins/agent/index.ts`.
> - A new helper function `selectAgentModel` is introduced in `packages/runner/src/handlers/pr-review.ts` to dynamically choose the agent model based on the configured API key (OpenRouter or Anthropic).
> - The `handlePRReview` function in `packages/runner/src/handlers/pr-review.ts` now uses the `selectedModel` for both the `agent-review` plugin configuration and the `adapterContext`.
> - Cost constants for OpenRouter models updated from $0.30/$2.50 to $0.50/$3.00 per Mtok (in/out) in `packages/runner/src/handlers/pr-review.ts`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bd8f9f2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->