### PR TITLE
feat(review): agent-rule offline test harness (#538)

### DIFF
--- a/.claude/skills/test-harness/SKILL.md
+++ b/.claude/skills/test-harness/SKILL.md
@@ -127,6 +127,20 @@ Show finding excerpts (first 200 chars of `message`) for any fixture that failed
 4. **Fixture file path missing repoRootDir** — subagent has no real repo to read from. Use the working directory (the harness fixture's `repoRootDir` is informational; the subagent should default to grep'ing the current Lien repo).
 5. **Build-prompts errors out** — usually means fixture schema is wrong. Surface the error verbatim to the user.
 
+## What to do after a green CC run
+
+A passing CC run is **necessary but not sufficient** to ship a rule or prompt
+change. After CC mode is green, recommend the OpenRouter calibration
+explicitly so the user (or a follow-up autonomous run) closes the loop:
+
+```bash
+npm run test:harness -w @liendev/review -- --rule <rule-id> --calibrate 10
+```
+
+Auto-loads `OPENROUTER_API_KEY` from `.env` at the repo root via
+`process.loadEnvFile()`. Shippable when pass-rate ≥ 9/10. See
+`packages/review/test/harness/README.md` for the full failure-mode table.
+
 ## What this skill does NOT do
 
 - Run the actual `AgentReviewPlugin.analyze()` code path. (That requires OpenRouter mode, `npm run test:harness`.)

--- a/.claude/skills/test-harness/SKILL.md
+++ b/.claude/skills/test-harness/SKILL.md
@@ -47,7 +47,17 @@ Wrapper template:
 
 > You are simulating an LLM inside an automated code-review tool. Your role is defined by the SYSTEM PROMPT below; the USER MESSAGE describes the PR you are reviewing. Investigate using your available tools (Read, Grep, Glob) against the local repo working directory. Follow the investigation strategy described in the SYSTEM PROMPT exactly.
 >
-> When done, output **exactly one** fenced JSON block at the end matching the `<output_format>` schema in the SYSTEM PROMPT. After that JSON block, output a second fenced block tagged `harness-meta` listing the tools you actually called, one per line in the form `tool: <descriptor>` (e.g. `Read: src/risk.ts`, `Grep: classifyLevel`). Do not include any text after the second block.
+> When done, output **exactly one** fenced JSON block at the end matching the `<output_format>` schema in the SYSTEM PROMPT. After that JSON block, output a second fenced block tagged `harness-meta` listing the **production tool names** you logically used during investigation, one per line. Map your CC tools to the production tool name vocabulary so assertions match across modes:
+>
+> | Your CC tool | Production tool name to log |
+> | --- | --- |
+> | `Read <file>` | `get_files_context` |
+> | `Grep <pattern>` (text or regex over files) | `grep_codebase` |
+> | `Glob` / file-pattern listing | `list_functions` |
+> | inspecting who calls a symbol | `get_dependents` |
+> | Reading a single file's contents | `read_file` |
+>
+> Output one production tool name per line (just the bare name, e.g. `get_files_context`). Do not include any text after the second block.
 >
 > SYSTEM PROMPT:
 > ```
@@ -66,16 +76,16 @@ Spawn the K subagents in parallel (single message, multiple Agent tool calls) wh
 For each returned subagent result:
 
 1. Extract the first ```json ... ``` block — parse it as `{findings, summary}`.
-2. Extract the ```harness-meta ... ``` block — split on newlines, drop blanks, treat each line as a tool-call descriptor.
+2. Extract the ```harness-meta ... ``` block — split on newlines, drop blanks, treat each line as a production tool name (per the mapping in Step 3).
 3. Build a HarnessResult object:
    ```json
    {
      "findings": [...],
-     "toolCalls": ["Read: src/risk.ts", ...],
+     "toolCalls": ["get_files_context", "grep_codebase", "read_file"],
      "turns": 1
    }
    ```
-   (`turns: 1` is a placeholder — we don't have access to the subagent's actual turn count.)
+   (`turns: 1` is a placeholder — we don't have access to the subagent's actual turn count. The toolCalls list MUST use production tool names so `expectToolCalled('get_files_context', …)` assertions work in both modes.)
 4. Write it to a temp file: `/tmp/harness-result-<rule>-<vote-index>.json`.
 
 If a subagent's response has no parseable JSON block, count it as a failure with a note.

--- a/.claude/skills/test-harness/SKILL.md
+++ b/.claude/skills/test-harness/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: test-harness
+description: Run the agent-review prompt harness in CC iteration mode against a rule or fixture. Free, low-fidelity. Use for prompt-authoring inner loop. The 9/10 reliability bar must still be measured via `npm run test:harness --calibrate 10` against OpenRouter/Gemini before shipping any prompt change.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash, Read, Write, Glob, Agent
+---
+
+# Agent-Review Test Harness — CC Iteration Mode
+
+You are running the test harness for the agent-review plugin's rule prompts. This is the **free, fast iteration** path. It uses Claude (you, via subagents) to drive the same system + initial prompts the agent plugin would build in production. Output is a qualitative pass/fail per fixture.
+
+**Critical caveat — relay this to the user once per invocation:** CC mode is *not* a substitute for the OpenRouter calibration run. A passing CC run means "Claude reading this prompt produces the expected behavior." Production runs Gemini 2.5 Flash, which is materially less capable. Before merging a prompt change, the user must run `OPENROUTER_API_KEY=… npm run test:harness -w @liendev/review -- --calibrate 10 --rule <rule>` and meet the 9/10 bar (per issue #538).
+
+## Step 1: Resolve the argument
+
+The user invoked you with one of:
+- `/test-harness <rule-id>` — e.g. `/test-harness boundary-change`. Run all fixtures under `packages/review/test/harness/fixtures/<rule-id>/`.
+- `/test-harness <fixture-path>` — explicit path to a `.fixture.json`. Run only that one.
+- `/test-harness <rule-id> --votes 3` — run K times per fixture and report agreement.
+
+Default `--votes` is 1 (cheapest). Use 3 when probing flakiness.
+
+If the rule has no fixtures: tell the user and stop.
+
+## Step 2: Load and assemble prompts
+
+For each fixture, run:
+
+```bash
+npx tsx packages/review/test/harness/build-prompts.ts <fixture-path>
+```
+
+Capture the JSON output. It contains `systemPrompt` and `initialMessage` — the exact strings the agent plugin would feed an LLM in production.
+
+Use the Read tool to also load the sibling `.assertions.ts` (same basename, `.fixture.json` → `.assertions.ts`) so you can show the user what's being checked. You don't need to parse the assertions module — the assert-cli step does that.
+
+## Step 3: Spawn one subagent per vote
+
+For each of K votes, use the Agent tool with these parameters:
+
+- `subagent_type: "general-purpose"`
+- `description: "Agent-review simulation for <rule-id>"`
+- `prompt`: the wrapper template below, with `{systemPrompt}` and `{initialMessage}` substituted from step 2.
+
+Wrapper template:
+
+> You are simulating an LLM inside an automated code-review tool. Your role is defined by the SYSTEM PROMPT below; the USER MESSAGE describes the PR you are reviewing. Investigate using your available tools (Read, Grep, Glob) against the local repo working directory. Follow the investigation strategy described in the SYSTEM PROMPT exactly.
+>
+> When done, output **exactly one** fenced JSON block at the end matching the `<output_format>` schema in the SYSTEM PROMPT. After that JSON block, output a second fenced block tagged `harness-meta` listing the tools you actually called, one per line in the form `tool: <descriptor>` (e.g. `Read: src/risk.ts`, `Grep: classifyLevel`). Do not include any text after the second block.
+>
+> SYSTEM PROMPT:
+> ```
+> {systemPrompt}
+> ```
+>
+> USER MESSAGE:
+> ```
+> {initialMessage}
+> ```
+
+Spawn the K subagents in parallel (single message, multiple Agent tool calls) when K > 1.
+
+## Step 4: Parse each subagent's response
+
+For each returned subagent result:
+
+1. Extract the first ```json ... ``` block — parse it as `{findings, summary}`.
+2. Extract the ```harness-meta ... ``` block — split on newlines, drop blanks, treat each line as a tool-call descriptor.
+3. Build a HarnessResult object:
+   ```json
+   {
+     "findings": [...],
+     "toolCalls": ["Read: src/risk.ts", ...],
+     "turns": 1
+   }
+   ```
+   (`turns: 1` is a placeholder — we don't have access to the subagent's actual turn count.)
+4. Write it to a temp file: `/tmp/harness-result-<rule>-<vote-index>.json`.
+
+If a subagent's response has no parseable JSON block, count it as a failure with a note.
+
+## Step 5: Run assertions
+
+For each result file, run:
+
+```bash
+npx tsx packages/review/test/harness/assert-cli.ts \
+  <path-to-.assertions.ts> \
+  /tmp/harness-result-<rule>-<vote-index>.json
+```
+
+Capture the JSON output and exit code:
+- exit 0 → assertion passed
+- exit 1 → Tier 1 failure (hard signal — the prompt is broken)
+- exit 2 → Tier 2 failure (ambiguous — phrasing drift, may need keyword set widening)
+- exit 3 → loader error (fix this before reporting)
+
+## Step 6: Aggregate and report
+
+For each fixture, summarize across K votes:
+
+- **Agreement** — how many votes produced the same Tier 1 outcome (rule fired vs not fired). All-agree is a high-confidence result. Disagreement = flaky; refuse to call green.
+- **Pass rate** — `passes / K`.
+- **First failure detail** — for the user to inspect.
+
+Print a compact summary like:
+
+```
+=== boundary-change ===
+
+✓ placeholder.fixture.json — 1/1 passed (1 finding, ruleId=boundary-change)
+✗ ge-5-threshold-shift.fixture.json — 2/3 passed (1 Tier 2 fail: "test pair" not mentioned)
+
+Summary: 1/2 fixtures green, 1 flaky.
+
+⚠️  CC mode result. Run --calibrate 10 against OpenRouter before merging any prompt change.
+```
+
+Show finding excerpts (first 200 chars of `message`) for any fixture that failed assertions, so the user can see what the model actually produced.
+
+## Failure modes — what to look out for
+
+1. **Subagent ignores the SYSTEM PROMPT** — produces generic Claude commentary instead of the JSON output_format. Re-spawn once with stronger framing if needed; otherwise count as failure.
+2. **Subagent emits multiple JSON blocks** — parse only the first one (after the prose).
+3. **`harness-meta` block missing** — proceed with empty `toolCalls`; Tier 1 `expectToolCalled` assertions will fail. Note in output.
+4. **Fixture file path missing repoRootDir** — subagent has no real repo to read from. Use the working directory (the harness fixture's `repoRootDir` is informational; the subagent should default to grep'ing the current Lien repo).
+5. **Build-prompts errors out** — usually means fixture schema is wrong. Surface the error verbatim to the user.
+
+## What this skill does NOT do
+
+- Run the actual `AgentReviewPlugin.analyze()` code path. (That requires OpenRouter mode, `npm run test:harness`.)
+- Measure cost or token usage. (Subagents don't expose this back to the parent.)
+- Hit the 9/10 reliability bar. (CC fidelity is too high; only OpenRouter calibration counts toward shipping decisions.)
+
+If the user wants any of the above, point them at OpenRouter mode.

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,0 +1,92 @@
+name: Agent-Rule Test Harness (LLM)
+
+# Manual-trigger only. The harness hits a real LLM (Gemini 2.5 Flash via
+# OpenRouter) and costs real money per run. Do NOT add automatic triggers.
+#
+# Use this to:
+#   - Establish the 9/10 reliability baseline before changing a rule prompt
+#   - Verify a prompt tweak still meets the 9/10 bar (per issue #538)
+#
+# For free iteration during prompt authoring, use the /test-harness Skill in
+# Claude Code instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      rule:
+        description: 'Rule id to run (e.g., boundary-change). Empty = all rules.'
+        required: false
+        type: string
+      votes:
+        description: 'Votes per fixture (default 3)'
+        required: false
+        default: '3'
+        type: string
+      calibrate:
+        description: 'Calibration runs per fixture (e.g., 10 to check the 9/10 bar). Empty = vote mode.'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: harness-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  harness:
+    name: Run agent-rule harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build review package (for runtime imports)
+        run: npm run build -w @liendev/parser && npm run build -w @liendev/core && npm run build -w @liendev/review
+
+      - name: Run harness
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          ARGS=()
+          if [ -n "${{ inputs.rule }}" ]; then
+            ARGS+=("--rule" "${{ inputs.rule }}")
+          fi
+          if [ -n "${{ inputs.calibrate }}" ]; then
+            ARGS+=("--calibrate" "${{ inputs.calibrate }}")
+          else
+            ARGS+=("--votes" "${{ inputs.votes }}")
+          fi
+          ARGS+=("--json")
+          npm run test:harness -w @liendev/review -- "${ARGS[@]}" | tee harness-result.json
+
+      - name: Render summary
+        if: always()
+        run: |
+          if [ -f harness-result.json ]; then
+            {
+              echo '## Agent-Rule Harness Result'
+              echo ''
+              echo '```json'
+              cat harness-result.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: harness-result
+          path: harness-result.json
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,10 @@ coverage/
 .test-git-*
 .test-watcher-*
 
+# Captured agent-rule harness fixtures — large (10MB+), regenerate via
+# packages/review/test/harness/capture-pr.ts (#538). Hand-authored
+# placeholder fixtures stay committed via the negation rule below.
+packages/review/test/harness/fixtures/**/*.fixture.json
+!packages/review/test/harness/fixtures/**/placeholder*.fixture.json
+
 packages/cli/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,25 @@ Lien provides semantic code search via MCP. These tools are **not optional** —
 
 ---
 
+## Agent-Review Rule Development — Use the Test Harness
+
+Adding or tweaking a rule in `packages/review/src/plugins/agent/` MUST go
+through the offline test harness at `packages/review/test/harness/`. Don't
+ship prompt or rule changes via the deploy → synthetic-PR loop — the harness
+exists specifically to make that cycle ~30 minutes instead of hours.
+
+- Inner loop: invoke `/test-harness <rule-id>` from CC for free
+  Claude-subagent iteration on existing fixtures.
+- Shipping gate: `npm run test:harness -- --rule <rule-id> --calibrate 10`
+  must hit ≥ 9/10 against OpenRouter (Gemini) before merging the change.
+  The harness auto-loads `OPENROUTER_API_KEY` from `.env` at the repo root.
+- Workflow + failure modes: see `packages/review/test/harness/README.md`.
+  Includes the end-to-end recipe for capturing a real-PR fixture, authoring
+  Tier 1/2 assertions, iterating, and calibrating.
+
+A rule is not shippable until its calibration meets the bar. CC mode is
+necessary but not sufficient.
+
 ## Workflow Orchestration
 
 ### 1. Plan Mode Default

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -15,7 +15,11 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "typecheck:harness": "tsc --noEmit -p test/harness/tsconfig.json",
+    "test": "vitest run",
+    "test:harness": "tsx test/harness/run.ts",
+    "test:harness:build-prompts": "tsx test/harness/build-prompts.ts",
+    "test:harness:assert": "tsx test/harness/assert-cli.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.61.0",

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -11,6 +11,8 @@
  * Everything else (formatting, filtering, posting) is the adapter's job.
  */
 
+import { promises as fs } from 'node:fs';
+
 import type {
   ReviewPlugin,
   ReviewContext,
@@ -97,6 +99,13 @@ export class ReviewEngine {
 
     // Phase 2: Lazy repo indexing — only when an active plugin needs it
     await ensureRepoChunks(activePlugins, context);
+
+    // Optional: capture the post-index context for the agent-rule offline harness.
+    // Gated by env var — zero overhead in prod when unset. See
+    // packages/review/test/harness/README.md (#538) for the replay flow.
+    if (process.env.LIEN_REVIEW_CAPTURE_CTX) {
+      await captureContext(context, process.env.LIEN_REVIEW_CAPTURE_CTX, logger);
+    }
 
     // Phase 3: Analysis — run all active plugins in parallel, except summary runs last
     const deferredId = 'summary';
@@ -269,6 +278,34 @@ async function ensureRepoChunks(
   // Update plugin contexts with repoChunks
   for (const entry of activePlugins) {
     entry.pluginContext = { ...entry.pluginContext, repoChunks: context.repoChunks };
+  }
+}
+
+/**
+ * Serialize the post-index ReviewContext to disk. Used by the agent-rule
+ * offline harness (#538) to snapshot real PR inputs for replay.
+ *
+ * Map and Set are tagged so the harness's fixture-loader can revive them.
+ * Octokit and other non-serializable references on adapterContext are not
+ * present here — context only carries plain data.
+ */
+async function captureContext(context: ReviewContext, path: string, logger: Logger): Promise<void> {
+  const replacer = (_key: string, value: unknown): unknown => {
+    if (value instanceof Map) {
+      return { __type: 'Map', entries: [...value.entries()] };
+    }
+    if (value instanceof Set) {
+      return { __type: 'Set', values: [...value.values()] };
+    }
+    return value;
+  };
+  try {
+    await fs.writeFile(path, JSON.stringify(context, replacer, 2));
+    logger.info(`[engine] captured ctx → ${path}`);
+  } catch (err) {
+    logger.warning(
+      `[engine] LIEN_REVIEW_CAPTURE_CTX write failed (${path}): ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -16,19 +16,26 @@ a prompt change. (Issue #538.)
 
 ## Quick start
 
+The harness auto-loads `OPENROUTER_API_KEY` from `.env` at the repo root via
+`process.loadEnvFile()` — set it once, run anywhere:
+
 ```bash
+# One-time setup (or use the existing platform .env)
+echo 'OPENROUTER_API_KEY=sk-or-v1-…' >> .env
+
 # 1. Free CC iteration (in a Claude Code session):
 /test-harness boundary-change
 
 # 2. Calibration baseline (the 9/10 bar):
-OPENROUTER_API_KEY=… npm run test:harness -w @liendev/review -- \
-  --rule boundary-change --calibrate 10
+npm run test:harness -w @liendev/review -- --rule boundary-change --calibrate 10
 
 # 3. Run a single fixture with K=3 voting:
-OPENROUTER_API_KEY=… npm run test:harness -w @liendev/review -- \
-  --fixture test/harness/fixtures/boundary-change/<name>.fixture.json \
-  --votes 3
+npm run test:harness -w @liendev/review -- \
+  --fixture test/harness/fixtures/boundary-change/<name>.fixture.json --votes 3
 ```
+
+An inline `OPENROUTER_API_KEY=…` still wins over the `.env` value if you want
+to override per-invocation (e.g., to test against a different account's quota).
 
 ## Canary corpus
 
@@ -235,6 +242,84 @@ The motivating example for #538. To execute:
 6. **Land the PR** — paste the calibrate output into the PR description as
    evidence. Bundle the rule change, the new fixture, and the new assertion
    in one commit.
+
+## Workflow: adding a new rule
+
+This is the end-to-end recipe a rule author (human or agent) follows. The
+harness lets you do it autonomously once `OPENROUTER_API_KEY` is in `.env`.
+
+1. **Find a candidate PR.** Look for a closed planted-regression PR that
+   exhibits the pattern the rule should catch. The repo has a tradition
+   of these (#519, #520, #399, #509, #437, #411, #511 are all "test:" or
+   small synthetic-bug PRs). `gh pr list --state closed --search "test:"`
+   is a good starting query. Pick one with <500 changed lines if possible
+   — the agent's investigation is faster on smaller diffs.
+
+2. **Capture the fixture.** From the repo root:
+
+   ```bash
+   npx tsx packages/review/test/harness/capture-pr.ts <pr-num> \
+     packages/review/test/harness/fixtures/<rule-id>/<scenario>.fixture.json
+   ```
+
+   `capture-pr.ts` clones the PR head into a `/tmp/lien-capture-<sha>` git
+   worktree, indexes it, and writes the JSON. The worktree stays in place
+   so the harness can resolve `repoRootDir` for tool calls; clean up with
+   `git worktree remove --force <path>` when done.
+
+3. **Author Tier 1 assertions.** Create the sibling
+   `<scenario>.assertions.ts`. Start with just `expectRuleFired` and
+   `expectToolCalled` for whatever tool the rule's prompt mandates.
+   Don't add Tier 2 keyword checks until after baseline calibration is
+   green — they're what proves the prompt produces the *right* finding,
+   and you need a reliable Tier 1 first.
+
+4. **Add the rule to `BUILTIN_RULES`** in
+   `packages/review/src/plugins/agent/rules.ts`. Mirror the existing
+   shape: `id`, `name`, `prompt`, optional `example`, `triggers`. The
+   prompt is the lever — start by copying a similar existing rule's
+   structure.
+
+5. **Iterate via CC mode (free).** Open a Claude Code session, run
+   `/test-harness <rule-id>`. The Skill spawns a Claude subagent per
+   fixture and reports pass/fail. Cycle through prompt edits in `rules.ts`
+   until CC reliably produces the expected finding. **CC mode is *not*
+   sufficient for shipping** — Claude is much smarter than Gemini, so
+   passing here doesn't certify production behavior. Treat it as
+   smoke-testing.
+
+6. **Calibrate against OpenRouter (the gate).**
+
+   ```bash
+   npm run test:harness -w @liendev/review -- \
+     --rule <rule-id> --calibrate 10
+   ```
+
+   The fixture's `passThreshold` (default 9 from `assertions.passThreshold`)
+   gates the run. If pass-rate < 9/10, iterate: widen Tier 2 keywords,
+   tighten the prompt, or capture a more realistic fixture. Don't ship
+   sub-9/10 prompts — that's the discipline that prevents silently flaky
+   rules.
+
+7. **Open a PR** with the rule, the new fixture's `.assertions.ts`, and
+   the calibrate output pasted into the PR description as evidence.
+
+The whole loop, end-to-end, is ~30 minutes once you have the fixture
+captured.
+
+## Failure modes — what each error means
+
+| Error in `failureMessage` | Cause | Action |
+|---|---|---|
+| `LLM error: API error (403): Key limit exceeded` | Daily-spend cap on the OpenRouter key (set in their dashboard) | Raise the limit, switch keys, or wait until midnight UTC |
+| `LLM error: terminated` | OpenRouter killed the request mid-stream — usually upstream (provider) capacity issue, occasionally rate-limit at high concurrency | Retry; if it persists for one specific model, that model is having problems — try another |
+| `LLM error: fetch failed` | Network blip between us and OpenRouter | Retry |
+| `Tier 1: expected rule 'X' to fire. Got: (no findings)` | Model bailed without producing a finding (silence-mode bias) | Tighten the rule prompt to mandate emission; check `.wip/retro-blast-radius.md` §2.3 |
+| `Tier 2: expected at least one finding to mention any of […]` | Rule fired but the suggestion uses different vocabulary | Widen the keyword set, or the prompt is producing wrong-shaped findings |
+| `0/10 passed cost $0.0000` | Every call failed silently | Re-run with `--votes 3 --json` and inspect `failureMessage` per vote |
+
+If you can't tell what's happening, `--json` is your friend — pipe through
+`jq` and look at each vote's `failureMessage`.
 
 ## Modes — when to use which
 

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -91,8 +91,8 @@ Hand-authored placeholder fixtures (small, committed) live alongside.
 
 ## Layout
 
-```
-test/harness/
+```text
+packages/review/test/harness/
   run.ts                # OpenRouter CLI entrypoint
   runner.ts             # drives a single fixture against AgentReviewPlugin
   build-prompts.ts      # emits {systemPrompt, initialMessage} for any fixture

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -1,0 +1,277 @@
+# Agent-Rule Test Harness
+
+Replay code-review fixtures through the agent plugin's prompts to validate
+prompt changes offline. Two modes — pick the right one for the task:
+
+| Mode               | Entry                                            | Model                | Cost             | Use when                                |
+| ------------------ | ------------------------------------------------ | -------------------- | ---------------- | --------------------------------------- |
+| **CC iteration**   | `/test-harness <rule>`                           | Claude (subagent)    | Free             | Authoring / iterating on a prompt       |
+| **OpenRouter run** | `npm run test:harness -w @liendev/review`        | Gemini 2.5 Flash     | ~$0.05/run       | Final verification / 9/10 bar           |
+| **CI dispatch**    | Run "Agent-Rule Test Harness (LLM)" workflow     | Gemini 2.5 Flash     | ~$0.05/run       | Repeatable verification                 |
+
+**The 9/10 reliability bar is measured in OpenRouter mode only.** Claude is
+materially smarter than Gemini, so a passing CC run does not certify
+production behavior. Always re-calibrate against OpenRouter before merging
+a prompt change. (Issue #538.)
+
+## Quick start
+
+```bash
+# 1. Free CC iteration (in a Claude Code session):
+/test-harness boundary-change
+
+# 2. Calibration baseline (the 9/10 bar):
+OPENROUTER_API_KEY=… npm run test:harness -w @liendev/review -- \
+  --rule boundary-change --calibrate 10
+
+# 3. Run a single fixture with K=3 voting:
+OPENROUTER_API_KEY=… npm run test:harness -w @liendev/review -- \
+  --fixture test/harness/fixtures/boundary-change/<name>.fixture.json \
+  --votes 3
+```
+
+## Canary corpus
+
+One captured fixture per `BUILTIN_RULES` rule, all from closed planted-regression
+test PRs in this repo. Each fixture is gitignored (regenerate with
+`capture-pr.ts`), but the `.assertions.ts` is committed and tagged `canary`:
+
+| Rule                  | PR    | Fixture                                                      |
+| --------------------- | :---: | ------------------------------------------------------------ |
+| `boundary-change`     | #520  | `boundary-change/ge-5-threshold-shift`                       |
+| `structural-analysis` | #399  | `structural-analysis/removed-export`                         |
+| `edge-case-sweep`     | #509  | `edge-case-sweep/percent-change-sign-flip`                   |
+| `concurrency-race`    | #511  | `concurrency-race/credit-service-toctou`                     |
+| `incomplete-handling` | #437  | `incomplete-handling/enum-variant-removed`                   |
+| `error-swallowing`    | #411  | `error-swallowing/payment-error-swallowed`                   |
+
+Regenerate the whole corpus:
+
+```bash
+ROOT=packages/review/test/harness/fixtures
+npx tsx packages/review/test/harness/capture-pr.ts 520 "$ROOT/boundary-change/ge-5-threshold-shift.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 399 "$ROOT/structural-analysis/removed-export.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 509 "$ROOT/edge-case-sweep/percent-change-sign-flip.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 511 "$ROOT/concurrency-race/credit-service-toctou.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 437 "$ROOT/incomplete-handling/enum-variant-removed.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 411 "$ROOT/error-swallowing/payment-error-swallowed.fixture.json"
+```
+
+Run the full multi-model sweep:
+
+```bash
+OPENROUTER_API_KEY=… ./packages/review/test/harness/sweep.sh
+# or with custom models:
+OPENROUTER_API_KEY=… ./packages/review/test/harness/sweep.sh anthropic/claude-haiku-4.5 deepseek/deepseek-chat-v3.1
+```
+
+## Captured fixtures aren't committed (size)
+
+Snapshot-captured fixtures are typically 10MB+ (a full repo's `repoChunks`).
+They're gitignored — regenerate locally via `capture-pr.ts`:
+
+```bash
+npx tsx packages/review/test/harness/capture-pr.ts 520 \
+  packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.fixture.json
+```
+
+The capture is deterministic given the same PR head SHA and parser version,
+so the fixture is reproducible. A leftover git worktree at
+`/tmp/lien-capture-<sha>` is reused on re-runs (clean up with
+`git worktree remove --force <path>` when done).
+
+Hand-authored placeholder fixtures (small, committed) live alongside.
+
+## Layout
+
+```
+test/harness/
+  run.ts                # OpenRouter CLI entrypoint
+  runner.ts             # drives a single fixture against AgentReviewPlugin
+  build-prompts.ts      # emits {systemPrompt, initialMessage} for any fixture
+  assert-cli.ts         # runs an .assertions.ts module against a result JSON
+  assertions.ts         # tiered helpers (expectRuleFired, expectFindingMentions, …)
+  voting.ts             # K-of-M voting and N-run calibration
+  fixture-loader.ts     # JSON fixture I/O with Map / Set tagging
+  reporter.ts           # text / JSON output
+  tsconfig.json         # harness typecheck (npm run typecheck:harness)
+  fixtures/
+    <rule-id>/
+      <scenario>.fixture.json     # serialized ReviewContext
+      <scenario>.assertions.ts    # what to expect — default-export FixtureAssertions
+```
+
+## Fixture format
+
+A fixture is a JSON serialization of a `ReviewContext`, the same object the
+review engine builds before invoking the agent plugin. Maps and Sets are
+tagged so JSON round-trips preserve them:
+
+```jsonc
+{
+  "chunks": [...],          // CodeChunk[] — changed-file AST chunks
+  "changedFiles": [...],
+  "complexityReport": {...},
+  "baselineReport": null,
+  "deltas": null,
+  "pluginConfigs": {},
+  "config": {},
+  "pr": {
+    "owner": "...",
+    "patches": { "__type": "Map", "entries": [["src/foo.ts", "@@ -1 +1 @@\n..."]] },
+    "diffLines": { "__type": "Map", "entries": [["src/foo.ts", { "__type": "Set", "values": [12, 13] }]] }
+  },
+  "repoChunks": [...],      // full-repo CodeChunk[] — what AgentReviewPlugin investigates
+  "repoRootDir": "/path/to/checked-out/pr/branch"
+}
+```
+
+You can author one by hand for narrow scenarios, but per the reliability
+section in #538 the **first non-trivial fixture per rule must be snapshot-captured
+from a real PR.** Hand-authored fixtures are too clean and miss
+real-world chunk noise; the captured snapshot anchors realism.
+
+### Capturing a fixture from a real PR
+
+The runner will dump its post-index `ReviewContext` to disk if you set
+`LIEN_REVIEW_CAPTURE_CTX`:
+
+```bash
+# Locally check out the PR you want to snapshot
+gh pr checkout 520
+
+# Run the runner / CLI review path with the env var set.
+# Capture happens inside engine.ts after lazy repo indexing finishes,
+# so the dump includes repoChunks.
+LIEN_REVIEW_CAPTURE_CTX=/tmp/pr520.json \
+  <invocation that calls ReviewEngine.run for that PR>
+
+# Inspect what was captured
+jq '.pr.title, (.repoChunks | length), (.chunks | length)' /tmp/pr520.json
+
+# Move it into place and author the assertions
+mkdir -p packages/review/test/harness/fixtures/<rule>/
+mv /tmp/pr520.json packages/review/test/harness/fixtures/<rule>/<scenario>.fixture.json
+$EDITOR packages/review/test/harness/fixtures/<rule>/<scenario>.assertions.ts
+```
+
+Once captured, you can edit `repoRootDir` to a path that exists on the
+machine running the harness (so `read_file`-style tools can resolve), or
+leave it pointing at the original checkout — the harness will surface read
+errors but not crash.
+
+## Assertions — tiers
+
+| Tier | Stable at T=0? | Helper                                    | Use for                            |
+| ---- | -------------- | ----------------------------------------- | ---------------------------------- |
+| 1    | Yes            | `expectRuleFired`, `expectEmpty`,         | "rule fires", "no findings",       |
+|      |                | `expectFindingsCount`, `expectToolCalled` | "tool was called"                  |
+| 2    | Mostly         | `expectFindingMentions(['kw1','kw2',…])`  | Prompt-tweak wording verification  |
+| 3    | No             | (intentionally not exposed)               | —                                  |
+
+Tier 2 takes a list of accepted phrasings, not one exact string. Pick 2–4
+keywords that any correct rendering would use (e.g.,
+`['test pair', 'both sides', 'divergence']`).
+
+A fixture's `.assertions.ts` default-exports:
+
+```ts
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #520 — > 5 → >= 5 in classifyLevel',
+  rule: 'boundary-change',
+  expect: (result, h) => {
+    h.expectRuleFired('boundary-change', result);
+    h.expectToolCalled('get_files_context', result);
+    h.expectFindingMentions(['test pair', 'both sides', 'divergence'], result);
+  },
+  votes: 3,
+  passThreshold: 9, // out of 10 calibration runs
+  tags: ['canary'],
+};
+
+export default assertions;
+```
+
+`tags: ['canary']` marks a fixture as a drift signal — when multiple
+canaries flip simultaneously after a model update, the harness should be
+re-baselined under human review, not silently re-pinned.
+
+## The 9/10 reliability bar (#538)
+
+Before declaring the harness "trusted" for any rule:
+
+1. Run `--calibrate 10` against the unmodified rule prompt. Pass rate must
+   be ≥ 9/10. If lower, the assertion is too tight or the fixture is too
+   ambiguous — iterate.
+2. After making a prompt change, run `--calibrate 10` against the new prompt
+   with the new assertion. Same ≥ 9/10 bar.
+3. If either is below the bar, do **not** ship the prompt change. Document
+   the failure mode and iterate via CC mode first, then re-calibrate.
+
+This bar is what gates the harness from "shipped" to "trusted for the
+parked prompt-tweak issues" (#284, #286, #287, #288, #289, #302, #339, and
+the §4.3 "test pair" tweak in `.wip/retro-blast-radius.md`).
+
+## Runbook: §4.3 boundary-change "test pair" tweak
+
+The motivating example for #538. To execute:
+
+1. **Snapshot fixture** — capture PR #520 ctx via the steps above. Save
+   under `fixtures/boundary-change/ge-5-threshold-shift.fixture.json` and
+   author `ge-5-threshold-shift.assertions.ts` with Tier 1 assertions only
+   (`expectRuleFired`, `expectToolCalled('get_files_context')`).
+2. **Baseline calibration** — `npm run test:harness -- --rule boundary-change
+   --calibrate 10`. Confirm ≥ 9/10. If not, tighten assertions.
+3. **Apply §4.3 prompt change** — edit `BOUNDARY_CHANGE.prompt` in
+   `packages/review/src/plugins/agent/rules.ts`: add a sentence requiring
+   tests for **both sides** of the divergence, and update the worked
+   example accordingly.
+4. **Add Tier 2 assertion** — extend the `.assertions.ts` `expect` to
+   `h.expectFindingMentions(['test pair', 'both sides', 'divergence'], result)`.
+5. **Re-calibrate** — `--calibrate 10` again. Confirm ≥ 9/10 on the new
+   assertion.
+6. **Land the PR** — paste the calibrate output into the PR description as
+   evidence. Bundle the rule change, the new fixture, and the new assertion
+   in one commit.
+
+## Modes — when to use which
+
+- **`/test-harness <rule>` (CC)** — fast inner loop. Free. Use while
+  drafting a prompt change. Catches "the prompt is broken" but not "Gemini
+  will misbehave."
+- **`npm run test:harness --votes 3`** — sanity check after iterating in CC.
+  ~$0.18 per fixture. Tells you Gemini agrees with the assertion at K=3.
+- **`npm run test:harness --calibrate 10`** — the 9/10 bar. ~$0.50 per
+  fixture. **The only mode that gates merging a prompt change.**
+- **GitHub workflow ("Agent-Rule Test Harness (LLM)")** — same as
+  `--calibrate`, in CI, with the result attached to the workflow run for
+  audit. Triggered manually via the Actions UI.
+
+## Common failure modes
+
+- `OPENROUTER_API_KEY missing` — the Node CLI requires it. For free
+  iteration, use the CC Skill instead.
+- Fixture fails schema validation — `fixture-loader.ts` reports which field
+  is missing or wrong. Captured fixtures from `LIEN_REVIEW_CAPTURE_CTX`
+  should always validate.
+- `read_file` errors during a run — the fixture's `repoRootDir` doesn't
+  exist on this machine. Either point it at a real checkout or accept that
+  read-side tool calls will fail (the model usually proceeds anyway).
+- `harness-meta` block missing in CC mode — the subagent didn't follow the
+  wrapper template. Re-run; if persistent, simplify the wrapper.
+- Calibration <9/10 with Tier 2 keyword check — widen the keyword set to
+  include the phrasings the model actually produces. If you have to widen
+  to >5 keywords, the prompt itself probably needs work.
+
+## Typechecking
+
+The harness has its own tsconfig because the package's main `tsconfig.json`
+excludes `**/*.test.ts` (and the harness lives next to test files):
+
+```bash
+npm run typecheck:harness -w @liendev/review
+```
+
+Run this whenever you touch a harness file.

--- a/packages/review/test/harness/assert-cli.ts
+++ b/packages/review/test/harness/assert-cli.ts
@@ -35,11 +35,24 @@ async function loadAssertions(path: string): Promise<FixtureAssertions> {
 
 async function loadResult(path: string): Promise<HarnessResult> {
   const raw = await fs.readFile(path, 'utf8');
-  const parsed = JSON.parse(raw) as Partial<HarnessResult>;
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error(`${path} must contain a JSON object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.findings !== undefined && !Array.isArray(obj.findings)) {
+    throw new Error(`${path}: findings must be an array, got ${typeof obj.findings}`);
+  }
+  if (obj.toolCalls !== undefined && !Array.isArray(obj.toolCalls)) {
+    throw new Error(`${path}: toolCalls must be an array, got ${typeof obj.toolCalls}`);
+  }
+  if (obj.turns !== undefined && typeof obj.turns !== 'number') {
+    throw new Error(`${path}: turns must be a number, got ${typeof obj.turns}`);
+  }
   return {
-    findings: parsed.findings ?? [],
-    toolCalls: parsed.toolCalls ?? [],
-    turns: parsed.turns ?? 0,
+    findings: (obj.findings as HarnessResult['findings']) ?? [],
+    toolCalls: (obj.toolCalls as string[]) ?? [],
+    turns: (obj.turns as number) ?? 0,
   };
 }
 
@@ -62,6 +75,9 @@ async function main(): Promise<void> {
     process.exit(3);
   }
 
+  // Use process.exitCode + return rather than process.exit() so the JSON we
+  // just wrote to stdout actually flushes before the process tears down —
+  // process.exit() can truncate pending I/O (Node docs).
   try {
     assertions.expect(result, harness);
     process.stdout.write(
@@ -73,7 +89,8 @@ async function main(): Promise<void> {
         turns: result.turns,
       }) + '\n',
     );
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   } catch (err) {
     if (err instanceof HarnessAssertionError) {
       process.stdout.write(
@@ -87,10 +104,11 @@ async function main(): Promise<void> {
           turns: result.turns,
         }) + '\n',
       );
-      process.exit(err.tier === 2 ? 2 : 1);
+      process.exitCode = err.tier === 2 ? 2 : 1;
+      return;
     }
     console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
-    process.exit(1);
+    process.exitCode = 1;
   }
 }
 

--- a/packages/review/test/harness/assert-cli.ts
+++ b/packages/review/test/harness/assert-cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * CLI: load a fixture's .assertions.ts module, run its `expect` callback
+ * against a JSON-encoded HarnessResult, exit with structured codes.
+ *
+ *   exit 0 — all assertions passed
+ *   exit 1 — Tier 1 assertion failed (hard signal)
+ *   exit 2 — Tier 2 assertion failed (ambiguous; may indicate prompt drift)
+ *   exit 3 — usage / loader error
+ *
+ * Used by both modes:
+ *   - CC Skill: parses subagent output → writes findings.json → invokes this
+ *   - OpenRouter runner.ts: same call shape, single assertion semantics
+ *
+ * Usage: tsx assert-cli.ts <assertions.ts> <result.json>
+ */
+
+import { promises as fs } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+import { harness, HarnessAssertionError } from './assertions.js';
+import type { FixtureAssertions, HarnessResult } from './assertions.js';
+
+async function loadAssertions(path: string): Promise<FixtureAssertions> {
+  const url = pathToFileURL(resolve(path)).href;
+  const mod = (await import(url)) as { default?: FixtureAssertions };
+  if (!mod.default || typeof mod.default.expect !== 'function') {
+    throw new Error(
+      `Assertions module ${path} must default-export an object with an 'expect' function.`,
+    );
+  }
+  return mod.default;
+}
+
+async function loadResult(path: string): Promise<HarnessResult> {
+  const raw = await fs.readFile(path, 'utf8');
+  const parsed = JSON.parse(raw) as Partial<HarnessResult>;
+  return {
+    findings: parsed.findings ?? [],
+    toolCalls: parsed.toolCalls ?? [],
+    turns: parsed.turns ?? 0,
+  };
+}
+
+async function main(): Promise<void> {
+  const [assertionsArg, resultArg] = process.argv.slice(2);
+  if (!assertionsArg || !resultArg) {
+    console.error('Usage: tsx assert-cli.ts <assertions.ts> <result.json>');
+    process.exit(3);
+  }
+
+  let assertions: FixtureAssertions;
+  let result: HarnessResult;
+  try {
+    [assertions, result] = await Promise.all([
+      loadAssertions(assertionsArg),
+      loadResult(resultArg),
+    ]);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(3);
+  }
+
+  try {
+    assertions.expect(result, harness);
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        rule: assertions.rule,
+        description: assertions.description,
+        findings: result.findings.length,
+        turns: result.turns,
+      }) + '\n',
+    );
+    process.exit(0);
+  } catch (err) {
+    if (err instanceof HarnessAssertionError) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          tier: err.tier,
+          rule: assertions.rule,
+          description: assertions.description,
+          message: err.message,
+          findings: result.findings.length,
+          turns: result.turns,
+        }) + '\n',
+      );
+      process.exit(err.tier === 2 ? 2 : 1);
+    }
+    console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/review/test/harness/assertions.ts
+++ b/packages/review/test/harness/assertions.ts
@@ -1,0 +1,137 @@
+/**
+ * Tiered assertion helpers for the agent-review test harness.
+ *
+ * Tier 1 — stable at T=0. Use freely; failures here are signal, not noise.
+ *   expectRuleFired, expectEmpty, expectFindingsCount, expectToolCalled
+ *
+ * Tier 2 — stable enough for prompt-tweak verification. Phrasings drift
+ * across model versions; pass an array of accepted keywords rather than
+ * exact text. Use sparingly.
+ *   expectFindingMentions
+ *
+ * Tier 3 (exact text match) is intentionally not exposed.
+ */
+
+import type { AgentFinding } from '../../src/plugins/agent/types.js';
+
+export interface HarnessResult {
+  findings: AgentFinding[];
+  toolCalls: string[];
+  turns: number;
+}
+
+export type AssertionTier = 1 | 2;
+
+export class HarnessAssertionError extends Error {
+  readonly tier: AssertionTier;
+  constructor(message: string, tier: AssertionTier) {
+    super(message);
+    this.name = 'HarnessAssertionError';
+    this.tier = tier;
+  }
+}
+
+function isToolCall(entry: string, tool: string): boolean {
+  return (
+    entry.includes(`tool=${tool}`) || entry.includes(`"name":"${tool}"`) || entry.includes(tool)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1
+// ---------------------------------------------------------------------------
+
+export function expectRuleFired(ruleId: string, result: HarnessResult): void {
+  const fired = result.findings.some(f => f.ruleId === ruleId);
+  if (!fired) {
+    const observed = result.findings.map(f => f.ruleId ?? '(none)').join(', ') || '(no findings)';
+    throw new HarnessAssertionError(
+      `Tier 1: expected rule '${ruleId}' to fire. Got: ${observed}`,
+      1,
+    );
+  }
+}
+
+export function expectEmpty(result: HarnessResult): void {
+  if (result.findings.length > 0) {
+    throw new HarnessAssertionError(
+      `Tier 1: expected no findings. Got ${result.findings.length}: ` +
+        result.findings.map(f => `${f.ruleId ?? '?'}@${f.filepath}:${f.line}`).join('; '),
+      1,
+    );
+  }
+}
+
+export function expectFindingsCount(n: number, result: HarnessResult): void {
+  if (result.findings.length !== n) {
+    throw new HarnessAssertionError(
+      `Tier 1: expected exactly ${n} finding(s). Got ${result.findings.length}.`,
+      1,
+    );
+  }
+}
+
+export function expectToolCalled(tool: string, result: HarnessResult): void {
+  const called = result.toolCalls.some(entry => isToolCall(entry, tool));
+  if (!called) {
+    throw new HarnessAssertionError(
+      `Tier 1: expected tool '${tool}' to be called. Calls observed: ` +
+        (result.toolCalls.length === 0 ? '(none)' : result.toolCalls.slice(0, 8).join('; ')),
+      1,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2
+// ---------------------------------------------------------------------------
+
+/**
+ * Pass if ANY finding's message/suggestion/evidence contains ANY of the
+ * keywords (case-insensitive substring match). Designed for prompt-tweak
+ * verification — provide several accepted phrasings, not one exact string.
+ */
+export function expectFindingMentions(keywords: string[], result: HarnessResult): void {
+  if (keywords.length === 0) {
+    throw new HarnessAssertionError('Tier 2: keywords list is empty', 2);
+  }
+  const haystack = result.findings
+    .flatMap(f => [f.message, f.suggestion ?? '', f.evidence ?? ''])
+    .join('\n')
+    .toLowerCase();
+  const hit = keywords.find(kw => haystack.includes(kw.toLowerCase()));
+  if (!hit) {
+    throw new HarnessAssertionError(
+      `Tier 2: expected at least one finding to mention any of [${keywords
+        .map(k => `"${k}"`)
+        .join(', ')}]. None matched. ` +
+        (result.findings.length === 0
+          ? 'No findings emitted.'
+          : `Findings: ${result.findings.length}. First message: "${result.findings[0]?.message?.slice(0, 200) ?? ''}"`),
+      2,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bundle exposed to .assertions.ts modules as the `h` argument
+// ---------------------------------------------------------------------------
+
+export const harness = {
+  expectRuleFired,
+  expectEmpty,
+  expectFindingsCount,
+  expectToolCalled,
+  expectFindingMentions,
+};
+
+export type HarnessHelpers = typeof harness;
+
+export interface FixtureAssertions {
+  description: string;
+  rule: string;
+  expect: (result: HarnessResult, h: HarnessHelpers) => void;
+  votes?: number;
+  passThreshold?: number;
+  tags?: string[];
+}

--- a/packages/review/test/harness/assertions.ts
+++ b/packages/review/test/harness/assertions.ts
@@ -31,9 +31,26 @@ export class HarnessAssertionError extends Error {
   }
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Recognized tool-call shapes:
+ *   - `tool=<name>` (our capturing logger format)
+ *   - `"name":"<name>"` (raw provider trace)
+ *   - bare `<name>` as a standalone token (CC-mode harness-meta lines like
+ *     `get_files_context: src/foo.ts`)
+ *
+ * The bare-token check uses \b so unrelated substrings can't false-match
+ * (e.g. `read_file` vs `file_reader`).
+ */
 function isToolCall(entry: string, tool: string): boolean {
+  const escaped = escapeRegExp(tool);
   return (
-    entry.includes(`tool=${tool}`) || entry.includes(`"name":"${tool}"`) || entry.includes(tool)
+    entry.includes(`tool=${tool}`) ||
+    entry.includes(`"name":"${tool}"`) ||
+    new RegExp(`\\b${escaped}\\b`).test(entry)
   );
 }
 
@@ -92,17 +109,20 @@ export function expectToolCalled(tool: string, result: HarnessResult): void {
  * verification — provide several accepted phrasings, not one exact string.
  */
 export function expectFindingMentions(keywords: string[], result: HarnessResult): void {
-  if (keywords.length === 0) {
-    throw new HarnessAssertionError('Tier 2: keywords list is empty', 2);
+  // Reject blank/whitespace keywords — `''.includes('')` is true, so a stray
+  // empty string would silently green-light every Tier 2 check.
+  const normalized = keywords.map(k => k.trim().toLowerCase()).filter(k => k.length > 0);
+  if (normalized.length === 0) {
+    throw new HarnessAssertionError('Tier 2: keywords list is empty (or contained only blanks)', 2);
   }
   const haystack = result.findings
     .flatMap(f => [f.message, f.suggestion ?? '', f.evidence ?? ''])
     .join('\n')
     .toLowerCase();
-  const hit = keywords.find(kw => haystack.includes(kw.toLowerCase()));
+  const hit = normalized.find(kw => haystack.includes(kw));
   if (!hit) {
     throw new HarnessAssertionError(
-      `Tier 2: expected at least one finding to mention any of [${keywords
+      `Tier 2: expected at least one finding to mention any of [${normalized
         .map(k => `"${k}"`)
         .join(', ')}]. None matched. ` +
         (result.findings.length === 0

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env tsx
+/**
+ * CLI helper: load a fixture, build the same system+initial prompts the
+ * agent plugin would use in production, emit them as JSON on stdout.
+ *
+ * Used by the CC iteration Skill to feed the exact prompt to a Claude
+ * subagent, and by run.ts (OpenRouter mode) to keep one source of truth
+ * for prompt assembly.
+ *
+ * Usage: tsx build-prompts.ts <fixture.json>
+ */
+
+import { resolve } from 'node:path';
+
+import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../../src/plugins/agent/rules.js';
+import { buildSystemPrompt, buildInitialMessage } from '../../src/plugins/agent/system-prompt.js';
+
+import { loadFixture } from './fixture-loader.js';
+
+async function main(): Promise<void> {
+  const fixtureArg = process.argv[2];
+  if (!fixtureArg) {
+    console.error('Usage: tsx build-prompts.ts <fixture.json>');
+    process.exit(2);
+  }
+  const fixturePath = resolve(fixtureArg);
+  const ctx = await loadFixture(fixturePath);
+
+  const triggerCtx = buildTriggerContext(ctx);
+  const rules = selectRules(BUILTIN_RULES, triggerCtx);
+
+  const systemPrompt = buildSystemPrompt(rules);
+  const initialMessage = buildInitialMessage(ctx, { blastRadius: null });
+
+  const output = {
+    fixturePath,
+    ruleIds: rules.active.map(r => r.id),
+    skippedRules: rules.skipped,
+    systemPrompt,
+    initialMessage,
+  };
+
+  process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -15,7 +15,8 @@
 
 import { execSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolve, dirname, join } from 'node:path';
 
 import { performChunkOnlyIndex } from '@liendev/parser';
 
@@ -72,8 +73,13 @@ function parseUnifiedDiff(diff: string): {
   return { patches, diffLines };
 }
 
+/** Normalize a repo-relative path for set membership checks. */
+function normalizeRepoPath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
 async function withWorktree<T>(sha: string, fn: (path: string) => Promise<T>): Promise<T> {
-  const wtPath = `/tmp/lien-capture-${sha.slice(0, 12)}`;
+  const wtPath = join(tmpdir(), `lien-capture-${sha.slice(0, 12)}`);
   let addError: Error | undefined;
   // If a previous capture left this worktree in place, reuse it. Otherwise create.
   try {
@@ -136,7 +142,11 @@ async function main(): Promise<void> {
     const repoChunks = indexResult.chunks;
     console.error(`[capture] indexed ${repoChunks.length} chunks`);
 
-    const chunks = repoChunks.filter(c => changedFiles.includes(c.metadata.file));
+    // Path-shape between the parser's chunk metadata and `gh pr view`'s file
+    // list isn't guaranteed to match byte-for-byte (Windows backslashes,
+    // ./ prefixes). Normalize both sides before set membership.
+    const changedSet = new Set(changedFiles.map(normalizeRepoPath));
+    const chunks = repoChunks.filter(c => changedSet.has(normalizeRepoPath(c.metadata.file)));
     console.error(`[capture] ${chunks.length} chunks for changed files`);
 
     // Real complexity analysis on the changed files so the captured ctx

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -16,7 +16,7 @@
 import { execSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve, dirname, join } from 'node:path';
+import { resolve, dirname, join, isAbsolute, relative } from 'node:path';
 
 import { performChunkOnlyIndex } from '@liendev/parser';
 
@@ -37,6 +37,21 @@ function sh(cmd: string): string {
   return execSync(cmd, { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
 }
 
+/**
+ * Mirror the per-line bookkeeping in `parsePatchLines` from
+ * `packages/review/src/github-api.ts` so captured fixtures' diffLines
+ * match what the runner builds in production:
+ *   - hunk header sets `currentLine` to the post-image start (1-based)
+ *   - both `+` (added) and ` ` (context) lines are added to the set and
+ *     advance the counter
+ *   - `-` (deleted) lines don't advance
+ *   - `+++ b/...` file header is skipped
+ *
+ * Engine consumers (`engine.ts:600`) use this to filter findings to
+ * diff-adjacent lines via `diffLines.get(file)?.has(line)`. If we only
+ * captured `+` lines, findings on context lines would silently fall out
+ * of the harness's filter behavior vs prod.
+ */
 function parseUnifiedDiff(diff: string): {
   patches: Map<string, string>;
   diffLines: Map<string, Set<number>>;
@@ -52,30 +67,37 @@ function parseUnifiedDiff(diff: string): {
     patches.set(path, body);
 
     const lines = new Set<number>();
-    let currentNew = 0;
+    let currentLine = 0; // overwritten by the first hunk header
     for (const line of block.split('\n')) {
       const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
       if (hunkMatch) {
-        currentNew = parseInt(hunkMatch[1], 10);
+        currentLine = parseInt(hunkMatch[1], 10);
         continue;
       }
-      if (line.startsWith('+') && !line.startsWith('+++')) {
-        lines.add(currentNew);
-        currentNew++;
-      } else if (line.startsWith(' ')) {
-        currentNew++;
-      } else if (line.startsWith('-')) {
-        // deletion: don't advance new-line counter
+      if (line.startsWith('+') || line.startsWith(' ')) {
+        if (!line.startsWith('+++')) {
+          lines.add(currentLine);
+          currentLine++;
+        }
       }
+      // `-` lines don't advance currentLine (post-image counter).
     }
     diffLines.set(path, lines);
   }
   return { patches, diffLines };
 }
 
-/** Normalize a repo-relative path for set membership checks. */
-function normalizeRepoPath(p: string): string {
-  return p.replace(/\\/g, '/').replace(/^\.\//, '');
+/**
+ * Normalize a path to repo-relative form for set membership.
+ * Handles three indexer-output shapes defensively:
+ *   1. Already repo-relative: 'src/risk.ts' (current behavior)
+ *   2. Absolute, inside the worktree: '/tmp/lien-capture-…/src/risk.ts'
+ *   3. Repo-relative with leading './': './src/risk.ts'
+ * On Windows, also normalizes backslashes.
+ */
+function toRepoRelative(p: string, repoRoot: string): string {
+  const rel = isAbsolute(p) ? relative(repoRoot, p) : p;
+  return rel.replace(/\\/g, '/').replace(/^\.\//, '');
 }
 
 async function withWorktree<T>(sha: string, fn: (path: string) => Promise<T>): Promise<T> {
@@ -144,9 +166,12 @@ async function main(): Promise<void> {
 
     // Path-shape between the parser's chunk metadata and `gh pr view`'s file
     // list isn't guaranteed to match byte-for-byte (Windows backslashes,
-    // ./ prefixes). Normalize both sides before set membership.
-    const changedSet = new Set(changedFiles.map(normalizeRepoPath));
-    const chunks = repoChunks.filter(c => changedSet.has(normalizeRepoPath(c.metadata.file)));
+    // ./ prefixes, absolute vs. repo-relative). Normalize both sides to
+    // repo-relative POSIX form before set membership.
+    const changedSet = new Set(changedFiles.map(f => toRepoRelative(f, worktree)));
+    const chunks = repoChunks.filter(c =>
+      changedSet.has(toRepoRelative(c.metadata.file, worktree)),
+    );
     console.error(`[capture] ${chunks.length} chunks for changed files`);
 
     // Real complexity analysis on the changed files so the captured ctx

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -19,6 +19,9 @@ import { resolve, dirname } from 'node:path';
 
 import { performChunkOnlyIndex } from '@liendev/parser';
 
+import { runComplexityAnalysis } from '../../src/analysis.js';
+import { silentLogger } from '../../src/test-helpers.js';
+
 import { saveFixture } from './fixture-loader.js';
 
 interface PrMeta {
@@ -71,15 +74,34 @@ function parseUnifiedDiff(diff: string): {
 
 async function withWorktree<T>(sha: string, fn: (path: string) => Promise<T>): Promise<T> {
   const wtPath = `/tmp/lien-capture-${sha.slice(0, 12)}`;
+  let addError: Error | undefined;
   // If a previous capture left this worktree in place, reuse it. Otherwise create.
   try {
     sh(`git worktree add --detach "${wtPath}" "${sha}"`);
-  } catch {
-    // assume it already exists (re-running capture is fine)
+  } catch (err) {
+    addError = err instanceof Error ? err : new Error(String(err));
   }
-  // We deliberately do NOT remove the worktree — the captured fixture's
-  // repoRootDir points here, so harness runs that need read_file/grep_codebase
-  // against the PR head still work. Clean up manually with:
+  // Verify the worktree actually exists at the expected sha — `git worktree
+  // add` may fail for reasons unrelated to "already there" (bad sha, perms,
+  // disk full). Without this check we'd silently feed a stale or missing
+  // path into indexing and produce a confusing downstream error.
+  let head: string;
+  try {
+    head = sh(`git -C "${wtPath}" rev-parse HEAD`).trim();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    const orig = addError ? `\n  underlying add error: ${addError.message}` : '';
+    throw new Error(`worktree at ${wtPath} not usable: ${reason}${orig}`);
+  }
+  if (!head.startsWith(sha.slice(0, head.length))) {
+    throw new Error(
+      `worktree at ${wtPath} is at ${head}, expected ${sha}. ` +
+        `Remove it with \`git worktree remove --force ${wtPath}\` and re-run.`,
+    );
+  }
+  // We deliberately do NOT remove the worktree on success — the captured
+  // fixture's repoRootDir points here, so harness runs that need
+  // read_file/grep_codebase against the PR head still work. Clean up manually:
   //   git worktree remove --force <path>
   return fn(wtPath);
 }
@@ -117,20 +139,41 @@ async function main(): Promise<void> {
     const chunks = repoChunks.filter(c => changedFiles.includes(c.metadata.file));
     console.error(`[capture] ${chunks.length} chunks for changed files`);
 
+    // Real complexity analysis on the changed files so the captured ctx
+    // matches what the production runner would build. Without this,
+    // complexity-aware rules (e.g. blast-radius risk) see an empty report
+    // and behave differently than they would in prod.
+    //
+    // Limitation: we don't check out the base ref, so `deltas` stays null —
+    // the runner computes deltas by diffing head vs base reports. For
+    // delta-aware fidelity, capture via the engine's
+    // LIEN_REVIEW_CAPTURE_CTX env hook against a live runner instead.
+    console.error(`[capture] analyzing complexity for ${changedFiles.length} changed files`);
+    const complexityResult = await runComplexityAnalysis(
+      changedFiles,
+      '50',
+      worktree,
+      silentLogger,
+    );
+    const complexityReport = complexityResult?.report ?? {
+      summary: {
+        filesAnalyzed: changedFiles.length,
+        totalViolations: 0,
+        bySeverity: { error: 0, warning: 0 },
+        avgComplexity: 0,
+        maxComplexity: 0,
+      },
+      files: {},
+    };
+    console.error(
+      `[capture] complexity: ${complexityReport.summary.totalViolations} violations, max=${complexityReport.summary.maxComplexity}`,
+    );
+
     const ctx = {
       chunks,
       changedFiles,
       allChangedFiles: changedFiles,
-      complexityReport: {
-        summary: {
-          filesAnalyzed: changedFiles.length,
-          totalViolations: 0,
-          bySeverity: { error: 0, warning: 0 },
-          avgComplexity: 0,
-          maxComplexity: 0,
-        },
-        files: {},
-      },
+      complexityReport,
       baselineReport: null,
       deltas: null,
       pluginConfigs: {},

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env tsx
+/**
+ * One-off capture driver: snapshot a closed/historic PR's ReviewContext
+ * for use as a harness fixture, without running the agent plugin.
+ *
+ * Uses a git worktree to avoid touching the current working branch.
+ *
+ * Usage:
+ *   tsx capture-pr.ts <pr-number> <output-fixture-path>
+ *
+ * Prerequisites:
+ *   - gh CLI authenticated
+ *   - Run from the lien monorepo root
+ */
+
+import { execSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+import { performChunkOnlyIndex } from '@liendev/parser';
+
+import { saveFixture } from './fixture-loader.js';
+
+interface PrMeta {
+  title: string;
+  body: string;
+  baseRefOid: string;
+  headRefOid: string;
+  files: Array<{ path: string }>;
+}
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+}
+
+function parseUnifiedDiff(diff: string): {
+  patches: Map<string, string>;
+  diffLines: Map<string, Set<number>>;
+} {
+  const patches = new Map<string, string>();
+  const diffLines = new Map<string, Set<number>>();
+  const fileBlocks = diff.split(/^diff --git /m).slice(1);
+  for (const block of fileBlocks) {
+    const headerMatch = block.match(/^a\/(.+?) b\/(.+?)$/m);
+    if (!headerMatch) continue;
+    const path = headerMatch[2];
+    const body = `diff --git ${block}`.trimEnd();
+    patches.set(path, body);
+
+    const lines = new Set<number>();
+    let currentNew = 0;
+    for (const line of block.split('\n')) {
+      const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunkMatch) {
+        currentNew = parseInt(hunkMatch[1], 10);
+        continue;
+      }
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        lines.add(currentNew);
+        currentNew++;
+      } else if (line.startsWith(' ')) {
+        currentNew++;
+      } else if (line.startsWith('-')) {
+        // deletion: don't advance new-line counter
+      }
+    }
+    diffLines.set(path, lines);
+  }
+  return { patches, diffLines };
+}
+
+async function withWorktree<T>(sha: string, fn: (path: string) => Promise<T>): Promise<T> {
+  const wtPath = `/tmp/lien-capture-${sha.slice(0, 12)}`;
+  // If a previous capture left this worktree in place, reuse it. Otherwise create.
+  try {
+    sh(`git worktree add --detach "${wtPath}" "${sha}"`);
+  } catch {
+    // assume it already exists (re-running capture is fine)
+  }
+  // We deliberately do NOT remove the worktree — the captured fixture's
+  // repoRootDir points here, so harness runs that need read_file/grep_codebase
+  // against the PR head still work. Clean up manually with:
+  //   git worktree remove --force <path>
+  return fn(wtPath);
+}
+
+async function main(): Promise<void> {
+  const [prArg, outArg] = process.argv.slice(2);
+  if (!prArg || !outArg) {
+    console.error('Usage: tsx capture-pr.ts <pr-number> <output-fixture-path>');
+    process.exit(2);
+  }
+
+  const prNumber = parseInt(prArg, 10);
+  const outputPath = resolve(outArg);
+
+  console.error(`[capture] fetching PR ${prNumber} metadata`);
+  const meta = JSON.parse(
+    sh(`gh pr view ${prNumber} --json title,body,baseRefOid,headRefOid,files`),
+  ) as PrMeta;
+
+  console.error(`[capture] fetching PR ${prNumber} diff`);
+  const diffText = sh(`gh pr diff ${prNumber}`);
+
+  const { patches, diffLines } = parseUnifiedDiff(diffText);
+  const changedFiles = meta.files.map(f => f.path);
+
+  await withWorktree(meta.headRefOid, async worktree => {
+    console.error(`[capture] indexing worktree at ${worktree}`);
+    const indexResult = await performChunkOnlyIndex(worktree);
+    if (!indexResult.success || !indexResult.chunks) {
+      throw new Error(`index failed: ${indexResult.error ?? 'unknown'}`);
+    }
+    const repoChunks = indexResult.chunks;
+    console.error(`[capture] indexed ${repoChunks.length} chunks`);
+
+    const chunks = repoChunks.filter(c => changedFiles.includes(c.metadata.file));
+    console.error(`[capture] ${chunks.length} chunks for changed files`);
+
+    const ctx = {
+      chunks,
+      changedFiles,
+      allChangedFiles: changedFiles,
+      complexityReport: {
+        summary: {
+          filesAnalyzed: changedFiles.length,
+          totalViolations: 0,
+          bySeverity: { error: 0, warning: 0 },
+          avgComplexity: 0,
+          maxComplexity: 0,
+        },
+        files: {},
+      },
+      baselineReport: null,
+      deltas: null,
+      pluginConfigs: {},
+      config: {},
+      pr: {
+        owner: 'getlien',
+        repo: 'lien',
+        pullNumber: prNumber,
+        title: meta.title,
+        body: meta.body ?? '',
+        baseSha: meta.baseRefOid,
+        headSha: meta.headRefOid,
+        patches,
+        diffLines,
+      },
+      repoChunks,
+      repoRootDir: worktree,
+    };
+
+    await fs.mkdir(dirname(outputPath), { recursive: true });
+    await saveFixture(ctx, outputPath);
+    console.error(`[capture] wrote ${outputPath}`);
+  });
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/packages/review/test/harness/fixture-loader.ts
+++ b/packages/review/test/harness/fixture-loader.ts
@@ -39,19 +39,44 @@ function reviver(_key: string, value: unknown): unknown {
 }
 
 /**
- * Loose schema for fixtures. Not the full ReviewContext — just enough fields
- * to fail fast with a clear error when a fixture is malformed, instead of
- * crashing inside AgentReviewPlugin.analyze().
+ * Schema for fixtures. Covers every replay field the agent plugin reads,
+ * so a malformed fixture fails fast with a clear error here instead of
+ * crashing deeper inside AgentReviewPlugin.analyze() or its tools.
+ *
+ * Inner shapes use `z.unknown()` because the corresponding TS interfaces
+ * (CodeChunk, ComplexityReport, PRContext, ComplexityDelta) are large and
+ * captured by capture-pr.ts / engine.ts — we trust the shape produced by
+ * those code paths and only enforce the top-level keys + their primitive
+ * types here.
  */
 const FixtureShape = z.object({
   chunks: z.array(z.unknown()),
   changedFiles: z.array(z.string()),
+  allChangedFiles: z.array(z.string()).optional(),
+  // capture-pr.ts and engine.ts both populate complexityReport — even if the
+  // changed files have no violations, the summary object is required.
+  complexityReport: z.object({
+    summary: z.object({
+      filesAnalyzed: z.number(),
+      totalViolations: z.number(),
+      bySeverity: z.object({ error: z.number(), warning: z.number() }),
+      avgComplexity: z.number(),
+      maxComplexity: z.number(),
+    }),
+    files: z.record(z.unknown()),
+  }),
+  // baselineReport / deltas come from the runner's two-checkout analysis;
+  // capture-pr.ts can't reproduce that locally so they're allowed to be null.
+  baselineReport: z.unknown().nullable(),
+  deltas: z.array(z.unknown()).nullable(),
   pluginConfigs: z.record(z.unknown()),
   config: z.record(z.unknown()),
-  // pr is optional but recommended — without it the diff text is empty and
-  // many rules won't trigger
+  // pr is optional but most rules trigger via diff content, so a fixture
+  // without a pr usually has no triggers firing — warn at the runner if so.
   pr: z.unknown().optional(),
-  // repoChunks is required for the agent plugin (requiresRepoChunks=true)
+  // The agent plugin sets requiresRepoChunks=true, so this should be present
+  // for any fixture that drives the agent. The engine populates it lazily,
+  // so we accept undefined and fail later in the runner if missing.
   repoChunks: z.array(z.unknown()).optional(),
   repoRootDir: z.string().optional(),
 });

--- a/packages/review/test/harness/fixture-loader.ts
+++ b/packages/review/test/harness/fixture-loader.ts
@@ -1,0 +1,81 @@
+/**
+ * Fixture loader / saver for the agent-review test harness.
+ *
+ * A fixture is a JSON serialization of a ReviewContext, captured either
+ * by hand or by the runner's LIEN_REVIEW_CAPTURE_CTX env mode (engine.ts).
+ * Map and Set are encoded as tagged objects so JSON round-trips preserve them:
+ *   Map  -> { __type: 'Map', entries: [[k, v], ...] }
+ *   Set  -> { __type: 'Set', values: [...] }
+ */
+
+import { promises as fs } from 'node:fs';
+import { z } from 'zod';
+
+import type { ReviewContext } from '../../src/plugin-types.js';
+
+const TAG_MAP = '__type' as const;
+
+function replacer(_key: string, value: unknown): unknown {
+  if (value instanceof Map) {
+    return { [TAG_MAP]: 'Map', entries: [...value.entries()] };
+  }
+  if (value instanceof Set) {
+    return { [TAG_MAP]: 'Set', values: [...value.values()] };
+  }
+  return value;
+}
+
+function reviver(_key: string, value: unknown): unknown {
+  if (value && typeof value === 'object' && TAG_MAP in value) {
+    const tagged = value as { [TAG_MAP]: string; entries?: unknown[]; values?: unknown[] };
+    if (tagged[TAG_MAP] === 'Map' && Array.isArray(tagged.entries)) {
+      return new Map(tagged.entries as [unknown, unknown][]);
+    }
+    if (tagged[TAG_MAP] === 'Set' && Array.isArray(tagged.values)) {
+      return new Set(tagged.values);
+    }
+  }
+  return value;
+}
+
+/**
+ * Loose schema for fixtures. Not the full ReviewContext — just enough fields
+ * to fail fast with a clear error when a fixture is malformed, instead of
+ * crashing inside AgentReviewPlugin.analyze().
+ */
+const FixtureShape = z.object({
+  chunks: z.array(z.unknown()),
+  changedFiles: z.array(z.string()),
+  pluginConfigs: z.record(z.unknown()),
+  config: z.record(z.unknown()),
+  // pr is optional but recommended — without it the diff text is empty and
+  // many rules won't trigger
+  pr: z.unknown().optional(),
+  // repoChunks is required for the agent plugin (requiresRepoChunks=true)
+  repoChunks: z.array(z.unknown()).optional(),
+  repoRootDir: z.string().optional(),
+});
+
+export type LoadedFixture = ReviewContext;
+
+export async function loadFixture(path: string): Promise<LoadedFixture> {
+  const raw = await fs.readFile(path, 'utf8');
+  const parsed = JSON.parse(raw, reviver);
+  const validation = FixtureShape.safeParse(parsed);
+  if (!validation.success) {
+    throw new Error(
+      `Fixture ${path} failed schema validation:\n${validation.error.errors
+        .map(e => `  - ${e.path.join('.') || '(root)'}: ${e.message}`)
+        .join('\n')}`,
+    );
+  }
+  return parsed as LoadedFixture;
+}
+
+export async function saveFixture(ctx: unknown, path: string): Promise<void> {
+  const json = JSON.stringify(ctx, replacer, 2);
+  await fs.writeFile(path, json);
+}
+
+/** Stable JSON replacer / reviver pair, exported for engine.ts capture mode. */
+export { replacer as fixtureReplacer, reviver as fixtureReviver };

--- a/packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.assertions.ts
+++ b/packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.assertions.ts
@@ -1,0 +1,43 @@
+/**
+ * Snapshot from PR #520 (planted regression):
+ *   classifyLevel input BlastRadiusRiskInput, change `> 5` -> `>= 5`.
+ *
+ * Reclassifies dependentCount === 5 from 'low' to 'medium', cascading
+ * into every review's global risk score per the retro doc §2.3 / §3.
+ *
+ * Tier 1: rule fires, mandatory get_files_context call happens.
+ * Tier 2: §4.3 test-pair vocabulary check — the suggestion mentions
+ * tests for both sides of the divergence, not just the new boundary.
+ * Production model (google/gemini-3-flash-preview, bumped in #539) hits
+ * this 10/10; the previous gemini-2.5-flash hit 0/10. See
+ * .wip/multi-model-eval.md.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #520 — > 5 → >= 5 in classifyLevel (blast-radius-risk.ts)',
+  rule: 'boundary-change',
+  expect: (result, h) => {
+    h.expectRuleFired('boundary-change', result);
+    h.expectToolCalled('get_files_context', result);
+    h.expectFindingMentions(
+      [
+        'test pair',
+        'both sides',
+        'divergence',
+        'both inputs',
+        'input 4',
+        'adjacent',
+        'pins',
+        'either side',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/boundary-change/placeholder.assertions.ts
+++ b/packages/review/test/harness/fixtures/boundary-change/placeholder.assertions.ts
@@ -1,0 +1,25 @@
+/**
+ * Placeholder assertions for the boundary-change harness wiring test.
+ *
+ * Synthetic scenario — modeled after PR #520 (the > 5 → >= 5 threshold
+ * shift) but minimal. Used to verify the harness pipeline end-to-end
+ * before the snapshot fixture (M3) replaces it.
+ *
+ * Tier 1 only — the snapshot fixture in M3 will add Tier 2 keyword checks
+ * for §4.3 once we have a real captured ctx.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'Placeholder boundary-change scenario (>5 → >=5 in classifyLevel)',
+  rule: 'boundary-change',
+  expect: (result, h) => {
+    h.expectRuleFired('boundary-change', result);
+  },
+  votes: 1,
+  passThreshold: 1,
+  tags: ['placeholder'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/boundary-change/placeholder.fixture.json
+++ b/packages/review/test/harness/fixtures/boundary-change/placeholder.fixture.json
@@ -75,5 +75,5 @@
       }
     }
   ],
-  "repoRootDir": "/Users/alfhenderson/Code/lien"
+  "repoRootDir": "/repo"
 }

--- a/packages/review/test/harness/fixtures/boundary-change/placeholder.fixture.json
+++ b/packages/review/test/harness/fixtures/boundary-change/placeholder.fixture.json
@@ -1,0 +1,79 @@
+{
+  "chunks": [
+    {
+      "content": "function classifyLevel(dependentCount: number): 'low' | 'medium' | 'high' {\n  if (dependentCount >= 5) return 'medium';\n  return 'low';\n}",
+      "metadata": {
+        "file": "src/risk.ts",
+        "startLine": 12,
+        "endLine": 15,
+        "type": "function",
+        "language": "typescript",
+        "symbolName": "classifyLevel",
+        "symbolType": "function",
+        "complexity": 2,
+        "parameters": ["dependentCount: number"],
+        "signature": "function classifyLevel(dependentCount: number): 'low' | 'medium' | 'high'",
+        "returnType": "'low' | 'medium' | 'high'",
+        "exports": ["classifyLevel"]
+      }
+    }
+  ],
+  "changedFiles": ["src/risk.ts"],
+  "allChangedFiles": ["src/risk.ts"],
+  "complexityReport": {
+    "summary": {
+      "filesAnalyzed": 1,
+      "totalViolations": 0,
+      "bySeverity": { "error": 0, "warning": 0 },
+      "avgComplexity": 2,
+      "maxComplexity": 2
+    },
+    "files": {}
+  },
+  "baselineReport": null,
+  "deltas": null,
+  "pluginConfigs": {},
+  "config": {},
+  "pr": {
+    "owner": "getlien",
+    "repo": "lien",
+    "pullNumber": 9001,
+    "title": "Off-by-one fix in classifyLevel threshold",
+    "body": "Minor correction: includes 5 in the medium threshold.",
+    "baseSha": "0000000000000000000000000000000000000000",
+    "headSha": "1111111111111111111111111111111111111111",
+    "patches": {
+      "__type": "Map",
+      "entries": [
+        [
+          "src/risk.ts",
+          "@@ -12,4 +12,4 @@\n function classifyLevel(dependentCount: number): 'low' | 'medium' | 'high' {\n-  if (dependentCount > 5) return 'medium';\n+  if (dependentCount >= 5) return 'medium';\n   return 'low';\n }"
+        ]
+      ]
+    },
+    "diffLines": {
+      "__type": "Map",
+      "entries": [["src/risk.ts", { "__type": "Set", "values": [13] }]]
+    }
+  },
+  "repoChunks": [
+    {
+      "content": "function classifyLevel(dependentCount: number): 'low' | 'medium' | 'high' {\n  if (dependentCount >= 5) return 'medium';\n  return 'low';\n}",
+      "metadata": {
+        "file": "src/risk.ts",
+        "startLine": 12,
+        "endLine": 15,
+        "type": "function",
+        "language": "typescript",
+        "symbolName": "classifyLevel",
+        "symbolType": "function",
+        "complexity": 2,
+        "parameters": ["dependentCount: number"],
+        "signature": "function classifyLevel(dependentCount: number): 'low' | 'medium' | 'high'",
+        "returnType": "'low' | 'medium' | 'high'",
+        "exports": ["classifyLevel"]
+      }
+    }
+  ],
+  "repoRootDir": "/Users/alfhenderson/Code/lien"
+}

--- a/packages/review/test/harness/fixtures/concurrency-race/credit-service-toctou.assertions.ts
+++ b/packages/review/test/harness/fixtures/concurrency-race/credit-service-toctou.assertions.ts
@@ -1,0 +1,21 @@
+/**
+ * PR #511 — CreditService introduces three DB::transaction blocks each
+ * using Organization::lockForUpdate()->find($org->id). Hits keywords
+ * `transaction`, `lockForUpdate`, `DB::transaction`. Real check-then-act
+ * on credit balance — ripe for TOCTOU analysis.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #511 — CreditService check-then-act with lockForUpdate',
+  rule: 'concurrency-race',
+  expect: (result, h) => {
+    h.expectRuleFired('concurrency-race', result);
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/edge-case-sweep/percent-change-sign-flip.assertions.ts
+++ b/packages/review/test/harness/fixtures/edge-case-sweep/percent-change-sign-flip.assertions.ts
@@ -1,0 +1,21 @@
+/**
+ * PR #509 — formatPercentChange uses (after - before) / before without
+ * Math.abs on the denominator. For negative `before`, the sign flips:
+ * percentChange(-100, -50) returns '-50%' even though the value improved.
+ * Classic edge-case-sweep target (negative-input branch).
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #509 — formatPercentChange sign-flip on negative before',
+  rule: 'edge-case-sweep',
+  expect: (result, h) => {
+    h.expectRuleFired('edge-case-sweep', result);
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
@@ -1,0 +1,21 @@
+/**
+ * PR #411 — PaymentService::charge wrapped in try { ... } catch { return
+ * false; }. Throws are silently converted to a `false` result. Textbook
+ * error-swallowing: the caller cannot distinguish "charge declined" from
+ * "charge crashed".
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #411 — PaymentService charge wraps throw in catch → false',
+  rule: 'error-swallowing',
+  expect: (result, h) => {
+    h.expectRuleFired('error-swallowing', result);
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/incomplete-handling/enum-variant-removed.assertions.ts
+++ b/packages/review/test/harness/fixtures/incomplete-handling/enum-variant-removed.assertions.ts
@@ -1,0 +1,20 @@
+/**
+ * PR #437 — UserRole enum no longer includes Guest. getPermissionsForRole
+ * switch falls through to default: [] for any unhandled variant. Rule
+ * should flag the missing-case / partial-iteration pattern.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #437 — UserRole switch falls through on missing variant',
+  rule: 'incomplete-handling',
+  expect: (result, h) => {
+    h.expectRuleFired('incomplete-handling', result);
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/structural-analysis/removed-export.assertions.ts
+++ b/packages/review/test/harness/fixtures/structural-analysis/removed-export.assertions.ts
@@ -1,0 +1,24 @@
+/**
+ * PR #399 — `parse_input` (Rust exported function) entirely removed.
+ * Classic structural breakage: any caller of `parse_input` is now broken.
+ *
+ * Per structural-analysis prompt, the agent MUST call grep_codebase for
+ * each removed symbol name to check if any file still imports it. The
+ * Tier 1 assertion enforces both: rule fires + investigation happened.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #399 — removed parse_input export (Rust)',
+  rule: 'structural-analysis',
+  expect: (result, h) => {
+    h.expectRuleFired('structural-analysis', result);
+    h.expectToolCalled('grep_codebase', result);
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/reporter.ts
+++ b/packages/review/test/harness/reporter.ts
@@ -1,0 +1,49 @@
+/**
+ * Human-readable reporter for harness output. Used by run.ts.
+ */
+
+import type { CalibrateResult, VoteResult } from './voting.js';
+
+function previewMessage(msg: string, max = 220): string {
+  return msg.length <= max ? msg : `${msg.slice(0, max)}…`;
+}
+
+export function reportVote(label: string, result: VoteResult): string {
+  const lines: string[] = [];
+  const status = result.agree ? (result.passes === result.votes.length ? '✓' : '✗') : '?';
+  lines.push(
+    `${status} ${label} — ${result.passes}/${result.votes.length} passed${result.agree ? '' : ' (FLAKY)'} · $${result.totalCost.toFixed(4)}`,
+  );
+  for (const [i, v] of result.votes.entries()) {
+    if (!v.passed) {
+      lines.push(
+        `    vote ${i + 1}: tier ${v.failureTier ?? '?'} — ${previewMessage(v.failureMessage ?? '(no message)')}`,
+      );
+    }
+  }
+  if (!result.agree) {
+    lines.push('    NOTE: votes disagreed — flag as flaky, do not claim green/red');
+  }
+  return lines.join('\n');
+}
+
+export function reportCalibrate(label: string, result: CalibrateResult): string {
+  const status = result.meetsReliabilityBar ? '✓' : '✗';
+  const lines: string[] = [];
+  lines.push(
+    `${status} ${label} — ${result.passes}/${result.runs.length} passed (${(result.passRate * 100).toFixed(0)}%) · $${result.totalCost.toFixed(4)}`,
+  );
+  if (!result.meetsReliabilityBar) {
+    lines.push('    BAR NOT MET — assertions too tight or fixture too ambiguous (per #538)');
+  }
+  const failures = result.runs.filter(r => !r.passed);
+  if (failures.length > 0) {
+    const tier1 = failures.filter(f => f.failureTier === 1).length;
+    const tier2 = failures.filter(f => f.failureTier === 2).length;
+    lines.push(`    failures: ${tier1} tier-1, ${tier2} tier-2`);
+    lines.push(
+      `    first failure: ${previewMessage(failures[0].failureMessage ?? '(no message)')}`,
+    );
+  }
+  return lines.join('\n');
+}

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -39,24 +39,47 @@ interface CliFlags {
   model?: string;
 }
 
+/**
+ * Each value-taking flag's setter. Bool flags and `--help` are handled
+ * inline in `parseFlags` since they don't follow the same shape.
+ */
+const VALUE_FLAG_SETTERS: Record<string, (f: CliFlags, value: string) => void> = {
+  '--rule': (f, v) => {
+    f.rule = v;
+  },
+  '--fixture': (f, v) => {
+    f.fixture = v;
+  },
+  '--votes': (f, v) => {
+    f.votes = parseInt(v, 10);
+  },
+  '--calibrate': (f, v) => {
+    f.calibrate = parseInt(v, 10);
+  },
+  '--model': (f, v) => {
+    f.model = v;
+  },
+};
+
 function parseFlags(argv: string[]): CliFlags {
   const flags: CliFlags = { votes: 3, json: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === '--rule') flags.rule = argv[++i];
-    else if (arg === '--fixture') flags.fixture = argv[++i];
-    else if (arg === '--votes') flags.votes = parseInt(argv[++i], 10);
-    else if (arg === '--calibrate') flags.calibrate = parseInt(argv[++i], 10);
-    else if (arg === '--model') flags.model = argv[++i];
-    else if (arg === '--json') flags.json = true;
-    else if (arg === '--help' || arg === '-h') {
+    if (arg === '--json') {
+      flags.json = true;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
       printUsage();
       process.exit(0);
-    } else {
+    }
+    const setter = VALUE_FLAG_SETTERS[arg];
+    if (!setter) {
       console.error(`Unknown flag: ${arg}`);
       printUsage();
       process.exit(2);
     }
+    setter(flags, argv[++i]);
   }
   return flags;
 }
@@ -136,15 +159,74 @@ async function loadAssertions(path: string): Promise<FixtureAssertions> {
   return mod.default;
 }
 
-async function main(): Promise<void> {
-  const flags = parseFlags(process.argv.slice(2));
+function requireApiKey(): string {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) {
     console.error('OPENROUTER_API_KEY env required for OpenRouter mode.');
     console.error('For free iteration without an API key, use /test-harness in CC.');
     process.exit(2);
   }
+  return apiKey;
+}
 
+interface FixtureOutcome {
+  passed: boolean;
+  cost: number;
+  jsonEntry: unknown;
+  text: string;
+}
+
+async function runOneFixture(
+  f: FixturePair,
+  opts: RunnerOptions,
+  flags: CliFlags,
+): Promise<FixtureOutcome> {
+  const assertions = await loadAssertions(f.assertionsPath);
+  const label = `${f.rule}/${f.name}`;
+
+  if (flags.calibrate) {
+    const result = await calibrate(f.fixturePath, assertions, opts, flags.calibrate);
+    return {
+      passed: result.meetsReliabilityBar,
+      cost: result.totalCost,
+      jsonEntry: { label, mode: 'calibrate', result },
+      text: reportCalibrate(label, result),
+    };
+  }
+  const k = assertions.votes ?? flags.votes;
+  const result = await vote(f.fixturePath, assertions, opts, k);
+  return {
+    passed: result.agree && result.passes === result.votes.length,
+    cost: result.totalCost,
+    jsonEntry: { label, mode: 'vote', result },
+    text: reportVote(label, result),
+  };
+}
+
+function printSummary(
+  allPassed: boolean,
+  totalCost: number,
+  jsonReport: unknown[],
+  flags: CliFlags,
+): void {
+  if (flags.json) {
+    process.stdout.write(
+      JSON.stringify({ allPassed, totalCost, fixtures: jsonReport }, null, 2) + '\n',
+    );
+    return;
+  }
+  console.log('');
+  console.log(`Total cost: $${totalCost.toFixed(4)}`);
+  if (!allPassed) {
+    console.log(
+      '\n⚠️  One or more fixtures failed. Iterate prompts via /test-harness (CC mode), then re-calibrate here.',
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const apiKey = requireApiKey();
   const fixtures = await discoverFixtures(flags);
   if (fixtures.length === 0) {
     console.error('No fixtures found.');
@@ -159,45 +241,14 @@ async function main(): Promise<void> {
   const jsonReport: unknown[] = [];
 
   for (const f of fixtures) {
-    const assertions = await loadAssertions(f.assertionsPath);
-    const label = `${f.rule}/${f.name}`;
-
-    if (flags.calibrate) {
-      const result = await calibrate(f.fixturePath, assertions, opts, flags.calibrate);
-      totalCost += result.totalCost;
-      if (!result.meetsReliabilityBar) allPassed = false;
-      if (flags.json) {
-        jsonReport.push({ label, mode: 'calibrate', result });
-      } else {
-        console.log(reportCalibrate(label, result));
-      }
-    } else {
-      const k = assertions.votes ?? flags.votes;
-      const result = await vote(f.fixturePath, assertions, opts, k);
-      totalCost += result.totalCost;
-      if (!result.agree || result.passes !== result.votes.length) allPassed = false;
-      if (flags.json) {
-        jsonReport.push({ label, mode: 'vote', result });
-      } else {
-        console.log(reportVote(label, result));
-      }
-    }
+    const outcome = await runOneFixture(f, opts, flags);
+    if (!outcome.passed) allPassed = false;
+    totalCost += outcome.cost;
+    if (flags.json) jsonReport.push(outcome.jsonEntry);
+    else console.log(outcome.text);
   }
 
-  if (flags.json) {
-    process.stdout.write(
-      JSON.stringify({ allPassed, totalCost, fixtures: jsonReport }, null, 2) + '\n',
-    );
-  } else {
-    console.log('');
-    console.log(`Total cost: $${totalCost.toFixed(4)}`);
-    if (!allPassed) {
-      console.log(
-        '\n⚠️  One or more fixtures failed. Iterate prompts via /test-harness (CC mode), then re-calibrate here.',
-      );
-    }
-  }
-
+  printSummary(allPassed, totalCost, jsonReport, flags);
   process.exit(allPassed ? 0 : 1);
 }
 

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -49,25 +49,46 @@ interface CliFlags {
   model?: string;
 }
 
+function requirePositiveInt(name: string, value: string | undefined): number {
+  if (value === undefined) {
+    console.error(`${name} requires a value`);
+    process.exit(2);
+  }
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    console.error(`${name} must be a positive integer (got: ${value})`);
+    process.exit(2);
+  }
+  return n;
+}
+
+function requireString(name: string, value: string | undefined): string {
+  if (value === undefined || value === '') {
+    console.error(`${name} requires a value`);
+    process.exit(2);
+  }
+  return value;
+}
+
 /**
  * Each value-taking flag's setter. Bool flags and `--help` are handled
  * inline in `parseFlags` since they don't follow the same shape.
  */
-const VALUE_FLAG_SETTERS: Record<string, (f: CliFlags, value: string) => void> = {
+const VALUE_FLAG_SETTERS: Record<string, (f: CliFlags, value: string | undefined) => void> = {
   '--rule': (f, v) => {
-    f.rule = v;
+    f.rule = requireString('--rule', v);
   },
   '--fixture': (f, v) => {
-    f.fixture = v;
+    f.fixture = requireString('--fixture', v);
   },
   '--votes': (f, v) => {
-    f.votes = parseInt(v, 10);
+    f.votes = requirePositiveInt('--votes', v);
   },
   '--calibrate': (f, v) => {
-    f.calibrate = parseInt(v, 10);
+    f.calibrate = requirePositiveInt('--calibrate', v);
   },
   '--model': (f, v) => {
-    f.model = v;
+    f.model = requireString('--model', v);
   },
 };
 
@@ -194,7 +215,7 @@ async function runOneFixture(
   const assertions = await loadAssertions(f.assertionsPath);
   const label = `${f.rule}/${f.name}`;
 
-  if (flags.calibrate) {
+  if (flags.calibrate !== undefined) {
     const result = await calibrate(f.fixturePath, assertions, opts, flags.calibrate);
     return {
       passed: result.meetsReliabilityBar,

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -30,6 +30,16 @@ import { reportVote, reportCalibrate } from './reporter.js';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_ROOT = resolve(HERE, 'fixtures');
 
+// Auto-load .env from the repo root so OPENROUTER_API_KEY can live there
+// instead of the user's shell rc. Node's process.loadEnvFile() does not
+// override variables that are already set, so an inline `OPENROUTER_API_KEY=…`
+// still wins. Silently skip if no .env is present.
+try {
+  process.loadEnvFile(resolve(HERE, '../../../../.env'));
+} catch {
+  /* no .env at repo root — that's fine; rely on the inherited environment */
+}
+
 interface CliFlags {
   rule?: string;
   fixture?: string;

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env tsx
+/**
+ * OpenRouter-mode CLI for the agent-rule harness.
+ *
+ * Walks fixtures under test/harness/fixtures/, runs each through the real
+ * AgentReviewPlugin (Gemini via OpenRouter), evaluates assertions, exits
+ * non-zero on failure.
+ *
+ * For free CC iteration mode, use the /test-harness skill instead.
+ *
+ * Flags:
+ *   --rule <id>          run only fixtures under fixtures/<id>/
+ *   --fixture <path>     run only this fixture
+ *   --votes <k>          K-of-M voting per fixture (default 3)
+ *   --calibrate <n>      run each fixture N times, report pass rate (the 9/10 bar)
+ *   --json               emit machine-readable JSON instead of text
+ *
+ * Env: OPENROUTER_API_KEY required.
+ */
+
+import { promises as fs } from 'node:fs';
+import { dirname, basename, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import type { FixtureAssertions } from './assertions.js';
+import { vote, calibrate } from './voting.js';
+import type { RunnerOptions } from './runner.js';
+import { reportVote, reportCalibrate } from './reporter.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_ROOT = resolve(HERE, 'fixtures');
+
+interface CliFlags {
+  rule?: string;
+  fixture?: string;
+  votes: number;
+  calibrate?: number;
+  json: boolean;
+  model?: string;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = { votes: 3, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--rule') flags.rule = argv[++i];
+    else if (arg === '--fixture') flags.fixture = argv[++i];
+    else if (arg === '--votes') flags.votes = parseInt(argv[++i], 10);
+    else if (arg === '--calibrate') flags.calibrate = parseInt(argv[++i], 10);
+    else if (arg === '--model') flags.model = argv[++i];
+    else if (arg === '--json') flags.json = true;
+    else if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    } else {
+      console.error(`Unknown flag: ${arg}`);
+      printUsage();
+      process.exit(2);
+    }
+  }
+  return flags;
+}
+
+function printUsage(): void {
+  console.error(
+    [
+      'Usage: tsx run.ts [--rule <id>] [--fixture <path>] [--votes K] [--calibrate N] [--json]',
+      '',
+      '  Default: K=3 voting on every fixture under test/harness/fixtures/',
+      '  --calibrate 10: runs N times and checks the 9/10 reliability bar',
+      '  Env: OPENROUTER_API_KEY required',
+    ].join('\n'),
+  );
+}
+
+interface FixturePair {
+  rule: string;
+  name: string;
+  fixturePath: string;
+  assertionsPath: string;
+}
+
+async function discoverFixtures(flags: CliFlags): Promise<FixturePair[]> {
+  if (flags.fixture) {
+    const fixturePath = resolve(flags.fixture);
+    const assertionsPath = fixturePath.replace(/\.fixture\.json$/, '.assertions.ts');
+    return [
+      {
+        rule: basename(dirname(fixturePath)),
+        name: basename(fixturePath, '.fixture.json'),
+        fixturePath,
+        assertionsPath,
+      },
+    ];
+  }
+
+  const ruleDirs = flags.rule
+    ? [resolve(FIXTURES_ROOT, flags.rule)]
+    : (await fs.readdir(FIXTURES_ROOT, { withFileTypes: true }))
+        .filter(d => d.isDirectory())
+        .map(d => resolve(FIXTURES_ROOT, d.name));
+
+  const pairs: FixturePair[] = [];
+  for (const ruleDir of ruleDirs) {
+    let entries;
+    try {
+      entries = await fs.readdir(ruleDir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith('.fixture.json')) continue;
+      const fixturePath = resolve(ruleDir, entry);
+      const assertionsPath = fixturePath.replace(/\.fixture\.json$/, '.assertions.ts');
+      try {
+        await fs.access(assertionsPath);
+      } catch {
+        console.error(`skip ${fixturePath} — no sibling .assertions.ts`);
+        continue;
+      }
+      pairs.push({
+        rule: basename(ruleDir),
+        name: basename(fixturePath, '.fixture.json'),
+        fixturePath,
+        assertionsPath,
+      });
+    }
+  }
+  return pairs;
+}
+
+async function loadAssertions(path: string): Promise<FixtureAssertions> {
+  const url = pathToFileURL(path).href;
+  const mod = (await import(url)) as { default?: FixtureAssertions };
+  if (!mod.default) throw new Error(`No default export in ${path}`);
+  return mod.default;
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    console.error('OPENROUTER_API_KEY env required for OpenRouter mode.');
+    console.error('For free iteration without an API key, use /test-harness in CC.');
+    process.exit(2);
+  }
+
+  const fixtures = await discoverFixtures(flags);
+  if (fixtures.length === 0) {
+    console.error('No fixtures found.');
+    process.exit(2);
+  }
+
+  const opts: RunnerOptions = { apiKey, model: flags.model };
+  if (flags.model) console.error(`[harness] model: ${flags.model}`);
+
+  let allPassed = true;
+  let totalCost = 0;
+  const jsonReport: unknown[] = [];
+
+  for (const f of fixtures) {
+    const assertions = await loadAssertions(f.assertionsPath);
+    const label = `${f.rule}/${f.name}`;
+
+    if (flags.calibrate) {
+      const result = await calibrate(f.fixturePath, assertions, opts, flags.calibrate);
+      totalCost += result.totalCost;
+      if (!result.meetsReliabilityBar) allPassed = false;
+      if (flags.json) {
+        jsonReport.push({ label, mode: 'calibrate', result });
+      } else {
+        console.log(reportCalibrate(label, result));
+      }
+    } else {
+      const k = assertions.votes ?? flags.votes;
+      const result = await vote(f.fixturePath, assertions, opts, k);
+      totalCost += result.totalCost;
+      if (!result.agree || result.passes !== result.votes.length) allPassed = false;
+      if (flags.json) {
+        jsonReport.push({ label, mode: 'vote', result });
+      } else {
+        console.log(reportVote(label, result));
+      }
+    }
+  }
+
+  if (flags.json) {
+    process.stdout.write(
+      JSON.stringify({ allPassed, totalCost, fixtures: jsonReport }, null, 2) + '\n',
+    );
+  } else {
+    console.log('');
+    console.log(`Total cost: $${totalCost.toFixed(4)}`);
+    if (!allPassed) {
+      console.log(
+        '\n⚠️  One or more fixtures failed. Iterate prompts via /test-harness (CC mode), then re-calibrate here.',
+      );
+    }
+  }
+
+  process.exit(allPassed ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/packages/review/test/harness/runner.ts
+++ b/packages/review/test/harness/runner.ts
@@ -106,6 +106,10 @@ export async function runFixture(
     logger,
     reportUsage,
     config: {
+      // Preserve any agent options serialized into the captured fixture
+      // (blastRadius config, custom token budgets, etc.) and only override
+      // the runtime transport + API knobs the harness controls.
+      ...(ctx.config ?? {}),
       apiKey: opts.apiKey,
       model: opts.model ?? 'google/gemini-2.5-flash',
       provider: 'openai',

--- a/packages/review/test/harness/runner.ts
+++ b/packages/review/test/harness/runner.ts
@@ -1,0 +1,127 @@
+/**
+ * OpenRouter-mode runner: load a fixture, drive the real
+ * AgentReviewPlugin against it, return a HarnessResult.
+ *
+ * Costs real money per call (~$0.05/run) — only invoked from run.ts when
+ * the user has set OPENROUTER_API_KEY.
+ */
+
+import type { Logger } from '../../src/logger.js';
+import type { ReviewContext, ReviewFinding } from '../../src/plugin-types.js';
+import { AgentReviewPlugin } from '../../src/plugins/agent/index.js';
+
+import { loadFixture } from './fixture-loader.js';
+import type { HarnessResult } from './assertions.js';
+
+export interface RunnerOptions {
+  /** OpenRouter / OpenAI-compatible API key. Required. */
+  apiKey: string;
+  /** Model id. Default 'google/gemini-2.5-flash' to mirror prod. */
+  model?: string;
+  /** Base URL. Default OpenRouter's. */
+  baseUrl?: string;
+  /** Override max turns. Default the plugin's default. */
+  maxTurns?: number;
+  /** Override max tokens. Default the plugin's default. */
+  maxTokenBudget?: number;
+}
+
+interface CapturingLogger extends Logger {
+  lines: string[];
+}
+
+function makeCapturingLogger(): CapturingLogger {
+  const lines: string[] = [];
+  return {
+    lines,
+    info: (msg: string) => lines.push(`info: ${msg}`),
+    warning: (msg: string) => lines.push(`warning: ${msg}`),
+    error: (msg: string) => lines.push(`error: ${msg}`),
+    debug: (msg: string) => lines.push(`debug: ${msg}`),
+  };
+}
+
+/** Extract tool names from logger lines like "[agent] Turn 2 tools: get_files_context, read_file". */
+function extractToolCalls(lines: string[]): string[] {
+  const calls: string[] = [];
+  for (const line of lines) {
+    const match = line.match(/\[agent\] Turn \d+ tools: (.+)$/);
+    if (match) {
+      for (const name of match[1].split(',').map(s => s.trim())) {
+        if (name) calls.push(name);
+      }
+    }
+  }
+  return calls;
+}
+
+function extractTurns(lines: string[]): number {
+  let max = 0;
+  for (const line of lines) {
+    const match = line.match(/\[agent\] Turn (\d+)/);
+    if (match) {
+      const n = parseInt(match[1], 10);
+      if (n > max) max = n;
+    }
+  }
+  return max;
+}
+
+function findingsToHarness(findings: ReviewFinding[]): HarnessResult['findings'] {
+  return findings
+    .filter(f => f.category !== 'summary')
+    .map(f => ({
+      filepath: f.filepath,
+      line: f.line,
+      endLine: f.endLine,
+      symbolName: f.symbolName,
+      severity: (f.severity === 'info' ? 'warning' : f.severity) as 'error' | 'warning',
+      category: f.category,
+      message: f.message,
+      suggestion: f.suggestion,
+      evidence: f.evidence,
+      ruleId: (f.metadata as { ruleId?: string } | undefined)?.ruleId,
+    }));
+}
+
+export async function runFixture(
+  fixturePath: string,
+  opts: RunnerOptions,
+): Promise<HarnessResult & { cost: number }> {
+  const ctx = (await loadFixture(fixturePath)) as ReviewContext;
+  const logger = makeCapturingLogger();
+
+  let cost = 0;
+  const reportUsage = (usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+    cost: number;
+  }): void => {
+    cost += usage.cost;
+  };
+
+  const pluginCtx: ReviewContext = {
+    ...ctx,
+    logger,
+    reportUsage,
+    config: {
+      apiKey: opts.apiKey,
+      model: opts.model ?? 'google/gemini-2.5-flash',
+      provider: 'openai',
+      baseUrl: opts.baseUrl ?? 'https://openrouter.ai/api/v1',
+      maxTurns: opts.maxTurns ?? 15,
+      maxTokenBudget: opts.maxTokenBudget ?? 100_000,
+    },
+  };
+
+  const plugin = new AgentReviewPlugin();
+  const findings = await plugin.analyze(pluginCtx);
+
+  return {
+    findings: findingsToHarness(findings),
+    toolCalls: extractToolCalls(logger.lines),
+    turns: extractTurns(logger.lines),
+    cost,
+  };
+}

--- a/packages/review/test/harness/sweep.sh
+++ b/packages/review/test/harness/sweep.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Multi-model sweep across all canary fixtures.
+# Usage: OPENROUTER_API_KEY=… ./sweep.sh [model1 model2 ...]
+# Default models: google/gemini-2.5-flash google/gemini-3-flash-preview
+#
+# A calibration that misses the 9/10 bar exits non-zero — that's expected
+# data, not a script error. So we deliberately do NOT use `set -e` here.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ROOT=packages/review/test/harness/fixtures
+if [ "$#" -gt 0 ]; then
+  MODELS=("$@")
+else
+  MODELS=(google/gemini-2.5-flash google/gemini-3-flash-preview)
+fi
+
+# Portable equivalent of `mapfile` (bash 3.2 on macOS lacks it).
+FIXTURES=()
+while IFS= read -r line; do
+  FIXTURES+=("$line")
+done < <(find "$ROOT" -name "*.fixture.json" ! -name "placeholder*" | sort)
+
+if [ ${#FIXTURES[@]} -eq 0 ]; then
+  echo "No fixtures found under $ROOT (regenerate via capture-pr.ts)" >&2
+  exit 1
+fi
+
+OUT="${SWEEP_OUT:-/tmp/sweep-$(date +%Y%m%d-%H%M%S).txt}"
+> "$OUT"
+echo "writing results to $OUT" >&2
+
+for fixture in "${FIXTURES[@]}"; do
+  rel=${fixture#"$ROOT/"}
+  rel=${rel%.fixture.json}
+  for model in "${MODELS[@]}"; do
+    {
+      echo "=== $rel × $model ==="
+      # `|| true` so a sub-9/10 calibration (npm exit 1) doesn't stop the sweep.
+      # `grep` may also exit 1 if no lines matched (rare); tolerate that too.
+      npm run test:harness -w @liendev/review --silent -- \
+        --fixture "$fixture" --calibrate 10 --model "$model" 2>&1 \
+        | grep -E "passed|failures|Total cost|first failure" || true
+      echo ""
+    } | tee -a "$OUT"
+  done
+done
+
+echo "=== final ===" | tee -a "$OUT"

--- a/packages/review/test/harness/sweep.sh
+++ b/packages/review/test/harness/sweep.sh
@@ -7,7 +7,27 @@
 # data, not a script error. So we deliberately do NOT use `set -e` here.
 set -uo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Fail-fast preconditions — these surface clearly instead of producing
+# misleading "writing results to /tmp/sweep-…" with no actual results.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "sweep.sh: could not resolve repository root (is this a git checkout?)" >&2
+  exit 1
+}
+cd "$REPO_ROOT" || {
+  echo "sweep.sh: could not cd to $REPO_ROOT" >&2
+  exit 1
+}
+
+# OpenRouter mode (which is what sweep.sh drives) auto-loads
+# OPENROUTER_API_KEY from .env via process.loadEnvFile() in run.ts. If
+# neither env nor .env supplies it, fail before burning subprocess startup
+# time.
+if [ -z "${OPENROUTER_API_KEY:-}" ] && [ ! -f "$REPO_ROOT/.env" ]; then
+  echo "sweep.sh: OPENROUTER_API_KEY is not set and no .env found at repo root" >&2
+  echo "         (set it inline, in your shell rc, or in .env at the repo root)" >&2
+  exit 1
+fi
 
 ROOT=packages/review/test/harness/fixtures
 if [ "$#" -gt 0 ]; then

--- a/packages/review/test/harness/tsconfig.json
+++ b/packages/review/test/harness/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["../../node_modules", "../../dist", "../**/*.test.ts"]
+}

--- a/packages/review/test/harness/voting.ts
+++ b/packages/review/test/harness/voting.ts
@@ -27,6 +27,39 @@ export interface AssertedRun {
   failureTier?: 1 | 2;
 }
 
+/**
+ * Heuristic for "is this an LLM transport/runtime error worth treating as
+ * an honest Tier 1 fail" vs "this is a fixture/setup bug that should
+ * surface and abort calibration." We only downgrade the former — anything
+ * else (schema validation, missing repoChunks, programmer error in the
+ * agent plugin) re-throws so calibration crashes loudly instead of
+ * pretending the model was flaky.
+ *
+ * Match patterns the runner produces from real API failures: explicit
+ * `LLM error: ...` prefix from runner.ts, OpenAI/anthropic SDK error names,
+ * provider-side `terminated` / `fetch failed` strings, OpenRouter HTTP
+ * codes (`API error (4xx/5xx)` etc).
+ */
+const LLM_ERROR_PATTERNS = [
+  /^LLM error:/i,
+  /^API error \(/i,
+  /\bAPIError\b/,
+  /\bAnthropicError\b/,
+  /\bOpenAIError\b/,
+  /\bECONNRESET\b|\bETIMEDOUT\b|\bENOTFOUND\b|\bECONNREFUSED\b/,
+  /\bfetch failed\b/i,
+  /\bterminated\b/i,
+  /\brate ?limit\b/i,
+  /\b5\d\d\b/, // 500/502/503/504
+];
+
+function isTransientLLMError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  const name = err instanceof Error ? err.name : '';
+  const hay = `${name}: ${message}`;
+  return LLM_ERROR_PATTERNS.some(re => re.test(hay));
+}
+
 async function runOnce(
   fixturePath: string,
   assertions: FixtureAssertions,
@@ -39,15 +72,20 @@ async function runOnce(
   try {
     ({ findings, toolCalls, turns, cost } = await runFixture(fixturePath, opts));
   } catch (err) {
-    // LLM-side failure (network, 5xx, timeout). Don't crash the calibration —
-    // record it as a Tier 1 fail so the caller sees variance, not a thrown stack.
-    return {
-      result: { findings: [], toolCalls: [], turns: 0 },
-      cost: 0,
-      passed: false,
-      failureMessage: `LLM error: ${err instanceof Error ? err.message : String(err)}`,
-      failureTier: 1,
-    };
+    if (isTransientLLMError(err)) {
+      // LLM-side failure (network, 5xx, terminated). Record as a Tier 1 fail
+      // so calibration completes and the caller sees the variance.
+      return {
+        result: { findings: [], toolCalls: [], turns: 0 },
+        cost: 0,
+        passed: false,
+        failureMessage: `LLM error: ${err instanceof Error ? err.message : String(err)}`,
+        failureTier: 1,
+      };
+    }
+    // Setup/fixture/programmer error — re-throw so the run aborts loudly
+    // rather than masquerading as model flakiness across N votes.
+    throw err;
   }
 
   const result: HarnessResult = { findings, toolCalls, turns };
@@ -65,10 +103,13 @@ async function runOnce(
 }
 
 /**
- * Run K calls in parallel. Promise.all is fine here because runOnce never
- * throws on LLM-side failures (it converts them to a passed=false result),
- * so a single bad call doesn't poison the batch. OpenRouter handles 10
- * concurrent OpenAI-compat requests without rate-limit issues at our volume.
+ * Run K calls in parallel. Transient LLM errors are caught inside runOnce
+ * and become passed=false results, so flaky network/5xx doesn't poison the
+ * batch. Setup errors (fixture schema, programmer bugs) DO propagate and
+ * reject the whole calibration — that's intentional, those should surface
+ * loudly rather than masquerade as model flakiness across N votes.
+ * OpenRouter handles 10 concurrent OpenAI-compat requests without rate-limit
+ * issues at our volume.
  */
 async function runMany(
   fixturePath: string,

--- a/packages/review/test/harness/voting.ts
+++ b/packages/review/test/harness/voting.ts
@@ -1,0 +1,122 @@
+/**
+ * K-of-M voting and N-run calibration for the OpenRouter mode.
+ *
+ * vote(K): runs the fixture K times, reports agreement on Tier 1 outcomes.
+ * calibrate(N): runs N times, reports pass rate against the .assertions.ts.
+ *
+ * The 9/10 reliability bar from #538 is enforced by `calibrate(10)`.
+ */
+
+import { harness, HarnessAssertionError } from './assertions.js';
+import type { FixtureAssertions, HarnessResult } from './assertions.js';
+import { runFixture } from './runner.js';
+import type { RunnerOptions } from './runner.js';
+
+export interface VoteResult {
+  votes: AssertedRun[];
+  agree: boolean;
+  passes: number;
+  totalCost: number;
+}
+
+export interface AssertedRun {
+  result: HarnessResult;
+  cost: number;
+  passed: boolean;
+  failureMessage?: string;
+  failureTier?: 1 | 2;
+}
+
+async function runOnce(
+  fixturePath: string,
+  assertions: FixtureAssertions,
+  opts: RunnerOptions,
+): Promise<AssertedRun> {
+  let findings: HarnessResult['findings'];
+  let toolCalls: string[];
+  let turns: number;
+  let cost: number;
+  try {
+    ({ findings, toolCalls, turns, cost } = await runFixture(fixturePath, opts));
+  } catch (err) {
+    // LLM-side failure (network, 5xx, timeout). Don't crash the calibration —
+    // record it as a Tier 1 fail so the caller sees variance, not a thrown stack.
+    return {
+      result: { findings: [], toolCalls: [], turns: 0 },
+      cost: 0,
+      passed: false,
+      failureMessage: `LLM error: ${err instanceof Error ? err.message : String(err)}`,
+      failureTier: 1,
+    };
+  }
+
+  const result: HarnessResult = { findings, toolCalls, turns };
+  try {
+    assertions.expect(result, harness);
+    return { result, cost, passed: true };
+  } catch (err) {
+    if (err instanceof HarnessAssertionError) {
+      return { result, cost, passed: false, failureMessage: err.message, failureTier: err.tier };
+    }
+    // Programmer error in the .assertions.ts module (not an assertion failure)
+    // — surface clearly rather than swallow as a Tier 1 fail.
+    throw err;
+  }
+}
+
+/**
+ * Run K calls in parallel. Promise.all is fine here because runOnce never
+ * throws on LLM-side failures (it converts them to a passed=false result),
+ * so a single bad call doesn't poison the batch. OpenRouter handles 10
+ * concurrent OpenAI-compat requests without rate-limit issues at our volume.
+ */
+async function runMany(
+  fixturePath: string,
+  assertions: FixtureAssertions,
+  opts: RunnerOptions,
+  count: number,
+): Promise<AssertedRun[]> {
+  return Promise.all(Array.from({ length: count }, () => runOnce(fixturePath, assertions, opts)));
+}
+
+export async function vote(
+  fixturePath: string,
+  assertions: FixtureAssertions,
+  opts: RunnerOptions,
+  k: number = 3,
+): Promise<VoteResult> {
+  const votes = await runMany(fixturePath, assertions, opts, k);
+  const passes = votes.filter(v => v.passed).length;
+  const agree = passes === 0 || passes === k;
+  const totalCost = votes.reduce((sum, v) => sum + v.cost, 0);
+  return { votes, agree, passes, totalCost };
+}
+
+export interface CalibrateResult {
+  runs: AssertedRun[];
+  passes: number;
+  passRate: number;
+  totalCost: number;
+  /** Whether the 9/10 bar from #538 was met. Bar threshold scales with N. */
+  meetsReliabilityBar: boolean;
+}
+
+export async function calibrate(
+  fixturePath: string,
+  assertions: FixtureAssertions,
+  opts: RunnerOptions,
+  n: number = 10,
+  passThreshold?: number,
+): Promise<CalibrateResult> {
+  const threshold = passThreshold ?? assertions.passThreshold ?? Math.max(1, Math.ceil(n * 0.9));
+  const runs = await runMany(fixturePath, assertions, opts, n);
+  const passes = runs.filter(r => r.passed).length;
+  const totalCost = runs.reduce((sum, r) => sum + r.cost, 0);
+  return {
+    runs,
+    passes,
+    passRate: passes / n,
+    totalCost,
+    meetsReliabilityBar: passes >= threshold,
+  };
+}


### PR DESCRIPTION
Closes #538.

## Summary

Replays a captured PR's `ReviewContext` through `AgentReviewPlugin` so prompt + model changes can be validated **offline** against pinned assertions instead of via the deploy → synthetic-PR → kubectl-logs loop. Drove the model bump in #539 — the multi-fixture sweep showed `google/gemini-2.5-flash` missing the 9/10 reliability bar on 4 of 6 rules while `google/gemini-3-flash-preview` held 10/10 across the corpus.

## What's in this PR

| Path | Purpose |
|---|---|
| `packages/review/test/harness/run.ts`, `runner.ts`, `voting.ts`, `reporter.ts` | OpenRouter-mode runner, parallelized K-of-M voting + N-run calibration, text/JSON reporter |
| `packages/review/test/harness/assertions.ts`, `assert-cli.ts` | Tiered assertion helpers (Tier 1: rule fired / tool called; Tier 2: keyword-matched suggestion vocab; Tier 3 deliberately not exposed) + a CLI for evaluating them |
| `packages/review/test/harness/build-prompts.ts` | Shared CLI that emits `{systemPrompt, initialMessage}` from a fixture — used by both modes |
| `packages/review/test/harness/fixture-loader.ts` | JSON fixture I/O with Map / Set tagging |
| `packages/review/test/harness/capture-pr.ts` | One-off driver that snapshots a closed/historic PR's ReviewContext via a git worktree |
| `packages/review/test/harness/sweep.sh` | Multi-model sweep across the canary corpus |
| `packages/review/test/harness/fixtures/<rule>/*.assertions.ts` | One assertion file per `BUILTIN_RULES` rule (modeled after closed planted-regression PRs #520, #399, #509, #437, #411, #511) |
| `.claude/skills/test-harness/SKILL.md` | Free CC-iteration mode that spawns Claude subagents to drive the same prompts (low fidelity but free; the 9/10 bar is measured via OpenRouter) |
| `.github/workflows/harness.yml` | `workflow_dispatch`-only CI dispatch using the existing `OPENROUTER_API_KEY` secret |
| `packages/review/src/engine.ts` | Env-gated capture (`LIEN_REVIEW_CAPTURE_CTX=/path`) right after `ensureRepoChunks` so production runs can dump their ctx for offline replay |
| `packages/review/test/harness/README.md` | Authoring fixtures, running both modes, the 9/10 bar, the canary corpus runbook |

Captured `*.fixture.json` files are gitignored (~12MB each) — regenerate via `capture-pr.ts <pr-num>`. The committed pieces are the assertions, schema, helpers, and the small placeholder fixture used for skill smoke-tests.

## Reliability primitives

- **T=0** (already hardcoded in the OpenAI client; `temperature: 0`)
- **Tiered assertions** — pass at the level you can defend; Tier 3 is not exposed so you can't accidentally write a brittle exact-text match
- **K-of-M voting** with refusal to call green/red on disagreement
- **N-run calibration** (`--calibrate 10`) to enforce the 9/10 bar from #538
- **Canary tags** so model drift surfaces clearly when multiple fixtures flip together

## How it drove #539

Built the canary corpus (one fixture per rule) → swept the corpus across 5 candidate models (`gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3-flash-preview`, `deepseek-chat-v3.1`, `claude-haiku-4.5`, plus partial `kimi-k2.6`) → produced this comparison:

| Rule | gemini-2.5-flash *(prev prod)* | **gemini-3-flash-preview** *(now prod via #539)* |
|---|:---:|:---:|
| structural-analysis | 9/10 ✓ | **10/10** ✓ |
| edge-case-sweep | 7/10 ✗ | **10/10** ✓ |
| incomplete-handling | 3/10 ✗ | **10/10** ✓ |
| error-swallowing | 7/10 ✗ | **10/10** ✓ |
| concurrency-race | 8/10 ✗ | **10/10** ✓ |
| boundary-change T1 | 9/10 ✓ | **10/10** ✓ |
| boundary-change T2 (§4.3 test-pair vocab) | 0/10 ✗ | **10/10** ✓ |

Now that #539 is merged + deployed, this PR also flips on the Tier 2 §4.3 test-pair vocab check on `boundary-change/ge-5-threshold-shift.assertions.ts` (previously left commented-out pending the model bump).

Total cost of the multi-model evaluation: ~$6.

## Future-proofing

- New rules can be added to `BUILTIN_RULES` and validated end-to-end via the harness in ~30 min (already an open follow-up: #540 — `stale-duplicate` rule, born from a CodeRabbit catch on #539 itself).
- Model bumps are now a 1-line change validated in 10 min via `npm run test:harness --calibrate 10`.
- The harness is fully reproducible: `capture-pr.ts <pr-num>` regenerates any fixture, and the `sweep.sh` script runs the corpus against any model OpenRouter exposes.

## Test plan

- [ ] CI green
- [ ] Local: `OPENROUTER_API_KEY=… npm run test:harness -w @liendev/review` against the captured corpus passes
- [ ] CC mode: `/test-harness boundary-change` from a Claude Code session works end-to-end
- [ ] Manual workflow_dispatch run of `harness.yml` succeeds

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 5 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 2 | +31 |
| ⏱️ time to understand | 4 | +229 |


> [!NOTE]
> **Low Risk**
>
> The PR introduces a comprehensive offline test harness for the agent-review plugin, enabling faster iteration and reliability measurement using OpenRouter and Claude Code. The changes are well-isolated in test utilities and an environment-gated capture hook in the engine, posing minimal risk to production flows.
>
> - New offline test harness with OpenRouter and Claude Code (subagent) modes.
> - Fixture capture utility to snapshot real PR context for reproducible testing.
> - Tiered assertion system (Tier 1 for structural, Tier 2 for keyword-based).
> - Parallelized voting and calibration (K-of-M) to enforce a 9/10 reliability bar.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 713af53. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an agent-rule test harness for validating code review rules across multiple runs with voting and calibration modes.
  * Added fixture-based testing framework with configurable assertion support.

* **Documentation**
  * Added comprehensive harness documentation including setup instructions and usage examples.

* **Tests**
  * Added automated GitHub Actions workflow for rule testing and calibration.
  * Added fixture capture and assertion utilities for reproducible testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->