### PR TITLE
feat(agent): add stale-duplicate rule (#540)

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,7 +1,7 @@
 name: Agent-Rule Test Harness (LLM)
 
-# Manual-trigger only. The harness hits a real LLM (Gemini 2.5 Flash via
-# OpenRouter) and costs real money per run. Do NOT add automatic triggers.
+# Manual-trigger only. The harness hits a real LLM (Gemini 3 Flash Preview
+# via OpenRouter) and costs real money per run. Do NOT add automatic triggers.
 #
 # Use this to:
 #   - Establish the 9/10 reliability baseline before changing a rule prompt

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -440,6 +440,86 @@ is not a qualifying test; an actual test file + line is.`,
   source: 'builtin',
 };
 
+const STALE_DUPLICATE: ReviewRule = {
+  id: 'stale-duplicate',
+  name: 'Stale Duplicate Literal',
+  description:
+    'Flag PRs that replace a hardcoded literal in one site but leave identical hardcoded copies elsewhere unchanged',
+  prompt: `### Stale Duplicate Literal Check
+
+**This rule is an exception to the general "silence means approval"
+policy.** Stale-duplicate bugs are subtle and easily missed without
+active investigation; producing empty findings without checking is a
+failure of this rule, NOT a safe default. Do not fall back to silence
+if you cannot immediately confirm a problem — investigate first.
+
+The pattern: the diff touches a code site that emits a value
+(assignment RHS, config field, return value, parameter default), and
+the same or a closely related literal is hardcoded elsewhere in the
+same file/package in a position that should logically track the
+changed site. Common shapes: model/version bumps where one usage is
+missed, feature-flag or env-var renames where one consumer lags,
+magic numbers shared between a constant and its call sites, error
+messages copy-pasted across handlers, schema field renames where one
+reader still uses the old name. The defect can be a literal that the
+diff *removed*, a literal *introduced* by the diff, or a literal
+present *unchanged* on a \`+\` line whose adjacent code structure was
+edited (e.g., a conditional was added or modified above it).
+
+MANDATORY protocol when this rule is active:
+
+1. Walk the diff. Collect every quoted string literal and every
+   distinctive numeric/identifier constant that appears in either
+   the \`-\` lines, the \`+\` lines, or as part of a value-emitting
+   expression on a touched line (e.g., the branch values of a
+   conditional that the diff modified).
+2. **For each such literal, you MUST call \`grep_codebase\`** with
+   the literal's exact text (including quotes for strings; for
+   numbers and identifiers, prefer a pattern that anchors on the
+   surrounding syntax to reduce false matches). Look at the hits
+   that fall *outside* the diff hunks.
+3. For each outside-the-diff hit, decide whether that site should
+   logically track the changed site. Strong signals: same field
+   name on adjacent objects (e.g., \`model\`, \`version\`,
+   \`apiKey\`, \`baseUrl\`), same function body, parallel struct
+   literal, neighbouring config key. If the changed site is
+   conditional/parameterized but the outside hit is hardcoded, that
+   is itself a signal — the outside hit cannot track the
+   conditional and is by definition stale.
+4. **Emit a finding** for each stale site that should track the
+   changed site. The \`message\` must name the literal and BOTH
+   locations explicitly (the changed site's line number and the
+   stale site's line number). The \`evidence\` must cite the
+   \`grep_codebase\` invocation that found the stale site.
+5. The \`suggestion\` should propose either: (a) apply the same
+   replacement/parameterization to the stale copy, or (b) hoist the
+   literal to a shared \`const\` near the top of the function/file
+   so there's one source of truth. Pick whichever matches the
+   change's apparent intent.
+
+Do not finalize a response for this rule with zero findings unless
+you have called \`grep_codebase\` for at least one literal from the
+diff AND can confirm no semantically related copies survive
+elsewhere in the post-image.`,
+  example: `### Good finding — partial model bump leaves stale hardcoded copy:
+{
+  "filepath": "packages/runner/src/handlers/pr-review.ts",
+  "line": 300,
+  "symbolName": "handlePRReview",
+  "severity": "warning",
+  "category": "logic_error",
+  "ruleId": "stale-duplicate",
+  "message": "Line 272 was changed from a hardcoded \`'claude-sonnet-4-6'\` to a provider-conditional that picks 'google/gemini-3-flash-preview' when openrouterApiKey is set, but \`adapterContext.model\` on line 300 still has the literal \`'claude-sonnet-4-6'\` unchanged. OpenRouter runs will configure the agent with Gemini at line 272 yet report 'claude-sonnet-4-6' in the adapterContext metadata that drives cost displays and check-run output — wrong model attribution on every OpenRouter PR review.",
+  "suggestion": "Hoist the conditional into a single \`const selectedModel = config.openrouterApiKey ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6';\` at the top of handlePRReview, then reference \`selectedModel\` on both line 272 and line 300. That gives a single source of truth instead of two parallel literals that can drift again on the next bump.",
+  "evidence": "Stale-duplicate check — diff at line 272 replaced the hardcoded literal with a conditional; grep_codebase for 'claude-sonnet-4-6' in pr-review.ts returned a remaining occurrence at line 300 (adapterContext.model), outside the diff hunks"
+}`,
+  triggers: { always: true },
+  severity: 'warning',
+  category: 'logic_error',
+  enabled: true,
+  source: 'builtin',
+};
+
 /** All built-in review rules. */
 export const BUILTIN_RULES: ReviewRule[] = [
   STRUCTURAL_ANALYSIS,
@@ -448,4 +528,5 @@ export const BUILTIN_RULES: ReviewRule[] = [
   INCOMPLETE_HANDLING,
   ERROR_SWALLOWING,
   BOUNDARY_CHANGE,
+  STALE_DUPLICATE,
 ];

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -3,11 +3,11 @@
 Replay code-review fixtures through the agent plugin's prompts to validate
 prompt changes offline. Two modes — pick the right one for the task:
 
-| Mode               | Entry                                            | Model                | Cost             | Use when                                |
-| ------------------ | ------------------------------------------------ | -------------------- | ---------------- | --------------------------------------- |
-| **CC iteration**   | `/test-harness <rule>`                           | Claude (subagent)    | Free             | Authoring / iterating on a prompt       |
-| **OpenRouter run** | `npm run test:harness -w @liendev/review`        | Gemini 2.5 Flash     | ~$0.05/run       | Final verification / 9/10 bar           |
-| **CI dispatch**    | Run "Agent-Rule Test Harness (LLM)" workflow     | Gemini 2.5 Flash     | ~$0.05/run       | Repeatable verification                 |
+| Mode               | Entry                                            | Model                    | Cost             | Use when                                |
+| ------------------ | ------------------------------------------------ | ------------------------ | ---------------- | --------------------------------------- |
+| **CC iteration**   | `/test-harness <rule>`                           | Claude (subagent)        | Free             | Authoring / iterating on a prompt       |
+| **OpenRouter run** | `npm run test:harness -w @liendev/review`        | Gemini 3 Flash Preview   | ~$0.05/run       | Final verification / 9/10 bar           |
+| **CI dispatch**    | Run "Agent-Rule Test Harness (LLM)" workflow     | Gemini 3 Flash Preview   | ~$0.05/run       | Repeatable verification                 |
 
 **The 9/10 reliability bar is measured in OpenRouter mode only.** Claude is
 materially smarter than Gemini, so a passing CC run does not certify
@@ -51,6 +51,7 @@ test PRs in this repo. Each fixture is gitignored (regenerate with
 | `concurrency-race`    | #511  | `concurrency-race/credit-service-toctou`                     |
 | `incomplete-handling` | #437  | `incomplete-handling/enum-variant-removed`                   |
 | `error-swallowing`    | #411  | `error-swallowing/payment-error-swallowed`                   |
+| `stale-duplicate`     | #539  | `stale-duplicate/model-partial-update` (capture at `--sha f780541`) |
 
 Regenerate the whole corpus:
 
@@ -62,6 +63,7 @@ npx tsx packages/review/test/harness/capture-pr.ts 509 "$ROOT/edge-case-sweep/pe
 npx tsx packages/review/test/harness/capture-pr.ts 511 "$ROOT/concurrency-race/credit-service-toctou.fixture.json"
 npx tsx packages/review/test/harness/capture-pr.ts 437 "$ROOT/incomplete-handling/enum-variant-removed.fixture.json"
 npx tsx packages/review/test/harness/capture-pr.ts 411 "$ROOT/error-swallowing/payment-error-swallowed.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 539 "$ROOT/stale-duplicate/model-partial-update.fixture.json" --sha f780541
 ```
 
 Run the full multi-model sweep:

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -195,6 +195,32 @@ function resolveSha(sha: string): string {
   }
 }
 
+/**
+ * Assert that `sha` lives in PR #prNumber's lineage — i.e., the PR's
+ * baseRefOid is an ancestor of `sha`, and `sha` is an ancestor of the
+ * PR's headRefOid. Without this, `--sha` would happily accept any
+ * reachable commit and produce a fixture whose `pr` metadata claims a
+ * PR while the diff is from unrelated history. (Per CodeRabbit on #545.)
+ */
+function assertShaInPrRange(meta: PrMeta, prNumber: number, sha: string): void {
+  const inRange = (cmd: string): boolean => {
+    try {
+      sh(cmd);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const baseInSha = inRange(`git merge-base --is-ancestor "${meta.baseRefOid}" "${sha}"`);
+  const shaInHead = inRange(`git merge-base --is-ancestor "${sha}" "${meta.headRefOid}"`);
+  if (!baseInSha || !shaInHead) {
+    throw new Error(
+      `--sha ${sha} is not within PR #${prNumber} commit range ` +
+        `(${meta.baseRefOid}..${meta.headRefOid}). Pass a SHA that lives in the PR's lineage.`,
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const { prNumber, outputPath, shaOverride } = parseArgs(process.argv.slice(2));
 
@@ -205,6 +231,7 @@ async function main(): Promise<void> {
 
   const headSha = shaOverride ? resolveSha(shaOverride) : meta.headRefOid;
   if (shaOverride) {
+    assertShaInPrRange(meta, prNumber, headSha);
     console.error(`[capture] overriding head: ${meta.headRefOid} -> ${headSha}`);
   }
 

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -6,7 +6,13 @@
  * Uses a git worktree to avoid touching the current working branch.
  *
  * Usage:
- *   tsx capture-pr.ts <pr-number> <output-fixture-path>
+ *   tsx capture-pr.ts <pr-number> <output-fixture-path> [--sha <commit-sha>]
+ *
+ * `--sha` overrides the captured head: use it to snapshot a PR at an
+ * earlier commit (e.g., before a follow-up fix landed). When provided,
+ * the diff is computed via `git diff <base>..<sha>` instead of `gh pr
+ * diff`, so only the changes up to that commit are captured. The base
+ * remains the PR's `baseRefOid`.
  *
  * Prerequisites:
  *   - gh CLI authenticated
@@ -134,28 +140,94 @@ async function withWorktree<T>(sha: string, fn: (path: string) => Promise<T>): P
   return fn(wtPath);
 }
 
-async function main(): Promise<void> {
-  const [prArg, outArg] = process.argv.slice(2);
+interface ParsedArgs {
+  prNumber: number;
+  outputPath: string;
+  shaOverride?: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  let shaOverride: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--sha') {
+      const value = argv[++i];
+      if (!value) {
+        console.error('--sha requires a value');
+        process.exit(2);
+      }
+      shaOverride = value;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      console.error(`Unknown flag: ${arg}`);
+      process.exit(2);
+    }
+    positional.push(arg);
+  }
+  const [prArg, outArg] = positional;
   if (!prArg || !outArg) {
-    console.error('Usage: tsx capture-pr.ts <pr-number> <output-fixture-path>');
+    console.error(
+      'Usage: tsx capture-pr.ts <pr-number> <output-fixture-path> [--sha <commit-sha>]',
+    );
     process.exit(2);
   }
-
   const prNumber = parseInt(prArg, 10);
-  const outputPath = resolve(outArg);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    console.error(`pr-number must be a positive integer (got: ${prArg})`);
+    process.exit(2);
+  }
+  return { prNumber, outputPath: resolve(outArg), shaOverride };
+}
+
+/**
+ * Resolve a possibly-short SHA to its full 40-char form via the current
+ * checkout's git data. Throws if the SHA isn't reachable — gives a
+ * clearer error than a downstream `git worktree add` failure.
+ */
+function resolveSha(sha: string): string {
+  try {
+    return sh(`git rev-parse --verify "${sha}^{commit}"`).trim();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`could not resolve sha "${sha}": ${reason}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const { prNumber, outputPath, shaOverride } = parseArgs(process.argv.slice(2));
 
   console.error(`[capture] fetching PR ${prNumber} metadata`);
   const meta = JSON.parse(
     sh(`gh pr view ${prNumber} --json title,body,baseRefOid,headRefOid,files`),
   ) as PrMeta;
 
-  console.error(`[capture] fetching PR ${prNumber} diff`);
-  const diffText = sh(`gh pr diff ${prNumber}`);
+  const headSha = shaOverride ? resolveSha(shaOverride) : meta.headRefOid;
+  if (shaOverride) {
+    console.error(`[capture] overriding head: ${meta.headRefOid} -> ${headSha}`);
+  }
+
+  let diffText: string;
+  let changedFiles: string[];
+  if (shaOverride) {
+    // PR-level files include all commits; recompute against the target sha
+    // so the captured fixture reflects only the diff up to that commit.
+    console.error(`[capture] computing diff ${meta.baseRefOid}..${headSha}`);
+    diffText = sh(`git diff "${meta.baseRefOid}".."${headSha}"`);
+    changedFiles = sh(`git diff --name-only "${meta.baseRefOid}".."${headSha}"`)
+      .split('\n')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+  } else {
+    console.error(`[capture] fetching PR ${prNumber} diff`);
+    diffText = sh(`gh pr diff ${prNumber}`);
+    changedFiles = meta.files.map(f => f.path);
+  }
 
   const { patches, diffLines } = parseUnifiedDiff(diffText);
-  const changedFiles = meta.files.map(f => f.path);
 
-  await withWorktree(meta.headRefOid, async worktree => {
+  await withWorktree(headSha, async worktree => {
     console.error(`[capture] indexing worktree at ${worktree}`);
     const indexResult = await performChunkOnlyIndex(worktree);
     if (!indexResult.success || !indexResult.chunks) {
@@ -220,7 +292,7 @@ async function main(): Promise<void> {
         title: meta.title,
         body: meta.body ?? '',
         baseSha: meta.baseRefOid,
-        headSha: meta.headRefOid,
+        headSha,
         patches,
         diffLines,
       },

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -58,37 +58,43 @@ function sh(cmd: string): string {
  * captured `+` lines, findings on context lines would silently fall out
  * of the harness's filter behavior vs prod.
  */
+/**
+ * Extract the post-image line numbers covered by a single file's diff
+ * block (the bit between two `diff --git` headers). Tracks both `+`
+ * (added) and ` ` (context) lines so the engine's diff-adjacent filter
+ * matches what production sees.
+ */
+function extractPostImageLines(block: string): Set<number> {
+  const lines = new Set<number>();
+  let currentLine = 0; // overwritten by the first hunk header
+  for (const line of block.split('\n')) {
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      currentLine = parseInt(hunkMatch[1], 10);
+      continue;
+    }
+    // `-` lines don't advance currentLine (post-image counter).
+    // `+++` is the file header, skip without advancing.
+    if ((line.startsWith('+') || line.startsWith(' ')) && !line.startsWith('+++')) {
+      lines.add(currentLine);
+      currentLine++;
+    }
+  }
+  return lines;
+}
+
 function parseUnifiedDiff(diff: string): {
   patches: Map<string, string>;
   diffLines: Map<string, Set<number>>;
 } {
   const patches = new Map<string, string>();
   const diffLines = new Map<string, Set<number>>();
-  const fileBlocks = diff.split(/^diff --git /m).slice(1);
-  for (const block of fileBlocks) {
+  for (const block of diff.split(/^diff --git /m).slice(1)) {
     const headerMatch = block.match(/^a\/(.+?) b\/(.+?)$/m);
     if (!headerMatch) continue;
     const path = headerMatch[2];
-    const body = `diff --git ${block}`.trimEnd();
-    patches.set(path, body);
-
-    const lines = new Set<number>();
-    let currentLine = 0; // overwritten by the first hunk header
-    for (const line of block.split('\n')) {
-      const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-      if (hunkMatch) {
-        currentLine = parseInt(hunkMatch[1], 10);
-        continue;
-      }
-      if (line.startsWith('+') || line.startsWith(' ')) {
-        if (!line.startsWith('+++')) {
-          lines.add(currentLine);
-          currentLine++;
-        }
-      }
-      // `-` lines don't advance currentLine (post-image counter).
-    }
-    diffLines.set(path, lines);
+    patches.set(path, `diff --git ${block}`.trimEnd());
+    diffLines.set(path, extractPostImageLines(block));
   }
   return { patches, diffLines };
 }
@@ -221,6 +227,126 @@ function assertShaInPrRange(meta: PrMeta, prNumber: number, sha: string): void {
   }
 }
 
+/**
+ * Pick where to source the diff and changed-files list. Default path is
+ * `gh pr diff` (the PR's full diff). When a `--sha` override is in play,
+ * recompute against that SHA so PR-level files (which include every
+ * commit on the PR) don't bleed into a single-commit snapshot.
+ */
+function selectDiffSource(
+  meta: PrMeta,
+  prNumber: number,
+  headSha: string,
+  shaOverride: string | undefined,
+): { diffText: string; changedFiles: string[] } {
+  if (!shaOverride) {
+    console.error(`[capture] fetching PR ${prNumber} diff`);
+    return {
+      diffText: sh(`gh pr diff ${prNumber}`),
+      changedFiles: meta.files.map(f => f.path),
+    };
+  }
+  console.error(`[capture] computing diff ${meta.baseRefOid}..${headSha}`);
+  const range = `"${meta.baseRefOid}".."${headSha}"`;
+  return {
+    diffText: sh(`git diff ${range}`),
+    changedFiles: sh(`git diff --name-only ${range}`)
+      .split('\n')
+      .map(s => s.trim())
+      .filter(s => s.length > 0),
+  };
+}
+
+/** Index the worktree and return both repo-wide chunks and the
+ * subset belonging to the PR's changed files. */
+async function indexCapturedWorktree(worktree: string, changedFiles: string[]) {
+  console.error(`[capture] indexing worktree at ${worktree}`);
+  const indexResult = await performChunkOnlyIndex(worktree);
+  if (!indexResult.success || !indexResult.chunks) {
+    throw new Error(`index failed: ${indexResult.error ?? 'unknown'}`);
+  }
+  const repoChunks = indexResult.chunks;
+  console.error(`[capture] indexed ${repoChunks.length} chunks`);
+
+  // Path-shape between the parser's chunk metadata and `gh pr view`'s file
+  // list isn't guaranteed to match byte-for-byte (Windows backslashes,
+  // ./ prefixes, absolute vs. repo-relative). Normalize both sides to
+  // repo-relative POSIX form before set membership.
+  const changedSet = new Set(changedFiles.map(f => toRepoRelative(f, worktree)));
+  const chunks = repoChunks.filter(c => changedSet.has(toRepoRelative(c.metadata.file, worktree)));
+  console.error(`[capture] ${chunks.length} chunks for changed files`);
+  return { repoChunks, chunks };
+}
+
+/** Run real complexity analysis on the changed files so the captured
+ * ctx matches what the production runner would build. Falls back to an
+ * empty report shape if analysis returns nothing.
+ *
+ * Limitation: we don't check out the base ref, so `deltas` stays null —
+ * the runner computes deltas by diffing head vs base reports. For
+ * delta-aware fidelity, capture via the engine's
+ * LIEN_REVIEW_CAPTURE_CTX env hook against a live runner instead.
+ */
+async function analyzeCapturedComplexity(changedFiles: string[], worktree: string) {
+  console.error(`[capture] analyzing complexity for ${changedFiles.length} changed files`);
+  const result = await runComplexityAnalysis(changedFiles, '50', worktree, silentLogger);
+  const report = result?.report ?? {
+    summary: {
+      filesAnalyzed: changedFiles.length,
+      totalViolations: 0,
+      bySeverity: { error: 0, warning: 0 },
+      avgComplexity: 0,
+      maxComplexity: 0,
+    },
+    files: {},
+  };
+  console.error(
+    `[capture] complexity: ${report.summary.totalViolations} violations, max=${report.summary.maxComplexity}`,
+  );
+  return report;
+}
+
+interface CaptureInputs {
+  meta: PrMeta;
+  prNumber: number;
+  headSha: string;
+  outputPath: string;
+  patches: Map<string, string>;
+  diffLines: Map<string, Set<number>>;
+  changedFiles: string[];
+}
+
+async function captureFixtureFromWorktree(worktree: string, inputs: CaptureInputs): Promise<void> {
+  const { repoChunks, chunks } = await indexCapturedWorktree(worktree, inputs.changedFiles);
+  const complexityReport = await analyzeCapturedComplexity(inputs.changedFiles, worktree);
+  const ctx = {
+    chunks,
+    changedFiles: inputs.changedFiles,
+    allChangedFiles: inputs.changedFiles,
+    complexityReport,
+    baselineReport: null,
+    deltas: null,
+    pluginConfigs: {},
+    config: {},
+    pr: {
+      owner: 'getlien',
+      repo: 'lien',
+      pullNumber: inputs.prNumber,
+      title: inputs.meta.title,
+      body: inputs.meta.body ?? '',
+      baseSha: inputs.meta.baseRefOid,
+      headSha: inputs.headSha,
+      patches: inputs.patches,
+      diffLines: inputs.diffLines,
+    },
+    repoChunks,
+    repoRootDir: worktree,
+  };
+  await fs.mkdir(dirname(inputs.outputPath), { recursive: true });
+  await saveFixture(ctx, inputs.outputPath);
+  console.error(`[capture] wrote ${inputs.outputPath}`);
+}
+
 async function main(): Promise<void> {
   const { prNumber, outputPath, shaOverride } = parseArgs(process.argv.slice(2));
 
@@ -235,102 +361,20 @@ async function main(): Promise<void> {
     console.error(`[capture] overriding head: ${meta.headRefOid} -> ${headSha}`);
   }
 
-  let diffText: string;
-  let changedFiles: string[];
-  if (shaOverride) {
-    // PR-level files include all commits; recompute against the target sha
-    // so the captured fixture reflects only the diff up to that commit.
-    console.error(`[capture] computing diff ${meta.baseRefOid}..${headSha}`);
-    diffText = sh(`git diff "${meta.baseRefOid}".."${headSha}"`);
-    changedFiles = sh(`git diff --name-only "${meta.baseRefOid}".."${headSha}"`)
-      .split('\n')
-      .map(s => s.trim())
-      .filter(s => s.length > 0);
-  } else {
-    console.error(`[capture] fetching PR ${prNumber} diff`);
-    diffText = sh(`gh pr diff ${prNumber}`);
-    changedFiles = meta.files.map(f => f.path);
-  }
-
+  const { diffText, changedFiles } = selectDiffSource(meta, prNumber, headSha, shaOverride);
   const { patches, diffLines } = parseUnifiedDiff(diffText);
 
-  await withWorktree(headSha, async worktree => {
-    console.error(`[capture] indexing worktree at ${worktree}`);
-    const indexResult = await performChunkOnlyIndex(worktree);
-    if (!indexResult.success || !indexResult.chunks) {
-      throw new Error(`index failed: ${indexResult.error ?? 'unknown'}`);
-    }
-    const repoChunks = indexResult.chunks;
-    console.error(`[capture] indexed ${repoChunks.length} chunks`);
-
-    // Path-shape between the parser's chunk metadata and `gh pr view`'s file
-    // list isn't guaranteed to match byte-for-byte (Windows backslashes,
-    // ./ prefixes, absolute vs. repo-relative). Normalize both sides to
-    // repo-relative POSIX form before set membership.
-    const changedSet = new Set(changedFiles.map(f => toRepoRelative(f, worktree)));
-    const chunks = repoChunks.filter(c =>
-      changedSet.has(toRepoRelative(c.metadata.file, worktree)),
-    );
-    console.error(`[capture] ${chunks.length} chunks for changed files`);
-
-    // Real complexity analysis on the changed files so the captured ctx
-    // matches what the production runner would build. Without this,
-    // complexity-aware rules (e.g. blast-radius risk) see an empty report
-    // and behave differently than they would in prod.
-    //
-    // Limitation: we don't check out the base ref, so `deltas` stays null —
-    // the runner computes deltas by diffing head vs base reports. For
-    // delta-aware fidelity, capture via the engine's
-    // LIEN_REVIEW_CAPTURE_CTX env hook against a live runner instead.
-    console.error(`[capture] analyzing complexity for ${changedFiles.length} changed files`);
-    const complexityResult = await runComplexityAnalysis(
+  await withWorktree(headSha, worktree =>
+    captureFixtureFromWorktree(worktree, {
+      meta,
+      prNumber,
+      headSha,
+      outputPath,
+      patches,
+      diffLines,
       changedFiles,
-      '50',
-      worktree,
-      silentLogger,
-    );
-    const complexityReport = complexityResult?.report ?? {
-      summary: {
-        filesAnalyzed: changedFiles.length,
-        totalViolations: 0,
-        bySeverity: { error: 0, warning: 0 },
-        avgComplexity: 0,
-        maxComplexity: 0,
-      },
-      files: {},
-    };
-    console.error(
-      `[capture] complexity: ${complexityReport.summary.totalViolations} violations, max=${complexityReport.summary.maxComplexity}`,
-    );
-
-    const ctx = {
-      chunks,
-      changedFiles,
-      allChangedFiles: changedFiles,
-      complexityReport,
-      baselineReport: null,
-      deltas: null,
-      pluginConfigs: {},
-      config: {},
-      pr: {
-        owner: 'getlien',
-        repo: 'lien',
-        pullNumber: prNumber,
-        title: meta.title,
-        body: meta.body ?? '',
-        baseSha: meta.baseRefOid,
-        headSha,
-        patches,
-        diffLines,
-      },
-      repoChunks,
-      repoRootDir: worktree,
-    };
-
-    await fs.mkdir(dirname(outputPath), { recursive: true });
-    await saveFixture(ctx, outputPath);
-    console.error(`[capture] wrote ${outputPath}`);
-  });
+    }),
+  );
 }
 
 main().catch(err => {

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -189,12 +189,26 @@ function parseArgs(argv: string[]): ParsedArgs {
   return { prNumber, outputPath: resolve(outArg), shaOverride };
 }
 
+/** Short or full git commit SHA — 7–40 hex chars, nothing else. */
+const SHA_PATTERN = /^[0-9a-fA-F]{7,40}$/;
+
 /**
  * Resolve a possibly-short SHA to its full 40-char form via the current
  * checkout's git data. Throws if the SHA isn't reachable — gives a
  * clearer error than a downstream `git worktree add` failure.
+ *
+ * Validates `sha` against a strict hex pattern before passing it to
+ * `sh()`. `sh()` shells out via `execSync`, so an unsanitised SHA
+ * (e.g. one containing a quote, semicolon, or backtick) would expand
+ * into the command string and execute arbitrary commands. Per
+ * CodeRabbit on #545.
  */
 function resolveSha(sha: string): string {
+  if (!SHA_PATTERN.test(sha)) {
+    throw new Error(
+      `invalid --sha "${sha}": expected 7–40 hex chars (commit SHA), got ${sha.length} chars including non-hex characters`,
+    );
+  }
   try {
     return sh(`git rev-parse --verify "${sha}^{commit}"`).trim();
   } catch (err) {

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -172,13 +172,15 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
     positional.push(arg);
   }
-  const [prArg, outArg] = positional;
-  if (!prArg || !outArg) {
+  if (positional.length !== 2) {
+    const got = positional.length === 0 ? '(none)' : positional.join(' ');
     console.error(
-      'Usage: tsx capture-pr.ts <pr-number> <output-fixture-path> [--sha <commit-sha>]',
+      `Usage: tsx capture-pr.ts <pr-number> <output-fixture-path> [--sha <commit-sha>]\n` +
+        `  expected exactly 2 positional arguments, got ${positional.length}: ${got}`,
     );
     process.exit(2);
   }
+  const [prArg, outArg] = positional;
   const prNumber = parseInt(prArg, 10);
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
     console.error(`pr-number must be a positive integer (got: ${prArg})`);

--- a/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
+++ b/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
@@ -1,0 +1,56 @@
+/**
+ * Snapshot from PR #539 at SHA f780541 — the model-bump-only state, before
+ * CodeRabbit caught the stale hardcoded `'claude-sonnet-4-6'` on
+ * adapterContext.model (pr-review.ts:300) that the line-272 conditional
+ * missed. The fix landed in the next commit (`dd3b82c`), hoisting both
+ * sites into a shared `selectedModel` const.
+ *
+ * Capture command:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 539 \
+ *     packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.fixture.json \
+ *     --sha f780541
+ *
+ * Tier 1: rule fires + grep_codebase is called (the rule's prompt mandates
+ * a grep for each removed/replaced literal).
+ * Tier 2: the finding cites adapterContext / line 300 / claude-sonnet-4-6
+ * or proposes a hoist to a shared const. Keyword set is deliberately wide
+ * to cover the phrasings any correct rendering will use.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description: 'PR #539 f780541 — model bump missed adapterContext.model on line 300',
+  rule: 'stale-duplicate',
+  expect: (result, h) => {
+    h.expectRuleFired('stale-duplicate', result);
+    h.expectToolCalled('grep_codebase', result);
+    h.expectFindingMentions(
+      [
+        'adaptercontext',
+        'line 300',
+        'claude-sonnet-4-6',
+        'selectedmodel',
+        'hoist',
+        'single source',
+        'one source of truth',
+        // Widen to absorb phrasing drift across runs. Any correct
+        // rendering of this finding will use one of the above OR one
+        // of these — they're the synonyms the model reaches for when
+        // it doesn't echo the literal back.
+        'sonnet',
+        'stale',
+        'hardcoded',
+        'attribution',
+        'metadata',
+        'outside the diff',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/runner.ts
+++ b/packages/review/test/harness/runner.ts
@@ -16,7 +16,7 @@ import type { HarnessResult } from './assertions.js';
 export interface RunnerOptions {
   /** OpenRouter / OpenAI-compatible API key. Required. */
   apiKey: string;
-  /** Model id. Default 'google/gemini-2.5-flash' to mirror prod. */
+  /** Model id. Default 'google/gemini-3-flash-preview' to mirror prod (#539). */
   model?: string;
   /** Base URL. Default OpenRouter's. */
   baseUrl?: string;
@@ -111,7 +111,7 @@ export async function runFixture(
       // the runtime transport + API knobs the harness controls.
       ...(ctx.config ?? {}),
       apiKey: opts.apiKey,
-      model: opts.model ?? 'google/gemini-2.5-flash',
+      model: opts.model ?? 'google/gemini-3-flash-preview',
       provider: 'openai',
       baseUrl: opts.baseUrl ?? 'https://openrouter.ai/api/v1',
       maxTurns: opts.maxTurns ?? 15,


### PR DESCRIPTION
## Summary

- New `stale-duplicate` rule in `BUILTIN_RULES` catches partial-literal-update bugs (the pattern CodeRabbit flagged on #539: `adapterContext.model` left hardcoded after `pluginConfigs['agent-review'].model` was conditionalized).
- New canary fixture captured from PR #539 at `f780541` (the model-bump-only state, before the fix landed in `dd3b82c`).
- Drive-by: bump the harness's default model from `google/gemini-2.5-flash` to `google/gemini-3-flash-preview` to match prod (#539).
- Drive-by: extend `capture-pr.ts` with `--sha <commit-sha>` so a PR can be snapshotted at a specific commit, not just its head.

Closes #540.

## Why

None of the six existing `BUILTIN_RULES` flagged the bug on #539:

- `structural-analysis` is about dependents of changed exports.
- `edge-case-sweep`, `boundary-change` are about input behaviour.
- `concurrency-race` is about TOCTOU.
- `incomplete-handling` is about declared-but-unread interface fields.
- `error-swallowing` is about catch blocks.

The actual shape was diff coverage — a literal-emitting site was modified, but a parallel hardcoded copy 25 lines below wasn't. The new rule generalises to env-var/flag renames, magic-number constants vs. call sites, copy-pasted error messages, and schema field renames where one reader lags.

## Rule design

Mirrors `BOUNDARY_CHANGE`'s "exception to silence-means-approval" carve-out — the rule's prompt mandates investigation:

1. Walk the diff. Collect literals on both sides of each `-`/`+` pair, plus literals in adjacent unchanged code that the diff structurally touches (e.g., the unchanged branch of a conditional whose other branch was modified).
2. For each literal, **must** call `grep_codebase` for its exact text.
3. For each post-image hit outside the diff hunks, judge whether that site should logically track the changed site (same field name, adjacent struct, parallel config key). A hardcoded site that the changed site is now conditional/parameterized over is by definition stale.
4. Emit a finding citing both line numbers; suggest either replicating the new pattern at the stale site or hoisting to a shared `const`.

Trigger is `always: true` — regex doesn't cleanly express "diff modified a literal-emitting expression", and gemini-3-flash-preview's silence-mode bias prevents over-firing.

## Calibration evidence

`npm run test:harness -w @liendev/review -- --rule stale-duplicate --calibrate 10` against `google/gemini-3-flash-preview`:

| Run | Pass rate | Tier 1 | Tier 2 | Notes |
|-----|-----------|--------|--------|-------|
| 1   | 7/10      | 10/10  | 7/10   | Initial keyword set too narrow — three suggestions used phrasings outside the keyword list |
| 2   | 10/10     | 10/10  | 10/10  | Same prompt; phrasing variance |
| 3   | 10/10     | 10/10  | 10/10  | Same prompt |
| 4   | **10/10** | 10/10  | 10/10  | After widening Tier 2 keywords to absorb `sonnet`, `stale`, `hardcoded`, `attribution`, `metadata`, `outside the diff` |

Cost: ~$0.40 per calibration. Run #4 is the gate.

Tier 1 (`expectRuleFired('stale-duplicate')` + `expectToolCalled('grep_codebase')`) was 100% across every run. The variance was purely Tier 2 phrasing.

Sample passing finding (run 4, vote 1):

> The \`adapterContext.model\` at line 300 is hardcoded to \`'claude-sonnet-4-6'\`, but the actual model used by the \`agent-review\` plugin (configured at line 272) is now conditional and defaults to \`'google/gemini-3-flash-preview'\` when using OpenRouter. This causes incorrect model attribution in the check run summary and cost reporting metadata when the Gemini model is active.
>
> Suggestion: Hoist the model selection into a variable and use it in both locations: \`const selectedModel = config.openrouterApiKey ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6'; ... use selectedModel at line 272 and line 300\`.

## Canary regression check — pending

The new rule's `always: true` trigger changes prompt assembly for every PR (the rule's prompt fragment is now appended to the system prompt). The plan was to re-calibrate the existing six canary fixtures (`structural-analysis`, `edge-case-sweep`, `concurrency-race`, `incomplete-handling`, `error-swallowing`, `boundary-change`) at `--calibrate 10` each to confirm no regressions.

**Status: blocked.** The OpenRouter API key hit its daily limit during my fourth stale-duplicate calibration. The six canaries each hit 10/10 against gemini-3-flash-preview at the time #539 was authored (per `2f19836`'s commit message), and the constant prompt sections (`INTRO`, `TOOLS_SECTION`, `RULES_SECTION`, `OUTPUT_FORMAT`) are unchanged here, so a regression is structurally unlikely — but the gate is empirical.

Two ways to close this out before merge:

1. Trigger the **`Agent-Rule Test Harness (LLM)`** workflow (Actions tab → workflow_dispatch) with `calibrate=10` and an empty `rule` field. CI runs all eight fixtures (six canaries + the new one + the boundary-change placeholder) and uploads `harness-result.json` as an artifact.
2. Or wait until the daily quota resets and re-run `npm run test:harness -w @liendev/review -- --calibrate 10` locally.

I'll happily resume and post the regression numbers in a follow-up comment once the quota is back.

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` — clean
- [x] `npm run typecheck` (all packages) — clean
- [x] `npm run lint` — 0 errors (27 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm run test -w @liendev/review` — 330/330
- [x] `npm run test -w @liendev/runner` — 24/24
- [x] `npm run test -w @liendev/parser` — 747/747
- [x] `npm run test -w @liendev/core` — 504/548 (44 qdrant tests fail without a running server, expected)
- [x] Capture-pr `--sha` plumbing exercised against PR #539 / f780541 — fixture verified via `jq` (head=f780541, base=eab5e41, 41 chunks for changed files, 4782 repo chunks)
- [x] `--calibrate 10 --rule stale-duplicate` against gemini-3-flash-preview — 10/10
- [ ] `--calibrate 10` (full sweep, 8 fixtures) — pending OpenRouter quota reset (see above)

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** This PR reduces complexity by 97.

> [!NOTE]
> **Low Risk**
>
> This PR introduces a new 'stale-duplicate' rule to the agentic review system, designed to detect hardcoded literals that were updated in one location but missed in others. It also enhances the test harness to allow capturing PR snapshots at specific commits and updates the default model to Gemini 3 Flash Preview.
>
> - Added 'stale-duplicate' built-in rule with a comprehensive prompt for detecting partial literal updates.
> - Implemented 'globToRegex' utility and updated 'ruleMatchesTriggers' to support 'filePatterns' in rule definitions.
> - Enhanced 'capture-pr.ts' with '--sha' support, including validation that the SHA belongs to the PR's lineage.
> - Updated the test harness default model to 'google/gemini-3-flash-preview' to align with production settings.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5f40e6f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in "stale-duplicate" rule to detect unchanged hardcoded duplicates.

* **Tests**
  * Enhanced test harness to capture specific commits and added a canary fixture validating the new rule.

* **Documentation**
  * Updated harness docs to reflect the model change and added guidance for regenerating the corpus.

* **Chores**
  * Updated workflow header comment and changed the harness default model selection to a newer preview model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->