### PR TITLE
feat(agent): add untrusted-input-validation rule (#543)

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -520,6 +520,131 @@ elsewhere in the post-image.`,
   source: 'builtin',
 };
 
+const UNTRUSTED_INPUT_VALIDATION: ReviewRule = {
+  id: 'untrusted-input-validation',
+  name: 'Untrusted Input Validation',
+  description:
+    'Flag code that parses untrusted input (JSON, env, argv, request body, file contents) and lets the parsed result flow to a typed consumer without runtime validation',
+  prompt: `### Untrusted Input Validation Check
+
+**This rule is an exception to the general "silence means approval"
+policy.** When a diff parses untrusted input, an unguarded value
+escaping into typed consumer code is a real bug — silence is not a
+safe default. Investigate every parse site introduced or modified by
+the diff before deciding the rule has nothing to say.
+
+The pattern: a function reads untrusted bytes — \`JSON.parse\`,
+\`process.env\` / \`os.getenv\` / \`System.getenv\` / \`ENV[…]\`,
+\`process.argv\` consumed via \`parseInt\` / \`Integer.parseInt\` /
+\`strconv.Atoi\` / \`int(…)\`, schema-validated payload (Zod /
+Pydantic / struct-tag / Bean Validation / serde), file contents — and
+the parsed result flows to a typed consumer without runtime
+validation. \`as Type\`, \`Partial<T>\`, \`@ts-expect-error\`,
+defensive defaults, and TypeScript narrowing alone are NOT validation.
+
+MANDATORY protocol when this rule is active:
+
+1. Walk the diff. Identify every site that produces a value from
+   untrusted bytes (the keyword set above is a hint — if the diff
+   contains one, there's at least one site to inspect).
+2. **For each site, you MUST call \`get_files_context\` (or
+   \`read_file\`)** on the function and on each consumer of the parsed
+   value. Trace the parsed value to its uses. Look for one of these
+   four unguarded shapes:
+   - **Cast-without-validate**: \`JSON.parse(raw) as MyType\`,
+     \`Partial<T>\` casts, raw \`json.loads(s)\` consumed via attribute
+     access, \`json.Unmarshal(b, &v)\` whose \`err\` is dropped.
+   - **Schema gaps**: a Zod / Pydantic / struct-tag schema that omits
+     a field the consumer reads. The consumer compiles fine because
+     of the type narrowing the schema produces, but a real-world
+     payload missing the field surfaces as a runtime crash deeper in.
+   - **NaN-on-parse**: \`parseInt\` / \`int(s)\` / \`strconv.Atoi\` /
+     \`Integer.parseInt\` whose failure return (NaN, exception,
+     \`(0, err)\`) is not checked before the value is used numerically.
+   - **Blank-keyword / truthy-coerce**: empty-string, zero, or null
+     slipping past a truthiness check (\`if (x)\`, \`if x:\`) that
+     should have been a typed check (\`x !== undefined\`,
+     \`isinstance(x, int)\`).
+3. Emit a finding for each unguarded path. The \`message\` must name
+   the parse site by line, the consumer by line, and the exact
+   malformed input (e.g. \`{"findings": {}}\`,
+   \`--votes foo\`, missing \`complexityReport\` field) that survives
+   the cast and crashes the consumer.
+4. The \`evidence\` must cite the consumer code that reads the
+   unvalidated value — quote the access pattern (e.g.
+   \`.findings.length\`, \`config.x\` numeric ops). Don't just say
+   "the cast is the only validation" without naming a specific
+   downstream read.
+5. The \`suggestion\` should propose a concrete fix:
+   parse-as-unknown-then-validate (\`Array.isArray\`, \`typeof === 'number'\`),
+   schema completion (add the missing fields), \`Number.isFinite\` /
+   \`Number.isInteger\` guard, or \`x !== ''\` / \`isinstance(x, T)\`
+   typed check.
+
+Do not finalize a response for this rule with zero findings unless
+you have called \`get_files_context\` on the parse-site function AND
+on each downstream consumer AND none of the four unguarded shapes
+matches.`,
+  example: `### Good finding — cast-without-validate (CodeRabbit on PR #541):
+{
+  "filepath": "packages/review/test/harness/assert-cli.ts",
+  "line": 38,
+  "symbolName": "loadResult",
+  "severity": "warning",
+  "category": "logic_error",
+  "ruleId": "untrusted-input-validation",
+  "message": "loadResult parses an arbitrary JSON file via JSON.parse and casts the result to Partial<HarnessResult>. A malformed file like {\\"findings\\": {}} (object instead of array) will pass the cast but later fail inside the assertion runner with a misleading 'findings.length is not a function' rather than a clean exit-3 loader error. The downstream code at lines 65–94 reads .findings.length, .toolCalls.some, and .turns numerically — none are guarded.",
+  "suggestion": "Parse as unknown, then validate: type-check parsed.findings (Array.isArray), parsed.toolCalls (Array.isArray), and parsed.turns (typeof === 'number') before constructing the HarnessResult. Throw a descriptive error that the caller can surface as exit 3.",
+  "evidence": "Inspected loadResult and its callers in main(); the cast is the only validation layer. Consumer at line 67 calls parsed.findings.some(...) which crashes on a non-array."
+}
+
+### Good finding — NaN-on-parse:
+{
+  "filepath": "packages/review/test/harness/run.ts",
+  "line": 49,
+  "symbolName": "parseFlags",
+  "severity": "warning",
+  "category": "logic_error",
+  "ruleId": "untrusted-input-validation",
+  "message": "parseFlags accepts --votes and --calibrate via parseInt(argv[++i], 10) without checking for NaN. \`--votes foo\` produces NaN and silently propagates: vote() then runs Promise.all(new Array(NaN)) which is an empty array, the calibration shows 0/0 passed, and the user gets no error indication that their flag was malformed.",
+  "suggestion": "Use a Number.isInteger guard: const n = Number(argv[++i]); if (!Number.isInteger(n) || n <= 0) { console.error('--votes requires a positive integer'); process.exit(2); }. Same for --calibrate.",
+  "evidence": "Phase 2 untrusted-input check — parseInt return value flows directly into flags.votes / flags.calibrate, then into vote() and calibrate() at run.ts:218–227 which use the value as an array length."
+}`,
+  triggers: {
+    keywords: [
+      // JS / TS
+      '\\bJSON\\.parse\\b',
+      '\\bprocess\\.env\\b',
+      '\\bprocess\\.argv\\b',
+      '\\bparseInt\\b',
+      // Python
+      '\\bjson\\.loads\\b',
+      '\\bos\\.environ\\b',
+      '\\bos\\.getenv\\b',
+      // Go
+      '\\bjson\\.Unmarshal\\b',
+      '\\bos\\.Getenv\\b',
+      '\\bstrconv\\.Atoi\\b',
+      // Java
+      '\\breadValue\\b',
+      '\\bSystem\\.getenv\\b',
+      '\\bInteger\\.parseInt\\b',
+      // PHP
+      '\\bjson_decode\\b',
+      '\\bgetenv\\b',
+      // Rust
+      '\\bserde_json::from',
+      '\\benv::var\\b',
+      // Ruby
+      '\\bENV\\[',
+    ],
+  },
+  severity: 'warning',
+  category: 'logic_error',
+  enabled: true,
+  source: 'builtin',
+};
+
 /** All built-in review rules. */
 export const BUILTIN_RULES: ReviewRule[] = [
   STRUCTURAL_ANALYSIS,
@@ -529,4 +654,5 @@ export const BUILTIN_RULES: ReviewRule[] = [
   ERROR_SWALLOWING,
   BOUNDARY_CHANGE,
   STALE_DUPLICATE,
+  UNTRUSTED_INPUT_VALIDATION,
 ];

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -52,6 +52,7 @@ test PRs in this repo. Each fixture is gitignored (regenerate with
 | `incomplete-handling` | #437  | `incomplete-handling/enum-variant-removed`                   |
 | `error-swallowing`    | #411  | `error-swallowing/payment-error-swallowed`                   |
 | `stale-duplicate`     | #539  | `stale-duplicate/model-partial-update` (capture at `--sha f780541`) |
+| `untrusted-input-validation` | #541 | `untrusted-input-validation/harness-initial` (capture at `--sha 7cb0149`) |
 
 Regenerate the whole corpus:
 
@@ -64,6 +65,7 @@ npx tsx packages/review/test/harness/capture-pr.ts 511 "$ROOT/concurrency-race/c
 npx tsx packages/review/test/harness/capture-pr.ts 437 "$ROOT/incomplete-handling/enum-variant-removed.fixture.json"
 npx tsx packages/review/test/harness/capture-pr.ts 411 "$ROOT/error-swallowing/payment-error-swallowed.fixture.json"
 npx tsx packages/review/test/harness/capture-pr.ts 539 "$ROOT/stale-duplicate/model-partial-update.fixture.json" --sha f780541
+npx tsx packages/review/test/harness/capture-pr.ts 541 "$ROOT/untrusted-input-validation/harness-initial.fixture.json" --sha 7cb0149
 ```
 
 Run the full multi-model sweep:

--- a/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
+++ b/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
@@ -1,0 +1,68 @@
+/**
+ * Snapshot from PR #541 at SHA 7cb0149 — the initial commit of the harness,
+ * before CodeRabbit's review caught the multiple unvalidated-input bugs that
+ * landed fixes in `637dd85`. The diff has at least three concrete instances
+ * of the four sub-patterns this rule targets:
+ *
+ *   - assert-cli.ts:38     — cast-without-validate (`JSON.parse(raw) as Partial<HarnessResult>`)
+ *   - fixture-loader.ts:46 — schema gap (FixtureShape missing complexityReport / baselineReport / deltas)
+ *   - run.ts:48-49         — NaN-on-parse (`parseInt(argv[++i], 10)` for --votes / --calibrate)
+ *
+ * Capture command:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 541 \
+ *     packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.fixture.json \
+ *     --sha 7cb0149
+ *
+ * Tier 1: rule fires + get_files_context is called (the rule's prompt
+ * mandates inspecting consumers of the parsed value).
+ * Tier 2: the finding mentions one of the four sub-pattern vocabulary
+ * families. Set is wide because four sub-patterns can each render with
+ * different language; any correct rendering of any one pattern will land.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #541 7cb0149 — initial harness commit before CodeRabbit-fix landed; ' +
+    'loadResult cast, narrow FixtureShape, parseInt-NaN',
+  rule: 'untrusted-input-validation',
+  expect: (result, h) => {
+    h.expectRuleFired('untrusted-input-validation', result);
+    h.expectToolCalled('get_files_context', result);
+    h.expectFindingMentions(
+      [
+        // Function/symbol names from the buggy code
+        'loadresult',
+        'fixtureshape',
+        'parseflags',
+        // Vocabulary the model reaches for across the four sub-patterns
+        'json.parse',
+        'parseint',
+        'cast',
+        'as partial',
+        'as harnessresult',
+        'validate',
+        'validation',
+        'schema',
+        'shape',
+        'nan',
+        'number.isinteger',
+        'isfinite',
+        'untrusted',
+        'runtime',
+        'type-check',
+        'typeof',
+        'unguarded',
+        'unvalidated',
+        'array.isarray',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;


### PR DESCRIPTION
## Summary

- New `untrusted-input-validation` rule in `BUILTIN_RULES` catches the four-shape pattern CodeRabbit flagged on #541: parse-then-cast, schema gaps, NaN-on-parse, and truthy-coerce on user input.
- Captured canary fixture from PR #541 at SHA `7cb0149` — the initial harness commit, before the CodeRabbit-driven fixes landed in `637dd85`. Three of the four sub-patterns coexist in this single fixture (`loadResult` cast, narrow `FixtureShape`, `parseInt`-NaN).
- Multi-language keyword triggers (JS/TS, Python, Go, Java, PHP, Rust, Ruby) so PRs that don't cross an untrusted boundary don't pay the prompt cost.

Closes #543.

## Why

CodeRabbit's review on #541 produced four findings of the same shape — code that parses untrusted bytes and lets the result flow to a typed consumer without runtime validation. None of the existing seven `BUILTIN_RULES` targeted this shape. It's universal: `JSON.parse`, env var reads, CLI arg conversions, and schema-validated payloads cross untrusted boundaries in every codebase, and casts / type narrowing alone are not validation.

## Rule design

Mirrors `BOUNDARY_CHANGE` / `STALE_DUPLICATE`'s "exception to silence-means-approval" carve-out. When the diff parses untrusted input, the rule MUST investigate before deciding silence — call `get_files_context` on the parse-site function AND on each downstream consumer, then check for one of these four unguarded shapes:

1. **Cast-without-validate** — `JSON.parse(raw) as MyType`, `Partial<T>`, raw `json.loads(...)` consumed via attribute access, `json.Unmarshal` whose `err` is dropped.
2. **Schema gaps** — Zod / Pydantic / struct-tag / Bean-Validation schema that omits a field the consumer reads.
3. **NaN-on-parse** — `parseInt` / `int(s)` / `strconv.Atoi` / `Integer.parseInt` without checking the failure return.
4. **Blank-keyword / truthy-coerce** — empty-string / zero / null slipping past `if (x)` that should have been a typed check.

Trigger is keyword-based (not `always: true`), per the issue's proposal. The keyword set covers seven language families with safe word-boundary patterns. PRs whose diff doesn't contain any of those keywords skip this rule entirely.

## Calibration evidence

`npm run test:harness -w @liendev/review -- --rule untrusted-input-validation --calibrate 10` against `google/gemini-3-flash-preview`:

| Run | Pass rate | Tier 1 | Tier 2 | Notes |
|-----|-----------|--------|--------|-------|
| Standalone | **9/10** ✅ | 9/10 | 9/10 | One Tier 1 silence-mode bail (model produced no findings on a single vote). The other 9 fired and matched the wide Tier 2 keyword set on the first try. Cost $0.68. |
| In canary regression | **10/10** ✅ | 10/10 | 10/10 | Same fixture, run as part of the full sweep. Cost $0.42. |

The wide Tier 2 keyword set covers vocabulary from each of the four sub-patterns (`loadresult`, `fixtureshape`, `parseflags`, `cast`, `as partial`, `validate`, `schema`, `nan`, `number.isinteger`, `untrusted`, `unguarded`, `array.isarray`, etc.) so a finding about any of the patterns lands.

## Canary regression sweep

Full sweep across the new corpus of 9 fixtures: **8 of 9 hit ≥9/10**, totalCost $3.96.

| Fixture | Passes | Meets bar |
|---|---:|:---:|
| `boundary-change/ge-5-threshold-shift`        | 10/10 | ✅ |
| `boundary-change/placeholder`                 | 10/10 | ✅ |
| `concurrency-race/credit-service-toctou`      |  8/10 | ❌ |
| `edge-case-sweep/percent-change-sign-flip`    | 10/10 | ✅ |
| `error-swallowing/payment-error-swallowed`    | 10/10 | ✅ |
| `incomplete-handling/enum-variant-removed`    | 10/10 | ✅ |
| `stale-duplicate/model-partial-update`        | 10/10 | ✅ |
| `structural-analysis/removed-export`          | 10/10 | ✅ |
| `untrusted-input-validation/harness-initial` (new) | 10/10 | ✅ |

### Why concurrency-race's 8/10 isn't a regression of this PR

- The new rule's keywords (`\bJSON\.parse\b`, `\bparseInt\b`, `\bos\.getenv\b`, etc.) **do not match** the concurrency-race fixture's diff. I verified this by grepping the captured diff text — no hits.
- That means the new rule's prompt fragment is **not appended** for the concurrency-race fixture. Its system prompt is byte-for-byte identical to what it was on PR #545's sweep.
- Both failing votes were Tier 1 silence-mode bails on the existing `concurrency-race` rule prompt — the model produced no findings, not a wrong/different finding.
- Concurrency-race was **9/10** on PR #545's sweep — already at the bar. The fixture is genuinely on the bubble against gemini-3-flash-preview.

The right fix is a separate prompt-tightening pass on the existing `concurrency-race` rule (probably stronger "MUST emit" language modeled on `BOUNDARY_CHANGE`'s carve-out). That's out of scope for this PR — happy to file a follow-up issue if useful.

OpenRouter daily key limit was hit during the sweep, so I couldn't re-run concurrency-race in isolation to confirm it bounces back to 9–10/10. The harness's `Agent-Rule Test Harness (LLM)` workflow_dispatch can run it once the quota resets if you want a second data point.

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` — clean
- [x] `npm run typecheck` (all packages) — clean
- [x] `npm run lint` — 0 errors (27 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm run test -w @liendev/review` — 348/348 (was 330; the +18 are param-expanded keyword-sanity entries for the new rule)
- [x] `npm run test -w @liendev/runner` — 24/24
- [x] `npm run test -w @liendev/parser` — 747/747
- [x] Capture-pr `--sha 7cb0149` produced a valid fixture (head=7cb0149…, base=2f19836…, 25 changed files, 4884 repo chunks)
- [x] `--calibrate 10 --rule untrusted-input-validation` — 9/10 standalone, 10/10 in sweep
- [x] Canary regression sweep — 8/9 ≥ bar; concurrency-race's 8/10 is pre-existing variance, not caused by this PR (see above)

## Related

- #541 — the PR whose CodeRabbit review motivated this rule
- #545 — `stale-duplicate` rule (sibling, shipped Mar 2026, established the workflow this PR reuses)
- #538 — the harness used to validate this rule
- #540 — `stale-duplicate` issue (companion to #543)
- #546 — `incomplete-input-validation` (related but distinct shape — input completeness vs. parsed-result validation)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit be041a8. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new built-in security review rule to detect unvalidated parsing of untrusted inputs across multiple languages.

* **Tests**
  * Added test fixtures and assertions to verify the new security rule behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->