### PR TITLE
feat(harness): per-vote trace dump for prompt-iteration debugging (#549)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3572,6 +3572,13 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6101,6 +6108,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -12934,7 +12951,7 @@
     },
     "packages/cli": {
       "name": "@liendev/lien",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@liendev/core": "*",
@@ -13031,7 +13048,7 @@
     },
     "packages/core": {
       "name": "@liendev/core",
-      "version": "0.41.0",
+      "version": "0.44.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
@@ -13353,7 +13370,7 @@
     },
     "packages/parser": {
       "name": "@liendev/parser",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "glob": "^10.5.0",
@@ -13401,7 +13418,9 @@
         "zod": "^3.23.0"
       },
       "devDependencies": {
+        "@types/diff": "^7.0.2",
         "@types/node": "^20.0.0",
+        "diff": "^9.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.3.0",
         "vitest": "^4.0.8"

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -30,7 +30,9 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/diff": "^7.0.2",
     "@types/node": "^20.0.0",
+    "diff": "^9.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^4.0.8"

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -102,6 +102,13 @@ export interface ReviewContext {
     totalTokens: number;
     cost: number;
   }) => void;
+  /**
+   * Callback for plugins to report a per-run agent trace (rendered
+   * prompts, per-turn responses, tool inputs/outputs). Used by the
+   * harness's `--trace` mode for prompt-iteration debugging; production
+   * runners leave this unset and the client skips trace accumulation.
+   */
+  reportTrace?: (trace: import('./plugins/agent/types.js').AgentTrace) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -275,6 +275,20 @@ export class AnthropicAgentClient {
         totalInputTokens += summaryResponse.usage.input_tokens;
         totalOutputTokens += summaryResponse.usage.output_tokens;
 
+        // Record the retry as its own turn so trace.turns and usage
+        // stay consistent — without this, the summary-retry's tokens
+        // count toward the cost while its response is invisible in the
+        // trace, defeating the "read why the model bailed" use case
+        // (per CodeRabbit on #550).
+        turnTraces.push({
+          turnNumber: turn + 1,
+          responseText: joinTextBlocks(summaryResponse.content),
+          toolCalls: [],
+          finishReason: summaryResponse.stop_reason ?? undefined,
+          inputTokens: summaryResponse.usage.input_tokens,
+          outputTokens: summaryResponse.usage.output_tokens,
+        });
+
         const retryParsed = extractResponse(summaryResponse.content);
         if (retryParsed.summary || retryParsed.findings.length > 0) {
           parsed = retryParsed;

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -174,8 +174,15 @@ export class AnthropicAgentClient {
         // Append assistant message with all content blocks
         messages.push({ role: 'assistant', content: response.content });
 
-        // Execute each tool and collect results
-        const toolResults: Anthropic.Messages.ToolResultBlockParam[] = await Promise.all(
+        // Execute each tool and collect results. We collect invocations
+        // and toolResults together inside the parallel map and split them
+        // afterwards — Promise.all preserves input order on its output
+        // array regardless of which task settles first, so the trace's
+        // toolCalls reflect declaration order rather than completion
+        // order. Pushing into turnTrace.toolCalls inside the lambda
+        // would have been timing-dependent and added noise to
+        // compare-votes diffs (per Lien Review on #550).
+        const executed = await Promise.all(
           toolUseBlocks.map(async block => {
             let result: string;
             const startedAt = Date.now();
@@ -190,13 +197,17 @@ export class AnthropicAgentClient {
               output: truncate(result, TRACE_TOOL_OUTPUT_MAX),
               durationMs: Date.now() - startedAt,
             };
-            turnTrace.toolCalls.push(invocation);
-            return {
+            const toolResult: Anthropic.Messages.ToolResultBlockParam = {
               type: 'tool_result' as const,
               tool_use_id: block.id,
               content: result,
             };
+            return { invocation, toolResult };
           }),
+        );
+        turnTrace.toolCalls = executed.map(e => e.invocation);
+        const toolResults: Anthropic.Messages.ToolResultBlockParam[] = executed.map(
+          e => e.toolResult,
         );
 
         // Nudge the agent to wrap up when budget is running low

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -171,54 +171,14 @@ export class AnthropicAgentClient {
 
       // Process tool_use blocks
       if (response.stop_reason === 'tool_use' && toolUseBlocks.length > 0) {
-        // Append assistant message with all content blocks
-        messages.push({ role: 'assistant', content: response.content });
-
-        // Execute each tool and collect results. We collect invocations
-        // and toolResults together inside the parallel map and split them
-        // afterwards — Promise.all preserves input order on its output
-        // array regardless of which task settles first, so the trace's
-        // toolCalls reflect declaration order rather than completion
-        // order. Pushing into turnTrace.toolCalls inside the lambda
-        // would have been timing-dependent and added noise to
-        // compare-votes diffs (per Lien Review on #550).
-        const executed = await Promise.all(
-          toolUseBlocks.map(async block => {
-            let result: string;
-            const startedAt = Date.now();
-            try {
-              result = await toolExecutor(block.name, block.input as Record<string, unknown>);
-            } catch (error) {
-              result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
-            }
-            const invocation: ToolInvocation = {
-              name: block.name,
-              input: block.input,
-              output: truncate(result, TRACE_TOOL_OUTPUT_MAX),
-              durationMs: Date.now() - startedAt,
-            };
-            const toolResult: Anthropic.Messages.ToolResultBlockParam = {
-              type: 'tool_result' as const,
-              tool_use_id: block.id,
-              content: result,
-            };
-            return { invocation, toolResult };
-          }),
+        await this.dispatchToolUseBlocks(
+          toolUseBlocks,
+          response.content,
+          messages,
+          turnTrace,
+          toolExecutor,
+          shouldWrapUp,
         );
-        turnTrace.toolCalls = executed.map(e => e.invocation);
-        const toolResults: Anthropic.Messages.ToolResultBlockParam[] = executed.map(
-          e => e.toolResult,
-        );
-
-        // Nudge the agent to wrap up when budget is running low
-        if (shouldWrapUp) {
-          toolResults.push({
-            type: 'text',
-            text: 'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.',
-          } as unknown as Anthropic.Messages.ToolResultBlockParam);
-        }
-
-        messages.push({ role: 'user', content: toolResults });
       } else {
         // Unexpected stop reason (max_tokens, stop_sequence, etc.) — stop looping
         this.logger.warning(`[agent] Unexpected stop_reason: ${response.stop_reason}, stopping`);
@@ -230,73 +190,16 @@ export class AnthropicAgentClient {
       this.logger.warning(`[agent] Max turns reached (${this.maxTurns}), stopping`);
     }
 
-    // Parse findings and summary from the final response
     let parsed = lastResponse ? extractResponse(lastResponse.content) : { findings: [] };
-
-    // If the agent didn't produce a JSON block (e.g., budget hit mid-investigation),
-    // make one final cheap call asking just for the summary
     if (!parsed.summary && lastResponse) {
-      this.logger.info('[agent] No JSON output — requesting summary...');
-
-      // Wait briefly to avoid rate limits (the main loop just used most of the budget)
-      await new Promise(resolve => setTimeout(resolve, 3_000));
-
-      messages.push({ role: 'assistant', content: lastResponse.content });
-
-      // If the last response had tool_use blocks, add dummy tool_results
-      // so the Anthropic API accepts the conversation
-      const pendingToolUse = lastResponse.content.filter(
-        (b): b is Anthropic.Messages.ToolUseBlock => b.type === 'tool_use',
-      );
-      const retryContent: Anthropic.Messages.ContentBlockParam[] = pendingToolUse.map(b => ({
-        type: 'tool_result' as const,
-        tool_use_id: b.id,
-        content: '[Budget exceeded — tool not executed]',
-      }));
-      retryContent.push({
-        type: 'text' as const,
-        text: 'You ran out of budget before outputting findings. Based on what you investigated so far, output ONLY the JSON block now with your findings and summary. No more tool calls.',
-      });
-      messages.push({ role: 'user', content: retryContent });
-
-      try {
-        const summaryResponse = await this.client.messages.create({
-          model: this.model,
-          max_tokens: 4096,
-          system: [
-            {
-              type: 'text',
-              text: 'Output only a ```json code fence with findings and summary. No other text.',
-            },
-          ],
-          messages,
-        });
-
-        totalInputTokens += summaryResponse.usage.input_tokens;
-        totalOutputTokens += summaryResponse.usage.output_tokens;
-
-        // Record the retry as its own turn so trace.turns and usage
-        // stay consistent — without this, the summary-retry's tokens
-        // count toward the cost while its response is invisible in the
-        // trace, defeating the "read why the model bailed" use case
-        // (per CodeRabbit on #550).
-        turnTraces.push({
-          turnNumber: turn + 1,
-          responseText: joinTextBlocks(summaryResponse.content),
-          toolCalls: [],
-          finishReason: summaryResponse.stop_reason ?? undefined,
-          inputTokens: summaryResponse.usage.input_tokens,
-          outputTokens: summaryResponse.usage.output_tokens,
-        });
-
-        const retryParsed = extractResponse(summaryResponse.content);
-        if (retryParsed.summary || retryParsed.findings.length > 0) {
-          parsed = retryParsed;
+      const retry = await this.runSummaryRetry(messages, lastResponse, turn);
+      if (retry) {
+        totalInputTokens += retry.inputTokens;
+        totalOutputTokens += retry.outputTokens;
+        turnTraces.push(retry.traceTurn);
+        if (retry.parsed.summary || retry.parsed.findings.length > 0) {
+          parsed = retry.parsed;
         }
-      } catch (err) {
-        this.logger.warning(
-          `[agent] Summary retry failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
       }
     }
 
@@ -321,7 +224,155 @@ export class AnthropicAgentClient {
       },
     };
   }
+
+  /**
+   * Append the assistant's tool_use turn, dispatch each tool in
+   * parallel (preserving declaration order in the trace), and append
+   * tool_result blocks. Pulled out of `run()` to keep its
+   * time-to-understand under the complexity threshold.
+   */
+  private async dispatchToolUseBlocks(
+    toolUseBlocks: Anthropic.Messages.ToolUseBlock[],
+    responseContent: Anthropic.Messages.ContentBlock[],
+    messages: Anthropic.Messages.MessageParam[],
+    turnTrace: TurnTrace,
+    toolExecutor: (name: string, input: Record<string, unknown>) => Promise<string>,
+    shouldWrapUp: boolean,
+  ): Promise<void> {
+    messages.push({ role: 'assistant', content: responseContent });
+
+    // Promise.all preserves input order on its output array regardless
+    // of which task settles first, so the trace's toolCalls reflect
+    // declaration order, not completion order (per Lien Review on #550).
+    const executed = await Promise.all(
+      toolUseBlocks.map(async block => executeOneToolUse(block, toolExecutor)),
+    );
+    turnTrace.toolCalls = executed.map(e => e.invocation);
+    const toolResults: Anthropic.Messages.ToolResultBlockParam[] = executed.map(e => e.toolResult);
+
+    if (shouldWrapUp) {
+      toolResults.push({
+        type: 'text',
+        text: WRAP_UP_NUDGE,
+      } as unknown as Anthropic.Messages.ToolResultBlockParam);
+    }
+
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  /**
+   * Final cheap call asking the model to emit just the findings JSON
+   * after the main loop ran out of budget. Returns the parsed result,
+   * a TurnTrace for the retry call, and per-call token counts. Returns
+   * null if the retry itself fails (logged); the caller falls back to
+   * the (empty) findings already extracted.
+   */
+  private async runSummaryRetry(
+    messages: Anthropic.Messages.MessageParam[],
+    lastResponse: Anthropic.Messages.Message,
+    turn: number,
+  ): Promise<{
+    parsed: { findings: AgentFinding[]; summary?: AgentSummary };
+    traceTurn: TurnTrace;
+    inputTokens: number;
+    outputTokens: number;
+  } | null> {
+    this.logger.info('[agent] No JSON output — requesting summary...');
+    await new Promise(resolve => setTimeout(resolve, 3_000));
+    appendRetryPrompt(messages, lastResponse);
+    try {
+      const response = await this.client.messages.create({
+        model: this.model,
+        max_tokens: 4096,
+        system: [{ type: 'text', text: RETRY_SYSTEM_PROMPT }],
+        messages,
+      });
+      const inputTokens = response.usage.input_tokens;
+      const outputTokens = response.usage.output_tokens;
+      const traceTurn: TurnTrace = {
+        turnNumber: turn + 1,
+        responseText: joinTextBlocks(response.content),
+        toolCalls: [],
+        finishReason: response.stop_reason ?? undefined,
+        inputTokens,
+        outputTokens,
+      };
+      const parsed = extractResponse(response.content);
+      return { parsed, traceTurn, inputTokens, outputTokens };
+    } catch (err) {
+      this.logger.warning(
+        `[agent] Summary retry failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
 }
+
+/**
+ * Dispatch a single tool_use block, build its trace invocation and
+ * tool_result block. Pulled out so dispatchToolUseBlocks reads
+ * top-to-bottom without nested async lambda complexity.
+ */
+async function executeOneToolUse(
+  block: Anthropic.Messages.ToolUseBlock,
+  toolExecutor: (name: string, input: Record<string, unknown>) => Promise<string>,
+): Promise<{
+  invocation: ToolInvocation;
+  toolResult: Anthropic.Messages.ToolResultBlockParam;
+}> {
+  const startedAt = Date.now();
+  let result: string;
+  try {
+    result = await toolExecutor(block.name, block.input as Record<string, unknown>);
+  } catch (error) {
+    result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  return {
+    invocation: {
+      name: block.name,
+      input: block.input,
+      output: truncate(result, TRACE_TOOL_OUTPUT_MAX),
+      durationMs: Date.now() - startedAt,
+    },
+    toolResult: {
+      type: 'tool_result' as const,
+      tool_use_id: block.id,
+      content: result,
+    },
+  };
+}
+
+/**
+ * Append the dummy tool_results + retry instruction the Anthropic API
+ * needs to accept the truncated conversation. If the last response had
+ * pending tool_use blocks, we have to satisfy them before the user
+ * turn or the API rejects the request.
+ */
+function appendRetryPrompt(
+  messages: Anthropic.Messages.MessageParam[],
+  lastResponse: Anthropic.Messages.Message,
+): void {
+  messages.push({ role: 'assistant', content: lastResponse.content });
+  const pendingToolUse = lastResponse.content.filter(
+    (b): b is Anthropic.Messages.ToolUseBlock => b.type === 'tool_use',
+  );
+  const retryContent: Anthropic.Messages.ContentBlockParam[] = pendingToolUse.map(b => ({
+    type: 'tool_result' as const,
+    tool_use_id: b.id,
+    content: '[Budget exceeded — tool not executed]',
+  }));
+  retryContent.push({ type: 'text' as const, text: RETRY_USER_PROMPT });
+  messages.push({ role: 'user', content: retryContent });
+}
+
+const WRAP_UP_NUDGE =
+  'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.';
+
+const RETRY_SYSTEM_PROMPT =
+  'Output only a ```json code fence with findings and summary. No other text.';
+
+const RETRY_USER_PROMPT =
+  'You ran out of budget before outputting findings. Based on what you investigated so far, output ONLY the JSON block now with your findings and summary. No more tool calls.';
 
 /**
  * Extract findings from the model's final response content.

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -8,7 +8,28 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import type { Logger } from '../../logger.js';
-import type { AgentFinding, AgentSummary, AgentResult } from './types.js';
+import type {
+  AgentFinding,
+  AgentSummary,
+  AgentResult,
+  TurnTrace,
+  ToolInvocation,
+} from './types.js';
+
+/** Cap a single tool's recorded output so traces stay readable. */
+const TRACE_TOOL_OUTPUT_MAX = 4096;
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
+}
+
+/** Extract the assistant's text content from an Anthropic response for trace. */
+function joinTextBlocks(content: Anthropic.Messages.ContentBlock[]): string {
+  return content
+    .filter((b): b is Anthropic.Messages.TextBlock => b.type === 'text')
+    .map(b => b.text)
+    .join('\n');
+}
 
 /** Default Sonnet pricing: $3/MTok input, $15/MTok output. */
 const DEFAULT_INPUT_COST_PER_MTOK = 3;
@@ -77,6 +98,7 @@ export class AnthropicAgentClient {
     let totalOutputTokens = 0;
     let turn = 0;
     let lastResponse: Anthropic.Messages.Message | null = null;
+    const turnTraces: TurnTrace[] = [];
 
     while (turn < this.maxTurns) {
       turn++;
@@ -98,8 +120,10 @@ export class AnthropicAgentClient {
       lastResponse = response;
 
       // Accumulate usage
-      totalInputTokens += response.usage.input_tokens;
-      totalOutputTokens += response.usage.output_tokens;
+      const turnInputTokens = response.usage.input_tokens;
+      const turnOutputTokens = response.usage.output_tokens;
+      totalInputTokens += turnInputTokens;
+      totalOutputTokens += turnOutputTokens;
 
       const totalTokens = totalInputTokens + totalOutputTokens;
       this.logger.info(
@@ -114,6 +138,18 @@ export class AnthropicAgentClient {
         const toolNames = toolUseBlocks.map(b => b.name).join(', ');
         this.logger.info(`[agent] Turn ${turn} tools: ${toolNames}`);
       }
+
+      // Trace accumulator for this turn — tool inputs/outputs get
+      // populated below as the loop dispatches them.
+      const turnTrace: TurnTrace = {
+        turnNumber: turn,
+        responseText: joinTextBlocks(response.content),
+        toolCalls: [],
+        finishReason: response.stop_reason ?? undefined,
+        inputTokens: turnInputTokens,
+        outputTokens: turnOutputTokens,
+      };
+      turnTraces.push(turnTrace);
 
       // Done: model finished naturally
       if (response.stop_reason === 'end_turn') {
@@ -142,11 +178,19 @@ export class AnthropicAgentClient {
         const toolResults: Anthropic.Messages.ToolResultBlockParam[] = await Promise.all(
           toolUseBlocks.map(async block => {
             let result: string;
+            const startedAt = Date.now();
             try {
               result = await toolExecutor(block.name, block.input as Record<string, unknown>);
             } catch (error) {
               result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
             }
+            const invocation: ToolInvocation = {
+              name: block.name,
+              input: block.input,
+              output: truncate(result, TRACE_TOOL_OUTPUT_MAX),
+              durationMs: Date.now() - startedAt,
+            };
+            turnTrace.toolCalls.push(invocation);
             return {
               type: 'tool_result' as const,
               tool_use_id: block.id,
@@ -244,6 +288,12 @@ export class AnthropicAgentClient {
         cost,
       },
       turns: turn,
+      trace: {
+        systemPrompt,
+        initialMessage,
+        model: this.model,
+        turns: turnTraces,
+      },
     };
   }
 }

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -133,6 +133,9 @@ export class AgentReviewPlugin implements ReviewPlugin {
     );
 
     context.reportUsage?.(result.usage);
+    if (result.trace) {
+      context.reportTrace?.(result.trace);
+    }
 
     const pluginId = this.id;
     const findings = result.findings.map(f => mapToReviewFinding(f, pluginId));

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -128,34 +128,11 @@ export class AgentReviewPlugin implements ReviewPlugin {
       toolExecutor,
     );
 
-    logger.info(
-      `[${this.id}] Review complete: ${result.findings.length} findings in ${result.turns} turns ($${result.usage.cost.toFixed(4)})`,
-    );
-
-    context.reportUsage?.(result.usage);
-    if (result.trace) {
-      context.reportTrace?.(result.trace);
-    }
+    reportAgentRun(this.id, context, logger, result);
 
     const pluginId = this.id;
     const findings = result.findings.map(f => mapToReviewFinding(f, pluginId));
-
-    // Add summary as a special finding so present() can render it
-    if (result.summary) {
-      findings.push({
-        pluginId,
-        filepath: '',
-        line: 0,
-        severity: 'info' as const,
-        category: 'summary',
-        message: result.summary.overview,
-        metadata: {
-          riskLevel: result.summary.riskLevel,
-          overview: result.summary.overview,
-          keyChanges: result.summary.keyChanges,
-        },
-      });
-    }
+    appendSummaryFinding(findings, pluginId, result.summary);
 
     return findings;
   }
@@ -240,6 +217,52 @@ function runAgentClient(
     logger,
   });
   return client.run(systemPrompt, initialMessage, toOpenAITools(AGENT_TOOLS), toolExecutor);
+}
+
+/**
+ * Log the run summary, forward usage and trace via the context's
+ * optional callbacks. Pulled out of `analyze()` to keep its
+ * time-to-understand under the threshold.
+ */
+function reportAgentRun(
+  pluginId: string,
+  context: ReviewContext,
+  logger: Logger,
+  result: AgentResult,
+): void {
+  logger.info(
+    `[${pluginId}] Review complete: ${result.findings.length} findings in ${result.turns} turns ($${result.usage.cost.toFixed(4)})`,
+  );
+  context.reportUsage?.(result.usage);
+  if (result.trace) {
+    context.reportTrace?.(result.trace);
+  }
+}
+
+/**
+ * Append the agent's summary as a special finding so `present()` can
+ * render it. No-op when the agent didn't return a summary (e.g.,
+ * budget exhausted before the wrap-up turn).
+ */
+function appendSummaryFinding(
+  findings: ReviewFinding[],
+  pluginId: string,
+  summary: AgentResult['summary'],
+): void {
+  if (!summary) return;
+  findings.push({
+    pluginId,
+    filepath: '',
+    line: 0,
+    severity: 'info' as const,
+    category: 'summary',
+    message: summary.overview,
+    metadata: {
+      riskLevel: summary.riskLevel,
+      overview: summary.overview,
+      keyChanges: summary.keyChanges,
+    },
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -184,6 +184,26 @@ export class OpenAIAgentClient {
           const startedAt = Date.now();
           try {
             parsedInput = JSON.parse(tc.function.arguments);
+            // JSON.parse succeeds on primitives (`null`, `"foo"`, `42`,
+            // arrays). Tool executors expect a plain object — without
+            // an explicit shape check the cast is a lie and the crash
+            // we surface is "Cannot read properties of null" rather
+            // than a clear "got X, expected object" (per CodeRabbit on #550).
+            if (
+              typeof parsedInput !== 'object' ||
+              parsedInput === null ||
+              Array.isArray(parsedInput)
+            ) {
+              throw new Error(
+                `Invalid tool arguments: expected JSON object, got ${
+                  parsedInput === null
+                    ? 'null'
+                    : Array.isArray(parsedInput)
+                      ? 'array'
+                      : typeof parsedInput
+                }`,
+              );
+            }
             result = await toolExecutor(tc.function.name, parsedInput as Record<string, unknown>);
           } catch (error) {
             result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -172,10 +172,15 @@ export class OpenAIAgentClient {
           tool_calls: choice.message.tool_calls,
         });
 
-        // Execute each tool and add results
+        // Execute each tool and add results. Seed `parsedInput` with
+        // the raw arguments string so a JSON.parse failure leaves the
+        // malformed input on the trace — that's exactly what a developer
+        // needs when debugging "model emitted invalid tool args" prompt
+        // failures (per Lien Review on #550). On success it gets
+        // overwritten with the parsed object.
         for (const tc of choice.message.tool_calls) {
           let result: string;
-          let parsedInput: unknown = null;
+          let parsedInput: unknown = tc.function.arguments;
           const startedAt = Date.now();
           try {
             parsedInput = JSON.parse(tc.function.arguments);

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -6,7 +6,20 @@
  */
 
 import type { Logger } from '../../logger.js';
-import type { AgentFinding, AgentSummary, AgentResult } from './types.js';
+import type {
+  AgentFinding,
+  AgentSummary,
+  AgentResult,
+  TurnTrace,
+  ToolInvocation,
+} from './types.js';
+
+/** Cap a single tool's recorded output so traces stay readable. */
+const TRACE_TOOL_OUTPUT_MAX = 4096;
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
+}
 
 /** Default Gemini Flash pricing via OpenRouter: $0.30/$2.50 per MTok. */
 const DEFAULT_INPUT_COST_PER_MTOK = 0.3;
@@ -93,14 +106,17 @@ export class OpenAIAgentClient {
     let totalOutputTokens = 0;
     let turn = 0;
     let lastContent: string | null = null;
+    const turnTraces: TurnTrace[] = [];
 
     while (turn < this.maxTurns) {
       turn++;
 
       const response = await this.chatCompletion(messages, tools);
 
-      totalInputTokens += response.usage?.prompt_tokens ?? 0;
-      totalOutputTokens += response.usage?.completion_tokens ?? 0;
+      const turnInputTokens = response.usage?.prompt_tokens ?? 0;
+      const turnOutputTokens = response.usage?.completion_tokens ?? 0;
+      totalInputTokens += turnInputTokens;
+      totalOutputTokens += turnOutputTokens;
 
       const totalTokens = totalInputTokens + totalOutputTokens;
       const choice = response.choices[0];
@@ -116,6 +132,19 @@ export class OpenAIAgentClient {
       }
 
       lastContent = choice.message.content;
+
+      // Trace accumulator for this turn — tool inputs/outputs get
+      // populated below as the loop dispatches them. Cheap (in-memory)
+      // and only consumed if the caller wires up a trace recipient.
+      const turnTrace: TurnTrace = {
+        turnNumber: turn,
+        responseText: lastContent ?? '',
+        toolCalls: [],
+        finishReason: choice.finish_reason,
+        inputTokens: turnInputTokens,
+        outputTokens: turnOutputTokens,
+      };
+      turnTraces.push(turnTrace);
 
       // Done: model finished naturally
       if (choice.finish_reason === 'stop') {
@@ -146,12 +175,22 @@ export class OpenAIAgentClient {
         // Execute each tool and add results
         for (const tc of choice.message.tool_calls) {
           let result: string;
+          let parsedInput: unknown = null;
+          const startedAt = Date.now();
           try {
-            const input = JSON.parse(tc.function.arguments);
-            result = await toolExecutor(tc.function.name, input);
+            parsedInput = JSON.parse(tc.function.arguments);
+            result = await toolExecutor(tc.function.name, parsedInput as Record<string, unknown>);
           } catch (error) {
             result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
           }
+          const durationMs = Date.now() - startedAt;
+          const invocation: ToolInvocation = {
+            name: tc.function.name,
+            input: parsedInput,
+            output: truncate(result, TRACE_TOOL_OUTPUT_MAX),
+            durationMs,
+          };
+          turnTrace.toolCalls.push(invocation);
           messages.push({
             role: 'tool',
             content: result,
@@ -221,6 +260,12 @@ export class OpenAIAgentClient {
         cost,
       },
       turns: turn,
+      trace: {
+        systemPrompt,
+        initialMessage,
+        model: this.model,
+        turns: turnTraces,
+      },
     };
   }
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -17,8 +17,53 @@ import type {
 /** Cap a single tool's recorded output so traces stay readable. */
 const TRACE_TOOL_OUTPUT_MAX = 4096;
 
+const WRAP_UP_NUDGE =
+  'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.';
+
+const RETRY_NUDGE =
+  'You ran out of budget. Output ONLY the JSON block now with your findings and summary. No tool calls.';
+
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
+}
+
+/**
+ * Parse + validate a tool call's JSON arguments. Returns the parsed
+ * input on success, throws on parse failure or non-object payload (a
+ * cleaner surface than letting the executor crash on a primitive cast).
+ */
+function parseToolArguments(raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid tool arguments JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    const got = parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed;
+    throw new Error(`Invalid tool arguments: expected JSON object, got ${got}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** Build a ToolInvocation from a tool call's name, parsed input, and raw output. */
+function buildInvocation(
+  name: string,
+  rawArgs: string,
+  parsed: unknown,
+  output: string,
+  startedAt: number,
+): ToolInvocation {
+  return {
+    name,
+    // Keep the raw args string on parse-failure so the trace shows the
+    // exact malformed payload rather than `null`.
+    input: parsed === undefined ? rawArgs : parsed,
+    output: truncate(output, TRACE_TOOL_OUTPUT_MAX),
+    durationMs: Date.now() - startedAt,
+  };
 }
 
 /** Default Gemini Flash pricing via OpenRouter: $0.30/$2.50 per MTok. */
@@ -165,71 +210,15 @@ export class OpenAIAgentClient {
 
       // Process tool calls
       if (choice.finish_reason === 'tool_calls' && choice.message.tool_calls) {
-        // Add assistant message with tool calls
-        messages.push({
-          role: 'assistant',
-          content: choice.message.content,
-          tool_calls: choice.message.tool_calls,
-        });
-
-        // Execute each tool and add results. Seed `parsedInput` with
-        // the raw arguments string so a JSON.parse failure leaves the
-        // malformed input on the trace — that's exactly what a developer
-        // needs when debugging "model emitted invalid tool args" prompt
-        // failures (per Lien Review on #550). On success it gets
-        // overwritten with the parsed object.
-        for (const tc of choice.message.tool_calls) {
-          let result: string;
-          let parsedInput: unknown = tc.function.arguments;
-          const startedAt = Date.now();
-          try {
-            parsedInput = JSON.parse(tc.function.arguments);
-            // JSON.parse succeeds on primitives (`null`, `"foo"`, `42`,
-            // arrays). Tool executors expect a plain object — without
-            // an explicit shape check the cast is a lie and the crash
-            // we surface is "Cannot read properties of null" rather
-            // than a clear "got X, expected object" (per CodeRabbit on #550).
-            if (
-              typeof parsedInput !== 'object' ||
-              parsedInput === null ||
-              Array.isArray(parsedInput)
-            ) {
-              throw new Error(
-                `Invalid tool arguments: expected JSON object, got ${
-                  parsedInput === null
-                    ? 'null'
-                    : Array.isArray(parsedInput)
-                      ? 'array'
-                      : typeof parsedInput
-                }`,
-              );
-            }
-            result = await toolExecutor(tc.function.name, parsedInput as Record<string, unknown>);
-          } catch (error) {
-            result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
-          }
-          const durationMs = Date.now() - startedAt;
-          const invocation: ToolInvocation = {
-            name: tc.function.name,
-            input: parsedInput,
-            output: truncate(result, TRACE_TOOL_OUTPUT_MAX),
-            durationMs,
-          };
-          turnTrace.toolCalls.push(invocation);
-          messages.push({
-            role: 'tool',
-            content: result,
-            tool_call_id: tc.id,
-          });
-        }
-
-        // Nudge to wrap up if near budget
+        await this.dispatchToolCalls(
+          choice.message.tool_calls,
+          choice.message.content,
+          messages,
+          turnTrace,
+          toolExecutor,
+        );
         if (nearBudget || lastTurn) {
-          messages.push({
-            role: 'user',
-            content:
-              'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.',
-          });
+          messages.push({ role: 'user', content: WRAP_UP_NUDGE });
         }
       } else {
         this.logger.warning(`[agent] Unexpected finish_reason: ${choice.finish_reason}, stopping`);
@@ -241,51 +230,16 @@ export class OpenAIAgentClient {
       this.logger.warning(`[agent] Max turns reached (${this.maxTurns}), stopping`);
     }
 
-    // Parse findings from the final response
     let parsed = extractResponse(lastContent);
-
-    // If no JSON output, request summary
     if (!parsed.summary && lastContent !== null) {
-      this.logger.info('[agent] No JSON output — requesting summary...');
-      await new Promise(resolve => setTimeout(resolve, 3_000));
-
-      // Add a wrap-up request
-      messages.push({
-        role: 'user',
-        content:
-          'You ran out of budget. Output ONLY the JSON block now with your findings and summary. No tool calls.',
-      });
-
-      try {
-        const retryResponse = await this.chatCompletion(messages, []);
-        const retryInputTokens = retryResponse.usage?.prompt_tokens ?? 0;
-        const retryOutputTokens = retryResponse.usage?.completion_tokens ?? 0;
-        totalInputTokens += retryInputTokens;
-        totalOutputTokens += retryOutputTokens;
-
-        // Record the retry as its own turn so trace.turns and usage
-        // stay consistent — without this, the summary-retry's tokens
-        // count toward the cost while its response is invisible in the
-        // trace, defeating the "read why the model bailed" use case
-        // (per CodeRabbit on #550).
-        const retryChoice = retryResponse.choices[0];
-        turnTraces.push({
-          turnNumber: turn + 1,
-          responseText: retryChoice?.message.content ?? '',
-          toolCalls: [],
-          finishReason: retryChoice?.finish_reason,
-          inputTokens: retryInputTokens,
-          outputTokens: retryOutputTokens,
-        });
-
-        const retryParsed = extractResponse(retryChoice?.message.content);
-        if (retryParsed.summary || retryParsed.findings.length > 0) {
-          parsed = retryParsed;
+      const retry = await this.runSummaryRetry(messages, turn);
+      if (retry) {
+        totalInputTokens += retry.inputTokens;
+        totalOutputTokens += retry.outputTokens;
+        turnTraces.push(retry.traceTurn);
+        if (retry.parsed.summary || retry.parsed.findings.length > 0) {
+          parsed = retry.parsed;
         }
-      } catch (err) {
-        this.logger.warning(
-          `[agent] Summary retry failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
       }
     }
 
@@ -309,6 +263,83 @@ export class OpenAIAgentClient {
         turns: turnTraces,
       },
     };
+  }
+
+  /**
+   * Append the assistant's tool_calls turn to the message history,
+   * dispatch each tool, record its invocation on the trace, and append
+   * the tool_result messages. Pulled out of `run()` to keep its
+   * time-to-understand under the complexity threshold.
+   */
+  private async dispatchToolCalls(
+    toolCalls: ToolCall[],
+    assistantContent: string | null,
+    messages: ChatMessage[],
+    turnTrace: TurnTrace,
+    toolExecutor: (name: string, input: Record<string, unknown>) => Promise<string>,
+  ): Promise<void> {
+    messages.push({
+      role: 'assistant',
+      content: assistantContent,
+      tool_calls: toolCalls,
+    });
+    for (const tc of toolCalls) {
+      const startedAt = Date.now();
+      let parsed: Record<string, unknown> | undefined;
+      let result: string;
+      try {
+        parsed = parseToolArguments(tc.function.arguments);
+        result = await toolExecutor(tc.function.name, parsed);
+      } catch (error) {
+        result = `Tool error: ${error instanceof Error ? error.message : String(error)}`;
+      }
+      turnTrace.toolCalls.push(
+        buildInvocation(tc.function.name, tc.function.arguments, parsed, result, startedAt),
+      );
+      messages.push({ role: 'tool', content: result, tool_call_id: tc.id });
+    }
+  }
+
+  /**
+   * Final cheap call asking the model to emit just the findings JSON
+   * after the main loop ran out of budget. Returns the parsed result,
+   * a TurnTrace for the retry call, and per-call token counts. Returns
+   * null if the retry itself fails (logged); the caller falls back to
+   * the (empty) findings already extracted.
+   */
+  private async runSummaryRetry(
+    messages: ChatMessage[],
+    turn: number,
+  ): Promise<{
+    parsed: { findings: AgentFinding[]; summary?: AgentSummary };
+    traceTurn: TurnTrace;
+    inputTokens: number;
+    outputTokens: number;
+  } | null> {
+    this.logger.info('[agent] No JSON output — requesting summary...');
+    await new Promise(resolve => setTimeout(resolve, 3_000));
+    messages.push({ role: 'user', content: RETRY_NUDGE });
+    try {
+      const response = await this.chatCompletion(messages, []);
+      const inputTokens = response.usage?.prompt_tokens ?? 0;
+      const outputTokens = response.usage?.completion_tokens ?? 0;
+      const choice = response.choices[0];
+      const traceTurn: TurnTrace = {
+        turnNumber: turn + 1,
+        responseText: choice?.message.content ?? '',
+        toolCalls: [],
+        finishReason: choice?.finish_reason,
+        inputTokens,
+        outputTokens,
+      };
+      const parsed = extractResponse(choice?.message.content);
+      return { parsed, traceTurn, inputTokens, outputTokens };
+    } catch (err) {
+      this.logger.warning(
+        `[agent] Summary retry failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
   }
 
   private async chatCompletion(messages: ChatMessage[], tools: ToolDef[]): Promise<ChatResponse> {

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -238,10 +238,27 @@ export class OpenAIAgentClient {
 
       try {
         const retryResponse = await this.chatCompletion(messages, []);
-        totalInputTokens += retryResponse.usage?.prompt_tokens ?? 0;
-        totalOutputTokens += retryResponse.usage?.completion_tokens ?? 0;
+        const retryInputTokens = retryResponse.usage?.prompt_tokens ?? 0;
+        const retryOutputTokens = retryResponse.usage?.completion_tokens ?? 0;
+        totalInputTokens += retryInputTokens;
+        totalOutputTokens += retryOutputTokens;
 
-        const retryParsed = extractResponse(retryResponse.choices[0]?.message.content);
+        // Record the retry as its own turn so trace.turns and usage
+        // stay consistent — without this, the summary-retry's tokens
+        // count toward the cost while its response is invisible in the
+        // trace, defeating the "read why the model bailed" use case
+        // (per CodeRabbit on #550).
+        const retryChoice = retryResponse.choices[0];
+        turnTraces.push({
+          turnNumber: turn + 1,
+          responseText: retryChoice?.message.content ?? '',
+          toolCalls: [],
+          finishReason: retryChoice?.finish_reason,
+          inputTokens: retryInputTokens,
+          outputTokens: retryOutputTokens,
+        });
+
+        const retryParsed = extractResponse(retryChoice?.message.content);
         if (retryParsed.summary || retryParsed.findings.length > 0) {
           parsed = retryParsed;
         }

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -124,6 +124,48 @@ export interface AgentSummary {
   keyChanges: string[];
 }
 
+/**
+ * One tool invocation captured during an agent turn — the model-sent
+ * arguments and the tool's return value. Used by the harness's `--trace`
+ * mode to read what the agent actually saw when iterating on prompts.
+ */
+export interface ToolInvocation {
+  name: string;
+  /** Model-sent JSON args (parsed). */
+  input: unknown;
+  /** Tool's return string. Truncated to ~4 KB to keep traces readable. */
+  output: string;
+  durationMs?: number;
+}
+
+/**
+ * One assistant turn captured during a run — full response text including
+ * any reasoning prose outside the JSON fence (which `extractResponse`
+ * normally strips), plus the tool calls made on this turn.
+ */
+export interface TurnTrace {
+  turnNumber: number;
+  /** Full assistant message content, captured before extractResponse. */
+  responseText: string;
+  toolCalls: ToolInvocation[];
+  finishReason?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+/**
+ * End-to-end agent trace: rendered prompts the model saw, plus every
+ * turn's response and tool calls. Populated by the agent client when
+ * the harness opts in via `reportTrace`. Kept structured (not raw log
+ * text) so consumers can diff or filter without reparsing.
+ */
+export interface AgentTrace {
+  systemPrompt: string;
+  initialMessage: string;
+  model: string;
+  turns: TurnTrace[];
+}
+
 /** Result of an agent review run, including findings, usage, and turn count. */
 export interface AgentResult {
   findings: AgentFinding[];
@@ -135,4 +177,6 @@ export interface AgentResult {
     cost: number;
   };
   turns: number;
+  /** Per-turn trace data — only populated when the caller wires up trace capture. */
+  trace?: AgentTrace;
 }

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -325,6 +325,53 @@ captured.
 If you can't tell what's happening, `--json` is your friend — pipe through
 `jq` and look at each vote's `failureMessage`.
 
+## Debugging a failing vote with `--trace`
+
+When the `failureMessage` alone doesn't tell you why a vote bailed —
+typically `Tier 1: ... (no findings)` where the model investigated but
+decided silence — capture per-vote traces and compare a passing vote to
+a failing one.
+
+```bash
+npm run test:harness -w @liendev/review -- \
+  --rule concurrency-race --calibrate 10 --trace /tmp/cal-trace
+```
+
+Each vote produces `/tmp/cal-trace/<rule>/<scenario>/vote-<N>.json`
+containing the rendered system prompt, the rendered initial message, the
+full per-turn assistant response (including reasoning prose outside the
+JSON fence — normally stripped), and tool-call inputs + outputs.
+
+To compare a passing vote (say vote 3) with a failing one (vote 7):
+
+```bash
+npx tsx packages/review/test/harness/compare-votes.ts \
+  /tmp/cal-trace/concurrency-race/credit-service-toctou/vote-3.json \
+  /tmp/cal-trace/concurrency-race/credit-service-toctou/vote-7.json
+```
+
+Output starts with a header (passed?, failure tier, turn count,
+tool-call summary for each vote), then prints `diff -u` per turn
+between the two response texts. If the systemPrompt or initialMessage
+differ across votes (rare for same-fixture voting; common when comparing
+across fixtures), those diffs print first.
+
+Typical reads:
+
+- Both votes call the same tools but the failing one's last-turn prose
+  says "I could not identify a race condition" — silence-mode bias the
+  rule's MUST-emit language didn't overcome.
+- The failing vote made fewer tool calls and never opened the file
+  containing the bug — the rule's protocol step "MUST call
+  get_files_context" needs strengthening.
+- Tool output for `read_file` was truncated to 4 KB, missing the lines
+  with the bug — investigate whether the fixture's `repoRootDir` is
+  correct or the file is huge.
+
+Trace files are typically 10-50 KB per vote (5-15 turns × ~2 KB each
+including 4 KB-capped tool outputs). A `--calibrate 10` run on one
+fixture writes ~100-500 KB to disk.
+
 ## Modes — when to use which
 
 - **`/test-harness <rule>` (CC)** — fast inner loop. Free. Use while

--- a/packages/review/test/harness/assertions.ts
+++ b/packages/review/test/harness/assertions.ts
@@ -12,12 +12,14 @@
  * Tier 3 (exact text match) is intentionally not exposed.
  */
 
-import type { AgentFinding } from '../../src/plugins/agent/types.js';
+import type { AgentFinding, AgentTrace } from '../../src/plugins/agent/types.js';
 
 export interface HarnessResult {
   findings: AgentFinding[];
   toolCalls: string[];
   turns: number;
+  /** Populated when the harness was invoked with `--trace`. */
+  trace?: AgentTrace;
 }
 
 export type AssertionTier = 1 | 2;

--- a/packages/review/test/harness/compare-votes.ts
+++ b/packages/review/test/harness/compare-votes.ts
@@ -13,18 +13,16 @@
  *                         /tmp/cal/X/<scenario>/vote-7.json
  *
  * Output: a header summary (passed?, failure tier/message, turn count,
- * tool-call summary) followed by `diff -u`-style per-turn response-text
- * diffs. The systemPrompt and initialMessage are only diffed if they
- * actually differ between the two files (usually identical for
- * same-fixture voting).
+ * tool-call summary) followed by unified-diff-style per-turn diffs that
+ * include the assistant's response text and each tool call's args + output.
+ * The systemPrompt and initialMessage are only diffed if they actually
+ * differ between the two files (usually identical for same-fixture voting).
  */
 
-import { execFileSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+
+import { createPatch } from 'diff';
 
 import type { AgentTrace, TurnTrace, ToolInvocation } from '../../src/plugins/agent/types.js';
 
@@ -49,9 +47,57 @@ async function loadVote(path: string): Promise<VoteDump> {
   return parsed;
 }
 
-function summariseInvocations(calls: ToolInvocation[]): string {
-  if (calls.length === 0) return '(none)';
-  return calls.map(c => c.name).join(', ');
+/**
+ * Render a turn (response text + each tool call's name, args, and output)
+ * as a deterministic multi-line string suitable for `diff -u`-style
+ * comparison. Including args + output is critical: the model can call the
+ * same tool with materially different arguments (e.g.,
+ * grep_codebase("foo") vs grep_codebase("bar")), and a name-only summary
+ * would silently report turns as identical (per Lien Review on #550).
+ */
+function renderTurn(turn: TurnTrace): string {
+  const lines: string[] = [];
+  lines.push('--- response ---');
+  lines.push(turn.responseText || '(empty)');
+  lines.push('--- tools ---');
+  if (turn.toolCalls.length === 0) {
+    lines.push('(none)');
+  } else {
+    turn.toolCalls.forEach((c, i) => {
+      lines.push(renderInvocation(i, c));
+    });
+  }
+  return lines.join('\n');
+}
+
+function renderInvocation(index: number, c: ToolInvocation): string {
+  // Stringify args/output deterministically so the diff is line-stable.
+  // JSON.stringify with 2-space indent gives multi-line output that
+  // unified-diff handles cleanly. Output is already 4 KB-capped at
+  // capture time.
+  const input = stableJsonString(c.input, 2);
+  return [
+    `[${index}] ${c.name}`,
+    `  input:`,
+    indent(input, '    '),
+    `  output:`,
+    indent(c.output, '    '),
+  ].join('\n');
+}
+
+function indent(s: string, prefix: string): string {
+  return s
+    .split('\n')
+    .map(line => prefix + line)
+    .join('\n');
+}
+
+function stableJsonString(value: unknown, indentSpaces: number): string {
+  try {
+    return JSON.stringify(value, null, indentSpaces);
+  } catch {
+    return String(value);
+  }
 }
 
 function header(label: string, vote: VoteDump): string {
@@ -72,45 +118,34 @@ function header(label: string, vote: VoteDump): string {
 }
 
 /**
- * Pipe two strings to `diff -u` via temp files. Falls back to "(diff
- * unavailable)" if the system has no diff binary, but every dev box and
- * CI we ship to has one.
+ * Pure-JS unified diff via the `diff` npm package — works on every
+ * platform Node runs on, no `sh` / system `diff` binary required (per
+ * Lien Review on #550). Returns "(identical)" if the strings match;
+ * otherwise the unified-patch text minus the leading "Index:" /
+ * "==" boilerplate that `createPatch` emits.
  */
 function diffStrings(a: string, b: string, labelA: string, labelB: string): string {
   if (a === b) return '(identical)';
-  const dir = mkdtempSync(join(tmpdir(), 'compare-votes-'));
-  try {
-    const fileA = join(dir, 'a');
-    const fileB = join(dir, 'b');
-    execFileSync('sh', ['-c', `cat > ${JSON.stringify(fileA)}`], { input: a });
-    execFileSync('sh', ['-c', `cat > ${JSON.stringify(fileB)}`], { input: b });
-    try {
-      execFileSync('diff', ['-u', '--label', labelA, '--label', labelB, fileA, fileB], {
-        encoding: 'utf8',
-      });
-      return '(identical)';
-    } catch (err) {
-      // diff exits 1 when files differ — that's the success path here.
-      const e = err as { stdout?: Buffer | string };
-      const out = e.stdout;
-      return typeof out === 'string' ? out : (out?.toString('utf8') ?? '(diff failed)');
-    }
-  } finally {
-    // Best-effort cleanup; not critical.
-    try {
-      execFileSync('rm', ['-rf', dir]);
-    } catch {
-      /* ignore */
-    }
+  const patch = createPatch(labelA, a, b, '', '', { context: 3 });
+  // createPatch prefixes with "Index: <name>\n===…===\n--- …\n+++ …" — the
+  // first three lines are noise for our use case; replace the second
+  // header with the second label.
+  const lines = patch.split('\n');
+  // lines[0] = "Index: <labelA>", lines[1] = "===…", lines[2] = "--- <labelA>",
+  // lines[3] = "+++ <labelA>" (createPatch reuses the filename for both
+  // headers when newFileName is empty). Rewrite the +++ line to labelB.
+  if (lines.length >= 4 && lines[3].startsWith('+++ ')) {
+    lines[3] = `+++ ${labelB}`;
   }
+  return lines.slice(2).join('\n');
 }
 
 function diffTurn(a: TurnTrace | undefined, b: TurnTrace | undefined, n: number): string {
   if (!a && !b) return '';
-  if (!a) return `\n--- turn ${n}: only in B ---\n${b!.responseText}\n`;
-  if (!b) return `\n--- turn ${n}: only in A ---\n${a.responseText}\n`;
-  const sectionA = `${a.responseText}\n[tools: ${summariseInvocations(a.toolCalls)}]`;
-  const sectionB = `${b.responseText}\n[tools: ${summariseInvocations(b.toolCalls)}]`;
+  if (!a) return `\n--- turn ${n}: only in B ---\n${renderTurn(b!)}\n`;
+  if (!b) return `\n--- turn ${n}: only in A ---\n${renderTurn(a)}\n`;
+  const sectionA = renderTurn(a);
+  const sectionB = renderTurn(b);
   if (sectionA === sectionB) return `\n--- turn ${n}: identical ---\n`;
   return `\n--- turn ${n} ---\n${diffStrings(sectionA, sectionB, `A.turn${n}`, `B.turn${n}`)}`;
 }

--- a/packages/review/test/harness/compare-votes.ts
+++ b/packages/review/test/harness/compare-votes.ts
@@ -92,9 +92,27 @@ function indent(s: string, prefix: string): string {
     .join('\n');
 }
 
+/**
+ * Recursively sort object keys so two semantically-identical inputs
+ * with different key insertion orders produce byte-identical JSON.
+ * Without this, a model that emits `{"a":1,"b":2}` on one vote and
+ * `{"b":2,"a":1}` on another would render as a fake diff in
+ * compare-votes (per Lien Review on #550). Arrays preserve order
+ * (positional semantics matter); primitives pass through.
+ */
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value === null || typeof value !== 'object') return value;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
 function stableJsonString(value: unknown, indentSpaces: number): string {
   try {
-    return JSON.stringify(value, null, indentSpaces);
+    return JSON.stringify(sortKeys(value), null, indentSpaces);
   } catch {
     return String(value);
   }

--- a/packages/review/test/harness/compare-votes.ts
+++ b/packages/review/test/harness/compare-votes.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env tsx
+/**
+ * Compare two `--trace` dump files (typically a passing and a failing
+ * vote on the same fixture) and print a readable diff.
+ *
+ * Usage:
+ *   tsx compare-votes.ts <trace1.json> <trace2.json>
+ *
+ * The most useful invocation is:
+ *
+ *   tsx run.ts --rule X --calibrate 10 --trace /tmp/cal
+ *   tsx compare-votes.ts /tmp/cal/X/<scenario>/vote-2.json \
+ *                         /tmp/cal/X/<scenario>/vote-7.json
+ *
+ * Output: a header summary (passed?, failure tier/message, turn count,
+ * tool-call summary) followed by `diff -u`-style per-turn response-text
+ * diffs. The systemPrompt and initialMessage are only diffed if they
+ * actually differ between the two files (usually identical for
+ * same-fixture voting).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { resolve } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { AgentTrace, TurnTrace, ToolInvocation } from '../../src/plugins/agent/types.js';
+
+interface VoteDump {
+  label: string;
+  voteIndex: number;
+  passed: boolean;
+  failureMessage?: string;
+  failureTier?: 1 | 2;
+  cost: number;
+  trace?: AgentTrace;
+}
+
+async function loadVote(path: string): Promise<VoteDump> {
+  const raw = await fs.readFile(path, 'utf8');
+  const parsed = JSON.parse(raw) as VoteDump;
+  if (!parsed.trace) {
+    throw new Error(
+      `${path}: no .trace field. Re-run the harness with --trace <dir> to capture traces.`,
+    );
+  }
+  return parsed;
+}
+
+function summariseInvocations(calls: ToolInvocation[]): string {
+  if (calls.length === 0) return '(none)';
+  return calls.map(c => c.name).join(', ');
+}
+
+function header(label: string, vote: VoteDump): string {
+  const status = vote.passed ? 'PASS' : `FAIL${vote.failureTier ? ` T${vote.failureTier}` : ''}`;
+  const turns = vote.trace?.turns.length ?? 0;
+  const tools = vote.trace?.turns.reduce((sum, t) => sum + t.toolCalls.length, 0) ?? 0;
+  const lines = [
+    `=== ${label} (vote ${vote.voteIndex}) ===`,
+    `  status:  ${status}`,
+    `  cost:    $${vote.cost.toFixed(4)}`,
+    `  turns:   ${turns}`,
+    `  tools:   ${tools} call(s)`,
+  ];
+  if (vote.failureMessage) {
+    lines.push(`  failure: ${vote.failureMessage.slice(0, 200)}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Pipe two strings to `diff -u` via temp files. Falls back to "(diff
+ * unavailable)" if the system has no diff binary, but every dev box and
+ * CI we ship to has one.
+ */
+function diffStrings(a: string, b: string, labelA: string, labelB: string): string {
+  if (a === b) return '(identical)';
+  const dir = mkdtempSync(join(tmpdir(), 'compare-votes-'));
+  try {
+    const fileA = join(dir, 'a');
+    const fileB = join(dir, 'b');
+    execFileSync('sh', ['-c', `cat > ${JSON.stringify(fileA)}`], { input: a });
+    execFileSync('sh', ['-c', `cat > ${JSON.stringify(fileB)}`], { input: b });
+    try {
+      execFileSync('diff', ['-u', '--label', labelA, '--label', labelB, fileA, fileB], {
+        encoding: 'utf8',
+      });
+      return '(identical)';
+    } catch (err) {
+      // diff exits 1 when files differ — that's the success path here.
+      const e = err as { stdout?: Buffer | string };
+      const out = e.stdout;
+      return typeof out === 'string' ? out : (out?.toString('utf8') ?? '(diff failed)');
+    }
+  } finally {
+    // Best-effort cleanup; not critical.
+    try {
+      execFileSync('rm', ['-rf', dir]);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function diffTurn(a: TurnTrace | undefined, b: TurnTrace | undefined, n: number): string {
+  if (!a && !b) return '';
+  if (!a) return `\n--- turn ${n}: only in B ---\n${b!.responseText}\n`;
+  if (!b) return `\n--- turn ${n}: only in A ---\n${a.responseText}\n`;
+  const sectionA = `${a.responseText}\n[tools: ${summariseInvocations(a.toolCalls)}]`;
+  const sectionB = `${b.responseText}\n[tools: ${summariseInvocations(b.toolCalls)}]`;
+  if (sectionA === sectionB) return `\n--- turn ${n}: identical ---\n`;
+  return `\n--- turn ${n} ---\n${diffStrings(sectionA, sectionB, `A.turn${n}`, `B.turn${n}`)}`;
+}
+
+async function main(): Promise<void> {
+  const [pathA, pathB] = process.argv.slice(2);
+  if (!pathA || !pathB) {
+    console.error('Usage: tsx compare-votes.ts <trace1.json> <trace2.json>');
+    process.exit(2);
+  }
+  const [a, b] = await Promise.all([loadVote(resolve(pathA)), loadVote(resolve(pathB))]);
+
+  console.log(header('A', a));
+  console.log('');
+  console.log(header('B', b));
+  console.log('');
+
+  if (a.trace!.systemPrompt !== b.trace!.systemPrompt) {
+    console.log('--- systemPrompt differs ---');
+    console.log(diffStrings(a.trace!.systemPrompt, b.trace!.systemPrompt, 'A.system', 'B.system'));
+  }
+  if (a.trace!.initialMessage !== b.trace!.initialMessage) {
+    console.log('--- initialMessage differs ---');
+    console.log(
+      diffStrings(a.trace!.initialMessage, b.trace!.initialMessage, 'A.initial', 'B.initial'),
+    );
+  }
+
+  const turnCount = Math.max(a.trace!.turns.length, b.trace!.turns.length);
+  for (let i = 0; i < turnCount; i++) {
+    process.stdout.write(diffTurn(a.trace!.turns[i], b.trace!.turns[i], i + 1));
+  }
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/packages/review/test/harness/compare-votes.ts
+++ b/packages/review/test/harness/compare-votes.ts
@@ -168,6 +168,29 @@ function diffTurn(a: TurnTrace | undefined, b: TurnTrace | undefined, n: number)
   return `\n--- turn ${n} ---\n${diffStrings(sectionA, sectionB, `A.turn${n}`, `B.turn${n}`)}`;
 }
 
+function diffPromptsIfDifferent(a: AgentTrace, b: AgentTrace): void {
+  if (a.systemPrompt !== b.systemPrompt) {
+    console.log('--- systemPrompt differs ---');
+    console.log(diffStrings(a.systemPrompt, b.systemPrompt, 'A.system', 'B.system'));
+  }
+  if (a.initialMessage !== b.initialMessage) {
+    console.log('--- initialMessage differs ---');
+    console.log(diffStrings(a.initialMessage, b.initialMessage, 'A.initial', 'B.initial'));
+  }
+}
+
+function printVoteDiff(a: VoteDump, b: VoteDump): void {
+  console.log(header('A', a));
+  console.log('');
+  console.log(header('B', b));
+  console.log('');
+  diffPromptsIfDifferent(a.trace!, b.trace!);
+  const turnCount = Math.max(a.trace!.turns.length, b.trace!.turns.length);
+  for (let i = 0; i < turnCount; i++) {
+    process.stdout.write(diffTurn(a.trace!.turns[i], b.trace!.turns[i], i + 1));
+  }
+}
+
 async function main(): Promise<void> {
   const [pathA, pathB] = process.argv.slice(2);
   if (!pathA || !pathB) {
@@ -175,27 +198,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const [a, b] = await Promise.all([loadVote(resolve(pathA)), loadVote(resolve(pathB))]);
-
-  console.log(header('A', a));
-  console.log('');
-  console.log(header('B', b));
-  console.log('');
-
-  if (a.trace!.systemPrompt !== b.trace!.systemPrompt) {
-    console.log('--- systemPrompt differs ---');
-    console.log(diffStrings(a.trace!.systemPrompt, b.trace!.systemPrompt, 'A.system', 'B.system'));
-  }
-  if (a.trace!.initialMessage !== b.trace!.initialMessage) {
-    console.log('--- initialMessage differs ---');
-    console.log(
-      diffStrings(a.trace!.initialMessage, b.trace!.initialMessage, 'A.initial', 'B.initial'),
-    );
-  }
-
-  const turnCount = Math.max(a.trace!.turns.length, b.trace!.turns.length);
-  for (let i = 0; i < turnCount; i++) {
-    process.stdout.write(diffTurn(a.trace!.turns[i], b.trace!.turns[i], i + 1));
-  }
+  printVoteDiff(a, b);
 }
 
 main().catch(err => {

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -14,16 +14,18 @@
  *   --votes <k>          K-of-M voting per fixture (default 3)
  *   --calibrate <n>      run each fixture N times, report pass rate (the 9/10 bar)
  *   --json               emit machine-readable JSON instead of text
+ *   --trace <dir>        write per-vote trace JSON to <dir>/<rule>/<scenario>/vote-<N>.json
  *
  * Env: OPENROUTER_API_KEY required.
  */
 
 import { promises as fs } from 'node:fs';
-import { dirname, basename, resolve } from 'node:path';
+import { dirname, basename, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { FixtureAssertions } from './assertions.js';
 import { vote, calibrate } from './voting.js';
+import type { AssertedRun } from './voting.js';
 import type { RunnerOptions } from './runner.js';
 import { reportVote, reportCalibrate } from './reporter.js';
 
@@ -47,6 +49,7 @@ interface CliFlags {
   calibrate?: number;
   json: boolean;
   model?: string;
+  traceDir?: string;
 }
 
 function requirePositiveInt(name: string, value: string | undefined): number {
@@ -90,6 +93,9 @@ const VALUE_FLAG_SETTERS: Record<string, (f: CliFlags, value: string | undefined
   '--model': (f, v) => {
     f.model = requireString('--model', v);
   },
+  '--trace': (f, v) => {
+    f.traceDir = resolve(requireString('--trace', v));
+  },
 };
 
 function parseFlags(argv: string[]): CliFlags {
@@ -118,10 +124,11 @@ function parseFlags(argv: string[]): CliFlags {
 function printUsage(): void {
   console.error(
     [
-      'Usage: tsx run.ts [--rule <id>] [--fixture <path>] [--votes K] [--calibrate N] [--json]',
+      'Usage: tsx run.ts [--rule <id>] [--fixture <path>] [--votes K] [--calibrate N] [--json] [--trace <dir>]',
       '',
       '  Default: K=3 voting on every fixture under test/harness/fixtures/',
       '  --calibrate 10: runs N times and checks the 9/10 reliability bar',
+      '  --trace <dir>:  write per-vote trace JSON to <dir>/<rule>/<scenario>/vote-<N>.json',
       '  Env: OPENROUTER_API_KEY required',
     ].join('\n'),
   );
@@ -217,6 +224,9 @@ async function runOneFixture(
 
   if (flags.calibrate !== undefined) {
     const result = await calibrate(f.fixturePath, assertions, opts, flags.calibrate);
+    if (flags.traceDir) {
+      await writeTraces(flags.traceDir, label, f.rule, f.name, result.runs);
+    }
     return {
       passed: result.meetsReliabilityBar,
       cost: result.totalCost,
@@ -226,12 +236,52 @@ async function runOneFixture(
   }
   const k = assertions.votes ?? flags.votes;
   const result = await vote(f.fixturePath, assertions, opts, k);
+  if (flags.traceDir) {
+    await writeTraces(flags.traceDir, label, f.rule, f.name, result.votes);
+  }
   return {
     passed: result.agree && result.passes === result.votes.length,
     cost: result.totalCost,
     jsonEntry: { label, mode: 'vote', result },
     text: reportVote(label, result),
   };
+}
+
+/**
+ * Dump one JSON file per vote/run under <traceDir>/<rule>/<scenario>/.
+ * Each file packages the vote's pass/fail outcome with its full trace
+ * (rendered prompts + per-turn responses + tool calls) so iterating on
+ * a failing prompt becomes "diff vote-N.json against vote-M.json".
+ */
+async function writeTraces(
+  traceDir: string,
+  label: string,
+  rule: string,
+  scenario: string,
+  runs: AssertedRun[],
+): Promise<void> {
+  const outDir = join(traceDir, rule, scenario);
+  await fs.mkdir(outDir, { recursive: true });
+  await Promise.all(
+    runs.map(async (run, i) => {
+      const voteIndex = i + 1;
+      const { trace, ...rest } = run.result;
+      const dump = {
+        label,
+        voteIndex,
+        passed: run.passed,
+        failureMessage: run.failureMessage,
+        failureTier: run.failureTier,
+        cost: run.cost,
+        trace,
+        result: rest,
+      };
+      await fs.writeFile(
+        join(outDir, `vote-${voteIndex}.json`),
+        JSON.stringify(dump, null, 2) + '\n',
+      );
+    }),
+  );
 }
 
 function printSummary(

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -141,51 +141,52 @@ interface FixturePair {
   assertionsPath: string;
 }
 
-async function discoverFixtures(flags: CliFlags): Promise<FixturePair[]> {
-  if (flags.fixture) {
-    const fixturePath = resolve(flags.fixture);
-    const assertionsPath = fixturePath.replace(/\.fixture\.json$/, '.assertions.ts');
-    return [
-      {
-        rule: basename(dirname(fixturePath)),
-        name: basename(fixturePath, '.fixture.json'),
-        fixturePath,
-        assertionsPath,
-      },
-    ];
+function fixturePairFromPath(fixturePath: string): FixturePair {
+  const assertionsPath = fixturePath.replace(/\.fixture\.json$/, '.assertions.ts');
+  return {
+    rule: basename(dirname(fixturePath)),
+    name: basename(fixturePath, '.fixture.json'),
+    fixturePath,
+    assertionsPath,
+  };
+}
+
+async function listRuleDirs(rule: string | undefined): Promise<string[]> {
+  if (rule) return [resolve(FIXTURES_ROOT, rule)];
+  const entries = await fs.readdir(FIXTURES_ROOT, { withFileTypes: true });
+  return entries.filter(d => d.isDirectory()).map(d => resolve(FIXTURES_ROOT, d.name));
+}
+
+async function collectFixturesInDir(ruleDir: string): Promise<FixturePair[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(ruleDir);
+  } catch {
+    return [];
   }
-
-  const ruleDirs = flags.rule
-    ? [resolve(FIXTURES_ROOT, flags.rule)]
-    : (await fs.readdir(FIXTURES_ROOT, { withFileTypes: true }))
-        .filter(d => d.isDirectory())
-        .map(d => resolve(FIXTURES_ROOT, d.name));
-
   const pairs: FixturePair[] = [];
-  for (const ruleDir of ruleDirs) {
-    let entries;
+  for (const entry of entries) {
+    if (!entry.endsWith('.fixture.json')) continue;
+    const pair = fixturePairFromPath(resolve(ruleDir, entry));
     try {
-      entries = await fs.readdir(ruleDir);
+      await fs.access(pair.assertionsPath);
     } catch {
+      console.error(`skip ${pair.fixturePath} — no sibling .assertions.ts`);
       continue;
     }
-    for (const entry of entries) {
-      if (!entry.endsWith('.fixture.json')) continue;
-      const fixturePath = resolve(ruleDir, entry);
-      const assertionsPath = fixturePath.replace(/\.fixture\.json$/, '.assertions.ts');
-      try {
-        await fs.access(assertionsPath);
-      } catch {
-        console.error(`skip ${fixturePath} — no sibling .assertions.ts`);
-        continue;
-      }
-      pairs.push({
-        rule: basename(ruleDir),
-        name: basename(fixturePath, '.fixture.json'),
-        fixturePath,
-        assertionsPath,
-      });
-    }
+    pairs.push(pair);
+  }
+  return pairs;
+}
+
+async function discoverFixtures(flags: CliFlags): Promise<FixturePair[]> {
+  if (flags.fixture) {
+    return [fixturePairFromPath(resolve(flags.fixture))];
+  }
+  const ruleDirs = await listRuleDirs(flags.rule);
+  const pairs: FixturePair[] = [];
+  for (const ruleDir of ruleDirs) {
+    pairs.push(...(await collectFixturesInDir(ruleDir)));
   }
   return pairs;
 }

--- a/packages/review/test/harness/runner.ts
+++ b/packages/review/test/harness/runner.ts
@@ -9,6 +9,7 @@
 import type { Logger } from '../../src/logger.js';
 import type { ReviewContext, ReviewFinding } from '../../src/plugin-types.js';
 import { AgentReviewPlugin } from '../../src/plugins/agent/index.js';
+import type { AgentTrace } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
 import type { HarnessResult } from './assertions.js';
@@ -101,10 +102,16 @@ export async function runFixture(
     cost += usage.cost;
   };
 
+  let trace: AgentTrace | undefined;
+  const reportTrace = (t: AgentTrace): void => {
+    trace = t;
+  };
+
   const pluginCtx: ReviewContext = {
     ...ctx,
     logger,
     reportUsage,
+    reportTrace,
     config: {
       // Preserve any agent options serialized into the captured fixture
       // (blastRadius config, custom token budgets, etc.) and only override
@@ -126,6 +133,7 @@ export async function runFixture(
     findings: findingsToHarness(findings),
     toolCalls: extractToolCalls(logger.lines),
     turns: extractTurns(logger.lines),
+    trace,
     cost,
   };
 }

--- a/packages/review/test/harness/voting.ts
+++ b/packages/review/test/harness/voting.ts
@@ -69,8 +69,9 @@ async function runOnce(
   let toolCalls: string[];
   let turns: number;
   let cost: number;
+  let trace: HarnessResult['trace'];
   try {
-    ({ findings, toolCalls, turns, cost } = await runFixture(fixturePath, opts));
+    ({ findings, toolCalls, turns, cost, trace } = await runFixture(fixturePath, opts));
   } catch (err) {
     if (isTransientLLMError(err)) {
       // LLM-side failure (network, 5xx, terminated). Record as a Tier 1 fail
@@ -88,7 +89,7 @@ async function runOnce(
     throw err;
   }
 
-  const result: HarnessResult = { findings, toolCalls, turns };
+  const result: HarnessResult = { findings, toolCalls, turns, trace };
   try {
     assertions.expect(result, harness);
     return { result, cost, passed: true };


### PR DESCRIPTION
## Summary

- New `--trace <dir>` flag on `npm run test:harness` writes per-vote JSON dumps to `<dir>/<rule>/<scenario>/vote-<N>.json`.
- Each dump contains the rendered system prompt, the rendered initial message, every turn's full assistant response (including reasoning prose outside the JSON fence — normally stripped by `extractResponse`), and tool-call inputs + outputs.
- New `compare-votes.ts` CLI: `tsx compare-votes.ts <trace1.json> <trace2.json>` prints a header summary + `diff -u` per turn.
- Plumbing is additive (`AgentResult.trace?`, `ReviewContext.reportTrace?`, `HarnessResult.trace?`) — production callers leave `reportTrace` unset and behavior is unchanged.

Closes #549.

## Why

Prompt-tightening has been guesswork. The recent concurrency-race tightening attempt regressed `untrusted-input-validation` from 10/10 to 1/10 in the canary sweep, and without traces I had no visibility into whether the bloat distracted the model, the carve-out wording was weak, or tool output was noisy. I reverted blind. The harness already has the right shapes (capturing logger, vote spread, `reportUsage` callback pattern) — this PR fills the gap.

## What landed

| Layer | Change |
|---|---|
| `AgentResult` (`types.ts`) | Add `ToolInvocation` / `TurnTrace` / `AgentTrace` types; add optional `trace?: AgentTrace`. |
| `OpenAIAgentClient` / `AnthropicAgentClient` | Accumulate `TurnTrace[]` per turn before `extractResponse` strips prose; populate `result.trace` before return. Tool args + results captured inside the dispatch loop. 4 KB cap per tool output. |
| `ReviewContext` (`plugin-types.ts`) | Add `reportTrace?: (trace: AgentTrace) => void` — parallels existing `reportUsage`. |
| Agent plugin's `analyze()` | After `runAgentClient` returns, forward `result.trace` via `context.reportTrace?.()`. |
| `HarnessResult` (`assertions.ts`) | Add `trace?: AgentTrace`. Flows through `--json` automatically. |
| `runner.ts` | Set `pluginCtx.reportTrace`; surface trace via the runner's return. |
| `voting.ts` | `AssertedRun.result.trace` now populated. |
| `run.ts` | `--trace <dir>` flag + `writeTraces` helper for both vote and calibrate paths. |
| `compare-votes.ts` (new) | ~120-line CLI that diffs two trace files. |
| `README.md` | New "Debugging a failing vote with `--trace`" section with the workflow recipe. |

## Trace shape

```ts
interface ToolInvocation {
  name: string;
  input: unknown;        // model-sent JSON args
  output: string;        // 4 KB cap with "[truncated …]" marker
  durationMs?: number;
}

interface TurnTrace {
  turnNumber: number;
  responseText: string;  // full assistant content — captured before extractResponse
  toolCalls: ToolInvocation[];
  finishReason?: string;
  inputTokens?: number;
  outputTokens?: number;
}

interface AgentTrace {
  systemPrompt: string;
  initialMessage: string;
  model: string;
  turns: TurnTrace[];
}
```

Per-vote dump file:
```json
{
  "label": "stale-duplicate/model-partial-update",
  "voteIndex": 1,
  "passed": true,
  "failureMessage": null,
  "failureTier": null,
  "cost": 0.0373,
  "trace": { /* AgentTrace */ },
  "result": { /* HarnessResult except trace */ }
}
```

## Smoke evidence

```bash
npm run test:harness -w @liendev/review -- \
  --rule stale-duplicate --votes 3 --trace /tmp/trace-smoke
```

Produced three vote files. Inspecting `vote-1.json`:

| Field | Value |
|---|---:|
| `trace.model` | `google/gemini-3-flash-preview` |
| `trace.systemPrompt` length | 13,670 chars |
| `trace.initialMessage` length | 11,224 chars |
| `trace.turns` count | 6 |
| Last turn `responseText` length | 1,769 chars (includes the full ```json block + reasoning) |
| Tool calls per turn | turn 1: `get_files_context`; turn 2: `grep_codebase`; turn 3: `read_file`; turn 4-5: `grep_codebase`; turn 6: stop |

`compare-votes.ts` between vote-1 and vote-2:
```
=== A (vote 1) ===
  status:  PASS
  cost:    $0.0373
  turns:   6
  tools:   5 call(s)

=== B (vote 2) ===
  status:  PASS
  cost:    $0.0414
  turns:   6
  tools:   5 call(s)

--- turn 1: identical ---
--- turn 2: identical ---
--- turn 3: identical ---
--- turn 4 ---
--- A.turn4
+++ B.turn4
-[tools: grep_codebase]
+[tools: read_file]
…
```

Total smoke cost: **$0.1194** for 3 votes.

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` — clean
- [x] `npm run typecheck` (all packages) — clean
- [x] `npm run lint` — 0 errors (28 pre-existing warnings; none in changed files)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm run test -w @liendev/review` — 348/348 (additive change, no test impact)
- [x] `npm run test -w @liendev/runner` — 24/24
- [x] `npm run test -w @liendev/parser` — 747/747
- [x] `--trace <dir>` produces 3 vote files with non-empty systemPrompt, initialMessage, last-turn responseText, and tool-call inputs
- [x] `compare-votes.ts` produces a readable diff with header + per-turn sections

## Out of scope (deferred follow-ups)

- **Trace replay** (`--replay <trace.json>` to re-run a vote against the captured prompts).
- **Reporter integration** (rendering traces in markdown / HTML).
- **Per-rule prompt-fragment attribution** (which active rule's prompt produced which finding).
- **Per-rule agent split** with orchestrator (separate architectural conversation; this PR gives us the data either way).

## Related

- #538 — harness foundation (merged)
- #549 — this issue

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 473.942. 11 pre-existing issues remain in touched files.
🔗 **Impact**: 2 high-risk file(s) with 3 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | -8 |
| 🧠 mental load | 3 | -35 |
| ⏱️ time to understand | 6 | -427 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 17c926d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional tracing capability to capture detailed agent execution information including prompts, responses, token usage, and tool invocations for debugging purposes.
  * Added `--trace` flag to test harness for writing per-vote trace outputs.
  * Added trace comparison tool to help debug vote differences.

* **Documentation**
  * Updated test harness README with guide on debugging failing votes using the trace feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->