### PR TITLE
feat(harness): capture extended-reasoning prose on OpenAI-compat traces (#552)

### DIFF
--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -48,6 +48,32 @@ function parseToolArguments(raw: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
+/**
+ * Assemble a per-turn trace entry from a chat-completion choice.
+ * Pulled out of `run()` so the turn-trace shape can grow (e.g. the
+ * reasoning field added in #552) without bumping the loop body's
+ * time-to-understand against the complexity threshold.
+ */
+function buildTurnTrace(
+  turnNumber: number,
+  choice: ChatResponse['choices'][number],
+  inputTokens: number,
+  outputTokens: number,
+): TurnTrace {
+  return {
+    turnNumber,
+    responseText: choice.message.content ?? '',
+    // OpenRouter surfaces extended-reasoning prose here for models like
+    // gemini-3-flash-preview; on tool-calling turns this is where the
+    // model's intermediate thinking lives (#552).
+    reasoning: choice.message.reasoning ?? undefined,
+    toolCalls: [],
+    finishReason: choice.finish_reason,
+    inputTokens,
+    outputTokens,
+  };
+}
+
 /** Build a ToolInvocation from a tool call's name, parsed input, and raw output. */
 function buildInvocation(
   name: string,
@@ -188,22 +214,7 @@ export class OpenAIAgentClient {
       }
 
       lastContent = choice.message.content;
-
-      // Trace accumulator for this turn — tool inputs/outputs get
-      // populated below as the loop dispatches them. Cheap (in-memory)
-      // and only consumed if the caller wires up a trace recipient.
-      const turnTrace: TurnTrace = {
-        turnNumber: turn,
-        responseText: lastContent ?? '',
-        // OpenRouter surfaces extended-reasoning prose here for models
-        // like gemini-3-flash-preview; on tool-calling turns this is
-        // where the model's intermediate thinking lives (#552).
-        reasoning: choice.message.reasoning ?? undefined,
-        toolCalls: [],
-        finishReason: choice.finish_reason,
-        inputTokens: turnInputTokens,
-        outputTokens: turnOutputTokens,
-      };
+      const turnTrace = buildTurnTrace(turn, choice, turnInputTokens, turnOutputTokens);
       turnTraces.push(turnTrace);
 
       // Done: model finished naturally

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -105,7 +105,18 @@ interface ToolDef {
 
 interface ChatResponse {
   choices: Array<{
-    message: { role: string; content: string | null; tool_calls?: ToolCall[] };
+    message: {
+      role: string;
+      content: string | null;
+      /**
+       * Extended-reasoning prose, surfaced by OpenRouter for models
+       * with reasoning support (e.g. gemini-3-flash-preview when we
+       * pass `reasoning: { effort: 'high' }`). Lives separate from
+       * `content`, which on tool-calling turns is typically null.
+       */
+      reasoning?: string | null;
+      tool_calls?: ToolCall[];
+    };
     finish_reason: string;
   }>;
   usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
@@ -184,6 +195,10 @@ export class OpenAIAgentClient {
       const turnTrace: TurnTrace = {
         turnNumber: turn,
         responseText: lastContent ?? '',
+        // OpenRouter surfaces extended-reasoning prose here for models
+        // like gemini-3-flash-preview; on tool-calling turns this is
+        // where the model's intermediate thinking lives (#552).
+        reasoning: choice.message.reasoning ?? undefined,
         toolCalls: [],
         finishReason: choice.finish_reason,
         inputTokens: turnInputTokens,
@@ -327,6 +342,7 @@ export class OpenAIAgentClient {
       const traceTurn: TurnTrace = {
         turnNumber: turn + 1,
         responseText: choice?.message.content ?? '',
+        reasoning: choice?.message.reasoning ?? undefined,
         toolCalls: [],
         finishReason: choice?.finish_reason,
         inputTokens,

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -147,6 +147,14 @@ export interface TurnTrace {
   turnNumber: number;
   /** Full assistant message content, captured before extractResponse. */
   responseText: string;
+  /**
+   * Extended-reasoning prose, captured from `message.reasoning` on
+   * OpenAI-compat responses (notably `google/gemini-3-flash-preview`,
+   * which emits its prose here on tool-calling turns and only puts the
+   * final JSON in `content`). Undefined when the model didn't emit
+   * reasoning or the provider doesn't support the field. (#552)
+   */
+  reasoning?: string;
   toolCalls: ToolInvocation[];
   finishReason?: string;
   inputTokens?: number;

--- a/packages/review/test/harness/compare-votes.ts
+++ b/packages/review/test/harness/compare-votes.ts
@@ -59,9 +59,9 @@ function renderTurn(turn: TurnTrace): string {
   const lines: string[] = [];
   // Reasoning first because that's the model's "why" for this turn
   // (when present — e.g. gemini-3-flash-preview emits it on tool-calling
-  // turns where `responseText` is typically empty). Skip the section
-  // entirely when absent so older traces render unchanged. (#552)
-  if (turn.reasoning && turn.reasoning.length > 0) {
+  // turns where `responseText` is typically empty). Empty strings are
+  // falsy so the truthy check skips both undefined and "". (#552)
+  if (turn.reasoning) {
     lines.push('--- reasoning ---');
     lines.push(turn.reasoning);
   }

--- a/packages/review/test/harness/compare-votes.ts
+++ b/packages/review/test/harness/compare-votes.ts
@@ -57,6 +57,14 @@ async function loadVote(path: string): Promise<VoteDump> {
  */
 function renderTurn(turn: TurnTrace): string {
   const lines: string[] = [];
+  // Reasoning first because that's the model's "why" for this turn
+  // (when present — e.g. gemini-3-flash-preview emits it on tool-calling
+  // turns where `responseText` is typically empty). Skip the section
+  // entirely when absent so older traces render unchanged. (#552)
+  if (turn.reasoning && turn.reasoning.length > 0) {
+    lines.push('--- reasoning ---');
+    lines.push(turn.reasoning);
+  }
   lines.push('--- response ---');
   lines.push(turn.responseText || '(empty)');
   lines.push('--- tools ---');


### PR DESCRIPTION
## Summary

The trace dump shipped in #550 captured `message.content` but not `message.reasoning`. For `google/gemini-3-flash-preview` (our production default) and other reasoning-enabled models surfaced via OpenRouter, the prose lives in `reasoning` — a separate field. On tool-calling turns `content` is typically null and `reasoning` carries the model's actual thinking. Trace files showed `responseText: \"\"` for the very turns we most wanted to read.

This PR captures `reasoning` alongside `content` and surfaces it in `compare-votes`.

Closes #552.

## Smoke evidence

`--rule stale-duplicate --votes 1 --trace /tmp/reasoning-smoke` against gemini-3-flash-preview:

| Turn | finishReason | responseText | reasoning |
|---|---|---:|---:|
| 1 | tool_calls | 0 chars | **250 chars** |
| 2 | tool_calls | 0 chars | **531 chars** |
| 3 | tool_calls | 0 chars | 0 chars (model chose not to emit) |
| 4 | stop | 1,677 chars | 694 chars |
| 5 | stop | 2,155 chars | 2,712 chars |

Sample turn-1 reasoning preview:

> **Reviewing Model Bump**
>
> I'm currently examining the PR that proposes upgrading the default \`agent-review\` model. My focus is on verifying structural integrity, specifically scrutinizing import statements, as part of this model version transition.

Smoke cost: \$0.1091.

## Plumbing

| File | Change |
|---|---|
| `types.ts` | Add `reasoning?: string` to `TurnTrace`. Additive. |
| `openai-client.ts` | Extend `ChatResponse.choices[].message` with `reasoning?: string \| null`. Capture in both the main-loop turn-trace and the summary-retry turn-trace. |
| `compare-votes.ts` | `renderTurn` emits a `--- reasoning ---` section before `--- response ---` when reasoning is non-empty. Skipped entirely when absent so older traces render unchanged. |

## Out of scope

- **Anthropic `thinking` block capture**. The Anthropic client doesn't request thinking blocks (no `thinking` parameter on `messages.create`), so its responses don't carry reasoning. Would need the parameter wired up first; separate decision.
- **Reasoning-aware diff scoring**. compare-votes treats reasoning and content the same in its diff render — fine for now; revisit if reasoning noise drowns out the substantive diffs.
- **Truncation cap on reasoning**. Currently uncapped (tool outputs are 4 KB-capped, but reasoning is the whole reason we built this — don't want to truncate). Revisit if traces grow >50 KB per vote.

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (28 pre-existing warnings, none in changed files)
- [x] `npm run format:check` — clean
- [x] `npm run test -w @liendev/review` — 348/348
- [x] Smoke `--votes 1 --trace`: tool-calling turns now have non-empty `reasoning`; older traces without the field still render correctly via the `if (turn.reasoning)` guard

## Related

- #549 / #550 — trace dump foundation (merged)
- #538 — harness foundation (merged)

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 7. 3 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | -7 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 785537c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended reasoning from AI models is now captured and stored in trace data
  * Reasoning information is displayed in turn comparisons for improved debugging insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->