### PR TITLE
fix(agent): loosen summary-retry guard to recover from null-content turns

### DIFF
--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -257,7 +257,16 @@ export class OpenAIAgentClient {
     }
 
     let parsed = extractResponse(lastContent);
-    if (!parsed.summary && lastContent !== null) {
+    // Fire the summary-retry whenever we have *any* loop history but no
+    // findings JSON. The previous guard `lastContent !== null` skipped
+    // retry whenever the model emitted reasoning but null content — the
+    // exact case gemini-3-flash-preview produces when it ends a turn
+    // with finish_reason=tool_calls but no actual tool_calls (its
+    // mid-investigation reasoning lives in the separate `reasoning`
+    // field, not `content`). Result: silent-bail failures on rules
+    // whose runs the model was actively investigating. Trace evidence
+    // gathered after #553 — see PR description.
+    if (!parsed.summary && turn > 0) {
       const retry = await this.runSummaryRetry(messages, turn);
       if (retry) {
         totalInputTokens += retry.inputTokens;


### PR DESCRIPTION
## Summary

Single-line fix to the agent loop's summary-retry guard. Replaces `lastContent !== null` with `turn > 0` so the retry fires whenever we have any history but no findings JSON — closing a silent-bail failure mode that's been showing up on `concurrency-race` and other rules.

## The bug

The agent loop ends, then we check whether to fire a "you didn't emit JSON, please try again" retry:

```ts
if (!parsed.summary && lastContent !== null) {
  const retry = await this.runSummaryRetry(messages, turn);
  ...
}
```

`lastContent` is `choice.message.content` from the most recent turn. For `google/gemini-3-flash-preview` (production default), `content` is null on tool-calling turns — the model's prose lives in `message.reasoning`, a separate field.

In practice gemini sometimes emits `finish_reason=tool_calls` with no actual `tool_calls` populated. Our agent loop's `else` branch breaks ("Unexpected finish_reason"). The retry guard then skips because `lastContent === null`. The caller sees zero findings.

But the model wasn't silent — it had emitted kilobytes of reasoning across previous turns explicitly identifying real bugs. We were just discarding the work.

## Diagnosis

This was invisible until the trace + reasoning capture shipped in #550 / #553.

After #553 made `reasoning` visible in the trace, a `--calibrate 10 --trace /tmp/x` run on `concurrency-race` produced 3 silent failures. Reading the failing votes' reasoning showed the model had already found the TOCTOU and was actively mid-investigation. Excerpt from a failing vote's last-turn reasoning:

> **Confirming Race Condition**: I've confirmed the TOCTOU race condition I suspected. The `Organization::hasCredits` check happens before any lock is acquired on the organization record. This means multiple concurrent webhooks for the same organization could pass this initial credit check, even if there aren't enough credits for all of them. The actual deduction is deferred. […]
>
> **Detecting Concurrency Issues**: I've identified another potential concurrency issue: `findOrCreateReviewRun` is not atomic. […]

The model wanted to keep going. The loop bailed. The retry path that would have rescued the findings was blocked by the wrong guard.

## Fix

Replace `lastContent !== null` with `turn > 0`. Same intent ("we have history but no JSON"), correct expression.

```diff
-    if (!parsed.summary && lastContent !== null) {
+    if (!parsed.summary && turn > 0) {
```

The retry path itself is unchanged; it just gets a chance to fire in the previously-blocked case.

## Calibration evidence

`--calibrate 10` against `gemini-3-flash-preview`, before vs after this fix:

| Fixture | Before | After |
|---|---:|---:|
| `concurrency-race/credit-service-toctou` | **7/10** ❌ | **10/10** ✅ |
| `boundary-change/ge-5-threshold-shift` | 10/10 | 10/10 |
| `boundary-change/placeholder` | 10/10 | 10/10 |
| `edge-case-sweep/percent-change-sign-flip` | 10/10 | 10/10 |
| `error-swallowing/payment-error-swallowed` | 10/10 | 10/10 |
| `incomplete-handling/enum-variant-removed` | 10/10 | 10/10 |
| `stale-duplicate/model-partial-update` | 10/10 | 10/10 |
| `structural-analysis/removed-export` | 10/10 | 10/10 |
| `untrusted-input-validation/harness-initial` | 10/10 | 10/10 |

Full canary regression sweep (9 fixtures × 10 runs): `allPassed: true`. Total cost: $3.87.

The 3 votes that recovered on concurrency-race now produce findings on par with the non-retry votes — they identify the same TOCTOU at line 82 / 132 plus adjacent `incomplete-handling` issues like the unused `InsufficientCreditsException`.

## Why this matters beyond concurrency-race

The same null-content quirk can hit any keyword-triggered rule. The `concurrency-race` fixture happens to surface it most often (large diff, lots of investigation), but every rule whose runs the model is actively investigating could silently bail on a bad day. Patching the retry guard fixes them all in one place.

## Anthropic client

Unaffected. Its existing guard is `!parsed.summary && lastResponse` — doesn't depend on the content/reasoning split. (Also doesn't currently request `thinking` blocks, so `reasoning`-vs-`content` doesn't apply on that path.)

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (28 pre-existing warnings, none in changed files)
- [x] `npm run format:check` — clean
- [x] `npm run test -w @liendev/review` — 348/348
- [x] Concurrency-race standalone calibration: 7/10 → **10/10**
- [x] Full canary regression sweep (9 fixtures): all pass at 10/10

## Related

- #549 / #550 — trace dump that made the loop visible
- #553 — reasoning capture that exposed the actual model behavior
- #538 — harness foundation

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 6. 3 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | -6 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3a31925. Updates automatically on new commits.</sup>
<!-- /lien-stats -->