### PR TITLE
feat(plugin): ship Claude Code plugin for one-time install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "lien",
+  "description": "Lien — local semantic code search and dependency analysis for AI assistants.",
+  "owner": { "name": "Lien" },
+  "plugins": [
+    {
+      "name": "lien",
+      "description": "Local semantic code search and dependency analysis for your codebase via MCP. Ships the Explore agent plus Lien's MCP tools (semantic_search, get_files_context, get_dependents, list_functions, get_complexity, find_similar). No per-project setup required.",
+      "category": "development",
+      "source": "./plugins/claude",
+      "homepage": "https://lien.dev"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,26 @@ cd packages/cli
 npm link
 ```
 
+### Dogfooding Lien while working on Lien
+
+The repo contains a Claude Code plugin at `plugins/claude/` and a marketplace manifest at `.claude-plugin/marketplace.json` — these are distribution files for end users. **Do not `/plugin install lien` in your dev environment** when working on Lien itself: that points the MCP server at the npm-published `@liendev/lien`, so you'd be testing the released build instead of your local changes.
+
+Instead, register Lien per-project against your local `dist/`:
+
+```jsonc
+// .mcp.json in this repo, or the corresponding entry in ~/.claude.json
+{
+  "mcpServers": {
+    "lien": {
+      "command": "node",
+      "args": ["/absolute/path/to/lien/packages/cli/dist/index.js", "serve", "-r", "."]
+    }
+  }
+}
+```
+
+Rebuild (`npm run build`) and restart your MCP client to pick up changes.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Lien connects AI coding assistants like Cursor and Claude Code to your codebase 
 
 ### Claude Code (recommended) — one-time plugin install
 
-```
+```text
 /plugin marketplace add getlien/lien
 /plugin install lien
 ```

--- a/README.md
+++ b/README.md
@@ -25,24 +25,28 @@ Lien connects AI coding assistants like Cursor and Claude Code to your codebase 
 
 ## Quick Start
 
+### Claude Code (recommended) — one-time plugin install
+
+```
+/plugin marketplace add getlien/lien
+/plugin install lien
+```
+
+That's it. Lien's MCP tools and the Explore agent are now available in every Claude Code session, in every repo. First use in a new git repo triggers a one-time index automatically — no `lien init` per project.
+
+### Other editors (Cursor, Windsurf, OpenCode, Kilo Code, Antigravity)
+
 ```bash
 # 1. Install
 npm install -g @liendev/lien
 
-# 2. Add to your project - create .cursor/mcp.json
-{
-  "mcpServers": {
-    "lien": {
-      "command": "lien",
-      "args": ["serve"]
-    }
-  }
-}
+# 2. Wire it up for your editor
+lien init
 
-# 3. Restart your AI assistant (Cursor, Claude Code) and start asking questions!
+# 3. Restart your editor and start asking questions
 ```
 
-That's it—zero configuration needed. Lien auto-detects your project and indexes on first use.
+`lien init` writes the right MCP config for your editor and (for Claude Code's legacy per-project flow, via `lien init --legacy`) copies an Explore agent into `.claude/agents/`. Lien auto-detects your project and indexes on first use.
 
 **👉 [Full installation guide](https://lien.dev/guide/installation)**
 

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -42,6 +42,10 @@ program
     ]),
   )
   .option('-p, --path <path>', 'Path to initialize (defaults to current directory)')
+  .option(
+    '--legacy',
+    'Use legacy per-project setup for Claude Code instead of recommending the plugin',
+  )
   .action(initCommand);
 
 program

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -323,7 +323,7 @@ describe('initCommand', () => {
     const perProjectEditors: EditorId[] = ['cursor', 'claude-code', 'opencode', 'kilo-code'];
 
     for (const editorId of perProjectEditors) {
-      await initCommand({ editor: editorId });
+      await initCommand({ editor: editorId, legacy: editorId === 'claude-code' });
     }
 
     // Check cursor config doesn't have --root

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -94,8 +94,19 @@ describe('initCommand', () => {
 
   // --- Claude Code ---
 
-  it('should create .mcp.json for claude-code', async () => {
+  it('should point users at the plugin by default and skip writing .mcp.json', async () => {
+    const logSpy = vi.spyOn(console, 'log');
+
     await initCommand({ editor: 'claude-code' });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('/plugin install lien'));
+
+    const configPath = path.join(testDir, '.mcp.json');
+    await expect(fs.access(configPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('should create .mcp.json for claude-code with --legacy', async () => {
+    await initCommand({ editor: 'claude-code', legacy: true });
 
     const configPath = path.join(testDir, '.mcp.json');
     const raw = await fs.readFile(configPath, 'utf-8');
@@ -108,11 +119,11 @@ describe('initCommand', () => {
     });
   });
 
-  it('should merge into existing .mcp.json for claude-code', async () => {
+  it('should merge into existing .mcp.json for claude-code with --legacy', async () => {
     const configPath = path.join(testDir, '.mcp.json');
     await fs.writeFile(configPath, JSON.stringify({ mcpServers: { other: { command: 'other' } } }));
 
-    await initCommand({ editor: 'claude-code' });
+    await initCommand({ editor: 'claude-code', legacy: true });
 
     const raw = await fs.readFile(configPath, 'utf-8');
     const config = JSON.parse(raw);
@@ -121,9 +132,9 @@ describe('initCommand', () => {
     expect(config.mcpServers.other).toEqual({ command: 'other' });
   });
 
-  it('should show Claude Code restart message', async () => {
+  it('should show Claude Code restart message under --legacy', async () => {
     const logSpy = vi.spyOn(console, 'log');
-    await initCommand({ editor: 'claude-code' });
+    await initCommand({ editor: 'claude-code', legacy: true });
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining('Restart Claude Code to activate.'),
     );

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -72,6 +72,7 @@ const EDITORS: Record<EditorId, EditorDefinition> = {
 export interface InitOptions {
   editor?: EditorId;
   path?: string;
+  legacy?: boolean;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -173,6 +174,17 @@ export async function initCommand(options: InitOptions = {}) {
     process.exit(1);
   } else {
     editorId = await promptForEditor();
+  }
+
+  if (editorId === 'claude-code' && !options.legacy) {
+    console.log(chalk.cyan('\nLien now ships as a Claude Code plugin.'));
+    console.log('\nInstall it once and it works in every session, in every repo:\n');
+    console.log(chalk.bold('  /plugin marketplace add getlien/lien'));
+    console.log(chalk.bold('  /plugin install lien\n'));
+    console.log(
+      chalk.dim('Pass --legacy to fall back to per-project .mcp.json + Explore agent install.\n'),
+    );
+    return;
   }
 
   const editor = EDITORS[editorId];

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -36,8 +36,8 @@ const {
   },
   mockSetupGitDetection: vi.fn().mockResolvedValue({ gitPollInterval: null }),
   mockSetupCleanupHandlers: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(undefined)),
-  mockIsGitRepo: vi.fn(async () => true),
-  mockIndexCodebase: vi.fn(async () => undefined),
+  mockIsGitRepo: vi.fn(async (_dir: string) => true),
+  mockIndexCodebase: vi.fn(async (_opts: { rootDir: string; verbose?: boolean }) => undefined),
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
@@ -295,6 +295,32 @@ describe('startMCPServer', () => {
         rootDir: '/test/no-git-dir',
         verbose: true,
       });
+    });
+
+    it('indexes when rootDir is a subdirectory of a git repo', async () => {
+      // .git lives at /test/repo, but rootDir is the nested package.
+      mockIsGitRepo.mockImplementation(async (dir: string) => dir === '/test/repo');
+
+      await startMCPServer({ rootDir: '/test/repo/packages/foo' });
+
+      expect(mockIsGitRepo).toHaveBeenCalledWith('/test/repo/packages/foo');
+      expect(mockIsGitRepo).toHaveBeenCalledWith('/test/repo');
+      expect(mockIndexCodebase).toHaveBeenCalledWith({
+        rootDir: '/test/repo/packages/foo',
+        verbose: true,
+      });
+    });
+
+    it('does not block server.connect on initial indexing', async () => {
+      mockIsGitRepo.mockResolvedValue(true);
+      // Simulate a slow index. If handleAutoIndexing awaited this, the test
+      // would hang on startMCPServer's promise instead of resolving.
+      mockIndexCodebase.mockImplementation(() => new Promise(() => {}));
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      expect(mockServerInstance.connect).toHaveBeenCalledOnce();
+      expect(mockIndexCodebase).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -9,6 +9,8 @@ const {
   mockEmbeddings,
   mockSetupGitDetection,
   mockSetupCleanupHandlers,
+  mockIsGitRepo,
+  mockIndexCodebase,
 } = vi.hoisted(() => ({
   mockServerInstance: {
     connect: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +36,8 @@ const {
   },
   mockSetupGitDetection: vi.fn().mockResolvedValue({ gitPollInterval: null }),
   mockSetupCleanupHandlers: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(undefined)),
+  mockIsGitRepo: vi.fn(async () => true),
+  mockIndexCodebase: vi.fn(async () => undefined),
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
@@ -54,6 +58,8 @@ vi.mock('@liendev/core', () => ({
   }),
   createVectorDB: vi.fn(async () => mockVectorDB),
   VERSION_CHECK_INTERVAL_MS: 60000,
+  isGitRepo: mockIsGitRepo,
+  indexCodebase: mockIndexCodebase,
 }));
 
 vi.mock('../watcher/index.js', () => ({
@@ -244,5 +250,51 @@ describe('startMCPServer', () => {
     expect(typeof toolContext.checkAndReconnect).toBe('function');
     expect(typeof toolContext.getIndexMetadata).toBe('function');
     expect(typeof toolContext.getReindexState).toBe('function');
+  });
+
+  describe('auto-indexing guard', () => {
+    beforeEach(() => {
+      mockVectorDB.hasData.mockResolvedValue(false);
+      mockIndexCodebase.mockClear();
+      mockIsGitRepo.mockReset();
+      delete process.env.LIEN_FORCE_INDEX;
+    });
+
+    afterEach(() => {
+      delete process.env.LIEN_FORCE_INDEX;
+    });
+
+    it('runs initial index when rootDir is a git repo', async () => {
+      mockIsGitRepo.mockResolvedValue(true);
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      expect(mockIsGitRepo).toHaveBeenCalledWith('/test/project');
+      expect(mockIndexCodebase).toHaveBeenCalledWith({
+        rootDir: '/test/project',
+        verbose: true,
+      });
+    });
+
+    it('skips initial index when rootDir has no .git', async () => {
+      mockIsGitRepo.mockResolvedValue(false);
+
+      await startMCPServer({ rootDir: '/test/no-git-dir' });
+
+      expect(mockIsGitRepo).toHaveBeenCalledWith('/test/no-git-dir');
+      expect(mockIndexCodebase).not.toHaveBeenCalled();
+    });
+
+    it('still indexes a non-git dir when LIEN_FORCE_INDEX=1', async () => {
+      mockIsGitRepo.mockResolvedValue(false);
+      process.env.LIEN_FORCE_INDEX = '1';
+
+      await startMCPServer({ rootDir: '/test/no-git-dir' });
+
+      expect(mockIndexCodebase).toHaveBeenCalledWith({
+        rootDir: '/test/no-git-dir',
+        verbose: true,
+      });
+    });
   });
 });

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -2,7 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import type { EmbeddingService, VectorDBInterface } from '@liendev/core';
 import {
   WorkerEmbeddings,
@@ -71,9 +71,26 @@ async function initializeDatabase(
   return { embeddings, vectorDB };
 }
 
+// Walk parent directories to detect whether startDir is inside a git work tree.
+// Plain isGitRepo only checks the exact dir, so it misses subdir invocations
+// (e.g. opening Claude Code in a monorepo package).
+async function isInsideGitWorkTree(startDir: string): Promise<boolean> {
+  let cur = resolve(startDir);
+  while (true) {
+    if (await isGitRepo(cur)) return true;
+    const parent = dirname(cur);
+    if (parent === cur) return false;
+    cur = parent;
+  }
+}
+
 /**
  * Run auto-indexing if needed (first run with no index).
  * Always enabled by default - no config needed.
+ *
+ * The actual indexCodebase call is fired without await — initial indexing can
+ * take minutes, and blocking before server.connect() would time out the MCP
+ * handshake. Tools return empty results until the background index lands.
  */
 async function handleAutoIndexing(
   vectorDB: VectorDBInterface,
@@ -81,30 +98,28 @@ async function handleAutoIndexing(
   log: LogFn,
 ): Promise<void> {
   const hasIndex = await vectorDB.hasData();
+  if (hasIndex) return;
 
-  if (!hasIndex) {
-    const forceIndex = process.env.LIEN_FORCE_INDEX === '1';
-    if (!forceIndex && !(await isGitRepo(rootDir))) {
-      log(
-        `Skipped auto-indexing: ${rootDir} has no .git directory. ` +
-          `Run 'lien index' or set LIEN_FORCE_INDEX=1 to index anyway.`,
-        'warning',
-      );
-      return;
-    }
+  const forceIndex = process.env.LIEN_FORCE_INDEX === '1';
+  if (!forceIndex && !(await isInsideGitWorkTree(rootDir))) {
+    log(
+      `Skipped auto-indexing: ${rootDir} is not inside a git work tree. ` +
+        `Set LIEN_FORCE_INDEX=1 to index anyway.`,
+      'warning',
+    );
+    return;
+  }
 
-    log('📦 No index found - running initial indexing...');
-    log('⏱️  This may take 5-20 minutes depending on project size');
+  log('📦 No index found - running initial indexing in the background...');
+  log('⏱️  Server is ready; tools will return empty results until indexing completes.');
 
-    try {
-      const { indexCodebase } = await import('@liendev/core');
-      await indexCodebase({ rootDir, verbose: true });
-      log('✅ Initial indexing complete!');
-    } catch (error) {
+  const { indexCodebase } = await import('@liendev/core');
+  void indexCodebase({ rootDir, verbose: true })
+    .then(() => log('✅ Initial indexing complete!'))
+    .catch(error => {
       log(`⚠️  Initial indexing failed: ${error}`, 'warning');
       log('You can manually run: lien index', 'warning');
-    }
-  }
+    });
 }
 
 /**

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -4,7 +4,12 @@ import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import type { EmbeddingService, VectorDBInterface } from '@liendev/core';
-import { WorkerEmbeddings, VERSION_CHECK_INTERVAL_MS, createVectorDB } from '@liendev/core';
+import {
+  WorkerEmbeddings,
+  VERSION_CHECK_INTERVAL_MS,
+  createVectorDB,
+  isGitRepo,
+} from '@liendev/core';
 import { FileWatcher } from '../watcher/index.js';
 import { createMCPServerConfig, registerMCPHandlers } from './server-config.js';
 import { createReindexStateManager } from './reindex-state-manager.js';
@@ -78,6 +83,16 @@ async function handleAutoIndexing(
   const hasIndex = await vectorDB.hasData();
 
   if (!hasIndex) {
+    const forceIndex = process.env.LIEN_FORCE_INDEX === '1';
+    if (!forceIndex && !(await isGitRepo(rootDir))) {
+      log(
+        `Skipped auto-indexing: ${rootDir} has no .git directory. ` +
+          `Run 'lien index' or set LIEN_FORCE_INDEX=1 to index anyway.`,
+        'warning',
+      );
+      return;
+    }
+
     log('📦 No index found - running initial indexing...');
     log('⏱️  This may take 5-20 minutes depending on project size');
 

--- a/packages/cli/test/cli/init.test.ts
+++ b/packages/cli/test/cli/init.test.ts
@@ -20,20 +20,20 @@ describe('initCommand', () => {
   });
 
   describe('Explore agent installation', () => {
-    it('installs .claude/agents/Explore.md for claude-code', async () => {
-      await initCommand({ editor: 'claude-code', path: tmpDir });
+    it('installs .claude/agents/Explore.md for claude-code under --legacy', async () => {
+      await initCommand({ editor: 'claude-code', path: tmpDir, legacy: true });
 
       const agentPath = path.join(tmpDir, '.claude', 'agents', 'Explore.md');
       const content = await fs.readFile(agentPath, 'utf-8');
       expect(content).toBe(EXPLORE_AGENT_CONTENT);
     });
 
-    it('does not overwrite existing Explore.md', async () => {
+    it('does not overwrite existing Explore.md under --legacy', async () => {
       const agentPath = path.join(tmpDir, '.claude', 'agents', 'Explore.md');
       await fs.mkdir(path.dirname(agentPath), { recursive: true });
       await fs.writeFile(agentPath, 'custom content');
 
-      await initCommand({ editor: 'claude-code', path: tmpDir });
+      await initCommand({ editor: 'claude-code', path: tmpDir, legacy: true });
 
       const content = await fs.readFile(agentPath, 'utf-8');
       expect(content).toBe('custom content');
@@ -41,6 +41,13 @@ describe('initCommand', () => {
 
     it('does not install Explore agent for non-claude-code editors', async () => {
       await initCommand({ editor: 'cursor', path: tmpDir });
+
+      const agentPath = path.join(tmpDir, '.claude', 'agents', 'Explore.md');
+      await expect(fs.access(agentPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('does not install Explore agent for claude-code without --legacy (plugin path)', async () => {
+      await initCommand({ editor: 'claude-code', path: tmpDir });
 
       const agentPath = path.join(tmpDir, '.claude', 'agents', 'Explore.md');
       await expect(fs.access(agentPath)).rejects.toMatchObject({ code: 'ENOENT' });

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "lien",
+  "description": "Local semantic code search and dependency analysis for your codebase via MCP. Ships the Explore agent plus Lien's MCP tools (semantic_search, get_files_context, get_dependents, list_functions, get_complexity, find_similar). No per-project setup required.",
+  "author": { "name": "Lien" },
+  "homepage": "https://lien.dev"
+}

--- a/plugins/claude/.mcp.json
+++ b/plugins/claude/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "lien": {
+    "command": "npx",
+    "args": ["-y", "@liendev/lien", "serve"]
+  }
+}

--- a/plugins/claude/agents/Explore.md
+++ b/plugins/claude/agents/Explore.md
@@ -1,0 +1,55 @@
+---
+name: Explore
+description: >-
+  Fast codebase explorer enhanced with Lien semantic search. Use for questions
+  like "where is X?", "how does X work?", "what depends on X?", "find all
+  controllers", "what are the most complex functions?", and any codebase
+  discovery or exploration task.
+model: sonnet
+disallowedTools: Write, Edit, NotebookEdit, Agent
+color: purple
+---
+
+# Lien-Enhanced Codebase Explorer
+
+You are a codebase exploration agent with access to Lien semantic code search
+tools. Answer questions about the codebase quickly and accurately.
+
+## Tool Selection
+
+Choose the right tool for each query type:
+
+### Lien Tools (use FIRST)
+
+| Query Type | Tool |
+|------------|------|
+| "Where is X?" / "How does X work?" | `semantic_search` — phrase as full question |
+| "Find all controllers/services" | `list_functions` with pattern regex |
+| "Show all classes/interfaces" | `list_functions` with symbolType filter |
+| "What does this file do?" / "What tests cover this?" | `get_files_context` |
+| "What depends on this?" / "Safe to change?" | `get_dependents` |
+| "Most complex functions?" / "Tech debt hotspots?" | `get_complexity` |
+| "Find similar code to this pattern" | `find_similar` |
+
+### Fallback Tools (when Lien tools are insufficient)
+
+| Task | Tool |
+|------|------|
+| Exact string / literal match | `Grep` |
+| File path patterns | `Glob` |
+| Read file contents | `Read` |
+| Directory listing, git log/diff | `Bash` |
+
+### Rules
+
+1. **Start with Lien tools.** For any "where/how/what" question, use `semantic_search` first.
+2. **Use `list_functions` for structural queries.** 10x faster than semantic_search for name-based lookups.
+3. **Fall back to Grep only for exact strings** — literal text, config keys, error messages, TODOs.
+4. **Combine tools for depth.** semantic_search to locate, Read to examine, get_dependents for impact.
+5. **Be concise.** Return the answer with file paths and line numbers, not a narration of your search.
+
+### semantic_search tips
+
+- Phrase as full questions: "How does the code handle authentication?" not "auth"
+- Describe what code DOES, not function names
+- Use limit 5-15 depending on breadth needed


### PR DESCRIPTION
## Summary

Adds a Claude Code plugin so users can install Lien once and get the MCP tools + Explore agent in every session, every repo — no per-project `lien init` needed.

- `plugins/claude/` — plugin scaffold (`.claude-plugin/plugin.json`, `.mcp.json`, `agents/Explore.md`)
- `.claude-plugin/marketplace.json` — self-hosted marketplace pointing at `./plugins/claude`
- `handleAutoIndexing` now skips first-run indexing when `rootDir` has no `.git` (override with `LIEN_FORCE_INDEX=1`), so the plugin doesn't index scratch dirs when Claude Code is opened in `~/Documents` or similar
- `lien init --editor=claude-code` prints the plugin install hint and exits; `--legacy` preserves the per-project `.mcp.json` + Explore agent install for users mid-migration
- README quick-start leads with `/plugin install lien` for Claude Code
- CONTRIBUTING notes the dogfooding setup so contributors keep their local-build MCP entry instead of installing the npm-published plugin

Install path for users:
```
/plugin marketplace add getlien/lien
/plugin install lien
```

Submission to `anthropics/claude-plugins-official` is deferred until after end-to-end verification of the self-hosted path.

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` (0 errors)
- [ ] `npm run format:check` clean
- [ ] `npm run test -w packages/cli` — 638 tests pass (including 3 new auto-indexing guard tests)
- [ ] `npm run test -w @liendev/review` — 348 tests pass
- [ ] Manual: in a non-git scratch dir, `serve` logs the "skipped auto-indexing" hint and starts without indexing
- [ ] Manual: in a fresh git repo, `serve` runs the initial index
- [ ] Manual: `LIEN_FORCE_INDEX=1` forces indexing in a non-git dir
- [ ] Manual: `/plugin marketplace add <repo>` + `/plugin install lien` in a fresh Claude Code session surfaces `mcp__lien__*` tools and the `Explore` agent with no prior `lien init`
- [ ] Manual: `lien init --editor=claude-code` prints the plugin hint and writes nothing
- [ ] Manual: `lien init --editor=claude-code --legacy` writes `.mcp.json` and `.claude/agents/Explore.md` as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lien is available as a Claude marketplace plugin and exposes its MCP-powered tools and an Explore agent.

* **Improvements**
  * CLI supports a `--legacy` per-project setup mode.
  * Auto-indexing now respects Git repository presence and a force-index override.

* **Tests**
  * Added/updated tests for auto-indexing behavior and legacy vs default init flows.

* **Documentation**
  * Updated quick-start and contributor guidance for Claude plugin setup and legacy usage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/555)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 1 new function is more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +61 |


> [!NOTE]
> **Low Risk**
>
> This PR introduces a Claude Code plugin and improves the auto-indexing behavior of the MCP server. It successfully addresses previous issues where auto-indexing would block the server startup (causing MCP handshake timeouts) and fail to detect git repositories when started from a subdirectory. The implementation of the auto-indexing guard and the background indexing process are well-handled and covered by new tests.
>
> - Added Claude Code plugin scaffold and marketplace manifest for one-time installation.
> - Implemented `isInsideGitWorkTree` to correctly detect git repositories from subdirectories by walking up the directory tree.
> - Modified `handleAutoIndexing` to run indexing in the background, ensuring the MCP server can connect immediately and avoid client timeouts.
> - Updated `lien init` to recommend the plugin path for Claude Code users while maintaining a `--legacy` flag for per-project setups.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 90d509c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->