### PR TITLE
fix(indexer): drop chunks for files removed on git branch switch

### DIFF
--- a/packages/cli/src/mcp/git-detection.ts
+++ b/packages/cli/src/mcp/git-detection.ts
@@ -49,6 +49,7 @@ async function handleGitStartup(
       await checkAndReconnect();
       const count = await indexMultipleFiles(filteredFiles, vectorDB, embeddings, {
         verbose: false,
+        rootDir,
       });
       const duration = Date.now() - startTime;
       reindexStateManager.completeReindex(duration);
@@ -120,6 +121,7 @@ function createGitPollInterval(
           await checkAndReconnect();
           const count = await indexMultipleFiles(filteredFiles, vectorDB, embeddings, {
             verbose: false,
+            rootDir,
           });
           const duration = Date.now() - startTime;
           reindexStateManager.completeReindex(duration);
@@ -193,6 +195,7 @@ async function detectAndFilterGitChanges(
  */
 async function executeGitReindex(
   filteredFiles: string[],
+  rootDir: string,
   vectorDB: VectorDBInterface,
   embeddings: EmbeddingService,
   reindexStateManager: ReturnType<typeof createReindexStateManager>,
@@ -205,7 +208,10 @@ async function executeGitReindex(
 
   try {
     await checkAndReconnect();
-    const count = await indexMultipleFiles(filteredFiles, vectorDB, embeddings, { verbose: false });
+    const count = await indexMultipleFiles(filteredFiles, vectorDB, embeddings, {
+      verbose: false,
+      rootDir,
+    });
     const duration = Date.now() - startTime;
     reindexStateManager.completeReindex(duration);
     log(`✓ Reindexed ${count} files in ${duration}ms`);
@@ -263,6 +269,7 @@ function createGitChangeHandler(
 
       await executeGitReindex(
         filteredFiles,
+        rootDir,
         vectorDB,
         embeddings,
         reindexStateManager,

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -252,6 +252,36 @@ describe('startMCPServer', () => {
     expect(typeof toolContext.getReindexState).toBe('function');
   });
 
+  describe('getIndexMetadata indexedRef fields', () => {
+    it('returns null indexedBranch/indexedCommit when git detection is unavailable', async () => {
+      mockSetupGitDetection.mockResolvedValue({ gitTracker: null, gitPollInterval: null });
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
+      const metadata = toolContext.getIndexMetadata();
+      expect(metadata.indexedBranch).toBeNull();
+      expect(metadata.indexedCommit).toBeNull();
+    });
+
+    it('surfaces branch + commit from GitStateTracker.getState() when available', async () => {
+      const fakeGitTracker = {
+        getState: () => ({ branch: 'feature-x', commit: 'abc1234', timestamp: 1234567890 }),
+      };
+      mockSetupGitDetection.mockResolvedValue({
+        gitTracker: fakeGitTracker,
+        gitPollInterval: null,
+      });
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
+      const metadata = toolContext.getIndexMetadata();
+      expect(metadata.indexedBranch).toBe('feature-x');
+      expect(metadata.indexedCommit).toBe('abc1234');
+    });
+  });
+
   describe('auto-indexing guard', () => {
     beforeEach(() => {
       mockVectorDB.hasData.mockResolvedValue(false);

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
-import type { EmbeddingService, VectorDBInterface } from '@liendev/core';
+import type { EmbeddingService, VectorDBInterface, GitState } from '@liendev/core';
 import {
   WorkerEmbeddings,
   VERSION_CHECK_INTERVAL_MS,
@@ -188,16 +188,23 @@ interface VersionCheckingResult {
     pendingFileCount?: number;
     lastReindexDurationMs?: number | null;
     msSinceLastReindex?: number | null;
+    indexedBranch?: string | null;
+    indexedCommit?: string | null;
   };
 }
 
 /**
  * Setup version checking and reconnection logic.
+ *
+ * @param getGitState - Returns the GitStateTracker's current state if git
+ *   detection is active for this rootDir. Wired in by `startMCPServer` after
+ *   `setupGitDetection` populates the tracker.
  */
 function setupVersionChecking(
   vectorDB: VectorDBInterface,
   log: LogFn,
   reindexStateManager: ReturnType<typeof createReindexStateManager>,
+  getGitState: () => GitState | null,
 ): VersionCheckingResult {
   const checkAndReconnect = async () => {
     try {
@@ -212,6 +219,7 @@ function setupVersionChecking(
 
   const getIndexMetadata = () => {
     const reindex = reindexStateManager.getState();
+    const gitState = getGitState();
     return {
       indexVersion: vectorDB.getCurrentVersion(),
       indexDate: vectorDB.getVersionDate(),
@@ -223,6 +231,8 @@ function setupVersionChecking(
       msSinceLastReindex: reindex.lastReindexTimestamp
         ? Date.now() - reindex.lastReindexTimestamp
         : null,
+      indexedBranch: gitState?.branch ?? null,
+      indexedCommit: gitState?.commit ?? null,
     };
   };
 
@@ -307,9 +317,13 @@ async function setupAndConnectServer(
   log: LogFn,
   versionCheckInterval: NodeJS.Timeout,
   reindexStateManager: ReturnType<typeof createReindexStateManager>,
-  options: { rootDir: string; watch: boolean | undefined },
+  options: {
+    rootDir: string;
+    watch: boolean | undefined;
+    onGitTrackerReady: (state: () => GitState | null) => void;
+  },
 ): Promise<void> {
-  const { rootDir, watch } = options;
+  const { rootDir, watch, onGitTrackerReady } = options;
   const { vectorDB, embeddings } = toolContext;
 
   // Register all MCP handlers
@@ -330,7 +344,7 @@ async function setupAndConnectServer(
   );
 
   // Setup git detection (will use event-driven approach if fileWatcher is available)
-  const { gitPollInterval } = await setupGitDetection(
+  const { gitTracker, gitPollInterval } = await setupGitDetection(
     rootDir,
     vectorDB,
     embeddings,
@@ -339,6 +353,7 @@ async function setupAndConnectServer(
     fileWatcher,
     toolContext.checkAndReconnect,
   );
+  onGitTrackerReady(() => (gitTracker ? gitTracker.getState() : null));
 
   // Setup cleanup handlers
   const cleanup = setupCleanupHandlers(
@@ -379,11 +394,15 @@ export async function startMCPServer(options: MCPServerOptions): Promise<void> {
   // Create reindex state manager
   const reindexStateManager = createReindexStateManager();
 
+  // Holder for the GitStateTracker state getter. setupGitDetection runs later
+  // inside setupAndConnectServer; until then, indexed-ref fields read as null.
+  let getGitState: () => GitState | null = () => null;
+
   const {
     interval: versionCheckInterval,
     checkAndReconnect,
     getIndexMetadata,
-  } = setupVersionChecking(vectorDB, log, reindexStateManager);
+  } = setupVersionChecking(vectorDB, log, reindexStateManager, () => getGitState());
   const toolContext: ToolContext = {
     vectorDB,
     embeddings,
@@ -397,5 +416,8 @@ export async function startMCPServer(options: MCPServerOptions): Promise<void> {
   await setupAndConnectServer(server, toolContext, log, versionCheckInterval, reindexStateManager, {
     rootDir,
     watch,
+    onGitTrackerReady: state => {
+      getGitState = state;
+    },
   });
 }

--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -58,6 +58,10 @@ export interface IndexMetadata {
   pendingFileCount?: number;
   lastReindexDurationMs?: number | null;
   msSinceLastReindex?: number | null;
+  /** Git branch the index was last reconciled with. Null when not in a git repo. */
+  indexedBranch?: string | null;
+  /** Git commit SHA the index was last reconciled with. Null when not in a git repo. */
+  indexedCommit?: string | null;
 }
 
 /**

--- a/packages/core/src/indexer/branch-switch.test.ts
+++ b/packages/core/src/indexer/branch-switch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { indexMultipleFiles } from './incremental.js';
+import { VectorDB } from '../vectordb/lancedb.js';
+import { MockEmbeddings } from '../test/helpers/mock-embeddings.js';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(repoDir: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd: repoDir });
+}
+
+describe('incremental indexing across git branch switch', () => {
+  let repoDir: string;
+  let indexPath: string;
+  let vectorDB: VectorDB;
+  let embeddings: MockEmbeddings;
+
+  beforeEach(async () => {
+    repoDir = await createTestDir();
+    indexPath = path.join(repoDir, '.lien');
+    await fs.mkdir(indexPath, { recursive: true });
+
+    await git(repoDir, 'init', '-q', '-b', 'main');
+    await git(repoDir, 'config', 'user.email', 'test@lien.dev');
+    await git(repoDir, 'config', 'user.name', 'Lien Test');
+    await git(repoDir, 'config', 'commit.gpgsign', 'false');
+
+    embeddings = new MockEmbeddings();
+    vectorDB = new VectorDB(indexPath);
+    await vectorDB.initialize();
+    await embeddings.initialize();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(repoDir);
+  });
+
+  it('drops chunks for a file deleted on the new branch', async () => {
+    // Arrange: commit a file on main and index it.
+    const fooDir = path.join(repoDir, 'foo');
+    await fs.mkdir(fooDir, { recursive: true });
+    const fooPath = path.join(fooDir, 'bar.py');
+    await fs.writeFile(fooPath, 'def quux():\n    return 42\n');
+    await git(repoDir, 'add', '.');
+    await git(repoDir, 'commit', '-q', '-m', 'add foo/bar.py');
+
+    await indexMultipleFiles([fooPath], vectorDB, embeddings, { rootDir: repoDir });
+
+    const before = await vectorDB.scanWithFilter({ file: 'foo/bar.py' });
+    expect(before.length).toBeGreaterThan(0);
+
+    // Act: branch off, delete the file, commit, and reindex via the deleted path.
+    await git(repoDir, 'checkout', '-q', '-b', 'feature');
+    await fs.unlink(fooPath);
+    await git(repoDir, 'add', '-A');
+    await git(repoDir, 'commit', '-q', '-m', 'remove foo/bar.py');
+
+    await indexMultipleFiles([fooPath], vectorDB, embeddings, { rootDir: repoDir });
+
+    // Assert: no chunks remain for the deleted file.
+    const after = await vectorDB.scanWithFilter({ file: 'foo/bar.py' });
+    expect(after).toEqual([]);
+  });
+});

--- a/packages/core/src/indexer/branch-switch.test.ts
+++ b/packages/core/src/indexer/branch-switch.test.ts
@@ -40,6 +40,21 @@ describe('incremental indexing across git branch switch', () => {
     await cleanupTestDir(repoDir);
   });
 
+  it('indexes a file passed as a path relative to rootDir', async () => {
+    // Regression for the Lien Review finding: fs ops in the indexer used the
+    // raw filepath, so a relative path against a non-cwd rootDir failed silently.
+    const fooDir = path.join(repoDir, 'foo');
+    await fs.mkdir(fooDir, { recursive: true });
+    await fs.writeFile(path.join(fooDir, 'bar.py'), 'def quux():\n    return 42\n');
+
+    // Pass the path RELATIVE TO rootDir, not absolute. Process cwd is the lien
+    // package dir at test time, so this is the precise scenario the fix covers.
+    await indexMultipleFiles(['foo/bar.py'], vectorDB, embeddings, { rootDir: repoDir });
+
+    const chunks = await vectorDB.scanWithFilter({ file: 'foo/bar.py' });
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
   it('drops chunks for a file deleted on the new branch', async () => {
     // Arrange: commit a file on main and index it.
     const fooDir = path.join(repoDir, 'foo');

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -35,15 +35,14 @@ export function normalizeToRelativePath(filepath: string, rootDir?: string): str
     return normalized;
   }
 
-  // Convert absolute to relative
+  // Convert absolute to relative. Require a separator after `root` so that
+  // `/app` does not falsely prefix-match `/apple/...` — fall through to
+  // path.relative for everything else (incl. paths outside root, which
+  // produce a leading `../`).
   if (normalized.startsWith(root + '/')) {
     return normalized.slice(root.length + 1);
   }
-  if (normalized.startsWith(root)) {
-    return normalized.slice(root.length);
-  }
 
-  // Fallback: use path.relative
   return path.relative(root, filepath).replace(/\\/g, '/');
 }
 
@@ -167,10 +166,17 @@ export async function indexSingleFile(
   // This ensures paths from git diff (absolute) match paths from scanner (relative)
   const normalizedPath = normalizeToRelativePath(filepath, rootDir);
 
+  // Resolve to an absolute path for filesystem operations. Callers (esp. git
+  // integration) may pass repo-relative paths that would otherwise be resolved
+  // against process.cwd() — which can differ from rootDir.
+  const absolutePath = path.isAbsolute(filepath)
+    ? filepath
+    : path.resolve(rootDir || process.cwd(), filepath);
+
   try {
-    // Check if file exists (use original filepath for filesystem operations)
+    // Check if file exists (use absolute filepath for filesystem operations)
     try {
-      await fs.access(filepath);
+      await fs.access(absolutePath);
     } catch {
       // File doesn't exist - delete from index and manifest using normalized path
       if (verbose) {
@@ -184,7 +190,7 @@ export async function indexSingleFile(
     }
 
     // Read file content
-    const content = await fs.readFile(filepath, 'utf-8');
+    const content = await fs.readFile(absolutePath, 'utf-8');
 
     // Process file content (chunking + embeddings) - use normalized path for storage
     const result = await processFileContent(
@@ -196,8 +202,8 @@ export async function indexSingleFile(
     );
 
     // Get actual file mtime and compute content hash for manifest
-    const stats = await fs.stat(filepath);
-    const contentHash = await computeContentHash(filepath);
+    const stats = await fs.stat(absolutePath);
+    const contentHash = await computeContentHash(absolutePath);
     const manifest = new ManifestManager(vectorDB.dbPath);
 
     if (result === null) {
@@ -252,10 +258,16 @@ async function processSingleFileForIndexing(
   rootDir?: string,
 ): Promise<Result<FileProcessResult, string>> {
   try {
-    // Read file stats and content using original path (for filesystem access)
-    const stats = await fs.stat(filepath);
-    const content = await fs.readFile(filepath, 'utf-8');
-    const contentHash = await computeContentHash(filepath);
+    // Resolve to an absolute path for filesystem operations. Callers may pass
+    // repo-relative paths that would otherwise resolve against process.cwd().
+    const absolutePath = path.isAbsolute(filepath)
+      ? filepath
+      : path.resolve(rootDir || process.cwd(), filepath);
+
+    // Read file stats and content using the absolute path
+    const stats = await fs.stat(absolutePath);
+    const content = await fs.readFile(absolutePath, 'utf-8');
+    const contentHash = await computeContentHash(absolutePath);
 
     // Process content using normalized path (for storage)
     const result = await processFileContent(normalizedPath, content, embeddings, verbose, rootDir);

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -165,7 +165,7 @@ export async function indexSingleFile(
 
   // Normalize to relative path for consistent storage and queries
   // This ensures paths from git diff (absolute) match paths from scanner (relative)
-  const normalizedPath = normalizeToRelativePath(filepath);
+  const normalizedPath = normalizeToRelativePath(filepath, rootDir);
 
   try {
     // Check if file exists (use original filepath for filesystem operations)
@@ -446,7 +446,7 @@ export async function indexMultipleFiles(
 
   for (const filepath of filepaths) {
     const task = limit(async () => {
-      const normalizedPath = normalizeToRelativePath(filepath);
+      const normalizedPath = normalizeToRelativePath(filepath, rootDir);
       const result = await processSingleFileForIndexing(
         filepath,
         normalizedPath,

--- a/packages/core/src/indexer/normalize-path.test.ts
+++ b/packages/core/src/indexer/normalize-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeToRelativePath } from './incremental.js';
+
+describe('normalizeToRelativePath', () => {
+  it('strips the root prefix when filepath is under root', () => {
+    expect(normalizeToRelativePath('/app/src/main.ts', '/app')).toBe('src/main.ts');
+  });
+
+  it('returns the input when filepath is already relative', () => {
+    expect(normalizeToRelativePath('src/main.ts', '/app')).toBe('src/main.ts');
+  });
+
+  it('handles trailing slash on root', () => {
+    expect(normalizeToRelativePath('/app/src/main.ts', '/app/')).toBe('src/main.ts');
+  });
+
+  it('does NOT falsely prefix-match a sibling directory', () => {
+    // Regression for the Lien Review finding: previously '/apple/main.ts' was
+    // sliced as 'le/main.ts' because startsWith('/app') matched without
+    // requiring a trailing separator.
+    expect(normalizeToRelativePath('/apple/main.ts', '/app')).toBe('../apple/main.ts');
+  });
+
+  it('returns a relative-up path when filepath is outside root', () => {
+    expect(normalizeToRelativePath('/elsewhere/file.ts', '/app')).toBe('../elsewhere/file.ts');
+  });
+
+  it('normalizes Windows-style separators in input', () => {
+    expect(normalizeToRelativePath('/app\\src\\main.ts', '/app')).toBe('src/main.ts');
+  });
+});


### PR DESCRIPTION
Closes #556.

## Summary

After `git checkout B`, Lien's MCP tools kept returning chunks for files that no longer existed on the new branch. Path normalization at index time and at deletion time used different roots — `indexMultipleFiles` dropped `rootDir` and fell back to `process.cwd()`, so the deletion targeted a key that was never written.

The fix:

- Thread `rootDir` through `indexSingleFile` and `indexMultipleFiles` into `normalizeToRelativePath`, so storage and deletion keys are computed against the same root.
- Pass `rootDir` at every `indexMultipleFiles` call site in `git-detection.ts` (`handleGitStartup`, `createGitPollInterval`, `executeGitReindex` — previously all omitted it).
- Add `indexedBranch` + `indexedCommit` to `indexInfo`, sourced from `GitStateTracker.getState()`. This is the safety net the issue asked for: callers (and humans reviewing tool output) can detect drift even if a future regression sneaks past review.
- Repro/regression test (`packages/core/src/indexer/branch-switch.test.ts`) does a real `git init` → commit → index → branch + delete + commit → reindex → assert no chunks remain for the deleted file. **This test fails on `main` (pre-fix) and passes here**, so the bug is locked in.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` (0 errors, only pre-existing warnings)
- [x] `npm run format:check` clean
- [x] `npm run test -w packages/cli` — 642 pass (incl. 2 new `getIndexMetadata indexedRef fields` tests)
- [x] `npm run test -w @liendev/core --` — 499/499 pass (excluding `qdrant.test.ts` which fails without a running Qdrant server, as expected)
- [x] New `branch-switch.test.ts` passes here, fails on `main`
- [ ] Manual: in a real repo with the local Lien build — checkout a branch that removes a file, wait for the watcher (≤5s), confirm `mcp__lien__get_files_context` for the removed path returns no chunks, and that `indexedBranch` in `indexInfo` reports the new branch.

## Out of scope

- A manual `reindex_now` MCP tool — useful escape hatch, but a separate feature, not part of this bug fix.
- One latent path-key bug in `packages/cli/src/mcp/utils/metadata-shaper.ts:122` (`normalizeToRelativePath(r.metadata.file)` without `rootDir`) affects dedup keying in search-result post-processing. Separate from #556 — different code path, different impact. Will file a follow-up.
- Cross-worktree (`git worktree add`) support.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> The PR successfully addresses the issue where files removed during a git branch switch were not being dropped from the index. It achieves this by consistently threading the `rootDir` through the indexing pipeline, ensuring that path normalization for both storage and deletion uses the same reference point. Additionally, it enhances the index metadata with git branch and commit information, providing better observability for potential drift.
>
> - Threaded `rootDir` through `indexSingleFile`, `indexMultipleFiles`, and `normalizeToRelativePath` to ensure consistent path keys.
> - Updated all git-triggered reindexing call sites in `git-detection.ts` to pass the correct `rootDir`.
> - Added `indexedBranch` and `indexedCommit` fields to the MCP server's index metadata, sourced from the `GitStateTracker`.
> - Improved `normalizeToRelativePath` to avoid false prefix matches (e.g., `/app` matching `/apple`) and added comprehensive tests for path normalization.
> - Added a regression test that simulates a git branch switch and verifies that deleted files are correctly removed from the vector database.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit cd59c8d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git metadata (indexed branch and commit information) now exposed in the server's index information response.

* **Tests**
  * Added coverage for git metadata retrieval scenarios.
  * Added integration test for incremental indexing behavior across git branch switches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/557)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->