### PR TITLE
fix(git): use tip-to-tip diff for branch-switch reconciliation

### DIFF
--- a/packages/core/src/git/utils.test.ts
+++ b/packages/core/src/git/utils.test.ts
@@ -318,5 +318,39 @@ describe('Git Utils', () => {
       expect(Array.isArray(changedFiles)).toBe(true);
       expect(changedFiles.some(f => f.endsWith('file2.txt'))).toBe(true);
     });
+
+    it('lists branch-exclusive files in both diff directions (tip-to-tip)', async () => {
+      // Regression for #556 round 2: getChangedFiles must use direct tip-to-tip
+      // (two-dot) semantics, not three-dot. Three-dot would silently omit files
+      // that exist only on the FROM branch when diffing FROM...TO.
+      if (!isGitInstalled) {
+        console.log('Skipping test - git not installed');
+        return;
+      }
+
+      await execAsync('git init', { cwd: testDir });
+      await execAsync('git config user.email "test@example.com"', { cwd: testDir });
+      await execAsync('git config user.name "Test User"', { cwd: testDir });
+
+      // main has nothing yet — empty initial commit so a branch can exist.
+      await execAsync('git commit --allow-empty -m "init"', { cwd: testDir });
+      const mainBranch = await getCurrentBranch(testDir);
+
+      // feature adds foo.txt.
+      await execAsync('git checkout -b feature', { cwd: testDir });
+      await fs.writeFile(path.join(testDir, 'foo.txt'), 'hello');
+      await execAsync('git add .', { cwd: testDir });
+      await execAsync('git commit -m "add foo.txt"', { cwd: testDir });
+
+      // feature -> main: foo.txt exists on feature but not main. Direct tip-to-tip
+      // diff lists foo.txt as a deletion. Three-dot diff would return empty
+      // because main added nothing relative to merge base.
+      const featureToMain = await getChangedFiles(testDir, 'feature', mainBranch);
+      expect(featureToMain.some(f => f.endsWith('foo.txt'))).toBe(true);
+
+      // main -> feature: foo.txt also shows up (added on feature).
+      const mainToFeature = await getChangedFiles(testDir, mainBranch, 'feature');
+      expect(mainToFeature.some(f => f.endsWith('foo.txt'))).toBe(true);
+    });
   });
 });

--- a/packages/core/src/git/utils.ts
+++ b/packages/core/src/git/utils.ts
@@ -88,14 +88,14 @@ export async function getChangedFiles(
   validateGitRef(toRef, 'toRef');
 
   try {
-    const { stdout } = await execFileAsync(
-      'git',
-      ['diff', '--name-only', `${fromRef}...${toRef}`],
-      {
-        cwd: rootDir,
-        timeout: 10000, // 10 second timeout for diffs
-      },
-    );
+    // Direct tip-to-tip diff (two refs as separate args). Three-dot (`A...B`)
+    // is the merge-base / PR-diff form, which silently omits files that exist
+    // only on `fromRef` — wrong semantic for branch-switch reconciliation
+    // (see #556). Mirrors `getChangedFilesBetweenCommits` below.
+    const { stdout } = await execFileAsync('git', ['diff', '--name-only', fromRef, toRef], {
+      cwd: rootDir,
+      timeout: 10000, // 10 second timeout for diffs
+    });
 
     const files = stdout
       .trim()

--- a/packages/core/src/indexer/branch-switch.test.ts
+++ b/packages/core/src/indexer/branch-switch.test.ts
@@ -5,6 +5,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { indexMultipleFiles } from './incremental.js';
 import { VectorDB } from '../vectordb/lancedb.js';
+import { GitStateTracker } from '../git/tracker.js';
 import { MockEmbeddings } from '../test/helpers/mock-embeddings.js';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
 
@@ -53,6 +54,51 @@ describe('incremental indexing across git branch switch', () => {
 
     const chunks = await vectorDB.scanWithFilter({ file: 'foo/bar.py' });
     expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  it('reconciles chunks via the GitStateTracker pipeline when switching to a branch without the file', async () => {
+    // This is the user-reported scenario: file exists on `feature`, doesn't on `main`.
+    // Switching feature → main must drop chunks for the file.
+    //
+    // Bypassing GitStateTracker (as the v1 test did) misses the production bug:
+    // `git diff --name-only feature...main` is empty because `main` added nothing
+    // relative to merge base, so the change handler never even sees `foo/bar.py`.
+
+    // .lien/ holds the GitStateTracker's state file; mirror what real users do
+    // by gitignoring it so subsequent `git checkout` ops aren't blocked.
+    await fs.writeFile(path.join(repoDir, '.gitignore'), '.lien/\n');
+    await git(repoDir, 'add', '.gitignore');
+    await git(repoDir, 'commit', '-q', '-m', 'initial');
+
+    const tracker = new GitStateTracker(repoDir, indexPath);
+    await tracker.initialize();
+
+    // Create feature, add foo/bar.py, commit.
+    await git(repoDir, 'checkout', '-q', '-b', 'feature');
+    const fooDir = path.join(repoDir, 'foo');
+    await fs.mkdir(fooDir, { recursive: true });
+    const fooPath = path.join(fooDir, 'bar.py');
+    await fs.writeFile(fooPath, 'def quux():\n    return 42\n');
+    await git(repoDir, 'add', '.');
+    await git(repoDir, 'commit', '-q', '-m', 'add foo/bar.py on feature');
+
+    // Simulate the watcher firing — detectChanges → indexMultipleFiles.
+    const changedOntoFeature = await tracker.detectChanges();
+    expect(changedOntoFeature).toBeTruthy();
+    await indexMultipleFiles(changedOntoFeature!, vectorDB, embeddings, { rootDir: repoDir });
+
+    const onFeature = await vectorDB.scanWithFilter({ file: 'foo/bar.py' });
+    expect(onFeature.length).toBeGreaterThan(0);
+
+    // Switch back to main. foo/bar.py vanishes from the working tree.
+    await git(repoDir, 'checkout', '-q', 'main');
+
+    const changedBackToMain = await tracker.detectChanges();
+    await indexMultipleFiles(changedBackToMain ?? [], vectorDB, embeddings, { rootDir: repoDir });
+
+    // Assert: no chunks remain for foo/bar.py on main.
+    const onMain = await vectorDB.scanWithFilter({ file: 'foo/bar.py' });
+    expect(onMain).toEqual([]);
   });
 
   it('drops chunks for a file deleted on the new branch', async () => {


### PR DESCRIPTION
Closes #556 (round 2). Follows up on #557 / commit `4ad9a04`.

## Summary

[v1](https://github.com/getlien/lien/pull/557) fixed path-key normalization so the deletion path could even find chunks to delete. The reporter [verified after the merge](https://github.com/getlien/lien/issues/556#issuecomment-4458114793) that branch-switch detection now fires correctly, but the reindex is **additive** — chunks for files that no longer exist on the new branch stay in the index.

Root cause: \`getChangedFiles\` in \`packages/core/src/git/utils.ts\` ran \`git diff --name-only A...B\` (three-dot — "changes on B's side of merge base", the GitHub PR-diff semantic). For branch-switch reconciliation we want tip-to-tip ("files that differ between A and B"), which is two-dot.

The user's exact scenario:

- \`main\` doesn't have \`foo/bar.py\`. Branch \`feature\` adds it.
- User switches \`main → feature\` → three-dot returns \`foo/bar.py\` (feature added it relative to merge base). Indexed.
- User switches \`feature → main\` → three-dot \`feature...main\` returns **empty** (main added nothing relative to merge base). \`indexMultipleFiles\` is never called for \`foo/bar.py\`, the deletion path is never reached, chunks survive on \`main\`.

Two-dot \`feature..main\` lists \`foo/bar.py\` as deleted; the rest of the pipeline (\`indexMultipleFiles\` → \`fs.stat\` throws → \`handleFileNotFound\` → \`deleteByFile\`) handles it correctly.

## Changes

- \`packages/core/src/git/utils.ts\` — \`getChangedFiles\` now passes \`fromRef\` and \`toRef\` as two positional args, matching \`getChangedFilesBetweenCommits\` which already had it right. \`change-detector.ts\` calls into the same function, so its bug cascades fixed.
- \`packages/core/src/git/utils.test.ts\` — focused regression test that creates a branch-exclusive file and asserts both diff directions list it. Fails on \`main\` (pre-fix), passes here.
- \`packages/core/src/indexer/branch-switch.test.ts\` — full-pipeline test that drives \`GitStateTracker.detectChanges()\` end-to-end. The v1 test bypassed \`detectChanges\` (passed the deleted path directly into \`indexMultipleFiles\`), which is exactly why v1 passed locally while production stayed broken. Also adds a \`.gitignore\` for \`.lien/\` to mirror real-world setup so the tracker's state file doesn't block subsequent \`git checkout\` ops.

## Note on the reported \`indexInfo.indexDate\` / \`indexVersion\` "side bug"

Not a bug. Both fields come from \`vectorDB.getCurrentVersion()\` / \`getVersionDate()\`, which only re-read after the next \`checkVersion()\` poll on \`VERSION_CHECK_INTERVAL_MS\`. They lag by up to that interval but they update — confirmed by tracing \`writeVersionFile\` calls at \`packages/core/src/indexer/index.ts:213,466\`. Observed staleness immediately after a branch-switch reindex is just the poll cycle, not a structural defect.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` (0 errors, only pre-existing warnings)
- [x] \`npm run format:check\` clean
- [x] \`npm run test -w packages/cli\` — 642 pass
- [x] \`npm run test -w @liendev/core --\` excluding qdrant — 2385+ pass (qdrant failures expected without local Qdrant)
- [x] Both new tests fail on \`main\` (pre-fix), pass here
- [ ] Manual end-to-end against the reporter's scenario: index on a branch where \`foo/bar.py\` exists, switch to one where it doesn't, confirm \`mcp__lien__list_functions\` for symbols in that file and \`mcp__lien__find_similar\` against its content return zero chunks.

## Out of scope

- A defensive "reconcile manifest against disk" sweep that runs after every reindex — would catch this entire class of bug without needing the diff to be perfect. Not required by the current failure mode now that the diff is correct, but worth a separate hardening PR.
- Manual \`reindex_now\` MCP tool — separate feature.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> The PR correctly switches from three-dot (`A...B`) to two-dot (`A B`) git diff semantics for branch-switch reconciliation. This ensures that files existing on the previous branch but missing on the new branch are correctly identified as deletions and removed from the index, resolving a bug where the index remained additive during branch switches.
>
> - Updated `getChangedFiles` in `packages/core/src/git/utils.ts` to use tip-to-tip diffing by passing refs as separate arguments to `git diff`.
> - Added regression tests in `packages/core/src/git/utils.test.ts` and `packages/core/src/indexer/branch-switch.test.ts` to verify deletion detection during branch switches.
> - Improved test environment stability by adding `.lien/` to `.gitignore` in integration tests to prevent git state files from blocking checkouts.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b204b3d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->