### PR TITLE
fix(git): always run git-state poll alongside the file watcher

### DIFF
--- a/packages/cli/src/mcp/git-detection.test.ts
+++ b/packages/cli/src/mcp/git-detection.test.ts
@@ -129,4 +129,46 @@ describe('setupGitDetection — poll gate', () => {
     expect(result.gitTracker).toBeNull();
     expect(result.gitPollInterval).toBeNull();
   });
+
+  it('does NOT call detectChanges when a reindex is already in progress', async () => {
+    // Regression for the Lien Review finding on PR #561: detectChanges has the
+    // side effect of advancing the tracker's saved state. If the poll calls
+    // detectChanges and THEN bails because another reindex is running, the
+    // returned changedFiles are dropped on the floor and the tracker's state
+    // has already moved past them — they'll never be processed.
+    const reindexStateManager = {
+      ...makeReindexStateManager(),
+      getState: () => ({
+        inProgress: true,
+        pendingFiles: ['foo.ts'],
+        lastReindexTimestamp: null,
+        lastReindexDurationMs: null,
+      }),
+    };
+
+    vi.useFakeTimers();
+    try {
+      const result = await setupGitDetection(
+        '/tmp/fake-repo',
+        {} as VectorDBInterface,
+        {} as EmbeddingService,
+        () => {},
+        reindexStateManager,
+        { watchGit: vi.fn() } as unknown as FileWatcher,
+        async () => {},
+      );
+
+      // Trigger one poll cycle by advancing the timer.
+      await vi.advanceTimersByTimeAsync(10000);
+      await vi.advanceTimersByTimeAsync(0); // flush pending microtasks
+
+      // The tick should have observed inProgress=true and bailed BEFORE
+      // calling detectChanges (which would mutate tracker state).
+      expect(mockGitStateTrackerInstance.detectChanges).not.toHaveBeenCalled();
+
+      clearInterval(result.gitPollInterval!);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/cli/src/mcp/git-detection.test.ts
+++ b/packages/cli/src/mcp/git-detection.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// All deps live in @liendev/core / @liendev/parser; mock them so we exercise
+// only setupGitDetection's wiring (especially the now-always-on poll).
+const {
+  mockIsGitAvailable,
+  mockIsGitRepo,
+  mockIndexMultipleFiles,
+  mockGitStateTrackerInstance,
+  mockCreateGitignoreFilter,
+} = vi.hoisted(() => ({
+  mockIsGitAvailable: vi.fn(async () => true),
+  mockIsGitRepo: vi.fn(async () => true),
+  mockIndexMultipleFiles: vi.fn(async () => 0),
+  mockGitStateTrackerInstance: {
+    initialize: vi.fn(async () => null),
+    detectChanges: vi.fn(async () => null),
+    getState: vi.fn(() => null),
+  },
+  mockCreateGitignoreFilter: vi.fn(async () => () => false),
+}));
+
+vi.mock('@liendev/core', () => ({
+  isGitAvailable: mockIsGitAvailable,
+  isGitRepo: mockIsGitRepo,
+  indexMultipleFiles: mockIndexMultipleFiles,
+  GitStateTracker: vi.fn(function (this: unknown) {
+    Object.assign(this as object, mockGitStateTrackerInstance);
+  }),
+  DEFAULT_GIT_POLL_INTERVAL_MS: 10000,
+}));
+
+vi.mock('@liendev/parser', () => ({
+  createGitignoreFilter: mockCreateGitignoreFilter,
+}));
+
+import { setupGitDetection } from './git-detection.js';
+import type { FileWatcher } from '../watcher/index.js';
+import type { VectorDBInterface, EmbeddingService } from '@liendev/core';
+
+function makeReindexStateManager() {
+  return {
+    getState: () => ({
+      inProgress: false,
+      pendingFiles: [],
+      lastReindexTimestamp: null,
+      lastReindexDurationMs: null,
+    }),
+    startReindex: vi.fn(),
+    completeReindex: vi.fn(),
+    failReindex: vi.fn(),
+    resetIfStuck: vi.fn(() => false),
+  };
+}
+
+describe('setupGitDetection — poll gate', () => {
+  let intervalsCreated: NodeJS.Timeout[];
+  let realSetInterval: typeof setInterval;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsGitAvailable.mockResolvedValue(true);
+    mockIsGitRepo.mockResolvedValue(true);
+    mockGitStateTrackerInstance.initialize.mockResolvedValue(null);
+    mockGitStateTrackerInstance.detectChanges.mockResolvedValue(null);
+
+    // Capture every setInterval call so we can clean them up after the test.
+    intervalsCreated = [];
+    realSetInterval = global.setInterval;
+    global.setInterval = ((handler: () => void, ms: number) => {
+      const id = realSetInterval(handler, ms);
+      intervalsCreated.push(id);
+      return id;
+    }) as unknown as typeof setInterval;
+  });
+
+  afterEach(() => {
+    for (const id of intervalsCreated) clearInterval(id);
+    global.setInterval = realSetInterval;
+  });
+
+  it('always creates a git poll interval, even when fileWatcher is non-null', async () => {
+    // Regression for #556 v3: pre-fix, the poll was gated behind
+    // `fileWatcher === null`. That left a watcher-only setup with no backstop
+    // when chokidar/FSEvents missed git's atomic ref rewrites.
+    const fileWatcher = { watchGit: vi.fn() } as unknown as FileWatcher;
+
+    const result = await setupGitDetection(
+      '/tmp/fake-repo',
+      {} as VectorDBInterface,
+      {} as EmbeddingService,
+      () => {},
+      makeReindexStateManager(),
+      fileWatcher,
+      async () => {},
+    );
+
+    expect(result.gitPollInterval).not.toBeNull();
+    expect(fileWatcher.watchGit).toHaveBeenCalledOnce();
+  });
+
+  it('still creates a poll interval when fileWatcher is null (fallback path)', async () => {
+    const result = await setupGitDetection(
+      '/tmp/fake-repo',
+      {} as VectorDBInterface,
+      {} as EmbeddingService,
+      () => {},
+      makeReindexStateManager(),
+      null,
+      async () => {},
+    );
+
+    expect(result.gitPollInterval).not.toBeNull();
+  });
+
+  it('returns null tracker + interval when not in a git repo', async () => {
+    mockIsGitRepo.mockResolvedValue(false);
+
+    const result = await setupGitDetection(
+      '/tmp/not-a-repo',
+      {} as VectorDBInterface,
+      {} as EmbeddingService,
+      () => {},
+      makeReindexStateManager(),
+      { watchGit: vi.fn() } as unknown as FileWatcher,
+      async () => {},
+    );
+
+    expect(result.gitTracker).toBeNull();
+    expect(result.gitPollInterval).toBeNull();
+  });
+});

--- a/packages/cli/src/mcp/git-detection.ts
+++ b/packages/cli/src/mcp/git-detection.ts
@@ -88,18 +88,22 @@ function createGitPollInterval(
     if (pollInProgress) return;
     pollInProgress = true;
     try {
+      // Check inProgress BEFORE calling detectChanges: detectChanges has the
+      // side effect of advancing the tracker's saved state. If we return
+      // after calling it, we'd lose the diff — the next call would only see
+      // changes since this point. Skipping the whole tick when another
+      // reindex is running preserves the change set for the next cycle.
+      const currentState = reindexStateManager.getState();
+      if (currentState.inProgress) {
+        log(
+          `Background reindex already in progress (${currentState.pendingFiles.length} files pending), skipping git poll cycle`,
+          'debug',
+        );
+        return;
+      }
+
       const changedFiles = await gitTracker.detectChanges();
       if (changedFiles && changedFiles.length > 0) {
-        // Check if a reindex is already in progress (file watch or previous git poll)
-        const currentState = reindexStateManager.getState();
-        if (currentState.inProgress) {
-          log(
-            `Background reindex already in progress (${currentState.pendingFiles.length} files pending), skipping git poll cycle`,
-            'debug',
-          );
-          return;
-        }
-
         // Invalidate filter when .gitignore files change
         if (changedFiles.some(isGitignoreFile)) {
           isIgnored = null;

--- a/packages/cli/src/mcp/git-detection.ts
+++ b/packages/cli/src/mcp/git-detection.ts
@@ -329,7 +329,12 @@ async function setupGitDetection(
     log(`Failed to check git state on startup: ${error}`, 'warning');
   }
 
-  // If file watcher is available, use event-driven detection
+  // Register the event-driven handler when the file watcher is available — it's
+  // the fast path when it works. But ALWAYS also run the poll as a backstop:
+  // chokidar/FSEvents can miss git's atomic ref rewrites (write .git/HEAD.lock,
+  // rename over .git/HEAD), in which case the watcher never fires and the
+  // tracker never reconciles. The poll guarantees eventual consistency.
+  // Concurrency between the two is handled by `reindexStateManager`.
   if (fileWatcher) {
     const gitChangeHandler = createGitChangeHandler(
       rootDir,
@@ -341,14 +346,14 @@ async function setupGitDetection(
       checkAndReconnect,
     );
     fileWatcher.watchGit(gitChangeHandler);
-
-    log('✓ Git detection enabled (event-driven via file watcher)');
-    return { gitTracker, gitPollInterval: null };
   }
 
-  // Fallback to polling if no file watcher (--no-watch mode)
   const pollIntervalSeconds = DEFAULT_GIT_POLL_INTERVAL_MS / 1000;
-  log(`✓ Git detection enabled (polling fallback every ${pollIntervalSeconds}s)`);
+  const detectionMode = fileWatcher
+    ? `event-driven via file watcher + ${pollIntervalSeconds}s safety poll`
+    : `polling every ${pollIntervalSeconds}s`;
+  log(`✓ Git detection enabled (${detectionMode})`);
+
   const gitPollInterval = createGitPollInterval(
     rootDir,
     gitTracker,


### PR DESCRIPTION
Closes #556 (round 3, please-let-this-be-the-last-one). Follows #559.

## Summary

After [merging v2](https://github.com/getlien/lien/pull/559), I dogfooded the local build against the user's repro. **The bug still reproduced**, and the cause turned out to be one layer further upstream than v2 fixed.

### What v2 fixed (still correct)

\`getChangedFiles\` was using \`A...B\` (three-dot, "changes on B's side of merge base") which silently omits files that exist only on A. v2 switched it to \`A..B\` (tip-to-tip), so when \`detectChanges()\` runs after a branch switch, it returns the right set of changed/deleted files.

### What was still broken

\`GitStateTracker.detectChanges()\` was barely ever running. Live dogfood:

| Stage | filesAnalyzed | Sentinel in index? | indexedBranch |
|---|---|---|---|
| On \`main\` (baseline) | 633 | n/a | \`main\` |
| After creating sentinel on \`dogfood-556\` | 634 | YES | \`main\` *(stuck)* |
| After switching back to \`main\` (file gone) | 634 | YES (BUG) | \`main\` *(stuck)* |

\`indexedBranch\` / \`indexedCommit\` only advance when \`detectChanges()\` updates the tracker's internal state. They never advanced across either checkout — proof that the tracker never ran. Yet \`lastReindexDurationMs\` *did* update, so *some* reindex fired (file watcher catching the file creation when committing on \`dogfood-556\`) — just not the git-tracker chain that includes the deletion.

Most likely cause: chokidar / FSEvents on macOS missing git's atomic ref rewrite (\`git\` writes \`.git/HEAD.lock\` then renames over \`.git/HEAD\`; FSEvents reports the rename of the \`.lock\`, not a change event on \`HEAD\` itself). So \`fileWatcher.watchGit\` never fires, and the entire git-tracker chain — including v2's diff fix — sits idle.

## Fix

\`createGitPollInterval\` already exists (\`packages/cli/src/mcp/git-detection.ts:75\`) and runs \`tracker.detectChanges() → indexMultipleFiles\` every \`DEFAULT_GIT_POLL_INTERVAL_MS\` (10s). It was gated behind \`fileWatcher === null\`, i.e. only ran in \`--no-watch\` mode. **Drop the gate.** Always run the poll, alongside the watcher when present. The watcher remains the fast path when it works; the poll guarantees eventual consistency when it doesn't.

Concurrency between the two is already handled by \`reindexStateManager\` (cooldown, in-progress check, \`startReindex\`/\`completeReindex\` accounting). Duplicate firings are cheap (skipped via the \`inProgress\` flag).

This is sufficient for the reported failure mode: poll fires every 10s → \`detectChanges()\` returns the deleted file (thanks to v2's two-dot diff) → \`indexMultipleFiles\` → \`fs.stat\` throws → \`handleFileNotFound\` → \`deleteByFile\`. Chunks drop. \`indexedBranch\` advances. UX feels right (with up to 10s detection lag — tunable later).

## Test plan

- [x] New \`packages/cli/src/mcp/git-detection.test.ts\` covers:
  - poll is created when \`fileWatcher\` is non-null (regression for the gate)
  - poll is still created when \`fileWatcher\` is null (fallback path preserved)
  - not-a-git-repo case still returns \`{ gitTracker: null, gitPollInterval: null }\`
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` (0 errors, only pre-existing warnings)
- [x] \`npm run format:check\` clean
- [x] \`npm run test -w packages/cli\` — **645 pass** (642 + 3 new from this PR)
- [ ] **Manual end-to-end (post-merge):** Cut a release so the npm \`@liendev/lien\` includes v1 + v2 + v3, reload the plugin, re-run the dogfood loop. Expect sentinel chunks to drop within ~10s of \`git checkout\` and \`indexedBranch\` to advance with each switch.

## Out of scope

- Investigating chokidar's actual reliability for \`.git/HEAD\` (option (a) from our triage). The poll covers it; chasing platform-specific FSEvents/inotify semantics is much larger and platform-fragile. File as a follow-up if 10s detection lag is ever too slow.
- Defensive manifest-vs-disk reconcile sweep (option (c)). Belt-and-suspenders worth doing eventually, but the poll alone fixes the reported failure.
- Tightening \`DEFAULT_GIT_POLL_INTERVAL_MS\` (currently 10s). Tune in a separate, opinionated PR if user testing shows it's sluggish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced git detection reliability by implementing a safety polling mechanism that works alongside event-driven detection to consistently capture changes.

* **Tests**
  * Added comprehensive test coverage for git detection polling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/561)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR improves the reliability of git state detection by enabling a polling mechanism as a backstop to the file watcher. This ensures that git changes (like branch switches) are eventually detected even if the underlying file watcher (e.g., chokidar/FSEvents) misses the atomic ref updates to `.git/HEAD`.
>
> - Enabled git polling interval even when a file watcher is active.
> - Moved the reindex-in-progress check before calling `gitTracker.detectChanges()` to prevent premature advancement of the internal git state when changes cannot yet be processed.
> - Updated logging to reflect the dual detection mode (event-driven + safety poll).
> - Added comprehensive tests verifying the polling logic and its interaction with the reindex state manager.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 163cb60. Updates automatically on new commits.</sup>
<!-- /lien-stats -->