### PR TITLE
fix(mcp): advance indexInfo.indexDate on incremental reindexes

### DIFF
--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -283,36 +283,76 @@ describe('startMCPServer', () => {
     });
   });
 
-  describe('getIndexMetadata indexDate source', () => {
-    it('uses lastReindexTimestamp when set (advances on incremental reindexes)', async () => {
-      const fixedTimestamp = 1714521600000; // 2024-05-01T00:00:00Z
+  describe('getIndexMetadata indexDate / msSinceLastReindex sources', () => {
+    function withReindexTimestamp(ts: number | null) {
       vi.mocked(createReindexStateManager).mockReturnValueOnce({
         getState: vi.fn().mockReturnValue({
           inProgress: false,
           pendingFiles: [],
-          lastReindexTimestamp: fixedTimestamp,
-          lastReindexDurationMs: 200,
+          lastReindexTimestamp: ts,
+          lastReindexDurationMs: ts === null ? null : 200,
         }),
         startReindex: vi.fn(),
         completeReindex: vi.fn(),
         failReindex: vi.fn(),
       } as unknown as ReturnType<typeof createReindexStateManager>);
+    }
+
+    it('uses lastReindexTimestamp when it is the most recent reconciliation', async () => {
+      const reindexTs = 1714521600000; // 2024-05-01
+      mockVectorDB.getCurrentVersion.mockReturnValue(1); // very old
+      withReindexTimestamp(reindexTs);
 
       await startMCPServer({ rootDir: '/test/project' });
 
       const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
       const metadata = toolContext.getIndexMetadata();
-      expect(metadata.indexDate).toBe(new Date(fixedTimestamp).toLocaleString());
+      expect(metadata.indexDate).toBe(new Date(reindexTs).toLocaleString());
     });
 
-    it('falls back to vectorDB.getVersionDate() when no reindex has run', async () => {
-      // Default reindexStateManager mock returns lastReindexTimestamp: null.
-      // getVersionDate is mocked to return '2026-01-01' in the suite beforeEach.
+    it('uses vectorDB.getCurrentVersion() when it is newer (external full reindex)', async () => {
+      // Scenario: an external `lien index` bumped the version file mid-session.
+      // Lien Review caught this — we previously preferred the older incremental
+      // timestamp unconditionally.
+      const versionTs = 2000000000000; // 2033
+      const olderReindexTs = 1714521600000; // 2024
+      mockVectorDB.getCurrentVersion.mockReturnValue(versionTs);
+      withReindexTimestamp(olderReindexTs);
+
       await startMCPServer({ rootDir: '/test/project' });
 
       const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
       const metadata = toolContext.getIndexMetadata();
-      expect(metadata.indexDate).toBe('2026-01-01');
+      expect(metadata.indexDate).toBe(new Date(versionTs).toLocaleString());
+    });
+
+    it('reports msSinceLastReindex based on the version file when no in-session reindex has run', async () => {
+      // Scenario: server restart, index was built hours ago via prior `lien
+      // index`. Should report "hours ago", not "unknown". Lien Review's
+      // second finding.
+      const versionTs = Date.now() - 60 * 60 * 1000; // 1h ago
+      mockVectorDB.getCurrentVersion.mockReturnValue(versionTs);
+      // No override → default mock returns lastReindexTimestamp: null.
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
+      const metadata = toolContext.getIndexMetadata();
+      expect(metadata.msSinceLastReindex).not.toBeNull();
+      expect(metadata.msSinceLastReindex).toBeGreaterThanOrEqual(60 * 60 * 1000);
+      expect(metadata.msSinceLastReindex).toBeLessThan(60 * 60 * 1000 + 10_000);
+    });
+
+    it('falls back to getVersionDate() (and null msSinceLastReindex) when neither source has a value', async () => {
+      mockVectorDB.getCurrentVersion.mockReturnValue(0);
+      mockVectorDB.getVersionDate.mockReturnValue('Unknown');
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
+      const metadata = toolContext.getIndexMetadata();
+      expect(metadata.indexDate).toBe('Unknown');
+      expect(metadata.msSinceLastReindex).toBeNull();
     });
   });
 

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -124,6 +124,7 @@ import { FileWatcher } from '../watcher/index.js';
 import { createMCPServerConfig, registerMCPHandlers } from './server-config.js';
 import { setupCleanupHandlers } from './cleanup.js';
 import { setupGitDetection } from './git-detection.js';
+import { createReindexStateManager } from './reindex-state-manager.js';
 
 describe('startMCPServer', () => {
   let processOnSpy: ReturnType<typeof vi.spyOn>;
@@ -279,6 +280,39 @@ describe('startMCPServer', () => {
       const metadata = toolContext.getIndexMetadata();
       expect(metadata.indexedBranch).toBe('feature-x');
       expect(metadata.indexedCommit).toBe('abc1234');
+    });
+  });
+
+  describe('getIndexMetadata indexDate source', () => {
+    it('uses lastReindexTimestamp when set (advances on incremental reindexes)', async () => {
+      const fixedTimestamp = 1714521600000; // 2024-05-01T00:00:00Z
+      vi.mocked(createReindexStateManager).mockReturnValueOnce({
+        getState: vi.fn().mockReturnValue({
+          inProgress: false,
+          pendingFiles: [],
+          lastReindexTimestamp: fixedTimestamp,
+          lastReindexDurationMs: 200,
+        }),
+        startReindex: vi.fn(),
+        completeReindex: vi.fn(),
+        failReindex: vi.fn(),
+      } as unknown as ReturnType<typeof createReindexStateManager>);
+
+      await startMCPServer({ rootDir: '/test/project' });
+
+      const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
+      const metadata = toolContext.getIndexMetadata();
+      expect(metadata.indexDate).toBe(new Date(fixedTimestamp).toLocaleString());
+    });
+
+    it('falls back to vectorDB.getVersionDate() when no reindex has run', async () => {
+      // Default reindexStateManager mock returns lastReindexTimestamp: null.
+      // getVersionDate is mocked to return '2026-01-01' in the suite beforeEach.
+      await startMCPServer({ rootDir: '/test/project' });
+
+      const toolContext = vi.mocked(registerMCPHandlers).mock.calls[0][1];
+      const metadata = toolContext.getIndexMetadata();
+      expect(metadata.indexDate).toBe('2026-01-01');
     });
   });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -220,9 +220,18 @@ function setupVersionChecking(
   const getIndexMetadata = () => {
     const reindex = reindexStateManager.getState();
     const gitState = getGitState();
+    // Prefer the last *content* reindex time over the version-file date.
+    // `getVersionDate()` only advances on full `indexCodebase` runs (the
+    // version file is a cross-process invalidation token), so it stays frozen
+    // across the incremental reindexes that file-watcher and git-poll fire.
+    // `reindexStateManager.lastReindexTimestamp` tracks every reindex op,
+    // which is what users / AI clients actually want to see.
+    const indexDate = reindex.lastReindexTimestamp
+      ? new Date(reindex.lastReindexTimestamp).toLocaleString()
+      : vectorDB.getVersionDate();
     return {
       indexVersion: vectorDB.getCurrentVersion(),
-      indexDate: vectorDB.getVersionDate(),
+      indexDate,
       reindexInProgress: reindex.inProgress,
       pendingFileCount: reindex.pendingFiles.length,
       lastReindexDurationMs: reindex.lastReindexDurationMs,

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -220,26 +220,33 @@ function setupVersionChecking(
   const getIndexMetadata = () => {
     const reindex = reindexStateManager.getState();
     const gitState = getGitState();
-    // Prefer the last *content* reindex time over the version-file date.
-    // `getVersionDate()` only advances on full `indexCodebase` runs (the
-    // version file is a cross-process invalidation token), so it stays frozen
-    // across the incremental reindexes that file-watcher and git-poll fire.
-    // `reindexStateManager.lastReindexTimestamp` tracks every reindex op,
-    // which is what users / AI clients actually want to see.
-    const indexDate = reindex.lastReindexTimestamp
-      ? new Date(reindex.lastReindexTimestamp).toLocaleString()
-      : vectorDB.getVersionDate();
+    // `getCurrentVersion()` is the version-file timestamp — only bumped on
+    // full `indexCodebase` runs (it's a cross-process invalidation token).
+    // `lastReindexTimestamp` is bumped on every in-process reindex (full or
+    // incremental). Neither one alone is the right freshness signal:
+    //   - external `lien index` updates the version file but never touches
+    //     this process's reindex state → version is newer.
+    //   - in-session incremental reindexes update reindex state but never
+    //     touch the version file → reindex state is newer.
+    // Take the max so the field always reports the most recent reconciliation
+    // regardless of which path caused it.
+    const versionTs = vectorDB.getCurrentVersion();
+    const reindexTs = reindex.lastReindexTimestamp ?? 0;
+    const effectiveTimestamp = Math.max(versionTs, reindexTs);
+    const indexDate =
+      effectiveTimestamp > 0
+        ? new Date(effectiveTimestamp).toLocaleString()
+        : vectorDB.getVersionDate(); // 'Unknown' when both sources are empty
     return {
-      indexVersion: vectorDB.getCurrentVersion(),
+      indexVersion: versionTs,
       indexDate,
       reindexInProgress: reindex.inProgress,
       pendingFileCount: reindex.pendingFiles.length,
       lastReindexDurationMs: reindex.lastReindexDurationMs,
-      // Note: msSinceLastReindex is computed at call time, not cached.
-      // This ensures AI assistants always get current freshness info.
-      msSinceLastReindex: reindex.lastReindexTimestamp
-        ? Date.now() - reindex.lastReindexTimestamp
-        : null,
+      // Computed at call time, not cached, so AI clients always see current
+      // freshness. Same max-of-both source as `indexDate` — index built in a
+      // previous session should report its age, not "unknown".
+      msSinceLastReindex: effectiveTimestamp > 0 ? Date.now() - effectiveTimestamp : null,
       indexedBranch: gitState?.branch ?? null,
       indexedCommit: gitState?.commit ?? null,
     };


### PR DESCRIPTION
Follow-up to [#556](https://github.com/getlien/lien/issues/556) — addresses the cosmetic [residual flagged in the closing comment](https://github.com/getlien/lien/issues/556#issuecomment-4458655180).

## Summary

After the v1/v2/v3 fixes landed, the reporter confirmed branch-switch reconciliation works end-to-end. One residual: \`indexInfo.indexDate\` stayed at its original value across reindexes, even though \`indexedCommit\`, \`lastReindexDurationMs\`, and \`msSinceLastReindex\` were correctly advancing.

## Root cause

\`indexDate\` was sourced from \`vectorDB.getVersionDate()\` → \`new Date(currentVersion).toLocaleString()\` (\`packages/core/src/vectordb/lancedb.ts:249\`). \`currentVersion\` is the numeric timestamp in \`.lien-index-version\`, written by \`writeVersionFile()\` only at the end of a **full** \`indexCodebase\` run (\`packages/core/src/indexer/index.ts:213,466\`). The incremental reindexes that file-watcher and the always-on git poll fire (\`indexSingleFile\` / \`indexMultipleFiles\`) intentionally don't bump that file — it's a cross-process invalidation token and bumping it on every change would cause needless reconnect storms in other clients tracking the same index.

So \`indexDate\` reflected "when was the index last fully rebuilt", not "when was content last reconciled". Two genuinely different concepts mashed into one display field.

## Fix

In \`getIndexMetadata\` (\`packages/cli/src/mcp/server.ts\`), prefer the existing \`reindexStateManager.lastReindexTimestamp\` (which tracks every reindex op, full or incremental, and is already used to derive \`msSinceLastReindex\`). Fall back to \`vectorDB.getVersionDate()\` pre-first-reindex.

\`indexVersion\` stays put — it's the cross-process token. Diverging semantics from \`indexDate\` is intentional: version = schema token, date = content freshness. The latter is what humans / AI assistants actually want to see.

## Test plan

- [x] \`server.test.ts\` gains two cases under \`getIndexMetadata indexDate source\`:
  - uses \`lastReindexTimestamp\` when set (proves the new path)
  - falls back to \`getVersionDate()\` when null (regression guard for first-boot)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` (0 errors)
- [x] \`npm run format:check\` clean
- [x] \`npm run test -w packages/cli\` — all green (17 tests in \`server.test.ts\`)
- [ ] Manual: dogfood loop → after a checkout-triggered reindex, \`indexInfo.indexDate\` should reflect "now" (matching the \`msSinceLastReindex\` window) instead of the original version-file timestamp.

## Out of scope

- Changing \`writeVersionFile\` semantics (would cause reconnect storms in cross-process consumers).
- Renaming \`indexDate\` to something more explicit. Possible follow-up but doesn't help any user today.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> The PR correctly addresses the issue where `indexInfo.indexDate` remained stale during incremental reindexes. By taking the maximum of the version-file timestamp and the in-session reindex timestamp, the metadata now accurately reflects the most recent reconciliation regardless of whether it was a full or incremental update. The implementation includes robust fallbacks for cases where no reindex has occurred yet, and the added tests verify both the preferred path and the fallback logic.
>
> - Updated `getIndexMetadata` to use the maximum of `vectorDB.getCurrentVersion()` and `reindexStateManager.lastReindexTimestamp` as the effective index date.
> - Ensured `msSinceLastReindex` is calculated from the same effective timestamp, providing accurate freshness info even after server restarts.
> - Added comprehensive unit tests in `server.test.ts` covering various scenarios including external full reindexes and first-boot fallbacks.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 223fe38. Updates automatically on new commits.</sup>
<!-- /lien-stats -->