### PR TITLE
chore: add changeset for plugin + branch-switch fixes

### DIFF
--- a/.changeset/plugin-and-branch-switch-fixes.md
+++ b/.changeset/plugin-and-branch-switch-fixes.md
@@ -1,0 +1,17 @@
+---
+'@liendev/parser': minor
+'@liendev/core': minor
+'@liendev/lien': minor
+---
+
+Ship the Claude Code plugin and a saga of fixes for branch-switch reconciliation in `lien serve`.
+
+**Claude Code plugin** (#555). Install once with `/plugin marketplace add getlien/lien` + `/plugin install lien` and Lien's MCP tools + the Explore agent are available in every session, in every repo — no per-project `lien init` needed. The `serve` command also gains an `LIEN_FORCE_INDEX=1` opt-in and skips auto-indexing in non-git directories so the plugin doesn't index scratch dirs.
+
+**Branch-switch reconciliation, full saga (#556).** When you `git checkout` away from a branch that had files which don't exist on the new branch, Lien now actually drops the chunks for those files from the index. Required three layered fixes:
+
+- **Path-key normalization** (#557): `indexMultipleFiles` and `indexSingleFile` now thread `rootDir` through `normalizeToRelativePath`, so chunks at index time and deletion time use the same relative-path key. `indexedBranch` / `indexedCommit` are surfaced in `indexInfo` so callers can detect drift.
+- **Tip-to-tip diff** (#559): `getChangedFiles` switched from three-dot (`A...B`, "PR-diff" semantic — silently omits files that exist only on `A`) to two-dot (`A..B`, direct tip diff). Also fixes a false-prefix bug in `normalizeToRelativePath` where `/apple/foo` against root `/app` would slice to `le/foo` instead of falling through to `path.relative`.
+- **Always-on git poll** (#561): the `.git/HEAD` file watcher misses git's atomic ref rewrites (chokidar/FSEvents on macOS reports the rename of `.git/HEAD.lock`, not a change event on `HEAD` itself), so the existing event-driven trigger never fired in practice. `createGitPollInterval` now runs alongside the file watcher as a backstop instead of only as a `--no-watch` fallback. Includes a fix for the `detectChanges`-already-advanced-state race when both watcher and poll fire concurrently.
+
+**Freshness metadata** (#562). `indexInfo.indexDate` and `msSinceLastReindex` now reflect the most recent reconciliation (max of version-file timestamp and in-session reindex timestamp), so both external `lien index` and in-process incremental reindexes surface correctly.

--- a/.changeset/plugin-and-branch-switch-fixes.md
+++ b/.changeset/plugin-and-branch-switch-fixes.md
@@ -8,7 +8,7 @@ Ship the Claude Code plugin and a saga of fixes for branch-switch reconciliation
 
 **Claude Code plugin** (#555). Install once with `/plugin marketplace add getlien/lien` + `/plugin install lien` and Lien's MCP tools + the Explore agent are available in every session, in every repo — no per-project `lien init` needed. The `serve` command also gains an `LIEN_FORCE_INDEX=1` opt-in and skips auto-indexing in non-git directories so the plugin doesn't index scratch dirs.
 
-**Branch-switch reconciliation, full saga (#556).** When you `git checkout` away from a branch that had files which don't exist on the new branch, Lien now actually drops the chunks for those files from the index. Required three layered fixes:
+**Branch-switch reconciliation, full saga (#556).** When you `git checkout` away from a branch that had files which don't exist on the new branch, Lien now actually drops the chunks for those files from the index. Required three-layered fixes:
 
 - **Path-key normalization** (#557): `indexMultipleFiles` and `indexSingleFile` now thread `rootDir` through `normalizeToRelativePath`, so chunks at index time and deletion time use the same relative-path key. `indexedBranch` / `indexedCommit` are surfaced in `indexInfo` so callers can detect drift.
 - **Tip-to-tip diff** (#559): `getChangedFiles` switched from three-dot (`A...B`, "PR-diff" semantic — silently omits files that exist only on `A`) to two-dot (`A..B`, direct tip diff). Also fixes a false-prefix bug in `normalizeToRelativePath` where `/apple/foo` against root `/app` would slice to `le/foo` instead of falling through to `path.relative`.


### PR DESCRIPTION
Adds a changeset to bump `@liendev/parser`, `@liendev/core`, `@liendev/lien` from `0.44.0` → `0.45.0` (linked-minor).

The changeset bundles everything that's landed on `main` since `0.44.0`:

- #555 — Claude Code plugin scaffold + `/plugin install lien` flow
- #557 — path-key normalization + `indexedBranch` / `indexedCommit` metadata
- #559 — tip-to-tip diff in `getChangedFiles` + false-prefix fix in `normalizeToRelativePath`
- #561 — always-on git poll (the actual #556 fix)
- #562 — `indexDate` / `msSinceLastReindex` based on max-of-both-timestamps

Once this merges, the `changesets/action@v1` workflow opens a "Version Packages" PR bumping the three packages and rewriting `CHANGELOG.md`. Merging *that* triggers `npm publish` via OIDC trusted publishing. Plugin users get the fix on their next `npx -y @liendev/lien` cold-start.

## Test plan

- [x] Changeset file lints (`minor` for all three linked packages, matches `.changeset/config.json:linked`)
- [ ] After merge: confirm the "Version Packages" PR appears within a few minutes
- [ ] Sanity-check the proposed CHANGELOG entry in that PR before merging the version bump

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 77 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 7 high-risk file(s) with 102 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 19 | — |
| ⏱️ time to understand | 46 | — |
| 🐛 estimated bugs | 1 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit dcd004b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code plugin integration: Lien's MCP tools and Explore agent are now automatically available in every Claude Code session without requiring per-project setup.

* **Bug Fixes**
  * Fixed index retaining stale data when switching git branches; reconciliation now removes stale chunks properly.
  * Improved index freshness tracking accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/563)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->