### PR TITLE
docs(site): lead with Claude Code plugin install

### DIFF
--- a/packages/site/docs/guide/getting-started.md
+++ b/packages/site/docs/guide/getting-started.md
@@ -1,10 +1,27 @@
 # Quick Start
 
-This guide walks you through setting up Lien with Cursor or Claude Code in under 2 minutes.
+This guide walks you through setting up Lien with your editor in under 2 minutes.
 
 ## Step 1: Configure Your Editor
 
-Run `lien init` and select your editor:
+### Claude Code (recommended path)
+
+Install the plugin once and you're done — no per-project setup:
+
+```text
+/plugin marketplace add getlien/lien
+/plugin install lien
+```
+
+Lien's MCP tools and the Explore agent become available in every Claude Code session, in every repo.
+
+::: tip
+If you previously used `lien init --editor claude-code` per project, you can leave those `.mcp.json` files in place or remove them — the plugin's MCP server replaces them. `lien init --editor claude-code --legacy` is still available if you need the old per-project flow for any reason.
+:::
+
+### Other editors (Cursor, Windsurf, OpenCode, Kilo Code, Antigravity)
+
+These editors don't have a plugin marketplace yet. Run `lien init` per project and select your editor:
 
 ```bash
 lien init
@@ -14,21 +31,20 @@ Or specify it directly:
 
 ```bash
 lien init --editor cursor
-lien init --editor claude-code
 lien init --editor windsurf
 lien init --editor opencode
 lien init --editor kilo-code
 lien init --editor antigravity
 ```
 
-This writes the correct MCP config for your editor. That's it—Lien works with **zero configuration**.
+This writes the correct MCP config for your editor.
 
 ::: details What does `lien init` create?
 
 | Editor | Config File | Scope |
 |--------|-------------|-------|
 | Cursor | `.cursor/mcp.json` | Per-project |
-| Claude Code | `.mcp.json` | Per-project |
+| Claude Code (`--legacy` only) | `.mcp.json` | Per-project |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | Global (with `--root`) |
 | OpenCode | `opencode.json` | Per-project |
 | Kilo Code | `.kilocode/mcp.json` | Per-project |

--- a/packages/site/docs/guide/installation.md
+++ b/packages/site/docs/guide/installation.md
@@ -6,9 +6,24 @@
 - At least 200MB free disk space (for ML model)
 - 8GB+ RAM recommended for large codebases
 
-## Global Installation (Recommended)
+## Claude Code Plugin (Recommended)
 
-Install Lien globally to use it across all your projects:
+For Claude Code users, the simplest path is the one-time plugin install — no `npm install`, no per-project `lien init`. Lien's MCP tools and the Explore agent become available in every Claude Code session, in every repo.
+
+```text
+/plugin marketplace add getlien/lien
+/plugin install lien
+```
+
+The plugin spawns Lien on demand via `npx -y @liendev/lien`, so it always pulls the latest release. To upgrade, restart Claude Code — the next spawn fetches the newest version automatically.
+
+::: tip Working on Lien itself?
+Contributors should NOT install the plugin in their dev environment — that points the MCP server at the npm-published binary, bypassing your local changes. See [CONTRIBUTING.md](https://github.com/getlien/lien/blob/main/CONTRIBUTING.md) for the dogfooding setup that points at your local build instead.
+:::
+
+## Global Installation (for Cursor, Windsurf, OpenCode, Kilo Code, Antigravity)
+
+These editors don't have a plugin marketplace yet, so install Lien globally and wire it up per-project with `lien init`:
 
 ```bash
 npm install -g @liendev/lien
@@ -20,7 +35,15 @@ Verify installation:
 lien --version
 ```
 
-## Using npx (No Installation)
+Then in each project:
+
+```bash
+lien init
+```
+
+`lien init` writes the correct MCP config for your editor — `.cursor/mcp.json` for Cursor, `opencode.json` for OpenCode, and so on. See the [Quick Start guide](/guide/getting-started) for the full per-editor flow.
+
+## Using npx (no global install)
 
 You can run Lien without installing it globally:
 
@@ -31,26 +54,33 @@ npx @liendev/lien serve
 ```
 
 ::: tip
-Global installation is recommended for better performance and convenience.
+For frequent use, global installation gives better cold-start performance.
 :::
 
 ## Upgrading
 
-To upgrade to the latest version:
+**Plugin users (Claude Code):** restart Claude Code. The plugin's `npx -y @liendev/lien` invocation re-resolves to the latest npm version on every cold start, so a restart is all you need.
+
+**Global install users:** bump the package and restart your editor.
 
 ```bash
 npm update -g @liendev/lien
 ```
 
-After upgrading, restart your AI assistant (Cursor or Claude Desktop) completely to load the new version.
-
 ::: warning
-Code changes (new features) require restarting your AI assistant. The auto-reconnect feature only handles data changes (reindexing).
+Code changes (new features and bug fixes) require restarting your editor. The auto-reconnect feature only handles data changes (reindexing).
 :::
 
 ## Uninstalling
 
-To remove Lien:
+**Plugin users:**
+
+```text
+/plugin uninstall lien
+/plugin marketplace remove getlien/lien
+```
+
+**Global install:**
 
 ```bash
 # Remove global package

--- a/packages/site/docs/index.md
+++ b/packages/site/docs/index.md
@@ -41,6 +41,17 @@ features:
 
 ## Quick Start
 
+### Claude Code (recommended) — one-time plugin install
+
+```text
+/plugin marketplace add getlien/lien
+/plugin install lien
+```
+
+That's it. Lien's MCP tools and the Explore agent are available in every Claude Code session, in every repo — no per-project setup. First use in a new git repo triggers a one-time index automatically.
+
+### Other editors (Cursor, Windsurf, OpenCode, Kilo Code, Antigravity)
+
 **1. Install Lien:**
 
 ```bash
@@ -53,11 +64,11 @@ npm install -g @liendev/lien
 lien init
 ```
 
-This writes the correct MCP config for your editor (Cursor, Claude Code, Windsurf, OpenCode, Kilo Code, or Antigravity).
+This writes the correct MCP config for your editor.
 
 **3. Restart your editor** and start asking questions about your codebase!
 
-That's it—no configuration files needed. Lien auto-detects your project structure and indexes on first use.
+Lien auto-detects your project structure and indexes on first use.
 
 ## How It Works
 


### PR DESCRIPTION
After shipping the plugin in `@liendev/lien@0.45.0`, the docs site still led with `npm install -g @liendev/lien` + `lien init` everywhere. New users landing on the site got pointed at the older flow even though the one-line plugin install is now the recommended path for Claude Code.

## Changes

- **`docs/index.md` Quick Start** — split into two paths: "Claude Code (recommended) — one-time plugin install" and "Other editors (npm + lien init)".
- **`docs/guide/installation.md`** — adds a new top section "Claude Code Plugin (Recommended)" before the legacy "Global Installation" path. Rewrites Upgrading and Uninstalling sections to cover both paths. Includes a contributor-dogfooding tip pointing at `CONTRIBUTING.md` (don't install the plugin if you're hacking on Lien itself).
- **`docs/guide/getting-started.md`** — Step 1 now branches: plugin command for Claude Code, `lien init` for Cursor/Windsurf/OpenCode/Kilo Code/Antigravity. Notes the `--legacy` flag for users still on per-project `.mcp.json`.

## Test plan

- [x] `npm run docs:build` clean (vitepress 1.6.4, 4.98s)
- [ ] After merge: visual check on the live site that the install paths read well in the rendered theme.

## Out of scope

- A dedicated "Claude Code plugin" page under `docs/guide/`. The plugin is currently a one-line install + a couple of integration notes that fit cleanly into existing pages; a separate page would be padding.
- Screenshots of the `/plugin install` flow. Worth doing once the marketplace submission lands and the install path stabilizes.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 77 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 7 high-risk file(s) with 102 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 19 | — |
| ⏱️ time to understand | 46 | — |
| 🐛 estimated bugs | 1 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bd32ca4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->