### PR TITLE
feat(plugin): edit-gate hook — enforce Lien impact analysis before Edit/Write

### DIFF
--- a/packages/cli/src/cli/gate-cmd.test.ts
+++ b/packages/cli/src/cli/gate-cmd.test.ts
@@ -19,14 +19,14 @@ describe('gateCommand', () => {
   let tmpHome: string;
   let STORE: string;
   let DISABLED: string;
-  let BLOCKING: string;
+  let ADVISORY: string;
+  let LEGACY_BLOCKING: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errSpy: ReturnType<typeof vi.spyOn>;
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let homeSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
-    // Redirect $HOME so the test never touches the developer's real ~/.lien.
     tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-gate-test-'));
     homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
 
@@ -37,7 +37,8 @@ describe('gateCommand', () => {
       extractRepoId(resolveProjectRoot(process.cwd())),
     );
     DISABLED = path.join(STORE, 'gate-disabled');
-    BLOCKING = path.join(STORE, 'gate-blocking');
+    ADVISORY = path.join(STORE, 'gate-advisory');
+    LEGACY_BLOCKING = path.join(STORE, 'gate-blocking');
 
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -54,37 +55,64 @@ describe('gateCommand', () => {
     await fs.rm(tmpHome, { recursive: true, force: true });
   });
 
-  it('off writes gate-disabled and clears gate-blocking', async () => {
-    await fs.mkdir(STORE, { recursive: true });
-    await fs.writeFile(BLOCKING, '');
-    await gateCommand('off');
-    expect(await exists(DISABLED)).toBe(true);
-    expect(await exists(BLOCKING)).toBe(false);
-  });
-
-  it('on clears both flags', async () => {
+  it('on clears every flag (blocking is the default, no flag needed)', async () => {
     await fs.mkdir(STORE, { recursive: true });
     await fs.writeFile(DISABLED, '');
-    await fs.writeFile(BLOCKING, '');
+    await fs.writeFile(ADVISORY, '');
+    await fs.writeFile(LEGACY_BLOCKING, '');
     await gateCommand('on');
     expect(await exists(DISABLED)).toBe(false);
-    expect(await exists(BLOCKING)).toBe(false);
+    expect(await exists(ADVISORY)).toBe(false);
+    expect(await exists(LEGACY_BLOCKING)).toBe(false);
   });
 
-  it('block writes gate-blocking and clears gate-disabled', async () => {
+  it('block is an alias of on', async () => {
     await fs.mkdir(STORE, { recursive: true });
-    await fs.writeFile(DISABLED, '');
+    await fs.writeFile(ADVISORY, '');
     await gateCommand('block');
-    expect(await exists(BLOCKING)).toBe(true);
+    expect(await exists(ADVISORY)).toBe(false);
     expect(await exists(DISABLED)).toBe(false);
   });
 
-  it('status reports the current mode without mutating state', async () => {
+  it('off writes gate-disabled and clears advisory/legacy flags', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(ADVISORY, '');
+    await fs.writeFile(LEGACY_BLOCKING, '');
+    await gateCommand('off');
+    expect(await exists(DISABLED)).toBe(true);
+    expect(await exists(ADVISORY)).toBe(false);
+    expect(await exists(LEGACY_BLOCKING)).toBe(false);
+  });
+
+  it('advisory writes gate-advisory and clears disabled/legacy flags', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(DISABLED, '');
+    await fs.writeFile(LEGACY_BLOCKING, '');
+    await gateCommand('advisory');
+    expect(await exists(ADVISORY)).toBe(true);
+    expect(await exists(DISABLED)).toBe(false);
+    expect(await exists(LEGACY_BLOCKING)).toBe(false);
+  });
+
+  it('status reports off when gate-disabled exists', async () => {
     await fs.mkdir(STORE, { recursive: true });
     await fs.writeFile(DISABLED, '');
     await gateCommand('status');
     expect(logSpy).toHaveBeenCalledWith(expect.anything(), 'off');
     expect(await exists(DISABLED)).toBe(true);
+  });
+
+  it('status reports advisory when gate-advisory exists', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(ADVISORY, '');
+    await gateCommand('status');
+    expect(logSpy).toHaveBeenCalledWith(expect.anything(), 'advisory (UI-only)');
+  });
+
+  it('status reports on (blocking) when no flags are set', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await gateCommand('status');
+    expect(logSpy).toHaveBeenCalledWith(expect.anything(), 'on (blocking)');
   });
 
   it('rejects unknown actions with exit 1', async () => {

--- a/packages/cli/src/cli/gate-cmd.test.ts
+++ b/packages/cli/src/cli/gate-cmd.test.ts
@@ -4,8 +4,14 @@ import os from 'os';
 import fs from 'fs/promises';
 import { extractRepoId } from '@liendev/parser';
 import { gateCommand } from './gate-cmd.js';
+import { resolveProjectRoot } from './project-root.js';
 
-const STORE = path.join(os.homedir(), '.lien', 'indices', extractRepoId(process.cwd()));
+const STORE = path.join(
+  os.homedir(),
+  '.lien',
+  'indices',
+  extractRepoId(resolveProjectRoot(process.cwd())),
+);
 const DISABLED = path.join(STORE, 'gate-disabled');
 const BLOCKING = path.join(STORE, 'gate-blocking');
 

--- a/packages/cli/src/cli/gate-cmd.test.ts
+++ b/packages/cli/src/cli/gate-cmd.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import { extractRepoId } from '@liendev/parser';
+import { gateCommand } from './gate-cmd.js';
+
+const STORE = path.join(os.homedir(), '.lien', 'indices', extractRepoId(process.cwd()));
+const DISABLED = path.join(STORE, 'gate-disabled');
+const BLOCKING = path.join(STORE, 'gate-blocking');
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('gateCommand', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+    await fs.rm(DISABLED, { force: true });
+    await fs.rm(BLOCKING, { force: true });
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    await fs.rm(DISABLED, { force: true });
+    await fs.rm(BLOCKING, { force: true });
+  });
+
+  it('off writes gate-disabled and clears gate-blocking', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(BLOCKING, '');
+    await gateCommand('off');
+    expect(await exists(DISABLED)).toBe(true);
+    expect(await exists(BLOCKING)).toBe(false);
+  });
+
+  it('on clears both flags', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(DISABLED, '');
+    await fs.writeFile(BLOCKING, '');
+    await gateCommand('on');
+    expect(await exists(DISABLED)).toBe(false);
+    expect(await exists(BLOCKING)).toBe(false);
+  });
+
+  it('block writes gate-blocking and clears gate-disabled', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(DISABLED, '');
+    await gateCommand('block');
+    expect(await exists(BLOCKING)).toBe(true);
+    expect(await exists(DISABLED)).toBe(false);
+  });
+
+  it('status reports the current mode without mutating state', async () => {
+    await fs.mkdir(STORE, { recursive: true });
+    await fs.writeFile(DISABLED, '');
+    await gateCommand('status');
+    expect(logSpy).toHaveBeenCalledWith(expect.anything(), 'off');
+    expect(await exists(DISABLED)).toBe(true);
+  });
+
+  it('rejects unknown actions with exit 1', async () => {
+    await expect(gateCommand('nope')).rejects.toThrow('exit:1');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('invalid action'));
+  });
+});

--- a/packages/cli/src/cli/gate-cmd.test.ts
+++ b/packages/cli/src/cli/gate-cmd.test.ts
@@ -6,15 +6,6 @@ import { extractRepoId } from '@liendev/parser';
 import { gateCommand } from './gate-cmd.js';
 import { resolveProjectRoot } from './project-root.js';
 
-const STORE = path.join(
-  os.homedir(),
-  '.lien',
-  'indices',
-  extractRepoId(resolveProjectRoot(process.cwd())),
-);
-const DISABLED = path.join(STORE, 'gate-disabled');
-const BLOCKING = path.join(STORE, 'gate-blocking');
-
 async function exists(p: string): Promise<boolean> {
   try {
     await fs.access(p);
@@ -25,26 +16,42 @@ async function exists(p: string): Promise<boolean> {
 }
 
 describe('gateCommand', () => {
+  let tmpHome: string;
+  let STORE: string;
+  let DISABLED: string;
+  let BLOCKING: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errSpy: ReturnType<typeof vi.spyOn>;
   let exitSpy: ReturnType<typeof vi.spyOn>;
+  let homeSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
+    // Redirect $HOME so the test never touches the developer's real ~/.lien.
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-gate-test-'));
+    homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+
+    STORE = path.join(
+      tmpHome,
+      '.lien',
+      'indices',
+      extractRepoId(resolveProjectRoot(process.cwd())),
+    );
+    DISABLED = path.join(STORE, 'gate-disabled');
+    BLOCKING = path.join(STORE, 'gate-blocking');
+
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`exit:${code ?? 0}`);
     }) as never);
-    await fs.rm(DISABLED, { force: true });
-    await fs.rm(BLOCKING, { force: true });
   });
 
   afterEach(async () => {
     logSpy.mockRestore();
     errSpy.mockRestore();
     exitSpy.mockRestore();
-    await fs.rm(DISABLED, { force: true });
-    await fs.rm(BLOCKING, { force: true });
+    homeSpy.mockRestore();
+    await fs.rm(tmpHome, { recursive: true, force: true });
   });
 
   it('off writes gate-disabled and clears gate-blocking', async () => {

--- a/packages/cli/src/cli/gate-cmd.ts
+++ b/packages/cli/src/cli/gate-cmd.ts
@@ -3,12 +3,13 @@ import os from 'os';
 import fs from 'fs/promises';
 import chalk from 'chalk';
 import { extractRepoId } from '@liendev/parser';
+import { resolveProjectRoot } from './project-root.js';
 
 const VALID_ACTIONS = ['on', 'off', 'block', 'status'] as const;
 type GateAction = (typeof VALID_ACTIONS)[number];
 
 function getStoreRoot(): string {
-  const repoId = extractRepoId(process.cwd());
+  const repoId = extractRepoId(resolveProjectRoot(process.cwd()));
   return path.join(os.homedir(), '.lien', 'indices', repoId);
 }
 

--- a/packages/cli/src/cli/gate-cmd.ts
+++ b/packages/cli/src/cli/gate-cmd.ts
@@ -1,17 +1,10 @@
 import path from 'path';
-import os from 'os';
 import fs from 'fs/promises';
 import chalk from 'chalk';
-import { extractRepoId } from '@liendev/parser';
-import { resolveProjectRoot } from './project-root.js';
+import { getStoreRoot } from './store-paths.js';
 
 const VALID_ACTIONS = ['on', 'off', 'block', 'status'] as const;
 type GateAction = (typeof VALID_ACTIONS)[number];
-
-function getStoreRoot(): string {
-  const repoId = extractRepoId(resolveProjectRoot(process.cwd()));
-  return path.join(os.homedir(), '.lien', 'indices', repoId);
-}
 
 function getFlagPath(name: 'disabled' | 'blocking'): string {
   return path.join(getStoreRoot(), `gate-${name}`);
@@ -47,29 +40,35 @@ export async function gateCommand(action: string): Promise<void> {
     process.exit(1);
   }
 
-  switch (action as GateAction) {
-    case 'on':
-      await removeFlag('disabled');
-      await removeFlag('blocking');
-      console.log(chalk.green('Lien gate: on (advisory)'));
-      return;
-    case 'off':
-      await writeFlag('disabled');
-      await removeFlag('blocking');
-      console.log(chalk.yellow('Lien gate: off (sentinels still recorded)'));
-      return;
-    case 'block':
-      await removeFlag('disabled');
-      await writeFlag('blocking');
-      console.log(chalk.green('Lien gate: blocking (exit 2 on miss)'));
-      return;
-    case 'status': {
-      const disabled = await exists(getFlagPath('disabled'));
-      const blocking = await exists(getFlagPath('blocking'));
-      const state = disabled ? 'off' : blocking ? 'blocking' : 'on (advisory)';
-      console.log(chalk.dim('Lien gate:'), state);
-      console.log(chalk.dim('Flag dir:'), getStoreRoot());
-      return;
+  try {
+    switch (action as GateAction) {
+      case 'on':
+        await removeFlag('disabled');
+        await removeFlag('blocking');
+        console.log(chalk.green('Lien gate: on (advisory)'));
+        return;
+      case 'off':
+        await writeFlag('disabled');
+        await removeFlag('blocking');
+        console.log(chalk.yellow('Lien gate: off (sentinels still recorded)'));
+        return;
+      case 'block':
+        await removeFlag('disabled');
+        await writeFlag('blocking');
+        console.log(chalk.green('Lien gate: blocking (exit 2 on miss)'));
+        return;
+      case 'status': {
+        const disabled = await exists(getFlagPath('disabled'));
+        const blocking = await exists(getFlagPath('blocking'));
+        const state = disabled ? 'off' : blocking ? 'blocking' : 'on (advisory)';
+        console.log(chalk.dim('Lien gate:'), state);
+        console.log(chalk.dim('Flag dir:'), getStoreRoot());
+        return;
+      }
     }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Error: gate ${action} failed: ${msg}`));
+    process.exit(1);
   }
 }

--- a/packages/cli/src/cli/gate-cmd.ts
+++ b/packages/cli/src/cli/gate-cmd.ts
@@ -1,0 +1,74 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import chalk from 'chalk';
+import { extractRepoId } from '@liendev/parser';
+
+const VALID_ACTIONS = ['on', 'off', 'block', 'status'] as const;
+type GateAction = (typeof VALID_ACTIONS)[number];
+
+function getStoreRoot(): string {
+  const repoId = extractRepoId(process.cwd());
+  return path.join(os.homedir(), '.lien', 'indices', repoId);
+}
+
+function getFlagPath(name: 'disabled' | 'blocking'): string {
+  return path.join(getStoreRoot(), `gate-${name}`);
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureStoreDir(): Promise<void> {
+  await fs.mkdir(getStoreRoot(), { recursive: true });
+}
+
+async function writeFlag(name: 'disabled' | 'blocking'): Promise<void> {
+  await ensureStoreDir();
+  await fs.writeFile(getFlagPath(name), '');
+}
+
+async function removeFlag(name: 'disabled' | 'blocking'): Promise<void> {
+  await fs.rm(getFlagPath(name), { force: true });
+}
+
+export async function gateCommand(action: string): Promise<void> {
+  if (!VALID_ACTIONS.includes(action as GateAction)) {
+    console.error(
+      chalk.red(`Error: invalid action "${action}". Use one of: ${VALID_ACTIONS.join(', ')}`),
+    );
+    process.exit(1);
+  }
+
+  switch (action as GateAction) {
+    case 'on':
+      await removeFlag('disabled');
+      await removeFlag('blocking');
+      console.log(chalk.green('Lien gate: on (advisory)'));
+      return;
+    case 'off':
+      await writeFlag('disabled');
+      await removeFlag('blocking');
+      console.log(chalk.yellow('Lien gate: off (sentinels still recorded)'));
+      return;
+    case 'block':
+      await removeFlag('disabled');
+      await writeFlag('blocking');
+      console.log(chalk.green('Lien gate: blocking (exit 2 on miss)'));
+      return;
+    case 'status': {
+      const disabled = await exists(getFlagPath('disabled'));
+      const blocking = await exists(getFlagPath('blocking'));
+      const state = disabled ? 'off' : blocking ? 'blocking' : 'on (advisory)';
+      console.log(chalk.dim('Lien gate:'), state);
+      console.log(chalk.dim('Flag dir:'), getStoreRoot());
+      return;
+    }
+  }
+}

--- a/packages/cli/src/cli/gate-cmd.ts
+++ b/packages/cli/src/cli/gate-cmd.ts
@@ -3,10 +3,10 @@ import fs from 'fs/promises';
 import chalk from 'chalk';
 import { getStoreRoot } from './store-paths.js';
 
-const VALID_ACTIONS = ['on', 'off', 'block', 'status'] as const;
+const VALID_ACTIONS = ['on', 'off', 'block', 'advisory', 'status'] as const;
 type GateAction = (typeof VALID_ACTIONS)[number];
 
-function getFlagPath(name: 'disabled' | 'blocking'): string {
+function getFlagPath(name: 'disabled' | 'advisory'): string {
   return path.join(getStoreRoot(), `gate-${name}`);
 }
 
@@ -23,13 +23,20 @@ async function ensureStoreDir(): Promise<void> {
   await fs.mkdir(getStoreRoot(), { recursive: true });
 }
 
-async function writeFlag(name: 'disabled' | 'blocking'): Promise<void> {
+async function writeFlag(name: 'disabled' | 'advisory'): Promise<void> {
   await ensureStoreDir();
   await fs.writeFile(getFlagPath(name), '');
 }
 
-async function removeFlag(name: 'disabled' | 'blocking'): Promise<void> {
+async function removeFlag(name: 'disabled' | 'advisory'): Promise<void> {
   await fs.rm(getFlagPath(name), { force: true });
+}
+
+async function removeLegacyBlockingFlag(): Promise<void> {
+  // Older versions wrote ~/.lien/indices/<id>/gate-blocking to mean "enforce".
+  // Now enforcement is the default; the flag is orphaned. Clean it up so
+  // `status` doesn't surface stale state.
+  await fs.rm(path.join(getStoreRoot(), 'gate-blocking'), { force: true });
 }
 
 export async function gateCommand(action: string): Promise<void> {
@@ -43,24 +50,30 @@ export async function gateCommand(action: string): Promise<void> {
   try {
     switch (action as GateAction) {
       case 'on':
+      case 'block':
         await removeFlag('disabled');
-        await removeFlag('blocking');
-        console.log(chalk.green('Lien gate: on (advisory)'));
+        await removeFlag('advisory');
+        await removeLegacyBlockingFlag();
+        console.log(chalk.green('Lien gate: on (blocking; exit 2 on miss)'));
         return;
       case 'off':
         await writeFlag('disabled');
-        await removeFlag('blocking');
+        await removeFlag('advisory');
+        await removeLegacyBlockingFlag();
         console.log(chalk.yellow('Lien gate: off (sentinels still recorded)'));
         return;
-      case 'block':
+      case 'advisory':
         await removeFlag('disabled');
-        await writeFlag('blocking');
-        console.log(chalk.green('Lien gate: blocking (exit 2 on miss)'));
+        await writeFlag('advisory');
+        await removeLegacyBlockingFlag();
+        console.log(
+          chalk.yellow('Lien gate: advisory (UI-only nudge; model is NOT shown the message)'),
+        );
         return;
       case 'status': {
         const disabled = await exists(getFlagPath('disabled'));
-        const blocking = await exists(getFlagPath('blocking'));
-        const state = disabled ? 'off' : blocking ? 'blocking' : 'on (advisory)';
+        const advisory = await exists(getFlagPath('advisory'));
+        const state = disabled ? 'off' : advisory ? 'advisory (UI-only)' : 'on (blocking)';
         console.log(chalk.dim('Lien gate:'), state);
         console.log(chalk.dim('Flag dir:'), getStoreRoot());
         return;

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -103,6 +103,7 @@ program
   .description('Print Lien storage paths and supported extensions (for hook scripts)')
   .option('--store', 'Print the storage root for the current repo')
   .option('--extensions', 'Print the indexed-file extensions, one per line')
+  .option('--root', 'Print the resolved project root (walks up for .git)')
   .action(pathCommand);
 
 program

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -8,6 +8,8 @@ import { indexCommand } from './index-cmd.js';
 import { serveCommand } from './serve.js';
 import { complexityCommand } from './complexity.js';
 import { configSetCommand, configGetCommand, configListCommand } from './config.js';
+import { pathCommand } from './path-cmd.js';
+import { gateCommand } from './gate-cmd.js';
 
 // Get version from package.json dynamically
 const __filename = fileURLToPath(import.meta.url);
@@ -95,6 +97,18 @@ configCmd
 configCmd.command('get <key>').description('Get a config value').action(configGetCommand);
 
 configCmd.command('list').description('Show all current config').action(configListCommand);
+
+program
+  .command('path')
+  .description('Print Lien storage paths and supported extensions (for hook scripts)')
+  .option('--store', 'Print the storage root for the current repo')
+  .option('--extensions', 'Print the indexed-file extensions, one per line')
+  .action(pathCommand);
+
+program
+  .command('gate <action>')
+  .description('Control the Lien edit-gate hook: on | off | block | status')
+  .action(gateCommand);
 
 program.action(() => {
   program.help();

--- a/packages/cli/src/cli/path-cmd.test.ts
+++ b/packages/cli/src/cli/path-cmd.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import os from 'os';
 import { extractRepoId } from '@liendev/parser';
 import { pathCommand } from './path-cmd.js';
+import { resolveProjectRoot } from './project-root.js';
 
 describe('pathCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -23,10 +24,20 @@ describe('pathCommand', () => {
     exitSpy.mockRestore();
   });
 
-  it('--store prints ~/.lien/indices/<repoId> for the current cwd', () => {
+  it('--store prints ~/.lien/indices/<repoId> resolved against the project root', () => {
     pathCommand({ store: true });
-    const expected = path.join(os.homedir(), '.lien', 'indices', extractRepoId(process.cwd()));
+    const expected = path.join(
+      os.homedir(),
+      '.lien',
+      'indices',
+      extractRepoId(resolveProjectRoot(process.cwd())),
+    );
     expect(logSpy).toHaveBeenCalledWith(expected);
+  });
+
+  it('--root prints the resolved project root', () => {
+    pathCommand({ root: true });
+    expect(logSpy).toHaveBeenCalledWith(resolveProjectRoot(process.cwd()));
   });
 
   it('--extensions prints supported extensions, one per line, with no leading dot', () => {

--- a/packages/cli/src/cli/path-cmd.test.ts
+++ b/packages/cli/src/cli/path-cmd.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import { extractRepoId } from '@liendev/parser';
+import { pathCommand } from './path-cmd.js';
+
+describe('pathCommand', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('--store prints ~/.lien/indices/<repoId> for the current cwd', () => {
+    pathCommand({ store: true });
+    const expected = path.join(os.homedir(), '.lien', 'indices', extractRepoId(process.cwd()));
+    expect(logSpy).toHaveBeenCalledWith(expected);
+  });
+
+  it('--extensions prints supported extensions, one per line, with no leading dot', () => {
+    pathCommand({ extensions: true });
+    expect(logSpy).toHaveBeenCalled();
+    const lines = logSpy.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(lines).toContain('ts');
+    expect(lines).toContain('py');
+    expect(lines.every((l: string) => !l.startsWith('.'))).toBe(true);
+  });
+
+  it('rejects no flags with a clear error and exit 1', () => {
+    expect(() => pathCommand({})).toThrow('exit:1');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('specify one of'));
+  });
+
+  it('rejects both flags as mutually exclusive', () => {
+    expect(() => pathCommand({ store: true, extensions: true })).toThrow('exit:1');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+  });
+});

--- a/packages/cli/src/cli/path-cmd.ts
+++ b/packages/cli/src/cli/path-cmd.ts
@@ -2,27 +2,34 @@ import path from 'path';
 import os from 'os';
 import chalk from 'chalk';
 import { extractRepoId, getSupportedExtensions } from '@liendev/parser';
+import { resolveProjectRoot } from './project-root.js';
 
 interface PathOptions {
   store?: boolean;
   extensions?: boolean;
+  root?: boolean;
 }
 
 export function pathCommand(options: PathOptions): void {
-  const selectedFlags = [options.store, options.extensions].filter(Boolean).length;
+  const selectedFlags = [options.store, options.extensions, options.root].filter(Boolean).length;
 
   if (selectedFlags === 0) {
-    console.error(chalk.red('Error: specify one of --store or --extensions'));
+    console.error(chalk.red('Error: specify one of --store, --extensions, --root'));
     process.exit(1);
   }
 
   if (selectedFlags > 1) {
-    console.error(chalk.red('Error: --store and --extensions are mutually exclusive'));
+    console.error(chalk.red('Error: --store, --extensions, --root are mutually exclusive'));
     process.exit(1);
   }
 
+  if (options.root) {
+    console.log(resolveProjectRoot(process.cwd()));
+    return;
+  }
+
   if (options.store) {
-    const repoId = extractRepoId(process.cwd());
+    const repoId = extractRepoId(resolveProjectRoot(process.cwd()));
     console.log(path.join(os.homedir(), '.lien', 'indices', repoId));
     return;
   }

--- a/packages/cli/src/cli/path-cmd.ts
+++ b/packages/cli/src/cli/path-cmd.ts
@@ -1,8 +1,7 @@
-import path from 'path';
-import os from 'os';
 import chalk from 'chalk';
-import { extractRepoId, getSupportedExtensions } from '@liendev/parser';
+import { getSupportedExtensions } from '@liendev/parser';
 import { resolveProjectRoot } from './project-root.js';
+import { getStoreRoot } from './store-paths.js';
 
 interface PathOptions {
   store?: boolean;
@@ -29,8 +28,7 @@ export function pathCommand(options: PathOptions): void {
   }
 
   if (options.store) {
-    const repoId = extractRepoId(resolveProjectRoot(process.cwd()));
-    console.log(path.join(os.homedir(), '.lien', 'indices', repoId));
+    console.log(getStoreRoot());
     return;
   }
 

--- a/packages/cli/src/cli/path-cmd.ts
+++ b/packages/cli/src/cli/path-cmd.ts
@@ -1,0 +1,35 @@
+import path from 'path';
+import os from 'os';
+import chalk from 'chalk';
+import { extractRepoId, getSupportedExtensions } from '@liendev/parser';
+
+interface PathOptions {
+  store?: boolean;
+  extensions?: boolean;
+}
+
+export function pathCommand(options: PathOptions): void {
+  const selectedFlags = [options.store, options.extensions].filter(Boolean).length;
+
+  if (selectedFlags === 0) {
+    console.error(chalk.red('Error: specify one of --store or --extensions'));
+    process.exit(1);
+  }
+
+  if (selectedFlags > 1) {
+    console.error(chalk.red('Error: --store and --extensions are mutually exclusive'));
+    process.exit(1);
+  }
+
+  if (options.store) {
+    const repoId = extractRepoId(process.cwd());
+    console.log(path.join(os.homedir(), '.lien', 'indices', repoId));
+    return;
+  }
+
+  if (options.extensions) {
+    for (const ext of getSupportedExtensions()) {
+      console.log(ext);
+    }
+  }
+}

--- a/packages/cli/src/cli/project-root.test.ts
+++ b/packages/cli/src/cli/project-root.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import { resolveProjectRoot } from './project-root.js';
+
+describe('resolveProjectRoot', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-root-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('walks upward to find a .git directory', async () => {
+    const root = await fs.realpath(tmp);
+    await fs.mkdir(path.join(root, '.git'));
+    const deep = path.join(root, 'a', 'b', 'c');
+    await fs.mkdir(deep, { recursive: true });
+    expect(resolveProjectRoot(deep)).toBe(root);
+  });
+
+  it('recognizes .git as a file (git worktrees)', async () => {
+    const root = await fs.realpath(tmp);
+    await fs.writeFile(path.join(root, '.git'), 'gitdir: /elsewhere\n');
+    const deep = path.join(root, 'sub');
+    await fs.mkdir(deep);
+    expect(resolveProjectRoot(deep)).toBe(root);
+  });
+
+  it('falls back to the start path when no marker exists', async () => {
+    const root = await fs.realpath(tmp);
+    expect(resolveProjectRoot(root)).toBe(root);
+  });
+
+  it('returns the start path itself when it contains the marker', async () => {
+    const root = await fs.realpath(tmp);
+    await fs.mkdir(path.join(root, '.git'));
+    expect(resolveProjectRoot(root)).toBe(root);
+  });
+});

--- a/packages/cli/src/cli/project-root.ts
+++ b/packages/cli/src/cli/project-root.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Walk upward from `start` looking for a `.git` marker (file or dir).
+ * Falls back to the resolved start path if none is found.
+ * Lets the gate/store stay stable when commands are run from a subdir.
+ */
+export function resolveProjectRoot(start: string = process.cwd()): string {
+  let dir = path.resolve(start);
+  const fsRoot = path.parse(dir).root;
+  while (dir !== fsRoot) {
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return path.resolve(start);
+}

--- a/packages/cli/src/cli/store-paths.ts
+++ b/packages/cli/src/cli/store-paths.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import os from 'os';
+import { extractRepoId } from '@liendev/parser';
+import { resolveProjectRoot } from './project-root.js';
+
+/**
+ * Return the per-repo store root that backs the index and the edit-gate.
+ * Resolved against the project root (walks up for .git) so the value stays
+ * stable from any subdirectory. Output uses forward slashes so the bash
+ * hook scripts can splice it without escape-character mishaps on Windows.
+ */
+export function getStoreRoot(cwd: string = process.cwd()): string {
+  const repoId = extractRepoId(resolveProjectRoot(cwd));
+  return path.join(os.homedir(), '.lien', 'indices', repoId).replace(/\\/g, '/');
+}

--- a/plugins/claude/commands/lien-gate.md
+++ b/plugins/claude/commands/lien-gate.md
@@ -1,6 +1,6 @@
 ---
-description: Toggle the Lien edit-gate hook (advisory/blocking/off) for this session
-argument-hint: on | off | block | status
+description: Toggle the Lien edit-gate hook (blocking / advisory / off) for this session
+argument-hint: on | block | advisory | off | status
 allowed-tools: Bash(lien gate:*)
 ---
 
@@ -8,7 +8,13 @@ Run `lien gate $ARGUMENTS` and report its output verbatim.
 
 If `$ARGUMENTS` is empty, run `lien gate status`.
 
-- `on` — advisory mode (default): missed gate emits a `systemMessage`.
-- `off` — disabled until the next Claude Code session (sentinels are still recorded).
-- `block` — blocking mode: missed gate exits 2 and feeds the message back as a tool error. Persists across sessions.
+- `on` (default) — **blocking mode**: a missed gate fails the edit with exit 2,
+  feeding the nudge back to Claude as a tool error. This is the only mode that
+  actually changes Claude's behavior; Claude Code does not surface PreToolUse
+  `systemMessage` output to the model on subsequent turns.
+- `block` — alias of `on`.
+- `advisory` — **UI-only nudge**: the missed-gate message is recorded as a
+  `hook_system_message` attachment but Claude does NOT see it. Useful if you
+  only want a visible signal in the Claude Code UI without behavior change.
+- `off` — disabled until you re-enable it. Sentinels are still recorded.
 - `status` — print current mode and the flag directory.

--- a/plugins/claude/commands/lien-gate.md
+++ b/plugins/claude/commands/lien-gate.md
@@ -1,0 +1,14 @@
+---
+description: Toggle the Lien edit-gate hook (advisory/blocking/off) for this session
+argument-hint: on | off | block | status
+allowed-tools: Bash(lien gate:*)
+---
+
+Run `lien gate $ARGUMENTS` and report its output verbatim.
+
+If `$ARGUMENTS` is empty, run `lien gate status`.
+
+- `on` — advisory mode (default): missed gate emits a `systemMessage`.
+- `off` — disabled until the next Claude Code session (sentinels are still recorded).
+- `block` — blocking mode: missed gate exits 2 and feeds the message back as a tool error. Persists across sessions.
+- `status` — print current mode and the flag directory.

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -58,10 +58,14 @@ if [ -f "$store/gate-disabled" ]; then
   exit 0
 fi
 
-# Determine blocking mode (file flag or env var).
-mode="advisory"
-if [ -f "$store/gate-blocking" ] || [ "${LIEN_GATE:-}" = "block" ]; then
-  mode="block"
+# Determine mode. Default is "block" because Claude Code's hook channels
+# don't actually surface a PreToolUse systemMessage back to the model on
+# the next turn (verified live in 2.1.142). Only exit 2 + stderr reaches
+# the model. Advisory mode stays available as an opt-down for users who
+# only want the UI signal without behavior change.
+mode="block"
+if [ -f "$store/gate-advisory" ] || [ "${LIEN_GATE:-}" = "advisory" ]; then
+  mode="advisory"
 fi
 
 # Extension filter: skip if file extension isn't in Lien's indexed set.

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -68,18 +68,28 @@ fi
 ttl_min="${LIEN_GATE_TTL_MIN:-60}"
 session_dir="$store/gate-sessions/$session_id"
 
-# Hash the file path to keep sentinel filenames bounded and filesystem-safe.
-# Use md5 first 8 chars to mirror extractRepoId's scheme.
-hash="$(printf '%s' "$file_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"
+# Canonicalize file_path to a workspace-relative form before hashing, so
+# that the gate matches sentinels written by sentinel.sh regardless of
+# whether the caller used absolute or relative paths. Claude Code's
+# Edit/Write payloads carry absolute paths; the model typically passes
+# relative paths to MCP tools.
+rel_path="$file_path"
+if [ -n "$cwd" ]; then
+  case "$file_path" in
+    "$cwd"/*) rel_path="${file_path#$cwd/}";;
+    "$cwd") rel_path="";;
+  esac
+fi
+
+# Hash the canonical path. md5 first 8 chars mirrors extractRepoId.
+hash="$(printf '%s' "$rel_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"
 if [ -z "$hash" ]; then
-  hash="$(printf '%s' "$file_path" | md5 2>/dev/null | awk '{print substr($NF,1,8)}')"
+  hash="$(printf '%s' "$rel_path" | md5 2>/dev/null | awk '{print substr($NF,1,8)}')"
 fi
 [ -n "$hash" ] || exit 0
 
-# A sentinel younger than TTL satisfies the gate.
-# For an existing file, accept fc-/dep-/fs- for that path.
-# For a new file (Write of a non-existent path), accept any recent fs-* OR
-# any recent fc-* (loose: "you at least looked around the codebase").
+# Resolve absolute target for the existence check (gate semantic depends
+# on whether the file exists yet).
 target_path="$file_path"
 [ -n "$cwd" ] && [ "${file_path#/}" = "$file_path" ] && target_path="$cwd/$file_path"
 
@@ -109,14 +119,15 @@ if [ "$satisfied" = "1" ]; then
   exit 0
 fi
 
-# Build the nudge message.
+# Build the nudge message — show the canonical (relative) path.
+display_path="${rel_path:-$file_path}"
 if [ -e "$target_path" ]; then
-  msg="Lien gate: no recent impact analysis for $file_path. Run one of:
-  • mcp__plugin_lien_lien__get_files_context({ filepaths: \"$file_path\" })  — required before Edit/Write
-  • mcp__plugin_lien_lien__get_dependents({ filepath: \"$file_path\" })       — required before changing an exported symbol
+  msg="Lien gate: no recent impact analysis for $display_path. Run one of:
+  • mcp__plugin_lien_lien__get_files_context({ filepaths: \"$display_path\" })  — required before Edit/Write
+  • mcp__plugin_lien_lien__get_dependents({ filepath: \"$display_path\" })       — required before changing an exported symbol
 Disable for this session: \`lien gate off\` (or LIEN_GATE=off)."
 else
-  msg="Lien gate: about to create $file_path with no prior find_similar call. Consider:
+  msg="Lien gate: about to create $display_path with no prior find_similar call. Consider:
   • mcp__plugin_lien_lien__find_similar({ code: \"<the pattern you're about to write>\" })
 to see if this already exists. Disable for this session: \`lien gate off\`."
 fi

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -34,6 +34,12 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 [ -n "$file_path" ] || exit 0
 [ -n "$session_id" ] || exit 0
 
+# Defensive: session_id will be embedded in a filesystem path. Reject anything
+# outside [A-Za-z0-9_-] so a crafted value can't traverse out of gate-sessions/.
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) exit 0;;
+esac
+
 # Resolve the project root and storage root via `lien path`, so the
 # results stay invariant whether Claude Code's cwd is the repo root or
 # a subdirectory.

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -108,11 +108,13 @@ fi
 # on whether the file exists yet).
 target_path="$file_path"
 if [ "${file_path#/}" = "$file_path" ]; then
-  # Relative — resolve against root if available, else cwd.
-  if [ -n "$root" ]; then
-    target_path="$root/$file_path"
-  elif [ -n "$cwd" ]; then
+  # Relative — Claude Code's file_path is conventionally process-cwd
+  # relative, so prefer $cwd. Fall back to $root only if cwd is absent
+  # from the hook payload.
+  if [ -n "$cwd" ]; then
     target_path="$cwd/$file_path"
+  elif [ -n "$root" ]; then
+    target_path="$root/$file_path"
   fi
 fi
 

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -133,8 +133,13 @@ if [ -d "$session_dir" ]; then
       fi
     done
   else
-    # New file — any recent fs-* or fc-* sentinel.
-    if find "$session_dir" -maxdepth 1 -type f \( -name 'fs-*' -o -name 'fc-*' \) -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
+    # New file — only a recent find_similar call satisfies the gate.
+    # Accepting unrelated fc-* sentinels would defeat the nudge, since
+    # the model almost always calls get_files_context for context.
+    # sentinel.sh writes fs-any on every successful find_similar so a
+    # zero-result search still satisfies (avoids an infinite nudge loop
+    # for genuinely novel files).
+    if find "$session_dir" -maxdepth 1 -type f -name 'fs-*' -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
       satisfied=1
     fi
   fi

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# PreToolUse hook: gate Edit/Write on Lien-indexed files until impact
+# analysis (get_files_context / get_dependents / find_similar) has run
+# in the current session.
+#
+# Advisory by default: emits a systemMessage and exits 0.
+# Blocking mode via `lien gate block` or LIEN_GATE=block: exits 2 on miss.
+# Disabled via `lien gate off` or LIEN_GATE=off: silent exit 0.
+#
+# Gracefully degrades (silent exit 0) if `jq` or `lien` are missing.
+
+set -u
+
+emit_message() {
+  # $1 = message string
+  printf '{"systemMessage":%s}\n' "$(printf '%s' "$1" | jq -Rs .)"
+}
+
+# Hard prerequisites — if missing, do nothing.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+# Environment kill switch (matches LIEN_FORCE_INDEX pattern in mcp/server.ts).
+if [ "${LIEN_GATE:-}" = "off" ]; then
+  exit 0
+fi
+
+input="$(cat)"
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+# No file path or session — can't gate; silently pass.
+[ -n "$file_path" ] || exit 0
+[ -n "$session_id" ] || exit 0
+
+# Resolve the storage root from the same source-of-truth the indexer uses.
+# Run from the session's cwd so extractRepoId picks up the right repo.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+else
+  store="$(lien path --store 2>/dev/null)"
+fi
+[ -n "$store" ] || exit 0
+
+# Persistent kill switch from `lien gate off`.
+if [ -f "$store/gate-disabled" ]; then
+  exit 0
+fi
+
+# Determine blocking mode (file flag or env var).
+mode="advisory"
+if [ -f "$store/gate-blocking" ] || [ "${LIEN_GATE:-}" = "block" ]; then
+  mode="block"
+fi
+
+# Extension filter: skip if file extension isn't in Lien's indexed set.
+# getSupportedExtensions returns bare extensions (e.g. "ts"), no leading dot.
+ext="${file_path##*.}"
+if [ "$ext" = "$file_path" ]; then
+  # No extension at all — skip.
+  exit 0
+fi
+if ! lien path --extensions 2>/dev/null | grep -Fxq "$ext"; then
+  exit 0
+fi
+
+ttl_min="${LIEN_GATE_TTL_MIN:-60}"
+session_dir="$store/gate-sessions/$session_id"
+
+# Hash the file path to keep sentinel filenames bounded and filesystem-safe.
+# Use md5 first 8 chars to mirror extractRepoId's scheme.
+hash="$(printf '%s' "$file_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"
+if [ -z "$hash" ]; then
+  hash="$(printf '%s' "$file_path" | md5 2>/dev/null | awk '{print substr($NF,1,8)}')"
+fi
+[ -n "$hash" ] || exit 0
+
+# A sentinel younger than TTL satisfies the gate.
+# For an existing file, accept fc-/dep-/fs- for that path.
+# For a new file (Write of a non-existent path), accept any recent fs-* OR
+# any recent fc-* (loose: "you at least looked around the codebase").
+target_path="$file_path"
+[ -n "$cwd" ] && [ "${file_path#/}" = "$file_path" ] && target_path="$cwd/$file_path"
+
+satisfied=0
+if [ -d "$session_dir" ]; then
+  if [ -e "$target_path" ]; then
+    # Existing file — strict match.
+    for prefix in fc dep fs; do
+      f="$session_dir/$prefix-$hash"
+      if [ -f "$f" ]; then
+        # mtime within TTL?
+        if find "$f" -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
+          satisfied=1
+          break
+        fi
+      fi
+    done
+  else
+    # New file — any recent fs-* or fc-* sentinel.
+    if find "$session_dir" -maxdepth 1 -type f \( -name 'fs-*' -o -name 'fc-*' \) -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
+      satisfied=1
+    fi
+  fi
+fi
+
+if [ "$satisfied" = "1" ]; then
+  exit 0
+fi
+
+# Build the nudge message.
+if [ -e "$target_path" ]; then
+  msg="Lien gate: no recent impact analysis for $file_path. Run one of:
+  • mcp__plugin_lien_lien__get_files_context({ filepaths: \"$file_path\" })  — required before Edit/Write
+  • mcp__plugin_lien_lien__get_dependents({ filepath: \"$file_path\" })       — required before changing an exported symbol
+Disable for this session: \`lien gate off\` (or LIEN_GATE=off)."
+else
+  msg="Lien gate: about to create $file_path with no prior find_similar call. Consider:
+  • mcp__plugin_lien_lien__find_similar({ code: \"<the pattern you're about to write>\" })
+to see if this already exists. Disable for this session: \`lien gate off\`."
+fi
+
+if [ "$mode" = "block" ]; then
+  printf '%s\n' "$msg" >&2
+  exit 2
+fi
+
+emit_message "$msg"
+exit 0

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -34,14 +34,18 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 [ -n "$file_path" ] || exit 0
 [ -n "$session_id" ] || exit 0
 
-# Resolve the storage root from the same source-of-truth the indexer uses.
-# Run from the session's cwd so extractRepoId picks up the right repo.
+# Resolve the project root and storage root via `lien path`, so the
+# results stay invariant whether Claude Code's cwd is the repo root or
+# a subdirectory.
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  root="$(cd "$cwd" && lien path --root 2>/dev/null)"
   store="$(cd "$cwd" && lien path --store 2>/dev/null)"
 else
+  root="$(lien path --root 2>/dev/null)"
   store="$(lien path --store 2>/dev/null)"
 fi
 [ -n "$store" ] || exit 0
+[ -n "$root" ] || root="$cwd"
 
 # Persistent kill switch from `lien gate off`.
 if [ -f "$store/gate-disabled" ]; then
@@ -68,18 +72,20 @@ fi
 ttl_min="${LIEN_GATE_TTL_MIN:-60}"
 session_dir="$store/gate-sessions/$session_id"
 
-# Canonicalize file_path to a workspace-relative form before hashing, so
-# that the gate matches sentinels written by sentinel.sh regardless of
-# whether the caller used absolute or relative paths. Claude Code's
-# Edit/Write payloads carry absolute paths; the model typically passes
-# relative paths to MCP tools.
+# Canonicalize file_path to a project-root-relative form before hashing,
+# so the gate matches sentinels written by sentinel.sh regardless of
+# whether the caller used absolute, root-relative, or cwd-relative paths.
+# Claude Code's Edit/Write carry absolute paths; the model typically
+# passes root-relative paths to MCP tools because Lien's index is
+# root-relative.
 rel_path="$file_path"
-if [ -n "$cwd" ]; then
-  case "$file_path" in
-    "$cwd"/*) rel_path="${file_path#$cwd/}";;
-    "$cwd") rel_path="";;
+for base in "$root" "$cwd"; do
+  [ -z "$base" ] && continue
+  case "$rel_path" in
+    "$base"/*) rel_path="${rel_path#$base/}"; break;;
+    "$base") rel_path=""; break;;
   esac
-fi
+done
 # Strip a leading "./" so "./foo.ts" and "foo.ts" hash identically.
 case "$rel_path" in
   ./*) rel_path="${rel_path#./}";;
@@ -95,7 +101,14 @@ fi
 # Resolve absolute target for the existence check (gate semantic depends
 # on whether the file exists yet).
 target_path="$file_path"
-[ -n "$cwd" ] && [ "${file_path#/}" = "$file_path" ] && target_path="$cwd/$file_path"
+if [ "${file_path#/}" = "$file_path" ]; then
+  # Relative — resolve against root if available, else cwd.
+  if [ -n "$root" ]; then
+    target_path="$root/$file_path"
+  elif [ -n "$cwd" ]; then
+    target_path="$cwd/$file_path"
+  fi
+fi
 
 satisfied=0
 if [ -d "$session_dir" ]; then

--- a/plugins/claude/hooks/gate.sh
+++ b/plugins/claude/hooks/gate.sh
@@ -80,6 +80,10 @@ if [ -n "$cwd" ]; then
     "$cwd") rel_path="";;
   esac
 fi
+# Strip a leading "./" so "./foo.ts" and "foo.ts" hash identically.
+case "$rel_path" in
+  ./*) rel_path="${rel_path#./}";;
+esac
 
 # Hash the canonical path. md5 first 8 chars mirrors extractRepoId.
 hash="$(printf '%s' "$rel_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -1,0 +1,40 @@
+{
+  "description": "Lien edit-gate: nudges Claude to run impact analysis (get_files_context / get_dependents / find_similar) before Edit/Write on indexed files",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/gate.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__plugin_lien_lien__(get_files_context|get_dependents|find_similar)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sentinel.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-clean.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -6,8 +6,7 @@
 # Matched tools:
 #   mcp__plugin_lien_lien__get_files_context  → fc-<hash>
 #   mcp__plugin_lien_lien__get_dependents     → dep-<hash>
-#   mcp__plugin_lien_lien__find_similar       → fs-<hash> (per cited file)
-#                                              + fs-any (any successful call)
+#   mcp__plugin_lien_lien__find_similar       → fs-any
 #
 # Best-effort: never fails the post-tool-use pipeline.
 
@@ -106,19 +105,11 @@ case "$tool_name" in
     ;;
 
   mcp__plugin_lien_lien__find_similar)
-    # Always mark "find_similar was called this session" so the new-file
-    # gate is satisfied even when the search returns zero results.
+    # find_similar is a search, not impact analysis on a specific file.
+    # Writing only fs-any keeps the semantic honest: "the model has
+    # checked for duplication once this session." Strict-match Edits
+    # still need their own get_files_context call.
     : > "$session_dir/fs-any"
-
-    # Also write per-cited-file sentinels so subsequent strict-match
-    # edits on those files pass. tool_result is the MCP wire format:
-    # { content: [ { type: "text", text: "<json string>" } ] }
-    text="$(printf '%s' "$input" | jq -r '.tool_result.content[0].text // .tool_response.content[0].text // empty' 2>/dev/null)"
-    if [ -n "$text" ]; then
-      printf '%s' "$text" | jq -r '.results[]?.metadata.file // empty' 2>/dev/null | while IFS= read -r p; do
-        [ -n "$p" ] && write_sentinel fs "$p"
-      done
-    fi
     ;;
 esac
 

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# PostToolUse hook: write sentinels for Lien impact-analysis calls.
+# Sentinels live under <store>/gate-sessions/<session_id>/ and carry the
+# call timestamp in their mtime.
+#
+# Matched tools:
+#   mcp__plugin_lien_lien__get_files_context  → fc-<hash>
+#   mcp__plugin_lien_lien__get_dependents     → dep-<hash>
+#   mcp__plugin_lien_lien__find_similar       → fs-<hash> (per cited file)
+#
+# Best-effort: never fails the post-tool-use pipeline.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+[ -n "$tool_name" ] || exit 0
+[ -n "$session_id" ] || exit 0
+
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+else
+  store="$(lien path --store 2>/dev/null)"
+fi
+[ -n "$store" ] || exit 0
+
+session_dir="$store/gate-sessions/$session_id"
+mkdir -p "$session_dir" 2>/dev/null || exit 0
+
+hash_path() {
+  # $1 = file path → 8-char md5 hex
+  if command -v md5sum >/dev/null 2>&1; then
+    printf '%s' "$1" | md5sum | awk '{print substr($1,1,8)}'
+  else
+    printf '%s' "$1" | md5 | awk '{print substr($NF,1,8)}'
+  fi
+}
+
+write_sentinel() {
+  # $1 = prefix (fc|dep|fs), $2 = file path
+  local prefix="$1" file_path="$2" h
+  [ -n "$file_path" ] || return
+  h="$(hash_path "$file_path")"
+  [ -n "$h" ] || return
+  : > "$session_dir/$prefix-$h"
+}
+
+case "$tool_name" in
+  mcp__plugin_lien_lien__get_files_context)
+    # tool_input.filepaths is string | string[]
+    paths_json="$(printf '%s' "$input" | jq -c '.tool_input.filepaths // empty')"
+    if [ -n "$paths_json" ]; then
+      if printf '%s' "$paths_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$paths_json" | jq -r '.[]' | while IFS= read -r p; do
+          write_sentinel fc "$p"
+        done
+      else
+        p="$(printf '%s' "$paths_json" | jq -r '.')"
+        write_sentinel fc "$p"
+      fi
+    fi
+    ;;
+
+  mcp__plugin_lien_lien__get_dependents)
+    p="$(printf '%s' "$input" | jq -r '.tool_input.filepath // empty')"
+    write_sentinel dep "$p"
+    ;;
+
+  mcp__plugin_lien_lien__find_similar)
+    # tool_result is the MCP wire format: { content: [ { type: "text", text: "<json string>" } ] }
+    # The inner JSON has { results: [ { metadata: { file: "..." } } ] }
+    text="$(printf '%s' "$input" | jq -r '.tool_result.content[0].text // .tool_response.content[0].text // empty' 2>/dev/null)"
+    if [ -n "$text" ]; then
+      printf '%s' "$text" | jq -r '.results[]?.metadata.file // empty' 2>/dev/null | while IFS= read -r p; do
+        [ -n "$p" ] && write_sentinel fs "$p"
+      done
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -34,8 +34,7 @@ session_dir="$store/gate-sessions/$session_id"
 mkdir -p "$session_dir" 2>/dev/null || exit 0
 
 canonicalize() {
-  # Strip $cwd/ prefix from an absolute path so the sentinel hash agrees
-  # with the gate's hash regardless of which form the caller used.
+  # Match gate.sh: strip $cwd/ prefix, then strip a leading "./".
   local p="$1"
   if [ -n "$cwd" ]; then
     case "$p" in
@@ -43,6 +42,9 @@ canonicalize() {
       "$cwd") p="";;
     esac
   fi
+  case "$p" in
+    ./*) p="${p#./}";;
+  esac
   printf '%s' "$p"
 }
 

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -23,6 +23,18 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 [ -n "$tool_name" ] || exit 0
 [ -n "$session_id" ] || exit 0
 
+# Defensive: see gate.sh — keep session_id confined to safe filename chars.
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) exit 0;;
+esac
+
+# Skip sentinel write if the tool itself failed — otherwise a malformed
+# get_files_context call would still satisfy the gate on its target file.
+tool_error="$(printf '%s' "$input" | jq -r '
+  .tool_response.isError // .tool_result.isError // empty
+')"
+[ "$tool_error" = "true" ] && exit 0
+
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
   root="$(cd "$cwd" && lien path --root 2>/dev/null)"
   store="$(cd "$cwd" && lien path --store 2>/dev/null)"

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -7,6 +7,7 @@
 #   mcp__plugin_lien_lien__get_files_context  → fc-<hash>
 #   mcp__plugin_lien_lien__get_dependents     → dep-<hash>
 #   mcp__plugin_lien_lien__find_similar       → fs-<hash> (per cited file)
+#                                              + fs-any (any successful call)
 #
 # Best-effort: never fails the post-tool-use pipeline.
 
@@ -85,7 +86,7 @@ write_sentinel() {
 
 case "$tool_name" in
   mcp__plugin_lien_lien__get_files_context)
-    # tool_input.filepaths is string | string[]
+    # tool_input.filepaths is string | string[].
     paths_json="$(printf '%s' "$input" | jq -c '.tool_input.filepaths // empty')"
     if [ -n "$paths_json" ]; then
       if printf '%s' "$paths_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
@@ -105,8 +106,13 @@ case "$tool_name" in
     ;;
 
   mcp__plugin_lien_lien__find_similar)
-    # tool_result is the MCP wire format: { content: [ { type: "text", text: "<json string>" } ] }
-    # The inner JSON has { results: [ { metadata: { file: "..." } } ] }
+    # Always mark "find_similar was called this session" so the new-file
+    # gate is satisfied even when the search returns zero results.
+    : > "$session_dir/fs-any"
+
+    # Also write per-cited-file sentinels so subsequent strict-match
+    # edits on those files pass. tool_result is the MCP wire format:
+    # { content: [ { type: "text", text: "<json string>" } ] }
     text="$(printf '%s' "$input" | jq -r '.tool_result.content[0].text // .tool_response.content[0].text // empty' 2>/dev/null)"
     if [ -n "$text" ]; then
       printf '%s' "$text" | jq -r '.results[]?.metadata.file // empty' 2>/dev/null | while IFS= read -r p; do

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -24,24 +24,28 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 [ -n "$session_id" ] || exit 0
 
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  root="$(cd "$cwd" && lien path --root 2>/dev/null)"
   store="$(cd "$cwd" && lien path --store 2>/dev/null)"
 else
+  root="$(lien path --root 2>/dev/null)"
   store="$(lien path --store 2>/dev/null)"
 fi
 [ -n "$store" ] || exit 0
+[ -n "$root" ] || root="$cwd"
 
 session_dir="$store/gate-sessions/$session_id"
 mkdir -p "$session_dir" 2>/dev/null || exit 0
 
 canonicalize() {
-  # Match gate.sh: strip $cwd/ prefix, then strip a leading "./".
-  local p="$1"
-  if [ -n "$cwd" ]; then
+  # Match gate.sh: try $root then $cwd, then strip a leading "./".
+  local p="$1" base
+  for base in "$root" "$cwd"; do
+    [ -z "$base" ] && continue
     case "$p" in
-      "$cwd"/*) p="${p#$cwd/}";;
-      "$cwd") p="";;
+      "$base"/*) p="${p#$base/}"; break;;
+      "$base") p=""; break;;
     esac
-  fi
+  done
   case "$p" in
     ./*) p="${p#./}";;
   esac

--- a/plugins/claude/hooks/sentinel.sh
+++ b/plugins/claude/hooks/sentinel.sh
@@ -33,8 +33,21 @@ fi
 session_dir="$store/gate-sessions/$session_id"
 mkdir -p "$session_dir" 2>/dev/null || exit 0
 
+canonicalize() {
+  # Strip $cwd/ prefix from an absolute path so the sentinel hash agrees
+  # with the gate's hash regardless of which form the caller used.
+  local p="$1"
+  if [ -n "$cwd" ]; then
+    case "$p" in
+      "$cwd"/*) p="${p#$cwd/}";;
+      "$cwd") p="";;
+    esac
+  fi
+  printf '%s' "$p"
+}
+
 hash_path() {
-  # $1 = file path → 8-char md5 hex
+  # $1 = canonical file path → 8-char md5 hex
   if command -v md5sum >/dev/null 2>&1; then
     printf '%s' "$1" | md5sum | awk '{print substr($1,1,8)}'
   else
@@ -43,10 +56,11 @@ hash_path() {
 }
 
 write_sentinel() {
-  # $1 = prefix (fc|dep|fs), $2 = file path
-  local prefix="$1" file_path="$2" h
+  # $1 = prefix (fc|dep|fs), $2 = file path (absolute or relative)
+  local prefix="$1" file_path="$2" rel h
   [ -n "$file_path" ] || return
-  h="$(hash_path "$file_path")"
+  rel="$(canonicalize "$file_path")"
+  h="$(hash_path "$rel")"
   [ -n "$h" ] || return
   : > "$session_dir/$prefix-$h"
 }

--- a/plugins/claude/hooks/session-clean.sh
+++ b/plugins/claude/hooks/session-clean.sh
@@ -21,9 +21,12 @@ fi
 # `lien gate off` clears at session boundary; explicit `block` persists.
 rm -f "$store/gate-disabled"
 
+# Only GC sessions that have been inactive for >24h. The dir's mtime
+# tracks the last sentinel write, so concurrent Claude Code sessions
+# for the same repo keep each other's sentinels intact.
 sessions_root="$store/gate-sessions"
 if [ -d "$sessions_root" ] && [ -n "$session_id" ]; then
-  find "$sessions_root" -mindepth 1 -maxdepth 1 -type d ! -name "$session_id" -exec rm -rf {} + 2>/dev/null
+  find "$sessions_root" -mindepth 1 -maxdepth 1 -type d ! -name "$session_id" -mtime +1 -exec rm -rf {} + 2>/dev/null
 fi
 
 exit 0

--- a/plugins/claude/hooks/session-clean.sh
+++ b/plugins/claude/hooks/session-clean.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SessionStart hook: garbage-collect stale gate-sessions/ dirs and clear
+# the session-disable flag (which only persists until the next session).
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+else
+  store="$(lien path --store 2>/dev/null)"
+fi
+[ -n "$store" ] || exit 0
+
+# `lien gate off` clears at session boundary; explicit `block` persists.
+rm -f "$store/gate-disabled"
+
+sessions_root="$store/gate-sessions"
+if [ -d "$sessions_root" ] && [ -n "$session_id" ]; then
+  find "$sessions_root" -mindepth 1 -maxdepth 1 -type d ! -name "$session_id" -exec rm -rf {} + 2>/dev/null
+fi
+
+exit 0

--- a/plugins/claude/hooks/session-clean.sh
+++ b/plugins/claude/hooks/session-clean.sh
@@ -11,6 +11,11 @@ input="$(cat)"
 session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
 cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 
+# Defensive: session_id is matched against directory names below.
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) session_id="";;
+esac
+
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
   store="$(cd "$cwd" && lien path --store 2>/dev/null)"
 else


### PR DESCRIPTION
Closes #560.

## Summary

Ships a `PreToolUse`/`PostToolUse`/`SessionStart` hook trio with the Claude Code plugin that nudges the model to run `get_files_context` / `get_dependents` / `find_similar` before `Edit`/`Write` on Lien-indexed files.

**Blocking by default** — discovered during live dogfooding that Claude Code 2.1.142 records a PreToolUse `systemMessage` to the transcript but does not surface it to the model on subsequent turns. Only exit 2 + stderr (the blocking path) reaches the model. Advisory mode is preserved as an explicit opt-down for users who only want the UI signal.

State lives under `~/.lien/indices/<repoId>/gate-sessions/<session_id>/`, reusing `extractRepoId` after walking up for `.git` (so behavior is stable from any subdirectory). `SessionStart` GCs sessions idle >24h; concurrent Claude Code sessions for the same repo don't clobber each other.

Three new CLI subcommands expose the path/state machinery to the shell scripts:

- `lien path --store | --extensions | --root` — single source of truth for the bash hooks.
- `lien gate on | block | advisory | off | status` — toggle and inspect the gate; `/lien-gate` slash command wraps it.

## What ships

| Path | Purpose |
| --- | --- |
| `plugins/claude/hooks/hooks.json` | Registers the three hook events |
| `plugins/claude/hooks/gate.sh` | PreToolUse gate: TTL-bounded sentinel lookup, ext filter, blocking by default |
| `plugins/claude/hooks/sentinel.sh` | PostToolUse writer: `fc-<hash>` for `get_files_context`, `dep-<hash>` for `get_dependents`, `fs-any` for `find_similar`. Validates `session_id`, skips when `tool_response.isError` is true |
| `plugins/claude/hooks/session-clean.sh` | SessionStart GC: removes session dirs idle >24h; clears `gate-disabled` |
| `plugins/claude/commands/lien-gate.md` | `/lien-gate` slash command |
| `packages/cli/src/cli/path-cmd.ts` | `lien path` |
| `packages/cli/src/cli/gate-cmd.ts` | `lien gate` |
| `packages/cli/src/cli/store-paths.ts` | Shared `getStoreRoot()` (used by both commands) |
| `packages/cli/src/cli/project-root.ts` | `resolveProjectRoot()` — walks up for `.git` |

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; pre-existing warnings unchanged)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test -w packages/cli` (664/664), `-w @liendev/parser` (747/747), `-w @liendev/review` (348/348). Core has one pre-existing flake in `embeddings/worker-embeddings.test.ts` (worker exit), unrelated to this change.
- [x] Shell smoke tests on each hook script (indexed/non-indexed extension, env overrides, sentinel satisfied/aged-out, sentinel-writer paths, SessionStart GC, multi-file `get_files_context`, traversal-attempt `session_id` rejected, `isError: true` suppresses sentinel).
- [x] **Live dogfooding through Claude Code** (see findings below).
- [ ] **Reviewer**: install/refresh the plugin locally and confirm the gate fires on a fresh `Edit`. Note that `/reload-plugins` reads from `~/.claude/plugins/cache/...`, not the source directory — to test changes from this PR you'll need to either `/plugin uninstall lien && /plugin install lien@lien` or copy hook files into the cache snapshot.

## Live dogfooding findings

Six findings from running the gate end-to-end inside a real Claude Code session. Each is reflected in the current PR head.

1. **`systemMessage` is silent to the model.** Probed via a discriminating PostToolUse hook on `Read` that emitted a directive ("emit a specific sentinel string"). The marker landed in the transcript as a `hook_system_message` attachment but never appeared in the model's next-turn input, and the model did not emit the string. Same channel mechanism is used by gate.sh in advisory mode — so the original "advisory by default" shipped a hook that the model didn't actually see. Default flipped to blocking.

2. **Path canonicalization mismatch was a real bug.** Initial design hashed file paths verbatim. Claude Code passes `tool_input.file_path` as **absolute**; the model passes relative paths to MCP tools. Hashes never matched → gate fired even after a satisfying call. Fixed by normalizing both sides to a project-root-relative form before hashing (commit `83db553`).

3. **Project-root resolution.** Running `lien gate off` from a subdir wrote the flag into a different store than the hook (which uses Claude Code's `cwd`) read from. `resolveProjectRoot()` walks up for `.git`; `lien path --root` exposes it to shell scripts. Hooks now canonicalize against `$root` with `$cwd` as fallback (commit `4b96691`).

4. **Multi-session safety.** Original `SessionStart` cleanup wiped all other-session dirs unconditionally. With two concurrent Claude Code sessions on the same repo, the second's startup would have destroyed the first's sentinels. Now only sessions idle >24h get GC'd (commit `c0f7b73`).

5. **`fc-*` was satisfying the new-file gate.** The model calls `get_files_context` constantly for context-gathering, so unrelated `fc-*` sentinels were silently satisfying the new-file branch and defeating the `find_similar` nudge. Tightened to `fs-*` only (commit `0d1da1e`). Paired with an `fs-any` marker so an empty `find_similar` result doesn't cause an infinite nudge loop.

6. **Per-cited `fs-<hash>` from `find_similar` was dead code.** Live dogfooding showed Claude Code's PostToolUse payload for MCP tool results doesn't use the `tool_response.content[0].text` shape sentinel.sh was reading. Only `fs-any` was getting written in practice. The per-cited semantic was also conceptually weak — `find_similar` is search, not impact analysis on a specific file — so dropped entirely (commit `1f0851f`).

## CodeRabbit feedback addressed

Fixed: filesystem try/catch in `gateCommand`; shared `getStoreRoot()` (also Windows-safe via forward-slash normalization); `session_id` sanitization in all three hooks; `isError` check before sentinel write; test isolation via mocked `os.homedir()`; tightened new-file gate; relative-vs-cwd preference for `target_path` resolution.

Skipped (with reasons): try/catch around `extractRepoId`/`getSupportedExtensions` (don't throw); `Bash(lien gate *)` rewrite (CodeRabbit wrong — every installed plugin uses the colon form); `MultiEdit` payload "iteration" (MultiEdit is multi-edit-single-file, `tool_input.file_path` is the right field); null-terminated jq for newline-in-filename (vanishingly rare; the literal kept being collapsed and broke the multi-path case for normal users).

## Notes for review

- **Default is blocking.** Users who want UI-only (no enforcement) can run `lien gate advisory`. Users who want it off entirely: `lien gate off`.
- **`jq` is a soft prereq.** Every hook checks `command -v jq` and silently exits 0 if missing — the gate degrades to a no-op rather than failing edits.
- **Cache-refresh wrinkle.** `/reload-plugins` reads cached snapshots; full `/plugin uninstall && /plugin install` (or marketplace refresh) is needed to pick up hook source changes during dev.
