### PR TITLE
feat(plugin): post-read impact annotator

### DIFF
--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -3,46 +3,11 @@ import path from 'path';
 import os from 'os';
 import {
   annotateCommand,
-  toRelative,
   isTrivial,
   formatDependents,
   formatTests,
   formatComplexity,
 } from './annotate-cmd.js';
-import { toAbsolutePath } from '../types/paths.js';
-
-describe('toRelative', () => {
-  const root = toAbsolutePath('/repo/root');
-
-  it('resolves a relative input against cwd, not root', () => {
-    // CLI invoked from /repo/root → cwd === root → behavior matches naive form.
-    expect(toRelative('src/foo.ts', root, root)).toBe('src/foo.ts');
-  });
-
-  it('handles a subdir cwd: src/foo.ts means <subdir>/src/foo.ts', () => {
-    // Running `lien annotate src/foo.ts` from /repo/root/packages/cli
-    // should resolve to /repo/root/packages/cli/src/foo.ts → relative
-    // form against the root is packages/cli/src/foo.ts.
-    expect(toRelative('src/foo.ts', root, toAbsolutePath('/repo/root/packages/cli'))).toBe(
-      'packages/cli/src/foo.ts',
-    );
-  });
-
-  it('strips an absolute path that lives under root', () => {
-    expect(toRelative('/repo/root/src/foo.ts', root, root)).toBe('src/foo.ts');
-  });
-
-  it('returns empty sentinel when the resolved path escapes root', () => {
-    // Returning a relative-but-escaping path would violate the
-    // RelativePath brand contract (which guarantees a path under root).
-    // Empty is the explicit "no useful relative form" signal.
-    expect(toRelative('../outside.ts', root, root)).toBe('');
-  });
-
-  it('returns empty for empty input', () => {
-    expect(toRelative('', root, root)).toBe('');
-  });
-});
 
 describe('isTrivial', () => {
   it('is trivial when no deps, no complexity, and tests present', () => {

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -13,20 +13,30 @@ import {
 describe('toRelative', () => {
   const root = '/repo/root';
 
-  it('returns clean relative input untouched', () => {
-    expect(toRelative('src/foo.ts', root)).toBe('src/foo.ts');
+  it('resolves a relative input against cwd, not root', () => {
+    // CLI invoked from /repo/root → cwd === root → behavior matches naive form.
+    expect(toRelative('src/foo.ts', root, root)).toBe('src/foo.ts');
+  });
+
+  it('handles a subdir cwd: src/foo.ts means <subdir>/src/foo.ts', () => {
+    // Running `lien annotate src/foo.ts` from /repo/root/packages/cli
+    // should resolve to /repo/root/packages/cli/src/foo.ts → relative
+    // form against the root is packages/cli/src/foo.ts.
+    expect(toRelative('src/foo.ts', root, '/repo/root/packages/cli')).toBe(
+      'packages/cli/src/foo.ts',
+    );
   });
 
   it('strips an absolute path that lives under root', () => {
-    expect(toRelative('/repo/root/src/foo.ts', root)).toBe('src/foo.ts');
+    expect(toRelative('/repo/root/src/foo.ts', root, root)).toBe('src/foo.ts');
   });
 
   it('returns the input untouched when resolved path escapes root', () => {
-    expect(toRelative('../outside.ts', root)).toBe('../outside.ts');
+    expect(toRelative('../outside.ts', root, root)).toBe('../outside.ts');
   });
 
   it('returns empty for empty input', () => {
-    expect(toRelative('', root)).toBe('');
+    expect(toRelative('', root, root)).toBe('');
   });
 });
 

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -9,9 +9,10 @@ import {
   formatTests,
   formatComplexity,
 } from './annotate-cmd.js';
+import { toAbsolutePath } from '../types/paths.js';
 
 describe('toRelative', () => {
-  const root = '/repo/root';
+  const root = toAbsolutePath('/repo/root');
 
   it('resolves a relative input against cwd, not root', () => {
     // CLI invoked from /repo/root → cwd === root → behavior matches naive form.
@@ -22,7 +23,7 @@ describe('toRelative', () => {
     // Running `lien annotate src/foo.ts` from /repo/root/packages/cli
     // should resolve to /repo/root/packages/cli/src/foo.ts → relative
     // form against the root is packages/cli/src/foo.ts.
-    expect(toRelative('src/foo.ts', root, '/repo/root/packages/cli')).toBe(
+    expect(toRelative('src/foo.ts', root, toAbsolutePath('/repo/root/packages/cli'))).toBe(
       'packages/cli/src/foo.ts',
     );
   });
@@ -31,8 +32,11 @@ describe('toRelative', () => {
     expect(toRelative('/repo/root/src/foo.ts', root, root)).toBe('src/foo.ts');
   });
 
-  it('returns the input untouched when resolved path escapes root', () => {
-    expect(toRelative('../outside.ts', root, root)).toBe('../outside.ts');
+  it('returns empty sentinel when the resolved path escapes root', () => {
+    // Returning a relative-but-escaping path would violate the
+    // RelativePath brand contract (which guarantees a path under root).
+    // Empty is the explicit "no useful relative form" signal.
+    expect(toRelative('../outside.ts', root, root)).toBe('');
   });
 
   it('returns empty for empty input', () => {

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import {
+  annotateCommand,
+  toRelative,
+  isTrivial,
+  formatDependents,
+  formatTests,
+  formatComplexity,
+} from './annotate-cmd.js';
+
+describe('toRelative', () => {
+  const root = '/repo/root';
+
+  it('returns clean relative input untouched', () => {
+    expect(toRelative('src/foo.ts', root)).toBe('src/foo.ts');
+  });
+
+  it('strips an absolute path that lives under root', () => {
+    expect(toRelative('/repo/root/src/foo.ts', root)).toBe('src/foo.ts');
+  });
+
+  it('returns the input untouched when resolved path escapes root', () => {
+    expect(toRelative('../outside.ts', root)).toBe('../outside.ts');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(toRelative('', root)).toBe('');
+  });
+});
+
+describe('isTrivial', () => {
+  it('is trivial when no deps, no complexity, and tests present', () => {
+    expect(isTrivial(0, 0, 1)).toBe(true);
+    expect(isTrivial(1, 0, 1)).toBe(true);
+  });
+
+  it('is non-trivial without test coverage', () => {
+    expect(isTrivial(0, 0, 0)).toBe(false);
+  });
+
+  it('is non-trivial when there are complexity warnings', () => {
+    expect(isTrivial(0, 1, 1)).toBe(false);
+  });
+
+  it('is non-trivial above the dependent threshold', () => {
+    expect(isTrivial(2, 0, 1)).toBe(false);
+  });
+});
+
+describe('formatDependents', () => {
+  it('singular form for one dependent', () => {
+    expect(formatDependents(1, 'low', [])).toBe('1 file imports this; risk: low.');
+  });
+
+  it('plural form and reasoning when present', () => {
+    expect(formatDependents(14, 'high', ['14 callers', '3 untested'])).toBe(
+      '14 files import this; risk: high (14 callers, 3 untested).',
+    );
+  });
+
+  it('omits the parenthetical when reasoning is empty', () => {
+    expect(formatDependents(3, 'medium', [])).toBe('3 files import this; risk: medium.');
+  });
+});
+
+describe('formatTests', () => {
+  it('reports no coverage when array is empty', () => {
+    expect(formatTests([])).toBe('No test coverage.');
+  });
+
+  it('lists up to two test files inline', () => {
+    expect(formatTests(['a.test.ts', 'b.test.ts'])).toBe('Test coverage: a.test.ts, b.test.ts.');
+  });
+
+  it('truncates extras with a (+N more) suffix', () => {
+    expect(formatTests(['a.test.ts', 'b.test.ts', 'c.test.ts', 'd.test.ts'])).toBe(
+      'Test coverage: a.test.ts, b.test.ts (+2 more).',
+    );
+  });
+});
+
+describe('formatComplexity', () => {
+  it('singular for one violation', () => {
+    expect(formatComplexity({ max: 12, warningCount: 1 })).toBe(
+      'Max cyclomatic complexity: 12 (1 function over warn threshold).',
+    );
+  });
+
+  it('plural for multiple', () => {
+    expect(formatComplexity({ max: 18, warningCount: 3 })).toBe(
+      'Max cyclomatic complexity: 18 (3 functions over warn threshold).',
+    );
+  });
+});
+
+describe('annotateCommand (integration)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let tmpHome: string;
+  let homeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // Redirect home so a real-world `~/.lien` index never gets touched.
+    const fs = await import('fs/promises');
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-annotate-test-'));
+    homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+  });
+
+  afterEach(async () => {
+    const fs = await import('fs/promises');
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    homeSpy.mockRestore();
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('silently exits for a non-existent file', async () => {
+    await annotateCommand('this/path/does/not/exist.ts');
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('silently exits for an empty path', async () => {
+    await annotateCommand('');
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('silently exits when the index is missing (tmpHome has none)', async () => {
+    await annotateCommand('packages/cli/src/cli/index.ts');
+    // VectorDB init against an empty tmp home should fail or return empty;
+    // either way, the command must not throw or print errors.
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -50,18 +50,55 @@ describe('isTrivial', () => {
 });
 
 describe('formatDependents', () => {
-  it('singular form for one dependent', () => {
-    expect(formatDependents(1, 'low', [])).toBe('1 file imports this; risk: low.');
-  });
+  const dep = (filepath: string, isTestFile = false) => ({ filepath, isTestFile });
 
-  it('plural form and reasoning when present', () => {
-    expect(formatDependents(14, 'high', ['14 callers', '3 untested'])).toBe(
-      '14 files import this; risk: high (14 callers, 3 untested).',
+  it('singular form for one dependent, with its path listed', () => {
+    expect(formatDependents([dep('src/auth.ts')], 'low', [])).toBe(
+      '1 file imports this — src/auth.ts; risk: low.',
     );
   });
 
-  it('omits the parenthetical when reasoning is empty', () => {
-    expect(formatDependents(3, 'medium', [])).toBe('3 files import this; risk: medium.');
+  it('plural form, listing up to MAX_DEPS_LISTED files, with reasoning', () => {
+    const deps = [
+      dep('handlers/login.ts'),
+      dep('handlers/logout.ts'),
+      dep('handlers/refresh.ts'),
+      dep('handlers/session.ts'),
+    ];
+    expect(formatDependents(deps, 'high', ['4 callers', '1 untested'])).toBe(
+      '4 files import this — handlers/login.ts, handlers/logout.ts, handlers/refresh.ts, handlers/session.ts; risk: high (4 callers, 1 untested).',
+    );
+  });
+
+  it('truncates with +N more when over the listed cap', () => {
+    const many = Array.from({ length: 14 }, (_, i) => dep(`src/file-${i}.ts`));
+    const formatted = formatDependents(many, 'critical', ['14 callers']);
+    expect(formatted).toContain('14 files import this');
+    expect(formatted).toContain('src/file-0.ts');
+    expect(formatted).toContain('src/file-3.ts');
+    expect(formatted).toContain('+10 more');
+    expect(formatted).toContain('risk: critical (14 callers)');
+  });
+
+  it('sorts production dependents before tests', () => {
+    const deps = [
+      dep('test/auth.test.ts', true),
+      dep('src/api.ts'),
+      dep('test/api.test.ts', true),
+      dep('src/handlers.ts'),
+    ];
+    const formatted = formatDependents(deps, 'medium', []);
+    // Both prod files should appear before either test file in the listing.
+    const idxApi = formatted.indexOf('src/api.ts');
+    const idxHandlers = formatted.indexOf('src/handlers.ts');
+    const idxAuthTest = formatted.indexOf('test/auth.test.ts');
+    expect(Math.max(idxApi, idxHandlers)).toBeLessThan(idxAuthTest);
+  });
+
+  it('omits the risk parenthetical when reasoning is empty', () => {
+    expect(formatDependents([dep('src/a.ts'), dep('src/b.ts')], 'medium', [])).toBe(
+      '2 files import this — src/a.ts, src/b.ts; risk: medium.',
+    );
   });
 });
 

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -48,7 +48,17 @@ async function run(file: string): Promise<void> {
   const log = () => undefined;
   const result = await findDependents(vectorDB, filepath, false, log);
 
-  const allChunks = result.allChunks as unknown as CodeChunk[];
+  // LanceDB returns chunks whose `metadata.imports` is an Apache Arrow
+  // Vector — iterable but lacking .some() and other array methods.
+  // findTestAssociationsFromChunks uses .some(), so coerce per-chunk
+  // before handing it off.
+  const allChunks = result.allChunks.map(c => ({
+    ...c,
+    metadata: {
+      ...c.metadata,
+      imports: c.metadata?.imports ? Array.from(c.metadata.imports as Iterable<string>) : [],
+    },
+  })) as unknown as CodeChunk[];
   const testsMap = findTestAssociationsFromChunks([filepath], allChunks, rootDir);
   const tests = testsMap.get(filepath) ?? [];
 

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -10,7 +10,11 @@ import { findDependents, type DependentInfo } from '../mcp/handlers/dependency-a
 import { resolveProjectRoot } from './project-root.js';
 import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/paths.js';
 
-const HIGH_COMPLEXITY_THRESHOLD = 15;
+// Complexity threshold lives in @liendev/core (dependency-analyzer's
+// COMPLEXITY_THRESHOLDS.HIGH_COMPLEXITY_DEPENDENT = 10) and surfaces
+// pre-filtered via result.complexityMetrics.highComplexityDependents.
+// Don't define a local threshold — keeps this annotator from drifting
+// from the rest of Lien's risk semantics.
 const MAX_TESTS_LISTED = 2;
 const MAX_DEPS_LISTED = 4;
 
@@ -126,7 +130,19 @@ async function run(file: string): Promise<void> {
     await vectorDB.initialize();
 
     const log = () => undefined;
-    const result = await findDependents(vectorDB, filepath, false, log);
+    // includeAllChunks=true: annotator needs the chunks for test-association
+    // and complexity lookups. The default (false) keeps the MCP path cheap.
+    const result = await findDependents(
+      vectorDB,
+      filepath,
+      false,
+      log,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
     const allChunks = adaptChunkImports(result.allChunks);
 
     const tests =
@@ -138,6 +154,16 @@ async function run(file: string): Promise<void> {
     // target file's own complexity (`complexity.max`) is reported
     // separately on the display line below — different signal.
     const maxDependentComplexity = result.complexityMetrics.maxComplexity;
+    // Strict join: is any high-complexity dependent (per the core's
+    // threshold of 10) actually untested? Avoids the previous proxy that
+    // could escalate risk when uncovered/complex pairs were unrelated.
+    // Uses the core-filtered highComplexityDependents so this code never
+    // drifts from the rest of Lien's risk semantics.
+    const hasHighComplexityUncovered = anyHighComplexityUncovered(
+      result.complexityMetrics.highComplexityDependents,
+      allChunks,
+      rootDir,
+    );
 
     if (isTrivial(dependentCount, complexity.warningCount, tests.length)) return;
 
@@ -149,6 +175,7 @@ async function run(file: string): Promise<void> {
       dependentCount,
       uncovered,
       maxDependentComplexity,
+      hasHighComplexityUncovered,
     );
   } finally {
     if (needsChdir) process.chdir(originalCwd);
@@ -163,17 +190,13 @@ function emitAnnotation(
   dependentCount: number,
   uncovered: number,
   maxDependentComplexity: number,
+  hasHighComplexityUncovered: boolean,
 ): void {
   const risk = computeBlastRadiusRisk({
     dependentCount,
     uncoveredDependents: uncovered,
     maxDependentComplexity,
-    // Approximation: any uncovered dependent + at least one high-complexity
-    // dependent in the set. We don't have per-dependent test-coverage joined
-    // with per-dependent complexity here; this proxy errs toward escalating
-    // risk when both conditions are present in the population.
-    hasHighComplexityUncovered:
-      uncovered > 0 && maxDependentComplexity >= HIGH_COMPLEXITY_THRESHOLD,
+    hasHighComplexityUncovered,
   });
 
   const lines: string[] = [`Lien impact for ${filepath}:`];
@@ -199,6 +222,23 @@ export function isTrivial(
 interface ComplexitySummary {
   max: number;
   warningCount: number;
+}
+
+/**
+ * Returns true when at least one dependent that the core classifies as
+ * high-complexity (>= COMPLEXITY_THRESHOLDS.HIGH_COMPLEXITY_DEPENDENT)
+ * has no test coverage. Performs the strict join the blast-radius risk
+ * model wants: "is a complex blast-radius node actually untested?"
+ */
+function anyHighComplexityUncovered(
+  highComplexityDependents: ReadonlyArray<{ filepath: string }>,
+  allChunks: CodeChunk[],
+  rootDir: string,
+): boolean {
+  if (highComplexityDependents.length === 0) return false;
+  const filepaths = highComplexityDependents.map(d => d.filepath);
+  const testsMap = findTestAssociationsFromChunks(filepaths, allChunks, rootDir);
+  return filepaths.some(p => (testsMap.get(p) ?? []).length === 0);
 }
 
 function computeComplexitySummary(chunks: CodeChunk[], filepath: string): ComplexitySummary {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -30,14 +30,16 @@ export async function annotateCommand(file: string): Promise<void> {
 }
 
 async function run(file: string): Promise<void> {
-  const rootDir = resolveProjectRoot(process.cwd());
-  const filepath = toRelative(file, rootDir);
+  const cwd = process.cwd();
+  const rootDir = resolveProjectRoot(cwd);
+  const filepath = toRelative(file, rootDir, cwd);
   if (!filepath) return;
 
   // Guard against non-existent paths — findDependents's suffix matching
   // can otherwise return spurious hits for unrelated imports that happen
-  // to share a basename.
-  const abs = path.isAbsolute(file) ? file : path.resolve(rootDir, file);
+  // to share a basename. Resolve relative inputs against cwd, not rootDir,
+  // so `lien annotate src/foo.ts` from a subdir finds <subdir>/src/foo.ts.
+  const abs = path.isAbsolute(file) ? file : path.resolve(cwd, file);
   if (!fs.existsSync(abs)) return;
 
   const vectorDB = new VectorDB(rootDir);
@@ -75,9 +77,12 @@ async function run(file: string): Promise<void> {
   console.log(lines.join('\n'));
 }
 
-export function toRelative(file: string, rootDir: string): string {
+export function toRelative(file: string, rootDir: string, cwd: string = process.cwd()): string {
   if (!file) return '';
-  const abs = path.isAbsolute(file) ? file : path.resolve(rootDir, file);
+  // Relative inputs are conventionally process-cwd-relative (POSIX). Only
+  // fall back to rootDir if cwd is somehow empty.
+  const base = cwd || rootDir;
+  const abs = path.isAbsolute(file) ? file : path.resolve(base, file);
   const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
   // Edge: file outside the resolved root. Hand back the input unchanged
   // and let findDependents come up empty — silent exit downstream.

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -134,10 +134,22 @@ async function run(file: string): Promise<void> {
     const complexity = computeComplexitySummary(allChunks, filepath);
     const dependentCount = result.dependents.length;
     const uncovered = result.uncoveredProductionDependents;
+    // Dependents' max complexity feeds the blast-radius risk score. The
+    // target file's own complexity (`complexity.max`) is reported
+    // separately on the display line below — different signal.
+    const maxDependentComplexity = result.complexityMetrics.maxComplexity;
 
     if (isTrivial(dependentCount, complexity.warningCount, tests.length)) return;
 
-    emitAnnotation(filepath, result.dependents, tests, complexity, dependentCount, uncovered);
+    emitAnnotation(
+      filepath,
+      result.dependents,
+      tests,
+      complexity,
+      dependentCount,
+      uncovered,
+      maxDependentComplexity,
+    );
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
@@ -150,12 +162,18 @@ function emitAnnotation(
   complexity: ComplexitySummary,
   dependentCount: number,
   uncovered: number,
+  maxDependentComplexity: number,
 ): void {
   const risk = computeBlastRadiusRisk({
     dependentCount,
     uncoveredDependents: uncovered,
-    maxDependentComplexity: complexity.max,
-    hasHighComplexityUncovered: uncovered > 0 && complexity.max >= HIGH_COMPLEXITY_THRESHOLD,
+    maxDependentComplexity,
+    // Approximation: any uncovered dependent + at least one high-complexity
+    // dependent in the set. We don't have per-dependent test-coverage joined
+    // with per-dependent complexity here; this proxy errs toward escalating
+    // risk when both conditions are present in the population.
+    hasHighComplexityUncovered:
+      uncovered > 0 && maxDependentComplexity >= HIGH_COMPLEXITY_THRESHOLD,
   });
 
   const lines: string[] = [`Lien impact for ${filepath}:`];
@@ -168,24 +186,6 @@ function emitAnnotation(
   }
 
   console.log(lines.join('\n'));
-}
-
-export function toRelative(
-  file: string,
-  rootDir: AbsolutePath,
-  cwd: AbsolutePath = toAbsolutePath(process.cwd()),
-): RelativePath {
-  if (!file) return '' as RelativePath;
-  // Relative inputs are conventionally process-cwd-relative (POSIX). Only
-  // fall back to rootDir if cwd is somehow empty.
-  const base = cwd || rootDir;
-  const abs = path.isAbsolute(file) ? file : path.resolve(base, file);
-  const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
-  // Edge: file outside the resolved root. Return an empty sentinel — the
-  // caller's `if (!filepath) return` short-circuits downstream, and the
-  // RelativePath brand stays sound (we never return an absolute string).
-  if (rel.startsWith('..')) return '' as RelativePath;
-  return rel as RelativePath;
 }
 
 export function isTrivial(

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -53,18 +53,33 @@ interface ResolvedPaths {
  *     from a subdir means <subdir>/src/foo.ts to the user.
  */
 function resolvePaths(file: string): ResolvedPaths | null {
+  if (!file) return null;
   const originalCwd = toAbsolutePath(process.cwd());
   const rootDir = resolveProjectRoot(originalCwd);
-  const filepath = toRelative(file, rootDir, originalCwd);
-  if (!filepath) return null;
 
-  // Guard against non-existent paths — findDependents's suffix matching
-  // can otherwise return spurious hits for unrelated imports that happen
-  // to share a basename.
-  const abs: AbsolutePath = path.isAbsolute(file)
+  // Resolve to an absolute path that actually exists on disk. POSIX
+  // convention is cwd-relative for relative inputs, so try that first.
+  // If the file isn't there, fall back to root-relative — handles the
+  // case where a user (or the model) pastes a repo-relative path like
+  // `packages/cli/src/foo.ts` while invoked from a subdirectory. Without
+  // the fallback `path.resolve('/repo/packages/cli', 'packages/cli/...')`
+  // produces `/repo/packages/cli/packages/cli/...`, which doesn't exist,
+  // and the annotator exits silently for a file that really does.
+  let abs: AbsolutePath = path.isAbsolute(file)
     ? toAbsolutePath(file)
     : toAbsolutePath(path.resolve(originalCwd, file));
+  if (!fs.existsSync(abs) && !path.isAbsolute(file)) {
+    const rootRelative = toAbsolutePath(path.resolve(rootDir, file));
+    if (fs.existsSync(rootRelative)) abs = rootRelative;
+  }
   if (!fs.existsSync(abs)) return null;
+
+  // Compute project-root-relative form from the validated abs so it
+  // matches whatever Lien's indexer stored. Reject paths outside the
+  // root (path.relative would produce a `..`-prefixed traversal).
+  const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
+  if (!rel || rel.startsWith('..')) return null;
+  const filepath = rel as RelativePath;
 
   return { originalCwd, rootDir, filepath, abs };
 }

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -32,52 +32,78 @@ export async function annotateCommand(file: string): Promise<void> {
 
 async function run(file: string): Promise<void> {
   // Path-handling contract for this whole flow:
-  //   - `cwd` and `rootDir` are AbsolutePath (process.cwd / path.resolve
-  //     guarantee absolute).
+  //   - `originalCwd` and `rootDir` are AbsolutePath (process.cwd /
+  //     path.resolve guarantee absolute).
   //   - `filepath` is RelativePath — project-root-relative. This is the
   //     form Lien's indexer stores in chunk metadata, so passing the
   //     relative form keeps matching consistent regardless of caller cwd.
   //   - `abs` is AbsolutePath, used only for the on-disk existence check.
-  const cwd: AbsolutePath = toAbsolutePath(process.cwd());
-  const rootDir: AbsolutePath = resolveProjectRoot(cwd);
-  const filepath: RelativePath = toRelative(file, rootDir, cwd);
+  const originalCwd: AbsolutePath = toAbsolutePath(process.cwd());
+  const rootDir: AbsolutePath = resolveProjectRoot(originalCwd);
+  const filepath: RelativePath = toRelative(file, rootDir, originalCwd);
   if (!filepath) return;
 
   // Guard against non-existent paths — findDependents's suffix matching
   // can otherwise return spurious hits for unrelated imports that happen
-  // to share a basename. Resolve relative inputs against cwd, not rootDir,
-  // so `lien annotate src/foo.ts` from a subdir finds <subdir>/src/foo.ts.
+  // to share a basename. Resolve relative inputs against the *original*
+  // cwd, not rootDir, so `lien annotate src/foo.ts` from a subdir still
+  // means <subdir>/src/foo.ts to the user.
   const abs: AbsolutePath = path.isAbsolute(file)
     ? toAbsolutePath(file)
-    : toAbsolutePath(path.resolve(cwd, file));
+    : toAbsolutePath(path.resolve(originalCwd, file));
   if (!fs.existsSync(abs)) return;
 
-  const vectorDB = new VectorDB(rootDir);
-  await vectorDB.initialize();
+  // Align cwd with the project root for the analysis pass. Lien's
+  // internal path normalizers (createPathNormalizer in findDependents,
+  // ComplexityAnalyzer.normalizeFilePath) read process.cwd() as the
+  // workspace root. Today this happens to work because they only strip
+  // the prefix when present and chunks store project-root-relative
+  // paths; aligning cwd makes the contract robust to future internal
+  // changes without threading workspaceRoot through every signature.
+  // Restored in `finally` so test runs don't pollute each other.
+  const needsChdir = originalCwd !== rootDir;
+  if (needsChdir) process.chdir(rootDir);
+  try {
+    const vectorDB = new VectorDB(rootDir);
+    await vectorDB.initialize();
 
-  const log = () => undefined;
-  const result = await findDependents(vectorDB, filepath, false, log);
+    const log = () => undefined;
+    const result = await findDependents(vectorDB, filepath, false, log);
 
-  // LanceDB returns chunks whose `metadata.imports` is an Apache Arrow
-  // Vector — iterable but lacking .some() and other array methods.
-  // findTestAssociationsFromChunks uses .some(), so coerce per-chunk
-  // before handing it off.
-  const allChunks = result.allChunks.map(c => ({
-    ...c,
-    metadata: {
-      ...c.metadata,
-      imports: c.metadata?.imports ? Array.from(c.metadata.imports as Iterable<string>) : [],
-    },
-  })) as unknown as CodeChunk[];
-  const testsMap = findTestAssociationsFromChunks([filepath], allChunks, rootDir);
-  const tests = testsMap.get(filepath) ?? [];
+    // LanceDB returns chunks whose `metadata.imports` is an Apache Arrow
+    // Vector — iterable but lacking .some() and other array methods.
+    // findTestAssociationsFromChunks uses .some(), so coerce per-chunk
+    // before handing it off.
+    const allChunks = result.allChunks.map(c => ({
+      ...c,
+      metadata: {
+        ...c.metadata,
+        imports: c.metadata?.imports ? Array.from(c.metadata.imports as Iterable<string>) : [],
+      },
+    })) as unknown as CodeChunk[];
+    const testsMap = findTestAssociationsFromChunks([filepath], allChunks, rootDir);
+    const tests = testsMap.get(filepath) ?? [];
 
-  const complexity = computeComplexitySummary(allChunks, filepath);
-  const dependentCount = result.dependents.length;
-  const uncovered = result.uncoveredProductionDependents;
+    const complexity = computeComplexitySummary(allChunks, filepath);
+    const dependentCount = result.dependents.length;
+    const uncovered = result.uncoveredProductionDependents;
 
-  if (isTrivial(dependentCount, complexity.warningCount, tests.length)) return;
+    if (isTrivial(dependentCount, complexity.warningCount, tests.length)) return;
 
+    emitAnnotation(filepath, result.dependents, tests, complexity, dependentCount, uncovered);
+  } finally {
+    if (needsChdir) process.chdir(originalCwd);
+  }
+}
+
+function emitAnnotation(
+  filepath: RelativePath,
+  dependents: DependentInfo[],
+  tests: string[],
+  complexity: ComplexitySummary,
+  dependentCount: number,
+  uncovered: number,
+): void {
   const risk = computeBlastRadiusRisk({
     dependentCount,
     uncoveredDependents: uncovered,
@@ -87,7 +113,7 @@ async function run(file: string): Promise<void> {
 
   const lines: string[] = [`Lien impact for ${filepath}:`];
   if (dependentCount > 0) {
-    lines.push(`  • ${formatDependents(result.dependents, risk.level, risk.reasoning)}`);
+    lines.push(`  • ${formatDependents(dependents, risk.level, risk.reasoning)}`);
   }
   lines.push(`  • ${formatTests(tests)}`);
   if (complexity.warningCount > 0) {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -30,28 +30,71 @@ export async function annotateCommand(file: string): Promise<void> {
   }
 }
 
-async function run(file: string): Promise<void> {
-  // Path-handling contract for this whole flow:
-  //   - `originalCwd` and `rootDir` are AbsolutePath (process.cwd /
-  //     path.resolve guarantee absolute).
-  //   - `filepath` is RelativePath — project-root-relative. This is the
-  //     form Lien's indexer stores in chunk metadata, so passing the
-  //     relative form keeps matching consistent regardless of caller cwd.
-  //   - `abs` is AbsolutePath, used only for the on-disk existence check.
-  const originalCwd: AbsolutePath = toAbsolutePath(process.cwd());
-  const rootDir: AbsolutePath = resolveProjectRoot(originalCwd);
-  const filepath: RelativePath = toRelative(file, rootDir, originalCwd);
-  if (!filepath) return;
+interface ResolvedPaths {
+  originalCwd: AbsolutePath;
+  rootDir: AbsolutePath;
+  filepath: RelativePath;
+  abs: AbsolutePath;
+}
+
+/**
+ * Resolve the input path into the four forms `run()` needs, or return
+ * null if the path is unusable (empty, escapes the project root, or
+ * doesn't exist on disk).
+ *
+ * Path-handling contract:
+ *   - originalCwd / rootDir are AbsolutePath (process.cwd / path.resolve
+ *     guarantee absolute).
+ *   - filepath is RelativePath — project-root-relative. This is the form
+ *     Lien's indexer stores in chunk metadata, so passing the relative
+ *     form keeps matching consistent regardless of caller cwd.
+ *   - abs is AbsolutePath, used only for the on-disk existence check.
+ *     Resolved against the *original* cwd so `lien annotate src/foo.ts`
+ *     from a subdir means <subdir>/src/foo.ts to the user.
+ */
+function resolvePaths(file: string): ResolvedPaths | null {
+  const originalCwd = toAbsolutePath(process.cwd());
+  const rootDir = resolveProjectRoot(originalCwd);
+  const filepath = toRelative(file, rootDir, originalCwd);
+  if (!filepath) return null;
 
   // Guard against non-existent paths — findDependents's suffix matching
   // can otherwise return spurious hits for unrelated imports that happen
-  // to share a basename. Resolve relative inputs against the *original*
-  // cwd, not rootDir, so `lien annotate src/foo.ts` from a subdir still
-  // means <subdir>/src/foo.ts to the user.
+  // to share a basename.
   const abs: AbsolutePath = path.isAbsolute(file)
     ? toAbsolutePath(file)
     : toAbsolutePath(path.resolve(originalCwd, file));
-  if (!fs.existsSync(abs)) return;
+  if (!fs.existsSync(abs)) return null;
+
+  return { originalCwd, rootDir, filepath, abs };
+}
+
+/**
+ * Coerce per-chunk `metadata.imports` to a plain array.
+ *
+ * LanceDB returns chunks whose `imports` field is an Apache Arrow Vector
+ * — iterable but lacking `.some()` and other array methods.
+ * `findTestAssociationsFromChunks` uses `.some()`, so the coercion has to
+ * happen at the annotate-cmd boundary before the chunks flow downstream.
+ */
+function adaptChunkImports(chunks: DependencyAnalysisChunk[]): CodeChunk[] {
+  return chunks.map(c => ({
+    ...c,
+    metadata: {
+      ...c.metadata,
+      imports: c.metadata?.imports ? Array.from(c.metadata.imports as Iterable<string>) : [],
+    },
+  })) as unknown as CodeChunk[];
+}
+
+// Aliasing the chunk type findDependents returns — keeps the helper's
+// signature honest without leaking the SearchResult import here.
+type DependencyAnalysisChunk = Awaited<ReturnType<typeof findDependents>>['allChunks'][number];
+
+async function run(file: string): Promise<void> {
+  const paths = resolvePaths(file);
+  if (!paths) return;
+  const { originalCwd, rootDir, filepath } = paths;
 
   // Align cwd with the project root for the analysis pass. Lien's
   // internal path normalizers (createPathNormalizer in findDependents,
@@ -69,21 +112,10 @@ async function run(file: string): Promise<void> {
 
     const log = () => undefined;
     const result = await findDependents(vectorDB, filepath, false, log);
+    const allChunks = adaptChunkImports(result.allChunks);
 
-    // LanceDB returns chunks whose `metadata.imports` is an Apache Arrow
-    // Vector — iterable but lacking .some() and other array methods.
-    // findTestAssociationsFromChunks uses .some(), so coerce per-chunk
-    // before handing it off.
-    const allChunks = result.allChunks.map(c => ({
-      ...c,
-      metadata: {
-        ...c.metadata,
-        imports: c.metadata?.imports ? Array.from(c.metadata.imports as Iterable<string>) : [],
-      },
-    })) as unknown as CodeChunk[];
-    const testsMap = findTestAssociationsFromChunks([filepath], allChunks, rootDir);
-    const tests = testsMap.get(filepath) ?? [];
-
+    const tests =
+      findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
     const complexity = computeComplexitySummary(allChunks, filepath);
     const dependentCount = result.dependents.length;
     const uncovered = result.uncoveredProductionDependents;

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -6,11 +6,12 @@ import {
   computeBlastRadiusRisk,
   type CodeChunk,
 } from '@liendev/parser';
-import { findDependents } from '../mcp/handlers/dependency-analyzer.js';
+import { findDependents, type DependentInfo } from '../mcp/handlers/dependency-analyzer.js';
 import { resolveProjectRoot } from './project-root.js';
 
 const HIGH_COMPLEXITY_THRESHOLD = 15;
 const MAX_TESTS_LISTED = 2;
+const MAX_DEPS_LISTED = 4;
 
 /**
  * Produce a short impact summary for a single file. Output is empty when
@@ -64,7 +65,7 @@ async function run(file: string): Promise<void> {
 
   const lines: string[] = [`Lien impact for ${filepath}:`];
   if (dependentCount > 0) {
-    lines.push(`  • ${formatDependents(dependentCount, risk.level, risk.reasoning)}`);
+    lines.push(`  • ${formatDependents(result.dependents, risk.level, risk.reasoning)}`);
   }
   lines.push(`  • ${formatTests(tests)}`);
   if (complexity.warningCount > 0) {
@@ -109,10 +110,20 @@ function computeComplexitySummary(chunks: CodeChunk[], filepath: string): Comple
   }
 }
 
-export function formatDependents(count: number, level: string, reasoning: string[]): string {
+export function formatDependents(
+  dependents: DependentInfo[],
+  level: string,
+  reasoning: string[],
+): string {
+  const count = dependents.length;
+  // Production dependents first — those are the ones whose breakage matters
+  // most when changing this file. Tests follow as secondary context.
+  const ordered = [...dependents].sort((a, b) => Number(a.isTestFile) - Number(b.isTestFile));
+  const shown = ordered.slice(0, MAX_DEPS_LISTED).map(d => d.filepath);
+  const extra = count > MAX_DEPS_LISTED ? `, +${count - MAX_DEPS_LISTED} more` : '';
   const noun = count === 1 ? 'file imports' : 'files import';
   const reason = reasoning.length > 0 ? ` (${reasoning.join(', ')})` : '';
-  return `${count} ${noun} this; risk: ${level}${reason}.`;
+  return `${count} ${noun} this — ${shown.join(', ')}${extra}; risk: ${level}${reason}.`;
 }
 
 export function formatTests(tests: string[]): string {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -1,0 +1,129 @@
+import fs from 'fs';
+import path from 'path';
+import { VectorDB, ComplexityAnalyzer } from '@liendev/core';
+import {
+  findTestAssociationsFromChunks,
+  computeBlastRadiusRisk,
+  type CodeChunk,
+} from '@liendev/parser';
+import { findDependents } from '../mcp/handlers/dependency-analyzer.js';
+import { resolveProjectRoot } from './project-root.js';
+
+const HIGH_COMPLEXITY_THRESHOLD = 15;
+const MAX_TESTS_LISTED = 2;
+
+/**
+ * Produce a short impact summary for a single file. Output is empty when
+ * impact is trivial (no dependents, no complexity warnings, test coverage
+ * present) — that's the signal to the PostToolUse hook to stay silent.
+ *
+ * All errors result in empty stdout and exit 0, so a missing index or
+ * unknown file never breaks the hook pipeline.
+ */
+export async function annotateCommand(file: string): Promise<void> {
+  try {
+    await run(file);
+  } catch {
+    // Silent — never break the consuming hook.
+  }
+}
+
+async function run(file: string): Promise<void> {
+  const rootDir = resolveProjectRoot(process.cwd());
+  const filepath = toRelative(file, rootDir);
+  if (!filepath) return;
+
+  // Guard against non-existent paths — findDependents's suffix matching
+  // can otherwise return spurious hits for unrelated imports that happen
+  // to share a basename.
+  const abs = path.isAbsolute(file) ? file : path.resolve(rootDir, file);
+  if (!fs.existsSync(abs)) return;
+
+  const vectorDB = new VectorDB(rootDir);
+  await vectorDB.initialize();
+
+  const log = () => undefined;
+  const result = await findDependents(vectorDB, filepath, false, log);
+
+  const allChunks = result.allChunks as unknown as CodeChunk[];
+  const testsMap = findTestAssociationsFromChunks([filepath], allChunks, rootDir);
+  const tests = testsMap.get(filepath) ?? [];
+
+  const complexity = computeComplexitySummary(allChunks, filepath);
+  const dependentCount = result.dependents.length;
+  const uncovered = result.uncoveredProductionDependents;
+
+  if (isTrivial(dependentCount, complexity.warningCount, tests.length)) return;
+
+  const risk = computeBlastRadiusRisk({
+    dependentCount,
+    uncoveredDependents: uncovered,
+    maxDependentComplexity: complexity.max,
+    hasHighComplexityUncovered: uncovered > 0 && complexity.max >= HIGH_COMPLEXITY_THRESHOLD,
+  });
+
+  const lines: string[] = [`Lien impact for ${filepath}:`];
+  if (dependentCount > 0) {
+    lines.push(`  • ${formatDependents(dependentCount, risk.level, risk.reasoning)}`);
+  }
+  lines.push(`  • ${formatTests(tests)}`);
+  if (complexity.warningCount > 0) {
+    lines.push(`  • ${formatComplexity(complexity)}`);
+  }
+
+  console.log(lines.join('\n'));
+}
+
+export function toRelative(file: string, rootDir: string): string {
+  if (!file) return '';
+  const abs = path.isAbsolute(file) ? file : path.resolve(rootDir, file);
+  const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
+  // Edge: file outside the resolved root. Hand back the input unchanged
+  // and let findDependents come up empty — silent exit downstream.
+  return rel.startsWith('..') ? file : rel;
+}
+
+export function isTrivial(
+  dependentCount: number,
+  complexityWarnings: number,
+  testCount: number,
+): boolean {
+  return dependentCount <= 1 && complexityWarnings === 0 && testCount > 0;
+}
+
+interface ComplexitySummary {
+  max: number;
+  warningCount: number;
+}
+
+function computeComplexitySummary(chunks: CodeChunk[], filepath: string): ComplexitySummary {
+  try {
+    const report = ComplexityAnalyzer.analyzeFromChunks(chunks, [filepath]);
+    const fileData = report.files[filepath];
+    if (!fileData) return { max: 0, warningCount: 0 };
+    const cyclomatic = fileData.violations.filter(v => v.metricType === 'cyclomatic');
+    const max = cyclomatic.reduce((m, v) => Math.max(m, v.complexity), 0);
+    return { max, warningCount: cyclomatic.length };
+  } catch {
+    return { max: 0, warningCount: 0 };
+  }
+}
+
+export function formatDependents(count: number, level: string, reasoning: string[]): string {
+  const noun = count === 1 ? 'file imports' : 'files import';
+  const reason = reasoning.length > 0 ? ` (${reasoning.join(', ')})` : '';
+  return `${count} ${noun} this; risk: ${level}${reason}.`;
+}
+
+export function formatTests(tests: string[]): string {
+  if (tests.length === 0) return 'No test coverage.';
+  const shown = tests.slice(0, MAX_TESTS_LISTED).join(', ');
+  const extra =
+    tests.length > MAX_TESTS_LISTED ? ` (+${tests.length - MAX_TESTS_LISTED} more)` : '';
+  return `Test coverage: ${shown}${extra}.`;
+}
+
+export function formatComplexity(summary: ComplexitySummary): string {
+  const noun = summary.warningCount === 1 ? 'function' : 'functions';
+  return `Max cyclomatic complexity: ${summary.max} (${summary.warningCount} ${noun} over warn threshold).`;
+}

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -8,6 +8,7 @@ import {
 } from '@liendev/parser';
 import { findDependents, type DependentInfo } from '../mcp/handlers/dependency-analyzer.js';
 import { resolveProjectRoot } from './project-root.js';
+import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/paths.js';
 
 const HIGH_COMPLEXITY_THRESHOLD = 15;
 const MAX_TESTS_LISTED = 2;
@@ -30,16 +31,25 @@ export async function annotateCommand(file: string): Promise<void> {
 }
 
 async function run(file: string): Promise<void> {
-  const cwd = process.cwd();
-  const rootDir = resolveProjectRoot(cwd);
-  const filepath = toRelative(file, rootDir, cwd);
+  // Path-handling contract for this whole flow:
+  //   - `cwd` and `rootDir` are AbsolutePath (process.cwd / path.resolve
+  //     guarantee absolute).
+  //   - `filepath` is RelativePath — project-root-relative. This is the
+  //     form Lien's indexer stores in chunk metadata, so passing the
+  //     relative form keeps matching consistent regardless of caller cwd.
+  //   - `abs` is AbsolutePath, used only for the on-disk existence check.
+  const cwd: AbsolutePath = toAbsolutePath(process.cwd());
+  const rootDir: AbsolutePath = resolveProjectRoot(cwd);
+  const filepath: RelativePath = toRelative(file, rootDir, cwd);
   if (!filepath) return;
 
   // Guard against non-existent paths — findDependents's suffix matching
   // can otherwise return spurious hits for unrelated imports that happen
   // to share a basename. Resolve relative inputs against cwd, not rootDir,
   // so `lien annotate src/foo.ts` from a subdir finds <subdir>/src/foo.ts.
-  const abs = path.isAbsolute(file) ? file : path.resolve(cwd, file);
+  const abs: AbsolutePath = path.isAbsolute(file)
+    ? toAbsolutePath(file)
+    : toAbsolutePath(path.resolve(cwd, file));
   if (!fs.existsSync(abs)) return;
 
   const vectorDB = new VectorDB(rootDir);
@@ -87,16 +97,22 @@ async function run(file: string): Promise<void> {
   console.log(lines.join('\n'));
 }
 
-export function toRelative(file: string, rootDir: string, cwd: string = process.cwd()): string {
-  if (!file) return '';
+export function toRelative(
+  file: string,
+  rootDir: AbsolutePath,
+  cwd: AbsolutePath = toAbsolutePath(process.cwd()),
+): RelativePath {
+  if (!file) return '' as RelativePath;
   // Relative inputs are conventionally process-cwd-relative (POSIX). Only
   // fall back to rootDir if cwd is somehow empty.
   const base = cwd || rootDir;
   const abs = path.isAbsolute(file) ? file : path.resolve(base, file);
   const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
-  // Edge: file outside the resolved root. Hand back the input unchanged
-  // and let findDependents come up empty — silent exit downstream.
-  return rel.startsWith('..') ? file : rel;
+  // Edge: file outside the resolved root. Return an empty sentinel — the
+  // caller's `if (!filepath) return` short-circuits downstream, and the
+  // RelativePath brand stays sound (we never return an absolute string).
+  if (rel.startsWith('..')) return '' as RelativePath;
+  return rel as RelativePath;
 }
 
 export function isTrivial(

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -8,6 +8,8 @@ import { indexCommand } from './index-cmd.js';
 import { serveCommand } from './serve.js';
 import { complexityCommand } from './complexity.js';
 import { configSetCommand, configGetCommand, configListCommand } from './config.js';
+import { pathCommand } from './path-cmd.js';
+import { annotateCommand } from './annotate-cmd.js';
 
 // Get version from package.json dynamically
 const __filename = fileURLToPath(import.meta.url);
@@ -95,6 +97,19 @@ configCmd
 configCmd.command('get <key>').description('Get a config value').action(configGetCommand);
 
 configCmd.command('list').description('Show all current config').action(configListCommand);
+
+program
+  .command('path')
+  .description('Print Lien storage paths and supported extensions (for hook scripts)')
+  .option('--store', 'Print the storage root for the current repo')
+  .option('--extensions', 'Print the indexed-file extensions, one per line')
+  .option('--root', 'Print the resolved project root (walks up for .git)')
+  .action(pathCommand);
+
+program
+  .command('annotate <file>')
+  .description('Print a short impact summary for a single file (for hook annotation)')
+  .action(annotateCommand);
 
 program.action(() => {
   program.help();

--- a/packages/cli/src/cli/path-cmd.test.ts
+++ b/packages/cli/src/cli/path-cmd.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import { extractRepoId } from '@liendev/parser';
+import { pathCommand } from './path-cmd.js';
+import { resolveProjectRoot } from './project-root.js';
+
+describe('pathCommand', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('--store prints ~/.lien/indices/<repoId> resolved against the project root', () => {
+    pathCommand({ store: true });
+    const expected = path.join(
+      os.homedir(),
+      '.lien',
+      'indices',
+      extractRepoId(resolveProjectRoot(process.cwd())),
+    );
+    expect(logSpy).toHaveBeenCalledWith(expected);
+  });
+
+  it('--root prints the resolved project root', () => {
+    pathCommand({ root: true });
+    expect(logSpy).toHaveBeenCalledWith(resolveProjectRoot(process.cwd()));
+  });
+
+  it('--extensions prints supported extensions, one per line, with no leading dot', () => {
+    pathCommand({ extensions: true });
+    expect(logSpy).toHaveBeenCalled();
+    const lines = logSpy.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(lines).toContain('ts');
+    expect(lines).toContain('py');
+    expect(lines.every((l: string) => !l.startsWith('.'))).toBe(true);
+  });
+
+  it('rejects no flags with a clear error and exit 1', () => {
+    expect(() => pathCommand({})).toThrow('exit:1');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('specify one of'));
+  });
+
+  it('rejects both flags as mutually exclusive', () => {
+    expect(() => pathCommand({ store: true, extensions: true })).toThrow('exit:1');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+  });
+});

--- a/packages/cli/src/cli/path-cmd.test.ts
+++ b/packages/cli/src/cli/path-cmd.test.ts
@@ -26,12 +26,11 @@ describe('pathCommand', () => {
 
   it('--store prints ~/.lien/indices/<repoId> resolved against the project root', () => {
     pathCommand({ store: true });
-    const expected = path.join(
-      os.homedir(),
-      '.lien',
-      'indices',
-      extractRepoId(resolveProjectRoot(process.cwd())),
-    );
+    // getStoreRoot() normalizes to forward slashes for Windows compatibility,
+    // so the test expectation has to do the same.
+    const expected = path
+      .join(os.homedir(), '.lien', 'indices', extractRepoId(resolveProjectRoot(process.cwd())))
+      .replace(/\\/g, '/');
     expect(logSpy).toHaveBeenCalledWith(expected);
   });
 

--- a/packages/cli/src/cli/path-cmd.ts
+++ b/packages/cli/src/cli/path-cmd.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+import { getSupportedExtensions } from '@liendev/parser';
+import { resolveProjectRoot } from './project-root.js';
+import { getStoreRoot } from './store-paths.js';
+
+interface PathOptions {
+  store?: boolean;
+  extensions?: boolean;
+  root?: boolean;
+}
+
+export function pathCommand(options: PathOptions): void {
+  const selectedFlags = [options.store, options.extensions, options.root].filter(Boolean).length;
+
+  if (selectedFlags === 0) {
+    console.error(chalk.red('Error: specify one of --store, --extensions, --root'));
+    process.exit(1);
+  }
+
+  if (selectedFlags > 1) {
+    console.error(chalk.red('Error: --store, --extensions, --root are mutually exclusive'));
+    process.exit(1);
+  }
+
+  if (options.root) {
+    console.log(resolveProjectRoot(process.cwd()));
+    return;
+  }
+
+  if (options.store) {
+    console.log(getStoreRoot());
+    return;
+  }
+
+  if (options.extensions) {
+    for (const ext of getSupportedExtensions()) {
+      console.log(ext);
+    }
+  }
+}

--- a/packages/cli/src/cli/project-root.test.ts
+++ b/packages/cli/src/cli/project-root.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import { resolveProjectRoot } from './project-root.js';
+
+describe('resolveProjectRoot', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-root-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('walks upward to find a .git directory', async () => {
+    const root = await fs.realpath(tmp);
+    await fs.mkdir(path.join(root, '.git'));
+    const deep = path.join(root, 'a', 'b', 'c');
+    await fs.mkdir(deep, { recursive: true });
+    expect(resolveProjectRoot(deep)).toBe(root);
+  });
+
+  it('recognizes .git as a file (git worktrees)', async () => {
+    const root = await fs.realpath(tmp);
+    await fs.writeFile(path.join(root, '.git'), 'gitdir: /elsewhere\n');
+    const deep = path.join(root, 'sub');
+    await fs.mkdir(deep);
+    expect(resolveProjectRoot(deep)).toBe(root);
+  });
+
+  it('falls back to the start path when no marker exists', async () => {
+    const root = await fs.realpath(tmp);
+    expect(resolveProjectRoot(root)).toBe(root);
+  });
+
+  it('returns the start path itself when it contains the marker', async () => {
+    const root = await fs.realpath(tmp);
+    await fs.mkdir(path.join(root, '.git'));
+    expect(resolveProjectRoot(root)).toBe(root);
+  });
+});

--- a/packages/cli/src/cli/project-root.ts
+++ b/packages/cli/src/cli/project-root.ts
@@ -9,10 +9,13 @@ import path from 'path';
 export function resolveProjectRoot(start: string = process.cwd()): string {
   let dir = path.resolve(start);
   const fsRoot = path.parse(dir).root;
-  while (dir !== fsRoot) {
+  // Loop is inclusive of fsRoot — a repo rooted at / (or a drive root) is
+  // rare but valid, and should still be detected before falling back.
+  while (true) {
     if (fs.existsSync(path.join(dir, '.git'))) {
       return dir;
     }
+    if (dir === fsRoot) break;
     dir = path.dirname(dir);
   }
   return path.resolve(start);

--- a/packages/cli/src/cli/project-root.ts
+++ b/packages/cli/src/cli/project-root.ts
@@ -1,22 +1,25 @@
 import fs from 'fs';
 import path from 'path';
+import { type AbsolutePath, toAbsolutePath } from '../types/paths.js';
 
 /**
  * Walk upward from `start` looking for a `.git` marker (file or dir).
  * Falls back to the resolved start path if none is found.
- * Lets the gate/store stay stable when commands are run from a subdir.
+ *
+ * Return type is `AbsolutePath` because `path.resolve` always produces an
+ * absolute path. Downstream code can rely on this without runtime checks.
  */
-export function resolveProjectRoot(start: string = process.cwd()): string {
+export function resolveProjectRoot(start: string = process.cwd()): AbsolutePath {
   let dir = path.resolve(start);
   const fsRoot = path.parse(dir).root;
   // Loop is inclusive of fsRoot — a repo rooted at / (or a drive root) is
   // rare but valid, and should still be detected before falling back.
   while (true) {
     if (fs.existsSync(path.join(dir, '.git'))) {
-      return dir;
+      return toAbsolutePath(dir);
     }
     if (dir === fsRoot) break;
     dir = path.dirname(dir);
   }
-  return path.resolve(start);
+  return toAbsolutePath(path.resolve(start));
 }

--- a/packages/cli/src/cli/project-root.ts
+++ b/packages/cli/src/cli/project-root.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Walk upward from `start` looking for a `.git` marker (file or dir).
+ * Falls back to the resolved start path if none is found.
+ * Lets the gate/store stay stable when commands are run from a subdir.
+ */
+export function resolveProjectRoot(start: string = process.cwd()): string {
+  let dir = path.resolve(start);
+  const fsRoot = path.parse(dir).root;
+  while (dir !== fsRoot) {
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return path.resolve(start);
+}

--- a/packages/cli/src/cli/store-paths.ts
+++ b/packages/cli/src/cli/store-paths.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import os from 'os';
+import { extractRepoId } from '@liendev/parser';
+import { resolveProjectRoot } from './project-root.js';
+
+/**
+ * Return the per-repo store root that backs the index and the edit-gate.
+ * Resolved against the project root (walks up for .git) so the value stays
+ * stable from any subdirectory. Output uses forward slashes so the bash
+ * hook scripts can splice it without escape-character mishaps on Windows.
+ */
+export function getStoreRoot(cwd: string = process.cwd()): string {
+  const repoId = extractRepoId(resolveProjectRoot(cwd));
+  return path.join(os.homedir(), '.lien', 'indices', repoId).replace(/\\/g, '/');
+}

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -598,6 +598,14 @@ export async function findDependents(
   indexVersion?: number,
   depth: number = 1,
   maxNodes: number = 500,
+  /**
+   * Surface the full normalized chunk set on the result.
+   * Cross-repo callers always get it (used by groupDependentsByRepo);
+   * other callers opt in by passing `true` only if they need the chunks
+   * (e.g., the annotator for test-association + complexity lookups).
+   * Default `false` keeps memory cost down for the common MCP path.
+   */
+  includeAllChunks: boolean = false,
 ): Promise<DependencyAnalysisResult> {
   const normalizePathCached = createPathNormalizer();
   const normalizedTarget = normalizePathCached(filepath);
@@ -646,11 +654,13 @@ export async function findDependents(
   const productionDependentCount = dependents.length - testDependentCount;
   const uncoveredProductionDependents = countUncoveredProductionDependents(dependents, ctx);
 
-  // Surface the full normalized chunk set on the result. Cross-repo callers
-  // need it for groupDependentsByRepo; single-repo callers (e.g. the
-  // post-Read annotator) use it for test-association and complexity
-  // analysis without paying for a second scan.
-  const allChunks = Array.from(allChunksByFile.values()).flat();
+  // Surface the full normalized chunk set only when the caller asks for it.
+  // Cross-repo paths always need it (groupDependentsByRepo); single-repo
+  // callers opt in via the `includeAllChunks` flag. Leaving it `[]` for
+  // the common case avoids allocating a flat array of every indexed chunk
+  // on each MCP get_dependents call.
+  const allChunks =
+    crossRepo || includeAllChunks ? Array.from(allChunksByFile.values()).flat() : [];
 
   return {
     dependents,

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -646,8 +646,11 @@ export async function findDependents(
   const productionDependentCount = dependents.length - testDependentCount;
   const uncoveredProductionDependents = countUncoveredProductionDependents(dependents, ctx);
 
-  // Only flatten all chunks when needed for cross-repo grouping (groupDependentsByRepo).
-  const allChunks = crossRepo ? Array.from(allChunksByFile.values()).flat() : [];
+  // Surface the full normalized chunk set on the result. Cross-repo callers
+  // need it for groupDependentsByRepo; single-repo callers (e.g. the
+  // post-Read annotator) use it for test-association and complexity
+  // analysis without paying for a second scan.
+  const allChunks = Array.from(allChunksByFile.values()).flat();
 
   return {
     dependents,

--- a/plugins/claude/hooks/annotate-clean.sh
+++ b/plugins/claude/hooks/annotate-clean.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SessionStart hook: GC stale annotated-sessions/ dirs.
+# Keeps state from concurrent sessions intact (don't wipe other-session
+# state on startup); only removes dirs that haven't been touched in >24h.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+else
+  store="$(lien path --store 2>/dev/null)"
+fi
+[ -n "$store" ] || exit 0
+
+sessions_root="$store/annotated-sessions"
+if [ -d "$sessions_root" ]; then
+  find "$sessions_root" -mindepth 1 -maxdepth 1 -type d -mtime +1 -exec rm -rf {} + 2>/dev/null
+fi
+
+exit 0

--- a/plugins/claude/hooks/annotate-clean.sh
+++ b/plugins/claude/hooks/annotate-clean.sh
@@ -18,9 +18,12 @@ else
 fi
 [ -n "$store" ] || exit 0
 
+# `find -mtime +N` truncates partial days; +1 actually means ">48h old",
+# not ">24h". Use -mmin +1440 (24 * 60 minutes) to express "older than 24
+# hours" exactly.
 sessions_root="$store/annotated-sessions"
 if [ -d "$sessions_root" ]; then
-  find "$sessions_root" -mindepth 1 -maxdepth 1 -type d -mtime +1 -exec rm -rf {} + 2>/dev/null
+  find "$sessions_root" -mindepth 1 -maxdepth 1 -type d -mmin +1440 -exec rm -rf {} + 2>/dev/null
 fi
 
 exit 0

--- a/plugins/claude/hooks/annotate-read.sh
+++ b/plugins/claude/hooks/annotate-read.sh
@@ -83,9 +83,13 @@ fi
 # Trivial impact → lien annotate prints nothing → stay silent.
 [ -n "$annotation" ] || exit 0
 
-# Record the annotation so suppression kicks in next time.
+# Record the annotation so suppression kicks in next time. Truncating an
+# existing touchfile doesn't update the parent dir's mtime on most
+# filesystems, so touch the dir explicitly to keep SessionStart cleanup
+# from GC'ing this session at the 24h threshold.
 mkdir -p "$session_dir" 2>/dev/null || exit 0
 : > "$touchfile"
+touch "$session_dir" 2>/dev/null
 
 # Emit the hookSpecificOutput JSON. additionalContext is the channel that
 # actually reaches the model on the next turn (verified in CC 2.1.142).

--- a/plugins/claude/hooks/annotate-read.sh
+++ b/plugins/claude/hooks/annotate-read.sh
@@ -49,6 +49,12 @@ fi
 # touchfile so we can use the raw file_path's md5 directly — no abs/rel
 # canonicalization required.
 ttl_min="${LIEN_ANNOTATE_TTL_MIN:-5}"
+# Guard against malformed env values: a non-numeric ttl would make
+# `find -mmin -<X>` a syntax error, defeat suppression, and let every
+# Read re-annotate. Fall back to the default if not a positive integer.
+case "$ttl_min" in
+  ''|*[!0-9]*) ttl_min=5;;
+esac
 hash="$(printf '%s' "$file_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"
 if [ -z "$hash" ]; then
   hash="$(printf '%s' "$file_path" | md5 2>/dev/null | awk '{print substr($NF,1,8)}')"
@@ -60,6 +66,9 @@ touchfile="$session_dir/$hash"
 if [ -f "$touchfile" ]; then
   if find "$touchfile" -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
     # Within TTL — already annotated this file recently. Stay silent.
+    # Touch the session dir so SessionStart cleanup sees this session as
+    # active even if no new annotation is emitted for >24h.
+    [ -d "$session_dir" ] && touch "$session_dir" 2>/dev/null
     exit 0
   fi
 fi

--- a/plugins/claude/hooks/annotate-read.sh
+++ b/plugins/claude/hooks/annotate-read.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Read: surface Lien impact analysis as a
+# system-reminder annotation alongside the file content.
+#
+# Suppresses repeat annotations for the same file within a session (default
+# 5 min TTL, configurable via LIEN_ANNOTATE_TTL_MIN). Skips files outside
+# Lien's indexed extension set. Best-effort throughout — never fails the
+# Read pipeline.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+[ -n "$file_path" ] || exit 0
+[ -n "$session_id" ] || exit 0
+
+# Defensive: session_id will be embedded in a filesystem path. Reject anything
+# outside [A-Za-z0-9_-] so a crafted value can't traverse out of the
+# session dir.
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) exit 0;;
+esac
+
+# Resolve store from the session's cwd so multi-repo setups work correctly.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+else
+  store="$(lien path --store 2>/dev/null)"
+fi
+[ -n "$store" ] || exit 0
+
+# Extension filter: skip if extension isn't in Lien's indexed set.
+ext="${file_path##*.}"
+if [ "$ext" = "$file_path" ]; then
+  # No extension at all.
+  exit 0
+fi
+if ! lien path --extensions 2>/dev/null | grep -Fxq "$ext"; then
+  exit 0
+fi
+
+# Per-session, per-file suppression. The same script reads and writes the
+# touchfile so we can use the raw file_path's md5 directly — no abs/rel
+# canonicalization required.
+ttl_min="${LIEN_ANNOTATE_TTL_MIN:-5}"
+hash="$(printf '%s' "$file_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"
+if [ -z "$hash" ]; then
+  hash="$(printf '%s' "$file_path" | md5 2>/dev/null | awk '{print substr($NF,1,8)}')"
+fi
+[ -n "$hash" ] || exit 0
+
+session_dir="$store/annotated-sessions/$session_id"
+touchfile="$session_dir/$hash"
+if [ -f "$touchfile" ]; then
+  if find "$touchfile" -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
+    # Within TTL — already annotated this file recently. Stay silent.
+    exit 0
+  fi
+fi
+
+# Invoke from cwd so resolveProjectRoot works under subdirectory cwds.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  annotation="$(cd "$cwd" && lien annotate "$file_path" 2>/dev/null)"
+else
+  annotation="$(lien annotate "$file_path" 2>/dev/null)"
+fi
+
+# Trivial impact → lien annotate prints nothing → stay silent.
+[ -n "$annotation" ] || exit 0
+
+# Record the annotation so suppression kicks in next time.
+mkdir -p "$session_dir" 2>/dev/null || exit 0
+: > "$touchfile"
+
+# Emit the hookSpecificOutput JSON. additionalContext is the channel that
+# actually reaches the model on the next turn (verified in CC 2.1.142).
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' \
+  "$(printf '%s' "$annotation" | jq -Rs .)"
+
+exit 0

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Suppresses repeats per session for 5 minutes.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-read.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-clean.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -19,7 +19,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-clean.sh",
-            "timeout": 10
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
Closes #567.

## Summary

Ships a `PostToolUse` hook on `Read` that surfaces Lien impact analysis as a system-reminder annotation. The model sees dependents (with actual file paths), test coverage, and complexity hotspots at the moment it reads an indexed file — before any edit decision — and Claude Code surfaces the annotation on the next turn via `hookSpecificOutput.additionalContext`.

Replaces the gate-based design (closed #560 / #566) after live dogfooding inside Claude Code 2.1.142 proved:

- PostToolUse `hookSpecificOutput.additionalContext` actually reaches the model (verified behaviorally — a directive in that field was acted on).
- `updatedToolOutput` is ignored for Read, so annotation has to be sidecar text, not content replacement. That's fine — the model receives the file content AND the impact summary alongside each other.
- Reading before editing is the natural agentic flow, so Read-time annotation is proactive (informs the edit decision) rather than reactive (corrects after the fact).

## What ships

| Path | Purpose |
| --- | --- |
| `packages/cli/src/cli/annotate-cmd.ts` | `lien annotate <file>` — 3–4 line impact summary. Empty stdout when trivial (≤1 dependent, no complexity warnings, has tests). |
| `packages/cli/src/cli/path-cmd.ts` | `lien path --store \| --extensions \| --root` — single source of truth for the hook. |
| `packages/cli/src/cli/project-root.ts` | `resolveProjectRoot()` walks up for `.git` so behavior is stable from any subdir. |
| `packages/cli/src/cli/store-paths.ts` | Shared `getStoreRoot()`; Windows-safe via forward-slash normalization. |
| `plugins/claude/hooks/hooks.json` | Registers PostToolUse:Read + SessionStart:cleanup. |
| `plugins/claude/hooks/annotate-read.sh` | Hook script: extension filter → suppression check → `lien annotate` → wrap output in `additionalContext` JSON. Per-session 5-min TTL touchfile. |
| `plugins/claude/hooks/annotate-clean.sh` | SessionStart GC: removes session dirs idle >24h. Preserves concurrent-session state. |

## Example annotation

When the model reads `packages/cli/src/cli/status.ts`, it now also sees:

```
Lien impact for packages/cli/src/cli/status.ts:
  • 2 files import this — packages/cli/src/cli/index.ts, packages/cli/src/cli/status.test.ts; risk: medium (2 callers, 1 untested).
  • No test coverage.
```

Dependent **paths** are listed inline (not just counts) so the model knows what its edit would affect. Production paths come before test paths; lists truncate at 4 with a `+N more` suffix:

```
Lien impact for packages/auth/src/session.ts:
  • 47 files import this — handlers/login.ts, handlers/logout.ts, api/router.ts, lib/auth.ts, +43 more; risk: critical (47 callers, 8 untested).
  • Test coverage: packages/auth/test/session.test.ts.
  • Max cyclomatic complexity: 18 (3 functions over warn threshold).
```

For trivial files (a leaf module with tests), the hook stays silent — no annotation noise.

## Reuse

All heavy lifting comes from existing functions; no new analysis logic:

- `findDependents` (`packages/cli/src/mcp/handlers/dependency-analyzer.ts:592`) — gets the dependent list + all chunks.
- `findTestAssociationsFromChunks` (`@liendev/parser`) — test coverage from the chunks `findDependents` already scanned (no second scan).
- `ComplexityAnalyzer.analyzeFromChunks` (`@liendev/core`) — single-file complexity from the same in-memory chunks.
- `computeBlastRadiusRisk` (`@liendev/parser`) — human-readable risk reasoning (`"14 callers, 3 untested"`).

## Test plan

- [x] `npm run format:check` — clean.
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged).
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — succeeds.
- [x] `npm run test -w packages/cli` — 680/680 (was 650 on main; +30 new across annotate-cmd, path-cmd, project-root).
- [x] **CLI smoke**: `lien annotate packages/cli/src/cli/status.ts` produces the example annotation above with actual paths; non-existent path → silent; subdir cwd → same output as repo root (project-root resolution works).
- [x] **Hook smoke**: six scenarios pass — Read of indexed `.ts` emits JSON, repeat Read suppressed within TTL, non-indexed extension silent, different `session_id` re-fires, traversal `session_id` silent, SessionStart cleanup preserves recent session dirs and removes >24h-idle ones.
- [x] **Live dogfood inside Claude Code 2.1.142**: confirmed end-to-end. Reading `status.ts`, `init.ts`, and `serve.ts` each produced a `<system-reminder>` block with real impact data (dependent paths, risk, test coverage). Repeat Reads suppressed correctly.
- [ ] **Reviewer**: install/refresh the plugin locally and Read an indexed file. Expect a `<system-reminder>` block with the Lien impact annotation in the next turn. `/reload-plugins` reads from `~/.claude/plugins/cache/...`, not the source directory — to test from this branch you'll need a full `/plugin uninstall lien && /plugin install lien@lien` or marketplace refresh.

## What's NOT in v1

- **Edit/Write annotator.** Catches the rare "edit without prior read" case. Trivially additive (same script, different matcher); deferred until real-world usage shows it's needed.
- **Cross-session suppression.** Per-session only — a fresh session re-annotates on first Read. Probably the right boundary; context resets are real.
- **Daemon-backed `lien annotate`.** Each invocation pays Node startup + LanceDB connect (~500ms–1.5s). Acceptable at v1; optimize only if it becomes a complaint.
- **Tool-use nudges in the annotation text.** The annotation gives the model evidence (dependent paths, risk reasoning); the model is free to call `get_files_context` / `get_dependents` etc. on its own. Adding generic "use Lien tools" advice would fight for context-window space and meta-instruct what the data already affords. Defer until dogfooding surfaces a specific recurring blind spot.
- **Threshold-based PreToolUse blocker** for genuinely irreversible high-impact edits. Separate, narrow feature; not needed for v1.

## Performance budget

`lien annotate` runs `findDependents` (one `scanAll` of the LanceDB index) + `analyzeFromChunks` (no second scan, reuses chunks) + `findTestAssociationsFromChunks` (also no second scan). On a medium codebase, ~500ms–1.5s. The hook timeout is 5000ms; if exceeded, the hook silently drops the annotation. Suppression eliminates repeat-Read cost within the 5-min window.

## Notes for review

- **`jq` is a soft prereq.** The hook checks `command -v jq` and exits 0 silently if missing — gate degrades to a no-op rather than failing Reads.
- **Defensive `session_id` validation** carries over from #566: rejects anything outside `[A-Za-z0-9_-]` before path interpolation.
- **No state-machine complexity.** The only persistent state is touchfiles for suppression. Same script writes and reads them, so no abs/rel canonicalization mismatch is possible — the class of bugs that bit #566 doesn't apply.
- **`LIEN_ANNOTATE_TTL_MIN` env var** overrides the 5-min suppression window (`=0` to annotate every Read; `=60` for hourly).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> The PR introduces a post-read impact annotator for Claude Code, providing the model with real-time insights into file dependents, test coverage, and complexity hotspots. The implementation leverages existing analysis logic and integrates via shell hooks and a new CLI command.
>
> - Added 'lien annotate' command for generating file impact summaries.
> - Added 'lien path' command to expose project configuration to hook scripts.
> - Implemented Claude Code hooks for automated impact annotation on file reads and session cleanup.
> - Enhanced 'findDependents' to optionally return all chunks, enabling comprehensive analysis in the annotator.
> - Implemented robust path resolution to handle repo-relative paths from any subdirectory.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0a859de. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `annotate` command to display per-file impact summaries including dependent modules, test coverage status, and complexity metrics
  * Added `path` command with `--root`, `--store`, and `--extensions` options for project configuration access
  * Integrated automated annotation hooks for session cleanup and code context during tool use

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->