### PR TITLE
chore(hooks): add SessionEnd cleanup for annotated-sessions

### DIFF
--- a/plugins/claude/hooks/annotate-end.sh
+++ b/plugins/claude/hooks/annotate-end.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SessionEnd hook: clean up the current session's annotated-sessions dir
+# on graceful exit. Belt-and-braces — SessionStart's 24h-idle GC remains
+# the load-bearing cleanup mechanism (covers crashes / force-quits).
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+[ -n "$session_id" ] || exit 0
+
+# Defensive: session_id is interpolated into a path. Same hardening as
+# the rest of the hook bundle — reject anything outside [A-Za-z0-9_-].
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) exit 0;;
+esac
+
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+else
+  store="$(lien path --store 2>/dev/null)"
+fi
+[ -n "$store" ] || exit 0
+
+session_dir="$store/annotated-sessions/$session_id"
+[ -d "$session_dir" ] && rm -rf "$session_dir" 2>/dev/null
+
+exit 0

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -23,6 +23,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-end.sh",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Tidy follow-up to #568.

## Why

The post-Read annotator writes per-session touchfiles under `~/.lien/indices/<repoId>/annotated-sessions/<session_id>/` for 5-minute suppression. Cleanup today is `SessionStart` only, with a 24h-idle threshold so it doesn't clobber concurrent sessions. That means short-lived sessions can leave directories sitting around for up to a day before any cleanup runs.

Not a correctness issue (touchfiles are empty, a few KB per session), just tidier housekeeping.

## What

- `plugins/claude/hooks/annotate-end.sh` — SessionEnd hook that removes the current session's dir on graceful exit. Reuses the same defensive scaffolding as the rest of the bundle: `jq`/`lien` command guards, `session_id` validated against `[A-Za-z0-9_-]` before path interpolation, silent exit on malformed input.
- `plugins/claude/hooks/hooks.json` — register the SessionEnd entry (timeout 30s).

## What stays load-bearing

`SessionStart` cleanup with its 24h-idle threshold remains the durable cleanup mechanism. It covers crashes, force-quits, OS reboots, and anything else where `SessionEnd` won't fire. The new hook is best-effort tidying on graceful exit, not a replacement.

## Test plan

- [x] `npm run format:check` — clean.
- [x] `npm run test -w packages/cli` — 676/676 (unchanged; no source files touched).
- [x] **Hook smoke**: 4 scenarios pass.
  - Happy path: SessionEnd removes own dir.
  - Traversal `session_id` (`../etc`) — rejected silently, store untouched.
  - Empty `session_id` — silent exit.
  - Concurrent sessions: only the matching dir is removed, others preserved.
- [ ] Reviewer: refresh the plugin cache, start a Claude Code session, do an indexed Read (creates the dir), exit normally, confirm `~/.lien/indices/<repoId>/annotated-sessions/<session_id>/` is gone.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 77 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 7 high-risk file(s) with 102 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 11 | — |
| 🧠 mental load | 19 | — |
| ⏱️ time to understand | 46 | — |
| 🐛 estimated bugs | 1 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8b0074d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->