### PR TITLE
test(harness): capture error-swallowing FP on PR #574 (null-guard shape)

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -68,6 +68,24 @@ npx tsx packages/review/test/harness/capture-pr.ts 539 "$ROOT/stale-duplicate/mo
 npx tsx packages/review/test/harness/capture-pr.ts 541 "$ROOT/untrusted-input-validation/harness-initial.fixture.json" --sha 7cb0149
 ```
 
+## Negative-regression fixtures
+
+These capture real-world false positives the rule produced on a non-bug
+PR. The assertion is `expectEmpty` — the rule must stay quiet on this
+diff. Bundled with the canary so calibration covers both directions
+(must-fire on planted regressions, must-stay-silent on these).
+
+| Rule | PR | Fixture | Why |
+|---|---|---|---|
+| `error-swallowing` | #574 | `error-swallowing/scanall-null-guard-fp` | Early `if (!table) throw` before try/catch was flagged as unguarded deref ([thread](https://github.com/getlien/lien/pull/574#discussion_r3252525960)) |
+
+Regenerate:
+
+```bash
+ROOT=packages/review/test/harness/fixtures
+npx tsx packages/review/test/harness/capture-pr.ts 574 "$ROOT/error-swallowing/scanall-null-guard-fp.fixture.json"
+```
+
 Run the full multi-model sweep:
 
 ```bash

--- a/packages/review/test/harness/fixtures/error-swallowing/scanall-null-guard-fp.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/scanall-null-guard-fp.assertions.ts
@@ -1,0 +1,36 @@
+/**
+ * PR #574 — negative regression: `scanAll` has an explicit `if (!table)`
+ * guard immediately before its try/catch. After the throw, TypeScript
+ * narrows `table` to non-null for the rest of the function, so
+ * `table.countRows()` inside the try cannot deref null. The rule fired a
+ * false positive against `packages/core/src/vectordb/query.ts:652`
+ * claiming the deref was unguarded — see
+ * https://github.com/getlien/lien/pull/574#discussion_r3252525960.
+ *
+ * The same shape appears across `query.ts`, `lancedb.ts`,
+ * `maintenance.ts`, and other VectorDB code (every method taking
+ * `table: LanceDBTable | null` does this guard), so silencing this FP
+ * shape is a high-leverage prompt fix.
+ *
+ * Calibration status (recorded 2026-05-16, against the unmodified prompt):
+ *   pending — fixture authored, calibration run not yet executed. Will
+ *   fail on the current prompt; that's the documented gap.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #574 — early `if (!table) throw` guard before try/catch should NOT fire error-swallowing',
+  rule: 'error-swallowing',
+  expect: (result, h) => {
+    // Tier 1: the rule must produce zero findings against this PR. The
+    // diff is a perf fix (single-shot scanAll); it changes no error-handling
+    // shape, so any error-swallowing finding is by definition a regression.
+    h.expectEmpty(result);
+  },
+  votes: 3,
+  passThreshold: 9,
+};
+
+export default assertions;


### PR DESCRIPTION
## Summary

Captures the false-positive surfaced by the `error-swallowing` rule on PR #574 against `packages/core/src/vectordb/query.ts:652`. The rule claimed `table.countRows()` was an unguarded null deref; the function actually has an explicit `if (!table) throw` immediately above the try/catch, so TypeScript narrows `table` to non-null for the rest of the function. See the [original review thread](https://github.com/getlien/lien/pull/574#discussion_r3252525960).

The same null-guard-before-try shape appears across `query.ts`, `lancedb.ts`, `maintenance.ts`, and other VectorDB code (every method taking `table: LanceDBTable | null` uses this pattern), so silencing this FP is a high-leverage prompt fix.

## What's in the diff

- **New fixture (gitignored .json)**: PR #574 captured via `capture-pr.ts`. 5,033 repo chunks, 150 changed-file chunks. Regenerate locally with `npx tsx packages/review/test/harness/capture-pr.ts 574 ...`.
- **New `.assertions.ts`**: Tier 1 `expectEmpty(result)` — the rule must produce zero findings on this diff. Any error-swallowing finding counts as a regression.
- **README update**: new "Negative-regression fixtures" section mirroring the canary-table format. Documents the capture command for reproducibility.

## What's NOT in this PR

- **No prompt change**. The `error-swallowing` rule prompt is unchanged. Running `--calibrate 10` against this fixture today will fail; that's the documented gap.
- **No calibration run**. Calibration requires OpenRouter spend (~\$0.50/run per the harness README) and the 9/10 bar gates merging a prompt change. Both belong in a follow-up.

## Follow-up work

1. CC iteration via `/test-harness error-swallowing` to refine the prompt so the early-null-guard shape stays quiet without losing the canary's detection of the payment-error-swallowed pattern (PR #411).
2. `--calibrate 10` against the updated prompt to confirm ≥ 9/10 on both the canary and this negative fixture.
3. Land both prompt change and assertion bundle.

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` ✓
- [x] Fixture validates via `jq '.pr.title, (.repoChunks | length), (.chunks | length)'` ✓ (5033, 150, title matches)
- [x] Fixture gitignored (.json not committed) ✓

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR introduces a negative-regression test fixture for the `error-swallowing` rule to prevent a specific false positive observed in PR #574. While the assertions and documentation are correctly implemented, the actual fixture data is omitted from the commit, which will prevent the test from running in shared environments.
>
> - Added `scanall-null-guard-fp.assertions.ts` to define expected behavior (no findings) for the false-positive case.
> - Updated `packages/review/test/harness/README.md` with instructions for regenerating the fixture and documentation of the regression case.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b1e36fc. Updates automatically on new commits.</sup>
<!-- /lien-stats -->