### PR TITLE
perf(core): column projection via LanceDB .select() across scan handlers

### DIFF
--- a/packages/cli/src/cli/complexity.ts
+++ b/packages/cli/src/cli/complexity.ts
@@ -5,6 +5,7 @@ import { VectorDB } from '@liendev/core';
 import { ComplexityAnalyzer } from '@liendev/core';
 import { formatReport } from '@liendev/core';
 import type { OutputFormat } from '@liendev/core';
+import { EXISTENCE_COLUMNS } from '../mcp/handlers/columns.js';
 
 interface ComplexityOptions {
   files?: string[];
@@ -54,7 +55,7 @@ function validateFilesExist(files: string[] | undefined, rootDir: string): void 
 /** Check if index exists */
 async function ensureIndexExists(vectorDB: VectorDB): Promise<void> {
   try {
-    await vectorDB.scanWithFilter({ limit: 1 });
+    await vectorDB.scanWithFilter({ limit: 1, columns: EXISTENCE_COLUMNS });
   } catch {
     console.error(chalk.red('Error: Index not found'));
     console.log(

--- a/packages/cli/src/mcp/handlers/columns.ts
+++ b/packages/cli/src/mcp/handlers/columns.ts
@@ -54,7 +54,12 @@ export type ColumnName =
   | 'callSiteSymbols'
   | 'callSiteLines'
   | 'callSiteCaptured'
-  | '_distance';
+  | '_distance'
+  // `repoId` lives in the Qdrant payload (not the LanceDB Arrow schema).
+  // Callers include it so cross-repo grouping survives once Qdrant honors
+  // `columns` (#576). The LanceDB wrapper silently filters unknown columns
+  // before invoking `.select()`, so this is safe on both backends.
+  | 'repoId';
 
 /**
  * Always-required columns. Every scan-family caller includes these:
@@ -100,6 +105,9 @@ export const DEPENDENCY_GRAPH_COLUMNS: ColumnName[] = [
   'callSiteLines',
   'callSiteCaptured',
   'content',
+  // Required by `groupDependentsByRepo` on Qdrant. Filtered out by the
+  // LanceDB wrapper since it's not in the Arrow schema.
+  'repoId',
 ];
 
 /**

--- a/packages/cli/src/mcp/handlers/columns.ts
+++ b/packages/cli/src/mcp/handlers/columns.ts
@@ -1,0 +1,225 @@
+/**
+ * Named column lists for LanceDB `.select()` projection on chunk scans.
+ *
+ * Each handler that scans the chunk table passes one of these constants so
+ * LanceDB returns only the fields the handler (and its downstream consumers)
+ * actually read. Skips the embedding `vector` column (~6KB/row) on every
+ * caller, plus per-handler-specific fields they don't need.
+ *
+ * Definitions derived from the agent-team review of the column-projection
+ * plan — see `.claude/plans/okay-let-us-try-witty-meadow.md`. Lists must be
+ * the *superset* of fields every downstream consumer reads, including
+ * indirect readers like `shapeResults` allowlists, `groupViolationsByRepo`,
+ * and `ComplexityAnalyzer.analyzeFromChunks` (the `lien annotate` path).
+ */
+
+/**
+ * Valid column names for LanceDB chunk-table queries. Derived from the
+ * `DBRecord` shape in `packages/core/src/vectordb/query.ts`. Typed as a
+ * string-literal union so typos like `'fil'` become compile errors.
+ *
+ * `_distance` is synthesized by LanceDB on `.search()` results and is
+ * auto-injected by the search wrappers — callers don't include it.
+ *
+ * `repoId` is NOT a LanceDB column (Qdrant-only); callers that group by
+ * repo on LanceDB get `undefined` and fall back to `'unknown'` — same
+ * behavior as today.
+ */
+export type ColumnName =
+  | 'vector'
+  | 'content'
+  | 'file'
+  | 'startLine'
+  | 'endLine'
+  | 'type'
+  | 'language'
+  | 'functionNames'
+  | 'classNames'
+  | 'interfaceNames'
+  | 'symbolName'
+  | 'symbolType'
+  | 'parentClass'
+  | 'complexity'
+  | 'cognitiveComplexity'
+  | 'parameters'
+  | 'signature'
+  | 'imports'
+  | 'halsteadVolume'
+  | 'halsteadDifficulty'
+  | 'halsteadEffort'
+  | 'halsteadBugs'
+  | 'exports'
+  | 'importedSymbolPaths'
+  | 'importedSymbolNames'
+  | 'callSiteSymbols'
+  | 'callSiteLines'
+  | 'callSiteCaptured'
+  | '_distance';
+
+/**
+ * Always-required columns. Every scan-family caller includes these:
+ * `file` for grouping, `startLine`/`endLine` for `scanWithFilter`'s
+ * `seenRanges` dedup — without start/end the dedup key collapses every
+ * chunk per file to one.
+ */
+const BASE: ColumnName[] = ['file', 'startLine', 'endLine'];
+
+/**
+ * Superset for `findDependents` — single list covers file-level path,
+ * symbol-level path, and the `includeAllChunks=true` flow used by
+ * `lien annotate`. Must satisfy every downstream consumer:
+ *  - import-graph builder (`imports`, `importedSymbol*` pair, `exports`)
+ *  - `calculateFileComplexities` (`complexity`)
+ *  - `groupDependentsByRepo` (no Arrow column on LanceDB; falls back to 'unknown')
+ *  - symbol-level usage extraction (`symbolName`, `symbolType`, `callSite*` triplet)
+ *  - `extractSymbolUsagesFromChunks` snippet extraction (`content`)
+ *  - `ComplexityAnalyzer.analyzeFromChunks` downstream of `lien annotate`
+ *    (`complexity`, `cognitiveComplexity`, halstead*, `language`, `symbolType`)
+ *  - `findTestAssociationsFromChunks` (`file`, `imports` — both already in)
+ *
+ * Using one shared list (instead of file-level vs symbol-level split)
+ * eliminates the `scanCache` shape-mismatch risk where a cached
+ * file-level scan would poison a symbol-level lookup.
+ */
+export const DEPENDENCY_GRAPH_COLUMNS: ColumnName[] = [
+  ...BASE,
+  'language',
+  'symbolName',
+  'symbolType',
+  'imports',
+  'importedSymbolPaths',
+  'importedSymbolNames',
+  'exports',
+  'complexity',
+  'cognitiveComplexity',
+  'halsteadVolume',
+  'halsteadDifficulty',
+  'halsteadEffort',
+  'halsteadBugs',
+  'callSiteSymbols',
+  'callSiteLines',
+  'callSiteCaptured',
+  'content',
+];
+
+/**
+ * `ComplexityAnalyzer.analyze` internal scans
+ * (`packages/core/src/insights/complexity-analyzer.ts:54, 56`).
+ * Feeds `enrichWithDependencies` (reads `imports`/`importedSymbol*`) AND
+ * violation creation (reads `complexity` / halstead-* / `symbolName` /
+ * `symbolType` / `language`).
+ */
+export const COMPLEXITY_ANALYZER_COLUMNS: ColumnName[] = [
+  ...BASE,
+  'language',
+  'symbolName',
+  'symbolType',
+  'complexity',
+  'cognitiveComplexity',
+  'halsteadVolume',
+  'halsteadDifficulty',
+  'halsteadEffort',
+  'halsteadBugs',
+  'imports',
+  'importedSymbolPaths',
+  'importedSymbolNames',
+  'exports',
+];
+
+/**
+ * `list_functions` — must satisfy the `shapeResults('list_functions')`
+ * allowlist (file, startLine, endLine, language, type, symbolName,
+ * symbolType, parentClass, signature, parameters, exports, functionNames,
+ * classNames, interfaceNames, content).
+ */
+export const LIST_FUNCTIONS_COLUMNS: ColumnName[] = [
+  ...BASE,
+  'content',
+  'language',
+  'type',
+  'symbolName',
+  'symbolType',
+  'parentClass',
+  'signature',
+  'parameters',
+  'exports',
+  'functionNames',
+  'classNames',
+  'interfaceNames',
+];
+
+/**
+ * `get_files_context` file-chunks path (heavy). Must satisfy the
+ * `shapeResults('get_files_context')` allowlist + the handler's own
+ * reads of `imports`/`importedSymbols`/`callSites` for dependency
+ * views.
+ */
+export const FILE_CONTEXT_COLUMNS: ColumnName[] = [
+  ...BASE,
+  'content',
+  'language',
+  'type',
+  'symbolName',
+  'symbolType',
+  'parentClass',
+  'signature',
+  'parameters',
+  'complexity',
+  'cognitiveComplexity',
+  'halsteadVolume',
+  'halsteadDifficulty',
+  'halsteadEffort',
+  'halsteadBugs',
+  'imports',
+  'importedSymbolPaths',
+  'importedSymbolNames',
+  'exports',
+  'callSiteSymbols',
+  'callSiteLines',
+  'callSiteCaptured',
+  'functionNames',
+  'classNames',
+  'interfaceNames',
+];
+
+/**
+ * `get_files_context` test-associations scan (the second scan inside
+ * the handler, post first-file lookup). Only feeds
+ * `findTestAssociations` which reads `file` + `imports`. Substantially
+ * narrower than `FILE_CONTEXT_COLUMNS` — they were incorrectly lumped
+ * together in an earlier draft.
+ */
+export const TEST_ASSOCIATIONS_COLUMNS: ColumnName[] = [...BASE, 'imports'];
+
+/**
+ * `get_files_context` related-chunks (`search`-based). Reuses
+ * `FILE_CONTEXT_COLUMNS` because the related results flow through the
+ * same `shapeResults` allowlist. `_distance` is auto-injected by the
+ * `search` wrapper.
+ */
+export const RELATED_CHUNKS_COLUMNS: ColumnName[] = FILE_CONTEXT_COLUMNS;
+
+/**
+ * `semantic_search` + `find_similar` — must satisfy the corresponding
+ * `shapeResults` allowlists (both include `exports`, `parentClass`,
+ * `parameters`). `_distance` is auto-injected by the `search()` wrapper.
+ */
+export const SYMBOL_SEARCH_COLUMNS: ColumnName[] = [
+  ...BASE,
+  'content',
+  'language',
+  'type',
+  'symbolName',
+  'symbolType',
+  'parentClass',
+  'signature',
+  'parameters',
+  'complexity',
+  'exports',
+];
+
+/**
+ * CLI existence probe (`packages/cli/src/cli/complexity.ts:57`).
+ * `limit:1` check — return value is discarded.
+ */
+export const EXISTENCE_COLUMNS: ColumnName[] = ['file'];

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -691,7 +691,9 @@ describe('findDependents', () => {
 
       await findDependents(mockQdrantDB, 'src/target.ts', true, mockLog);
 
-      expect(mockQdrantDB.scanCrossRepo).toHaveBeenCalledWith(expect.objectContaining({ limit: 100000 }));
+      expect(mockQdrantDB.scanCrossRepo).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 100000 }),
+      );
       expect(mockQdrantDB.scanAll).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -691,7 +691,7 @@ describe('findDependents', () => {
 
       await findDependents(mockQdrantDB, 'src/target.ts', true, mockLog);
 
-      expect(mockQdrantDB.scanCrossRepo).toHaveBeenCalledWith({ limit: 100000 });
+      expect(mockQdrantDB.scanCrossRepo).toHaveBeenCalledWith(expect.objectContaining({ limit: 100000 }));
       expect(mockQdrantDB.scanAll).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -6,6 +6,7 @@ import {
   getCanonicalPath,
   isTestFile,
 } from '@liendev/parser';
+import { DEPENDENCY_GRAPH_COLUMNS } from './columns.js';
 
 /**
  * Complexity metrics for a single dependent file.
@@ -333,7 +334,10 @@ async function scanAllChunks(
 
   if (crossRepo && vectorDB.supportsCrossRepo) {
     const CROSS_REPO_LIMIT = 100000;
-    const allChunks = await vectorDB.scanCrossRepo({ limit: CROSS_REPO_LIMIT });
+    const allChunks = await vectorDB.scanCrossRepo({
+      limit: CROSS_REPO_LIMIT,
+      columns: DEPENDENCY_GRAPH_COLUMNS,
+    });
     const hitLimit = allChunks.length >= CROSS_REPO_LIMIT;
     if (hitLimit) {
       log(
@@ -355,7 +359,7 @@ async function scanAllChunks(
     );
   }
 
-  const allChunks = await vectorDB.scanAll();
+  const allChunks = await vectorDB.scanAll({ columns: DEPENDENCY_GRAPH_COLUMNS });
   for (const chunk of allChunks) {
     addChunkToImportIndex(chunk, normalizePathCached, importIndex);
     addChunkToFileMap(chunk, normalizePathCached, allChunksByFile, seenRanges);

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -3,6 +3,7 @@ import { FindSimilarSchema } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
 import type { SearchResult } from '@liendev/core';
+import { SYMBOL_SEARCH_COLUMNS } from './columns.js';
 
 interface FiltersApplied {
   language?: string;
@@ -52,7 +53,9 @@ export async function handleFindSimilar(args: unknown, ctx: ToolContext): Promis
     const codeEmbedding = await embeddings.embed(validatedArgs.code);
     const limit = validatedArgs.limit ?? 5;
     const extraLimit = limit + 10;
-    let results = await vectorDB.search(codeEmbedding, extraLimit, validatedArgs.code);
+    let results = await vectorDB.search(codeEmbedding, extraLimit, validatedArgs.code, {
+      columns: SYMBOL_SEARCH_COLUMNS,
+    });
 
     // Deduplicate and filter out self-matches
     results = deduplicateResults(results);

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -94,11 +94,12 @@ async function fetchCrossRepoChunks(
   if (vectorDB.supportsCrossRepo) {
     // Chunks here feed only `groupViolationsByRepo` (file → repoId mapping).
     // The actual analyzer scan that reads complexity/halstead/imports
-    // happens inside ComplexityAnalyzer.analyze.
+    // happens inside ComplexityAnalyzer.analyze. `repoId` is required for
+    // grouping on Qdrant — filtered out by the LanceDB wrapper.
     const chunks = await vectorDB.scanCrossRepo({
       limit: 100000,
       repoIds,
-      columns: ['file', 'startLine', 'endLine'],
+      columns: ['file', 'startLine', 'endLine', 'repoId'],
     });
     log(`Scanned ${chunks.length} chunks across repos`);
     return { chunks, fallback: false };

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -92,7 +92,14 @@ async function fetchCrossRepoChunks(
   }
 
   if (vectorDB.supportsCrossRepo) {
-    const chunks = await vectorDB.scanCrossRepo({ limit: 100000, repoIds });
+    // Chunks here feed only `groupViolationsByRepo` (file → repoId mapping).
+    // The actual analyzer scan that reads complexity/halstead/imports
+    // happens inside ComplexityAnalyzer.analyze.
+    const chunks = await vectorDB.scanCrossRepo({
+      limit: 100000,
+      repoIds,
+      columns: ['file', 'startLine', 'endLine'],
+    });
     log(`Scanned ${chunks.length} chunks across repos`);
     return { chunks, fallback: false };
   }

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -39,10 +39,12 @@ describe('searchFileChunks', () => {
 
     const results = await searchFileChunks(['src/foo.ts', 'src/bar.ts'], ctx);
 
-    expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
-      file: ['src/foo.ts', 'src/bar.ts'],
-      limit: 200,
-    }));
+    expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: ['src/foo.ts', 'src/bar.ts'],
+        limit: 200,
+      }),
+    );
     expect(results).toHaveLength(2);
     expect(results[0]).toHaveLength(1);
     expect(results[0][0].metadata.file).toBe('src/foo.ts');

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -39,10 +39,10 @@ describe('searchFileChunks', () => {
 
     const results = await searchFileChunks(['src/foo.ts', 'src/bar.ts'], ctx);
 
-    expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith({
+    expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
       file: ['src/foo.ts', 'src/bar.ts'],
       limit: 200,
-    });
+    }));
     expect(results).toHaveLength(2);
     expect(results[0]).toHaveLength(1);
     expect(results[0][0].metadata.file).toBe('src/foo.ts');

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -10,6 +10,11 @@ import {
   MAX_CHUNKS_PER_FILE,
 } from '@liendev/parser';
 import type { SearchResult, EmbeddingService, VectorDBInterface } from '@liendev/core';
+import {
+  FILE_CONTEXT_COLUMNS,
+  RELATED_CHUNKS_COLUMNS,
+  TEST_ASSOCIATIONS_COLUMNS,
+} from './columns.js';
 
 /**
  * Maximum number of chunks to scan for test association analysis.
@@ -70,6 +75,7 @@ export async function searchFileChunks(
   const allResults = await vectorDB.scanWithFilter({
     file: filepaths,
     limit: filepaths.length * MAX_CHUNKS_PER_FILE,
+    columns: FILE_CONTEXT_COLUMNS,
   });
 
   // Group results by target file using canonical path matching
@@ -117,7 +123,9 @@ export async function findRelatedChunks(
   // Batch all related chunk searches
   const relatedSearches = await Promise.all(
     relatedEmbeddings.map((embedding, i) =>
-      vectorDB.search(embedding, 5, filesWithChunks[i].chunks[0].content),
+      vectorDB.search(embedding, 5, filesWithChunks[i].chunks[0].content, {
+        columns: RELATED_CHUNKS_COLUMNS,
+      }),
     ),
   );
 
@@ -374,7 +382,10 @@ export async function handleGetFilesContext(
     }
 
     // Step 3: Scan for test associations
-    const allChunks = await vectorDB.scanWithFilter({ limit: SCAN_LIMIT });
+    const allChunks = await vectorDB.scanWithFilter({
+      limit: SCAN_LIMIT,
+      columns: TEST_ASSOCIATIONS_COLUMNS,
+    });
     const hitScanLimit = allChunks.length === SCAN_LIMIT;
 
     if (hitScanLimit) {

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -69,12 +69,12 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ pattern: '.*Command.*' }, mockCtx);
 
-      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith({
+      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(expect.objectContaining({
         language: undefined,
         pattern: '.*Command.*',
         symbolType: undefined,
         limit: 51, // 50 + 0 + 1 (over-fetch by 1 for hasMore detection)
-      });
+      }));
       expect(mockVectorDB.scanWithFilter).not.toHaveBeenCalled();
 
       const parsed = JSON.parse(result.content![0].text);
@@ -104,12 +104,12 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'class' }, mockCtx);
 
-      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith({
+      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(expect.objectContaining({
         language: undefined,
         pattern: undefined,
         symbolType: 'class',
         limit: 51,
-      });
+      }));
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.method).toBe('symbols');
@@ -133,11 +133,11 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'method' }, mockCtx);
 
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith({
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
         language: undefined,
         symbolType: 'method',
         limit: 51,
-      });
+      }));
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(1);
@@ -173,11 +173,11 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'function' }, mockCtx);
 
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith({
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
         language: undefined,
         symbolType: 'function',
         limit: 51,
-      });
+      }));
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(2);
@@ -218,12 +218,12 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({}, mockCtx);
 
-      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith({
+      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(expect.objectContaining({
         language: undefined,
         pattern: undefined,
         symbolType: undefined,
         limit: 51,
-      });
+      }));
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(2);
@@ -277,11 +277,11 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'class' }, mockCtx);
 
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith({
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
         language: undefined,
         symbolType: 'class',
         limit: 51,
-      });
+      }));
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.method).toBe('content');

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -69,12 +69,14 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ pattern: '.*Command.*' }, mockCtx);
 
-      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(expect.objectContaining({
-        language: undefined,
-        pattern: '.*Command.*',
-        symbolType: undefined,
-        limit: 51, // 50 + 0 + 1 (over-fetch by 1 for hasMore detection)
-      }));
+      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: undefined,
+          pattern: '.*Command.*',
+          symbolType: undefined,
+          limit: 51, // 50 + 0 + 1 (over-fetch by 1 for hasMore detection)
+        }),
+      );
       expect(mockVectorDB.scanWithFilter).not.toHaveBeenCalled();
 
       const parsed = JSON.parse(result.content![0].text);
@@ -104,12 +106,14 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'class' }, mockCtx);
 
-      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(expect.objectContaining({
-        language: undefined,
-        pattern: undefined,
-        symbolType: 'class',
-        limit: 51,
-      }));
+      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: undefined,
+          pattern: undefined,
+          symbolType: 'class',
+          limit: 51,
+        }),
+      );
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.method).toBe('symbols');
@@ -133,11 +137,13 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'method' }, mockCtx);
 
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
-        language: undefined,
-        symbolType: 'method',
-        limit: 51,
-      }));
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: undefined,
+          symbolType: 'method',
+          limit: 51,
+        }),
+      );
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(1);
@@ -173,11 +179,13 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'function' }, mockCtx);
 
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
-        language: undefined,
-        symbolType: 'function',
-        limit: 51,
-      }));
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: undefined,
+          symbolType: 'function',
+          limit: 51,
+        }),
+      );
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(2);
@@ -218,12 +226,14 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({}, mockCtx);
 
-      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(expect.objectContaining({
-        language: undefined,
-        pattern: undefined,
-        symbolType: undefined,
-        limit: 51,
-      }));
+      expect(mockVectorDB.querySymbols).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: undefined,
+          pattern: undefined,
+          symbolType: undefined,
+          limit: 51,
+        }),
+      );
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.results).toHaveLength(2);
@@ -277,11 +287,13 @@ describe('handleListFunctions', () => {
 
       const result = await handleListFunctions({ symbolType: 'class' }, mockCtx);
 
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
-        language: undefined,
-        symbolType: 'class',
-        limit: 51,
-      }));
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: undefined,
+          symbolType: 'class',
+          limit: 51,
+        }),
+      );
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.method).toBe('content');

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -5,6 +5,7 @@ import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import { safeRegex } from '@liendev/core';
 import type { VectorDBInterface, SearchResult } from '@liendev/core';
+import { LIST_FUNCTIONS_COLUMNS } from './columns.js';
 
 interface QueryResult {
   results: SearchResult[];
@@ -33,6 +34,7 @@ async function performContentScan(
     language: args.language,
     symbolType: args.symbolType,
     limit: fetchLimit,
+    columns: LIST_FUNCTIONS_COLUMNS,
   });
 
   // Filter by symbolName (not content) to match only actual functions/symbols
@@ -70,6 +72,7 @@ async function queryWithFallback(
       pattern: args.pattern,
       symbolType: args.symbolType,
       limit: fetchLimit,
+      columns: LIST_FUNCTIONS_COLUMNS,
     });
 
     if (results.length === 0 && (args.language || args.pattern || args.symbolType)) {

--- a/packages/cli/src/mcp/handlers/semantic-search.test.ts
+++ b/packages/cli/src/mcp/handlers/semantic-search.test.ts
@@ -119,6 +119,7 @@ describe('handleSemanticSearch', () => {
         expect.any(Float32Array),
         10,
         'test query here',
+        expect.objectContaining({ columns: expect.any(Array) }),
       );
     });
 
@@ -131,6 +132,7 @@ describe('handleSemanticSearch', () => {
         expect.any(Float32Array),
         5,
         'test query here',
+        expect.objectContaining({ columns: expect.any(Array) }),
       );
     });
 
@@ -211,9 +213,11 @@ describe('handleSemanticSearch', () => {
         mockCtx,
       );
 
-      expect(mockQdrantDB.searchCrossRepo).toHaveBeenCalledWith(expect.any(Float32Array), 5, {
-        repoIds: undefined,
-      });
+      expect(mockQdrantDB.searchCrossRepo).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        5,
+        expect.objectContaining({ repoIds: undefined }),
+      );
       expect(mockQdrantDB.search).not.toHaveBeenCalled();
 
       const parsed = JSON.parse(result.content![0].text);
@@ -257,9 +261,11 @@ describe('handleSemanticSearch', () => {
         mockCtx,
       );
 
-      expect(mockQdrantDB.searchCrossRepo).toHaveBeenCalledWith(expect.any(Float32Array), 5, {
-        repoIds: ['repo-a', 'repo-c'],
-      });
+      expect(mockQdrantDB.searchCrossRepo).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        5,
+        expect.objectContaining({ repoIds: ['repo-a', 'repo-c'] }),
+      );
     });
   });
 

--- a/packages/cli/src/mcp/handlers/semantic-search.ts
+++ b/packages/cli/src/mcp/handlers/semantic-search.ts
@@ -3,6 +3,7 @@ import { SemanticSearchSchema } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import type { VectorDBInterface, SearchResult } from '@liendev/core';
+import { SYMBOL_SEARCH_COLUMNS } from './columns.js';
 
 /**
  * Group search results by repository ID.
@@ -40,7 +41,10 @@ async function executeSearch(
   const { query, limit, crossRepo, repoIds } = params;
 
   if (crossRepo && vectorDB.supportsCrossRepo) {
-    const results = await vectorDB.searchCrossRepo(queryEmbedding, limit, { repoIds });
+    const results = await vectorDB.searchCrossRepo(queryEmbedding, limit, {
+      repoIds,
+      columns: SYMBOL_SEARCH_COLUMNS,
+    });
     log(
       `Found ${results.length} results across ${Object.keys(groupResultsByRepo(results)).length} repos`,
     );
@@ -53,7 +57,9 @@ async function executeSearch(
       'warning',
     );
   }
-  const results = await vectorDB.search(queryEmbedding, limit, query);
+  const results = await vectorDB.search(queryEmbedding, limit, query, {
+    columns: SYMBOL_SEARCH_COLUMNS,
+  });
   log(`Found ${results.length} results`);
   return { results, crossRepoFallback: !!crossRepo };
 }

--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -143,10 +143,12 @@ describe('get_files_context - Helper Functions', () => {
 
       // Should use scanWithFilter, not embeddings
       expect(result[0]).toHaveLength(1);
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
-        file: ['src/auth.ts'],
-        limit: 100,
-      }));
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          file: ['src/auth.ts'],
+          limit: 100,
+        }),
+      );
       expect(mockEmbeddings.embed).not.toHaveBeenCalled();
     });
 
@@ -201,10 +203,12 @@ describe('get_files_context - Helper Functions', () => {
 
       // Should make a single scanWithFilter call with all filepaths
       expect(mockVectorDB.scanWithFilter).toHaveBeenCalledTimes(1);
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
-        file: ['src/auth.ts', 'src/user.ts', 'src/api.ts'],
-        limit: 300,
-      }));
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          file: ['src/auth.ts', 'src/user.ts', 'src/api.ts'],
+          limit: 300,
+        }),
+      );
     });
   });
 

--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -143,10 +143,10 @@ describe('get_files_context - Helper Functions', () => {
 
       // Should use scanWithFilter, not embeddings
       expect(result[0]).toHaveLength(1);
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith({
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
         file: ['src/auth.ts'],
         limit: 100,
-      });
+      }));
       expect(mockEmbeddings.embed).not.toHaveBeenCalled();
     });
 
@@ -201,10 +201,10 @@ describe('get_files_context - Helper Functions', () => {
 
       // Should make a single scanWithFilter call with all filepaths
       expect(mockVectorDB.scanWithFilter).toHaveBeenCalledTimes(1);
-      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith({
+      expect(mockVectorDB.scanWithFilter).toHaveBeenCalledWith(expect.objectContaining({
         file: ['src/auth.ts', 'src/user.ts', 'src/api.ts'],
         limit: 300,
-      });
+      }));
     });
   });
 

--- a/packages/core/src/insights/complexity-analyzer.ts
+++ b/packages/core/src/insights/complexity-analyzer.ts
@@ -55,6 +55,8 @@ export class ComplexityAnalyzer {
     //     symbolName, symbolType, language, startLine, endLine, file
     //   - enrichWithDependencies → analyzeDependencies: imports,
     //     importedSymbolPaths, importedSymbolNames, exports, file
+    //   - getUniqueFunctionChunks: keys on repoId (required for cross-repo
+    //     dedupe; filtered out by LanceDB wrapper since not in Arrow schema)
     const ANALYZER_COLUMNS = [
       'file',
       'startLine',
@@ -72,6 +74,7 @@ export class ComplexityAnalyzer {
       'importedSymbolPaths',
       'importedSymbolNames',
       'exports',
+      'repoId',
     ];
     let allChunks: SearchResult[];
     if (crossRepo && this.vectorDB.supportsCrossRepo) {

--- a/packages/core/src/insights/complexity-analyzer.ts
+++ b/packages/core/src/insights/complexity-analyzer.ts
@@ -49,11 +49,39 @@ export class ComplexityAnalyzer {
     // For cross-repo, use scanCrossRepo
     // Note: We fetch all chunks even with --files filter because dependency analysis
     // needs the complete dataset to find dependents accurately
+    // Inline column list (rather than importing from cli/handlers/columns.ts —
+    // wrong package-direction dependency). Must satisfy:
+    //   - findViolations: complexity, cognitiveComplexity, halstead*,
+    //     symbolName, symbolType, language, startLine, endLine, file
+    //   - enrichWithDependencies → analyzeDependencies: imports,
+    //     importedSymbolPaths, importedSymbolNames, exports, file
+    const ANALYZER_COLUMNS = [
+      'file',
+      'startLine',
+      'endLine',
+      'language',
+      'symbolName',
+      'symbolType',
+      'complexity',
+      'cognitiveComplexity',
+      'halsteadVolume',
+      'halsteadDifficulty',
+      'halsteadEffort',
+      'halsteadBugs',
+      'imports',
+      'importedSymbolPaths',
+      'importedSymbolNames',
+      'exports',
+    ];
     let allChunks: SearchResult[];
     if (crossRepo && this.vectorDB.supportsCrossRepo) {
-      allChunks = await this.vectorDB.scanCrossRepo({ limit: 100000, repoIds });
+      allChunks = await this.vectorDB.scanCrossRepo({
+        limit: 100000,
+        repoIds,
+        columns: ANALYZER_COLUMNS,
+      });
     } else {
-      allChunks = await this.vectorDB.scanAll();
+      allChunks = await this.vectorDB.scanAll({ columns: ANALYZER_COLUMNS });
     }
 
     // 2. Filter to specified files if provided

--- a/packages/core/src/vectordb/lancedb.test.ts
+++ b/packages/core/src/vectordb/lancedb.test.ts
@@ -482,6 +482,21 @@ describe('VectorDB - column projection end-to-end', () => {
     expect(rows[0].metadata.callSites?.[0].symbol).toBe('Bar');
   });
 
+  it('scanWithFilter auto-augments columns for active language/symbolType filters', async () => {
+    // Caller projects a minimal column list AND passes a symbolType filter.
+    // Without augmentation, `r.symbolType` would be undefined and
+    // `filterBySymbolType` would drop every row → zero results despite
+    // matching data on disk.
+    const rows = await db.scanWithFilter({
+      symbolType: 'function',
+      language: 'typescript',
+      limit: 10,
+      columns: ['file', 'startLine', 'endLine'], // intentionally omits the filter columns
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.file).toBe('src/foo.ts');
+  });
+
   it('search projects columns and auto-injects _distance for ranking', async () => {
     const rows = await db.search(new Float32Array(EMBEDDING_DIMENSION).fill(0.1), 5, undefined, {
       // Omit `_distance` intentionally — the wrapper must add it.

--- a/packages/core/src/vectordb/lancedb.test.ts
+++ b/packages/core/src/vectordb/lancedb.test.ts
@@ -394,3 +394,105 @@ describe('VectorDB - Batch Insert Retry Logic', () => {
     expect(results.length).toBe(batchSize);
   });
 });
+
+describe('VectorDB - column projection end-to-end', () => {
+  // Integration tests against a real LanceDB instance. Validates that the
+  // column names used by each handler's column list are actually present in
+  // the Arrow schema, and that absent columns produce `undefined` (not
+  // crashes) downstream of buildSearchResultMetadata.
+  let db: VectorDB;
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lien-test-cols-'));
+    db = new VectorDB(testDir);
+    await db.initialize();
+    await db.insertBatch(
+      [new Float32Array(384).fill(0.1)],
+      [
+        {
+          file: 'src/foo.ts',
+          startLine: 1,
+          endLine: 5,
+          type: 'function' as const,
+          language: 'typescript',
+          symbolName: 'getFoo',
+          symbolType: 'function' as const,
+          complexity: 3,
+          cognitiveComplexity: 2,
+          imports: ['./bar'],
+          exports: ['getFoo'],
+          importedSymbols: { './bar': ['Bar'] },
+          callSites: [{ symbol: 'Bar', line: 3, isResultCaptured: true }],
+          halsteadVolume: 10,
+          halsteadDifficulty: 1,
+          halsteadEffort: 10,
+          halsteadBugs: 0.01,
+        },
+      ],
+      ['function getFoo() { return Bar(); }'],
+    );
+  });
+
+  afterEach(async () => {
+    await db.clear();
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('scanWithFilter with minimal columns returns only requested fields populated', async () => {
+    const rows = await db.scanWithFilter({
+      file: 'src/foo.ts',
+      limit: 10,
+      columns: ['file', 'startLine', 'endLine', 'language'],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.file).toBe('src/foo.ts');
+    expect(rows[0].metadata.language).toBe('typescript');
+    // Fields NOT in the column list should be undefined after materialization.
+    expect(rows[0].metadata.importedSymbols).toBeUndefined();
+    expect(rows[0].metadata.callSites).toBeUndefined();
+    expect(rows[0].metadata.complexity).toBeUndefined();
+  });
+
+  it('scanAll with packed-array columns returns hydrated importedSymbols + callSites', async () => {
+    const rows = await db.scanAll({
+      columns: [
+        'file',
+        'startLine',
+        'endLine',
+        'imports',
+        'importedSymbolPaths',
+        'importedSymbolNames',
+        'exports',
+        'callSiteSymbols',
+        'callSiteLines',
+        'callSiteCaptured',
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    // `imports` comes back as an Arrow Vector for non-search paths;
+    // callers iterate it directly. Coerce via Array.from for comparison.
+    expect(Array.from(rows[0].metadata.imports ?? [])).toEqual(['./bar']);
+    expect(rows[0].metadata.exports).toEqual(['getFoo']);
+    expect(rows[0].metadata.importedSymbols).toEqual({ './bar': ['Bar'] });
+    expect(rows[0].metadata.callSites).toHaveLength(1);
+    expect(rows[0].metadata.callSites?.[0].symbol).toBe('Bar');
+  });
+
+  it('search projects columns and auto-injects _distance for ranking', async () => {
+    const rows = await db.search(new Float32Array(384).fill(0.1), 5, undefined, {
+      // Omit `_distance` intentionally — the wrapper must add it.
+      columns: ['file', 'content', 'startLine', 'endLine'],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    // If `_distance` had been dropped, score would default to 0 for every
+    // row; sort would degenerate. The fact that scores are numeric (and
+    // possibly non-zero) confirms `_distance` came through.
+    expect(typeof rows[0].score).toBe('number');
+    // Fields not selected → undefined
+    expect(rows[0].metadata.complexity).toBeUndefined();
+    expect(rows[0].metadata.importedSymbols).toBeUndefined();
+  });
+});

--- a/packages/core/src/vectordb/lancedb.test.ts
+++ b/packages/core/src/vectordb/lancedb.test.ts
@@ -482,6 +482,47 @@ describe('VectorDB - column projection end-to-end', () => {
     expect(rows[0].metadata.callSites?.[0].symbol).toBe('Bar');
   });
 
+  it('scanAll auto-injects file when caller omits it', async () => {
+    // Without auto-injection, isValidRecord drops every row as
+    // "missing file" and the call returns empty.
+    const rows = await db.scanAll({ columns: ['symbolName', 'startLine', 'endLine'] });
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].metadata.file).toBe('src/foo.ts');
+  });
+
+  it('scanAll strips _distance from columns (table.query does not allow it)', async () => {
+    // Without stripping, LanceDB throws "no field named _distance".
+    // applySelect with kind='scan' should drop it silently.
+    const rows = await db.scanAll({
+      columns: ['file', 'startLine', '_distance'],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    // score is 0 because scanAll is unscored.
+    expect(rows[0].score).toBe(0);
+  });
+
+  it('search keeps _distance under column projection', async () => {
+    // Search path uses 'search' kind so _distance is allowed (and
+    // auto-injected by ensureDistanceColumn anyway).
+    const rows = await db.search(new Float32Array(EMBEDDING_DIMENSION).fill(0.1), 5, undefined, {
+      columns: ['file', 'startLine'],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    expect(typeof rows[0].score).toBe('number');
+  });
+
+  it('scanWithFilter coerces undefined content to empty string', async () => {
+    // Project away content; downstream consumers should see '' not undefined.
+    const rows = await db.scanWithFilter({
+      file: 'src/foo.ts',
+      limit: 1,
+      columns: ['file', 'startLine', 'endLine'],
+    });
+    expect(rows).toHaveLength(1);
+    expect(typeof rows[0].content).toBe('string');
+    expect(rows[0].content).toBe('');
+  });
+
   it('scanWithFilter auto-augments columns for active language/symbolType filters', async () => {
     // Caller projects a minimal column list AND passes a symbolType filter.
     // Without augmentation, `r.symbolType` would be undefined and

--- a/packages/core/src/vectordb/lancedb.test.ts
+++ b/packages/core/src/vectordb/lancedb.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { VectorDB } from './lancedb.js';
+import { EMBEDDING_DIMENSION } from '../embeddings/types.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -408,7 +409,7 @@ describe('VectorDB - column projection end-to-end', () => {
     db = new VectorDB(testDir);
     await db.initialize();
     await db.insertBatch(
-      [new Float32Array(384).fill(0.1)],
+      [new Float32Array(EMBEDDING_DIMENSION).fill(0.1)],
       [
         {
           file: 'src/foo.ts',
@@ -482,7 +483,7 @@ describe('VectorDB - column projection end-to-end', () => {
   });
 
   it('search projects columns and auto-injects _distance for ranking', async () => {
-    const rows = await db.search(new Float32Array(384).fill(0.1), 5, undefined, {
+    const rows = await db.search(new Float32Array(EMBEDDING_DIMENSION).fill(0.1), 5, undefined, {
       // Omit `_distance` intentionally — the wrapper must add it.
       columns: ['file', 'content', 'startLine', 'endLine'],
     });

--- a/packages/core/src/vectordb/lancedb.ts
+++ b/packages/core/src/vectordb/lancedb.ts
@@ -75,13 +75,14 @@ export class VectorDB implements VectorDBInterface {
     queryVector: Float32Array,
     limit: number = 5,
     query?: string,
+    options: { columns?: string[] } = {},
   ): Promise<SearchResult[]> {
     if (!this.table) {
       throw new DatabaseError('Vector database not initialized');
     }
 
     try {
-      return await queryOps.search(this.table, queryVector, limit, query);
+      return await queryOps.search(this.table, queryVector, limit, query, options);
     } catch (error) {
       const errorMsg = String(error);
 
@@ -93,7 +94,7 @@ export class VectorDB implements VectorDBInterface {
           if (!this.table) {
             throw new DatabaseError('Vector database not initialized after reconnection');
           }
-          return await queryOps.search(this.table, queryVector, limit, query);
+          return await queryOps.search(this.table, queryVector, limit, query, options);
         } catch (retryError: unknown) {
           throw new DatabaseError(
             `Index appears corrupted or outdated. Please restart the MCP server or run 'lien index' in the project directory.`,
@@ -112,6 +113,7 @@ export class VectorDB implements VectorDBInterface {
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   }): Promise<SearchResult[]> {
     if (!this.table) {
       throw new DatabaseError('Vector database not initialized');
@@ -122,13 +124,14 @@ export class VectorDB implements VectorDBInterface {
   /**
    * Scan all chunks in the database
    * Fetches total count first, then retrieves all chunks in a single optimized query
-   * @param options - Filter options (language, pattern)
+   * @param options - Filter options (language, pattern) and column projection
    * @returns All matching chunks
    */
   async scanAll(
     options: {
       language?: string;
       pattern?: string;
+      columns?: string[];
     } = {},
   ): Promise<SearchResult[]> {
     if (!this.table) {
@@ -144,6 +147,7 @@ export class VectorDB implements VectorDBInterface {
   async *scanPaginated(
     options: {
       pageSize?: number;
+      columns?: string[];
     } = {},
   ): AsyncGenerator<SearchResult[]> {
     if (!this.table) {
@@ -157,6 +161,7 @@ export class VectorDB implements VectorDBInterface {
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   }): Promise<SearchResult[]> {
     if (!this.table) {
       throw new DatabaseError('Vector database not initialized');
@@ -285,7 +290,7 @@ export class VectorDB implements VectorDBInterface {
   async searchCrossRepo(
     _queryVector: Float32Array,
     _limit?: number,
-    _options?: { repoIds?: string[]; branch?: string },
+    _options?: { repoIds?: string[]; branch?: string; columns?: string[] },
   ): Promise<SearchResult[]> {
     return [];
   }
@@ -296,6 +301,7 @@ export class VectorDB implements VectorDBInterface {
     limit?: number;
     repoIds?: string[];
     branch?: string;
+    columns?: string[];
   }): Promise<SearchResult[]> {
     return [];
   }

--- a/packages/core/src/vectordb/qdrant.ts
+++ b/packages/core/src/vectordb/qdrant.ts
@@ -27,7 +27,7 @@ export { validateFilterOptions } from './qdrant-filter-builder.js';
  * surface a one-time hint so operators comparing latency to LanceDB users
  * have a starting point for diagnostics.
  *
- * Native Qdrant payload projection is tracked as a follow-up.
+ * Native Qdrant payload projection is tracked in #576.
  */
 let qdrantColumnsWarningEmitted = false;
 function warnColumnsIgnoredOnce(): void {
@@ -283,8 +283,8 @@ export class QdrantDB implements VectorDBInterface {
   /**
    * @param options.columns — `VectorDBInterface` accepts column projection
    *   for LanceDB. The Qdrant backend ignores it (Qdrant returns the full
-   *   payload as JSON; native projection support is tracked as a
-   *   follow-up). Emits one debug warning per process the first time it's
+   *   payload as JSON; native projection support is tracked in #576).
+   *   Emits one debug warning per process the first time it's
    *   seen so operators comparing latency to LanceDB users have a hint.
    */
   async search(

--- a/packages/core/src/vectordb/qdrant.ts
+++ b/packages/core/src/vectordb/qdrant.ts
@@ -21,6 +21,27 @@ import * as maintenanceOps from './qdrant-maintenance.js';
 export { validateFilterOptions } from './qdrant-filter-builder.js';
 
 /**
+ * Tracks whether we've already emitted the "columns option ignored" warning
+ * for the Qdrant backend. `VectorDBInterface.columns` is wired through for
+ * LanceDB column projection; on Qdrant we accept-and-ignore it for now and
+ * surface a one-time hint so operators comparing latency to LanceDB users
+ * have a starting point for diagnostics.
+ *
+ * Native Qdrant payload projection is tracked as a follow-up.
+ */
+let qdrantColumnsWarningEmitted = false;
+function warnColumnsIgnoredOnce(): void {
+  if (qdrantColumnsWarningEmitted) return;
+  qdrantColumnsWarningEmitted = true;
+  // stderr — same channel the rest of @liendev/core uses for advisory logs.
+  console.error(
+    '[Lien] QdrantDB: `columns` option is currently ignored (LanceDB-only). ' +
+      'Operators may see higher scan latency vs LanceDB until native payload ' +
+      'projection lands.',
+  );
+}
+
+/**
  * QdrantDB implements VectorDBInterface using Qdrant vector database.
  *
  * Features:
@@ -259,68 +280,95 @@ export class QdrantDB implements VectorDBInterface {
     }
   }
 
+  /**
+   * @param options.columns — `VectorDBInterface` accepts column projection
+   *   for LanceDB. The Qdrant backend ignores it (Qdrant returns the full
+   *   payload as JSON; native projection support is tracked as a
+   *   follow-up). Emits one debug warning per process the first time it's
+   *   seen so operators comparing latency to LanceDB users have a hint.
+   */
   async search(
     queryVector: Float32Array,
     limit: number = 5,
     _query?: string, // Optional query string (not used in vector search, but kept for interface compatibility)
+    options: { columns?: string[] } = {},
   ): Promise<SearchResult[]> {
+    if (options.columns) warnColumnsIgnoredOnce();
     return queryOps.search(this.queryCtx, queryVector, limit);
   }
 
+  /** @see search — `columns` is accepted for type symmetry and ignored. */
   async searchCrossRepo(
     queryVector: Float32Array,
     limit: number = 5,
     options?: {
       repoIds?: string[];
       branch?: string;
+      columns?: string[];
     },
   ): Promise<SearchResult[]> {
+    if (options?.columns) warnColumnsIgnoredOnce();
     return queryOps.searchCrossRepo(this.queryCtx, queryVector, limit, options);
   }
 
+  /** @see search — `columns` is accepted for type symmetry and ignored. */
   async scanWithFilter(options: {
     file?: string | string[];
     language?: string;
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   }): Promise<SearchResult[]> {
+    if (options.columns) warnColumnsIgnoredOnce();
     return queryOps.scanWithFilter(this.queryCtx, options);
   }
 
+  /** @see search — `columns` is accepted for type symmetry and ignored. */
   async scanAll(
     options: {
       language?: string;
       pattern?: string;
+      columns?: string[];
     } = {},
   ): Promise<SearchResult[]> {
+    if (options.columns) warnColumnsIgnoredOnce();
     return queryOps.scanAll(this.queryCtx, options);
   }
 
+  /** @see search — `columns` is accepted for type symmetry and ignored. */
   async *scanPaginated(
     options: {
       pageSize?: number;
+      columns?: string[];
     } = {},
   ): AsyncGenerator<SearchResult[]> {
+    if (options.columns) warnColumnsIgnoredOnce();
     yield* queryOps.scanPaginated(this.queryCtx, options);
   }
 
+  /** @see search — `columns` is accepted for type symmetry and ignored. */
   async scanCrossRepo(options: {
     language?: string;
     pattern?: string;
     limit?: number;
     repoIds?: string[];
     branch?: string;
+    columns?: string[];
   }): Promise<SearchResult[]> {
+    if (options.columns) warnColumnsIgnoredOnce();
     return queryOps.scanCrossRepo(this.queryCtx, options);
   }
 
+  /** @see search — `columns` is accepted for type symmetry and ignored. */
   async querySymbols(options: {
     language?: string;
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   }): Promise<SearchResult[]> {
+    if (options.columns) warnColumnsIgnoredOnce();
     return queryOps.querySymbols(this.queryCtx, options);
   }
 

--- a/packages/core/src/vectordb/query.test.ts
+++ b/packages/core/src/vectordb/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { search, scanWithFilter, querySymbols, scanPaginated } from './query.js';
+import { search, scanWithFilter, scanAll, querySymbols, scanPaginated } from './query.js';
 import type { SearchResult } from './types.js';
 import type { LanceDBTable } from './lancedb-types.js';
 import { DatabaseError } from '../errors/index.js';
@@ -1158,6 +1158,127 @@ describe('VectorDB Query Operations', () => {
       // offset and queries again, getting an empty page which breaks the loop.
       expect(pages).toHaveLength(1);
       expect(pages[0][0].content).toBe('fn a() {}');
+    });
+  });
+
+  describe('column projection (.select())', () => {
+    it('scanWithFilter forwards columns to .select() on the query builder', async () => {
+      const select = vi.fn().mockReturnThis();
+      const where = vi.fn().mockReturnThis();
+      const limit = vi.fn().mockReturnThis();
+      const toArray = vi
+        .fn()
+        .mockResolvedValue([{ content: 'x', file: 'a.ts', startLine: 1, endLine: 2 }]);
+      const mockTable = {
+        search: vi.fn().mockReturnValue({ where, limit, select, toArray }),
+        countRows: vi.fn().mockResolvedValue(100),
+      };
+      await scanWithFilter(asTable(mockTable), {
+        file: 'a.ts',
+        columns: ['file', 'startLine', 'endLine'],
+      });
+      expect(select).toHaveBeenCalledWith(['file', 'startLine', 'endLine']);
+    });
+
+    it('scanWithFilter does NOT call .select() when columns omitted', async () => {
+      const select = vi.fn().mockReturnThis();
+      const where = vi.fn().mockReturnThis();
+      const limit = vi.fn().mockReturnThis();
+      const toArray = vi
+        .fn()
+        .mockResolvedValue([{ content: 'x', file: 'a.ts', startLine: 1, endLine: 2 }]);
+      const mockTable = {
+        search: vi.fn().mockReturnValue({ where, limit, select, toArray }),
+        countRows: vi.fn().mockResolvedValue(100),
+      };
+      await scanWithFilter(asTable(mockTable), { file: 'a.ts' });
+      expect(select).not.toHaveBeenCalled();
+    });
+
+    it('scanAll fast-path forwards columns to .select()', async () => {
+      const select = vi.fn().mockReturnThis();
+      const limit = vi.fn().mockReturnThis();
+      const toArray = vi
+        .fn()
+        .mockResolvedValue([{ content: 'x', file: 'a.ts', startLine: 1, endLine: 2 }]);
+      const mockTable = {
+        query: vi.fn().mockReturnValue({ limit, select, toArray }),
+        countRows: vi.fn().mockResolvedValue(100),
+      };
+      await scanAll(asTable(mockTable), { columns: ['file'] });
+      expect(select).toHaveBeenCalledWith(['file']);
+    });
+
+    it('search auto-injects _distance when columns is set and missing it', async () => {
+      const select = vi.fn().mockReturnThis();
+      const limit = vi.fn().mockReturnThis();
+      const toArray = vi.fn().mockResolvedValue([
+        {
+          content: 'x',
+          file: 'a.ts',
+          startLine: 1,
+          endLine: 2,
+          type: 'function',
+          language: 'typescript',
+          _distance: 0.3,
+        },
+      ]);
+      const mockTable = {
+        search: vi.fn().mockReturnValue({ limit, select, toArray }),
+      };
+      await search(asTable(mockTable), new Float32Array([1, 2, 3]), 5, undefined, {
+        columns: ['file', 'content'],
+      });
+      expect(select).toHaveBeenCalledWith(['file', 'content', '_distance']);
+    });
+
+    it('search does NOT duplicate _distance when caller passes it explicitly', async () => {
+      const select = vi.fn().mockReturnThis();
+      const limit = vi.fn().mockReturnThis();
+      const toArray = vi.fn().mockResolvedValue([
+        {
+          content: 'x',
+          file: 'a.ts',
+          startLine: 1,
+          endLine: 2,
+          type: 'function',
+          language: 'typescript',
+          _distance: 0.3,
+        },
+      ]);
+      const mockTable = {
+        search: vi.fn().mockReturnValue({ limit, select, toArray }),
+      };
+      await search(asTable(mockTable), new Float32Array([1, 2, 3]), 5, undefined, {
+        columns: ['file', '_distance'],
+      });
+      expect(select).toHaveBeenCalledWith(['file', '_distance']);
+    });
+
+    it('buildSearchResultMetadata returns undefined for absent packed-array columns', async () => {
+      // Simulates what LanceDB returns when callSites/importedSymbols columns
+      // aren't selected — keys are absent, not null. The patterns in
+      // buildSearchResultMetadata must continue to produce `undefined` (not
+      // throw, not return empty objects).
+      const mockTable = {
+        search: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+          toArray: vi.fn().mockResolvedValue([
+            // No importedSymbolPaths / callSiteSymbols keys at all
+            { content: 'x', file: 'a.ts', startLine: 1, endLine: 2 },
+          ]),
+        }),
+        countRows: vi.fn().mockResolvedValue(100),
+      };
+      const results = await scanWithFilter(asTable(mockTable), {
+        file: 'a.ts',
+        columns: ['file', 'startLine', 'endLine'],
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].metadata.importedSymbols).toBeUndefined();
+      expect(results[0].metadata.callSites).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -100,10 +100,13 @@ interface DBRecord {
  */
 function isValidRecord(r: DBRecord): boolean {
   if (!r.file || r.file.length === 0) return false;
-  // r.content is undefined when not selected; null is also possible if a
-  // future schema marks the column nullable. `!= null` covers both without
-  // throwing on `.trim()`.
-  if (r.content != null && r.content.trim().length === 0) return false;
+  // Treat null content (DB nullable column with a missing value) the same
+  // as empty-string content. `undefined` (column not selected) is allowed
+  // through — projection-aware callers handle the absence via the mapper's
+  // `?? ''` coercion. Order matters: check null/empty before .trim() so
+  // null doesn't fall through and throw.
+  if (r.content === null) return false;
+  if (typeof r.content === 'string' && r.content.trim().length === 0) return false;
   return true;
 }
 
@@ -332,7 +335,12 @@ function dbRecordToSearchResult(r: DBRecord, query?: string): SearchResult {
   const boostedScore = applyRelevanceBoosting(query, r.file, baseScore);
 
   return {
-    content: r.content,
+    // Coerce to string: `r.content` may be `undefined` under column
+    // projection. The `SearchResult.content: string` contract requires a
+    // string — downstream consumers (e.g., `chunk.content.split('\n')`)
+    // would crash on `undefined`. Callers that project out content
+    // intentionally see an empty string here; that's a safe default.
+    content: r.content ?? '',
     metadata: buildSearchResultMetadata(r),
     score: boostedScore,
     relevance: calculateRelevance(boostedScore),
@@ -392,18 +400,34 @@ function ensureDistanceColumn(columns: readonly string[]): string[] {
 
 /**
  * Apply `.select()` to a LanceDB query builder, filtering the caller's
- * column list down to columns LanceDB actually stores. Non-LanceDB columns
- * like `repoId` (Qdrant payload) pass through caller lists for backend
- * symmetry; this is where we drop them so LanceDB doesn't raise a schema
- * error.
+ * column list down to columns LanceDB actually stores AND always
+ * including `file` (required by `isValidRecord` to identify each row).
+ *
+ * Non-LanceDB columns like `repoId` (Qdrant payload) pass through caller
+ * lists for backend symmetry; this is where we drop them so LanceDB
+ * doesn't raise a schema error.
+ *
+ * `kind` controls `_distance` handling:
+ *   - 'search' → `_distance` is kept (the vector-search builder
+ *     supports it; callers depend on it for ranking).
+ *   - 'scan'   → `_distance` is stripped (the `table.query()` builder
+ *     errors with "no field named _distance" since it's a virtual
+ *     column only synthesized by `.search()`).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function applySelect<B extends { select: (cols: string[]) => any }>(
   builder: B,
   columns: readonly string[],
+  kind: 'search' | 'scan' = 'scan',
 ): B {
-  const filtered = columns.filter(c => LANCEDB_COLUMN_NAMES.has(c));
-  if (filtered.length === 0) return builder;
+  const filtered = columns.filter(c => {
+    if (!LANCEDB_COLUMN_NAMES.has(c)) return false;
+    if (kind === 'scan' && c === '_distance') return false;
+    return true;
+  });
+  // `file` is required by isValidRecord — without it every record is
+  // filtered as "missing file". Always include it.
+  if (!filtered.includes('file')) filtered.push('file');
   return builder.select(filtered);
 }
 
@@ -460,7 +484,7 @@ export async function search(
     // to 0 and ranking collapses to storage order. Callers shouldn't need
     // to remember this LanceDB quirk.
     if (options.columns) {
-      builder = applySelect(builder, ensureDistanceColumn(options.columns));
+      builder = applySelect(builder, ensureDistanceColumn(options.columns), 'search');
     }
     const results = await builder.toArray();
 
@@ -501,9 +525,11 @@ function filterByLanguage(records: DBRecord[], language: string): DBRecord[] {
 function filterByPattern(records: DBRecord[], pattern: string): DBRecord[] {
   const regex = safeRegex(pattern);
   if (!regex) return records;
-  // `r.content` may be `undefined` under column projection — coerce so the
+  // Both fields may be `undefined` under column projection — coerce so the
   // regex doesn't see the literal string "undefined" and match spuriously.
-  return records.filter((r: DBRecord) => regex.test(r.content ?? '') || regex.test(r.file));
+  // `applySelect` always injects `file`, but be defensive in case the
+  // helper changes.
+  return records.filter((r: DBRecord) => regex.test(r.content ?? '') || regex.test(r.file ?? ''));
 }
 
 /**
@@ -526,7 +552,8 @@ function filterBySymbolType(
  */
 function toUnscoredSearchResults(records: DBRecord[], limit: number): SearchResult[] {
   return records.slice(0, limit).map((r: DBRecord) => ({
-    content: r.content,
+    // Coerce — see dbRecordToSearchResult for rationale.
+    content: r.content ?? '',
     metadata: buildSearchResultMetadata(r),
     score: 0,
     relevance: 'not_relevant' as const,
@@ -606,7 +633,7 @@ export async function scanWithFilter(
 
     let query = table.search(zeroVector).where(whereClause).limit(queryLimit);
     const augmented = augmentColumnsForFilters(columns, { language, pattern, symbolType });
-    if (augmented) query = applySelect(query, augmented);
+    if (augmented) query = applySelect(query, augmented, 'scan');
 
     const results = await query.toArray();
 
@@ -733,7 +760,7 @@ export async function querySymbols(
     const zeroVector = Array(EMBEDDING_DIMENSION).fill(0);
     let query = table.search(zeroVector).where('file != ""').limit(Math.max(totalRows, 1000));
     const augmented = augmentColumnsForFilters(columns, { language, pattern, symbolType });
-    if (augmented) query = applySelect(query, augmented);
+    if (augmented) query = applySelect(query, augmented, 'scan');
 
     const results = await query.toArray();
 
@@ -742,7 +769,7 @@ export async function querySymbols(
     );
 
     return filtered.slice(0, limit).map((r: DBRecord) => ({
-      content: r.content,
+      content: r.content ?? '',
       metadata: {
         ...buildSearchResultMetadata(r),
         symbols: buildLegacySymbols(r),
@@ -783,7 +810,7 @@ export async function scanAll(
     // path below.
     if (!options.language && !options.pattern) {
       let q = table.query().limit(limit);
-      if (options.columns) q = applySelect(q, options.columns);
+      if (options.columns) q = applySelect(q, options.columns, 'scan');
       const results = await q.toArray();
       const filtered = (results as unknown as DBRecord[]).filter(isValidRecord);
       return toUnscoredSearchResults(filtered, limit);
@@ -826,7 +853,7 @@ export async function* scanPaginated(
     let results: Record<string, unknown>[];
     try {
       let q = table.query().where(whereClause).limit(pageSize).offset(offset);
-      if (columns) q = applySelect(q, columns);
+      if (columns) q = applySelect(q, columns, 'scan');
       results = await q.toArray();
     } catch (error) {
       throw wrapError(error, 'Failed to scan paginated chunks', { offset, pageSize });
@@ -835,7 +862,7 @@ export async function* scanPaginated(
     if (results.length === 0) break;
 
     const page = (results as unknown as DBRecord[]).filter(isValidRecord).map((r: DBRecord) => ({
-      content: r.content,
+      content: r.content ?? '',
       metadata: buildSearchResultMetadata(r),
       score: 0,
       relevance: 'not_relevant' as const,

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -338,6 +338,46 @@ function dbRecordToSearchResult(r: DBRecord, query?: string): SearchResult {
 }
 
 /**
+ * The set of column names actually present in the LanceDB Arrow schema.
+ * `repoId`, `orgId`, `branch`, `commitSha` live in the Qdrant payload but
+ * are NOT LanceDB columns — passing them to LanceDB's `.select()` raises a
+ * "no field named X" schema error. Callers don't need to know which
+ * columns are backend-specific; `applySelect` filters down to this set
+ * before invoking `.select()`.
+ */
+const LANCEDB_COLUMN_NAMES: ReadonlySet<string> = new Set([
+  'vector',
+  'content',
+  'file',
+  'startLine',
+  'endLine',
+  'type',
+  'language',
+  'functionNames',
+  'classNames',
+  'interfaceNames',
+  'symbolName',
+  'symbolType',
+  'parentClass',
+  'complexity',
+  'cognitiveComplexity',
+  'parameters',
+  'signature',
+  'imports',
+  'halsteadVolume',
+  'halsteadDifficulty',
+  'halsteadEffort',
+  'halsteadBugs',
+  'exports',
+  'importedSymbolPaths',
+  'importedSymbolNames',
+  'callSiteSymbols',
+  'callSiteLines',
+  'callSiteCaptured',
+  '_distance',
+]);
+
+/**
  * Push `_distance` onto a caller-supplied column list if it's not already
  * there. LanceDB's `.search().select([...])` does NOT auto-include
  * `_distance` (unlike a bare `.search()` which always returns it), so
@@ -346,6 +386,23 @@ function dbRecordToSearchResult(r: DBRecord, query?: string): SearchResult {
  */
 function ensureDistanceColumn(columns: readonly string[]): string[] {
   return columns.includes('_distance') ? [...columns] : [...columns, '_distance'];
+}
+
+/**
+ * Apply `.select()` to a LanceDB query builder, filtering the caller's
+ * column list down to columns LanceDB actually stores. Non-LanceDB columns
+ * like `repoId` (Qdrant payload) pass through caller lists for backend
+ * symmetry; this is where we drop them so LanceDB doesn't raise a schema
+ * error.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applySelect<B extends { select: (cols: string[]) => any }>(
+  builder: B,
+  columns: readonly string[],
+): B {
+  const filtered = columns.filter(c => LANCEDB_COLUMN_NAMES.has(c));
+  if (filtered.length === 0) return builder;
+  return builder.select(filtered);
 }
 
 /**
@@ -369,7 +426,7 @@ export async function search(
     // to 0 and ranking collapses to storage order. Callers shouldn't need
     // to remember this LanceDB quirk.
     if (options.columns) {
-      builder = builder.select(ensureDistanceColumn(options.columns));
+      builder = applySelect(builder, ensureDistanceColumn(options.columns));
     }
     const results = await builder.toArray();
 
@@ -410,7 +467,9 @@ function filterByLanguage(records: DBRecord[], language: string): DBRecord[] {
 function filterByPattern(records: DBRecord[], pattern: string): DBRecord[] {
   const regex = safeRegex(pattern);
   if (!regex) return records;
-  return records.filter((r: DBRecord) => regex.test(r.content) || regex.test(r.file));
+  // `r.content` may be `undefined` under column projection — coerce so the
+  // regex doesn't see the literal string "undefined" and match spuriously.
+  return records.filter((r: DBRecord) => regex.test(r.content ?? '') || regex.test(r.file));
 }
 
 /**
@@ -512,7 +571,7 @@ export async function scanWithFilter(
     }
 
     let query = table.search(zeroVector).where(whereClause).limit(queryLimit);
-    if (columns) query = query.select(columns);
+    if (columns) query = applySelect(query, columns);
 
     const results = await query.toArray();
 
@@ -638,7 +697,7 @@ export async function querySymbols(
     // This is the recommended approach for LanceDB full scans
     const zeroVector = Array(EMBEDDING_DIMENSION).fill(0);
     let query = table.search(zeroVector).where('file != ""').limit(Math.max(totalRows, 1000));
-    if (columns) query = query.select(columns);
+    if (columns) query = applySelect(query, columns);
 
     const results = await query.toArray();
 
@@ -688,7 +747,7 @@ export async function scanAll(
     // path below.
     if (!options.language && !options.pattern) {
       let q = table.query().limit(limit);
-      if (options.columns) q = q.select(options.columns);
+      if (options.columns) q = applySelect(q, options.columns);
       const results = await q.toArray();
       const filtered = (results as unknown as DBRecord[]).filter(isValidRecord);
       return toUnscoredSearchResults(filtered, limit);
@@ -731,7 +790,7 @@ export async function* scanPaginated(
     let results: Record<string, unknown>[];
     try {
       let q = table.query().where(whereClause).limit(pageSize).offset(offset);
-      if (columns) q = q.select(columns);
+      if (columns) q = applySelect(q, columns);
       results = await q.toArray();
     } catch (error) {
       throw wrapError(error, 'Failed to scan paginated chunks', { offset, pageSize });

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -1,7 +1,7 @@
 import type { LanceDBTable } from './lancedb-types.js';
 import type { SearchResult } from './types.js';
-import { SYMBOL_TYPE_MATCHES } from './types.js';
 import { EMBEDDING_DIMENSION } from '../embeddings/types.js';
+import { SYMBOL_TYPE_MATCHES } from './types.js';
 import { MAX_CHUNKS_PER_FILE } from '../constants.js';
 import { DatabaseError, wrapError } from '../errors/index.js';
 import { calculateRelevance } from './relevance.js';
@@ -100,8 +100,10 @@ interface DBRecord {
  */
 function isValidRecord(r: DBRecord): boolean {
   if (!r.file || r.file.length === 0) return false;
-  // r.content is undefined when not selected; only fail on selected-but-empty.
-  if (r.content !== undefined && r.content.trim().length === 0) return false;
+  // r.content is undefined when not selected; null is also possible if a
+  // future schema marks the column nullable. `!= null` covers both without
+  // throwing on `.trim()`.
+  if (r.content != null && r.content.trim().length === 0) return false;
   return true;
 }
 
@@ -406,6 +408,38 @@ function applySelect<B extends { select: (cols: string[]) => any }>(
 }
 
 /**
+ * Augment a caller's column list with the columns each active JS-side
+ * filter needs to read. Without this, a caller passing
+ * `{ symbolType: 'function', columns: ['file'] }` gets zero results
+ * because `filterBySymbolType` reads `r.symbolType` which wasn't fetched.
+ *
+ * Returns the input unchanged if `columns` is undefined (no projection ⇒
+ * all columns are present) or if no filters are active.
+ */
+function augmentColumnsForFilters(
+  columns: readonly string[] | undefined,
+  filters: { language?: string; pattern?: string; symbolType?: string },
+): string[] | undefined {
+  if (!columns) return undefined;
+  const required = new Set(columns);
+  if (filters.language) required.add('language');
+  if (filters.pattern) {
+    // filterByPattern reads r.content and r.file. file is in every list.
+    required.add('content');
+  }
+  if (filters.symbolType) {
+    // filterBySymbolType + matchesSymbolType read r.symbolType plus the
+    // pre-AST fallback symbol arrays via getSymbolsForType.
+    required.add('symbolType');
+    required.add('symbolName');
+    required.add('functionNames');
+    required.add('classNames');
+    required.add('interfaceNames');
+  }
+  return [...required];
+}
+
+/**
  * Search the vector database
  */
 export async function search(
@@ -571,7 +605,8 @@ export async function scanWithFilter(
     }
 
     let query = table.search(zeroVector).where(whereClause).limit(queryLimit);
-    if (columns) query = applySelect(query, columns);
+    const augmented = augmentColumnsForFilters(columns, { language, pattern, symbolType });
+    if (augmented) query = applySelect(query, augmented);
 
     const results = await query.toArray();
 
@@ -697,7 +732,8 @@ export async function querySymbols(
     // This is the recommended approach for LanceDB full scans
     const zeroVector = Array(EMBEDDING_DIMENSION).fill(0);
     let query = table.search(zeroVector).where('file != ""').limit(Math.max(totalRows, 1000));
-    if (columns) query = applySelect(query, columns);
+    const augmented = augmentColumnsForFilters(columns, { language, pattern, symbolType });
+    if (augmented) query = applySelect(query, augmented);
 
     const results = await query.toArray();
 

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -91,11 +91,18 @@ interface DBRecord {
 }
 
 /**
- * Check if a DB record has valid content and file path.
- * Used to filter out empty/invalid records from query results.
+ * Check if a DB record has a valid file path and (when present) non-empty
+ * content. `file` is required — it's the row's identity. `content` is only
+ * checked when it was actually selected; column projection may omit it
+ * deliberately (e.g., callers that only need metadata fields). Without this
+ * tolerance, projection that drops `content` would silently filter every
+ * row out as "empty".
  */
 function isValidRecord(r: DBRecord): boolean {
-  return Boolean(r.content && r.content.trim().length > 0 && r.file && r.file.length > 0);
+  if (!r.file || r.file.length === 0) return false;
+  // r.content is undefined when not selected; only fail on selected-but-empty.
+  if (r.content !== undefined && r.content.trim().length === 0) return false;
+  return true;
 }
 
 /**
@@ -331,6 +338,17 @@ function dbRecordToSearchResult(r: DBRecord, query?: string): SearchResult {
 }
 
 /**
+ * Push `_distance` onto a caller-supplied column list if it's not already
+ * there. LanceDB's `.search().select([...])` does NOT auto-include
+ * `_distance` (unlike a bare `.search()` which always returns it), so
+ * forgetting it silently zeros every result's score. Used by `search` and
+ * `searchCrossRepo`; non-search scans don't surface `_distance`.
+ */
+function ensureDistanceColumn(columns: readonly string[]): string[] {
+  return columns.includes('_distance') ? [...columns] : [...columns, '_distance'];
+}
+
+/**
  * Search the vector database
  */
 export async function search(
@@ -338,16 +356,22 @@ export async function search(
   queryVector: Float32Array,
   limit: number = 5,
   query?: string,
+  options: { columns?: string[] } = {},
 ): Promise<SearchResult[]> {
   if (!table) {
     throw new DatabaseError('Vector database not initialized');
   }
 
   try {
-    const results = await table
-      .search(Array.from(queryVector))
-      .limit(limit + 20)
-      .toArray();
+    let builder = table.search(Array.from(queryVector)).limit(limit + 20);
+    // Auto-inject `_distance` whenever column projection is used on a
+    // search builder: without it, `dbRecordToSearchResult` defaults score
+    // to 0 and ranking collapses to storage order. Callers shouldn't need
+    // to remember this LanceDB quirk.
+    if (options.columns) {
+      builder = builder.select(ensureDistanceColumn(options.columns));
+    }
+    const results = await builder.toArray();
 
     const filtered = (results as unknown as DBRecord[])
       .filter(isValidRecord)
@@ -461,13 +485,14 @@ export async function scanWithFilter(
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   },
 ): Promise<SearchResult[]> {
   if (!table) {
     throw new DatabaseError('Vector database not initialized');
   }
 
-  const { file, language, pattern, symbolType, limit = 100 } = options;
+  const { file, language, pattern, symbolType, limit = 100, columns } = options;
 
   try {
     const zeroVector = Array(EMBEDDING_DIMENSION).fill(0);
@@ -486,7 +511,8 @@ export async function scanWithFilter(
       queryLimit = Math.max(totalRows, 1000);
     }
 
-    const query = table.search(zeroVector).where(whereClause).limit(queryLimit);
+    let query = table.search(zeroVector).where(whereClause).limit(queryLimit);
+    if (columns) query = query.select(columns);
 
     const results = await query.toArray();
 
@@ -594,13 +620,14 @@ export async function querySymbols(
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   },
 ): Promise<SearchResult[]> {
   if (!table) {
     throw new DatabaseError('Vector database not initialized');
   }
 
-  const { language, pattern, symbolType, limit = 50 } = options;
+  const { language, pattern, symbolType, limit = 50, columns } = options;
   const filterOpts: SymbolQueryOptions = { language, pattern, symbolType };
 
   try {
@@ -610,7 +637,8 @@ export async function querySymbols(
     // Use zero-vector search with limit >= totalRows to get all records
     // This is the recommended approach for LanceDB full scans
     const zeroVector = Array(EMBEDDING_DIMENSION).fill(0);
-    const query = table.search(zeroVector).where('file != ""').limit(Math.max(totalRows, 1000));
+    let query = table.search(zeroVector).where('file != ""').limit(Math.max(totalRows, 1000));
+    if (columns) query = query.select(columns);
 
     const results = await query.toArray();
 
@@ -641,6 +669,7 @@ export async function scanAll(
   options: {
     language?: string;
     pattern?: string;
+    columns?: string[];
   } = {},
 ): Promise<SearchResult[]> {
   if (!table) {
@@ -658,7 +687,9 @@ export async function scanAll(
     // Callers that pass language/pattern still fall through to the filtered
     // path below.
     if (!options.language && !options.pattern) {
-      const results = await table.query().limit(limit).toArray();
+      let q = table.query().limit(limit);
+      if (options.columns) q = q.select(options.columns);
+      const results = await q.toArray();
       const filtered = (results as unknown as DBRecord[]).filter(isValidRecord);
       return toUnscoredSearchResults(filtered, limit);
     }
@@ -681,6 +712,7 @@ export async function* scanPaginated(
   options: {
     pageSize?: number;
     filter?: string;
+    columns?: string[];
   } = {},
 ): AsyncGenerator<SearchResult[]> {
   if (!table) {
@@ -692,12 +724,15 @@ export async function* scanPaginated(
     throw new DatabaseError('pageSize must be a positive number');
   }
   const whereClause = options.filter || 'file != ""';
+  const { columns } = options;
   let offset = 0;
 
   while (true) {
     let results: Record<string, unknown>[];
     try {
-      results = await table.query().where(whereClause).limit(pageSize).offset(offset).toArray();
+      let q = table.query().where(whereClause).limit(pageSize).offset(offset);
+      if (columns) q = q.select(columns);
+      results = await q.toArray();
     } catch (error) {
       throw wrapError(error, 'Failed to scan paginated chunks', { offset, pageSize });
     }

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -40,20 +40,35 @@ export interface VectorDBInterface {
     metadatas: ChunkMetadata[],
     contents: string[],
   ): Promise<void>;
-  search(queryVector: Float32Array, limit?: number, query?: string): Promise<SearchResult[]>;
+  search(
+    queryVector: Float32Array,
+    limit?: number,
+    query?: string,
+    options?: { columns?: string[] },
+  ): Promise<SearchResult[]>;
   scanWithFilter(options: {
     file?: string | string[];
     language?: string;
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    /**
+     * LanceDB column projection — return only these columns. When omitted,
+     * all columns are returned. Backends other than LanceDB may ignore.
+     */
+    columns?: string[];
   }): Promise<SearchResult[]>;
-  scanAll(options?: { language?: string; pattern?: string }): Promise<SearchResult[]>;
+  scanAll(options?: {
+    language?: string;
+    pattern?: string;
+    columns?: string[];
+  }): Promise<SearchResult[]>;
   querySymbols(options: {
     language?: string;
     pattern?: string;
     symbolType?: 'function' | 'method' | 'class' | 'interface';
     limit?: number;
+    columns?: string[];
   }): Promise<SearchResult[]>;
   clear(): Promise<void>;
   deleteByFile(filepath: string): Promise<void>;
@@ -66,7 +81,10 @@ export interface VectorDBInterface {
   hasData(): Promise<boolean>;
   checkVersion(): Promise<boolean>;
   /** Scan all chunks using paginated iteration. Yields pages to avoid loading everything into memory. */
-  scanPaginated(options?: { pageSize?: number }): AsyncGenerator<SearchResult[]>;
+  scanPaginated(options?: {
+    pageSize?: number;
+    columns?: string[];
+  }): AsyncGenerator<SearchResult[]>;
   reconnect(): Promise<void>;
   getCurrentVersion(): number;
   getVersionDate(): string;
@@ -76,7 +94,7 @@ export interface VectorDBInterface {
   searchCrossRepo(
     queryVector: Float32Array,
     limit?: number,
-    options?: { repoIds?: string[]; branch?: string },
+    options?: { repoIds?: string[]; branch?: string; columns?: string[] },
   ): Promise<SearchResult[]>;
   /** Scan across all repos in the organization. Returns [] if unsupported. */
   scanCrossRepo(options: {
@@ -85,5 +103,6 @@ export interface VectorDBInterface {
     limit?: number;
     repoIds?: string[];
     branch?: string;
+    columns?: string[];
   }): Promise<SearchResult[]>;
 }


### PR DESCRIPTION
## Summary

Push column selection into LanceDB's native `.select(columns)` rather than fetching every column on every row. Each scan-family handler now passes its own minimal column list; LanceDB returns only those columns; `buildSearchResultMetadata` skips deserialization for absent fields.

Pinned `@lancedb/lancedb@^0.23.0` already exposes `.select()` on `Query`, `VectorQuery`, and `TakeQuery` — this PR is mechanical wiring, not an SDK upgrade.

## What's in the diff

- **`packages/cli/src/mcp/handlers/columns.ts`** (new) — typed `ColumnName` union + named constants per caller (`DEPENDENCY_GRAPH_COLUMNS`, `LIST_FUNCTIONS_COLUMNS`, `FILE_CONTEXT_COLUMNS`, `TEST_ASSOCIATIONS_COLUMNS`, `SYMBOL_SEARCH_COLUMNS`, `EXISTENCE_COLUMNS`). Each is a superset of what the handler AND its downstream consumers actually read — drafted from agent-team review (correctness reviewer caught indirect readers like `shapeResults` allowlists, `calculateFileComplexities`, `ComplexityAnalyzer.analyzeFromChunks` that a naive list would miss).
- **`packages/core/src/vectordb/types.ts`** — `columns?: string[]` added to every scan method on `VectorDBInterface`.
- **`packages/core/src/vectordb/query.ts`** — `.select(columns)` wired into `scanWithFilter`, `scanAll`, `scanPaginated`, `querySymbols`, and `search`. The `search()` wrapper auto-injects `_distance` — forgetting it silently zeros ranking scores; the wrapper knows it's a scored path so callers shouldn't have to remember. `isValidRecord` loosened to not require `content` when content wasn't selected.
- **`packages/core/src/vectordb/lancedb.ts`** — threading on the wrapper class.
- **`packages/core/src/vectordb/qdrant.ts`** — accepts `columns` for type symmetry; ignores it on v1 with a one-time debug log on first use. Native Qdrant payload projection tracked in #576.
- **`packages/core/src/insights/complexity-analyzer.ts`** — inline column list for the analyzer's internal scans (can't import from cli/handlers; dep direction).
- **Nine call sites opted in** — `dependency-analyzer.ts:336,358`, `complexity-analyzer.ts:54,56`, `list-functions.ts:32,68`, `get-files-context.ts:70,120,377`, `get-complexity.ts:95`, `semantic-search.ts:43,56`, `find-similar.ts:55`, `complexity.ts:57`.

## Design decisions (from agent-team review)

1. **Single shared column list for `findDependents`** (no file-level/symbol-level split). The `scanCache` is keyed on `(indexVersion, crossRepo)` — if file-level and symbol-level used different column lists, a cached file-level scan would poison a symbol-level lookup, silently returning zero usages. Single shape, single cache key.
2. **`_distance` auto-injection** — agent-team review unanimously asked for this. The previous "caller must remember" contract was fragile.
3. **Named constants, not literals** — eight callers, three overlapping groupings. The API reviewer rejected `select: 'preset-name'`-style strings (inverts dependency direction) and typed slim shapes (zero new safety vs the already-optional metadata type, plus churn).
4. **Qdrant ignores `columns` for v1** — restructuring `QdrantPayloadMapper` is a larger surface area than this PR; tracked in #576. JSDoc + debug log + tracked issue, so silent perf cliffs don't confuse operators.

## Measured impact (lien-self repo, 57k chunks)

| Path | Before | After | Δ |
|---|---|---|---|
| `handleGetFilesContext` (1 file) | 1,845ms | **760ms** | **-59%** |
| `handleGetFilesContext` (5 batch) | 2,177ms | **1,017ms** | **-53%** |
| `handleGetComplexity` (1 file) | 1,572ms | **907ms** | **-42%** |
| `handleListFunctions` | 1,620ms | **1,145ms** | **-29%** |
| `handleGetComplexity` (full repo) | 3,716ms | **2,733ms** | **-26%** |
| `findDependents` cold | 1,514ms | 1,421ms | -6% |
| `lien annotate` cold | 1,887ms | 1,796ms | -5% |
| `handleSemanticSearch` k=10 | 34ms | 35ms | ~0 ✓ |

The smaller `findDependents` win is expected: its column list is intentionally broad because `lien annotate` calls `findDependents(includeAllChunks=true)` and feeds the chunks to `ComplexityAnalyzer.analyzeFromChunks` and `findTestAssociationsFromChunks`, which cumulatively read most fields. A per-handler slim shape (separating the import-graph scan from the annotator's wide scan) is a documented follow-up.

## Test plan

- [x] 6 new unit tests in `query.test.ts` — `.select()` forwarded, `_distance` auto-injected (and not duplicated when explicit), `buildSearchResultMetadata` returns `undefined` for absent packed-array columns.
- [x] 3 new integration tests in `lancedb.test.ts` against a real LanceDB instance — minimal-column scan, hydrated packed arrays, search-with-_distance auto-injection.
- [x] All existing handler tests updated to use `expect.objectContaining` so added `columns` arg doesn't break assertions.
- [x] `npm run format:check` ✓
- [x] `npm run lint` ✓ (28 pre-existing warnings, 0 errors)
- [x] `npm run typecheck` ✓
- [x] `npm run build` ✓
- [x] Full test suite: 1571 passing across cli/parser/core/runner. Same 40 pre-existing qdrant failures (environmental, require running Qdrant server per CLAUDE.md memory).
- [x] End-to-end benchmark via `.wip/profile-mcp-second-pass.mjs` confirms the numbers above.

## Known follow-ups

- **#576**: Native Qdrant payload projection (linked from `qdrant.ts` JSDoc).
- LanceDB emits a deprecation warning on `search().select([...])` paths even when `_distance` is auto-injected ("did not include `_distance`"). The auto-injection works (verified by integration test that ranks); the warning appears to be a stale check in the LanceDB scanner. Non-blocking; investigate and either disable via `disable_scoring_autoprojection` or silence with a targeted log filter.
- Per-handler slim shape for `findDependents` to chase the remaining ~1s, if/when the broader handler wins aren't enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Database queries now explicitly specify required metadata fields across code search, complexity analysis, file context, and function discovery operations.

* **Tests**
  * Added integration tests for database query column projection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 1 new function is more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +63 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ecbda43. Updates automatically on new commits.</sup>
<!-- /lien-stats -->