### PR TITLE
test(harness): capture second error-swallowing FP — gitignore convention

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -78,12 +78,14 @@ diff. Bundled with the canary so calibration covers both directions
 | Rule | PR | Fixture | Why |
 |---|---|---|---|
 | `error-swallowing` | #574 | `error-swallowing/scanall-null-guard-fp` | Early `if (!table) throw` before try/catch was flagged as unguarded deref ([thread](https://github.com/getlien/lien/pull/574#discussion_r3252525960)) |
+| `error-swallowing` | #575 | `error-swallowing/harness-gitignore-convention-fp` | Gitignored `.fixture.json` (per project-wide convention) flagged as missing test data ([thread](https://github.com/getlien/lien/pull/575#discussion_r3252554373)) |
 
 Regenerate:
 
 ```bash
 ROOT=packages/review/test/harness/fixtures
 npx tsx packages/review/test/harness/capture-pr.ts 574 "$ROOT/error-swallowing/scanall-null-guard-fp.fixture.json"
+npx tsx packages/review/test/harness/capture-pr.ts 575 "$ROOT/error-swallowing/harness-gitignore-convention-fp.fixture.json" --sha b1e36fc
 ```
 
 Run the full multi-model sweep:

--- a/packages/review/test/harness/fixtures/error-swallowing/harness-gitignore-convention-fp.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/harness-gitignore-convention-fp.assertions.ts
@@ -1,0 +1,47 @@
+/**
+ * PR #575 — second negative regression on the `error-swallowing` rule.
+ *
+ * The PR added a `.assertions.ts` for a new harness fixture but
+ * intentionally did NOT commit the corresponding `.fixture.json` — that's
+ * the project-wide convention for this harness:
+ *
+ *   - `.gitignore:87` excludes
+ *     `packages/review/test/harness/fixtures/** /*.fixture.json` for every
+ *     fixture (10MB+ each).
+ *   - The `packages/review/test/harness/README.md` documents the pattern:
+ *     "Captured fixtures aren't committed (size). They're gitignored —
+ *     regenerate locally via `capture-pr.ts`."
+ *   - All 8 existing canary fixtures follow the same pattern.
+ *
+ * The `error-swallowing` rule flagged this as a 🟡 risk: "Without the
+ * fixture JSON, the test harness cannot execute these assertions in CI or
+ * for other developers, defeating the purpose of a regression test." That
+ * conclusion is locally plausible but globally wrong — the rule didn't
+ * recognize the surrounding convention (8 sibling `.assertions.ts` files
+ * paired with already-gitignored `.fixture.json` blobs).
+ *
+ * Comment thread: https://github.com/getlien/lien/pull/575#discussion_r3252554373
+ *
+ * Sister fixture: `scanall-null-guard-fp.assertions.ts` captures a
+ * different `error-swallowing` FP shape (early null-guard before try/catch
+ * read as unguarded deref). Both rules-iteration targets should be checked
+ * before any `error-swallowing` prompt change ships.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #575 — `.fixture.json` gitignored per harness convention should NOT fire error-swallowing as risk',
+  rule: 'error-swallowing',
+  expect: (result, h) => {
+    // Tier 1: the rule must produce zero findings. The PR's diff adds a
+    // documented harness fixture; gitignoring the captured JSON is
+    // project-standard. Any error-swallowing finding here is a regression.
+    h.expectEmpty(result);
+  },
+  votes: 3,
+  passThreshold: 9,
+};
+
+export default assertions;


### PR DESCRIPTION
## Summary

PR #575 (the null-guard FP fixture) attracted a second false positive from the same `error-swallowing` rule — this time on the act of *intentionally not committing* the captured `.fixture.json`. The rule flagged:

> 🟡 risk — Without the fixture JSON, the test harness cannot execute these assertions in CI or for other developers, defeating the purpose of a regression test.

That conclusion is locally plausible but globally wrong. The surrounding fixture dir already contains 8 `.assertions.ts` files paired with gitignored `.fixture.json` blobs — the project-wide convention documented in the README:

- `.gitignore:87` excludes `packages/review/test/harness/fixtures/**/*.fixture.json`
- All 8 existing canary fixtures follow the same pattern (commit `.assertions.ts`, gitignore the captured JSON, regenerate via `capture-pr.ts`)
- The README's "Negative-regression fixtures" section even includes the regenerate command for the specific fixture

Comment thread: https://github.com/getlien/lien/pull/575#discussion_r3252554373

This is the **second** `error-swallowing` FP shape captured as a harness fixture. The pattern: rule reads a snippet locally without observing nearby convention markers (gitignored blobs in the same dir, sibling files with the same shape, surrounding README guidance).

## What's in the diff

- **New fixture (gitignored)**: PR #575 captured via `capture-pr.ts 575 ... --sha b1e36fc`. 5,037 repo chunks, 10 changed-file chunks, 13MB.
- **New `.assertions.ts`**: Tier 1 `expectEmpty(result)`. The assertion's JSDoc documents the convention so a future contributor reading the file understands why the rule should stay quiet.
- **README update**: new row in the "Negative-regression fixtures" table, with the `--sha b1e36fc` regenerate command (since PR #575's head ref has been deleted post-merge).

## What's NOT in this PR

- **No rule prompt change.** Both `scanall-null-guard-fp` and the new `harness-gitignore-convention-fp` need to pass before the `error-swallowing` prompt is iterated. That's a separate PR.
- **No calibration run.** Same reason as PR #575 — costs OpenRouter spend, can be deferred until prompt iteration.

## Follow-up

The `error-swallowing` rule is now blocked behind two negative fixtures. Whenever someone iterates its prompt, they need to run:

\`\`\`bash
npm run test:harness -w @liendev/review -- --rule error-swallowing --calibrate 10
\`\`\`

…against both the canary (`payment-error-swallowed`) and the two FP fixtures. The bar is 9/10 on each.

## Test plan

- [x] `npm run typecheck:harness -w @liendev/review` ✓
- [x] Fixture validates via `jq '.pr.title, (.repoChunks | length), (.chunks | length)'` ✓
- [x] Fixture gitignored (.json not committed) ✓
- [x] README documents the regenerate command including `--sha b1e36fc` (PR #575's head ref was deleted on merge)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a new negative regression fixture to the test harness to prevent the `error-swallowing` rule from flagging gitignored fixture files as a risk. It follows the established project convention of committing assertions while gitignoring the large fixture JSON blobs.
>
> - Added `harness-gitignore-convention-fp.assertions.ts` with Tier 1 assertions (expecting zero findings).
> - Updated the harness README with instructions to regenerate the new fixture using a specific commit SHA.
> - Configured the fixture with a 9/10 pass threshold for calibration runs, matching the project's reliability bar.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fb69606. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test case for the error-swallowing rule covering scenarios where gitignored fixture files should not be treated as missing test data.

* **Documentation**
  * Updated test fixture documentation with additional fixture scenario and corresponding regeneration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getlien/lien/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->