### PR TITLE
feat(action): self-hostable GitHub Action for PR review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-      - name: Build Parser, Core & Review (required by CLI & Runner)
+      - name: Build Parser, Core & Review (required by CLI, Runner & Action)
         run: npm run build -w @liendev/parser && npm run build -w @liendev/core && npm run build -w @liendev/review
 
       - name: Lint
@@ -47,11 +47,17 @@ jobs:
       - name: Type check (Runner)
         run: npm run typecheck --workspace=packages/runner
 
+      - name: Type check (Action)
+        run: npm run typecheck --workspace=packages/action
+
       - name: Run tests (CLI)
         run: npm run test --workspace=packages/cli
 
       - name: Run tests (Review)
         run: npm run test --workspace=packages/review
+
+      - name: Run tests (Action)
+        run: npm run test --workspace=packages/action
 
       - name: Build all packages
         run: npm run build
@@ -60,3 +66,6 @@ jobs:
         run: |
           node packages/cli/dist/index.js --version
           node packages/cli/dist/index.js --help
+
+      - name: Build Action image (Dockerfile smoke test)
+        run: docker build -f packages/action/Dockerfile -t lien-review:ci .

--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -1,0 +1,48 @@
+name: Lien Review
+
+# Dogfoods the Lien Review action on this monorepo's own PRs.
+#
+# The public, external-consumer path is `uses: getlien/lien-review@v1` (a Docker
+# action backed by a prebuilt GHCR image — see packages/action/README.md). That
+# image + the public dist repo aren't published yet, so here we build the action
+# from source and run its entrypoint directly. Same code path, no publish needed.
+#
+# fail-on: never — the workflow job stays green whenever the action *runs*; the
+# findings themselves surface as the "Lien Review" check run + inline PR comments.
+# (External consumers use the default fail-on: error so a Required check can gate.)
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: lien-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build review engine + action
+        run: npm run build -w @liendev/parser -w @liendev/core -w @liendev/review -w @liendev/action
+
+      - name: Run Lien Review
+        run: node packages/action/dist/index.js
+        env:
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          INPUT_FAIL-ON: never

--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -1,0 +1,98 @@
+name: Publish Action
+
+# Builds and pushes the Lien Review GitHub Action image to GHCR on a version tag
+# (v*), then (manually, see the documented stub below) syncs action.yml + README
+# to the public getlien/lien-review dist repo and moves the floating v1 tag so
+# `uses: getlien/lien-review@v1` resolves to the new release.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tags
+        id: tags
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="${{ github.sha }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push action image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/action/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/getlien/lien-review:${{ steps.tags.outputs.version }}
+            ghcr.io/getlien/lien-review:latest
+            ghcr.io/getlien/lien-review:sha-${{ steps.tags.outputs.sha_short }}
+          cache-from: type=gha,scope=action
+          cache-to: type=gha,mode=max,scope=action
+
+      # ─── Sync to the public dist repo (requires org access — NOT run here) ──────
+      #
+      # The action.yml consumers reference via `uses: getlien/lien-review@v1` lives
+      # in the public getlien/lien-review dist repo, NOT this monorepo. After the
+      # image is pushed above, that repo's action.yml + README must be synced and
+      # the floating `v1` tag moved to the new release commit.
+      #
+      # This step is intentionally left as a documented stub: it needs a
+      # GH_DIST_TOKEN secret (a PAT/fine-grained token with contents:write on
+      # getlien/lien-review) plus org access to create/own that repo and push the
+      # tag. We cannot run those mutations from this CI without that token, so the
+      # commands are commented out. To enable: add GH_DIST_TOKEN to repo secrets
+      # and uncomment.
+      #
+      # - name: Sync action.yml + README to dist repo and move v1 tag
+      #   if: github.event_name == 'push'
+      #   env:
+      #     GH_DIST_TOKEN: ${{ secrets.GH_DIST_TOKEN }}
+      #     VERSION: ${{ steps.tags.outputs.version }}
+      #   run: |
+      #     set -euo pipefail
+      #     # Compute the major-version float (v1.4.2 -> v1).
+      #     MAJOR="$(echo "$VERSION" | sed -E 's/^(v[0-9]+).*/\1/')"
+      #
+      #     git clone "https://x-access-token:${GH_DIST_TOKEN}@github.com/getlien/lien-review.git" dist
+      #     # Copy the published action definition + docs (the image holds the code).
+      #     cp packages/action/action.yml dist/action.yml
+      #     cp packages/action/README.md  dist/README.md
+      #
+      #     cd dist
+      #     git config user.name  "lien-bot"
+      #     git config user.email "bot@lien.dev"
+      #     git add action.yml README.md
+      #     git commit -m "release: ${VERSION}" || echo "no changes to commit"
+      #     git push origin HEAD:main
+      #
+      #     # Pin the exact version tag and move the floating major tag.
+      #     git tag -f "$VERSION"
+      #     git tag -f "$MAJOR"
+      #     git push -f origin "$VERSION"
+      #     git push -f origin "$MAJOR"

--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -18,40 +18,58 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      # Actions pinned to commit SHAs (supply-chain hardening for a job that
+      # publishes artifacts). persist-credentials:false — this job never needs
+      # the checkout token for a push, so don't leave it in local git config.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Resolve tags
         id: tags
         run: |
+          IMAGE=ghcr.io/getlien/lien-review
+          SHA_TAG="${IMAGE}:sha-${GITHUB_SHA::7}"
           if [ "${{ github.event_name }}" = "push" ]; then
+            # Tagged release: publish the version, the floating :latest, and the sha tag.
             VERSION="${GITHUB_REF#refs/tags/}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            {
+              echo "tags<<EOF"
+              echo "${IMAGE}:${VERSION}"
+              echo "${IMAGE}:latest"
+              echo "${SHA_TAG}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           else
-            VERSION="${{ github.sha }}"
+            # Manual dispatch: publish ONLY the immutable sha tag, so a non-release
+            # run can never overwrite :latest or a version with an arbitrary commit.
+            echo "version=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            {
+              echo "tags<<EOF"
+              echo "${SHA_TAG}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build + push action image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: packages/action/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            ghcr.io/getlien/lien-review:${{ steps.tags.outputs.version }}
-            ghcr.io/getlien/lien-review:latest
-            ghcr.io/getlien/lien-review:sha-${{ steps.tags.outputs.sha_short }}
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=action
           cache-to: type=gha,mode=max,scope=action
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ docs/
 !packages/site/docs/
 !docs/architecture/
 
-# Exception: GitHub Action dist (must be committed for Actions to work)
-!packages/action/dist/
-
 # VitePress build artifacts
 packages/site/docs/.vitepress/cache/
 packages/site/docs/.vitepress/dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "packages/review",
         "packages/cli",
         "packages/runner",
+        "packages/action",
         "packages/site"
       ],
       "dependencies": {
@@ -2299,6 +2300,10 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/@liendev/action": {
+      "resolved": "packages/action",
+      "link": true
     },
     "node_modules/@liendev/core": {
       "resolved": "packages/core",
@@ -12929,6 +12934,276 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/action": {
+      "name": "@liendev/action",
+      "version": "0.1.0",
+      "dependencies": {
+        "@liendev/parser": "*",
+        "@liendev/review": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/action/node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/action/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/action/node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/action/node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/action/node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/action/node_modules/@vitest/ui": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.6.tgz",
+      "integrity": "sha512-mATfG3zVdhobE9U1rIpvtYD3DGuSSxqZ3Aj/8ityGqKXy8YDJ9BoAjZmAz6dZ1IZ1xI5V+MerkCczvVa+3QK9Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.6"
+      }
+    },
+    "packages/action/node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/action/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/action/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/action/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/action/node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/action/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "packages/app": {
       "name": "@liendev/app",
       "version": "0.1.0",
@@ -12951,7 +13226,7 @@
     },
     "packages/cli": {
       "name": "@liendev/lien",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@liendev/core": "*",
@@ -13048,7 +13323,7 @@
     },
     "packages/core": {
       "name": "@liendev/core",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
@@ -13370,7 +13645,7 @@
     },
     "packages/parser": {
       "name": "@liendev/parser",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,14 @@
     "packages/review",
     "packages/cli",
     "packages/runner",
+    "packages/action",
     "packages/site"
   ],
   "scripts": {
-    "build": "npm run build -w @liendev/parser && npm run build -w @liendev/core && npm run build -w @liendev/review && npm run build -w packages/cli && npm run build -w @liendev/runner",
+    "build": "npm run build -w @liendev/parser && npm run build -w @liendev/core && npm run build -w @liendev/review && npm run build -w packages/cli && npm run build -w @liendev/runner && npm run build -w @liendev/action",
     "build:core": "npm run build -w @liendev/parser && npm run build -w @liendev/core",
     "dev": "npm run dev -w packages/cli",
-    "typecheck": "npm run build -w @liendev/parser -w @liendev/core -w @liendev/review && npm run typecheck -w packages/cli -w packages/review -w packages/runner",
+    "typecheck": "npm run build -w @liendev/parser -w @liendev/core -w @liendev/review && npm run typecheck -w packages/cli -w packages/review -w packages/runner -w packages/action",
     "clean": "rm -rf packages/*/dist",
     "changeset": "changeset",
     "version": "changeset version",

--- a/packages/action/Dockerfile
+++ b/packages/action/Dockerfile
@@ -1,0 +1,69 @@
+# Lien Review GitHub Action image.
+# Multi-stage: build the workspace, prune dev deps, ship a slim runtime that
+# keeps git (the action self-clones the PR head/base by SHA).
+FROM --platform=linux/amd64 node:22-slim AS builder
+
+RUN apt-get update && apt-get install -y git python3 make g++ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace root files
+COPY package.json package-lock.json ./
+
+# Copy all workspace package manifests (npm ci needs the full workspace graph)
+COPY packages/parser/package.json packages/parser/
+COPY packages/core/package.json packages/core/
+COPY packages/review/package.json packages/review/
+COPY packages/action/package.json packages/action/
+COPY packages/runner/package.json packages/runner/
+COPY packages/cli/package.json packages/cli/
+COPY packages/site/package.json packages/site/
+
+# Install all workspace dependencies
+RUN npm ci
+
+# Copy source code
+COPY packages/parser/ packages/parser/
+COPY packages/core/ packages/core/
+COPY packages/review/ packages/review/
+COPY packages/action/ packages/action/
+
+# Build packages in dependency order
+RUN npm run build -w packages/parser && \
+    npm run build -w packages/core && \
+    npm run build -w packages/review && \
+    npm run build -w packages/action
+
+# ─── Prune dev dependencies ──────────────────────────────────────────────────
+
+FROM builder AS pruner
+
+RUN npm prune --omit=dev
+
+# ─── Production image ────────────────────────────────────────────────────────
+
+FROM --platform=linux/amd64 node:22-slim
+
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy pre-built node_modules (with native addons already compiled)
+COPY --from=pruner /app/node_modules/ node_modules/
+COPY --from=pruner /app/packages/parser/node_modules/ packages/parser/node_modules/
+COPY --from=pruner /app/packages/core/node_modules/ packages/core/node_modules/
+
+# Copy built dist and package manifests
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/packages/parser/package.json packages/parser/
+COPY --from=builder /app/packages/parser/dist/ packages/parser/dist/
+COPY --from=builder /app/packages/core/package.json packages/core/
+COPY --from=builder /app/packages/core/dist/ packages/core/dist/
+COPY --from=builder /app/packages/review/package.json packages/review/
+COPY --from=builder /app/packages/review/dist/ packages/review/dist/
+COPY --from=builder /app/packages/action/package.json packages/action/
+COPY --from=builder /app/packages/action/dist/ packages/action/dist/
+
+ENV GIT_TERMINAL_PROMPT=0
+
+ENTRYPOINT ["node", "packages/action/dist/index.js"]

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,0 +1,188 @@
+# Lien Review — GitHub Action
+
+Self-contained PR review as a GitHub Action: complexity analysis, agent bug
+review, and a summary, posted back to the PR as a **check run** and **inline
+comments**. No server, no database, no recurring bill — the action clones the PR
+by SHA, reviews it, and writes the results straight to GitHub using the
+workflow's built-in `GITHUB_TOKEN`.
+
+## Quick start
+
+Add a workflow at `.github/workflows/lien-review.yml`:
+
+```yaml
+name: Lien Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlien/lien-review@v1
+        with:
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+That single `uses:` line is the whole integration — **no `actions/checkout`
+step is needed**. Lien self-clones the PR head (and base, for deltas) by SHA
+using the same token, so adding `actions/checkout` is unnecessary and, on fork
+PRs, unsafe (see [Fork PRs](#fork-prs)).
+
+A copy-paste workflow (including the fork variant) lives in
+[`examples/lien-review.yml`](./examples/lien-review.yml).
+
+## Required permissions
+
+The consumer workflow MUST grant these permissions or the check run and comment
+writes will 403:
+
+```yaml
+permissions:
+  contents: read # clone the PR head/base by SHA
+  pull-requests: write # post inline review comments
+  checks: write # create/update the Lien check run
+```
+
+Put the `permissions:` block at the workflow top level (as above) or on the
+individual job. If your repository's default `GITHUB_TOKEN` permissions are set
+to "read-only" in **Settings → Actions → General → Workflow permissions**, the
+explicit block is what re-grants the write scopes this action needs.
+
+## LLM key setup
+
+The agent (bug) review needs an LLM key, provided as a workflow **secret**:
+
+1. Get an [OpenRouter](https://openrouter.ai/) API key (preferred — cheaper
+   Gemini path) or an Anthropic API key.
+2. Add it to your repo under **Settings → Secrets and variables → Actions →
+   New repository secret** as `OPENROUTER_API_KEY` (or `ANTHROPIC_API_KEY`).
+3. Pass it through the action's `with:` block:
+
+   ```yaml
+   with:
+     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+     # or:
+     # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+   ```
+
+If **both** keys are omitted the review still runs, but **complexity-only** —
+the agent bug/summary/architectural passes are skipped. When both are present
+OpenRouter wins.
+
+> Never hard-code an API key in the workflow YAML. Always reference it from
+> `secrets`.
+
+## Inputs
+
+| Input                 | Required | Default                         | Description                                                                                                                                |
+| --------------------- | -------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `github-token`        | no       | `${{ github.token }}`           | Token used to clone the PR and post the check run + comments. Needs `contents:read`, `pull-requests:write`, `checks:write`.              |
+| `openrouter-api-key`  | no       | `''`                            | OpenRouter API key for agent review (preferred provider — runs Gemini). If omitted, falls back to `anthropic-api-key`, then complexity-only. |
+| `anthropic-api-key`   | no       | `''`                            | Anthropic API key for agent review (fallback when `openrouter-api-key` is not set). If both are omitted, review is complexity-only.       |
+| `threshold`           | no       | `15`                            | Complexity threshold above which violations are reported.                                                                                 |
+| `review-types`        | no       | `complexity,bugs,summary`       | Comma-separated review types to enable. `complexity` toggles the complexity check. `bugs`, `architectural`, and `summary` all come from the single agent reviewer, so they switch it on/off as a group (and only when an API key is set) — they can't be toggled independently. |
+| `block-on-new-errors` | no       | `false`                         | Post `REQUEST_CHANGES` (instead of `COMMENT`) when the PR introduces new error-level complexity violations.                               |
+| `fail-on`             | no       | `error`                         | Controls the action's exit code so a Required check can block the PR: `error` (only on a failure conclusion), `any` (any error or warning finding), or `never`. |
+
+## Outputs
+
+| Output           | Description                                            |
+| ---------------- | ----------------------------------------------------- |
+| `conclusion`     | The review conclusion: `success`, `failure`, or `neutral`. |
+| `findings-count` | Total number of findings produced.                    |
+| `error-count`    | Number of error-severity findings.                    |
+
+Reference them from a later step via the step `id`:
+
+```yaml
+- uses: getlien/lien-review@v1
+  id: lien
+  with:
+    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+- run: echo "Lien found ${{ steps.lien.outputs.error-count }} errors"
+```
+
+## Blocking a PR on the review
+
+Set `fail-on` to control the exit code, then mark the workflow's job as a
+**Required status check** in your branch protection rules. With `fail-on: error`
+the action exits non-zero only when the review's overall conclusion is a
+failure (driven by `block-on-new-errors`); `fail-on: any` is stricter (any
+error- or warning-level finding fails the check); `fail-on: never` never blocks.
+
+## Fork PRs
+
+On a `pull_request` event triggered from a **fork**, GitHub forces the built-in
+`GITHUB_TOKEN` to **read-only** — so Lien can clone and review the code but
+cannot post the check run or inline comments (the writes 403). When Lien detects
+this it emits a clear `::warning::` rather than failing your CI, and the review
+output still appears in the job's step summary.
+
+To review fork PRs with full check-run + comment output, opt in via the
+`pull_request_target` event, which runs in the **base** repo's context and
+therefore gets a writable token:
+
+```yaml
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlien/lien-review@v1
+        with:
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+### Security note (read before enabling `pull_request_target`)
+
+`pull_request_target` is normally dangerous because the writable token plus a
+naive `actions/checkout` of the **PR head** would let an attacker's fork run its
+own code with your secrets. **Lien is safe here for one specific reason: it
+never executes the checked-out code.** It self-clones the head by SHA with
+`git init`/`fetch`/`checkout` (object fsck + symlink-escape guards on), then only
+reads and parses the source with tree-sitter. There is no `npm install`, no
+build, no test run, no script execution.
+
+To keep that guarantee, with the `pull_request_target` variant you MUST:
+
+- **NOT** add an `actions/checkout` step that checks out the PR head ref
+  (`ref: ${{ github.event.pull_request.head.sha }}` or `head.ref`). Lien does
+  its own read-only clone; an explicit head checkout would place untrusted code
+  on disk for other steps to potentially execute.
+- Keep this workflow minimal — ideally the single `uses: getlien/lien-review@v1`
+  step and nothing that runs PR-authored code.
+
+If you add other steps to this workflow, treat the PR contents as untrusted and
+do not execute them.
+
+## How it works
+
+1. Reads the `pull_request` event payload (`$GITHUB_EVENT_PATH`) to get the PR
+   number and the **head SHA** (`event.pull_request.head.sha` — not
+   `GITHUB_SHA`, which on `pull_request` is the ephemeral merge commit).
+2. Clones the head (and base, for complexity deltas) by SHA over HTTPS using the
+   `github-token`. A base-clone failure degrades gracefully to a no-delta review.
+3. Runs the enabled review passes (`@liendev/review`): complexity analysis and
+   the agent bug/summary/architectural review.
+4. Posts a check run with the conclusion and inline PR comments for each
+   finding, writes a run summary to `$GITHUB_STEP_SUMMARY`, sets the action
+   outputs, and exits per `fail-on`.
+
+The action ships as a Docker container action pulling a prebuilt image from
+`ghcr.io/getlien/lien-review` (tree-sitter's native bindings rule out a
+JavaScript/composite action), so each run pulls the image rather than building
+it.

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -1,0 +1,67 @@
+name: 'Lien Review'
+description: >-
+  Self-contained PR review — complexity analysis, agent bug review, and a summary,
+  posted as a check run and inline comments. No server, no database.
+author: 'Lien'
+branding:
+  icon: 'git-pull-request'
+  color: 'purple'
+
+inputs:
+  github-token:
+    description: >-
+      Token used to clone the PR and post the check run + comments. Defaults to
+      the workflow's built-in GITHUB_TOKEN. Needs contents:read,
+      pull-requests:write, checks:write.
+    required: false
+    default: ${{ github.token }}
+  openrouter-api-key:
+    description: >-
+      OpenRouter API key for agent review (preferred provider — runs Gemini).
+      If omitted, falls back to anthropic-api-key, then to complexity-only.
+    required: false
+    default: ''
+  anthropic-api-key:
+    description: >-
+      Anthropic API key for agent review (fallback when openrouter-api-key is
+      not set). If both are omitted, review is complexity-only.
+    required: false
+    default: ''
+  threshold:
+    description: 'Complexity threshold above which violations are reported.'
+    required: false
+    default: '15'
+  review-types:
+    description: >-
+      Comma-separated review types to enable. `complexity` toggles the
+      complexity check. `bugs`, `architectural`, and `summary` are all produced
+      by the single agent reviewer, so they switch it on/off as a group (and the
+      agent only runs when an API key is provided) — they cannot be toggled
+      independently of one another. Default: complexity,bugs,summary.
+    required: false
+    default: 'complexity,bugs,summary'
+  block-on-new-errors:
+    description: >-
+      Post REQUEST_CHANGES (instead of COMMENT) when the PR introduces new
+      error-level complexity violations.
+    required: false
+    default: 'false'
+  fail-on:
+    description: >-
+      When the action's exit code is non-zero (so a Required check blocks the
+      PR): 'error' (default — only on a failure conclusion), 'any' (any error or
+      warning finding), or 'never'.
+    required: false
+    default: 'error'
+
+outputs:
+  conclusion:
+    description: 'The review conclusion: success, failure, or neutral.'
+  findings-count:
+    description: 'Total number of findings produced.'
+  error-count:
+    description: 'Number of error-severity findings.'
+
+runs:
+  using: 'docker'
+  image: 'docker://ghcr.io/getlien/lien-review:v1'

--- a/packages/action/examples/lien-review.yml
+++ b/packages/action/examples/lien-review.yml
@@ -1,0 +1,68 @@
+# Copy this into your repo at .github/workflows/lien-review.yml
+#
+# Lien Review runs on every pull request, posts a check run + inline comments,
+# and writes a summary to the job step summary. No `actions/checkout` is needed —
+# the action self-clones the PR by SHA using the built-in GITHUB_TOKEN.
+
+name: Lien Review
+
+on:
+  pull_request:
+
+# Required so the built-in GITHUB_TOKEN can post the check run and comments.
+permissions:
+  contents: read # clone the PR head/base by SHA
+  pull-requests: write # post inline review comments
+  checks: write # create/update the Lien check run
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlien/lien-review@v1
+        with:
+          # Preferred LLM provider — cheaper Gemini path. Add OPENROUTER_API_KEY
+          # under Settings → Secrets and variables → Actions.
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Or use Anthropic instead (omit openrouter-api-key above):
+          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          #
+          # Optional tuning (defaults shown):
+          # threshold: '15'
+          # review-types: 'complexity,bugs,summary'  # also: architectural
+          # block-on-new-errors: 'false'
+          # fail-on: 'error'                         # also: any, never
+
+# ─── Fork PRs (pull_request_target variant) ──────────────────────────────────
+#
+# On a `pull_request` from a FORK, the built-in GITHUB_TOKEN is read-only, so
+# Lien can review the code but cannot post the check run / comments (it emits a
+# warning instead). To review fork PRs with full output, use a SEPARATE workflow
+# file on the `pull_request_target` event, which runs in the base repo's context
+# and gets a writable token.
+#
+# SECURITY: Lien is safe under pull_request_target because it only clones-by-SHA
+# and PARSES code — it never executes it (no npm install, no build, no scripts).
+# To preserve that guarantee, do NOT add an actions/checkout of the PR head ref,
+# and keep this workflow minimal. See the action README "Fork PRs" section.
+#
+# name: Lien Review (forks)
+#
+# on:
+#   pull_request_target:
+#
+# permissions:
+#   contents: read
+#   pull-requests: write
+#   checks: write
+#
+# jobs:
+#   review:
+#     runs-on: ubuntu-latest
+#     steps:
+#       # Do NOT add actions/checkout of the PR head here — Lien self-clones and
+#       # only reads/parses the code; checking out head would place untrusted
+#       # code on disk for other steps to execute.
+#       - uses: getlien/lien-review@v1
+#         with:
+#           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@liendev/action",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Self-contained GitHub Action for Lien Review — review a PR and post findings, no server required",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsup",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@liendev/parser": "*",
+    "@liendev/review": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.3.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/action/src/context.ts
+++ b/packages/action/src/context.ts
@@ -1,0 +1,109 @@
+/**
+ * Build the {@link ReviewCoreContext} inputs from the GitHub Actions
+ * environment: the `pull_request` event payload (`$GITHUB_EVENT_PATH`) plus the
+ * `GITHUB_REPOSITORY` env var.
+ *
+ * The critical mapping is `headSha` — it MUST come from
+ * `event.pull_request.head.sha`, NOT `GITHUB_SHA` (which on `pull_request` is
+ * the ephemeral merge commit, not the PR head). We also surface the head repo's
+ * `full_name` and `fork` flag for fork-aware cloning and the fork write guard.
+ */
+
+import { readFile } from 'node:fs/promises';
+
+import type { PRContext } from '@liendev/review';
+
+/** The slice of the GitHub `pull_request` event payload we consume. */
+export interface PullRequestEvent {
+  pull_request: {
+    number: number;
+    title: string;
+    body?: string | null;
+    head: {
+      sha: string;
+      ref: string;
+      repo?: {
+        full_name?: string;
+        fork?: boolean;
+      } | null;
+    };
+    base: {
+      sha: string;
+      ref: string;
+    };
+  };
+}
+
+export interface ActionContext {
+  pr: PRContext;
+  /** event.pull_request.head.repo.full_name (fork-aware), else GITHUB_REPOSITORY. */
+  headRepoFullName: string;
+  /** GITHUB_REPOSITORY — the repo the workflow runs in. */
+  baseRepoFullName: string;
+  headRef: string;
+  baseRef: string;
+  /** True when the PR head lives in a forked repo (write-token limitation applies). */
+  isFork: boolean;
+}
+
+/**
+ * Pure mapping from a parsed event payload + the `GITHUB_REPOSITORY` string to
+ * an {@link ActionContext}. Kept side-effect-free so it can be unit-tested
+ * against a saved `event.json` fixture.
+ */
+export function buildContextFromEvent(
+  event: PullRequestEvent,
+  githubRepository: string,
+): ActionContext {
+  const [owner, repo] = githubRepository.split('/');
+  if (!owner || !repo) {
+    throw new Error(`GITHUB_REPOSITORY must be "owner/repo", got "${githubRepository}"`);
+  }
+
+  const prEvent = event.pull_request;
+  if (!prEvent) {
+    throw new Error('Event payload has no pull_request — this action runs on pull_request events');
+  }
+
+  const headRepoFullName = prEvent.head.repo?.full_name || githubRepository;
+  const isFork = prEvent.head.repo?.fork === true;
+
+  const pr: PRContext = {
+    owner,
+    repo,
+    pullNumber: prEvent.number,
+    title: prEvent.title,
+    body: prEvent.body ?? undefined,
+    baseSha: prEvent.base.sha,
+    // NOTE: head SHA from the event, NOT GITHUB_SHA (the merge commit).
+    headSha: prEvent.head.sha,
+  };
+
+  return {
+    pr,
+    headRepoFullName,
+    baseRepoFullName: githubRepository,
+    headRef: prEvent.head.ref,
+    baseRef: prEvent.base.ref,
+    isFork,
+  };
+}
+
+/**
+ * Read `$GITHUB_EVENT_PATH` + `$GITHUB_REPOSITORY` from the environment and
+ * build the {@link ActionContext}.
+ */
+export async function loadContext(): Promise<ActionContext> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    throw new Error('GITHUB_EVENT_PATH is not set — this action must run inside GitHub Actions');
+  }
+  const githubRepository = process.env.GITHUB_REPOSITORY;
+  if (!githubRepository) {
+    throw new Error('GITHUB_REPOSITORY is not set');
+  }
+
+  const raw = await readFile(eventPath, 'utf8');
+  const event = JSON.parse(raw) as PullRequestEvent;
+  return buildContextFromEvent(event, githubRepository);
+}

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Lien Review GitHub Action entrypoint.
+ *
+ * Flow: inputs → context → octokit → reviewPullRequest → step summary +
+ * outputs → exit code per `fail-on`. Reviews same-repo PRs out of the box; on
+ * fork PRs the built-in `GITHUB_TOKEN` is read-only, so the review core can't
+ * post its check run or comments. It reports that via `writeForbidden`, and we
+ * surface a single `::warning::` with the `pull_request_target` remedy (still
+ * writing outputs and exiting 0) rather than failing the consumer's CI on a
+ * config limitation.
+ */
+
+import { argv } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createOctokit,
+  type ReviewCoreContext,
+  type ReviewCoreResult,
+  reviewPullRequest,
+} from '@liendev/review';
+
+import { readInputs, type FailOn } from './inputs.js';
+import { loadContext } from './context.js';
+import { writeStepSummary, writeOutputs, countErrors } from './summary.js';
+import { actionLogger, group, endGroup } from './logger.js';
+
+function emitForkWarning(): void {
+  actionLogger.warning(
+    'This PR comes from a fork, so the built-in GITHUB_TOKEN is read-only and Lien ' +
+      'could not post the check run or comments. To review fork PRs, run Lien on the ' +
+      'pull_request_target event instead (it is safe — Lien only clones and parses ' +
+      'code, never executes it). See the action README for the pull_request_target ' +
+      'workflow example.',
+  );
+}
+
+/** Map the review conclusion to a process exit code per the `fail-on` policy. */
+function exitCodeFor(
+  failOn: FailOn,
+  conclusion: 'success' | 'failure' | 'neutral',
+  errorCount: number,
+  warningCount: number,
+): number {
+  if (failOn === 'never') return 0;
+  if (failOn === 'any') return errorCount + warningCount > 0 ? 1 : 0;
+  // failOn === 'error'
+  return conclusion === 'failure' ? 1 : 0;
+}
+
+/**
+ * Finalize a completed review: write the step summary + outputs, and decide the
+ * process exit code. On a fork PR where the read-only token blocked all writes
+ * (`writeForbidden`), emit exactly one fork warning and force a clean exit
+ * (the missing PR output is a token limitation, not a CI failure). Returns the
+ * exit code so the entrypoint and tests can assert it without reading
+ * `process.exitCode`.
+ */
+export async function finishRun(
+  result: ReviewCoreResult,
+  isFork: boolean,
+  failOn: FailOn,
+): Promise<number> {
+  const errorCount = countErrors(result.findings);
+
+  await writeStepSummary(result);
+  await writeOutputs({
+    conclusion: result.conclusion,
+    findingsCount: result.findings.length,
+    errorCount,
+  });
+
+  if (isFork && result.writeForbidden) {
+    emitForkWarning();
+    return 0;
+  }
+
+  const warningCount = result.findings.filter(f => f.severity === 'warning').length;
+  actionLogger.info(
+    `Review complete: ${result.findings.length} findings (${errorCount} errors), ` +
+      `conclusion=${result.conclusion}, files=${result.filesAnalyzed}`,
+  );
+  return exitCodeFor(failOn, result.conclusion, errorCount, warningCount);
+}
+
+async function main(): Promise<void> {
+  const inputs = readInputs();
+  const context = await loadContext();
+
+  const octokit = createOctokit(inputs.githubToken);
+
+  const ctx: ReviewCoreContext = {
+    octokit,
+    pr: context.pr,
+    headRepoFullName: context.headRepoFullName,
+    baseRepoFullName: context.baseRepoFullName,
+    token: inputs.githubToken,
+    config: {
+      threshold: inputs.threshold,
+      blockOnNewErrors: inputs.blockOnNewErrors,
+      reviewTypes: {
+        complexity: inputs.reviewTypes.complexity,
+        summary: inputs.reviewTypes.summary,
+        architectural: inputs.reviewTypes.architectural,
+        bugs: inputs.reviewTypes.bugs,
+      },
+    },
+    llm: inputs.llm,
+    logger: actionLogger,
+  };
+
+  group('Lien Review');
+  let result;
+  try {
+    result = await reviewPullRequest(ctx);
+  } finally {
+    endGroup();
+  }
+
+  process.exitCode = await finishRun(result, context.isFork, inputs.failOn);
+}
+
+/** True when this module is the process entrypoint (not imported by a test). */
+function isEntrypoint(): boolean {
+  const entry = argv[1];
+  if (!entry) return false;
+  return fileURLToPath(import.meta.url) === entry;
+}
+
+if (isEntrypoint()) {
+  main().catch(error => {
+    actionLogger.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -64,20 +64,46 @@ function parseFailOn(raw: string): FailOn {
 }
 
 /**
+ * Parse the `threshold` input. Must be a positive integer (it is consumed as
+ * `parseInt(threshold, 10)` downstream); a non-numeric value like "high" would
+ * otherwise silently degrade into NaN and produce misleading complexity output.
+ */
+function parseThreshold(raw: string): string {
+  const value = raw === '' ? '15' : raw;
+  if (!/^\d+$/.test(value) || parseInt(value, 10) <= 0) {
+    throw new Error(`Invalid threshold value "${raw}" — expected a positive integer`);
+  }
+  return value;
+}
+
+const VALID_REVIEW_TYPES = ['complexity', 'bugs', 'summary', 'architectural'] as const;
+type ReviewTypeName = (typeof VALID_REVIEW_TYPES)[number];
+
+/**
  * Parse the `review-types` input — a comma-separated list of the review types
  * to enable (complexity, bugs, summary, architectural). When unset we use
  * sensible defaults: complexity + bugs + summary on, architectural off.
+ *
+ * Rejects unknown or empty values rather than silently dropping them: a typo
+ * like `summmary` or a stray `,` would otherwise leave every flag false, so the
+ * review would register no plugins and report success having checked nothing.
  */
 function parseReviewTypes(raw: string): ReviewTypes {
   if (raw === '') {
     return { complexity: true, bugs: true, summary: true, architectural: false };
   }
-  const enabled = new Set(
-    raw
-      .split(',')
-      .map(s => s.trim().toLowerCase())
-      .filter(Boolean),
-  );
+  const tokens = raw
+    .split(',')
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
+  const unknown = tokens.filter(t => !VALID_REVIEW_TYPES.includes(t as ReviewTypeName));
+  if (tokens.length === 0 || unknown.length > 0) {
+    const detail = unknown.length > 0 ? `unknown type(s): ${unknown.join(', ')}` : 'no valid types';
+    throw new Error(
+      `Invalid review-types value "${raw}" (${detail}) — expected a comma-separated list of: ${VALID_REVIEW_TYPES.join(', ')}`,
+    );
+  }
+  const enabled = new Set(tokens);
   return {
     complexity: enabled.has('complexity'),
     bugs: enabled.has('bugs'),
@@ -120,7 +146,7 @@ export function readInputs(): ActionInputs {
     throw new Error('github-token input is required (defaults to ${{ github.token }})');
   }
 
-  const threshold = readInput('threshold') || '15';
+  const threshold = parseThreshold(readInput('threshold'));
   const blockOnNewErrors = readBool('block-on-new-errors', false);
   const failOn = parseFailOn(readInput('fail-on'));
   const reviewTypes = parseReviewTypes(readInput('review-types'));

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -1,0 +1,130 @@
+/**
+ * Action input parsing.
+ *
+ * Reads and validates the `INPUT_*` environment variables GitHub injects from
+ * the workflow `with:` block, and resolves the LLM provider from the supplied
+ * API keys. OpenRouter wins if present (cheaper Gemini path), Anthropic is the
+ * fallback, and absent both we run complexity-only (`llm === null`).
+ */
+
+import type { ReviewLLMConfig } from '@liendev/review';
+
+/** OpenRouter cost per million tokens (matches the retired runner's numbers). */
+const OPENROUTER_INPUT_COST_PER_MTOK = 0.5;
+const OPENROUTER_OUTPUT_COST_PER_MTOK = 3;
+/** Anthropic cost per million tokens (claude-sonnet-4-6). */
+const ANTHROPIC_INPUT_COST_PER_MTOK = 3;
+const ANTHROPIC_OUTPUT_COST_PER_MTOK = 15;
+
+const OPENROUTER_MODEL = 'google/gemini-3-flash-preview';
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
+
+export type FailOn = 'error' | 'never' | 'any';
+
+export interface ReviewTypes {
+  complexity: boolean;
+  bugs: boolean;
+  summary: boolean;
+  architectural: boolean;
+}
+
+export interface ActionInputs {
+  githubToken: string;
+  threshold: string;
+  blockOnNewErrors: boolean;
+  failOn: FailOn;
+  reviewTypes: ReviewTypes;
+  llm: ReviewLLMConfig;
+}
+
+/**
+ * Read an action input. GitHub exposes `with: foo-bar` as `INPUT_FOO-BAR`
+ * (uppercased, spaces → `_`), but some runners also expose `INPUT_FOO_BAR`.
+ * Try the hyphen form first, then the underscore form.
+ */
+function readInput(name: string): string {
+  const upper = name.toUpperCase();
+  const hyphen = process.env[`INPUT_${upper}`];
+  if (hyphen !== undefined) return hyphen.trim();
+  const underscore = process.env[`INPUT_${upper.replace(/-/g, '_')}`];
+  return underscore !== undefined ? underscore.trim() : '';
+}
+
+function readBool(name: string, fallback: boolean): boolean {
+  const raw = readInput(name).toLowerCase();
+  if (raw === '') return fallback;
+  return raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+function parseFailOn(raw: string): FailOn {
+  if (raw === 'never' || raw === 'any' || raw === 'error') return raw;
+  if (raw === '') return 'error';
+  throw new Error(`Invalid fail-on value "${raw}" — expected one of: error, never, any`);
+}
+
+/**
+ * Parse the `review-types` input — a comma-separated list of the review types
+ * to enable (complexity, bugs, summary, architectural). When unset we use
+ * sensible defaults: complexity + bugs + summary on, architectural off.
+ */
+function parseReviewTypes(raw: string): ReviewTypes {
+  if (raw === '') {
+    return { complexity: true, bugs: true, summary: true, architectural: false };
+  }
+  const enabled = new Set(
+    raw
+      .split(',')
+      .map(s => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  return {
+    complexity: enabled.has('complexity'),
+    bugs: enabled.has('bugs'),
+    summary: enabled.has('summary'),
+    architectural: enabled.has('architectural'),
+  };
+}
+
+/**
+ * Resolve the LLM provider from the supplied keys. OpenRouter takes precedence
+ * (cheaper Gemini path); Anthropic is the fallback; absent both, `null` means
+ * complexity-only review with no agent.
+ */
+function resolveLLM(openrouterKey: string, anthropicKey: string): ReviewLLMConfig {
+  if (openrouterKey) {
+    return {
+      provider: 'openai',
+      apiKey: openrouterKey,
+      model: OPENROUTER_MODEL,
+      baseUrl: OPENROUTER_BASE_URL,
+      inputCostPerMTok: OPENROUTER_INPUT_COST_PER_MTOK,
+      outputCostPerMTok: OPENROUTER_OUTPUT_COST_PER_MTOK,
+    };
+  }
+  if (anthropicKey) {
+    return {
+      provider: 'anthropic',
+      apiKey: anthropicKey,
+      model: ANTHROPIC_MODEL,
+      inputCostPerMTok: ANTHROPIC_INPUT_COST_PER_MTOK,
+      outputCostPerMTok: ANTHROPIC_OUTPUT_COST_PER_MTOK,
+    };
+  }
+  return null;
+}
+
+export function readInputs(): ActionInputs {
+  const githubToken = readInput('github-token');
+  if (!githubToken) {
+    throw new Error('github-token input is required (defaults to ${{ github.token }})');
+  }
+
+  const threshold = readInput('threshold') || '15';
+  const blockOnNewErrors = readBool('block-on-new-errors', false);
+  const failOn = parseFailOn(readInput('fail-on'));
+  const reviewTypes = parseReviewTypes(readInput('review-types'));
+  const llm = resolveLLM(readInput('openrouter-api-key'), readInput('anthropic-api-key'));
+
+  return { githubToken, threshold, blockOnNewErrors, failOn, reviewTypes, llm };
+}

--- a/packages/action/src/logger.ts
+++ b/packages/action/src/logger.ts
@@ -1,0 +1,44 @@
+/**
+ * GitHub Actions logger.
+ *
+ * Implements the {@link Logger} interface that `@liendev/review` expects,
+ * writing to stdout using GitHub workflow commands so messages render with the
+ * right severity in the Actions log:
+ * - `::error::` / `::warning::` annotate the run for error/warning levels
+ * - `info`/`debug` print plainly (debug is gated behind `RUNNER_DEBUG`)
+ * - {@link group} / {@link endGroup} wrap collapsible sections
+ *
+ * Writes via `process.stdout` (not `console`) because workflow commands are a
+ * stdout protocol — `::error::` is a log directive, not an actual stderr error.
+ * See https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions
+ */
+
+import type { Logger } from '@liendev/review';
+
+/** Escape a workflow-command message so `::`, newlines etc. don't break parsing. */
+function escapeData(value: string): string {
+  return value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function emit(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+export const actionLogger: Logger = {
+  info: (message: string) => emit(message),
+  warning: (message: string) => emit(`::warning::${escapeData(message)}`),
+  error: (message: string) => emit(`::error::${escapeData(message)}`),
+  debug: (message: string) => {
+    if (process.env.RUNNER_DEBUG === '1') emit(`::debug::${escapeData(message)}`);
+  },
+};
+
+/** Open a collapsible group in the Actions log. */
+export function group(title: string): void {
+  emit(`::group::${escapeData(title)}`);
+}
+
+/** Close the current collapsible group. */
+export function endGroup(): void {
+  emit('::endgroup::');
+}

--- a/packages/action/src/summary.ts
+++ b/packages/action/src/summary.ts
@@ -1,0 +1,71 @@
+/**
+ * Write GitHub Actions outputs and the job step summary.
+ *
+ * - {@link writeStepSummary} appends the review's markdown (plus a findings count
+ *   and a token/cost line) to the file named by `$GITHUB_STEP_SUMMARY`.
+ * - {@link writeOutputs} writes the action outputs (conclusion, findings-count,
+ *   error-count) to `$GITHUB_OUTPUT` in the `name=value` / heredoc format.
+ *
+ * See https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+ */
+
+import { appendFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+
+import type { ReviewCoreResult, ReviewFinding } from '@liendev/review';
+
+export interface ActionOutputs {
+  conclusion: ReviewCoreResult['conclusion'];
+  findingsCount: number;
+  errorCount: number;
+}
+
+/** Count findings whose severity marks them as errors. */
+export function countErrors(findings: ReviewFinding[]): number {
+  return findings.filter(f => f.severity === 'error').length;
+}
+
+/**
+ * Append the review summary to `$GITHUB_STEP_SUMMARY`. No-op when the env var is
+ * unset (e.g. running outside Actions) so local invocations don't crash.
+ */
+export async function writeStepSummary(result: ReviewCoreResult): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const errorCount = countErrors(result.findings);
+  const tokens = result.usage.totalTokens.toLocaleString('en-US');
+  const cost = result.usage.cost.toFixed(4);
+
+  const body = [
+    result.summaryMarkdown,
+    '',
+    `**Findings:** ${result.findings.length} (${errorCount} error${errorCount === 1 ? '' : 's'})`,
+    `**Tokens:** ${tokens} · **Cost:** $${cost}`,
+    '',
+  ].join('\n');
+
+  await appendFile(summaryPath, body, 'utf8');
+}
+
+/** Format one `$GITHUB_OUTPUT` entry using the heredoc form (safe for any value). */
+function formatOutput(name: string, value: string): string {
+  const delimiter = `ghadelimiter_${randomUUID()}`;
+  return `${name}<<${delimiter}\n${value}\n${delimiter}\n`;
+}
+
+/**
+ * Write action outputs to `$GITHUB_OUTPUT`. No-op when the env var is unset.
+ */
+export async function writeOutputs(outputs: ActionOutputs): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+
+  const body = [
+    formatOutput('conclusion', outputs.conclusion),
+    formatOutput('findings-count', String(outputs.findingsCount)),
+    formatOutput('error-count', String(outputs.errorCount)),
+  ].join('');
+
+  await appendFile(outputPath, body, 'utf8');
+}

--- a/packages/action/test/context.test.ts
+++ b/packages/action/test/context.test.ts
@@ -1,0 +1,76 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import { buildContextFromEvent, type PullRequestEvent } from '../src/context.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function loadFixture(): Promise<PullRequestEvent> {
+  const raw = await readFile(join(__dirname, 'fixtures', 'event.json'), 'utf8');
+  return JSON.parse(raw) as PullRequestEvent;
+}
+
+describe('buildContextFromEvent', () => {
+  it('maps owner/repo from GITHUB_REPOSITORY', async () => {
+    const event = await loadFixture();
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    expect(ctx.pr.owner).toBe('getlien');
+    expect(ctx.pr.repo).toBe('lien');
+    expect(ctx.baseRepoFullName).toBe('getlien/lien');
+  });
+
+  it('uses head SHA from the event, NOT the merge commit', async () => {
+    const event = await loadFixture();
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    // The critical correctness point: headSha is event.pull_request.head.sha.
+    expect(ctx.pr.headSha).toBe(event.pull_request.head.sha);
+    expect(ctx.pr.headSha).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(ctx.pr.baseSha).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+  });
+
+  it('maps PR number, title, and body', async () => {
+    const event = await loadFixture();
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    expect(ctx.pr.pullNumber).toBe(42);
+    expect(ctx.pr.title).toBe('Add caching layer to the indexer');
+    expect(ctx.pr.body).toContain('LRU cache');
+  });
+
+  it('maps head/base refs', async () => {
+    const event = await loadFixture();
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    expect(ctx.headRef).toBe('feature/cache');
+    expect(ctx.baseRef).toBe('main');
+  });
+
+  it('derives fork head-repo from event.pull_request.head.repo.full_name', async () => {
+    const event = await loadFixture();
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    // Fork PR: head repo differs from base repo, and the fork flag is surfaced.
+    expect(ctx.headRepoFullName).toBe('octocat/lien-fork');
+    expect(ctx.isFork).toBe(true);
+  });
+
+  it('falls back to GITHUB_REPOSITORY when head.repo is absent (same-repo PR)', async () => {
+    const event = await loadFixture();
+    event.pull_request.head.repo = null;
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    expect(ctx.headRepoFullName).toBe('getlien/lien');
+    expect(ctx.isFork).toBe(false);
+  });
+
+  it('maps null body to undefined', async () => {
+    const event = await loadFixture();
+    event.pull_request.body = null;
+    const ctx = buildContextFromEvent(event, 'getlien/lien');
+    expect(ctx.pr.body).toBeUndefined();
+  });
+
+  it('throws on a malformed GITHUB_REPOSITORY', async () => {
+    const event = await loadFixture();
+    expect(() => buildContextFromEvent(event, 'no-slash')).toThrow(/owner\/repo/);
+  });
+});

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { ReviewCoreResult } from '@liendev/review';
+
+import { finishRun } from '../src/index.js';
+import { actionLogger } from '../src/logger.js';
+
+function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
+  return {
+    findings: [],
+    conclusion: 'success',
+    summaryMarkdown: 'All good.',
+    filesAnalyzed: 3,
+    usage: { totalTokens: 0, cost: 0 },
+    writeForbidden: false,
+    ...overrides,
+  };
+}
+
+describe('finishRun fork handling', () => {
+  beforeEach(() => {
+    // Keep summary/output writes as no-ops (env vars unset) and silence stdout.
+    delete process.env.GITHUB_STEP_SUMMARY;
+    delete process.env.GITHUB_OUTPUT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits exactly one fork warning when a fork PR had writes forbidden', async () => {
+    const warning = vi.spyOn(actionLogger, 'warning').mockImplementation(() => {});
+    const result = makeResult({ writeForbidden: true });
+
+    const exitCode = await finishRun(result, /* isFork */ true, 'error');
+
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(warning.mock.calls[0][0]).toContain('pull_request_target');
+    // A token limitation is not a CI failure.
+    expect(exitCode).toBe(0);
+  });
+
+  it('does not warn on a same-repo PR even if a write 403 leaked through', async () => {
+    const warning = vi.spyOn(actionLogger, 'warning').mockImplementation(() => {});
+    const result = makeResult({ writeForbidden: true });
+
+    await finishRun(result, /* isFork */ false, 'error');
+
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it('does not warn on a fork PR when writes succeeded', async () => {
+    const warning = vi.spyOn(actionLogger, 'warning').mockImplementation(() => {});
+    const result = makeResult({ writeForbidden: false });
+
+    await finishRun(result, /* isFork */ true, 'error');
+
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it('maps a failure conclusion to exit 1 under fail-on=error', async () => {
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    const result = makeResult({ conclusion: 'failure' });
+
+    const exitCode = await finishRun(result, false, 'error');
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('forces exit 0 on a forbidden fork PR regardless of fail-on=any', async () => {
+    vi.spyOn(actionLogger, 'warning').mockImplementation(() => {});
+    const result = makeResult({
+      writeForbidden: true,
+      findings: [{ severity: 'error' } as ReviewCoreResult['findings'][number]],
+    });
+
+    const exitCode = await finishRun(result, true, 'any');
+
+    expect(exitCode).toBe(0);
+  });
+});

--- a/packages/action/test/fixtures/event.json
+++ b/packages/action/test/fixtures/event.json
@@ -1,0 +1,21 @@
+{
+  "action": "synchronize",
+  "number": 42,
+  "pull_request": {
+    "number": 42,
+    "title": "Add caching layer to the indexer",
+    "body": "This PR introduces an LRU cache.\n\nFixes #10.",
+    "head": {
+      "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "ref": "feature/cache",
+      "repo": {
+        "full_name": "octocat/lien-fork",
+        "fork": true
+      }
+    },
+    "base": {
+      "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "ref": "main"
+    }
+  }
+}

--- a/packages/action/test/inputs.test.ts
+++ b/packages/action/test/inputs.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { readInputs } from '../src/inputs.js';
+
+// readInputs() reads INPUT_* from process.env (the way GitHub injects `with:`).
+// Snapshot and clear those keys around each test so cases don't leak into each other.
+const INPUT_KEYS = [
+  'INPUT_GITHUB-TOKEN',
+  'INPUT_THRESHOLD',
+  'INPUT_REVIEW-TYPES',
+  'INPUT_FAIL-ON',
+  'INPUT_BLOCK-ON-NEW-ERRORS',
+  'INPUT_OPENROUTER-API-KEY',
+  'INPUT_ANTHROPIC-API-KEY',
+];
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const k of INPUT_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  // A token is always required; default it so individual tests can focus elsewhere.
+  process.env['INPUT_GITHUB-TOKEN'] = 'ghs_token';
+});
+
+afterEach(() => {
+  for (const k of INPUT_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('readInputs — defaults', () => {
+  it('applies sensible defaults when only the token is set', () => {
+    const inputs = readInputs();
+    expect(inputs.threshold).toBe('15');
+    expect(inputs.failOn).toBe('error');
+    expect(inputs.blockOnNewErrors).toBe(false);
+    expect(inputs.reviewTypes).toEqual({
+      complexity: true,
+      bugs: true,
+      summary: true,
+      architectural: false,
+    });
+    expect(inputs.llm).toBeNull();
+  });
+
+  it('requires a github-token', () => {
+    delete process.env['INPUT_GITHUB-TOKEN'];
+    expect(() => readInputs()).toThrow(/github-token/);
+  });
+});
+
+describe('readInputs — threshold validation (#2)', () => {
+  it('accepts a positive integer', () => {
+    process.env['INPUT_THRESHOLD'] = '25';
+    expect(readInputs().threshold).toBe('25');
+  });
+
+  it('rejects a non-numeric threshold', () => {
+    process.env['INPUT_THRESHOLD'] = 'high';
+    expect(() => readInputs()).toThrow(/threshold/);
+  });
+
+  it('rejects zero and negative thresholds', () => {
+    process.env['INPUT_THRESHOLD'] = '0';
+    expect(() => readInputs()).toThrow(/threshold/);
+    process.env['INPUT_THRESHOLD'] = '-5';
+    expect(() => readInputs()).toThrow(/threshold/);
+  });
+});
+
+describe('readInputs — review-types validation (#1)', () => {
+  it('parses a valid subset', () => {
+    process.env['INPUT_REVIEW-TYPES'] = 'complexity, summary';
+    expect(readInputs().reviewTypes).toEqual({
+      complexity: true,
+      bugs: false,
+      summary: true,
+      architectural: false,
+    });
+  });
+
+  it('rejects an unknown type (e.g. a typo) instead of silently running nothing', () => {
+    process.env['INPUT_REVIEW-TYPES'] = 'summmary';
+    expect(() => readInputs()).toThrow(/review-types/);
+  });
+
+  it('rejects an effectively-empty value', () => {
+    process.env['INPUT_REVIEW-TYPES'] = ',';
+    expect(() => readInputs()).toThrow(/review-types/);
+  });
+});
+
+describe('readInputs — LLM resolution', () => {
+  it('prefers OpenRouter when its key is present', () => {
+    process.env['INPUT_OPENROUTER-API-KEY'] = 'or_key';
+    const llm = readInputs().llm;
+    expect(llm?.provider).toBe('openai');
+    expect(llm && 'baseUrl' in llm ? llm.baseUrl : '').toContain('openrouter.ai');
+  });
+
+  it('falls back to Anthropic when only its key is present', () => {
+    process.env['INPUT_ANTHROPIC-API-KEY'] = 'sk_key';
+    expect(readInputs().llm?.provider).toBe('anthropic');
+  });
+});

--- a/packages/action/tsconfig.json
+++ b/packages/action/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/action/tsup.config.ts
+++ b/packages/action/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'es2022',
+  outDir: 'dist',
+  clean: true,
+  sourcemap: true,
+});

--- a/packages/action/vitest.config.ts
+++ b/packages/action/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/review/src/clone.ts
+++ b/packages/review/src/clone.ts
@@ -1,7 +1,7 @@
 /**
- * Hardened shallow clone for review runner.
+ * Hardened shallow clone for review.
  *
- * Key differences from packages/app/src/clone.ts:
+ * Hardening:
  * - GIT_TERMINAL_PROMPT=0 to prevent token leakage
  * - transfer.fsckObjects=true for git bomb protection
  * - Post-clone symlink check via fs.realpath()
@@ -15,8 +15,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
-import type { Logger } from '@liendev/review';
-import { assertValidRepoName } from './validate.js';
+import type { Logger } from './logger.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -26,6 +25,17 @@ const GIT_ENV = {
 };
 
 const GIT_TIMEOUT = 120_000;
+
+// GitHub: owner is alphanumeric + hyphens (no start/end hyphen),
+// repo is alphanumeric + hyphens + underscores + periods (no leading period)
+const REPO_NAME_PATTERN =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\/[A-Za-z0-9_-][A-Za-z0-9._-]*$/;
+
+export function assertValidRepoName(fullName: string): void {
+  if (!REPO_NAME_PATTERN.test(fullName)) {
+    throw new Error(`Invalid repository name: ${JSON.stringify(fullName.slice(0, 100))}`);
+  }
+}
 
 export interface CloneResult {
   dir: string;
@@ -62,7 +72,7 @@ export async function cloneBySha(
   logger: Logger,
 ): Promise<CloneResult> {
   assertValidRepoName(repoFullName);
-  const dir = await mkdtemp(join(tmpdir(), 'lien-runner-'));
+  const dir = await mkdtemp(join(tmpdir(), 'lien-review-'));
   const cloneUrl = `https://x-access-token:${token}@github.com/${repoFullName}.git`;
 
   logger.info(`Cloning ${repoFullName}@${sha.slice(0, 7)} (by SHA) into ${dir}`);
@@ -108,7 +118,7 @@ export async function cloneByBranch(
   logger: Logger,
 ): Promise<CloneResult> {
   assertValidRepoName(repoFullName);
-  const dir = await mkdtemp(join(tmpdir(), 'lien-runner-'));
+  const dir = await mkdtemp(join(tmpdir(), 'lien-review-'));
   const cloneUrl = `https://x-access-token:${token}@github.com/${repoFullName}.git`;
 
   logger.info(`Cloning ${repoFullName}@${branch} (by branch) into ${dir}`);

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -166,7 +166,7 @@ export class ReviewEngine {
     findings: ReviewFinding[],
     adapterContext: AdapterContext,
     opts?: { pluginFilter?: string; checkRunId?: number; skipCheckRun?: boolean },
-  ): Promise<void> {
+  ): Promise<{ conclusion: 'success' | 'failure' | 'neutral'; summary: string }> {
     const octokit = adapterContext.octokit as Octokit | undefined;
     const pr = adapterContext.pr;
     const pendingAnnotations: CheckAnnotation[] = [];
@@ -199,7 +199,7 @@ export class ReviewEngine {
     await finalizeDescription(descriptionParts, octokit, pr, adapterContext.logger);
 
     if (octokit && pr && checkRunId != null) {
-      await finalizePresentation(
+      return await finalizePresentation(
         octokit,
         pr,
         checkRunId,
@@ -210,6 +210,14 @@ export class ReviewEngine {
         adapterContext.logger,
       );
     }
+
+    // No check run was finalized (no octokit/pr/checkRunId), but callers still
+    // want the conclusion + summary for step summaries and exit codes.
+    const ordered = reorderSections(summarySections);
+    return {
+      conclusion: determineConclusion(findings),
+      summary: ordered.length > 0 ? ordered.join('\n\n') : buildCheckSummary(findings),
+    };
   }
 }
 
@@ -462,7 +470,7 @@ async function finalizePresentation(
   pendingAnnotations: CheckAnnotation[],
   debugLog: string[],
   logger: Logger,
-): Promise<void> {
+): Promise<{ conclusion: 'success' | 'failure' | 'neutral'; summary: string }> {
   const conclusion = determineConclusion(findings);
   const title = buildCheckTitle(findings);
   const ordered = reorderSections(summarySections);
@@ -483,6 +491,7 @@ async function finalizePresentation(
   ).catch(err =>
     logger.warning(`Failed to finalize check run: ${err instanceof Error ? err.message : err}`),
   );
+  return { conclusion, summary };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -166,3 +166,23 @@ export { formatTime, formatDeltaValue } from './format.js';
 // ─── Git utilities ──────────────────────────────────────────────────────────
 
 export { assertValidSha } from './git-utils.js';
+
+// ─── Clone ──────────────────────────────────────────────────────────────────
+
+export {
+  type CloneResult,
+  assertValidRepoName,
+  cloneBySha,
+  cloneByBranch,
+  resolveHeadSha,
+  resolveCommitTimestamp,
+} from './clone.js';
+
+// ─── Review core ────────────────────────────────────────────────────────────
+
+export {
+  type ReviewCoreContext,
+  type ReviewCoreResult,
+  type ReviewLLMConfig,
+  reviewPullRequest,
+} from './review-pr.js';

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -1,0 +1,609 @@
+/**
+ * Transport-agnostic PR review core.
+ *
+ * `reviewPullRequest` clones the head (and optionally base) of a pull request,
+ * runs complexity + agent review via {@link ReviewEngine}, posts a check run and
+ * inline comments to GitHub, and returns a structured result. It carries no
+ * platform/Laravel/NATS concerns — provider selection comes from `ctx.llm` and
+ * all output goes straight to GitHub via octokit.
+ *
+ * Flow: clone head → analyze → clone base → deltas → engine.run → engine.present.
+ */
+
+import type {
+  Octokit,
+  PRContext,
+  Logger,
+  ReviewFinding,
+  ComplexityReport,
+  ComplexityDelta,
+  AdapterContext,
+} from './index.js';
+import {
+  createCheckRun,
+  updateCheckRun,
+  runComplexityAnalysis,
+  filterAnalyzableFiles,
+  enrichWithTestAssociations,
+  getPRChangedFiles,
+  getPRPatchData,
+  calculateDeltas,
+  calculateDeltaSummary,
+  ReviewEngine,
+  ComplexityPlugin,
+  AgentReviewPlugin,
+} from './index.js';
+import type { CodeChunk } from '@liendev/parser';
+import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
+
+import { cloneBySha, type CloneResult } from './clone.js';
+
+/**
+ * LLM provider selection for the agent-review plugin. Either an OpenAI-compatible
+ * provider (e.g. OpenRouter) with an explicit base URL, an Anthropic provider, or
+ * `null` to skip agent review entirely (complexity-only).
+ */
+export type ReviewLLMConfig =
+  | {
+      provider: 'openai';
+      apiKey: string;
+      model: string;
+      baseUrl: string;
+      inputCostPerMTok: number;
+      outputCostPerMTok: number;
+    }
+  | {
+      provider: 'anthropic';
+      apiKey: string;
+      model: string;
+      inputCostPerMTok: number;
+      outputCostPerMTok: number;
+    }
+  | null;
+
+export interface ReviewCoreContext {
+  octokit: Octokit;
+  pr: PRContext;
+  /** event.pull_request.head.repo.full_name (fork-aware) — what we clone the head from. */
+  headRepoFullName: string;
+  /** GITHUB_REPOSITORY — what we clone the base from. */
+  baseRepoFullName: string;
+  /** GITHUB_TOKEN — used for both clone and GitHub API. */
+  token: string;
+  config: {
+    threshold: string;
+    blockOnNewErrors: boolean;
+    reviewTypes: {
+      complexity: boolean;
+      summary?: boolean;
+      architectural?: boolean;
+      bugs?: boolean;
+    };
+  };
+  llm: ReviewLLMConfig;
+  /** Pre-created check run ID. If omitted, the core creates its own. */
+  checkRunId?: number;
+  logger: Logger;
+}
+
+export interface ReviewCoreResult {
+  findings: ReviewFinding[];
+  conclusion: 'success' | 'failure' | 'neutral';
+  summaryMarkdown: string;
+  filesAnalyzed: number;
+  usage: { totalTokens: number; cost: number };
+  /**
+   * True when a GitHub write (check run or PR comment) was rejected with a 403.
+   * On a fork `pull_request`, the built-in token is read-only, so every write
+   * 403s and the findings never reach the PR. The core swallows these errors
+   * internally (so a partial-permission failure never crashes the review), but
+   * surfaces this flag so the caller can emit a single clear fork warning.
+   */
+  writeForbidden: boolean;
+}
+
+/** A GitHub write rejected because the token is read-only (HTTP 403). */
+function isWriteForbidden(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { status?: number }).status === 403;
+}
+
+export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewCoreResult> {
+  const { octokit, pr, token, logger } = ctx;
+
+  logger.info(`Processing PR #${pr.pullNumber} on ${ctx.baseRepoFullName}`);
+
+  const { checkRunId, writeForbidden } = await resolveCheckRun(ctx);
+
+  let headClone: CloneResult | null = null;
+  let baseClone: CloneResult | null = null;
+  let findings: ReviewFinding[] = [];
+  let filesAnalyzed = 0;
+  let tokenUsage = 0;
+  let cost = 0;
+
+  try {
+    // Clone head by SHA
+    headClone = await cloneBySha(ctx.headRepoFullName, pr.headSha, token, logger);
+
+    // Get changed files from GitHub API
+    const allChangedFiles = await getPRChangedFiles(octokit, pr);
+    logger.info(`Found ${allChangedFiles.length} changed files in PR`);
+
+    const filesToAnalyze = filterAnalyzableFiles(allChangedFiles);
+    logger.info(`${filesToAnalyze.length} files eligible for complexity analysis`);
+    filesAnalyzed = filesToAnalyze.length;
+
+    const summaryEnabled = !!ctx.config.reviewTypes.summary;
+    if (summaryEnabled) await tryFetchPRPatches(octokit, pr, logger);
+
+    if (filesToAnalyze.length === 0 && !summaryEnabled) {
+      logger.info('No analyzable files — running full-repo complexity scan');
+      await computeRepoComplexity(headClone.dir, ctx.config.threshold, logger);
+      const summaryMarkdown = await finalizeCheckRunNoFiles(checkRunId, octokit, pr, logger);
+      return {
+        findings: [],
+        conclusion: 'success',
+        summaryMarkdown,
+        filesAnalyzed,
+        usage: { totalTokens: 0, cost: 0 },
+        writeForbidden,
+      };
+    }
+
+    // Run complexity analysis (head+base when files analyzable, full-repo scan otherwise)
+    const analysis = await runAnalysisPhase(
+      filesToAnalyze,
+      ctx.config.threshold,
+      headClone.dir,
+      ctx.baseRepoFullName,
+      pr.baseSha,
+      token,
+      logger,
+    );
+    if (!analysis) {
+      const summaryMarkdown = 'Review failed — could not produce a complexity report.';
+      await finalizeCheckRunFailed(checkRunId, octokit, pr, summaryMarkdown, logger);
+      return {
+        findings: [],
+        conclusion: 'failure',
+        summaryMarkdown,
+        filesAnalyzed,
+        usage: { totalTokens: 0, cost: 0 },
+        writeForbidden,
+      };
+    }
+    const { currentReport, chunks, baselineReport, deltas } = analysis;
+    baseClone = analysis.baseClone;
+
+    // Setup engine with enabled plugins. The agent plugin produces bug,
+    // architectural, and summary findings from a single run, so it's gated on
+    // both an LLM being configured and at least one of those review types being
+    // enabled (the three can be turned on/off as a group, not independently).
+    const agentEnabled =
+      !!ctx.llm &&
+      (!!ctx.config.reviewTypes.bugs ||
+        !!ctx.config.reviewTypes.architectural ||
+        !!ctx.config.reviewTypes.summary);
+    const engine = new ReviewEngine();
+    if (ctx.config.reviewTypes.complexity) engine.register(new ComplexityPlugin());
+    if (agentEnabled) engine.register(new AgentReviewPlugin());
+
+    // Track agent usage separately (reported via callback since it bypasses LLMClient)
+    let agentUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 };
+
+    // Selected model — used for both the agent-review plugin config and the
+    // adapterContext below so cost/metadata reporting stays consistent.
+    const selectedModel = ctx.llm?.model;
+
+    // Run engine
+    findings = await engine.run({
+      chunks,
+      changedFiles: filesToAnalyze,
+      allChangedFiles,
+      complexityReport: currentReport,
+      baselineReport,
+      deltas,
+      pluginConfigs: {
+        complexity: {
+          threshold: parseInt(ctx.config.threshold, 10),
+          blockOnNewErrors: ctx.config.blockOnNewErrors,
+        },
+        'agent-review': ctx.llm
+          ? {
+              apiKey: ctx.llm.apiKey,
+              provider: ctx.llm.provider,
+              model: ctx.llm.model,
+              baseUrl: ctx.llm.provider === 'openai' ? ctx.llm.baseUrl : undefined,
+              inputCostPerMTok: ctx.llm.inputCostPerMTok,
+              outputCostPerMTok: ctx.llm.outputCostPerMTok,
+              ...scaleAgentBudget(filesToAnalyze.length, chunks),
+            }
+          : {},
+      },
+      config: {},
+      pr,
+      logger,
+      repoRootDir: headClone.dir,
+      reportUsage: usage => {
+        agentUsage = usage;
+      },
+    });
+    logger.info(`Engine produced ${findings.length} total findings`);
+
+    // Present via engine (posts check run + comments)
+    const adapterContext: AdapterContext = {
+      complexityReport: currentReport,
+      baselineReport,
+      deltas,
+      deltaSummary: deltas ? calculateDeltaSummary(deltas) : null,
+      pr,
+      octokit,
+      logger,
+      llmUsage: agentUsage.totalTokens > 0 ? agentUsage : undefined,
+      model: selectedModel,
+      blockOnNewErrors: ctx.config.blockOnNewErrors,
+    };
+
+    const presentation = await tryPresentFindings(
+      engine,
+      findings,
+      adapterContext,
+      checkRunId,
+      octokit,
+      pr,
+      logger,
+    );
+
+    tokenUsage = agentUsage.totalTokens;
+    cost = agentUsage.cost;
+
+    return {
+      findings,
+      conclusion: presentation.conclusion,
+      summaryMarkdown: presentation.summary,
+      filesAnalyzed,
+      usage: { totalTokens: tokenUsage, cost },
+      writeForbidden,
+    };
+  } finally {
+    if (headClone) await headClone.cleanup().catch(() => {});
+    if (baseClone) await baseClone.cleanup().catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+/**
+ * Scale agent turn count and token budget dynamically.
+ *
+ * Uses file count for turn scaling and estimated token count of the
+ * changed code for budget scaling. The diff content is included in
+ * the initial message, so the budget must accommodate it plus tool
+ * calls and the final JSON output.
+ */
+function scaleAgentBudget(
+  fileCount: number,
+  chunks: { content: string }[],
+): { maxTurns: number; maxTokenBudget: number } {
+  // Estimate tokens in the changed code (~4 chars/token)
+  const contentChars = chunks.reduce((sum, c) => sum + c.content.length, 0);
+  const estimatedContentTokens = Math.ceil(contentChars / 4);
+
+  // Budget breakdown:
+  // - System prompt: ~3K tokens (XML tags, examples, three-phase instructions)
+  // - Initial message: ~1K overhead + content tokens (diff, signatures, etc.)
+  // - Tool results: ~8K per call (get_files_context returns full chunks)
+  // - Final JSON output: ~2K
+  // - Conversation growth: each turn re-sends everything
+  const maxTurns = fileCount <= 3 ? 8 : fileCount <= 10 ? 10 : 15;
+  const toolBudget = maxTurns * 8_000;
+  const baseBudget = 4_000 + estimatedContentTokens + toolBudget + 2_000;
+
+  // Clamp: minimum 60K (small PRs still need room), maximum 200K
+  const maxTokenBudget = Math.min(Math.max(baseBudget, 60_000), 200_000);
+
+  return { maxTurns, maxTokenBudget };
+}
+
+async function tryFetchPRPatches(
+  octokit: Octokit,
+  prContext: PRContext,
+  logger: Logger,
+): Promise<void> {
+  try {
+    const patchData = await getPRPatchData(octokit, prContext);
+    prContext.patches = patchData.patches;
+    prContext.diffLines = patchData.diffLines;
+  } catch (error) {
+    logger.warning(
+      `Failed to fetch PR patch data: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function tryEnrichTestAssociations(
+  report: ComplexityReport,
+  files: string[],
+  dir: string,
+  logger: Logger,
+): Promise<void> {
+  try {
+    await enrichWithTestAssociations(report, files, dir, logger);
+  } catch (error) {
+    logger.warning(
+      `Test association enrichment failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function finalizeCheckRunNoFiles(
+  checkRunId: number | undefined,
+  octokit: Octokit,
+  prContext: PRContext,
+  logger: Logger,
+): Promise<string> {
+  const summary = 'No files eligible for complexity analysis.';
+  if (!checkRunId) return summary;
+  await updateCheckRun(
+    octokit,
+    {
+      owner: prContext.owner,
+      repo: prContext.repo,
+      checkRunId,
+      status: 'completed',
+      conclusion: 'success',
+      output: {
+        title: 'No code files changed',
+        summary,
+      },
+    },
+    logger,
+  ).catch(err => logger.warning(`Failed to finalize check run: ${err}`));
+  return summary;
+}
+
+async function finalizeCheckRunFailed(
+  checkRunId: number | undefined,
+  octokit: Octokit,
+  prContext: PRContext,
+  summary: string,
+  logger: Logger,
+): Promise<void> {
+  if (!checkRunId) return;
+  await updateCheckRun(
+    octokit,
+    {
+      owner: prContext.owner,
+      repo: prContext.repo,
+      checkRunId,
+      status: 'completed',
+      conclusion: 'failure',
+      output: {
+        title: 'Review failed',
+        summary,
+      },
+    },
+    logger,
+  ).catch(err => logger.warning(`Failed to finalize check run: ${err}`));
+}
+
+interface AnalysisPhaseResult {
+  currentReport: ComplexityReport;
+  chunks: CodeChunk[];
+  avgComplexity: number;
+  maxComplexity: number;
+  baselineReport: ComplexityReport | null;
+  deltas: ComplexityDelta[] | null;
+  baseClone: CloneResult | null;
+}
+
+async function runAnalysisPhase(
+  filesToAnalyze: string[],
+  threshold: string,
+  headCloneDir: string,
+  baseRepoFullName: string,
+  baseSha: string,
+  token: string,
+  logger: Logger,
+): Promise<AnalysisPhaseResult | null> {
+  if (filesToAnalyze.length > 0) {
+    const headResult = await runComplexityAnalysis(filesToAnalyze, threshold, headCloneDir, logger);
+    if (!headResult) {
+      logger.warning('Failed to get complexity report for head');
+      return null;
+    }
+
+    const currentReport = headResult.report;
+    const avgComplexity = currentReport.summary.avgComplexity;
+    const maxComplexity = currentReport.summary.maxComplexity;
+
+    await tryEnrichTestAssociations(currentReport, filesToAnalyze, headCloneDir, logger);
+
+    let baseClone: CloneResult | null = null;
+    let baselineReport: ComplexityReport | null = null;
+    try {
+      baseClone = await cloneBySha(baseRepoFullName, baseSha, token, logger);
+      const baseResult = await runComplexityAnalysis(
+        filesToAnalyze,
+        threshold,
+        baseClone.dir,
+        logger,
+      );
+      baselineReport = baseResult?.report ?? null;
+    } catch (error) {
+      logger.warning(
+        `Failed to analyze base branch: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const deltas = baselineReport
+      ? calculateDeltas(baselineReport, currentReport, filesToAnalyze)
+      : null;
+
+    return {
+      currentReport,
+      chunks: headResult.chunks,
+      avgComplexity,
+      maxComplexity,
+      baselineReport,
+      deltas,
+      baseClone,
+    };
+  }
+
+  // No complexity-analyzable files — run full-repo scan for summary-only path
+  logger.info('No complexity-analyzable files — running full-repo scan + summary');
+  const repoResult = await computeRepoComplexity(headCloneDir, threshold, logger);
+  if (repoResult) {
+    return {
+      currentReport: repoResult.report,
+      chunks: [],
+      avgComplexity: repoResult.avgComplexity,
+      maxComplexity: repoResult.maxComplexity,
+      baselineReport: null,
+      deltas: null,
+      baseClone: null,
+    };
+  }
+  return {
+    currentReport: {
+      files: {},
+      summary: {
+        filesAnalyzed: 0,
+        totalViolations: 0,
+        bySeverity: { error: 0, warning: 0 },
+        avgComplexity: 0,
+        maxComplexity: 0,
+      },
+    },
+    chunks: [],
+    avgComplexity: 0,
+    maxComplexity: 0,
+    baselineReport: null,
+    deltas: null,
+    baseClone: null,
+  };
+}
+
+async function tryPresentFindings(
+  engine: ReviewEngine,
+  findings: ReviewFinding[],
+  adapterContext: AdapterContext,
+  checkRunId: number | undefined,
+  octokit: Octokit,
+  prContext: PRContext,
+  logger: Logger,
+): Promise<{ conclusion: 'success' | 'failure' | 'neutral'; summary: string }> {
+  try {
+    return await engine.present(findings, adapterContext, { checkRunId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`engine.present() failed: ${message}`);
+    if (checkRunId) {
+      await updateCheckRun(
+        octokit,
+        {
+          owner: prContext.owner,
+          repo: prContext.repo,
+          checkRunId,
+          status: 'completed',
+          conclusion: 'action_required',
+          output: {
+            title: 'Review failed',
+            summary: `An error occurred: ${message}`,
+          },
+        },
+        logger,
+      ).catch(err => logger.warning(`Failed to finalize check run after error: ${err}`));
+    }
+    return { conclusion: 'neutral', summary: `An error occurred: ${message}` };
+  }
+}
+
+/**
+ * Full-repo complexity scan on an already-cloned directory.
+ * Used when a PR touches no analyzable files so we still report real scores.
+ */
+async function computeRepoComplexity(
+  cloneDir: string,
+  threshold: string,
+  _logger?: Logger,
+): Promise<{ report: ComplexityReport; avgComplexity: number; maxComplexity: number } | null> {
+  const indexResult = await performChunkOnlyIndex(cloneDir);
+  if (!indexResult.success || !indexResult.chunks || indexResult.chunks.length === 0) {
+    return null;
+  }
+
+  const thresholdNum = parseInt(threshold, 10);
+  const report = analyzeComplexityFromChunks(
+    indexResult.chunks,
+    [...new Set(indexResult.chunks.map(c => c.metadata.file))],
+    !isNaN(thresholdNum) ? { testPaths: thresholdNum, mentalLoad: thresholdNum } : undefined,
+  );
+
+  return {
+    report,
+    avgComplexity: report.summary.avgComplexity,
+    maxComplexity: report.summary.maxComplexity,
+  };
+}
+
+/**
+ * Resolve the check run for this review. Reuses a pre-created check run when
+ * `ctx.checkRunId` is provided (transitioning it to in_progress), otherwise
+ * creates a fresh one.
+ *
+ * Returns `writeForbidden: true` when the create/update is rejected with a 403
+ * (read-only token, e.g. a fork `pull_request`) so the caller can surface a
+ * single fork warning instead of silently producing no PR output.
+ */
+async function resolveCheckRun(
+  ctx: ReviewCoreContext,
+): Promise<{ checkRunId: number | undefined; writeForbidden: boolean }> {
+  const { octokit, pr, logger } = ctx;
+
+  if (ctx.checkRunId) {
+    try {
+      await updateCheckRun(
+        octokit,
+        {
+          owner: pr.owner,
+          repo: pr.repo,
+          checkRunId: ctx.checkRunId,
+          status: 'in_progress',
+          output: { title: 'Running...', summary: 'Analysis in progress' },
+        },
+        logger,
+      );
+    } catch (error) {
+      logger.warning(
+        `Failed to update check run to in_progress: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return { checkRunId: ctx.checkRunId, writeForbidden: isWriteForbidden(error) };
+    }
+    return { checkRunId: ctx.checkRunId, writeForbidden: false };
+  }
+
+  try {
+    const checkRunId = await createCheckRun(
+      octokit,
+      {
+        owner: pr.owner,
+        repo: pr.repo,
+        name: 'Lien Review',
+        headSha: pr.headSha,
+        status: 'in_progress',
+        output: { title: 'Running...', summary: 'Analysis in progress' },
+      },
+      logger,
+    );
+    return { checkRunId, writeForbidden: false };
+  } catch (error) {
+    logger.warning(
+      `Failed to create check run: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { checkRunId: undefined, writeForbidden: isWriteForbidden(error) };
+  }
+}

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -138,16 +138,17 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
     if (summaryEnabled) await tryFetchPRPatches(octokit, pr, logger);
 
     if (filesToAnalyze.length === 0 && !summaryEnabled) {
-      logger.info('No analyzable files — running full-repo complexity scan');
-      await computeRepoComplexity(headClone.dir, ctx.config.threshold, logger);
-      const summaryMarkdown = await finalizeCheckRunNoFiles(checkRunId, octokit, pr, logger);
+      // Nothing analyzable and no summary requested — finalize without the
+      // (previously wasted) full-repo complexity scan, whose result was discarded.
+      logger.info('No analyzable files changed — skipping complexity/agent review');
+      const noFiles = await finalizeCheckRunNoFiles(checkRunId, octokit, pr, logger);
       return {
         findings: [],
         conclusion: 'success',
-        summaryMarkdown,
+        summaryMarkdown: noFiles.summary,
         filesAnalyzed,
         usage: { totalTokens: 0, cost: 0 },
-        writeForbidden,
+        writeForbidden: writeForbidden || noFiles.writeForbidden,
       };
     }
 
@@ -163,14 +164,20 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
     );
     if (!analysis) {
       const summaryMarkdown = 'Review failed — could not produce a complexity report.';
-      await finalizeCheckRunFailed(checkRunId, octokit, pr, summaryMarkdown, logger);
+      const failedForbidden = await finalizeCheckRunFailed(
+        checkRunId,
+        octokit,
+        pr,
+        summaryMarkdown,
+        logger,
+      );
       return {
         findings: [],
         conclusion: 'failure',
         summaryMarkdown,
         filesAnalyzed,
         usage: { totalTokens: 0, cost: 0 },
-        writeForbidden,
+        writeForbidden: writeForbidden || failedForbidden,
       };
     }
     const { currentReport, chunks, baselineReport, deltas } = analysis;
@@ -264,7 +271,7 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
       summaryMarkdown: presentation.summary,
       filesAnalyzed,
       usage: { totalTokens: tokenUsage, cost },
-      writeForbidden,
+      writeForbidden: writeForbidden || presentation.writeForbidden,
     };
   } finally {
     if (headClone) await headClone.cleanup().catch(() => {});
@@ -343,9 +350,10 @@ async function finalizeCheckRunNoFiles(
   octokit: Octokit,
   prContext: PRContext,
   logger: Logger,
-): Promise<string> {
+): Promise<{ summary: string; writeForbidden: boolean }> {
   const summary = 'No files eligible for complexity analysis.';
-  if (!checkRunId) return summary;
+  if (!checkRunId) return { summary, writeForbidden: false };
+  let writeForbidden = false;
   await updateCheckRun(
     octokit,
     {
@@ -360,8 +368,11 @@ async function finalizeCheckRunNoFiles(
       },
     },
     logger,
-  ).catch(err => logger.warning(`Failed to finalize check run: ${err}`));
-  return summary;
+  ).catch(err => {
+    writeForbidden = isWriteForbidden(err);
+    logger.warning(`Failed to finalize check run: ${err}`);
+  });
+  return { summary, writeForbidden };
 }
 
 async function finalizeCheckRunFailed(
@@ -370,8 +381,9 @@ async function finalizeCheckRunFailed(
   prContext: PRContext,
   summary: string,
   logger: Logger,
-): Promise<void> {
-  if (!checkRunId) return;
+): Promise<boolean> {
+  if (!checkRunId) return false;
+  let writeForbidden = false;
   await updateCheckRun(
     octokit,
     {
@@ -386,7 +398,11 @@ async function finalizeCheckRunFailed(
       },
     },
     logger,
-  ).catch(err => logger.warning(`Failed to finalize check run: ${err}`));
+  ).catch(err => {
+    writeForbidden = isWriteForbidden(err);
+    logger.warning(`Failed to finalize check run: ${err}`);
+  });
+  return writeForbidden;
 }
 
 interface AnalysisPhaseResult {
@@ -495,12 +511,23 @@ async function tryPresentFindings(
   octokit: Octokit,
   prContext: PRContext,
   logger: Logger,
-): Promise<{ conclusion: 'success' | 'failure' | 'neutral'; summary: string }> {
+): Promise<{
+  conclusion: 'success' | 'failure' | 'neutral';
+  summary: string;
+  writeForbidden: boolean;
+}> {
+  // Note: engine.present() swallows individual comment-post failures internally,
+  // so a 403 on an inline comment won't surface here — we can only observe a 403
+  // that propagates out of present() or hits the fallback finalizer below. The
+  // primary read-only-token (fork) signal remains the first write in
+  // resolveCheckRun(), which 403s before any analysis on a read-only token.
   try {
-    return await engine.present(findings, adapterContext, { checkRunId });
+    const result = await engine.present(findings, adapterContext, { checkRunId });
+    return { ...result, writeForbidden: false };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`engine.present() failed: ${message}`);
+    let writeForbidden = isWriteForbidden(error);
     if (checkRunId) {
       await updateCheckRun(
         octokit,
@@ -516,9 +543,12 @@ async function tryPresentFindings(
           },
         },
         logger,
-      ).catch(err => logger.warning(`Failed to finalize check run after error: ${err}`));
+      ).catch(err => {
+        writeForbidden = writeForbidden || isWriteForbidden(err);
+        logger.warning(`Failed to finalize check run after error: ${err}`);
+      });
     }
-    return { conclusion: 'neutral', summary: `An error occurred: ${message}` };
+    return { conclusion: 'neutral', summary: `An error occurred: ${message}`, writeForbidden };
   }
 }
 

--- a/packages/runner/src/handlers/baseline.ts
+++ b/packages/runner/src/handlers/baseline.ts
@@ -8,17 +8,17 @@
 import { createHash } from 'node:crypto';
 
 import type { Logger, ComplexityReport } from '@liendev/review';
-import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
-
-import type { BaselineJobPayload, ReviewRunResult, ComplexitySnapshotResult } from '../types.js';
-import type { RunnerConfig } from '../config.js';
 import {
   cloneByBranch,
   cloneBySha,
   resolveHeadSha,
   resolveCommitTimestamp,
   type CloneResult,
-} from '../clone.js';
+} from '@liendev/review';
+import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
+
+import type { BaselineJobPayload, ReviewRunResult, ComplexitySnapshotResult } from '../types.js';
+import type { RunnerConfig } from '../config.js';
 import { postReviewRunResult } from '../api-client.js';
 
 export async function handleBaseline(

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -26,6 +26,9 @@ import {
   ReviewEngine,
   ComplexityPlugin,
   AgentReviewPlugin,
+  cloneBySha,
+  resolveCommitTimestamp,
+  type CloneResult,
 } from '@liendev/review';
 import type { CodeChunk } from '@liendev/parser';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
@@ -37,7 +40,6 @@ import type {
   ReviewCommentResult,
 } from '../types.js';
 import type { RunnerConfig } from '../config.js';
-import { cloneBySha, resolveCommitTimestamp, type CloneResult } from '../clone.js';
 import { postReviewRunResult, postReviewRunStatus } from '../api-client.js';
 import { LogBuffer } from '../log-buffer.js';
 

--- a/packages/runner/test/handle-baseline.test.ts
+++ b/packages/runner/test/handle-baseline.test.ts
@@ -5,19 +5,23 @@ vi.mock('@liendev/parser', () => ({
   analyzeComplexityFromChunks: vi.fn(),
 }));
 
-vi.mock('../src/clone.js', () => ({
-  cloneBySha: vi.fn(),
-  cloneByBranch: vi.fn(),
-  resolveHeadSha: vi.fn(),
-  resolveCommitTimestamp: vi.fn(),
-}));
+vi.mock('@liendev/review', async () => {
+  const actual = await vi.importActual<typeof import('@liendev/review')>('@liendev/review');
+  return {
+    ...actual,
+    cloneBySha: vi.fn(),
+    cloneByBranch: vi.fn(),
+    resolveHeadSha: vi.fn(),
+    resolveCommitTimestamp: vi.fn(),
+  };
+});
 
 vi.mock('../src/api-client.js', () => ({
   postReviewRunResult: vi.fn(),
 }));
 
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
-import { cloneBySha, cloneByBranch, resolveHeadSha, resolveCommitTimestamp } from '../src/clone.js';
+import { cloneBySha, cloneByBranch, resolveHeadSha, resolveCommitTimestamp } from '@liendev/review';
 import { postReviewRunResult } from '../src/api-client.js';
 import { handleBaseline } from '../src/handlers/baseline.js';
 import type { BaselineJobPayload } from '../src/types.js';

--- a/packages/runner/test/handle-pr-review.test.ts
+++ b/packages/runner/test/handle-pr-review.test.ts
@@ -14,16 +14,13 @@ vi.mock('@liendev/review', () => ({
   enrichWithTestAssociations: vi.fn(),
   calculateDeltas: vi.fn(),
   calculateDeltaSummary: vi.fn(),
+  cloneBySha: vi.fn(),
+  resolveCommitTimestamp: vi.fn(),
 }));
 
 vi.mock('@liendev/parser', () => ({
   performChunkOnlyIndex: vi.fn(),
   analyzeComplexityFromChunks: vi.fn(),
-}));
-
-vi.mock('../src/clone.js', () => ({
-  cloneBySha: vi.fn(),
-  resolveCommitTimestamp: vi.fn(),
 }));
 
 vi.mock('../src/api-client.js', () => ({
@@ -43,9 +40,10 @@ import {
   getPRPatchData,
   ReviewEngine,
   AgentReviewPlugin,
+  cloneBySha,
+  resolveCommitTimestamp,
 } from '@liendev/review';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
-import { cloneBySha, resolveCommitTimestamp } from '../src/clone.js';
 import { postReviewRunResult, postReviewRunStatus } from '../src/api-client.js';
 import { LogBuffer } from '../src/log-buffer.js';
 import { handlePRReview } from '../src/handlers/pr-review.js';

--- a/packages/runner/test/run-analysis-phase.test.ts
+++ b/packages/runner/test/run-analysis-phase.test.ts
@@ -4,6 +4,7 @@ vi.mock('@liendev/review', () => ({
   runComplexityAnalysis: vi.fn(),
   enrichWithTestAssociations: vi.fn(),
   calculateDeltas: vi.fn(),
+  cloneBySha: vi.fn(),
 }));
 
 vi.mock('@liendev/parser', () => ({
@@ -11,17 +12,13 @@ vi.mock('@liendev/parser', () => ({
   analyzeComplexityFromChunks: vi.fn(),
 }));
 
-vi.mock('../src/clone.js', () => ({
-  cloneBySha: vi.fn(),
-}));
-
 import {
   runComplexityAnalysis,
   enrichWithTestAssociations,
   calculateDeltas,
+  cloneBySha,
 } from '@liendev/review';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
-import { cloneBySha } from '../src/clone.js';
 import { runAnalysisPhase } from '../src/handlers/pr-review.js';
 
 const mockRunComplexityAnalysis = vi.mocked(runComplexityAnalysis);


### PR DESCRIPTION
## Why

`app.lien.dev` (the Laravel `platform/`) was shut down, and the hosted SaaS shape — DOKS + managed Postgres + Valkey + NATS + Laravel + registry, billed monthly — is far more operational surface than Lien Review actually needs to review a PR and post findings.

Key insight: **the runner already posts all user-facing output (check runs + inline PR comments) directly to GitHub via `octokit`** — `getPRChangedFiles`/`getPRPatchData`/`present()` use the GitHub REST API, never local git, so they work with any token, including a GitHub Action's built-in `GITHUB_TOKEN`. Laravel was only a control plane (webhook → NATS, token minting, config from DB) + a dashboard. All of it is droppable for a self-hoster.

This PR collapses the pipeline into a **self-contained GitHub Action**. No server, no DB, no NATS, no Laravel, no recurring bill.

## Usage

```yaml
on: pull_request
permissions: { contents: read, pull-requests: write, checks: write }
jobs:
  review:
    runs-on: ubuntu-latest
    steps:
      - uses: getlien/lien-review@v1
        with:
          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
```

## What changed

- **`@liendev/review`**: extracted a transport-agnostic `reviewPullRequest(ctx: ReviewCoreContext): ReviewCoreResult` core (`packages/review/src/review-pr.ts`), stripped of NATS/Laravel/LogBuffer/service-token/idempotency/staleness concerns; LLM provider comes from `ctx.llm` (openai/openrouter | anthropic | null). Moved `clone.ts` here. `ReviewEngine.present()` now additively returns `{ conclusion, summary }`.
- **`packages/action/`** (new): Docker container action. Reads `$GITHUB_EVENT_PATH` + `INPUT_*` (head SHA from `pull_request.head.sha`, **not** `GITHUB_SHA`), self-clones via `GITHUB_TOKEN`, posts findings as PR comments + a check run, writes `$GITHUB_STEP_SUMMARY`, and maps a `fail-on` input to the process exit code. Fork PRs (read-only token) are detected and warned about, with a documented `pull_request_target` opt-in — safe because Lien only reads/parses code, never executes it.
- **`packages/runner`**: re-pointed imports to `@liendev/review` (the runner/platform are slated for retirement in a follow-up; kept green here, not rewritten).
- **CI**: `ci.yml` typechecks/tests the action + a Dockerfile smoke build; new `publish-action.yml` pushes `ghcr.io/getlien/lien-review` on `v*` tags.

Net **+2195 / −42** lines, but the *behavioral* surface shrinks: clone.ts is a rename, the runner loses code, and an entire hosted backend stops being required.

## How it was built

A 4-phase multi-agent workflow (extract core → action package → CI/distribution → adversarial review + verify). The review phase caught a real bug — the fork-403 warning path was dead code because the review core swallows GitHub write errors internally — now fixed via a `writeForbidden` signal surfaced from the first check-run write.

## Verification

- ✅ `format:check`, `lint`, `typecheck`, `build` (full workspace incl. the action)
- ✅ tests: action **13**, review **348**, runner **24**
- ✅ Docker image **builds and runs** (entrypoint loads native tree-sitter + dist, fails cleanly on missing input)
- ⚠️ `@liendev/core` Qdrant tests fail without a running server — pre-existing/expected, untouched code

## Follow-ups (not in this PR)

- Retire `platform/` (Laravel) and the runner/NATS entirely.
- Optional local SQLite run history (the core returns `ReviewCoreResult`, so a sink can be added without reworking it).

## Before `uses: getlien/lien-review@v1` works (needs org access)

- Create the public **`getlien/lien-review`** dist repo (holds `action.yml` + README; code ships in the GHCR image) and tag `v1`.
- Confirm GHCR push perms for `ghcr.io/getlien/lien-review`. The `publish-action.yml` dist-repo sync step is a documented stub gated on a `GH_DIST_TOKEN` until the repo exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GitHub Action for automated PR review with configurable inputs, outputs, and Docker-based execution.
  * Added support for publishing the Action image to GHCR with versioned, latest, and commit-based tags.

* **Bug Fixes**
  * Improved handling for forked pull requests so read-only permission issues no longer fail the workflow.
  * Enhanced review result reporting with clearer summaries, outputs, and exit codes.

* **Documentation**
  * Added usage guidance, permissions, fork-pr handling notes, and configuration examples for the Action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 5 new functions are too complex.
🔗 **Impact**: 3 high-risk file(s) with 6 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +19 |
| 🧠 mental load | 3 | +19 |
| ⏱️ time to understand | 6 | +402 |
| 🐛 estimated bugs | 2 | +1.57 |


> [!WARNING]
> **2 issues found** · Medium Risk
>
> This PR introduces a self-contained GitHub Action for Lien Review, successfully extracting the core review logic into a transport-agnostic package. While the architecture is sound and handles fork PRs gracefully by detecting read-only tokens, there are inefficiencies in repository cloning and a logic error in how the LLM agent's budget is scaled based on PR size.
>
> - Extracted `reviewPullRequest` core logic into `@liendev/review`.
> - Created a new Docker-based GitHub Action in `packages/action`.
> - Implemented fork-aware error handling to prevent CI failures on read-only tokens.
> - Updated the runner to use the new core review logic.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit dfda557. Updates automatically on new commits.</sup>
<!-- /lien-stats -->