### PR TITLE
chore(action): rename dogfood workflow to avoid Lien Review check name collision

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -1,6 +1,11 @@
-name: Lien Review
+name: Lien Self-Review
 
 # Dogfoods the Lien Review action on this monorepo's own PRs.
+#
+# NB: this workflow is named "Lien Self-Review" (not "Lien Review") on purpose —
+# the action posts its own check run named "Lien Review", so naming the workflow
+# the same would surface a confusing "Lien Review" (the verdict) alongside
+# "Lien Review / review" (this runner job).
 #
 # The public, external-consumer path is `uses: getlien/lien-review@v1` (a Docker
 # action backed by a prebuilt GHCR image — see packages/action/README.md). That


### PR DESCRIPTION
Cosmetic follow-up to #581. The action posts a check run named `Lien Review`; the dogfood workflow was also named `Lien Review`, so the PR checklist showed a confusing `Lien Review` (the verdict) next to `Lien Review / review` (the runner job). Renames the workflow to **Lien Self-Review** so the two are distinct. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the workflow to better reflect its self-review purpose.
  * Updated explanatory comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 83 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 8 high-risk file(s) with 122 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 12 | — |
| 🧠 mental load | 20 | — |
| ⏱️ time to understand | 49 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ee74d86. Updates automatically on new commits.</sup>
<!-- /lien-stats -->