### PR TITLE
feat(action): default the Lien Review check to advisory (fail-on: never)

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -11,9 +11,9 @@ name: Lien Review
 # image + the public dist repo aren't published yet, so here we build the action
 # from source and run its entrypoint directly. Same code path, no publish needed.
 #
-# fail-on: never — the check stays green whenever the action *runs*; findings are
-# advisory (annotations + comments). External consumers can set fail-on: error
-# to make this job gate the PR.
+# The review is advisory by default (fail-on defaults to 'never'), so the check
+# stays green whenever the action *runs*; findings show as annotations + comments.
+# Set fail-on: error/any here (or in any consumer workflow) to gate the PR.
 
 on:
   pull_request:
@@ -48,4 +48,3 @@ jobs:
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          INPUT_FAIL-ON: never

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -87,7 +87,7 @@ OpenRouter wins.
 | `threshold`           | no       | `15`                            | Complexity threshold above which violations are reported.                                                                                 |
 | `review-types`        | no       | `complexity,bugs,summary`       | Comma-separated review types to enable. `complexity` toggles the complexity check. `bugs`, `architectural`, and `summary` all come from the single agent reviewer, so they switch it on/off as a group (and only when an API key is set) — they can't be toggled independently. |
 | `block-on-new-errors` | no       | `false`                         | Post `REQUEST_CHANGES` (instead of `COMMENT`) when the PR introduces new error-level complexity violations.                               |
-| `fail-on`             | no       | `error`                         | Controls the action's exit code so a Required check can block the PR: `error` (only on a failure conclusion), `any` (any error or warning finding), or `never`. |
+| `fail-on`             | no       | `never`                         | Whether the review fails the check (so a Required check can block the PR). Default `never` — **advisory**, never fails CI. Opt into gating with `error` (a failure conclusion / new error-level findings) or `any` (any error or warning finding). |
 
 > The action posts **no check run of its own** — the workflow job is the single
 > status check. Findings surface as workflow annotations (inline on the diff),
@@ -114,11 +114,13 @@ Reference them from a later step via the step `id`:
 
 ## Blocking a PR on the review
 
-Set `fail-on` to control the exit code, then mark the workflow's job as a
-**Required status check** in your branch protection rules. With `fail-on: error`
-the action exits non-zero only when the review's overall conclusion is a
-failure (driven by `block-on-new-errors`); `fail-on: any` is stricter (any
-error- or warning-level finding fails the check); `fail-on: never` never blocks.
+By default the review is **advisory** (`fail-on: never`) — it never fails CI, so
+adding the action can't break anyone's pipeline. To gate merges on it, opt in by
+setting `fail-on` and marking the workflow's job as a **Required status check**
+in your branch protection rules. With `fail-on: error` the action exits non-zero
+only when the review's overall conclusion is a failure (driven by
+`block-on-new-errors`); `fail-on: any` is stricter (any error- or warning-level
+finding fails the check).
 
 ## Fork PRs
 

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -49,11 +49,13 @@ inputs:
     default: 'false'
   fail-on:
     description: >-
-      When the action's exit code is non-zero (so a Required check blocks the
-      PR): 'error' (default — only on a failure conclusion), 'any' (any error or
-      warning finding), or 'never'.
+      Whether the review fails the check (non-zero exit, so a Required check can
+      block the PR): 'never' (default — advisory; the review never fails CI),
+      'error' (fail on a failure conclusion, i.e. new error-level findings), or
+      'any' (fail on any error or warning finding). Opt into gating by setting
+      this to 'error' or 'any'.
     required: false
-    default: 'error'
+    default: 'never'
 
 outputs:
   conclusion:

--- a/packages/action/examples/lien-review.yml
+++ b/packages/action/examples/lien-review.yml
@@ -31,7 +31,7 @@ jobs:
           # threshold: '15'
           # review-types: 'complexity,bugs,summary'  # also: architectural
           # block-on-new-errors: 'false'
-          # fail-on: 'error'                         # also: any, never
+          # fail-on: 'never'                        # default (advisory); set 'error'/'any' to gate
 
 # ─── Fork PRs (pull_request_target variant) ──────────────────────────────────
 #

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -59,7 +59,10 @@ function readBool(name: string, fallback: boolean): boolean {
 
 function parseFailOn(raw: string): FailOn {
   if (raw === 'never' || raw === 'any' || raw === 'error') return raw;
-  if (raw === '') return 'error';
+  // Default: 'never' — the review is advisory out of the box (findings show as
+  // annotations + comments without failing CI). Consumers opt into gating with
+  // fail-on: error | any.
+  if (raw === '') return 'never';
   throw new Error(`Invalid fail-on value "${raw}" — expected one of: error, never, any`);
 }
 

--- a/packages/action/test/inputs.test.ts
+++ b/packages/action/test/inputs.test.ts
@@ -37,7 +37,7 @@ describe('readInputs — defaults', () => {
   it('applies sensible defaults when only the token is set', () => {
     const inputs = readInputs();
     expect(inputs.threshold).toBe('15');
-    expect(inputs.failOn).toBe('error');
+    expect(inputs.failOn).toBe('never');
     expect(inputs.blockOnNewErrors).toBe(false);
     expect(inputs.reviewTypes).toEqual({
       complexity: true,


### PR DESCRIPTION
## Why

Adding the action shouldn't be able to break a consumer's CI on day one. Make the review **advisory by default**: it surfaces findings (annotations + inline comments + step summary) without failing the check unless the consumer opts in.

## What

- Flip the default `fail-on` from `error` → **`never`** (`inputs.ts` + `action.yml`). Consumers gate merges by setting `fail-on: error` (or `any`) and marking the job a Required check.
- README + example: document advisory-by-default and the opt-in path.
- Dogfood workflow: dropped the now-redundant `INPUT_FAIL-ON: never` (it's the default).
- Test: default `failOn` expectation → `never`.

No behavior change for anyone who set `fail-on` explicitly. `getlien/lien` itself was already advisory; this just makes it the out-of-the-box default for everyone.

## Verification
Typecheck, build, lint (0 errors), prettier clean; `@liendev/action` 28 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for the review workflow to reflect the new default advisory behavior.
  * Clarified how CI blocking works when opting into stricter review settings.

* **Behavior Changes**
  * The review action now defaults to a non-blocking mode when no `fail-on` value is provided.
  * Findings continue to appear as annotations and inline PR comments without failing CI by default.

* **Bug Fixes**
  * Fixed default input handling so empty or missing review settings now use the advisory mode consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR changes the default behavior of the Lien Review GitHub Action to be advisory-only. It flips the default `fail-on` input from `error` to `never`, ensuring that the action does not break CI pipelines by default when first added. Users must now explicitly opt-in to gating PRs by setting `fail-on: error` or `fail-on: any`.
>
> - Changed default `fail-on` value from `error` to `never` in `action.yml` and `inputs.ts`.
> - Updated documentation and examples to reflect the new advisory-by-default behavior.
> - Updated tests to verify the new default value.
> - Removed redundant `INPUT_FAIL-ON: never` from the internal dogfooding workflow.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9c3790e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->