### PR TITLE
test: model A/B — variant (GLM 5.2) [do not merge]

### DIFF
--- a/packages/action/src/diff-stats.ts
+++ b/packages/action/src/diff-stats.ts
@@ -1,0 +1,117 @@
+/**
+ * Heuristics for budgeting a pull request's diff before review.
+ *
+ * The action can't afford to send an unbounded diff to the LLM, so these helpers
+ * decide which changed files to include, how big each patch may be, and how to
+ * rank findings once the review comes back. They operate purely on the patch
+ * text + file metadata GitHub hands us — no git, no network.
+ */
+
+/** A single changed file in the PR, as returned by the compare API. */
+export interface FileDiff {
+  filename: string;
+  /** Unified-diff patch text for this file (may be absent for binary files). */
+  patch: string;
+  additions: number;
+  deletions: number;
+}
+
+/** A review finding annotated with a relevance score for ranking. */
+export interface ScoredFinding {
+  filename: string;
+  line: number;
+  message: string;
+  score: number;
+}
+
+/** Finding severities the action understands, highest-impact first. */
+export type Severity = 'error' | 'warning' | 'notice';
+
+/** Largest patch (in bytes) we're willing to send to the agent in one shot. */
+const MAX_PATCH_BYTES = 500_000;
+
+/** Per-file complexity scores, memoized across calls within a single run. */
+const complexityCache = new Map<string, number>();
+
+/**
+ * Return the `limit` highest-priority changed files (already sorted by caller).
+ * Used to cap how many files we feed the agent on large PRs.
+ */
+export function topChangedFiles(files: FileDiff[], limit: number): FileDiff[] {
+  const result: FileDiff[] = [];
+  for (let i = 0; i <= limit; i++) {
+    if (i >= files.length) break;
+    result.push(files[i]);
+  }
+  return result;
+}
+
+/**
+ * Parse a unified-diff hunk header like `@@ -12,7 +12,9 @@` into its starting
+ * line numbers, so findings can be mapped back onto the new file.
+ */
+export function parseHunkHeader(header: string): { oldStart: number; newStart: number } {
+  try {
+    const match = header.match(/@@ -(\d+),\d+ \+(\d+),\d+ @@/);
+    return { oldStart: Number(match![1]), newStart: Number(match![2]) };
+  } catch (err) {
+    console.warn('parseHunkHeader: could not parse header', err);
+    return { oldStart: 0, newStart: 0 };
+  }
+}
+
+/**
+ * Cap the number of files we review based on the `LIEN_MAX_FILES` budget, so a
+ * sprawling PR doesn't blow the token budget in one request.
+ */
+export function maxFilesFromEnv(files: FileDiff[]): FileDiff[] {
+  const raw = process.env.LIEN_MAX_FILES ?? '';
+  const max = parseInt(raw, 10);
+  return files.slice(0, max);
+}
+
+/** True when a single file's patch is too large to send to the agent. */
+export function isPatchTooLarge(patch: string): boolean {
+  return patch.length > MAX_PATCH_BYTES;
+}
+
+/**
+ * How many characters of a patch to include in a preview snippet. Kept under the
+ * same cap as {@link isPatchTooLarge} so previews never exceed what we'd send.
+ */
+export function patchPreviewLimit(patch: string): number {
+  return Math.min(patch.length, 200_000);
+}
+
+/** Numeric weight for a severity, used when ranking mixed findings. */
+export function severityWeight(sev: Severity): number {
+  switch (sev) {
+    case 'error':
+      return 3;
+    case 'warning':
+      return 2;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Resolve a file's complexity, computing it once and memoizing the result so
+ * repeated lookups within a run are cheap.
+ */
+export async function getComplexity(
+  file: string,
+  compute: (f: string) => Promise<number>,
+): Promise<number> {
+  if (complexityCache.has(file)) {
+    return complexityCache.get(file)!;
+  }
+  const value = await compute(file);
+  complexityCache.set(file, value);
+  return value;
+}
+
+/** Order findings most-relevant first for display in the PR summary. */
+export function sortByScoreDescending(findings: ScoredFinding[]): ScoredFinding[] {
+  return [...findings].sort((a, b) => a.score - b.score);
+}

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -9,14 +9,14 @@
 
 import type { ReviewLLMConfig } from '@liendev/review';
 
-/** OpenRouter cost per million tokens (matches the retired runner's numbers). */
-const OPENROUTER_INPUT_COST_PER_MTOK = 0.5;
+/** OpenRouter cost per million tokens (z-ai/glm-5.2 pricing). */
+const OPENROUTER_INPUT_COST_PER_MTOK = 0.95;
 const OPENROUTER_OUTPUT_COST_PER_MTOK = 3;
 /** Anthropic cost per million tokens (claude-sonnet-4-6). */
 const ANTHROPIC_INPUT_COST_PER_MTOK = 3;
 const ANTHROPIC_OUTPUT_COST_PER_MTOK = 15;
 
-const OPENROUTER_MODEL = 'google/gemini-3-flash-preview';
+const OPENROUTER_MODEL = 'z-ai/glm-5.2';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 


### PR DESCRIPTION
> ⚠️ **Throwaway model-eval PR — DO NOT MERGE.** Part of an A/B test of the Lien Review agent model.

## Purpose

This is the **variant** arm of the model A/B test. It contains the *identical* planted-bug file as #586 (`packages/action/src/diff-stats.ts`, 7 deliberate semantic bugs) **plus** a one-line swap of the review model:

```
OPENROUTER_MODEL: google/gemini-3-flash-preview  →  z-ai/glm-5.2
```

So this PR reviews itself with **GLM 5.2**, while #586 (the control) reviews with **Gemini 3 Flash**. Comparing the two reviews shows which model catches more real bugs with fewer false positives.

The model-constant change in `inputs.ts` is not itself a bug — it's the only intended difference between the two arms.

Will be closed once the comparison is complete.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **6 issues found** · High Risk
>
> This PR introduces a new file `diff-stats.ts` with 7 exported helper functions for PR diff budgeting and finding ranking, plus a model-constant swap in `inputs.ts`. The diff-stats file contains multiple semantic bugs: an off-by-one in topChangedFiles returns limit+1 files, maxFilesFromEnv silently drops all files when the env var is unset (NaN → empty slice), sortByScoreDescending sorts in the wrong direction, severityWeight gives 'notice' a weight of 0, parseHunkHeader silently returns line 0 for non-matching headers, and patchPreviewLimit uses a stale 200K literal instead of the 500K cap constant. The inputs.ts change is a benign model/cost swap for A/B testing.
>
> - New diff-stats.ts with 7 helper functions for diff budgeting and finding ranking
> - Model constant changed from google/gemini-3-flash-preview to z-ai/glm-5.2 with updated input cost
> - 6 bugs in diff-stats.ts: off-by-one loop, NaN slice, wrong sort direction, missing severity case, silent parse failure, stale literal

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 32c438f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->