### PR TITLE
test: model A/B — variant (Kimi K2.6) [do not merge]

### DIFF
--- a/packages/action/src/diff-stats.ts
+++ b/packages/action/src/diff-stats.ts
@@ -1,0 +1,117 @@
+/**
+ * Heuristics for budgeting a pull request's diff before review.
+ *
+ * The action can't afford to send an unbounded diff to the LLM, so these helpers
+ * decide which changed files to include, how big each patch may be, and how to
+ * rank findings once the review comes back. They operate purely on the patch
+ * text + file metadata GitHub hands us — no git, no network.
+ */
+
+/** A single changed file in the PR, as returned by the compare API. */
+export interface FileDiff {
+  filename: string;
+  /** Unified-diff patch text for this file (may be absent for binary files). */
+  patch: string;
+  additions: number;
+  deletions: number;
+}
+
+/** A review finding annotated with a relevance score for ranking. */
+export interface ScoredFinding {
+  filename: string;
+  line: number;
+  message: string;
+  score: number;
+}
+
+/** Finding severities the action understands, highest-impact first. */
+export type Severity = 'error' | 'warning' | 'notice';
+
+/** Largest patch (in bytes) we're willing to send to the agent in one shot. */
+const MAX_PATCH_BYTES = 500_000;
+
+/** Per-file complexity scores, memoized across calls within a single run. */
+const complexityCache = new Map<string, number>();
+
+/**
+ * Return the `limit` highest-priority changed files (already sorted by caller).
+ * Used to cap how many files we feed the agent on large PRs.
+ */
+export function topChangedFiles(files: FileDiff[], limit: number): FileDiff[] {
+  const result: FileDiff[] = [];
+  for (let i = 0; i <= limit; i++) {
+    if (i >= files.length) break;
+    result.push(files[i]);
+  }
+  return result;
+}
+
+/**
+ * Parse a unified-diff hunk header like `@@ -12,7 +12,9 @@` into its starting
+ * line numbers, so findings can be mapped back onto the new file.
+ */
+export function parseHunkHeader(header: string): { oldStart: number; newStart: number } {
+  try {
+    const match = header.match(/@@ -(\d+),\d+ \+(\d+),\d+ @@/);
+    return { oldStart: Number(match![1]), newStart: Number(match![2]) };
+  } catch (err) {
+    console.warn('parseHunkHeader: could not parse header', err);
+    return { oldStart: 0, newStart: 0 };
+  }
+}
+
+/**
+ * Cap the number of files we review based on the `LIEN_MAX_FILES` budget, so a
+ * sprawling PR doesn't blow the token budget in one request.
+ */
+export function maxFilesFromEnv(files: FileDiff[]): FileDiff[] {
+  const raw = process.env.LIEN_MAX_FILES ?? '';
+  const max = parseInt(raw, 10);
+  return files.slice(0, max);
+}
+
+/** True when a single file's patch is too large to send to the agent. */
+export function isPatchTooLarge(patch: string): boolean {
+  return patch.length > MAX_PATCH_BYTES;
+}
+
+/**
+ * How many characters of a patch to include in a preview snippet. Kept under the
+ * same cap as {@link isPatchTooLarge} so previews never exceed what we'd send.
+ */
+export function patchPreviewLimit(patch: string): number {
+  return Math.min(patch.length, 200_000);
+}
+
+/** Numeric weight for a severity, used when ranking mixed findings. */
+export function severityWeight(sev: Severity): number {
+  switch (sev) {
+    case 'error':
+      return 3;
+    case 'warning':
+      return 2;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Resolve a file's complexity, computing it once and memoizing the result so
+ * repeated lookups within a run are cheap.
+ */
+export async function getComplexity(
+  file: string,
+  compute: (f: string) => Promise<number>,
+): Promise<number> {
+  if (complexityCache.has(file)) {
+    return complexityCache.get(file)!;
+  }
+  const value = await compute(file);
+  complexityCache.set(file, value);
+  return value;
+}
+
+/** Order findings most-relevant first for display in the PR summary. */
+export function sortByScoreDescending(findings: ScoredFinding[]): ScoredFinding[] {
+  return [...findings].sort((a, b) => a.score - b.score);
+}

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -9,14 +9,14 @@
 
 import type { ReviewLLMConfig } from '@liendev/review';
 
-/** OpenRouter cost per million tokens (matches the retired runner's numbers). */
-const OPENROUTER_INPUT_COST_PER_MTOK = 0.5;
-const OPENROUTER_OUTPUT_COST_PER_MTOK = 3;
+/** OpenRouter cost per million tokens (moonshotai/kimi-k2.6 pricing). */
+const OPENROUTER_INPUT_COST_PER_MTOK = 0.66;
+const OPENROUTER_OUTPUT_COST_PER_MTOK = 3.41;
 /** Anthropic cost per million tokens (claude-sonnet-4-6). */
 const ANTHROPIC_INPUT_COST_PER_MTOK = 3;
 const ANTHROPIC_OUTPUT_COST_PER_MTOK = 15;
 
-const OPENROUTER_MODEL = 'google/gemini-3-flash-preview';
+const OPENROUTER_MODEL = 'moonshotai/kimi-k2.6';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 


### PR DESCRIPTION
> ⚠️ **Throwaway model-eval PR — DO NOT MERGE.** Fourth arm of the Lien Review model A/B.

## Purpose

Same planted-bug file as #586/#587/#588 — identical 7 deliberate semantic bugs in `packages/action/src/diff-stats.ts` — but this arm reviews itself with **`moonshotai/kimi-k2.6`**.

```
OPENROUTER_MODEL: google/gemini-3-flash-preview  →  moonshotai/kimi-k2.6
```

The `inputs.ts` model/cost change is the only intended difference from the control (#586). Will be closed once the comparison is updated.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **7 issues found** · High Risk
>
> This PR introduces a new file `packages/action/src/diff-stats.ts` containing seven exported utility functions, all with real semantic bugs that will produce wrong output for valid inputs. The bugs range from off-by-one loops and ascending-sort mislabels to silent NaN-driven data loss and overly strict regexes that swallow errors. Because these helpers govern file budgeting, hunk mapping, and finding ranking, their defects cascade directly into the review pipeline: PRs may be capped incorrectly, line numbers mapped to 0, or high-priority findings buried at the bottom of the output. The `inputs.ts` change is a straightforward model/cost swap with no structural issues.
>
> - Added diff-stats.ts with 7 exported helper functions (file capping, hunk parsing, patch sizing, severity weighting, complexity memoization, finding ranking)
> - All 7 new functions contain semantic bugs producing wrong output for valid inputs
> - Updated OpenRouter model and token costs in inputs.ts to moonshotai/kimi-k2.6

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 59ff7f0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->