### PR TITLE
feat(action): default agent-review model to kimi-k2.7-code

### DIFF
--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -9,16 +9,17 @@
  */
 
 import type { ReviewLLMConfig } from '@liendev/review';
+import {
+  DEFAULT_REVIEW_MODEL,
+  DEFAULT_OPENROUTER_BASE_URL,
+  DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK,
+  DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK,
+} from '@liendev/review';
 
-/** OpenRouter cost per million tokens (moonshotai/kimi-k2.7-code pricing). */
-const OPENROUTER_INPUT_COST_PER_MTOK = 0.74;
-const OPENROUTER_OUTPUT_COST_PER_MTOK = 3.5;
 /** Anthropic cost per million tokens (claude-sonnet-4-6). */
 const ANTHROPIC_INPUT_COST_PER_MTOK = 3;
 const ANTHROPIC_OUTPUT_COST_PER_MTOK = 15;
 
-const OPENROUTER_MODEL = 'moonshotai/kimi-k2.7-code';
-const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 
 export type FailOn = 'error' | 'never' | 'any';
@@ -126,10 +127,10 @@ function resolveLLM(openrouterKey: string, anthropicKey: string): ReviewLLMConfi
     return {
       provider: 'openai',
       apiKey: openrouterKey,
-      model: OPENROUTER_MODEL,
-      baseUrl: OPENROUTER_BASE_URL,
-      inputCostPerMTok: OPENROUTER_INPUT_COST_PER_MTOK,
-      outputCostPerMTok: OPENROUTER_OUTPUT_COST_PER_MTOK,
+      model: DEFAULT_REVIEW_MODEL,
+      baseUrl: DEFAULT_OPENROUTER_BASE_URL,
+      inputCostPerMTok: DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK,
+      outputCostPerMTok: DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK,
     };
   }
   if (anthropicKey) {

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -3,20 +3,21 @@
  *
  * Reads and validates the `INPUT_*` environment variables GitHub injects from
  * the workflow `with:` block, and resolves the LLM provider from the supplied
- * API keys. OpenRouter wins if present (cheaper Gemini path), Anthropic is the
- * fallback, and absent both we run complexity-only (`llm === null`).
+ * API keys. OpenRouter wins if present (the primary agent-review path),
+ * Anthropic is the fallback, and absent both we run complexity-only
+ * (`llm === null`).
  */
 
 import type { ReviewLLMConfig } from '@liendev/review';
 
-/** OpenRouter cost per million tokens (matches the retired runner's numbers). */
-const OPENROUTER_INPUT_COST_PER_MTOK = 0.5;
-const OPENROUTER_OUTPUT_COST_PER_MTOK = 3;
+/** OpenRouter cost per million tokens (moonshotai/kimi-k2.7-code pricing). */
+const OPENROUTER_INPUT_COST_PER_MTOK = 0.74;
+const OPENROUTER_OUTPUT_COST_PER_MTOK = 3.5;
 /** Anthropic cost per million tokens (claude-sonnet-4-6). */
 const ANTHROPIC_INPUT_COST_PER_MTOK = 3;
 const ANTHROPIC_OUTPUT_COST_PER_MTOK = 15;
 
-const OPENROUTER_MODEL = 'google/gemini-3-flash-preview';
+const OPENROUTER_MODEL = 'moonshotai/kimi-k2.7-code';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 

--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared agent-review defaults — the single source of truth for the default
+ * model and its OpenRouter pricing.
+ *
+ * Consumed by the GitHub Action (`@liendev/action` inputs), the agent-review
+ * plugin's config schema, and the (legacy) runner, so bumping the default model
+ * is a one-line change here instead of parallel literals that drift across
+ * packages (see PR #592 review).
+ */
+
+/** Default agent-review model — OpenRouter model slug. */
+export const DEFAULT_REVIEW_MODEL = 'moonshotai/kimi-k2.7-code';
+
+/** OpenRouter API base URL (OpenAI-compatible endpoint). */
+export const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+/** OpenRouter cost per million tokens for {@link DEFAULT_REVIEW_MODEL}. */
+export const DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK = 0.74;
+export const DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK = 3.5;

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -186,3 +186,12 @@ export {
   type ReviewLLMConfig,
   reviewPullRequest,
 } from './review-pr.js';
+
+// ─── Defaults ───────────────────────────────────────────────────────────────
+
+export {
+  DEFAULT_REVIEW_MODEL,
+  DEFAULT_OPENROUTER_BASE_URL,
+  DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK,
+  DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK,
+} from './defaults.js';

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -24,13 +24,14 @@ import { OpenAIAgentClient, toOpenAITools } from './openai-client.js';
 import { buildSystemPrompt, buildInitialMessage } from './system-prompt.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
+import { DEFAULT_REVIEW_MODEL, DEFAULT_OPENROUTER_BASE_URL } from '../../defaults.js';
 
 const configSchema = z.object({
   apiKey: z.string().min(1),
-  model: z.string().default('google/gemini-3-flash-preview'),
+  model: z.string().default(DEFAULT_REVIEW_MODEL),
   /** 'openai' for OpenRouter/Gemini/DeepSeek, 'anthropic' for Claude */
   provider: z.enum(['openai', 'anthropic']).default('openai'),
-  baseUrl: z.string().default('https://openrouter.ai/api/v1'),
+  baseUrl: z.string().default(DEFAULT_OPENROUTER_BASE_URL),
   inputCostPerMTok: z.number().optional(),
   outputCostPerMTok: z.number().optional(),
   maxTurns: z.number().int().min(1).max(30).default(15),

--- a/packages/review/test/harness/runner.ts
+++ b/packages/review/test/harness/runner.ts
@@ -10,6 +10,7 @@ import type { Logger } from '../../src/logger.js';
 import type { ReviewContext, ReviewFinding } from '../../src/plugin-types.js';
 import { AgentReviewPlugin } from '../../src/plugins/agent/index.js';
 import type { AgentTrace } from '../../src/plugins/agent/types.js';
+import { DEFAULT_REVIEW_MODEL, DEFAULT_OPENROUTER_BASE_URL } from '../../src/defaults.js';
 
 import { loadFixture } from './fixture-loader.js';
 import type { HarnessResult } from './assertions.js';
@@ -17,7 +18,7 @@ import type { HarnessResult } from './assertions.js';
 export interface RunnerOptions {
   /** OpenRouter / OpenAI-compatible API key. Required. */
   apiKey: string;
-  /** Model id. Default 'google/gemini-3-flash-preview' to mirror prod (#539). */
+  /** Model id. Defaults to DEFAULT_REVIEW_MODEL to mirror prod. */
   model?: string;
   /** Base URL. Default OpenRouter's. */
   baseUrl?: string;
@@ -118,9 +119,9 @@ export async function runFixture(
       // the runtime transport + API knobs the harness controls.
       ...(ctx.config ?? {}),
       apiKey: opts.apiKey,
-      model: opts.model ?? 'google/gemini-3-flash-preview',
+      model: opts.model ?? DEFAULT_REVIEW_MODEL,
       provider: 'openai',
-      baseUrl: opts.baseUrl ?? 'https://openrouter.ai/api/v1',
+      baseUrl: opts.baseUrl ?? DEFAULT_OPENROUTER_BASE_URL,
       maxTurns: opts.maxTurns ?? 15,
       maxTokenBudget: opts.maxTokenBudget ?? 100_000,
     },

--- a/packages/runner/src/handlers/pr-review.ts
+++ b/packages/runner/src/handlers/pr-review.ts
@@ -29,6 +29,10 @@ import {
   cloneBySha,
   resolveCommitTimestamp,
   type CloneResult,
+  DEFAULT_REVIEW_MODEL,
+  DEFAULT_OPENROUTER_BASE_URL,
+  DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK,
+  DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK,
 } from '@liendev/review';
 import type { CodeChunk } from '@liendev/parser';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
@@ -277,9 +281,9 @@ export async function handlePRReview(
           apiKey: config.openrouterApiKey || config.anthropicApiKey,
           provider: config.openrouterApiKey ? 'openai' : 'anthropic',
           model: selectedModel,
-          baseUrl: config.openrouterApiKey ? 'https://openrouter.ai/api/v1' : undefined,
-          inputCostPerMTok: config.openrouterApiKey ? 0.5 : 3,
-          outputCostPerMTok: config.openrouterApiKey ? 3 : 15,
+          baseUrl: config.openrouterApiKey ? DEFAULT_OPENROUTER_BASE_URL : undefined,
+          inputCostPerMTok: config.openrouterApiKey ? DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK : 3,
+          outputCostPerMTok: config.openrouterApiKey ? DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK : 15,
           ...scaleAgentBudget(filesToAnalyze.length, chunks),
         },
       },
@@ -395,7 +399,7 @@ export async function handlePRReview(
  * adapterContext metadata.
  */
 function selectAgentModel(useOpenRouter: boolean): string {
-  return useOpenRouter ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6';
+  return useOpenRouter ? DEFAULT_REVIEW_MODEL : 'claude-sonnet-4-6';
 }
 
 /**


### PR DESCRIPTION
## What

Switch the default agent-review model (OpenRouter path) from `google/gemini-3-flash-preview` to **`moonshotai/kimi-k2.7-code`**, and update the cost constants to k2.7-code pricing (0.74 in / 3.50 out per MTok). Anthropic fallback unchanged.

## Why — evaluation evidence

Three independent datasets, all pointing the same way:

| Dataset | kimi-k2.7-code | gemini-3-flash (control) |
|---|---|---|
| 7-bug synthetic PR | **7/7 + 1 unplanted bug** the control missed, 0 FP | 7/7, 0 FP |
| harness single-pass (11 fixtures, incl. FP traps) | **10/11, 0 FP, 0 flaky** | 9/11 (1 reliable FP, 1 flaky) |
| **calibrate-10 (≥9/10 gate)** | **clears all 11** | 10/10 on ge-5; FP+flaky on 2 (single-pass) |

Decisive advantages: **precision** (passes the `gitignore-convention-fp` trap that gemini fails 0/3) and **reliability** (`stale-duplicate` 10/10 vs gemini flaky), with equal-or-better recall at comparable cost.

The one fixture kimi initially "failed" (`ge-5-threshold-shift`, 4/10) was traced to a **brittle Tier-2 keyword assertion**, not a model gap — both models emit the same correct finding; gemini only passed on the word "divergence". Fixed in #591; with that correction kimi clears the full gate.

## Note

This PR's own Lien Review run will be the first dogfood of k2.7-code (the dogfood workflow builds from PR source).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 1.004. 10 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 6 | -1 |
| 🐛 estimated bugs | 1 | -0.004 |


> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR centralizes the OpenRouter agent-review default model and pricing in a new shared defaults module and updates them to moonshotai/kimi-k2.7-code (0.74 in / 3.50 out per MTok). The action, runner, agent plugin schema, and test harness all consume the new shared constants, so the production paths are consistent. The only remaining drift is a single stale hardcoded URL fallback in the agent plugin's OpenAI client path, which is currently dead code but should track the shared constant to avoid future inconsistency.
>
> - New shared defaults module in packages/review/src/defaults.ts exports DEFAULT_REVIEW_MODEL, DEFAULT_OPENROUTER_BASE_URL, and OpenRouter cost constants.
> - Action, runner, agent plugin schema, and test harness now import from the shared defaults instead of repeating literals.
> - One stale hardcoded base URL fallback remains in packages/review/src/plugins/agent/index.ts runAgentClient.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fcc5546. Updates automatically on new commits.</sup>
<!-- /lien-stats -->