### PR TITLE
feat(review): boundary-change rule recommends a test pair (both sides)

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -387,7 +387,13 @@ MANDATORY protocol when this rule is active:
    Any other outcome — test absent, test exists but covers a
    different input, test exists but asserts the OLD behavior — is
    a finding. Cite the test file and line you inspected (or note
-   its absence) in \`evidence\`.
+   its absence) in \`evidence\`. In your \`suggestion\`, recommend
+   a **test pair** that pins the boundary from BOTH sides: the
+   divergence input (where classification changes) AND the
+   adjacent value on the unchanged side. For \`> 5\` → \`>= 5\`,
+   that is tests for both 5 (now medium) and 4 (still low) — a
+   single test at the boundary value alone leaves the other side
+   unverified.
 4. Consult <blast_radius>. For each listed dependent (especially
    uncovered ones marked ✗), name the concrete path by which the
    new boundary semantics cascade into that caller. This is
@@ -406,7 +412,7 @@ is not a qualifying test; an actual test file + line is.`,
   "category": "logic_error",
   "ruleId": "boundary-change",
   "message": "The PR frames this as an 'off-by-one fix', but the change is a behavior drift, not a correction. Shifting \`> 5\` to \`>= 5\` reclassifies dependentCount === 5 from 'low' to 'medium'. The existing test suite passes because no test exercises dependentCount === 5 — passing tests are evidence that the boundary was untested, not that the new behavior is intended. Per <blast_radius>, buildEntry and computeGlobalRisk both call classifyLevel via computeBlastRadiusRisk, so the shift cascades into every review's global risk score: a 5-dependent PR would now surface 'medium risk' instead of 'low'.",
-  "suggestion": "Add a test case asserting classifyLevel({ dependentCount: 5, ... }).level === 'low' (current behavior) or 'medium' (proposed behavior), then decide whether the shift is actually intended. If intended, document it in the commit message and update any documentation that describes the 'low at 5' threshold.",
+  "suggestion": "Add a test pair that pins the boundary from both sides: (a) classifyLevel({ dependentCount: 5, ... }).level === 'medium' (the new behavior at the divergence input) AND (b) classifyLevel({ dependentCount: 4, ... }).level === 'low' (the adjacent value, unchanged) — testing 5 alone leaves the other side unverified. Then decide whether the shift is intended; if so, document it in the commit message and update any docs describing the 'low at 5' threshold.",
   "evidence": "Boundary-change check — PR frames threshold change as a correction, but no test covers the boundary value where behavior diverges"
 }`,
   triggers: {

--- a/packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.assertions.ts
+++ b/packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.assertions.ts
@@ -47,10 +47,28 @@ const assertions: FixtureAssertions = {
     h.expectFindingMentions(['dependentCount === 5', 'dependentCount: 5', 'exactly 5'], result);
     h.expectFindingMentions(["low' to 'medium'", '"low" to "medium"', 'low to medium'], result);
     // (3) recommends a TEST PAIR — pin BOTH sides of the boundary, not just the
-    // value that crosses. Now achievable: after the boundary-change rule was
-    // updated to ask for it, "test pair" appears in 12/12 traced runs across
-    // gemini-3-flash + kimi-k2.7-code (was 0 before the rule change).
-    h.expectFindingMentions(['test pair', 'both sides', 'either side', 'adjacent', 'pin'], result);
+    // value that crosses. Accept either an explicit pair phrase OR a reference
+    // to the adjacent value (4): since gate (1) already requires the boundary
+    // value (5), a finding that also names 4 is recommending both sides — the
+    // real substance, independent of wording. The generic words "pin"/"adjacent"
+    // are deliberately NOT gated on (they can appear in a single-sided finding —
+    // PR #594 review). Now achievable after the boundary-change rule was updated
+    // to ask for a test pair; this list matches 22/22 traced gemini-3-flash +
+    // kimi-k2.7-code runs (was 0 before the rule change).
+    h.expectFindingMentions(
+      [
+        'test pair',
+        'both sides',
+        'either side',
+        'dependentCount: 4',
+        'dependentCount === 4',
+        'value 4',
+        'input 4',
+        '4 (low',
+        'and 4',
+      ],
+      result,
+    );
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.assertions.ts
+++ b/packages/review/test/harness/fixtures/boundary-change/ge-5-threshold-shift.assertions.ts
@@ -17,13 +17,19 @@
  * 10/10 only because it says "divergence" every run; kimi says it in ~40% of
  * runs, so it failed the brittle check despite an equivalent finding.
  *
- * The check now asserts the real shared substance as a conjunction: the finding
- * must name the boundary value (=== 5) AND state the low->medium flip. Two
- * separate expectFindingMentions calls => AND; each is any-of for phrasing
- * robustness. The aspirational "both sides" terms are deliberately NOT in the
- * gating lists — expectFindingMentions is an any-substring matcher, so mixing
- * them in would let a finding pass on vocabulary alone (the very brittleness
- * this recalibration removes). See PR #591 review (CodeRabbit + Lien self-review).
+ * The check asserts the real shared substance as a conjunction (separate
+ * expectFindingMentions calls => AND; each any-of for phrasing robustness):
+ * (1) names the boundary value (=== 5), (2) states the low->medium flip, and
+ * (3) recommends a TEST PAIR pinning both sides of the boundary.
+ *
+ * On gate (3): #591 had REMOVED a "both sides" check because it only ever
+ * matched the word "divergence" — neither model actually recommended both
+ * sides (gemini passed 10/10 on vocabulary; kimi failed ~60% despite an
+ * equivalent single-sided finding). The boundary-change rule was then updated
+ * to explicitly ask for a test pair; after that, gemini-3-flash and
+ * kimi-k2.7-code both emit "test pair" in 12/12 traced runs, so gate (3) is a
+ * real, achievable substance check that locks the improvement in. See PR #591
+ * (recalibration) plus the boundary-rule improvement that added gate (3).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -40,6 +46,11 @@ const assertions: FixtureAssertions = {
     // gemini-3-flash and kimi-k2.7-code runs (calibrate-10 + per-vote traces).
     h.expectFindingMentions(['dependentCount === 5', 'dependentCount: 5', 'exactly 5'], result);
     h.expectFindingMentions(["low' to 'medium'", '"low" to "medium"', 'low to medium'], result);
+    // (3) recommends a TEST PAIR — pin BOTH sides of the boundary, not just the
+    // value that crosses. Now achievable: after the boundary-change rule was
+    // updated to ask for it, "test pair" appears in 12/12 traced runs across
+    // gemini-3-flash + kimi-k2.7-code (was 0 before the rule change).
+    h.expectFindingMentions(['test pair', 'both sides', 'either side', 'adjacent', 'pin'], result);
   },
   votes: 3,
   passThreshold: 9,


### PR DESCRIPTION
## Why

The model A/B eval surfaced a real review-quality gap (not model-specific): on a threshold shift like `> 5` → `>= 5`, **neither `gemini-3-flash` nor `kimi-k2.7-code` recommended testing *both* sides of the boundary**. Both only suggested a test for the value that crosses (`5`), leaving the adjacent value (`4`) unverified. Boundary-value analysis wants a **test pair** — pin the boundary from both sides.

## What

- **`rules.ts` (boundary-change rule):** augment step 3 of the prompt + the worked-example `suggestion` to recommend a test pair: the divergence input (now reclassified) AND the adjacent value (unchanged). Minimal, style-consistent edit.
- **`ge-5-threshold-shift.assertions.ts`:** restore a both-sides Tier-2 gate (a 3rd `expectFindingMentions` for `test pair` / `both sides` / `adjacent` / `pin`). #591 had *removed* this as unachievable; the rule change makes it achievable, so the gate now locks the improvement in.

## Verification (harness, against the edited rule)

| | both-sides recommendation | calibrate-10 (3-gate, ≥9/10) |
|---|---|---|
| **before** rule change | 0/3 per model | n/a |
| **after** | **6/6** per model in traces; `"test pair"` in **12/12** | **kimi 10/10, gemini 10/10** |

No regression on the existing value/direction gates. Example output now: _"Add a test pair… `dependentCount: 5` (medium) and `4` (low)…"_.

_Independent of #593; based on current `main` (incl. #591/#592)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the boundary-change review guidance so findings now recommend checking both sides of a boundary shift, not just one value.
  * Added clearer examples for the expected test coverage around boundary changes, making review suggestions more precise and actionable.
* **Tests**
  * Updated the boundary-change test fixture to validate the stronger “test pair” requirement in boundary-related findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a prompt-engineering and harness-fixture change only. It updates the `boundary-change` rule's instructions and worked example to recommend a test pair covering both sides of a threshold shift, and restores a Tier-2 harness gate that checks for that recommendation. No runtime code, exported function semantics, or caller contracts were changed.
>
> - Updated `BOUNDARY_CHANGE.prompt` and example in `packages/review/src/plugins/agent/rules.ts` to recommend a boundary test pair (divergence input plus adjacent unchanged value)
> - Restored gate (3) in `ge-5-threshold-shift.assertions.ts` requiring the finding to mention a test pair, both sides, or the adjacent value `4`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 010f235. Updates automatically on new commits.</sup>
<!-- /lien-stats -->