### PR TITLE
fix(review): grep_codebase searches the real working tree

### DIFF
--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -250,6 +250,14 @@ const MAX_GREP_FILE_BYTES = 1_000_000;
  */
 const GREP_TIME_BUDGET_MS = 5_000;
 /**
+ * Cap each line at this length before regex matching. Bounds the input handed to
+ * a potentially backtracking pattern on very long (usually minified or data)
+ * lines. Not a full ReDoS defense — a crafted catastrophic pattern on a short
+ * line is still uninterruptible in JS — but it removes the easy long-line vector
+ * and pairs with the wall-clock budget below.
+ */
+const MAX_GREP_LINE_LENGTH = 2_000;
+/**
  * Directories never worth walking. Mirrors the heavy entries in
  * ALWAYS_IGNORE_PATTERNS so we prune them up front instead of reading every
  * entry and discarding it. `.github` is deliberately NOT skipped — CI
@@ -346,23 +354,30 @@ async function readGrepCandidate(absFile: string): Promise<string | null> {
 }
 
 /**
- * Append matching lines from `content` to `matches`. Collects one past the
- * result cap (a sentinel) so the caller can tell "exactly cap matches" from
- * "more than cap"; the extra is trimmed before returning. Line numbers are
- * 1-based.
+ * Append matching lines from `content` to `matches`; returns true if the
+ * wall-clock deadline was hit mid-file (checked per line, so a many-line file
+ * can't blow the budget). Collects one past the result cap (a sentinel) so the
+ * caller can tell "exactly cap matches" from "more than cap"; the extra is
+ * trimmed before returning. Each line is capped at MAX_GREP_LINE_LENGTH before
+ * testing to bound the regex input. Line numbers are 1-based.
  */
 function collectLineMatches(
   content: string,
   regex: RegExp,
   filepath: string,
   matches: GrepMatch[],
-): void {
+  deadline: number,
+): boolean {
   const lines = content.split('\n');
   for (let i = 0; i < lines.length && matches.length <= MAX_GREP_RESULTS; i++) {
-    if (regex.test(lines[i])) {
-      matches.push({ filepath, line: i + 1, match: lines[i].trim().slice(0, 200) });
+    if (Date.now() > deadline) return true;
+    const line = lines[i];
+    const probe = line.length > MAX_GREP_LINE_LENGTH ? line.slice(0, MAX_GREP_LINE_LENGTH) : line;
+    if (regex.test(probe)) {
+      matches.push({ filepath, line: i + 1, match: line.trim().slice(0, 200) });
     }
   }
+  return false;
 }
 
 /**
@@ -386,8 +401,10 @@ async function scanForMatches(
       break;
     }
     const content = await readGrepCandidate(absFile);
-    if (content !== null) {
-      collectLineMatches(content, regex, path.relative(rootDir, absFile), matches);
+    if (content === null) continue;
+    if (collectLineMatches(content, regex, path.relative(rootDir, absFile), matches, deadline)) {
+      timedOut = true;
+      break;
     }
   }
   const truncated = timedOut || matches.length > MAX_GREP_RESULTS;

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -264,8 +264,11 @@ interface GrepMatch {
 }
 
 /**
- * Recursively collect file paths under `dir`, pruning GREP_SKIP_DIRS, gitignored
- * paths, and symlinked directories (cycle/escape guard). Applying `isIgnored`
+ * Recursively collect file paths under `dir`, pruning GREP_SKIP_DIRS and
+ * gitignored paths. ALL symlinks (files and directories) are skipped — this
+ * guards against traversal cycles and reading targets outside repoRootDir, at
+ * the cost of missing references that live only behind a symlink (rare in a
+ * reviewed repo; read_file can still reach them by path). Applying `isIgnored`
  * during traversal means ignored directories (e.g. coverage/, .next/) are never
  * descended into, rather than walked and discarded afterward. Dotfiles and
  * dot-directories other than the skip set ARE included.
@@ -311,8 +314,10 @@ async function readGrepCandidate(absFile: string): Promise<string | null> {
 }
 
 /**
- * Append matching lines from `content` to `matches`, stopping at the global
- * result cap. Line numbers are 1-based.
+ * Append matching lines from `content` to `matches`. Collects one past the
+ * result cap (a sentinel) so the caller can tell "exactly cap matches" from
+ * "more than cap"; the extra is trimmed before returning. Line numbers are
+ * 1-based.
  */
 function collectLineMatches(
   content: string,
@@ -321,7 +326,7 @@ function collectLineMatches(
   matches: GrepMatch[],
 ): void {
   const lines = content.split('\n');
-  for (let i = 0; i < lines.length && matches.length < MAX_GREP_RESULTS; i++) {
+  for (let i = 0; i < lines.length && matches.length <= MAX_GREP_RESULTS; i++) {
     if (regex.test(lines[i])) {
       matches.push({ filepath, line: i + 1, match: lines[i].trim().slice(0, 200) });
     }
@@ -329,26 +334,32 @@ function collectLineMatches(
 }
 
 /**
- * Read and scan each file for `regex`, accumulating hits up to the result cap.
- * Bails out once the wall-clock deadline passes; `timedOut` then signals the
- * results may be incomplete.
+ * Read and scan each file for `regex`, accumulating hits up to one past the
+ * result cap. `truncated` is true when results are incomplete — either a
+ * genuine (cap+1)th match was found, or the wall-clock deadline passed. The
+ * sentinel overflow is trimmed off the returned matches.
  */
 async function scanForMatches(
   files: string[],
   regex: RegExp,
   rootDir: string,
   deadline: number,
-): Promise<{ matches: GrepMatch[]; timedOut: boolean }> {
+): Promise<{ matches: GrepMatch[]; truncated: boolean }> {
   const matches: GrepMatch[] = [];
+  let timedOut = false;
   for (const absFile of files) {
-    if (matches.length >= MAX_GREP_RESULTS) break;
-    if (Date.now() > deadline) return { matches, timedOut: true };
+    if (matches.length > MAX_GREP_RESULTS) break; // found the sentinel — there are more
+    if (Date.now() > deadline) {
+      timedOut = true;
+      break;
+    }
     const content = await readGrepCandidate(absFile);
     if (content !== null) {
       collectLineMatches(content, regex, path.relative(rootDir, absFile), matches);
     }
   }
-  return { matches, timedOut: false };
+  const truncated = timedOut || matches.length > MAX_GREP_RESULTS;
+  return { matches: matches.slice(0, MAX_GREP_RESULTS), truncated };
 }
 
 export async function grepCodebase(
@@ -375,19 +386,14 @@ export async function grepCodebase(
     await collectGrepFiles(ctx.repoRootDir, ctx.repoRootDir, isIgnored, files);
     files.sort(); // deterministic ordering across filesystems
 
-    const { matches, timedOut } = await scanForMatches(
+    const { matches, truncated } = await scanForMatches(
       files,
       regex,
       ctx.repoRootDir,
       Date.now() + GREP_TIME_BUDGET_MS,
     );
 
-    return JSON.stringify({
-      results: matches,
-      count: matches.length,
-      // truncated = results may be incomplete: hit the result cap or time budget.
-      truncated: timedOut || matches.length >= MAX_GREP_RESULTS,
-    });
+    return JSON.stringify({ results: matches, count: matches.length, truncated });
   } catch (err) {
     return JSON.stringify({ error: `grep_codebase failed: ${(err as Error).message}` });
   }

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -1,14 +1,17 @@
 /**
  * Agent tool implementations backed by in-memory CodeChunk[] arrays.
  *
- * No VectorDB or embeddings required — all tools work from the repoChunks
- * that the engine already produces via performChunkOnlyIndex().
+ * No VectorDB or embeddings required. Most tools work from the repoChunks
+ * that the engine already produces via performChunkOnlyIndex(); the
+ * exceptions are read_file and grep_codebase, which read the cloned repo
+ * from disk so they can see files the parser never chunks (config, YAML,
+ * CI workflows, etc.).
  */
 
 import fs from 'fs/promises';
 import path from 'path';
 
-import { analyzeComplexityFromChunks } from '@liendev/parser';
+import { analyzeComplexityFromChunks, createGitignoreFilter } from '@liendev/parser';
 
 import type { AgentToolContext } from './types.js';
 
@@ -234,28 +237,92 @@ export function getComplexity(input: Record<string, unknown>, ctx: AgentToolCont
 // ---------------------------------------------------------------------------
 
 const MAX_GREP_RESULTS = 30;
+/** Skip files larger than this — lockfiles, bundles, and binaries are noise. */
+const MAX_GREP_FILE_BYTES = 1_000_000;
+/**
+ * Directories never worth walking. Mirrors the heavy entries in
+ * ALWAYS_IGNORE_PATTERNS so we prune them up front instead of reading every
+ * entry and discarding it. `.github` is deliberately NOT skipped — CI
+ * workflows are exactly the kind of non-code reference we now want to find.
+ */
+const GREP_SKIP_DIRS = new Set(['node_modules', '.git', 'vendor', 'dist', 'build', '.lien']);
 
-export function grepCodebase(input: Record<string, unknown>, ctx: AgentToolContext): string {
+/**
+ * Recursively collect file paths under `dir`, pruning GREP_SKIP_DIRS and
+ * symlinked directories (cycle/escape guard). Dotfiles and dot-directories
+ * other than the skip set ARE included.
+ */
+async function collectGrepFiles(dir: string, acc: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // unreadable directory — skip rather than abort the whole grep
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (GREP_SKIP_DIRS.has(entry.name)) continue;
+      await collectGrepFiles(full, acc);
+    } else if (entry.isFile()) {
+      acc.push(full);
+    }
+  }
+}
+
+export async function grepCodebase(
+  input: Record<string, unknown>,
+  ctx: AgentToolContext,
+): Promise<string> {
   try {
     const pattern = input.pattern as string;
     if (!pattern) return JSON.stringify({ error: 'pattern is required' });
 
-    const regex = new RegExp(pattern, 'i');
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern, 'i');
+    } catch (err) {
+      return JSON.stringify({ error: `Invalid regex pattern: ${(err as Error).message}` });
+    }
+
+    // Search the real working tree (not just parser-chunked source) so refs in
+    // config, YAML, CI workflows, etc. are visible. Respect .gitignore +
+    // built-in excludes via the shared parser filter.
+    const isIgnored = await createGitignoreFilter(ctx.repoRootDir);
+    const files: string[] = [];
+    await collectGrepFiles(ctx.repoRootDir, files);
+    files.sort(); // deterministic ordering across filesystems
+
     const matches: Array<{ filepath: string; line: number; match: string }> = [];
 
-    for (const chunk of ctx.repoChunks) {
-      const lines = chunk.content.split('\n');
+    for (const absFile of files) {
+      if (matches.length >= MAX_GREP_RESULTS) break;
+
+      const relPath = path.relative(ctx.repoRootDir, absFile);
+      if (isIgnored(relPath)) continue;
+
+      let content: string;
+      try {
+        const stat = await fs.stat(absFile);
+        if (stat.size > MAX_GREP_FILE_BYTES) continue;
+        content = await fs.readFile(absFile, 'utf-8');
+      } catch {
+        continue; // disappeared / permission / not readable — skip
+      }
+      if (content.includes('\0')) continue; // binary
+
+      const lines = content.split('\n');
       for (let i = 0; i < lines.length; i++) {
         if (regex.test(lines[i])) {
           matches.push({
-            filepath: chunk.metadata.file,
-            line: chunk.metadata.startLine + i,
+            filepath: relPath,
+            line: i + 1,
             match: lines[i].trim().slice(0, 200),
           });
           if (matches.length >= MAX_GREP_RESULTS) break;
         }
       }
-      if (matches.length >= MAX_GREP_RESULTS) break;
     }
 
     return JSON.stringify({

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -250,14 +250,6 @@ const MAX_GREP_FILE_BYTES = 1_000_000;
  */
 const GREP_TIME_BUDGET_MS = 5_000;
 /**
- * Cap each line at this length before regex matching. Bounds the input handed to
- * a potentially backtracking pattern on very long (usually minified or data)
- * lines. Not a full ReDoS defense — a crafted catastrophic pattern on a short
- * line is still uninterruptible in JS — but it removes the easy long-line vector
- * and pairs with the wall-clock budget below.
- */
-const MAX_GREP_LINE_LENGTH = 2_000;
-/**
  * Directories never worth walking. Mirrors the heavy entries in
  * ALWAYS_IGNORE_PATTERNS so we prune them up front instead of reading every
  * entry and discarding it. `.github` is deliberately NOT skipped — CI
@@ -275,17 +267,23 @@ interface GrepMatch {
 /**
  * Decide whether a symlink entry should be grepped. Follows the link with
  * realpath and includes it only when it resolves to a regular file whose real
- * location stays inside `rootDir`. Directory symlinks (traversal cycle / escape
- * risk), out-of-tree targets, and broken links are excluded. This lets grep see
- * references behind symlinked config/source while never reading outside the
- * repo. `rootDir` must already be canonical (see grepCodebase) so the
- * containment comparison is like-for-like.
+ * location stays inside `rootDir` and is not itself gitignored (a non-ignored
+ * link must not become a back door to ignored content). Directory symlinks
+ * (traversal cycle / escape risk), out-of-tree targets, and broken links are
+ * excluded. This lets grep see references behind symlinked config/source while
+ * never reading outside the repo or past .gitignore. `rootDir` must already be
+ * canonical (see grepCodebase) so the containment comparison is like-for-like.
  */
-async function symlinkPointsToFileInRepo(rootDir: string, linkPath: string): Promise<boolean> {
+async function symlinkPointsToFileInRepo(
+  rootDir: string,
+  linkPath: string,
+  isIgnored: (relPath: string) => boolean,
+): Promise<boolean> {
   try {
     const real = await fs.realpath(linkPath);
     const rel = path.relative(rootDir, real);
-    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return false;
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return false; // escapes repo
+    if (isIgnored(rel)) return false; // target is gitignored — don't scan it via the link
     return (await fs.stat(real)).isFile();
   } catch {
     return false; // broken link / permission
@@ -295,17 +293,19 @@ async function symlinkPointsToFileInRepo(rootDir: string, linkPath: string): Pro
 /**
  * Classify a directory entry for the grep walk: 'file' to scan, 'dir' to
  * descend into, or 'skip'. Regular files scan; non-skip directories descend;
- * symlinks scan only when they point to a regular file inside the repo
- * (directory symlinks are skipped to avoid cycles/escapes).
+ * symlinks scan only when they point to a non-ignored regular file inside the
+ * repo (directory symlinks are skipped to avoid cycles/escapes).
  */
 async function classifyGrepEntry(
   rootDir: string,
   entry: Dirent,
   full: string,
+  isIgnored: (relPath: string) => boolean,
 ): Promise<'file' | 'dir' | 'skip'> {
   if (entry.isFile()) return 'file';
   if (entry.isDirectory()) return GREP_SKIP_DIRS.has(entry.name) ? 'skip' : 'dir';
-  if (entry.isSymbolicLink() && (await symlinkPointsToFileInRepo(rootDir, full))) return 'file';
+  if (entry.isSymbolicLink() && (await symlinkPointsToFileInRepo(rootDir, full, isIgnored)))
+    return 'file';
   return 'skip';
 }
 
@@ -331,7 +331,7 @@ async function collectGrepFiles(
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (isIgnored(path.relative(rootDir, full))) continue;
-    const kind = await classifyGrepEntry(rootDir, entry, full);
+    const kind = await classifyGrepEntry(rootDir, entry, full, isIgnored);
     if (kind === 'file') acc.push(full);
     else if (kind === 'dir') await collectGrepFiles(rootDir, full, isIgnored, acc);
   }
@@ -358,8 +358,9 @@ async function readGrepCandidate(absFile: string): Promise<string | null> {
  * wall-clock deadline was hit mid-file (checked per line, so a many-line file
  * can't blow the budget). Collects one past the result cap (a sentinel) so the
  * caller can tell "exactly cap matches" from "more than cap"; the extra is
- * trimmed before returning. Each line is capped at MAX_GREP_LINE_LENGTH before
- * testing to bound the regex input. Line numbers are 1-based.
+ * trimmed before returning. Lines are tested in full — no length clipping —
+ * to avoid dropping matches or skewing anchored patterns. Line numbers are
+ * 1-based.
  */
 function collectLineMatches(
   content: string,
@@ -371,10 +372,8 @@ function collectLineMatches(
   const lines = content.split('\n');
   for (let i = 0; i < lines.length && matches.length <= MAX_GREP_RESULTS; i++) {
     if (Date.now() > deadline) return true;
-    const line = lines[i];
-    const probe = line.length > MAX_GREP_LINE_LENGTH ? line.slice(0, MAX_GREP_LINE_LENGTH) : line;
-    if (regex.test(probe)) {
-      matches.push({ filepath, line: i + 1, match: line.trim().slice(0, 200) });
+    if (regex.test(lines[i])) {
+      matches.push({ filepath, line: i + 1, match: lines[i].trim().slice(0, 200) });
     }
   }
   return false;

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -240,6 +240,15 @@ const MAX_GREP_RESULTS = 30;
 /** Skip files larger than this — lockfiles, bundles, and binaries are noise. */
 const MAX_GREP_FILE_BYTES = 1_000_000;
 /**
+ * Wall-clock backstop for a single grep call. The agent-supplied pattern is
+ * compiled with `new RegExp` and could backtrack pathologically (ReDoS) or the
+ * repo could simply be huge; this bounds total scan time and returns partial
+ * results rather than hanging the worker. It does not interrupt a single
+ * `regex.test` already in flight — a non-backtracking engine (e.g. RE2) would,
+ * but that is a native dependency we avoid to keep the Action portable.
+ */
+const GREP_TIME_BUDGET_MS = 5_000;
+/**
  * Directories never worth walking. Mirrors the heavy entries in
  * ALWAYS_IGNORE_PATTERNS so we prune them up front instead of reading every
  * entry and discarding it. `.github` is deliberately NOT skipped — CI
@@ -247,12 +256,26 @@ const MAX_GREP_FILE_BYTES = 1_000_000;
  */
 const GREP_SKIP_DIRS = new Set(['node_modules', '.git', 'vendor', 'dist', 'build', '.lien']);
 
+/** A single grep hit: file path, 1-based line number, and trimmed matching text. */
+interface GrepMatch {
+  filepath: string;
+  line: number;
+  match: string;
+}
+
 /**
- * Recursively collect file paths under `dir`, pruning GREP_SKIP_DIRS and
- * symlinked directories (cycle/escape guard). Dotfiles and dot-directories
- * other than the skip set ARE included.
+ * Recursively collect file paths under `dir`, pruning GREP_SKIP_DIRS, gitignored
+ * paths, and symlinked directories (cycle/escape guard). Applying `isIgnored`
+ * during traversal means ignored directories (e.g. coverage/, .next/) are never
+ * descended into, rather than walked and discarded afterward. Dotfiles and
+ * dot-directories other than the skip set ARE included.
  */
-async function collectGrepFiles(dir: string, acc: string[]): Promise<void> {
+async function collectGrepFiles(
+  rootDir: string,
+  dir: string,
+  isIgnored: (relPath: string) => boolean,
+  acc: string[],
+): Promise<void> {
   let entries;
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
@@ -262,13 +285,70 @@ async function collectGrepFiles(dir: string, acc: string[]): Promise<void> {
   for (const entry of entries) {
     if (entry.isSymbolicLink()) continue;
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (GREP_SKIP_DIRS.has(entry.name)) continue;
-      await collectGrepFiles(full, acc);
-    } else if (entry.isFile()) {
+    if (isIgnored(path.relative(rootDir, full))) continue;
+    if (entry.isFile()) {
       acc.push(full);
+    } else if (entry.isDirectory() && !GREP_SKIP_DIRS.has(entry.name)) {
+      await collectGrepFiles(rootDir, full, isIgnored, acc);
     }
   }
+}
+
+/**
+ * Read a file's text for grepping, or null if it should be skipped: too large,
+ * binary (contains a NUL byte), or unreadable. Keeps those guards out of the
+ * main loop.
+ */
+async function readGrepCandidate(absFile: string): Promise<string | null> {
+  try {
+    const { size } = await fs.stat(absFile);
+    if (size > MAX_GREP_FILE_BYTES) return null;
+    const content = await fs.readFile(absFile, 'utf-8');
+    return content.includes('\0') ? null : content;
+  } catch {
+    return null; // disappeared / permission / not readable
+  }
+}
+
+/**
+ * Append matching lines from `content` to `matches`, stopping at the global
+ * result cap. Line numbers are 1-based.
+ */
+function collectLineMatches(
+  content: string,
+  regex: RegExp,
+  filepath: string,
+  matches: GrepMatch[],
+): void {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length && matches.length < MAX_GREP_RESULTS; i++) {
+    if (regex.test(lines[i])) {
+      matches.push({ filepath, line: i + 1, match: lines[i].trim().slice(0, 200) });
+    }
+  }
+}
+
+/**
+ * Read and scan each file for `regex`, accumulating hits up to the result cap.
+ * Bails out once the wall-clock deadline passes; `timedOut` then signals the
+ * results may be incomplete.
+ */
+async function scanForMatches(
+  files: string[],
+  regex: RegExp,
+  rootDir: string,
+  deadline: number,
+): Promise<{ matches: GrepMatch[]; timedOut: boolean }> {
+  const matches: GrepMatch[] = [];
+  for (const absFile of files) {
+    if (matches.length >= MAX_GREP_RESULTS) break;
+    if (Date.now() > deadline) return { matches, timedOut: true };
+    const content = await readGrepCandidate(absFile);
+    if (content !== null) {
+      collectLineMatches(content, regex, path.relative(rootDir, absFile), matches);
+    }
+  }
+  return { matches, timedOut: false };
 }
 
 export async function grepCodebase(
@@ -288,47 +368,25 @@ export async function grepCodebase(
 
     // Search the real working tree (not just parser-chunked source) so refs in
     // config, YAML, CI workflows, etc. are visible. Respect .gitignore +
-    // built-in excludes via the shared parser filter.
+    // built-in excludes via the shared parser filter, pruning ignored paths
+    // during the walk rather than after.
     const isIgnored = await createGitignoreFilter(ctx.repoRootDir);
     const files: string[] = [];
-    await collectGrepFiles(ctx.repoRootDir, files);
+    await collectGrepFiles(ctx.repoRootDir, ctx.repoRootDir, isIgnored, files);
     files.sort(); // deterministic ordering across filesystems
 
-    const matches: Array<{ filepath: string; line: number; match: string }> = [];
-
-    for (const absFile of files) {
-      if (matches.length >= MAX_GREP_RESULTS) break;
-
-      const relPath = path.relative(ctx.repoRootDir, absFile);
-      if (isIgnored(relPath)) continue;
-
-      let content: string;
-      try {
-        const stat = await fs.stat(absFile);
-        if (stat.size > MAX_GREP_FILE_BYTES) continue;
-        content = await fs.readFile(absFile, 'utf-8');
-      } catch {
-        continue; // disappeared / permission / not readable — skip
-      }
-      if (content.includes('\0')) continue; // binary
-
-      const lines = content.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        if (regex.test(lines[i])) {
-          matches.push({
-            filepath: relPath,
-            line: i + 1,
-            match: lines[i].trim().slice(0, 200),
-          });
-          if (matches.length >= MAX_GREP_RESULTS) break;
-        }
-      }
-    }
+    const { matches, timedOut } = await scanForMatches(
+      files,
+      regex,
+      ctx.repoRootDir,
+      Date.now() + GREP_TIME_BUDGET_MS,
+    );
 
     return JSON.stringify({
       results: matches,
       count: matches.length,
-      truncated: matches.length >= MAX_GREP_RESULTS,
+      // truncated = results may be incomplete: hit the result cap or time budget.
+      truncated: timedOut || matches.length >= MAX_GREP_RESULTS,
     });
   } catch (err) {
     return JSON.stringify({ error: `grep_codebase failed: ${(err as Error).message}` });

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -9,6 +9,7 @@
  */
 
 import fs from 'fs/promises';
+import type { Dirent } from 'fs';
 import path from 'path';
 
 import { analyzeComplexityFromChunks, createGitignoreFilter } from '@liendev/parser';
@@ -264,14 +265,48 @@ interface GrepMatch {
 }
 
 /**
+ * Decide whether a symlink entry should be grepped. Follows the link with
+ * realpath and includes it only when it resolves to a regular file whose real
+ * location stays inside `rootDir`. Directory symlinks (traversal cycle / escape
+ * risk), out-of-tree targets, and broken links are excluded. This lets grep see
+ * references behind symlinked config/source while never reading outside the
+ * repo. `rootDir` must already be canonical (see grepCodebase) so the
+ * containment comparison is like-for-like.
+ */
+async function symlinkPointsToFileInRepo(rootDir: string, linkPath: string): Promise<boolean> {
+  try {
+    const real = await fs.realpath(linkPath);
+    const rel = path.relative(rootDir, real);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return false;
+    return (await fs.stat(real)).isFile();
+  } catch {
+    return false; // broken link / permission
+  }
+}
+
+/**
+ * Classify a directory entry for the grep walk: 'file' to scan, 'dir' to
+ * descend into, or 'skip'. Regular files scan; non-skip directories descend;
+ * symlinks scan only when they point to a regular file inside the repo
+ * (directory symlinks are skipped to avoid cycles/escapes).
+ */
+async function classifyGrepEntry(
+  rootDir: string,
+  entry: Dirent,
+  full: string,
+): Promise<'file' | 'dir' | 'skip'> {
+  if (entry.isFile()) return 'file';
+  if (entry.isDirectory()) return GREP_SKIP_DIRS.has(entry.name) ? 'skip' : 'dir';
+  if (entry.isSymbolicLink() && (await symlinkPointsToFileInRepo(rootDir, full))) return 'file';
+  return 'skip';
+}
+
+/**
  * Recursively collect file paths under `dir`, pruning GREP_SKIP_DIRS and
- * gitignored paths. ALL symlinks (files and directories) are skipped — this
- * guards against traversal cycles and reading targets outside repoRootDir, at
- * the cost of missing references that live only behind a symlink (rare in a
- * reviewed repo; read_file can still reach them by path). Applying `isIgnored`
- * during traversal means ignored directories (e.g. coverage/, .next/) are never
- * descended into, rather than walked and discarded afterward. Dotfiles and
- * dot-directories other than the skip set ARE included.
+ * gitignored paths. Applying `isIgnored` during traversal means ignored
+ * directories (e.g. coverage/, .next/) are never descended into, rather than
+ * walked and discarded afterward. Dotfiles and dot-directories other than the
+ * skip set ARE included.
  */
 async function collectGrepFiles(
   rootDir: string,
@@ -286,14 +321,11 @@ async function collectGrepFiles(
     return; // unreadable directory — skip rather than abort the whole grep
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink()) continue;
     const full = path.join(dir, entry.name);
     if (isIgnored(path.relative(rootDir, full))) continue;
-    if (entry.isFile()) {
-      acc.push(full);
-    } else if (entry.isDirectory() && !GREP_SKIP_DIRS.has(entry.name)) {
-      await collectGrepFiles(rootDir, full, isIgnored, acc);
-    }
+    const kind = await classifyGrepEntry(rootDir, entry, full);
+    if (kind === 'file') acc.push(full);
+    else if (kind === 'dir') await collectGrepFiles(rootDir, full, isIgnored, acc);
   }
 }
 
@@ -380,16 +412,18 @@ export async function grepCodebase(
     // Search the real working tree (not just parser-chunked source) so refs in
     // config, YAML, CI workflows, etc. are visible. Respect .gitignore +
     // built-in excludes via the shared parser filter, pruning ignored paths
-    // during the walk rather than after.
-    const isIgnored = await createGitignoreFilter(ctx.repoRootDir);
+    // during the walk rather than after. Canonicalize the root first so symlink
+    // containment checks compare like-for-like (e.g. macOS /var vs /private/var).
+    const rootDir = await fs.realpath(ctx.repoRootDir);
+    const isIgnored = await createGitignoreFilter(rootDir);
     const files: string[] = [];
-    await collectGrepFiles(ctx.repoRootDir, ctx.repoRootDir, isIgnored, files);
+    await collectGrepFiles(rootDir, rootDir, isIgnored, files);
     files.sort(); // deterministic ordering across filesystems
 
     const { matches, truncated } = await scanForMatches(
       files,
       regex,
-      ctx.repoRootDir,
+      rootDir,
       Date.now() + GREP_TIME_BUDGET_MS,
     );
 

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -28,7 +28,7 @@ You have these tools to investigate the codebase:
 - get_dependents: Find all callers/importers of a file or symbol
 - get_files_context: Get all code chunks, imports, exports, and call sites for files
 - list_functions: Search for symbols by name pattern
-- grep_codebase: Search the entire repository for a text pattern (regex). Use to find all files that reference a symbol, including cross-package imports within this monorepo.
+- grep_codebase: Search the entire repository working tree for a text pattern (regex), including non-code files (config, JSON/YAML, CI workflows, scripts). Use to find all files that reference a symbol, including cross-package imports within this monorepo and references outside source code.
 - get_complexity: Get complexity metrics for files
 - read_file: Read file contents from the repo
 

--- a/packages/review/src/plugins/agent/tools.ts
+++ b/packages/review/src/plugins/agent/tools.ts
@@ -124,7 +124,8 @@ export const AGENT_TOOLS = [
       'files (config, JSON/YAML, CI workflows under .github, SQL, shell scripts) — not just ' +
       'source code. Use this to find all files that reference a specific symbol, import, or ' +
       'string. Critical for checking if deleted exports are still referenced elsewhere. ' +
-      'Respects .gitignore; skips binaries and very large files.',
+      'Respects .gitignore; skips binaries and very large files. Matching is time-budgeted, ' +
+      'so on very large repos or pathological patterns results may be partial (truncated=true).',
     input_schema: {
       type: 'object' as const,
       properties: {

--- a/packages/review/src/plugins/agent/tools.ts
+++ b/packages/review/src/plugins/agent/tools.ts
@@ -1,12 +1,16 @@
 /**
  * Anthropic tool definitions and dispatch for the agent review plugin.
  *
- * Defines 5 chunk-based tools (no embeddings required):
+ * Defines 6 tools (no embeddings required):
  * - get_files_context: retrieve all chunks for specific files
  * - get_dependents: find callers/importers of a symbol
  * - list_functions: search symbols by pattern
  * - get_complexity: complexity metrics for files
+ * - grep_codebase: regex search across the cloned repo's working tree
  * - read_file: read file contents from the cloned repo
+ *
+ * The first four are backed by in-memory chunks; grep_codebase and read_file
+ * read the cloned repo from disk (so they cover non-chunked files too).
  */
 
 import type { AgentToolContext } from './types.js';
@@ -116,9 +120,11 @@ export const AGENT_TOOLS = [
   {
     name: 'grep_codebase',
     description:
-      'Search the entire codebase for a text pattern (regex). Use this to find all files that ' +
-      'reference a specific symbol, import, or string. Critical for checking if deleted exports ' +
-      'are still imported elsewhere.',
+      'Search the entire repository working tree for a text pattern (regex), including non-code ' +
+      'files (config, JSON/YAML, CI workflows under .github, SQL, shell scripts) — not just ' +
+      'source code. Use this to find all files that reference a specific symbol, import, or ' +
+      'string. Critical for checking if deleted exports are still referenced elsewhere. ' +
+      'Respects .gitignore; skips binaries and very large files.',
     input_schema: {
       type: 'object' as const,
       properties: {

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -63,11 +63,12 @@ describe('grepCodebase — real working-tree search', () => {
     expect(files).toContain('README.md');
   });
 
-  it('respects .gitignore, prunes node_modules, and skips binary files', async () => {
+  it('respects .gitignore (files and dirs), prunes node_modules, and skips binary files', async () => {
     const SYM = 'OpenRouterClient';
     await write(root, 'src/app.ts', `const x = '${SYM}';\n`);
-    await write(root, '.gitignore', 'secret.txt\n');
-    await write(root, 'secret.txt', `${SYM} should be ignored\n`); // gitignored
+    await write(root, '.gitignore', 'secret.txt\ncoverage/\n');
+    await write(root, 'secret.txt', `${SYM} should be ignored\n`); // gitignored file
+    await write(root, 'coverage/report.txt', `${SYM} in ignored dir\n`); // gitignored dir, pruned in walk
     await write(root, 'node_modules/foo/index.js', `${SYM}\n`); // pruned + always-ignored
     // Binary: an embedded NUL byte trips the binary guard.
     await write(root, 'bin.dat', `\0${SYM}\0`);
@@ -77,6 +78,7 @@ describe('grepCodebase — real working-tree search', () => {
 
     expect(files).toContain('src/app.ts');
     expect(files).not.toContain('secret.txt');
+    expect(files).not.toContain(path.join('coverage', 'report.txt'));
     expect(files).not.toContain(path.join('node_modules', 'foo', 'index.js'));
     expect(files).not.toContain('bin.dat');
   });

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { grepCodebase } from '../src/plugins/agent/agent-tools.js';
+import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { silentLogger } from '../src/test-helpers.js';
+import type { AgentToolContext } from '../src/plugins/agent/types.js';
+
+/** Parsed shape of grepCodebase's JSON return. */
+interface GrepResult {
+  results?: Array<{ filepath: string; line: number; match: string }>;
+  count?: number;
+  truncated?: boolean;
+  error?: string;
+}
+
+async function write(root: string, rel: string, content: string): Promise<void> {
+  const full = path.join(root, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content, 'utf-8');
+}
+
+function ctxFor(repoRootDir: string): AgentToolContext {
+  return {
+    repoChunks: [],
+    repoRootDir,
+    graph: buildDependencyGraph([]),
+    logger: silentLogger,
+  };
+}
+
+async function runGrep(repoRootDir: string, pattern: string): Promise<GrepResult> {
+  return JSON.parse(await grepCodebase({ pattern }, ctxFor(repoRootDir))) as GrepResult;
+}
+
+describe('grepCodebase — real working-tree search', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-grep-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('finds references in non-code files (the bug fix): YAML, JSON, Markdown, and CI workflows', async () => {
+    const SYM = 'OpenRouterClient';
+    await write(root, 'src/app.ts', `export class ${SYM} {}\n`);
+    await write(root, '.github/workflows/ci.yml', `jobs:\n  run: node -e "${SYM}"\n`); // dot-dir
+    await write(root, 'config.json', `{ "client": "${SYM}" }\n`);
+    await write(root, 'README.md', `This project uses ${SYM} for routing.\n`);
+
+    const res = await runGrep(root, SYM);
+    const files = new Set((res.results ?? []).map(r => r.filepath));
+
+    expect(res.error).toBeUndefined();
+    expect(files).toContain('src/app.ts');
+    expect(files).toContain(path.join('.github', 'workflows', 'ci.yml'));
+    expect(files).toContain('config.json');
+    expect(files).toContain('README.md');
+  });
+
+  it('respects .gitignore, prunes node_modules, and skips binary files', async () => {
+    const SYM = 'OpenRouterClient';
+    await write(root, 'src/app.ts', `const x = '${SYM}';\n`);
+    await write(root, '.gitignore', 'secret.txt\n');
+    await write(root, 'secret.txt', `${SYM} should be ignored\n`); // gitignored
+    await write(root, 'node_modules/foo/index.js', `${SYM}\n`); // pruned + always-ignored
+    // Binary: an embedded NUL byte trips the binary guard.
+    await write(root, 'bin.dat', `\0${SYM}\0`);
+
+    const res = await runGrep(root, SYM);
+    const files = new Set((res.results ?? []).map(r => r.filepath));
+
+    expect(files).toContain('src/app.ts');
+    expect(files).not.toContain('secret.txt');
+    expect(files).not.toContain(path.join('node_modules', 'foo', 'index.js'));
+    expect(files).not.toContain('bin.dat');
+  });
+
+  it('reports true 1-based file line numbers', async () => {
+    await write(root, 'multi.ts', 'line one\nNEEDLE here\nline three\n');
+    const res = await runGrep(root, 'NEEDLE');
+    expect(res.results).toHaveLength(1);
+    expect(res.results![0]).toMatchObject({ filepath: 'multi.ts', line: 2 });
+  });
+
+  it('caps results and flags truncation', async () => {
+    // 50 matching lines in a single file — more than the internal cap (30).
+    const lines = Array.from({ length: 50 }, (_, i) => `match ${i} HIT`).join('\n');
+    await write(root, 'many.ts', lines);
+
+    const res = await runGrep(root, 'HIT');
+    expect(res.truncated).toBe(true);
+    expect(res.count).toBe(30);
+    expect(res.results).toHaveLength(30);
+  });
+
+  it('returns a clean error for an invalid regex instead of throwing', async () => {
+    await write(root, 'a.ts', 'anything\n');
+    const res = await runGrep(root, '(');
+    expect(res.error).toBeDefined();
+    expect(res.error).toMatch(/invalid regex/i);
+  });
+
+  it('requires a pattern', async () => {
+    const res = JSON.parse(await grepCodebase({}, ctxFor(root))) as GrepResult;
+    expect(res.error).toBe('pattern is required');
+  });
+});

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -90,8 +90,8 @@ describe('grepCodebase — real working-tree search', () => {
     expect(res.results![0]).toMatchObject({ filepath: 'multi.ts', line: 2 });
   });
 
-  it('caps results and flags truncation', async () => {
-    // 50 matching lines in a single file — more than the internal cap (30).
+  it('caps results and flags truncation only when matches exceed the cap', async () => {
+    // 50 matching lines — well over the internal cap (30) → truncated.
     const lines = Array.from({ length: 50 }, (_, i) => `match ${i} HIT`).join('\n');
     await write(root, 'many.ts', lines);
 
@@ -99,6 +99,16 @@ describe('grepCodebase — real working-tree search', () => {
     expect(res.truncated).toBe(true);
     expect(res.count).toBe(30);
     expect(res.results).toHaveLength(30);
+  });
+
+  it('does not flag truncation when matches exactly equal the cap', async () => {
+    // Exactly 30 matches and nothing dropped → truncated must be false.
+    const lines = Array.from({ length: 30 }, (_, i) => `match ${i} HIT`).join('\n');
+    await write(root, 'exact.ts', lines);
+
+    const res = await runGrep(root, 'HIT');
+    expect(res.count).toBe(30);
+    expect(res.truncated).toBe(false);
   });
 
   it('returns a clean error for an invalid regex instead of throwing', async () => {

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -83,6 +83,38 @@ describe('grepCodebase — real working-tree search', () => {
     expect(files).not.toContain('bin.dat');
   });
 
+  it('follows in-repo file symlinks but skips out-of-repo, directory, and broken links', async () => {
+    const SYM = 'OpenRouterClient';
+    // Real target inside the repo, plus a symlink to it → should be followed.
+    await write(root, 'shared/config.ts', `export const c = '${SYM}';\n`);
+    await fs.symlink(path.join(root, 'shared', 'config.ts'), path.join(root, 'linked-config.ts'));
+
+    // Symlink to a file OUTSIDE the repo → must be skipped (no escape).
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-grep-out-'));
+    await write(outside, 'secrets.ts', `const leak = '${SYM}';\n`);
+    await fs.symlink(path.join(outside, 'secrets.ts'), path.join(root, 'escape.ts'));
+
+    // Directory symlink → skipped (cycle/escape guard).
+    await write(root, 'realdir/inside.ts', `const d = '${SYM}';\n`);
+    await fs.symlink(path.join(root, 'realdir'), path.join(root, 'linkdir'));
+
+    // Broken symlink → skipped.
+    await fs.symlink(path.join(root, 'does-not-exist.ts'), path.join(root, 'broken.ts'));
+
+    try {
+      const res = await runGrep(root, SYM);
+      const files = new Set((res.results ?? []).map(r => r.filepath));
+
+      expect(files).toContain('linked-config.ts'); // followed in-repo file symlink
+      expect(files).toContain(path.join('shared', 'config.ts')); // and the real target
+      expect(files).not.toContain('escape.ts'); // out-of-repo target excluded
+      expect([...files]).not.toContain(path.join('linkdir', 'inside.ts')); // dir symlink not traversed
+      expect(files).not.toContain('broken.ts'); // broken link excluded
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it('reports true 1-based file line numbers', async () => {
     await write(root, 'multi.ts', 'line one\nNEEDLE here\nline three\n');
     const res = await runGrep(root, 'NEEDLE');

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -115,12 +115,25 @@ describe('grepCodebase — real working-tree search', () => {
     }
   });
 
-  it('still matches on very long lines (past the per-line cap) when the hit is near the start', async () => {
-    // A single line far longer than MAX_GREP_LINE_LENGTH with the needle early.
-    await write(root, 'long.ts', `const NEEDLE = '${'x'.repeat(5000)}';\n`);
+  it('matches anywhere on very long lines (no length clipping)', async () => {
+    // Needle sits well past 2000 chars — full-line matching must still find it.
+    await write(root, 'long.ts', `const x = '${'a'.repeat(4000)}NEEDLE';\n`);
     const res = await runGrep(root, 'NEEDLE');
     const files = new Set((res.results ?? []).map(r => r.filepath));
     expect(files).toContain('long.ts');
+  });
+
+  it('does not scan a gitignored target reached via a non-ignored symlink', async () => {
+    const SYM = 'OpenRouterClient';
+    await write(root, '.gitignore', 'private/\n');
+    await write(root, 'private/secret.ts', `const s = '${SYM}';\n`); // gitignored target
+    await fs.symlink(path.join(root, 'private', 'secret.ts'), path.join(root, 'link.ts')); // link not ignored
+    await write(root, 'ok.ts', `const k = '${SYM}';\n`); // control match
+
+    const res = await runGrep(root, SYM);
+    const files = new Set((res.results ?? []).map(r => r.filepath));
+    expect(files).toContain('ok.ts');
+    expect(files).not.toContain('link.ts'); // .gitignore not bypassed via the symlink
   });
 
   it('reports true 1-based file line numbers', async () => {

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -115,6 +115,14 @@ describe('grepCodebase — real working-tree search', () => {
     }
   });
 
+  it('still matches on very long lines (past the per-line cap) when the hit is near the start', async () => {
+    // A single line far longer than MAX_GREP_LINE_LENGTH with the needle early.
+    await write(root, 'long.ts', `const NEEDLE = '${'x'.repeat(5000)}';\n`);
+    const res = await runGrep(root, 'NEEDLE');
+    const files = new Set((res.results ?? []).map(r => r.filepath));
+    expect(files).toContain('long.ts');
+  });
+
   it('reports true 1-based file line numbers', async () => {
     await write(root, 'multi.ts', 'line one\nNEEDLE here\nline three\n');
     const res = await runGrep(root, 'NEEDLE');


### PR DESCRIPTION
## Problem

The agent-review tool `grep_codebase` only iterated **parser-chunked source code** (`ctx.repoChunks`). `performChunkOnlyIndex` chunks a fixed set of language extensions, so references living in **non-code files** — `.github/workflows/*.yml`, `package.json` scripts, JSON/YAML config, SQL, shell scripts, `.env.example` — were invisible to it.

That directly defeats the tool's stated purpose. Its own description tells the agent it is *"Critical for checking if deleted exports are still imported elsewhere"* — but a deleted export still wired up in a CI workflow or a config file was silently missed.

## Fix

Search the real working tree under `ctx.repoRootDir` instead of in-memory chunks:

- Recursive, **dotfile-inclusive** walk that keeps `.github` (CI workflows) while pruning heavy dirs (`node_modules`, `.git`, `dist`, `build`, `vendor`, `.lien`) and symlinked dirs.
- Respects `.gitignore` + built-in excludes by reusing `createGitignoreFilter` from `@liendev/parser` (already a dependency — no new packages).
- Guards: skips binaries (NUL-byte heuristic) and files larger than 1 MB; returns a clean error on invalid regex.
- Reports **true 1-based file line numbers** (the old per-chunk offset was approximate).
- Same JSON return shape (`{ results, count, truncated }`) — no consumer changes.

Pure-Node, no subprocess: deliberately avoids `git grep`/`ripgrep` so the self-hostable GitHub Action doesn't depend on a binary being present in the runner, and to mirror how `read_file` already accesses disk.

Tool/prompt descriptions updated so the model knows grep now covers non-code files.

## Tests

Adds `packages/review/test/plugins-agent-grep.test.ts` (none previously existed for this tool) — proves non-code/`.github` files are now matched, gitignored + `node_modules` + binary files are excluded, line numbers are correct, results cap/truncate, and invalid-regex / missing-pattern return clean errors.

## Verification

- `npm run format:check` ✅
- `npm run lint` ✅ (0 errors)
- `@liendev/review` typecheck ✅
- Full `@liendev/review` suite ✅ **354/354** (incl. the 6 new tests and the 100 prompt/rules tests)

## Notes / limitations

- Two tree walks per call (gitignore discovery + file collection); acceptable for PR-sized repos, bounded by the dir prune, 1 MB cap, and a 30-result early-exit. A per-run cache is a future optimization if it shows up hot.
- ReDoS: agent-supplied regex over many files could be expensive; mitigated by the result cap + line-length slice. A hard timeout is deferred unless needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codebase search now scans the full repository working tree on disk (including config, CI, scripts, and other non-code files).
  * Search respects `.gitignore` (including ignored directories) while still including hidden folders like `.github`.
* **Bug Fixes**
  * More reliable results: skips binaries/too-large files, tolerates unreadable directories, and accurately reports 1-based line numbers.
  * Invalid patterns now return a clear, structured error.
* **Tests**
  * Added filesystem-based integration tests covering `.gitignore`, symlinks, binary detection, long lines, truncation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 5 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 4 | +0 |


> [!WARNING]
> **2 issues found** · Medium Risk
>
> This PR correctly replaces grep_codebase's in-memory chunk search with a real working-tree walk, extending coverage to non-code files such as CI workflows, JSON/YAML config, and scripts. The change is safe for callers because dispatchTool already awaits the newly async grepCodebase and the return shape is unchanged. The new disk-reading path introduces two bounded but real issues: a stat-then-read TOCTOU race that can bypass the 1 MB size guard, and a wall-clock deadline that is not enforced during a single regex.test so a pathological pattern on one long line can exceed the budget.
>
> - grepCodebase now walks the real repo working tree and respects .gitignore via createGitignoreFilter
> - New guards for binary files, large files, invalid regex, symlinks, and a wall-clock scan deadline
> - Added focused tests for non-code file matching, gitignore pruning, line numbers, and truncation

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5287a70. Updates automatically on new commits.</sup>
<!-- /lien-stats -->