### PR TITLE
feat(parser): add Ruby AST support (+ fix extractSignature no-brace bloat)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8558,18 +8558,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/nats": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/nats/-/nats-2.29.3.tgz",
-      "integrity": "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "nkeys.js": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8584,18 +8572,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nkeys.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nkeys.js/-/nkeys.js-1.1.0.tgz",
-      "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tweetnacl": "1.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -10801,6 +10777,25 @@
         }
       }
     },
+    "node_modules/tree-sitter-ruby": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-ruby/-/tree-sitter-ruby-0.23.1.tgz",
+      "integrity": "sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tree-sitter-rust": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.24.0.tgz",
@@ -11468,12 +11463,6 @@
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -13653,6 +13642,7 @@
         "tree-sitter-javascript": "0.23.1",
         "tree-sitter-php": "^0.24.2",
         "tree-sitter-python": "^0.25.0",
+        "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "^0.24.0",
         "tree-sitter-typescript": "0.23.2"
       },

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -6,7 +6,7 @@ This package provides the core parsing and analysis capabilities used by Lien's 
 
 ## Features
 
-- **AST Parsing** — Tree-sitter-based parsing for TypeScript, JavaScript, Python, PHP, Rust, and Go
+- **AST Parsing** — Tree-sitter-based parsing for TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#, and Ruby
 - **Semantic Chunking** — Split code into meaningful chunks respecting function/class boundaries
 - **Complexity Analysis** — Cyclomatic, cognitive, and Halstead complexity metrics
 - **Dependency Analysis** — Import/export tracking with transitive dependent resolution
@@ -24,8 +24,11 @@ This package provides the core parsing and analysis capabilities used by Lien's 
 | PHP | Yes | Yes | Yes |
 | Rust | Yes | Yes | Yes |
 | Go | Yes | Yes | Yes |
+| Java | Yes | Yes | Yes |
+| C# | Yes | Yes | Yes |
+| Ruby | Yes | Yes | Yes |
 
-Line-based chunking and symbol extraction are available for additional languages including Java, C#, Ruby, and Vue.
+Line-based chunking and symbol extraction are available for additional languages including Vue, Liquid, C/C++, Swift, Kotlin, Scala, and Markdown.
 
 ## Usage
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -29,6 +29,7 @@
     "tree-sitter-javascript": "0.23.1",
     "tree-sitter-php": "^0.24.2",
     "tree-sitter-python": "^0.25.0",
+    "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "^0.24.0",
     "tree-sitter-typescript": "0.23.2"
   },

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -25,8 +25,13 @@ describe('AST Chunker', () => {
       expect(shouldUseAST('script.py')).toBe(true);
     });
 
+    it('should return true for Ruby files', () => {
+      expect(shouldUseAST('test.rb')).toBe(true);
+      expect(shouldUseAST('app/models/user.rb')).toBe(true);
+    });
+
     it('should return false for unsupported files', () => {
-      expect(shouldUseAST('test.rb')).toBe(false);
+      expect(shouldUseAST('test.swift')).toBe(false);
       expect(shouldUseAST('test.txt')).toBe(false);
     });
   });
@@ -520,10 +525,10 @@ export { default as qux } from './qux';`;
 
   describe('error handling', () => {
     it('should throw error for unsupported language', () => {
-      const content = 'puts "Hello"';
+      const content = 'print("Hello")';
 
-      // Ruby is not yet supported
-      expect(() => chunkByAST('test.rb', content)).toThrow();
+      // Swift is not AST-supported
+      expect(() => chunkByAST('test.swift', content)).toThrow();
     });
 
     it('should handle invalid syntax gracefully', () => {

--- a/packages/parser/src/ast/extractors/symbol-helpers.ts
+++ b/packages/parser/src/ast/extractors/symbol-helpers.ts
@@ -4,7 +4,23 @@ import type Parser from 'tree-sitter';
  * Extract function/method signature
  */
 export function extractSignature(node: Parser.SyntaxNode, content: string): string {
-  // Get the first line of the function (up to opening brace or arrow)
+  // Preferred: bound the signature by where the function body begins. This is
+  // language-agnostic — it works for brace languages (`… ) {`), colon languages
+  // (Python `… ):`), and `end` languages (Ruby `def … )`). The legacy brace/arrow
+  // scan below walked an entire no-brace body into the "signature" (e.g. Python,
+  // Ruby), which this avoids.
+  const bodyNode = node.childForFieldName('body');
+  if (bodyNode) {
+    const signature = content
+      .slice(node.startIndex, bodyNode.startIndex)
+      .replace(/\s+/g, ' ') // collapse newlines/indentation (matches the old join-with-space)
+      .replace(/(\{|=>|:)\s*$/, '') // drop a dangling block-opener if it was captured
+      .trim();
+    return clampSignatureLength(signature);
+  }
+
+  // Fallback: nodes with no `body` field (e.g. Rust trait signatures, abstract
+  // interface methods). Preserve the original first-line / brace-scan behavior.
   const startLine = node.startPosition.row;
   const lines = content.split('\n');
   let signature = lines[startLine] || '';
@@ -23,12 +39,14 @@ export function extractSignature(node: Parser.SyntaxNode, content: string): stri
   // Clean up signature
   signature = signature.split('{')[0].split('=>')[0].trim();
 
-  // Limit length
-  if (signature.length > 200) {
-    signature = signature.substring(0, 197) + '...';
-  }
+  return clampSignatureLength(signature);
+}
 
-  return signature;
+/**
+ * Truncate an over-long signature to keep stored chunks compact.
+ */
+function clampSignatureLength(signature: string): string {
+  return signature.length > 200 ? signature.substring(0, 197) + '...' : signature;
 }
 
 /**

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -38,6 +38,10 @@ describe('Language Registry', () => {
       expect(detectLanguage('Program.cs')).toBe('csharp');
     });
 
+    it('should detect Ruby files', () => {
+      expect(detectLanguage('app/models/user.rb')).toBe('ruby');
+    });
+
     it('should return null for unsupported extensions', () => {
       expect(detectLanguage('style.css')).toBeNull();
       expect(detectLanguage('data.json')).toBeNull();
@@ -67,6 +71,7 @@ describe('Language Registry', () => {
         'go',
         'java',
         'csharp',
+        'ruby',
       ];
       for (const lang of languages) {
         const def = getLanguage(lang);
@@ -99,9 +104,9 @@ describe('Language Registry', () => {
   });
 
   describe('getAllLanguages', () => {
-    it('should return all 8 registered languages', () => {
+    it('should return all 9 registered languages', () => {
       const all = getAllLanguages();
-      expect(all).toHaveLength(8);
+      expect(all).toHaveLength(9);
       const ids = all.map(d => d.id);
       expect(ids).toContain('typescript');
       expect(ids).toContain('javascript');
@@ -111,6 +116,7 @@ describe('Language Registry', () => {
       expect(ids).toContain('go');
       expect(ids).toContain('java');
       expect(ids).toContain('csharp');
+      expect(ids).toContain('ruby');
     });
 
     it('should return a defensive copy', () => {

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -8,6 +8,7 @@ import { rustDefinition } from './rust.js';
 import { goDefinition } from './go.js';
 import { javaDefinition } from './java.js';
 import { csharpDefinition } from './csharp.js';
+import { rubyDefinition } from './ruby.js';
 
 /**
  * All registered language definitions.
@@ -22,6 +23,7 @@ const definitions: LanguageDefinition[] = [
   goDefinition,
   javaDefinition,
   csharpDefinition,
+  rubyDefinition,
 ];
 
 /**
@@ -38,6 +40,7 @@ export const LANGUAGE_IDS = [
   'go',
   'java',
   'csharp',
+  'ruby',
 ] as const;
 export type SupportedLanguage = (typeof LANGUAGE_IDS)[number];
 

--- a/packages/parser/src/ast/languages/ruby.test.ts
+++ b/packages/parser/src/ast/languages/ruby.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import Ruby from 'tree-sitter-ruby';
+import { chunkByAST } from '../chunker.js';
+import {
+  RubyTraverser,
+  RubyExportExtractor,
+  RubyImportExtractor,
+  RubySymbolExtractor,
+} from './ruby.js';
+
+describe('Ruby Language', () => {
+  const parser = new Parser();
+  parser.setLanguage(Ruby);
+  const traverser = new RubyTraverser();
+  const exportExtractor = new RubyExportExtractor();
+  const importExtractor = new RubyImportExtractor();
+  const symbolExtractor = new RubySymbolExtractor();
+
+  const parse = (code: string) => parser.parse(code).rootNode;
+
+  describe('Traverser', () => {
+    it('should identify method and singleton_method as target nodes', () => {
+      expect(traverser.targetNodeTypes).toContain('method');
+      expect(traverser.targetNodeTypes).toContain('singleton_method');
+    });
+
+    it('should identify class as a container', () => {
+      expect(traverser.containerTypes).toContain('class');
+    });
+
+    it('should traverse through module as a transparent namespace', () => {
+      // module is NOT a container (it does not add a nesting level); we traverse
+      // into it so `module → class → method` still yields method chunks.
+      expect(traverser.containerTypes).not.toContain('module');
+      const moduleNode = parse('module M\n  def helper; end\nend').namedChild(0)!;
+      expect(traverser.shouldTraverseChildren(moduleNode)).toBe(true);
+    });
+
+    it('should extract children from class bodies', () => {
+      const classNode = parse('class Foo\n  def bar; end\nend').namedChild(0)!;
+      expect(traverser.shouldExtractChildren(classNode)).toBe(true);
+    });
+
+    it('should not extract children from a plain method', () => {
+      const methodNode = parse('def bar; end').namedChild(0)!;
+      expect(traverser.shouldExtractChildren(methodNode)).toBe(false);
+    });
+
+    it('should return body_statement as the class container body', () => {
+      const classNode = parse('class Foo\n  def bar; end\nend').namedChild(0)!;
+      const body = traverser.getContainerBody(classNode);
+      expect(body).not.toBeNull();
+      expect(body!.type).toBe('body_statement');
+    });
+
+    it('should traverse program root and body_statement nodes', () => {
+      const root = parse('class Foo\n  def bar; end\nend');
+      expect(traverser.shouldTraverseChildren(root)).toBe(true);
+      const body = root.namedChild(0)!.childForFieldName('body')!;
+      expect(traverser.shouldTraverseChildren(body)).toBe(true);
+    });
+
+    it('should not treat any node as a declaration with a function', () => {
+      const root = parse('x = 42');
+      root.namedChildren.forEach(child => {
+        expect(traverser.isDeclarationWithFunction(child)).toBe(false);
+      });
+    });
+
+    it('should find the parent class name for a method', () => {
+      const root = parse('class MyService\n  def call; end\nend');
+      const body = root.namedChild(0)!.childForFieldName('body')!;
+      const methodNode = body.namedChild(0)!;
+      expect(traverser.findParentContainerName(methodNode)).toBe('MyService');
+    });
+
+    it('should find the parent module name for a method', () => {
+      const root = parse('module Helpers\n  def format; end\nend');
+      const body = root.namedChild(0)!.childForFieldName('body')!;
+      const methodNode = body.namedChild(0)!;
+      expect(traverser.findParentContainerName(methodNode)).toBe('Helpers');
+    });
+
+    it('should find the nearest container name for a nested method', () => {
+      const root = parse('module Billing\n  class Invoice\n    def total; end\n  end\nend');
+      const moduleBody = root.namedChild(0)!.childForFieldName('body')!;
+      const classBody = moduleBody.namedChild(0)!.childForFieldName('body')!;
+      const methodNode = classBody.namedChild(0)!;
+      expect(traverser.findParentContainerName(methodNode)).toBe('Invoice');
+    });
+  });
+
+  describe('Export Extraction', () => {
+    it('should export a top-level class', () => {
+      expect(exportExtractor.extractExports(parse('class User\nend'))).toEqual(['User']);
+    });
+
+    it('should export a top-level module', () => {
+      expect(exportExtractor.extractExports(parse('module Billing\nend'))).toEqual(['Billing']);
+    });
+
+    it('should export a top-level method', () => {
+      expect(exportExtractor.extractExports(parse('def helper; end'))).toEqual(['helper']);
+    });
+
+    it('should export a top-level singleton method', () => {
+      expect(exportExtractor.extractExports(parse('def self.build; end'))).toEqual(['build']);
+    });
+
+    it('should export a top-level constant', () => {
+      expect(exportExtractor.extractExports(parse("VERSION = '1.0'"))).toEqual(['VERSION']);
+    });
+
+    it('should export multiple top-level definitions', () => {
+      const exports = exportExtractor.extractExports(
+        parse('class A\nend\nmodule B\nend\ndef c; end'),
+      );
+      expect(exports).toEqual(['A', 'B', 'c']);
+    });
+
+    it('should only export the top-level container, not nested members', () => {
+      const exports = exportExtractor.extractExports(
+        parse('module Billing\n  class Invoice\n    def total; end\n  end\nend'),
+      );
+      expect(exports).toEqual(['Billing']);
+    });
+
+    it('should return an empty array for a file with no definitions', () => {
+      expect(exportExtractor.extractExports(parse('x = compute(1, 2)'))).toEqual([]);
+    });
+
+    it('should deduplicate re-opened classes', () => {
+      const exports = exportExtractor.extractExports(parse('class A\nend\nclass A\nend'));
+      expect(exports).toEqual(['A']);
+    });
+  });
+
+  describe('Import Extraction', () => {
+    const firstCall = (code: string) => parse(code).namedChild(0)!;
+
+    it('should extract a require path', () => {
+      expect(importExtractor.extractImportPath(firstCall("require 'json'"))).toBe('json');
+    });
+
+    it('should extract a require_relative path', () => {
+      expect(importExtractor.extractImportPath(firstCall("require_relative '../lib/foo'"))).toBe(
+        '../lib/foo',
+      );
+    });
+
+    it('should extract a load path', () => {
+      expect(importExtractor.extractImportPath(firstCall("load 'config.rb'"))).toBe('config.rb');
+    });
+
+    it('should extract the path argument of autoload (skipping the symbol)', () => {
+      expect(importExtractor.extractImportPath(firstCall("autoload :Bar, 'bar'"))).toBe('bar');
+    });
+
+    it('should return null for non-require method calls', () => {
+      expect(importExtractor.extractImportPath(firstCall("puts 'hello'"))).toBeNull();
+      expect(importExtractor.extractImportPath(firstCall('compute(1, 2)'))).toBeNull();
+    });
+
+    it('should map require_relative to its basename symbol', () => {
+      const result = importExtractor.processImportSymbols(
+        firstCall("require_relative '../lib/foo'"),
+      );
+      expect(result).toEqual({ importPath: '../lib/foo', symbols: ['foo'] });
+    });
+
+    it('should declare call as the import node type', () => {
+      expect(importExtractor.importNodeTypes).toEqual(['call']);
+    });
+  });
+
+  describe('Symbol Extraction', () => {
+    const firstNamed = (code: string) => parse(code).namedChild(0)!;
+
+    it('should extract a top-level method as a function', () => {
+      const code = 'def helper(a, b)\n  a + b\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.name).toBe('helper');
+      expect(symbol.type).toBe('function');
+      expect(symbol.parameters).toEqual(['a', 'b']);
+    });
+
+    it('should extract a method inside a class as a method', () => {
+      const code = 'def call(req)\n  req\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code, 'MyService')!;
+      expect(symbol.type).toBe('method');
+      expect(symbol.parentClass).toBe('MyService');
+    });
+
+    it('should extract a singleton method', () => {
+      const code = 'def self.create(x)\n  new(x)\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.name).toBe('create');
+    });
+
+    it('should produce a clean signature that excludes the body', () => {
+      const code = 'def charge(card, retries = 3)\n  process(card)\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.signature).toContain('charge');
+      expect(symbol.signature).toContain('card');
+      expect(symbol.signature).toContain('retries = 3');
+      expect(symbol.signature).not.toContain('process');
+    });
+
+    it('should capture optional/default parameters', () => {
+      const code = 'def charge(card, retries = 3)\n  card\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.parameters).toEqual(['card', 'retries = 3']);
+    });
+
+    it('should extract a class with its superclass in the signature', () => {
+      const code = 'class CreditService < Base\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.type).toBe('class');
+      expect(symbol.name).toBe('CreditService');
+      expect(symbol.signature).toBe('class CreditService < Base');
+    });
+
+    it('should extract a class without a superclass', () => {
+      const code = 'class User\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.signature).toBe('class User');
+    });
+
+    it('should extract a module as a class-typed symbol', () => {
+      const code = 'module Billing\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      expect(symbol.type).toBe('class');
+      expect(symbol.name).toBe('Billing');
+      expect(symbol.signature).toBe('module Billing');
+    });
+
+    it('should extract a direct call site', () => {
+      const code = 'process(card)';
+      const callNode = firstNamed(code);
+      expect(symbolExtractor.extractCallSite(callNode)).toMatchObject({
+        symbol: 'process',
+        line: 1,
+      });
+    });
+
+    it('should extract a receiver call site by method name', () => {
+      const code = 'card.charge(amount)';
+      const callNode = firstNamed(code);
+      expect(symbolExtractor.extractCallSite(callNode)).toMatchObject({
+        symbol: 'charge',
+        line: 1,
+      });
+    });
+
+    it('should count if/elsif branches for cyclomatic complexity', () => {
+      const code = [
+        'def charge(card, retries)',
+        '  if card.nil?',
+        '    raise Error',
+        '  elsif retries > 0',
+        '    process(card)',
+        '  else',
+        '    fail',
+        '  end',
+        'end',
+      ].join('\n');
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      // base 1 + if + elsif (else is not a branch)
+      expect(symbol.complexity).toBe(3);
+    });
+
+    it('should count a modifier-if for cyclomatic complexity', () => {
+      const code = 'def notify(user)\n  send_email(user) if user.active?\nend';
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      // base 1 + if_modifier
+      expect(symbol.complexity).toBe(2);
+    });
+
+    it('should count case/when branches for cyclomatic complexity', () => {
+      const code = [
+        'def label(x)',
+        '  case x',
+        '  when 1 then :a',
+        '  when 2 then :b',
+        '  else :c',
+        '  end',
+        'end',
+      ].join('\n');
+      const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
+      // base 1 + two when arms
+      expect(symbol.complexity).toBe(3);
+    });
+  });
+
+  describe('AST Chunking Integration', () => {
+    const RUBY_FILE = [
+      "require 'json'",
+      "require_relative './base'",
+      '',
+      'module Billing',
+      '  class CreditService < Base',
+      '    def initialize(amount)',
+      '      @amount = amount',
+      '    end',
+      '',
+      '    def self.create(x)',
+      '      new(x)',
+      '    end',
+      '',
+      '    def charge(card)',
+      '      process(card)',
+      '    end',
+      '  end',
+      'end',
+    ].join('\n');
+
+    it('should extract method chunks from a nested module/class', () => {
+      const chunks = chunkByAST('billing.rb', RUBY_FILE);
+      const names = chunks.map(c => c.metadata.symbolName);
+      expect(names).toContain('initialize');
+      expect(names).toContain('create');
+      expect(names).toContain('charge');
+    });
+
+    it('should attach the enclosing class as parentClass', () => {
+      const chunks = chunkByAST('billing.rb', RUBY_FILE);
+      const charge = chunks.find(c => c.metadata.symbolName === 'charge');
+      expect(charge?.metadata.parentClass).toBe('CreditService');
+    });
+
+    it('should produce clean method signatures', () => {
+      const chunks = chunkByAST('billing.rb', RUBY_FILE);
+      const charge = chunks.find(c => c.metadata.symbolName === 'charge');
+      expect(charge?.metadata.signature).toContain('def charge(card)');
+      expect(charge?.metadata.signature).not.toContain('process');
+    });
+
+    it('should chunk a standalone top-level method', () => {
+      const chunks = chunkByAST('util.rb', 'def slugify(text)\n  text.downcase\nend');
+      expect(chunks.some(c => c.metadata.symbolName === 'slugify')).toBe(true);
+    });
+  });
+});

--- a/packages/parser/src/ast/languages/ruby.ts
+++ b/packages/parser/src/ast/languages/ruby.ts
@@ -1,0 +1,427 @@
+import Ruby from 'tree-sitter-ruby';
+import type Parser from 'tree-sitter';
+import type { SymbolInfo } from '../types.js';
+import type { LanguageDefinition } from './types.js';
+import type { LanguageTraverser, DeclarationFunctionInfo } from '../traversers/types.js';
+import type {
+  LanguageExportExtractor,
+  LanguageImportExtractor,
+  LanguageSymbolExtractor,
+} from '../extractors/types.js';
+import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
+import { calculateComplexity } from '../complexity/index.js';
+
+// =============================================================================
+// SHARED HELPERS
+// =============================================================================
+
+/**
+ * Ruby "import" methods. Unlike most languages, Ruby has no import *statement* —
+ * dependencies are loaded via ordinary method calls (`require 'json'`,
+ * `require_relative './foo'`, `load`, `autoload`). The grammar parses these as
+ * `call` nodes, so the import extractor filters call nodes by their method name.
+ */
+const REQUIRE_METHODS = new Set(['require', 'require_relative', 'load', 'autoload']);
+
+/**
+ * Return the content of the first string literal in an `argument_list`
+ * (e.g. the `'json'` in `require 'json'`). Returns null if absent or empty.
+ */
+function firstStringArgument(argsNode: Parser.SyntaxNode | null): string | null {
+  if (!argsNode) return null;
+  const stringNode = argsNode.namedChildren.find(c => c.type === 'string');
+  const contentNode = stringNode?.namedChildren.find(c => c.type === 'string_content');
+  return contentNode?.text ?? null;
+}
+
+/**
+ * Extract the require path from a `call` node if it is a require-like call,
+ * otherwise null (so non-import calls are skipped by the import extractor).
+ */
+function extractRequirePath(node: Parser.SyntaxNode): string | null {
+  if (node.type !== 'call') return null;
+  const method = node.childForFieldName('method');
+  if (!method || !REQUIRE_METHODS.has(method.text)) return null;
+  return firstStringArgument(node.childForFieldName('arguments'));
+}
+
+/**
+ * Reduce a require path to a bare module name for the imported-symbols map.
+ * `'../lib/foo'` → `foo`, `'active_record'` → `active_record`.
+ */
+function moduleBasename(path: string): string {
+  const base = path.split('/').pop() ?? path;
+  return base.replace(/\.rb$/, '');
+}
+
+// =============================================================================
+// TRAVERSER
+// =============================================================================
+
+/**
+ * Ruby AST traverser
+ *
+ * Ruby structure:
+ * - Methods are defined with `def` (`method`) or `def self.x` (`singleton_method`)
+ * - Classes and modules are containers whose methods we extract
+ * - Container bodies are `body_statement` nodes
+ */
+export class RubyTraverser implements LanguageTraverser {
+  targetNodeTypes = ['method', 'singleton_method'];
+
+  containerTypes = [
+    'class', // We extract methods, not the class itself
+    'singleton_class', // `class << self`
+  ];
+
+  declarationTypes: string[] = [];
+
+  functionTypes = ['method', 'singleton_method'];
+
+  shouldExtractChildren(node: Parser.SyntaxNode): boolean {
+    return this.containerTypes.includes(node.type);
+  }
+
+  isDeclarationWithFunction(_node: Parser.SyntaxNode): boolean {
+    return false;
+  }
+
+  getContainerBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+    if (this.containerTypes.includes(node.type)) {
+      return node.childForFieldName('body');
+    }
+    return null;
+  }
+
+  shouldTraverseChildren(node: Parser.SyntaxNode): boolean {
+    // `module` is treated as a transparent namespace: we traverse *through* it
+    // (without it counting as a container nesting level) so that the common
+    // `module → class → method` shape still yields method chunks. The shared
+    // chunker caps extractable targets at one container deep, and a Ruby class
+    // wrapped in a module would otherwise push methods out of range.
+    return node.type === 'program' || node.type === 'body_statement' || node.type === 'module';
+  }
+
+  findParentContainerName(node: Parser.SyntaxNode): string | undefined {
+    let current = node.parent;
+    while (current) {
+      if (current.type === 'class' || current.type === 'module') {
+        const nameNode = current.childForFieldName('name');
+        return nameNode?.text;
+      }
+      current = current.parent;
+    }
+    return undefined;
+  }
+
+  findFunctionInDeclaration(_node: Parser.SyntaxNode): DeclarationFunctionInfo {
+    return {
+      hasFunction: false,
+      functionNode: null,
+    };
+  }
+}
+
+// =============================================================================
+// EXPORT EXTRACTOR
+// =============================================================================
+
+/**
+ * Ruby export extractor
+ *
+ * Ruby has no explicit export syntax. All top-level (module-level) definitions
+ * are considered exported / loadable by other files:
+ * - Classes: `class User; end`
+ * - Modules: `module Billing; end`
+ * - Methods: `def helper; end` and `def self.helper; end`
+ * - Constants: `VERSION = '1.0'`
+ */
+export class RubyExportExtractor implements LanguageExportExtractor {
+  private readonly exportableTypes = new Set(['method', 'singleton_method', 'class', 'module']);
+
+  extractExports(rootNode: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const seen = new Set<string>();
+
+    const addExport = (name: string | undefined) => {
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        exports.push(name);
+      }
+    };
+
+    rootNode.namedChildren.forEach(child => {
+      if (this.exportableTypes.has(child.type)) {
+        addExport(child.childForFieldName('name')?.text);
+        return;
+      }
+
+      // Top-level constant assignment: `CONST = ...`
+      if (child.type === 'assignment') {
+        const left = child.childForFieldName('left');
+        if (left?.type === 'constant') {
+          addExport(left.text);
+        }
+      }
+    });
+
+    return exports;
+  }
+}
+
+// =============================================================================
+// IMPORT EXTRACTOR
+// =============================================================================
+
+/**
+ * Ruby import extractor
+ *
+ * Handles require-like calls:
+ * - require 'json'
+ * - require_relative './foo'
+ * - load 'config.rb'
+ * - autoload :Bar, 'bar'
+ */
+export class RubyImportExtractor implements LanguageImportExtractor {
+  // Require statements are method calls in Ruby; we filter by method name.
+  readonly importNodeTypes = ['call'];
+
+  extractImportPath(node: Parser.SyntaxNode): string | null {
+    return extractRequirePath(node);
+  }
+
+  processImportSymbols(node: Parser.SyntaxNode): { importPath: string; symbols: string[] } | null {
+    const importPath = extractRequirePath(node);
+    if (!importPath) return null;
+    return { importPath, symbols: [moduleBasename(importPath)] };
+  }
+}
+
+// =============================================================================
+// SYMBOL EXTRACTOR
+// =============================================================================
+
+/**
+ * Ruby symbol extractor
+ *
+ * Handles:
+ * - method (def foo)
+ * - singleton_method (def self.foo)
+ * - class (class Foo)
+ * - module (module Foo) — mapped to the 'class' symbol type
+ *
+ * Call sites: call (foo(), obj.method())
+ */
+export class RubySymbolExtractor implements LanguageSymbolExtractor {
+  readonly symbolNodeTypes = ['method', 'singleton_method', 'class', 'module'];
+
+  extractSymbol(node: Parser.SyntaxNode, content: string, parentClass?: string): SymbolInfo | null {
+    switch (node.type) {
+      case 'method':
+      case 'singleton_method':
+        return this.extractMethodInfo(node, content, parentClass);
+      case 'class':
+        return this.extractClassInfo(node, 'class');
+      case 'module':
+        return this.extractClassInfo(node, 'module');
+      default:
+        return null;
+    }
+  }
+
+  extractCallSite(node: Parser.SyntaxNode): { symbol: string; line: number; key: string } | null {
+    if (node.type !== 'call') return null;
+
+    const line = node.startPosition.row + 1;
+    // For both `foo(...)` and `obj.foo(...)` the called name is the `method` field.
+    const methodNode = node.childForFieldName('method');
+    if (methodNode?.type === 'identifier') {
+      return { symbol: methodNode.text, line, key: `${methodNode.text}:${line}` };
+    }
+
+    return null;
+  }
+
+  private extractMethodInfo(
+    node: Parser.SyntaxNode,
+    content: string,
+    parentClass?: string,
+  ): SymbolInfo | null {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+
+    return {
+      name: nameNode.text,
+      type: parentClass ? 'method' : 'function',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: extractSignature(node, content),
+      parameters: extractParameters(node, content),
+      complexity: calculateComplexity(node),
+    };
+  }
+
+  private extractClassInfo(
+    node: Parser.SyntaxNode,
+    keyword: 'class' | 'module',
+  ): SymbolInfo | null {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+
+    // superclass node text includes the leading `<` (e.g. `< Base`).
+    const superclass = node.childForFieldName('superclass');
+    const signature = superclass
+      ? `${keyword} ${nameNode.text} ${superclass.text}`
+      : `${keyword} ${nameNode.text}`;
+
+    return {
+      name: nameNode.text,
+      type: 'class',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      signature,
+    };
+  }
+}
+
+// =============================================================================
+// LANGUAGE DEFINITION
+// =============================================================================
+
+export const rubyDefinition: LanguageDefinition = {
+  id: 'ruby',
+  extensions: ['rb'],
+  grammar: Ruby,
+  traverser: new RubyTraverser(),
+  exportExtractor: new RubyExportExtractor(),
+  importExtractor: new RubyImportExtractor(),
+  symbolExtractor: new RubySymbolExtractor(),
+
+  complexity: {
+    // Structural control-flow branch points. NOTE: Ruby's logical operators
+    // (`&&`, `||`, `and`, `or`) are `binary` nodes, which the shared complexity
+    // engine only counts for the `binary_expression`/`boolean_operator` node
+    // types (JS/TS/Python). Counting generic `binary` here would also count
+    // arithmetic, so logical operators are intentionally not scored for Ruby.
+    decisionPoints: [
+      'if',
+      'elsif',
+      'unless',
+      'while',
+      'until',
+      'for',
+      'when',
+      'in_clause', // `case/in` pattern matching arm
+      'rescue',
+      'conditional', // ternary `a ? b : c`
+      'if_modifier', // `x if y`
+      'unless_modifier', // `x unless y`
+      'while_modifier', // `x while y`
+      'until_modifier', // `x until y`
+    ],
+    nestingTypes: ['if', 'unless', 'while', 'until', 'for', 'case', 'case_match', 'rescue'],
+    nonNestingTypes: [
+      'elsif',
+      'when',
+      'in_clause',
+      'conditional',
+      'if_modifier',
+      'unless_modifier',
+      'while_modifier',
+      'until_modifier',
+    ],
+    lambdaTypes: ['block', 'do_block', 'lambda'],
+    operatorSymbols: new Set([
+      '+',
+      '-',
+      '*',
+      '/',
+      '%',
+      '**',
+      '==',
+      '!=',
+      '<',
+      '>',
+      '<=',
+      '>=',
+      '<=>',
+      '=',
+      '+=',
+      '-=',
+      '*=',
+      '/=',
+      '%=',
+      '**=',
+      '||=',
+      '&&=',
+      '|=',
+      '&=',
+      '^=',
+      '<<=',
+      '>>=',
+      '&',
+      '|',
+      '^',
+      '~',
+      '<<',
+      '>>',
+      '&&',
+      '||',
+      '!',
+      '..',
+      '...',
+      '=>',
+      '->',
+      '::',
+      '.',
+      '&.',
+      '(',
+      ')',
+      '[',
+      ']',
+      '{',
+      '}',
+    ]),
+    operatorKeywords: new Set([
+      'if',
+      'elsif',
+      'else',
+      'unless',
+      'while',
+      'until',
+      'for',
+      'case',
+      'when',
+      'in',
+      'do',
+      'then',
+      'begin',
+      'rescue',
+      'ensure',
+      'raise',
+      'return',
+      'yield',
+      'break',
+      'next',
+      'redo',
+      'retry',
+      'def',
+      'class',
+      'module',
+      'self',
+      'super',
+      'and',
+      'or',
+      'not',
+      'require',
+      'require_relative',
+      'lambda',
+      'proc',
+    ]),
+  },
+
+  symbols: {
+    callExpressionTypes: ['call'],
+  },
+};

--- a/packages/parser/src/ast/python.test.ts
+++ b/packages/parser/src/ast/python.test.ts
@@ -170,6 +170,9 @@ def calculate_sum(numbers: list[int]) -> int:
     expect(chunks).toHaveLength(1);
     expect(chunks[0].metadata.signature).toBeDefined();
     expect(chunks[0].metadata.signature).toContain('calculate_sum');
+    // Signature must stop at the body — not swallow the function body (regression
+    // guard: the old brace-oriented extractor walked no-brace bodies into the signature).
+    expect(chunks[0].metadata.signature).not.toContain('return');
   });
 
   it('should handle multiline function definitions', () => {
@@ -187,5 +190,13 @@ def long_function(
     expect(chunks).toHaveLength(1);
     expect(chunks[0].metadata.symbolName).toBe('long_function');
     expect(chunks[0].metadata.parameters?.length).toBe(3);
+    // The signature should span the full multiline parameter list (collapsed to one
+    // line) and stop at the return type — without bleeding the body in.
+    const signature = chunks[0].metadata.signature ?? '';
+    expect(signature).toContain('long_function');
+    expect(signature).toContain('param1');
+    expect(signature).toContain('param3');
+    expect(signature).toContain('-> dict');
+    expect(signature).not.toContain('return');
   });
 });

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -352,6 +352,26 @@ describe('isTestFile - Precise Test Detection', () => {
     });
   });
 
+  describe('suffix and directory conventions (_spec/_test, spec/)', () => {
+    it('should match _spec. and _test. suffix files (Ruby/Go conventions)', () => {
+      expect(isTestFile('models/user_spec.rb')).toBe(true);
+      expect(isTestFile('lib/calculator_test.rb')).toBe(true);
+      expect(isTestFile('pkg/math_test.go')).toBe(true);
+    });
+
+    it('should match files in spec/ and specs/ directories', () => {
+      expect(isTestFile('spec/models/user_spec.rb')).toBe(true);
+      expect(isTestFile('app/specs/helper.rb')).toBe(true);
+    });
+
+    it('should not treat _spec/_test lookalikes as tests', () => {
+      // No `_` boundary before test/spec
+      expect(isTestFile('mytest.rb')).toBe(false);
+      expect(isTestFile('respec/config.rb')).toBe(false);
+      expect(isTestFile('spec.rb')).toBe(false);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle files at root level', () => {
       expect(isTestFile('auth.test.ts')).toBe(true);

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -306,17 +306,21 @@ export function getCanonicalPath(filepath: string, workspaceRoot: string): strin
  *
  * Uses precise regex patterns to avoid false positives:
  * - Files with .test. or .spec. extensions (e.g., foo.test.ts, bar.spec.js)
- * - Files in test/, tests/, or __tests__/ directories
+ * - Files with _test. or _spec. suffixes (e.g., user_spec.rb, math_test.go)
+ * - Files in test/, tests/, spec/, specs/, or __tests__/ directories
  *
  * Avoids false positives like:
  * - contest.ts (contains ".test." but isn't a test)
  * - latest/config.ts (contains "/test/" but isn't a test)
+ * - mytest.ts (no `_` boundary before "test")
  *
  * @param filepath - The file path to check
  * @returns True if the file is a test file
  */
 export function isTestFile(filepath: string): boolean {
   return (
-    /\.(test|spec)\.[^/]+$/.test(filepath) || /(^|[/\\])(test|tests|__tests__)[/\\]/.test(filepath)
+    /\.(test|spec)\.[^/]+$/.test(filepath) ||
+    /_(test|spec)\.[^/]+$/.test(filepath) ||
+    /(^|[/\\])(test|tests|spec|specs|__tests__)[/\\]/.test(filepath)
   );
 }


### PR DESCRIPTION
## Summary

Adds **Ruby** as the 9th AST-supported language, upgrading `.rb` files from line-based fallback chunking to full structural parsing (symbols, imports/exports, call sites, complexity). Also fixes a latent bug in the shared `extractSignature` helper that this work surfaced.

## What's included

### Ruby AST support
- **`ruby.ts`** — language definition (traverser, export/import/symbol extractors, complexity + Halstead config), modeled on `python.ts` with node types verified against the live `tree-sitter-ruby` grammar.
- **`ruby.test.ts`** — 44 tests covering the traverser, exports, imports, symbols, call sites, complexity, and end-to-end chunking.
- Registered `ruby` in the registry; added `tree-sitter-ruby@^0.23.1` to `package.json` + lockfile.
- `isTestFile` now recognizes `_spec.rb`/`_test.rb` suffixes and `spec/` directories, so Ruby test associations resolve.
- Parser README: corrected the AST table (Java/C# were wrongly listed as line-based-only) and added Ruby.

Two Ruby-specific design points:
- **Modules are transparent namespaces.** The shared chunker only extracts targets one container level deep; Ruby's idiomatic `module → class → method` is two levels. Treating `module` as a pass-through (traversed without adding a nesting level) keeps the change localized to Ruby instead of altering shared chunker depth logic for all 8 languages.
- **`require`/`require_relative` are method calls** in Ruby (not statements), so the import extractor filters `call` nodes by method name.

### Fix: `extractSignature` no-brace bloat
`extractSignature` scanned for `{` or `=>` to bound a signature, so for no-brace languages it walked the entire function body into the "signature." This was already latent for Python (no signature assertion caught it) and would have affected Ruby. Now bounded by the body node's start offset — language-agnostic across brace, colon (`def …:`), and `end` (`def …`) styles — with a guarded fallback to the original scan for bodiless declarations (e.g. Rust trait signatures). Added Python multiline-signature regression tests.

## Verification
- `typecheck` 0 errors · `eslint` 0 · `prettier --check` clean · `tsc` build clean
- **796/796 parser tests pass** — including 44 new Ruby tests and the Python regression guards; the `extractSignature` change does not regress any of the 8 existing languages.
- End-to-end smoke on a realistic Ruby file: `require`/`require_relative` resolved as imports, clean signatures, correct `parentClass`, cyclomatic complexity = 4 for a method with modifier-`if` + `if` + `elsif` (correctly excluding `&&`).

## Known v1 limitations (documented in code)
- Ruby logical operators (`&&`/`||`) are not counted in complexity — the shared engine special-cases `binary_expression`/`boolean_operator`, and Ruby's `binary` node would over-count arithmetic.
- Modules are not emitted as standalone chunks (their classes/methods are).
- Ruby is not added to review-rule triggers (review-package scope, deferred).

## Notes
- The lockfile update incidentally pruned 3 already-orphaned packages (`nats`/`nkeys.js`/`tweetnacl`).
- Review-harness coverage for Ruby is intentionally out of scope (most existing AST languages lack it too).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds Ruby as a fully AST-supported language and fixes a latent signature-extraction bug for no-brace languages. The changes are well-scoped: a new Ruby language definition with traverser/export/import/symbol extractors, registry registration, test-file pattern updates for Ruby conventions, and a body-node-bounded signature extractor. The implementation is consistent with existing language definitions, includes comprehensive tests, and the shared signature fix is covered by Python regression tests. No breaking changes or incorrect outputs were identified.
>
> - Added Ruby AST language support (traverser, extractors, complexity config, tests)
> - Fixed extractSignature to bound signatures by body node start, preventing no-brace body bloat
> - Extended isTestFile to recognize _spec/_test suffixes and spec/specs directories

<sup>Reviewed by [Lien Review](https://lien.dev) for commit c7f7c92. Updates automatically on new commits.</sup>
<!-- /lien-stats -->