### PR TITLE
fix(review): surface budget exhaustion + prevent single-turn overshoot

### DIFF
--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -12,12 +12,21 @@ import type {
   AgentFinding,
   AgentSummary,
   AgentResult,
+  AgentStopReason,
   TurnTrace,
   ToolInvocation,
 } from './types.js';
 
 /** Cap a single tool's recorded output so traces stay readable. */
 const TRACE_TOOL_OUTPUT_MAX = 4096;
+
+/**
+ * Cap a single tool result fed back to the model. A large file read or
+ * batched get_files_context can otherwise return tens of thousands of tokens
+ * in one turn, blowing the whole budget before the wrap-up nudge can fire.
+ * ~24K chars ≈ 6K tokens — enough context for a review, bounded per call.
+ */
+const TOOL_RESULT_MAX_CHARS = 24_000;
 
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
@@ -99,6 +108,9 @@ export class AnthropicAgentClient {
     let turn = 0;
     let lastResponse: Anthropic.Messages.Message | null = null;
     const turnTraces: TurnTrace[] = [];
+    // Defaults to 'max_turns': if the loop exits via its `while` condition
+    // without any explicit break below, the turn budget was the limit.
+    let stopReason: AgentStopReason = 'max_turns';
 
     while (turn < this.maxTurns) {
       turn++;
@@ -153,6 +165,7 @@ export class AnthropicAgentClient {
 
       // Done: model finished naturally
       if (response.stop_reason === 'end_turn') {
+        stopReason = 'completed';
         break;
       }
 
@@ -161,11 +174,14 @@ export class AnthropicAgentClient {
         this.logger.warning(
           `[agent] Token budget exceeded (${totalTokens}/${this.maxTokenBudget}), stopping`,
         );
+        stopReason = 'budget';
         break;
       }
 
-      // Approaching budget or last turn — tell the agent to wrap up
-      const nearBudget = totalTokens >= this.maxTokenBudget * 0.7;
+      // Approaching budget or last turn — tell the agent to wrap up.
+      // Threshold kept below the hard cap with headroom so a single capped
+      // tool result can't skip past the wrap-up window into the hard stop.
+      const nearBudget = totalTokens >= this.maxTokenBudget * 0.6;
       const lastTurn = turn >= this.maxTurns - 1;
       const shouldWrapUp = nearBudget || lastTurn;
 
@@ -182,6 +198,7 @@ export class AnthropicAgentClient {
       } else {
         // Unexpected stop reason (max_tokens, stop_sequence, etc.) — stop looping
         this.logger.warning(`[agent] Unexpected stop_reason: ${response.stop_reason}, stopping`);
+        stopReason = 'error';
         break;
       }
     }
@@ -206,6 +223,16 @@ export class AnthropicAgentClient {
     const cost =
       totalInputTokens * this.inputCostPerToken + totalOutputTokens * this.outputCostPerToken;
 
+    // Incomplete = the loop bailed on a limit (or error) AND never produced a
+    // verdict (no summary, even after the retry). Such a run must not be shown
+    // as a clean review.
+    const incomplete = stopReason !== 'completed' && !parsed.summary;
+    if (incomplete) {
+      this.logger.warning(
+        `[agent] Review incomplete (stopReason=${stopReason}, no summary after ${turn} turns)`,
+      );
+    }
+
     return {
       findings: parsed.findings,
       summary: parsed.summary,
@@ -216,6 +243,8 @@ export class AnthropicAgentClient {
         cost,
       },
       turns: turn,
+      stopReason,
+      incomplete,
       trace: {
         systemPrompt,
         initialMessage,
@@ -337,7 +366,7 @@ async function executeOneToolUse(
     toolResult: {
       type: 'tool_result' as const,
       tool_use_id: block.id,
-      content: result,
+      content: truncate(result, TOOL_RESULT_MAX_CHARS),
     },
   };
 }

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -117,6 +117,18 @@ export class AgentReviewPlugin implements ReviewPlugin {
       );
     }
 
+    // High-impact PRs need more room to investigate; a too-tight budget is the
+    // common cause of the agent bailing before producing a verdict.
+    const maxTokenBudget = scaleBudgetForBlastRadius(
+      config.maxTokenBudget,
+      blastRadius?.globalRisk.level,
+    );
+    if (maxTokenBudget !== config.maxTokenBudget) {
+      logger.info(
+        `[${this.id}] Token budget scaled ${config.maxTokenBudget} → ${maxTokenBudget} for ${blastRadius?.globalRisk.level} blast radius`,
+      );
+    }
+
     const systemPrompt = buildSystemPrompt(rules);
     const initialMessage = buildInitialMessage(context, { blastRadius });
     const result = await runAgentClient(
@@ -127,6 +139,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
       systemPrompt,
       initialMessage,
       toolExecutor,
+      maxTokenBudget,
     );
 
     reportAgentRun(this.id, context, logger, result);
@@ -134,6 +147,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
     const pluginId = this.id;
     const findings = result.findings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
+    appendIncompleteNotice(findings, pluginId, result);
 
     return findings;
   }
@@ -192,6 +206,7 @@ function runAgentClient(
   systemPrompt: string,
   initialMessage: string,
   toolExecutor: ToolExecutor,
+  maxTokenBudget: number,
 ): Promise<AgentResult> {
   if (provider === 'anthropic') {
     const client = new AnthropicAgentClient({
@@ -201,7 +216,7 @@ function runAgentClient(
       inputCostPerMTok: config.inputCostPerMTok,
       outputCostPerMTok: config.outputCostPerMTok,
       maxTurns: config.maxTurns,
-      maxTokenBudget: config.maxTokenBudget,
+      maxTokenBudget,
       logger,
     });
     return client.run(systemPrompt, initialMessage, AGENT_TOOLS, toolExecutor);
@@ -214,7 +229,7 @@ function runAgentClient(
     inputCostPerMTok: config.inputCostPerMTok,
     outputCostPerMTok: config.outputCostPerMTok,
     maxTurns: config.maxTurns,
-    maxTokenBudget: config.maxTokenBudget,
+    maxTokenBudget,
     logger,
   });
   return client.run(systemPrompt, initialMessage, toOpenAITools(AGENT_TOOLS), toolExecutor);
@@ -266,6 +281,57 @@ function appendSummaryFinding(
   });
 }
 
+/** Hard ceiling for the agent token budget (mirrors review-pr.ts scaling). */
+const MAX_AGENT_TOKEN_BUDGET = 200_000;
+
+/** Extra budget headroom for high-impact PRs, keyed by blast-radius risk. */
+const BLAST_RADIUS_BUDGET_MULTIPLIER: Record<string, number> = {
+  critical: 1.5,
+  high: 1.25,
+};
+
+/**
+ * Scale the agent's token budget up for high-impact changes. A critical
+ * blast radius means the agent has many dependents to investigate, which is
+ * exactly when a too-tight budget causes it to bail before a verdict. Clamped
+ * to the same ceiling as the file-size-based scaling in review-pr.ts.
+ */
+export function scaleBudgetForBlastRadius(baseBudget: number, riskLevel?: string): number {
+  const multiplier = riskLevel ? (BLAST_RADIUS_BUDGET_MULTIPLIER[riskLevel] ?? 1) : 1;
+  return Math.min(Math.round(baseBudget * multiplier), MAX_AGENT_TOKEN_BUDGET);
+}
+
+/**
+ * When the agent bailed on a budget/turn limit before producing a verdict,
+ * append a `summary` finding flagged `incomplete` so `present()` surfaces a
+ * clear warning instead of a misleading "no issues found" / clean review.
+ */
+function appendIncompleteNotice(
+  findings: ReviewFinding[],
+  pluginId: string,
+  result: AgentResult,
+): void {
+  if (!result.incomplete) return;
+  const reason =
+    result.stopReason === 'budget'
+      ? 'hit the token budget limit'
+      : result.stopReason === 'max_turns'
+        ? 'hit the turn limit'
+        : 'stopped unexpectedly';
+  const message =
+    `Lien Review did not finish — it ${reason} while investigating and stopped before ` +
+    `producing a verdict. Any findings shown are partial; re-run the review to retry.`;
+  findings.push({
+    pluginId,
+    filepath: '',
+    line: 0,
+    severity: 'warning' as const,
+    category: 'summary',
+    message,
+    metadata: { incomplete: true, stopReason: result.stopReason, overview: message },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Finding mapping
 // ---------------------------------------------------------------------------
@@ -310,10 +376,16 @@ function formatCheckSummary(findings: ReviewFinding[], name: string): string {
   const sections: string[] = [`### ${name}`];
 
   if (summary) {
-    const meta = summary.metadata as { riskLevel?: string; overview?: string } | undefined;
-    sections.push(
-      `**${capitalize(meta?.riskLevel ?? 'unknown')} Risk** — ${meta?.overview ?? summary.message}`,
-    );
+    const meta = summary.metadata as
+      | { riskLevel?: string; overview?: string; incomplete?: boolean }
+      | undefined;
+    if (meta?.incomplete) {
+      sections.push(`⚠️ **Review incomplete** — ${meta.overview ?? summary.message}`);
+    } else {
+      sections.push(
+        `**${capitalize(meta?.riskLevel ?? 'unknown')} Risk** — ${meta?.overview ?? summary.message}`,
+      );
+    }
   }
 
   if (bugs.length > 0) {
@@ -347,14 +419,17 @@ function buildDescription(
   commitSha?: string,
 ): string {
   const meta = summaryFinding?.metadata as
-    | { riskLevel?: string; overview?: string; keyChanges?: string[] }
+    | { riskLevel?: string; overview?: string; keyChanges?: string[]; incomplete?: boolean }
     | undefined;
   const risk = meta?.riskLevel ?? 'low';
   const overview = meta?.overview ?? summaryFinding?.message ?? '';
+  const incomplete = meta?.incomplete === true;
 
-  const calloutType = bugFindings.length > 0 ? 'WARNING' : 'NOTE';
-  const headline =
-    bugFindings.length > 0
+  // An incomplete review must never read as a clean/approving NOTE.
+  const calloutType = bugFindings.length > 0 || incomplete ? 'WARNING' : 'NOTE';
+  const headline = incomplete
+    ? '⚠️ **Review did not complete**'
+    : bugFindings.length > 0
       ? `**${bugFindings.length} issue${bugFindings.length === 1 ? '' : 's'} found** · ${capitalize(risk)} Risk`
       : `**${capitalize(risk)} Risk**`;
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -10,12 +10,21 @@ import type {
   AgentFinding,
   AgentSummary,
   AgentResult,
+  AgentStopReason,
   TurnTrace,
   ToolInvocation,
 } from './types.js';
 
 /** Cap a single tool's recorded output so traces stay readable. */
 const TRACE_TOOL_OUTPUT_MAX = 4096;
+
+/**
+ * Cap a single tool result fed back to the model. A large file read or
+ * batched get_files_context can otherwise return tens of thousands of tokens
+ * in one turn, blowing the whole budget before the wrap-up nudge can fire.
+ * ~24K chars ≈ 6K tokens — enough context for a review, bounded per call.
+ */
+const TOOL_RESULT_MAX_CHARS = 24_000;
 
 const WRAP_UP_NUDGE =
   'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.';
@@ -189,6 +198,9 @@ export class OpenAIAgentClient {
     let turn = 0;
     let lastContent: string | null = null;
     const turnTraces: TurnTrace[] = [];
+    // Defaults to 'max_turns': if the loop exits via its `while` condition
+    // without any explicit break below, the turn budget was the limit.
+    let stopReason: AgentStopReason = 'max_turns';
 
     while (turn < this.maxTurns) {
       turn++;
@@ -219,6 +231,7 @@ export class OpenAIAgentClient {
 
       // Done: model finished naturally
       if (choice.finish_reason === 'stop') {
+        stopReason = 'completed';
         break;
       }
 
@@ -227,11 +240,14 @@ export class OpenAIAgentClient {
         this.logger.warning(
           `[agent] Token budget exceeded (${totalTokens}/${this.maxTokenBudget}), stopping`,
         );
+        stopReason = 'budget';
         break;
       }
 
-      // Approaching budget or last turn — nudge to wrap up
-      const nearBudget = totalTokens >= this.maxTokenBudget * 0.7;
+      // Approaching budget or last turn — nudge to wrap up.
+      // Threshold kept below the hard cap with headroom so a single capped
+      // tool result can't skip past the wrap-up window into the hard stop.
+      const nearBudget = totalTokens >= this.maxTokenBudget * 0.6;
       const lastTurn = turn >= this.maxTurns - 1;
 
       // Process tool calls
@@ -248,6 +264,7 @@ export class OpenAIAgentClient {
         }
       } else {
         this.logger.warning(`[agent] Unexpected finish_reason: ${choice.finish_reason}, stopping`);
+        stopReason = 'error';
         break;
       }
     }
@@ -281,6 +298,16 @@ export class OpenAIAgentClient {
     const cost =
       totalInputTokens * this.inputCostPerToken + totalOutputTokens * this.outputCostPerToken;
 
+    // Incomplete = the loop bailed on a limit (or error) AND never produced a
+    // verdict (no summary, even after the retry). Such a run must not be shown
+    // as a clean review.
+    const incomplete = stopReason !== 'completed' && !parsed.summary;
+    if (incomplete) {
+      this.logger.warning(
+        `[agent] Review incomplete (stopReason=${stopReason}, no summary after ${turn} turns)`,
+      );
+    }
+
     return {
       findings: parsed.findings,
       summary: parsed.summary,
@@ -291,6 +318,8 @@ export class OpenAIAgentClient {
         cost,
       },
       turns: turn,
+      stopReason,
+      incomplete,
       trace: {
         systemPrompt,
         initialMessage,
@@ -331,7 +360,11 @@ export class OpenAIAgentClient {
       turnTrace.toolCalls.push(
         buildInvocation(tc.function.name, tc.function.arguments, parsed, result, startedAt),
       );
-      messages.push({ role: 'tool', content: result, tool_call_id: tc.id });
+      messages.push({
+        role: 'tool',
+        content: truncate(result, TOOL_RESULT_MAX_CHARS),
+        tool_call_id: tc.id,
+      });
     }
   }
 

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -174,6 +174,9 @@ export interface AgentTrace {
   turns: TurnTrace[];
 }
 
+/** Why the agent's tool-use loop ended. */
+export type AgentStopReason = 'completed' | 'budget' | 'max_turns' | 'error';
+
 /** Result of an agent review run, including findings, usage, and turn count. */
 export interface AgentResult {
   findings: AgentFinding[];
@@ -185,6 +188,14 @@ export interface AgentResult {
     cost: number;
   };
   turns: number;
+  /** Why the loop ended. 'completed' means the model finished naturally. */
+  stopReason: AgentStopReason;
+  /**
+   * True when the run stopped on a budget/turn limit (or error) before the
+   * agent produced a verdict (no summary). The findings are partial and the
+   * result must NOT be presented as a clean/approving review.
+   */
+  incomplete: boolean;
   /** Per-turn trace data — only populated when the caller wires up trace capture. */
   trace?: AgentTrace;
 }

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OpenAIAgentClient } from '../src/plugins/agent/openai-client.js';
+import { AgentReviewPlugin, scaleBudgetForBlastRadius } from '../src/plugins/agent/index.js';
+import { silentLogger } from '../src/test-helpers.js';
+import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// fetch mock helpers (OpenAI-compatible chat/completions)
+// ---------------------------------------------------------------------------
+
+type ChatResponse = {
+  choices: Array<{
+    message: { role: string; content: string | null; tool_calls?: unknown[] };
+    finish_reason: string;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+};
+
+/** Install a fetch mock that replays `responses` and records request bodies. */
+function mockFetch(responses: ChatResponse[]): { bodies: Array<Record<string, unknown>> } {
+  const bodies: Array<Record<string, unknown>> = [];
+  const queue = [...responses];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: { body: string }) => {
+      bodies.push(JSON.parse(init.body));
+      const next = queue.shift();
+      return { ok: true, status: 200, json: async () => next, text: async () => '' };
+    }),
+  );
+  return { bodies };
+}
+
+function toolCallTurn(totalTokens: number, content: string | null = null): ChatResponse {
+  return {
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content,
+          tool_calls: [
+            { id: 't1', type: 'function', function: { name: 'read_file', arguments: '{}' } },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+    usage: { prompt_tokens: totalTokens, completion_tokens: 0, total_tokens: totalTokens },
+  };
+}
+
+function stopTurn(content: string, totalTokens = 100): ChatResponse {
+  return {
+    choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: totalTokens, completion_tokens: 0, total_tokens: totalTokens },
+  };
+}
+
+const CLEAN_JSON =
+  '```json\n' +
+  JSON.stringify({
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'All good', keyChanges: [] },
+  }) +
+  '\n```';
+
+function makeClient(maxTokenBudget: number): OpenAIAgentClient {
+  return new OpenAIAgentClient({
+    apiKey: 'test',
+    baseUrl: 'http://mock.local',
+    model: 'test-model',
+    maxTurns: 8,
+    maxTokenBudget,
+    logger: silentLogger,
+  });
+}
+
+const noopTool = async () => 'ok';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('OpenAIAgentClient budget handling', () => {
+  it('marks the run incomplete when the budget is exhausted before a verdict', async () => {
+    // Turn 1 blows the 1k budget (2k tokens); the summary-retry also yields no JSON.
+    mockFetch([toolCallTurn(2000), stopTurn('I could not finish — no JSON.')]);
+    const client = makeClient(1000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(true);
+    expect(result.summary).toBeUndefined();
+    expect(result.findings).toHaveLength(0);
+  }, 15000); // the summary-retry sleeps 3s
+
+  it('marks a naturally-finished run complete (not incomplete)', async () => {
+    mockFetch([stopTurn(CLEAN_JSON)]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.stopReason).toBe('completed');
+    expect(result.incomplete).toBe(false);
+    expect(result.summary).toBeDefined();
+  });
+
+  it('caps an oversized tool result before feeding it back to the model', async () => {
+    const { bodies } = mockFetch([toolCallTurn(100), stopTurn(CLEAN_JSON)]);
+    const client = makeClient(1_000_000);
+    const hugeOutput = 'X'.repeat(100_000);
+
+    const result = await client.run('sys', 'init', [], async () => hugeOutput);
+
+    expect(result.stopReason).toBe('completed');
+    // The second request carries the tool result — it must be truncated.
+    const secondRequestMessages = bodies[1].messages as Array<{ role: string; content: string }>;
+    const toolMessage = secondRequestMessages.find(m => m.role === 'tool');
+    expect(toolMessage).toBeDefined();
+    expect(toolMessage!.content.length).toBeLessThan(hugeOutput.length);
+    expect(toolMessage!.content.length).toBeLessThanOrEqual(24_100);
+    expect(toolMessage!.content).toContain('…[truncated');
+  });
+});
+
+describe('scaleBudgetForBlastRadius', () => {
+  it('bumps the budget for critical and high blast radius', () => {
+    expect(scaleBudgetForBlastRadius(100_000, 'critical')).toBe(150_000);
+    expect(scaleBudgetForBlastRadius(100_000, 'high')).toBe(125_000);
+  });
+
+  it('leaves the budget unchanged for low/medium/unknown risk', () => {
+    expect(scaleBudgetForBlastRadius(100_000, 'medium')).toBe(100_000);
+    expect(scaleBudgetForBlastRadius(100_000, 'low')).toBe(100_000);
+    expect(scaleBudgetForBlastRadius(100_000, undefined)).toBe(100_000);
+  });
+
+  it('clamps to the 200k ceiling', () => {
+    expect(scaleBudgetForBlastRadius(180_000, 'critical')).toBe(200_000);
+  });
+});
+
+describe('AgentReviewPlugin.present — incomplete review', () => {
+  function incompleteSummaryFinding(): ReviewFinding {
+    const message =
+      'Lien Review did not finish — it hit the token budget limit while investigating and ' +
+      'stopped before producing a verdict. Any findings shown are partial; re-run the review to retry.';
+    return {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message,
+      metadata: { incomplete: true, stopReason: 'budget', overview: message },
+    };
+  }
+
+  it('surfaces a visible warning instead of a clean review', async () => {
+    const plugin = new AgentReviewPlugin();
+    const appendDescription = vi.fn();
+    const appendSummary = vi.fn();
+    const ctx = {
+      addAnnotations: vi.fn(),
+      appendDescription,
+      appendSummary,
+    } as unknown as PresentContext;
+
+    await plugin.present([incompleteSummaryFinding()], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('[!WARNING]');
+    expect(description).toContain('Review did not complete');
+    expect(description).not.toContain('No issues found');
+    expect(description).not.toMatch(/Low Risk/);
+
+    const summary = appendSummary.mock.calls[0][0] as string;
+    expect(summary).toContain('Review incomplete');
+    expect(summary).not.toContain('No issues found');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the agent-review failure mode observed on #596: the agent blew its token budget mid-investigation, bailed before emitting findings, and posted a **silent, misleading "clean" review** (0 findings reads as approved).

Root cause chain (from the #596 run log):
1. A single turn's tool result was **uncapped**, so one `read_file`/`get_files_context` jumped token usage from under the wrap-up threshold straight past the hard cap (121K/110K) in one turn — the graceful "wrap up now" nudge never fired.
2. The post-hoc summary-retry then failed, leaving `{findings: []}`.
3. That 0-findings result was posted identically to a genuinely clean review.

## Changes

**Prevent the overshoot**
- **Cap each tool result** fed back to the model (~24K chars ≈ 6K tokens) in both clients, so a single large tool result can't exhaust the budget in one turn.
- **Lower the wrap-up threshold** 0.7 → 0.6, leaving headroom so the agent is told to emit findings before the hard cap.
- **Scale the budget up** for critical (1.5×) / high (1.25×) blast-radius PRs — the case most likely to run out — clamped to the existing 200K ceiling.

**Make exhaustion visible (no more misleading clean review)**
- Track `stopReason` and an `incomplete` flag on `AgentResult`. A run that bails on a budget/turn limit *without producing a verdict* is now flagged.
- `present()` surfaces a `> [!WARNING] ⚠️ Review did not complete` callout and a "Review incomplete" check-summary line instead of the clean `[!NOTE]` / "No issues found".

Applies symmetrically to `openai-client.ts` (the active OpenRouter path) and `anthropic-client.ts`.

## Tests
New `test/plugins-agent-budget.test.ts` (7 tests, mocked `fetch`):
- budget exhaustion → `incomplete: true`, `stopReason: 'budget'`
- natural finish → `incomplete: false`, `stopReason: 'completed'`
- oversized tool result is truncated before the next request
- `scaleBudgetForBlastRadius` multipliers + 200K clamp
- `present()` renders the incomplete warning and never "No issues found"

Full review suite green (355/355) · typecheck/eslint/prettier clean · build OK.

## Cost note
The budget multiplier raises spend on critical/high blast-radius reviews specifically. The tool-result cap *reduces* per-turn tokens, so typical reviews should be cheaper or unchanged; the bump targets the high-impact PRs where bailing-with-empty-review was the prior (worse) outcome.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 4 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +4 |
| 🧠 mental load | 3 | +4 |
| ⏱️ time to understand | 6 | +102 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it hit the token budget limit while investigating and stopped before producing a verdict. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1f58033. Updates automatically on new commits.</sup>
<!-- /lien-stats -->