### PR TITLE
fix(review): size agent token budget to the model (Kimi) + log agent reasoning on bail

### DIFF
--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -17,3 +17,27 @@ export const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 /** OpenRouter cost per million tokens for {@link DEFAULT_REVIEW_MODEL}. */
 export const DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK = 0.74;
 export const DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK = 3.5;
+
+/** Hard ceiling for the scaled agent token budget — bounds worst-case cost. */
+export const MAX_REVIEW_TOKEN_BUDGET = 250_000;
+
+/**
+ * Per-model token-budget multiplier, calibrated to observed token appetite.
+ *
+ * The base budget formula (`scaleAgentBudget` in review-pr.ts) was tuned for
+ * Gemini 3 Flash (~8K tokens/turn). Kimi k2.7-code is a high-effort reasoning
+ * model that re-spends far more per turn (~30–48K observed), so PRs that Gemini
+ * finished were exhausting the budget and bailing without a verdict. Scale the
+ * budget for such models. Unknown models default to 1× (unchanged).
+ *
+ * Keyed on the model slug so it tracks the actual model in use (incl. A/B
+ * overrides), not just the default.
+ */
+export const REVIEW_TOKEN_BUDGET_MULTIPLIERS: Record<string, number> = {
+  [DEFAULT_REVIEW_MODEL]: 1.5,
+};
+
+/** Budget multiplier for a model slug (1× when unknown). */
+export function reviewTokenBudgetMultiplier(model: string): number {
+  return REVIEW_TOKEN_BUDGET_MULTIPLIERS[model] ?? 1;
+}

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -118,6 +118,9 @@ export class AnthropicAgentClient {
     // Defaults to 'max_turns': if the loop exits via its `while` condition
     // without any explicit break below, the turn budget was the limit.
     let stopReason: AgentStopReason = 'max_turns';
+    // Once near budget we drop the tools so the model is *forced* to emit its
+    // verdict next turn, rather than tool-calling until the hard cap.
+    let forceFinish = false;
 
     while (turn < this.maxTurns) {
       turn++;
@@ -133,7 +136,7 @@ export class AnthropicAgentClient {
           },
         ],
         messages,
-        tools,
+        tools: forceFinish ? [] : tools,
       });
 
       lastResponse = response;
@@ -192,6 +195,8 @@ export class AnthropicAgentClient {
       const nearBudget = totalTokens >= this.maxTokenBudget * 0.6;
       const lastTurn = turn >= this.maxTurns - 1;
       const shouldWrapUp = nearBudget || lastTurn;
+      // Drop tools next turn so the model must produce its verdict.
+      if (shouldWrapUp) forceFinish = true;
 
       // Process tool_use blocks
       if (response.stop_reason === 'tool_use' && toolUseBlocks.length > 0) {

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -35,6 +35,15 @@ function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
 }
 
+/**
+ * Parse a boolean-ish env flag. Only '1'/'true' (case-insensitive) enable —
+ * `!!process.env.X` would treat 'false'/'0' as truthy and leak logs.
+ */
+function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}
+
 /** Extract the assistant's text content from an Anthropic response for trace. */
 function joinTextBlocks(content: Anthropic.Messages.ContentBlock[]): string {
   return content
@@ -83,7 +92,7 @@ export class AnthropicAgentClient {
     this.maxTurns = options.maxTurns;
     this.maxTokenBudget = options.maxTokenBudget;
     this.logger = options.logger;
-    this.logAgentTurns = !!process.env.LIEN_REVIEW_LOG_AGENT;
+    this.logAgentTurns = envEnabled(process.env.LIEN_REVIEW_LOG_AGENT);
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -20,6 +20,9 @@ import type {
 /** Cap a single tool's recorded output so traces stay readable. */
 const TRACE_TOOL_OUTPUT_MAX = 4096;
 
+/** Cap per-turn reasoning/output printed to CI logs. */
+const AGENT_LOG_MAX = 4000;
+
 /**
  * Cap a single tool result fed back to the model. A large file read or
  * batched get_files_context can otherwise return tens of thousands of tokens
@@ -67,6 +70,9 @@ export class AnthropicAgentClient {
   private logger: Logger;
   private inputCostPerToken: number;
   private outputCostPerToken: number;
+  // Verbose per-turn reasoning/output logging, gated by env so normal runs
+  // stay readable. The last turn is always logged on an incomplete run.
+  private logAgentTurns: boolean;
 
   constructor(options: AgentClientOptions) {
     this.client = new Anthropic({
@@ -77,6 +83,7 @@ export class AnthropicAgentClient {
     this.maxTurns = options.maxTurns;
     this.maxTokenBudget = options.maxTokenBudget;
     this.logger = options.logger;
+    this.logAgentTurns = !!process.env.LIEN_REVIEW_LOG_AGENT;
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;
@@ -162,6 +169,7 @@ export class AnthropicAgentClient {
         outputTokens: turnOutputTokens,
       };
       turnTraces.push(turnTrace);
+      if (this.logAgentTurns) this.logTurn(turnTrace);
 
       // Done: model finished naturally
       if (response.stop_reason === 'end_turn') {
@@ -207,6 +215,10 @@ export class AnthropicAgentClient {
       this.logger.warning(`[agent] Max turns reached (${this.maxTurns}), stopping`);
     }
 
+    // Capture the last *investigation* turn before the summary-retry appends
+    // its own trace — that's what we want to surface on bail.
+    const lastLoopTurn = turnTraces[turnTraces.length - 1];
+
     let parsed = lastResponse ? extractResponse(lastResponse.content) : { findings: [] };
     if (!parsed.summary && lastResponse) {
       const retry = await this.runSummaryRetry(messages, lastResponse, turn);
@@ -231,6 +243,8 @@ export class AnthropicAgentClient {
       this.logger.warning(
         `[agent] Review incomplete (stopReason=${stopReason}, no summary after ${turn} turns)`,
       );
+      // Always surface what the agent was doing when it bailed.
+      this.logTurn(lastLoopTurn, 'last turn before bail');
     }
 
     return {
@@ -260,6 +274,25 @@ export class AnthropicAgentClient {
    * tool_result blocks. Pulled out of `run()` to keep its
    * time-to-understand under the complexity threshold.
    */
+  /**
+   * Print a turn's reasoning + output to the logger so CI logs show what the
+   * agent was actually thinking. Truncated to keep logs readable.
+   */
+  private logTurn(turn: TurnTrace | undefined, label?: string): void {
+    if (!turn) return;
+    const tag = label ? ` (${label})` : '';
+    if (turn.reasoning) {
+      this.logger.info(
+        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning, AGENT_LOG_MAX)}`,
+      );
+    }
+    if (turn.responseText) {
+      this.logger.info(
+        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText, AGENT_LOG_MAX)}`,
+      );
+    }
+  }
+
   private async dispatchToolUseBlocks(
     toolUseBlocks: Anthropic.Messages.ToolUseBlock[],
     responseContent: Anthropic.Messages.ContentBlock[],

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -136,7 +136,9 @@ export class AnthropicAgentClient {
           },
         ],
         messages,
-        tools: forceFinish ? [] : tools,
+        tools,
+        // tool_choice:'none' forbids tool calls, forcing a findings response.
+        ...(forceFinish ? { tool_choice: { type: 'none' as const } } : {}),
       });
 
       lastResponse = response;

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -24,7 +24,11 @@ import { OpenAIAgentClient, toOpenAITools } from './openai-client.js';
 import { buildSystemPrompt, buildInitialMessage } from './system-prompt.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
-import { DEFAULT_REVIEW_MODEL, DEFAULT_OPENROUTER_BASE_URL } from '../../defaults.js';
+import {
+  DEFAULT_REVIEW_MODEL,
+  DEFAULT_OPENROUTER_BASE_URL,
+  MAX_REVIEW_TOKEN_BUDGET,
+} from '../../defaults.js';
 
 const configSchema = z.object({
   apiKey: z.string().min(1),
@@ -281,9 +285,6 @@ function appendSummaryFinding(
   });
 }
 
-/** Hard ceiling for the agent token budget (mirrors review-pr.ts scaling). */
-const MAX_AGENT_TOKEN_BUDGET = 200_000;
-
 /** Extra budget headroom for high-impact PRs, keyed by blast-radius risk. */
 const BLAST_RADIUS_BUDGET_MULTIPLIER: Record<string, number> = {
   critical: 1.5,
@@ -294,11 +295,11 @@ const BLAST_RADIUS_BUDGET_MULTIPLIER: Record<string, number> = {
  * Scale the agent's token budget up for high-impact changes. A critical
  * blast radius means the agent has many dependents to investigate, which is
  * exactly when a too-tight budget causes it to bail before a verdict. Clamped
- * to the same ceiling as the file-size-based scaling in review-pr.ts.
+ * to the shared ceiling (MAX_REVIEW_TOKEN_BUDGET) used by review-pr.ts scaling.
  */
 export function scaleBudgetForBlastRadius(baseBudget: number, riskLevel?: string): number {
   const multiplier = riskLevel ? (BLAST_RADIUS_BUDGET_MULTIPLIER[riskLevel] ?? 1) : 1;
-  return Math.min(Math.round(baseBudget * multiplier), MAX_AGENT_TOKEN_BUDGET);
+  return Math.min(Math.round(baseBudget * multiplier), MAX_REVIEW_TOKEN_BUDGET);
 }
 
 /**

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -18,6 +18,9 @@ import type {
 /** Cap a single tool's recorded output so traces stay readable. */
 const TRACE_TOOL_OUTPUT_MAX = 4096;
 
+/** Cap per-turn reasoning/output printed to CI logs. */
+const AGENT_LOG_MAX = 4000;
+
 /**
  * Cap a single tool result fed back to the model. A large file read or
  * batched get_files_context can otherwise return tens of thousands of tokens
@@ -169,6 +172,10 @@ export class OpenAIAgentClient {
   private logger: Logger;
   private inputCostPerToken: number;
   private outputCostPerToken: number;
+  // Verbose per-turn reasoning/output logging, gated by env so normal runs
+  // stay readable. The last turn's reasoning is always logged on an
+  // incomplete run (see below) regardless of this flag.
+  private logAgentTurns: boolean;
 
   constructor(options: OpenAIClientOptions) {
     this.apiKey = options.apiKey;
@@ -177,6 +184,7 @@ export class OpenAIAgentClient {
     this.maxTurns = options.maxTurns;
     this.maxTokenBudget = options.maxTokenBudget;
     this.logger = options.logger;
+    this.logAgentTurns = !!process.env.LIEN_REVIEW_LOG_AGENT;
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;
@@ -228,6 +236,7 @@ export class OpenAIAgentClient {
       lastContent = choice.message.content;
       const turnTrace = buildTurnTrace(turn, choice, turnInputTokens, turnOutputTokens);
       turnTraces.push(turnTrace);
+      if (this.logAgentTurns) this.logTurn(turnTrace);
 
       // Done: model finished naturally
       if (choice.finish_reason === 'stop') {
@@ -273,6 +282,10 @@ export class OpenAIAgentClient {
       this.logger.warning(`[agent] Max turns reached (${this.maxTurns}), stopping`);
     }
 
+    // Capture the last *investigation* turn before the summary-retry appends
+    // its own (reasoning-less) trace — that's what we want to surface on bail.
+    const lastLoopTurn = turnTraces[turnTraces.length - 1];
+
     let parsed = extractResponse(lastContent);
     // Fire the summary-retry whenever we have *any* loop history but no
     // findings JSON. The previous guard `lastContent !== null` skipped
@@ -306,6 +319,9 @@ export class OpenAIAgentClient {
       this.logger.warning(
         `[agent] Review incomplete (stopReason=${stopReason}, no summary after ${turn} turns)`,
       );
+      // Always surface what the agent was doing when it bailed — the single
+      // most useful datum for diagnosing an incomplete run in CI logs.
+      this.logTurn(lastLoopTurn, 'last turn before bail');
     }
 
     return {
@@ -408,6 +424,26 @@ export class OpenAIAgentClient {
         `[agent] Summary retry failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       return null;
+    }
+  }
+
+  /**
+   * Print a turn's reasoning + output to the logger so CI logs show what the
+   * agent was actually thinking. Truncated so a verbose reasoning model (Kimi)
+   * doesn't flood the log.
+   */
+  private logTurn(turn: TurnTrace | undefined, label?: string): void {
+    if (!turn) return;
+    const tag = label ? ` (${label})` : '';
+    if (turn.reasoning) {
+      this.logger.info(
+        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning, AGENT_LOG_MAX)}`,
+      );
+    }
+    if (turn.responseText) {
+      this.logger.info(
+        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText, AGENT_LOG_MAX)}`,
+      );
     }
   }
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -40,6 +40,15 @@ function truncate(s: string, max: number): string {
 }
 
 /**
+ * Parse a boolean-ish env flag. Only '1'/'true' (case-insensitive) enable —
+ * `!!process.env.X` would treat 'false'/'0' as truthy and leak logs.
+ */
+export function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}
+
+/**
  * Parse + validate a tool call's JSON arguments. Returns the parsed
  * input on success, throws on parse failure or non-object payload (a
  * cleaner surface than letting the executor crash on a primitive cast).
@@ -184,7 +193,7 @@ export class OpenAIAgentClient {
     this.maxTurns = options.maxTurns;
     this.maxTokenBudget = options.maxTokenBudget;
     this.logger = options.logger;
-    this.logAgentTurns = !!process.env.LIEN_REVIEW_LOG_AGENT;
+    this.logAgentTurns = envEnabled(process.env.LIEN_REVIEW_LOG_AGENT);
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -274,7 +274,7 @@ export class OpenAIAgentClient {
         );
         if (nearBudget || lastTurn) {
           messages.push({ role: 'user', content: WRAP_UP_NUDGE });
-          // Next turn runs without tools so the model must produce findings.
+          // Next turn is forced to emit a JSON verdict (no tools).
           forceFinish = true;
         }
       } else {
@@ -410,7 +410,9 @@ export class OpenAIAgentClient {
     await new Promise(resolve => setTimeout(resolve, 3_000));
     messages.push({ role: 'user', content: RETRY_NUDGE });
     try {
-      const response = await this.chatCompletion(messages, []);
+      // forceVerdict: response_format:json_object guarantees a JSON response,
+      // the reliable safety net when the loop bailed without a verdict.
+      const response = await this.chatCompletion(messages, [], true);
       const inputTokens = response.usage?.prompt_tokens ?? 0;
       const outputTokens = response.usage?.completion_tokens ?? 0;
       const choice = response.choices[0];
@@ -456,7 +458,7 @@ export class OpenAIAgentClient {
   private async chatCompletion(
     messages: ChatMessage[],
     tools: ToolDef[],
-    forceNoTools = false,
+    forceVerdict = false,
   ): Promise<ChatResponse> {
     const body: Record<string, unknown> = {
       model: this.model,
@@ -465,12 +467,15 @@ export class OpenAIAgentClient {
       temperature: 0,
       reasoning: { effort: 'high' },
     };
-    if (tools.length > 0) {
+    if (forceVerdict) {
+      // Force a JSON verdict (no tools). response_format:json_object makes the
+      // output be a JSON object — the model cannot emit tool calls. It's more
+      // reliably honored across OpenRouter providers than tool_choice:'none'
+      // (which a Kimi provider ignored mid-investigation), and an empty tools
+      // array is too weak (the model still emits tool calls from the prompt).
+      body.response_format = { type: 'json_object' };
+    } else if (tools.length > 0) {
       body.tools = tools;
-      // tool_choice:'none' forbids tool calls server-side, forcing a text
-      // (findings) response. An empty tools array is too weak — the model
-      // still emits tool calls it learned from the system prompt.
-      if (forceNoTools) body.tool_choice = 'none';
     }
 
     const response = await fetch(`${this.baseUrl}/chat/completions`, {
@@ -524,11 +529,13 @@ function extractResponse(content: string | null): {
 } {
   if (!content) return { findings: [] };
 
+  // Prefer a ```json fence (normal turns); fall back to the raw body, which is
+  // what response_format:json_object returns on a forced-verdict turn.
   const jsonMatch = content.match(/```json\s*\n([\s\S]*?)\n\s*```/);
-  if (!jsonMatch) return { findings: [] };
+  const raw = jsonMatch ? jsonMatch[1] : content.trim();
 
   try {
-    const parsed = JSON.parse(jsonMatch[1]);
+    const parsed = JSON.parse(raw);
     const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
     const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
     return { findings: findings.filter(isValidFinding), summary };

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -217,7 +217,7 @@ export class OpenAIAgentClient {
     while (turn < this.maxTurns) {
       turn++;
 
-      const response = await this.chatCompletion(messages, forceFinish ? [] : tools);
+      const response = await this.chatCompletion(messages, tools, forceFinish);
 
       const turnInputTokens = response.usage?.prompt_tokens ?? 0;
       const turnOutputTokens = response.usage?.completion_tokens ?? 0;
@@ -453,7 +453,11 @@ export class OpenAIAgentClient {
     }
   }
 
-  private async chatCompletion(messages: ChatMessage[], tools: ToolDef[]): Promise<ChatResponse> {
+  private async chatCompletion(
+    messages: ChatMessage[],
+    tools: ToolDef[],
+    forceNoTools = false,
+  ): Promise<ChatResponse> {
     const body: Record<string, unknown> = {
       model: this.model,
       messages,
@@ -463,6 +467,10 @@ export class OpenAIAgentClient {
     };
     if (tools.length > 0) {
       body.tools = tools;
+      // tool_choice:'none' forbids tool calls server-side, forcing a text
+      // (findings) response. An empty tools array is too weak — the model
+      // still emits tool calls it learned from the system prompt.
+      if (forceNoTools) body.tool_choice = 'none';
     }
 
     const response = await fetch(`${this.baseUrl}/chat/completions`, {

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -209,11 +209,15 @@ export class OpenAIAgentClient {
     // Defaults to 'max_turns': if the loop exits via its `while` condition
     // without any explicit break below, the turn budget was the limit.
     let stopReason: AgentStopReason = 'max_turns';
+    // Once near budget we drop the tools so the model is *forced* to emit its
+    // verdict next turn. Kimi otherwise ignores the soft wrap-up nudge and
+    // keeps tool-calling until the hard cap, bailing without findings.
+    let forceFinish = false;
 
     while (turn < this.maxTurns) {
       turn++;
 
-      const response = await this.chatCompletion(messages, tools);
+      const response = await this.chatCompletion(messages, forceFinish ? [] : tools);
 
       const turnInputTokens = response.usage?.prompt_tokens ?? 0;
       const turnOutputTokens = response.usage?.completion_tokens ?? 0;
@@ -270,6 +274,8 @@ export class OpenAIAgentClient {
         );
         if (nearBudget || lastTurn) {
           messages.push({ role: 'user', content: WRAP_UP_NUDGE });
+          // Next turn runs without tools so the model must produce findings.
+          forceFinish = true;
         }
       } else {
         this.logger.warning(`[agent] Unexpected finish_reason: ${choice.finish_reason}, stopping`);

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -38,6 +38,7 @@ import {
 } from './index.js';
 import type { CodeChunk } from '@liendev/parser';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
+import { reviewTokenBudgetMultiplier, MAX_REVIEW_TOKEN_BUDGET } from './defaults.js';
 
 import { cloneBySha, type CloneResult } from './clone.js';
 
@@ -200,7 +201,7 @@ function buildPluginConfigs(
           baseUrl: ctx.llm.provider === 'openai' ? ctx.llm.baseUrl : undefined,
           inputCostPerMTok: ctx.llm.inputCostPerMTok,
           outputCostPerMTok: ctx.llm.outputCostPerMTok,
-          ...scaleAgentBudget(filesToAnalyze.length, chunks),
+          ...scaleAgentBudget(filesToAnalyze.length, chunks, ctx.llm.model),
         }
       : {},
   };
@@ -300,9 +301,10 @@ async function presentFindings(
  * the initial message, so the budget must accommodate it plus tool
  * calls and the final JSON output.
  */
-function scaleAgentBudget(
+export function scaleAgentBudget(
   fileCount: number,
   chunks: { content: string }[],
+  model: string,
 ): { maxTurns: number; maxTokenBudget: number } {
   // Estimate tokens in the changed code (~4 chars/token)
   const contentChars = chunks.reduce((sum, c) => sum + c.content.length, 0);
@@ -318,8 +320,12 @@ function scaleAgentBudget(
   const toolBudget = maxTurns * 8_000;
   const baseBudget = 4_000 + estimatedContentTokens + toolBudget + 2_000;
 
-  // Clamp: minimum 60K (small PRs still need room), maximum 200K
-  const maxTokenBudget = Math.min(Math.max(baseBudget, 60_000), 200_000);
+  // Scale by the model's token appetite — the breakdown above is per the
+  // Gemini-era ~8K/turn assumption; Kimi spends far more (see defaults.ts).
+  const scaled = baseBudget * reviewTokenBudgetMultiplier(model);
+
+  // Clamp: minimum 60K (small PRs still need room), maximum MAX_REVIEW_TOKEN_BUDGET
+  const maxTokenBudget = Math.min(Math.max(scaled, 60_000), MAX_REVIEW_TOKEN_BUDGET);
 
   return { maxTurns, maxTokenBudget };
 }

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -322,7 +322,10 @@ export function scaleAgentBudget(
 
   // Scale by the model's token appetite — the breakdown above is per the
   // Gemini-era ~8K/turn assumption; Kimi spends far more (see defaults.ts).
-  const scaled = baseBudget * reviewTokenBudgetMultiplier(model);
+  // Math.round keeps the result an integer: the agent-review config schema
+  // requires an int, and a fractional budget makes it reject the whole config
+  // (dropping the API key with it, so the agent silently doesn't run).
+  const scaled = Math.round(baseBudget * reviewTokenBudgetMultiplier(model));
 
   // Clamp: minimum 60K (small PRs still need room), maximum MAX_REVIEW_TOKEN_BUDGET
   const maxTokenBudget = Math.min(Math.max(scaled, 60_000), MAX_REVIEW_TOKEN_BUDGET);

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { OpenAIAgentClient } from '../src/plugins/agent/openai-client.js';
+import { OpenAIAgentClient, envEnabled } from '../src/plugins/agent/openai-client.js';
 import { AgentReviewPlugin, scaleBudgetForBlastRadius } from '../src/plugins/agent/index.js';
 import { scaleAgentBudget } from '../src/review-pr.js';
 import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
@@ -188,6 +188,21 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.incomplete).toBe(true);
     expect(lines.some(l => l.includes(reasoning))).toBe(true);
   }, 15000);
+});
+
+describe('envEnabled (LIEN_REVIEW_LOG_AGENT parsing)', () => {
+  it('enables only for 1/true (case-insensitive)', () => {
+    expect(envEnabled('1')).toBe(true);
+    expect(envEnabled('true')).toBe(true);
+    expect(envEnabled('TRUE')).toBe(true);
+  });
+
+  it('does not enable for falsey strings (the !! bug)', () => {
+    expect(envEnabled('false')).toBe(false);
+    expect(envEnabled('0')).toBe(false);
+    expect(envEnabled('')).toBe(false);
+    expect(envEnabled(undefined)).toBe(false);
+  });
 });
 
 describe('scaleBudgetForBlastRadius', () => {

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -154,8 +154,8 @@ describe('OpenAIAgentClient budget handling', () => {
 
     expect(result.stopReason).toBe('completed');
     expect(result.incomplete).toBe(false);
-    expect(bodies[0].tools).toBeDefined(); // turn 1 had tools
-    expect(bodies[1].tools).toBeUndefined(); // turn 2 forced: no tools
+    expect(bodies[0].tool_choice).toBeUndefined(); // turn 1: tools usable
+    expect(bodies[1].tool_choice).toBe('none'); // turn 2 forced: tools forbidden
   });
 
   it('logs the last-turn reasoning when a run is incomplete', async () => {

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -141,9 +141,9 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(toolMessage!.content).toContain('…[truncated');
   });
 
-  it('forces a verdict by dropping tools once near budget', async () => {
+  it('forces a JSON verdict (response_format, no tools) once near budget', async () => {
     // Turn 1 crosses the 0.6 wrap-up threshold (7k/10k) but not the hard cap;
-    // turn 2 must run without tools so the model produces findings.
+    // turn 2 is forced to emit a JSON verdict with no tools.
     const { bodies } = mockFetch([toolCallTurn(7000), stopTurn(CLEAN_JSON, 1000)]);
     const client = makeClient(10_000);
     const tools = [
@@ -154,9 +154,28 @@ describe('OpenAIAgentClient budget handling', () => {
 
     expect(result.stopReason).toBe('completed');
     expect(result.incomplete).toBe(false);
-    expect(bodies[0].tool_choice).toBeUndefined(); // turn 1: tools usable
-    expect(bodies[1].tool_choice).toBe('none'); // turn 2 forced: tools forbidden
+    expect(bodies[0].tools).toBeDefined(); // turn 1: tools usable
+    expect(bodies[0].response_format).toBeUndefined();
+    expect(bodies[1].tools).toBeUndefined(); // turn 2 forced: no tools
+    expect(bodies[1].response_format).toEqual({ type: 'json_object' });
   });
+
+  it('recovers a verdict via the json-forced summary-retry after a bail', async () => {
+    // Loop bails on budget with no verdict; the retry returns raw JSON (as
+    // response_format:json_object would) and must be parsed into a summary.
+    const rawVerdict = JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: 'recovered', keyChanges: [] },
+    });
+    mockFetch([toolCallTurn(2000), stopTurn(rawVerdict, 100)]);
+    const client = makeClient(1000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(false); // retry recovered a verdict
+    expect(result.summary?.overview).toBe('recovered');
+  }, 15000);
 
   it('logs the last-turn reasoning when a run is incomplete', async () => {
     const { logger, lines } = capturingLogger();

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -191,6 +191,30 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
       MAX_REVIEW_TOKEN_BUDGET,
     );
   });
+
+  it('always returns an integer budget (the config schema requires int)', () => {
+    // 40002 chars → ceil(/4)=10001 → base 96001 (odd); ×1.5 = 144001.5 must round.
+    const odd = [{ content: 'x'.repeat(40_002) }];
+    const { maxTokenBudget } = scaleAgentBudget(5, odd, DEFAULT_REVIEW_MODEL);
+    expect(Number.isInteger(maxTokenBudget)).toBe(true);
+    expect(maxTokenBudget).toBe(144_002);
+  });
+
+  it('produces a config the agent-review schema accepts', () => {
+    // Guards the exact failure a float budget caused: the schema rejects the
+    // whole config (dropping the API key), so the agent silently doesn't run.
+    const plugin = new AgentReviewPlugin();
+    const cfg = {
+      apiKey: 'k',
+      provider: 'openai' as const,
+      model: DEFAULT_REVIEW_MODEL,
+      baseUrl: 'http://mock.local',
+      inputCostPerMTok: 0.74,
+      outputCostPerMTok: 3.5,
+      ...scaleAgentBudget(5, [{ content: 'x'.repeat(40_002) }], DEFAULT_REVIEW_MODEL),
+    };
+    expect(() => plugin.configSchema.parse(cfg)).not.toThrow();
+  });
 });
 
 describe('AgentReviewPlugin.present — incomplete review', () => {

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -141,6 +141,23 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(toolMessage!.content).toContain('…[truncated');
   });
 
+  it('forces a verdict by dropping tools once near budget', async () => {
+    // Turn 1 crosses the 0.6 wrap-up threshold (7k/10k) but not the hard cap;
+    // turn 2 must run without tools so the model produces findings.
+    const { bodies } = mockFetch([toolCallTurn(7000), stopTurn(CLEAN_JSON, 1000)]);
+    const client = makeClient(10_000);
+    const tools = [
+      { type: 'function', function: { name: 'read_file', description: 'd', parameters: {} } },
+    ];
+
+    const result = await client.run('sys', 'init', tools as never, noopTool);
+
+    expect(result.stopReason).toBe('completed');
+    expect(result.incomplete).toBe(false);
+    expect(bodies[0].tools).toBeDefined(); // turn 1 had tools
+    expect(bodies[1].tools).toBeUndefined(); // turn 2 forced: no tools
+  });
+
   it('logs the last-turn reasoning when a run is incomplete', async () => {
     const { logger, lines } = capturingLogger();
     const reasoning = 'I am tracing the credit-service lock path for a race condition';

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { OpenAIAgentClient } from '../src/plugins/agent/openai-client.js';
 import { AgentReviewPlugin, scaleBudgetForBlastRadius } from '../src/plugins/agent/index.js';
+import { scaleAgentBudget } from '../src/review-pr.js';
+import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
 import { silentLogger } from '../src/test-helpers.js';
+import type { Logger } from '../src/logger.js';
 import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
 
 // ---------------------------------------------------------------------------
@@ -10,11 +13,21 @@ import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
 
 type ChatResponse = {
   choices: Array<{
-    message: { role: string; content: string | null; tool_calls?: unknown[] };
+    message: { role: string; content: string | null; reasoning?: string; tool_calls?: unknown[] };
     finish_reason: string;
   }>;
   usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
 };
+
+/** Logger that records every line for assertions. */
+function capturingLogger(): { logger: Logger; lines: string[] } {
+  const lines: string[] = [];
+  const record = (m: string) => lines.push(m);
+  return {
+    logger: { info: record, warning: record, error: record, debug: record },
+    lines,
+  };
+}
 
 /** Install a fetch mock that replays `responses` and records request bodies. */
 function mockFetch(responses: ChatResponse[]): { bodies: Array<Record<string, unknown>> } {
@@ -31,13 +44,18 @@ function mockFetch(responses: ChatResponse[]): { bodies: Array<Record<string, un
   return { bodies };
 }
 
-function toolCallTurn(totalTokens: number, content: string | null = null): ChatResponse {
+function toolCallTurn(
+  totalTokens: number,
+  content: string | null = null,
+  reasoning?: string,
+): ChatResponse {
   return {
     choices: [
       {
         message: {
           role: 'assistant',
           content,
+          ...(reasoning ? { reasoning } : {}),
           tool_calls: [
             { id: 't1', type: 'function', function: { name: 'read_file', arguments: '{}' } },
           ],
@@ -64,14 +82,14 @@ const CLEAN_JSON =
   }) +
   '\n```';
 
-function makeClient(maxTokenBudget: number): OpenAIAgentClient {
+function makeClient(maxTokenBudget: number, logger: Logger = silentLogger): OpenAIAgentClient {
   return new OpenAIAgentClient({
     apiKey: 'test',
     baseUrl: 'http://mock.local',
     model: 'test-model',
     maxTurns: 8,
     maxTokenBudget,
-    logger: silentLogger,
+    logger,
   });
 }
 
@@ -122,6 +140,18 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(toolMessage!.content.length).toBeLessThanOrEqual(24_100);
     expect(toolMessage!.content).toContain('…[truncated');
   });
+
+  it('logs the last-turn reasoning when a run is incomplete', async () => {
+    const { logger, lines } = capturingLogger();
+    const reasoning = 'I am tracing the credit-service lock path for a race condition';
+    mockFetch([toolCallTurn(2000, null, reasoning), stopTurn('no json here')]);
+    const client = makeClient(1000, logger);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(true);
+    expect(lines.some(l => l.includes(reasoning))).toBe(true);
+  }, 15000);
 });
 
 describe('scaleBudgetForBlastRadius', () => {
@@ -136,8 +166,30 @@ describe('scaleBudgetForBlastRadius', () => {
     expect(scaleBudgetForBlastRadius(100_000, undefined)).toBe(100_000);
   });
 
-  it('clamps to the 200k ceiling', () => {
-    expect(scaleBudgetForBlastRadius(180_000, 'critical')).toBe(200_000);
+  it('clamps to the shared ceiling', () => {
+    expect(scaleBudgetForBlastRadius(200_000, 'critical')).toBe(MAX_REVIEW_TOKEN_BUDGET);
+  });
+});
+
+describe('scaleAgentBudget — model-aware multiplier', () => {
+  // ~40K chars ≈ 10K content tokens; with 5 files (maxTurns 10, toolBudget 80K)
+  // base = 4000 + 10000 + 80000 + 2000 = 96000 (within [60K, ceiling], unclamped).
+  const chunks = [{ content: 'x'.repeat(40_000) }];
+
+  it('scales the budget up ~1.5x for Kimi vs a lean model', () => {
+    const lean = scaleAgentBudget(5, chunks, 'some/lean-model').maxTokenBudget;
+    const kimi = scaleAgentBudget(5, chunks, DEFAULT_REVIEW_MODEL).maxTokenBudget;
+    expect(lean).toBe(96_000);
+    expect(kimi).toBe(144_000);
+    expect(kimi).toBe(lean * 1.5);
+  });
+
+  it('clamps the scaled budget to the shared ceiling', () => {
+    // 15 files → big toolBudget; large content pushes base*1.5 past the ceiling.
+    const big = [{ content: 'x'.repeat(400_000) }];
+    expect(scaleAgentBudget(15, big, DEFAULT_REVIEW_MODEL).maxTokenBudget).toBe(
+      MAX_REVIEW_TOKEN_BUDGET,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Kimi k2.7-code (the default review model) is far more token-hungry than the Gemini 3 Flash the budget formula was tuned for, so normal-impact PRs were exhausting the budget and bailing without a verdict. This sizes the budget to the model and makes "why did it bail?" visible in CI logs.

## Data (from recent Kimi runs)

| PR | blast | files | budget | per-turn growth | outcome |
|---|---|---|---|---|---|
| #596 | critical | 9 | 165K (1.5× blast) | 24→53→90→130→**178K** | completed (turn 5) |
| #597 | medium | 5 | 108K (no scaling) | 16→37→71→**115K** | **bailed** turn 4 |

Kimi grows ~30–48K tokens/turn and needs ~5 turns + ~160–180K for a real multi-file review. The Gemini-era formula gives ~108K for a medium PR, so only critical PRs (which got the blast multiplier) survived.

## Changes

**Budget — `fix(review)`**
- `defaults.ts`: per-model budget multiplier (`reviewTokenBudgetMultiplier`), Kimi = **1.5×**, calibrated from the data above; unknown models stay 1× (auto-reverts if you A/B a leaner model). Keyed on the model slug.
- Raise the shared ceiling 200K → **250K** (`MAX_REVIEW_TOKEN_BUDGET`), used by both `scaleAgentBudget` (file/content scaling) and `scaleBudgetForBlastRadius` (impact scaling) so the two clamps can't drift.
- `scaleAgentBudget` now takes the model and applies the multiplier. Multipliers compose (model × blast) under the clamp. Budget is a **ceiling** — the agent still stops when done — so this only spends more where a review would otherwise bail.

**Observability — `feat(review)`** (answers "should we print agent logs to CI?")
- On an **incomplete** run, always log the last investigation turn's reasoning + output — directly explains the bail (the gap we hit debugging #597).
- Behind `LIEN_REVIEW_LOG_AGENT`, log every turn's reasoning + output for deep debugging (off by default — Kimi reasoning is verbose). Data already existed in the per-turn trace; this routes it to the logger (truncated).
- Both OpenAI + Anthropic clients.

## Tests
`plugins-agent-budget.test.ts`: `scaleAgentBudget` applies the Kimi 1.5× multiplier and clamps to the ceiling; the incomplete-run logging surfaces the last-turn reasoning. Full review suite green (368/368) · typecheck/eslint/prettier clean · build OK.

## Expected effect
Medium 5-file PR: 108K → **162K** (enough to finish, per the data). Critical: base×1.5(model)×1.5(blast) clamped to 250K. Most PRs finish in 1–2 turns well under budget, so typical cost is unchanged; the increase only engages where the agent actually needs the turns.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 2 new functions are too complex.
🔗 **Impact**: 2 high-risk file(s) with 5 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +4 |
| 🧠 mental load | 3 | +7 |
| ⏱️ time to understand | 7 | +71 |
| 🐛 estimated bugs | 2 | +3.223 |


> [!WARNING]
> **2 issues found** · Medium Risk
>
> The PR increases the agent token budget for Kimi (1.5× model multiplier, shared 250K ceiling) and adds per-turn logging plus forced-verdict handling when near budget. The budget math and OpenAI forced-verdict path are tested and look correct. However, the Anthropic client has two real behavioral gaps: its turn traces do not capture reasoning blocks, so the new logTurn() cannot surface them on incomplete runs; and its summary-retry path does not force a verdict, leaving the model free to tool-call during a retry meant to recover a verdict. These are behavioral inconsistencies between the two clients that reduce debuggability and recovery reliability for Anthropic runs.
>
> - Added model-specific token budget multiplier (Kimi 1.5×) and shared 250K ceiling in defaults.ts
> - scaleAgentBudget now takes model and applies multiplier, clamped to shared ceiling
> - OpenAI client forces JSON verdict via response_format:json_object when near budget and during summary retry
> - Anthropic client forces no-tool turn via tool_choice:'none' when near budget, but retry lacks the same forcing
> - Added per-turn reasoning/output logging gated by LIEN_REVIEW_LOG_AGENT, plus mandatory last-turn log on incomplete runs

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bcc6816. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review runs now adapt token budgeting based on the selected model, with a shared upper limit for more consistent behavior.
  * Agent logs can now include the most recent turn details when a run stops early, improving troubleshooting output.

* **Bug Fixes**
  * Improved budget capping so review jobs stay within the same maximum limit across scaling paths.
  * Logging for incomplete agent runs now captures the final meaningful turn more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->