### PR TITLE
fix(review): Anthropic client parity — capture reasoning + force the retry

### DIFF
--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -76,6 +76,18 @@ export function extractThinking(content: Anthropic.Messages.ContentBlock[]): str
 const THINKING_BUDGET_TOKENS = 4096;
 const MAX_TOKENS = 16_000;
 
+/**
+ * Bound a single request's output to the budget remaining, so one turn can't
+ * blow far past maxTokenBudget before the post-response check (and the retry
+ * can't pile on after the loop already stopped for budget). Floored above the
+ * thinking budget so thinking stays valid (budget_tokens < max_tokens) and a
+ * final verdict still fits.
+ */
+const MIN_REQUEST_MAX_TOKENS = THINKING_BUDGET_TOKENS + 2_048;
+export function requestMaxTokens(remainingBudget: number): number {
+  return Math.min(MAX_TOKENS, Math.max(remainingBudget, MIN_REQUEST_MAX_TOKENS));
+}
+
 /** Default Sonnet pricing: $3/MTok input, $15/MTok output. */
 const DEFAULT_INPUT_COST_PER_MTOK = 3;
 const DEFAULT_OUTPUT_COST_PER_MTOK = 15;
@@ -158,9 +170,10 @@ export class AnthropicAgentClient {
     while (turn < this.maxTurns) {
       turn++;
 
+      const used = totalInputTokens + totalOutputTokens;
       const response = await this.client.messages.create({
         model: this.model,
-        max_tokens: MAX_TOKENS,
+        max_tokens: requestMaxTokens(this.maxTokenBudget - used),
         thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET_TOKENS },
         system: [
           {
@@ -264,7 +277,14 @@ export class AnthropicAgentClient {
 
     let parsed = lastResponse ? extractResponse(lastResponse.content) : { findings: [] };
     if (!parsed.summary && lastResponse) {
-      const retry = await this.runSummaryRetry(messages, lastResponse, turn, tools);
+      const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
+      const retry = await this.runSummaryRetry(
+        messages,
+        lastResponse,
+        turn,
+        tools,
+        remainingBudget,
+      );
       if (retry) {
         totalInputTokens += retry.inputTokens;
         totalOutputTokens += retry.outputTokens;
@@ -353,16 +373,17 @@ export class AnthropicAgentClient {
       toolUseBlocks.map(async block => executeOneToolUse(block, toolExecutor)),
     );
     turnTrace.toolCalls = executed.map(e => e.invocation);
-    const toolResults: Anthropic.Messages.ToolResultBlockParam[] = executed.map(e => e.toolResult);
+    // Content is a mix of tool_result blocks plus (optionally) the wrap-up text
+    // nudge. A user turn may carry both, so type it as ContentBlockParam[] —
+    // the previous `as unknown as ToolResultBlockParam` cast lied about the
+    // element type for the text block.
+    const content: Anthropic.Messages.ContentBlockParam[] = executed.map(e => e.toolResult);
 
     if (shouldWrapUp) {
-      toolResults.push({
-        type: 'text',
-        text: WRAP_UP_NUDGE,
-      } as unknown as Anthropic.Messages.ToolResultBlockParam);
+      content.push({ type: 'text', text: WRAP_UP_NUDGE });
     }
 
-    messages.push({ role: 'user', content: toolResults });
+    messages.push({ role: 'user', content });
   }
 
   /**
@@ -377,6 +398,7 @@ export class AnthropicAgentClient {
     lastResponse: Anthropic.Messages.Message,
     turn: number,
     tools: Anthropic.Messages.Tool[],
+    remainingBudget: number,
   ): Promise<{
     parsed: { findings: AgentFinding[]; summary?: AgentSummary };
     traceTurn: TurnTrace;
@@ -389,7 +411,7 @@ export class AnthropicAgentClient {
     try {
       const response = await this.client.messages.create({
         model: this.model,
-        max_tokens: MAX_TOKENS,
+        max_tokens: requestMaxTokens(remainingBudget),
         thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET_TOKENS },
         system: [{ type: 'text', text: RETRY_SYSTEM_PROMPT }],
         messages,

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -52,6 +52,30 @@ function joinTextBlocks(content: Anthropic.Messages.ContentBlock[]): string {
     .join('\n');
 }
 
+/**
+ * Extract Claude's extended-thinking prose from a response, if present.
+ * Populates TurnTrace.reasoning so logTurn can surface it on incomplete runs
+ * (parity with the OpenAI path's `reasoning` field).
+ */
+export function extractThinking(content: Anthropic.Messages.ContentBlock[]): string | undefined {
+  const thinking = content
+    .filter((b): b is Anthropic.Messages.ThinkingBlock => b.type === 'thinking')
+    .map(b => b.thinking)
+    .join('\n')
+    .trim();
+  return thinking || undefined;
+}
+
+/**
+ * Extended-thinking config. Enabled for parity with the OpenAI path's
+ * `reasoning: { effort: 'high' }` — it also improves review quality and is
+ * what makes Claude emit the thinking blocks logTurn surfaces. Compatible with
+ * tool_choice:'none' (the forced-verdict turn); only 'any'/'tool' are not.
+ * budget_tokens must be < max_tokens.
+ */
+const THINKING_BUDGET_TOKENS = 4096;
+const MAX_TOKENS = 16_000;
+
 /** Default Sonnet pricing: $3/MTok input, $15/MTok output. */
 const DEFAULT_INPUT_COST_PER_MTOK = 3;
 const DEFAULT_OUTPUT_COST_PER_MTOK = 15;
@@ -136,7 +160,8 @@ export class AnthropicAgentClient {
 
       const response = await this.client.messages.create({
         model: this.model,
-        max_tokens: 8192,
+        max_tokens: MAX_TOKENS,
+        thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET_TOKENS },
         system: [
           {
             type: 'text',
@@ -147,6 +172,7 @@ export class AnthropicAgentClient {
         messages,
         tools,
         // tool_choice:'none' forbids tool calls, forcing a findings response.
+        // Compatible with extended thinking (unlike 'any'/'tool').
         ...(forceFinish ? { tool_choice: { type: 'none' as const } } : {}),
       });
 
@@ -177,6 +203,7 @@ export class AnthropicAgentClient {
       const turnTrace: TurnTrace = {
         turnNumber: turn,
         responseText: joinTextBlocks(response.content),
+        reasoning: extractThinking(response.content),
         toolCalls: [],
         finishReason: response.stop_reason ?? undefined,
         inputTokens: turnInputTokens,
@@ -237,7 +264,7 @@ export class AnthropicAgentClient {
 
     let parsed = lastResponse ? extractResponse(lastResponse.content) : { findings: [] };
     if (!parsed.summary && lastResponse) {
-      const retry = await this.runSummaryRetry(messages, lastResponse, turn);
+      const retry = await this.runSummaryRetry(messages, lastResponse, turn, tools);
       if (retry) {
         totalInputTokens += retry.inputTokens;
         totalOutputTokens += retry.outputTokens;
@@ -349,6 +376,7 @@ export class AnthropicAgentClient {
     messages: Anthropic.Messages.MessageParam[],
     lastResponse: Anthropic.Messages.Message,
     turn: number,
+    tools: Anthropic.Messages.Tool[],
   ): Promise<{
     parsed: { findings: AgentFinding[]; summary?: AgentSummary };
     traceTurn: TurnTrace;
@@ -361,15 +389,21 @@ export class AnthropicAgentClient {
     try {
       const response = await this.client.messages.create({
         model: this.model,
-        max_tokens: 4096,
+        max_tokens: MAX_TOKENS,
+        thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET_TOKENS },
         system: [{ type: 'text', text: RETRY_SYSTEM_PROMPT }],
         messages,
+        tools,
+        // Same forcing as the loop's wrap-up turn: tools present but forbidden,
+        // so the model must emit a findings verdict instead of tool-calling.
+        tool_choice: { type: 'none' as const },
       });
       const inputTokens = response.usage.input_tokens;
       const outputTokens = response.usage.output_tokens;
       const traceTurn: TurnTrace = {
         turnNumber: turn + 1,
         responseText: joinTextBlocks(response.content),
+        reasoning: extractThinking(response.content),
         toolCalls: [],
         finishReason: response.stop_reason ?? undefined,
         inputTokens,

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Logger } from '../src/logger.js';
+
+// Mock the Anthropic SDK so we can drive the client without a live API.
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: createMock };
+  },
+}));
+
+import { AnthropicAgentClient, extractThinking } from '../src/plugins/agent/anthropic-client.js';
+
+function capturingLogger(): { logger: Logger; lines: string[] } {
+  const lines: string[] = [];
+  const record = (m: string) => lines.push(m);
+  return { logger: { info: record, warning: record, error: record, debug: record }, lines };
+}
+
+type Block = Record<string, unknown>;
+function msg(content: Block[], inTok: number, outTok: number, stop: string) {
+  return { content, usage: { input_tokens: inTok, output_tokens: outTok }, stop_reason: stop };
+}
+const thinkingBlock = (t: string) => ({ type: 'thinking', thinking: t, signature: 'sig' });
+const toolUseBlock = { type: 'tool_use', id: 't1', name: 'read_file', input: {} };
+const textBlock = (t: string) => ({ type: 'text', text: t });
+
+const TOOLS = [
+  { name: 'read_file', description: 'd', input_schema: { type: 'object', properties: {} } },
+];
+
+function makeClient(maxTokenBudget: number, logger: Logger) {
+  return new AnthropicAgentClient({
+    apiKey: 'test',
+    model: 'claude-test',
+    maxTurns: 8,
+    maxTokenBudget,
+    logger,
+  });
+}
+
+afterEach(() => {
+  createMock.mockReset();
+});
+
+describe('extractThinking', () => {
+  it('returns concatenated thinking-block text', () => {
+    expect(extractThinking([thinkingBlock('pondering'), textBlock('hi')] as never)).toBe(
+      'pondering',
+    );
+  });
+
+  it('returns undefined when there are no thinking blocks', () => {
+    expect(extractThinking([textBlock('hi')] as never)).toBeUndefined();
+  });
+});
+
+describe('AnthropicAgentClient extended thinking + retry forcing', () => {
+  it('enables thinking on every request', async () => {
+    createMock.mockResolvedValueOnce(
+      msg(
+        [
+          textBlock(
+            '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"ok","keyChanges":[]}}\n```',
+          ),
+        ],
+        100,
+        50,
+        'end_turn',
+      ),
+    );
+    const { logger } = capturingLogger();
+    await makeClient(1_000_000, logger).run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    expect(createMock.mock.calls[0][0].thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
+  });
+
+  it('captures reasoning from thinking blocks and surfaces it on an incomplete run', async () => {
+    // Turn 1 blows the budget while thinking; retry yields no JSON → incomplete.
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('tracing the lock path'), toolUseBlock], 2000, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock('could not finish')], 100, 0, 'end_turn'));
+    const { logger, lines } = capturingLogger();
+
+    const result = await makeClient(1000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.incomplete).toBe(true);
+    expect(lines.some(l => l.includes('tracing the lock path'))).toBe(true);
+  }, 15000);
+
+  it('forces the retry with tool_choice:none + thinking (parity with the loop)', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 2000, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock('no verdict')], 100, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    await makeClient(1000, logger).run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    const retryArgs = createMock.mock.calls[1][0];
+    expect(retryArgs.tool_choice).toEqual({ type: 'none' });
+    expect(retryArgs.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
+    expect(retryArgs.tools).toBeDefined();
+  }, 15000);
+});

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -9,7 +9,11 @@ vi.mock('@anthropic-ai/sdk', () => ({
   },
 }));
 
-import { AnthropicAgentClient, extractThinking } from '../src/plugins/agent/anthropic-client.js';
+import {
+  AnthropicAgentClient,
+  extractThinking,
+  requestMaxTokens,
+} from '../src/plugins/agent/anthropic-client.js';
 
 function capturingLogger(): { logger: Logger; lines: string[] } {
   const lines: string[] = [];
@@ -55,6 +59,20 @@ describe('extractThinking', () => {
   });
 });
 
+describe('requestMaxTokens (budget clamp)', () => {
+  it('caps to the remaining budget', () => {
+    expect(requestMaxTokens(8000)).toBe(8000);
+  });
+  it('never exceeds the 16k ceiling', () => {
+    expect(requestMaxTokens(50_000)).toBe(16_000);
+  });
+  it('floors above the thinking budget even after a bail (remaining <= 0)', () => {
+    expect(requestMaxTokens(0)).toBe(6144);
+    expect(requestMaxTokens(-5000)).toBe(6144);
+    expect(requestMaxTokens(6144)).toBeGreaterThan(4096); // budget_tokens stays valid
+  });
+});
+
 describe('AnthropicAgentClient extended thinking + retry forcing', () => {
   it('enables thinking on every request', async () => {
     createMock.mockResolvedValueOnce(
@@ -93,6 +111,45 @@ describe('AnthropicAgentClient extended thinking + retry forcing', () => {
 
     expect(result.incomplete).toBe(true);
     expect(lines.some(l => l.includes('tracing the lock path'))).toBe(true);
+  }, 15000);
+
+  it('injects the wrap-up nudge as a valid text block and completes on the forced turn', async () => {
+    const verdict =
+      '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"ok","keyChanges":[]}}\n```';
+    // Turn 1 crosses the 0.6 wrap-up threshold (70k/100k) but not the hard cap;
+    // turn 2 is the forced wrap-up turn.
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 70_000, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(verdict)], 100, 50, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(100_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.stopReason).toBe('completed');
+    expect(result.incomplete).toBe(false);
+    // Forced turn forbids tools.
+    expect(createMock.mock.calls[1][0].tool_choice).toEqual({ type: 'none' });
+    // The wrap-up user turn mixes tool_result + a text nudge (no unsafe cast,
+    // a valid Anthropic content array — this path was previously untested).
+    const forced = createMock.mock.calls[1][0].messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const mixed = forced.find(
+      m =>
+        m.role === 'user' &&
+        Array.isArray(m.content) &&
+        m.content.some((b: { type: string }) => b.type === 'tool_result') &&
+        m.content.some((b: { type: string }) => b.type === 'text'),
+    );
+    expect(mixed).toBeDefined();
   }, 15000);
 
   it('forces the retry with tool_choice:none + thinking (parity with the loop)', async () => {


### PR DESCRIPTION
## Summary

Closes the two Anthropic-client behavioral gaps flagged in review on #598 — bringing it to parity with the OpenAI client.

### 1. Reasoning was never captured
`joinTextBlocks` only kept `text` blocks and the turn trace never set `reasoning`, so the new `logTurn()` couldn't surface the agent's reasoning on incomplete runs for the Anthropic path.

- Enable **extended thinking** (`thinking: { type: 'enabled', budget_tokens: 4096 }`, `max_tokens` 16K) — parity with the OpenAI path's `reasoning: { effort: 'high' }`. Per the API (verified via docs), thinking is compatible with `tool_choice:'none'` (the forced-verdict turn); only `'any'`/`'tool'` would error.
- Extract thinking blocks into `TurnTrace.reasoning` (`extractThinking`), on both the loop turn and the retry. Thinking blocks are preserved across tool turns (content is passed back verbatim).

### 2. The retry didn't force a verdict
The loop's wrap-up turn forces with `tool_choice:'none'`, but the summary-retry omitted tools entirely. While that already prevents tool-calling *for Claude*, it was an inconsistent mechanism. The retry now passes the tools with `tool_choice:'none'` (and thinking) — identical forcing to the loop.

## Tests
First tests for the Anthropic client (it had zero coverage), SDK-mocked:
- `extractThinking` returns thinking-block text / undefined.
- thinking is enabled on every request.
- reasoning is captured from thinking blocks and surfaced on an incomplete run.
- the retry forces `tool_choice:'none'` + thinking.

Full review suite green (379/379) · typecheck/eslint/prettier clean · build OK.

## Testing note
The Anthropic path is config-gated — the default review model is Kimi via the OpenAI path, so CI does not exercise the Anthropic client against a live key. This change is verified via typecheck (SDK 0.61.0 types), SDK-mocked unit tests, and Anthropic's documented extended-thinking + `tool_choice` constraints, rather than a live run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing and displaying Claude “thinking” output during agent runs and retries.
  * Improved trace logging so reasoning from incomplete or retried turns is available in logs.

* **Bug Fixes**
  * Made retry behavior more consistent by keeping thinking-enabled requests aligned across run paths.
  * Improved handling when responses include no reasoning content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +25 |
| 🐛 estimated bugs | 1 | +0.084 |


> [!NOTE]
> **Low Risk**
>
> The PR brings the Anthropic client to parity with the OpenAI path by capturing extended-thinking blocks into TurnTrace.reasoning and forcing the summary retry with tool_choice:'none' plus the same thinking config. The code changes are straightforward and the added unit tests cover the new behavior. No concrete bugs that produce wrong output or break callers were found. The main risk is a configuration assumption: thinking is now hard-enabled on every Anthropic request, which will fail if a caller configures a non-thinking-capable Anthropic model, but the Anthropic path is config-gated and intended for Claude extended-thinking models.
>
> - Added extractThinking to surface Claude thinking blocks as TurnTrace.reasoning
> - Enabled extended thinking (budget 4096, max_tokens up to 16k) on every request
> - Forced retry with tool_choice:'none' and the same thinking config as the loop
> - Fixed dispatchToolUseBlocks to send the wrap-up nudge as a real text block instead of casting it into a tool_result array
> - Added first SDK-mocked unit tests for the Anthropic client

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a61b8e5. Updates automatically on new commits.</sup>
<!-- /lien-stats -->