### PR TITLE
test(cli): add Ruby (Sinatra) to the e2e real-projects suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,9 @@ jobs:
           - project: MediatR
             language: CSharp
             script: test:e2e:csharp
+          - project: Sinatra
+            language: Ruby
+            script: test:e2e:ruby
 
     steps:
       - name: Checkout code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "test:e2e:go": "vitest run test/e2e/real-projects.test.ts -t 'Chi'",
     "test:e2e:java": "vitest run test/e2e/real-projects.test.ts -t 'JavaPoet'",
     "test:e2e:csharp": "vitest run test/e2e/real-projects.test.ts -t 'MediatR'",
+    "test:e2e:ruby": "vitest run test/e2e/real-projects.test.ts -t 'Sinatra'",
     "docs": "typedoc"
   },
   "keywords": [

--- a/packages/cli/test/e2e/README.md
+++ b/packages/cli/test/e2e/README.md
@@ -20,6 +20,9 @@ These tests:
 | PHP        | Monolog  | https://github.com/Seldaek/monolog        | Standard PHP logging, clear patterns       |
 | Rust       | Anyhow   | https://github.com/dtolnay/anyhow         | Error handling library, clean Rust patterns|
 | Go         | Chi      | https://github.com/go-chi/chi             | Lightweight HTTP router, clean Go patterns |
+| Java       | JavaPoet | https://github.com/square/javapoet        | Source-gen library, standard Java patterns |
+| C#         | MediatR  | https://github.com/jbogard/MediatR        | Mediator library, clean C# patterns        |
+| Ruby       | Sinatra  | https://github.com/sinatra/sinatra        | Web framework, classes/modules + require   |
 
 ## Running Tests
 

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -131,6 +131,15 @@ const TEST_PROJECTS: ProjectConfig[] = [
     expectedMinChunks: 30,
     sampleSearchQuery: 'mediator request handler',
   },
+  {
+    name: 'Sinatra',
+    repo: 'https://github.com/sinatra/sinatra.git',
+    branch: 'main',
+    language: 'ruby',
+    expectedMinFiles: 50, // sinatra + rack-protection + sinatra-contrib lib/ (~155 indexed)
+    expectedMinChunks: 300, // AST chunking yields ~1300 (def/class/module per chunk)
+    sampleSearchQuery: 'route handler matching http request',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds Ruby to the real-projects e2e matrix (`packages/cli/test/e2e/real-projects.test.ts`), giving the Ruby AST support shipped in #596 end-to-end coverage on a real codebase — the same treatment the other 8 languages get.

Project: **Sinatra** (`github.com/sinatra/sinatra`) — iconic Ruby web framework, multi-package (`sinatra` + `rack-protection` + `sinatra-contrib`) with classes, modules, and `require`/`require_relative` graphs. A good Ruby parallel to Express/Flask already in the suite.

## What it validates

The shared per-project test body exercises the full pipeline: clone → init → index → AST-chunk count > file count → AST metadata → status → complexity → `querySymbols` → file-scoped chunks → import/export metadata → `find_similar` → semantic search → reindex.

## Local dogfood (calibration)

Indexed Sinatra locally with the built CLI before wiring the test:

| Metric | Result |
|---|---|
| Files indexed | 155 |
| AST chunks | 1300 (8.4×) |
| Symbols | methods + classes, clean signatures (`def self.new(app, options = {})`) |
| Imports | `require`/`require_relative` on 300/300 scanned chunks |
| Exports | top-level class/module/method on 267/300 |
| Complexity | 155 analyzed, avg 1.8, 11 violations |
| Dependents | `lib/sinatra/base.rb` ← 25 importers; require graph resolves |
| testAssociations | `_test.rb` + `spec/` recognized |
| Semantic search | highly_relevant hits |

Thresholds are deliberately conservative (`expectedMinFiles: 50`, `expectedMinChunks: 300`) to tolerate upstream repo evolution, matching the style of the existing entries.

## Changes

- `real-projects.test.ts`: Sinatra entry in `TEST_PROJECTS`.
- `package.json`: `test:e2e:ruby` script, matching the per-language convention.
- `e2e/README.md`: add the Ruby row and backfill the missing Java/C# rows so the table matches `TEST_PROJECTS`.

## Verification

- `npm run test:e2e:ruby` → **14/14 Sinatra tests pass** locally (155 files / 1300 chunks; semantic search `highly_relevant` 0.996; reindex clean).
- prettier clean; `packages/cli` typecheck clean. (No `src/` changes, so the `eslint packages/*/src/` gate is unaffected.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the end-to-end testing guide with additional real-world project examples, including Java, C#, and Ruby.

* **Chores**
  * Added a new test script for running the Ruby-focused end-to-end check.
  * Extended automated test coverage to include another Ruby project in the real-projects suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a new Ruby (Sinatra) entry to the existing real-projects e2e test matrix, plus the corresponding package script and CI matrix row. The change is purely additive test configuration: it does not modify production code, shared helpers, or any existing project entries. The thresholds are conservative and consistent with the style of other entries, and the test runner pattern is identical to the eight already-supported languages. No callers, exports, or runtime logic are affected.
>
> - Adds Sinatra project config to TEST_PROJECTS in real-projects.test.ts
> - Adds test:e2e:ruby npm script in packages/cli/package.json
> - Adds Sinatra/Ruby row to the e2e CI matrix in .github/workflows/e2e.yml
> - Backfills missing Java/C# rows in the e2e README table

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1e1bf27. Updates automatically on new commits.</sup>
<!-- /lien-stats -->