### PR TITLE
docs(site): advertise Ruby AST support + release changeset (0.46.0)

### DIFF
--- a/.changeset/ruby-ast-support.md
+++ b/.changeset/ruby-ast-support.md
@@ -1,0 +1,26 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': minor
+---
+
+Add Ruby AST support.
+
+Ruby `.rb` files now get full structural parsing instead of the line-based
+fallback, bringing Ruby to parity with the other AST-supported languages
+(TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#):
+
+- **AST chunking** — one semantic chunk per `def` / `class` / `module` instead
+  of fixed line windows.
+- **Symbols** with clean signatures (`def self.new(app, options = {})`),
+  methods and `singleton_method`s, classes, and modules.
+- **Imports** from `require` / `require_relative` / `load` / `autoload`, feeding
+  dependency-graph resolution (`get_dependents`).
+- **Test associations** — `*_spec.rb` / `*_test.rb` and `spec/` directories are
+  recognized.
+- **Complexity metrics** for Ruby control flow. (Known v1 limitation: logical
+  operators `&&` / `||` are not yet counted.)
+
+Also fixes a latent `extractSignature` bug for no-brace languages (Python and
+now Ruby): signatures are bounded by the function body node rather than scanning
+for a brace, so multiline/no-brace declarations no longer pull their whole body
+into the signature.

--- a/packages/site/docs/guide/index.md
+++ b/packages/site/docs/guide/index.md
@@ -85,9 +85,10 @@ Lien is built with modern, performant tools:
 - Go
 - Java
 - C#
+- Ruby
 
 **Semantic Search** (chunking and embeddings):
-- All of the above, plus Vue, Liquid, C/C++, Ruby, Swift, Kotlin, Scala, Markdown
+- All of the above, plus Vue, Liquid, C/C++, Swift, Kotlin, Scala, Markdown
 
 ## Next Steps
 

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -80,9 +80,10 @@ Lien indexes and understands code in:
 - Go
 - Java
 - C#
+- Ruby
 
 **Semantic Search** (chunking and embeddings):
-- All of the above, plus C/C++, Vue, Ruby, Swift, Kotlin, Scala, and more!
+- All of the above, plus C/C++, Vue, Swift, Kotlin, Scala, and more!
 
 ## Complexity Analysis
 


### PR DESCRIPTION
## Summary

Prep to release Ruby AST support. Ruby parsing landed in #596 (and got e2e coverage in #600) but shipped **without a changeset**, so it's on `main` yet unreleased. This adds the changeset and updates the docs site to advertise Ruby.

## Changes

**Release prep — changeset**
- `.changeset/ruby-ast-support.md`: minor bump for `@liendev/parser` + `@liendev/lien` (`@liendev/core` follows via the `linked` config) → **0.45.0 → 0.46.0**. On merge, the `changesets/action` bot opens the "version packages" PR; merging that publishes to npm.

**Docs site**
- Move Ruby from the *Semantic Search* (fallback) list into the *Full AST Support* list in `how-it-works.md` and `guide/index.md` — Ruby now has real tree-sitter parsing, not line-based chunking.

Ruby was already correctly listed everywhere else (root README, `packages/parser/README.md` table, ecosystem-preset docs, the animated language background) — these two AST lists were the only gap.

## Verification

- `changeset status` → minor bump for `@liendev/parser`, `@liendev/lien` (core linked).
- `vitepress build docs` → clean (build complete in 10.6s).
- prettier clean on all changed files.
- Adding a changeset auto-triggers the full e2e suite on this PR (incl. the Ruby/Sinatra job added in #600).

## Not in this PR

No version bump or `npm publish` here — that's the release bot's job. This PR only declares the release via the changeset and fixes the docs.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 73 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 4 high-risk file(s) with 97 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 7 | — |
| 🧠 mental load | 27 | — |
| ⏱️ time to understand | 37 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6e27c45. Updates automatically on new commits.</sup>
<!-- /lien-stats -->