### PR TITLE
feat(parser): add Kotlin AST support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10739,6 +10739,31 @@
         }
       }
     },
+    "node_modules/tree-sitter-kotlin": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-kotlin/-/tree-sitter-kotlin-0.3.8.tgz",
+      "integrity": "sha512-A4obq6bjzmYrA+F0JLLoheFPcofFkctNaZSpnDd+GPn1SfVZLY4/GG4C0cYVBTOShuPBGGAOPLM1JWLZQV4m1g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-kotlin/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/tree-sitter-php": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.24.2.tgz",
@@ -13640,6 +13665,7 @@
         "tree-sitter-go": "^0.23.4",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "0.23.1",
+        "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-php": "^0.24.2",
         "tree-sitter-python": "^0.25.0",
         "tree-sitter-ruby": "^0.23.1",

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -6,7 +6,7 @@ This package provides the core parsing and analysis capabilities used by Lien's 
 
 ## Features
 
-- **AST Parsing** — Tree-sitter-based parsing for TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#, and Ruby
+- **AST Parsing** — Tree-sitter-based parsing for TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#, Ruby, and Kotlin
 - **Semantic Chunking** — Split code into meaningful chunks respecting function/class boundaries
 - **Complexity Analysis** — Cyclomatic, cognitive, and Halstead complexity metrics
 - **Dependency Analysis** — Import/export tracking with transitive dependent resolution
@@ -27,8 +27,9 @@ This package provides the core parsing and analysis capabilities used by Lien's 
 | Java | Yes | Yes | Yes |
 | C# | Yes | Yes | Yes |
 | Ruby | Yes | Yes | Yes |
+| Kotlin | Yes | Yes | Yes |
 
-Line-based chunking and symbol extraction are available for additional languages including Vue, Liquid, C/C++, Swift, Kotlin, Scala, and Markdown.
+Line-based chunking and symbol extraction are available for additional languages including Vue, Liquid, C/C++, Swift, Scala, and Markdown.
 
 ## Usage
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -27,6 +27,7 @@
     "tree-sitter-go": "^0.23.4",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "0.23.1",
+    "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-php": "^0.24.2",
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-ruby": "^0.23.1",

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -63,6 +63,12 @@ describe('Kotlin Language', () => {
       expect(traverser.isDeclarationWithFunction(prop)).toBe(true);
       expect(traverser.findFunctionInDeclaration(prop).hasFunction).toBe(true);
     });
+
+    it('does not treat a property with a call-argument lambda as function-valued', () => {
+      const root = parse('val count = xs.count { it > 0 }\n');
+      const prop = findNode(root, 'property_declaration')!;
+      expect(traverser.isDeclarationWithFunction(prop)).toBe(false);
+    });
   });
 
   // ===========================================================================
@@ -101,6 +107,13 @@ describe('Kotlin Language', () => {
       expect(exports).toContain('Repo');
       expect(exports).toContain('find');
     });
+
+    it('does not export members of a private container', () => {
+      const root = parse('private class Secret {\n  fun internalApi() {}\n}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).not.toContain('Secret');
+      expect(exports).not.toContain('internalApi');
+    });
   });
 
   // ===========================================================================
@@ -134,6 +147,11 @@ describe('Kotlin Language', () => {
       expect(importExtractor.extractImportPath(stdlib)).toBeNull();
       const [javaStd] = importHeaders('import java.util.ArrayList\n');
       expect(importExtractor.extractImportPath(javaStd)).toBeNull();
+    });
+
+    it('keeps kotlinx.* imports (external libraries, not stdlib)', () => {
+      const [kx] = importHeaders('import kotlinx.coroutines.flow.Flow\n');
+      expect(importExtractor.extractImportPath(kx)).toBe('kotlinx.coroutines.flow.Flow');
     });
 
     it('maps a non-wildcard import to its last segment as the symbol', () => {

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import Kotlin from 'tree-sitter-kotlin';
+import { chunkByAST } from '../chunker.js';
+import {
+  KotlinTraverser,
+  KotlinExportExtractor,
+  KotlinImportExtractor,
+  KotlinSymbolExtractor,
+} from './kotlin.js';
+
+describe('Kotlin Language', () => {
+  const parser = new Parser();
+  parser.setLanguage(Kotlin);
+  const traverser = new KotlinTraverser();
+  const exportExtractor = new KotlinExportExtractor();
+  const importExtractor = new KotlinImportExtractor();
+  const symbolExtractor = new KotlinSymbolExtractor();
+
+  const parse = (src: string) => parser.parse(src).rootNode;
+
+  // ===========================================================================
+  // TRAVERSER
+  // ===========================================================================
+  describe('Traverser', () => {
+    it('recognizes class and object declarations as containers', () => {
+      const root = parse('class A { fun m() {} }\nobject B { fun n() {} }\n');
+      const cls = findNode(root, 'class_declaration')!;
+      const obj = findNode(root, 'object_declaration')!;
+      expect(traverser.shouldExtractChildren(cls)).toBe(true);
+      expect(traverser.shouldExtractChildren(obj)).toBe(true);
+    });
+
+    it('finds the class body for child traversal', () => {
+      const root = parse('class A { fun m() {} }\n');
+      const cls = findNode(root, 'class_declaration')!;
+      const body = traverser.getContainerBody(cls);
+      expect(body?.type).toBe('class_body');
+    });
+
+    it('finds the enum class body', () => {
+      const root = parse('enum class E { A, B }\n');
+      const cls = findNode(root, 'class_declaration')!;
+      expect(traverser.getContainerBody(cls)?.type).toBe('enum_class_body');
+    });
+
+    it('traverses into source_file, class_body, and companion_object', () => {
+      const root = parse('class A {\n  companion object {\n    fun c() {}\n  }\n}\n');
+      expect(traverser.shouldTraverseChildren(root)).toBe(true);
+      expect(traverser.shouldTraverseChildren(findNode(root, 'class_body')!)).toBe(true);
+      expect(traverser.shouldTraverseChildren(findNode(root, 'companion_object')!)).toBe(true);
+    });
+
+    it('resolves the parent container name for a method', () => {
+      const root = parse('class Calc { fun add() {} }\n');
+      const fn = findNode(root, 'function_declaration')!;
+      expect(traverser.findParentContainerName(fn)).toBe('Calc');
+    });
+
+    it('detects a lambda inside a property declaration', () => {
+      const root = parse('val handler = { x: Int -> x + 1 }\n');
+      const prop = findNode(root, 'property_declaration')!;
+      expect(traverser.isDeclarationWithFunction(prop)).toBe(true);
+      expect(traverser.findFunctionInDeclaration(prop).hasFunction).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // EXPORT EXTRACTOR
+  // ===========================================================================
+  describe('Export Extraction', () => {
+    it('exports top-level public functions, classes, and objects', () => {
+      const root = parse('fun topFn() {}\nclass PublicClass\nobject Singleton\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('topFn');
+      expect(exports).toContain('PublicClass');
+      expect(exports).toContain('Singleton');
+    });
+
+    it('excludes private and internal declarations', () => {
+      const root = parse('private fun secret() {}\ninternal class Hidden\nfun open() {}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).not.toContain('secret');
+      expect(exports).not.toContain('Hidden');
+      expect(exports).toContain('open');
+    });
+
+    it('exports public members of a class', () => {
+      const root = parse(
+        'class Service {\n  fun publicMethod() {}\n  private fun helper() {}\n}\n',
+      );
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('Service');
+      expect(exports).toContain('publicMethod');
+      expect(exports).not.toContain('helper');
+    });
+
+    it('treats interface members as exported (implicitly public)', () => {
+      const root = parse('interface Repo {\n  fun find(): String\n}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('Repo');
+      expect(exports).toContain('find');
+    });
+  });
+
+  // ===========================================================================
+  // IMPORT EXTRACTOR
+  // ===========================================================================
+  describe('Import Extraction', () => {
+    const importHeaders = (src: string) => {
+      const root = parse(src);
+      const list = findNode(root, 'import_list');
+      return list ? list.namedChildren.filter(c => c.type === 'import_header') : [];
+    };
+
+    it('extracts a simple import path', () => {
+      const [imp] = importHeaders('import com.example.Service\n');
+      expect(importExtractor.extractImportPath(imp)).toBe('com.example.Service');
+    });
+
+    it('handles wildcard imports', () => {
+      const [imp] = importHeaders('import com.example.*\n');
+      expect(importExtractor.extractImportPath(imp)).toBe('com.example.*');
+    });
+
+    it('uses the alias as the imported symbol', () => {
+      const [imp] = importHeaders('import com.example.Foo as Bar\n');
+      const result = importExtractor.processImportSymbols(imp);
+      expect(result?.symbols).toContain('Bar');
+    });
+
+    it('filters out kotlin/java standard library imports', () => {
+      const [stdlib] = importHeaders('import kotlin.collections.List\n');
+      expect(importExtractor.extractImportPath(stdlib)).toBeNull();
+      const [javaStd] = importHeaders('import java.util.ArrayList\n');
+      expect(importExtractor.extractImportPath(javaStd)).toBeNull();
+    });
+
+    it('maps a non-wildcard import to its last segment as the symbol', () => {
+      const [imp] = importHeaders('import com.example.Service\n');
+      const result = importExtractor.processImportSymbols(imp);
+      expect(result?.importPath).toBe('com.example.Service');
+      expect(result?.symbols).toContain('Service');
+    });
+  });
+
+  // ===========================================================================
+  // SYMBOL EXTRACTION
+  // ===========================================================================
+  describe('Symbol Extraction', () => {
+    it('extracts a function with a clean block-body signature', () => {
+      const src = 'fun calculate(a: Int, b: Int): Int {\n  return a + b\n}\n';
+      const fn = findNode(parse(src), 'function_declaration')!;
+      const sym = symbolExtractor.extractSymbol(fn, src)!;
+      expect(sym.name).toBe('calculate');
+      expect(sym.type).toBe('function');
+      expect(sym.signature).toBe('fun calculate(a: Int, b: Int): Int');
+      expect(sym.parameters).toEqual(['a: Int', 'b: Int']);
+      expect(sym.returnType).toBe('Int');
+    });
+
+    it('extracts a clean signature for an expression-body function (no trailing =)', () => {
+      const src = 'fun double(x: Int): Int = x * 2\n';
+      const fn = findNode(parse(src), 'function_declaration')!;
+      const sym = symbolExtractor.extractSymbol(fn, src)!;
+      expect(sym.signature).toBe('fun double(x: Int): Int');
+      expect(sym.signature).not.toContain('=');
+    });
+
+    it('marks functions inside a class as methods', () => {
+      const src = 'class A {\n  fun m() {}\n}\n';
+      const fn = findNode(parse(src), 'function_declaration')!;
+      const sym = symbolExtractor.extractSymbol(fn, src, 'A')!;
+      expect(sym.type).toBe('method');
+      expect(sym.parentClass).toBe('A');
+    });
+
+    it('extracts class, interface, enum, and object symbols', () => {
+      const cls = symbolExtractor.extractSymbol(
+        findNode(parse('class Foo'), 'class_declaration')!,
+        '',
+      )!;
+      expect(cls).toMatchObject({ name: 'Foo', type: 'class', signature: 'class Foo' });
+
+      const iface = symbolExtractor.extractSymbol(
+        findNode(parse('interface Bar { fun x() }'), 'class_declaration')!,
+        '',
+      )!;
+      expect(iface).toMatchObject({ name: 'Bar', type: 'interface', signature: 'interface Bar' });
+
+      const en = symbolExtractor.extractSymbol(
+        findNode(parse('enum class Color { RED }'), 'class_declaration')!,
+        '',
+      )!;
+      expect(en).toMatchObject({ name: 'Color', type: 'class', signature: 'enum class Color' });
+
+      const obj = symbolExtractor.extractSymbol(
+        findNode(parse('object Registry { fun r() {} }'), 'object_declaration')!,
+        '',
+      )!;
+      expect(obj).toMatchObject({ name: 'Registry', type: 'class', signature: 'object Registry' });
+    });
+
+    it('extracts call sites for direct and navigation calls', () => {
+      const src = 'fun run() {\n  foo()\n  obj.bar.baz()\n}\n';
+      const calls = findAllNodes(parse(src), 'call_expression');
+      const names = calls.map(c => symbolExtractor.extractCallSite(c)?.symbol).filter(Boolean);
+      expect(names).toContain('foo');
+      expect(names).toContain('baz');
+    });
+  });
+
+  // ===========================================================================
+  // AST CHUNKING INTEGRATION
+  // ===========================================================================
+  describe('AST Chunking', () => {
+    const SOURCE = `package com.example.app
+
+import com.example.lib.Helper
+import com.example.util.*
+
+class OrderService(private val repo: Repository) {
+  fun place(order: Order): Boolean {
+    return when {
+      order.isValid() && repo.has(order.id) -> repo.save(order)
+      else -> false
+    }
+  }
+
+  companion object {
+    fun create(): OrderService = OrderService(Repository())
+  }
+}
+
+interface Repository {
+  fun save(o: Order): Boolean
+}
+
+object Defaults {
+  fun empty(): Order = Order()
+}
+
+fun topLevelHelper(x: Int): Int = x + 1
+`;
+
+    const chunks = chunkByAST('OrderService.kt', SOURCE);
+    const bySymbol = (name: string, type?: string) =>
+      chunks.find(
+        c => c.metadata.symbolName === name && (type ? c.metadata.symbolType === type : true),
+      );
+
+    it('produces more chunks than one (AST-bounded, not a single blob)', () => {
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it('chunks the class, its method, the companion method, the interface, the object, and the top-level fn', () => {
+      expect(bySymbol('OrderService', 'class')).toBeDefined();
+      expect(bySymbol('Defaults', 'class')).toBeDefined();
+      expect(bySymbol('Repository', 'interface')).toBeDefined();
+      expect(bySymbol('place', 'method')?.metadata.parentClass).toBe('OrderService');
+      expect(bySymbol('create')).toBeDefined(); // companion-object method
+      expect(bySymbol('topLevelHelper', 'function')).toBeDefined();
+    });
+
+    it('captures non-stdlib imports (incl. nested import_header under import_list)', () => {
+      const allImports = chunks.flatMap(c => c.metadata.imports ?? []);
+      expect(allImports).toContain('com.example.lib.Helper');
+      expect(allImports.some(i => i.startsWith('com.example.util'))).toBe(true);
+    });
+
+    it('computes complexity for a branchy method (counts when / && )', () => {
+      const place = bySymbol('place', 'method');
+      expect(place).toBeDefined();
+      expect(place?.metadata.complexity ?? 0).toBeGreaterThan(1);
+    });
+  });
+});
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+function findNode(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
+  if (node.type === type) return node;
+  for (const child of node.namedChildren) {
+    const found = findNode(child, type);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findAllNodes(
+  node: Parser.SyntaxNode,
+  type: string,
+  acc: Parser.SyntaxNode[] = [],
+): Parser.SyntaxNode[] {
+  if (node.type === type) acc.push(node);
+  for (const child of node.namedChildren) findAllNodes(child, type, acc);
+  return acc;
+}

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -1,0 +1,560 @@
+import Kotlin from 'tree-sitter-kotlin';
+import type Parser from 'tree-sitter';
+import type { SymbolInfo } from '../types.js';
+import type { LanguageDefinition } from './types.js';
+import type { LanguageTraverser, DeclarationFunctionInfo } from '../traversers/types.js';
+import type {
+  LanguageExportExtractor,
+  LanguageImportExtractor,
+  LanguageSymbolExtractor,
+} from '../extractors/types.js';
+import { calculateComplexity } from '../complexity/index.js';
+
+// =============================================================================
+// HELPERS
+//
+// The tree-sitter-kotlin grammar (fwcd) does NOT assign field names, so unlike
+// the Java definition we locate children by node TYPE rather than via
+// `childForFieldName`. These helpers centralize that.
+// =============================================================================
+
+/** First named child of a given type. */
+function childByType(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
+  return node.namedChildren.find(child => child.type === type) ?? null;
+}
+
+/** Whether a node has a child token of a given type (incl. anonymous keyword tokens). */
+function hasTokenChild(node: Parser.SyntaxNode, type: string): boolean {
+  return node.children.some(child => child.type === type);
+}
+
+/** First descendant of a given type (depth-first). */
+function findDescendant(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
+  for (const child of node.namedChildren) {
+    if (child.type === type) return child;
+    const found = findDescendant(child, type);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** The `function_body` child of a function_declaration ({ … } block OR `= expr`). */
+function functionBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  return childByType(node, 'function_body');
+}
+
+/**
+ * The function name: the first direct `simple_identifier` child of a
+ * function_declaration. (Extension-function receivers are `user_type` nodes, so
+ * the bare simple_identifier is the name in the common case.)
+ */
+function functionName(node: Parser.SyntaxNode): string | undefined {
+  return childByType(node, 'simple_identifier')?.text;
+}
+
+/** The declared name of a class/object declaration (`type_identifier`). */
+function declarationName(node: Parser.SyntaxNode): string | undefined {
+  return childByType(node, 'type_identifier')?.text;
+}
+
+const SIGNATURE_MAX = 200;
+
+function clamp(signature: string): string {
+  return signature.length > SIGNATURE_MAX
+    ? signature.slice(0, SIGNATURE_MAX - 3) + '...'
+    : signature;
+}
+
+/**
+ * Function signature, bounded by where the body begins. `function_body` covers
+ * both block bodies (`{ … }`) and expression bodies (`= expr`, which starts at
+ * the `=`), so slicing up to its start yields a clean `fun foo(a: Int): Int`
+ * for both. Abstract/interface methods have no body — use the whole node.
+ */
+function functionSignature(node: Parser.SyntaxNode, content: string): string {
+  const body = functionBody(node);
+  const end = body ? body.startIndex : node.endIndex;
+  const signature = content
+    .slice(node.startIndex, end)
+    .replace(/\s+/g, ' ')
+    .replace(/(\{|=)\s*$/, '') // drop a trailing block-opener / expression `=` if captured
+    .trim();
+  return clamp(signature);
+}
+
+/** Parameter texts from a function's `function_value_parameters`. */
+function functionParameters(node: Parser.SyntaxNode): string[] {
+  const params = childByType(node, 'function_value_parameters');
+  if (!params) return [];
+  return params.namedChildren.filter(p => p.text.trim()).map(p => p.text);
+}
+
+/**
+ * Return type: the type node that sits between the parameter list and the body.
+ * Kotlin's grammar emits it as `user_type` / `nullable_type` / `function_type`.
+ */
+function functionReturnType(node: Parser.SyntaxNode): string | undefined {
+  const children = node.namedChildren;
+  const paramsIndex = children.findIndex(c => c.type === 'function_value_parameters');
+  if (paramsIndex === -1) return undefined;
+  for (let i = paramsIndex + 1; i < children.length; i++) {
+    const c = children[i];
+    if (c.type === 'function_body') break;
+    if (c.type === 'user_type' || c.type === 'nullable_type' || c.type === 'function_type') {
+      return c.text;
+    }
+  }
+  return undefined;
+}
+
+/** Visibility modifier text (`private` / `internal` / `protected` / `public`), if any. */
+function visibilityModifier(node: Parser.SyntaxNode): string | null {
+  const modifiers = childByType(node, 'modifiers');
+  if (!modifiers) return null;
+  return modifiers.namedChildren.find(c => c.type === 'visibility_modifier')?.text ?? null;
+}
+
+/**
+ * Kotlin declarations are `public` by default. We treat a declaration as
+ * "exported" (importable / part of the API) unless it is explicitly `private`
+ * or `internal`. `protected` members stay visible to subclasses, so we keep
+ * them. (Inverse of Java's "has a `public` modifier" check.)
+ */
+function isExported(node: Parser.SyntaxNode): boolean {
+  const visibility = visibilityModifier(node);
+  return visibility !== 'private' && visibility !== 'internal';
+}
+
+// =============================================================================
+// TRAVERSER
+// =============================================================================
+
+/**
+ * Kotlin AST traverser.
+ *
+ * Methods live inside `class_declaration` / `object_declaration` bodies
+ * (`class_body` / `enum_class_body`). `companion_object` is transparent — its
+ * members are traversed so their methods are captured (attributed to the
+ * enclosing class). Lambdas can appear in property initializers
+ * (`val f = { … }`).
+ */
+export class KotlinTraverser implements LanguageTraverser {
+  targetNodeTypes = ['function_declaration'];
+
+  containerTypes = ['class_declaration', 'object_declaration'];
+
+  declarationTypes = ['property_declaration'];
+
+  functionTypes = ['lambda_literal', 'anonymous_function'];
+
+  shouldExtractChildren(node: Parser.SyntaxNode): boolean {
+    return this.containerTypes.includes(node.type);
+  }
+
+  isDeclarationWithFunction(node: Parser.SyntaxNode): boolean {
+    if (node.type !== 'property_declaration') return false;
+    return (
+      findDescendant(node, 'lambda_literal') !== null ||
+      findDescendant(node, 'anonymous_function') !== null
+    );
+  }
+
+  getContainerBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+    if (!this.containerTypes.includes(node.type)) return null;
+    return childByType(node, 'class_body') ?? childByType(node, 'enum_class_body');
+  }
+
+  shouldTraverseChildren(node: Parser.SyntaxNode): boolean {
+    return (
+      node.type === 'source_file' ||
+      node.type === 'class_body' ||
+      node.type === 'enum_class_body' ||
+      node.type === 'companion_object'
+    );
+  }
+
+  findParentContainerName(node: Parser.SyntaxNode): string | undefined {
+    let current = node.parent;
+    while (current) {
+      if (current.type === 'class_declaration' || current.type === 'object_declaration') {
+        return declarationName(current);
+      }
+      current = current.parent;
+    }
+    return undefined;
+  }
+
+  findFunctionInDeclaration(node: Parser.SyntaxNode): DeclarationFunctionInfo {
+    if (node.type !== 'property_declaration') {
+      return { hasFunction: false, functionNode: null };
+    }
+    const fn = findDescendant(node, 'lambda_literal') ?? findDescendant(node, 'anonymous_function');
+    return fn
+      ? { hasFunction: true, functionNode: fn }
+      : { hasFunction: false, functionNode: null };
+  }
+}
+
+// =============================================================================
+// EXPORT EXTRACTOR
+// =============================================================================
+
+/**
+ * Kotlin export extractor.
+ *
+ * Kotlin has no `export` keyword and is `public` by default — top-level
+ * declarations and (non-private/internal) members are importable. Interface
+ * members are implicitly public.
+ */
+export class KotlinExportExtractor implements LanguageExportExtractor {
+  extractExports(rootNode: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const seen = new Set<string>();
+
+    const addExport = (name?: string) => {
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        exports.push(name);
+      }
+    };
+
+    rootNode.namedChildren.forEach(child => this.extractFromNode(child, addExport));
+
+    return exports;
+  }
+
+  private extractFromNode(node: Parser.SyntaxNode, addExport: (name?: string) => void): void {
+    switch (node.type) {
+      case 'function_declaration':
+        if (isExported(node)) addExport(functionName(node));
+        break;
+      case 'property_declaration':
+        if (isExported(node)) addExport(this.propertyName(node));
+        break;
+      case 'class_declaration':
+      case 'object_declaration':
+        if (isExported(node)) addExport(declarationName(node));
+        this.extractMembers(node, addExport);
+        break;
+    }
+  }
+
+  private extractMembers(container: Parser.SyntaxNode, addExport: (name?: string) => void): void {
+    const body = childByType(container, 'class_body') ?? childByType(container, 'enum_class_body');
+    if (!body) return;
+
+    const isInterface = hasTokenChild(container, 'interface');
+
+    body.namedChildren.forEach(member => {
+      if (member.type === 'function_declaration') {
+        if (isInterface || isExported(member)) addExport(functionName(member));
+      } else if (member.type === 'property_declaration') {
+        if (isInterface || isExported(member)) addExport(this.propertyName(member));
+      } else if (member.type === 'companion_object') {
+        // Companion members are reached via the enclosing class name → part of its API.
+        member.namedChildren
+          .filter(m => m.type === 'class_body')
+          .forEach(cb =>
+            cb.namedChildren
+              .filter(m => m.type === 'function_declaration' && isExported(m))
+              .forEach(m => addExport(functionName(m))),
+          );
+      }
+    });
+  }
+
+  private propertyName(node: Parser.SyntaxNode): string | undefined {
+    // property_declaration → variable_declaration → simple_identifier
+    const variable = childByType(node, 'variable_declaration');
+    return (variable ? childByType(variable, 'simple_identifier') : null)?.text;
+  }
+}
+
+// =============================================================================
+// IMPORT EXTRACTOR
+// =============================================================================
+
+/** Kotlin/JVM standard-library prefixes that aren't useful as dependency edges. */
+function isKotlinStdLib(importPath: string): boolean {
+  return (
+    importPath.startsWith('kotlin.') ||
+    importPath.startsWith('kotlinx.') ||
+    importPath.startsWith('java.') ||
+    importPath.startsWith('javax.')
+  );
+}
+
+/**
+ * Kotlin import extractor.
+ *
+ * Handles `import a.b.C`, wildcard `import a.b.*`, and aliased
+ * `import a.b.C as D`. The grammar nests `import_header` nodes inside an
+ * `import_list`; the engine's import scan descends one level to reach them
+ * (see `collectImportNodes` in ast/symbols.ts). Standard-library imports
+ * (kotlin.*, kotlinx.*, java.*, javax.*) are filtered out.
+ */
+export class KotlinImportExtractor implements LanguageImportExtractor {
+  readonly importNodeTypes = ['import_header'];
+
+  extractImportPath(node: Parser.SyntaxNode): string | null {
+    const path = this.getImportPath(node);
+    if (!path || isKotlinStdLib(path)) return null;
+    return path;
+  }
+
+  processImportSymbols(node: Parser.SyntaxNode): { importPath: string; symbols: string[] } | null {
+    const path = this.getImportPath(node);
+    if (!path || isKotlinStdLib(path)) return null;
+
+    const parts = path.split('.');
+    const lastPart = parts[parts.length - 1];
+
+    if (lastPart === '*') {
+      const packagePath = parts.slice(0, -1).join('.');
+      const packageName = parts[parts.length - 2];
+      return { importPath: packagePath, symbols: packageName ? [packageName] : [] };
+    }
+
+    // `import a.b.C as D` — the imported symbol is the alias name when present.
+    // import_alias wraps the alias as a `type_identifier` (its text is `as D`).
+    const alias = childByType(node, 'import_alias');
+    const aliasName = alias ? childByType(alias, 'type_identifier')?.text : undefined;
+    return { importPath: path, symbols: [aliasName ?? lastPart] };
+  }
+
+  private getImportPath(node: Parser.SyntaxNode): string | null {
+    const identifier = childByType(node, 'identifier');
+    if (!identifier) return null;
+    const hasWildcard = hasTokenChild(node, 'wildcard_import');
+    return hasWildcard ? `${identifier.text}.*` : identifier.text;
+  }
+}
+
+// =============================================================================
+// SYMBOL EXTRACTOR
+// =============================================================================
+
+/**
+ * Kotlin symbol extractor.
+ *
+ * Handles `function_declaration`, `class_declaration` (class / interface / enum
+ * variants — distinguished by the keyword token), and `object_declaration`.
+ * `SymbolInfo.type` only has `function|method|class|interface`, so objects and
+ * enums map to `class` (keeping the keyword in the signature).
+ *
+ * Call sites: `call_expression` — `foo()` (simple_identifier) and `a.b.c()`
+ * (the member is the `simple_identifier` inside the trailing `navigation_suffix`).
+ */
+export class KotlinSymbolExtractor implements LanguageSymbolExtractor {
+  readonly symbolNodeTypes = ['function_declaration', 'class_declaration', 'object_declaration'];
+
+  extractSymbol(node: Parser.SyntaxNode, content: string, parentClass?: string): SymbolInfo | null {
+    switch (node.type) {
+      case 'function_declaration':
+        return this.extractFunctionInfo(node, content, parentClass);
+      case 'class_declaration':
+        return this.extractClassInfo(node);
+      case 'object_declaration':
+        return this.extractObjectInfo(node);
+      default:
+        return null;
+    }
+  }
+
+  extractCallSite(node: Parser.SyntaxNode): { symbol: string; line: number; key: string } | null {
+    if (node.type !== 'call_expression') return null;
+    const line = node.startPosition.row + 1;
+
+    const callee = node.namedChild(0);
+    if (!callee) return null;
+
+    let name: string | undefined;
+    if (callee.type === 'simple_identifier') {
+      name = callee.text; // foo()
+    } else if (callee.type === 'navigation_expression') {
+      // a.b.c() — the called member is the simple_identifier in the last navigation_suffix
+      const suffix = callee.namedChildren.filter(c => c.type === 'navigation_suffix').at(-1);
+      name = (suffix ? childByType(suffix, 'simple_identifier') : null)?.text;
+    }
+
+    if (!name) return null;
+    return { symbol: name, line, key: `${name}:${line}` };
+  }
+
+  private extractFunctionInfo(
+    node: Parser.SyntaxNode,
+    content: string,
+    parentClass?: string,
+  ): SymbolInfo | null {
+    const name = functionName(node);
+    if (!name) return null;
+
+    return {
+      name,
+      type: parentClass ? 'method' : 'function',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: functionSignature(node, content),
+      parameters: functionParameters(node),
+      returnType: functionReturnType(node),
+      complexity: calculateComplexity(node),
+    };
+  }
+
+  private extractClassInfo(node: Parser.SyntaxNode): SymbolInfo | null {
+    const name = declarationName(node);
+    if (!name) return null;
+
+    if (hasTokenChild(node, 'interface')) {
+      return this.makeSymbol(node, name, 'interface', `interface ${name}`);
+    }
+    if (hasTokenChild(node, 'enum')) {
+      return this.makeSymbol(node, name, 'class', `enum class ${name}`);
+    }
+    return this.makeSymbol(node, name, 'class', `class ${name}`);
+  }
+
+  private extractObjectInfo(node: Parser.SyntaxNode): SymbolInfo | null {
+    const name = declarationName(node);
+    if (!name) return null;
+    return this.makeSymbol(node, name, 'class', `object ${name}`);
+  }
+
+  private makeSymbol(
+    node: Parser.SyntaxNode,
+    name: string,
+    type: SymbolInfo['type'],
+    signature: string,
+  ): SymbolInfo {
+    return {
+      name,
+      type,
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      signature,
+    };
+  }
+}
+
+// =============================================================================
+// LANGUAGE DEFINITION
+// =============================================================================
+
+export const kotlinDefinition: LanguageDefinition = {
+  id: 'kotlin',
+  extensions: ['kt'],
+  grammar: Kotlin,
+  traverser: new KotlinTraverser(),
+  exportExtractor: new KotlinExportExtractor(),
+  importExtractor: new KotlinImportExtractor(),
+  symbolExtractor: new KotlinSymbolExtractor(),
+
+  complexity: {
+    decisionPoints: [
+      'if_expression',
+      'when_entry',
+      'for_statement',
+      'while_statement',
+      'do_while_statement',
+      'catch_block',
+      'elvis_expression',
+      'conjunction_expression', // &&
+      'disjunction_expression', // ||
+    ],
+    nestingTypes: [
+      'if_expression',
+      'when_expression',
+      'for_statement',
+      'while_statement',
+      'do_while_statement',
+      'catch_block',
+      'lambda_literal',
+      'anonymous_function',
+    ],
+    nonNestingTypes: ['when_entry', 'elvis_expression'],
+    lambdaTypes: ['lambda_literal', 'anonymous_function'],
+    operatorSymbols: new Set([
+      '+',
+      '-',
+      '*',
+      '/',
+      '%',
+      '==',
+      '!=',
+      '===',
+      '!==',
+      '<',
+      '>',
+      '<=',
+      '>=',
+      '=',
+      '+=',
+      '-=',
+      '*=',
+      '/=',
+      '%=',
+      '&&',
+      '||',
+      '!',
+      '?:',
+      '?.',
+      '.',
+      '::',
+      '->',
+      '..',
+      '(',
+      ')',
+      '[',
+      ']',
+      '{',
+      '}',
+    ]),
+    operatorKeywords: new Set([
+      'if',
+      'else',
+      'when',
+      'for',
+      'while',
+      'do',
+      'return',
+      'break',
+      'continue',
+      'throw',
+      'try',
+      'catch',
+      'finally',
+      'fun',
+      'class',
+      'object',
+      'interface',
+      'enum',
+      'val',
+      'var',
+      'is',
+      'as',
+      'in',
+      'by',
+      'import',
+      'package',
+      'override',
+      'abstract',
+      'open',
+      'sealed',
+      'data',
+      'suspend',
+      'companion',
+      'private',
+      'internal',
+      'protected',
+      'public',
+      'this',
+      'super',
+      'null',
+    ]),
+  },
+
+  symbols: {
+    callExpressionTypes: ['call_expression'],
+  },
+};

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -28,14 +28,19 @@ function hasTokenChild(node: Parser.SyntaxNode, type: string): boolean {
   return node.children.some(child => child.type === type);
 }
 
-/** First descendant of a given type (depth-first). */
-function findDescendant(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
-  for (const child of node.namedChildren) {
-    if (child.type === type) return child;
-    const found = findDescendant(child, type);
-    if (found) return found;
-  }
-  return null;
+/**
+ * The function-valued initializer of a property, if the property's initializer
+ * is *directly* a lambda or anonymous function (`val f = { … }`). Checks the
+ * initializer (the last named child) rather than any descendant, so a lambda
+ * passed as a call argument (`val n = xs.count { it > 0 }`) is NOT treated as a
+ * function-valued property.
+ */
+function propertyInitializerFunction(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  const initializer = node.namedChildren.at(-1);
+  if (!initializer) return null;
+  return initializer.type === 'lambda_literal' || initializer.type === 'anonymous_function'
+    ? initializer
+    : null;
 }
 
 /** The `function_body` child of a function_declaration ({ … } block OR `= expr`). */
@@ -152,11 +157,7 @@ export class KotlinTraverser implements LanguageTraverser {
   }
 
   isDeclarationWithFunction(node: Parser.SyntaxNode): boolean {
-    if (node.type !== 'property_declaration') return false;
-    return (
-      findDescendant(node, 'lambda_literal') !== null ||
-      findDescendant(node, 'anonymous_function') !== null
-    );
+    return node.type === 'property_declaration' && propertyInitializerFunction(node) !== null;
   }
 
   getContainerBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
@@ -188,7 +189,7 @@ export class KotlinTraverser implements LanguageTraverser {
     if (node.type !== 'property_declaration') {
       return { hasFunction: false, functionNode: null };
     }
-    const fn = findDescendant(node, 'lambda_literal') ?? findDescendant(node, 'anonymous_function');
+    const fn = propertyInitializerFunction(node);
     return fn
       ? { hasFunction: true, functionNode: fn }
       : { hasFunction: false, functionNode: null };
@@ -233,8 +234,11 @@ export class KotlinExportExtractor implements LanguageExportExtractor {
         break;
       case 'class_declaration':
       case 'object_declaration':
-        if (isExported(node)) addExport(declarationName(node));
-        this.extractMembers(node, addExport);
+        // A private/internal container exposes nothing — skip it and its members.
+        if (isExported(node)) {
+          addExport(declarationName(node));
+          this.extractMembers(node, addExport);
+        }
         break;
     }
   }
@@ -274,11 +278,14 @@ export class KotlinExportExtractor implements LanguageExportExtractor {
 // IMPORT EXTRACTOR
 // =============================================================================
 
-/** Kotlin/JVM standard-library prefixes that aren't useful as dependency edges. */
+/**
+ * Kotlin/JVM standard-library prefixes that aren't useful as dependency edges.
+ * Note: `kotlinx.*` (coroutines, serialization, …) are separate external
+ * libraries, not the stdlib, so they are kept as real import edges.
+ */
 function isKotlinStdLib(importPath: string): boolean {
   return (
     importPath.startsWith('kotlin.') ||
-    importPath.startsWith('kotlinx.') ||
     importPath.startsWith('java.') ||
     importPath.startsWith('javax.')
   );

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -104,9 +104,9 @@ describe('Language Registry', () => {
   });
 
   describe('getAllLanguages', () => {
-    it('should return all 9 registered languages', () => {
+    it('should return all 10 registered languages', () => {
       const all = getAllLanguages();
-      expect(all).toHaveLength(9);
+      expect(all).toHaveLength(10);
       const ids = all.map(d => d.id);
       expect(ids).toContain('typescript');
       expect(ids).toContain('javascript');
@@ -117,6 +117,7 @@ describe('Language Registry', () => {
       expect(ids).toContain('java');
       expect(ids).toContain('csharp');
       expect(ids).toContain('ruby');
+      expect(ids).toContain('kotlin');
     });
 
     it('should return a defensive copy', () => {

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -9,6 +9,7 @@ import { goDefinition } from './go.js';
 import { javaDefinition } from './java.js';
 import { csharpDefinition } from './csharp.js';
 import { rubyDefinition } from './ruby.js';
+import { kotlinDefinition } from './kotlin.js';
 
 /**
  * All registered language definitions.
@@ -24,6 +25,7 @@ const definitions: LanguageDefinition[] = [
   javaDefinition,
   csharpDefinition,
   rubyDefinition,
+  kotlinDefinition,
 ];
 
 /**
@@ -41,6 +43,7 @@ export const LANGUAGE_IDS = [
   'java',
   'csharp',
   'ruby',
+  'kotlin',
 ] as const;
 export type SupportedLanguage = (typeof LANGUAGE_IDS)[number];
 

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -31,6 +31,33 @@ export function extractSymbolInfo(
 }
 
 /**
+ * Collect the import nodes to process from the root.
+ *
+ * Most grammars place import statements as direct children of the root node, but
+ * some wrap them in a container — e.g. Kotlin's `import_list` holds the
+ * `import_header` children. We therefore also descend one level into a
+ * non-matching direct child to find imports nested inside such a container. This
+ * is backward compatible: languages whose import nodes are already direct
+ * children match in the first branch and are never descended into.
+ */
+function collectImportNodes(
+  rootNode: Parser.SyntaxNode,
+  nodeTypeSet: Set<string>,
+): Parser.SyntaxNode[] {
+  const nodes: Parser.SyntaxNode[] = [];
+  for (const child of rootNode.namedChildren) {
+    if (nodeTypeSet.has(child.type)) {
+      nodes.push(child);
+    } else {
+      for (const grandchild of child.namedChildren) {
+        if (nodeTypeSet.has(grandchild.type)) nodes.push(grandchild);
+      }
+    }
+  }
+  return nodes;
+}
+
+/**
  * Extract import paths using the language-specific extractor.
  *
  * When `filepath` is provided, relative specifiers (`./foo`, `../bar`) are
@@ -48,10 +75,8 @@ function extractImportPaths(
   const imports: string[] = [];
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
-  for (const child of rootNode.namedChildren) {
-    if (!nodeTypeSet.has(child.type)) continue;
-
-    const result = importExtractor.extractImportPath(child);
+  for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
+    const result = importExtractor.extractImportPath(node);
     if (result) imports.push(filepath ? resolveRelativeImport(filepath, result) : result);
   }
 
@@ -109,9 +134,7 @@ function extractSymbolsWithExtractor(
   const importedSymbols: Record<string, string[]> = {};
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
-  for (const node of rootNode.namedChildren) {
-    if (!nodeTypeSet.has(node.type)) continue;
-
+  for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
     const result = importExtractor.processImportSymbols(node);
     if (result) {
       const key = filepath ? resolveRelativeImport(filepath, result.importPath) : result.importPath;

--- a/packages/parser/src/symbol-extractor.ts
+++ b/packages/parser/src/symbol-extractor.ts
@@ -54,6 +54,16 @@ const LANGUAGE_EXTRACTORS: Record<string, LanguageExtractors> = {
   },
   ruby: { functions: extractRubyFunctions, classes: extractRubyClasses },
   rb: { functions: extractRubyFunctions, classes: extractRubyClasses },
+  kotlin: {
+    functions: extractKotlinFunctions,
+    classes: extractKotlinClasses,
+    interfaces: extractKotlinInterfaces,
+  },
+  kt: {
+    functions: extractKotlinFunctions,
+    classes: extractKotlinClasses,
+    interfaces: extractKotlinInterfaces,
+  },
   rust: { functions: extractRustFunctions },
   rs: { functions: extractRustFunctions },
 };
@@ -361,6 +371,49 @@ function extractRubyClasses(content: string): string[] {
   // Module definitions: module Name
   const moduleMatches = content.matchAll(/module\s+(\w+)/g);
   for (const match of moduleMatches) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+}
+
+// Kotlin Functions
+function extractKotlinFunctions(content: string): string[] {
+  const names = new Set<string>();
+
+  // Function definitions: fun name(...), suspend fun name(...), fun <T> name(...)
+  const functionMatches = content.matchAll(/\bfun\s+(?:<[^>]+>\s*)?(\w+)\s*\(/g);
+  for (const match of functionMatches) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+}
+
+function extractKotlinClasses(content: string): string[] {
+  const names = new Set<string>();
+
+  // Class definitions: class Name, data/sealed/enum/abstract/open class Name
+  const classMatches = content.matchAll(/\b(?:data|sealed|enum|abstract|open)?\s*class\s+(\w+)/g);
+  for (const match of classMatches) {
+    names.add(match[1]);
+  }
+
+  // Object declarations (singletons): object Name
+  const objectMatches = content.matchAll(/\bobject\s+(\w+)/g);
+  for (const match of objectMatches) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+}
+
+function extractKotlinInterfaces(content: string): string[] {
+  const names = new Set<string>();
+
+  // Interface definitions: interface Name
+  const interfaceMatches = content.matchAll(/\binterface\s+(\w+)/g);
+  for (const match of interfaceMatches) {
     names.add(match[1]);
   }
 

--- a/packages/parser/src/symbol-extractor.ts
+++ b/packages/parser/src/symbol-extractor.ts
@@ -381,8 +381,10 @@ function extractRubyClasses(content: string): string[] {
 function extractKotlinFunctions(content: string): string[] {
   const names = new Set<string>();
 
-  // Function definitions: fun name(...), suspend fun name(...), fun <T> name(...)
-  const functionMatches = content.matchAll(/\bfun\s+(?:<[^>]+>\s*)?(\w+)\s*\(/g);
+  // Function definitions, capturing the name immediately before the parameter
+  // list. The lazy `[^(\n]*?` skips optional generic params (incl. bounds like
+  // `<T : Comparable<T>>`) and extension receivers (`fun String.slugify()`).
+  const functionMatches = content.matchAll(/\bfun\s+[^(\n]*?(\w+)\s*\(/g);
   for (const match of functionMatches) {
     names.add(match[1]);
   }


### PR DESCRIPTION
## Summary

Upgrades Kotlin `.kt` files from line-based fallback to full **tree-sitter AST parsing**, bringing Kotlin to parity with the other 9 AST languages — same arc as Ruby (#596). This is PR 1 of 3 (AST → e2e → docs/release 0.47.0).

## What it adds

`packages/parser/src/ast/languages/kotlin.ts` (modeled on `java.ts`). The `tree-sitter-kotlin` grammar exposes **no field names**, so children are located by node **type**:

- **Symbols** — `function_declaration` (method/function), `class_declaration` (class / interface / enum variants, distinguished by keyword token), `object_declaration`. `SymbolInfo.type` has no `object`/`enum`, so those map to `class` with the keyword kept in the signature (`object Foo`, `enum class Color`).
- **Clean signatures** for both block bodies and expression bodies (`fun f(): Int = x` → `fun f(): Int`, no trailing `=`).
- **Imports** — `import_header` (incl. wildcard `import a.*` and alias `import a.B as C`); `kotlin.*`/`kotlinx.*`/`java.*` filtered.
- **Exports** — Kotlin is public-by-default, so the export check is inverted vs Java (excludes `private`/`internal`).
- **Call sites** — `call_expression` for `foo()` and `a.b.c()` (navigation).
- **Complexity** — counts `when` branches, `if`, loops, `catch`, elvis, and `&&`/`||` (`conjunction`/`disjunction`).

## Engine change (backward compatible)

`symbols.ts`: the import scan now descends **one level** so grammars that wrap imports in a container (Kotlin's `import_list` holds `import_header`s) are handled. Languages whose import nodes are direct children are unaffected (they match before any descent).

## Other wiring

Registry (+`kotlin`), regex fallback (`symbol-extractor.ts`), parser README table, registry count test (9→10), and `tree-sitter-kotlin@^0.3.8` (peer `tree-sitter ^0.21`; added to the lock preserving the repo's dual 0.21/0.25 `tree-sitter` topology).

## Scope

`.kt` only (no `.kts`/Gradle scripts), per plan. `scanner.ts`, the JVM ecosystem preset, `isTestFile` (`*Test.kt`/`src/test/`), and review display-names were already wired.

## Verification

- New `kotlin.test.ts` — **24 cases** (traverser, exports, imports, symbols incl. expression-body + call sites, and AST-chunking integration: class/method/companion-method/interface/object/top-level fn, imports, complexity).
- **Full parser suite green: 820/820** (no regression in the other 9 languages from the import-scan change).
- typecheck / eslint / prettier clean.
- Grammar binding verified loading against the repo's `tree-sitter@0.25.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kotlin support for AST parsing and symbol extraction.
  * Kotlin files are now recognized in language detection and registry listings.
  * Import handling now captures nested imports and aliases more reliably.

* **Bug Fixes**
  * Improved extraction of Kotlin function, class, interface, and object symbols.
  * Better handling of Kotlin visibility rules, companion objects, and chained calls.

* **Tests**
  * Added coverage for Kotlin parsing, exports, imports, symbols, and chunking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 1 new function is more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +21 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit f2733cf. Updates automatically on new commits.</sup>
<!-- /lien-stats -->