### PR TITLE
test(cli): Kotlin e2e coverage + docs & changeset (release 0.47.0)

### DIFF
--- a/.changeset/kotlin-ast-support.md
+++ b/.changeset/kotlin-ast-support.md
@@ -1,0 +1,26 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': minor
+---
+
+Add Kotlin AST support.
+
+Kotlin `.kt` files now get full structural parsing instead of the line-based
+fallback, bringing Kotlin to parity with the other AST-supported languages
+(TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#, Ruby):
+
+- **AST chunking** — one semantic chunk per `fun` / `class` / `object` /
+  `interface` instead of fixed line windows.
+- **Symbols** with clean signatures (`fun <T> map(t: T): R`, `suspend fun
+  fetch()`, `object Registry`, `enum class Color`), including expression-body
+  functions (`fun f() = expr`).
+- **Imports** from `import` declarations (incl. wildcard `import a.*` and
+  aliases `import a.B as C`); `kotlin.*` / `java.*` filtered, but external
+  `kotlinx.*` libraries are kept as dependency edges.
+- **Exports** — public-by-default visibility (top-level and member declarations
+  unless `private` / `internal`).
+- **Complexity metrics** counting `when`, `if`, loops, `catch`, elvis, and the
+  `&&` / `||` operators.
+
+The `tree-sitter-kotlin` grammar exposes no field names, so symbols are located
+by node type rather than via field accessors.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,6 +81,9 @@ jobs:
           - project: Sinatra
             language: Ruby
             script: test:e2e:ruby
+          - project: Klaxon
+            language: Kotlin
+            script: test:e2e:kotlin
 
     steps:
       - name: Checkout code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "test:e2e:java": "vitest run test/e2e/real-projects.test.ts -t 'JavaPoet'",
     "test:e2e:csharp": "vitest run test/e2e/real-projects.test.ts -t 'MediatR'",
     "test:e2e:ruby": "vitest run test/e2e/real-projects.test.ts -t 'Sinatra'",
+    "test:e2e:kotlin": "vitest run test/e2e/real-projects.test.ts -t 'Klaxon'",
     "docs": "typedoc"
   },
   "keywords": [

--- a/packages/cli/test/e2e/README.md
+++ b/packages/cli/test/e2e/README.md
@@ -23,6 +23,7 @@ These tests:
 | Java       | JavaPoet | https://github.com/square/javapoet        | Source-gen library, standard Java patterns |
 | C#         | MediatR  | https://github.com/jbogard/MediatR        | Mediator library, clean C# patterns        |
 | Ruby       | Sinatra  | https://github.com/sinatra/sinatra        | Web framework, classes/modules + require   |
+| Kotlin     | Klaxon   | https://github.com/cbeust/klaxon          | JSON library, classes/objects + imports    |
 
 ## Running Tests
 

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -140,6 +140,15 @@ const TEST_PROJECTS: ProjectConfig[] = [
     expectedMinChunks: 300, // AST chunking yields ~1300 (def/class/module per chunk)
     sampleSearchQuery: 'route handler matching http request',
   },
+  {
+    name: 'Klaxon',
+    repo: 'https://github.com/cbeust/klaxon.git',
+    branch: 'master',
+    language: 'kotlin',
+    expectedMinFiles: 40, // ~101 indexed (src/main + tests)
+    expectedMinChunks: 250, // AST chunking yields ~960 (fun/class/object per chunk)
+    sampleSearchQuery: 'parse json string into an object',
+  },
 ];
 
 /**

--- a/packages/site/docs/guide/index.md
+++ b/packages/site/docs/guide/index.md
@@ -86,9 +86,10 @@ Lien is built with modern, performant tools:
 - Java
 - C#
 - Ruby
+- Kotlin
 
 **Semantic Search** (chunking and embeddings):
-- All of the above, plus Vue, Liquid, C/C++, Swift, Kotlin, Scala, Markdown
+- All of the above, plus Vue, Liquid, C/C++, Swift, Scala, Markdown
 
 ## Next Steps
 

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -81,9 +81,10 @@ Lien indexes and understands code in:
 - Java
 - C#
 - Ruby
+- Kotlin
 
 **Semantic Search** (chunking and embeddings):
-- All of the above, plus C/C++, Vue, Swift, Kotlin, Scala, and more!
+- All of the above, plus C/C++, Vue, Swift, Scala, and more!
 
 ## Complexity Analysis
 


### PR DESCRIPTION
## Summary

Completes the Kotlin arc started in #603 (Kotlin AST support): end-to-end coverage on a real repo, docs-site update, and the release changeset (**0.46.0 → 0.47.0**).

## Changes

**e2e** — adds **Klaxon** (`cbeust/klaxon`, pure-Kotlin JSON library) to the real-projects matrix:
- entry in `TEST_PROJECTS` (`language: 'kotlin'`, conservative thresholds: 40 files / 250 chunks vs. ~101 / ~960 actual)
- `Klaxon` row in the `e2e.yml` matrix (so CI actually runs it)
- `test:e2e:kotlin` script + README row

**docs site** — moves Kotlin from the *Semantic Search* fallback list into *Full AST Support* in `how-it-works.md` and `guide/index.md` (the parser README + root README already reflect Kotlin).

**release** — `.changeset/kotlin-ast-support.md`: minor for `@liendev/parser` + `@liendev/lien` (core follows via the `linked` config). The changeset also auto-triggers the full e2e suite on this PR, exercising the new Kotlin job.

## Verification

- `npm run test:e2e:kotlin` (FORCE_COLOR=0): **14/14 green** — Klaxon indexes ~101 files → ~960 AST chunks; 100/100 chunks with imports, 100/100 with exports; search "parse json string into an object" → highly_relevant; reindex clean.
- Dogfooded Kotlin AST on a large codebase too (JetBrains/Exposed, 797 files → ~10.6k chunks): clean signatures for generics/`suspend`/`override`/default-params, `object`/`enum class` labeled correctly, imports/exports populated.
- `changeset status` → minor (parser + lien). `vitepress build docs` clean. prettier clean.

## Note on the publish

Merging this opens the changesets "version packages" PR (0.47.0). Merging **that** publishes to npm — left for maintainer go-ahead.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR completes the Kotlin AST support arc by adding Klaxon to the real-projects e2e matrix, updating docs to list Kotlin under Full AST Support, and adding a minor-version changeset for 0.47.0. The code change is a single additive entry in TEST_PROJECTS with conservative thresholds (40 files / 250 chunks vs. observed ~101 / ~960), plus matching CI matrix and npm script entries. No existing callers or behavior are modified.
>
> - Adds Klaxon Kotlin project to e2e real-projects test matrix
> - Adds test:e2e:kotlin script and corresponding CI matrix row
> - Updates docs and adds changeset for 0.47.0 minor release

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3df2ef3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->