### PR TITLE
feat(parser): add Swift AST support

### DIFF
--- a/.changeset/swift-ast-support.md
+++ b/.changeset/swift-ast-support.md
@@ -1,0 +1,13 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': minor
+---
+
+feat: add Swift AST support
+
+Swift (`.swift`) now uses full Tree-sitter AST parsing instead of line-based
+chunking — symbols, imports, call sites, complexity, and test associations —
+bringing the count of AST-supported languages to 11. struct/class/actor/enum/
+extension are recognised (keeping the keyword in the signature), protocols map
+to interfaces, and `Tests/` directories / `*Tests.swift` files are detected as
+tests. Validated with an e2e index of SwiftyJSON.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,6 +84,9 @@ jobs:
           - project: Klaxon
             language: Kotlin
             script: test:e2e:kotlin
+          - project: SwiftyJSON
+            language: Swift
+            script: test:e2e:swift
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -48,6 +48,3 @@ jobs:
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # TEMP DEBUG (revert before merge): log per-turn agent reasoning/output
-          # to diagnose the "No JSON output — 0 findings" silent failure on this PR.
-          LIEN_REVIEW_LOG_AGENT: '1'

--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -48,3 +48,6 @@ jobs:
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # TEMP DEBUG (revert before merge): log per-turn agent reasoning/output
+          # to diagnose the "No JSON output — 0 findings" silent failure on this PR.
+          LIEN_REVIEW_LOG_AGENT: '1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13670,6 +13670,7 @@
         "tree-sitter-python": "^0.25.0",
         "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "^0.24.0",
+        "tree-sitter-swift": "^0.7.1",
         "tree-sitter-typescript": "0.23.2"
       },
       "devDependencies": {
@@ -13726,6 +13727,40 @@
       },
       "engines": {
         "node": ">=22.21.0"
+      }
+    },
+    "node_modules/tree-sitter-swift": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-swift/-/tree-sitter-swift-0.7.1.tgz",
+      "integrity": "sha512-pneKVTuGamaBsqqqfB9BvNQjktzh/0IVPR54jLB5Fq/JTDQwYHd0Wo6pVyZ5jAYpbztzq+rJ/rpL9ruxTmSoKw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0",
+        "tree-sitter-cli": "^0.23",
+        "which": "2.0.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
+      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "test:e2e:csharp": "vitest run test/e2e/real-projects.test.ts -t 'MediatR'",
     "test:e2e:ruby": "vitest run test/e2e/real-projects.test.ts -t 'Sinatra'",
     "test:e2e:kotlin": "vitest run test/e2e/real-projects.test.ts -t 'Klaxon'",
+    "test:e2e:swift": "vitest run test/e2e/real-projects.test.ts -t 'SwiftyJSON'",
     "docs": "typedoc"
   },
   "keywords": [

--- a/packages/cli/test/e2e/README.md
+++ b/packages/cli/test/e2e/README.md
@@ -24,6 +24,7 @@ These tests:
 | C#         | MediatR  | https://github.com/jbogard/MediatR        | Mediator library, clean C# patterns        |
 | Ruby       | Sinatra  | https://github.com/sinatra/sinatra        | Web framework, classes/modules + require   |
 | Kotlin     | Klaxon   | https://github.com/cbeust/klaxon          | JSON library, classes/objects + imports    |
+| Swift      | SwiftyJSON | https://github.com/SwiftyJSON/SwiftyJSON | JSON library, structs/extensions + imports |
 
 ## Running Tests
 

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -149,6 +149,15 @@ const TEST_PROJECTS: ProjectConfig[] = [
     expectedMinChunks: 250, // AST chunking yields ~960 (fun/class/object per chunk)
     sampleSearchQuery: 'parse json string into an object',
   },
+  {
+    name: 'SwiftyJSON',
+    repo: 'https://github.com/SwiftyJSON/SwiftyJSON.git',
+    branch: 'master',
+    language: 'swift',
+    expectedMinFiles: 15, // ~26 indexed (Source + Tests)
+    expectedMinChunks: 150, // AST chunking yields ~356 (func/struct/extension per chunk)
+    sampleSearchQuery: 'parse json data into typed values',
+  },
 ];
 
 /**

--- a/packages/core/src/vectordb/boosting/strategies.ts
+++ b/packages/core/src/vectordb/boosting/strategies.ts
@@ -46,8 +46,14 @@ function isTestFile(filepath: string): boolean {
     return true;
   }
 
-  // Swift: XCTest `FooTests.swift` files and Swift Package Manager `Tests/` dirs
-  if (lower.endsWith('.swift') && (/tests?\.swift$/.test(lower) || /(^|\/)tests?\//.test(lower))) {
+  // Swift: XCTest `FooTests.swift` files and Swift Package Manager `Tests/` dirs.
+  // Matches the parser helper (packages/parser/src/utils/path-matching.ts): use
+  // the original-case path with capital `Tests` and both path separators, so
+  // `Contest.swift` is not a false positive and `\Tests\` paths are caught.
+  if (
+    lower.endsWith('.swift') &&
+    (/Tests?\.swift$/.test(filepath) || /(^|[/\\])Tests?[/\\]/.test(filepath))
+  ) {
     return true;
   }
 

--- a/packages/core/src/vectordb/boosting/strategies.ts
+++ b/packages/core/src/vectordb/boosting/strategies.ts
@@ -46,6 +46,11 @@ function isTestFile(filepath: string): boolean {
     return true;
   }
 
+  // Swift: XCTest `FooTests.swift` files and Swift Package Manager `Tests/` dirs
+  if (lower.endsWith('.swift') && (/tests?\.swift$/.test(lower) || /(^|\/)tests?\//.test(lower))) {
+    return true;
+  }
+
   return false;
 }
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -6,7 +6,7 @@ This package provides the core parsing and analysis capabilities used by Lien's 
 
 ## Features
 
-- **AST Parsing** — Tree-sitter-based parsing for TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#, Ruby, and Kotlin
+- **AST Parsing** — Tree-sitter-based parsing for TypeScript, JavaScript, Python, PHP, Rust, Go, Java, C#, Ruby, Kotlin, and Swift
 - **Semantic Chunking** — Split code into meaningful chunks respecting function/class boundaries
 - **Complexity Analysis** — Cyclomatic, cognitive, and Halstead complexity metrics
 - **Dependency Analysis** — Import/export tracking with transitive dependent resolution
@@ -28,8 +28,9 @@ This package provides the core parsing and analysis capabilities used by Lien's 
 | C# | Yes | Yes | Yes |
 | Ruby | Yes | Yes | Yes |
 | Kotlin | Yes | Yes | Yes |
+| Swift | Yes | Yes | Yes |
 
-Line-based chunking and symbol extraction are available for additional languages including Vue, Liquid, C/C++, Swift, Scala, and Markdown.
+Line-based chunking and symbol extraction are available for additional languages including Vue, Liquid, C/C++, Scala, and Markdown.
 
 ## Usage
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -32,6 +32,7 @@
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "^0.24.0",
+    "tree-sitter-swift": "^0.7.1",
     "tree-sitter-typescript": "0.23.2"
   },
   "devDependencies": {

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -31,7 +31,7 @@ describe('AST Chunker', () => {
     });
 
     it('should return false for unsupported files', () => {
-      expect(shouldUseAST('test.swift')).toBe(false);
+      expect(shouldUseAST('test.scala')).toBe(false);
       expect(shouldUseAST('test.txt')).toBe(false);
     });
   });
@@ -527,8 +527,8 @@ export { default as qux } from './qux';`;
     it('should throw error for unsupported language', () => {
       const content = 'print("Hello")';
 
-      // Swift is not AST-supported
-      expect(() => chunkByAST('test.swift', content)).toThrow();
+      // Scala is not AST-supported
+      expect(() => chunkByAST('test.scala', content)).toThrow();
     });
 
     it('should handle invalid syntax gracefully', () => {

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -42,11 +42,15 @@ describe('Language Registry', () => {
       expect(detectLanguage('app/models/user.rb')).toBe('ruby');
     });
 
+    it('should detect Swift files', () => {
+      expect(detectLanguage('Sources/App/Order.swift')).toBe('swift');
+    });
+
     it('should return null for unsupported extensions', () => {
       expect(detectLanguage('style.css')).toBeNull();
       expect(detectLanguage('data.json')).toBeNull();
       expect(detectLanguage('README.md')).toBeNull();
-      expect(detectLanguage('main.swift')).toBeNull();
+      expect(detectLanguage('main.scala')).toBeNull();
     });
 
     it('should handle paths with directories', () => {
@@ -72,6 +76,8 @@ describe('Language Registry', () => {
         'java',
         'csharp',
         'ruby',
+        'kotlin',
+        'swift',
       ];
       for (const lang of languages) {
         const def = getLanguage(lang);
@@ -85,8 +91,8 @@ describe('Language Registry', () => {
     });
 
     it('should throw for unregistered languages', () => {
-      expect(() => getLanguage('swift' as SupportedLanguage)).toThrow(
-        'No language definition registered for: swift',
+      expect(() => getLanguage('scala' as SupportedLanguage)).toThrow(
+        'No language definition registered for: scala',
       );
     });
   });
@@ -98,15 +104,15 @@ describe('Language Registry', () => {
     });
 
     it('should return false for unregistered languages', () => {
-      expect(languageExists('swift')).toBe(false);
+      expect(languageExists('scala')).toBe(false);
       expect(languageExists('')).toBe(false);
     });
   });
 
   describe('getAllLanguages', () => {
-    it('should return all 10 registered languages', () => {
+    it('should return all 11 registered languages', () => {
       const all = getAllLanguages();
-      expect(all).toHaveLength(10);
+      expect(all).toHaveLength(11);
       const ids = all.map(d => d.id);
       expect(ids).toContain('typescript');
       expect(ids).toContain('javascript');
@@ -118,6 +124,7 @@ describe('Language Registry', () => {
       expect(ids).toContain('csharp');
       expect(ids).toContain('ruby');
       expect(ids).toContain('kotlin');
+      expect(ids).toContain('swift');
     });
 
     it('should return a defensive copy', () => {

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -10,6 +10,7 @@ import { javaDefinition } from './java.js';
 import { csharpDefinition } from './csharp.js';
 import { rubyDefinition } from './ruby.js';
 import { kotlinDefinition } from './kotlin.js';
+import { swiftDefinition } from './swift.js';
 
 /**
  * All registered language definitions.
@@ -26,6 +27,7 @@ const definitions: LanguageDefinition[] = [
   csharpDefinition,
   rubyDefinition,
   kotlinDefinition,
+  swiftDefinition,
 ];
 
 /**
@@ -44,6 +46,7 @@ export const LANGUAGE_IDS = [
   'csharp',
   'ruby',
   'kotlin',
+  'swift',
 ] as const;
 export type SupportedLanguage = (typeof LANGUAGE_IDS)[number];
 

--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import Swift from 'tree-sitter-swift';
+import { chunkByAST } from '../chunker.js';
+import {
+  SwiftTraverser,
+  SwiftExportExtractor,
+  SwiftImportExtractor,
+  SwiftSymbolExtractor,
+} from './swift.js';
+
+describe('Swift Language', () => {
+  const parser = new Parser();
+  parser.setLanguage(Swift);
+  const traverser = new SwiftTraverser();
+  const exportExtractor = new SwiftExportExtractor();
+  const importExtractor = new SwiftImportExtractor();
+  const symbolExtractor = new SwiftSymbolExtractor();
+
+  const parse = (src: string) => parser.parse(src).rootNode;
+
+  // ===========================================================================
+  // TRAVERSER
+  // ===========================================================================
+  describe('Traverser', () => {
+    it('recognizes class/struct and protocol declarations as containers', () => {
+      const root = parse('struct A { func m() {} }\nprotocol B { func n() }\n');
+      const struct = findNode(root, 'class_declaration')!;
+      const proto = findNode(root, 'protocol_declaration')!;
+      expect(traverser.shouldExtractChildren(struct)).toBe(true);
+      expect(traverser.shouldExtractChildren(proto)).toBe(true);
+    });
+
+    it('finds the class body for child traversal (struct/class/actor/extension)', () => {
+      const root = parse('struct A { func m() {} }\n');
+      const struct = findNode(root, 'class_declaration')!;
+      expect(traverser.getContainerBody(struct)?.type).toBe('class_body');
+    });
+
+    it('finds the enum class body', () => {
+      const root = parse('enum E { case a, b }\n');
+      const en = findNode(root, 'class_declaration')!;
+      expect(traverser.getContainerBody(en)?.type).toBe('enum_class_body');
+    });
+
+    it('finds the protocol body', () => {
+      const root = parse('protocol P { func m() }\n');
+      const proto = findNode(root, 'protocol_declaration')!;
+      expect(traverser.getContainerBody(proto)?.type).toBe('protocol_body');
+    });
+
+    it('traverses into source_file, class_body, and protocol_body', () => {
+      const root = parse('struct A {\n  func m() {}\n}\n');
+      expect(traverser.shouldTraverseChildren(root)).toBe(true);
+      expect(traverser.shouldTraverseChildren(findNode(root, 'class_body')!)).toBe(true);
+    });
+
+    it('resolves the parent container name for a method', () => {
+      const root = parse('struct Calc { func add() {} }\n');
+      const fn = findNode(root, 'function_declaration')!;
+      expect(traverser.findParentContainerName(fn)).toBe('Calc');
+    });
+
+    it('detects a closure inside a property declaration', () => {
+      const root = parse('let handler = { (x: Int) in x + 1 }\n');
+      const prop = findNode(root, 'property_declaration')!;
+      expect(traverser.isDeclarationWithFunction(prop)).toBe(true);
+      expect(traverser.findFunctionInDeclaration(prop).hasFunction).toBe(true);
+    });
+
+    it('does not treat a property with a call-argument closure as function-valued', () => {
+      const root = parse('let mapped = xs.map { $0 + 1 }\n');
+      const prop = findNode(root, 'property_declaration')!;
+      expect(traverser.isDeclarationWithFunction(prop)).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // EXPORT EXTRACTOR
+  // ===========================================================================
+  describe('Export Extraction', () => {
+    it('exports top-level functions, structs, classes, and protocols (internal by default)', () => {
+      const root = parse('func topFn() {}\nstruct PublicStruct {}\nprotocol Service {}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('topFn');
+      expect(exports).toContain('PublicStruct');
+      expect(exports).toContain('Service');
+    });
+
+    it('excludes private and fileprivate declarations', () => {
+      const root = parse(
+        'private func secret() {}\nfileprivate struct Hidden {}\nfunc shown() {}\n',
+      );
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).not.toContain('secret');
+      expect(exports).not.toContain('Hidden');
+      expect(exports).toContain('shown');
+    });
+
+    it('exports non-private members of a struct', () => {
+      const root = parse(
+        'struct Service {\n  func publicMethod() {}\n  private func helper() {}\n}\n',
+      );
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('Service');
+      expect(exports).toContain('publicMethod');
+      expect(exports).not.toContain('helper');
+    });
+
+    it('treats protocol members as exported (implicitly part of the surface)', () => {
+      const root = parse('protocol Repo {\n  func find() -> String\n}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('Repo');
+      expect(exports).toContain('find');
+    });
+
+    it('does not export members of a private container', () => {
+      const root = parse('private struct Secret {\n  func internalApi() {}\n}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).not.toContain('Secret');
+      expect(exports).not.toContain('internalApi');
+    });
+  });
+
+  // ===========================================================================
+  // IMPORT EXTRACTOR
+  // ===========================================================================
+  describe('Import Extraction', () => {
+    const imports = (src: string) => findAllNodes(parse(src), 'import_declaration');
+
+    it('extracts a simple import path', () => {
+      const [imp] = imports('import Foundation\n');
+      expect(importExtractor.extractImportPath(imp)).toBe('Foundation');
+    });
+
+    it('extracts a dotted / import-kind path', () => {
+      const [imp] = imports('import struct Combine.Just\n');
+      expect(importExtractor.extractImportPath(imp)).toBe('Combine.Just');
+    });
+
+    it('filters out the Swift standard library module', () => {
+      const [stdlib] = imports('import Swift\n');
+      expect(importExtractor.extractImportPath(stdlib)).toBeNull();
+    });
+
+    it('keeps real framework imports (Foundation, UIKit, …)', () => {
+      const [uikit] = imports('import UIKit\n');
+      expect(importExtractor.extractImportPath(uikit)).toBe('UIKit');
+    });
+
+    it('maps an import to its last segment as the symbol', () => {
+      const [imp] = imports('import struct Combine.Just\n');
+      const result = importExtractor.processImportSymbols(imp);
+      expect(result?.importPath).toBe('Combine.Just');
+      expect(result?.symbols).toContain('Just');
+    });
+  });
+
+  // ===========================================================================
+  // SYMBOL EXTRACTION
+  // ===========================================================================
+  describe('Symbol Extraction', () => {
+    it('extracts a function with a clean signature, params, and return type', () => {
+      const src = 'func calculate(a: Int, b: Int) -> Int {\n  return a + b\n}\n';
+      const fn = findNode(parse(src), 'function_declaration')!;
+      const sym = symbolExtractor.extractSymbol(fn, src)!;
+      expect(sym.name).toBe('calculate');
+      expect(sym.type).toBe('function');
+      expect(sym.signature).toBe('func calculate(a: Int, b: Int) -> Int');
+      expect(sym.parameters).toEqual(['a: Int', 'b: Int']);
+      expect(sym.returnType).toBe('Int');
+    });
+
+    it('marks functions inside a type as methods', () => {
+      const src = 'struct A {\n  func m() {}\n}\n';
+      const fn = findNode(parse(src), 'function_declaration')!;
+      const sym = symbolExtractor.extractSymbol(fn, src, 'A')!;
+      expect(sym.type).toBe('method');
+      expect(sym.parentClass).toBe('A');
+    });
+
+    it('extracts an initializer as a method', () => {
+      const src = 'struct A {\n  init(x: Int) {}\n}\n';
+      const init = findNode(parse(src), 'init_declaration')!;
+      const sym = symbolExtractor.extractSymbol(init, src, 'A')!;
+      expect(sym.name).toBe('init');
+      expect(sym.type).toBe('method');
+    });
+
+    it('maps struct / enum / extension / class to class with the real keyword in the signature', () => {
+      const struct = symbolExtractor.extractSymbol(
+        findNode(parse('struct Foo { let x: Int }'), 'class_declaration')!,
+        '',
+      )!;
+      expect(struct).toMatchObject({ name: 'Foo', type: 'class', signature: 'struct Foo' });
+
+      const en = symbolExtractor.extractSymbol(
+        findNode(parse('enum Color { case red }'), 'class_declaration')!,
+        '',
+      )!;
+      expect(en).toMatchObject({ name: 'Color', type: 'class', signature: 'enum Color' });
+
+      const ext = symbolExtractor.extractSymbol(
+        findNode(parse('extension String { func x() {} }'), 'class_declaration')!,
+        '',
+      )!;
+      expect(ext).toMatchObject({ name: 'String', type: 'class', signature: 'extension String' });
+
+      const cls = symbolExtractor.extractSymbol(
+        findNode(parse('class Bar {}'), 'class_declaration')!,
+        '',
+      )!;
+      expect(cls).toMatchObject({ name: 'Bar', type: 'class', signature: 'class Bar' });
+    });
+
+    it('maps a protocol to an interface', () => {
+      const proto = symbolExtractor.extractSymbol(
+        findNode(parse('protocol Drawable { func draw() }'), 'protocol_declaration')!,
+        '',
+      )!;
+      expect(proto).toMatchObject({
+        name: 'Drawable',
+        type: 'interface',
+        signature: 'protocol Drawable',
+      });
+    });
+
+    it('extracts call sites for direct and navigation calls', () => {
+      const src = 'func run() {\n  foo()\n  obj.bar.baz()\n}\n';
+      const calls = findAllNodes(parse(src), 'call_expression');
+      const names = calls.map(c => symbolExtractor.extractCallSite(c)?.symbol).filter(Boolean);
+      expect(names).toContain('foo');
+      expect(names).toContain('baz');
+    });
+  });
+
+  // ===========================================================================
+  // AST CHUNKING INTEGRATION
+  // ===========================================================================
+  describe('AST Chunking', () => {
+    const SOURCE = `import Foundation
+import Swift
+
+struct OrderService {
+  let repo: Repository
+
+  func place(_ order: Order) -> Bool {
+    guard order.isValid else { return false }
+    switch order.kind {
+    case .standard where order.total > 0 && repo.has(order.id):
+      return repo.save(order)
+    default:
+      return false
+    }
+  }
+}
+
+protocol Repository {
+  func save(_ o: Order) -> Bool
+}
+
+enum OrderKind {
+  case standard
+  case express
+}
+
+extension OrderService {
+  func summary() -> String { return "order" }
+}
+
+func topLevelHelper(_ x: Int) -> Int { return x + 1 }
+`;
+
+    const chunks = chunkByAST('OrderService.swift', SOURCE);
+    const bySymbol = (name: string, type?: string) =>
+      chunks.find(
+        c => c.metadata.symbolName === name && (type ? c.metadata.symbolType === type : true),
+      );
+
+    it('produces more chunks than one (AST-bounded, not a single blob)', () => {
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it('chunks the struct, its method, the protocol, the enum, the extension method, and the top-level fn', () => {
+      expect(bySymbol('OrderService', 'class')).toBeDefined();
+      expect(bySymbol('Repository', 'interface')).toBeDefined();
+      expect(bySymbol('OrderKind', 'class')).toBeDefined();
+      expect(bySymbol('place', 'method')?.metadata.parentClass).toBe('OrderService');
+      expect(bySymbol('summary', 'method')).toBeDefined();
+      expect(bySymbol('topLevelHelper', 'function')).toBeDefined();
+    });
+
+    it('captures real framework imports and filters the Swift stdlib module', () => {
+      const allImports = chunks.flatMap(c => c.metadata.imports ?? []);
+      expect(allImports).toContain('Foundation');
+      expect(allImports).not.toContain('Swift');
+    });
+
+    it('computes complexity for a branchy method (counts guard / switch / && )', () => {
+      const place = bySymbol('place', 'method');
+      expect(place).toBeDefined();
+      expect(place?.metadata.complexity ?? 0).toBeGreaterThan(1);
+    });
+  });
+});
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+function findNode(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
+  if (node.type === type) return node;
+  for (const child of node.namedChildren) {
+    const found = findNode(child, type);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findAllNodes(
+  node: Parser.SyntaxNode,
+  type: string,
+  acc: Parser.SyntaxNode[] = [],
+): Parser.SyntaxNode[] {
+  if (node.type === type) acc.push(node);
+  for (const child of node.namedChildren) findAllNodes(child, type, acc);
+  return acc;
+}

--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -225,6 +225,15 @@ describe('Swift Language', () => {
       });
     });
 
+    it('extracts protocol method requirements as methods', () => {
+      const src = 'protocol Repo {\n  func find() -> String\n}\n';
+      const pfd = findNode(parse(src), 'protocol_function_declaration')!;
+      const sym = symbolExtractor.extractSymbol(pfd, src, 'Repo')!;
+      expect(sym.name).toBe('find');
+      expect(sym.type).toBe('method');
+      expect(sym.parentClass).toBe('Repo');
+    });
+
     it('extracts call sites for direct and navigation calls', () => {
       const src = 'func run() {\n  foo()\n  obj.bar.baz()\n}\n';
       const calls = findAllNodes(parse(src), 'call_expression');
@@ -288,6 +297,8 @@ func topLevelHelper(_ x: Int) -> Int { return x + 1 }
       expect(bySymbol('place', 'method')?.metadata.parentClass).toBe('OrderService');
       expect(bySymbol('summary', 'method')).toBeDefined();
       expect(bySymbol('topLevelHelper', 'function')).toBeDefined();
+      // protocol method requirement is chunked as a method of the protocol
+      expect(bySymbol('save', 'method')?.metadata.parentClass).toBe('Repository');
     });
 
     it('captures real framework imports and filters the Swift stdlib module', () => {

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -1,0 +1,563 @@
+import Swift from 'tree-sitter-swift';
+import type Parser from 'tree-sitter';
+import type { SymbolInfo } from '../types.js';
+import type { LanguageDefinition } from './types.js';
+import type { LanguageTraverser, DeclarationFunctionInfo } from '../traversers/types.js';
+import type {
+  LanguageExportExtractor,
+  LanguageImportExtractor,
+  LanguageSymbolExtractor,
+} from '../extractors/types.js';
+import { extractSignature, extractReturnType } from '../extractors/symbol-helpers.js';
+import { calculateComplexity } from '../complexity/index.js';
+
+// =============================================================================
+// HELPERS
+//
+// The tree-sitter-swift grammar (alex-pinkus) DOES expose field names
+// (`name`, `body`, `return_type`, `declaration_kind`, …), so — unlike Kotlin —
+// we use `childForFieldName` like the Java definition. The Swift-specific
+// wrinkles are: class/struct/actor/enum/extension all share the
+// `class_declaration` node (distinguished by the `declaration_kind` keyword),
+// parameters are bare `parameter` children (no `parameters` wrapper field), and
+// visibility lives under a `modifiers` child.
+// =============================================================================
+
+/** First named child of a given type. */
+function childByType(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
+  return node.namedChildren.find(child => child.type === type) ?? null;
+}
+
+/** First descendant of a given type (depth-first), or null. */
+function findFirst(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode | null {
+  for (const child of node.namedChildren) {
+    if (child.type === type) return child;
+    const found = findFirst(child, type);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * The `class_declaration` keyword (`class` / `struct` / `actor` / `enum` /
+ * `extension`), read from the `declaration_kind` field. Defaults to `class`.
+ */
+function declarationKeyword(node: Parser.SyntaxNode): string {
+  return node.childForFieldName('declaration_kind')?.text ?? 'class';
+}
+
+/** The declared name of a class/protocol declaration (handles `extension`'s `user_type`). */
+function declarationName(node: Parser.SyntaxNode): string | undefined {
+  return node.childForFieldName('name')?.text;
+}
+
+/**
+ * The name of a function-like node. Swift's `init`/`deinit`/`subscript`
+ * declarations have no `name` field — fall back to the keyword.
+ */
+function functionLikeName(node: Parser.SyntaxNode): string | undefined {
+  const name = node.childForFieldName('name')?.text;
+  if (name) return name;
+  switch (node.type) {
+    case 'init_declaration':
+      return 'init';
+    case 'deinit_declaration':
+      return 'deinit';
+    case 'subscript_declaration':
+      return 'subscript';
+    default:
+      return undefined;
+  }
+}
+
+/** Parameter texts. Swift function params are bare `parameter` children (no field). */
+function swiftParameters(node: Parser.SyntaxNode): string[] {
+  return node.namedChildren.filter(c => c.type === 'parameter' && c.text.trim()).map(c => c.text);
+}
+
+/**
+ * The function-valued initializer of a property, if the property's value is
+ * *directly* a closure (`let handler = { … }`). Checks the `value` field rather
+ * than any descendant, so a closure passed as a call argument
+ * (`let n = xs.map { … }`) is NOT treated as a function-valued property.
+ */
+function propertyInitializerFunction(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  const value = node.childForFieldName('value');
+  return value?.type === 'lambda_literal' ? value : null;
+}
+
+/** Visibility modifier text (`public` / `private` / `fileprivate` / `internal` / `open`), if any. */
+function visibilityModifier(node: Parser.SyntaxNode): string | null {
+  const modifiers = childByType(node, 'modifiers');
+  if (!modifiers) return null;
+  return modifiers.namedChildren.find(c => c.type === 'visibility_modifier')?.text ?? null;
+}
+
+/**
+ * Swift declarations are `internal` (module-visible) by default. We treat a
+ * declaration as "exported" (part of the file's API surface) unless it is
+ * explicitly `private` or `fileprivate` — so default/`internal`/`public`/`open`
+ * are surfaced. (Analogous to Kotlin's "public unless private/internal".)
+ */
+function isExported(node: Parser.SyntaxNode): boolean {
+  const visibility = visibilityModifier(node);
+  return visibility !== 'private' && visibility !== 'fileprivate';
+}
+
+/** The property's bound identifier (`let foo = …` → `foo`). */
+function propertyName(node: Parser.SyntaxNode): string | undefined {
+  const pattern = node.childForFieldName('name');
+  if (!pattern) return undefined;
+  return findFirst(pattern, 'simple_identifier')?.text ?? pattern.text;
+}
+
+// =============================================================================
+// TRAVERSER
+// =============================================================================
+
+/**
+ * Swift AST traverser.
+ *
+ * Functions/methods/initializers live inside `class_declaration` (which covers
+ * class / struct / actor / enum / extension) and `protocol_declaration` bodies
+ * (`class_body` / `enum_class_body` / `protocol_body`). Closures can appear as
+ * property initializers (`let handler = { … }`).
+ */
+export class SwiftTraverser implements LanguageTraverser {
+  targetNodeTypes = [
+    'function_declaration',
+    'init_declaration',
+    'deinit_declaration',
+    'subscript_declaration',
+  ];
+
+  containerTypes = ['class_declaration', 'protocol_declaration'];
+
+  declarationTypes = ['property_declaration'];
+
+  functionTypes = ['lambda_literal'];
+
+  shouldExtractChildren(node: Parser.SyntaxNode): boolean {
+    return this.containerTypes.includes(node.type);
+  }
+
+  isDeclarationWithFunction(node: Parser.SyntaxNode): boolean {
+    return node.type === 'property_declaration' && propertyInitializerFunction(node) !== null;
+  }
+
+  getContainerBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+    if (!this.containerTypes.includes(node.type)) return null;
+    return node.childForFieldName('body');
+  }
+
+  shouldTraverseChildren(node: Parser.SyntaxNode): boolean {
+    return (
+      node.type === 'source_file' ||
+      node.type === 'class_body' ||
+      node.type === 'enum_class_body' ||
+      node.type === 'protocol_body'
+    );
+  }
+
+  findParentContainerName(node: Parser.SyntaxNode): string | undefined {
+    let current = node.parent;
+    while (current) {
+      if (current.type === 'class_declaration' || current.type === 'protocol_declaration') {
+        return declarationName(current);
+      }
+      current = current.parent;
+    }
+    return undefined;
+  }
+
+  findFunctionInDeclaration(node: Parser.SyntaxNode): DeclarationFunctionInfo {
+    if (node.type !== 'property_declaration') {
+      return { hasFunction: false, functionNode: null };
+    }
+    const fn = propertyInitializerFunction(node);
+    return fn
+      ? { hasFunction: true, functionNode: fn }
+      : { hasFunction: false, functionNode: null };
+  }
+}
+
+// =============================================================================
+// EXPORT EXTRACTOR
+// =============================================================================
+
+/**
+ * Swift export extractor.
+ *
+ * Swift has no `export` keyword. Top-level declarations and (non-private/
+ * fileprivate) members form the file's API surface. Protocol members are
+ * implicitly part of the protocol's surface.
+ */
+export class SwiftExportExtractor implements LanguageExportExtractor {
+  extractExports(rootNode: Parser.SyntaxNode): string[] {
+    const exports: string[] = [];
+    const seen = new Set<string>();
+
+    const addExport = (name?: string) => {
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        exports.push(name);
+      }
+    };
+
+    rootNode.namedChildren.forEach(child => this.extractFromNode(child, addExport));
+
+    return exports;
+  }
+
+  private extractFromNode(node: Parser.SyntaxNode, addExport: (name?: string) => void): void {
+    switch (node.type) {
+      case 'function_declaration':
+      case 'init_declaration':
+      case 'deinit_declaration':
+      case 'subscript_declaration':
+        if (isExported(node)) addExport(functionLikeName(node));
+        break;
+      case 'property_declaration':
+        if (isExported(node)) addExport(propertyName(node));
+        break;
+      case 'class_declaration':
+      case 'protocol_declaration':
+        // A private/fileprivate container exposes nothing — skip it and its members.
+        if (isExported(node)) {
+          addExport(declarationName(node));
+          this.extractMembers(node, addExport);
+        }
+        break;
+    }
+  }
+
+  private extractMembers(container: Parser.SyntaxNode, addExport: (name?: string) => void): void {
+    const body = container.childForFieldName('body');
+    if (!body) return;
+
+    // Protocol members are implicitly part of the protocol's surface.
+    const isProtocol = container.type === 'protocol_declaration';
+
+    body.namedChildren.forEach(member => {
+      switch (member.type) {
+        case 'function_declaration':
+        case 'protocol_function_declaration':
+        case 'init_declaration':
+        case 'deinit_declaration':
+        case 'subscript_declaration':
+          if (isProtocol || isExported(member)) addExport(functionLikeName(member));
+          break;
+        case 'property_declaration':
+        case 'protocol_property_declaration':
+          if (isProtocol || isExported(member)) addExport(propertyName(member));
+          break;
+        case 'class_declaration':
+        case 'protocol_declaration':
+          // Nested types — recurse so their names/members are surfaced too.
+          this.extractFromNode(member, addExport);
+          break;
+      }
+    });
+  }
+}
+
+// =============================================================================
+// IMPORT EXTRACTOR
+// =============================================================================
+
+/**
+ * The Swift standard library module. `Foundation`, `UIKit`, `SwiftUI`,
+ * `Combine`, etc. are real external frameworks and are kept as import edges.
+ */
+function isSwiftStdLib(importPath: string): boolean {
+  return importPath === 'Swift' || importPath.startsWith('Swift.');
+}
+
+/**
+ * Swift import extractor.
+ *
+ * Handles `import Foundation`, dotted `import Combine.Just`, and import-kind
+ * forms (`import struct Combine.Just` — the `struct`/`class`/… keyword is an
+ * anonymous token and is ignored; the module path is what matters). Only the
+ * `Swift` stdlib module is filtered out.
+ */
+export class SwiftImportExtractor implements LanguageImportExtractor {
+  readonly importNodeTypes = ['import_declaration'];
+
+  extractImportPath(node: Parser.SyntaxNode): string | null {
+    const path = this.getImportPath(node);
+    if (!path || isSwiftStdLib(path)) return null;
+    return path;
+  }
+
+  processImportSymbols(node: Parser.SyntaxNode): { importPath: string; symbols: string[] } | null {
+    const path = this.getImportPath(node);
+    if (!path || isSwiftStdLib(path)) return null;
+
+    const parts = path.split('.');
+    const lastPart = parts[parts.length - 1];
+    return { importPath: path, symbols: [lastPart] };
+  }
+
+  private getImportPath(node: Parser.SyntaxNode): string | null {
+    return childByType(node, 'identifier')?.text ?? null;
+  }
+}
+
+// =============================================================================
+// SYMBOL EXTRACTOR
+// =============================================================================
+
+/**
+ * Swift symbol extractor.
+ *
+ * Handles `function_declaration`, `init`/`deinit`/`subscript` declarations,
+ * `class_declaration` (class / struct / actor / enum / extension — distinguished
+ * by the `declaration_kind` keyword), and `protocol_declaration`. `SymbolInfo.type`
+ * only has `function|method|class|interface`, so struct/actor/enum/extension map
+ * to `class` (keeping the real keyword in the signature) and protocol maps to
+ * `interface`.
+ *
+ * Call sites: `call_expression` — `foo()` (simple_identifier callee) and
+ * `a.b.c()` (the member is the `simple_identifier` in the trailing
+ * `navigation_suffix`).
+ */
+export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
+  readonly symbolNodeTypes = [
+    'function_declaration',
+    'init_declaration',
+    'deinit_declaration',
+    'subscript_declaration',
+    'class_declaration',
+    'protocol_declaration',
+  ];
+
+  extractSymbol(node: Parser.SyntaxNode, content: string, parentClass?: string): SymbolInfo | null {
+    switch (node.type) {
+      case 'function_declaration':
+      case 'init_declaration':
+      case 'deinit_declaration':
+      case 'subscript_declaration':
+        return this.extractFunctionInfo(node, content, parentClass);
+      case 'class_declaration':
+        return this.extractClassInfo(node);
+      case 'protocol_declaration':
+        return this.extractProtocolInfo(node);
+      default:
+        return null;
+    }
+  }
+
+  extractCallSite(node: Parser.SyntaxNode): { symbol: string; line: number; key: string } | null {
+    if (node.type !== 'call_expression') return null;
+    const line = node.startPosition.row + 1;
+
+    const callee = node.namedChild(0);
+    if (!callee) return null;
+
+    let name: string | undefined;
+    if (callee.type === 'simple_identifier') {
+      name = callee.text; // foo()
+    } else if (callee.type === 'navigation_expression') {
+      // a.b.c() — the called member is the simple_identifier in the last navigation_suffix
+      const suffix = callee.namedChildren.filter(c => c.type === 'navigation_suffix').at(-1);
+      name = suffix ? (findFirst(suffix, 'simple_identifier')?.text ?? undefined) : undefined;
+    }
+
+    if (!name) return null;
+    return { symbol: name, line, key: `${name}:${line}` };
+  }
+
+  private extractFunctionInfo(
+    node: Parser.SyntaxNode,
+    content: string,
+    parentClass?: string,
+  ): SymbolInfo | null {
+    const name = functionLikeName(node);
+    if (!name) return null;
+
+    return {
+      name,
+      type: parentClass ? 'method' : 'function',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: extractSignature(node, content),
+      parameters: swiftParameters(node),
+      returnType: extractReturnType(node, content),
+      complexity: calculateComplexity(node),
+    };
+  }
+
+  private extractClassInfo(node: Parser.SyntaxNode): SymbolInfo | null {
+    const name = declarationName(node);
+    if (!name) return null;
+    const keyword = declarationKeyword(node);
+    return this.makeSymbol(node, name, 'class', `${keyword} ${name}`);
+  }
+
+  private extractProtocolInfo(node: Parser.SyntaxNode): SymbolInfo | null {
+    const name = declarationName(node);
+    if (!name) return null;
+    return this.makeSymbol(node, name, 'interface', `protocol ${name}`);
+  }
+
+  private makeSymbol(
+    node: Parser.SyntaxNode,
+    name: string,
+    type: SymbolInfo['type'],
+    signature: string,
+  ): SymbolInfo {
+    return {
+      name,
+      type,
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      signature,
+    };
+  }
+}
+
+// =============================================================================
+// LANGUAGE DEFINITION
+// =============================================================================
+
+export const swiftDefinition: LanguageDefinition = {
+  id: 'swift',
+  extensions: ['swift'],
+  grammar: Swift,
+  traverser: new SwiftTraverser(),
+  exportExtractor: new SwiftExportExtractor(),
+  importExtractor: new SwiftImportExtractor(),
+  symbolExtractor: new SwiftSymbolExtractor(),
+
+  complexity: {
+    decisionPoints: [
+      'if_statement',
+      'guard_statement',
+      'switch_entry', // each `case` / `default` branch
+      'for_statement',
+      'while_statement',
+      'repeat_while_statement',
+      'catch_block',
+      'conjunction_expression', // &&
+      'disjunction_expression', // ||
+      'nil_coalescing_expression', // ??
+      'ternary_expression',
+    ],
+    nestingTypes: [
+      'if_statement',
+      'guard_statement',
+      'switch_statement',
+      'for_statement',
+      'while_statement',
+      'repeat_while_statement',
+      'do_statement',
+      'catch_block',
+      'lambda_literal',
+    ],
+    nonNestingTypes: [
+      'switch_entry',
+      'conjunction_expression',
+      'disjunction_expression',
+      'nil_coalescing_expression',
+      'ternary_expression',
+    ],
+    lambdaTypes: ['lambda_literal'],
+    operatorSymbols: new Set([
+      '+',
+      '-',
+      '*',
+      '/',
+      '%',
+      '==',
+      '!=',
+      '===',
+      '!==',
+      '<',
+      '>',
+      '<=',
+      '>=',
+      '=',
+      '+=',
+      '-=',
+      '*=',
+      '/=',
+      '%=',
+      '&&',
+      '||',
+      '!',
+      '??',
+      '?.',
+      '.',
+      '->',
+      '..<',
+      '...',
+      '(',
+      ')',
+      '[',
+      ']',
+      '{',
+      '}',
+    ]),
+    operatorKeywords: new Set([
+      'if',
+      'else',
+      'guard',
+      'switch',
+      'case',
+      'default',
+      'for',
+      'while',
+      'repeat',
+      'do',
+      'return',
+      'break',
+      'continue',
+      'fallthrough',
+      'throw',
+      'throws',
+      'try',
+      'catch',
+      'defer',
+      'func',
+      'class',
+      'struct',
+      'actor',
+      'enum',
+      'protocol',
+      'extension',
+      'init',
+      'deinit',
+      'subscript',
+      'var',
+      'let',
+      'is',
+      'as',
+      'in',
+      'where',
+      'some',
+      'any',
+      'async',
+      'await',
+      'import',
+      'static',
+      'final',
+      'lazy',
+      'weak',
+      'override',
+      'private',
+      'fileprivate',
+      'internal',
+      'public',
+      'open',
+      'self',
+      'super',
+      'nil',
+    ]),
+  },
+
+  symbols: {
+    callExpressionTypes: ['call_expression'],
+  },
+};

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -126,6 +126,7 @@ function propertyName(node: Parser.SyntaxNode): string | undefined {
 export class SwiftTraverser implements LanguageTraverser {
   targetNodeTypes = [
     'function_declaration',
+    'protocol_function_declaration', // abstract method requirements inside a protocol
     'init_declaration',
     'deinit_declaration',
     'subscript_declaration',
@@ -325,6 +326,7 @@ export class SwiftImportExtractor implements LanguageImportExtractor {
 export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
   readonly symbolNodeTypes = [
     'function_declaration',
+    'protocol_function_declaration',
     'init_declaration',
     'deinit_declaration',
     'subscript_declaration',
@@ -335,6 +337,7 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
   extractSymbol(node: Parser.SyntaxNode, content: string, parentClass?: string): SymbolInfo | null {
     switch (node.type) {
       case 'function_declaration':
+      case 'protocol_function_declaration':
       case 'init_declaration':
       case 'deinit_declaration':
       case 'subscript_declaration':

--- a/packages/parser/src/symbol-extractor.ts
+++ b/packages/parser/src/symbol-extractor.ts
@@ -439,6 +439,13 @@ function extractSwiftFunctions(content: string): string[] {
     names.add(match[1]);
   }
 
+  // init / deinit / subscript are function-like members (matches the AST symbol
+  // extractor). The negative lookbehind avoids `.init(...)` call sites.
+  const memberMatches = content.matchAll(/(?<![.\w])(init|deinit|subscript)\b/g);
+  for (const match of memberMatches) {
+    names.add(match[1]);
+  }
+
   return Array.from(names);
 }
 

--- a/packages/parser/src/symbol-extractor.ts
+++ b/packages/parser/src/symbol-extractor.ts
@@ -64,6 +64,11 @@ const LANGUAGE_EXTRACTORS: Record<string, LanguageExtractors> = {
     classes: extractKotlinClasses,
     interfaces: extractKotlinInterfaces,
   },
+  swift: {
+    functions: extractSwiftFunctions,
+    classes: extractSwiftClasses,
+    interfaces: extractSwiftInterfaces,
+  },
   rust: { functions: extractRustFunctions },
   rs: { functions: extractRustFunctions },
 };
@@ -416,6 +421,48 @@ function extractKotlinInterfaces(content: string): string[] {
   // Interface definitions: interface Name
   const interfaceMatches = content.matchAll(/\binterface\s+(\w+)/g);
   for (const match of interfaceMatches) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+}
+
+// Swift Functions
+function extractSwiftFunctions(content: string): string[] {
+  const names = new Set<string>();
+
+  // Function definitions: func name(...), public func name(...), func name<T>(...).
+  // Swift places generic parameters AFTER the name, so allow an optional `<…>`
+  // between the name and the parameter list.
+  const functionMatches = content.matchAll(/\bfunc\s+(\w+)\s*(?:<[^>]*>)?\s*\(/g);
+  for (const match of functionMatches) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+}
+
+function extractSwiftClasses(content: string): string[] {
+  const names = new Set<string>();
+
+  // Type definitions: class/struct/actor/enum/extension Name. The negative
+  // lookahead avoids capturing `func` from `class func` (a static method).
+  const typeMatches = content.matchAll(
+    /\b(?:class|struct|actor|enum|extension)\s+(?!func\b)(\w+)/g,
+  );
+  for (const match of typeMatches) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+}
+
+function extractSwiftInterfaces(content: string): string[] {
+  const names = new Set<string>();
+
+  // Protocol definitions: protocol Name
+  const protocolMatches = content.matchAll(/\bprotocol\s+(\w+)/g);
+  for (const match of protocolMatches) {
     names.add(match[1]);
   }
 

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -314,6 +314,10 @@ export function getCanonicalPath(filepath: string, workspaceRoot: string): strin
  * - latest/config.ts (contains "/test/" but isn't a test)
  * - mytest.ts (no `_` boundary before "test")
  *
+ * Swift uses different conventions (XCTest `FooTests.swift` files and a
+ * Swift Package Manager `Tests/` directory). Those checks are scoped to
+ * `.swift` paths so behavior for other languages is unchanged.
+ *
  * @param filepath - The file path to check
  * @returns True if the file is a test file
  */
@@ -321,6 +325,8 @@ export function isTestFile(filepath: string): boolean {
   return (
     /\.(test|spec)\.[^/]+$/.test(filepath) ||
     /_(test|spec)\.[^/]+$/.test(filepath) ||
-    /(^|[/\\])(test|tests|spec|specs|__tests__)[/\\]/.test(filepath)
+    /(^|[/\\])(test|tests|spec|specs|__tests__)[/\\]/.test(filepath) ||
+    (/\.swift$/.test(filepath) &&
+      (/Tests?\.swift$/.test(filepath) || /(^|[/\\])Tests?[/\\]/.test(filepath)))
   );
 }

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -36,12 +36,13 @@ function truncate(s: string, max: number): string {
 }
 
 /**
- * Parse a boolean-ish env flag. Only '1'/'true' (case-insensitive) enable —
- * `!!process.env.X` would treat 'false'/'0' as truthy and leak logs.
+ * Parse a boolean-ish env *disable* flag. Per-turn agent logging is ON by
+ * default; only an explicit '0'/'false' (case-insensitive) disables it.
+ * Parsed precisely so an unrelated value doesn't accidentally silence it.
  */
-function envEnabled(value: string | undefined): boolean {
+function envDisabled(value: string | undefined): boolean {
   const v = value?.trim().toLowerCase();
-  return v === '1' || v === 'true';
+  return v === '0' || v === 'false';
 }
 
 /** Extract the assistant's text content from an Anthropic response for trace. */
@@ -115,8 +116,9 @@ export class AnthropicAgentClient {
   private logger: Logger;
   private inputCostPerToken: number;
   private outputCostPerToken: number;
-  // Verbose per-turn reasoning/output logging, gated by env so normal runs
-  // stay readable. The last turn is always logged on an incomplete run.
+  // Verbose per-turn reasoning/output logging — ON by default so every review
+  // is diagnosable; set LIEN_REVIEW_LOG_AGENT=0 (or false) to silence it. The
+  // last turn is always logged on an incomplete run regardless.
   private logAgentTurns: boolean;
 
   constructor(options: AgentClientOptions) {
@@ -128,7 +130,7 @@ export class AnthropicAgentClient {
     this.maxTurns = options.maxTurns;
     this.maxTokenBudget = options.maxTokenBudget;
     this.logger = options.logger;
-    this.logAgentTurns = envEnabled(process.env.LIEN_REVIEW_LOG_AGENT);
+    this.logAgentTurns = !envDisabled(process.env.LIEN_REVIEW_LOG_AGENT);
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -40,12 +40,14 @@ function truncate(s: string, max: number): string {
 }
 
 /**
- * Parse a boolean-ish env flag. Only '1'/'true' (case-insensitive) enable —
- * `!!process.env.X` would treat 'false'/'0' as truthy and leak logs.
+ * Parse a boolean-ish env *disable* flag. Per-turn agent logging is ON by
+ * default (so every review is diagnosable); only an explicit '0'/'false'
+ * (case-insensitive) disables it. Parsed precisely so an unrelated value
+ * doesn't accidentally silence the trace.
  */
-export function envEnabled(value: string | undefined): boolean {
+export function envDisabled(value: string | undefined): boolean {
   const v = value?.trim().toLowerCase();
-  return v === '1' || v === 'true';
+  return v === '0' || v === 'false';
 }
 
 /**
@@ -181,9 +183,9 @@ export class OpenAIAgentClient {
   private logger: Logger;
   private inputCostPerToken: number;
   private outputCostPerToken: number;
-  // Verbose per-turn reasoning/output logging, gated by env so normal runs
-  // stay readable. The last turn's reasoning is always logged on an
-  // incomplete run (see below) regardless of this flag.
+  // Verbose per-turn reasoning/output logging — ON by default so every review
+  // is diagnosable; set LIEN_REVIEW_LOG_AGENT=0 (or false) to silence it. The
+  // last turn's reasoning is always logged on an incomplete run regardless.
   private logAgentTurns: boolean;
 
   constructor(options: OpenAIClientOptions) {
@@ -193,7 +195,7 @@ export class OpenAIAgentClient {
     this.maxTurns = options.maxTurns;
     this.maxTokenBudget = options.maxTokenBudget;
     this.logger = options.logger;
-    this.logAgentTurns = envEnabled(process.env.LIEN_REVIEW_LOG_AGENT);
+    this.logAgentTurns = !envDisabled(process.env.LIEN_REVIEW_LOG_AGENT);
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { OpenAIAgentClient, envEnabled } from '../src/plugins/agent/openai-client.js';
+import { OpenAIAgentClient, envDisabled } from '../src/plugins/agent/openai-client.js';
 import { AgentReviewPlugin, scaleBudgetForBlastRadius } from '../src/plugins/agent/index.js';
 import { scaleAgentBudget } from '../src/review-pr.js';
 import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
@@ -190,18 +190,18 @@ describe('OpenAIAgentClient budget handling', () => {
   }, 15000);
 });
 
-describe('envEnabled (LIEN_REVIEW_LOG_AGENT parsing)', () => {
-  it('enables only for 1/true (case-insensitive)', () => {
-    expect(envEnabled('1')).toBe(true);
-    expect(envEnabled('true')).toBe(true);
-    expect(envEnabled('TRUE')).toBe(true);
+describe('envDisabled (LIEN_REVIEW_LOG_AGENT parsing — logging on by default)', () => {
+  it('disables only for 0/false (case-insensitive)', () => {
+    expect(envDisabled('0')).toBe(true);
+    expect(envDisabled('false')).toBe(true);
+    expect(envDisabled('FALSE')).toBe(true);
   });
 
-  it('does not enable for falsey strings (the !! bug)', () => {
-    expect(envEnabled('false')).toBe(false);
-    expect(envEnabled('0')).toBe(false);
-    expect(envEnabled('')).toBe(false);
-    expect(envEnabled(undefined)).toBe(false);
+  it('stays enabled (not disabled) for everything else, incl. unset', () => {
+    expect(envDisabled('1')).toBe(false);
+    expect(envDisabled('true')).toBe(false);
+    expect(envDisabled('')).toBe(false);
+    expect(envDisabled(undefined)).toBe(false);
   });
 });
 

--- a/packages/site/docs/guide/index.md
+++ b/packages/site/docs/guide/index.md
@@ -87,9 +87,10 @@ Lien is built with modern, performant tools:
 - C#
 - Ruby
 - Kotlin
+- Swift
 
 **Semantic Search** (chunking and embeddings):
-- All of the above, plus Vue, Liquid, C/C++, Swift, Scala, Markdown
+- All of the above, plus Vue, Liquid, C/C++, Scala, Markdown
 
 ## Next Steps
 

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -82,9 +82,10 @@ Lien indexes and understands code in:
 - C#
 - Ruby
 - Kotlin
+- Swift
 
 **Semantic Search** (chunking and embeddings):
-- All of the above, plus C/C++, Vue, Swift, Scala, and more!
+- All of the above, plus C/C++, Vue, Scala, and more!
 
 ## Complexity Analysis
 


### PR DESCRIPTION
## What

Upgrades **Swift** from line-based chunking to full Tree-sitter AST parsing — symbols, imports, call sites, complexity, and test associations — bringing it in line with the other AST languages (now **11**: TS, JS, PHP, Python, Rust, Go, Java, C#, Ruby, Kotlin, **Swift**). Follows the Ruby (0.46.0) / Kotlin (0.47.0) playbook.

This is **PR 1 of the arc** (AST support). PR 2 will add the e2e project + docs-site move + changeset (the changeset auto-triggers the full e2e suite and opens the release).

## Grammar

`tree-sitter-swift@^0.7.1` (alex-pinkus). Loads against the repo's `tree-sitter@0.25.0`; ships prebuilds for all 6 target platforms (incl. linux-x64/arm64 for CI) so there's **no native compile**.

Unlike Kotlin, the grammar exposes field names (`name`/`body`/`return_type`/`declaration_kind`), so `swift.ts` follows the `java.ts` field-based pattern. Swift-specific handling:
- `class` / `struct` / `actor` / `enum` / `extension` all share **one** `class_declaration` node, distinguished by the `declaration_kind` keyword → all map to `SymbolInfo.type: class` with the real keyword kept in the signature (`struct Foo`, `enum Color`, `extension AFError`).
- `protocol_declaration` → `interface` (its `protocol_function_declaration` members are abstract → not chunked).
- `init` / `deinit` / `subscript` are methods.
- Only the `Swift` stdlib module is filtered from imports; `Foundation`/`UIKit`/`Combine`/etc. are kept as real edges.
- `isTestFile` now recognises Swift conventions (`Tests/` dirs, `*Tests.swift`), **scoped to `.swift`** so other languages are unchanged (updated in both the parser and core copies).

## Validation

- ✅ `npm run typecheck` / `lint` / `format:check` / `build` (parser + core) clean
- ✅ Full parser suite **852 tests** green (28 new Swift cases + registry flips), no regressions
- ✅ **Dogfood on Alamofire**: 98 files, **0 parse errors**, 3183 chunks (~15.6ms/file). Symbol mix: 523 class / 1645 method (all with `parentClass`) / 116 function / 27 interface. Imports correctly capture Foundation/UIKit/Combine/XCTest and filter `Swift`; 44 test files detected.

## ⚠️ Distribution decision needed before merge

`tree-sitter-swift` declares **`tree-sitter-cli@^0.23` as a hard runtime `dependency`** (plus `which`). `tree-sitter-cli` has an `install` script that downloads a ~Rust binary from GitHub — it's the parser *generator* and is **unused at runtime** (the grammar loads from bundled prebuilds). Every Swift grammar version since 0.3.x has this.

- Our lockfile is hand-edited to add only `tree-sitter-swift` + `tree-sitter-cli` while preserving the dual `tree-sitter` 0.21/0.25 topology (`node-addon-api@8`/`node-gyp-build`/`which` already resolve at root). CI `npm ci` is the authoritative validator.
- **However**, our lockfile can't shield **end users**: `npm install @liendev/lien` re-resolves from published manifests, so consumers would also pull `tree-sitter-cli` + its binary download.

**Options** (let's decide before merging the release PR): (a) accept it — it's how the ecosystem ships Swift; (b) publish/vendor a lean fork of the grammar with `tree-sitter-cli` moved to devDeps; (c) defer Swift. This PR's CI run will also tell us whether the `tree-sitter-cli` install is reliable in CI.

No AST-supported-language docs-site change or changeset here — that's PR 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full Swift (`.swift`) AST support, including AST-based chunking, symbol extraction, import/export extraction, and language detection.
  * Swift is now included in supported-language listings across the product docs.
  * E2E coverage expanded with the Swift SwiftyJSON real-project scenario.
* **Bug Fixes**
  * Improved Swift test-file recognition and aligned unsupported-language expectations in the test suite.
* **Documentation**
  * Updated guide pages to reflect Swift under Full AST Support rather than Semantic Search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 1 new function is too complex.
🔗 **Impact**: 1 high-risk file(s) with 3 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +16 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 2 | +0 |
| 🐛 estimated bugs | 2 | +0 |


> [!WARNING]
> **3 issues found** · High Risk
>
> This PR adds full Tree-sitter AST support for Swift, which is broad but generally follows established language patterns and is well covered by tests. However, it also contains an unrelated, unannounced breaking change in the agent clients that flips LIEN_REVIEW_LOG_AGENT from opt-in to opt-on, which can leak sensitive review content into logs for existing users. Additionally, Swift constructor call sites are not semantically linked to the init method symbols the extractor creates, weakening dependency graphs for Swift code.
>
> - Added Swift language definition with AST traverser, export/import/symbol extractors, and complexity configuration
> - Flipped default for LIEN_REVIEW_LOG_AGENT from disabled to enabled in both Anthropic and OpenAI agent clients
> - Added Swift test-file detection in parser path-matching and core boosting strategies

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7dd83d3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->