### PR TITLE
test(parser): document + lock in Swift constructor-call linkage

### DIFF
--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -241,6 +241,23 @@ describe('Swift Language', () => {
       expect(names).toContain('foo');
       expect(names).toContain('baz');
     });
+
+    it('links constructor calls to the type symbol, explicit .init() to init', () => {
+      // Swift initialization is `Foo(...)` (no `new`): the callee is the type
+      // name, so the call links to the type's class symbol (as JS does for
+      // `new Foo()`). An explicit `T.init()` links the initializer directly.
+      const src =
+        'func run() {\n' +
+        '  let a = Foo()\n' + // bare constructor -> type symbol
+        '  let b = Namespace.Widget(x: 1)\n' + // qualified constructor -> type symbol
+        '  let c = T.init()\n' + // explicit initializer -> init symbol
+        '}\n';
+      const calls = findAllNodes(parse(src), 'call_expression');
+      const names = calls.map(c => symbolExtractor.extractCallSite(c)?.symbol).filter(Boolean);
+      expect(names).toContain('Foo');
+      expect(names).toContain('Widget');
+      expect(names).toContain('init');
+    });
   });
 
   // ===========================================================================

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -351,6 +351,21 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
     }
   }
 
+  /**
+   * Resolve a call site to the called symbol name. Dependency matching is by
+   * bare name (call.symbol === symbol.name), so the name we record determines
+   * which definition the call links to.
+   *
+   * Constructor calls are worth a note: Swift spells initialization `Foo(...)`
+   * (no `new`), so the callee is the type name and we record `Foo` — linking the
+   * call to the type's `class_declaration` symbol, exactly as JS records
+   * `new Foo()` against the class and Python records `Foo()`. So blast-radius for
+   * "who constructs Foo" is found via the TYPE symbol (a safe over-approximation),
+   * not the `init` method symbol. An explicit `Foo.init()` records `init` and
+   * links the initializer directly. The standalone `init`/`deinit`/`subscript`
+   * symbols are definitions for search/listing (as Java emits constructor
+   * symbols); they intentionally carry no implicit-`Foo()` caller edges.
+   */
   extractCallSite(node: Parser.SyntaxNode): { symbol: string; line: number; key: string } | null {
     if (node.type !== 'call_expression') return null;
     const line = node.startPosition.row + 1;
@@ -360,9 +375,10 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
 
     let name: string | undefined;
     if (callee.type === 'simple_identifier') {
-      name = callee.text; // foo()
+      name = callee.text; // foo() / Foo() constructor — links to the fn or type symbol
     } else if (callee.type === 'navigation_expression') {
-      // a.b.c() — the called member is the simple_identifier in the last navigation_suffix
+      // a.b.c() / Mod.Type() / Type.init() — the called member is the
+      // simple_identifier in the last navigation_suffix
       const suffix = callee.namedChildren.filter(c => c.type === 'navigation_suffix').at(-1);
       name = suffix ? (findFirst(suffix, 'simple_identifier')?.text ?? undefined) : undefined;
     }


### PR DESCRIPTION
**Follow-up to #606** (stacked on `worktree-swift-ast`; GitHub will retarget this to `main` once #606 merges).

Addresses the agent-review finding on `SwiftSymbolExtractor.extractCallSite` (constructor calls vs the `init` method symbol).

## Investigation

Traced how call sites link to symbols: `dependency-analyzer.ts` matches **by bare name** (`call.symbol === targetSymbol`) — call sites carry no `parentClass`/qualifier. Cross-language precedent:
- **JavaScript** records `new Foo()` as `{symbol: 'Foo'}` → links to the **class** symbol (no `init`-named symbol exists).
- **Java** emits constructor symbols that are **orphaned** (object-creation calls aren't linked) — an accepted gap.

Verified Swift's actual behavior across many forms: `Foo()`, `Foo(x:1)`, `Namespace.Widget()`, `Foo.Bar.Baz()`, `Optional(5)`, `String(describing:)` all record the **type name** → link to the type's class symbol; `T.init()` records **`init`** → links the initializer directly. (`[Int]()` array-literal is the only dropped form — no useful symbol anyway.)

**So the finding's premise is largely already handled:** "who constructs `Foo`" is discoverable via the **type** symbol (a safe blast-radius over-approximation, exactly like JS), and explicit `.init()` via the `init` symbol. A heuristic that recorded `init` for bare `Foo()` would *regress* this (break the type linkage; `init` is ambiguous across all types) and diverge from JS/Java.

## Change

No behavior change (so no changeset):
- **Document** the constructor-call design on `extractCallSite`.
- **Add tests** locking it in (`Foo()` → type, `Namespace.Widget()` → type, `T.init()` → init) — closes the agent's "no constructor-call assertion" evidence.
- `init`/`deinit`/`subscript` remain definition symbols (as Java emits constructor symbols) for search/listing.

If you'd prefer init-method-level granularity (so `get_dependents({symbol:'init'})` finds implicit `Foo()` callers), that needs call-graph infra changes (multi-symbol or qualified `Type.init` edges) across all languages — happy to scope that separately, but I'd recommend against it given the type-level query already covers blast-radius.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fdd30fc. Updates automatically on new commits.</sup>
<!-- /lien-stats -->