### PR TITLE
perf(review): tune verdict turn to stop rambling/truncating

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -339,6 +339,19 @@ function appendIncompleteNotice(
 // Finding mapping
 // ---------------------------------------------------------------------------
 
+/**
+ * Cap free-text finding fields. A verbose model (Kimi) can dump a multi-thousand
+ * character stream-of-consciousness into a single `message`/`evidence`, which
+ * both bloats the PR comment and risks truncating the whole verdict JSON. Trim
+ * to a readable length at the display boundary.
+ */
+const MAX_FINDING_TEXT_CHARS = 1200;
+
+export function clampText(text: string | undefined): string | undefined {
+  if (!text || text.length <= MAX_FINDING_TEXT_CHARS) return text;
+  return `${text.slice(0, MAX_FINDING_TEXT_CHARS - 1).trimEnd()}…`;
+}
+
 function mapToReviewFinding(f: AgentFinding, pluginId: string): ReviewFinding {
   return {
     pluginId,
@@ -348,9 +361,9 @@ function mapToReviewFinding(f: AgentFinding, pluginId: string): ReviewFinding {
     symbolName: f.symbolName,
     severity: f.severity,
     category: f.category,
-    message: f.message,
-    suggestion: f.suggestion,
-    evidence: f.evidence,
+    message: clampText(f.message) ?? f.message,
+    suggestion: clampText(f.suggestion),
+    evidence: clampText(f.evidence),
     ...(f.ruleId ? { metadata: { ruleId: f.ruleId } } : {}),
   };
 }

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -509,9 +509,15 @@ export class OpenAIAgentClient {
     const body: Record<string, unknown> = {
       model: this.model,
       messages,
-      max_tokens: 16384,
+      // Headroom so a multi-finding verdict completes instead of truncating
+      // mid-JSON (a truncated verdict is unparseable and wastes the whole run).
+      max_tokens: 24_576,
       temperature: 0,
-      reasoning: { effort: 'high' },
+      // High reasoning drives investigation quality, but on the forced-verdict
+      // turn the findings are already decided — high effort there just makes the
+      // model re-reason and ramble into the JSON (blowing the output cap). Use
+      // low effort to emit the verdict concisely.
+      reasoning: { effort: forceVerdict ? 'low' : 'high' },
     };
     if (forceVerdict) {
       // Force a JSON verdict (no tools). response_format:json_object makes the

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { OpenAIAgentClient, envDisabled } from '../src/plugins/agent/openai-client.js';
-import { AgentReviewPlugin, scaleBudgetForBlastRadius } from '../src/plugins/agent/index.js';
+import {
+  AgentReviewPlugin,
+  scaleBudgetForBlastRadius,
+  clampText,
+} from '../src/plugins/agent/index.js';
 import { scaleAgentBudget } from '../src/review-pr.js';
 import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
 import { silentLogger } from '../src/test-helpers.js';
@@ -165,6 +169,11 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(bodies[0].response_format).toBeUndefined();
     expect(bodies[1].tools).toBeUndefined(); // turn 2 forced: no tools
     expect(bodies[1].response_format).toEqual({ type: 'json_object' });
+    // Investigation turn reasons hard; the forced-verdict turn drops to low
+    // effort (findings already decided) so it emits the JSON without rambling.
+    expect(bodies[0].reasoning).toEqual({ effort: 'high' });
+    expect(bodies[1].reasoning).toEqual({ effort: 'low' });
+    expect(bodies[0].max_tokens).toBe(24_576);
   });
 
   it('recovers a verdict via the json-forced summary-retry after a bail', async () => {
@@ -435,5 +444,19 @@ describe('AgentReviewPlugin.present — incomplete review', () => {
     const summary = appendSummary.mock.calls[0][0] as string;
     expect(summary).toContain('Review incomplete');
     expect(summary).not.toContain('No issues found');
+  });
+});
+
+describe('clampText (finding free-text cap)', () => {
+  it('leaves short text unchanged', () => {
+    expect(clampText('short message')).toBe('short message');
+    expect(clampText(undefined)).toBeUndefined();
+  });
+
+  it('truncates an over-long message with an ellipsis', () => {
+    const long = 'x'.repeat(5000);
+    const out = clampText(long)!;
+    expect(out.length).toBeLessThanOrEqual(1200);
+    expect(out.endsWith('…')).toBe(true);
   });
 });

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -459,4 +459,13 @@ describe('clampText (finding free-text cap)', () => {
     expect(out.length).toBeLessThanOrEqual(1200);
     expect(out.endsWith('…')).toBe(true);
   });
+
+  it('keeps text exactly at the cap and truncates one over', () => {
+    // Boundary: 1200 chars passes through unchanged; 1201 is truncated. Guards
+    // against a `<= 1200` → `< 1200` regression silently clipping at-cap text.
+    expect(clampText('y'.repeat(1200))).toBe('y'.repeat(1200));
+    const over = clampText('y'.repeat(1201))!;
+    expect(over.length).toBeLessThanOrEqual(1200);
+    expect(over.endsWith('…')).toBe(true);
+  });
 });


### PR DESCRIPTION
**Follow-up #3** — the verdict/output budget tuning we discussed (stacked on #608; GitHub retargets it up the chain as the parents merge).

## Why
On #608's own review runs, Kimi dumped a multi-thousand-char stream-of-consciousness into a single finding `message`, which (a) hit the per-turn output cap **mid-JSON** → unparseable verdict → wasted run, and (b) posted a 4,087-char wall-of-text finding. (#608 already makes that degrade gracefully to an "incomplete" notice; this reduces how often it happens and cleans up the output.)

## Changes (output-side, no rule/prompt change → no harness calibration)
- **Forced-verdict turn: reasoning effort `high` → `low`.** By the verdict turn the findings are already decided; high effort just makes the model re-reason and ramble into the JSON. Investigation turns keep `high` effort, so bug-finding quality is unchanged.
- **`max_tokens` 16384 → 24576**, so a multi-finding verdict completes instead of truncating.
- **Cap finding `message`/`suggestion`/`evidence` at 1200 chars** (`clampText`) at the display boundary — a verbose model can't post a wall of text.

## Tests
391 review tests pass, including: the forced-verdict turn uses `{effort:'low'}` while the investigation turn uses `{effort:'high'}` and `max_tokens` is 24576; `clampText` leaves short text alone and truncates long text with an ellipsis.

## Explicitly out of scope (harness-gated follow-ups)
- **Input-context budget** (`scaleAgentBudget` turn/token limits) — tuning these affects how much the agent investigates, so it needs harness validation rather than guessed numbers.
- **Prompt-level conciseness** (instructing concise finding messages at the source) — a prompt change that should go through `npm run test:harness --calibrate`.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 3 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 3 | +1 |
| ⏱️ time to understand | 6 | +0 |
| 🐛 estimated bugs | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR tunes the OpenAI-compatible agent client's output behavior to reduce rambling and truncation: it raises max_tokens to 24,576, drops reasoning effort to 'low' only on the forced-verdict turn, and caps finding free-text fields at 1,200 characters via the new clampText helper. The changed code is straightforward and the tests cover the key boundaries (exactly 1200 vs. 1201 characters, reasoning effort switching, and max_tokens value). No callers are broken and no logic errors were found.
>
> - OpenAI client: max_tokens 16384 → 24576; reasoning effort switches to 'low' on forced-verdict turns while investigation turns remain 'high'
> - New clampText helper caps finding message/suggestion/evidence to 1200 characters at the display boundary

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e79011d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->