### PR TITLE
test(parser): document + lock in Swift constructor-call linkage

### DIFF
--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -241,6 +241,23 @@ describe('Swift Language', () => {
       expect(names).toContain('foo');
       expect(names).toContain('baz');
     });
+
+    it('links constructor calls to the type symbol, explicit .init() to init', () => {
+      // Swift initialization is `Foo(...)` (no `new`): the callee is the type
+      // name, so the call links to the type's class symbol (as JS does for
+      // `new Foo()`). An explicit `T.init()` links the initializer directly.
+      const src =
+        'func run() {\n' +
+        '  let a = Foo()\n' + // bare constructor -> type symbol
+        '  let b = Namespace.Widget(x: 1)\n' + // qualified constructor -> type symbol
+        '  let c = T.init()\n' + // explicit initializer -> init symbol
+        '}\n';
+      const calls = findAllNodes(parse(src), 'call_expression');
+      const names = calls.map(c => symbolExtractor.extractCallSite(c)?.symbol).filter(Boolean);
+      expect(names).toContain('Foo');
+      expect(names).toContain('Widget');
+      expect(names).toContain('init');
+    });
   });
 
   // ===========================================================================

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -351,6 +351,21 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
     }
   }
 
+  /**
+   * Resolve a call site to the called symbol name. Dependency matching is by
+   * bare name (call.symbol === symbol.name), so the name we record determines
+   * which definition the call links to.
+   *
+   * Constructor calls are worth a note: Swift spells initialization `Foo(...)`
+   * (no `new`), so the callee is the type name and we record `Foo` — linking the
+   * call to the type's `class_declaration` symbol, exactly as JS records
+   * `new Foo()` against the class and Python records `Foo()`. So blast-radius for
+   * "who constructs Foo" is found via the TYPE symbol (a safe over-approximation),
+   * not the `init` method symbol. An explicit `Foo.init()` records `init` and
+   * links the initializer directly. The standalone `init`/`deinit`/`subscript`
+   * symbols are definitions for search/listing (as Java emits constructor
+   * symbols); they intentionally carry no implicit-`Foo()` caller edges.
+   */
   extractCallSite(node: Parser.SyntaxNode): { symbol: string; line: number; key: string } | null {
     if (node.type !== 'call_expression') return null;
     const line = node.startPosition.row + 1;
@@ -360,9 +375,10 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
 
     let name: string | undefined;
     if (callee.type === 'simple_identifier') {
-      name = callee.text; // foo()
+      name = callee.text; // foo() / Foo() constructor — links to the fn or type symbol
     } else if (callee.type === 'navigation_expression') {
-      // a.b.c() — the called member is the simple_identifier in the last navigation_suffix
+      // a.b.c() / Mod.Type() / Type.init() — the called member is the
+      // simple_identifier in the last navigation_suffix
       const suffix = callee.namedChildren.filter(c => c.type === 'navigation_suffix').at(-1);
       name = suffix ? (findFirst(suffix, 'simple_identifier')?.text ?? undefined) : undefined;
     }


### PR DESCRIPTION
Follow-up to the merged Swift AST support (was #607; reopened fresh after the stacked base branch was deleted on merge).

Documents the constructor-call design in `SwiftSymbolExtractor.extractCallSite` and locks it in with tests: `Foo()` records the type name → links to the type's class symbol (like JS `new Foo()`); `T.init()` records `init`. No behavior change, no changeset. 30 Swift tests pass.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR only adds documentation (a JSDoc comment) and a unit test locking in existing behavior for Swift constructor-call linkage. The implementation of `SwiftSymbolExtractor.extractCallSite` is unchanged; it already records `Foo` for `Foo()` / `Namespace.Widget()` and `init` for `T.init()`. No callers are affected and no runtime behavior changes.
>
> - Added a JSDoc comment documenting the Swift constructor-call design and why `Foo()` links to the type symbol.
> - Added a unit test verifying `Foo()`, `Namespace.Widget(x: 1)`, and `T.init()` resolve to the expected symbols.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3f1cd89. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Swift call sites are matched to symbols in parsing notes, including constructor and initializer cases.

* **Tests**
  * Added coverage for Swift call-site symbol extraction.
  * Verified that bare and qualified constructors link to the type symbol, while explicit `init` calls link to the initializer symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->