### PR TITLE
fix(review): harden agent-review against flaky-provider failures

### DIFF
--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -535,28 +535,37 @@ function extractResponse(content: Anthropic.Messages.ContentBlock[]): {
   // so the verdict may not live in the last one.
   const text = textBlocks.map(b => b.text).join('\n');
 
-  // Try, in order: a ```json fence (normal turns); the raw body (a forced
-  // verdict turn may emit bare JSON); and a JSON object embedded in prose. The
-  // last guards against a model that prefixed reasoning — without it that turn
-  // parses to an empty result and the run is silently treated as clean.
-  const fenced = text.match(/```json\s*\n([\s\S]*?)\n\s*```/)?.[1];
-  const candidates = [fenced, text.trim(), embeddedJsonObject(text)];
+  // Candidate JSON strings, in priority order: each ```json fence LAST first (a
+  // few-shot/example fence precedes the real verdict), then the raw body, then a
+  // JSON object embedded in prose. Prefer a candidate carrying a `summary` (the
+  // verdict marker) so an example can't beat the real verdict; fall back to the
+  // first findings-only candidate if nothing carries a summary.
+  const fences = [...text.matchAll(/```json\s*\n([\s\S]*?)\n\s*```/g)].map(m => m[1]).reverse();
+  const candidates = [...fences, text.trim(), embeddedJsonObject(text)];
 
+  let fallback: { findings: AgentFinding[] } | undefined;
   for (const candidate of candidates) {
     if (!candidate) continue;
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(candidate);
-      const rawFindings = Array.isArray(parsed) ? parsed : parsed.findings;
-      const findings: unknown[] = Array.isArray(rawFindings) ? rawFindings : [];
-      const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
-      if (summary || findings.length > 0) {
-        return { findings: findings.filter(isValidFinding), summary };
-      }
+      parsed = JSON.parse(candidate);
     } catch {
-      // not parseable — try the next candidate
+      continue; // not parseable — try the next candidate
     }
+    const { findings, summary } = readVerdict(parsed);
+    if (summary) return { findings, summary };
+    if (findings.length > 0 && !fallback) fallback = { findings };
   }
-  return { findings: [] };
+  return fallback ?? { findings: [] };
+}
+
+/** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
+function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
+  const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
+  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
+  const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
+  return { findings, summary };
 }
 
 /** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -300,13 +300,15 @@ export class AnthropicAgentClient {
     const cost =
       totalInputTokens * this.inputCostPerToken + totalOutputTokens * this.outputCostPerToken;
 
-    // Incomplete = the loop bailed on a limit (or error) AND never produced a
-    // verdict (no summary, even after the retry). Such a run must not be shown
-    // as a clean review.
-    const incomplete = stopReason !== 'completed' && !parsed.summary;
+    // Incomplete = the agent never produced a structured verdict (no summary,
+    // even after the retry). A genuine clean review always carries a summary, so
+    // the ABSENCE of one — not the stop reason — is what marks a run incomplete.
+    // This also catches an `end_turn` that emitted prose instead of the findings
+    // JSON: that must NOT be reported as a clean 0-findings review.
+    const incomplete = !parsed.summary;
     if (incomplete) {
       this.logger.warning(
-        `[agent] Review incomplete (stopReason=${stopReason}, no summary after ${turn} turns)`,
+        `[agent] Review incomplete (stopReason=${stopReason}, no verdict/summary after ${turn} turns)`,
       );
       // Always surface what the agent was doing when it bailed.
       this.logTurn(lastLoopTurn, 'last turn before bail');
@@ -528,21 +530,34 @@ function extractResponse(content: Anthropic.Messages.ContentBlock[]): {
 
   const text = textBlocks[textBlocks.length - 1].text;
 
-  const jsonMatch = text.match(/```json\s*\n([\s\S]*?)\n\s*```/);
-  if (!jsonMatch) {
-    return { findings: [] };
+  // Try, in order: a ```json fence (normal turns); the raw body (a forced
+  // verdict turn may emit bare JSON); and a JSON object embedded in prose. The
+  // last guards against a model that prefixed reasoning — without it that turn
+  // parses to an empty result and the run is silently treated as clean.
+  const fenced = text.match(/```json\s*\n([\s\S]*?)\n\s*```/)?.[1];
+  const candidates = [fenced, text.trim(), embeddedJsonObject(text)];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const parsed = JSON.parse(candidate);
+      const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
+      const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
+      if (summary || findings.length > 0) {
+        return { findings: findings.filter(isValidFinding), summary };
+      }
+    } catch {
+      // not parseable — try the next candidate
+    }
   }
+  return { findings: [] };
+}
 
-  try {
-    const parsed = JSON.parse(jsonMatch[1]);
-
-    const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
-    const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
-
-    return { findings: findings.filter(isValidFinding), summary };
-  } catch {
-    return { findings: [] };
-  }
+/** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */
+function embeddedJsonObject(content: string): string | undefined {
+  const start = content.indexOf('{');
+  const end = content.lastIndexOf('}');
+  return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
 }
 
 /** Type guard to validate a summary object. */

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -528,7 +528,9 @@ function extractResponse(content: Anthropic.Messages.ContentBlock[]): {
     return { findings: [] };
   }
 
-  const text = textBlocks[textBlocks.length - 1].text;
+  // Concatenate ALL text blocks — Anthropic can split a response across blocks,
+  // so the verdict may not live in the last one.
+  const text = textBlocks.map(b => b.text).join('\n');
 
   // Try, in order: a ```json fence (normal turns); the raw body (a forced
   // verdict turn may emit bare JSON); and a JSON object embedded in prose. The
@@ -541,7 +543,8 @@ function extractResponse(content: Anthropic.Messages.ContentBlock[]): {
     if (!candidate) continue;
     try {
       const parsed = JSON.parse(candidate);
-      const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
+      const rawFindings = Array.isArray(parsed) ? parsed : parsed.findings;
+      const findings: unknown[] = Array.isArray(rawFindings) ? rawFindings : [];
       const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
       if (summary || findings.length > 0) {
         return { findings: findings.filter(isValidFinding), summary };

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -348,14 +348,17 @@ export class AnthropicAgentClient {
   private logTurn(turn: TurnTrace | undefined, label?: string): void {
     if (!turn) return;
     const tag = label ? ` (${label})` : '';
-    if (turn.reasoning) {
+    // Guard on trimmed content: tool-call turns emit tool calls (logged
+    // separately) and often whitespace-only text, which would otherwise print
+    // a blank, confusing "output:" line.
+    if (turn.reasoning?.trim()) {
       this.logger.info(
-        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning, AGENT_LOG_MAX)}`,
+        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning.trim(), AGENT_LOG_MAX)}`,
       );
     }
-    if (turn.responseText) {
+    if (turn.responseText?.trim()) {
       this.logger.info(
-        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText, AGENT_LOG_MAX)}`,
+        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText.trim(), AGENT_LOG_MAX)}`,
       );
     }
   }

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -318,10 +318,12 @@ function appendIncompleteNotice(
       ? 'hit the token budget limit'
       : result.stopReason === 'max_turns'
         ? 'hit the turn limit'
-        : 'stopped unexpectedly';
+        : result.stopReason === 'completed'
+          ? 'ended without emitting a parseable JSON verdict'
+          : 'stopped unexpectedly';
   const message =
-    `Lien Review did not finish — it ${reason} while investigating and stopped before ` +
-    `producing a verdict. Any findings shown are partial; re-run the review to retry.`;
+    `Lien Review did not finish — it ${reason} while investigating. ` +
+    `Any findings shown are partial; re-run the review to retry.`;
   findings.push({
     pluginId,
     filepath: '',

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -42,8 +42,26 @@ const RETRY_NUDGE =
  */
 const CHAT_MAX_ATTEMPTS = 3;
 const CHAT_RETRY_BASE_DELAY_MS = 500;
+/** Per-request abort timeout. A hung connection otherwise stalls a turn for
+ * minutes before fetch eventually rejects; abort + retry recovers faster. */
+const CHAT_REQUEST_TIMEOUT_MS = 120_000;
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/** fetch with an abort timeout so a hung connection rejects (and is retried). */
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
@@ -238,7 +256,19 @@ export class OpenAIAgentClient {
     while (turn < this.maxTurns) {
       turn++;
 
-      const response = await this.chatCompletion(messages, tools, forceFinish);
+      let response: ChatResponse;
+      try {
+        response = await this.chatCompletion(messages, tools, forceFinish);
+      } catch (err) {
+        // Transient failures are already retried inside chatCompletion; a throw
+        // here means it gave up. End the run gracefully (stopReason 'error' → no
+        // summary → incomplete notice) rather than crashing the whole plugin.
+        this.logger.warning(
+          `[agent] chat request failed after retries (${err instanceof Error ? err.message : String(err)}); ending run`,
+        );
+        stopReason = 'error';
+        break;
+      }
 
       const turnInputTokens = response.usage?.prompt_tokens ?? 0;
       const turnOutputTokens = response.usage?.completion_tokens ?? 0;
@@ -506,16 +536,31 @@ export class OpenAIAgentClient {
     for (let attempt = 1; attempt <= CHAT_MAX_ATTEMPTS; attempt++) {
       if (attempt > 1) await sleep(CHAT_RETRY_BASE_DELAY_MS * (attempt - 1));
 
-      const response = await fetch(`${this.baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.apiKey}`,
-          'HTTP-Referer': 'https://lien.dev',
-          'X-Title': 'Lien Review',
-        },
-        body: JSON.stringify(body),
-      });
+      let response: Response;
+      try {
+        response = await fetchWithTimeout(
+          `${this.baseUrl}/chat/completions`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${this.apiKey}`,
+              'HTTP-Referer': 'https://lien.dev',
+              'X-Title': 'Lien Review',
+            },
+            body: JSON.stringify(body),
+          },
+          CHAT_REQUEST_TIMEOUT_MS,
+        );
+      } catch (err) {
+        // fetch() rejected: a network error, or our abort timeout firing on a
+        // hung connection. Both are transient — retry.
+        lastError = new Error(
+          `Request to ${this.model} failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        this.logger.warning(`[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`);
+        continue;
+      }
 
       if (!response.ok) {
         const err = await response.text();
@@ -596,7 +641,8 @@ function extractResponse(content: string | null): {
     if (!candidate) continue;
     try {
       const parsed = JSON.parse(candidate);
-      const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
+      const rawFindings = Array.isArray(parsed) ? parsed : parsed.findings;
+      const findings: unknown[] = Array.isArray(rawFindings) ? rawFindings : [];
       const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
       // Accept only a candidate that yields a real verdict or findings, so an
       // empty `{}` earlier in the prose doesn't mask the actual JSON later.

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -629,37 +629,46 @@ export function toOpenAITools(
 // Response parsing (same as anthropic-client.ts)
 // ---------------------------------------------------------------------------
 
+/** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
+function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
+  const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
+  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
+  const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
+  return { findings, summary };
+}
+
 function extractResponse(content: string | null): {
   findings: AgentFinding[];
   summary?: AgentSummary;
 } {
   if (!content) return { findings: [] };
 
-  // Try, in order: a ```json fence (normal turns); the raw body
-  // (response_format:json_object on a forced-verdict turn); and finally a JSON
-  // object embedded in surrounding prose. The last guards against a model that
-  // ignored json_object and prefixed reasoning — without it that turn parses to
-  // an empty result and the run is silently treated as a clean 0-findings review.
-  const fenced = content.match(/```json\s*\n([\s\S]*?)\n\s*```/)?.[1];
-  const candidates = [fenced, content.trim(), embeddedJsonObject(content)];
+  // Candidate JSON strings, in priority order:
+  //  1. each ```json fence, LAST first — the model emits its verdict last, so a
+  //     few-shot/example fence earlier in the prose must not win;
+  //  2. the raw body (response_format:json_object forced-verdict turn);
+  //  3. a JSON object embedded in surrounding prose (model ignored json_object).
+  const fences = [...content.matchAll(/```json\s*\n([\s\S]*?)\n\s*```/g)].map(m => m[1]).reverse();
+  const candidates = [...fences, content.trim(), embeddedJsonObject(content)];
 
+  // Prefer a candidate carrying a `summary` (the verdict marker) so an
+  // `{"findings": [...]}`-only example can't beat the real verdict; fall back to
+  // the first findings-only candidate if nothing carries a summary.
+  let fallback: { findings: AgentFinding[] } | undefined;
   for (const candidate of candidates) {
     if (!candidate) continue;
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(candidate);
-      const rawFindings = Array.isArray(parsed) ? parsed : parsed.findings;
-      const findings: unknown[] = Array.isArray(rawFindings) ? rawFindings : [];
-      const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
-      // Accept only a candidate that yields a real verdict or findings, so an
-      // empty `{}` earlier in the prose doesn't mask the actual JSON later.
-      if (summary || findings.length > 0) {
-        return { findings: findings.filter(isValidFinding), summary };
-      }
+      parsed = JSON.parse(candidate);
     } catch {
-      // not parseable — try the next candidate
+      continue; // not parseable — try the next candidate
     }
+    const { findings, summary } = readVerdict(parsed);
+    if (summary) return { findings, summary };
+    if (findings.length > 0 && !fallback) fallback = { findings };
   }
-  return { findings: [] };
+  return fallback ?? { findings: [] };
 }
 
 /** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -35,6 +35,16 @@ const WRAP_UP_NUDGE =
 const RETRY_NUDGE =
   'You ran out of budget. Output ONLY the JSON block now with your findings and summary. No tool calls.';
 
+/**
+ * Transient-failure retry for the chat endpoint. OpenRouter/Kimi intermittently
+ * returns a 200 with an empty/truncated body (which makes JSON parsing throw
+ * "Unexpected end of JSON input"), or a 429/5xx — both recover on a retry.
+ */
+const CHAT_MAX_ATTEMPTS = 3;
+const CHAT_RETRY_BASE_DELAY_MS = 500;
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
 }
@@ -492,23 +502,54 @@ export class OpenAIAgentClient {
       body.tools = tools;
     }
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.apiKey}`,
-        'HTTP-Referer': 'https://lien.dev',
-        'X-Title': 'Lien Review',
-      },
-      body: JSON.stringify(body),
-    });
+    let lastError: Error | undefined;
+    for (let attempt = 1; attempt <= CHAT_MAX_ATTEMPTS; attempt++) {
+      if (attempt > 1) await sleep(CHAT_RETRY_BASE_DELAY_MS * (attempt - 1));
 
-    if (!response.ok) {
-      const err = await response.text();
-      throw new Error(`API error (${response.status}): ${err}`);
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+          'HTTP-Referer': 'https://lien.dev',
+          'X-Title': 'Lien Review',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const err = await response.text();
+        // 429/5xx are transient — retry; other 4xx are fatal (bad request/auth).
+        if (response.status === 429 || response.status >= 500) {
+          lastError = new Error(`API error (${response.status}): ${truncate(err, 200)}`);
+          this.logger.warning(
+            `[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`,
+          );
+          continue;
+        }
+        throw new Error(`API error (${response.status}): ${err}`);
+      }
+
+      // Read as text and parse defensively: an empty/truncated 200 body makes
+      // response.json() throw a bare "Unexpected end of JSON input" that would
+      // otherwise crash the whole review. Treat it as transient and retry.
+      const text = await response.text();
+      if (!text.trim()) {
+        lastError = new Error(`Empty response body from ${this.model} (status ${response.status})`);
+        this.logger.warning(`[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`);
+        continue;
+      }
+      try {
+        return JSON.parse(text) as ChatResponse;
+      } catch {
+        lastError = new Error(
+          `Unparseable response body from ${this.model} (status ${response.status}): ${truncate(text, 200)}`,
+        );
+        this.logger.warning(`[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`);
+      }
     }
 
-    return (await response.json()) as ChatResponse;
+    throw lastError ?? new Error(`chatCompletion failed for ${this.model}`);
   }
 }
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -328,13 +328,16 @@ export class OpenAIAgentClient {
     const cost =
       totalInputTokens * this.inputCostPerToken + totalOutputTokens * this.outputCostPerToken;
 
-    // Incomplete = the loop bailed on a limit (or error) AND never produced a
-    // verdict (no summary, even after the retry). Such a run must not be shown
-    // as a clean review.
-    const incomplete = stopReason !== 'completed' && !parsed.summary;
+    // Incomplete = the agent never produced a structured verdict (no summary,
+    // even after the retry). A genuine clean review always carries a summary, so
+    // the ABSENCE of one — not the stop reason — is what marks a run incomplete.
+    // Critically this also catches a `finish_reason: 'stop'` turn that emitted
+    // prose instead of the findings JSON (the model "completed" but delivered no
+    // verdict): that must NOT be reported as a clean 0-findings review.
+    const incomplete = !parsed.summary;
     if (incomplete) {
       this.logger.warning(
-        `[agent] Review incomplete (stopReason=${stopReason}, no summary after ${turn} turns)`,
+        `[agent] Review incomplete (stopReason=${stopReason}, no verdict/summary after ${turn} turns)`,
       );
       // Always surface what the agent was doing when it bailed — the single
       // most useful datum for diagnosing an incomplete run in CI logs.
@@ -540,19 +543,37 @@ function extractResponse(content: string | null): {
 } {
   if (!content) return { findings: [] };
 
-  // Prefer a ```json fence (normal turns); fall back to the raw body, which is
-  // what response_format:json_object returns on a forced-verdict turn.
-  const jsonMatch = content.match(/```json\s*\n([\s\S]*?)\n\s*```/);
-  const raw = jsonMatch ? jsonMatch[1] : content.trim();
+  // Try, in order: a ```json fence (normal turns); the raw body
+  // (response_format:json_object on a forced-verdict turn); and finally a JSON
+  // object embedded in surrounding prose. The last guards against a model that
+  // ignored json_object and prefixed reasoning — without it that turn parses to
+  // an empty result and the run is silently treated as a clean 0-findings review.
+  const fenced = content.match(/```json\s*\n([\s\S]*?)\n\s*```/)?.[1];
+  const candidates = [fenced, content.trim(), embeddedJsonObject(content)];
 
-  try {
-    const parsed = JSON.parse(raw);
-    const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
-    const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
-    return { findings: findings.filter(isValidFinding), summary };
-  } catch {
-    return { findings: [] };
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const parsed = JSON.parse(candidate);
+      const findings: unknown[] = Array.isArray(parsed) ? parsed : (parsed.findings ?? []);
+      const summary = isValidSummary(parsed.summary) ? parsed.summary : undefined;
+      // Accept only a candidate that yields a real verdict or findings, so an
+      // empty `{}` earlier in the prose doesn't mask the actual JSON later.
+      if (summary || findings.length > 0) {
+        return { findings: findings.filter(isValidFinding), summary };
+      }
+    } catch {
+      // not parseable — try the next candidate
+    }
   }
+  return { findings: [] };
+}
+
+/** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */
+function embeddedJsonObject(content: string): string | undefined {
+  const start = content.indexOf('{');
+  const end = content.lastIndexOf('}');
+  return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
 }
 
 function isValidSummary(value: unknown): value is AgentSummary {

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -486,14 +486,17 @@ export class OpenAIAgentClient {
   private logTurn(turn: TurnTrace | undefined, label?: string): void {
     if (!turn) return;
     const tag = label ? ` (${label})` : '';
-    if (turn.reasoning) {
+    // Guard on trimmed content: on tool-call turns the model emits tool calls
+    // (logged separately) and often a whitespace-only `content`, which would
+    // otherwise print a blank, confusing "output:" line.
+    if (turn.reasoning?.trim()) {
       this.logger.info(
-        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning, AGENT_LOG_MAX)}`,
+        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning.trim(), AGENT_LOG_MAX)}`,
       );
     }
-    if (turn.responseText) {
+    if (turn.responseText?.trim()) {
       this.logger.info(
-        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText, AGENT_LOG_MAX)}`,
+        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText.trim(), AGENT_LOG_MAX)}`,
       );
     }
   }

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -37,31 +37,20 @@ const RETRY_NUDGE =
 
 /**
  * Transient-failure retry for the chat endpoint. OpenRouter/Kimi intermittently
- * returns a 200 with an empty/truncated body (which makes JSON parsing throw
- * "Unexpected end of JSON input"), or a 429/5xx — both recover on a retry.
+ * returns a 200 with an empty/truncated body, a 429/5xx, or hangs the
+ * connection — all recover on a retry. 2 attempts (one retry) absorbs flakes
+ * while keeping worst-case latency bounded on a genuine outage.
  */
-const CHAT_MAX_ATTEMPTS = 3;
+const CHAT_MAX_ATTEMPTS = 2;
 const CHAT_RETRY_BASE_DELAY_MS = 500;
-/** Per-request abort timeout. A hung connection otherwise stalls a turn for
- * minutes before fetch eventually rejects; abort + retry recovers faster. */
+/**
+ * Per-request abort timeout, covering BOTH the response headers and the body
+ * read — a hang in either rejects (and is retried) instead of stalling a turn
+ * forever. Generous so a slow large-context reasoning turn isn't aborted.
+ */
 const CHAT_REQUEST_TIMEOUT_MS = 120_000;
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
-
-/** fetch with an abort timeout so a hung connection rejects (and is retried). */
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
 
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
@@ -536,25 +525,12 @@ export class OpenAIAgentClient {
     for (let attempt = 1; attempt <= CHAT_MAX_ATTEMPTS; attempt++) {
       if (attempt > 1) await sleep(CHAT_RETRY_BASE_DELAY_MS * (attempt - 1));
 
-      let response: Response;
+      let res: { ok: boolean; status: number; text: string };
       try {
-        response = await fetchWithTimeout(
-          `${this.baseUrl}/chat/completions`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.apiKey}`,
-              'HTTP-Referer': 'https://lien.dev',
-              'X-Title': 'Lien Review',
-            },
-            body: JSON.stringify(body),
-          },
-          CHAT_REQUEST_TIMEOUT_MS,
-        );
+        res = await this.postChat(body);
       } catch (err) {
-        // fetch() rejected: a network error, or our abort timeout firing on a
-        // hung connection. Both are transient — retry.
+        // Network error, or the abort timeout firing on a hung connection
+        // (header OR body stream). Transient — retry.
         lastError = new Error(
           `Request to ${this.model} failed: ${err instanceof Error ? err.message : String(err)}`,
         );
@@ -562,39 +538,66 @@ export class OpenAIAgentClient {
         continue;
       }
 
-      if (!response.ok) {
-        const err = await response.text();
+      if (!res.ok) {
         // 429/5xx are transient — retry; other 4xx are fatal (bad request/auth).
-        if (response.status === 429 || response.status >= 500) {
-          lastError = new Error(`API error (${response.status}): ${truncate(err, 200)}`);
+        if (res.status === 429 || res.status >= 500) {
+          lastError = new Error(`API error (${res.status}): ${truncate(res.text, 200)}`);
           this.logger.warning(
             `[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`,
           );
           continue;
         }
-        throw new Error(`API error (${response.status}): ${err}`);
+        throw new Error(`API error (${res.status}): ${res.text}`);
       }
 
-      // Read as text and parse defensively: an empty/truncated 200 body makes
-      // response.json() throw a bare "Unexpected end of JSON input" that would
-      // otherwise crash the whole review. Treat it as transient and retry.
-      const text = await response.text();
-      if (!text.trim()) {
-        lastError = new Error(`Empty response body from ${this.model} (status ${response.status})`);
+      // Parse defensively: an empty/truncated 200 body would otherwise throw a
+      // bare "Unexpected end of JSON input" and crash the review. Retry it.
+      if (!res.text.trim()) {
+        lastError = new Error(`Empty response body from ${this.model} (status ${res.status})`);
         this.logger.warning(`[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`);
         continue;
       }
       try {
-        return JSON.parse(text) as ChatResponse;
+        return JSON.parse(res.text) as ChatResponse;
       } catch {
         lastError = new Error(
-          `Unparseable response body from ${this.model} (status ${response.status}): ${truncate(text, 200)}`,
+          `Unparseable response body from ${this.model} (status ${res.status}): ${truncate(res.text, 200)}`,
         );
         this.logger.warning(`[agent] ${lastError.message} — retry ${attempt}/${CHAT_MAX_ATTEMPTS}`);
       }
     }
 
     throw lastError ?? new Error(`chatCompletion failed for ${this.model}`);
+  }
+
+  /**
+   * POST the chat request and read the FULL body under a single abort timeout,
+   * so a hang in either the headers or the body stream rejects (and is retried)
+   * rather than stalling the turn indefinitely (the body read was previously
+   * outside the timeout, which let a hung stream hang the whole review).
+   */
+  private async postChat(
+    body: Record<string, unknown>,
+  ): Promise<{ ok: boolean; status: number; text: string }> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), CHAT_REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+          'HTTP-Referer': 'https://lien.dev',
+          'X-Title': 'Lien Review',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      return { ok: response.ok, status: response.status, text };
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -240,6 +240,50 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.summary).toBeDefined();
     expect(result.incomplete).toBe(false);
   });
+
+  it('retries when fetch itself rejects (network error / timeout)', async () => {
+    // `fetch failed` (a network error or an aborted hung connection) rejects
+    // before any response — previously this crashed the review. Retry & recover.
+    let calls = 0;
+    const ok = stopTurn(CLEAN_JSON);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new TypeError('fetch failed');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ok,
+          text: async () => JSON.stringify(ok),
+        };
+      }),
+    );
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(calls).toBeGreaterThanOrEqual(2); // retried after the rejection
+    expect(result.stopReason).toBe('completed');
+    expect(result.summary).toBeDefined();
+  });
+
+  it('degrades to an incomplete review when chat requests keep failing', async () => {
+    // Persistent network failure: after retries exhaust, the run ends gracefully
+    // as incomplete (surfacing a "did not finish" notice), not a plugin crash.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      }),
+    );
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(true);
+    expect(result.summary).toBeUndefined();
+  }, 20000); // retries + the summary-retry's own attempts/sleep
 });
 
 describe('envDisabled (LIEN_REVIEW_LOG_AGENT parsing — logging on by default)', () => {

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -29,8 +29,14 @@ function capturingLogger(): { logger: Logger; lines: string[] } {
   };
 }
 
-/** Install a fetch mock that replays `responses` and records request bodies. */
-function mockFetch(responses: ChatResponse[]): { bodies: Array<Record<string, unknown>> } {
+/**
+ * Install a fetch mock that replays `responses` and records request bodies.
+ * A `null` queue entry simulates a transient empty 200 body (provider hiccup) —
+ * the client reads `response.text()`, so it serializes each response there.
+ */
+function mockFetch(responses: Array<ChatResponse | null>): {
+  bodies: Array<Record<string, unknown>>;
+} {
   const bodies: Array<Record<string, unknown>> = [];
   const queue = [...responses];
   vi.stubGlobal(
@@ -38,7 +44,8 @@ function mockFetch(responses: ChatResponse[]): { bodies: Array<Record<string, un
     vi.fn(async (_url: string, init: { body: string }) => {
       bodies.push(JSON.parse(init.body));
       const next = queue.shift();
-      return { ok: true, status: 200, json: async () => next, text: async () => '' };
+      const text = next == null ? '' : JSON.stringify(next);
+      return { ok: true, status: 200, json: async () => next, text: async () => text };
     }),
   );
   return { bodies };
@@ -218,6 +225,20 @@ describe('OpenAIAgentClient budget handling', () => {
 
     expect(result.incomplete).toBe(false);
     expect(result.summary?.overview).toBe('wrapped');
+  });
+
+  it('retries a transient empty response body instead of crashing', async () => {
+    // A 200 with an empty body makes response.json() throw "Unexpected end of
+    // JSON input" — previously that crashed the whole agent-review. The client
+    // must retry and recover, not throw.
+    mockFetch([null, stopTurn(CLEAN_JSON)]); // turn 1: empty body, then a valid verdict
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.stopReason).toBe('completed');
+    expect(result.summary).toBeDefined();
+    expect(result.incomplete).toBe(false);
   });
 });
 

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -188,6 +188,37 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.incomplete).toBe(true);
     expect(lines.some(l => l.includes(reasoning))).toBe(true);
   }, 15000);
+
+  it('flags a stop turn with no parseable verdict incomplete (no silent clean)', async () => {
+    // The model ends with finish_reason:'stop' (stopReason 'completed') but emits
+    // prose, not findings JSON; the summary-retry also yields prose. A verdict was
+    // never produced, so the run must be incomplete — NOT a clean 0-findings review
+    // (the old `stopReason !== 'completed'` guard let this through silently).
+    mockFetch([stopTurn('I reviewed the changes; looks fine.'), stopTurn('Still no JSON, sorry.')]);
+    const client = makeClient(1_000_000); // generous budget — the model just stops early
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.stopReason).toBe('completed');
+    expect(result.summary).toBeUndefined();
+    expect(result.incomplete).toBe(true);
+  }, 15000); // the summary-retry sleeps 3s
+
+  it('recovers a JSON verdict embedded in surrounding prose', async () => {
+    // The model ignored json_object and wrapped the verdict in reasoning prose.
+    // Lenient extraction must recover it on the same turn (no retry needed).
+    const verdict = JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: 'wrapped', keyChanges: [] },
+    });
+    mockFetch([stopTurn(`Here is my analysis.\n${verdict}\nThat's everything.`)]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(false);
+    expect(result.summary?.overview).toBe('wrapped');
+  });
 });
 
 describe('envDisabled (LIEN_REVIEW_LOG_AGENT parsing — logging on by default)', () => {
@@ -271,8 +302,8 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
 describe('AgentReviewPlugin.present — incomplete review', () => {
   function incompleteSummaryFinding(): ReviewFinding {
     const message =
-      'Lien Review did not finish — it hit the token budget limit while investigating and ' +
-      'stopped before producing a verdict. Any findings shown are partial; re-run the review to retry.';
+      'Lien Review did not finish — it hit the token budget limit while investigating. ' +
+      'Any findings shown are partial; re-run the review to retry.';
     return {
       pluginId: 'agent-review',
       filepath: '',

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -227,6 +227,40 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.summary?.overview).toBe('wrapped');
   });
 
+  it('prefers the real verdict over an earlier example JSON block', async () => {
+    // The model echoes a few-shot example ```json block, then its real verdict.
+    // The OLD first-fence logic would return the example; we must pick the last.
+    const example =
+      '```json\n' +
+      JSON.stringify({
+        findings: [
+          {
+            filepath: 'x.ts',
+            line: 1,
+            severity: 'warning',
+            category: 'logic_error',
+            message: 'eg',
+          },
+        ],
+        summary: { riskLevel: 'high', overview: 'EXAMPLE', keyChanges: [] },
+      }) +
+      '\n```';
+    const real =
+      '```json\n' +
+      JSON.stringify({
+        findings: [],
+        summary: { riskLevel: 'low', overview: 'REAL', keyChanges: [] },
+      }) +
+      '\n```';
+    mockFetch([stopTurn(`Here is the format:\n${example}\n\nMy actual review:\n${real}`)]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.summary?.overview).toBe('REAL');
+    expect(result.findings).toHaveLength(0);
+  });
+
   it('retries a transient empty response body instead of crashing', async () => {
     // A 200 with an empty body makes response.json() throw "Unexpected end of
     // JSON input" — previously that crashed the whole agent-review. The client


### PR DESCRIPTION
Agent-review resilience (was #608; reopened fresh after the stacked base branch was deleted on merge). Hardens the agent against six provider-flakiness failure modes that produced bad/false reviews:

- **Silent false-clean** — a `stop` turn with no parseable verdict was reported as a clean 0-findings review. Now `incomplete` is verdict-based (complete iff a summary was produced) → surfaces a "did not finish" notice.
- **Prose-wrapped JSON** — verdict embedded in reasoning prose is now recovered.
- **Empty body** — unguarded `response.json()` on a 200 with empty body crashed the plugin; now retried.
- **Fetch rejection / hung connection** — `fetch` wrapped in an AbortController timeout (covering headers **and** body read) + retried; a persistent failure degrades to a visible incomplete review instead of stalling.
- **Verdict selection** — prefer the summary-bearing candidate and the last `​```json` fence, so a few-shot example block can't beat the real verdict.
- **Blank log lines** — tool-call turns no longer print empty `output:` lines.

390 review tests pass (incl. regression tests for each mode). No changeset (review package built from source, not published).

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 2 new functions are too complex.
🔗 **Impact**: 2 high-risk file(s) with 4 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +0 |
| 🧠 mental load | 4 | +21 |
| ⏱️ time to understand | 7 | +199 |
| 🐛 estimated bugs | 2 | +0.115 |


> [!NOTE]
> **Low Risk**
>
> This PR hardens the agent-review plugin against provider flakiness by making incomplete detection verdict-based (!parsed.summary), improving JSON verdict extraction from prose/fences, adding fetch retries with AbortController timeouts in the OpenAI client, and suppressing blank tool-call log lines. The logic changes are internally consistent: callers in index.ts were updated to surface the new 'completed but no parseable verdict' case, and parsed JSON is validated through isValidFinding/isValidSummary before being consumed. No edge cases in the changed code produce wrong output — empty/null bodies and unparseable responses are retried or degrade to an incomplete notice, and the extraction fallback ordering correctly prefers summary-bearing candidates.
>
> - Incomplete flag now depends on absence of a parsed summary rather than stopReason, preventing silent false-clean reviews
> - OpenAI chat path wrapped in per-request abort timeout and transient-failure retry loop
> - JSON verdict extraction now handles prose-wrapped JSON, multiple fences, and cross-block Anthropic responses

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a4dccd3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->