### PR TITLE
feat(review): deterministic stale-duplicate signal + honest harness replay

### DIFF
--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -457,23 +457,15 @@ export async function grepCodebase(
       return JSON.stringify({ error: `Invalid regex pattern: ${(err as Error).message}` });
     }
 
-    // The working tree may be absent (offline fixture replay against a captured
-    // ReviewContext whose repoRootDir is a long-gone temp dir). Say so loudly
-    // rather than returning a silent empty result.
-    if (await repoTreeUnavailable(ctx.repoRootDir)) {
-      return JSON.stringify({
-        results: [],
-        count: 0,
-        unavailable: true,
-        reason: REPLAY_UNAVAILABLE_REASON,
-      });
-    }
-
     // Search the real working tree (not just parser-chunked source) so refs in
     // config, YAML, CI workflows, etc. are visible. Respect .gitignore +
     // built-in excludes via the shared parser filter, pruning ignored paths
     // during the walk rather than after. Canonicalize the root first so symlink
     // containment checks compare like-for-like (e.g. macOS /var vs /private/var).
+    // A missing root (offline fixture replay against a long-gone temp dir)
+    // surfaces here as ENOENT/ENOTDIR and is translated in the catch below —
+    // handled on the real operation rather than a pre-check, to avoid a TOCTOU
+    // window and a redundant stat.
     const rootDir = await fs.realpath(ctx.repoRootDir);
     const isIgnored = await createGitignoreFilter(rootDir);
     const files: string[] = [];
@@ -489,6 +481,15 @@ export async function grepCodebase(
 
     return JSON.stringify({ results: matches, count: matches.length, truncated });
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return JSON.stringify({
+        results: [],
+        count: 0,
+        unavailable: true,
+        reason: REPLAY_UNAVAILABLE_REASON,
+      });
+    }
     return JSON.stringify({ error: `grep_codebase failed: ${(err as Error).message}` });
   }
 }

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -410,6 +410,31 @@ async function scanForMatches(
   return { matches: matches.slice(0, MAX_GREP_RESULTS), truncated };
 }
 
+/**
+ * Message returned by the disk-backed tools when the working tree is absent.
+ * Spelled out so the agent does NOT read an empty/missing result as "no match
+ * exists" — in offline fixture replay the captured repoRootDir is long gone, so
+ * grep/read are blind and a silent empty result has caused grep-dependent rules
+ * to be misdiagnosed as model failures. Points the agent at the deterministic
+ * signals and in-memory chunk tools, which work regardless of the working tree.
+ */
+const REPLAY_UNAVAILABLE_REASON =
+  'The repository working tree is not available in this run (e.g. offline fixture ' +
+  'replay), so disk-backed search is blind here — a zero/empty result does NOT mean ' +
+  '"no match exists". Rely on the pre-computed signals in your initial message ' +
+  '(<stale_literal_candidates>, <blast_radius>, <deleted_exports>) and the ' +
+  'chunk-backed tools (get_files_context, get_dependents, list_functions) instead.';
+
+/** True when the repo working tree is not on disk (e.g. harness fixture replay). */
+async function repoTreeUnavailable(repoRootDir: string): Promise<boolean> {
+  try {
+    await fs.access(repoRootDir);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 export async function grepCodebase(
   input: Record<string, unknown>,
   ctx: AgentToolContext,
@@ -423,6 +448,18 @@ export async function grepCodebase(
       regex = new RegExp(pattern, 'i');
     } catch (err) {
       return JSON.stringify({ error: `Invalid regex pattern: ${(err as Error).message}` });
+    }
+
+    // The working tree may be absent (offline fixture replay against a captured
+    // ReviewContext whose repoRootDir is a long-gone temp dir). Say so loudly
+    // rather than returning a silent empty result.
+    if (await repoTreeUnavailable(ctx.repoRootDir)) {
+      return JSON.stringify({
+        results: [],
+        count: 0,
+        unavailable: true,
+        reason: REPLAY_UNAVAILABLE_REASON,
+      });
     }
 
     // Search the real working tree (not just parser-chunked source) so refs in
@@ -496,10 +533,14 @@ export async function readFile(
       content: numbered,
     });
   } catch (err) {
-    const message =
-      (err as NodeJS.ErrnoException).code === 'ENOENT'
-        ? `File not found: ${input.filepath}`
-        : `read_file failed: ${(err as Error).message}`;
-    return JSON.stringify({ error: message });
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Distinguish "this one file is missing" from "the whole working tree is
+      // gone" (offline replay) — the latter is blind, not a real 404.
+      if (await repoTreeUnavailable(ctx.repoRootDir)) {
+        return JSON.stringify({ unavailable: true, reason: REPLAY_UNAVAILABLE_REASON });
+      }
+      return JSON.stringify({ error: `File not found: ${input.filepath}` });
+    }
+    return JSON.stringify({ error: `read_file failed: ${(err as Error).message}` });
   }
 }

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -425,13 +425,20 @@ const REPLAY_UNAVAILABLE_REASON =
   '(<stale_literal_candidates>, <blast_radius>, <deleted_exports>) and the ' +
   'chunk-backed tools (get_files_context, get_dependents, list_functions) instead.';
 
-/** True when the repo working tree is not on disk (e.g. harness fixture replay). */
+/**
+ * True when the repo working tree is not on disk (e.g. harness fixture replay).
+ * Only a genuinely missing root (ENOENT / ENOTDIR) counts — a root that exists
+ * but is unreadable (EACCES, EMFILE, transient I/O) must surface as a real
+ * error, not be masked as replay blindness, so return false and let the caller
+ * fail normally.
+ */
 async function repoTreeUnavailable(repoRootDir: string): Promise<boolean> {
   try {
     await fs.access(repoRootDir);
     return false;
-  } catch {
-    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === 'ENOENT' || code === 'ENOTDIR';
   }
 }
 

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -480,7 +480,9 @@ MANDATORY protocol when this rule is active:
    still appear unchanged elsewhere — the discovery work (which would
    otherwise require \`grep_codebase\`) is already done for you. When
    the block is present it is your primary worklist: do NOT re-grep for
-   the literals it already lists.
+   the literals it already lists. If the block reads "None", the scan
+   ran and was clean — the discovery step is complete, so do not grep
+   for the diff's literals.
 2. The block covers literals the diff *moved away from*. If the diff
    also *introduces* a literal, or leaves one *unchanged* on a \`+\`
    line whose surrounding structure was edited (e.g. a conditional
@@ -509,9 +511,11 @@ MANDATORY protocol when this rule is active:
 
 Do not finalize a response for this rule with zero findings unless
 you have reviewed every entry in the \`<stale_literal_candidates>\`
-block (or, when no block is present, called \`grep_codebase\` for at
-least one literal from the diff) AND can confirm no semantically
-related copies survive elsewhere in the post-image.`,
+block (a "None" block, or a block whose entries you all judged
+unrelated, satisfies this) — or, when NO block is present at all (the
+scan could not run), called \`grep_codebase\` for at least one literal
+from the diff — AND can confirm no semantically related copies survive
+elsewhere in the post-image.`,
   example: `### Good finding — partial model bump leaves stale hardcoded copy:
 {
   "filepath": "packages/runner/src/handlers/pr-review.ts",

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -474,17 +474,20 @@ edited (e.g., a conditional was added or modified above it).
 
 MANDATORY protocol when this rule is active:
 
-1. Walk the diff. Collect every quoted string literal and every
-   distinctive numeric/identifier constant that appears in either
-   the \`-\` lines, the \`+\` lines, or as part of a value-emitting
-   expression on a touched line (e.g., the branch values of a
-   conditional that the diff modified).
-2. **For each such literal, you MUST call \`grep_codebase\`** with
-   the literal's exact text (including quotes for strings; for
-   numbers and identifiers, prefer a pattern that anchors on the
-   surrounding syntax to reduce false matches). Look at the hits
-   that fall *outside* the diff hunks.
-3. For each outside-the-diff hit, decide whether that site should
+1. **Check for a \`<stale_literal_candidates>\` block in your initial
+   message FIRST.** Lien pre-computes it by deterministically scanning
+   the indexed repo for literals this PR changed in one place that
+   still appear unchanged elsewhere — the discovery work (which would
+   otherwise require \`grep_codebase\`) is already done for you. When
+   the block is present it is your primary worklist: do NOT re-grep for
+   the literals it already lists.
+2. The block covers literals the diff *moved away from*. If the diff
+   also *introduces* a literal, or leaves one *unchanged* on a \`+\`
+   line whose surrounding structure was edited (e.g. a conditional
+   added above it), you MAY call \`grep_codebase\` to check those shapes
+   — but the pre-computed block is authoritative for the literals it
+   lists, so do not duplicate its work.
+3. For each candidate or outside-the-diff hit, decide whether that site should
    logically track the changed site. Strong signals: same field
    name on adjacent objects (e.g., \`model\`, \`version\`,
    \`apiKey\`, \`baseUrl\`), same function body, parallel struct
@@ -495,8 +498,9 @@ MANDATORY protocol when this rule is active:
 4. **Emit a finding** for each stale site that should track the
    changed site. The \`message\` must name the literal and BOTH
    locations explicitly (the changed site's line number and the
-   stale site's line number). The \`evidence\` must cite the
-   \`grep_codebase\` invocation that found the stale site.
+   stale site's line number). The \`evidence\` must cite where the
+   stale site was found — the matching \`<stale_literal_candidates>\`
+   entry, or a \`grep_codebase\` invocation if you searched yourself.
 5. The \`suggestion\` should propose either: (a) apply the same
    replacement/parameterization to the stale copy, or (b) hoist the
    literal to a shared \`const\` near the top of the function/file
@@ -504,9 +508,10 @@ MANDATORY protocol when this rule is active:
    change's apparent intent.
 
 Do not finalize a response for this rule with zero findings unless
-you have called \`grep_codebase\` for at least one literal from the
-diff AND can confirm no semantically related copies survive
-elsewhere in the post-image.`,
+you have reviewed every entry in the \`<stale_literal_candidates>\`
+block (or, when no block is present, called \`grep_codebase\` for at
+least one literal from the diff) AND can confirm no semantically
+related copies survive elsewhere in the post-image.`,
   example: `### Good finding — partial model bump leaves stale hardcoded copy:
 {
   "filepath": "packages/runner/src/handlers/pr-review.ts",

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -15,6 +15,10 @@
 import type { ReviewContext } from '../../plugin-types.js';
 import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
+import {
+  computeStaleLiteralCandidates,
+  renderStaleLiteralCandidates,
+} from '../../stale-literal-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -174,6 +178,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderChangedFunctions(context));
   appendIfPresent(sections, renderBlastRadius(opts));
   appendIfPresent(sections, renderDeletedExports(context));
+  appendIfPresent(sections, renderStaleLiteralCandidates(computeStaleLiteralCandidates(context)));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -15,10 +15,7 @@
 import type { ReviewContext } from '../../plugin-types.js';
 import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
-import {
-  computeStaleLiteralCandidates,
-  renderStaleLiteralCandidates,
-} from '../../stale-literal-signals.js';
+import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -178,7 +175,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderChangedFunctions(context));
   appendIfPresent(sections, renderBlastRadius(opts));
   appendIfPresent(sections, renderDeletedExports(context));
-  appendIfPresent(sections, renderStaleLiteralCandidates(computeStaleLiteralCandidates(context)));
+  appendIfPresent(sections, renderStaleLiteralSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -277,7 +277,6 @@ function findStaleSites(
       const dedupKey = `${file}:${absLine}`;
       if (seen.has(dedupKey)) continue;
       if (fileChanged?.has(absLine)) continue; // a line this PR touched — not a survivor
-      if (file === lit.file && absLine === lit.changedLine) continue; // the touched site itself
       if (!lineContainsLiteral(lines[i], lit)) continue;
 
       seen.add(dedupKey);

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -1,0 +1,373 @@
+/**
+ * Deterministic "stale duplicate literal" signal for PR reviews.
+ *
+ * The stale-duplicate rule asks the agent to grep for literals the diff changed
+ * in one place but left hardcoded elsewhere. That grep-and-reason step is the
+ * flaky, model-dependent part — and in the offline harness the agent's
+ * grep/read tools are blind (they read a capture-time temp dir that no longer
+ * exists), so the rule can never find the surviving copy.
+ *
+ * This module pre-computes the structural fact instead, mirroring the
+ * `<blast_radius>` / `<deleted_exports>` precedents: collect every distinctive
+ * literal the diff TOUCHES (on a `+` or `-` line — this covers both a literal
+ * the PR removed and one it conditionalized in place), then scan the indexed
+ * repo's post-image chunk content for the SAME literal surviving unchanged
+ * OUTSIDE the diff. The result is injected as a
+ * `<stale_literal_candidates>` block so the agent confirms a handed-to-it
+ * candidate (narrow judgement) rather than discovering it via blind grep.
+ *
+ * It injects FACTS (literal + locations + a short snippet), never reconstructed
+ * chunk content — a blunt content dump was tried and regressed unrelated rules.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LiteralKind = 'string' | 'number';
+
+/** A literal the diff moved away from (net-removed within a file's patch). */
+export interface ChangedLiteral {
+  /** Inner text for strings (no quotes); the numeric token for numbers. */
+  value: string;
+  kind: LiteralKind;
+  /** Display form: quoted for strings, raw for numbers. */
+  display: string;
+  /** File whose diff removed/changed this literal. */
+  file: string;
+  /** Best-effort new-file line near where the change occurred. */
+  changedLine: number;
+}
+
+/** A surviving occurrence of a changed literal, outside the diff. */
+export interface StaleSite {
+  file: string;
+  line: number;
+  snippet: string;
+  isComment: boolean;
+  isTest: boolean;
+}
+
+export interface StaleLiteralCandidate {
+  /** Display form of the literal (quoted for strings). */
+  literal: string;
+  kind: LiteralKind;
+  changedSite: { file: string; line: number };
+  staleSites: StaleSite[];
+  confidence: 'low' | 'medium' | 'high';
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max literals reported, highest-confidence first — keeps the prompt compact. */
+const MAX_CANDIDATES = 8;
+/** Max surviving sites listed per literal. */
+const MAX_SITES_PER_LITERAL = 5;
+/** Snippet length cap per site. */
+const MAX_SNIPPET_CHARS = 160;
+
+/**
+ * String literals too common to be a useful stale-duplicate signal. Anything
+ * shorter than 3 chars or all-punctuation is also dropped (see isDistinctiveString).
+ */
+const LOW_SIGNAL_STRINGS = new Set([
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'function',
+]);
+
+const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
+/** Decimals (0.74, 3.5) or integers with >= 3 digits (100, 4096). Skips small ints / indices. */
+const NUMBER_RE = /(?<![\w.])(\d[\d_]*\.\d+|\d{3,})(?![\w.])/g;
+const COMMENT_RE = /^(\/\/|\/\*|\*|#|--|<!--)/;
+const TEST_PATH_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/)/;
+const VALUE_EMITTING_RE = /[=:]|=>|\breturn\b/;
+
+// ---------------------------------------------------------------------------
+// Literal extraction
+// ---------------------------------------------------------------------------
+
+interface RawLiteral {
+  key: string;
+  value: string;
+  kind: LiteralKind;
+  display: string;
+}
+
+function isDistinctiveString(inner: string): boolean {
+  const t = inner.trim();
+  if (t.length < 3) return false;
+  if (LOW_SIGNAL_STRINGS.has(t.toLowerCase())) return false;
+  if (!/[A-Za-z0-9]/.test(t)) return false; // must carry at least one alphanumeric
+  // Bias toward configuration-like literals (model/version names, env keys,
+  // paths, kebab/snake identifiers, copied messages) and away from common short
+  // words that legitimately recur everywhere ('type', 'name', 'user').
+  return /[-_./:]/.test(t) || /\d/.test(t) || t.length >= 6;
+}
+
+/** Extract distinctive string + numeric literals from one line of code. */
+function extractLiteralsFromText(text: string): RawLiteral[] {
+  const out: RawLiteral[] = [];
+
+  for (const m of text.matchAll(STRING_RE)) {
+    const quote = m[1];
+    const inner = m[2];
+    // Template literals with interpolation aren't stable literals — skip.
+    if (quote === '`' && inner.includes('${')) continue;
+    if (!isDistinctiveString(inner)) continue;
+    out.push({
+      key: `s:${inner}`,
+      value: inner,
+      kind: 'string',
+      display: `${quote}${inner}${quote}`,
+    });
+  }
+
+  for (const m of text.matchAll(NUMBER_RE)) {
+    const value = m[1];
+    out.push({ key: `n:${value}`, value, kind: 'number', display: value });
+  }
+
+  return out;
+}
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+function recordLiterals(
+  touched: Map<string, ChangedLiteral>,
+  text: string,
+  file: string,
+  line: number,
+): void {
+  for (const lit of extractLiteralsFromText(text)) {
+    if (!touched.has(lit.key)) {
+      touched.set(lit.key, {
+        value: lit.value,
+        kind: lit.kind,
+        display: lit.display,
+        file,
+        changedLine: line,
+      });
+    }
+  }
+}
+
+/**
+ * Walk one file's unified-diff patch, tracking the new-file line number, and
+ * collect every distinctive literal that appears on a `+` or `-` line (the
+ * literals the diff touches — whether removed outright or conditionalized in
+ * place). Keyed so each literal is recorded once, at its first touched line.
+ */
+function scanPatch(file: string, patch: string): Map<string, ChangedLiteral> {
+  const touched = new Map<string, ChangedLiteral>();
+  let newLine = 0;
+
+  for (const raw of patch.split('\n')) {
+    const header = raw.match(HUNK_HEADER_RE);
+    if (header) {
+      newLine = parseInt(header[1], 10);
+      continue;
+    }
+    if (raw.startsWith('+++') || raw.startsWith('---')) continue;
+
+    if (raw.startsWith('+')) {
+      recordLiterals(touched, raw.slice(1), file, newLine);
+      newLine++;
+    } else if (raw.startsWith('-')) {
+      recordLiterals(touched, raw.slice(1), file, newLine);
+      // a removed line does not advance the new-file counter
+    } else {
+      newLine++; // context line
+    }
+  }
+
+  return touched;
+}
+
+/**
+ * Collect every distinctive literal each changed file's diff touches.
+ * Exposed for testing.
+ */
+export function extractChangedLiterals(patches: Map<string, string>): ChangedLiteral[] {
+  const result: ChangedLiteral[] = [];
+  for (const [file, patch] of patches) {
+    result.push(...scanPatch(file, patch).values());
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Surviving-occurrence scan
+// ---------------------------------------------------------------------------
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Does `line` contain the literal `lit` as a real token (not a substring of a larger word)? */
+function lineContainsLiteral(line: string, lit: ChangedLiteral): boolean {
+  if (lit.kind === 'string') {
+    // Match the exact string literal in any quote style.
+    return (
+      line.includes(`'${lit.value}'`) ||
+      line.includes(`"${lit.value}"`) ||
+      line.includes(`\`${lit.value}\``)
+    );
+  }
+  // number: bounded so 100 doesn't match 1000 or foo100
+  return new RegExp(`(?<![\\w.])${escapeRegExp(lit.value)}(?![\\w.])`).test(line);
+}
+
+function classifySnippet(line: string): { snippet: string; isComment: boolean } {
+  const trimmed = line.trim();
+  return {
+    snippet: trimmed.slice(0, MAX_SNIPPET_CHARS),
+    isComment: COMMENT_RE.test(trimmed),
+  };
+}
+
+/**
+ * Scan the indexed repo (post-image chunk content) for the literal surviving
+ * outside the diff. Because chunks are the head state, the changed site no
+ * longer contains the moved-away literal — any hit is by definition a survivor.
+ * `changedLines` is consulted defensively to never re-report a touched line.
+ */
+function findStaleSites(
+  lit: ChangedLiteral,
+  repoChunks: CodeChunk[],
+  changedLines: Map<string, Set<number>>,
+): StaleSite[] {
+  const seen = new Set<string>();
+  const sites: StaleSite[] = [];
+
+  for (const chunk of repoChunks) {
+    const file = chunk.metadata.file;
+    const fileChanged = changedLines.get(file);
+    const lines = chunk.content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const absLine = chunk.metadata.startLine + i;
+      const dedupKey = `${file}:${absLine}`;
+      if (seen.has(dedupKey)) continue;
+      if (fileChanged?.has(absLine)) continue; // a line this PR touched — not a survivor
+      if (file === lit.file && absLine === lit.changedLine) continue; // the touched site itself
+      if (!lineContainsLiteral(lines[i], lit)) continue;
+
+      seen.add(dedupKey);
+      const { snippet, isComment } = classifySnippet(lines[i]);
+      sites.push({
+        file,
+        line: absLine,
+        snippet,
+        isComment,
+        isTest: TEST_PATH_RE.test(file),
+      });
+      if (sites.length >= MAX_SITES_PER_LITERAL) return sites;
+    }
+  }
+
+  return sites;
+}
+
+function scoreConfidence(
+  kind: LiteralKind,
+  sites: StaleSite[],
+): StaleLiteralCandidate['confidence'] {
+  const realCode = sites.filter(s => !s.isComment && !s.isTest);
+  if (realCode.length === 0) return 'low';
+  const valueEmitting = realCode.some(s => VALUE_EMITTING_RE.test(s.snippet));
+  if (kind === 'number') return valueEmitting ? 'medium' : 'low';
+  return valueEmitting ? 'high' : 'medium';
+}
+
+const CONFIDENCE_RANK: Record<StaleLiteralCandidate['confidence'], number> = {
+  high: 2,
+  medium: 1,
+  low: 0,
+};
+
+/**
+ * Pre-compute stale-duplicate literal candidates from the review context.
+ * Returns [] when there is no diff or no full-repo index to scan against.
+ */
+export function computeStaleLiteralCandidates(context: ReviewContext): StaleLiteralCandidate[] {
+  const patches = context.pr?.patches;
+  const repoChunks = context.repoChunks;
+  if (!patches || patches.size === 0) return [];
+  if (!repoChunks || repoChunks.length === 0) return [];
+
+  const changedLines = context.pr?.diffLines ?? new Map<string, Set<number>>();
+  const candidates: StaleLiteralCandidate[] = [];
+
+  for (const lit of extractChangedLiterals(patches)) {
+    const staleSites = findStaleSites(lit, repoChunks, changedLines);
+    if (staleSites.length === 0) continue;
+    candidates.push({
+      literal: lit.display,
+      kind: lit.kind,
+      changedSite: { file: lit.file, line: lit.changedLine },
+      staleSites,
+      confidence: scoreConfidence(lit.kind, staleSites),
+    });
+  }
+
+  candidates.sort((a, b) => {
+    const byConf = CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence];
+    if (byConf !== 0) return byConf;
+    return b.staleSites.length - a.staleSites.length;
+  });
+
+  return candidates.slice(0, MAX_CANDIDATES);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render stale-literal candidates as a `<stale_literal_candidates>` block for
+ * the agent's initial message. Returns '' when there are no candidates so
+ * callers can append unconditionally.
+ */
+export function renderStaleLiteralCandidates(candidates: StaleLiteralCandidate[]): string {
+  if (candidates.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('<stale_literal_candidates>');
+  lines.push(
+    'Pre-computed by a deterministic scan of the indexed repo (no grep needed — this is done for you). ' +
+      'Each entry is a literal this PR changed in one place but that STILL appears unchanged elsewhere. ' +
+      'For each, judge whether the surviving site should track the changed site: if yes, emit a ' +
+      'stale-duplicate finding citing BOTH locations; if it is unrelated (different meaning, a comment, ' +
+      'or a test fixture), stay silent. Confidence is a hint, not a verdict.',
+  );
+
+  for (const c of candidates) {
+    lines.push('');
+    lines.push(
+      `- ${c.literal} (${c.kind}) — changed at ${c.changedSite.file}:${c.changedSite.line}; ` +
+        `still present at [confidence: ${c.confidence}]:`,
+    );
+    for (const s of c.staleSites) {
+      const tags = [s.isComment ? 'comment' : null, s.isTest ? 'test' : null]
+        .filter(Boolean)
+        .join(', ');
+      const suffix = tags ? ` (${tags})` : '';
+      lines.push(`    - ${s.file}:${s.line}${suffix}  \`${s.snippet}\``);
+    }
+  }
+
+  lines.push('</stale_literal_candidates>');
+  return lines.join('\n');
+}

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -163,36 +163,56 @@ function recordLiterals(
   }
 }
 
+interface PatchScan {
+  literals: ChangedLiteral[];
+  /** New-file line numbers the diff added/changed, per file (the `+` lines). */
+  touchedLinesByFile: Map<string, Set<number>>;
+}
+
 /**
- * Walk one file's unified-diff patch, tracking the new-file line number, and
- * collect every distinctive literal that appears on a `+` or `-` line (the
+ * Walk every file's unified-diff patch, tracking the new-file line number, and
+ * collect (a) every distinctive literal that appears on a `+` or `-` line (the
  * literals the diff touches — whether removed outright or conditionalized in
- * place). Keyed so each literal is recorded once, at its first touched line.
+ * place) and (b) the set of new-file lines the diff changed. The latter lets
+ * the survivor scan exclude the touched site itself even when `pr.diffLines`
+ * isn't provided — without it a literal conditionalized in place would report
+ * its own `+` line as a stale survivor.
  */
-function scanPatch(file: string, patch: string): Map<string, ChangedLiteral> {
-  const touched = new Map<string, ChangedLiteral>();
-  let newLine = 0;
+function scanPatches(patches: Map<string, string>): PatchScan {
+  const literals: ChangedLiteral[] = [];
+  const touchedLinesByFile = new Map<string, Set<number>>();
 
-  for (const raw of patch.split('\n')) {
-    const header = raw.match(HUNK_HEADER_RE);
-    if (header) {
-      newLine = parseInt(header[1], 10);
-      continue;
-    }
-    if (raw.startsWith('+++') || raw.startsWith('---')) continue;
+  for (const [file, patch] of patches) {
+    const touched = new Map<string, ChangedLiteral>();
+    const touchedLines = new Set<number>();
+    let newLine = 0;
 
-    if (raw.startsWith('+')) {
-      recordLiterals(touched, raw.slice(1), file, newLine);
-      newLine++;
-    } else if (raw.startsWith('-')) {
-      recordLiterals(touched, raw.slice(1), file, newLine);
-      // a removed line does not advance the new-file counter
-    } else {
-      newLine++; // context line
+    for (const raw of patch.split('\n')) {
+      const header = raw.match(HUNK_HEADER_RE);
+      if (header) {
+        newLine = parseInt(header[1], 10);
+        continue;
+      }
+      if (raw.startsWith('+++') || raw.startsWith('---')) continue;
+      if (raw.startsWith('\\')) continue; // "\ No newline at end of file" — not a content line
+
+      if (raw.startsWith('+')) {
+        touchedLines.add(newLine);
+        recordLiterals(touched, raw.slice(1), file, newLine);
+        newLine++;
+      } else if (raw.startsWith('-')) {
+        recordLiterals(touched, raw.slice(1), file, newLine);
+        // a removed line does not advance the new-file counter
+      } else {
+        newLine++; // context line
+      }
     }
+
+    literals.push(...touched.values());
+    touchedLinesByFile.set(file, touchedLines);
   }
 
-  return touched;
+  return { literals, touchedLinesByFile };
 }
 
 /**
@@ -200,11 +220,7 @@ function scanPatch(file: string, patch: string): Map<string, ChangedLiteral> {
  * Exposed for testing.
  */
 export function extractChangedLiterals(patches: Map<string, string>): ChangedLiteral[] {
-  const result: ChangedLiteral[] = [];
-  for (const [file, patch] of patches) {
-    result.push(...scanPatch(file, patch).values());
-  }
-  return result;
+  return scanPatches(patches).literals;
 }
 
 // ---------------------------------------------------------------------------
@@ -297,6 +313,23 @@ const CONFIDENCE_RANK: Record<StaleLiteralCandidate['confidence'], number> = {
   low: 0,
 };
 
+/** Merge the patch-derived touched lines with any caller-provided diffLines. */
+function mergeChangedLines(
+  touchedLinesByFile: Map<string, Set<number>>,
+  provided: Map<string, Set<number>> | undefined,
+): Map<string, Set<number>> {
+  const merged = new Map<string, Set<number>>();
+  for (const [file, set] of touchedLinesByFile) merged.set(file, new Set(set));
+  if (provided) {
+    for (const [file, set] of provided) {
+      const existing = merged.get(file) ?? new Set<number>();
+      for (const n of set) existing.add(n);
+      merged.set(file, existing);
+    }
+  }
+  return merged;
+}
+
 /**
  * Pre-compute stale-duplicate literal candidates from the review context.
  * Returns [] when there is no diff or no full-repo index to scan against.
@@ -307,10 +340,14 @@ export function computeStaleLiteralCandidates(context: ReviewContext): StaleLite
   if (!patches || patches.size === 0) return [];
   if (!repoChunks || repoChunks.length === 0) return [];
 
-  const changedLines = context.pr?.diffLines ?? new Map<string, Set<number>>();
+  const { literals, touchedLinesByFile } = scanPatches(patches);
+  // Exclude the diff's own touched lines so a literal conditionalized in place
+  // doesn't report its own `+` line as a survivor. Derived from the patch, so
+  // this holds even when pr.diffLines is absent; union the two when both exist.
+  const changedLines = mergeChangedLines(touchedLinesByFile, context.pr?.diffLines);
   const candidates: StaleLiteralCandidate[] = [];
 
-  for (const lit of extractChangedLiterals(patches)) {
+  for (const lit of literals) {
     const staleSites = findStaleSites(lit, repoChunks, changedLines);
     if (staleSites.length === 0) continue;
     candidates.push({
@@ -370,4 +407,32 @@ export function renderStaleLiteralCandidates(candidates: StaleLiteralCandidate[]
 
   lines.push('</stale_literal_candidates>');
   return lines.join('\n');
+}
+
+/**
+ * Emitted when the deterministic scan ran but found nothing. Distinguishes
+ * "scan completed, clean" from "scan never ran" — without it, an omitted block
+ * is ambiguous and the rule would force a redundant grep fallback even after a
+ * clean scan.
+ */
+const STALE_LITERAL_NONE_BLOCK = `<stale_literal_candidates>
+None — the deterministic scan found no changed literal surviving unchanged elsewhere. The stale-duplicate discovery step is complete; you do not need to grep for the diff's literals.
+</stale_literal_candidates>`;
+
+/**
+ * Build the `<stale_literal_candidates>` section for the agent's initial
+ * message. Returns the candidate block when there are candidates, an explicit
+ * "None" block when the scan ran but was clean, or '' when no scan was possible
+ * (no diff or no repo index — e.g. CLI mode). Callers append unconditionally.
+ */
+export function renderStaleLiteralSection(context: ReviewContext): string {
+  const patches = context.pr?.patches;
+  const repoChunks = context.repoChunks;
+  const scanPossible = !!patches && patches.size > 0 && !!repoChunks && repoChunks.length > 0;
+  if (!scanPossible) return '';
+
+  const candidates = computeStaleLiteralCandidates(context);
+  return candidates.length > 0
+    ? renderStaleLiteralCandidates(candidates)
+    : STALE_LITERAL_NONE_BLOCK;
 }

--- a/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
+++ b/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
@@ -10,8 +10,12 @@
  *     packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.fixture.json \
  *     --sha f780541
  *
- * Tier 1: rule fires + grep_codebase is called (the rule's prompt mandates
- * a grep for each removed/replaced literal).
+ * Tier 1: rule fires. (We no longer assert grep_codebase: the deterministic
+ * <stale_literal_candidates> signal now pre-computes the surviving copy and
+ * injects it, so a correct agent confirms the candidate instead of grepping —
+ * and in fixture replay grep_codebase is blind against the dead repoRootDir
+ * anyway. See packages/review/src/stale-literal-signals.ts and memory
+ * project_harness_grep_read_replay_blindness.)
  * Tier 2: the finding cites adapterContext / line 300 / claude-sonnet-4-6
  * or proposes a hoist to a shared const. Keyword set is deliberately wide
  * to cover the phrasings any correct rendering will use.
@@ -24,7 +28,6 @@ const assertions: FixtureAssertions = {
   rule: 'stale-duplicate',
   expect: (result, h) => {
     h.expectRuleFired('stale-duplicate', result);
-    h.expectToolCalled('grep_codebase', result);
     h.expectFindingMentions(
       [
         'adaptercontext',

--- a/packages/review/test/plugins-agent-replay-blindness.test.ts
+++ b/packages/review/test/plugins-agent-replay-blindness.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { grepCodebase, readFile } from '../src/plugins/agent/agent-tools.js';
+import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { silentLogger } from '../src/test-helpers.js';
+import type { AgentToolContext } from '../src/plugins/agent/types.js';
+
+interface ToolResult {
+  unavailable?: boolean;
+  reason?: string;
+  error?: string;
+  count?: number;
+  content?: string;
+}
+
+function ctxFor(repoRootDir: string): AgentToolContext {
+  return {
+    repoChunks: [],
+    repoRootDir,
+    graph: buildDependencyGraph([]),
+    logger: silentLogger,
+  };
+}
+
+const MISSING_ROOT = path.join(os.tmpdir(), 'lien-replay-gone-9d3f1a2b', 'pr-head');
+
+describe('agent tools — loud behavior when the working tree is unavailable (replay)', () => {
+  it('grep_codebase reports unavailable instead of a silent empty result', async () => {
+    const res = JSON.parse(
+      await grepCodebase({ pattern: 'anything' }, ctxFor(MISSING_ROOT)),
+    ) as ToolResult;
+    expect(res.unavailable).toBe(true);
+    expect(res.count).toBe(0);
+    expect(res.reason).toMatch(/not available/i);
+    expect(res.reason).toMatch(/stale_literal_candidates/); // points at the deterministic signals
+  });
+
+  it('read_file reports unavailable when the whole tree is gone', async () => {
+    const res = JSON.parse(
+      await readFile({ filepath: 'src/app.ts' }, ctxFor(MISSING_ROOT)),
+    ) as ToolResult;
+    expect(res.unavailable).toBe(true);
+    expect(res.reason).toMatch(/not available/i);
+  });
+});
+
+describe('agent tools — real tree still behaves normally (no regression)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-replay-real-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('grep_codebase finds a real match (not flagged unavailable)', async () => {
+    await fs.writeFile(path.join(root, 'app.ts'), "const m = 'claude-sonnet-4-6';\n", 'utf-8');
+    const res = JSON.parse(
+      await grepCodebase({ pattern: 'claude-sonnet-4-6' }, ctxFor(root)),
+    ) as ToolResult;
+    expect(res.unavailable).toBeUndefined();
+    expect(res.count).toBe(1);
+  });
+
+  it('read_file returns a real 404 (not unavailable) when only the file is missing', async () => {
+    const res = JSON.parse(await readFile({ filepath: 'nope.ts' }, ctxFor(root))) as ToolResult;
+    expect(res.unavailable).toBeUndefined();
+    expect(res.error).toMatch(/File not found/);
+  });
+
+  it('read_file returns content for an existing file', async () => {
+    await fs.writeFile(path.join(root, 'app.ts'), 'line one\nline two\n', 'utf-8');
+    const res = JSON.parse(await readFile({ filepath: 'app.ts' }, ctxFor(root))) as ToolResult;
+    expect(res.unavailable).toBeUndefined();
+    expect(res.content).toContain('line one');
+  });
+});

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  extractChangedLiterals,
+  computeStaleLiteralCandidates,
+  renderStaleLiteralCandidates,
+} from '../src/stale-literal-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+  };
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  repoChunks?: CodeChunk[];
+  diffLines?: Map<string, Set<number>>;
+}): ReviewContext {
+  const pr =
+    opts.patches || opts.diffLines
+      ? { patches: opts.patches, diffLines: opts.diffLines }
+      : undefined;
+  return { pr, repoChunks: opts.repoChunks } as unknown as ReviewContext;
+}
+
+// The canonical PR #539 shape: an unconditional model literal is
+// conditionalized in place (so it lands on BOTH a `-` and a `+` line) while a
+// sibling site keeps it hardcoded.
+const CONDITIONALIZE_PATCH = `@@ -10,3 +10,4 @@
+   const cfg = load();
+-  const model = 'claude-sonnet-4-6';
++  const model = cfg.openrouterApiKey
++    ? 'gemini-3-flash'
++    : 'claude-sonnet-4-6';
+   return model;`;
+
+const PR_REVIEW_CONTENT = [
+  'const cfg = load();', // 10
+  'const model = cfg.openrouterApiKey', // 11
+  "  ? 'gemini-3-flash'", // 12
+  "  : 'claude-sonnet-4-6';", // 13
+  'return model;', // 14
+  '', // 15
+  'function reportMeta() {', // 16
+  '  // legacy attribution', // 17
+  '  const ctx = {};', // 18
+  '  ctx.provider = "openrouter";', // 19
+  "  adapterContext.model = 'claude-sonnet-4-6';", // 20
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// extractChangedLiterals
+// ---------------------------------------------------------------------------
+
+describe('extractChangedLiterals', () => {
+  it('extracts a distinctive literal touched on a `-` line', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'feature-flag-alpha';\n+const x = readFlag();"],
+    ]);
+    const lits = extractChangedLiterals(patches);
+    expect(lits.map(l => l.value)).toContain('feature-flag-alpha');
+  });
+
+  it('extracts a literal touched on a `+` line (conditionalized in place)', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const values = extractChangedLiterals(patches).map(l => l.value);
+    expect(values).toContain('claude-sonnet-4-6');
+    expect(values).toContain('gemini-3-flash');
+  });
+
+  it('records each literal once even when on both `-` and `+`', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const sonnet = extractChangedLiterals(patches).filter(l => l.value === 'claude-sonnet-4-6');
+    expect(sonnet).toHaveLength(1);
+  });
+
+  it('skips low-signal literals (short, common words, booleans)', () => {
+    const patches = new Map([
+      [
+        'src/a.ts',
+        "@@ -1,4 +1,4 @@\n-const a = 'ab';\n-const b = 'name';\n-const c = true;\n+const d = 'kind';",
+      ],
+    ]);
+    const values = extractChangedLiterals(patches).map(l => l.value);
+    expect(values).not.toContain('ab'); // < 3 chars
+    expect(values).not.toContain('name'); // common, no special char, < 6
+    expect(values).not.toContain('true'); // boolean keyword
+    expect(values).not.toContain('kind'); // common, no special char, < 6
+  });
+
+  it('keeps configuration-like strings (special chars / digits / length)', () => {
+    const patches = new Map([
+      [
+        'src/a.ts',
+        "@@ -1,3 +1,3 @@\n-const u = 'baseUrl';\n-const p = 'src/config/app.json';\n+const v = 'v2.1.0';",
+      ],
+    ]);
+    const values = extractChangedLiterals(patches).map(l => l.value);
+    expect(values).toContain('baseUrl'); // length >= 6
+    expect(values).toContain('src/config/app.json'); // has '/'
+    expect(values).toContain('v2.1.0'); // has digits + '.'
+  });
+
+  it('extracts distinctive numbers but skips small ones', () => {
+    const patches = new Map([
+      ['src/a.ts', '@@ -1,2 +1,2 @@\n-const max = 4096;\n-const n = 42;\n+const max = 8192;'],
+    ]);
+    const values = extractChangedLiterals(patches).map(l => l.value);
+    expect(values).toContain('4096'); // >= 3 digits
+    expect(values).not.toContain('42'); // < 3 digits
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStaleLiteralCandidates
+// ---------------------------------------------------------------------------
+
+describe('computeStaleLiteralCandidates', () => {
+  it('returns [] when there is no diff', () => {
+    expect(computeStaleLiteralCandidates(makeContext({ repoChunks: [] }))).toEqual([]);
+  });
+
+  it('returns [] when there is no repo index to scan', () => {
+    const patches = new Map([['src/a.ts', CONDITIONALIZE_PATCH]]);
+    expect(computeStaleLiteralCandidates(makeContext({ patches }))).toEqual([]);
+  });
+
+  it('flags a literal conditionalized at one site but hardcoded at a sibling site', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const diffLines = new Map([['src/pr-review.ts', new Set([11, 12, 13])]]);
+    const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+
+    const sonnet = candidates.find(c => c.literal === "'claude-sonnet-4-6'");
+    expect(sonnet).toBeDefined();
+    expect(sonnet!.kind).toBe('string');
+    expect(sonnet!.staleSites.map(s => s.line)).toContain(20); // the hardcoded sibling
+    expect(sonnet!.staleSites.map(s => s.line)).not.toContain(13); // the changed site itself
+    expect(sonnet!.confidence).toBe('high'); // survivor is value-emitting code
+  });
+
+  it('does not flag the PR-introduced value that has no stale copy', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const diffLines = new Map([['src/pr-review.ts', new Set([11, 12, 13])]]);
+    const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'gemini-3-flash'")).toBeUndefined();
+  });
+
+  it('returns no candidate when the literal does not survive elsewhere', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'lonely-literal-xyz';\n+const x = compute();"],
+    ]);
+    const diffLines = new Map([['src/a.ts', new Set([1])]]);
+    const repoChunks = [makeChunk('src/a.ts', 1, 'const x = compute();\nreturn x;')];
+    expect(computeStaleLiteralCandidates(makeContext({ patches, repoChunks, diffLines }))).toEqual(
+      [],
+    );
+  });
+
+  it('flags a comment-only survivor at low confidence', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const m = 'model-x-9000';\n+const m = pick();"],
+    ]);
+    const diffLines = new Map([['src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('src/a.ts', 1, 'const m = pick();'),
+      makeChunk('src/notes.ts', 5, "// historical default was 'model-x-9000'"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    const cand = candidates.find(c => c.literal === "'model-x-9000'");
+    expect(cand).toBeDefined();
+    expect(cand!.confidence).toBe('low');
+    expect(cand!.staleSites[0].isComment).toBe(true);
+  });
+
+  it('marks survivors in test files', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const m = 'model-x-9000';\n+const m = pick();"],
+    ]);
+    const diffLines = new Map([['src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('src/a.ts', 1, 'const m = pick();'),
+      makeChunk('src/a.test.ts', 5, "expect(m).toBe('model-x-9000');"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    const cand = candidates.find(c => c.literal === "'model-x-9000'");
+    expect(cand!.staleSites[0].isTest).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderStaleLiteralCandidates
+// ---------------------------------------------------------------------------
+
+describe('renderStaleLiteralCandidates', () => {
+  it('returns empty string for no candidates', () => {
+    expect(renderStaleLiteralCandidates([])).toBe('');
+  });
+
+  it('renders the block naming the literal and both locations', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const diffLines = new Map([['src/pr-review.ts', new Set([11, 12, 13])]]);
+    const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+
+    const md = renderStaleLiteralCandidates(candidates);
+    expect(md).toContain('<stale_literal_candidates>');
+    expect(md).toContain('</stale_literal_candidates>');
+    expect(md).toContain("'claude-sonnet-4-6'");
+    expect(md).toContain('src/pr-review.ts:20'); // the stale site
+    expect(md).toMatch(/changed at src\/pr-review\.ts:1[1-3]/); // the touched site
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring (zero-LLM proof the signal reaches the agent)
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection', () => {
+  it('includes the <stale_literal_candidates> block when candidates exist', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const diffLines = new Map([['src/pr-review.ts', new Set([11, 12, 13])]]);
+    const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+    const context = {
+      ...makeContext({ patches, repoChunks, diffLines }),
+      changedFiles: ['src/pr-review.ts'],
+      chunks: [],
+    } as unknown as ReviewContext;
+
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).toContain('<stale_literal_candidates>');
+    expect(message).toContain("'claude-sonnet-4-6'");
+    expect(message).toContain('src/pr-review.ts:20');
+  });
+
+  it('omits the block entirely when there are no candidates', () => {
+    const context = {
+      ...makeContext({ repoChunks: [] }),
+      changedFiles: ['src/a.ts'],
+      chunks: [],
+    } as unknown as ReviewContext;
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).not.toContain('<stale_literal_candidates>');
+  });
+});

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -181,6 +181,28 @@ describe('computeStaleLiteralCandidates', () => {
     expect(candidates.find(c => c.literal === "'gemini-3-flash'")).toBeUndefined();
   });
 
+  it('reports a survivor on a context line adjacent to a pure removal', () => {
+    // Regression: a removed-outright literal records changedLine as the *next*
+    // new-file line (a `-` line does not advance the counter). An earlier guard
+    // that skipped `absLine === changedLine` wrongly suppressed a real survivor
+    // sitting on that adjacent context line. Touched-line exclusion is now
+    // derived only from `+` lines (none here), so the survivor must surface.
+    const patch =
+      '@@ -5,3 +5,2 @@\n' +
+      '   const a = 1;\n' +
+      "-  const old = 'shared-token-abc';\n" +
+      "   const other = 'shared-token-abc';";
+    const patches = new Map([['src/a.ts', patch]]);
+    const repoChunks = [
+      makeChunk('src/a.ts', 5, "const a = 1;\nconst other = 'shared-token-abc';"),
+    ];
+
+    const candidates = computeStaleLiteralCandidates(makeContext({ patches, repoChunks }));
+    const cand = candidates.find(c => c.literal === "'shared-token-abc'");
+    expect(cand).toBeDefined();
+    expect(cand!.staleSites.map(s => s.line)).toContain(6); // the surviving context line
+  });
+
   it('returns no candidate when the literal does not survive elsewhere', () => {
     const patches = new Map([
       ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'lonely-literal-xyz';\n+const x = compute();"],

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -5,6 +5,7 @@ import {
   extractChangedLiterals,
   computeStaleLiteralCandidates,
   renderStaleLiteralCandidates,
+  renderStaleLiteralSection,
 } from '../src/stale-literal-signals.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
 
@@ -156,6 +157,19 @@ describe('computeStaleLiteralCandidates', () => {
     expect(sonnet!.confidence).toBe('high'); // survivor is value-emitting code
   });
 
+  it('excludes the conditionalized-in-place site even when diffLines is absent', () => {
+    // No diffLines provided — touched lines must be derived from the patch so
+    // the literal's own `+` else-branch (line 13) is not reported as a survivor.
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+
+    const candidates = computeStaleLiteralCandidates(makeContext({ patches, repoChunks }));
+    const sonnet = candidates.find(c => c.literal === "'claude-sonnet-4-6'");
+    expect(sonnet).toBeDefined();
+    expect(sonnet!.staleSites.map(s => s.line)).toContain(20); // the real sibling
+    expect(sonnet!.staleSites.map(s => s.line)).not.toContain(13); // its own changed `+` line
+  });
+
   it('does not flag the PR-introduced value that has no stale copy', () => {
     const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
     const diffLines = new Map([['src/pr-review.ts', new Set([11, 12, 13])]]);
@@ -260,7 +274,7 @@ describe('buildInitialMessage injection', () => {
     expect(message).toContain('src/pr-review.ts:20');
   });
 
-  it('omits the block entirely when there are no candidates', () => {
+  it('omits the block entirely when no scan was possible (no diff / no index)', () => {
     const context = {
       ...makeContext({ repoChunks: [] }),
       changedFiles: ['src/a.ts'],
@@ -268,5 +282,50 @@ describe('buildInitialMessage injection', () => {
     } as unknown as ReviewContext;
     const message = buildInitialMessage(context, { blastRadius: null });
     expect(message).not.toContain('<stale_literal_candidates>');
+  });
+
+  it('emits an explicit "None" block when the scan ran but found nothing', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'lonely-literal-xyz';\n+const x = compute();"],
+    ]);
+    const repoChunks = [makeChunk('src/a.ts', 1, 'const x = compute();')];
+    const context = {
+      ...makeContext({ patches, repoChunks }),
+      changedFiles: ['src/a.ts'],
+      chunks: [],
+    } as unknown as ReviewContext;
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).toContain('<stale_literal_candidates>');
+    expect(message).toContain('None');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderStaleLiteralSection — distinguishes "clean scan" from "no scan"
+// ---------------------------------------------------------------------------
+
+describe('renderStaleLiteralSection', () => {
+  it('returns "" when no scan was possible (no diff or no index)', () => {
+    expect(renderStaleLiteralSection(makeContext({ repoChunks: [] }))).toBe('');
+    const patches = new Map([['src/a.ts', CONDITIONALIZE_PATCH]]);
+    expect(renderStaleLiteralSection(makeContext({ patches }))).toBe(''); // no repoChunks
+  });
+
+  it('returns a "None" block when the scan ran but found nothing', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'lonely-literal-xyz';\n+const x = compute();"],
+    ]);
+    const repoChunks = [makeChunk('src/a.ts', 1, 'const x = compute();')];
+    const section = renderStaleLiteralSection(makeContext({ patches, repoChunks }));
+    expect(section).toContain('<stale_literal_candidates>');
+    expect(section).toContain('None');
+  });
+
+  it('returns the candidate block when there are candidates', () => {
+    const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+    const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+    const section = renderStaleLiteralSection(makeContext({ patches, repoChunks }));
+    expect(section).toContain("'claude-sonnet-4-6'");
+    expect(section).not.toContain('None —');
   });
 });


### PR DESCRIPTION
## Why

Lien's agent-review leaned on the LLM to do **fuzzy grep-and-reason** for the `stale-duplicate` rule. That step is the flaky, model-dependent part — and in the offline harness the agent's `grep_codebase`/`read_file` tools are **blind** (they resolve `ctx.repoRootDir`, a capture-time temp dir that no longer exists in replay), so the rule could never find the surviving copy *for any model*. This makes review outcomes model-dependent and the rule effectively untestable offline.

This PR moves the structural fact out of the LLM's hands and into a **deterministic, pre-computed signal**, then makes the harness behave honestly when the working tree is gone. Both are verifiable with **zero LLM / zero calibration spend**.

## What

**1. Deterministic stale-duplicate literal signal** (`3e021d0`)
- New `stale-literal-signals.ts`: walk the diff for distinctive literals it *touches* (removed outright, or conditionalized in place — the canonical PR #539 shape), scan the indexed repo's post-image chunk content for the same literal surviving **outside** the diff, and emit ranked candidates.
- Injected as a `<stale_literal_candidates>` block in `buildInitialMessage`, mirroring the existing `<blast_radius>` / `<deleted_exports>` precedent.
- `STALE_DUPLICATE` rule now **confirms** pre-computed candidates (narrow judgement) instead of being required to grep; grep is demoted to a fallback for shapes the signal doesn't cover.
- Injects **facts** (literal + locations + snippet), never reconstructed chunk content — a blunt content dump was tried previously and regressed unrelated rules, so this is deliberately targeted. Distinctiveness gate + hard caps bound over-fire and prompt size (protects the #613 input-budget win).
- Harness assertion: dropped the now-obsolete `grep_codebase` Tier-1 requirement.

**2. Loud replay blindness** (`b9149e2`)
- `grep_codebase` / `read_file` now detect a missing working tree and return an explicit `{ unavailable, reason }` that points the agent at the deterministic signals and chunk-backed tools — instead of a silent empty result that reads as "no match exists" and gets misdiagnosed as a model failure. `read_file` still distinguishes a genuine per-file 404 from a gone tree.

## Verification (zero LLM)
- 22 unit tests added (17 signal + 5 replay-blindness), all zero-LLM.
- Full `@liendev/review` suite: **414 passing**. `typecheck`, `typecheck:harness`, `format:check` clean; `lint` 0 errors.
- No changeset (review ships via the action build, not npm).

## Follow-up (not in this PR)
Optional one-off `--calibrate 10` on `stale-duplicate` (kimi) to measure the end-to-end lift now that the signal is injected — deliberately deferred to avoid calibration spend; the zero-LLM signal correctness + injection proof is the deliverable here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter review signals that precompute likely duplicate literals and surface them in agent prompts for more targeted analysis.
  * Review prompts now include an additional candidate block when relevant, improving detection of stale duplicate code.

* **Bug Fixes**
  * Disk-based search and file reads now clearly report when the repository snapshot is unavailable instead of returning empty or misleading results.
  * Existing review behavior was updated to work correctly in replay/offline scenarios while still handling real files normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 2 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 3 | +37 |
| ⏱️ time to understand | 4 | +2 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it stopped unexpectedly while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9b46ec1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->