### PR TITLE
fix(review): restrict stale-literal signal to string literals

### DIFF
--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -27,14 +27,17 @@ import type { ReviewContext } from './plugin-types.js';
 // Types
 // ---------------------------------------------------------------------------
 
-export type LiteralKind = 'string' | 'number';
+// Only string literals carry cross-file identity (a model name, flag key, schema
+// field, copied message). Numbers were tried and dropped — a bare `0.5` or `2.5`
+// matches CSS classes, test values, and unrelated ratios with no shared meaning.
+export type LiteralKind = 'string';
 
-/** A literal the diff moved away from (net-removed within a file's patch). */
+/** A distinctive string literal the diff touches (on a `+` or `-` line). */
 export interface ChangedLiteral {
-  /** Inner text for strings (no quotes); the numeric token for numbers. */
+  /** Inner text of the string literal, without surrounding quotes. */
   value: string;
   kind: LiteralKind;
-  /** Display form: quoted for strings, raw for numbers. */
+  /** Display form: the literal re-quoted, e.g. `'claude-sonnet-4-6'`. */
   display: string;
   /** File whose diff removed/changed this literal. */
   file: string;
@@ -88,8 +91,6 @@ const LOW_SIGNAL_STRINGS = new Set([
 ]);
 
 const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
-/** Decimals (0.74, 3.5) or integers with >= 3 digits (100, 4096). Skips small ints / indices. */
-const NUMBER_RE = /(?<![\w.])(\d[\d_]*\.\d+|\d{3,})(?![\w.])/g;
 const COMMENT_RE = /^(\/\/|\/\*|\*|#|--|<!--)/;
 const TEST_PATH_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/)/;
 const VALUE_EMITTING_RE = /[=:]|=>|\breturn\b/;
@@ -116,7 +117,7 @@ function isDistinctiveString(inner: string): boolean {
   return /[-_./:]/.test(t) || /\d/.test(t) || t.length >= 6;
 }
 
-/** Extract distinctive string + numeric literals from one line of code. */
+/** Extract distinctive string literals from one line of code. */
 function extractLiteralsFromText(text: string): RawLiteral[] {
   const out: RawLiteral[] = [];
 
@@ -132,11 +133,6 @@ function extractLiteralsFromText(text: string): RawLiteral[] {
       kind: 'string',
       display: `${quote}${inner}${quote}`,
     });
-  }
-
-  for (const m of text.matchAll(NUMBER_RE)) {
-    const value = m[1];
-    out.push({ key: `n:${value}`, value, kind: 'number', display: value });
   }
 
   return out;
@@ -227,22 +223,13 @@ export function extractChangedLiterals(patches: Map<string, string>): ChangedLit
 // Surviving-occurrence scan
 // ---------------------------------------------------------------------------
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Does `line` contain the literal `lit` as a real token (not a substring of a larger word)? */
+/** Does `line` contain the string literal `lit` in any quote style? */
 function lineContainsLiteral(line: string, lit: ChangedLiteral): boolean {
-  if (lit.kind === 'string') {
-    // Match the exact string literal in any quote style.
-    return (
-      line.includes(`'${lit.value}'`) ||
-      line.includes(`"${lit.value}"`) ||
-      line.includes(`\`${lit.value}\``)
-    );
-  }
-  // number: bounded so 100 doesn't match 1000 or foo100
-  return new RegExp(`(?<![\\w.])${escapeRegExp(lit.value)}(?![\\w.])`).test(line);
+  return (
+    line.includes(`'${lit.value}'`) ||
+    line.includes(`"${lit.value}"`) ||
+    line.includes(`\`${lit.value}\``)
+  );
 }
 
 function classifySnippet(line: string): { snippet: string; isComment: boolean } {
@@ -295,15 +282,10 @@ function findStaleSites(
   return sites;
 }
 
-function scoreConfidence(
-  kind: LiteralKind,
-  sites: StaleSite[],
-): StaleLiteralCandidate['confidence'] {
+function scoreConfidence(sites: StaleSite[]): StaleLiteralCandidate['confidence'] {
   const realCode = sites.filter(s => !s.isComment && !s.isTest);
-  if (realCode.length === 0) return 'low';
-  const valueEmitting = realCode.some(s => VALUE_EMITTING_RE.test(s.snippet));
-  if (kind === 'number') return valueEmitting ? 'medium' : 'low';
-  return valueEmitting ? 'high' : 'medium';
+  if (realCode.length === 0) return 'low'; // only comments/tests survive — weak signal
+  return realCode.some(s => VALUE_EMITTING_RE.test(s.snippet)) ? 'high' : 'medium';
 }
 
 const CONFIDENCE_RANK: Record<StaleLiteralCandidate['confidence'], number> = {
@@ -354,7 +336,7 @@ export function computeStaleLiteralCandidates(context: ReviewContext): StaleLite
       kind: lit.kind,
       changedSite: { file: lit.file, line: lit.changedLine },
       staleSites,
-      confidence: scoreConfidence(lit.kind, staleSites),
+      confidence: scoreConfidence(staleSites),
     });
   }
 
@@ -392,7 +374,7 @@ export function renderStaleLiteralCandidates(candidates: StaleLiteralCandidate[]
   for (const c of candidates) {
     lines.push('');
     lines.push(
-      `- ${c.literal} (${c.kind}) — changed at ${c.changedSite.file}:${c.changedSite.line}; ` +
+      `- ${c.literal} — changed at ${c.changedSite.file}:${c.changedSite.line}; ` +
         `still present at [confidence: ${c.confidence}]:`,
     );
     for (const s of c.staleSites) {

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -116,13 +116,15 @@ describe('extractChangedLiterals', () => {
     expect(values).toContain('v2.1.0'); // has digits + '.'
   });
 
-  it('extracts distinctive numbers but skips small ones', () => {
+  it('does not extract numeric literals (numbers lack cross-file identity)', () => {
+    // A bare number like 4096 or 2.5 matches CSS classes, test values, and
+    // unrelated ratios with no shared meaning, so the signal is strings-only.
     const patches = new Map([
-      ['src/a.ts', '@@ -1,2 +1,2 @@\n-const max = 4096;\n-const n = 42;\n+const max = 8192;'],
+      ['src/a.ts', '@@ -1,2 +1,2 @@\n-const max = 4096;\n-const ratio = 2.5;\n+const max = 8192;'],
     ]);
     const values = extractChangedLiterals(patches).map(l => l.value);
-    expect(values).toContain('4096'); // >= 3 digits
-    expect(values).not.toContain('42'); // < 3 digits
+    expect(values).not.toContain('4096');
+    expect(values).not.toContain('2.5');
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to #614, prompted by verifying the signal actually reaches the harness.

Running `build-prompts` on the real PR #539 fixture (zero LLM) confirmed the
`<stale_literal_candidates>` block **does** fire in harness replay — it surfaces
`'claude-sonnet-4-6'` at `pr-review.ts:300` at high confidence, exactly the stale
copy that `grep_codebase`/`read_file` can never see in replay (dead `repoRootDir`).
So stale-duplicate is genuinely deterministic now, not left to blind grep.

But the same proof exposed **numeric over-fire**: `2.5` matched Tailwind `py-2.5`
classes, and `0.3`/`0.5` matched test files and unrelated ratios — ~30 lines of
noise that bloats the prompt (against #613's budget win) and risks false-positive
findings on other fixtures (stale-duplicate is `always: true`).

## What

Drop numeric literal extraction; the signal is **strings-only**. Numbers lack
cross-file identity (the same `0.5` means different things in different files),
whereas a string — model name, flag key, schema field, copied message — is a
shared identifier, which is exactly what stale-duplicate detects. Threshold
*numbers* are the boundary-change rule's territory.

Re-proved on the real fixture: the block now contains a single clean candidate
(`'claude-sonnet-4-6'` → line 300) and nothing else.

## Verification (zero LLM)
- 23 stale-literal unit tests (incl. a new "numbers are not extracted" test); full review suite **420 passing**.
- `typecheck`, `typecheck:harness`, `format:check` clean; `lint` 0 errors; build succeeds.
- `build-prompts` on the captured PR #539 fixture confirms the clean strings-only block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-literal detection to focus on string literals, reducing false positives from numeric values.
  * Updated candidate summaries to show clearer “changed at …; still present at …” status information.
  * Simplified confidence results so they better reflect where a literal still appears in code, comments, or tests.
* **Tests**
  * Updated coverage to match the new string-only literal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR narrows the stale-duplicate literal signal from string+number literals to strings only. The change is well-scoped: it removes numeric extraction and matching, simplifies confidence scoring, updates the rendering and test expectations, and the suite passes. No dependents rely on the removed 'number' kind, and the remaining string-only path handles the documented cases (distinctive config-like strings, template-literal interpolation skipping, touched-line exclusion).
>
> - Removed numeric literal extraction and NUMBER_RE; LiteralKind is now 'string' only
> - Simplified lineContainsLiteral and scoreConfidence to string-only semantics
> - Added a regression test asserting numbers are not extracted
> - Updated rendering to drop the per-candidate kind annotation

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ca54ca0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->