### PR TITLE
feat(review): deterministic discovery signal for untrusted-input-validation

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -559,9 +559,12 @@ defensive defaults, and TypeScript narrowing alone are NOT validation.
 
 MANDATORY protocol when this rule is active:
 
-1. Walk the diff. Identify every site that produces a value from
-   untrusted bytes (the keyword set above is a hint — if the diff
-   contains one, there's at least one site to inspect).
+1. **Check for a \`<untrusted_input_sites>\` block in your initial
+   message FIRST.** Lien pre-computes the parse sites this PR
+   introduced/modified (the discovery step is done for you), so it is
+   your worklist — inspect every site it lists, skip none. If no block
+   is present, walk the diff yourself, using the keyword set above as a
+   hint (if the diff contains one, there's at least one site to inspect).
 2. **For each site, you MUST call \`get_files_context\` (or
    \`read_file\`)** on the function and on each consumer of the parsed
    value. Trace the parsed value to its uses. Look for one of these
@@ -597,8 +600,10 @@ MANDATORY protocol when this rule is active:
    typed check.
 
 Do not finalize a response for this rule with zero findings unless
-you have called \`get_files_context\` on the parse-site function AND
-on each downstream consumer AND none of the four unguarded shapes
+you have inspected every site in the \`<untrusted_input_sites>\` block
+(or, when no block is present, every parse site you found in the diff),
+called \`get_files_context\` on each parse-site function AND its
+downstream consumers, AND confirmed none of the four unguarded shapes
 matches.`,
   example: `### Good finding — cast-without-validate (CodeRabbit on PR #541):
 {

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -16,6 +16,7 @@ import type { ReviewContext } from '../../plugin-types.js';
 import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
+import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -176,6 +177,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderBlastRadius(opts));
   appendIfPresent(sections, renderDeletedExports(context));
   appendIfPresent(sections, renderStaleLiteralSection(context));
+  appendIfPresent(sections, renderUntrustedInputSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/src/untrusted-input-signals.ts
+++ b/packages/review/src/untrusted-input-signals.ts
@@ -44,38 +44,44 @@ const COMMENT_RE = /^(\/\/|\/\*|\*|#|--|<!--)/;
 
 /**
  * Untrusted-read constructs, mirroring UNTRUSTED_INPUT_VALIDATION's trigger
- * keywords. Ordered most-specific first: `find()` returns the first match and
- * some bare constructs are substrings of qualified ones (`parseInt` ⊂
- * `Integer.parseInt`, `getenv` ⊂ `os.getenv`/`System.getenv`), so the qualified
- * form must be listed first to win the label. One site per line.
+ * keywords. Two ordering/shape rules keep this precise:
+ *  - Call-style constructs require a following `(`, so a construct NAME that
+ *    appears in a string, regex, or identifier (e.g. this module's own pattern
+ *    table, `'JSON.parse'` / `/\bparseInt\b/`) is not flagged as a real site.
+ *    Env-style accessors are matched bare — they're often used without a call
+ *    (`process.env.X`, `os.environ[...]`, `ENV[...]`).
+ *  - Most-specific first: `find()` returns the first match and some bare
+ *    constructs are substrings of qualified ones (`parseInt(` ⊂
+ *    `Integer.parseInt(`, `getenv(` ⊂ `os.getenv(`), so the qualified form is
+ *    listed first to win the label. One site per line.
  */
 const PARSE_PATTERNS: ReadonlyArray<{ label: string; re: RegExp }> = [
   // JS / TS
-  { label: 'JSON.parse', re: /\bJSON\.parse\b/ },
+  { label: 'JSON.parse', re: /\bJSON\.parse\s*\(/ },
   { label: 'process.env', re: /\bprocess\.env\b/ },
   { label: 'process.argv', re: /\bprocess\.argv\b/ },
-  { label: 'Integer.parseInt', re: /\bInteger\.parseInt\b/ }, // before bare parseInt (Java)
-  { label: 'parseInt', re: /\bparseInt\b/ },
+  { label: 'Integer.parseInt', re: /\bInteger\.parseInt\s*\(/ }, // before bare parseInt (Java)
+  { label: 'parseInt', re: /\bparseInt\s*\(/ },
   // Python
-  { label: 'json.loads', re: /\bjson\.loads\b/ },
+  { label: 'json.loads', re: /\bjson\.loads\s*\(/ },
   { label: 'os.environ', re: /\bos\.environ\b/ },
-  { label: 'os.getenv', re: /\bos\.getenv\b/ },
+  { label: 'os.getenv', re: /\bos\.getenv\s*\(/ },
   // Go
-  { label: 'json.Unmarshal', re: /\bjson\.Unmarshal\b/ },
-  { label: 'os.Getenv', re: /\bos\.Getenv\b/ },
-  { label: 'strconv.Atoi', re: /\bstrconv\.Atoi\b/ },
+  { label: 'json.Unmarshal', re: /\bjson\.Unmarshal\s*\(/ },
+  { label: 'os.Getenv', re: /\bos\.Getenv\s*\(/ },
+  { label: 'strconv.Atoi', re: /\bstrconv\.Atoi\s*\(/ },
   // Java
-  { label: 'System.getenv', re: /\bSystem\.getenv\b/ },
-  { label: 'readValue', re: /\breadValue\b/ },
+  { label: 'System.getenv', re: /\bSystem\.getenv\s*\(/ },
+  { label: 'readValue', re: /\breadValue\s*\(/ },
   // PHP
-  { label: 'json_decode', re: /\bjson_decode\b/ },
+  { label: 'json_decode', re: /\bjson_decode\s*\(/ },
   // Rust
-  { label: 'serde_json::from', re: /\bserde_json::from/ },
-  { label: 'env::var', re: /\benv::var\b/ },
+  { label: 'serde_json::from', re: /\bserde_json::from\w*\s*\(/ },
+  { label: 'env::var', re: /\benv::var\s*\(/ },
   // Ruby
   { label: 'ENV[', re: /\bENV\[/ },
   // PHP / generic env (kept last — broadest)
-  { label: 'getenv', re: /\bgetenv\b/ },
+  { label: 'getenv', re: /\bgetenv\s*\(/ },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/untrusted-input-signals.ts
+++ b/packages/review/src/untrusted-input-signals.ts
@@ -127,11 +127,14 @@ export function extractUntrustedInputSites(patches: Map<string, string>): Untrus
       if (raw.startsWith('+')) {
         const text = raw.slice(1);
         const key = `${file}:${newLine}`;
-        // A parse keyword in a comment/JSDoc line, or inside a string literal,
-        // is prose/data — not a real parse site. Skip comments outright and
-        // match against the string-stripped line so a construct name in a label
-        // (incl. this module's own pattern table) isn't flagged.
-        const probe = stripStringContents(text);
+        // A parse keyword in a comment, or inside a string literal, is
+        // prose/data — not a real parse site. Match against the line with string
+        // contents and comments stripped (strings first, so `//` inside a string
+        // is already gone) so a construct name in a label or comment — incl. this
+        // module's own pattern table — isn't flagged.
+        const probe = stripStringContents(text)
+          .replace(/\/\*.*?\*\//g, ' ') // inline block comments
+          .replace(/\/\/.*$/, ''); // trailing line comment
         const match = COMMENT_RE.test(text.trim())
           ? undefined
           : PARSE_PATTERNS.find(p => p.re.test(probe));

--- a/packages/review/src/untrusted-input-signals.ts
+++ b/packages/review/src/untrusted-input-signals.ts
@@ -1,0 +1,171 @@
+/**
+ * Deterministic discovery signal for the untrusted-input-validation rule.
+ *
+ * Unlike stale-duplicate (where the whole structural fact is pre-computable),
+ * untrusted-input is a HYBRID: the *discovery* half — finding the sites that
+ * read untrusted bytes (`JSON.parse`, `process.env`, `parseInt`, `json.loads`,
+ * `strconv.Atoi`, …) — is deterministic from the diff, but the *judgement* half
+ * — does the parsed value flow to a typed consumer without runtime validation —
+ * is data-flow reasoning that resists determinism and stays with the LLM.
+ *
+ * This module pre-computes the parse sites the diff introduces/modifies and
+ * injects them as an `<untrusted_input_sites>` worklist, mirroring the
+ * `<deleted_exports>` / `<stale_literal_candidates>` precedents. It hands the
+ * agent a concrete list to trace, which counters the silence-bias failure mode
+ * (the agent investigates but emits nothing). It injects only locations — never
+ * a verdict; the agent still traces each site to its consumers and judges.
+ */
+
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UntrustedInputSite {
+  file: string;
+  /** New-file line number where the parse construct appears. */
+  line: number;
+  /** The matched untrusted-read construct, e.g. 'JSON.parse'. */
+  pattern: string;
+  snippet: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cap the worklist so the prompt stays compact (protects the input budget). */
+const MAX_SITES = 12;
+const MAX_SNIPPET_CHARS = 160;
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/**
+ * Untrusted-read constructs, mirroring UNTRUSTED_INPUT_VALIDATION's trigger
+ * keywords. Ordered most-specific first so a line is labelled by its most
+ * precise match (e.g. `os.getenv` before the bare `getenv`); one site per line.
+ */
+const PARSE_PATTERNS: ReadonlyArray<{ label: string; re: RegExp }> = [
+  // JS / TS
+  { label: 'JSON.parse', re: /\bJSON\.parse\b/ },
+  { label: 'process.env', re: /\bprocess\.env\b/ },
+  { label: 'process.argv', re: /\bprocess\.argv\b/ },
+  { label: 'parseInt', re: /\bparseInt\b/ },
+  // Python
+  { label: 'json.loads', re: /\bjson\.loads\b/ },
+  { label: 'os.environ', re: /\bos\.environ\b/ },
+  { label: 'os.getenv', re: /\bos\.getenv\b/ },
+  // Go
+  { label: 'json.Unmarshal', re: /\bjson\.Unmarshal\b/ },
+  { label: 'os.Getenv', re: /\bos\.Getenv\b/ },
+  { label: 'strconv.Atoi', re: /\bstrconv\.Atoi\b/ },
+  // Java
+  { label: 'Integer.parseInt', re: /\bInteger\.parseInt\b/ },
+  { label: 'System.getenv', re: /\bSystem\.getenv\b/ },
+  { label: 'readValue', re: /\breadValue\b/ },
+  // PHP
+  { label: 'json_decode', re: /\bjson_decode\b/ },
+  // Rust
+  { label: 'serde_json::from', re: /\bserde_json::from/ },
+  { label: 'env::var', re: /\benv::var\b/ },
+  // Ruby
+  { label: 'ENV[', re: /\bENV\[/ },
+  // PHP / generic env (kept last — broadest)
+  { label: 'getenv', re: /\bgetenv\b/ },
+];
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect the untrusted-read sites the diff introduces or modifies — matches on
+ * `+` lines only (added/changed code), tracking the new-file line number. One
+ * site per line, labelled by its most specific construct. Returns all sites
+ * (uncapped); the render layer caps and notes any overflow. Exposed for testing.
+ */
+export function extractUntrustedInputSites(patches: Map<string, string>): UntrustedInputSite[] {
+  const sites: UntrustedInputSite[] = [];
+  const seen = new Set<string>();
+
+  for (const [file, patch] of patches) {
+    let newLine = 0;
+    for (const raw of patch.split('\n')) {
+      const header = raw.match(HUNK_HEADER_RE);
+      if (header) {
+        newLine = parseInt(header[1], 10);
+        continue;
+      }
+      if (raw.startsWith('+++') || raw.startsWith('---')) continue;
+      if (raw.startsWith('\\')) continue; // "\ No newline at end of file"
+
+      if (raw.startsWith('+')) {
+        const text = raw.slice(1);
+        const match = PARSE_PATTERNS.find(p => p.re.test(text));
+        const key = `${file}:${newLine}`;
+        if (match && !seen.has(key)) {
+          seen.add(key);
+          sites.push({
+            file,
+            line: newLine,
+            pattern: match.label,
+            snippet: text.trim().slice(0, MAX_SNIPPET_CHARS),
+          });
+        }
+        newLine++;
+      } else if (raw.startsWith('-')) {
+        // a removed line does not advance the new-file counter
+      } else {
+        newLine++; // context line
+      }
+    }
+  }
+
+  return sites;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the parse-site worklist as an `<untrusted_input_sites>` block for the
+ * agent's initial message. Returns '' when there are no sites so callers can
+ * append unconditionally.
+ */
+export function renderUntrustedInputSites(sites: UntrustedInputSite[]): string {
+  if (sites.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('<untrusted_input_sites>');
+  lines.push(
+    'Pre-computed: sites this PR introduced/modified that read untrusted input ' +
+      '(parsed/env/argv). This is the discovery step done for you — do NOT skip it. ' +
+      'For EACH site, trace the parsed value to its consumers (get_files_context / ' +
+      'read_file) and check the four unguarded shapes: cast-without-validate, schema ' +
+      'gap, NaN-on-parse, blank/truthy-coerce. Emit a finding for each unguarded path; ' +
+      'stay silent on a site only after tracing it and confirming the value is validated. ' +
+      'The list covers parse calls on changed lines; if a consumer of an unchanged parse ' +
+      'site was edited, inspect that too.',
+  );
+  for (const s of sites.slice(0, MAX_SITES)) {
+    lines.push(`    - ${s.file}:${s.line}  [${s.pattern}]  \`${s.snippet}\``);
+  }
+  if (sites.length > MAX_SITES) {
+    lines.push(
+      `    - [+${sites.length - MAX_SITES} more parse site(s) on changed lines — also scan the diff so none is missed]`,
+    );
+  }
+  lines.push('</untrusted_input_sites>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<untrusted_input_sites>` section from the review context. Returns
+ * '' when there is no diff to scan.
+ */
+export function renderUntrustedInputSection(context: ReviewContext): string {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return '';
+  return renderUntrustedInputSites(extractUntrustedInputSites(patches));
+}

--- a/packages/review/src/untrusted-input-signals.ts
+++ b/packages/review/src/untrusted-input-signals.ts
@@ -39,17 +39,22 @@ export interface UntrustedInputSite {
 const MAX_SITES = 12;
 const MAX_SNIPPET_CHARS = 160;
 const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+/** Full-line comment / JSDoc markers — a parse keyword in prose is not a real site. */
+const COMMENT_RE = /^(\/\/|\/\*|\*|#|--|<!--)/;
 
 /**
  * Untrusted-read constructs, mirroring UNTRUSTED_INPUT_VALIDATION's trigger
- * keywords. Ordered most-specific first so a line is labelled by its most
- * precise match (e.g. `os.getenv` before the bare `getenv`); one site per line.
+ * keywords. Ordered most-specific first: `find()` returns the first match and
+ * some bare constructs are substrings of qualified ones (`parseInt` ⊂
+ * `Integer.parseInt`, `getenv` ⊂ `os.getenv`/`System.getenv`), so the qualified
+ * form must be listed first to win the label. One site per line.
  */
 const PARSE_PATTERNS: ReadonlyArray<{ label: string; re: RegExp }> = [
   // JS / TS
   { label: 'JSON.parse', re: /\bJSON\.parse\b/ },
   { label: 'process.env', re: /\bprocess\.env\b/ },
   { label: 'process.argv', re: /\bprocess\.argv\b/ },
+  { label: 'Integer.parseInt', re: /\bInteger\.parseInt\b/ }, // before bare parseInt (Java)
   { label: 'parseInt', re: /\bparseInt\b/ },
   // Python
   { label: 'json.loads', re: /\bjson\.loads\b/ },
@@ -60,7 +65,6 @@ const PARSE_PATTERNS: ReadonlyArray<{ label: string; re: RegExp }> = [
   { label: 'os.Getenv', re: /\bos\.Getenv\b/ },
   { label: 'strconv.Atoi', re: /\bstrconv\.Atoi\b/ },
   // Java
-  { label: 'Integer.parseInt', re: /\bInteger\.parseInt\b/ },
   { label: 'System.getenv', re: /\bSystem\.getenv\b/ },
   { label: 'readValue', re: /\breadValue\b/ },
   // PHP
@@ -101,8 +105,12 @@ export function extractUntrustedInputSites(patches: Map<string, string>): Untrus
 
       if (raw.startsWith('+')) {
         const text = raw.slice(1);
-        const match = PARSE_PATTERNS.find(p => p.re.test(text));
         const key = `${file}:${newLine}`;
+        // A parse keyword inside a comment / JSDoc line (incl. this module's own
+        // docstring) is prose, not a real parse site — skip it.
+        const match = COMMENT_RE.test(text.trim())
+          ? undefined
+          : PARSE_PATTERNS.find(p => p.re.test(text));
         if (match && !seen.has(key)) {
           seen.add(key);
           sites.push({

--- a/packages/review/src/untrusted-input-signals.ts
+++ b/packages/review/src/untrusted-input-signals.ts
@@ -89,6 +89,21 @@ const PARSE_PATTERNS: ReadonlyArray<{ label: string; re: RegExp }> = [
 // ---------------------------------------------------------------------------
 
 /**
+ * Blank out the *contents* of quoted string literals so a construct NAME that
+ * lives inside a string (a label in this module's own pattern table, a keyword
+ * in rules.ts, a fixture asserting on the text) isn't matched as a real call or
+ * access. Quote delimiters are kept so the line still tokenizes sanely. Regex
+ * literals aren't stripped, but the call-style `(` requirement and the bare
+ * env-accessor shapes already keep those from matching.
+ */
+function stripStringContents(line: string): string {
+  return line
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/`(?:\\.|[^`\\])*`/g, '``');
+}
+
+/**
  * Collect the untrusted-read sites the diff introduces or modifies — matches on
  * `+` lines only (added/changed code), tracking the new-file line number. One
  * site per line, labelled by its most specific construct. Returns all sites
@@ -112,11 +127,14 @@ export function extractUntrustedInputSites(patches: Map<string, string>): Untrus
       if (raw.startsWith('+')) {
         const text = raw.slice(1);
         const key = `${file}:${newLine}`;
-        // A parse keyword inside a comment / JSDoc line (incl. this module's own
-        // docstring) is prose, not a real parse site — skip it.
+        // A parse keyword in a comment/JSDoc line, or inside a string literal,
+        // is prose/data — not a real parse site. Skip comments outright and
+        // match against the string-stripped line so a construct name in a label
+        // (incl. this module's own pattern table) isn't flagged.
+        const probe = stripStringContents(text);
         const match = COMMENT_RE.test(text.trim())
           ? undefined
-          : PARSE_PATTERNS.find(p => p.re.test(text));
+          : PARSE_PATTERNS.find(p => p.re.test(probe));
         if (match && !seen.has(key)) {
           seen.add(key);
           sites.push({

--- a/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
+++ b/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
@@ -13,8 +13,12 @@
  *     packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.fixture.json \
  *     --sha 7cb0149
  *
- * Tier 1: rule fires + get_files_context is called (the rule's prompt
- * mandates inspecting consumers of the parsed value).
+ * Tier 1: rule fires + get_files_context is called (the rule still mandates
+ * inspecting consumers of the parsed value — get_files_context reads in-memory
+ * repoChunks, so unlike grep/read it is NOT blind in replay). The *discovery*
+ * half is now deterministic: a pre-computed <untrusted_input_sites> worklist is
+ * injected (see packages/review/src/untrusted-input-signals.ts), which hands the
+ * agent the parse sites and counters the silence-bias 0-findings failure mode.
  * Tier 2: the finding mentions one of the four sub-pattern vocabulary
  * families. Set is wide because four sub-patterns can each render with
  * different language; any correct rendering of any one pattern will land.

--- a/packages/review/test/untrusted-input-signals.test.ts
+++ b/packages/review/test/untrusted-input-signals.test.ts
@@ -100,6 +100,21 @@ describe('extractUntrustedInputSites', () => {
     expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
   });
 
+  it('strips string contents: a construct name in a label is not a site, but a real access on the same line is', () => {
+    // Mirrors this module's own PARSE_PATTERNS table: a quoted label must not be
+    // flagged, while a genuine access elsewhere on the line must be.
+    const patch =
+      "@@ -1,1 +1,2 @@\n x=1\n+const t = { label: 'process.env', call: process.env.HOME };";
+    const sites = extractUntrustedInputSites(new Map([['a.ts', patch]]));
+    expect(sites).toHaveLength(1);
+    expect(sites[0].pattern).toBe('process.env');
+  });
+
+  it('does not flag a bare env construct that only appears inside a string label', () => {
+    const patch = "@@ -1,1 +1,2 @@\n x=1\n+const patterns = ['process.env', 'ENV[', 'os.environ'];";
+    expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
+  });
+
   it('labels Integer.parseInt as the qualified Java construct, not bare parseInt', () => {
     const sites = extractUntrustedInputSites(
       new Map([['A.java', '@@ -1,1 +1,2 @@\n int x = 1;\n+int n = Integer.parseInt(s);']]),

--- a/packages/review/test/untrusted-input-signals.test.ts
+++ b/packages/review/test/untrusted-input-signals.test.ts
@@ -80,6 +80,23 @@ describe('extractUntrustedInputSites', () => {
     const patch = '@@ -1,1 +1,2 @@\n x=1\n+const a = JSON.parse(x); const b = JSON.parse(y);';
     expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(1);
   });
+
+  it('ignores parse keywords inside comment / JSDoc lines', () => {
+    const patch =
+      '@@ -1,1 +1,3 @@\n' +
+      ' const x = 1;\n' +
+      '+// parsed via JSON.parse below, then validated\n' +
+      '+ * reads untrusted bytes — JSON.parse, parseInt, json.loads';
+    expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
+  });
+
+  it('labels Integer.parseInt as the qualified Java construct, not bare parseInt', () => {
+    const sites = extractUntrustedInputSites(
+      new Map([['A.java', '@@ -1,1 +1,2 @@\n int x = 1;\n+int n = Integer.parseInt(s);']]),
+    );
+    expect(sites).toHaveLength(1);
+    expect(sites[0].pattern).toBe('Integer.parseInt');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/untrusted-input-signals.test.ts
+++ b/packages/review/test/untrusted-input-signals.test.ts
@@ -115,6 +115,15 @@ describe('extractUntrustedInputSites', () => {
     expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
   });
 
+  it('ignores parse keywords in a trailing comment but keeps a real call on the line', () => {
+    const noSite =
+      '@@ -1,1 +1,2 @@\n x=1\n+const n = compute(); // formerly parseInt(raw), JSON.parse(s)';
+    expect(extractUntrustedInputSites(new Map([['a.ts', noSite]]))).toHaveLength(0);
+
+    const withCall = '@@ -1,1 +1,2 @@\n x=1\n+const v = JSON.parse(raw); // load the config file';
+    expect(extractUntrustedInputSites(new Map([['a.ts', withCall]]))).toHaveLength(1);
+  });
+
   it('labels Integer.parseInt as the qualified Java construct, not bare parseInt', () => {
     const sites = extractUntrustedInputSites(
       new Map([['A.java', '@@ -1,1 +1,2 @@\n int x = 1;\n+int n = Integer.parseInt(s);']]),

--- a/packages/review/test/untrusted-input-signals.test.ts
+++ b/packages/review/test/untrusted-input-signals.test.ts
@@ -90,6 +90,16 @@ describe('extractUntrustedInputSites', () => {
     expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
   });
 
+  it('does not flag construct names that appear as strings or regexes (not calls)', () => {
+    // The signal must not flag its own pattern table or any mention-in-prose.
+    const patch =
+      '@@ -1,1 +1,3 @@\n' +
+      ' const x = 1;\n' +
+      "+const label = 'JSON.parse';\n" +
+      '+const re = /\\bparseInt\\b/;';
+    expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
+  });
+
   it('labels Integer.parseInt as the qualified Java construct, not bare parseInt', () => {
     const sites = extractUntrustedInputSites(
       new Map([['A.java', '@@ -1,1 +1,2 @@\n int x = 1;\n+int n = Integer.parseInt(s);']]),

--- a/packages/review/test/untrusted-input-signals.test.ts
+++ b/packages/review/test/untrusted-input-signals.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  extractUntrustedInputSites,
+  renderUntrustedInputSites,
+  renderUntrustedInputSection,
+} from '../src/untrusted-input-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+function ctxWithPatches(patches?: Map<string, string>): ReviewContext {
+  return {
+    pr: patches ? { patches } : undefined,
+    changedFiles: patches ? [...patches.keys()] : [],
+    chunks: [],
+  } as unknown as ReviewContext;
+}
+
+// Mirrors the real PR #541 shapes: a JSON.parse cast and a parseInt(argv).
+const LOAD_RESULT_PATCH =
+  '@@ -36,3 +36,4 @@\n' +
+  '   function loadResult(path) {\n' +
+  "     const raw = fs.readFileSync(path, 'utf-8');\n" +
+  '+    return JSON.parse(raw) as Partial<HarnessResult>;\n' +
+  '   }';
+
+const PARSE_FLAGS_PATCH =
+  '@@ -46,2 +46,3 @@\n' +
+  '   if (arg === "--votes") {\n' +
+  '+    flags.votes = parseInt(argv[++i], 10);\n' +
+  '   }';
+
+// ---------------------------------------------------------------------------
+// extractUntrustedInputSites
+// ---------------------------------------------------------------------------
+
+describe('extractUntrustedInputSites', () => {
+  it('extracts a JSON.parse site on a + line with the right line number', () => {
+    const sites = extractUntrustedInputSites(new Map([['test/assert-cli.ts', LOAD_RESULT_PATCH]]));
+    expect(sites).toHaveLength(1);
+    expect(sites[0]).toMatchObject({ file: 'test/assert-cli.ts', line: 38, pattern: 'JSON.parse' });
+    expect(sites[0].snippet).toContain('JSON.parse(raw)');
+  });
+
+  it('extracts a parseInt site', () => {
+    const sites = extractUntrustedInputSites(new Map([['test/run.ts', PARSE_FLAGS_PATCH]]));
+    expect(sites).toHaveLength(1);
+    expect(sites[0]).toMatchObject({ file: 'test/run.ts', line: 47, pattern: 'parseInt' });
+  });
+
+  it('detects multiple language constructs across files', () => {
+    const patches = new Map([
+      ['a.py', '@@ -1,1 +1,2 @@\n x = 1\n+cfg = json.loads(raw)'],
+      ['b.go', '@@ -1,1 +1,2 @@\n y := 1\n+n, _ := strconv.Atoi(s)'],
+      ['c.rs', '@@ -1,1 +1,2 @@\n let z = 1;\n+let v = env::var("KEY").unwrap();'],
+    ]);
+    const patterns = extractUntrustedInputSites(patches)
+      .map(s => s.pattern)
+      .sort();
+    expect(patterns).toEqual(['env::var', 'json.loads', 'strconv.Atoi']);
+  });
+
+  it('labels a line by its most specific construct (os.getenv, not getenv)', () => {
+    const sites = extractUntrustedInputSites(
+      new Map([['a.py', '@@ -1,1 +1,2 @@\n x=1\n+val = os.getenv("HOME")']]),
+    );
+    expect(sites).toHaveLength(1);
+    expect(sites[0].pattern).toBe('os.getenv');
+  });
+
+  it('ignores parse constructs on removed and context lines', () => {
+    const patch =
+      '@@ -1,3 +1,3 @@\n' +
+      '   const ok = JSON.parse(safe);\n' + // context — unchanged, not a new site
+      '-  const bad = JSON.parse(removed);\n' + // removed — gone
+      '+  const renamed = compute();';
+    expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(0);
+  });
+
+  it('records one site per line and dedups', () => {
+    const patch = '@@ -1,1 +1,2 @@\n x=1\n+const a = JSON.parse(x); const b = JSON.parse(y);';
+    expect(extractUntrustedInputSites(new Map([['a.ts', patch]]))).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rendering
+// ---------------------------------------------------------------------------
+
+describe('renderUntrustedInputSites', () => {
+  it('returns "" for no sites', () => {
+    expect(renderUntrustedInputSites([])).toBe('');
+  });
+
+  it('renders the block listing each site with file:line and construct', () => {
+    const md = renderUntrustedInputSites([
+      {
+        file: 'test/assert-cli.ts',
+        line: 38,
+        pattern: 'JSON.parse',
+        snippet: 'return JSON.parse(raw)',
+      },
+    ]);
+    expect(md).toContain('<untrusted_input_sites>');
+    expect(md).toContain('</untrusted_input_sites>');
+    expect(md).toContain('test/assert-cli.ts:38');
+    expect(md).toContain('[JSON.parse]');
+  });
+
+  it('caps the list and notes the overflow rather than dropping silently', () => {
+    const many = Array.from({ length: 15 }, (_, i) => ({
+      file: 'a.ts',
+      line: i + 1,
+      pattern: 'JSON.parse',
+      snippet: `JSON.parse(x${i})`,
+    }));
+    const md = renderUntrustedInputSites(many);
+    expect(md).toContain('[+3 more parse site(s)');
+    // 12 rendered site lines + the overflow note
+    expect(md.match(/\[JSON\.parse\]/g)).toHaveLength(12);
+  });
+});
+
+describe('renderUntrustedInputSection', () => {
+  it('returns "" when there is no diff', () => {
+    expect(renderUntrustedInputSection(ctxWithPatches())).toBe('');
+  });
+
+  it('renders the block from context patches', () => {
+    const section = renderUntrustedInputSection(
+      ctxWithPatches(new Map([['test/assert-cli.ts', LOAD_RESULT_PATCH]])),
+    );
+    expect(section).toContain('<untrusted_input_sites>');
+    expect(section).toContain('test/assert-cli.ts:38');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage untrusted-input injection', () => {
+  it('includes the <untrusted_input_sites> block when parse sites exist', () => {
+    const ctx = ctxWithPatches(new Map([['test/run.ts', PARSE_FLAGS_PATCH]]));
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).toContain('<untrusted_input_sites>');
+    expect(message).toContain('test/run.ts:47');
+    expect(message).toContain('[parseInt]');
+  });
+
+  it('omits the block when the diff has no untrusted-input sites', () => {
+    const patch = '@@ -1,1 +1,2 @@\n const x = 1;\n+const y = x + 1;';
+    const ctx = ctxWithPatches(new Map([['a.ts', patch]]));
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).not.toContain('<untrusted_input_sites>');
+  });
+});


### PR DESCRIPTION
## Why

Same deterministic treatment as #614/#615, now for `untrusted-input-validation` — but a **hybrid**, per the design: only the *discovery* half is determinizable. Finding the sites that read untrusted bytes (`JSON.parse`, `process.env`, `parseInt`, `json.loads`, `strconv.Atoi`, …) is deterministic from the diff; deciding whether the parsed value flows to a typed consumer *without runtime validation* is data-flow reasoning that stays with the LLM.

The rule's failure mode is kimi's silence bias — it investigates but emits 0 findings. Handing it a concrete pre-computed worklist (instead of relying on it to discover sites) directly counters that.

Unlike stale-duplicate, untrusted isn't blocked by blind tools: its `get_files_context` consumer-tracing reads in-memory `repoChunks`, so it works in replay. So this PR keeps that requirement and only determinizes discovery.

## What

- **`untrusted-input-signals.ts`** — `extractUntrustedInputSites` matches the rule's trigger constructs on `+` lines (one site per line, labelled by its most specific construct), and `renderUntrustedInputSites` injects an `<untrusted_input_sites>` worklist (capped at 12 with an explicit overflow note — no silent truncation).
- **`system-prompt.ts`** — inject the section in `buildInitialMessage` (mirrors `<stale_literal_candidates>` / `<deleted_exports>`).
- **`rules.ts`** — `UNTRUSTED_INPUT_VALIDATION` step 1 now leads with the worklist; the `get_files_context` consumer-tracing requirement is unchanged.

## Verification (zero LLM)
- 13 new unit tests; full review suite **433 passing**. `typecheck`, `typecheck:harness`, `format:check` clean; `lint` 0 errors.
- `build-prompts` on the captured PR #541 fixture confirms the block surfaces all three canonical bug sites: `assert-cli.ts:38 [JSON.parse]` (cast-without-validate), `run.ts:48 [parseInt]` (NaN-on-parse), `fixture-loader.ts:63 [JSON.parse]` (schema-gap consumer).

## Note
The end-to-end emit lift on kimi (Tier-1 silence → finding) would need an OpenRouter `--calibrate` to *measure* — deliberately deferred (cost). The zero-LLM deliverable is the deterministic discovery signal + its injection, which is what primes the silence-biased agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an untrusted-input review section that automatically highlights likely input-validation sites from changed code.
  * Review guidance now includes a precomputed worklist of relevant locations, helping ensure all flagged sites are checked.
* **Bug Fixes**
  * Improved review completeness checks so all identified sites are covered before a finding is ruled out.
  * Added a cap and overflow note for large worklists to keep the review prompt manageable.
* **Tests**
  * Added coverage for site detection, rendering, and message integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 2 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 2 | +29 |
| ⏱️ time to understand | 1 | +65 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it stopped unexpectedly while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8ccfd6c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->