### PR TITLE
fix(review): add timeout diagnostics to kimi/OpenRouter request logs

### DIFF
--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -53,7 +53,8 @@ const CHAT_REQUEST_TIMEOUT_MS = 120_000;
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
 /** Rough token estimate from a serialized request body (~4 chars/token). */
-const approxTokens = (bytes: number): number => Math.round(bytes / 4);
+const approxTokens = (bytes: number): number =>
+  Number.isFinite(bytes) ? Math.round(bytes / 4) : 0;
 
 /**
  * Build the diagnostic message for a request that hit the abort timeout. The
@@ -613,16 +614,19 @@ export class OpenAIAgentClient {
   private async postChat(
     body: Record<string, unknown>,
   ): Promise<{ ok: boolean; status: number; text: string }> {
+    const payload = JSON.stringify(body);
+    const messageCount = Array.isArray(body.messages) ? body.messages.length : 0;
+    const bodyBytes = Buffer.byteLength(payload, 'utf8'); // true UTF-8 size, not UTF-16 units
+
     const controller = new AbortController();
     let timedOut = false;
+    // Stamp the start instant right as the timeout window opens (before the timer
+    // is armed and the request begins) so reported elapsed lines up with the limit.
+    const startedAt = Date.now();
     const timer = setTimeout(() => {
       timedOut = true;
       controller.abort();
     }, CHAT_REQUEST_TIMEOUT_MS);
-
-    const payload = JSON.stringify(body);
-    const messageCount = Array.isArray(body.messages) ? body.messages.length : 0;
-    const startedAt = Date.now();
     // Track which phase is in flight so a timeout can report whether the hang was
     // before the response headers arrived or during the body stream.
     let phase: 'connection/headers' | 'body read' = 'connection/headers';
@@ -651,7 +655,7 @@ export class OpenAIAgentClient {
             elapsedMs: Date.now() - startedAt,
             limitMs: CHAT_REQUEST_TIMEOUT_MS,
             phase,
-            bodyBytes: payload.length,
+            bodyBytes,
             messageCount,
           }),
         );

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -52,6 +52,31 @@ const CHAT_REQUEST_TIMEOUT_MS = 120_000;
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
+/** Rough token estimate from a serialized request body (~4 chars/token). */
+const approxTokens = (bytes: number): number => Math.round(bytes / 4);
+
+/**
+ * Build the diagnostic message for a request that hit the abort timeout. The
+ * bare AbortError ("This operation was aborted") says nothing about why — this
+ * surfaces how long we waited vs the limit, which phase hung (connection/headers
+ * vs body read), and how big the request was, so a reader can tell a genuinely
+ * slow/hung Kimi turn from an early provider reset or a ballooned context.
+ * Exported for unit testing.
+ */
+export function formatChatTimeout(opts: {
+  elapsedMs: number;
+  limitMs: number;
+  phase: 'connection/headers' | 'body read';
+  bodyBytes: number;
+  messageCount: number;
+}): string {
+  return (
+    `timed out after ${opts.elapsedMs}ms (limit ${opts.limitMs}ms) during ${opts.phase} — ` +
+    `request was ${opts.bodyBytes} bytes (~${approxTokens(opts.bodyBytes)} input tokens) ` +
+    `across ${opts.messageCount} message(s)`
+  );
+}
+
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
 }
@@ -589,7 +614,19 @@ export class OpenAIAgentClient {
     body: Record<string, unknown>,
   ): Promise<{ ok: boolean; status: number; text: string }> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), CHAT_REQUEST_TIMEOUT_MS);
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, CHAT_REQUEST_TIMEOUT_MS);
+
+    const payload = JSON.stringify(body);
+    const messageCount = Array.isArray(body.messages) ? body.messages.length : 0;
+    const startedAt = Date.now();
+    // Track which phase is in flight so a timeout can report whether the hang was
+    // before the response headers arrived or during the body stream.
+    let phase: 'connection/headers' | 'body read' = 'connection/headers';
+
     try {
       const response = await fetch(`${this.baseUrl}/chat/completions`, {
         method: 'POST',
@@ -599,11 +636,27 @@ export class OpenAIAgentClient {
           'HTTP-Referer': 'https://lien.dev',
           'X-Title': 'Lien Review',
         },
-        body: JSON.stringify(body),
+        body: payload,
         signal: controller.signal,
       });
+      phase = 'body read';
       const text = await response.text();
       return { ok: response.ok, status: response.status, text };
+    } catch (err) {
+      // The controller is aborted only by our own timer, so any abort here is a
+      // timeout — replace the opaque AbortError with actionable diagnostics.
+      if (timedOut) {
+        throw new Error(
+          formatChatTimeout({
+            elapsedMs: Date.now() - startedAt,
+            limitMs: CHAT_REQUEST_TIMEOUT_MS,
+            phase,
+            bodyBytes: payload.length,
+            messageCount,
+          }),
+        );
+      }
+      throw err;
     } finally {
       clearTimeout(timer);
     }

--- a/packages/review/test/plugins-agent-timeout-log.test.ts
+++ b/packages/review/test/plugins-agent-timeout-log.test.ts
@@ -29,4 +29,15 @@ describe('formatChatTimeout', () => {
     expect(msg).toContain('during connection/headers');
     expect(msg).toContain('~100 input tokens'); // 400 / 4
   });
+
+  it('does not emit NaN/Infinity token counts for a non-finite body size', () => {
+    const msg = formatChatTimeout({
+      elapsedMs: 1,
+      limitMs: 2,
+      phase: 'body read',
+      bodyBytes: Number.NaN,
+      messageCount: 1,
+    });
+    expect(msg).toContain('~0 input tokens');
+  });
 });

--- a/packages/review/test/plugins-agent-timeout-log.test.ts
+++ b/packages/review/test/plugins-agent-timeout-log.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { formatChatTimeout } from '../src/plugins/agent/openai-client.js';
+
+describe('formatChatTimeout', () => {
+  it('reports elapsed vs limit, phase, byte/token size, and message count', () => {
+    const msg = formatChatTimeout({
+      elapsedMs: 120013,
+      limitMs: 120000,
+      phase: 'body read',
+      bodyBytes: 84232,
+      messageCount: 9,
+    });
+    expect(msg).toContain('timed out after 120013ms');
+    expect(msg).toContain('limit 120000ms');
+    expect(msg).toContain('during body read');
+    expect(msg).toContain('84232 bytes');
+    expect(msg).toContain('~21058 input tokens'); // 84232 / 4
+    expect(msg).toContain('across 9 message(s)');
+  });
+
+  it('distinguishes a hang before the response headers from a body-stream hang', () => {
+    const msg = formatChatTimeout({
+      elapsedMs: 4200,
+      limitMs: 120000,
+      phase: 'connection/headers',
+      bodyBytes: 400,
+      messageCount: 2,
+    });
+    expect(msg).toContain('during connection/headers');
+    expect(msg).toContain('~100 input tokens'); // 400 / 4
+  });
+});


### PR DESCRIPTION
## Why

On PR #616's own review run, Kimi requests repeatedly failed with the opaque `This operation was aborted` and the run ended with no findings:

```
Warning: [agent] Request to moonshotai/kimi-k2.7-code failed: This operation was aborted — retry 1/2
Warning: [agent] Request to moonshotai/kimi-k2.7-code failed: This operation was aborted — retry 2/2
Warning: [agent] chat request failed after retries (...aborted); ending run
```

That message is the 120s `AbortController` timeout firing — but it says nothing about *why*, so you can't distinguish a genuinely slow/hung Kimi turn (hitting ~120s) from an early provider reset or a context that ballooned the request.

## What

`postChat` now replaces the bare AbortError with a diagnostic message:

```
timed out after 120013ms (limit 120000ms) during body read — request was 84232 bytes (~21058 input tokens) across 9 message(s)
```

- **elapsed vs limit** → is it the full 120s (slow/hung) or an early abort?
- **phase** → did it hang before the response headers, or mid body-stream?
- **request size** → bytes / approx input tokens / message count → is context bloat the cause?

The enriched message flows to all three existing log points: the per-attempt retry warning, the top-level `ending run`, and the summary-retry failure. Scope is the OpenRouter/Kimi path (`openai-client.ts`) — the Anthropic client uses the SDK with its own timeout handling and isn't the source of these aborts.

## Verification
- 2 new zero-LLM unit tests on `formatChatTimeout`; full review suite **422 passing**. The existing retry/timeout budget tests (mocked-fetch rejection → `timedOut=false` → rethrow unchanged) still pass. `typecheck`/`format`/`lint` clean.

## Follow-up (not in this PR)
Once these logs show the pattern (e.g. consistently hitting ~120s on large-context turns), the natural next step is to tune `CHAT_REQUEST_TIMEOUT_MS` and/or trim per-turn context — deferred until the data says which.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout errors for chat requests with clearer details about how long the request ran, what stage stalled, and the size of the request.
  * Added more helpful diagnostics when a request fails before response headers or while reading the response body.
  * Preserved existing non-timeout error behavior while making timeout failures easier to understand and troubleshoot.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 6 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 2 | +0 |
| 🐛 estimated bugs | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a diagnostic formatter for OpenRouter/Kimi timeout aborts and wires it into `postChat` in `openai-client.ts`. The change is narrowly scoped to one internal code path, has a single internal caller, and is covered by new unit tests. The timeout tracking (`timedOut` flag + `startedAt` + `phase`) is correct: only aborts triggered by the local timer are replaced with the enriched message, while non-timeout fetch rejections are rethrown unchanged. The diagnostic message exposes elapsed time, limit, hang phase, request bytes, approximate tokens, and message count — useful for distinguishing slow/hung turns from early resets or context bloat. The existing retry logic in `chatCompletion` and the summary-retry path will propagate the new message naturally. Edge cases (NaN/Infinity bytes) are guarded. No stale literals or breaking changes were found.
>
> - `formatChatTimeout` builds rich timeout diagnostics for OpenRouter/Kimi aborts.
> - `postChat` now tracks phase and replaces AbortError with the diagnostic message only when its own timer fired.
> - Two new unit tests cover the formatter; existing retry/timeout budget tests remain passing.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 796862f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->