### PR TITLE
feat(review): OpenRouter provider routing + per-request provider/latency logging

### DIFF
--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -18,6 +18,28 @@ export const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 export const DEFAULT_OPENROUTER_INPUT_COST_PER_MTOK = 0.74;
 export const DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK = 3.5;
 
+/**
+ * Default OpenRouter provider-routing preferences, sent as the request's
+ * `provider` block. `moonshotai/kimi-k2.7-code` is multiplexed across several
+ * upstream providers of varying speed, and slow ones drive the intermittent
+ * 120s request timeouts. `sort: 'throughput'` steers to the fastest endpoint
+ * (the direct lever against those timeouts); `allow_fallbacks` keeps the run
+ * resilient if that endpoint fails. Overridable via the `providerRouting`
+ * config (e.g. add `ignore`/`order` once logs name a flaky provider).
+ */
+export const DEFAULT_PROVIDER_ROUTING: Record<string, unknown> = {
+  sort: 'throughput',
+  allow_fallbacks: true,
+};
+
+/**
+ * Per-request abort timeout (ms) for OpenRouter chat calls — covers response
+ * headers AND body read. Generous so a slow large-context reasoning turn isn't
+ * cut off. Overridable via the `requestTimeoutMs` config; don't lower/raise the
+ * default without evidence from the per-request latency logs.
+ */
+export const DEFAULT_CHAT_REQUEST_TIMEOUT_MS = 120_000;
+
 /** Hard ceiling for the scaled agent token budget — bounds worst-case cost. */
 export const MAX_REVIEW_TOKEN_BUDGET = 250_000;
 

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -40,6 +40,14 @@ const configSchema = z.object({
   outputCostPerMTok: z.number().optional(),
   maxTurns: z.number().int().min(1).max(30).default(15),
   maxTokenBudget: z.number().int().default(100_000),
+  /**
+   * OpenRouter `provider` routing block (openai path only), sent verbatim on
+   * each request. Omit to use DEFAULT_PROVIDER_ROUTING; set `null` to send no
+   * routing preferences; set e.g. `{ ignore: ['slow-provider'] }` to steer.
+   */
+  providerRouting: z.record(z.unknown()).nullable().optional(),
+  /** Per-request abort timeout in ms (openai path). Omit for the default 120s. */
+  requestTimeoutMs: z.number().int().positive().optional(),
   // Legacy — maps to apiKey
   anthropicApiKey: z.string().optional(),
   blastRadius: z
@@ -234,6 +242,8 @@ function runAgentClient(
     outputCostPerMTok: config.outputCostPerMTok,
     maxTurns: config.maxTurns,
     maxTokenBudget,
+    providerRouting: config.providerRouting,
+    requestTimeoutMs: config.requestTimeoutMs,
     logger,
   });
   return client.run(systemPrompt, initialMessage, toOpenAITools(AGENT_TOOLS), toolExecutor);

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger } from '../../logger.js';
+import { DEFAULT_PROVIDER_ROUTING, DEFAULT_CHAT_REQUEST_TIMEOUT_MS } from '../../defaults.js';
 import type {
   AgentFinding,
   AgentSummary,
@@ -43,12 +44,8 @@ const RETRY_NUDGE =
  */
 const CHAT_MAX_ATTEMPTS = 2;
 const CHAT_RETRY_BASE_DELAY_MS = 500;
-/**
- * Per-request abort timeout, covering BOTH the response headers and the body
- * read — a hang in either rejects (and is retried) instead of stalling a turn
- * forever. Generous so a slow large-context reasoning turn isn't aborted.
- */
-const CHAT_REQUEST_TIMEOUT_MS = 120_000;
+// Per-request abort timeout (headers + body) is per-instance and configurable —
+// see `requestTimeoutMs` / DEFAULT_CHAT_REQUEST_TIMEOUT_MS.
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -171,6 +168,13 @@ interface OpenAIClientOptions {
   maxTurns: number;
   maxTokenBudget: number;
   logger: Logger;
+  /**
+   * OpenRouter `provider` routing block, sent verbatim on each request. Defaults
+   * to DEFAULT_PROVIDER_ROUTING; pass `null` to send no routing preferences.
+   */
+  providerRouting?: Record<string, unknown> | null;
+  /** Per-request abort timeout in ms. Defaults to DEFAULT_CHAT_REQUEST_TIMEOUT_MS. */
+  requestTimeoutMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +216,38 @@ interface ChatResponse {
     finish_reason: string;
   }>;
   usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+  /**
+   * OpenRouter routing metadata — names the upstream provider that actually
+   * served the request. `endpoints.available[]` marks the selected one;
+   * `attempt` > 1 means earlier providers failed and it fell back. Used only
+   * for diagnostic logging (see describeServingProvider).
+   */
+  openrouter_metadata?: {
+    summary?: string;
+    attempt?: number;
+    endpoints?: { available?: Array<{ provider?: string; selected?: boolean }> };
+    attempts?: Array<{ provider?: string; status?: number }>;
+  };
+  /** Older/simpler top-level provider name some responses carry. */
+  provider?: string;
+}
+
+/**
+ * Extract a short "who served this" label from an OpenRouter response for
+ * per-request logging. Prefers the selected endpoint's provider, then the last
+ * attempt, then the top-level `provider`, then the human `summary`. Appends the
+ * attempt number when it fell back (attempt > 1). Returns 'unknown' if the
+ * response carried no routing metadata.
+ */
+export function describeServingProvider(
+  resp: Pick<ChatResponse, 'openrouter_metadata' | 'provider'>,
+): string {
+  const meta = resp.openrouter_metadata;
+  const selected = meta?.endpoints?.available?.find(e => e.selected)?.provider;
+  const lastAttempt = meta?.attempts?.[meta.attempts.length - 1]?.provider;
+  const name = selected ?? lastAttempt ?? resp.provider ?? meta?.summary ?? 'unknown';
+  const attempt = meta?.attempt ?? 0;
+  return attempt > 1 ? `${name} (attempt ${attempt}, fell back)` : name;
 }
 
 /**
@@ -226,6 +262,10 @@ export class OpenAIAgentClient {
   private logger: Logger;
   private inputCostPerToken: number;
   private outputCostPerToken: number;
+  /** OpenRouter `provider` routing block sent on each request (null = omit). */
+  private providerRouting: Record<string, unknown> | null;
+  /** Per-request abort timeout (ms). */
+  private requestTimeoutMs: number;
   // Verbose per-turn reasoning/output logging — ON by default so every review
   // is diagnosable; set LIEN_REVIEW_LOG_AGENT=0 (or false) to silence it. The
   // last turn's reasoning is always logged on an incomplete run regardless.
@@ -242,6 +282,10 @@ export class OpenAIAgentClient {
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;
+    // `undefined` → default routing; explicit `null` → omit the provider block.
+    this.providerRouting =
+      options.providerRouting === undefined ? DEFAULT_PROVIDER_ROUTING : options.providerRouting;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_CHAT_REQUEST_TIMEOUT_MS;
   }
 
   async run(
@@ -555,12 +599,15 @@ export class OpenAIAgentClient {
     } else if (tools.length > 0) {
       body.tools = tools;
     }
+    // Steer OpenRouter routing (e.g. prefer fastest providers) to cut the
+    // intermittent upstream timeouts. Omitted when providerRouting is null.
+    if (this.providerRouting) body.provider = this.providerRouting;
 
     let lastError: Error | undefined;
     for (let attempt = 1; attempt <= CHAT_MAX_ATTEMPTS; attempt++) {
       if (attempt > 1) await sleep(CHAT_RETRY_BASE_DELAY_MS * (attempt - 1));
 
-      let res: { ok: boolean; status: number; text: string };
+      let res: { ok: boolean; status: number; text: string; elapsedMs: number };
       try {
         res = await this.postChat(body);
       } catch (err) {
@@ -593,7 +640,15 @@ export class OpenAIAgentClient {
         continue;
       }
       try {
-        return JSON.parse(res.text) as ChatResponse;
+        const parsed = JSON.parse(res.text) as ChatResponse;
+        // Per-request diagnostics: which upstream provider served this, and how
+        // long it took — so slow/aborted turns can be traced to a provider.
+        if (this.logAgentTurns) {
+          this.logger.info(
+            `[agent] served by ${describeServingProvider(parsed)} in ${res.elapsedMs}ms`,
+          );
+        }
+        return parsed;
       } catch {
         lastError = new Error(
           `Unparseable response body from ${this.model} (status ${res.status}): ${truncate(res.text, 200)}`,
@@ -613,7 +668,7 @@ export class OpenAIAgentClient {
    */
   private async postChat(
     body: Record<string, unknown>,
-  ): Promise<{ ok: boolean; status: number; text: string }> {
+  ): Promise<{ ok: boolean; status: number; text: string; elapsedMs: number }> {
     const payload = JSON.stringify(body);
     const messageCount = Array.isArray(body.messages) ? body.messages.length : 0;
     const bodyBytes = Buffer.byteLength(payload, 'utf8'); // true UTF-8 size, not UTF-16 units
@@ -626,7 +681,7 @@ export class OpenAIAgentClient {
     const timer = setTimeout(() => {
       timedOut = true;
       controller.abort();
-    }, CHAT_REQUEST_TIMEOUT_MS);
+    }, this.requestTimeoutMs);
     // Track which phase is in flight so a timeout can report whether the hang was
     // before the response headers arrived or during the body stream.
     let phase: 'connection/headers' | 'body read' = 'connection/headers';
@@ -645,7 +700,7 @@ export class OpenAIAgentClient {
       });
       phase = 'body read';
       const text = await response.text();
-      return { ok: response.ok, status: response.status, text };
+      return { ok: response.ok, status: response.status, text, elapsedMs: Date.now() - startedAt };
     } catch (err) {
       // The controller is aborted only by our own timer, so any abort here is a
       // timeout — replace the opaque AbortError with actionable diagnostics.
@@ -653,7 +708,7 @@ export class OpenAIAgentClient {
         throw new Error(
           formatChatTimeout({
             elapsedMs: Date.now() - startedAt,
-            limitMs: CHAT_REQUEST_TIMEOUT_MS,
+            limitMs: this.requestTimeoutMs,
             phase,
             bodyBytes,
             messageCount,

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -282,9 +282,16 @@ export class OpenAIAgentClient {
     this.inputCostPerToken = (options.inputCostPerMTok ?? DEFAULT_INPUT_COST_PER_MTOK) / 1_000_000;
     this.outputCostPerToken =
       (options.outputCostPerMTok ?? DEFAULT_OUTPUT_COST_PER_MTOK) / 1_000_000;
-    // `undefined` → default routing; explicit `null` → omit the provider block.
+    // Explicit config wins on any endpoint (opt-in). When unset, the default
+    // routing applies ONLY to OpenRouter — other OpenAI-compatible endpoints
+    // (Gemini/DeepSeek direct) reject an unknown top-level `provider` field, so
+    // omit it there. `null` explicitly omits it anywhere.
     this.providerRouting =
-      options.providerRouting === undefined ? DEFAULT_PROVIDER_ROUTING : options.providerRouting;
+      options.providerRouting !== undefined
+        ? options.providerRouting
+        : options.baseUrl.includes('openrouter.ai')
+          ? DEFAULT_PROVIDER_ROUTING
+          : null;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_CHAT_REQUEST_TIMEOUT_MS;
   }
 

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -36,6 +36,13 @@ export interface AgentConfig {
   outputCostPerMTok?: number;
   maxTurns: number;
   maxTokenBudget: number;
+  /**
+   * OpenRouter `provider` routing block (openai path), sent verbatim on each
+   * request. Omit for DEFAULT_PROVIDER_ROUTING; `null` to send no preferences.
+   */
+  providerRouting?: Record<string, unknown> | null;
+  /** Per-request abort timeout in ms (openai path). Omit for the 120s default. */
+  requestTimeoutMs?: number;
   /** Inject transitive blast radius into the agent's initial message. */
   blastRadius?: BlastRadiusConfig;
 }

--- a/packages/review/test/plugins-agent-provider-routing.test.ts
+++ b/packages/review/test/plugins-agent-provider-routing.test.ts
@@ -47,12 +47,16 @@ function stopTurn(extra: Record<string, unknown> = {}): Record<string, unknown> 
 }
 
 function makeClient(
-  opts: Partial<{ providerRouting: Record<string, unknown> | null; requestTimeoutMs: number }> = {},
+  opts: Partial<{
+    providerRouting: Record<string, unknown> | null;
+    requestTimeoutMs: number;
+    baseUrl: string;
+  }> = {},
   logger: Logger = silentLogger,
 ): OpenAIAgentClient {
   return new OpenAIAgentClient({
     apiKey: 'test',
-    baseUrl: 'http://mock.local',
+    baseUrl: 'https://openrouter.ai/api/v1', // prod endpoint — default routing applies
     model: 'test-model',
     maxTurns: 8,
     maxTokenBudget: 1_000_000,
@@ -114,11 +118,26 @@ describe('describeServingProvider', () => {
 // ---------------------------------------------------------------------------
 
 describe('OpenAIAgentClient provider routing', () => {
-  it('sends the default provider routing block when unconfigured', async () => {
+  it('sends the default provider routing block on OpenRouter when unconfigured', async () => {
     const { bodies } = mockFetch([stopTurn()]);
     await makeClient().run('sys', 'init', [], noopTool);
     expect(bodies[0].provider).toEqual(DEFAULT_PROVIDER_ROUTING);
     expect(bodies[0].provider).toEqual({ sort: 'throughput', allow_fallbacks: true });
+  });
+
+  it('omits the default block for a non-OpenRouter endpoint (Gemini/DeepSeek reject unknown fields)', async () => {
+    const { bodies } = mockFetch([stopTurn()]);
+    await makeClient({ baseUrl: 'https://api.deepseek.com/v1' }).run('sys', 'init', [], noopTool);
+    expect(bodies[0].provider).toBeUndefined();
+  });
+
+  it('still honors an explicit routing block on a non-OpenRouter endpoint (opt-in)', async () => {
+    const { bodies } = mockFetch([stopTurn()]);
+    await makeClient({
+      baseUrl: 'https://api.deepseek.com/v1',
+      providerRouting: { order: ['x'] },
+    }).run('sys', 'init', [], noopTool);
+    expect(bodies[0].provider).toEqual({ order: ['x'] });
   });
 
   it('sends a caller-supplied routing block verbatim', async () => {

--- a/packages/review/test/plugins-agent-provider-routing.test.ts
+++ b/packages/review/test/plugins-agent-provider-routing.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OpenAIAgentClient, describeServingProvider } from '../src/plugins/agent/openai-client.js';
+import { DEFAULT_PROVIDER_ROUTING } from '../src/defaults.js';
+import { silentLogger } from '../src/test-helpers.js';
+import type { Logger } from '../src/logger.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror plugins-agent-budget.test.ts — kept local/self-contained)
+// ---------------------------------------------------------------------------
+
+function capturingLogger(): { logger: Logger; lines: string[] } {
+  const lines: string[] = [];
+  const record = (m: string) => lines.push(m);
+  return { logger: { info: record, warning: record, error: record, debug: record }, lines };
+}
+
+/** Install a fetch mock that replays `responses` and records request bodies. */
+function mockFetch(responses: Array<Record<string, unknown>>): {
+  bodies: Array<Record<string, unknown>>;
+} {
+  const bodies: Array<Record<string, unknown>> = [];
+  const queue = [...responses];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: { body: string }) => {
+      bodies.push(JSON.parse(init.body));
+      const next = queue.shift();
+      const text = next == null ? '' : JSON.stringify(next);
+      return { ok: true, status: 200, json: async () => next, text: async () => text };
+    }),
+  );
+  return { bodies };
+}
+
+const CLEAN_JSON =
+  '```json\n' +
+  JSON.stringify({ findings: [], summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] } }) +
+  '\n```';
+
+/** A finish_reason:'stop' turn carrying the clean verdict + optional routing metadata. */
+function stopTurn(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    choices: [{ message: { role: 'assistant', content: CLEAN_JSON }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 },
+    ...extra,
+  };
+}
+
+function makeClient(
+  opts: Partial<{ providerRouting: Record<string, unknown> | null; requestTimeoutMs: number }> = {},
+  logger: Logger = silentLogger,
+): OpenAIAgentClient {
+  return new OpenAIAgentClient({
+    apiKey: 'test',
+    baseUrl: 'http://mock.local',
+    model: 'test-model',
+    maxTurns: 8,
+    maxTokenBudget: 1_000_000,
+    logger,
+    ...opts,
+  });
+}
+
+const noopTool = async () => 'ok';
+
+afterEach(() => vi.unstubAllGlobals());
+
+// ---------------------------------------------------------------------------
+// describeServingProvider
+// ---------------------------------------------------------------------------
+
+describe('describeServingProvider', () => {
+  it('names the selected endpoint provider', () => {
+    expect(
+      describeServingProvider({
+        openrouter_metadata: {
+          attempt: 1,
+          endpoints: {
+            available: [
+              { provider: 'Moonshot', selected: false },
+              { provider: 'Fireworks', selected: true },
+            ],
+          },
+        },
+      }),
+    ).toBe('Fireworks');
+  });
+
+  it('flags a fallback (attempt > 1) using the last attempt provider', () => {
+    expect(
+      describeServingProvider({
+        openrouter_metadata: {
+          attempt: 2,
+          attempts: [
+            { provider: 'Slow', status: 502 },
+            { provider: 'Together', status: 200 },
+          ],
+        },
+      }),
+    ).toBe('Together (attempt 2, fell back)');
+  });
+
+  it('falls back to the top-level provider field, then summary, then unknown', () => {
+    expect(describeServingProvider({ provider: 'DeepInfra' })).toBe('DeepInfra');
+    expect(
+      describeServingProvider({ openrouter_metadata: { summary: 'available=1, selected=X' } }),
+    ).toBe('available=1, selected=X');
+    expect(describeServingProvider({})).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request body — provider routing block
+// ---------------------------------------------------------------------------
+
+describe('OpenAIAgentClient provider routing', () => {
+  it('sends the default provider routing block when unconfigured', async () => {
+    const { bodies } = mockFetch([stopTurn()]);
+    await makeClient().run('sys', 'init', [], noopTool);
+    expect(bodies[0].provider).toEqual(DEFAULT_PROVIDER_ROUTING);
+    expect(bodies[0].provider).toEqual({ sort: 'throughput', allow_fallbacks: true });
+  });
+
+  it('sends a caller-supplied routing block verbatim', async () => {
+    const { bodies } = mockFetch([stopTurn()]);
+    await makeClient({ providerRouting: { order: ['fireworks', 'together'] } }).run(
+      'sys',
+      'init',
+      [],
+      noopTool,
+    );
+    expect(bodies[0].provider).toEqual({ order: ['fireworks', 'together'] });
+  });
+
+  it('omits the provider block when routing is explicitly null', async () => {
+    const { bodies } = mockFetch([stopTurn()]);
+    await makeClient({ providerRouting: null }).run('sys', 'init', [], noopTool);
+    expect(bodies[0].provider).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-request diagnostics — serving provider + latency logging
+// ---------------------------------------------------------------------------
+
+describe('OpenAIAgentClient per-request diagnostics', () => {
+  it('logs the serving provider and latency for each request', async () => {
+    mockFetch([
+      stopTurn({
+        openrouter_metadata: {
+          attempt: 1,
+          endpoints: { available: [{ provider: 'Fireworks', selected: true }] },
+        },
+      }),
+    ]);
+    const { logger, lines } = capturingLogger();
+    await makeClient({}, logger).run('sys', 'init', [], noopTool);
+    expect(lines.some(l => /served by Fireworks in \d+ms/.test(l))).toBe(true);
+  });
+
+  it('completes a normal run with a custom requestTimeoutMs (option accepted)', async () => {
+    mockFetch([stopTurn()]);
+    const result = await makeClient({ requestTimeoutMs: 30_000 }).run('sys', 'init', [], noopTool);
+    expect(result.incomplete).toBe(false);
+    expect(result.summary).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #617's timeout *diagnostics* — this is the *mitigation* for the intermittent kimi `This operation was aborted`. The trigger is upstream provider latency (OpenRouter multiplexes `kimi-k2.7-code` across several providers of varying speed). These are the parts **we** control.

## What

- **Provider routing (main lever):** send an OpenRouter `provider` block on each request, default `{ sort: 'throughput', allow_fallbacks: true }` — prefer the fastest endpoint, keep fallback resilience. Configurable via a new `providerRouting` config (set `{ ignore: [...] }` / `{ order: [...] }` once logs name a slow provider; `null` omits it).
- **Per-request diagnostics:** log `served by <provider> in <ms>ms` each turn via `describeServingProvider`, which reads OpenRouter's routing metadata or the top-level `provider` field. This is how we'll confirm whether slow/aborted turns cluster on a provider.
- **Configurable timeout:** `requestTimeoutMs` config (default 120s, `DEFAULT_CHAT_REQUEST_TIMEOUT_MS`). The knob ships; **the value is unchanged** pending real latency data (Part 3 is data-gated).

Scope is the OpenRouter/OpenAI path (`openai-client.ts`); the Anthropic client uses the SDK (own timeout) and is untouched.

## Verification

- **8 zero-LLM unit tests** (`plugins-agent-provider-routing.test.ts`): default block sent; caller override sent verbatim; `null` omits it; `describeServingProvider` parses selected-endpoint / fallback-attempt / top-level-provider / summary / unknown; the `served by … in …ms` line is logged; a custom `requestTimeoutMs` run completes.
- Full review suite **450 passing**; `typecheck` / `typecheck:harness` / `format:check` / `build` clean; `lint` 0 errors.
- **Live-verified against OpenRouter** (one tiny request): the `provider` block is *accepted* (no 400 — it would have broken every review) and the response carries the serving provider as a top-level `provider` field (e.g. `"Together"`). Notably the documented `openrouter_metadata` object was **absent**, so the top-level-`provider` fallback in `describeServingProvider` is the real-world path — and it's covered by a unit test.

## Follow-up (data-gated)
Once the `served by … in …ms` logs accumulate: if timeouts cluster on a provider, add `ignore`/`order` via config; if turns finish just past 120s, raise `requestTimeoutMs`. No blind changes.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 1 new function is too complex.
🔗 **Impact**: 1 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +15 |
| 🧠 mental load | 3 | +3 |
| ⏱️ time to understand | 6 | +19 |
| 🐛 estimated bugs | 1 | +0 |


> [!WARNING]
> **1 issue found** · Low Risk
>
> The PR adds OpenRouter provider routing and per-request latency/provider logging to the OpenAI agent path. The changes are additive, config is validated (Zod positive-int timeout, nullable record routing), and the new `describeServingProvider` degrades gracefully to 'unknown'. The main issue is a stale-duplicate literal: `runAgentClient` hardcodes the OpenRouter base URL fallback instead of reusing the existing `DEFAULT_OPENROUTER_BASE_URL` constant, creating a maintenance drift risk if the canonical URL ever changes.
>
> - Introduced DEFAULT_PROVIDER_ROUTING and DEFAULT_CHAT_REQUEST_TIMEOUT_MS constants
> - OpenAIAgentClient now sends a configurable OpenRouter provider block and logs serving provider + elapsed ms per turn
> - Stale hardcoded OpenRouter base URL fallback in index.ts should use DEFAULT_OPENROUTER_BASE_URL

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 12edade. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable OpenRouter provider routing and request timeouts.
  * Improved request logging to show which provider handled a response and how long it took.

* **Bug Fixes**
  * Requests now use a more resilient default routing setup and a longer default timeout, reducing premature failures.

* **Tests**
  * Added coverage for routing behavior, timeout handling, and provider/latency logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->