### PR TITLE
fix(review): count real findings separately from the summary in the per-plugin log

### DIFF
--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -331,8 +331,14 @@ async function runActivePlugins(
       if (verbose) logger.debug(`[engine] Running "${plugin.id}"...`);
 
       const pluginFindings = await plugin.analyze(pluginContext);
+      // Count real (postable) findings separately from the summary entry some
+      // plugins append (category 'summary' → the PR callout, not an inline
+      // comment). Counting the summary as a finding read as "a finding went
+      // missing" when a review was actually clean (0 real + 1 summary).
+      const real = pluginFindings.filter(f => f.category !== 'summary').length;
+      const hasSummary = pluginFindings.length > real;
       logger.info(
-        `Plugin "${plugin.id}": ${pluginFindings.length} findings (${Date.now() - start}ms)`,
+        `Plugin "${plugin.id}": ${real} findings${hasSummary ? ' (+summary)' : ''} (${Date.now() - start}ms)`,
       );
       return pluginFindings;
     }),

--- a/packages/review/test/engine.test.ts
+++ b/packages/review/test/engine.test.ts
@@ -38,6 +38,54 @@ describe('ReviewEngine', () => {
     expect(results[0]).toEqual(finding);
   });
 
+  it('logs the real finding count separately from an appended summary', async () => {
+    const engine = new ReviewEngine();
+    const infos: string[] = [];
+    const logger = { ...silentLogger, info: (msg: string) => infos.push(msg) };
+    const real: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: 'a.ts',
+      line: 5,
+      severity: 'warning',
+      category: 'bug',
+      message: 'real issue',
+    };
+    const summary: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message: 'overview',
+    };
+    engine.register(createTestPlugin({ id: 'agent-review', analyze: () => [real, summary] }));
+
+    await engine.run(createTestContext({ logger }));
+
+    // 1 real finding + 1 summary → "1 findings (+summary)", not "2 findings".
+    expect(infos.some(m => /Plugin "agent-review": 1 findings \(\+summary\)/.test(m))).toBe(true);
+  });
+
+  it('omits the (+summary) annotation when a plugin returns only real findings', async () => {
+    const engine = new ReviewEngine();
+    const infos: string[] = [];
+    const logger = { ...silentLogger, info: (msg: string) => infos.push(msg) };
+    const finding: ReviewFinding = {
+      pluginId: 'complexity',
+      filepath: 'a.ts',
+      line: 3,
+      severity: 'warning',
+      category: 'complexity',
+      message: 'x',
+    };
+    engine.register(createTestPlugin({ id: 'complexity', analyze: () => [finding] }));
+
+    await engine.run(createTestContext({ logger }));
+
+    expect(infos.some(m => /Plugin "complexity": 1 findings \(\d+ms\)/.test(m))).toBe(true);
+    expect(infos.some(m => m.includes('+summary'))).toBe(false);
+  });
+
   it('rejects duplicate plugin IDs', () => {
     const engine = new ReviewEngine();
     engine.register(createTestPlugin({ id: 'a' }));


### PR DESCRIPTION
## Why

On #618 the CI logged `Plugin "agent-review": 1 findings` on a review that found **0 real issues** — which reads as if an inline finding went missing. It hadn't: the agent plugin always appends a `category:'summary'` entry (the PR-body/review callout, not an inline comment), and the engine's per-plugin log counted `pluginFindings.length`, which includes it. `0 real + 1 summary` → `1 findings`.

## What

`engine.ts` now logs the **real (postable) finding count** and annotates the summary only when present:
- `Plugin "agent-review": 0 findings (+summary)` — clean review, summary posted as the callout.
- `Plugin "agent-review": 2 findings (+summary)` — 2 inline findings + summary.
- `Plugin "complexity": 12 findings` — unchanged (no summary entry).

No behavior change — logging only. It removes the "did we drop a finding?" ambiguity.

## Verification
- +2 engine tests (real+summary → `1 findings (+summary)`; real-only → no annotation). Full review suite **454 passing**; `typecheck` / `build` / `format:check` clean; `lint` 0 errors.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR is a logging-only change in the review engine. It separates the count of real (postable) findings from summary entries when printing per-plugin results, removing the misleading "1 findings" message for clean reviews that only produced a summary callout. The returned findings array and all downstream behavior are unchanged, so no callers are affected.
>
> - runActivePlugins now logs real finding count and appends '(+summary)' only when a summary entry is present
> - Added engine tests covering both the summary-annotated and real-only log messages

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 191e9fa. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin logging so only real findings are counted in the visible result count.
  * When a plugin includes an extra summary item, the log now clearly shows `(+summary)` instead of inflating the finding count.
  * Preserved the standard log format for plugins that return only regular findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->