### PR TITLE
fix(cli): remove unpublished @liendev/review from dependencies

### DIFF
--- a/.changeset/remove-phantom-review-dep.md
+++ b/.changeset/remove-phantom-review-dep.md
@@ -1,0 +1,5 @@
+---
+"@liendev/lien": patch
+---
+
+fix: remove unpublished @liendev/review from dependencies; npm install was failing with E404.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10656,7 +10656,6 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
@@ -10680,6 +10679,19 @@
         "tree-sitter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
+      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter-go": {
@@ -10836,6 +10848,27 @@
       },
       "peerDependenciesMeta": {
         "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-swift": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-swift/-/tree-sitter-swift-0.7.1.tgz",
+      "integrity": "sha512-pneKVTuGamaBsqqqfB9BvNQjktzh/0IVPR54jLB5Fq/JTDQwYHd0Wo6pVyZ5jAYpbztzq+rJ/rpL9ruxTmSoKw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0",
+        "tree-sitter-cli": "^0.23",
+        "which": "2.0.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
           "optional": true
         }
       }
@@ -13235,12 +13268,11 @@
     },
     "packages/cli": {
       "name": "@liendev/lien",
-      "version": "0.45.0",
+      "version": "0.48.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@liendev/core": "*",
         "@liendev/parser": "*",
-        "@liendev/review": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/figlet": "1.7.0",
         "chalk": "5.3.0",
@@ -13654,7 +13686,7 @@
     },
     "packages/parser": {
       "name": "@liendev/parser",
-      "version": "0.45.0",
+      "version": "0.48.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "glob": "^10.5.0",
@@ -13727,40 +13759,6 @@
       },
       "engines": {
         "node": ">=22.21.0"
-      }
-    },
-    "node_modules/tree-sitter-swift": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-swift/-/tree-sitter-swift-0.7.1.tgz",
-      "integrity": "sha512-pneKVTuGamaBsqqqfB9BvNQjktzh/0IVPR54jLB5Fq/JTDQwYHd0Wo6pVyZ5jAYpbztzq+rJ/rpL9ruxTmSoKw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0",
-        "tree-sitter-cli": "^0.23",
-        "which": "2.0.2"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.22.1"
-      },
-      "peerDependenciesMeta": {
-        "tree_sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-cli": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
-      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "tree-sitter": "cli.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,6 @@
   "dependencies": {
     "@liendev/core": "*",
     "@liendev/parser": "*",
-    "@liendev/review": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/figlet": "1.7.0",
     "chalk": "5.3.0",


### PR DESCRIPTION
## What / Why

Review finding (adversarially confirmed with a live repro): `packages/cli/package.json` declared `"@liendev/review": "*"` as a runtime dependency. `@liendev/review` is `"private": true` and never published to npm, so **`npm install @liendev/lien` fails with E404** for every fresh consumer of the published 0.48.0.

Root cause: PR #510 removed the `lien review` CLI command but left the dependency line behind.

## Fix

- Verified `packages/cli/src` has **zero** imports from `@liendev/review` (grep, no matches).
- Deleted the `"@liendev/review": "*"` line from `packages/cli/package.json`.
- Pruned the lockfile with `npm install --package-lock-only`. The lockfile diff also includes npm normalization noise: stale `0.45.0` → `0.48.0` version sync for the cli/parser workspace entries and re-sorting of the `tree-sitter-swift`/`tree-sitter-cli` entries.
- Root `build`/`typecheck` scripts still build `@liendev/review` — left untouched, since review is a dependency of `@liendev/action` and typechecks in its own right (not cli-specific coupling).
- Changeset: patch for `@liendev/lien`.

**This unblocks a patch release** — once published, fresh installs of `@liendev/lien` work again.

## Verification

- `npm run format:check` — pass
- `npm run lint` — 0 errors (28 pre-existing warnings)
- `npm run typecheck` — pass
- `npm run build` — pass (all packages incl. review and action)
- `npm run test -w @liendev/lien` — **40 files, 676 tests passed**

Remaining `@liendev/review` references in the lockfile are legitimate: the workspace link and `@liendev/action`'s dependency.

## Caveats / Follow-up

- Lockfile regenerated — on conflict after another PR merges, rebase and re-run `npm install --package-lock-only`.
- Recommended follow-up (separate Wave-2 PR): CI smoke test that packs the cli tarball, installs it in a scratch dir, and runs `lien --version` — would have caught this class of bug before publish.
- Noted while investigating (out of scope, not touched): the lockfile still carries an `"extraneous": true` entry for a removed `packages/app` workspace that also referenced `@liendev/review`; a full `npm install` on main would clean it up.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 82 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 5 high-risk file(s) with 116 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 9 | — |
| 🧠 mental load | 32 | — |
| ⏱️ time to understand | 39 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8188449. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an invalid dependency entry to prevent install failures during package setup.
  * Updated the release metadata to reflect a patch-level update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->