### PR TITLE
perf(indexer): batch manifest deletions instead of one write per file

### DIFF
--- a/.changeset/manifest-batch-deletions.md
+++ b/.changeset/manifest-batch-deletions.md
@@ -1,0 +1,6 @@
+---
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+Batch manifest deletions: removing K files now performs a single manifest read+write instead of one per file, matching the batched update path. Speeds up incremental indexing after branch switches and directory renames.

--- a/packages/cli/src/mcp/file-change-handler.test.ts
+++ b/packages/cli/src/mcp/file-change-handler.test.ts
@@ -21,6 +21,7 @@ vi.mock('@liendev/core', async () => {
       return {
         load: vi.fn().mockResolvedValue({ files: {} }),
         removeFile: vi.fn().mockResolvedValue(undefined),
+        removeFiles: vi.fn().mockResolvedValue(undefined),
         transaction: vi.fn().mockResolvedValue(null),
       };
     }),
@@ -48,6 +49,7 @@ vi.mock('fs/promises', () => ({
 }));
 
 import { isFileIgnored, isGitignoreFile, createFileChangeHandler } from './file-change-handler.js';
+import { ManifestManager } from '@liendev/core';
 import { createGitignoreFilter } from '@liendev/parser';
 
 function createMockVectorDB(dbPath = '/project/.lien/indices/abc') {
@@ -203,6 +205,39 @@ describe('createFileChangeHandler', () => {
 
     // Deletion should always be processed regardless of gitignore
     expect(checkAndReconnect).toHaveBeenCalledOnce();
+  });
+
+  it('should batch manifest removals for batch deletion events', async () => {
+    // Make the gitignore filter allow everything
+    vi.mocked(createGitignoreFilter).mockResolvedValue(() => false);
+
+    const vectorDB = createMockVectorDB();
+    const handler = createFileChangeHandler(
+      '/project',
+      vectorDB,
+      createMockEmbeddings(),
+      log,
+      reindexStateManager,
+      checkAndReconnect,
+    );
+    const manifest = vi.mocked(ManifestManager).mock.results.at(-1)!.value;
+
+    await handler({
+      type: 'batch',
+      filepath: '/project/src/deleted1.ts',
+      added: [],
+      modified: [],
+      deleted: ['/project/src/deleted1.ts', '/project/src/deleted2.ts'],
+    });
+
+    expect(vectorDB.deleteByFile).toHaveBeenCalledTimes(2);
+    // Manifest removal happens once for the whole batch, not per file
+    expect(manifest.removeFiles).toHaveBeenCalledOnce();
+    expect(manifest.removeFiles).toHaveBeenCalledWith([
+      '/project/src/deleted1.ts',
+      '/project/src/deleted2.ts',
+    ]);
+    expect(manifest.removeFile).not.toHaveBeenCalled();
   });
 
   it('should call checkAndReconnect before processing batch events with files to process', async () => {

--- a/packages/cli/src/mcp/file-change-handler.ts
+++ b/packages/cli/src/mcp/file-change-handler.ts
@@ -43,18 +43,22 @@ async function handleBatchDeletions(
   log: LogFn,
 ): Promise<void> {
   const failures: string[] = [];
+  const removedFiles: string[] = [];
 
   for (const filepath of deletedFiles) {
     log(`🗑️  File deleted: ${filepath}`);
     try {
       await vectorDB.deleteByFile(filepath);
-      await manifest.removeFile(filepath);
+      removedFiles.push(filepath);
       log(`✓ Removed ${filepath} from index`);
     } catch (error) {
       log(`Failed to remove ${filepath}: ${error}`, 'warning');
       failures.push(filepath);
     }
   }
+
+  // Batch manifest removal: one read+write instead of one per file
+  await manifest.removeFiles(removedFiles);
 
   if (failures.length > 0) {
     throw new Error(`Failed to delete ${failures.length} file(s): ${failures.join(', ')}`);

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -173,19 +173,21 @@ async function handleDeletions(
     return 0;
   }
 
-  let removedCount = 0;
+  const removedFiles: string[] = [];
 
   for (const filepath of deletedFiles) {
     try {
       await vectorDB.deleteByFile(filepath);
-      await manifest.removeFile(filepath);
-      removedCount++;
+      removedFiles.push(filepath);
     } catch {
       // Continue on error, just count failures
     }
   }
 
-  return removedCount;
+  // Batch manifest removal: one read+write instead of one per file
+  await manifest.removeFiles(removedFiles);
+
+  return removedFiles.length;
 }
 
 /**

--- a/packages/core/src/indexer/manifest.test.ts
+++ b/packages/core/src/indexer/manifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ManifestManager } from './manifest.js';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
 
@@ -112,6 +112,60 @@ describe('ManifestManager', () => {
     });
   });
 
+  describe('removeFiles', () => {
+    it('should not error when removing from non-existent manifest', async () => {
+      // Should not throw
+      await expect(manifestManager.removeFiles(['test.ts'])).resolves.toBeUndefined();
+    });
+
+    it('should remove all files and persist with a single save', async () => {
+      await manifestManager.updateFiles([
+        { filepath: 'test1.ts', lastModified: Date.now(), chunkCount: 3 },
+        { filepath: 'test2.ts', lastModified: Date.now(), chunkCount: 5 },
+        { filepath: 'test3.ts', lastModified: Date.now(), chunkCount: 7 },
+      ]);
+
+      const saveSpy = vi.spyOn(manifestManager, 'save');
+
+      await manifestManager.removeFiles(['test1.ts', 'test2.ts']);
+
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+
+      const manifest = await manifestManager.load();
+      expect(manifest?.files['test1.ts']).toBeUndefined();
+      expect(manifest?.files['test2.ts']).toBeUndefined();
+      expect(manifest?.files['test3.ts']).toBeTruthy();
+    });
+
+    it('should be a no-op for an empty array', async () => {
+      await manifestManager.updateFiles([
+        { filepath: 'test.ts', lastModified: Date.now(), chunkCount: 5 },
+      ]);
+
+      const saveSpy = vi.spyOn(manifestManager, 'save');
+
+      await manifestManager.removeFiles([]);
+
+      expect(saveSpy).not.toHaveBeenCalled();
+
+      const manifest = await manifestManager.load();
+      expect(manifest?.files['test.ts']).toBeTruthy();
+    });
+
+    it('should tolerate paths that are not in the manifest', async () => {
+      await manifestManager.updateFiles([
+        { filepath: 'test1.ts', lastModified: Date.now(), chunkCount: 3 },
+        { filepath: 'test2.ts', lastModified: Date.now(), chunkCount: 5 },
+      ]);
+
+      await manifestManager.removeFiles(['test1.ts', 'missing.ts']);
+
+      const manifest = await manifestManager.load();
+      expect(manifest?.files['test1.ts']).toBeUndefined();
+      expect(manifest?.files['test2.ts']).toBeTruthy();
+    });
+  });
+
   describe('updateFiles', () => {
     it('should create manifest if it does not exist', async () => {
       const entries = [
@@ -170,6 +224,31 @@ describe('ManifestManager', () => {
       expect(manifest?.files['file1.ts']?.chunkCount).toBe(1);
       expect(manifest?.files['file2.ts']?.chunkCount).toBe(2);
       expect(manifest?.files['file3.ts']?.chunkCount).toBe(3);
+    });
+
+    it('should serialize concurrent removeFiles and updateFiles without race conditions', async () => {
+      await manifestManager.updateFiles([
+        { filepath: 'file1.ts', lastModified: 100, chunkCount: 1 },
+        { filepath: 'file2.ts', lastModified: 200, chunkCount: 2 },
+        { filepath: 'file3.ts', lastModified: 300, chunkCount: 3 },
+      ]);
+
+      // Start mixed concurrent operations without awaiting in between
+      const operations = [
+        manifestManager.removeFiles(['file1.ts', 'file2.ts']),
+        manifestManager.updateFiles([
+          { filepath: 'file4.ts', lastModified: 400, chunkCount: 4 },
+          { filepath: 'file5.ts', lastModified: 500, chunkCount: 5 },
+        ]),
+        manifestManager.removeFiles(['file4.ts']),
+      ];
+
+      await Promise.all(operations);
+
+      const manifest = await manifestManager.load();
+      expect(Object.keys(manifest?.files || {}).sort()).toEqual(['file3.ts', 'file5.ts']);
+      expect(manifest?.files['file3.ts']?.chunkCount).toBe(3);
+      expect(manifest?.files['file5.ts']?.chunkCount).toBe(5);
     });
   });
 

--- a/packages/core/src/indexer/manifest.ts
+++ b/packages/core/src/indexer/manifest.ts
@@ -159,6 +159,23 @@ export class ManifestManager {
    * @param filepath - Path to the file to remove
    */
   async removeFile(filepath: string): Promise<void> {
+    await this.removeFiles([filepath]);
+  }
+
+  /**
+   * Removes multiple file entries at once (more efficient than individual removals).
+   * Protected by lock to prevent race conditions during concurrent updates.
+   *
+   * Note: If the manifest doesn't exist, this is a no-op (not an error).
+   * This can happen legitimately after clearing the index or on fresh installs.
+   *
+   * @param filepaths - Paths of the files to remove
+   */
+  async removeFiles(filepaths: string[]): Promise<void> {
+    if (filepaths.length === 0) {
+      return;
+    }
+
     // Chain this operation to the lock to ensure atomicity
     this.updateLock = this.updateLock
       .then(async () => {
@@ -168,11 +185,16 @@ export class ManifestManager {
           return;
         }
 
-        delete manifest.files[filepath];
+        for (const filepath of filepaths) {
+          delete manifest.files[filepath];
+        }
+
         await this.save(manifest);
       })
       .catch(error => {
-        console.error(`[Lien] Failed to remove manifest entry for ${filepath}: ${error}`);
+        console.error(
+          `[Lien] Failed to remove manifest entries for ${filepaths.length} files: ${error}`,
+        );
         // Return to reset lock - don't let errors block future operations
         return undefined;
       });


### PR DESCRIPTION
## What / Why

Review finding (adversarially confirmed): `ManifestManager` only exposed single-file `removeFile()` — a full manifest read+parse+stringify+write per call. Additions were explicitly batched via `updateFiles()` to avoid exactly this cost, but both deletion call sites looped per file: `handleDeletions` (`packages/core/src/indexer/index.ts`) and `handleBatchDeletions` (`packages/cli/src/mcp/file-change-handler.ts`). Deleting K files in an N-file repo cost O(K×N) manifest I/O — triggered by ordinary branch switches and directory renames.

## Fix

- Added `ManifestManager.removeFiles(filepaths: string[])`: load once, delete all keys, save once. Mirrors `updateFiles()`'s structure and its promise-chained locking discipline (`updateLock` chaining with error-swallowing catch to keep the lock usable), plus `removeFile()`'s no-manifest no-op semantics. Empty array is a no-op (no load, no save).
- `removeFile()` kept, now delegates to `removeFiles([filepath])` — behavior unchanged for the remaining single-file callers in `incremental.ts`.
- Both loop call sites now collect successfully vector-deleted paths and issue one `removeFiles()` call per batch. Per-file failure semantics preserved: only files whose `vectorDB.deleteByFile` succeeded are removed from the manifest; failure counting/throwing unchanged.

## Tests

- `manifest.test.ts`: new `removeFiles` suite — removes all listed files and persists with a single `save` (spy), empty-array no-op (no save), missing keys tolerated, no-op on non-existent manifest; plus a concurrency test mixing concurrent `removeFiles`/`updateFiles` (serializes correctly via the lock).
- `file-change-handler.test.ts`: batch deletion event calls `manifest.removeFiles` exactly once with all deleted paths (and `removeFile` not at all).

## Verification

- `npm run format:check` — pass
- `npm run lint` — pass (0 errors, 28 pre-existing warnings)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm run test -w @liendev/core -- --exclude '**/qdrant.test.ts'` — 527 passed, 0 failed (qdrant tests excluded: known-red on main without a local Qdrant server; a parallel PR is removing them). Note: `worker-embeddings.test.ts` tests all pass but the vitest fork worker crashes on teardown (`v8::HandleScope` fatal in the native transformers worker) — reproduced on the unmodified tree in this worktree (symlinked node_modules), pre-existing and unrelated to this change.
- `npm run test -w @liendev/lien` — 677 passed, 0 failed (40 files, includes file-change-handler tests)

## Caveats

- `packages/core/src/indexer/incremental.ts` still uses single-file `removeFile()` in two places; those are genuinely single-file paths (single-file reindex with 0 chunks), left as-is per scope.
- Changeset added: patch for `@liendev/core` and `@liendev/lien`.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a batched `ManifestManager.removeFiles()` method and switches the two per-file deletion loops (`handleDeletions` in `packages/core/src/indexer/index.ts` and `handleBatchDeletions` in `packages/cli/src/mcp/file-change-handler.ts`) to issue a single manifest write per batch. `removeFile()` is preserved as a thin wrapper. The implementation correctly mirrors the existing `updateFiles()` lock-chaining pattern, no-manifest no-op semantics, and error-swallowing behavior. Tests cover the new method, empty-input no-op, missing-key tolerance, non-existent manifest, concurrency serialization, and the batch call site. No breaking changes or caller malfunctions were found.
>
> - Added `ManifestManager.removeFiles(filepaths: string[])` with single load/delete-all/save and empty-array no-op.
> - Refactored `removeFile()` to delegate to `removeFiles([filepath])`, preserving behavior for existing single-file callers.
> - Converted `handleDeletions` and `handleBatchDeletions` to collect successfully vector-deleted paths and call `removeFiles()` once.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7c76294. Updates automatically on new commits.</sup>
<!-- /lien-stats -->