### PR TITLE
perf(review): bound the stale-literal signal scan to a single repo pass

### DIFF
--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -270,6 +270,37 @@ interface RepoScanResult {
 }
 
 /**
+ * Record every touched-literal survivor found on one repo line into
+ * `sitesByLiteral`, respecting each literal's own MAX_SITES_PER_LITERAL cap.
+ * Split out of {@link scanRepoForStaleSites} so the triple-nested scan (chunks
+ * x lines x values-on-a-line) reads as two single-purpose passes instead of
+ * one deeply nested one.
+ */
+function recordSurvivorsForLine(
+  line: string,
+  absLine: number,
+  file: string,
+  isTest: boolean,
+  touchedValues: Set<string>,
+  sitesByLiteral: Map<string, StaleSite[]>,
+): void {
+  const values = extractQuotedValues(line);
+  if (!values) return;
+
+  let classified: { snippet: string; isComment: boolean } | undefined;
+  for (const value of values) {
+    if (!touchedValues.has(value)) continue;
+    const sites = sitesByLiteral.get(value);
+    if (sites && sites.length >= MAX_SITES_PER_LITERAL) continue; // this literal is already capped
+
+    classified ??= classifySnippet(line);
+    const site: StaleSite = { file, line: absLine, ...classified, isTest };
+    if (sites) sites.push(site);
+    else sitesByLiteral.set(value, [site]);
+  }
+}
+
+/**
  * Scan the indexed repo (post-image chunk content) ONCE for every touched
  * literal at once, building `literal value -> surviving sites` directly.
  * Because chunks are the head state, the changed site no longer contains the
@@ -308,20 +339,7 @@ function scanRepoForStaleSites(
       const absLine = chunk.metadata.startLine + i;
       if (fileChanged?.has(absLine)) continue; // a line this PR touched — not a survivor
 
-      const values = extractQuotedValues(lines[i]);
-      if (!values) continue;
-
-      let classified: { snippet: string; isComment: boolean } | undefined;
-      for (const value of values) {
-        if (!touchedValues.has(value)) continue;
-        const sites = sitesByLiteral.get(value);
-        if (sites && sites.length >= MAX_SITES_PER_LITERAL) continue; // this literal is already capped
-
-        classified ??= classifySnippet(lines[i]);
-        const site: StaleSite = { file, line: absLine, ...classified, isTest };
-        if (sites) sites.push(site);
-        else sitesByLiteral.set(value, [site]);
-      }
+      recordSurvivorsForLine(lines[i], absLine, file, isTest, touchedValues, sitesByLiteral);
     }
   }
 
@@ -369,6 +387,52 @@ export function computeStaleLiteralCandidates(context: ReviewContext): StaleLite
 }
 
 /**
+ * Turn scan results into the final ranked, capped candidate list: attach each
+ * touched literal to its surviving sites (dropping literals with none), score
+ * confidence, then sort highest-confidence-and-most-sites first.
+ */
+function buildRankedCandidates(
+  literals: ChangedLiteral[],
+  sitesByLiteral: Map<string, StaleSite[]>,
+): StaleLiteralCandidate[] {
+  const candidates: StaleLiteralCandidate[] = [];
+  for (const lit of literals) {
+    const staleSites = sitesByLiteral.get(lit.value);
+    if (!staleSites || staleSites.length === 0) continue;
+    candidates.push({
+      literal: lit.display,
+      kind: lit.kind,
+      changedSite: { file: lit.file, line: lit.changedLine },
+      staleSites,
+      confidence: scoreConfidence(staleSites),
+    });
+  }
+
+  candidates.sort((a, b) => {
+    const byConf = CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence];
+    if (byConf !== 0) return byConf;
+    return b.staleSites.length - a.staleSites.length;
+  });
+
+  return candidates.slice(0, MAX_CANDIDATES);
+}
+
+/** Log the budget-exceeded diagnostic: elapsed time, scan coverage, and touched-literal count. */
+function logScanTimeout(
+  context: ReviewContext,
+  elapsedMs: number,
+  chunksScanned: number,
+  totalChunks: number,
+  touchedCount: number,
+): void {
+  context.logger?.warning(
+    `stale-literal-signals: repo scan exceeded its budget (${elapsedMs}ms elapsed) ` +
+      `after ${chunksScanned}/${totalChunks} chunks for ${touchedCount} touched ` +
+      'literal(s); returning partial results.',
+  );
+}
+
+/**
  * Same as {@link computeStaleLiteralCandidates}, but with an explicit
  * absolute deadline (a value comparable to `Date.now()`) instead of the
  * default budget. Exposed for testing the budget-exceeded path
@@ -402,33 +466,16 @@ export function computeStaleLiteralCandidatesWithDeadline(
   );
 
   if (timedOut) {
-    context.logger?.warning(
-      `stale-literal-signals: repo scan exceeded its budget (${Date.now() - startedAt}ms elapsed) ` +
-        `after ${chunksScanned}/${repoChunks.length} chunks for ${touchedValues.size} touched ` +
-        'literal(s); returning partial results.',
+    logScanTimeout(
+      context,
+      Date.now() - startedAt,
+      chunksScanned,
+      repoChunks.length,
+      touchedValues.size,
     );
   }
 
-  const candidates: StaleLiteralCandidate[] = [];
-  for (const lit of literals) {
-    const staleSites = sitesByLiteral.get(lit.value);
-    if (!staleSites || staleSites.length === 0) continue;
-    candidates.push({
-      literal: lit.display,
-      kind: lit.kind,
-      changedSite: { file: lit.file, line: lit.changedLine },
-      staleSites,
-      confidence: scoreConfidence(staleSites),
-    });
-  }
-
-  candidates.sort((a, b) => {
-    const byConf = CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence];
-    if (byConf !== 0) return byConf;
-    return b.staleSites.length - a.staleSites.length;
-  });
-
-  return candidates.slice(0, MAX_CANDIDATES);
+  return buildRankedCandidates(literals, sitesByLiteral);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -223,14 +223,15 @@ export function extractChangedLiterals(patches: Map<string, string>): ChangedLit
 // Surviving-occurrence scan
 // ---------------------------------------------------------------------------
 
-/** Does `line` contain the string literal `lit` in any quote style? */
-function lineContainsLiteral(line: string, lit: ChangedLiteral): boolean {
-  return (
-    line.includes(`'${lit.value}'`) ||
-    line.includes(`"${lit.value}"`) ||
-    line.includes(`\`${lit.value}\``)
-  );
-}
+/**
+ * Wall-clock backstop for the repo-wide survivor scan, mirroring
+ * grep_codebase's GREP_TIME_BUDGET_MS (agent-tools.ts). A pathological input
+ * (a huge indexed repo, or a diff that touches an unusually large number of
+ * distinct literals) could otherwise scan for a long time on every PR — this
+ * rule triggers unconditionally, before the LLM even runs. On budget hit we
+ * return whatever was found so far rather than stalling the review.
+ */
+const STALE_LITERAL_TIME_BUDGET_MS = 5_000;
 
 function classifySnippet(line: string): { snippet: string; isComment: boolean } {
   const trimmed = line.trim();
@@ -241,45 +242,90 @@ function classifySnippet(line: string): { snippet: string; isComment: boolean } 
 }
 
 /**
- * Scan the indexed repo (post-image chunk content) for the literal surviving
- * outside the diff. Because chunks are the head state, the changed site no
- * longer contains the moved-away literal — any hit is by definition a survivor.
- * `changedLines` is consulted defensively to never re-report a touched line.
+ * Extract the distinct quoted-string token values present on one repo line
+ * (any quote style, no distinctiveness filtering — the caller already knows
+ * which values are worth looking for). Returns null when the line has no
+ * quote character at all, so the common case (most lines) skips the regex
+ * entirely.
+ *
+ * Note: this parses proper quote-delimited tokens, so a value nested inside a
+ * *differently*-quoted outer string (e.g. a backtick template that itself
+ * contains a single-quoted copy of the literal) is not found as a separate
+ * token — unlike a raw substring search. That combination hasn't shown up in
+ * practice; if it ever matters, matching would need a substring/automaton
+ * scan instead of tokenization.
  */
-function findStaleSites(
-  lit: ChangedLiteral,
-  repoChunks: CodeChunk[],
-  changedLines: Map<string, Set<number>>,
-): StaleSite[] {
-  const seen = new Set<string>();
-  const sites: StaleSite[] = [];
+function extractQuotedValues(line: string): Set<string> | null {
+  if (!/['"`]/.test(line)) return null;
+  const values = new Set<string>();
+  for (const m of line.matchAll(STRING_RE)) values.add(m[2]);
+  return values.size > 0 ? values : null;
+}
 
-  for (const chunk of repoChunks) {
+interface RepoScanResult {
+  /** literal value -> its surviving sites, capped at MAX_SITES_PER_LITERAL, in traversal order. */
+  sitesByLiteral: Map<string, StaleSite[]>;
+  timedOut: boolean;
+  chunksScanned: number;
+}
+
+/**
+ * Scan the indexed repo (post-image chunk content) ONCE for every touched
+ * literal at once, building `literal value -> surviving sites` directly.
+ * Because chunks are the head state, the changed site no longer contains the
+ * moved-away literal — any hit is by definition a survivor. `changedLines` is
+ * consulted defensively to never re-report a touched line.
+ *
+ * This replaces a previous per-literal scan (call this once per touched
+ * literal, re-walking every repo line each time), which made the cost
+ * O(literals x repo-lines) — unconditional on every PR, with the common
+ * zero-match case paying full cost. A single pass makes it
+ * O(repo-lines + literals).
+ */
+function scanRepoForStaleSites(
+  repoChunks: CodeChunk[],
+  touchedValues: Set<string>,
+  changedLines: Map<string, Set<number>>,
+  deadline: number,
+): RepoScanResult {
+  const sitesByLiteral = new Map<string, StaleSite[]>();
+  let timedOut = false;
+  let chunksScanned = 0;
+
+  chunkLoop: for (const chunk of repoChunks) {
+    chunksScanned++;
     const file = chunk.metadata.file;
     const fileChanged = changedLines.get(file);
+    const isTest = TEST_PATH_RE.test(file);
     const lines = chunk.content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
-      const absLine = chunk.metadata.startLine + i;
-      const dedupKey = `${file}:${absLine}`;
-      if (seen.has(dedupKey)) continue;
-      if (fileChanged?.has(absLine)) continue; // a line this PR touched — not a survivor
-      if (!lineContainsLiteral(lines[i], lit)) continue;
+      if (Date.now() > deadline) {
+        timedOut = true;
+        break chunkLoop;
+      }
 
-      seen.add(dedupKey);
-      const { snippet, isComment } = classifySnippet(lines[i]);
-      sites.push({
-        file,
-        line: absLine,
-        snippet,
-        isComment,
-        isTest: TEST_PATH_RE.test(file),
-      });
-      if (sites.length >= MAX_SITES_PER_LITERAL) return sites;
+      const absLine = chunk.metadata.startLine + i;
+      if (fileChanged?.has(absLine)) continue; // a line this PR touched — not a survivor
+
+      const values = extractQuotedValues(lines[i]);
+      if (!values) continue;
+
+      let classified: { snippet: string; isComment: boolean } | undefined;
+      for (const value of values) {
+        if (!touchedValues.has(value)) continue;
+        const sites = sitesByLiteral.get(value);
+        if (sites && sites.length >= MAX_SITES_PER_LITERAL) continue; // this literal is already capped
+
+        classified ??= classifySnippet(lines[i]);
+        const site: StaleSite = { file, line: absLine, ...classified, isTest };
+        if (sites) sites.push(site);
+        else sitesByLiteral.set(value, [site]);
+      }
     }
   }
 
-  return sites;
+  return { sitesByLiteral, timedOut, chunksScanned };
 }
 
 function scoreConfidence(sites: StaleSite[]): StaleLiteralCandidate['confidence'] {
@@ -316,21 +362,57 @@ function mergeChangedLines(
  * Returns [] when there is no diff or no full-repo index to scan against.
  */
 export function computeStaleLiteralCandidates(context: ReviewContext): StaleLiteralCandidate[] {
+  return computeStaleLiteralCandidatesWithDeadline(
+    context,
+    Date.now() + STALE_LITERAL_TIME_BUDGET_MS,
+  );
+}
+
+/**
+ * Same as {@link computeStaleLiteralCandidates}, but with an explicit
+ * absolute deadline (a value comparable to `Date.now()`) instead of the
+ * default budget. Exposed for testing the budget-exceeded path
+ * deterministically — pass an already-past deadline — without relying on
+ * real elapsed time.
+ */
+export function computeStaleLiteralCandidatesWithDeadline(
+  context: ReviewContext,
+  deadline: number,
+): StaleLiteralCandidate[] {
+  const startedAt = Date.now();
   const patches = context.pr?.patches;
   const repoChunks = context.repoChunks;
   if (!patches || patches.size === 0) return [];
   if (!repoChunks || repoChunks.length === 0) return [];
 
   const { literals, touchedLinesByFile } = scanPatches(patches);
+  if (literals.length === 0) return [];
+
   // Exclude the diff's own touched lines so a literal conditionalized in place
   // doesn't report its own `+` line as a survivor. Derived from the patch, so
   // this holds even when pr.diffLines is absent; union the two when both exist.
   const changedLines = mergeChangedLines(touchedLinesByFile, context.pr?.diffLines);
-  const candidates: StaleLiteralCandidate[] = [];
+  const touchedValues = new Set(literals.map(lit => lit.value));
 
+  const { sitesByLiteral, timedOut, chunksScanned } = scanRepoForStaleSites(
+    repoChunks,
+    touchedValues,
+    changedLines,
+    deadline,
+  );
+
+  if (timedOut) {
+    context.logger?.warning(
+      `stale-literal-signals: repo scan exceeded its budget (${Date.now() - startedAt}ms elapsed) ` +
+        `after ${chunksScanned}/${repoChunks.length} chunks for ${touchedValues.size} touched ` +
+        'literal(s); returning partial results.',
+    );
+  }
+
+  const candidates: StaleLiteralCandidate[] = [];
   for (const lit of literals) {
-    const staleSites = findStaleSites(lit, repoChunks, changedLines);
-    if (staleSites.length === 0) continue;
+    const staleSites = sitesByLiteral.get(lit.value);
+    if (!staleSites || staleSites.length === 0) continue;
     candidates.push({
       literal: lit.display,
       kind: lit.kind,

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -275,6 +275,13 @@ interface RepoScanResult {
  * Split out of {@link scanRepoForStaleSites} so the triple-nested scan (chunks
  * x lines x values-on-a-line) reads as two single-purpose passes instead of
  * one deeply nested one.
+ *
+ * `seenSites` dedupes by `file:line:value`: repoChunks can contain overlapping
+ * ranges for the same file (e.g. an enclosing chunk and a nested one), which
+ * would otherwise revisit the same physical line more than once and record
+ * the same survivor twice — filling the per-literal cap with duplicates and
+ * skewing confidence scoring toward literals that just happen to sit in
+ * overlapping chunks.
  */
 function recordSurvivorsForLine(
   line: string,
@@ -283,6 +290,7 @@ function recordSurvivorsForLine(
   isTest: boolean,
   touchedValues: Set<string>,
   sitesByLiteral: Map<string, StaleSite[]>,
+  seenSites: Set<string>,
 ): void {
   const values = extractQuotedValues(line);
   if (!values) return;
@@ -292,6 +300,10 @@ function recordSurvivorsForLine(
     if (!touchedValues.has(value)) continue;
     const sites = sitesByLiteral.get(value);
     if (sites && sites.length >= MAX_SITES_PER_LITERAL) continue; // this literal is already capped
+
+    const siteKey = `${file}:${absLine}:${value}`;
+    if (seenSites.has(siteKey)) continue; // already recorded via an overlapping chunk
+    seenSites.add(siteKey);
 
     classified ??= classifySnippet(line);
     const site: StaleSite = { file, line: absLine, ...classified, isTest };
@@ -320,6 +332,7 @@ function scanRepoForStaleSites(
   deadline: number,
 ): RepoScanResult {
   const sitesByLiteral = new Map<string, StaleSite[]>();
+  const seenSites = new Set<string>();
   let timedOut = false;
   let chunksScanned = 0;
 
@@ -339,7 +352,15 @@ function scanRepoForStaleSites(
       const absLine = chunk.metadata.startLine + i;
       if (fileChanged?.has(absLine)) continue; // a line this PR touched — not a survivor
 
-      recordSurvivorsForLine(lines[i], absLine, file, isTest, touchedValues, sitesByLiteral);
+      recordSurvivorsForLine(
+        lines[i],
+        absLine,
+        file,
+        isTest,
+        touchedValues,
+        sitesByLiteral,
+        seenSites,
+      );
     }
   }
 
@@ -432,25 +453,38 @@ function logScanTimeout(
   );
 }
 
+/** Result of a full scan pass: the ranked candidates plus whether the budget was exceeded. */
+interface StaleLiteralScanResult {
+  candidates: StaleLiteralCandidate[];
+  timedOut: boolean;
+  /** Chunks actually scanned before the deadline (or the full count when not timed out). */
+  chunksScanned: number;
+  /** Total chunks available to scan (0 when no repo index was provided). */
+  totalChunks: number;
+}
+
 /**
- * Same as {@link computeStaleLiteralCandidates}, but with an explicit
- * absolute deadline (a value comparable to `Date.now()`) instead of the
- * default budget. Exposed for testing the budget-exceeded path
- * deterministically — pass an already-past deadline — without relying on
- * real elapsed time.
+ * Does the actual scan work shared by {@link computeStaleLiteralCandidatesWithDeadline}
+ * and {@link renderStaleLiteralSection}. Unlike the exported candidate-only
+ * entry points, this also surfaces `timedOut` — rendering needs it to avoid
+ * asserting "scan complete, nothing found" when the scan actually aborted
+ * before finishing (see `renderStaleLiteralSection`).
  */
-export function computeStaleLiteralCandidatesWithDeadline(
-  context: ReviewContext,
-  deadline: number,
-): StaleLiteralCandidate[] {
+function computeStaleLiteralScan(context: ReviewContext, deadline: number): StaleLiteralScanResult {
   const startedAt = Date.now();
   const patches = context.pr?.patches;
   const repoChunks = context.repoChunks;
-  if (!patches || patches.size === 0) return [];
-  if (!repoChunks || repoChunks.length === 0) return [];
+  if (!patches || patches.size === 0) {
+    return { candidates: [], timedOut: false, chunksScanned: 0, totalChunks: 0 };
+  }
+  if (!repoChunks || repoChunks.length === 0) {
+    return { candidates: [], timedOut: false, chunksScanned: 0, totalChunks: 0 };
+  }
 
   const { literals, touchedLinesByFile } = scanPatches(patches);
-  if (literals.length === 0) return [];
+  if (literals.length === 0) {
+    return { candidates: [], timedOut: false, chunksScanned: 0, totalChunks: repoChunks.length };
+  }
 
   // Exclude the diff's own touched lines so a literal conditionalized in place
   // doesn't report its own `+` line as a survivor. Derived from the patch, so
@@ -475,7 +509,26 @@ export function computeStaleLiteralCandidatesWithDeadline(
     );
   }
 
-  return buildRankedCandidates(literals, sitesByLiteral);
+  return {
+    candidates: buildRankedCandidates(literals, sitesByLiteral),
+    timedOut,
+    chunksScanned,
+    totalChunks: repoChunks.length,
+  };
+}
+
+/**
+ * Same as {@link computeStaleLiteralCandidates}, but with an explicit
+ * absolute deadline (a value comparable to `Date.now()`) instead of the
+ * default budget. Exposed for testing the budget-exceeded path
+ * deterministically — pass an already-past deadline — without relying on
+ * real elapsed time.
+ */
+export function computeStaleLiteralCandidatesWithDeadline(
+  context: ReviewContext,
+  deadline: number,
+): StaleLiteralCandidate[] {
+  return computeStaleLiteralScan(context, deadline).candidates;
 }
 
 // ---------------------------------------------------------------------------
@@ -520,29 +573,60 @@ export function renderStaleLiteralCandidates(candidates: StaleLiteralCandidate[]
 }
 
 /**
- * Emitted when the deterministic scan ran but found nothing. Distinguishes
- * "scan completed, clean" from "scan never ran" — without it, an omitted block
- * is ambiguous and the rule would force a redundant grep fallback even after a
- * clean scan.
+ * Emitted when the deterministic scan ran to completion but found nothing.
+ * Distinguishes "scan completed, clean" from "scan never ran" — without it,
+ * an omitted block is ambiguous and the rule would force a redundant grep
+ * fallback even after a clean scan.
  */
 const STALE_LITERAL_NONE_BLOCK = `<stale_literal_candidates>
 None — the deterministic scan found no changed literal surviving unchanged elsewhere. The stale-duplicate discovery step is complete; you do not need to grep for the diff's literals.
 </stale_literal_candidates>`;
 
 /**
- * Build the `<stale_literal_candidates>` section for the agent's initial
- * message. Returns the candidate block when there are candidates, an explicit
- * "None" block when the scan ran but was clean, or '' when no scan was possible
- * (no diff or no repo index — e.g. CLI mode). Callers append unconditionally.
+ * Emitted when the scan hit its time budget before finding any survivors.
+ * Deliberately distinct from {@link STALE_LITERAL_NONE_BLOCK}: an incomplete
+ * scan must never claim discovery is "complete" — that would tell the agent
+ * it can skip grepping exactly when the scan didn't get to look everywhere.
  */
-export function renderStaleLiteralSection(context: ReviewContext): string {
+function renderStaleLiteralTimeoutBlock(chunksScanned: number, totalChunks: number): string {
+  return `<stale_literal_candidates>
+Scan incomplete (time budget exceeded after ${chunksScanned} of ${totalChunks} chunks) — the deterministic pre-scan did not finish checking the repo, so no "clean" verdict can be given. Grep for the diff's changed literals yourself if you suspect a stale duplicate.
+</stale_literal_candidates>`;
+}
+
+/**
+ * Same as {@link renderStaleLiteralSection}, but with an explicit absolute
+ * deadline instead of the default budget. Exposed for testing the
+ * timeout-path rendering deterministically — pass an already-past deadline —
+ * mirroring {@link computeStaleLiteralCandidatesWithDeadline}.
+ */
+export function renderStaleLiteralSectionWithDeadline(
+  context: ReviewContext,
+  deadline: number,
+): string {
   const patches = context.pr?.patches;
   const repoChunks = context.repoChunks;
   const scanPossible = !!patches && patches.size > 0 && !!repoChunks && repoChunks.length > 0;
   if (!scanPossible) return '';
 
-  const candidates = computeStaleLiteralCandidates(context);
-  return candidates.length > 0
-    ? renderStaleLiteralCandidates(candidates)
+  const { candidates, timedOut, chunksScanned, totalChunks } = computeStaleLiteralScan(
+    context,
+    deadline,
+  );
+  if (candidates.length > 0) return renderStaleLiteralCandidates(candidates);
+  return timedOut
+    ? renderStaleLiteralTimeoutBlock(chunksScanned, totalChunks)
     : STALE_LITERAL_NONE_BLOCK;
+}
+
+/**
+ * Build the `<stale_literal_candidates>` section for the agent's initial
+ * message. Returns the candidate block when there are candidates, an explicit
+ * "None" block when the scan ran to completion and was clean, an explicit
+ * "incomplete" block when the scan hit its time budget before finding any
+ * survivors, or '' when no scan was possible (no diff or no repo index — e.g.
+ * CLI mode). Callers append unconditionally.
+ */
+export function renderStaleLiteralSection(context: ReviewContext): string {
+  return renderStaleLiteralSectionWithDeadline(context, Date.now() + STALE_LITERAL_TIME_BUDGET_MS);
 }

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { CodeChunk } from '@liendev/parser';
 import type { ReviewContext } from '../src/plugin-types.js';
 import {
@@ -7,6 +7,7 @@ import {
   computeStaleLiteralCandidatesWithDeadline,
   renderStaleLiteralCandidates,
   renderStaleLiteralSection,
+  renderStaleLiteralSectionWithDeadline,
 } from '../src/stale-literal-signals.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
 import { silentLogger } from '../src/test-helpers.js';
@@ -385,6 +386,27 @@ describe('scanRepoForStaleSites (single-pass restructure)', () => {
     expect(candidates).toHaveLength(1);
     expect(warnings).toHaveLength(0);
   });
+
+  it('dedupes survivors when repoChunks contain overlapping ranges for the same file', () => {
+    // Two chunks both cover src/dup.ts:6 (e.g. an enclosing chunk and a
+    // nested one indexed separately). Without dedup, the single-pass scan
+    // would revisit that physical line twice and record the same survivor
+    // twice, filling the per-literal cap with duplicates.
+    const patch =
+      '@@ -1,1 +1,1 @@\n' + "-const old = 'shared-token-abc';\n" + '+const old = compute();';
+    const patches = new Map([['src/a.ts', patch]]);
+    const repoChunks = [
+      makeChunk('src/dup.ts', 5, "const a = 1;\nconst other = 'shared-token-abc';"), // lines 5-6
+      makeChunk('src/dup.ts', 6, "const other = 'shared-token-abc';\nconst b = 2;"), // lines 6-7, overlaps at line 6
+    ];
+
+    const candidates = computeStaleLiteralCandidates(makeContext({ patches, repoChunks }));
+    const cand = candidates.find(c => c.literal === "'shared-token-abc'");
+    expect(cand).toBeDefined();
+    // Exactly one site for src/dup.ts:6, not two.
+    expect(cand!.staleSites).toHaveLength(1);
+    expect(cand!.staleSites[0]).toMatchObject({ file: 'src/dup.ts', line: 6 });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -487,5 +509,61 @@ describe('renderStaleLiteralSection', () => {
     const section = renderStaleLiteralSection(makeContext({ patches, repoChunks }));
     expect(section).toContain("'claude-sonnet-4-6'");
     expect(section).not.toContain('None —');
+  });
+
+  it('emits an incomplete-scan notice — not the "None" claim — when the budget is exceeded before finding any survivors', () => {
+    // A survivor exists (src/other.ts), but an already-past deadline trips
+    // the very first check deterministically, so the scan never gets to see
+    // it. Rendering must not tell the agent "discovery is complete" here.
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'timeout-none-literal';\n+const x = compute();"],
+    ]);
+    const repoChunks = [makeChunk('src/other.ts', 1, "const y = 'timeout-none-literal';")];
+
+    const section = renderStaleLiteralSectionWithDeadline(
+      makeContext({ patches, repoChunks }),
+      Date.now() - 1,
+    );
+
+    expect(section).toContain('<stale_literal_candidates>');
+    expect(section).toContain('Scan incomplete');
+    expect(section).not.toContain('None —');
+    expect(section).not.toContain('discovery step is complete');
+  });
+
+  it('still renders the normal candidate block (no incomplete-scan notice) when the scan finds survivors before timing out on a later chunk', () => {
+    // Deliberate design choice: the candidate block never claims completeness
+    // ("no grep needed" only covers the listed candidates), so a timeout that
+    // still yields candidates does not need the incomplete-scan notice — only
+    // the zero-candidate "None" claim was ever misleading.
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'timeout-partial-literal';\n+const x = compute();"],
+    ]);
+    const repoChunks = [
+      makeChunk('src/found.ts', 1, "const y = 'timeout-partial-literal';"), // survivor found here
+      makeChunk('src/unreached.ts', 1, "const z = 'timeout-partial-literal';"), // scan never gets here
+    ];
+
+    const deadline = 2_000;
+    let call = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+      call++;
+      if (call === 1) return 1_000; // startedAt
+      if (call === 2) return 1_500; // deadline check for src/found.ts's line — not yet exceeded
+      return 3_000; // deadline check for src/unreached.ts's line, and any later call — exceeded
+    });
+
+    try {
+      const section = renderStaleLiteralSectionWithDeadline(
+        makeContext({ patches, repoChunks }),
+        deadline,
+      );
+      expect(section).toContain("'timeout-partial-literal'");
+      expect(section).toContain('src/found.ts:1');
+      expect(section).not.toContain('src/unreached.ts');
+      expect(section).not.toContain('Scan incomplete');
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -4,10 +4,12 @@ import type { ReviewContext } from '../src/plugin-types.js';
 import {
   extractChangedLiterals,
   computeStaleLiteralCandidates,
+  computeStaleLiteralCandidatesWithDeadline,
   renderStaleLiteralCandidates,
   renderStaleLiteralSection,
 } from '../src/stale-literal-signals.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { silentLogger } from '../src/test-helpers.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -248,6 +250,140 @@ describe('computeStaleLiteralCandidates', () => {
     );
     const cand = candidates.find(c => c.literal === "'model-x-9000'");
     expect(cand!.staleSites[0].isTest).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single repo-wide pass (perf restructure): equivalence, traversal, budget
+// ---------------------------------------------------------------------------
+
+/** A CodeChunk whose `.content` getter increments a shared counter on every access. */
+function makeCountingChunk(
+  file: string,
+  startLine: number,
+  content: string,
+  accessCounter: { count: number },
+): CodeChunk {
+  return {
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+    get content(): string {
+      accessCounter.count++;
+      return content;
+    },
+  } as unknown as CodeChunk;
+}
+
+describe('scanRepoForStaleSites (single-pass restructure)', () => {
+  it('produces identical candidates to a multi-literal, multi-file fixture, including per-literal caps and first-N-in-traversal-order', () => {
+    // Two touched literals in one diff; the first has more surviving sites
+    // than MAX_SITES_PER_LITERAL (5) spread across multiple repo chunks, the
+    // second has exactly one. Proves the single shared pass still enforces
+    // each literal's own cap independently and keeps first-N traversal order.
+    const patch =
+      "@@ -1,2 +1,2 @@\n-const key = 'shared-config-key';\n-const flag = 'legacy-mode-flag';\n+const key = resolveKey();\n+const flag = resolveFlag();";
+    const patches = new Map([['src/config.ts', patch]]);
+
+    const repoChunks = [
+      makeChunk(
+        'src/other1.ts',
+        1,
+        "const a = 'shared-config-key';\nconst b = 'shared-config-key';",
+      ),
+      makeChunk(
+        'src/other2.ts',
+        1,
+        "const c = 'shared-config-key';\nconst d = 'shared-config-key';\nconst e = 'shared-config-key';",
+      ),
+      makeChunk(
+        'src/other3.ts',
+        1,
+        "const f = 'shared-config-key';\nconst g = 'legacy-mode-flag';",
+      ),
+    ];
+
+    const candidates = computeStaleLiteralCandidates(makeContext({ patches, repoChunks }));
+
+    const key = candidates.find(c => c.literal === "'shared-config-key'");
+    expect(key).toBeDefined();
+    // Capped at MAX_SITES_PER_LITERAL (5): the first five in chunk/line order,
+    // NOT the sixth occurrence in other3.ts.
+    expect(key!.staleSites.map(s => `${s.file}:${s.line}`)).toEqual([
+      'src/other1.ts:1',
+      'src/other1.ts:2',
+      'src/other2.ts:1',
+      'src/other2.ts:2',
+      'src/other2.ts:3',
+    ]);
+
+    const flag = candidates.find(c => c.literal === "'legacy-mode-flag'");
+    expect(flag).toBeDefined();
+    expect(flag!.staleSites.map(s => `${s.file}:${s.line}`)).toEqual(['src/other3.ts:2']);
+  });
+
+  it('reads each repo chunk exactly once, regardless of how many literals are touched', () => {
+    const counter = { count: 0 };
+    const repoChunks = [
+      makeCountingChunk(
+        'src/a.ts',
+        1,
+        "const a = 'alpha-value';\nconst b = 'beta-value';",
+        counter,
+      ),
+      makeCountingChunk('src/b.ts', 1, "const c = 'gamma-value';", counter),
+    ];
+    // Three distinct touched literals — under the old per-literal scan this
+    // would read every chunk's content 3x (once per literal); the single-pass
+    // scan must read each chunk's content exactly once regardless.
+    const patch =
+      "@@ -1,3 +1,3 @@\n-const x = 'alpha-value';\n-const y = 'beta-value';\n-const z = 'gamma-value';\n+const x = f();\n+const y = g();\n+const z = h();";
+    const patches = new Map([['src/other.ts', patch]]);
+
+    computeStaleLiteralCandidates(makeContext({ patches, repoChunks }));
+
+    expect(counter.count).toBe(repoChunks.length);
+  });
+
+  it('returns partial results and logs a diagnostic when the wall-clock budget is exceeded', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'budget-test-literal';\n+const x = compute();"],
+    ]);
+    const repoChunks = [makeChunk('src/other.ts', 1, "const y = 'budget-test-literal';")];
+    const warnings: string[] = [];
+    const context: ReviewContext = {
+      ...makeContext({ patches, repoChunks }),
+      logger: { ...silentLogger, warning: (msg: string) => warnings.push(msg) },
+    };
+
+    // An already-past deadline trips the very first check deterministically —
+    // no reliance on real elapsed time.
+    const candidates = computeStaleLiteralCandidatesWithDeadline(context, Date.now() - 1);
+
+    expect(candidates).toEqual([]); // scan aborted before finding the survivor
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('budget');
+  });
+
+  it('does not log when the scan completes within budget', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const x = 'on-time-literal';\n+const x = compute();"],
+    ]);
+    const repoChunks = [makeChunk('src/other.ts', 1, "const y = 'on-time-literal';")];
+    const warnings: string[] = [];
+    const context: ReviewContext = {
+      ...makeContext({ patches, repoChunks }),
+      logger: { ...silentLogger, warning: (msg: string) => warnings.push(msg) },
+    };
+
+    const candidates = computeStaleLiteralCandidates(context);
+
+    expect(candidates).toHaveLength(1);
+    expect(warnings).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What

`computeStaleLiteralCandidates` (via the old `findStaleSites`) re-walked every
line of every indexed repo chunk once **per distinct touched literal**. The
rule triggers unconditionally (`always: true`) and is rendered before the LLM
even runs, so this cost — O(literals × repo-lines) — was paid on every single
PR review, including the common case where none of the touched literals
survive elsewhere in the repo (the only early exit, `MAX_SITES_PER_LITERAL`,
fires after matches are found).

## Why

Adversarially-confirmed review finding: no time budget bounded this scan,
unlike `grep_codebase` in the same package (`GREP_TIME_BUDGET_MS`), and
`chunk.content.split('\n')` was being redone once per literal per chunk
instead of once per chunk.

## Approach

- Restructured to a single repo-wide pass: `scanRepoForStaleSites` builds
  `literal value -> surviving sites` directly while walking `repoChunks`
  exactly once, using a per-line quoted-token extraction (`extractQuotedValues`)
  checked against the small set of touched literal values — O(repo-lines +
  literals) instead of O(literals × repo-lines).
- `MAX_SITES_PER_LITERAL`'s "first-N in traversal order, per literal" semantics
  are preserved exactly: sites are still capped independently per literal
  value, in chunk-then-line order.
- Added `STALE_LITERAL_TIME_BUDGET_MS` (5s, mirroring `GREP_TIME_BUDGET_MS`)
  as a wall-clock backstop. On budget hit, the scan returns whatever it found
  so far and logs a diagnostic via `context.logger.warning(...)` (chunks
  scanned, elapsed ms, touched-literal count) so a slow review is
  diagnosable instead of silently truncated.
- No prompt or rule changes. The rendered `<stale_literal_candidates>` /
  "None" block format is untouched, and output is identical to before for any
  input that completes within budget — verified by a multi-literal,
  multi-file regression fixture (see tests below). One accepted, documented
  edge case: because the new path extracts proper quote-delimited tokens
  rather than doing a raw substring search, a literal value nested inside a
  *differently*-quoted outer string (e.g. inside a backtick template) is no
  longer matched as a separate token. This wasn't exercised by any existing
  test/fixture and is called out in a code comment.
- `computeStaleLiteralCandidates(context)` keeps its existing signature/
  behavior; a new `computeStaleLiteralCandidatesWithDeadline(context, deadline)`
  is exported alongside it purely so the budget-exceeded path can be tested
  deterministically (inject an already-past deadline) without any reliance on
  real elapsed time.

## Verification

```
npm run format:check   # pass
npm run lint           # pass (0 errors; pre-existing warnings only)
npm run typecheck      # @liendev/review typecheck: pass (clean)
npm run build          # pass (parser, core, review, cli, action)
npm run test -w @liendev/review   # 458/458 passed (25 files), incl. 27/27 in
                                    # stale-literal-signals.test.ts
```

Added tests (all new, existing 23 unmodified and green):
- Multi-literal/multi-file regression fixture proving output equivalence,
  including the per-literal `MAX_SITES_PER_LITERAL` cap and first-N-in-
  traversal-order selection.
- A counting-chunk structural test proving each repo chunk's `.content` is
  read exactly once regardless of how many literals are touched (would have
  been `chunks × literals` reads under the old per-literal scan).
- Budget-hit path: an injected already-past deadline deterministically
  exercises the timeout branch, asserting partial (empty) results plus
  exactly one logged warning diagnostic — no timing-based flakiness.
- A budget-not-hit control test asserting no diagnostic is logged on the
  normal path.

## Caveats

- `npm run typecheck` (root, chains all workspaces) currently fails on
  `packages/cli` with `Property 'removeFiles' does not exist on type
  'ManifestManager'`. This is **pre-existing and unrelated** to this change:
  this worktree's `node_modules` (per the documented worktree symlink
  workaround) resolves `@liendev/core` back to the main checkout's
  `packages/core/dist`, which is stale relative to main's own already-merged
  source (the manifest-batching PR added `removeFiles`, but that checkout's
  `dist/` hasn't been rebuilt). `git diff` confirms zero changes to
  `packages/cli` in this PR, and `@liendev/review`'s own `tsc --noEmit` passes
  cleanly. `npm run build` (root, tsup-based) also passes end to end.
- `@liendev/review` is private (no changeset needed).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 15. 1 pre-existing issue remains in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | -15 |


> [!NOTE]
> **Low Risk**
>
> This PR restructures the stale-literal survivor scan into a single repo-wide pass with a 5s wall-clock budget, preserving the existing per-literal cap and traversal-order semantics. It adds explicit 'incomplete scan' rendering so the agent is not told discovery is complete when the budget aborts the scan, and reintroduces line/value deduplication across overlapping chunks. No exports were removed or changed in signature, and the stricter whole-token matching is intentionally scoped and documented.
>
> - Single-pass survivor scan via scanRepoForStaleSites and extractQuotedValues, replacing O(literals × repo-lines) per-literal walk
> - Added STALE_LITERAL_TIME_BUDGET_MS and deterministic deadline entry points for timeout testing
> - Distinguishes a clean zero-match scan from a budget-aborted scan in renderStaleLiteralSection

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 03cee34. Updates automatically on new commits.</sup>
<!-- /lien-stats -->