### PR TITLE
feat(review): promote out-of-diff findings to visible review body

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -176,22 +176,37 @@ export class AgentReviewPlugin implements ReviewPlugin {
     const archFindings = findings.filter(f => f.category === 'architectural');
     const summaryFinding = findings.find(f => f.category === 'summary');
 
-    // 1. Post inline comments for bug findings on the diff
-    //    Minimize outdated comments only when we have new ones to replace them
+    // 1. Post bug findings. GitHub only anchors inline review comments to lines
+    //    inside the PR's diff hunks, so split findings by whether their line is
+    //    in the diff. Anchorable findings become inline comments. The rest — a
+    //    finding whose *cause* is in the diff but whose *manifestation* is in
+    //    untouched code, often the sharpest findings the engine produces — are
+    //    promoted to a visible, above-the-fold review comment instead of
+    //    silently degrading into the collapsed "Prompt for AI Agents" block.
+    //    Minimize outdated comments only when we have new ones to replace them.
     if (bugFindings.length > 0 && context.postInlineComments) {
       if (context.minimizeOutdatedComments) {
         await context.minimizeOutdatedComments(marker);
       }
-      const reviewBody = buildFixPrompt(bugFindings, marker);
-      const result = await context.postInlineComments(bugFindings, reviewBody);
 
-      // If some findings were outside the diff, post them as a review comment
-      if (result && result.skipped > 0 && context.postReviewComment) {
-        const outsideDiff = bugFindings.filter(f => !context.pr?.patches?.has(f.filepath));
-        if (outsideDiff.length > 0) {
-          const outsideBody = `${marker}outside-diff -->\n**⚠️ Issues found outside the diff:**\n\n${outsideDiff.map(f => `- 🔴 **${f.filepath}:${f.line}**${f.symbolName ? ` in \`${f.symbolName}\`` : ''}\n  ${f.message}${f.suggestion ? `\n  💡 *${f.suggestion}*` : ''}`).join('\n\n')}`;
-          await context.postReviewComment(outsideBody);
-        }
+      const { anchorable, unanchorable } = partitionByDiffAnchorability(
+        bugFindings,
+        context.pr?.diffLines,
+      );
+
+      // Inline comments for findings anchorable to a changed line. The collapsed
+      // "fix all" prompt keeps listing every bug finding, as before.
+      if (anchorable.length > 0) {
+        const reviewBody = buildFixPrompt(bugFindings, marker);
+        await context.postInlineComments(anchorable, reviewBody);
+      }
+
+      // Promote unanchorable findings to a visible review comment.
+      if (unanchorable.length > 0 && context.postReviewComment) {
+        context.logger.info(
+          `[${this.id}] ${unanchorable.length} finding(s) outside the diff promoted to the review body`,
+        );
+        await context.postReviewComment(buildOutOfDiffReviewBody(unanchorable, marker));
       }
     }
 
@@ -489,6 +504,68 @@ function buildDescription(
   parts.push(footer);
 
   return parts.join('\n\n');
+}
+
+/**
+ * Split bug findings by whether GitHub can anchor an inline comment to them.
+ * GitHub only accepts inline review comments on lines inside the PR's diff
+ * hunks; `diffLines` maps each changed file to that set of line numbers.
+ *
+ * A finding is `anchorable` when its (filepath, line) is a changed line.
+ * Everything else is `unanchorable` — typically a finding whose *cause* is in
+ * the diff but whose *manifestation* is in untouched code. Those are promoted
+ * to a visible review comment rather than dropped from inline posting.
+ *
+ * When `diffLines` is absent (e.g. the runner failed to fetch patch data) the
+ * determination can't be made, so every finding is treated as anchorable and
+ * the inline-posting path does its own diff-line filtering. Nothing is promoted
+ * in that case — matching the pre-existing degradation.
+ */
+export interface AnchorabilityPartition {
+  anchorable: ReviewFinding[];
+  unanchorable: ReviewFinding[];
+}
+
+export function partitionByDiffAnchorability(
+  findings: ReviewFinding[],
+  diffLines: Map<string, Set<number>> | undefined,
+): AnchorabilityPartition {
+  if (!diffLines || diffLines.size === 0) {
+    return { anchorable: [...findings], unanchorable: [] };
+  }
+  const anchorable: ReviewFinding[] = [];
+  const unanchorable: ReviewFinding[] = [];
+  for (const f of findings) {
+    if (diffLines.get(f.filepath)?.has(f.line)) anchorable.push(f);
+    else unanchorable.push(f);
+  }
+  return { anchorable, unanchorable };
+}
+
+/**
+ * Render findings that can't be anchored to a diff line as a visible,
+ * above-the-fold PR review comment. Each renders as a marked bullet naming the
+ * severity, category, symbol, and exact `file:line`, flagged "(outside this
+ * diff)" so a reviewer understands why it isn't an inline comment.
+ *
+ * The dedup marker (`…:outside-diff`) shares the plugin marker prefix, so
+ * `minimizeOutdatedComments(marker)` collapses the previous run's promoted
+ * comment before a fresh one is posted — no double-posting across re-runs.
+ */
+export function buildOutOfDiffReviewBody(findings: ReviewFinding[], marker: string): string {
+  const count = findings.length;
+  const headline = `**⚠️ ${count} issue${count === 1 ? '' : 's'} relating to your changes, outside this diff**`;
+  const intro =
+    'Caused by changes in this PR but on lines GitHub cannot attach an inline ' +
+    'comment to (outside the diff hunks):';
+  const bullets = findings.map(f => {
+    const emoji = f.severity === 'error' ? '🔴' : f.severity === 'warning' ? '🟡' : 'ℹ️';
+    const category = f.category.replace(/_/g, ' ');
+    const symbol = f.symbolName ? ` in \`${f.symbolName}\`` : '';
+    const suggestion = f.suggestion ? `\n  💡 *${f.suggestion}*` : '';
+    return `- ${emoji} **${category}**${symbol} — \`${f.filepath}:${f.line}\` *(outside this diff)*\n  ${f.message}${suggestion}`;
+  });
+  return `${marker}outside-diff -->\n${headline}\n\n${intro}\n\n${bullets.join('\n\n')}`;
 }
 
 /**

--- a/packages/review/test/plugins-agent-out-of-diff.test.ts
+++ b/packages/review/test/plugins-agent-out-of-diff.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AgentReviewPlugin,
+  partitionByDiffAnchorability,
+  buildOutOfDiffReviewBody,
+} from '../src/plugins/agent/index.js';
+import { silentLogger } from '../src/test-helpers.js';
+import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
+import type { PRContext } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function bug(overrides?: Partial<ReviewFinding>): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: 'src/a.ts',
+    line: 10,
+    severity: 'warning',
+    category: 'logic_error',
+    message: 'Something is off here.',
+    ...overrides,
+  };
+}
+
+const MARKER = '<!-- lien-plugin:agent-review:';
+
+/** A PresentContext that records every posting call for assertions. */
+function recordingContext(overrides?: {
+  diffLines?: Map<string, Set<number>>;
+  inlineResult?: { posted: number; skipped: number };
+}): {
+  ctx: PresentContext;
+  calls: string[];
+  postInlineComments: ReturnType<typeof vi.fn>;
+  postReviewComment: ReturnType<typeof vi.fn>;
+  minimizeOutdatedComments: ReturnType<typeof vi.fn>;
+} {
+  const calls: string[] = [];
+  const postInlineComments = vi.fn(async (findings: ReviewFinding[]) => {
+    calls.push('postInlineComments');
+    return overrides?.inlineResult ?? { posted: findings.length, skipped: 0 };
+  });
+  const postReviewComment = vi.fn(async () => {
+    calls.push('postReviewComment');
+  });
+  const minimizeOutdatedComments = vi.fn(async () => {
+    calls.push('minimizeOutdatedComments');
+    return 0;
+  });
+
+  const pr = {
+    owner: 'o',
+    repo: 'r',
+    pullNumber: 1,
+    title: 't',
+    baseSha: 'base',
+    headSha: 'head',
+    diffLines: overrides?.diffLines,
+  } as PRContext;
+
+  const ctx = {
+    complexityReport: { files: {}, summary: {} },
+    baselineReport: null,
+    deltas: null,
+    deltaSummary: null,
+    pr,
+    logger: silentLogger,
+    addAnnotations: vi.fn(),
+    appendSummary: vi.fn(),
+    appendDescription: vi.fn(),
+    postInlineComments,
+    postReviewComment,
+    minimizeOutdatedComments,
+  } as unknown as PresentContext;
+
+  return { ctx, calls, postInlineComments, postReviewComment, minimizeOutdatedComments };
+}
+
+// ---------------------------------------------------------------------------
+// partitionByDiffAnchorability
+// ---------------------------------------------------------------------------
+
+describe('partitionByDiffAnchorability', () => {
+  it('anchors a finding whose line is a changed line', () => {
+    const diffLines = new Map([['src/a.ts', new Set([10, 11, 12])]]);
+    const f = bug({ filepath: 'src/a.ts', line: 11 });
+    const { anchorable, unanchorable } = partitionByDiffAnchorability([f], diffLines);
+    expect(anchorable).toEqual([f]);
+    expect(unanchorable).toEqual([]);
+  });
+
+  it('treats a finding in a changed file but on an unchanged line as unanchorable', () => {
+    // The exact target case: the file IS in the diff, but the manifestation
+    // line (538) is not inside any diff hunk. File-level checks miss this.
+    const diffLines = new Map([['src/a.ts', new Set([10, 11, 12])]]);
+    const f = bug({ filepath: 'src/a.ts', line: 538 });
+    const { anchorable, unanchorable } = partitionByDiffAnchorability([f], diffLines);
+    expect(anchorable).toEqual([]);
+    expect(unanchorable).toEqual([f]);
+  });
+
+  it('treats a finding in an untouched file as unanchorable', () => {
+    const diffLines = new Map([['src/a.ts', new Set([10])]]);
+    const f = bug({ filepath: 'src/untouched.ts', line: 5 });
+    const { anchorable, unanchorable } = partitionByDiffAnchorability([f], diffLines);
+    expect(anchorable).toEqual([]);
+    expect(unanchorable).toEqual([f]);
+  });
+
+  it('splits a mixed batch correctly', () => {
+    const diffLines = new Map([
+      ['src/a.ts', new Set([10])],
+      ['src/b.ts', new Set([20, 21])],
+    ]);
+    const inA = bug({ filepath: 'src/a.ts', line: 10 });
+    const outA = bug({ filepath: 'src/a.ts', line: 999 });
+    const inB = bug({ filepath: 'src/b.ts', line: 21 });
+    const { anchorable, unanchorable } = partitionByDiffAnchorability([inA, outA, inB], diffLines);
+    expect(anchorable).toEqual([inA, inB]);
+    expect(unanchorable).toEqual([outA]);
+  });
+
+  it('falls back to all-anchorable when diffLines is undefined', () => {
+    const f = bug();
+    const { anchorable, unanchorable } = partitionByDiffAnchorability([f], undefined);
+    expect(anchorable).toEqual([f]);
+    expect(unanchorable).toEqual([]);
+  });
+
+  it('falls back to all-anchorable when diffLines is empty', () => {
+    const f = bug();
+    const { anchorable, unanchorable } = partitionByDiffAnchorability([f], new Map());
+    expect(anchorable).toEqual([f]);
+    expect(unanchorable).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOutOfDiffReviewBody
+// ---------------------------------------------------------------------------
+
+describe('buildOutOfDiffReviewBody', () => {
+  it('renders a visible, above-the-fold bullet (no <details> collapse)', () => {
+    const body = buildOutOfDiffReviewBody(
+      [
+        bug({
+          filepath: 'packages/review/src/stale-literal-signals.ts',
+          line: 538,
+          symbolName: 'renderStaleLiteralSection',
+          category: 'logic_error',
+          message: 'The timeout flag is discarded, so this function now lies.',
+          suggestion: 'Thread the flag through.',
+        }),
+      ],
+      MARKER,
+    );
+
+    expect(body).not.toContain('<details>');
+    expect(body).toContain('🟡 **logic error**');
+    expect(body).toContain('in `renderStaleLiteralSection`');
+    expect(body).toContain('`packages/review/src/stale-literal-signals.ts:538`');
+    expect(body).toContain('*(outside this diff)*');
+    expect(body).toContain('The timeout flag is discarded');
+    expect(body).toContain('💡 *Thread the flag through.*');
+  });
+
+  it('embeds the outside-diff dedup marker sharing the plugin prefix', () => {
+    const body = buildOutOfDiffReviewBody([bug()], MARKER);
+    expect(body.startsWith(`${MARKER}outside-diff -->`)).toBe(true);
+    // The minimize call uses the bare prefix; it must substring-match this body.
+    expect(body.includes(MARKER)).toBe(true);
+  });
+
+  it('uses the error emoji for error findings', () => {
+    const body = buildOutOfDiffReviewBody([bug({ severity: 'error' })], MARKER);
+    expect(body).toContain('🔴');
+  });
+
+  it('pluralizes the headline count', () => {
+    expect(buildOutOfDiffReviewBody([bug()], MARKER)).toContain('1 issue relating');
+    expect(buildOutOfDiffReviewBody([bug(), bug()], MARKER)).toContain('2 issues relating');
+  });
+
+  it('omits the symbol and suggestion fragments when absent', () => {
+    const body = buildOutOfDiffReviewBody(
+      [bug({ symbolName: undefined, suggestion: undefined })],
+      MARKER,
+    );
+    expect(body).not.toContain(' in `');
+    expect(body).not.toContain('💡');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// present() — placement decision & routing
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPlugin.present — out-of-diff promotion', () => {
+  const plugin = new AgentReviewPlugin();
+
+  it('anchors in-diff findings inline and promotes out-of-diff findings to the body', async () => {
+    const diffLines = new Map([['src/a.ts', new Set([10])]]);
+    const { ctx, postInlineComments, postReviewComment } = recordingContext({ diffLines });
+
+    const inDiff = bug({ filepath: 'src/a.ts', line: 10, message: 'in-diff finding' });
+    const outOfDiff = bug({ filepath: 'src/a.ts', line: 538, message: 'out-of-diff finding' });
+
+    await plugin.present([inDiff, outOfDiff], ctx);
+
+    // Inline comments receive ONLY the anchorable finding.
+    expect(postInlineComments).toHaveBeenCalledTimes(1);
+    const inlineArg = postInlineComments.mock.calls[0][0] as ReviewFinding[];
+    expect(inlineArg).toEqual([inDiff]);
+
+    // The promoted body is posted and names the out-of-diff finding.
+    expect(postReviewComment).toHaveBeenCalledTimes(1);
+    const promoted = postReviewComment.mock.calls[0][0] as string;
+    expect(promoted).toContain('`src/a.ts:538`');
+    expect(promoted).toContain('out-of-diff finding');
+    expect(promoted).not.toContain('<details>');
+  });
+
+  it('promotes without posting an inline review when every finding is out-of-diff', async () => {
+    const diffLines = new Map([['src/a.ts', new Set([10])]]);
+    const { ctx, postInlineComments, postReviewComment } = recordingContext({ diffLines });
+
+    await plugin.present([bug({ filepath: 'src/a.ts', line: 538 })], ctx);
+
+    expect(postInlineComments).not.toHaveBeenCalled();
+    expect(postReviewComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts no promoted body when every finding is anchorable', async () => {
+    const diffLines = new Map([['src/a.ts', new Set([10, 11])]]);
+    const { ctx, postInlineComments, postReviewComment } = recordingContext({ diffLines });
+
+    await plugin.present([bug({ line: 10 }), bug({ line: 11 })], ctx);
+
+    expect(postInlineComments).toHaveBeenCalledTimes(1);
+    expect(postReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('does not count promoted findings as skipped — inline gets only anchorable', async () => {
+    // Truthful-counter guarantee: the inline path never sees out-of-diff
+    // findings, so its returned `skipped` can only reflect dedup, never
+    // promotion.
+    const diffLines = new Map([['src/a.ts', new Set([10])]]);
+    const { ctx, postInlineComments } = recordingContext({ diffLines });
+
+    await plugin.present([bug({ line: 10 }), bug({ line: 20 }), bug({ line: 30 })], ctx);
+
+    const inlineArg = postInlineComments.mock.calls[0][0] as ReviewFinding[];
+    expect(inlineArg).toHaveLength(1);
+    expect(inlineArg[0].line).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dedup / re-run simulation
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPlugin.present — promoted-body dedup across re-runs', () => {
+  const plugin = new AgentReviewPlugin();
+
+  it('minimizes outdated comments before posting, with a marker that matches the promoted body', async () => {
+    const diffLines = new Map([['src/a.ts', new Set([10])]]);
+    const { ctx, calls, postReviewComment, minimizeOutdatedComments } = recordingContext({
+      diffLines,
+    });
+
+    await plugin.present([bug({ filepath: 'src/a.ts', line: 538 })], ctx);
+
+    // Minimize runs first so the previous run's promoted comment collapses.
+    expect(calls.indexOf('minimizeOutdatedComments')).toBeLessThan(
+      calls.indexOf('postReviewComment'),
+    );
+
+    const marker = minimizeOutdatedComments.mock.calls[0][0] as string;
+    const promoted = postReviewComment.mock.calls[0][0] as string;
+    // The bare prefix passed to minimize substring-matches the promoted body,
+    // so GitHub would collapse the prior promoted comment on the next run.
+    expect(promoted.includes(marker)).toBe(true);
+  });
+
+  it('re-run posts an identical promoted body (stable under minimize+repost)', async () => {
+    const diffLines = new Map([['src/a.ts', new Set([10])]]);
+    const finding = bug({ filepath: 'src/a.ts', line: 538 });
+
+    const run1 = recordingContext({ diffLines });
+    await plugin.present([finding], run1.ctx);
+
+    const run2 = recordingContext({ diffLines });
+    await plugin.present([finding], run2.ctx);
+
+    const body1 = run1.postReviewComment.mock.calls[0][0] as string;
+    const body2 = run2.postReviewComment.mock.calls[0][0] as string;
+    expect(body2).toBe(body1);
+    // Each run minimizes before reposting → no double-posting accumulation.
+    expect(run2.minimizeOutdatedComments).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Lien Review posts findings as GitHub inline review comments. GitHub's API only anchors inline comments to lines **inside the PR's diff hunks**. Findings whose *cause* is in the diff but whose *manifestation* is in untouched code (e.g. "your new timeout flag is discarded, so this untouched rendering function at line 538 now lies") are **unanchorable**.

Today those findings degrade badly:
- The old promotion path (`agent/index.ts`) used a **file-level** check — `!context.pr?.patches?.has(f.filepath)`. It only rescued findings whose *file* was entirely absent from the diff.
- A finding whose file **is** in the diff but whose target **line** is not in a hunk (the exact case observed on getlien/lien #628) fell through: it landed only in the collapsed `<details>` "🤖 Prompt for AI Agents" block, or vanished entirely when no inline comment was posted at all.

These cross-boundary findings are often the smartest the engine produces, and they systematically got the weakest presentation slot.

## Plan (implemented)

Pure formatting/posting change in the agent plugin's `present()` — **zero LLM-prompt or rule changes**, so no harness calibration needed.

1. **Line-level placement decision.** `partitionByDiffAnchorability(findings, pr.diffLines)` splits bug findings into `anchorable` (their `(filepath, line)` is a changed line) and `unanchorable`. `PRContext.diffLines` is already populated by the runner (`review-pr.ts`), so no extra API calls.
2. **Anchorable → inline comments**, exactly as before. The collapsed "fix all" prompt still lists every bug finding.
3. **Unanchorable → promoted** to a visible, above-the-fold review comment (`buildOutOfDiffReviewBody`) — outside any `<details>` — clearly marked with severity emoji, humanized category, symbol, exact `file:line`, and `*(outside this diff)*`.
4. **Truthful counter (design point 3).** Inline posting now receives *only* anchorable findings, so the `{posted, skipped}` it returns reflects **dedup only** — out-of-diff findings are presented (promoted), never counted as skipped.

### Dedup / re-run safety
The promoted comment carries the `…:outside-diff` marker under the shared plugin prefix `<!-- lien-plugin:agent-review:`. `present()` already calls `minimizeOutdatedComments(marker)` first whenever there are bug findings, and that prefix substring-matches the promoted body — so the previous run's promoted comment is collapsed as "outdated" before a fresh identical one is posted. No double-posting across re-runs (verified by a two-run simulation test). Inline-comment dedup (keyed by `filepath::line::category` on the current head SHA) is untouched.

## Before / after presentation

**Before** (unanchorable finding, file in diff but line not in a hunk) — buried in the collapsed block:
```
**3 issues found**
▸ 🤖 Prompt for AI Agents      ← collapsed <details>; the cross-boundary finding is only in here
```

**After** — promoted above the fold as its own visible review comment:
```
⚠️ 1 issue relating to your changes, outside this diff

Caused by changes in this PR but on lines GitHub cannot attach an inline
comment to (outside the diff hunks):

- 🟡 **logic error** in `renderStaleLiteralSection` — `packages/review/src/stale-literal-signals.ts:538` *(outside this diff)*
  The timeout flag is discarded, so this function now lies.
  💡 *Thread the flag through.*
```
Anchorable findings still post as inline comments with the same "fix all" prompt block as before.

## Option 2 (nearest-in-diff-line anchoring): **rejected**

The task floated optionally anchoring an unanchorable finding to the *nearest in-diff line of the same file* with a "relates to line 538, outside this diff" prefix. I rejected it:

- An inline comment carries a strong "**this exact line** is the problem" semantic. Anchoring a cross-boundary finding onto an unrelated nearest changed line **inverts the very insight** that makes these findings valuable (cause ≠ manifestation location) and reads as a mislocated comment.
- The promoted above-the-fold bullet already cites the precise `file:line`, is honest about being outside the diff, and is more scannable than a note buried on an arbitrary line.
- It would add a novel failure mode (wrong-line comments) plus extra dedup/marker complexity for marginal discoverability gain.
- If Files-tab discoverability later proves necessary, the correct future step is a GitHub **file-level** comment (`subject_type: file`), not a fake line anchor — out of scope here.

## Tests

New `packages/review/test/plugins-agent-out-of-diff.test.ts` (17 tests):
- `partitionByDiffAnchorability`: line-in-hunk → anchorable; **file-in-diff-but-line-not → unanchorable** (the target bug); untouched file → unanchorable; mixed batch; undefined/empty `diffLines` → all anchorable (graceful fallback).
- `buildOutOfDiffReviewBody`: no `<details>`, severity emoji, humanized category, `file:line`, `*(outside this diff)*`, suggestion, singular/plural, marker prefix; omits symbol/suggestion when absent.
- `present()` routing: inline gets **only** anchorable; promoted body posted for unanchorable; no promoted body when all anchorable; no inline review when all unanchorable; truthful-counter guarantee.
- Dedup re-run simulation: minimize-before-post ordering, marker substring-matches promoted body, identical body across two runs.

## Gates (all green)
`format:check` ✓ · `lint` (0 errors) ✓ · `typecheck` ✓ · `build` ✓ · `test -w @liendev/review` ✓ (471 tests, incl. 17 new)

`@liendev/review` is `"private": true` → **no changeset needed** (verified).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 78. 3 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | -63 |


> [!NOTE]
> **Low Risk**
>
> This PR refactors the agent plugin's `present()` to route bug findings at the line level: findings whose `(filepath, line)` sits inside a diff hunk are posted as inline comments, while findings in changed files but outside any hunk are promoted to a visible review comment. The change is purely presentational, with no LLM-prompt or rule changes. The implementation handles missing `diffLines` gracefully, preserves the collapsed 'fix all' prompt for all bug findings, and uses a shared marker prefix for deduplication. Tests cover the key routing cases, pluralization, marker stability, and re-run dedup behavior.
>
> - Line-level anchorability partitioning via `partitionByDiffAnchorability`
> - Promotion of unanchorable findings to a visible review body via `buildOutOfDiffReviewBody`
> - Inline comments now receive only anchorable findings; promoted findings are no longer counted as skipped

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 58ea8a5. Updates automatically on new commits.</sup>
<!-- /lien-stats -->