### PR TITLE
docs: resync package maps, add Lien Review docs, purge stale references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,14 @@ target/
 # Misc
 *.orig
 
+# Ad-hoc screenshots dropped at repo root (competitive analysis, dogfooding,
+# manual QA) — not build output, just scratch. Root-only (not recursive) so
+# real image assets under packages/*/public etc. are unaffected.
+/*.png
+/*.jpg
+/*.jpeg
+/*.gif
+
 # Private documentation
 .private/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,28 +10,43 @@ Local-first semantic code search tool providing context to AI coding assistants 
 - License: AGPL-3.0 | Domain: lien.dev
 
 **Monorepo Structure:**
-- `packages/` — TypeScript packages (parser, core, review, cli, action, site)
+- `packages/` — TypeScript packages: `parser` and `core` publish as `@liendev/parser`/`@liendev/core`; `cli` publishes as `@liendev/lien`; `review`, `action`, and `site` are private (unpublished).
+- Dependency chain: `parser` ← `core` ← `cli`; `review` depends on `parser` only (not `core`); `action` wraps `review` as a self-hostable GitHub Action ([ADR-009](docs/architecture/decisions/0009-extract-parser-package.md)).
 
 **Package Structure:**
 ```
-packages/cli/src/
-├── cli/         # Commands (init, index, serve, status)
-├── mcp/         # MCP server
-├── indexer/     # Chunking, scanning, test associations
-├── embeddings/  # Local embeddings (transformers.js)
-├── vectordb/    # LanceDB vector storage
-├── config/      # Config management & migration
-├── frameworks/  # Framework detection (Node.js, Laravel)
-└── git/         # Git integration
+packages/parser/src/        # AST parsing, chunking, complexity, scanning — zero deps on core
+├── ast/
+│   ├── languages/   # Per-language definitions (single source of truth)
+│   ├── traversers/  # Language-specific AST traversal classes
+│   ├── extractors/  # Language-specific import/export/symbol extraction classes
+│   └── complexity/  # Complexity metrics (cyclomatic, cognitive, Halstead)
+├── risk/            # Blast-radius risk scoring
+├── insights/        # Complexity report types
+├── ecosystem-presets.ts  # Project-type detection — replaced the old frameworks/
+│                         # plugin system (ADR-007); NOT a `frameworks/` directory
+└── scanner.ts, gitignore.ts, chunker.ts, dependency-analyzer.ts,
+    test-associations.ts, symbol-extractor.ts, content-hash.ts
 
-packages/core/src/indexer/ast/
-├── languages/   # Per-language definitions (single source of truth)
-├── traversers/  # Language-specific AST traversal classes
-├── extractors/  # Language-specific export extraction classes
-├── complexity/  # Complexity metrics (cyclomatic, cognitive, Halstead)
-├── parser.ts    # Tree-sitter parser wrapper
-├── chunker.ts   # AST-based semantic chunking
-└── symbols.ts   # Symbol extraction
+packages/core/src/          # Embeddings, vector DB, config, git — depends on parser
+├── indexer/     # Indexing orchestration: manifest, incremental updates, scanning glue
+├── embeddings/  # Local embeddings (transformers.js, worker thread)
+├── vectordb/    # LanceDB vector storage
+├── config/      # Config management & migration (GlobalConfig + per-project ConfigService)
+├── git/         # Git state tracking
+└── insights/    # ComplexityAnalyzer + formatters (text/JSON/SARIF)
+
+packages/cli/src/           # CLI + MCP server — depends on core and parser
+├── cli/         # Commands: init, index, serve, status, config, complexity, path, annotate
+├── mcp/         # MCP server and tool handlers (semantic_search, get_dependents, etc.)
+├── watcher/     # File watching
+├── types/       # Shared TypeScript types
+└── utils/       # CLI utilities
+
+packages/review/src/        # PR review engine (plugins, blast-radius render, prompt building)
+                             # — depends on parser only, not core
+packages/action/src/        # Self-hostable GitHub Action wrapping @liendev/review
+packages/site/              # VitePress docs site (lien.dev)
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,19 +42,20 @@ Rebuild (`npm run build`) and restart your MCP client to pick up changes.
 
 ## Project Structure
 
+Lien is a 6-package monorepo. `CLAUDE.md`'s ["What is Lien?"](./CLAUDE.md#what-is-lien) section (which contains "Package Structure") is the single source of truth for the per-package directory layout — start there. In short:
+
 ```
 lien/
-├── packages/cli/          # Main CLI package
-│   ├── src/
-│   │   ├── cli/          # Command-line interface
-│   │   ├── mcp/          # MCP server implementation
-│   │   ├── indexer/      # Code indexing logic
-│   │   ├── embeddings/   # Local embedding generation
-│   │   └── vectordb/     # LanceDB integration
-│   ├── test/             # Test suites
-│   └── package.json
-├── scripts/              # Build and release automation
-└── .cursor/              # Cursor AI rules and guidelines
+├── packages/
+│   ├── parser/    # @liendev/parser — AST parsing, chunking, complexity, scanning
+│   ├── core/      # @liendev/core — embeddings, vector DB, config, git (depends on parser)
+│   ├── cli/       # @liendev/lien — CLI + MCP server (depends on core and parser)
+│   ├── review/    # @liendev/review (private) — PR review engine (depends on parser only)
+│   ├── action/    # @liendev/action (private) — self-hostable GitHub Action wrapping review
+│   └── site/      # @liendev/site (private) — VitePress docs site (lien.dev)
+├── docs/architecture/     # Architecture docs and ADRs
+├── scripts/               # Build and release automation
+└── .cursor/               # Cursor AI rules and guidelines
 ```
 
 ## Making Changes
@@ -209,159 +210,21 @@ Update `CHANGELOG.md` with every release following [Keep a Changelog](https://ke
 - Improved error handling for missing index files
 ```
 
-## Adding a New Framework
+## Adding a New Ecosystem Preset
 
-Lien's framework plugin system makes it easy to add support for new languages and frameworks. Here's how to add support for a new framework (e.g., Django, Ruby on Rails):
+Lien detects project type via lightweight **ecosystem presets** (marker file → include/exclude patterns), not a plugin/detector system. The old `FrameworkDetector` plugin architecture (~3,000 LOC) was removed in favor of this simpler model — see [ADR-007](docs/architecture/decisions/0007-replace-framework-detection-with-ecosystem-presets.md) for the full rationale.
 
-### 1. Create Framework Directory
+To add support for a new ecosystem (e.g., a new language or build tool):
 
-```
-packages/cli/src/frameworks/myframework/
-  ├── detector.ts         # Detection logic
-  ├── config.ts          # Default configuration
-  └── test-patterns.ts   # Test file patterns
-```
+1. Add an entry to `ECOSYSTEM_PRESETS` in `packages/parser/src/ecosystem-presets.ts` — a `{ name, markerFiles, excludePatterns }` object literal.
+2. Add a test case in `packages/parser/src/ecosystem-presets.test.ts`.
+3. Update the ecosystem preset list in `packages/site/docs/guide/configuration.md` and README.md's Supported Languages section if relevant.
 
-### 2. Implement detector.ts
-
-```typescript
-import fs from 'fs/promises';
-import path from 'path';
-import { FrameworkDetector, DetectionResult } from '../types.js';
-import { generateMyFrameworkConfig } from './config.js';
-
-export const myframeworkDetector: FrameworkDetector = {
-  name: 'myframework',
-  
-  async detect(rootDir: string, relativePath: string): Promise<DetectionResult> {
-    const fullPath = path.join(rootDir, relativePath);
-    const result: DetectionResult = {
-      detected: false,
-      name: 'myframework',
-      path: relativePath,
-      confidence: 'low',
-      evidence: [],
-    };
-    
-    // Check for framework markers (e.g., package files, config files)
-    const markerPath = path.join(fullPath, 'myframework.json');
-    try {
-      await fs.access(markerPath);
-      result.detected = true;
-      result.confidence = 'high';
-      result.evidence.push('Found myframework.json');
-    } catch {
-      return result;
-    }
-    
-    // Add more detection logic...
-    
-    return result;
-  },
-  
-  async generateConfig(rootDir: string, relativePath: string) {
-    return generateMyFrameworkConfig(rootDir, relativePath);
-  },
-};
-```
-
-### 3. Implement config.ts
-
-```typescript
-import { FrameworkConfig } from '../../config/schema.js';
-import { myframeworkTestPatterns } from './test-patterns.js';
-
-export async function generateMyFrameworkConfig(
-  rootDir: string,
-  relativePath: string
-): Promise<FrameworkConfig> {
-  return {
-    include: [
-      'src/**/*.myext',
-      'lib/**/*.myext',
-    ],
-    exclude: [
-      'vendor/**',
-      'build/**',
-      'dist/**',
-    ],
-    testPatterns: myframeworkTestPatterns,
-  };
-}
-```
-
-### 4. Implement test-patterns.ts
-
-```typescript
-import { TestPatternConfig } from '../../config/schema.js';
-
-export const myframeworkTestPatterns: TestPatternConfig = {
-  directories: ['tests', 'spec'],
-  extensions: ['.test.myext', '.spec.myext'],
-  prefixes: ['test_'],
-  suffixes: ['_test', '.test'],
-  frameworks: ['mytest', 'myspec'],
-};
-```
-
-### 5. Register in registry.ts
-
-```typescript
-// packages/cli/src/frameworks/registry.ts
-import { myframeworkDetector } from './myframework/detector.js';
-
-// Add to the detectors array
-registerFramework(myframeworkDetector);
-```
-
-### 6. Add Integration Tests
-
-Create `packages/cli/test/integration/myframework.test.ts`:
-
-```typescript
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { detectAllFrameworks } from '../../src/frameworks/detector-service.js';
-
-describe('MyFramework Detection', () => {
-  it('detects myframework in project', async () => {
-    // Test detection logic...
-  });
-  
-  it('generates correct config', async () => {
-    // Test config generation...
-  });
-});
-```
-
-### 7. Submit Pull Request
-
-Your PR should include:
-- Detector implementation with high-quality detection logic
-- Default config and test patterns
-- Integration tests with >80% coverage
-- Documentation update in README.md (add to Supported Frameworks section)
-- Example usage if the framework has unique requirements
-
-### Testing Your Framework Plugin
-
-```bash
-# Build
-npm run build
-
-# Test detection
-lien init --path /path/to/myframework/project
-
-# Verify config generation
-cat /path/to/myframework/project/.lien.config.json
-
-# Run integration tests
-cd packages/cli
-npm test -- test/integration/myframework.test.ts
-```
+No detector classes, confidence levels, or registry — just add an object to the array.
 
 ## Adding a New AST Language
 
-Each AST-supported language is a **single self-contained file** in `packages/core/src/indexer/ast/languages/` containing everything: traverser class, export extractor class, import extractor class, and the `LanguageDefinition` that wires them together.
+Each AST-supported language is a **single self-contained file** in `packages/parser/src/ast/languages/` containing everything: traverser class, export extractor class, import extractor class, and the `LanguageDefinition` that wires them together.
 
 ### Steps
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,41 @@ Lien tracks code complexity with intuitive outputs:
 - ⏱️ **Time to understand** - Halstead effort as readable duration (~2h 30m)
 - 🐛 **Estimated bugs** - Halstead prediction (Volume / 3000)
 
+## Lien Review
+
+Lien Review is a self-hostable **GitHub Action** that reviews pull requests: complexity analysis, agent-driven bug review, and a PR summary — posted back as inline comments and workflow annotations. No server, no database, no recurring bill.
+
+```yaml
+# .github/workflows/lien-review.yml
+name: Lien Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlien/lien-review@v1
+        with:
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+That single `uses:` line is the whole integration — Lien self-clones the PR by SHA using the workflow's own token, so no `actions/checkout` step is needed.
+
+| Feature | Description |
+|---------|-------------|
+| Complexity analysis | Flags new/worsened cyclomatic, cognitive, and Halstead complexity violations |
+| Agent bug review | LLM-driven review for correctness bugs (OpenRouter or Anthropic) |
+| PR summary | A concise summary of the change, posted as a step summary |
+| Advisory by default | `fail-on: never` — the check never blocks a PR unless you opt in |
+
+**👉 [Lien Review guide](https://lien.dev/guide/lien-review)** · [Action reference](./packages/action/README.md)
+
 ## Documentation
 
 - **[Installation](https://lien.dev/guide/installation)** - npm, npx, or local setup
@@ -78,6 +113,7 @@ Lien tracks code complexity with intuitive outputs:
 - **[Configuration](https://lien.dev/guide/configuration)** - Customize indexing, thresholds, performance
 - **[CLI Commands](https://lien.dev/guide/cli-commands)** - Full command reference
 - **[MCP Tools](https://lien.dev/guide/mcp-tools)** - Complete API reference for all 6 tools
+- **[Lien Review](https://lien.dev/guide/lien-review)** - GitHub Action PR review setup
 - **[How It Works](https://lien.dev/how-it-works)** - Architecture overview
 
 ## Supported Languages

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,6 +14,7 @@ A bird's-eye view of Lien's architecture showing:
 - Data layer (embeddings, VectorDB factory with the LanceDB backend)
 - Optional services (git tracking, file watching, ecosystem presets)
 - External dependencies
+- Lien Review — the separate GitHub Action product surface (`packages/review` + `packages/action`)
 
 **Read this first** to understand the overall system structure.
 
@@ -186,39 +187,44 @@ All processing happens locally. No cloud services required. Your code never leav
 
 ## 🔍 Code Organization
 
-```
-packages/cli/src/
-├── cli/              # CLI commands (init, index, serve, status, config, complexity)
-├── mcp/              # MCP server, tools, and handlers
-│   ├── handlers/     # Tool handlers (semantic-search, find-similar, get-files-context, etc.)
-│   ├── schemas/      # Zod schemas for tool input validation
-│   └── utils/        # Response budgeting, metadata shaping, path matching
-├── indexer/          # File scanning, chunking, test associations
-├── embeddings/       # Local embedding generation with cache
-├── vectordb/         # LanceDB integration
-├── config/           # Per-project configuration (ConfigService)
-├── git/              # Git state tracking
-├── watcher/          # File watching (uses ecosystem presets for patterns)
-├── types/            # Shared TypeScript types
-├── utils/            # Utilities (banner, etc.)
-├── errors/           # Custom error classes
-└── constants.ts      # Centralized constants
+See `CLAUDE.md`'s "Package Structure" section for the canonical, actively-maintained version of this map. Summary:
 
-packages/core/src/
+```
+packages/parser/src/     # @liendev/parser — zero deps on core; AST, chunking, complexity, scanning
+├── ast/
+│   ├── languages/    # Per-language definitions (JS, TS, Python, PHP, Rust, etc.)
+│   ├── traversers/   # Language-specific AST traversal
+│   ├── extractors/   # Import/export/symbol extraction
+│   └── complexity/   # Cyclomatic, cognitive, Halstead analyzers
+├── risk/             # Blast-radius risk scoring
+├── insights/         # Complexity report types
+├── ecosystem-presets.ts  # Project-type detection (see ADR-007)
+└── scanner.ts, chunker.ts, dependency-analyzer.ts, test-associations.ts, ...
+
+packages/core/src/       # @liendev/core — depends on parser; embeddings, vector DB, config, git
 ├── config/           # GlobalConfig + per-project ConfigService + schema
-├── indexer/          # Scanner, chunker, manifest, ecosystem presets, dependency analyzer
-│   └── ast/          # AST parser, chunker, symbols, complexity metrics
-│       ├── languages/  # Per-language definitions (JS, TS, Python, PHP, Rust)
-│       ├── traversers/ # Language-specific AST traversal
-│       ├── extractors/ # Import/export/symbol extraction
-│       └── complexity/ # Cyclomatic, cognitive, Halstead analyzers
-├── insights/         # Complexity analyzer and formatters (text, JSON, SARIF)
+├── indexer/          # Indexing orchestration: manifest, incremental updates
+├── insights/         # ComplexityAnalyzer (VectorDB-aware wrapper) and formatters (text, JSON, SARIF)
 ├── vectordb/         # VectorDB factory, LanceDB, query, batch-insert, maintenance
 ├── embeddings/       # WorkerEmbeddings (transformers.js in worker thread)
 ├── git/              # Git tracker and utilities
 ├── errors/           # Error codes and classes
 ├── types/            # Shared types (CodeChunk, etc.)
 └── utils/            # Result type, versioning, path matching
+
+packages/cli/src/        # @liendev/lien — depends on core and parser
+├── cli/              # CLI commands (init, index, serve, status, config, complexity, path, annotate)
+├── mcp/              # MCP server, tools, and handlers
+│   ├── handlers/     # Tool handlers (semantic-search, find-similar, get-files-context, etc.)
+│   ├── schemas/      # Zod schemas for tool input validation
+│   └── utils/        # Response budgeting, metadata shaping, path matching
+├── watcher/          # File watching (uses ecosystem presets for patterns)
+├── types/            # Shared TypeScript types
+└── utils/            # Utilities (banner, etc.)
+
+packages/review/src/     # @liendev/review (private) — depends on parser only, not core
+packages/action/src/     # @liendev/action (private) — GitHub Action entry wrapping @liendev/review
+packages/site/           # @liendev/site (private) — VitePress docs site (lien.dev)
 ```
 
 ## 🚀 Performance Characteristics
@@ -283,11 +289,18 @@ Our Mermaid diagrams follow these conventions:
 
 ## 🔄 Version History
 
-### v0.35.0 (Current)
+### v0.49.x (Current)
+- ✅ Docs resynced to match current package layout and product surface
+- ✅ `@liendev/parser` extracted from `@liendev/core` (ADR-009)
+- ✅ Qdrant backend retired; LanceDB is the only backend (ADR-010)
+- ✅ Lien Review shipped as a self-hostable GitHub Action (`packages/review` + `packages/action`), replacing the retired hosted runner/platform
+- ✅ `lien path` and `lien annotate` commands added (hook-facing)
+- ✅ ADR-009, ADR-010 added
+
+### v0.35.0
 - ✅ Docs updated to match current state of codebase
 - ✅ Six MCP tools documented (`get_dependents`, `get_complexity` added)
 - ✅ Ecosystem presets replace framework detection (ADR-007)
-- ✅ VectorDB factory pattern (Qdrant backend retired in v0.49 — ADR-0010)
 - ✅ Global configuration system (`lien config`)
 - ✅ Complexity analyzer and `lien complexity` CLI
 - ✅ Embedding backend simplified to WorkerEmbeddings only (ADR-008)
@@ -332,7 +345,7 @@ If something in the architecture is unclear:
 
 ---
 
-**Last Updated:** February 10, 2026
+**Last Updated:** July 2, 2026
 **Maintained By:** Lien contributors
-**Status:** ✅ Complete and up-to-date (v0.35.0)
+**Status:** ✅ Complete and up-to-date (v0.49.x)
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -12,7 +12,7 @@ flowchart TB
     
     subgraph "Configuration Loading"
         LOAD_CONFIG[Load Configuration]
-        DETECT_FW[Detect Frameworks]
+        DETECT_FW[Detect Ecosystems]
         MERGE_CONFIG[Merge with Defaults]
     end
     
@@ -20,7 +20,7 @@ flowchart TB
         SCAN_START[Start File Scanning]
         READ_GITIGNORE[Read .gitignore]
         APPLY_PATTERNS[Apply Include/Exclude Patterns]
-        FILTER_FRAMEWORK[Filter by Framework Boundaries]
+        FILTER_FRAMEWORK[Apply Ecosystem Exclude Patterns]
         FILE_LIST[Generate File List]
     end
     

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -62,6 +62,13 @@ graph TB
         GITCMD[Git CLI]
     end
 
+    subgraph "Lien Review (packages/review + packages/action)"
+        GHACTION[GitHub Action Entry]
+        REVIEWENGINE[Review Engine]
+        COMPLEXITYCHECK[Complexity Plugin]
+        AGENTREVIEW[Agent Bug/Summary Review]
+    end
+
     %% CLI to Core
     CLI --> CONFIG
     INIT --> CONFIG
@@ -120,6 +127,13 @@ graph TB
     GIT --> GITCMD
     WATCHER --> INDEXER
 
+    %% Lien Review — separate product surface, shares only the parser
+    %% package (AST + complexity). Does not depend on core/embeddings/vectordb.
+    GHACTION --> REVIEWENGINE
+    REVIEWENGINE --> COMPLEXITYCHECK
+    REVIEWENGINE --> AGENTREVIEW
+    REVIEWENGINE -.->|uses parser AST + complexity, not core| AST
+
     %% Styling
     classDef cliClass fill:#e1f5ff,stroke:#01579b,stroke-width:2px
     classDef mcpClass fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
@@ -127,6 +141,7 @@ graph TB
     classDef dataClass fill:#fff3e0,stroke:#e65100,stroke-width:2px
     classDef optionalClass fill:#fce4ec,stroke:#880e4f,stroke-width:2px
     classDef externalClass fill:#f5f5f5,stroke:#424242,stroke-width:2px
+    classDef reviewClass fill:#ede7f6,stroke:#311b92,stroke-width:2px
 
     class CLI,INIT,INDEX,SERVE,STATUS,CONFIGCMD,COMPLX cliClass
     class MCP,TOOLS,SEMANTIC,SIMILAR,CONTEXT,LIST,DEPENDENTS,COMPLEXITY mcpClass
@@ -134,6 +149,7 @@ graph TB
     class EMBEDDINGS,VECTORDB,QUERY,BATCHINS,MAINT,CACHE dataClass
     class GIT,WATCHER,ECOSYSTEM optionalClass
     class TRANSFORMERS,LANCEDB,GITCMD externalClass
+    class GHACTION,REVIEWENGINE,COMPLEXITYCHECK,AGENTREVIEW reviewClass
 ```
 
 ## Component Descriptions
@@ -188,6 +204,18 @@ graph TB
 - **transformers.js**: Local embedding generation (all-MiniLM-L6-v2 model, runs in worker thread — see [ADR-008](decisions/0008-keep-transformers-js-worker-embeddings.md))
 - **LanceDB**: Vector database for semantic search (local, zero-config)
 - **Git CLI**: For repository state tracking
+
+### Lien Review (packages/review + packages/action)
+Lien Review is a separate product surface from the CLI/MCP pipeline above: a self-hostable GitHub Action that reviews pull requests in CI rather than serving a local AI assistant.
+
+- **GitHub Action Entry** (`packages/action`): Docker container action; reads the `pull_request` event, self-clones the PR head (and base, for complexity deltas) by SHA, and posts results — no `actions/checkout`, no server, no database.
+- **Review Engine** (`packages/review`): Orchestrates the enabled review passes and posts inline PR comments, workflow annotations, and a step summary.
+- **Complexity Plugin**: Flags new/worsened cyclomatic, cognitive, and Halstead complexity violations on the diff.
+- **Agent Bug/Summary Review**: LLM-driven review (OpenRouter or Anthropic) for correctness bugs, architectural concerns, and a PR summary.
+
+Critically, `packages/review` depends on **`@liendev/parser` only** — it does not import `@liendev/core`, so it carries none of the embeddings/vectordb/LanceDB dependency weight (this is the point of [ADR-009](decisions/0009-extract-parser-package.md)). See [`packages/action/README.md`](../../packages/action/README.md) for the full setup guide, or the [Lien Review site page](../../packages/site/docs/guide/lien-review.md).
+
+**Retired**: the earlier hosted-SaaS shape for review — `packages/runner` (a NATS-based review runner) and `platform/` (a Laravel 12 control plane + its K8s infra) — was removed in favor of this self-hostable Action. There's no ADR for this pivot (it predates the ADR log's review coverage); see the retirement commit for the full rationale.
 
 ## Data Flow
 
@@ -261,6 +289,17 @@ Non-essential features (git tracking, file watching) are optional and can be dis
 
 ## Recent Architectural Improvements
 
+### Qdrant Backend Retirement
+- **Removed**: The experimental Qdrant vector DB backend, its config keys, and its untested-in-CI test suite
+- **Kept**: The `VectorDBInterface` seam and `createVectorDB` factory, so a future backend can be reintroduced without touching call sites
+- **Benefit**: One backend (LanceDB), fully tested in CI; three latent bugs eliminated at the root
+- **Details**: See [ADR-010](decisions/0010-retire-qdrant-backend.md)
+
+### Parser Package Extraction
+- **Extracted**: `@liendev/parser` from `@liendev/core` — all AST parsing, chunking, complexity, and scanning code
+- **Benefit**: `@liendev/review` (and the Lien Review GitHub Action) now depends on parsing only, dropping ~100MB of embeddings/vectordb/LanceDB dependency weight it never used
+- **Details**: See [ADR-009](decisions/0009-extract-parser-package.md)
+
 ### Ecosystem Presets (Replaced Framework Detection)
 - **Replaced**: Rigid per-framework detection with lightweight ecosystem presets
 - **Benefit**: Zero-config auto-detection of project type; simpler codebase without framework-specific code
@@ -317,4 +356,6 @@ All major architectural decisions are documented in [docs/architecture/decisions
 - [ADR-006: Consolidated Language Files with Import Extractors](decisions/0006-consolidated-language-files-with-import-extractors.md)
 - [ADR-007: Replace Framework Detection with Ecosystem Presets](decisions/0007-replace-framework-detection-with-ecosystem-presets.md)
 - [ADR-008: Keep transformers.js WorkerEmbeddings as Sole Embedding Backend](decisions/0008-keep-transformers-js-worker-embeddings.md)
+- [ADR-009: Extract `@liendev/parser` from `@liendev/core`](decisions/0009-extract-parser-package.md)
+- [ADR-010: Retire the Qdrant Backend](decisions/0010-retire-qdrant-backend.md)
 

--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default withMermaid(
             items: [
               { text: 'MCP Tools', link: '/guide/mcp-tools' },
               { text: 'CLI Commands', link: '/guide/cli-commands' },
+              { text: 'Lien Review', link: '/guide/lien-review' },
             ]
           },
         ]

--- a/packages/site/docs/guide/cli-commands.md
+++ b/packages/site/docs/guide/cli-commands.md
@@ -14,8 +14,9 @@ lien init [options]
 
 | Option | Description |
 |--------|-------------|
-| `--editor <editor>` | Editor to configure MCP for (`cursor`, `claude-code`, `windsurf`, `opencode`, `kilo-code`, `antigravity`) |
-| `--path <path>` | Path to initialize (defaults to current directory) |
+| `-e, --editor <editor>` | Editor to configure MCP for (`cursor`, `claude-code`, `windsurf`, `opencode`, `kilo-code`, `antigravity`) |
+| `-p, --path <path>` | Path to initialize (defaults to current directory) |
+| `--legacy` | Use legacy per-project setup for Claude Code instead of recommending the plugin |
 
 ### Behavior
 
@@ -54,8 +55,8 @@ lien index [options]
 
 | Option | Description |
 |--------|-------------|
-| `--force` | Clear existing index and rebuild from scratch |
-| `--verbose` | Show detailed logging during indexing |
+| `-f, --force` | Clear existing index and rebuild from scratch |
+| `-v, --verbose` | Show detailed logging during indexing |
 
 ### Behavior
 
@@ -124,8 +125,9 @@ lien serve [options]
 
 | Option | Description |
 |--------|-------------|
+| `-p, --port <port>` | Port number (reserved for future use; the MCP server runs over stdio) |
 | `--no-watch` | Disable file watching for this session |
-| `--root <path>` | Root directory to serve (defaults to current directory) |
+| `-r, --root <path>` | Root directory to serve (defaults to current directory) |
 
 ### Behavior
 
@@ -215,32 +217,39 @@ Windsurf uses a global config file, so `lien init` automatically includes `--roo
 Show indexing status and statistics.
 
 ```bash
-lien status
+lien status [options]
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-v, --verbose` | Also show indexing settings (concurrency, batch size, chunk size/overlap defaults) |
+| `--format <type>` | Output format: `text` (default) or `json` |
 
 ### Output
 
 ```
-📊 Lien Status
+Status
 
-Project: /path/to/your/project
+Configuration: ✓ Using defaults (no per-project config needed)
+Index location: ~/.lien/indices/abc123
+Index status: ✓ Exists
+Index files: 1,234
+Last modified: 7/2/2026, 9:41:03 AM
+Last reindex: 7/2/2026, 9:40:12 AM
 
-Index Status:
-  Location: ~/.lien/indices/abc123
-  Last indexed: 2 hours ago
-  Files indexed: 1,234
-  Chunks created: 5,678
-  Test associations: 234
-  Disk usage: 142 MB
-
-Frameworks:
-  • nodejs (.)
-    - 1,100 files
-    - 5,200 chunks
-  • laravel (backend)
-    - 134 files
-    - 478 chunks
+Features:
+Git detection: ✓ Enabled
+  Poll interval: 2s
+  Current branch: main
+  Current commit: a1b2c3d4
+File watching: ✓ Enabled (default)
+  Batch window: 500ms (collects rapid changes, force-flush after 5s)
+  Disable with: lien serve --no-watch
 ```
+
+With `--verbose`, an additional "Indexing Settings (defaults)" block prints the concurrency, batch size, and chunk size/overlap defaults. With `--format json`, the same data is emitted as a single JSON object (`version`, `indexPath`, `indexStatus`, `indexFiles`, `git`, `features`, `settings`) for scripting.
 
 ## lien config
 
@@ -435,6 +444,57 @@ lien complexity --format json --fail-on error
 git diff --name-only HEAD~1 | xargs lien complexity --files
 ```
 
+## lien path
+
+Print Lien storage paths and supported extensions. This is a plumbing command intended for **hook scripts** (e.g. a Claude Code `PostToolUse` hook) rather than everyday interactive use.
+
+```bash
+lien path [options]
+```
+
+### Options
+
+Exactly one of the following is required — they are mutually exclusive:
+
+| Option | Description |
+|--------|-------------|
+| `--store` | Print the storage root for the current repo (e.g. `~/.lien/indices/abc123`) |
+| `--extensions` | Print the indexed-file extensions, one per line |
+| `--root` | Print the resolved project root (walks up the directory tree looking for `.git`) |
+
+### Examples
+
+```bash
+lien path --root
+# /Users/you/projects/my-app
+
+lien path --store
+# /Users/you/.lien/indices/a1b2c3d4
+
+lien path --extensions
+# .ts
+# .tsx
+# .js
+# ...
+```
+
+## lien annotate
+
+Print a short impact summary for a single file: dependent count and blast-radius risk, test coverage, and complexity warnings. This is a plumbing command intended for **hook scripts** — for example, a `PostToolUse` hook that annotates a just-edited file — rather than everyday interactive use. It never throws: on any error (missing index, unresolvable path) it exits 0 with empty output, so it never breaks a hook pipeline. Output is also empty when the impact is trivial (0-1 dependents, no complexity warnings, existing test coverage).
+
+```bash
+lien annotate <file>
+```
+
+### Example
+
+```bash
+lien annotate packages/cli/src/cli/status.ts
+# Lien impact for packages/cli/src/cli/status.ts:
+#   • 3 files import this — packages/cli/src/cli/index.ts, ...; risk: low.
+#   • Test coverage: packages/cli/src/cli/status.test.ts.
+```
+
 ## lien --version
 
 Show installed version.
@@ -453,22 +513,26 @@ lien --help
 ```
 
 ```
+Quick start: run 'lien serve' in your project directory
+
 Usage: lien [options] [command]
 
-Local semantic code search for AI assistants
+Local semantic code search for AI assistants via MCP
 
 Options:
-  -V, --version      output the version number
-  -h, --help         display help for command
+  -V, --version         output the version number
+  -h, --help            display help for command
 
 Commands:
-  init [options]     Initialize Lien in current directory
-  index [options]    Index your codebase
-  serve [options]    Start MCP server
-  status             Show indexing status
-  config             Manage global configuration
-  complexity         Analyze code complexity
-  help [command]     display help for command
+  init [options]        Initialize Lien in the current directory
+  index [options]       Index the codebase for semantic search
+  serve [options]       Start the MCP server (works with Cursor, Claude Code, Windsurf, and any MCP client)
+  status [options]      Show indexing status and statistics
+  complexity [options]  Analyze code complexity
+  config                Manage global configuration (~/.lien/config.json)
+  path [options]        Print Lien storage paths and supported extensions (for hook scripts)
+  annotate <file>       Print a short impact summary for a single file (for hook annotation)
+  help [command]        display help for command
 ```
 
 ## Environment Variables

--- a/packages/site/docs/guide/lien-review.md
+++ b/packages/site/docs/guide/lien-review.md
@@ -1,0 +1,71 @@
+# Lien Review
+
+Lien Review is a self-hostable **GitHub Action** that reviews pull requests: complexity analysis, an agent-driven bug review, and a PR summary — posted back to GitHub as inline comments and workflow annotations. There's no server, no database, and no recurring bill: the action clones the PR by SHA, reviews it, and writes results straight to GitHub using the workflow's built-in `GITHUB_TOKEN`.
+
+This page covers setup. For the complete input/output reference, fork-PR handling, and security notes, see [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md) in the repo.
+
+## Quick start
+
+Add a workflow at `.github/workflows/lien-review.yml`:
+
+```yaml
+name: Lien Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlien/lien-review@v1
+        with:
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+That single `uses:` line is the whole integration — **no `actions/checkout` step is needed**. Lien self-clones the PR head (and base, for complexity deltas) by SHA using the same token.
+
+## Required permissions
+
+The workflow must grant these or the comment writes will 403:
+
+```yaml
+permissions:
+  contents: read # clone the PR head/base by SHA
+  pull-requests: write # post inline review comments
+```
+
+## LLM key setup
+
+The agent (bug) review needs an LLM key, provided as a workflow **secret**:
+
+1. Get an [OpenRouter](https://openrouter.ai/) API key (preferred — cheaper Gemini path) or an Anthropic API key.
+2. Add it under **Settings → Secrets and variables → Actions → New repository secret** as `OPENROUTER_API_KEY` (or `ANTHROPIC_API_KEY`).
+3. Pass it through the action's `with:` block, as shown above.
+
+If both keys are omitted, the review still runs but **complexity-only** — the agent bug/summary/architectural passes are skipped.
+
+## What it checks
+
+| Feature | Description |
+|---------|-------------|
+| Complexity analysis | Flags new/worsened cyclomatic, cognitive, and Halstead complexity violations |
+| Agent bug review | LLM-driven review for correctness bugs (OpenRouter or Anthropic) |
+| PR summary | A concise summary of the change, posted as a step summary |
+| Advisory by default | `fail-on: never` — the check never blocks a PR unless you opt in |
+
+## Blocking a PR on the review
+
+By default the review is **advisory** — it never fails CI. To gate merges on it, set `fail-on: error` (or `any`) and mark the workflow's job as a **Required status check** in your branch protection rules. See the [inputs table](https://github.com/getlien/lien/blob/main/packages/action/README.md#inputs) for the full set of options (`threshold`, `review-types`, `block-on-new-errors`, `fail-on`).
+
+## Fork PRs
+
+On a `pull_request` event from a fork, GitHub forces the built-in `GITHUB_TOKEN` to read-only, so Lien can still review the code but can't post inline comments (findings still show up as workflow annotations and in the step summary). To get inline comments on fork PRs, opt into the `pull_request_target` variant documented in [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md#fork-prs) — read the security note there first.
+
+## Relationship to the MCP tools
+
+Lien Review is a separate product surface from the [MCP tools](/guide/mcp-tools): the MCP tools run locally inside your AI assistant, while Lien Review runs in CI against a pull request. Both share the same underlying AST parsing and complexity analysis (`@liendev/parser`), but Lien Review needs no local index and no `lien init` — it's a drop-in GitHub Action.


### PR DESCRIPTION
## What / Why

The repo's self-documentation had drifted through two package splits (ADR-007 framework→ecosystem-presets, ADR-009 core→parser) and the platform→Action pivot, none of which had been back-propagated into contributor docs. The Qdrant backend was also just removed (#624 / ADR-010) and needed to not linger anywhere non-historical. This addresses the confirmed critical + high/medium doc-drift findings from the whole-repo review.

## Changes

1. **CLAUDE.md** — regenerated "Package Structure" from the actual tree (verified via `find packages/*/src -maxdepth 2 -type d`). It previously claimed `packages/cli/src/{indexer,embeddings,vectordb,config,frameworks,git}` (none of which exist under `cli`) and AST under `core` (it's `packages/parser/src/ast` per ADR-009). New map: parser (ast/risk/insights/ecosystem-presets), core (indexer/embeddings/vectordb/config/git/insights), cli (cli/mcp/watcher/types/utils), review, action, site — with the parser→core→cli dependency chain called out.
2. **CONTRIBUTING.md** — deleted the ~150-line "Adding a New Framework" section documenting the deleted `FrameworkDetector` plugin system (ADR-007 removed ~3,000 LOC of it), replaced with a short "Adding a New Ecosystem Preset" how-to + ADR-007 link. Replaced the stale `packages/cli/`-only Project Structure tree with the accurate 6-package layout, pointing to CLAUDE.md as the single source of truth. Fixed the AST-language section's `packages/core/src/indexer/ast/` path to `packages/parser/src/ast/`.
3. **README.md + packages/site** — added a "Lien Review" section mirroring the MCP Tools section (the GitHub Action PR-review product, actively shipping, previously undocumented in either place). Added `packages/site/docs/guide/lien-review.md`, linked from the sidebar (`.vitepress/config.ts`), summarizing setup/permissions/fork-PR handling and linking to `packages/action/README.md` for the full reference.
4. **docs/architecture** — added a "Lien Review" subgraph + component-description section to `system-overview.md` (packages/review + packages/action, with the dashed edge back to the shared `AST` node calling out that review depends on parser only, not core). Added ADR-009 and ADR-010 to the ADR list (previously stopped at ADR-008 despite both already existing in `decisions/`). Added a note on the platform/runner retirement (no ADR exists for that pivot — noted in prose, not fabricated). Fixed the stale `packages/cli/src/{indexer,...}` code-organization tree in `docs/architecture/README.md` and relabeled `data-flow.md`'s `DETECT_FW`/`FILTER_FRAMEWORK` nodes from framework-detection language to ecosystem-preset language. Refreshed the version-history footer (was frozen at "v0.35.0 (Current)" / "Last Updated: February 10, 2026" despite the repo being at 0.49.1).
5. **cli-commands.md** — documented `lien path` and `lien annotate` (registered in `packages/cli/src/cli/index.ts`, previously undocumented hook-facing commands). Synced the `init` (`--legacy`), `serve` (`-p/--port`), and `status` (`-v/--verbose`, `--format`) option tables against the actual commander registrations; `lien status` previously had **no** options table at all, and its sample output was entirely fabricated (showed a "Frameworks:" per-ecosystem breakdown that doesn't exist in the current `status.ts`) — replaced with real output shape. `configuration.md`'s Qdrant note was already accurate/intentional (a "was removed in v0.49" callout matching ADR-010's wording) — left as-is.
6. **.gitignore** — added root-only `*.png`/`*.jpg`/`*.jpeg`/`*.gif` patterns (anchored, non-recursive) to stop the ~14 stray competitive-analysis screenshots at repo root from showing as untracked noise. Did not touch or delete any of the local files.

## Verification

```
npm run docs:build                    # vitepress build succeeds (16.7s, no errors)
npm run format:check                  # pass
npm run lint                          # 0 errors, 22 pre-existing warnings (unrelated files)
npm run typecheck                     # pass (parser/core/review build + cli/review/action typecheck)
npm run build                         # pass (parser, core, review, cli, action all build)

grep -rn -i qdrant docs/ README.md    # only ADR-0010 itself, the ADR index, other ADRs'
                                       # historical context, and the intentional "was
                                       # removed" notes in system-overview/config-system/
                                       # architecture-README — no stale current-feature refs

grep -rn -i framework docs/ README.md CONTRIBUTING.md
                                       # only test-framework detection (jest/vitest/pytest,
                                       # unrelated to the removed FrameworkDetector plugin),
                                       # "CLI Framework: Commander.js", and accurate
                                       # removal/deprecation notes remain

find packages/*/src -maxdepth 2 -type d | sort
                                       # cross-checked against every package map written in
                                       # this PR; confirmed packages/cli/src has NO
                                       # indexer/embeddings/vectordb/config/git/frameworks
                                       # subdirectories (all live in core or were deleted)
```

## Caveats

- Scope is docs/prose/gitignore only — no source, workflow, or config-schema changes. Other agents in this campaign own the corresponding code fixes.
- No ADR exists for the platform/runner retirement (commit `06cf2b6`, #593); noted in prose in `system-overview.md` rather than inventing one, since authoring a new ADR is outside this PR's scope.
- Did not rewrite `docs/architecture/config-system.md`'s legacy-config-format sections (the `frameworks` array in `.lien.config.json`) — that's documenting a still-loaded (deprecated, backward-compat) config schema per ADR-007's "Neutral" consequences, not the deleted `FrameworkDetector` code, so it stays.
- Not a changeset-worthy change (docs only).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This is a documentation-only PR that resyncs contributor docs, package maps, and site guides to reflect the current monorepo structure (parser/core/cli/review/action/site), removes stale references to the retired FrameworkDetector plugin system and Qdrant backend, and adds Lien Review documentation. No source code, workflow, or config schemas are modified, so there is no runtime impact on callers or behavior.
>
> - Regenerated package structure maps in CLAUDE.md, CONTRIBUTING.md, and docs/architecture to match the actual six-package layout and dependency chain
> - Removed stale FrameworkDetector plugin documentation and replaced it with ecosystem-preset guidance
> - Added Lien Review documentation to README.md, site sidebar, and a new guide page
> - Updated stale version-history footer and ADR index to include ADR-009 and ADR-010

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 059f672. Updates automatically on new commits.</sup>
<!-- /lien-stats -->