### PR TITLE
ci: test parser/core, add root test script, and add release/docs/harness safety nets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
         # as a known environmental issue; run it manually with
         # `npm run test -w @liendev/core -- src/embeddings/worker-embeddings.test.ts`
         # when validating WorkerEmbeddings changes by hand.
+        #
+        # This --exclude flag is intentionally duplicated in the root `test`
+        # script in package.json rather than moved into
+        # packages/core/vitest.config.ts: a config-level `exclude` removes
+        # the file from vitest's file-discovery set entirely, which breaks
+        # the manual re-run command above ("No test files found" -- verified
+        # empirically). Keeping the exclude as a CLI flag preserves that
+        # escape hatch. If you change one occurrence, change the other.
         run: npm run test --workspace=packages/core -- --exclude '**/worker-embeddings.test.ts'
 
       - name: Run tests (CLI)
@@ -88,6 +96,8 @@ jobs:
     name: Release smoke test (npm pack -> external install)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     # Every other job installs via the npm workspace protocol (`npm ci` at
     # the repo root), which resolves @liendev/core and @liendev/parser from
@@ -103,6 +113,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -148,6 +160,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,25 @@ jobs:
       - name: Type check (Action)
         run: npm run typecheck --workspace=packages/action
 
+      - name: Run tests (Parser)
+        run: npm run test --workspace=packages/parser
+
+      - name: Run tests (Core)
+        # worker-embeddings.test.ts is excluded here (root `npm test` mirrors
+        # this same exclude): its "parity with LocalEmbeddings" case runs
+        # onnxruntime-node inference in both the main thread (LocalEmbeddings)
+        # and a real worker_thread (WorkerEmbeddings) at once, which
+        # reproducibly segfaults the process on teardown ("FATAL ERROR:
+        # v8::HandleScope::CreateHandle() Cannot create a handle without a
+        # HandleScope") even when run in isolation as the only file in the
+        # suite. This is a native cross-isolate onnxruntime-node conflict,
+        # not a vitest pool/isolate scheduling issue -- config-only fixes
+        # (singleFork, isolate:false, pool:'threads') don't touch it. Tracked
+        # as a known environmental issue; run it manually with
+        # `npm run test -w @liendev/core -- src/embeddings/worker-embeddings.test.ts`
+        # when validating WorkerEmbeddings changes by hand.
+        run: npm run test --workspace=packages/core -- --exclude '**/worker-embeddings.test.ts'
+
       - name: Run tests (CLI)
         run: npm run test --workspace=packages/cli
 
@@ -64,3 +83,80 @@ jobs:
 
       - name: Build Action image (Dockerfile smoke test)
         run: docker build -f packages/action/Dockerfile -t lien-review:ci .
+
+  release-smoke-test:
+    name: Release smoke test (npm pack -> external install)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Every other job installs via the npm workspace protocol (`npm ci` at
+    # the repo root), which resolves @liendev/core and @liendev/parser from
+    # the local workspace and never touches the public registry for our own
+    # packages. That means a phantom/unpublished/private dependency in
+    # packages/cli/package.json (like the @liendev/review dependency that
+    # broke `npm install` for real users until #620) is invisible to CI.
+    # This job packs the CLI exactly as it will be published and installs
+    # the tarball into a scratch project with no workspace and no monorepo
+    # lockfile -- the same resolution path an external `npm install
+    # @liendev/lien` gets -- so a phantom dependency fails the PR instead of
+    # shipping.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages required for the CLI tarball
+        run: npm run build:core && npm run build -w packages/cli
+
+      - name: Pack @liendev/lien tarball
+        run: npm pack -w @liendev/lien
+
+      - name: Install tarball as an external consumer
+        run: |
+          set -euo pipefail
+          TARBALL="$(pwd)/$(ls liendev-lien-*.tgz)"
+          SCRATCH="$(mktemp -d)"
+          echo "SCRATCH_DIR=$SCRATCH" >> "$GITHUB_ENV"
+          cd "$SCRATCH"
+          npm init -y >/dev/null
+          npm install "$TARBALL"
+
+      - name: Run the installed CLI binary
+        run: |
+          set -euo pipefail
+          "$SCRATCH_DIR/node_modules/.bin/lien" --version
+          "$SCRATCH_DIR/node_modules/.bin/lien" --help
+
+  docs-build:
+    name: Docs build (VitePress)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # packages/site is a workspace but is NOT part of the root `build`
+    # script, so a broken VitePress build (bad frontmatter, a dead internal
+    # link, a markdown-it/mermaid plugin error) only ever surfaced after
+    # merge, on the push-to-main deploy-docs.yml run. Wiring the same build
+    # command into this PR-triggered workflow catches it before merge.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs (VitePress)
+        run: npm run docs:build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache HuggingFace embedding model
+        # Indexing (WorkerEmbeddings, see packages/core/src/embeddings/worker.ts)
+        # downloads the embedding model to ~/.cache/huggingface on first use.
+        # Without a cache, all 11 matrix jobs re-download it from HuggingFace
+        # in parallel every run -- real run 28366970070 (2026-06-29) failed on
+        # 'fetch failed' mid-download and misreported 154 tests as skipped.
+        # Keyed on the lockfile (bumps on @huggingface/transformers upgrades)
+        # and constants.ts (bumps if DEFAULT_EMBEDDING_MODEL changes).
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/core/src/constants.ts') }}
+          restore-keys: |
+            huggingface-${{ runner.os }}-
+
       - name: Build Lien
         run: npm run build
 

--- a/.github/workflows/harness-attestation.yml
+++ b/.github/workflows/harness-attestation.yml
@@ -29,11 +29,15 @@ jobs:
   attestation:
     name: Require harness evidence or bypass label
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check whether this PR touches an agent-review rule
         id: touch

--- a/.github/workflows/harness-attestation.yml
+++ b/.github/workflows/harness-attestation.yml
@@ -1,0 +1,62 @@
+name: Harness Attestation Gate
+
+# Cheap, no-LLM audit trail for CLAUDE.md's mandatory harness-calibration
+# rule: any PR touching packages/review/src/plugins/agent/** must show
+# evidence of having cleared the >= 9/10 harness bar (a link to a
+# harness.yml run or artifact, or a pasted harness-result.json summary, in
+# the PR body) or explicitly opt out via the `skip-harness-gate` label for
+# non-behavioral changes (docs, comments, refactors with no prompt/rule
+# behavior change).
+#
+# This does NOT run the paid OpenRouter calibration itself -- that's
+# .github/workflows/harness.yml (workflow_dispatch only, costs real money).
+# This job only checks that a PR *says* it ran the gate; it is an audit
+# trail, not a re-verification.
+#
+# Deliberately triggers on EVERY PR (no top-level `paths:` filter) and
+# no-ops internally via a git-diff check instead: a `required` status check
+# tied to a path-filtered workflow trigger never reports for PRs that don't
+# touch the path, which leaves those PRs' required check stuck "pending"
+# forever. Always running and conditionally passing keeps this safe to mark
+# required in branch protection.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+jobs:
+  attestation:
+    name: Require harness evidence or bypass label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether this PR touches an agent-review rule
+        id: touch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          if git diff --name-only "origin/$BASE_REF...HEAD" | grep -qE '^packages/review/src/plugins/agent/'; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check PR body for harness evidence
+        if: steps.touch.outputs.touched == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-harness-gate')
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$PR_BODY" | grep -qEi 'harness-result|actions/runs/[0-9]+|calibrate'; then
+            echo "Found harness evidence in PR body."
+            exit 0
+          fi
+
+          echo "::error::This PR touches packages/review/src/plugins/agent/** but the PR body has no harness evidence (a link to a harness.yml run/artifact, or a 'calibrate' mention) and no 'skip-harness-gate' label. Per CLAUDE.md, rule/prompt changes need a >=9/10 calibration run (npm run test:harness -- --rule <rule-id> --calibrate 10) before merging. Paste the harness.yml run link (or harness-result.json summary) in the PR description, or add the 'skip-harness-gate' label for non-behavioral changes."
+          exit 1

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "packages/action",
     "packages/site"
   ],
+  "//test-exclude-reason": "The --exclude '**/worker-embeddings.test.ts' flag on the `test` script below is intentionally duplicated in .github/workflows/ci.yml's 'Run tests (Core)' step rather than moved into packages/core/vitest.config.ts -- see the comment there for the onnxruntime-node segfault rationale and why a config-level exclude would break the documented manual re-run command. Keep both occurrences in sync.",
   "scripts": {
     "build": "npm run build -w @liendev/parser && npm run build -w @liendev/core && npm run build -w @liendev/review && npm run build -w packages/cli && npm run build -w @liendev/action",
     "build:core": "npm run build -w @liendev/parser && npm run build -w @liendev/core",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "docs:dev": "npm run docs:dev -w packages/site",
     "docs:build": "npm run docs:build -w packages/site",
     "docs:preview": "npm run docs:preview -w packages/site",
+    "test": "npm run test -w @liendev/parser && npm run test -w @liendev/core -- --exclude '**/worker-embeddings.test.ts' && npm run test -w @liendev/review && npm run test -w packages/cli && npm run test -w @liendev/action",
     "test:coverage": "npm run test:coverage -w @liendev/core",
     "lint": "eslint packages/*/src/",
     "lint:fix": "eslint --fix packages/*/src/",


### PR DESCRIPTION
## What

Fixes the six confirmed CI safety-net gaps from the review:

1. **parser + core never tested in CI.** `build-and-test` builds them but only ran `npm run test` for cli/review/action. Added `Run tests (Parser)` and `Run tests (Core)` steps.
2. **No root `npm test`.** CLAUDE.md's pre-commit gate documents `npm test` as a required step, but no such script existed. Added one that fans out to parser, core, review, cli, action (with the same core exclude as CI, see below).
3. **No release-gating smoke test.** Every existing job installs via the npm workspace protocol (`npm ci` at the repo root), which resolves `@liendev/core`/`@liendev/parser` from the local workspace and never hits the public registry — so a phantom/unpublished dependency (the class of bug fixed in #620) is invisible to CI. Added a `release-smoke-test` job that packs `@liendev/lien` and installs the tarball into a scratch project with no workspace/lockfile, then runs `lien --version`/`--help`.
4. **E2E re-downloads the embedding model every job, uncached.** Added an `actions/cache@v4` step in `e2e.yml` over `~/.cache/huggingface`, keyed on `package-lock.json` + `packages/core/src/constants.ts` (bumps on transformers.js upgrades or model changes).
5. **VitePress docs build only runs on push to main.** Added a `docs-build` job to `ci.yml` (which already triggers on PRs) running `npm run docs:build`.
6. **No CI enforcement of the harness-calibration gate.** Added `.github/workflows/harness-attestation.yml`: a free, no-LLM check that a PR touching `packages/review/src/plugins/agent/**` either links harness evidence (a `harness.yml` run URL or `harness-result.json`/`calibrate` mention) in its body, or carries a `skip-harness-gate` label for non-behavioral changes. It does **not** run the paid OpenRouter calibration — that stays manual-trigger-only in `harness.yml`.

## Approach notes

**Core's `worker-embeddings.test.ts` exclude.** Per the task, I investigated a vitest-config fix before reaching for exclusion. Confirmed via local repro that this is **not** a scheduling/pool issue: the file crashes the process (`FATAL ERROR: v8::HandleScope::CreateHandle()`) even run in complete isolation as the only test file, and narrows further to just the "parity with LocalEmbeddings" case, which runs onnxruntime-node inference in the main thread (`LocalEmbeddings`) and a real `worker_thread` (`WorkerEmbeddings`) at the same time — a native cross-isolate onnxruntime-node conflict that no `poolOptions`/`isolate`/`pool` setting touches. Excluded only `worker-embeddings.test.ts` via `--exclude`, in both `ci.yml` and the new root `test` script, with a comment explaining why and how to run it manually. Did **not** touch `packages/core/vitest.config.ts` or the test file itself — out of scope for a CI-workflow-only PR, and changing test/runtime logic risks colliding with other in-flight worktree agents.

**Harness-attestation trigger design.** Initially scoped the workflow's `on.pull_request.paths` to `packages/review/src/plugins/agent/**`, but that's a known GitHub Actions footgun: a `required` status check tied to a path-filtered trigger never posts a status for PRs that don't touch the path, leaving those PRs' required check stuck "pending" forever. Reworked it to always trigger on every PR and no-op internally via a `git diff` check against the PR's actual base ref (mirroring the existing pattern in `e2e.yml`'s `check-trigger` job) — safe to mark `required` in branch protection.

**Release-smoke-test scope.** Builds only `parser` + `core` + `cli` (via the existing `build:core` script), not the full monorepo, to keep it fast and independent of the main matrix.

## Verification

- `npm run format:check && npm run lint && npm run typecheck && npm run build` — all green (lint: 0 errors, 22 pre-existing warnings unrelated to this diff).
- `npm run test -w @liendev/parser` — 28 files / 854 tests passed.
- `npm run test -w @liendev/core -- --exclude '**/worker-embeddings.test.ts'` — 32 files / 497 tests passed. Without the exclude, reproduced the native segfault locally (both as part of the full suite and in isolation running only `worker-embeddings.test.ts`, and narrowed to just its "parity" test).
- `npm test` (new root script) — dispatched through all 5 workspaces cleanly: parser 854, core 497, review 478, cli 677, action 28 = 2534 tests, 0 failures.
- Dry-ran the release-smoke-test shell logic end-to-end locally: `npm run build:core && npm run build -w packages/cli`, `npm pack -w @liendev/lien` → `liendev-lien-0.49.1.tgz`, then `npm install <tarball>` into a scratch dir with no lockfile/workspace. Dependency resolution succeeded against the real npm registry with 0 errors (the exact check this job exists to make — a phantom/unpublished dependency would 404 here). Note: this sandbox's local macOS Command Line Tools/clang has an unrelated, pre-existing toolchain regression (`__builtin_clzg` / libc++ header mismatch) that blocks native compilation of `tree-sitter-*` addons for *any* fresh `npm install` in this environment (documented in the worktree setup notes), so I could not run the compiled `lien --version`/`--help` step locally end-to-end. This is a local-sandbox-only limitation — GitHub Actions' `ubuntu-latest` already compiles these same native addons successfully in every other job's `npm ci` (evidenced by the existing e2e Kotlin/Swift/etc. jobs), so it isn't expected to reproduce there.
- Dry-ran the harness-attestation git-diff logic against real history: a commit that touched `packages/review/src/plugins/agent/**` (#630) correctly resolves `touched=true`; the current diff (which doesn't touch that path) resolves `touched=false`. Also unit-tested the PR-body grep against sample bodies (no evidence / run-link / calibrate-mention / empty), all correct.
- Validated all touched/new YAML files parse (`js-yaml`) and diffed job/trigger structure.
- `npm run docs:build` — VitePress build succeeds standalone with just `npm ci` (no cross-package build needed), matching what the new `docs-build` job runs.

## For the maintainer — required-status-check ruleset

I own only `.github/workflows/` and root `package.json` scripts, not branch protection. Please add these **new** job names to the required-status-check ruleset (existing `build-and-test` presumably already is):

- `release-smoke-test` (ci.yml)
- `docs-build` (ci.yml)
- `attestation` (harness-attestation.yml) — safe to require; it always posts a status (see design note above), never gets stuck pending.

## Caveats / out of scope

- Did not modify `packages/core/vitest.config.ts` or `worker-embeddings.test.ts` itself — see approach note above.
- Did not touch branch-protection rules (admin-only, per constraints).
- The harness-attestation check is an honor-system audit trail (string-matches the PR body), not a re-execution of calibration — by design, to avoid triggering paid OpenRouter spend automatically.
- No changeset: this PR only touches `.github/workflows/` and root `package.json` scripts, no published package manifests.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 79 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 5 high-risk file(s) with 119 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 9 | — |
| 🧠 mental load | 30 | — |
| ⏱️ time to understand | 38 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d1dfe99. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage across multiple packages in CI.
  * Added validation for the published CLI install path.
  * Cached embedding model data to speed up end-to-end test runs.

* **Documentation**
  * Added a docs build check in CI to catch documentation issues earlier.

* **Chores**
  * Added a PR gate for specific review-related changes when required evidence is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->