### PR TITLE
perf(cli): put get_files_context on the fast scan path with a cache

### DIFF
--- a/.changeset/get-files-context-scan-cache.md
+++ b/.changeset/get-files-context-scan-cache.md
@@ -1,0 +1,6 @@
+---
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+Speed up `get_files_context`'s test-association scan: it now calls `scanAll` (a direct column-projected `table.query()`) instead of an unfiltered `scanWithFilter`, which routed through a full-table zero-vector ANN search — roughly 10x slower on large indexes. Results are also cached per `indexVersion`, mirroring `get_dependents`' scan cache, so repeated calls in one session skip the full-table scan entirely until the index is rebuilt. `get_files_context` is the tool CLAUDE.md mandates before every file edit, so this is the hottest call in the daily agent loop.

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { searchFileChunks } from './get-files-context.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  searchFileChunks,
+  handleGetFilesContext,
+  clearTestAssociationScanCache,
+} from './get-files-context.js';
+import { TEST_ASSOCIATIONS_COLUMNS } from './columns.js';
+import type { ToolContext } from '../types.js';
 import type { SearchResult } from '@liendev/core';
 
 describe('searchFileChunks', () => {
@@ -109,5 +115,137 @@ describe('searchFileChunks', () => {
     const results = await searchFileChunks(['src/foo.ts'], ctx);
 
     expect(results[0]).toHaveLength(3);
+  });
+});
+
+describe('handleGetFilesContext - test-association scan (scanAll fast path + cache)', () => {
+  const mockLog = vi.fn();
+  const mockCheckAndReconnect = vi.fn().mockResolvedValue(undefined);
+
+  function makeChunk(file: string, imports: string[] = []): SearchResult {
+    return {
+      content: '',
+      metadata: {
+        file,
+        startLine: 1,
+        endLine: 5,
+        type: 'block',
+        language: 'typescript',
+        imports,
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+  }
+
+  function makeCtx(options: {
+    scanAll: ReturnType<typeof vi.fn>;
+    indexVersion: number | (() => number);
+  }): ToolContext {
+    const { indexVersion } = options;
+    const getVersion: () => number =
+      typeof indexVersion === 'function' ? indexVersion : () => indexVersion;
+
+    return {
+      vectorDB: {
+        scanAll: options.scanAll,
+        // Per-file lookup (Step 1) — irrelevant to these tests, always empty.
+        scanWithFilter: vi.fn().mockResolvedValue([]),
+      } as any,
+      embeddings: { embed: vi.fn() } as any,
+      rootDir: '/fake/workspace',
+      log: mockLog,
+      checkAndReconnect: mockCheckAndReconnect,
+      getIndexMetadata: vi.fn(() => ({
+        indexVersion: getVersion(),
+        indexDate: '2026-07-01',
+      })),
+      getReindexState: vi.fn(() => ({
+        inProgress: false,
+        pendingFiles: [],
+        lastReindexTimestamp: null,
+        lastReindexDurationMs: null,
+      })),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTestAssociationScanCache();
+  });
+
+  it('uses scanAll (not an unfiltered scanWithFilter) for the test-association scan', async () => {
+    const scanAll = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+    await handleGetFilesContext({ filepaths: 'src/auth.ts', includeRelated: false }, ctx);
+
+    expect(scanAll).toHaveBeenCalledTimes(1);
+    expect(scanAll).toHaveBeenCalledWith({ columns: TEST_ASSOCIATIONS_COLUMNS });
+  });
+
+  it('returns the same test associations via scanAll as scanWithFilter previously produced', async () => {
+    const scanAll = vi.fn().mockResolvedValue([
+      makeChunk('src/__tests__/auth.test.ts', ['../auth']),
+      makeChunk('src/helper.ts', ['./auth']), // imports the target but is not a test file
+    ]);
+    const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+    const result = await handleGetFilesContext(
+      { filepaths: 'src/auth.ts', includeRelated: false },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed.testAssociations).toEqual(['src/__tests__/auth.test.ts']);
+  });
+
+  it('caches the scan across calls with the same indexVersion (no re-scan)', async () => {
+    const scanAll = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({ scanAll, indexVersion: 42 });
+
+    await handleGetFilesContext({ filepaths: 'src/a.ts', includeRelated: false }, ctx);
+    await handleGetFilesContext({ filepaths: 'src/b.ts', includeRelated: false }, ctx);
+
+    expect(scanAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('busts the cache when indexVersion changes (reindex)', async () => {
+    const scanAll = vi.fn().mockResolvedValue([]);
+    let indexVersion = 1;
+    const ctx = makeCtx({ scanAll, indexVersion: () => indexVersion });
+
+    await handleGetFilesContext({ filepaths: 'src/a.ts', includeRelated: false }, ctx);
+    indexVersion = 2;
+    await handleGetFilesContext({ filepaths: 'src/b.ts', includeRelated: false }, ctx);
+
+    expect(scanAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not serve a stale cache entry after clearTestAssociationScanCache()', async () => {
+    const scanAll = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({ scanAll, indexVersion: 7 });
+
+    await handleGetFilesContext({ filepaths: 'src/a.ts', includeRelated: false }, ctx);
+    clearTestAssociationScanCache();
+    await handleGetFilesContext({ filepaths: 'src/b.ts', includeRelated: false }, ctx);
+
+    expect(scanAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache when indexVersion is unavailable', async () => {
+    const scanAll = vi.fn().mockResolvedValue([]);
+    const ctx: ToolContext = {
+      ...makeCtx({ scanAll, indexVersion: 1 }),
+      getIndexMetadata: vi.fn(() => ({
+        indexVersion: undefined as unknown as number,
+        indexDate: '2026-07-01',
+      })),
+    };
+
+    await handleGetFilesContext({ filepaths: 'src/a.ts', includeRelated: false }, ctx);
+    await handleGetFilesContext({ filepaths: 'src/b.ts', includeRelated: false }, ctx);
+
+    expect(scanAll).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -16,12 +16,6 @@ import {
   TEST_ASSOCIATIONS_COLUMNS,
 } from './columns.js';
 
-/**
- * Maximum number of chunks to scan for test association analysis.
- * Larger codebases may have incomplete results if they exceed this limit.
- */
-const SCAN_LIMIT = 10000;
-
 // ============================================================================
 // Types
 // ============================================================================
@@ -48,6 +42,70 @@ interface FileData {
 
 /** Path cache for normalized path lookups */
 type PathCache = Map<string, string>;
+
+// ============================================================================
+// Test-Association Scan Cache
+// ============================================================================
+
+/**
+ * Cached full-table scan results used for test-association lookups, keyed
+ * by indexVersion. Mirrors the `scanCache` pattern in dependency-analyzer.ts:
+ * a module-level cache invalidated whenever the index is rebuilt (the
+ * indexVersion signal changes), so repeated get_files_context calls within
+ * one session skip the full-table scan when nothing has changed.
+ *
+ * Implemented as a small parallel cache rather than sharing
+ * dependency-analyzer's `scanCache` directly — that cache stores a much
+ * richer shape (an import index plus a per-file chunk map built for BFS
+ * dependency walks) that this handler doesn't need; it only reads the flat
+ * chunk list that `findTestAssociations` consumes.
+ */
+let testAssociationScanCache: {
+  indexVersion: number;
+  chunks: SearchResult[];
+} | null = null;
+
+/**
+ * Clear the test-association scan cache. Exported for testing.
+ */
+export function clearTestAssociationScanCache(): void {
+  testAssociationScanCache = null;
+}
+
+/**
+ * Scan all chunks for test-association analysis, using the indexVersion-keyed
+ * cache when available.
+ *
+ * Uses `scanAll` — a direct column-projected `table.query()` — instead of
+ * `scanWithFilter` with no file filter. Without a file filter,
+ * `scanWithFilter` routes through a full-table zero-vector ANN search
+ * (`table.search(...).where(...)`), which is roughly 10x slower than
+ * `scanAll`'s direct scan on large indexes (see the fast-path comment on
+ * `scanAll` in packages/core/src/vectordb/query.ts).
+ */
+async function getOrScanAllChunksForTestAssociations(
+  vectorDB: VectorDBInterface,
+  indexVersion: number | undefined,
+  log: LogFn,
+): Promise<SearchResult[]> {
+  if (
+    indexVersion !== undefined &&
+    testAssociationScanCache !== null &&
+    testAssociationScanCache.indexVersion === indexVersion
+  ) {
+    log(`Using cached chunk scan for test associations (version ${indexVersion})`);
+    return testAssociationScanCache.chunks;
+  }
+
+  const chunks = await vectorDB.scanAll({ columns: TEST_ASSOCIATIONS_COLUMNS });
+
+  if (indexVersion !== undefined) {
+    testAssociationScanCache = { indexVersion, chunks };
+  }
+
+  log(`Scanned ${chunks.length} chunks for test associations`);
+  return chunks;
+}
 
 // ============================================================================
 // Helper Functions (Exported for Testing)
@@ -267,15 +325,6 @@ export function buildFilesData(
   return filesData;
 }
 
-/**
- * Build warning note when scan limit is reached.
- */
-function buildScanLimitNote(hitScanLimit: boolean): string | undefined {
-  return hitScanLimit
-    ? 'Scanned 10,000 chunks (limit reached). Test associations may be incomplete for large codebases.'
-    : undefined;
-}
-
 /** Index metadata shape from context */
 interface IndexInfo {
   indexVersion: number;
@@ -361,6 +410,10 @@ export async function handleGetFilesContext(
     // Check if index has been updated and reconnect if needed
     await checkAndReconnect();
 
+    // Capture index metadata once: used both for the response and as the
+    // cache key for the test-association scan below (mirrors get_dependents).
+    const indexInfo = getIndexMetadata();
+
     // Compute workspace root for path matching
     const workspaceRoot = process.cwd().replace(/\\/g, '/');
 
@@ -381,19 +434,15 @@ export async function handleGetFilesContext(
       relatedChunksMap = await findRelatedChunks(filepaths, fileChunksMap, handlerCtx);
     }
 
-    // Step 3: Scan for test associations
-    const allChunks = await vectorDB.scanWithFilter({
-      limit: SCAN_LIMIT,
-      columns: TEST_ASSOCIATIONS_COLUMNS,
-    });
-    const hitScanLimit = allChunks.length === SCAN_LIMIT;
-
-    if (hitScanLimit) {
-      log(
-        `Scanned ${SCAN_LIMIT} chunks (limit reached). Test associations may be incomplete for large codebases.`,
-        'warning',
-      );
-    }
+    // Step 3: Scan for test associations. Uses the fast column-projected
+    // scanAll path (cached by indexVersion) instead of an unfiltered
+    // scanWithFilter, which is ~10x slower on large indexes — see
+    // getOrScanAllChunksForTestAssociations for details.
+    const allChunks = await getOrScanAllChunksForTestAssociations(
+      vectorDB,
+      indexInfo.indexVersion,
+      log,
+    );
 
     const testAssociationsMap = findTestAssociations(filepaths, allChunks, handlerCtx);
 
@@ -409,11 +458,8 @@ export async function handleGetFilesContext(
     log(`Found ${totalChunks} total chunks`);
 
     // Step 5: Build and return response
-    const note = buildScanLimitNote(hitScanLimit);
-    const indexInfo = getIndexMetadata();
-
     return isSingleFile
-      ? buildSingleFileResponse(filepaths[0], filesData, indexInfo, note)
-      : buildMultiFileResponse(filesData, indexInfo, note);
+      ? buildSingleFileResponse(filepaths[0], filesData, indexInfo)
+      : buildMultiFileResponse(filesData, indexInfo);
   })(args);
 }


### PR DESCRIPTION
## What

`get_files_context`'s test-association scan called `vectorDB.scanWithFilter({ limit: SCAN_LIMIT, columns: TEST_ASSOCIATIONS_COLUMNS })` with **no file filter**, on every invocation. In `packages/core/src/vectordb/query.ts`, `scanWithFilter` with no `file` option hits the "full scan" branch: `table.countRows()` followed by a zero-vector ANN search (`table.search(zeroVector).where('file != ""')`), truncating the JS array to `SCAN_LIMIT` only *after* the full scan comes back.

`get_files_context` is the tool CLAUDE.md mandates before every file edit, so this scan runs on the hottest path in the daily agent loop.

## Why / Approach

- Switch the scan to `vectorDB.scanAll({ columns: TEST_ASSOCIATIONS_COLUMNS })`. With no `language`/`pattern` filter, `scanAll` takes the direct `table.query()` fast path (already used by `get_dependents` via `dependency-analyzer.ts`) instead of the zero-vector ANN search — the ~10x speedup is already documented in `scanAll`'s own comment in `query.ts` (~250ms vs ~2.2s on a 57k-chunk index for the same "unfiltered scan" comparison).
- Added an `indexVersion`-keyed cache (`testAssociationScanCache` in `get-files-context.ts`) so repeated `get_files_context` calls in one session skip the full-table scan entirely until a reindex bumps `indexVersion`. Mirrors the `scanCache` pattern in `dependency-analyzer.ts` (same cache-key signal — `getIndexMetadata().indexVersion`, captured once per call, same as `get_dependents` already does).
- **Not shared with `dependency-analyzer`'s cache directly** — that cache stores a much richer shape (an import index + per-file chunk map built for BFS dependent walks) that this handler doesn't need; it only reads the flat chunk list `findTestAssociations` consumes. A parallel, smaller cache was simpler than generalizing dependency-analyzer's cache for one more caller (DRY-per-3rd-use didn't apply here — the shapes genuinely differ).
- Removed the now-dead `SCAN_LIMIT` (10,000) / `hitScanLimit` truncation + warning: `scanAll` returns every matching row (same as the single-repo path in `dependency-analyzer.ts` already does — it has no analogous cap), so the old "may be incomplete for large codebases" note no longer applies and was actively stale (it compared `allChunks.length === SCAN_LIMIT` against an array that, post-switch, is never artificially truncated).

## Verification

- `npm run format:check && npm run lint && npm run typecheck && npm run build` — all green (lint: 0 errors, pre-existing warnings only, unrelated to this diff).
- `npx vitest run` in `packages/core` (excluding `worker-embeddings.test.ts` per the known fork-teardown crash) — 32 files / 497 tests passed.
- `npm test` in `packages/cli` (the repo's own script, which excludes `test/e2e/**`; also excluded `test/benchmarks/**` for this run since neither exercises this change and both are slow/network-bound) — 39 files / 675 tests passed, including the new/updated `get-files-context.test.ts`.
- New tests added in `packages/cli/src/mcp/handlers/get-files-context.test.ts` (`handleGetFilesContext - test-association scan (scanAll fast path + cache)`):
  - asserts `scanAll` (not `scanWithFilter`) is called for the test-association scan, with the expected column list
  - asserts the same test-association results come back through `scanAll` as `scanWithFilter` previously produced (correctness)
  - asserts a second call with the same `indexVersion` reuses the cache (`scanAll` called once across two calls)
  - asserts a changed `indexVersion` (simulating a reindex) busts the cache (`scanAll` called again)
  - asserts `clearTestAssociationScanCache()` busts the cache
  - asserts no caching happens when `indexVersion` is unavailable (defensive; doesn't occur in production since `getIndexMetadata()` always returns one)

**Rough cost note:** call count drops from "1 full-table scan per `get_files_context` call" to "1 full-table scan per index version" (i.e., once until the next reindex) for the test-association step, and the scan itself moves off the ~10x-slower ANN-search path per the `scanAll` comment cited above.

## Caveats

- Did not attempt to change `dependency-analyzer.ts`'s own cache — out of scope, and it already uses `scanAll` correctly.
- Noticed but did not touch: `buildSingleFileResponse`/`buildMultiFileResponse` still accept an optional `note` param that no longer has any caller passing a truthy value (its only source, the scan-limit warning, was removed here). Left as-is since it's a harmless, cheap extensibility point mirroring `get_dependents`' response `note`.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR optimizes `get_files_context` by replacing its unfiltered `scanWithFilter` test-association scan with `scanAll` and adding a per-`indexVersion` module-level cache. The change is localized to one handler, preserves the existing response shape, and removes the now-stale 10,000-row scan limit and warning. No breaking changes or incorrect outputs were identified.
>
> - Test-association scan now uses `scanAll` instead of zero-vector ANN `scanWithFilter`
> - Added `testAssociationScanCache` keyed by `indexVersion`, with fallback to no cache when `indexVersion` is unavailable
> - Removed `SCAN_LIMIT` constant and the associated incomplete-results warning

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 330922c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->