### PR TITLE
fix(parser): chunk TypeScript abstract classes and their methods

### DIFF
--- a/.changeset/typescript-abstract-class-chunking.md
+++ b/.changeset/typescript-abstract-class-chunking.md
@@ -1,0 +1,6 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': minor
+---
+
+Fix TypeScript abstract classes not being chunked. tree-sitter-typescript parses `abstract class Foo {}` as a distinct `abstract_class_declaration` node (and an unimplemented method as `abstract_method_signature`), separate from `class_declaration`/`method_definition`. Neither was recognized by the traverser, so an abstract class collapsed into a single anonymous `block` chunk and its methods didn't exist as searchable symbols. Abstract classes now chunk like regular classes: the class itself is a named `class` symbol, concrete methods keep their body/complexity, and abstract method signatures are extracted sanely (no body to measure, so complexity defaults to a baseline of 1).

--- a/packages/parser/src/ast/languages/javascript.ts
+++ b/packages/parser/src/ast/languages/javascript.ts
@@ -20,12 +20,17 @@ import { calculateComplexity } from '../complexity/index.js';
 // =============================================================================
 
 /**
- * TypeScript/JavaScript AST traverser
+ * JavaScript AST traverser
  *
- * Handles TypeScript and JavaScript AST node types and traversal patterns.
- * Both languages share the same AST structure (via tree-sitter-typescript).
+ * Handles JavaScript AST node types and traversal patterns. TypeScript shares
+ * this same base (via tree-sitter-typescript, a superset grammar) and extends
+ * it below to recognize TS-only container node types.
+ *
+ * Container-node checks (`getContainerBody`, `findParentContainerName`) key
+ * off `containerTypes` rather than hardcoding 'class_declaration', so a
+ * subclass can widen what counts as a container just by extending that array.
  */
-export class TypeScriptTraverser implements LanguageTraverser {
+export class JavaScriptTraverser implements LanguageTraverser {
   targetNodeTypes = [
     'function_declaration',
     'function',
@@ -55,7 +60,7 @@ export class TypeScriptTraverser implements LanguageTraverser {
   }
 
   getContainerBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
-    if (node.type === 'class_declaration') {
+    if (this.containerTypes.includes(node.type)) {
       return node.childForFieldName('body');
     }
     return null;
@@ -70,7 +75,7 @@ export class TypeScriptTraverser implements LanguageTraverser {
   findParentContainerName(node: Parser.SyntaxNode): string | undefined {
     let current = node.parent;
     while (current) {
-      if (current.type === 'class_declaration') {
+      if (this.containerTypes.includes(current.type)) {
         const nameNode = current.childForFieldName('name');
         return nameNode?.text;
       }
@@ -104,9 +109,28 @@ export class TypeScriptTraverser implements LanguageTraverser {
 }
 
 /**
- * JavaScript uses the same traverser as TypeScript
+ * TypeScript AST traverser
+ *
+ * tree-sitter-typescript parses `abstract class Foo {}` as a distinct
+ * `abstract_class_declaration` node — separate from `class_declaration` —
+ * even though its shape (a `name` and a `class_body`) is identical. Without
+ * this, an abstract class falls through every container/traversal check in
+ * the JS base and collapses into a single anonymous chunk, hiding its
+ * methods. Widening `containerTypes` here is enough: `getContainerBody` and
+ * `findParentContainerName` both key off that array already, and its body
+ * node type is still `class_body`, which `shouldTraverseChildren` already
+ * recognizes.
  */
-export class JavaScriptTraverser extends TypeScriptTraverser {}
+export class TypeScriptTraverser extends JavaScriptTraverser {
+  constructor() {
+    super();
+    // Widen (not replace) the JS base's lists — done in the constructor,
+    // rather than as same-named field initializers, so TypeScript doesn't
+    // treat this as a self-referential read of an uninitialized field.
+    this.targetNodeTypes = [...this.targetNodeTypes, 'abstract_method_signature'];
+    this.containerTypes = [...this.containerTypes, 'abstract_class_declaration'];
+  }
+}
 
 // =============================================================================
 // EXPORT EXTRACTORS
@@ -565,7 +589,9 @@ export class TypeScriptImportExtractor extends JavaScriptImportExtractor {}
  * Also handles call site extraction for call_expression and new_expression.
  */
 export class JavaScriptSymbolExtractor implements LanguageSymbolExtractor {
-  readonly symbolNodeTypes = [
+  // Not `readonly`: TypeScriptSymbolExtractor widens this list in its
+  // constructor to add TS-only node types (see below).
+  symbolNodeTypes = [
     'function_declaration',
     'function',
     'arrow_function',
@@ -669,7 +695,7 @@ export class JavaScriptSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractMethodInfo(
+  protected extractMethodInfo(
     node: Parser.SyntaxNode,
     content: string,
     parentClass?: string,
@@ -690,7 +716,7 @@ export class JavaScriptSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: Parser.SyntaxNode): SymbolInfo | null {
+  protected extractClassInfo(node: Parser.SyntaxNode): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -718,9 +744,41 @@ export class JavaScriptSymbolExtractor implements LanguageSymbolExtractor {
 }
 
 /**
- * TypeScript uses the same symbol extraction as JavaScript
+ * TypeScript symbol extractor
+ *
+ * Extends the JS base with the two TS-only node types tree-sitter-typescript
+ * produces for abstract classes: the class itself parses as
+ * `abstract_class_declaration` (not `class_declaration`), and an abstract
+ * method (declared but not implemented) parses as `abstract_method_signature`
+ * (not `method_definition`). Both otherwise have the same shape as their
+ * concrete counterparts, so this reuses `extractClassInfo`/`extractMethodInfo`
+ * from the JS base rather than duplicating them.
  */
-export class TypeScriptSymbolExtractor extends JavaScriptSymbolExtractor {}
+export class TypeScriptSymbolExtractor extends JavaScriptSymbolExtractor {
+  constructor() {
+    super();
+    this.symbolNodeTypes = [
+      ...this.symbolNodeTypes,
+      'abstract_class_declaration',
+      'abstract_method_signature',
+    ];
+  }
+
+  override extractSymbol(
+    node: Parser.SyntaxNode,
+    content: string,
+    parentClass?: string,
+  ): SymbolInfo | null {
+    switch (node.type) {
+      case 'abstract_class_declaration':
+        return this.extractClassInfo(node);
+      case 'abstract_method_signature':
+        return this.extractMethodInfo(node, content, parentClass);
+      default:
+        return super.extractSymbol(node, content, parentClass);
+    }
+  }
+}
 
 // =============================================================================
 // LANGUAGE DEFINITION

--- a/packages/parser/src/ast/languages/typescript.test.ts
+++ b/packages/parser/src/ast/languages/typescript.test.ts
@@ -128,4 +128,313 @@ interface User { name: string; }`;
       );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Abstract classes
+  //
+  // tree-sitter-typescript parses `abstract class Foo {}` as a distinct
+  // `abstract_class_declaration` node (not `class_declaration`), and an
+  // abstract method as `abstract_method_signature` (not `method_definition`).
+  // Regression coverage for the previous behavior: an abstract class became a
+  // single anonymous `type: 'block'` chunk with none of its methods visible
+  // as symbols.
+  // ---------------------------------------------------------------------------
+  describe('Abstract Classes', () => {
+    describe('Traverser', () => {
+      it('should treat abstract_class_declaration as a container', () => {
+        const code = 'abstract class Base { work() {} }';
+        const tree = parser.parse(code);
+        const classNode = tree.rootNode.namedChild(0)!;
+        expect(classNode.type).toBe('abstract_class_declaration');
+        expect(traverser.shouldExtractChildren(classNode)).toBe(true);
+      });
+
+      it('should resolve the class_body for an abstract class', () => {
+        const code = 'abstract class Base { work() {} }';
+        const tree = parser.parse(code);
+        const classNode = tree.rootNode.namedChild(0)!;
+        const body = traverser.getContainerBody(classNode);
+        expect(body?.type).toBe('class_body');
+      });
+
+      it('should find the parent container name through an abstract class', () => {
+        const code = 'abstract class Base { work() {} }';
+        const tree = parser.parse(code);
+        const classNode = tree.rootNode.namedChild(0)!;
+        const classBody = classNode.childForFieldName('body')!;
+        const methodNode = classBody.namedChild(0)!;
+        expect(traverser.findParentContainerName(methodNode)).toBe('Base');
+      });
+
+      it('should include abstract_method_signature in target node types', () => {
+        expect(traverser.targetNodeTypes).toContain('abstract_method_signature');
+      });
+
+      it('should not mutate the JavaScript traverser containerTypes', async () => {
+        const { JavaScriptTraverser } = await import('./javascript.js');
+        const jsTraverser = new JavaScriptTraverser();
+        expect(jsTraverser.containerTypes).not.toContain('abstract_class_declaration');
+        expect(traverser.containerTypes).toContain('abstract_class_declaration');
+      });
+    });
+
+    describe('Symbol Extraction', () => {
+      it('should extract the abstract class itself as a class symbol', () => {
+        const code = 'abstract class BaseService { doWork() {} }';
+        const tree = parser.parse(code);
+        const classNode = tree.rootNode.namedChild(0)!;
+        const symbol = symbolExtractor.extractSymbol(classNode, code);
+        expect(symbol?.name).toBe('BaseService');
+        expect(symbol?.type).toBe('class');
+      });
+
+      it('should extract an abstract method signature as a method symbol', () => {
+        const code = `abstract class BaseService {
+  abstract doWork(x: number): void;
+}`;
+        const tree = parser.parse(code);
+        const classBody = tree.rootNode.namedChild(0)!.childForFieldName('body')!;
+        const methodNode = classBody.namedChild(0)!;
+        expect(methodNode.type).toBe('abstract_method_signature');
+
+        const symbol = symbolExtractor.extractSymbol(methodNode, code, 'BaseService');
+        expect(symbol?.name).toBe('doWork');
+        expect(symbol?.type).toBe('method');
+        expect(symbol?.parentClass).toBe('BaseService');
+        expect(symbol?.signature).toContain('abstract doWork');
+        // No body to walk, so complexity should be a sane baseline, not undefined/NaN.
+        expect(symbol?.complexity).toBe(1);
+      });
+    });
+
+    describe('AST Chunking', () => {
+      it('should chunk an abstract class as a named class, not an anonymous block', () => {
+        const content = `abstract class BaseService {
+  abstract doWork(): void;
+
+  concreteMethod() {
+    return 1;
+  }
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        const classChunk = chunks.find(c => c.metadata.symbolName === 'BaseService');
+        expect(classChunk).toBeDefined();
+        expect(classChunk?.metadata.symbolType).toBe('class');
+        expect(classChunk?.metadata.type).toBe('class');
+      });
+
+      it('should chunk the concrete method with a body and complexity', () => {
+        const content = `abstract class BaseService {
+  abstract doWork(): void;
+
+  concreteMethod(flag: boolean) {
+    if (flag) {
+      return 1;
+    }
+    return 2;
+  }
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        const methodChunk = chunks.find(c => c.metadata.symbolName === 'concreteMethod');
+        expect(methodChunk).toBeDefined();
+        expect(methodChunk?.metadata.symbolType).toBe('method');
+        expect(methodChunk?.metadata.parentClass).toBe('BaseService');
+        expect(methodChunk?.metadata.complexity).toBeGreaterThanOrEqual(2);
+        expect(methodChunk?.content).toContain('return 1');
+      });
+
+      it('should chunk the abstract method signature without crashing', () => {
+        const content = `abstract class BaseService {
+  abstract doWork(): void;
+
+  concreteMethod() {
+    return 1;
+  }
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        const abstractChunk = chunks.find(c => c.metadata.symbolName === 'doWork');
+        expect(abstractChunk).toBeDefined();
+        expect(abstractChunk?.metadata.symbolType).toBe('method');
+        expect(abstractChunk?.metadata.parentClass).toBe('BaseService');
+      });
+
+      it('should export the class name for an exported abstract class', () => {
+        const content = `export abstract class BaseService {
+  abstract doWork(): void;
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        const classChunk = chunks.find(c => c.metadata.symbolName === 'BaseService');
+        expect(classChunk).toBeDefined();
+        expect(classChunk?.metadata.exports).toContain('BaseService');
+      });
+
+      it('should still chunk methods when the abstract class also declares properties', () => {
+        const content = `export abstract class BaseService {
+  protected readonly name: string = 'base';
+
+  abstract doWork(): void;
+
+  concreteMethod() {
+    return this.name;
+  }
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        expect(chunks.find(c => c.metadata.symbolName === 'BaseService')).toBeDefined();
+        expect(chunks.find(c => c.metadata.symbolName === 'doWork')).toBeDefined();
+        expect(chunks.find(c => c.metadata.symbolName === 'concreteMethod')).toBeDefined();
+      });
+
+      it('should chunk a generic abstract class and its methods', () => {
+        const content = `export abstract class Repository<T> {
+  protected items: T[] = [];
+
+  abstract findById(id: string): T | undefined;
+
+  add(item: T): void {
+    this.items.push(item);
+  }
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        expect(chunks.find(c => c.metadata.symbolName === 'Repository')?.metadata.symbolType).toBe(
+          'class',
+        );
+        expect(chunks.find(c => c.metadata.symbolName === 'findById')?.metadata.parentClass).toBe(
+          'Repository',
+        );
+        expect(chunks.find(c => c.metadata.symbolName === 'add')?.metadata.parentClass).toBe(
+          'Repository',
+        );
+      });
+
+      it('should chunk an abstract class that extends another class', () => {
+        const content = `abstract class Animal {
+  abstract speak(): string;
+}
+
+abstract class Pet extends Animal {
+  abstract speak(): string;
+
+  play() {
+    return 'playing';
+  }
+}`;
+        const chunks = chunkByAST('test.ts', content);
+        expect(chunks.find(c => c.metadata.symbolName === 'Animal')?.metadata.symbolType).toBe(
+          'class',
+        );
+        expect(chunks.find(c => c.metadata.symbolName === 'Pet')?.metadata.symbolType).toBe(
+          'class',
+        );
+        expect(chunks.find(c => c.metadata.symbolName === 'play')?.metadata.parentClass).toBe(
+          'Pet',
+        );
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Other TS-only surface — documents current chunking/extraction behavior
+  // for grammar unique to TypeScript. Not all of these produce dedicated
+  // symbols today (enums and namespaces still fall back to opaque `block`
+  // chunks); these tests lock in that documented behavior rather than
+  // silently regressing it, and are separate from the abstract-class fix
+  // above.
+  // ---------------------------------------------------------------------------
+  describe('Other TS-only surface', () => {
+    it('should extract type-only named imports like regular named imports', () => {
+      const code = "import type { Foo } from './foo';";
+      const tree = parser.parse(code);
+      const result = importExtractor.processImportSymbols(tree.rootNode.namedChild(0)!);
+      expect(result).not.toBeNull();
+      expect(result!.importPath).toBe('./foo');
+      expect(result!.symbols).toContain('Foo');
+    });
+
+    it('should extract inline type-qualified named imports alongside value imports', () => {
+      const code = "import { type Bar, baz } from './bar';";
+      const tree = parser.parse(code);
+      const result = importExtractor.processImportSymbols(tree.rootNode.namedChild(0)!);
+      expect(result).not.toBeNull();
+      expect(result!.symbols).toContain('Bar');
+      expect(result!.symbols).toContain('baz');
+    });
+
+    it('should extract type-only re-exports and type alias exports', () => {
+      const code = "export type { Foo } from './foo';\nexport type Bar = string;";
+      const tree = parser.parse(code);
+      const exports = exportExtractor.extractExports(tree.rootNode);
+      expect(exports).toContain('Foo');
+      expect(exports).toContain('Bar');
+    });
+
+    it('should preserve type parameters in function and class signatures', () => {
+      const content = `export function identity<T>(x: T): T {
+  return x;
+}
+
+export class Box<T> {
+  get(): T {
+    return null as unknown as T;
+  }
+}`;
+      const chunks = chunkByAST('test.ts', content);
+      const identityChunk = chunks.find(c => c.metadata.symbolName === 'identity');
+      expect(identityChunk?.metadata.signature).toContain('<T>');
+
+      const boxChunk = chunks.find(c => c.metadata.symbolName === 'Box');
+      expect(boxChunk?.metadata.symbolType).toBe('class');
+
+      const getChunk = chunks.find(c => c.metadata.symbolName === 'get');
+      expect(getChunk?.metadata.parentClass).toBe('Box');
+    });
+
+    it('should still recognize a decorated class as a class symbol', () => {
+      const content = `@Component()
+export class Widget {
+  render() {
+    return 'ok';
+  }
+}`;
+      const chunks = chunkByAST('test.ts', content);
+      const classChunk = chunks.find(c => c.metadata.symbolName === 'Widget');
+      expect(classChunk).toBeDefined();
+      expect(classChunk?.metadata.symbolType).toBe('class');
+      expect(chunks.find(c => c.metadata.symbolName === 'render')?.metadata.parentClass).toBe(
+        'Widget',
+      );
+    });
+
+    it('documents that enum bodies are not yet extracted as dedicated symbols', () => {
+      // Known gap, out of scope for the abstract-class fix: enum_declaration
+      // is neither a targetNodeType nor a containerType, so it falls into the
+      // generic "uncovered code" block rather than becoming its own symbol.
+      const content = `export enum Color {
+  Red,
+  Green,
+}
+
+export function useColor() {
+  return Color.Red;
+}`;
+      const chunks = chunkByAST('test.ts', content);
+      expect(chunks.find(c => c.metadata.symbolName === 'Color')).toBeUndefined();
+      expect(chunks.some(c => c.content.includes('enum Color'))).toBe(true);
+      // Unrelated top-level symbols after the enum still chunk correctly.
+      expect(chunks.find(c => c.metadata.symbolName === 'useColor')).toBeDefined();
+    });
+
+    it('documents that namespace bodies are not yet extracted as dedicated symbols', () => {
+      // Known gap, out of scope for the abstract-class fix: internal_module
+      // (namespace) is neither a targetNodeType nor a containerType, so its
+      // nested function also isn't surfaced as its own symbol.
+      const content = `export namespace MyNamespace {
+  export function foo() {
+    return 1;
+  }
+}`;
+      const chunks = chunkByAST('test.ts', content);
+      expect(chunks.find(c => c.metadata.symbolName === 'foo')).toBeUndefined();
+      expect(chunks.some(c => c.content.includes('namespace MyNamespace'))).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What

tree-sitter-typescript parses `abstract class Foo {}` as a distinct `abstract_class_declaration` node (and an unimplemented method as `abstract_method_signature`), separate from `class_declaration`/`method_definition`. `TypeScriptTraverser`/`TypeScriptSymbolExtractor` only recognized the concrete node types, so an abstract class collapsed into a single anonymous `type: 'block'` chunk with none of its methods visible as symbols — invisible to semantic search, `list_functions`, `get_dependents`, etc. Base/abstract classes are typically the most-depended-on code in an OO TypeScript codebase, so this was exactly the code you least want hidden from the index.

Fixes the review finding: "TypeScript abstract classes chunk as opaque blocks" (high, adversarially confirmed).

## Approach

`packages/parser/src/ast/languages/javascript.ts`:
- Renamed the (previously TS-named but actually JS/TS-shared) base traverser class to `JavaScriptTraverser`, matching the naming convention already used for the export/import/symbol extractors in the same file (`JavaScriptXExtractor` base, `TypeScriptXExtractor extends` it).
- `getContainerBody` / `findParentContainerName` now key off `this.containerTypes` instead of hardcoding `'class_declaration'`, so a subclass can widen "what counts as a container" just by extending that array.
- `TypeScriptTraverser extends JavaScriptTraverser`, widening `containerTypes` (+ `abstract_class_declaration`) and `targetNodeTypes` (+ `abstract_method_signature`) in its constructor. (Field re-initialization with `this.x = [...this.x, ...]` in a same-named subclass field looks correct at runtime but TypeScript's control-flow analysis flags it as "used before initialization" — hence doing the widening in the constructor body instead, after `super()` has already run the parent's field initializers.)
- `JavaScriptSymbolExtractor.extractClassInfo` / `extractMethodInfo` changed from `private` to `protected` so `TypeScriptSymbolExtractor` can reuse them for the two new node types (both have the identical shape — `name` + `class_body` / `name` + `parameters` + optional `body` — as their concrete counterparts) instead of duplicating the extraction logic.
- `abstract_method_signature` has no `body` field; `extractSignature`'s existing no-body fallback (already exercised by Rust trait signatures) handles it without changes — verified it doesn't crash and complexity defaults to a sane baseline (1).

## Tests

Extended `packages/parser/src/ast/languages/typescript.test.ts` from 10 to 31 tests:
- **Abstract class regression coverage**: traverser unit tests (container recognition, body resolution, parent-name walk, target node types), symbol-extraction unit tests (class + abstract method signature), and `chunkByAST` integration tests — concrete methods keep body/complexity, abstract methods extract sanely, exported/generic/property-bearing/`extends`-clause variants.
- **Other TS-only surface** the file had zero coverage for (per the review's "thin because it inherits JS" note): type-only imports/exports, generics (signature preserves `<T>`), decorated classes. Also two tests that explicitly document a **pre-existing, out-of-scope** gap: enum and namespace bodies still aren't extracted as dedicated symbols (neither node type is a `targetNodeType` nor `containerType`) — noted below, not fixed here.

## Verification

From the worktree root:
```
npm run format:check   # pass
npm run lint           # pass, 0 errors (pre-existing warnings elsewhere, unrelated)
npm run typecheck      # pass
npm run build          # pass, all packages
npm run test -w @liendev/parser   # 875/875 passed (28 files), typescript.test.ts: 31/31
npm run test -w packages/cli      # 677/677 passed (40 files)
```
`npm run test -w @liendev/core` hit the documented `worker-embeddings.test.ts` vitest fork-crash on teardown (pre-existing, reproduces on clean main in symlinked worktrees); re-ran with `--exclude '**/worker-embeddings.test.ts'` and got 497/497 passed (32 files).

Manually reproduced the bug pre-fix (`chunkByAST` on an abstract class produced a single `{ type: 'block', symbolName: undefined }` chunk) and confirmed post-fix output (named `class` chunk + per-method chunks with correct `parentClass`/complexity).

## Caveats / out of scope

- **Enums and namespaces** (`enum_declaration`, `internal_module`) still fall back to the generic "uncovered code" block rather than becoming dedicated symbols — this is a pre-existing gap, not a regression, and is outside this fix's scope (only `abstract_class_declaration`/`abstract_method_signature` were in scope). Documented with two explicit tests rather than silently left uncovered.
- Noticed a **pre-existing, unrelated** minor bug in `findUncoveredRanges` (`packages/parser/src/ast/chunker.ts`): when a top-level container's covered range fully encloses a nested child's range (e.g. a class and its method), `currentStart` is set to `range.end + 1` unconditionally per range rather than `max(currentStart, range.end + 1)`, so processing the nested (smaller) range after the container can regress `currentStart` backward and produce a spurious trailing 1-line "uncovered" block duplicating the container's closing brace. Reproduces identically on a plain (non-abstract) exported class on current `main`, so it's not something this PR introduces — flagging for a separate fix rather than touching it here.
- Did not touch `packages/core` — despite `CLAUDE.md` documenting the AST/language code under `packages/core/src/indexer/ast/languages`, that code has actually moved to `packages/parser/src/ast/languages` (confirmed via `get_dependents`/`get_files_context` and a filesystem check); this matches a previously-flagged stale-docs finding.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes TypeScript abstract class chunking by widening the parser's recognized node types (`abstract_class_declaration` and `abstract_method_signature`) through a cleaner JS/TS traverser/extractor hierarchy. The change is well-isolated to `packages/parser/src/ast/languages/javascript.ts` and its test file, with 31 tests covering the new behavior plus related TS-only surface. No breaking changes were introduced: `TypeScriptTraverser`/`TypeScriptSymbolExtractor` still export the same names, and the new `JavaScriptTraverser`/`JavaScriptSymbolExtractor` bases are additive. All edge cases examined (nameless classes, exported abstract classes, generic abstract classes, abstract methods without bodies) are handled correctly by the existing helpers or covered by tests.
>
> - Abstract classes now produce named `class` chunks and their methods become searchable symbols instead of collapsing into an anonymous block
> - Refactored JS/TS traverser and symbol extractor to use a proper base/subclass relationship rather than TS aliases
> - Added regression and surface-area tests for abstract classes, type-only imports/exports, generics, and decorated classes

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 46c8142. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TypeScript abstract classes and abstract methods now appear correctly in parsed output and symbol listings.
  * Abstract classes are chunked like normal classes instead of collapsing into unnamed blocks.
  * Parent class/method relationships are now resolved more reliably for TypeScript-specific syntax.

* **Tests**
  * Added broader TypeScript coverage for abstract classes, type-only imports/exports, decorators, generics, and other TypeScript-only syntax.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->