### PR TITLE
refactor(review): dedupe Anthropic/OpenAI agent clients via shared helper module

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared helpers for the review agent's provider clients.
+ *
+ * The Anthropic (`anthropic-client.ts`) and OpenAI-compatible
+ * (`openai-client.ts`) clients run structurally identical loops over two
+ * different wire formats. This module holds the byte-identical, provider-
+ * agnostic pieces both depend on — output caps, the boolean-ish env-disable
+ * parser, per-turn trace logging, and the verdict-extraction pipeline
+ * (fence-priority JSON recovery + finding/summary validation). Extracting them
+ * here means a fix lands once, not twice.
+ *
+ * Everything that touches a provider's API shape (message formatting,
+ * tool-call encoding, the turn loop itself) deliberately stays in the
+ * per-client files — those are NOT interchangeable and must not be unified
+ * without a behavior-preserving driver + adapter (see the PR body for the
+ * turn-loop follow-up plan).
+ */
+
+import type { Logger } from '../../logger.js';
+import type { AgentFinding, AgentSummary, TurnTrace } from './types.js';
+
+/** Cap a single tool's recorded output so traces stay readable. */
+export const TRACE_TOOL_OUTPUT_MAX = 4096;
+
+/** Cap per-turn reasoning/output printed to CI logs. */
+export const AGENT_LOG_MAX = 4000;
+
+/**
+ * Cap a single tool result fed back to the model. A large file read or
+ * batched get_files_context can otherwise return tens of thousands of tokens
+ * in one turn, blowing the whole budget before the wrap-up nudge can fire.
+ * ~16K chars ≈ 4K tokens — enough context for a review, bounded per call.
+ */
+export const TOOL_RESULT_MAX_CHARS = 16_000;
+
+/**
+ * Soft nudge appended once the run nears its budget (or on the last turn):
+ * stop investigating and emit the findings JSON now. Identical wording on both
+ * clients so the model sees the same instruction regardless of provider.
+ */
+export const WRAP_UP_NUDGE =
+  'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.';
+
+export function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
+}
+
+/**
+ * Parse a boolean-ish env *disable* flag. Per-turn agent logging is ON by
+ * default (so every review is diagnosable); only an explicit '0'/'false'
+ * (case-insensitive) disables it. Parsed precisely so an unrelated value
+ * doesn't accidentally silence the trace.
+ */
+export function envDisabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '0' || v === 'false';
+}
+
+/**
+ * Print a turn's reasoning + output to the logger so CI logs show what the
+ * agent was actually thinking. Truncated so a verbose reasoning model (Kimi)
+ * doesn't flood the log.
+ */
+export function logTurn(logger: Logger, turn: TurnTrace | undefined, label?: string): void {
+  if (!turn) return;
+  const tag = label ? ` (${label})` : '';
+  // Guard on trimmed content: on tool-call turns the model emits tool calls
+  // (logged separately) and often a whitespace-only `content`, which would
+  // otherwise print a blank, confusing "output:" line.
+  if (turn.reasoning?.trim()) {
+    logger.info(
+      `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning.trim(), AGENT_LOG_MAX)}`,
+    );
+  }
+  if (turn.responseText?.trim()) {
+    logger.info(
+      `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText.trim(), AGENT_LOG_MAX)}`,
+    );
+  }
+}
+
+/**
+ * Extract findings + summary from the model's final response *text*.
+ *
+ * Each provider client renders its response to a plain string first (the
+ * Anthropic client joins its text blocks, the OpenAI client passes
+ * `message.content`) and then hands it here, so the recovery logic is a single
+ * shared implementation. Candidate JSON strings are tried in priority order:
+ *  1. each ```json fence, LAST first — the model emits its verdict last, so a
+ *     few-shot/example fence earlier in the prose must not win;
+ *  2. the raw body (a response_format:json_object / forced-verdict turn);
+ *  3. a JSON object embedded in surrounding prose (model ignored json_object).
+ *
+ * Prefer a candidate carrying a `summary` (the verdict marker) so an
+ * `{"findings": [...]}`-only example can't beat the real verdict; fall back to
+ * the first findings-only candidate if nothing carries a summary.
+ */
+export function extractFindingsFromText(text: string): {
+  findings: AgentFinding[];
+  summary?: AgentSummary;
+} {
+  const fences = [...text.matchAll(/```json\s*\n([\s\S]*?)\n\s*```/g)].map(m => m[1]).reverse();
+  const candidates = [...fences, text.trim(), embeddedJsonObject(text)];
+
+  let fallback: { findings: AgentFinding[] } | undefined;
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue; // not parseable — try the next candidate
+    }
+    const { findings, summary } = readVerdict(parsed);
+    if (summary) return { findings, summary };
+    if (findings.length > 0 && !fallback) fallback = { findings };
+  }
+  return fallback ?? { findings: [] };
+}
+
+/** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
+export function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
+  const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
+  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
+  const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
+  return { findings, summary };
+}
+
+/** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */
+export function embeddedJsonObject(content: string): string | undefined {
+  const start = content.indexOf('{');
+  const end = content.lastIndexOf('}');
+  return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
+}
+
+/** Type guard to validate a summary object. */
+export function isValidSummary(value: unknown): value is AgentSummary {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.riskLevel === 'string' &&
+    typeof obj.overview === 'string' &&
+    Array.isArray(obj.keyChanges)
+  );
+}
+
+/** Type guard to validate an agent finding has required fields. */
+export function isValidFinding(value: unknown): value is AgentFinding {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.filepath === 'string' &&
+    typeof obj.line === 'number' &&
+    (obj.severity === 'error' || obj.severity === 'warning') &&
+    typeof obj.category === 'string' &&
+    typeof obj.message === 'string'
+  );
+}

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -16,34 +16,15 @@ import type {
   TurnTrace,
   ToolInvocation,
 } from './types.js';
-
-/** Cap a single tool's recorded output so traces stay readable. */
-const TRACE_TOOL_OUTPUT_MAX = 4096;
-
-/** Cap per-turn reasoning/output printed to CI logs. */
-const AGENT_LOG_MAX = 4000;
-
-/**
- * Cap a single tool result fed back to the model. A large file read or
- * batched get_files_context can otherwise return tens of thousands of tokens
- * in one turn, blowing the whole budget before the wrap-up nudge can fire.
- * ~16K chars ≈ 4K tokens — enough context for a review, bounded per call.
- */
-const TOOL_RESULT_MAX_CHARS = 16_000;
-
-function truncate(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
-}
-
-/**
- * Parse a boolean-ish env *disable* flag. Per-turn agent logging is ON by
- * default; only an explicit '0'/'false' (case-insensitive) disables it.
- * Parsed precisely so an unrelated value doesn't accidentally silence it.
- */
-function envDisabled(value: string | undefined): boolean {
-  const v = value?.trim().toLowerCase();
-  return v === '0' || v === 'false';
-}
+import {
+  TRACE_TOOL_OUTPUT_MAX,
+  TOOL_RESULT_MAX_CHARS,
+  WRAP_UP_NUDGE,
+  truncate,
+  envDisabled,
+  logTurn,
+  extractFindingsFromText,
+} from './agent-client-shared.js';
 
 /** Extract the assistant's text content from an Anthropic response for trace. */
 function joinTextBlocks(content: Anthropic.Messages.ContentBlock[]): string {
@@ -225,7 +206,7 @@ export class AnthropicAgentClient {
         outputTokens: turnOutputTokens,
       };
       turnTraces.push(turnTrace);
-      if (this.logAgentTurns) this.logTurn(turnTrace);
+      if (this.logAgentTurns) logTurn(this.logger, turnTrace);
 
       // Done: model finished naturally
       if (response.stop_reason === 'end_turn') {
@@ -311,7 +292,7 @@ export class AnthropicAgentClient {
         `[agent] Review incomplete (stopReason=${stopReason}, no verdict/summary after ${turn} turns)`,
       );
       // Always surface what the agent was doing when it bailed.
-      this.logTurn(lastLoopTurn, 'last turn before bail');
+      logTurn(this.logger, lastLoopTurn, 'last turn before bail');
     }
 
     return {
@@ -341,28 +322,6 @@ export class AnthropicAgentClient {
    * tool_result blocks. Pulled out of `run()` to keep its
    * time-to-understand under the complexity threshold.
    */
-  /**
-   * Print a turn's reasoning + output to the logger so CI logs show what the
-   * agent was actually thinking. Truncated to keep logs readable.
-   */
-  private logTurn(turn: TurnTrace | undefined, label?: string): void {
-    if (!turn) return;
-    const tag = label ? ` (${label})` : '';
-    // Guard on trimmed content: tool-call turns emit tool calls (logged
-    // separately) and often whitespace-only text, which would otherwise print
-    // a blank, confusing "output:" line.
-    if (turn.reasoning?.trim()) {
-      this.logger.info(
-        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning.trim(), AGENT_LOG_MAX)}`,
-      );
-    }
-    if (turn.responseText?.trim()) {
-      this.logger.info(
-        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText.trim(), AGENT_LOG_MAX)}`,
-      );
-    }
-  }
-
   private async dispatchToolUseBlocks(
     toolUseBlocks: Anthropic.Messages.ToolUseBlock[],
     responseContent: Anthropic.Messages.ContentBlock[],
@@ -506,9 +465,6 @@ function appendRetryPrompt(
   messages.push({ role: 'user', content: retryContent });
 }
 
-const WRAP_UP_NUDGE =
-  'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.';
-
 const RETRY_SYSTEM_PROMPT =
   'Output only a ```json code fence with findings and summary. No other text.';
 
@@ -518,83 +474,14 @@ const RETRY_USER_PROMPT =
 /**
  * Extract findings from the model's final response content.
  *
- * Looks for a ```json ... ``` block in text content and parses it as
- * the agent's structured output containing findings and summary.
+ * Concatenates ALL text blocks — Anthropic can split a response across blocks,
+ * so the verdict may not live in the last one — then hands the joined text to
+ * the shared fence-priority recovery pipeline (see `extractFindingsFromText`).
  */
 function extractResponse(content: Anthropic.Messages.ContentBlock[]): {
   findings: AgentFinding[];
   summary?: AgentSummary;
 } {
-  const textBlocks = content.filter((b): b is Anthropic.Messages.TextBlock => b.type === 'text');
-
-  if (textBlocks.length === 0) {
-    return { findings: [] };
-  }
-
-  // Concatenate ALL text blocks — Anthropic can split a response across blocks,
-  // so the verdict may not live in the last one.
-  const text = textBlocks.map(b => b.text).join('\n');
-
-  // Candidate JSON strings, in priority order: each ```json fence LAST first (a
-  // few-shot/example fence precedes the real verdict), then the raw body, then a
-  // JSON object embedded in prose. Prefer a candidate carrying a `summary` (the
-  // verdict marker) so an example can't beat the real verdict; fall back to the
-  // first findings-only candidate if nothing carries a summary.
-  const fences = [...text.matchAll(/```json\s*\n([\s\S]*?)\n\s*```/g)].map(m => m[1]).reverse();
-  const candidates = [...fences, text.trim(), embeddedJsonObject(text)];
-
-  let fallback: { findings: AgentFinding[] } | undefined;
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(candidate);
-    } catch {
-      continue; // not parseable — try the next candidate
-    }
-    const { findings, summary } = readVerdict(parsed);
-    if (summary) return { findings, summary };
-    if (findings.length > 0 && !fallback) fallback = { findings };
-  }
-  return fallback ?? { findings: [] };
-}
-
-/** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
-function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
-  const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
-  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
-  const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
-  const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
-  return { findings, summary };
-}
-
-/** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */
-function embeddedJsonObject(content: string): string | undefined {
-  const start = content.indexOf('{');
-  const end = content.lastIndexOf('}');
-  return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
-}
-
-/** Type guard to validate a summary object. */
-function isValidSummary(value: unknown): value is AgentSummary {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.riskLevel === 'string' &&
-    typeof obj.overview === 'string' &&
-    Array.isArray(obj.keyChanges)
-  );
-}
-
-/** Type guard to validate an agent finding has required fields. */
-function isValidFinding(value: unknown): value is AgentFinding {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.filepath === 'string' &&
-    typeof obj.line === 'number' &&
-    (obj.severity === 'error' || obj.severity === 'warning') &&
-    typeof obj.category === 'string' &&
-    typeof obj.message === 'string'
-  );
+  const text = joinTextBlocks(content);
+  return text ? extractFindingsFromText(text) : { findings: [] };
 }

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -15,23 +15,20 @@ import type {
   TurnTrace,
   ToolInvocation,
 } from './types.js';
+import {
+  TRACE_TOOL_OUTPUT_MAX,
+  TOOL_RESULT_MAX_CHARS,
+  WRAP_UP_NUDGE,
+  truncate,
+  envDisabled,
+  logTurn,
+  extractFindingsFromText,
+} from './agent-client-shared.js';
 
-/** Cap a single tool's recorded output so traces stay readable. */
-const TRACE_TOOL_OUTPUT_MAX = 4096;
-
-/** Cap per-turn reasoning/output printed to CI logs. */
-const AGENT_LOG_MAX = 4000;
-
-/**
- * Cap a single tool result fed back to the model. A large file read or
- * batched get_files_context can otherwise return tens of thousands of tokens
- * in one turn, blowing the whole budget before the wrap-up nudge can fire.
- * ~16K chars ≈ 4K tokens — enough context for a review, bounded per call.
- */
-const TOOL_RESULT_MAX_CHARS = 16_000;
-
-const WRAP_UP_NUDGE =
-  'You are running low on budget. Stop investigating and output your findings JSON now. Do not make any more tool calls. If you found no issues, output an empty findings array.';
+// `envDisabled` is re-exported so its existing test import path
+// (`plugins-agent-budget.test.ts`) stays valid after the move to the shared
+// module — the parsing behavior it guards is unchanged.
+export { envDisabled };
 
 const RETRY_NUDGE =
   'You ran out of budget. Output ONLY the JSON block now with your findings and summary. No tool calls.';
@@ -73,21 +70,6 @@ export function formatChatTimeout(opts: {
     `request was ${opts.bodyBytes} bytes (~${approxTokens(opts.bodyBytes)} input tokens) ` +
     `across ${opts.messageCount} message(s)`
   );
-}
-
-function truncate(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
-}
-
-/**
- * Parse a boolean-ish env *disable* flag. Per-turn agent logging is ON by
- * default (so every review is diagnosable); only an explicit '0'/'false'
- * (case-insensitive) disables it. Parsed precisely so an unrelated value
- * doesn't accidentally silence the trace.
- */
-export function envDisabled(value: string | undefined): boolean {
-  const v = value?.trim().toLowerCase();
-  return v === '0' || v === 'false';
 }
 
 /**
@@ -357,7 +339,7 @@ export class OpenAIAgentClient {
       lastContent = choice.message.content;
       const turnTrace = buildTurnTrace(turn, choice, turnInputTokens, turnOutputTokens);
       turnTraces.push(turnTrace);
-      if (this.logAgentTurns) this.logTurn(turnTrace);
+      if (this.logAgentTurns) logTurn(this.logger, turnTrace);
 
       // Done: model finished naturally
       if (choice.finish_reason === 'stop') {
@@ -447,7 +429,7 @@ export class OpenAIAgentClient {
       );
       // Always surface what the agent was doing when it bailed — the single
       // most useful datum for diagnosing an incomplete run in CI logs.
-      this.logTurn(lastLoopTurn, 'last turn before bail');
+      logTurn(this.logger, lastLoopTurn, 'last turn before bail');
     }
 
     return {
@@ -552,29 +534,6 @@ export class OpenAIAgentClient {
         `[agent] Summary retry failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       return null;
-    }
-  }
-
-  /**
-   * Print a turn's reasoning + output to the logger so CI logs show what the
-   * agent was actually thinking. Truncated so a verbose reasoning model (Kimi)
-   * doesn't flood the log.
-   */
-  private logTurn(turn: TurnTrace | undefined, label?: string): void {
-    if (!turn) return;
-    const tag = label ? ` (${label})` : '';
-    // Guard on trimmed content: on tool-call turns the model emits tool calls
-    // (logged separately) and often a whitespace-only `content`, which would
-    // otherwise print a blank, confusing "output:" line.
-    if (turn.reasoning?.trim()) {
-      this.logger.info(
-        `[agent] Turn ${turn.turnNumber} reasoning${tag}:\n${truncate(turn.reasoning.trim(), AGENT_LOG_MAX)}`,
-      );
-    }
-    if (turn.responseText?.trim()) {
-      this.logger.info(
-        `[agent] Turn ${turn.turnNumber} output${tag}:\n${truncate(turn.responseText.trim(), AGENT_LOG_MAX)}`,
-      );
     }
   }
 
@@ -751,76 +710,17 @@ export function toOpenAITools(
 }
 
 // ---------------------------------------------------------------------------
-// Response parsing (same as anthropic-client.ts)
+// Response parsing
 // ---------------------------------------------------------------------------
 
-/** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
-function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
-  const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
-  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
-  const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
-  const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
-  return { findings, summary };
-}
-
+/**
+ * Extract findings from a chat completion's message content, delegating to the
+ * shared fence-priority recovery pipeline (see `extractFindingsFromText`). A
+ * null/empty content (e.g. a tool-calls turn) yields no findings.
+ */
 function extractResponse(content: string | null): {
   findings: AgentFinding[];
   summary?: AgentSummary;
 } {
-  if (!content) return { findings: [] };
-
-  // Candidate JSON strings, in priority order:
-  //  1. each ```json fence, LAST first — the model emits its verdict last, so a
-  //     few-shot/example fence earlier in the prose must not win;
-  //  2. the raw body (response_format:json_object forced-verdict turn);
-  //  3. a JSON object embedded in surrounding prose (model ignored json_object).
-  const fences = [...content.matchAll(/```json\s*\n([\s\S]*?)\n\s*```/g)].map(m => m[1]).reverse();
-  const candidates = [...fences, content.trim(), embeddedJsonObject(content)];
-
-  // Prefer a candidate carrying a `summary` (the verdict marker) so an
-  // `{"findings": [...]}`-only example can't beat the real verdict; fall back to
-  // the first findings-only candidate if nothing carries a summary.
-  let fallback: { findings: AgentFinding[] } | undefined;
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(candidate);
-    } catch {
-      continue; // not parseable — try the next candidate
-    }
-    const { findings, summary } = readVerdict(parsed);
-    if (summary) return { findings, summary };
-    if (findings.length > 0 && !fallback) fallback = { findings };
-  }
-  return fallback ?? { findings: [] };
-}
-
-/** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */
-function embeddedJsonObject(content: string): string | undefined {
-  const start = content.indexOf('{');
-  const end = content.lastIndexOf('}');
-  return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
-}
-
-function isValidSummary(value: unknown): value is AgentSummary {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.riskLevel === 'string' &&
-    typeof obj.overview === 'string' &&
-    Array.isArray(obj.keyChanges)
-  );
-}
-
-function isValidFinding(value: unknown): value is AgentFinding {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.filepath === 'string' &&
-    typeof obj.line === 'number' &&
-    (obj.severity === 'error' || obj.severity === 'warning') &&
-    typeof obj.category === 'string' &&
-    typeof obj.message === 'string'
-  );
+  return content ? extractFindingsFromText(content) : { findings: [] };
 }

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import {
+  truncate,
+  envDisabled,
+  logTurn,
+  extractFindingsFromText,
+  readVerdict,
+  embeddedJsonObject,
+  isValidSummary,
+  isValidFinding,
+  AGENT_LOG_MAX,
+} from '../src/plugins/agent/agent-client-shared.js';
+import type { Logger } from '../src/logger.js';
+import type { TurnTrace } from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// These helpers were extracted verbatim from anthropic-client.ts /
+// openai-client.ts, where they were byte-identical duplicates. The suite
+// pins the behavior both clients relied on — especially the fence-priority
+// verdict recovery that guards against the #552/#553 silent-bailout incidents.
+// ---------------------------------------------------------------------------
+
+const summary = { riskLevel: 'low', overview: 'ok', keyChanges: [] };
+const finding = {
+  filepath: 'src/x.ts',
+  line: 10,
+  severity: 'warning',
+  category: 'logic_error',
+  message: 'off-by-one',
+};
+const fence = (obj: unknown) => '```json\n' + JSON.stringify(obj) + '\n```';
+
+describe('truncate', () => {
+  it('leaves a string at or under the cap unchanged', () => {
+    expect(truncate('abc', 3)).toBe('abc');
+    expect(truncate('abc', 10)).toBe('abc');
+  });
+
+  it('truncates over the cap with a byte-count suffix', () => {
+    const out = truncate('abcdef', 3);
+    expect(out).toBe('abc\n…[truncated 3 chars]');
+  });
+});
+
+describe('envDisabled (LIEN_REVIEW_LOG_AGENT parsing)', () => {
+  it('disables only for 0/false (case-insensitive)', () => {
+    expect(envDisabled('0')).toBe(true);
+    expect(envDisabled('false')).toBe(true);
+    expect(envDisabled('FALSE')).toBe(true);
+    expect(envDisabled('  False  ')).toBe(true);
+  });
+
+  it('stays enabled for everything else, incl. unset', () => {
+    expect(envDisabled('1')).toBe(false);
+    expect(envDisabled('true')).toBe(false);
+    expect(envDisabled('')).toBe(false);
+    expect(envDisabled(undefined)).toBe(false);
+  });
+});
+
+describe('logTurn', () => {
+  function capturingLogger(): { logger: Logger; lines: string[] } {
+    const lines: string[] = [];
+    const record = (m: string) => lines.push(m);
+    return { logger: { info: record, warning: record, error: record, debug: record }, lines };
+  }
+
+  it('is a no-op for an undefined turn', () => {
+    const { logger, lines } = capturingLogger();
+    logTurn(logger, undefined);
+    expect(lines).toHaveLength(0);
+  });
+
+  it('prints reasoning and output, tagging with the label', () => {
+    const { logger, lines } = capturingLogger();
+    const turn: TurnTrace = {
+      turnNumber: 3,
+      responseText: 'the output',
+      reasoning: 'the reasoning',
+      toolCalls: [],
+      inputTokens: 1,
+      outputTokens: 2,
+    };
+    logTurn(logger, turn, 'last turn before bail');
+    expect(lines.some(l => l.includes('Turn 3 reasoning (last turn before bail)'))).toBe(true);
+    expect(lines.some(l => l.includes('the reasoning'))).toBe(true);
+    expect(lines.some(l => l.includes('Turn 3 output (last turn before bail)'))).toBe(true);
+    expect(lines.some(l => l.includes('the output'))).toBe(true);
+  });
+
+  it('skips whitespace-only reasoning/output (no blank "output:" line)', () => {
+    const { logger, lines } = capturingLogger();
+    const turn: TurnTrace = {
+      turnNumber: 1,
+      responseText: '   ',
+      reasoning: undefined,
+      toolCalls: [],
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    logTurn(logger, turn);
+    expect(lines).toHaveLength(0);
+  });
+
+  it('truncates very long reasoning to the log cap', () => {
+    const { logger, lines } = capturingLogger();
+    const turn: TurnTrace = {
+      turnNumber: 1,
+      responseText: '',
+      reasoning: 'x'.repeat(AGENT_LOG_MAX + 500),
+      toolCalls: [],
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    logTurn(logger, turn);
+    expect(lines.some(l => l.includes('…[truncated'))).toBe(true);
+  });
+});
+
+describe('isValidFinding', () => {
+  it('accepts a well-formed finding', () => {
+    expect(isValidFinding(finding)).toBe(true);
+    expect(isValidFinding({ ...finding, severity: 'error' })).toBe(true);
+  });
+
+  it('rejects malformed findings', () => {
+    expect(isValidFinding(null)).toBe(false);
+    expect(isValidFinding('nope')).toBe(false);
+    expect(isValidFinding({ ...finding, line: '10' })).toBe(false); // line must be number
+    expect(isValidFinding({ ...finding, severity: 'info' })).toBe(false); // bad severity
+    expect(isValidFinding({ ...finding, filepath: undefined })).toBe(false);
+  });
+});
+
+describe('isValidSummary', () => {
+  it('accepts a well-formed summary', () => {
+    expect(isValidSummary(summary)).toBe(true);
+  });
+
+  it('rejects malformed summaries', () => {
+    expect(isValidSummary(null)).toBe(false);
+    expect(isValidSummary({ riskLevel: 'low', overview: 'ok' })).toBe(false); // no keyChanges
+    expect(isValidSummary({ riskLevel: 1, overview: 'ok', keyChanges: [] })).toBe(false);
+    expect(isValidSummary({ riskLevel: 'low', overview: 'ok', keyChanges: 'x' })).toBe(false);
+  });
+});
+
+describe('embeddedJsonObject', () => {
+  it('slices the first { to the last } out of prose', () => {
+    expect(embeddedJsonObject('before {"a":1} after')).toBe('{"a":1}');
+  });
+
+  it('spans nested braces to the outermost close', () => {
+    expect(embeddedJsonObject('x {"a":{"b":2}} y')).toBe('{"a":{"b":2}}');
+  });
+
+  it('returns undefined when there is no object', () => {
+    expect(embeddedJsonObject('no braces here')).toBeUndefined();
+    expect(embeddedJsonObject('}{')).toBeUndefined(); // close precedes open
+  });
+});
+
+describe('readVerdict', () => {
+  it('reads a {findings, summary} object', () => {
+    const { findings, summary: s } = readVerdict({ findings: [finding], summary });
+    expect(findings).toHaveLength(1);
+    expect(s).toEqual(summary);
+  });
+
+  it('treats a bare array as findings with no summary', () => {
+    const { findings, summary: s } = readVerdict([finding, finding]);
+    expect(findings).toHaveLength(2);
+    expect(s).toBeUndefined();
+  });
+
+  it('filters out invalid findings', () => {
+    const { findings } = readVerdict({ findings: [finding, { bogus: true }] });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('drops an invalid summary but keeps findings', () => {
+    const { findings, summary: s } = readVerdict({
+      findings: [finding],
+      summary: { riskLevel: 'low' },
+    });
+    expect(findings).toHaveLength(1);
+    expect(s).toBeUndefined();
+  });
+});
+
+describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
+  it('parses a single json fence carrying a summary', () => {
+    const out = extractFindingsFromText(`Here it is:\n${fence({ findings: [], summary })}`);
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('prefers the LAST fence — the real verdict beats an earlier example', () => {
+    const example = fence({ findings: [finding], summary: { ...summary, overview: 'EXAMPLE' } });
+    const real = fence({ findings: [], summary: { ...summary, overview: 'REAL' } });
+    const out = extractFindingsFromText(`Format:\n${example}\n\nMy review:\n${real}`);
+    expect(out.summary?.overview).toBe('REAL');
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('prefers a summary-bearing candidate over a findings-only one tried first', () => {
+    // Candidates are tried last-fence-first. Here the first-tried fence has
+    // findings but no summary (sets the fallback); the second-tried fence is the
+    // real verdict. The summary marker must override the earlier fallback.
+    const findingsOnly = fence({ findings: [finding] });
+    const verdict = fence({ findings: [], summary });
+    const out = extractFindingsFromText(`${verdict}\n${findingsOnly}`);
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('parses a raw JSON body with no fence (forced-verdict turn)', () => {
+    const out = extractFindingsFromText(JSON.stringify({ findings: [finding], summary }));
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(1);
+  });
+
+  it('recovers a JSON object embedded in surrounding prose', () => {
+    const verdict = JSON.stringify({ findings: [], summary });
+    const out = extractFindingsFromText(`Here is my analysis.\n${verdict}\nThat's everything.`);
+    expect(out.summary).toEqual(summary);
+  });
+
+  it('falls back to a findings-only verdict when nothing carries a summary', () => {
+    const out = extractFindingsFromText(fence({ findings: [finding] }));
+    expect(out.summary).toBeUndefined();
+    expect(out.findings).toHaveLength(1);
+  });
+
+  it('returns an empty verdict for unparseable / summary-less prose', () => {
+    expect(extractFindingsFromText('just some prose, no JSON at all')).toEqual({ findings: [] });
+    expect(extractFindingsFromText('')).toEqual({ findings: [] });
+  });
+
+  it('skips an unparseable fence (tried first) and recovers from a valid one', () => {
+    // The broken fence is placed LAST so it is tried FIRST (fences run in
+    // reverse); JSON.parse throws, the loop must continue to the good fence.
+    const broken = '```json\n{not valid json,,,}\n```';
+    const good = fence({ findings: [], summary });
+    const out = extractFindingsFromText(`${good}\n${broken}`);
+    expect(out.summary).toEqual(summary);
+  });
+});


### PR DESCRIPTION
## What

Deduplicates the near-identical `anthropic-client.ts` and `openai-client.ts` agent clients by extracting their byte-identical, provider-agnostic pieces into a new `packages/review/src/plugins/agent/agent-client-shared.ts` that both import.

Addresses the campaign architecture finding: both clients (~600–800 lines each) carried structurally-cloned copies of the verdict-parsing pipeline, output caps, the env-disable parser, and per-turn trace logging — so every bug fix had to land twice.

## Why

`readVerdict`, `embeddedJsonObject`, `isValidSummary`, `isValidFinding`, the fence-priority JSON-recovery core, `truncate`, `envDisabled`, and `logTurn` were duplicated verbatim across the two files. This is exactly the maintenance hazard that produced divergence risk on the `#552`/`#553` incident paths. Consolidating the pure helpers removes ~215 lines of the highest-churn duplication with near-zero behavioral risk.

## Extracted vs. deliberately left per-client

| Piece | Decision | Rationale |
|---|---|---|
| `truncate`, `envDisabled` | **Extracted** | byte-identical pure functions |
| `TRACE_TOOL_OUTPUT_MAX`, `AGENT_LOG_MAX`, `TOOL_RESULT_MAX_CHARS`, `WRAP_UP_NUDGE` | **Extracted** | identical constants |
| `readVerdict`, `embeddedJsonObject`, `isValidSummary`, `isValidFinding` | **Extracted** | byte-identical parsing/validation |
| fence-priority JSON recovery → `extractFindingsFromText(text)` | **Extracted** | identical core; each client keeps a thin `extractResponse` adapter that renders its response to text first (Anthropic joins text blocks; OpenAI takes `message.content`) |
| `logTurn` | **Extracted** | byte-identical; now a free fn taking `logger` |
| The turn loop (budget tracking, near-budget/last-turn wrap-up, forced-verdict, incomplete detection, per-turn trace assembly) | **Left per-client** | see risk analysis below |
| Summary-retry assembly (`appendRetryPrompt`, `RETRY_SYSTEM_PROMPT`/`RETRY_USER_PROMPT` vs `RETRY_NUDGE`) | **Left per-client** | provider-specific |
| API shape / message formatting / tool-call encoding (`chatCompletion`, `postChat`, `dispatchToolCalls`, `dispatchToolUseBlocks`, `parseToolArguments`, `toOpenAITools`, `formatChatTimeout`, `describeServingProvider`, `extractThinking`, `requestMaxTokens`, provider routing, `ChatResponse`/`ChatMessage`/`ToolDef` types) | **Left per-client** | genuinely provider-specific |

`envDisabled` is re-exported from `openai-client.ts` so `plugins-agent-budget.test.ts`'s existing import path stays valid (no test changes).

## Behavior-preservation argument

- Only byte-identical / pure code was moved. `extractFindingsFromText` is the original candidate-building + priority loop verbatim; the two `extractResponse` wrappers reproduce the exact prior input handling (Anthropic: empty text-block set → `{findings:[]}`, else join with `\n`; OpenAI: `null`/empty content → `{findings:[]}`).
- The `#552`/`#553` incident guards (the reasoning-vs-content silent-bail retry trigger, forced-verdict mechanics, incomplete-run detection) live inside the per-client turn loops and are **untouched**.
- **Proof:** all existing agent-client tests pass **unmodified** — `plugins-agent-anthropic` (9), `plugins-agent-budget` (25, incl. the silent-bail / example-vs-real-verdict / embedded-prose cases), `plugins-agent-provider-routing` (10), `plugins-agent-timeout-log` (3). Added `plugins-agent-client-shared.test.ts` (27) pinning the shared helpers, including reconstructable `#552`/`#553`-shape regressions (last-fence-wins, findings-only fallback, embedded-prose recovery, unparseable-fence skip).

## Turn-loop dedup — recommended follow-up (deliberately NOT attempted here)

Per the high-care brief, I stopped at the safe helper extraction. A shared loop driver would need a ~10-method provider adapter, and these woven divergences make one-pass behavior-preservation hard to guarantee:

1. **Wrap-up nudge placement** — Anthropic appends `WRAP_UP_NUDGE` as a text block *inside* the tool-result user turn (the API requires tool_results to immediately follow tool_use); OpenAI pushes it as a *separate* user message after the tool messages.
2. **Forced-finish lever** — Anthropic sets `tool_choice:{type:'none'}` on the next in-loop request; OpenAI switches to `response_format:{type:'json_object'}` + drops tools via `chatCompletion(forceVerdict)`.
3. **Summary-retry assembly** — Anthropic must satisfy pending `tool_use` with dummy tool_results before the retry prompt and uses a distinct system prompt + thinking; OpenAI just pushes `RETRY_NUDGE`.
4. **Usage / stop signals** — `usage.input_tokens`/`output_tokens` + `end_turn`/`tool_use` vs `usage?.prompt_tokens ?? 0` + `stop`/`tool_calls`.
5. **Request construction** — cache-controlled system array + extended thinking + budget-derived `max_tokens` vs fixed `max_tokens` + reasoning effort + provider routing + fetch retry/abort-timeout.

The loop is lower-churn and higher-risk than the parsing helpers, so deferring it is the right trade. If pursued, land it behind the same test suite plus harness calibration, and reconstruct the `#552`/`#553` loop-path fixtures first.

## Verification (from worktree root)

- `npm run format:check` — clean
- `npm run lint` — **0 errors** (22 pre-existing warnings, none in touched files)
- `npm run typecheck` — pass (all packages)
- `npm run build` — pass (all packages)
- `npm run test -w @liendev/review` — **505/505 passing** across 27 files (existing agent tests unmodified; +27 new shared-helper tests)

Note: an earlier baseline run showed 2 `analysis.test.ts` failures — these were the known stale-`dist` gotcha (its `@liendev/core`/`@liendev/parser` deps resolving to main's gitignored dist); rebuilding main cleared them and the full suite is green.

## Scope / caveats

- `@liendev/review` is **private** (`"private": true`) — no changeset.
- Line-count: `anthropic-client.ts` 601→487, `openai-client.ts` 827→726, new shared module 159 lines.
- No unrelated issues observed in the touched files.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +0 |
| 🧠 mental load | 3 | +0 |
| ⏱️ time to understand | 3 | +5 |
| 🐛 estimated bugs | 2 | +0.019 |


> [!NOTE]
> **Low Risk**
>
> This PR is a pure refactor that extracts byte-identical helper functions and constants from the Anthropic and OpenAI agent clients into a new shared module. No exports were removed; `envDisabled` is re-exported from `openai-client.ts` to preserve the existing test import path. The per-client turn loops, provider-specific message formatting, and retry logic remain untouched, and the new shared `extractFindingsFromText` reproduces the original fence-priority JSON recovery exactly.
>
> - Moved shared constants (`TRACE_TOOL_OUTPUT_MAX`, `AGENT_LOG_MAX`, `TOOL_RESULT_MAX_CHARS`, `WRAP_UP_NUDGE`) and pure helpers (`truncate`, `envDisabled`, `logTurn`, verdict-parsing pipeline) into `agent-client-shared.ts`.
> - Both clients now import the shared helpers; `extractResponse` thin adapters preserve the original Anthropic text-block joining and OpenAI `message.content` handling.
> - Added 27 unit tests for the extracted shared helpers, covering fence-priority recovery, env-disable parsing, turn logging, and validation guards.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6d59ee3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->