### PR TITLE
test(review): trace-based harness Tier-1 extraction + pin Kimi as calibration model

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,7 +1,9 @@
 name: Agent-Rule Test Harness (LLM)
 
-# Manual-trigger only. The harness hits a real LLM (Gemini 3 Flash Preview
-# via OpenRouter) and costs real money per run. Do NOT add automatic triggers.
+# Manual-trigger only. The harness hits a real LLM via OpenRouter — the
+# prod default model (moonshotai/kimi-k2.7-code, from
+# packages/review/src/defaults.ts) unless a --model override is passed —
+# and costs real money per run. Do NOT add automatic triggers.
 #
 # Use this to:
 #   - Establish the 9/10 reliability baseline before changing a rule prompt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,11 +99,16 @@ exists specifically to make that cycle ~30 minutes instead of hours.
 - Inner loop: invoke `/test-harness <rule-id>` from CC for free
   Claude-subagent iteration on existing fixtures.
 - Shipping gate: `npm run test:harness -- --rule <rule-id> --calibrate 10`
-  must hit ≥ 9/10 against OpenRouter (Gemini) before merging the change.
-  The harness auto-loads `OPENROUTER_API_KEY` from `.env` at the repo root.
+  must hit ≥ 9/10 against OpenRouter, on the prod default model
+  (`moonshotai/kimi-k2.7-code` — omit `--model` to use it) before merging
+  the change. The harness auto-loads `OPENROUTER_API_KEY` from `.env` at
+  the repo root.
 - Workflow + failure modes: see `packages/review/test/harness/README.md`.
   Includes the end-to-end recipe for capturing a real-PR fixture, authoring
-  Tier 1/2 assertions, iterating, and calibrating.
+  Tier 1/2 assertions, iterating, and calibrating. A couple of existing
+  canaries were calibrated on Gemini and are currently known-red on Kimi —
+  see the README's "Known-red reconciliation" note; that's tracked
+  separately, not a blocker for new rule work.
 
 A rule is not shippable until its calibration meets the bar. CC mode is
 necessary but not sufficient.

--- a/packages/review/test/harness-runner.test.ts
+++ b/packages/review/test/harness-runner.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The test harness's Tier-1 fields (`toolCalls`, `turns`) must come from the
+ * structured `AgentTrace` the agent client always returns via `reportTrace`
+ * — not from regex-parsing `logger.info` lines like "[agent] Turn 2 tools:
+ * get_files_context, read_file". The old regex extractor was only ever as
+ * stable as that log line's exact wording; the trace carries the same data
+ * structurally (`trace.turns[].toolCalls[].name`), independent of any log
+ * phrasing.
+ *
+ * Two layers of coverage:
+ *  - Pure unit tests of `toolCallsFromTrace`/`turnCountFromTrace` against
+ *    hand-built `AgentTrace` objects, including one where the free-text
+ *    `reasoning`/`responseText` deliberately *mentions* tool names that were
+ *    never actually invoked (the exact shape that would fool a text-scraper).
+ *  - A fixture-replay through `runFixture` with a mocked OpenAI-compat
+ *    `fetch`, proving the wiring end-to-end without hitting OpenRouter.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { runFixture, toolCallsFromTrace, turnCountFromTrace } from './harness/runner.js';
+import { expectRuleFired, expectToolCalled } from './harness/assertions.js';
+import type { AgentTrace, TurnTrace } from '../src/plugins/agent/types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLACEHOLDER_FIXTURE = resolve(
+  HERE,
+  'harness/fixtures/boundary-change/placeholder.fixture.json',
+);
+
+function turn(turnNumber: number, toolNames: string[], responseText = ''): TurnTrace {
+  return {
+    turnNumber,
+    responseText,
+    toolCalls: toolNames.map(name => ({ name, input: {}, output: '' })),
+  };
+}
+
+function traceOf(turns: TurnTrace[]): AgentTrace {
+  return { systemPrompt: 'sys', initialMessage: 'init', model: 'test-model', turns };
+}
+
+describe('toolCallsFromTrace / turnCountFromTrace (pure trace helpers)', () => {
+  it('flattens tool calls across turns, in order', () => {
+    const trace = traceOf([
+      turn(1, ['get_files_context']),
+      turn(2, ['get_dependents', 'read_file']),
+    ]);
+    expect(toolCallsFromTrace(trace)).toEqual(['get_files_context', 'get_dependents', 'read_file']);
+    expect(turnCountFromTrace(trace)).toBe(2);
+  });
+
+  it('ignores tool names mentioned only in free-text reasoning/response prose', () => {
+    const trace = traceOf([
+      {
+        turnNumber: 1,
+        responseText: 'I will call get_dependents and read_file next.',
+        reasoning: '[agent] Turn 1 tools: get_dependents, read_file',
+        toolCalls: [{ name: 'get_files_context', input: {}, output: '' }],
+      },
+    ]);
+    // Only the structurally-issued tool call counts — the prose above uses
+    // the exact old log-line format but names tools that were never called.
+    expect(toolCallsFromTrace(trace)).toEqual(['get_files_context']);
+  });
+
+  it('counts a summary-retry turn (no tool calls) toward the turn count', () => {
+    const trace = traceOf([turn(1, ['get_files_context']), turn(2, [], '{}')]);
+    expect(turnCountFromTrace(trace)).toBe(2);
+    expect(toolCallsFromTrace(trace)).toEqual(['get_files_context']);
+  });
+
+  it('defaults to empty when no trace is present', () => {
+    expect(toolCallsFromTrace(undefined)).toEqual([]);
+    expect(turnCountFromTrace(undefined)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture replay: runFixture end-to-end, with a mocked OpenAI-compat fetch.
+// ---------------------------------------------------------------------------
+
+type ChatResponse = {
+  choices: Array<{
+    message: { role: string; content: string | null; reasoning?: string; tool_calls?: unknown[] };
+    finish_reason: string;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+};
+
+function mockFetch(responses: ChatResponse[]): void {
+  const queue = [...responses];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: { body: string }) => {
+      JSON.parse(init.body); // sanity: the client always sends a valid JSON body
+      const next = queue.shift();
+      return {
+        ok: true,
+        status: 200,
+        json: async () => next,
+        text: async () => JSON.stringify(next),
+      };
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const CLEAN_JSON =
+  '```json\n' +
+  JSON.stringify({
+    findings: [
+      {
+        filepath: 'src/risk.ts',
+        line: 13,
+        severity: 'warning',
+        category: 'boundary_change',
+        message: 'Off-by-one boundary shift.',
+        ruleId: 'boundary-change',
+      },
+    ],
+    summary: { riskLevel: 'low', overview: 'Looks fine.', keyChanges: [] },
+  }) +
+  '\n```';
+
+describe('runFixture — HarnessResult.toolCalls/turns come from the trace', () => {
+  it('reports only the structurally-invoked tool, unaffected by misleading reasoning prose', async () => {
+    mockFetch([
+      {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              // Deliberately names tools that were never actually called, in
+              // the exact shape the old regex extractor scraped from logs.
+              // A text-scraping approach would misreport these as called.
+              reasoning: '[agent] Turn 7 tools: read_file, grep_codebase',
+              tool_calls: [
+                {
+                  id: 't1',
+                  type: 'function',
+                  function: {
+                    name: 'get_files_context',
+                    arguments: JSON.stringify({ filepaths: ['src/risk.ts'] }),
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 500, completion_tokens: 50, total_tokens: 550 },
+      },
+      {
+        choices: [{ message: { role: 'assistant', content: CLEAN_JSON }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 200, completion_tokens: 80, total_tokens: 280 },
+      },
+    ]);
+
+    const result = await runFixture(PLACEHOLDER_FIXTURE, {
+      apiKey: 'test-key',
+      baseUrl: 'http://mock.local',
+    });
+
+    // Structural extraction: exactly the one real tool call — nothing from
+    // the misleading "[agent] Turn 7 tools: ..." reasoning text.
+    expect(result.toolCalls).toEqual(['get_files_context']);
+    expectToolCalled('get_files_context', result);
+
+    // Two loop turns, straight from `trace.turns.length` — no "[agent] Turn
+    // N" log line was ever inspected.
+    expect(result.turns).toBe(2);
+    expect(result.trace?.turns).toHaveLength(2);
+
+    expectRuleFired('boundary-change', result);
+  });
+});

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -3,16 +3,22 @@
 Replay code-review fixtures through the agent plugin's prompts to validate
 prompt changes offline. Two modes — pick the right one for the task:
 
-| Mode               | Entry                                            | Model                    | Cost             | Use when                                |
-| ------------------ | ------------------------------------------------ | ------------------------ | ---------------- | --------------------------------------- |
-| **CC iteration**   | `/test-harness <rule>`                           | Claude (subagent)        | Free             | Authoring / iterating on a prompt       |
-| **OpenRouter run** | `npm run test:harness -w @liendev/review`        | Gemini 3 Flash Preview   | ~$0.05/run       | Final verification / 9/10 bar           |
-| **CI dispatch**    | Run "Agent-Rule Test Harness (LLM)" workflow     | Gemini 3 Flash Preview   | ~$0.05/run       | Repeatable verification                 |
+| Mode               | Entry                                            | Model                              | Cost             | Use when                                |
+| ------------------ | ------------------------------------------------ | ----------------------------------- | ---------------- | --------------------------------------- |
+| **CC iteration**   | `/test-harness <rule>`                           | Claude (subagent)                   | Free             | Authoring / iterating on a prompt       |
+| **OpenRouter run** | `npm run test:harness -w @liendev/review`        | `moonshotai/kimi-k2.7-code` (prod default) | ~$0.05/run       | Final verification / 9/10 bar           |
+| **CI dispatch**    | Run "Agent-Rule Test Harness (LLM)" workflow     | `moonshotai/kimi-k2.7-code` (prod default) | ~$0.05/run       | Repeatable verification                 |
 
-**The 9/10 reliability bar is measured in OpenRouter mode only.** Claude is
-materially smarter than Gemini, so a passing CC run does not certify
-production behavior. Always re-calibrate against OpenRouter before merging
-a prompt change. (Issue #538.)
+**The 9/10 reliability bar is measured in OpenRouter mode only, against the
+prod default model** (`moonshotai/kimi-k2.7-code`, from
+`packages/review/src/defaults.ts` — the harness resolves to it whenever
+`--model` is omitted). Claude is materially smarter than Kimi, so a passing
+CC run does not certify production behavior. Always re-calibrate against
+OpenRouter before merging a prompt change. (Issue #538.)
+
+Pass `--model <slug>` to calibrate against a different model (e.g. for an
+A/B comparison, or to reproduce the historical Gemini baseline some older
+canaries were tuned against — see "Known-red reconciliation" below).
 
 ## Quick start
 
@@ -245,6 +251,29 @@ This bar is what gates the harness from "shipped" to "trusted for the
 parked prompt-tweak issues" (#284, #286, #287, #288, #289, #302, #339, and
 the §4.3 "test pair" tweak in `.wip/retro-blast-radius.md`).
 
+### Known-red reconciliation: Gemini-calibrated canaries vs the Kimi default
+
+The canary corpus predates the Kimi cutover (#592/#591) and some fixtures
+were calibrated (and last hit ≥ 9/10) against `google/gemini-3-flash-preview`,
+not the current prod default. Running `--calibrate 10` with no `--model`
+now exercises Kimi, and two canaries are **known-red** there:
+`stale-duplicate/model-partial-update` and
+`untrusted-input-validation/harness-initial` (2/8 rules). This is expected,
+already-understood drift from the Kimi cutover (#592) — not a regression
+introduced by this doc change, and not something this change attempts to
+fix. See `packages/review/src/defaults.ts` for the current default model.
+
+Because of this, the bar for **touching an existing rule's prompt** is not
+"single-rule calibrate ≥ 9/10 on every canary in the repo" — it's ≥ 9/10 on
+the rule(s) you actually changed. The bar for **the full corpus** (e.g.
+before a model swap, or a change that touches shared prompt scaffolding used
+by multiple rules) is **no regression vs main's pass/fail pattern**, checked
+by re-running the full canary sweep (`sweep.sh`, or `--calibrate 10` with no
+`--rule` filter) on both branches and diffing which fixtures flip — not
+"every fixture is green." Do not spend calibration budget trying to push the
+two known-red fixtures above 9/10 as a side effect of unrelated work; that's
+tracked as its own fix separately.
+
 ## Runbook: §4.3 boundary-change "test pair" tweak
 
 The motivating example for #538. To execute:
@@ -308,9 +337,9 @@ harness lets you do it autonomously once `OPENROUTER_API_KEY` is in `.env`.
    `/test-harness <rule-id>`. The Skill spawns a Claude subagent per
    fixture and reports pass/fail. Cycle through prompt edits in `rules.ts`
    until CC reliably produces the expected finding. **CC mode is *not*
-   sufficient for shipping** — Claude is much smarter than Gemini, so
-   passing here doesn't certify production behavior. Treat it as
-   smoke-testing.
+   sufficient for shipping** — Claude is much smarter than Kimi (the prod
+   default), so passing here doesn't certify production behavior. Treat it
+   as smoke-testing.
 
 6. **Calibrate against OpenRouter (the gate).**
 
@@ -395,10 +424,11 @@ fixture writes ~100-500 KB to disk.
 ## Modes — when to use which
 
 - **`/test-harness <rule>` (CC)** — fast inner loop. Free. Use while
-  drafting a prompt change. Catches "the prompt is broken" but not "Gemini
+  drafting a prompt change. Catches "the prompt is broken" but not "Kimi
   will misbehave."
 - **`npm run test:harness --votes 3`** — sanity check after iterating in CC.
-  ~$0.18 per fixture. Tells you Gemini agrees with the assertion at K=3.
+  ~$0.18 per fixture. Tells you Kimi (the prod default) agrees with the
+  assertion at K=3.
 - **`npm run test:harness --calibrate 10`** — the 9/10 bar. ~$0.50 per
   fixture. **The only mode that gates merging a prompt change.**
 - **GitHub workflow ("Agent-Rule Test Harness (LLM)")** — same as

--- a/packages/review/test/harness/runner.ts
+++ b/packages/review/test/harness/runner.ts
@@ -6,11 +6,11 @@
  * the user has set OPENROUTER_API_KEY.
  */
 
-import type { Logger } from '../../src/logger.js';
 import type { ReviewContext, ReviewFinding } from '../../src/plugin-types.js';
 import { AgentReviewPlugin } from '../../src/plugins/agent/index.js';
 import type { AgentTrace } from '../../src/plugins/agent/types.js';
 import { DEFAULT_REVIEW_MODEL, DEFAULT_OPENROUTER_BASE_URL } from '../../src/defaults.js';
+import { silentLogger } from '../../src/test-helpers.js';
 
 import { loadFixture } from './fixture-loader.js';
 import type { HarnessResult } from './assertions.js';
@@ -28,45 +28,35 @@ export interface RunnerOptions {
   maxTokenBudget?: number;
 }
 
-interface CapturingLogger extends Logger {
-  lines: string[];
+/**
+ * The harness doesn't need per-line log capture: `AgentReviewPlugin` reports
+ * a fully structured `AgentTrace` via `reportTrace` regardless (see
+ * `toolCallsFromTrace`/`turnCountFromTrace` below), and nothing here reads
+ * raw log text, so `runFixture` passes the shared `silentLogger` (below).
+ * `openai-client.ts`'s `[agent] Turn N: ...` / `[agent] Turn N tools: ...`
+ * calls stay as human-readable production logs (untouched) — they're just
+ * not depended on here anymore.
+ */
+
+/**
+ * Flatten every tool call made across the run from the structured trace.
+ * Previously this regex-parsed logger lines like "[agent] Turn 2 tools:
+ * get_files_context, read_file" — stable only as long as nobody reworded
+ * that log line. The trace carries the same data structurally (each turn's
+ * `toolCalls[].name`), independent of any log phrasing.
+ */
+export function toolCallsFromTrace(trace: AgentTrace | undefined): string[] {
+  if (!trace) return [];
+  return trace.turns.flatMap(turn => turn.toolCalls.map(call => call.name));
 }
 
-function makeCapturingLogger(): CapturingLogger {
-  const lines: string[] = [];
-  return {
-    lines,
-    info: (msg: string) => lines.push(`info: ${msg}`),
-    warning: (msg: string) => lines.push(`warning: ${msg}`),
-    error: (msg: string) => lines.push(`error: ${msg}`),
-    debug: (msg: string) => lines.push(`debug: ${msg}`),
-  };
-}
-
-/** Extract tool names from logger lines like "[agent] Turn 2 tools: get_files_context, read_file". */
-function extractToolCalls(lines: string[]): string[] {
-  const calls: string[] = [];
-  for (const line of lines) {
-    const match = line.match(/\[agent\] Turn \d+ tools: (.+)$/);
-    if (match) {
-      for (const name of match[1].split(',').map(s => s.trim())) {
-        if (name) calls.push(name);
-      }
-    }
-  }
-  return calls;
-}
-
-function extractTurns(lines: string[]): number {
-  let max = 0;
-  for (const line of lines) {
-    const match = line.match(/\[agent\] Turn (\d+)/);
-    if (match) {
-      const n = parseInt(match[1], 10);
-      if (n > max) max = n;
-    }
-  }
-  return max;
+/**
+ * Turn count from the structured trace (mirrors `compare-votes.ts`'s
+ * `trace.turns.length`), rather than the max turn number regex-parsed out
+ * of "[agent] Turn N" log lines.
+ */
+export function turnCountFromTrace(trace: AgentTrace | undefined): number {
+  return trace?.turns.length ?? 0;
 }
 
 function findingsToHarness(findings: ReviewFinding[]): HarnessResult['findings'] {
@@ -91,7 +81,6 @@ export async function runFixture(
   opts: RunnerOptions,
 ): Promise<HarnessResult & { cost: number }> {
   const ctx = (await loadFixture(fixturePath)) as ReviewContext;
-  const logger = makeCapturingLogger();
 
   let cost = 0;
   const reportUsage = (usage: {
@@ -110,7 +99,7 @@ export async function runFixture(
 
   const pluginCtx: ReviewContext = {
     ...ctx,
-    logger,
+    logger: silentLogger,
     reportUsage,
     reportTrace,
     config: {
@@ -132,8 +121,8 @@ export async function runFixture(
 
   return {
     findings: findingsToHarness(findings),
-    toolCalls: extractToolCalls(logger.lines),
-    turns: extractTurns(logger.lines),
+    toolCalls: toolCallsFromTrace(trace),
+    turns: turnCountFromTrace(trace),
     trace,
     cost,
   };

--- a/packages/review/test/harness/sweep.sh
+++ b/packages/review/test/harness/sweep.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
-# Multi-model sweep across all canary fixtures.
+# Multi-model sweep across all canary fixtures — an experimental A/B/
+# regression tool, distinct from the single-rule `--calibrate` shipping
+# gate (see run.ts / README.md), which defaults to the prod model
+# (`moonshotai/kimi-k2.7-code`, from src/defaults.ts) whenever --model is
+# omitted.
 # Usage: OPENROUTER_API_KEY=… ./sweep.sh [model1 model2 ...]
-# Default models: google/gemini-2.5-flash google/gemini-3-flash-preview
+# Default models: moonshotai/kimi-k2.7-code google/gemini-3-flash-preview
+#   (Kimi is the prod default; Gemini 3 Flash is kept as the original
+#   calibration baseline some canaries were tuned against, for regression
+#   comparison. A couple of canaries are known-red on Kimi — see the
+#   README's "Known-red reconciliation" note — so this sweep's bar is "no
+#   regression vs main," not literal 9/10 on every fixture/model pair.)
 #
 # A calibration that misses the 9/10 bar exits non-zero — that's expected
 # data, not a script error. So we deliberately do NOT use `set -e` here.
@@ -33,7 +42,7 @@ ROOT=packages/review/test/harness/fixtures
 if [ "$#" -gt 0 ]; then
   MODELS=("$@")
 else
-  MODELS=(google/gemini-2.5-flash google/gemini-3-flash-preview)
+  MODELS=(moonshotai/kimi-k2.7-code google/gemini-3-flash-preview)
 fi
 
 # Portable equivalent of `mapfile` (bash 3.2 on macOS lacks it).


### PR DESCRIPTION
## What

Two related, confirmed review findings on the agent-review test harness (doc + test-infra only — no rule prompt or agent-facing text changed, no calibration spend):

1. **Tier-1 extraction was regex-parsing free-text logs.** `runner.ts`'s `extractToolCalls`/`extractTurns` matched `logger.info` lines like `"[agent] Turn N tools: get_files_context, read_file"` emitted by `openai-client.ts`. The same `runFixture` already receives a fully structured `AgentTrace` via `reportTrace` (`trace.turns[].toolCalls[].name`) carrying exactly this data. "Stable at T=0" was really "stable until someone rewords a log line."
2. **The documented calibration model had drifted from reality.** `CLAUDE.md`, the harness `README.md`, and `.github/workflows/harness.yml` all described the 9/10 bar as measured against Gemini, but `runner.ts` defaults to `DEFAULT_REVIEW_MODEL` (`moonshotai/kimi-k2.7-code`, the prod model) whenever `--model` is omitted — has been since the Kimi cutover (#592). `sweep.sh`'s default model list was still all-Gemini too.

## Approach

- **runner.ts**: replaced `extractToolCalls`/`extractTurns` (regex over captured logger lines) with `toolCallsFromTrace`/`turnCountFromTrace`, pure functions over the structured `AgentTrace`. `HarnessResult`'s shape and the Tier-1 helper API (`expectToolCalled`, `expectRuleFired`, etc. in `assertions.ts`) are **unchanged** — fixtures/assertions don't need to change. The harness no longer needs a capturing logger at all; it now passes the shared `silentLogger` from `src/test-helpers.ts` (already used elsewhere in the package) instead of a bespoke one.
  - `openai-client.ts`'s `[agent] Turn N: ...` / `[agent] Turn N tools: ...` `logger.info` calls are **kept untouched** as human-readable production/CI logs — the harness just no longer depends on their exact wording.
- **Docs**: updated `CLAUDE.md`'s "Agent-Review Rule Development" section, the harness `README.md` (mode table, reliability-bar paragraph, the CC-vs-OpenRouter comparisons throughout), `harness.yml`'s header comment, and `sweep.sh`'s default model list + header comment to name Kimi as the pinned single-rule `--calibrate` default. Added a **"Known-red reconciliation"** section to the README: two canaries (`stale-duplicate/model-partial-update`, `untrusted-input-validation/harness-initial`) were calibrated on Gemini and are currently known-red on Kimi — documented as pre-existing, already-understood drift (not something this PR fixes), with the policy made explicit: single-rule work is gated on the rule(s) you touched hitting ≥9/10, and the full-corpus/model-swap bar is "no regression vs main's pass/fail pattern," not literal 9/10 on every fixture.
- **sweep.sh**: default `MODELS` is now `(moonshotai/kimi-k2.7-code google/gemini-3-flash-preview)` — Kimi first (prod default), Gemini kept as the original calibration baseline for regression comparison, documented as such.

## Tests

Added `packages/review/test/harness-runner.test.ts`:
- Pure unit tests of `toolCallsFromTrace`/`turnCountFromTrace` against hand-built `AgentTrace` objects, including one where `responseText`/`reasoning` deliberately *mention* tool names that were never actually invoked, in the exact shape of the old log line (`"[agent] Turn N tools: ..."`) — proving extraction is structural, not text-based.
- A fixture-replay through `runFixture` (mocked OpenAI-compat `fetch`, no network/cost) against the existing `boundary-change/placeholder.fixture.json`, asserting `HarnessResult.toolCalls`/`turns` match the trace exactly and are unaffected by misleading reasoning prose, and that `expectToolCalled`/`expectRuleFired` still work unchanged against the new extraction.

## Verification

```
npm run typecheck:harness -w @liendev/review   # pass
npm run typecheck -w packages/review           # pass
npm run test -w @liendev/review                # 27 files / 483 tests passed (incl. new harness-runner.test.ts, 5 tests)
npm run format:check && npm run lint && npm run typecheck && npm run build   # all pass, repo root (0 lint errors; pre-existing warnings only, none in touched files)
bash -n packages/review/test/harness/sweep.sh  # syntax OK
```

No OpenRouter calibration was run (not needed — no rule prompt or agent-facing text changed).

## Caveats / out of scope

- Did not fix the two known-red canaries (`stale-duplicate`, `untrusted-input-validation`) — tracked separately per the task, documented instead.
- Noticed but did **not** touch: `packages/action/{action.yml,README.md,src/inputs.ts}` and `packages/action/examples/lien-review.yml` still say the OpenRouter path "runs Gemini" — same underlying staleness, but it's the Action's user-facing docs, not the test harness, and out of scope for this change.
- `@liendev/review` is private (`"private": true` in package.json) — no changeset.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR refactors the agent-review test harness to derive Tier-1 metrics (`toolCalls`, `turns`) from the structured `AgentTrace` reported by the agent client instead of regex-parsing `logger.info` lines. It also pins documentation and scripts to the current prod default model (`moonshotai/kimi-k2.7-code`). The new helper functions are simple, side-effect-free, and handle `undefined`/empty trace correctly. The switch to `silentLogger` is safe because no harness code consumes raw log text anymore. No rule prompts, agent-facing text, or calibration spend changed. No production code is affected.
>
> - Replaced regex-based `extractToolCalls`/`extractTurns` with pure `toolCallsFromTrace`/`turnCountFromTrace` over `AgentTrace`
> - Switched `runFixture` from a bespoke capturing logger to the shared `silentLogger`
> - Updated harness docs and `sweep.sh` defaults to reflect the Kimi prod default model

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a1dd162. Updates automatically on new commits.</sup>
<!-- /lien-stats -->