### PR TITLE
test(cli): add real MCP protocol round-trip integration test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,6 +87,9 @@ jobs:
           - project: SwiftyJSON
             language: Swift
             script: test:e2e:swift
+          - project: MCP Round Trip
+            language: Protocol
+            script: test:e2e:mcp
 
     steps:
       - name: Checkout code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run test/e2e/real-projects.test.ts --reporter=verbose",
+    "test:e2e:mcp": "vitest run test/e2e/mcp-roundtrip.test.ts --reporter=verbose",
     "test:e2e:python": "vitest run test/e2e/real-projects.test.ts -t 'Requests'",
     "test:e2e:typescript": "vitest run test/e2e/real-projects.test.ts -t 'Zod'",
     "test:e2e:javascript": "vitest run test/e2e/real-projects.test.ts -t 'Express'",

--- a/packages/cli/test/e2e/README.md
+++ b/packages/cli/test/e2e/README.md
@@ -1,8 +1,12 @@
-# E2E Tests with Real Projects
+# E2E Tests
+
+Gated tests that are excluded from the fast suite (`npm test`) because they
+load real, non-mocked dependencies (a git clone, the real local embedding
+model, or both) that are too slow/heavy for the default `vitest run`.
+
+## Real Open Source Projects (`real-projects.test.ts`)
 
 End-to-end tests that validate Lien works correctly on real open source projects.
-
-## Overview
 
 These tests:
 - Clone popular open source projects for each supported language
@@ -213,9 +217,28 @@ A: Pin to a specific commit SHA instead of branch name, or update expected value
 **Q: Why shallow clones?**  
 A: Speed. We only need latest code to validate Lien works.
 
+## MCP Protocol Round Trip (`mcp-roundtrip.test.ts`)
+
+Drives a real `@modelcontextprotocol/sdk` `Client` against a real MCP
+`Server` (connected over `InMemoryTransport.createLinkedPair()`), backed by
+a real LanceDB index of a small in-memory fixture repo built via the real
+`indexCodebase()` path. Unlike `server.test.ts` (which mocks the SDK's
+`Server`/transport classes and only asserts setup calls) and the handler
+unit tests (which mock the vector DB), this proves a client can actually
+connect and get a real `tools/call` response for `semantic_search` and
+`get_files_context`.
+
+Uses `LocalEmbeddings` (in-process, no worker thread) loaded once for the
+whole file — same approach as `real-projects.test.ts` — which is why it
+lives here instead of the fast suite.
+
+```bash
+npm run test:e2e:mcp -w @liendev/lien
+```
+
 ## Future Enhancements
 
-- [ ] Add semantic search validation (requires MCP server)
+- [x] Add semantic search validation (requires MCP server) — see `mcp-roundtrip.test.ts`
 - [ ] Add performance benchmarks (index time, search latency)
 - [ ] Add multi-language project test (e.g., Django + React)
 - [ ] Cache git clones between runs

--- a/packages/cli/test/e2e/mcp-roundtrip.test.ts
+++ b/packages/cli/test/e2e/mcp-roundtrip.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { indexCodebase, LocalEmbeddings, VectorDB } from '@liendev/core';
+import { createTestDir, cleanupTestDir, createTestFile } from '@liendev/core/test';
+import { createMCPServerConfig, registerMCPHandlers } from '../../src/mcp/server-config.js';
+import { createReindexStateManager } from '../../src/mcp/reindex-state-manager.js';
+import type { ToolContext } from '../../src/mcp/types.js';
+
+/**
+ * Real MCP protocol round-trip test.
+ *
+ * server.test.ts mocks the SDK's `Server`/`StdioServerTransport` classes and
+ * only asserts that setup functions were *called*. The handler unit tests
+ * (e.g. semantic-search.test.ts, get-files-context.test.ts) mock the vector
+ * DB underneath. Neither half ever proves that a real MCP client can
+ * connect to a real server and get a real tool response back — this test
+ * closes that gap.
+ *
+ * It stands up:
+ * - a real fixture repo on disk (temp dir, cleaned up in afterAll)
+ * - a real LanceDB index built via the real `indexCodebase()` path
+ * - the real `Server` + the real `registerMCPHandlers` (nothing mocked)
+ * - a real `Client` from the MCP SDK, connected over
+ *   `InMemoryTransport.createLinkedPair()` (the SDK's in-process transport
+ *   pair — faster and more hermetic than spawning a stdio subprocess, and
+ *   exercises the exact same request/response wire format)
+ *
+ * If a tool handler throws on real DB result shapes, a schema/handler
+ * mismatch breaks `tools/call` dispatch, or the server never registers a
+ * handler in the first place, this test fails. None of the mocked halves
+ * above can catch any of that.
+ *
+ * Gated out of the fast suite: `test/e2e/**` is excluded by the `test`
+ * script (see package.json) because — like real-projects.test.ts — it loads
+ * the real local embedding model (`LocalEmbeddings`, in-process, no worker
+ * thread) rather than a mock. The model is loaded once in `beforeAll`,
+ * mirroring real-projects.test.ts's pattern. Run directly with
+ * `npm run test:e2e:mcp -w @liendev/lien`.
+ */
+const TIMEOUT = 60_000;
+
+const FIXTURE_FILES: Record<string, string> = {
+  'math-utils.ts': `export function addNumbers(a: number, b: number): number {
+  return a + b;
+}
+
+export function multiplyNumbers(a: number, b: number): number {
+  return a * b;
+}
+`,
+  'math-utils.test.ts': `import { describe, it, expect } from 'vitest';
+import { addNumbers } from './math-utils';
+
+describe('addNumbers', () => {
+  it('adds two numbers', () => {
+    expect(addNumbers(2, 3)).toBe(5);
+  });
+});
+`,
+  'greeter.py': `def greet_user(name: str) -> str:
+    """Return a friendly greeting for the given user name."""
+    return f"Hello, {name}!"
+`,
+};
+
+/** Parse the JSON text payload out of a real tools/call response. */
+function parseToolResponse(result: CallToolResult): any {
+  const [first] = result.content as Array<{ type: string; text: string }>;
+  expect(first?.type).toBe('text');
+  return JSON.parse(first.text);
+}
+
+describe('MCP protocol round trip (real server, real client, real index)', () => {
+  let fixtureDir: string;
+  let embeddings: LocalEmbeddings;
+  let vectorDB: VectorDB;
+  let client: Client;
+  let server: Server;
+
+  beforeAll(async () => {
+    fixtureDir = await createTestDir();
+    for (const [name, content] of Object.entries(FIXTURE_FILES)) {
+      await createTestFile(fixtureDir, name, content);
+    }
+
+    // In-process embedding model (no worker thread) — same class
+    // real-projects.test.ts uses, loaded once for the whole suite.
+    embeddings = new LocalEmbeddings();
+    await embeddings.initialize();
+
+    // The real indexing path — same function the CLI's `lien index` and the
+    // MCP server's auto-indexing call.
+    const indexResult = await indexCodebase({ rootDir: fixtureDir, embeddings });
+    if (!indexResult.success) {
+      throw new Error(`Fixture indexing failed: ${indexResult.error}`);
+    }
+
+    vectorDB = new VectorDB(fixtureDir);
+    await vectorDB.initialize();
+
+    const reindexStateManager = createReindexStateManager();
+    const toolContext: ToolContext = {
+      vectorDB,
+      embeddings,
+      rootDir: fixtureDir,
+      log: () => {},
+      // No live file watcher/version-file churn in this test, so reconnect
+      // is a real no-op function rather than a mock assertion target.
+      checkAndReconnect: async () => {},
+      getIndexMetadata: () => ({
+        indexVersion: vectorDB.getCurrentVersion(),
+        indexDate: vectorDB.getVersionDate(),
+      }),
+      getReindexState: () => reindexStateManager.getState(),
+    };
+
+    // Real server config + real handler registration — the exact function
+    // startMCPServer calls in production.
+    const serverConfig = createMCPServerConfig('lien', '0.0.0-test');
+    server = new Server(
+      { name: serverConfig.name, version: serverConfig.version },
+      { capabilities: serverConfig.capabilities, instructions: serverConfig.instructions },
+    );
+    registerMCPHandlers(server, toolContext, () => {});
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'lien-roundtrip-test-client', version: '0.0.0' }, {});
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  }, TIMEOUT);
+
+  afterAll(async () => {
+    await client?.close();
+    await server?.close();
+    await embeddings?.dispose();
+    if (vectorDB) {
+      await fs.rm(vectorDB.dbPath, { recursive: true, force: true }).catch(() => {});
+    }
+    if (fixtureDir) {
+      await cleanupTestDir(fixtureDir);
+    }
+  });
+
+  it('lists the real registered tools over the wire', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map(t => t.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'semantic_search',
+        'get_files_context',
+        'find_similar',
+        'list_functions',
+      ]),
+    );
+  });
+
+  it(
+    'semantic_search round-trips through the real handler to real indexed chunks',
+    async () => {
+      const response = await client.callTool({
+        name: 'semantic_search',
+        arguments: { query: 'function that adds two numbers together', limit: 10 },
+      });
+
+      expect(response.isError).not.toBe(true);
+      const payload = parseToolResponse(response as CallToolResult);
+
+      expect(Array.isArray(payload.results)).toBe(true);
+      expect(payload.results.length).toBeGreaterThan(0);
+
+      // Real chunk content from the real fixture file, produced by a real
+      // vector search against a real index — not a mocked stand-in.
+      const symbolNames = payload.results.map((r: any) => r.metadata.symbolName).filter(Boolean);
+      expect(symbolNames).toContain('addNumbers');
+
+      const mathResult = payload.results.find((r: any) => r.metadata.symbolName === 'addNumbers');
+      expect(mathResult.metadata.file).toBe('math-utils.ts');
+      expect(mathResult.content).toContain('return a + b');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'get_files_context round-trips through the real handler for a specific fixture file',
+    async () => {
+      const response = await client.callTool({
+        name: 'get_files_context',
+        arguments: { filepaths: 'math-utils.ts' },
+      });
+
+      expect(response.isError).not.toBe(true);
+      const payload = parseToolResponse(response as CallToolResult);
+
+      expect(payload.file).toBe('math-utils.ts');
+      expect(payload.chunks.length).toBeGreaterThan(0);
+      expect(payload.chunks.some((c: any) => c.content.includes('addNumbers'))).toBe(true);
+
+      // Proves the real test-association scan (a full real chunk scan, not a
+      // mocked DB) found the real fixture test file that imports this one.
+      expect(payload.testAssociations).toContain('math-utils.test.ts');
+    },
+    TIMEOUT,
+  );
+
+  it('returns a real MCP tool error for an unregistered tool name', async () => {
+    const response = await client.callTool({ name: 'not_a_real_tool', arguments: {} });
+
+    expect(response.isError).toBe(true);
+    const payload = parseToolResponse(response as CallToolResult);
+    expect(payload.message ?? payload.error).toMatch(/unknown tool/i);
+  });
+});


### PR DESCRIPTION
## What

Review finding (testing, high): `packages/cli/src/mcp/server.test.ts` mocks
the MCP SDK itself (`vi.mock '@modelcontextprotocol/sdk/server/index.js'`
and `/stdio.js`) plus `@liendev/core`, the watcher, etc. — it only asserts
setup functions were called, never that a client connects and gets a real
response. The handler unit tests (`semantic-search.test.ts`,
`get-files-context.test.ts`) mock the vector DB underneath. The flagship
"index a repo, query over MCP" flow was only ever tested as two
disconnected, fully-mocked halves.

Adds `packages/cli/test/e2e/mcp-roundtrip.test.ts`: one integration test
file that drives a **real** `@modelcontextprotocol/sdk` `Client` against a
**real** `Server` (nothing mocked — the real `registerMCPHandlers`, the real
tool handlers, a real `VectorDB`), backed by a **real** LanceDB index built
via the real `indexCodebase()` path over a tiny fixture repo (a TS module,
its test file, and a Python module). Asserts genuine `tools/call` round
trips for `semantic_search` and `get_files_context`, plus a tool-list sanity
check and an unregistered-tool error-path check.

## Approach

**Transport**: `InMemoryTransport.createLinkedPair()` (available in the
installed SDK, `@modelcontextprotocol/sdk@1.26.0`) rather than spawning a
`StdioClientTransport` subprocess — same request/response wire format and
schema validation, but hermetic and fast (no process spawn, no build
freshness dependency).

**Embeddings/speed**: The real handler wiring is what's under test, not
embedding quality, but `semantic_search`'s handler filters out results only
when *every* result is `not_relevant` (real cosine-distance thresholds), so
a mock embedding (uncorrelated with meaning) risks a flaky 0-result run.
Rather than risk that, the test uses `LocalEmbeddings` (in-process, no
worker thread — avoids the known `worker-embeddings.test.ts` cross-isolate
teardown crash) loaded once in `beforeAll`, mirroring
`test/e2e/real-projects.test.ts`'s existing pattern. The model is already
cached locally by that same e2e suite, so this is fast in practice
(~1.5s including model load), but it's still a real model load, so the file
is **gated** the same way as `real-projects.test.ts`: it lives under
`test/e2e/`, which the `test` script (`vitest run --exclude 'test/e2e/**'`)
already excludes, and gets its own `test:e2e:mcp` script + a new matrix
entry in `.github/workflows/e2e.yml` (no git clone needed, so it's cheap
compared to the other entries).

**Fixture note**: a fixture test file using a bare top-level `test(...)`
call produces zero AST chunks (confirmed via `chunkFile`) and is silently
dropped from the index — real behavior, not a bug in this PR. The fixture
uses `describe`/`it` (matching this repo's own test style) so it indexes
and its `testAssociations` reverse-lookup can be asserted for real.

## What this proves that the mocked halves didn't

- The real `Server` + real `registerMCPHandlers` actually complete the MCP
  handshake and dispatch `tools/list` / `tools/call` to a real client.
- `semantic_search` and `get_files_context` handlers work end-to-end
  against **real** LanceDB result shapes (columns, relevance scoring,
  metadata shaping) — a schema/handler mismatch, wrong column projection, or
  a handler throwing on a real (non-mocked) DB shape would fail this test
  and didn't have any test that could catch it before.
- Unknown-tool dispatch returns a real serialized `LienError` over the real
  transport.

## Verification

```
npm run format:check && npm run lint && npm run typecheck && npm run build   # all green
npm run test -w @liendev/lien                                                # 40 files / 683 tests passing (unchanged; new file excluded, as intended)
npm run test:e2e:mcp -w @liendev/lien                                        # new file: 4/4 passing, ~0.9-1.7s incl. model load
```

Ran the new file standalone 5+ times (including back-to-back loops) to check
for flakiness from the real-embedding relevance scoring — consistently
green.

## Caveats / out of scope

- Not a lockfile change; test-only addition to an already-published package
  (`@liendev/lien`) — no changeset (verified `test/` isn't part of the
  published `files` allowlist and no shipped `src/` was touched).
- Pre-existing, unrelated hygiene gap noticed while building this: some
  existing tests that construct a `VectorDB` from `createTestDir()`
  (`test/integration/indexing-flow.test.ts`, `test/benchmarks/performance.test.ts`)
  only clean up the source temp dir, not the derived `~/.lien/indices/<hash>`
  directory `VectorDB` actually writes to. This test's own `afterAll`
  removes both. Not fixed here — out of scope for this task, flagging for a
  separate pass.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a single gated E2E integration test that exercises the real MCP SDK, real server/client handlers, real VectorDB, and real LanceDB index over an in-memory transport. It touches no shipped source code and changes no public exports. The new test code is straightforward: it builds a fixture, indexes it, registers real handlers, runs round-trip tool calls, and cleans up. No production callers are affected, and the test-only helper that parses JSON responses is used only against the test-controlled server with immediate assertions on the payload shape.
>
> - Added packages/cli/test/e2e/mcp-roundtrip.test.ts with real MCP client/server round-trips for semantic_search and get_files_context
> - Added test:e2e:mcp script and CI matrix entry; file lives under test/e2e so it is excluded from the default fast suite
> - No shipped src/ changes or barrel/export modifications

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5acdbb1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end MCP round-trip test to validate tool calls against a real client/server setup.
  * Expanded the E2E workflow to run an additional MCP test in parallel when enabled.
  * Added a CLI script to run the new MCP E2E test directly.

* **Documentation**
  * Updated E2E testing docs with clearer guidance on when real integration tests run and what the MCP round-trip test covers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->