### PR TITLE
feat(core,cli): add optional structural-only mode (embeddings.enabled)

### DIFF
--- a/.changeset/structural-only-mode.md
+++ b/.changeset/structural-only-mode.md
@@ -1,0 +1,14 @@
+---
+'@liendev/core': minor
+'@liendev/lien': minor
+---
+
+Add an optional structural-only mode: embeddings can now be disabled so the local index and MCP server run on pure AST/structural analysis, with no embedding computation, no model download, and no embedding worker thread.
+
+- New project config: `embeddings.enabled` in `.lien.config.json` (default: `true` — no behavior change for existing users). Toggle it with `lien config set embeddings.enabled false` / `true`.
+- New CLI flag: `lien index --no-embeddings` forces structural-only mode for a single run.
+- `lien serve` reads the same config: when disabled, it never constructs a `WorkerEmbeddings` instance or spawns the embedding worker.
+- Structural chunks are still persisted to the vector store (via a new `NullEmbeddings` service that writes zero-vector placeholders), so `get_files_context`, `get_dependents`, `list_functions`, and `get_complexity` keep working unchanged — they read structural columns via `scanAll`/`scanWithFilter`, never vectors.
+- `semantic_search` and `find_similar` return a clear `note` ("disabled — structural-only mode") instead of crashing or silently returning misleading empty results.
+- `lien status` reports the current embeddings mode (text and JSON output).
+- Toggling `embeddings.enabled` requires `lien index --force` to take effect on already-indexed files — incremental indexing only reprocesses changed files, so unchanged chunks keep their old vectors (real or placeholder) until a full reindex.

--- a/packages/cli/src/cli/config.test.ts
+++ b/packages/cli/src/cli/config.test.ts
@@ -166,5 +166,17 @@ describe('config command', () => {
       expect(allOutput).toContain('embeddings.enabled');
       expect(allOutput).toContain('Project Configuration');
     });
+
+    it('should print a friendly error instead of rejecting when the global config fails to load', async () => {
+      mockLoadGlobalConfig.mockRejectedValue(new Error('Invalid JSON syntax'));
+
+      await expect(configListCommand()).resolves.toBeUndefined();
+
+      const allOutput = vi.mocked(console.log).mock.calls.flat().join(' ');
+      expect(allOutput).toContain('Failed to load global config');
+      expect(allOutput).toContain('Invalid JSON syntax');
+      // Project config section must still render even though global failed.
+      expect(allOutput).toContain('Project Configuration');
+    });
   });
 });

--- a/packages/cli/src/cli/config.test.ts
+++ b/packages/cli/src/cli/config.test.ts
@@ -5,12 +5,28 @@ import { configSetCommand, configGetCommand, configListCommand } from './config.
 vi.mock('@liendev/core', () => ({
   loadGlobalConfig: vi.fn(),
   mergeGlobalConfig: vi.fn(),
+  configService: {
+    load: vi.fn(),
+    save: vi.fn(),
+  },
 }));
 
-import { loadGlobalConfig, mergeGlobalConfig } from '@liendev/core';
+import { loadGlobalConfig, mergeGlobalConfig, configService } from '@liendev/core';
+import type { LienConfig } from '@liendev/core';
 
 const mockLoadGlobalConfig = vi.mocked(loadGlobalConfig);
 const mockMergeGlobalConfig = vi.mocked(mergeGlobalConfig);
+const mockConfigServiceLoad = vi.mocked(configService.load);
+const mockConfigServiceSave = vi.mocked(configService.save);
+
+const baseProjectConfig: LienConfig = {
+  core: { chunkSize: 200, chunkOverlap: 20, concurrency: 4, embeddingBatchSize: 32 },
+  chunking: { useAST: true, astFallback: 'line-based' },
+  mcp: { port: 7133, transport: 'stdio', autoIndexOnFirstRun: true },
+  gitDetection: { enabled: true, pollIntervalMs: 2000 },
+  fileWatching: { enabled: true, debounceMs: 300 },
+  embeddings: { enabled: true },
+};
 
 describe('config command', () => {
   beforeEach(() => {
@@ -22,13 +38,15 @@ describe('config command', () => {
     });
     mockLoadGlobalConfig.mockResolvedValue({ backend: 'lancedb' });
     mockMergeGlobalConfig.mockResolvedValue({ backend: 'lancedb' });
+    mockConfigServiceLoad.mockResolvedValue({ ...baseProjectConfig });
+    mockConfigServiceSave.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  describe('configSetCommand', () => {
+  describe('configSetCommand (global keys)', () => {
     it('should set a valid backend value', async () => {
       await configSetCommand('backend', 'lancedb');
       expect(mockMergeGlobalConfig).toHaveBeenCalledWith({ backend: 'lancedb' });
@@ -49,7 +67,55 @@ describe('config command', () => {
     });
   });
 
-  describe('configGetCommand', () => {
+  describe('configSetCommand (project keys)', () => {
+    it('should set embeddings.enabled to false via ConfigService', async () => {
+      await configSetCommand('embeddings.enabled', 'false');
+
+      expect(mockConfigServiceLoad).toHaveBeenCalledWith(process.cwd());
+      expect(mockConfigServiceSave).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.objectContaining({ embeddings: { enabled: false } }),
+      );
+      // Global config must not be touched for a project-scoped key.
+      expect(mockMergeGlobalConfig).not.toHaveBeenCalled();
+    });
+
+    it('should set embeddings.enabled to true via ConfigService', async () => {
+      mockConfigServiceLoad.mockResolvedValue({
+        ...baseProjectConfig,
+        embeddings: { enabled: false },
+      });
+
+      await configSetCommand('embeddings.enabled', 'true');
+
+      expect(mockConfigServiceSave).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.objectContaining({ embeddings: { enabled: true } }),
+      );
+    });
+
+    it('should preserve the rest of the loaded project config when setting embeddings.enabled', async () => {
+      await configSetCommand('embeddings.enabled', 'false');
+
+      expect(mockConfigServiceSave).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.objectContaining({ core: baseProjectConfig.core, mcp: baseProjectConfig.mcp }),
+      );
+    });
+
+    it('should reject invalid values for embeddings.enabled', async () => {
+      await expect(configSetCommand('embeddings.enabled', 'maybe')).rejects.toThrow('process.exit');
+      expect(mockConfigServiceSave).not.toHaveBeenCalled();
+    });
+
+    it('should exit with an error when the project config fails to load', async () => {
+      mockConfigServiceLoad.mockRejectedValue(new Error('Invalid JSON syntax'));
+
+      await expect(configSetCommand('embeddings.enabled', 'true')).rejects.toThrow('process.exit');
+    });
+  });
+
+  describe('configGetCommand (global keys)', () => {
     it('should display a set value', async () => {
       mockLoadGlobalConfig.mockResolvedValue({ backend: 'lancedb' });
       await configGetCommand('backend');
@@ -67,14 +133,38 @@ describe('config command', () => {
     });
   });
 
+  describe('configGetCommand (project keys)', () => {
+    it('should read embeddings.enabled from ConfigService', async () => {
+      mockConfigServiceLoad.mockResolvedValue({
+        ...baseProjectConfig,
+        embeddings: { enabled: false },
+      });
+
+      await configGetCommand('embeddings.enabled');
+
+      expect(mockConfigServiceLoad).toHaveBeenCalledWith(process.cwd());
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('false'));
+      // Global config must not be consulted for a project-scoped key.
+      expect(mockLoadGlobalConfig).not.toHaveBeenCalled();
+    });
+  });
+
   describe('configListCommand', () => {
-    it('should list all config keys', async () => {
+    it('should list all global config keys', async () => {
       mockLoadGlobalConfig.mockResolvedValue({
         backend: 'lancedb',
       });
 
       await configListCommand();
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('backend'));
+    });
+
+    it('should also list project config keys', async () => {
+      await configListCommand();
+
+      const allOutput = vi.mocked(console.log).mock.calls.flat().join(' ');
+      expect(allOutput).toContain('embeddings.enabled');
+      expect(allOutput).toContain('Project Configuration');
     });
   });
 });

--- a/packages/cli/src/cli/config.ts
+++ b/packages/cli/src/cli/config.ts
@@ -133,16 +133,23 @@ export async function configGetCommand(key: string) {
 }
 
 export async function configListCommand() {
-  const globalConfig = await loadGlobalConfig();
-
   console.log(chalk.bold('Global Configuration'));
   console.log(chalk.dim(`File: ${GLOBAL_CONFIG_PATH}\n`));
 
-  for (const [key, meta] of Object.entries(ALLOWED_KEYS)) {
-    if (meta.scope !== 'global') continue;
-    const value = getNestedValue(globalConfig, key);
-    const display = value ?? chalk.dim('(not set)');
-    console.log(`  ${chalk.cyan(key)}: ${display}  ${chalk.dim(`— ${meta.description}`)}`);
+  try {
+    const globalConfig = await loadGlobalConfig();
+    for (const [key, meta] of Object.entries(ALLOWED_KEYS)) {
+      if (meta.scope !== 'global') continue;
+      const value = getNestedValue(globalConfig, key);
+      const display = value ?? chalk.dim('(not set)');
+      console.log(`  ${chalk.cyan(key)}: ${display}  ${chalk.dim(`— ${meta.description}`)}`);
+    }
+  } catch (error) {
+    console.log(
+      chalk.red(
+        `  Failed to load global config: ${error instanceof Error ? error.message : error}`,
+      ),
+    );
   }
 
   try {

--- a/packages/cli/src/cli/config.ts
+++ b/packages/cli/src/cli/config.ts
@@ -1,20 +1,41 @@
 import chalk from 'chalk';
 import path from 'path';
 import os from 'os';
-import { loadGlobalConfig, mergeGlobalConfig, type GlobalConfig } from '@liendev/core';
+import {
+  loadGlobalConfig,
+  mergeGlobalConfig,
+  configService,
+  type GlobalConfig,
+  type LienConfig,
+} from '@liendev/core';
 
-const CONFIG_PATH = path.join(os.homedir(), '.lien', 'config.json');
+const GLOBAL_CONFIG_PATH = path.join(os.homedir(), '.lien', 'config.json');
+const PROJECT_CONFIG_FILENAME = '.lien.config.json';
 
-/** Allowed config keys and their valid values */
-const ALLOWED_KEYS: Record<string, { values: readonly string[]; description: string }> = {
+/**
+ * Allowed config keys, split by scope:
+ * - "global": machine-wide, stored in ~/.lien/config.json
+ * - "project": per-repo, stored in <cwd>/.lien.config.json (via ConfigService)
+ */
+const ALLOWED_KEYS: Record<
+  string,
+  { scope: 'global' | 'project'; values: readonly string[]; description: string }
+> = {
   backend: {
+    scope: 'global',
     values: ['lancedb'],
     description: 'Vector database backend',
   },
+  'embeddings.enabled': {
+    scope: 'project',
+    values: ['true', 'false'],
+    description:
+      'Compute embeddings for semantic search (false = structural-only mode; run `lien index --force` after changing this)',
+  },
 };
 
-/** Get a nested value from config using dot-notation key */
-function getConfigValue(config: GlobalConfig, key: string): string | undefined {
+/** Get a nested value from an object using a dot-notation key */
+function getNestedValue(config: object, key: string): string | undefined {
   const parts = key.split('.');
   let current: unknown = config;
   for (const part of parts) {
@@ -25,13 +46,29 @@ function getConfigValue(config: GlobalConfig, key: string): string | undefined {
 }
 
 /** Convert a dot-notation key + value into a partial GlobalConfig */
-function buildPartialConfig(key: string, value: string): Partial<GlobalConfig> {
+function buildPartialGlobalConfig(key: string, value: string): Partial<GlobalConfig> {
   switch (key) {
     case 'backend':
       return { backend: value as GlobalConfig['backend'] };
     default:
       return {};
   }
+}
+
+/** Apply a dot-notation project config key onto a full LienConfig */
+function applyProjectConfigValue(config: LienConfig, key: string, value: string): LienConfig {
+  switch (key) {
+    case 'embeddings.enabled':
+      return { ...config, embeddings: { ...config.embeddings, enabled: value === 'true' } };
+    default:
+      return config;
+  }
+}
+
+/** Print a config-related error and exit non-zero. */
+function failWithConfigError(action: string, error: unknown): never {
+  console.error(chalk.red(`Failed to ${action}:`), error instanceof Error ? error.message : error);
+  process.exit(1);
 }
 
 export async function configSetCommand(key: string, value: string) {
@@ -48,22 +85,45 @@ export async function configSetCommand(key: string, value: string) {
     process.exit(1);
   }
 
-  const partial = buildPartialConfig(key, value);
+  if (allowed.scope === 'project') {
+    const rootDir = process.cwd();
+    try {
+      const current = await configService.load(rootDir);
+      const updated = applyProjectConfigValue(current, key, value);
+      await configService.save(rootDir, updated);
+    } catch (error) {
+      failWithConfigError(`set ${key}`, error);
+    }
+
+    console.log(chalk.green(`Set ${key} = ${value}`));
+    console.log(chalk.dim(`Config: ${path.join(rootDir, PROJECT_CONFIG_FILENAME)}`));
+    return;
+  }
+
+  const partial = buildPartialGlobalConfig(key, value);
   await mergeGlobalConfig(partial);
 
   console.log(chalk.green(`Set ${key} = ${value}`));
-  console.log(chalk.dim(`Config: ${CONFIG_PATH}`));
+  console.log(chalk.dim(`Config: ${GLOBAL_CONFIG_PATH}`));
 }
 
 export async function configGetCommand(key: string) {
-  if (!ALLOWED_KEYS[key]) {
+  const allowed = ALLOWED_KEYS[key];
+  if (!allowed) {
     console.error(chalk.red(`Unknown config key: "${key}"`));
     console.log(chalk.dim('Valid keys:'), Object.keys(ALLOWED_KEYS).join(', '));
     process.exit(1);
   }
 
-  const config = await loadGlobalConfig();
-  const value = getConfigValue(config, key);
+  let value: string | undefined;
+  try {
+    value =
+      allowed.scope === 'project'
+        ? getNestedValue(await configService.load(process.cwd()), key)
+        : getNestedValue(await loadGlobalConfig(), key);
+  } catch (error) {
+    failWithConfigError(`get ${key}`, error);
+  }
 
   if (value === undefined) {
     console.log(chalk.dim(`${key}: (not set)`));
@@ -73,14 +133,36 @@ export async function configGetCommand(key: string) {
 }
 
 export async function configListCommand() {
-  const config = await loadGlobalConfig();
+  const globalConfig = await loadGlobalConfig();
 
   console.log(chalk.bold('Global Configuration'));
-  console.log(chalk.dim(`File: ${CONFIG_PATH}\n`));
+  console.log(chalk.dim(`File: ${GLOBAL_CONFIG_PATH}\n`));
 
   for (const [key, meta] of Object.entries(ALLOWED_KEYS)) {
-    const value = getConfigValue(config, key);
+    if (meta.scope !== 'global') continue;
+    const value = getNestedValue(globalConfig, key);
     const display = value ?? chalk.dim('(not set)');
     console.log(`  ${chalk.cyan(key)}: ${display}  ${chalk.dim(`— ${meta.description}`)}`);
+  }
+
+  try {
+    const projectConfig = await configService.load(process.cwd());
+
+    console.log(chalk.bold('\nProject Configuration'));
+    console.log(chalk.dim(`File: ${path.join(process.cwd(), PROJECT_CONFIG_FILENAME)}\n`));
+
+    for (const [key, meta] of Object.entries(ALLOWED_KEYS)) {
+      if (meta.scope !== 'project') continue;
+      const value = getNestedValue(projectConfig, key);
+      const display = value ?? chalk.dim('(not set)');
+      console.log(`  ${chalk.cyan(key)}: ${display}  ${chalk.dim(`— ${meta.description}`)}`);
+    }
+  } catch (error) {
+    console.log(chalk.bold('\nProject Configuration'));
+    console.log(
+      chalk.red(
+        `  Failed to load ${PROJECT_CONFIG_FILENAME}: ${error instanceof Error ? error.message : error}`,
+      ),
+    );
   }
 }

--- a/packages/cli/src/cli/index-cmd.test.ts
+++ b/packages/cli/src/cli/index-cmd.test.ts
@@ -159,4 +159,31 @@ describe('indexCommand', () => {
       }),
     );
   });
+
+  describe('--no-embeddings', () => {
+    it('should pass skipEmbeddings: true when --no-embeddings is set', async () => {
+      // Commander's negatable flag sets `embeddings: false` when --no-embeddings is passed.
+      await indexCommand({ embeddings: false });
+
+      expect(mockIndexCodebase).toHaveBeenCalledWith(
+        expect.objectContaining({ skipEmbeddings: true }),
+      );
+    });
+
+    it('should leave skipEmbeddings undefined when the flag is not passed', async () => {
+      // Commander defaults negatable flags to true when omitted; indexCodebase
+      // must fall back to the project config rather than force embeddings on.
+      await indexCommand({ embeddings: true });
+
+      const call = mockIndexCodebase.mock.calls[0][0];
+      expect(call.skipEmbeddings).toBeUndefined();
+    });
+
+    it('should leave skipEmbeddings undefined when embeddings option is absent entirely', async () => {
+      await indexCommand({});
+
+      const call = mockIndexCodebase.mock.calls[0][0];
+      expect(call.skipEmbeddings).toBeUndefined();
+    });
+  });
 });

--- a/packages/cli/src/cli/index-cmd.ts
+++ b/packages/cli/src/cli/index-cmd.ts
@@ -178,7 +178,11 @@ function displayFinalResult(
   }
 }
 
-export async function indexCommand(options: { verbose?: boolean; force?: boolean }) {
+export async function indexCommand(options: {
+  verbose?: boolean;
+  force?: boolean;
+  embeddings?: boolean;
+}) {
   showCompactBanner();
 
   try {
@@ -196,11 +200,18 @@ export async function indexCommand(options: { verbose?: boolean; force?: boolean
     const tracker = createProgressTracker();
     startMessageRotation(spinner, tracker);
 
+    // Commander's --no-embeddings negatable flag defaults `embeddings` to
+    // true when omitted, so only force skipEmbeddings when the flag was
+    // explicitly passed. Leave it undefined otherwise so indexCodebase()
+    // falls back to the project config's embeddings.enabled setting.
+    const skipEmbeddings = options.embeddings === false ? true : undefined;
+
     // Run indexing with progress callback
     const result = await indexCodebase({
       rootDir: process.cwd(),
       verbose: options.verbose || false,
       force: options.force || false,
+      skipEmbeddings,
       onProgress: createProgressCallback(spinner, tracker),
     });
 

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -55,6 +55,10 @@ program
   .description('Index the codebase for semantic search')
   .option('-f, --force', 'Force full reindex (skip incremental)')
   .option('-v, --verbose', 'Show detailed logging during indexing')
+  .option(
+    '--no-embeddings',
+    'Skip embedding computation (structural-only mode: no model download, no embedding worker)',
+  )
   .action(indexCommand);
 
 program
@@ -87,11 +91,11 @@ program
 
 const configCmd = program
   .command('config')
-  .description('Manage global configuration (~/.lien/config.json)');
+  .description('Manage configuration (global: ~/.lien/config.json, project: ./.lien.config.json)');
 
 configCmd
   .command('set <key> <value>')
-  .description('Set a global config value')
+  .description('Set a config value (global or project, depending on the key)')
   .action(configSetCommand);
 
 configCmd.command('get <key>').description('Get a config value').action(configGetCommand);

--- a/packages/cli/src/cli/init.test.ts
+++ b/packages/cli/src/cli/init.test.ts
@@ -298,18 +298,20 @@ describe('initCommand', () => {
     expect(configFiles).toHaveLength(0);
   });
 
-  // --- Legacy config warning ---
+  // --- Project config note ---
 
-  it('should warn about legacy .lien.config.json', async () => {
-    const legacyPath = path.join(testDir, '.lien.config.json');
-    await fs.writeFile(legacyPath, JSON.stringify({ version: '0.2.0' }));
+  it('should note that .lien.config.json is found and only embeddings.enabled is used', async () => {
+    const projectConfigPath = path.join(testDir, '.lien.config.json');
+    await fs.writeFile(projectConfigPath, JSON.stringify({ version: '0.2.0' }));
 
     const logSpy = vi.spyOn(console, 'log');
 
     await initCommand({ editor: 'cursor' });
 
     expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('.lien.config.json found but no longer used'),
+      expect.stringContaining(
+        '.lien.config.json found — only its "embeddings.enabled" setting is used',
+      ),
     );
   });
 

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -203,12 +203,15 @@ export async function initCommand(options: InitOptions = {}) {
     console.log(JSON.stringify(snippet, null, 2));
   }
 
-  // Check if old config exists and warn
-  const legacyConfigPath = path.join(rootDir, '.lien.config.json');
+  // Check if a project config exists and note what it's used for.
+  // Most settings in it are legacy/unused — only `embeddings.enabled` is
+  // currently read (see `lien config set embeddings.enabled false`).
+  const projectConfigPath = path.join(rootDir, '.lien.config.json');
   try {
-    await fs.access(legacyConfigPath);
-    console.log(chalk.yellow('⚠️  Note: .lien.config.json found but no longer used'));
-    console.log(chalk.dim('  You can safely delete it.'));
+    await fs.access(projectConfigPath);
+    console.log(
+      chalk.dim('  Note: .lien.config.json found — only its "embeddings.enabled" setting is used.'),
+    );
   } catch {
     // Config doesn't exist - that's fine
   }

--- a/packages/cli/src/cli/status.test.ts
+++ b/packages/cli/src/cli/status.test.ts
@@ -182,6 +182,28 @@ describe('statusCommand', () => {
     expect(allOutput).toContain('lien index --force');
   });
 
+  it('should report "Using defaults" in the Configuration banner when embeddings are enabled', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await statusCommand();
+
+    const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+    expect(allOutput).toContain('Configuration:');
+    expect(allOutput).toContain('Using defaults');
+  });
+
+  it('should NOT claim "Using defaults" in the Configuration banner when embeddings are disabled', async () => {
+    vi.mocked(resolveEmbeddingsEnabled).mockResolvedValue(false);
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await statusCommand();
+
+    const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+    expect(allOutput).toContain('Configuration:');
+    expect(allOutput).not.toContain('Using defaults');
+    expect(allOutput).toContain('Customized (embeddings disabled)');
+  });
+
   it('should include embeddings.enabled in JSON output', async () => {
     vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
 

--- a/packages/cli/src/cli/status.test.ts
+++ b/packages/cli/src/cli/status.test.ts
@@ -9,6 +9,7 @@ vi.mock('@liendev/core', async () => {
     getCurrentBranch: vi.fn().mockResolvedValue('main'),
     getCurrentCommit: vi.fn().mockResolvedValue('abc12345def67890'),
     readVersionFile: vi.fn().mockResolvedValue(0),
+    resolveEmbeddingsEnabled: vi.fn().mockResolvedValue(true),
   };
 });
 
@@ -35,7 +36,13 @@ vi.mock('fs/promises', () => ({
 }));
 
 import { statusCommand } from './status.js';
-import { isGitRepo, getCurrentBranch, getCurrentCommit, readVersionFile } from '@liendev/core';
+import {
+  isGitRepo,
+  getCurrentBranch,
+  getCurrentCommit,
+  readVersionFile,
+  resolveEmbeddingsEnabled,
+} from '@liendev/core';
 import fs from 'fs/promises';
 
 describe('statusCommand', () => {
@@ -47,6 +54,7 @@ describe('statusCommand', () => {
     vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
     vi.mocked(fs.readdir).mockResolvedValue([]);
     vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(resolveEmbeddingsEnabled).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -148,6 +156,67 @@ describe('statusCommand', () => {
     expect(data.features).toEqual({ fileWatching: true, gitDetection: true });
     expect(data.settings).toBeDefined();
     expect(data.settings.concurrency).toBeDefined();
+  });
+
+  it('should show embeddings as enabled by default', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await statusCommand();
+
+    const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+    expect(allOutput).toContain('Embeddings:');
+    expect(allOutput).toContain('Enabled');
+    expect(allOutput).not.toContain('structural-only mode');
+  });
+
+  it('should show embeddings as disabled (structural-only) when config disables them', async () => {
+    vi.mocked(resolveEmbeddingsEnabled).mockResolvedValue(false);
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await statusCommand();
+
+    const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+    expect(allOutput).toContain('Embeddings:');
+    expect(allOutput).toContain('Disabled (structural-only mode)');
+    expect(allOutput).toContain('lien config set embeddings.enabled true');
+    expect(allOutput).toContain('lien index --force');
+  });
+
+  it('should include embeddings.enabled in JSON output', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await statusCommand({ format: 'json' });
+
+    const calls = consoleLogSpy.mock.calls as string[][];
+    const jsonCall = calls.find(call => {
+      try {
+        JSON.parse(call[0]);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    const data = JSON.parse(jsonCall![0]);
+    expect(data.embeddings).toEqual({ enabled: true });
+  });
+
+  it('should reflect disabled embeddings in JSON output', async () => {
+    vi.mocked(resolveEmbeddingsEnabled).mockResolvedValue(false);
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    await statusCommand({ format: 'json' });
+
+    const calls = consoleLogSpy.mock.calls as string[][];
+    const jsonCall = calls.find(call => {
+      try {
+        JSON.parse(call[0]);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    const data = JSON.parse(jsonCall![0]);
+    expect(data.embeddings).toEqual({ enabled: false });
   });
 
   it('should show file count in index', async () => {

--- a/packages/cli/src/cli/status.ts
+++ b/packages/cli/src/cli/status.ts
@@ -10,6 +10,7 @@ import {
   getCurrentBranch,
   getCurrentCommit,
   readVersionFile,
+  resolveEmbeddingsEnabled,
   DEFAULT_CONCURRENCY,
   DEFAULT_EMBEDDING_BATCH_SIZE,
   DEFAULT_GIT_POLL_INTERVAL_MS,
@@ -137,6 +138,27 @@ function printWatchStatus() {
   console.log(chalk.dim('  Disable with:'), chalk.bold('lien serve --no-watch'));
 }
 
+async function printEmbeddingsStatus(rootDir: string) {
+  const enabled = await resolveEmbeddingsEnabled(rootDir);
+  if (enabled) {
+    console.log(chalk.dim('Embeddings:'), chalk.green('✓ Enabled'));
+    console.log(
+      chalk.dim('  Disable with:'),
+      chalk.bold('lien config set embeddings.enabled false'),
+    );
+  } else {
+    console.log(chalk.dim('Embeddings:'), chalk.yellow('✗ Disabled (structural-only mode)'));
+    console.log(
+      chalk.dim('  semantic_search / find_similar are unavailable; structural tools still work.'),
+    );
+    console.log(
+      chalk.dim('  Re-enable with:'),
+      chalk.bold('lien config set embeddings.enabled true'),
+    );
+    console.log(chalk.dim('  Then reindex with:'), chalk.bold('lien index --force'));
+  }
+}
+
 function printIndexingSettings() {
   console.log(chalk.bold('\nIndexing Settings (defaults):'));
   console.log(chalk.dim('Concurrency:'), DEFAULT_CONCURRENCY);
@@ -167,16 +189,14 @@ export async function statusCommand(options: { verbose?: boolean; format?: strin
 
   showCompactBanner();
   console.log(chalk.bold('Status\n'));
-  console.log(
-    chalk.dim('Configuration:'),
-    chalk.green('✓ Using defaults (no per-project config needed)'),
-  );
+  console.log(chalk.dim('Configuration:'), chalk.green('✓ Using defaults'));
 
   await printIndexStatus(indexPath);
 
   console.log(chalk.bold('\nFeatures:'));
   await printGitStatus(rootDir, indexPath);
   printWatchStatus();
+  await printEmbeddingsStatus(rootDir);
 
   if (options.verbose) {
     printIndexingSettings();
@@ -195,6 +215,7 @@ async function outputJson(rootDir: string, indexPath: string) {
     lastReindex: null as string | null,
     git: { enabled: false, branch: null, commit: null },
     features: { fileWatching: true, gitDetection: true },
+    embeddings: { enabled: await resolveEmbeddingsEnabled(rootDir) },
     settings: {
       concurrency: DEFAULT_CONCURRENCY,
       batchSize: DEFAULT_EMBEDDING_BATCH_SIZE,

--- a/packages/cli/src/cli/status.ts
+++ b/packages/cli/src/cli/status.ts
@@ -138,8 +138,7 @@ function printWatchStatus() {
   console.log(chalk.dim('  Disable with:'), chalk.bold('lien serve --no-watch'));
 }
 
-async function printEmbeddingsStatus(rootDir: string) {
-  const enabled = await resolveEmbeddingsEnabled(rootDir);
+function printEmbeddingsStatus(enabled: boolean) {
   if (enabled) {
     console.log(chalk.dim('Embeddings:'), chalk.green('✓ Enabled'));
     console.log(
@@ -187,16 +186,23 @@ export async function statusCommand(options: { verbose?: boolean; format?: strin
     return;
   }
 
+  const embeddingsEnabled = await resolveEmbeddingsEnabled(rootDir);
+
   showCompactBanner();
   console.log(chalk.bold('Status\n'));
-  console.log(chalk.dim('Configuration:'), chalk.green('✓ Using defaults'));
+  console.log(
+    chalk.dim('Configuration:'),
+    embeddingsEnabled
+      ? chalk.green('✓ Using defaults')
+      : chalk.yellow('✗ Customized (embeddings disabled)'),
+  );
 
   await printIndexStatus(indexPath);
 
   console.log(chalk.bold('\nFeatures:'));
   await printGitStatus(rootDir, indexPath);
   printWatchStatus();
-  await printEmbeddingsStatus(rootDir);
+  printEmbeddingsStatus(embeddingsEnabled);
 
   if (options.verbose) {
     printIndexingSettings();

--- a/packages/cli/src/mcp/handlers/find-similar.test.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.test.ts
@@ -462,6 +462,47 @@ describe('handleFindSimilar', () => {
     });
   });
 
+  describe('embeddings disabled (structural-only mode)', () => {
+    it('returns a clear disabled note instead of searching', async () => {
+      const disabledCtx: ToolContext = { ...mockCtx, embeddingsEnabled: false };
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        disabledCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toEqual([]);
+      expect(parsed.note).toContain('disabled');
+      expect(parsed.note).toContain('structural-only mode');
+      expect(parsed.note).toContain('lien config set embeddings.enabled true');
+      expect(parsed.indexInfo).toBeDefined();
+    });
+
+    it('does not call embed() or vectorDB.search() when disabled', async () => {
+      const disabledCtx: ToolContext = { ...mockCtx, embeddingsEnabled: false };
+
+      await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        disabledCtx,
+      );
+
+      expect(mockEmbeddings.embed).not.toHaveBeenCalled();
+      expect(mockVectorDB.search).not.toHaveBeenCalled();
+    });
+
+    it('is not an error result', async () => {
+      const disabledCtx: ToolContext = { ...mockCtx, embeddingsEnabled: false };
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }' },
+        disabledCtx,
+      );
+
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
   describe('filtersApplied metadata', () => {
     it('should not include filtersApplied when no filtering occurred', async () => {
       const mockResults = [createMockResult({ relevance: 'highly_relevant' })];

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -39,6 +39,11 @@ function pruneIrrelevantResults(results: SearchResult[]): {
   return { filtered, prunedCount: beforePrune - filtered.length };
 }
 
+/** Message returned by semantic_search/find_similar when embeddings are disabled. */
+const EMBEDDINGS_DISABLED_NOTE =
+  'find_similar relies on embeddings, which are disabled (structural-only mode). Re-enable with ' +
+  '`lien config set embeddings.enabled true` and run `lien index --force` to compute embeddings.';
+
 /**
  * Handle find_similar tool calls.
  * Finds code structurally similar to a given snippet.
@@ -47,6 +52,14 @@ export async function handleFindSimilar(args: unknown, ctx: ToolContext): Promis
   const { vectorDB, embeddings, log, checkAndReconnect, getIndexMetadata } = ctx;
 
   return await wrapToolHandler(FindSimilarSchema, async validatedArgs => {
+    if (ctx.embeddingsEnabled === false) {
+      return {
+        indexInfo: getIndexMetadata(),
+        results: [],
+        note: EMBEDDINGS_DISABLED_NOTE,
+      };
+    }
+
     log(`Finding similar code...`);
     await checkAndReconnect();
 

--- a/packages/cli/src/mcp/handlers/semantic-search.test.ts
+++ b/packages/cli/src/mcp/handlers/semantic-search.test.ts
@@ -422,6 +422,38 @@ describe('handleSemanticSearch', () => {
     });
   });
 
+  describe('embeddings disabled (structural-only mode)', () => {
+    it('returns a clear disabled note instead of searching', async () => {
+      const disabledCtx: ToolContext = { ...mockCtx, embeddingsEnabled: false };
+
+      const result = await handleSemanticSearch({ query: 'handles authentication' }, disabledCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toEqual([]);
+      expect(parsed.note).toContain('disabled');
+      expect(parsed.note).toContain('structural-only mode');
+      expect(parsed.note).toContain('lien config set embeddings.enabled true');
+      expect(parsed.indexInfo).toBeDefined();
+    });
+
+    it('does not call embed() or vectorDB.search() when disabled', async () => {
+      const disabledCtx: ToolContext = { ...mockCtx, embeddingsEnabled: false };
+
+      await handleSemanticSearch({ query: 'handles authentication' }, disabledCtx);
+
+      expect(mockEmbeddings.embed).not.toHaveBeenCalled();
+      expect(mockVectorDB.search).not.toHaveBeenCalled();
+    });
+
+    it('is not an error result', async () => {
+      const disabledCtx: ToolContext = { ...mockCtx, embeddingsEnabled: false };
+
+      const result = await handleSemanticSearch({ query: 'handles authentication' }, disabledCtx);
+
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
   describe('logging', () => {
     it('should log search query', async () => {
       mockVectorDB.search.mockResolvedValue([]);

--- a/packages/cli/src/mcp/handlers/semantic-search.ts
+++ b/packages/cli/src/mcp/handlers/semantic-search.ts
@@ -90,6 +90,11 @@ function processResults(
   return { results, notes };
 }
 
+/** Message returned by semantic_search/find_similar when embeddings are disabled. */
+const EMBEDDINGS_DISABLED_NOTE =
+  'Semantic search is disabled (structural-only mode). Re-enable with ' +
+  '`lien config set embeddings.enabled true` and run `lien index --force` to compute embeddings.';
+
 /**
  * Handle semantic_search tool calls.
  * Searches the codebase by meaning using embeddings.
@@ -102,6 +107,14 @@ export async function handleSemanticSearch(
   const { vectorDB, embeddings, log, checkAndReconnect, getIndexMetadata } = ctx;
 
   return await wrapToolHandler(SemanticSearchSchema, async validatedArgs => {
+    if (ctx.embeddingsEnabled === false) {
+      return {
+        indexInfo: getIndexMetadata(),
+        results: [],
+        note: EMBEDDINGS_DISABLED_NOTE,
+      };
+    }
+
     const { crossRepo, repoIds, query, limit } = validatedArgs;
 
     log(`Searching for: "${query}"${crossRepo ? ' (cross-repo)' : ''}`);

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -7,10 +7,12 @@ const {
   mockTransportInstance,
   mockVectorDB,
   mockEmbeddings,
+  mockNullEmbeddingsInstance,
   mockSetupGitDetection,
   mockSetupCleanupHandlers,
   mockIsGitRepo,
   mockIndexCodebase,
+  mockResolveEmbeddingsEnabled,
 } = vi.hoisted(() => ({
   mockServerInstance: {
     connect: vi.fn().mockResolvedValue(undefined),
@@ -34,10 +36,14 @@ const {
   mockEmbeddings: {
     initialize: vi.fn().mockResolvedValue(undefined),
   },
+  mockNullEmbeddingsInstance: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+  },
   mockSetupGitDetection: vi.fn().mockResolvedValue({ gitPollInterval: null }),
   mockSetupCleanupHandlers: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(undefined)),
   mockIsGitRepo: vi.fn(async (_dir: string) => true),
   mockIndexCodebase: vi.fn(async (_opts: { rootDir: string; verbose?: boolean }) => undefined),
+  mockResolveEmbeddingsEnabled: vi.fn(async (_dir: string) => true),
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
@@ -56,7 +62,11 @@ vi.mock('@liendev/core', () => ({
   WorkerEmbeddings: vi.fn(function (this: any) {
     Object.assign(this, mockEmbeddings);
   }),
+  NullEmbeddings: vi.fn(function (this: any) {
+    Object.assign(this, mockNullEmbeddingsInstance);
+  }),
   createVectorDB: vi.fn(async () => mockVectorDB),
+  resolveEmbeddingsEnabled: mockResolveEmbeddingsEnabled,
   VERSION_CHECK_INTERVAL_MS: 60000,
   isGitRepo: mockIsGitRepo,
   indexCodebase: mockIndexCodebase,
@@ -119,7 +129,7 @@ vi.mock('url', () => ({
 import { startMCPServer } from './server.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { WorkerEmbeddings, createVectorDB } from '@liendev/core';
+import { WorkerEmbeddings, NullEmbeddings, createVectorDB } from '@liendev/core';
 import { FileWatcher } from '../watcher/index.js';
 import { createMCPServerConfig, registerMCPHandlers } from './server-config.js';
 import { setupCleanupHandlers } from './cleanup.js';
@@ -147,6 +157,8 @@ describe('startMCPServer', () => {
     mockVectorDB.getCurrentVersion.mockReturnValue(1);
     mockVectorDB.getVersionDate.mockReturnValue('2026-01-01');
     mockEmbeddings.initialize.mockResolvedValue(undefined);
+    mockNullEmbeddingsInstance.initialize.mockResolvedValue(undefined);
+    mockResolveEmbeddingsEnabled.mockResolvedValue(true);
     mockSetupGitDetection.mockResolvedValue({ gitPollInterval: null });
     mockSetupCleanupHandlers.mockReturnValue(vi.fn().mockResolvedValue(undefined));
     vi.mocked(createVectorDB).mockImplementation(async () => mockVectorDB as any);
@@ -174,6 +186,43 @@ describe('startMCPServer', () => {
     expect(createVectorDB).toHaveBeenCalledWith('/test/project');
     expect(mockEmbeddings.initialize).toHaveBeenCalledOnce();
     expect(mockVectorDB.initialize).toHaveBeenCalledOnce();
+  });
+
+  it('should not construct WorkerEmbeddings or call its initialize when embeddings are disabled', async () => {
+    mockResolveEmbeddingsEnabled.mockResolvedValue(false);
+
+    await startMCPServer({ rootDir: '/test/project' });
+
+    // No embedding worker/model spawn: the whole point of structural-only mode.
+    expect(WorkerEmbeddings).not.toHaveBeenCalled();
+    expect(mockEmbeddings.initialize).not.toHaveBeenCalled();
+
+    // NullEmbeddings is used in its place, and the vector DB still initializes normally.
+    expect(NullEmbeddings).toHaveBeenCalledOnce();
+    expect(createVectorDB).toHaveBeenCalledWith('/test/project');
+    expect(mockVectorDB.initialize).toHaveBeenCalledOnce();
+  });
+
+  it('should mark the tool context as embeddings-disabled when structural-only', async () => {
+    mockResolveEmbeddingsEnabled.mockResolvedValue(false);
+
+    await startMCPServer({ rootDir: '/test/project' });
+
+    expect(registerMCPHandlers).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ embeddingsEnabled: false }),
+      expect.any(Function),
+    );
+  });
+
+  it('should mark the tool context as embeddings-enabled by default', async () => {
+    await startMCPServer({ rootDir: '/test/project' });
+
+    expect(registerMCPHandlers).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ embeddingsEnabled: true }),
+      expect.any(Function),
+    );
   });
 
   it('should create MCP server and register handlers', async () => {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -6,8 +6,10 @@ import { dirname, join, resolve } from 'path';
 import type { EmbeddingService, VectorDBInterface, GitState } from '@liendev/core';
 import {
   WorkerEmbeddings,
+  NullEmbeddings,
   VERSION_CHECK_INTERVAL_MS,
   createVectorDB,
+  resolveEmbeddingsEnabled,
   isGitRepo,
 } from '@liendev/core';
 import { FileWatcher } from '../watcher/index.js';
@@ -39,12 +41,24 @@ export interface MCPServerOptions {
 /**
  * Initialize embeddings and vector database.
  * Uses factory to create the vector database backend.
+ *
+ * When embeddings are disabled via project config, uses a `NullEmbeddings`
+ * stub instead of `WorkerEmbeddings` — this is what actually skips the
+ * model download and worker-thread spawn (the CPU/heat cost the
+ * structural-only mode exists to avoid).
  */
 async function initializeDatabase(
   rootDir: string,
   log: LogFn,
-): Promise<{ embeddings: EmbeddingService; vectorDB: VectorDBInterface }> {
-  const embeddings = new WorkerEmbeddings();
+): Promise<{
+  embeddings: EmbeddingService;
+  vectorDB: VectorDBInterface;
+  embeddingsEnabled: boolean;
+}> {
+  const embeddingsEnabled = await resolveEmbeddingsEnabled(rootDir);
+  const embeddings: EmbeddingService = embeddingsEnabled
+    ? new WorkerEmbeddings()
+    : new NullEmbeddings();
 
   // Create vector DB using global config (auto-detects backend and orgId)
   log('Creating vector database...');
@@ -61,14 +75,18 @@ async function initializeDatabase(
     );
   }
 
-  log('Loading embedding model...');
-  await embeddings.initialize();
+  if (embeddingsEnabled) {
+    log('Loading embedding model...');
+    await embeddings.initialize();
+  } else {
+    log('Embeddings disabled (embeddings.enabled: false) — running in structural-only mode.');
+  }
 
   log('Loading vector database...');
   await vectorDB.initialize();
 
   log('Embeddings and vector DB ready');
-  return { embeddings, vectorDB };
+  return { embeddings, vectorDB, embeddingsEnabled };
 }
 
 // Walk parent directories to detect whether startDir is inside a git work tree.
@@ -296,7 +314,11 @@ function createMCPLog(server: Server, verbose: boolean | undefined): LogFn {
 async function initializeComponents(
   rootDir: string,
   earlyLog: LogFn,
-): Promise<{ embeddings: EmbeddingService; vectorDB: VectorDBInterface }> {
+): Promise<{
+  embeddings: EmbeddingService;
+  vectorDB: VectorDBInterface;
+  embeddingsEnabled: boolean;
+}> {
   try {
     const result = await initializeDatabase(rootDir, earlyLog);
 
@@ -403,7 +425,7 @@ export async function startMCPServer(options: MCPServerOptions): Promise<void> {
   const earlyLog = createEarlyLog(verbose);
   earlyLog('Initializing MCP server...');
 
-  const { embeddings, vectorDB } = await initializeComponents(rootDir, earlyLog);
+  const { embeddings, vectorDB, embeddingsEnabled } = await initializeComponents(rootDir, earlyLog);
   const server = createMCPServer();
   const log = createMCPLog(server, verbose);
 
@@ -427,6 +449,7 @@ export async function startMCPServer(options: MCPServerOptions): Promise<void> {
     checkAndReconnect,
     getIndexMetadata,
     getReindexState: () => reindexStateManager.getState(),
+    embeddingsEnabled,
   };
 
   await setupAndConnectServer(server, toolContext, log, versionCheckInterval, reindexStateManager, {

--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -32,6 +32,13 @@ export interface ToolContext {
   getIndexMetadata: () => IndexMetadata;
   /** Get current reindex state */
   getReindexState: () => ReindexState;
+  /**
+   * Whether embeddings are enabled for this session (structural-only mode
+   * when false — see config `embeddings.enabled`). Defaults to `true` when
+   * omitted so existing callers/tests are unaffected. semantic_search and
+   * find_similar check this before querying; the other four tools ignore it.
+   */
+  embeddingsEnabled?: boolean;
 }
 
 /**

--- a/packages/cli/test/integration/embeddings-disabled.test.ts
+++ b/packages/cli/test/integration/embeddings-disabled.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs/promises';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { indexCodebase, NullEmbeddings, VectorDB, WorkerEmbeddings } from '@liendev/core';
+import { createTestDir, cleanupTestDir, createTestFile } from '@liendev/core/test';
+import { createMCPServerConfig, registerMCPHandlers } from '../../src/mcp/server-config.js';
+import { createReindexStateManager } from '../../src/mcp/reindex-state-manager.js';
+import type { ToolContext } from '../../src/mcp/types.js';
+
+/**
+ * Real MCP protocol round trip proving structural-only mode end to end:
+ *
+ * - The real `indexCodebase({ skipEmbeddings: true })` path builds a real
+ *   LanceDB index of a tiny fixture repo, without ever touching a real
+ *   embedding model.
+ * - The 4 structural tools (get_files_context, get_dependents,
+ *   list_functions, get_complexity) are exercised over a real MCP
+ *   client/server round trip and must return correct data, exactly as they
+ *   would with embeddings enabled — they only read structural columns via
+ *   scanAll/scanWithFilter, never vectors.
+ * - semantic_search and find_similar must report the "disabled" note
+ *   instead of crashing or silently returning misleading empty results.
+ *
+ * Uses `NullEmbeddings` (no real model) so, unlike test/e2e/mcp-roundtrip.test.ts,
+ * this doesn't need the local embedding model and can run in the default
+ * fast suite.
+ */
+const TIMEOUT = 30_000;
+
+const FIXTURE_FILES: Record<string, string> = {
+  'math-utils.ts': `export function addNumbers(a: number, b: number): number {
+  return a + b;
+}
+
+export function multiplyNumbers(a: number, b: number): number {
+  return a * b;
+}
+`,
+  'main.ts': `import { addNumbers } from './math-utils.js';
+
+export function sumAll(values: number[]): number {
+  return values.reduce((total, v) => addNumbers(total, v), 0);
+}
+`,
+  'math-utils.test.ts': `import { describe, it, expect } from 'vitest';
+import { addNumbers } from './math-utils';
+
+describe('addNumbers', () => {
+  it('adds two numbers', () => {
+    expect(addNumbers(2, 3)).toBe(5);
+  });
+});
+`,
+};
+
+/** Parse the JSON text payload out of a real tools/call response. */
+function parseToolResponse(result: CallToolResult): any {
+  const [first] = result.content as Array<{ type: string; text: string }>;
+  expect(first?.type).toBe('text');
+  return JSON.parse(first.text);
+}
+
+describe('Structural-only mode (embeddings disabled) — real MCP round trip', () => {
+  let fixtureDir: string;
+  let vectorDB: VectorDB;
+  let client: Client;
+  let server: Server;
+  let workerInitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(async () => {
+    workerInitSpy = vi.spyOn(WorkerEmbeddings.prototype, 'initialize');
+
+    fixtureDir = await createTestDir();
+    for (const [name, content] of Object.entries(FIXTURE_FILES)) {
+      await createTestFile(fixtureDir, name, content);
+    }
+
+    // The real indexing path with embeddings explicitly off — same flag
+    // `lien index --no-embeddings` and a disabled project config route to.
+    const indexResult = await indexCodebase({ rootDir: fixtureDir, skipEmbeddings: true });
+    if (!indexResult.success) {
+      throw new Error(`Fixture indexing failed: ${indexResult.error}`);
+    }
+
+    vectorDB = new VectorDB(fixtureDir);
+    await vectorDB.initialize();
+
+    const reindexStateManager = createReindexStateManager();
+    const toolContext: ToolContext = {
+      vectorDB,
+      embeddings: new NullEmbeddings(),
+      rootDir: fixtureDir,
+      log: () => {},
+      checkAndReconnect: async () => {},
+      getIndexMetadata: () => ({
+        indexVersion: vectorDB.getCurrentVersion(),
+        indexDate: vectorDB.getVersionDate(),
+      }),
+      getReindexState: () => reindexStateManager.getState(),
+      embeddingsEnabled: false,
+    };
+
+    const serverConfig = createMCPServerConfig('lien', '0.0.0-test');
+    server = new Server(
+      { name: serverConfig.name, version: serverConfig.version },
+      { capabilities: serverConfig.capabilities, instructions: serverConfig.instructions },
+    );
+    registerMCPHandlers(server, toolContext, () => {});
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'lien-structural-only-test-client', version: '0.0.0' }, {});
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  }, TIMEOUT);
+
+  afterAll(async () => {
+    workerInitSpy.mockRestore();
+    await client?.close();
+    await server?.close();
+    if (vectorDB) {
+      await fs.rm(vectorDB.dbPath, { recursive: true, force: true }).catch(() => {});
+    }
+    if (fixtureDir) {
+      await cleanupTestDir(fixtureDir);
+    }
+  });
+
+  it('indexed the fixture without ever initializing a real embedding worker', () => {
+    expect(workerInitSpy).not.toHaveBeenCalled();
+  });
+
+  describe('structural tools still work correctly', () => {
+    it(
+      'get_files_context returns real chunks and test associations',
+      async () => {
+        const response = await client.callTool({
+          name: 'get_files_context',
+          arguments: { filepaths: 'math-utils.ts' },
+        });
+
+        expect(response.isError).not.toBe(true);
+        const payload = parseToolResponse(response as CallToolResult);
+
+        expect(payload.file).toBe('math-utils.ts');
+        expect(payload.chunks.length).toBeGreaterThan(0);
+        expect(payload.chunks.some((c: any) => c.content.includes('addNumbers'))).toBe(true);
+        expect(payload.testAssociations).toContain('math-utils.test.ts');
+      },
+      TIMEOUT,
+    );
+
+    it(
+      'get_dependents finds the real importer of math-utils.ts',
+      async () => {
+        const response = await client.callTool({
+          name: 'get_dependents',
+          arguments: { filepath: 'math-utils.ts' },
+        });
+
+        expect(response.isError).not.toBe(true);
+        const payload = parseToolResponse(response as CallToolResult);
+
+        expect(payload.dependentCount).toBeGreaterThan(0);
+        expect(payload.dependents.some((d: any) => d.filepath === 'main.ts')).toBe(true);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      'list_functions finds the real exported functions by pattern',
+      async () => {
+        const response = await client.callTool({
+          name: 'list_functions',
+          arguments: { pattern: '.*Numbers$' },
+        });
+
+        expect(response.isError).not.toBe(true);
+        const payload = parseToolResponse(response as CallToolResult);
+
+        const symbolNames = payload.results.map((r: any) => r.metadata.symbolName);
+        expect(symbolNames).toEqual(expect.arrayContaining(['addNumbers', 'multiplyNumbers']));
+      },
+      TIMEOUT,
+    );
+
+    it(
+      'get_complexity analyzes the real indexed functions without crashing',
+      async () => {
+        const response = await client.callTool({
+          name: 'get_complexity',
+          arguments: { files: ['main.ts'] },
+        });
+
+        expect(response.isError).not.toBe(true);
+        const payload = parseToolResponse(response as CallToolResult);
+
+        expect(payload.summary).toBeDefined();
+        expect(payload.summary.filesAnalyzed).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe('semantic tools report disabled instead of crashing or lying', () => {
+    it(
+      'semantic_search returns a clear disabled note, not an error or misleading empty result',
+      async () => {
+        const response = await client.callTool({
+          name: 'semantic_search',
+          arguments: { query: 'function that adds two numbers together' },
+        });
+
+        expect(response.isError).not.toBe(true);
+        const payload = parseToolResponse(response as CallToolResult);
+
+        expect(payload.results).toEqual([]);
+        expect(payload.note).toContain('disabled');
+        expect(payload.note).toContain('structural-only mode');
+      },
+      TIMEOUT,
+    );
+
+    it(
+      'find_similar returns a clear disabled note, not an error or misleading empty result',
+      async () => {
+        const response = await client.callTool({
+          name: 'find_similar',
+          arguments: { code: 'function addNumbers(a, b) { return a + b; }' },
+        });
+
+        expect(response.isError).not.toBe(true);
+        const payload = parseToolResponse(response as CallToolResult);
+
+        expect(payload.results).toEqual([]);
+        expect(payload.note).toContain('disabled');
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/packages/core/src/config/embeddings-enabled.test.ts
+++ b/packages/core/src/config/embeddings-enabled.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { resolveEmbeddingsEnabled } from './embeddings-enabled.js';
+import { defaultConfig } from './schema.js';
+import type { LienConfig } from './schema.js';
+
+describe('resolveEmbeddingsEnabled', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-embeddings-enabled-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('defaults to true when no project config exists', async () => {
+    await expect(resolveEmbeddingsEnabled(testDir)).resolves.toBe(true);
+  });
+
+  it('returns false when embeddings.enabled is explicitly false in .lien.config.json', async () => {
+    const configPath = path.join(testDir, '.lien.config.json');
+    const config: LienConfig = { ...defaultConfig, embeddings: { enabled: false } };
+    await fs.writeFile(configPath, JSON.stringify(config));
+
+    await expect(resolveEmbeddingsEnabled(testDir)).resolves.toBe(false);
+  });
+
+  it('returns true when embeddings.enabled is explicitly true', async () => {
+    const configPath = path.join(testDir, '.lien.config.json');
+    const config: LienConfig = { ...defaultConfig, embeddings: { enabled: true } };
+    await fs.writeFile(configPath, JSON.stringify(config));
+
+    await expect(resolveEmbeddingsEnabled(testDir)).resolves.toBe(true);
+  });
+
+  it('falls back to true (not throw) for a malformed config file', async () => {
+    const configPath = path.join(testDir, '.lien.config.json');
+    await fs.writeFile(configPath, '{ not valid json');
+
+    await expect(resolveEmbeddingsEnabled(testDir)).resolves.toBe(true);
+  });
+
+  it('uses a preloaded config instead of reading from disk', async () => {
+    // No file on disk at all — if this reads the preloaded config value
+    // rather than hitting the filesystem, it must return false here.
+    const preloaded: LienConfig = { ...defaultConfig, embeddings: { enabled: false } };
+
+    await expect(resolveEmbeddingsEnabled(testDir, preloaded)).resolves.toBe(false);
+  });
+});

--- a/packages/core/src/config/embeddings-enabled.ts
+++ b/packages/core/src/config/embeddings-enabled.ts
@@ -1,0 +1,28 @@
+import type { LienConfig } from './schema.js';
+import { configService } from './service.js';
+
+/**
+ * Resolve whether embeddings are enabled for a project, from
+ * `.lien.config.json`'s `embeddings.enabled` (default: true).
+ *
+ * A malformed or unreadable project config must never block indexing,
+ * serving, or status reporting — on any config error this falls back to
+ * "enabled", matching the default every user got before this setting
+ * existed (the project config file was not read at all until this
+ * feature shipped, so a stale/invalid one must stay a no-op).
+ *
+ * @param rootDir - Project root to load `.lien.config.json` from
+ * @param preloadedConfig - Optional already-loaded config, to skip the
+ *   disk read (e.g. when a caller already has `IndexingOptions.config`)
+ */
+export async function resolveEmbeddingsEnabled(
+  rootDir: string,
+  preloadedConfig?: LienConfig,
+): Promise<boolean> {
+  try {
+    const config = preloadedConfig ?? (await configService.load(rootDir));
+    return config.embeddings?.enabled !== false;
+  } catch {
+    return true;
+  }
+}

--- a/packages/core/src/config/merge.test.ts
+++ b/packages/core/src/config/merge.test.ts
@@ -89,6 +89,22 @@ describe('deepMergeConfig', () => {
     expect(result.fileWatching.debounceMs).toBe(500);
   });
 
+  it('should merge embeddings config', () => {
+    const userConfig: Partial<LienConfig> = {
+      embeddings: { enabled: false },
+    };
+
+    const result = deepMergeConfig(defaultConfig, userConfig);
+
+    expect(result.embeddings.enabled).toBe(false);
+  });
+
+  it('should default embeddings.enabled to true when unspecified', () => {
+    const result = deepMergeConfig(defaultConfig, {});
+
+    expect(result.embeddings).toEqual({ enabled: true });
+  });
+
   it('should work with actual Lien config', () => {
     const userConfig: Partial<LienConfig> = {
       core: {

--- a/packages/core/src/config/merge.ts
+++ b/packages/core/src/config/merge.ts
@@ -30,6 +30,10 @@ export function deepMergeConfig(defaults: LienConfig, user: Partial<LienConfig>)
       ...defaults.fileWatching,
       ...user.fileWatching,
     },
+    embeddings: {
+      ...defaults.embeddings,
+      ...user.embeddings,
+    },
     storage: user.storage ?? defaults.storage,
     complexity: user.complexity
       ? {

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -53,6 +53,18 @@ export interface LienConfig {
     enabled: boolean;
     debounceMs: number;
   };
+  embeddings: {
+    /**
+     * Compute embeddings for semantic search (default: true).
+     * Set to false for structural-only mode: no model download, no
+     * embedding worker, no CPU cost on index/reindex. Structural tools
+     * (get_files_context, get_dependents, list_functions, get_complexity)
+     * keep working; semantic_search and find_similar report as disabled.
+     * Toggling this requires a full reindex (`lien index --force`) to take
+     * effect on already-indexed files.
+     */
+    enabled: boolean;
+  };
   complexity?: {
     enabled: boolean;
     thresholds: {
@@ -144,6 +156,9 @@ export const defaultConfig: LienConfig = {
   fileWatching: {
     enabled: true, // Enabled by default (fast with incremental indexing!)
     debounceMs: DEFAULT_DEBOUNCE_MS,
+  },
+  embeddings: {
+    enabled: true, // Embeddings on by default — no behavior change for existing users
   },
   complexity: {
     enabled: true,

--- a/packages/core/src/config/service.test.ts
+++ b/packages/core/src/config/service.test.ts
@@ -309,6 +309,40 @@ describe('ConfigService', () => {
       expect(result.valid).toBe(true);
       expect(result.warnings.some(w => w.includes('legacy'))).toBe(true);
     });
+
+    it('should accept embeddings.enabled: false', () => {
+      const config: LienConfig = {
+        ...defaultConfig,
+        embeddings: { enabled: false },
+      };
+
+      const result = service.validate(config);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject a non-boolean embeddings.enabled', () => {
+      const invalidConfig = {
+        ...defaultConfig,
+        embeddings: { enabled: 'false' as unknown as boolean },
+      };
+
+      const result = service.validate(invalidConfig);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('embeddings.enabled'))).toBe(true);
+    });
+
+    it('should reject a config missing the required embeddings field', () => {
+      const invalidConfig = { ...defaultConfig } as Partial<LienConfig>;
+      delete invalidConfig.embeddings;
+
+      const result = service.validate(invalidConfig);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('embeddings'))).toBe(true);
+    });
   });
 
   describe('validatePartial', () => {
@@ -342,6 +376,17 @@ describe('ConfigService', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.includes('chunkSize'))).toBe(true);
+    });
+
+    it('should validate partial config with only embeddings settings', () => {
+      const partialConfig: Partial<LienConfig> = {
+        embeddings: { enabled: false },
+      };
+
+      const result = service.validatePartial(partialConfig);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
     });
 
     it('should allow missing fields in partial config', () => {

--- a/packages/core/src/config/service.ts
+++ b/packages/core/src/config/service.ts
@@ -196,6 +196,11 @@ export class ConfigService {
       this.validateFileWatchingConfig(config.fileWatching, errors, warnings);
     }
 
+    // Validate embeddings settings if present
+    if (config.embeddings) {
+      this.validateEmbeddingsConfig(config.embeddings, errors);
+    }
+
     return {
       valid: errors.length === 0,
       errors,
@@ -241,6 +246,13 @@ export class ConfigService {
       return;
     }
     this.validateFileWatchingConfig(config.fileWatching, errors, warnings);
+
+    // Validate embeddings settings
+    if (!config.embeddings) {
+      errors.push('Missing required field: embeddings');
+      return;
+    }
+    this.validateEmbeddingsConfig(config.embeddings, errors);
   }
 
   /**
@@ -403,6 +415,20 @@ export class ConfigService {
         warnings.push(
           'fileWatching.debounceMs is very short (<100ms). This may cause excessive reindexing',
         );
+      }
+    }
+  }
+
+  /**
+   * Validate embeddings configuration settings
+   */
+  private validateEmbeddingsConfig(
+    embeddings: Partial<LienConfig['embeddings']>,
+    errors: string[],
+  ): void {
+    if (embeddings.enabled !== undefined) {
+      if (typeof embeddings.enabled !== 'boolean') {
+        errors.push('embeddings.enabled must be a boolean');
       }
     }
   }

--- a/packages/core/src/embeddings/null-embeddings.test.ts
+++ b/packages/core/src/embeddings/null-embeddings.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { NullEmbeddings } from './null-embeddings.js';
+import { EMBEDDING_DIMENSION } from './types.js';
+
+describe('NullEmbeddings', () => {
+  it('initializes without doing anything observable (no model download, no worker)', async () => {
+    const service = new NullEmbeddings();
+    await expect(service.initialize()).resolves.toBeUndefined();
+  });
+
+  it('embed() returns a zero-filled vector of the correct dimension', async () => {
+    const service = new NullEmbeddings();
+    const vector = await service.embed('some code');
+
+    expect(vector).toBeInstanceOf(Float32Array);
+    expect(vector.length).toBe(EMBEDDING_DIMENSION);
+    expect(Array.from(vector).every(v => v === 0)).toBe(true);
+  });
+
+  it('embed() does not need initialize() to have been called first', async () => {
+    const service = new NullEmbeddings();
+    const vector = await service.embed('uninitialized call');
+
+    expect(vector.length).toBe(EMBEDDING_DIMENSION);
+  });
+
+  it('embedBatch() returns one zero vector per input text, in order', async () => {
+    const service = new NullEmbeddings();
+    const texts = ['a', 'b', 'c'];
+    const vectors = await service.embedBatch(texts);
+
+    expect(vectors).toHaveLength(texts.length);
+    vectors.forEach(vector => {
+      expect(vector.length).toBe(EMBEDDING_DIMENSION);
+      expect(Array.from(vector).every(v => v === 0)).toBe(true);
+    });
+  });
+
+  it('embedBatch() returns an empty array for an empty input', async () => {
+    const service = new NullEmbeddings();
+    const vectors = await service.embedBatch([]);
+
+    expect(vectors).toEqual([]);
+  });
+
+  it('dispose() resolves without error', async () => {
+    const service = new NullEmbeddings();
+    await expect(service.dispose()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/embeddings/null-embeddings.ts
+++ b/packages/core/src/embeddings/null-embeddings.ts
@@ -1,0 +1,43 @@
+import type { EmbeddingService } from './types.js';
+import { EMBEDDING_DIMENSION } from './types.js';
+
+/**
+ * No-op embedding service used for structural-only mode.
+ *
+ * When embeddings are disabled (config `embeddings.enabled: false`, or
+ * `lien index --no-embeddings`), this service is substituted for
+ * `WorkerEmbeddings`/`LocalEmbeddings` wherever an `EmbeddingService` is
+ * expected. `embed`/`embedBatch` return zero-filled vectors of the correct
+ * dimension instead of computing real ones, so the existing
+ * chunk -> vector -> VectorDB pipeline (and its fixed-width LanceDB vector
+ * column) runs completely unchanged: structural columns (imports, exports,
+ * callSites, complexity, etc.) are populated normally, and the structural
+ * tools — `get_files_context`, `get_dependents`, `list_functions`,
+ * `get_complexity` — which read via column scans rather than vector search,
+ * keep working against a normally-persisted index.
+ *
+ * Semantic search over all-zero vectors is meaningless by design. Callers
+ * must gate `semantic_search`/`find_similar` on whether embeddings are
+ * enabled rather than relying on the vectors themselves (see
+ * `mcp/handlers/semantic-search.ts` and `mcp/handlers/find-similar.ts`).
+ *
+ * `initialize()` and `dispose()` are no-ops: no model download, no worker
+ * thread, no CPU cost.
+ */
+export class NullEmbeddings implements EmbeddingService {
+  async initialize(): Promise<void> {
+    // No model to load.
+  }
+
+  async embed(_text: string): Promise<Float32Array> {
+    return new Float32Array(EMBEDDING_DIMENSION);
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    return texts.map(() => new Float32Array(EMBEDDING_DIMENSION));
+  }
+
+  async dispose(): Promise<void> {
+    // Nothing to clean up.
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,7 @@ export {
 export { LocalEmbeddings } from './embeddings/local.js';
 export { WorkerEmbeddings } from './embeddings/worker-embeddings.js';
 export { CachedEmbeddings } from './embeddings/cache.js';
+export { NullEmbeddings } from './embeddings/null-embeddings.js';
 export type { EmbeddingService } from './embeddings/types.js';
 export { EMBEDDING_DIMENSION, EMBEDDING_DIMENSIONS } from './embeddings/types.js';
 
@@ -105,6 +106,16 @@ export {
   ConfigValidationError,
 } from './config/global-config.js';
 export type { GlobalConfig } from './config/global-config.js';
+
+// =============================================================================
+// PROJECT CONFIGURATION (.lien.config.json)
+// =============================================================================
+
+export { configService, ConfigService } from './config/service.js';
+export type { ValidationResult } from './config/service.js';
+export { defaultConfig } from './config/schema.js';
+export type { LienConfig } from './config/schema.js';
+export { resolveEmbeddingsEnabled } from './config/embeddings-enabled.js';
 
 // =============================================================================
 // GIT UTILITIES

--- a/packages/core/src/indexer/index.test.ts
+++ b/packages/core/src/indexer/index.test.ts
@@ -123,12 +123,14 @@ describe('indexCodebase - embeddings enabled/disabled', () => {
       expect(rows.length).toBeGreaterThan(0);
     });
 
-    it('an explicit skipEmbeddings: true still honors a caller-provided embeddings instance', async () => {
-      // If the caller went to the trouble of pre-initializing a warm
-      // embeddings service and *also* passed skipEmbeddings, their explicit
-      // instance wins over the NullEmbeddings substitution.
+    it('skipEmbeddings: true wins even when the caller also passes a real embeddings instance', async () => {
+      // `skipEmbeddings` is authoritative. Even if the caller went to the
+      // trouble of pre-initializing a warm embeddings service and *also*
+      // passed skipEmbeddings, structural-only mode must win — the caller's
+      // instance must never be used to compute real vectors.
       const mockEmbeddings = new MockEmbeddings();
       await mockEmbeddings.initialize();
+      const embedSpy = vi.spyOn(mockEmbeddings, 'embed');
       const embedBatchSpy = vi.spyOn(mockEmbeddings, 'embedBatch');
 
       const result = await indexCodebase({
@@ -139,7 +141,29 @@ describe('indexCodebase - embeddings enabled/disabled', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(embedBatchSpy).toHaveBeenCalled();
+      expect(result.chunksCreated).toBeGreaterThan(0);
+      expect(embedSpy).not.toHaveBeenCalled();
+      expect(embedBatchSpy).not.toHaveBeenCalled();
+      expect(workerInitSpy).not.toHaveBeenCalled();
+    });
+
+    it('an explicit real embeddings instance without skipEmbeddings is used as-is (regression guard)', async () => {
+      // The WorkerEmbeddings-specific case from the reported finding: a
+      // pre-initialized real embedding service, passed alongside
+      // `skipEmbeddings: true`, must never have its worker touched.
+      const workerEmbeddings = new WorkerEmbeddings();
+      const embedBatchSpy = vi.spyOn(workerEmbeddings, 'embedBatch');
+
+      const result = await indexCodebase({
+        rootDir: testDir,
+        force: true,
+        skipEmbeddings: true,
+        embeddings: workerEmbeddings,
+      });
+
+      expect(result.success).toBe(true);
+      expect(workerInitSpy).not.toHaveBeenCalled();
+      expect(embedBatchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/indexer/index.test.ts
+++ b/packages/core/src/indexer/index.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { indexCodebase } from './index.js';
+import { VectorDB } from '../vectordb/lancedb.js';
+import { WorkerEmbeddings } from '../embeddings/worker-embeddings.js';
+import { MockEmbeddings } from '../test/helpers/mock-embeddings.js';
+import { createTestDir, cleanupTestDir, createTestFile } from '../test/helpers/test-db.js';
+import { defaultConfig } from '../config/schema.js';
+import type { LienConfig } from '../config/schema.js';
+
+const MATH_TS = `export function add(a: number, b: number): number {
+  return a + b;
+}
+`;
+
+const MAIN_TS = `import { add } from './math.js';
+
+export function sumAll(values: number[]): number {
+  return values.reduce((total, v) => add(total, v), 0);
+}
+`;
+
+describe('indexCodebase - embeddings enabled/disabled', () => {
+  let testDir: string;
+  let workerInitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+    await createTestFile(testDir, 'src/math.ts', MATH_TS);
+    await createTestFile(testDir, 'src/main.ts', MAIN_TS);
+
+    // Proves the real embedding worker (model download + worker thread) is
+    // never touched in structural-only mode.
+    workerInitSpy = vi.spyOn(WorkerEmbeddings.prototype, 'initialize');
+  });
+
+  afterEach(async () => {
+    workerInitSpy.mockRestore();
+    await cleanupTestDir(testDir);
+  });
+
+  describe('embeddings disabled via skipEmbeddings option', () => {
+    it('indexes successfully without constructing/initializing a real embedding worker', async () => {
+      const result = await indexCodebase({ rootDir: testDir, skipEmbeddings: true, force: true });
+
+      expect(result.success).toBe(true);
+      expect(result.chunksCreated).toBeGreaterThan(0);
+      expect(workerInitSpy).not.toHaveBeenCalled();
+    });
+
+    it('persists chunks with real structural metadata (imports/exports/symbolName)', async () => {
+      const result = await indexCodebase({ rootDir: testDir, skipEmbeddings: true, force: true });
+      expect(result.success).toBe(true);
+
+      const db = new VectorDB(testDir);
+      await db.initialize();
+      const rows = await db.scanAll();
+
+      // A file produces multiple chunks (e.g. an import-header chunk plus
+      // one per function) — find the one carrying the function's symbol.
+      const mainChunk = rows.find(
+        r => r.metadata.file.endsWith('main.ts') && r.metadata.symbolName === 'sumAll',
+      );
+      expect(mainChunk).toBeDefined();
+      expect(mainChunk!.metadata.imports).toContain('src/math.js');
+      expect(mainChunk!.metadata.exports).toContain('sumAll');
+
+      const mathChunk = rows.find(
+        r => r.metadata.file.endsWith('math.ts') && r.metadata.symbolName === 'add',
+      );
+      expect(mathChunk).toBeDefined();
+      expect(mathChunk!.metadata.exports).toContain('add');
+    });
+  });
+
+  describe('embeddings disabled via project config (.lien.config.json)', () => {
+    it('skips the embedding worker purely from embeddings.enabled: false, with no explicit flag', async () => {
+      const config: LienConfig = { ...defaultConfig, embeddings: { enabled: false } };
+      await fs.writeFile(path.join(testDir, '.lien.config.json'), JSON.stringify(config, null, 2));
+
+      const result = await indexCodebase({ rootDir: testDir, force: true });
+
+      expect(result.success).toBe(true);
+      expect(result.chunksCreated).toBeGreaterThan(0);
+      expect(workerInitSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not block indexing on a malformed project config (falls back to enabled)', async () => {
+      await fs.writeFile(path.join(testDir, '.lien.config.json'), '{ not valid json');
+
+      const mockEmbeddings = new MockEmbeddings();
+      await mockEmbeddings.initialize();
+      const result = await indexCodebase({
+        rootDir: testDir,
+        force: true,
+        embeddings: mockEmbeddings,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.chunksCreated).toBeGreaterThan(0);
+    });
+  });
+
+  describe('embeddings enabled (default, existing behavior)', () => {
+    it('uses the provided embedding service as-is — no NullEmbeddings substitution', async () => {
+      const mockEmbeddings = new MockEmbeddings();
+      await mockEmbeddings.initialize();
+      const embedBatchSpy = vi.spyOn(mockEmbeddings, 'embedBatch');
+
+      const result = await indexCodebase({
+        rootDir: testDir,
+        force: true,
+        embeddings: mockEmbeddings,
+      });
+
+      expect(result.success).toBe(true);
+      expect(embedBatchSpy).toHaveBeenCalled();
+
+      const db = new VectorDB(testDir);
+      await db.initialize();
+      const rows = await db.scanAll();
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it('an explicit skipEmbeddings: true still honors a caller-provided embeddings instance', async () => {
+      // If the caller went to the trouble of pre-initializing a warm
+      // embeddings service and *also* passed skipEmbeddings, their explicit
+      // instance wins over the NullEmbeddings substitution.
+      const mockEmbeddings = new MockEmbeddings();
+      await mockEmbeddings.initialize();
+      const embedBatchSpy = vi.spyOn(mockEmbeddings, 'embedBatch');
+
+      const result = await indexCodebase({
+        rootDir: testDir,
+        force: true,
+        skipEmbeddings: true,
+        embeddings: mockEmbeddings,
+      });
+
+      expect(result.success).toBe(true);
+      expect(embedBatchSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('reports failure without throwing when the directory has no indexable files', async () => {
+    const emptyDir = await createTestDir();
+    try {
+      const result = await indexCodebase({ rootDir: emptyDir, skipEmbeddings: true, force: true });
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    } finally {
+      await cleanupTestDir(emptyDir);
+    }
+  });
+});

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -659,10 +659,13 @@ export async function indexCodebase(options: IndexingOptions = {}): Promise<Inde
     options.onProgress?.({ phase: 'initializing', message: 'Loading configuration...' });
 
     const skipEmbeddings = await resolveSkipEmbeddings(options, rootDir);
-    const effectiveOptions: IndexingOptions =
-      skipEmbeddings && !options.embeddings
-        ? { ...options, embeddings: new NullEmbeddings() }
-        : options;
+    // `skipEmbeddings` is authoritative: even if the caller also passed a
+    // real `options.embeddings` instance (e.g. a pre-initialized
+    // WorkerEmbeddings), structural-only mode must win so no real vectors
+    // are ever computed.
+    const effectiveOptions: IndexingOptions = skipEmbeddings
+      ? { ...options, embeddings: new NullEmbeddings() }
+      : options;
 
     // Initialize vector database (use factory to select backend from global config)
     options.onProgress?.({ phase: 'initializing', message: 'Initializing vector database...' });

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_EMBEDDING_BATCH_SIZE,
 } from '../constants.js';
 import { WorkerEmbeddings } from '../embeddings/worker-embeddings.js';
+import { NullEmbeddings } from '../embeddings/null-embeddings.js';
 import { createVectorDB } from '../vectordb/factory.js';
 import { writeVersionFile } from '../vectordb/version.js';
 import { ManifestManager } from './manifest.js';
@@ -31,6 +32,7 @@ import { indexMultipleFiles, normalizeToRelativePath } from './incremental.js';
 import type { EmbeddingService } from '../embeddings/types.js';
 import { ChunkBatchProcessor } from './chunk-batch-processor.js';
 import type { VectorDBInterface } from '../vectordb/types.js';
+import { resolveEmbeddingsEnabled } from '../config/embeddings-enabled.js';
 import {
   extractRepoId,
   scanCodebase,
@@ -39,7 +41,6 @@ import {
   chunkFile,
   computeContentHash,
 } from '@liendev/parser';
-import type { CodeChunk } from '@liendev/parser';
 
 /**
  * Options for indexing a codebase
@@ -57,10 +58,14 @@ export interface IndexingOptions {
   config?: LienConfig;
   /** Progress callback for external UI */
   onProgress?: (progress: IndexingProgress) => void;
-  /** Skip embedding generation and VectorDB storage — return raw chunks in-memory */
+  /**
+   * Skip real embedding computation. Indexing still proceeds normally
+   * (chunking + full persistence to the vector store) but uses zero-vector
+   * placeholders instead of computed embeddings — structural-only mode.
+   * When omitted, falls back to the project config's `embeddings.enabled`
+   * setting (default: true, i.e. embeddings run as before).
+   */
   skipEmbeddings?: boolean;
-  /** Explicit list of files to index (skips full repo scan when provided) */
-  filesToIndex?: string[];
 }
 
 /**
@@ -84,8 +89,6 @@ export interface IndexingResult {
   durationMs: number;
   incremental: boolean;
   error?: string;
-  /** Raw chunks when skipEmbeddings is true */
-  chunks?: CodeChunk[];
 }
 
 /** Extracted config values with defaults for indexing */
@@ -591,108 +594,21 @@ async function performFullIndex(
 }
 
 /**
- * Process a single file for chunk-only indexing (no embeddings).
- * Reads the file, chunks it, and appends results to the output array.
+ * Resolve whether this indexing run should skip real embedding computation.
+ *
+ * Precedence: an explicit `options.skipEmbeddings` always wins (this is how
+ * `lien index --no-embeddings` forces structural-only mode for a single
+ * run). Otherwise, falls back to the project config's `embeddings.enabled`
+ * (default: true) via {@link resolveEmbeddingsEnabled}, which already
+ * handles a malformed/unreadable config safely.
  */
-async function chunkFileForCollection(
-  file: string,
-  rootDir: string,
-  indexConfig: IndexingConfig,
-  output: CodeChunk[],
-): Promise<boolean> {
-  try {
-    const absolutePath = path.isAbsolute(file) ? file : path.join(rootDir, file);
-    const relativePath = normalizeToRelativePath(file, rootDir);
-    const content = await fs.readFile(absolutePath, 'utf-8');
-
-    const chunks = chunkFile(relativePath, content, {
-      chunkSize: indexConfig.chunkSize,
-      chunkOverlap: indexConfig.chunkOverlap,
-      useAST: indexConfig.useAST,
-      astFallback: indexConfig.astFallback,
-      repoId: indexConfig.repoId,
-      orgId: indexConfig.orgId,
-    });
-
-    if (chunks.length > 0) {
-      output.push(...chunks);
-      return true;
-    }
-    return false;
-  } catch (error) {
-    console.error(
-      `[indexer] Failed to process ${file}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return false;
-  }
-}
-
-/**
- * Perform chunk-only indexing (no embeddings or VectorDB).
- * Returns raw chunks in-memory for direct analysis.
- */
-async function performChunkOnlyIndex(
-  rootDir: string,
-  options: IndexingOptions,
-  startTime: number,
-): Promise<IndexingResult> {
-  options.onProgress?.({ phase: 'scanning', message: 'Scanning codebase...' });
-  const files = options.filesToIndex ?? (await scanFilesToIndex(rootDir));
-
-  if (files.length === 0) {
-    return {
-      success: false,
-      filesIndexed: 0,
-      chunksCreated: 0,
-      durationMs: Date.now() - startTime,
-      incremental: false,
-      error: 'No files found to index',
-    };
+async function resolveSkipEmbeddings(options: IndexingOptions, rootDir: string): Promise<boolean> {
+  if (typeof options.skipEmbeddings === 'boolean') {
+    return options.skipEmbeddings;
   }
 
-  const indexConfig = getIndexingConfig(rootDir);
-  const allChunks: CodeChunk[] = [];
-  let filesProcessed = 0;
-
-  options.onProgress?.({
-    phase: 'indexing',
-    message: `Processing ${files.length} files (chunk-only)...`,
-    filesTotal: files.length,
-    filesProcessed: 0,
-  });
-
-  const limit = pLimit(indexConfig.concurrency);
-  await Promise.all(
-    files.map(file =>
-      limit(async () => {
-        await chunkFileForCollection(file, rootDir, indexConfig, allChunks);
-        filesProcessed++;
-        options.onProgress?.({
-          phase: 'indexing',
-          message: 'Processing files...',
-          filesTotal: files.length,
-          filesProcessed,
-        });
-      }),
-    ),
-  );
-
-  options.onProgress?.({
-    phase: 'complete',
-    message: 'Chunk-only indexing complete',
-    filesTotal: files.length,
-    filesProcessed,
-    chunksProcessed: allChunks.length,
-  });
-
-  return {
-    success: true,
-    filesIndexed: filesProcessed,
-    chunksCreated: allChunks.length,
-    durationMs: Date.now() - startTime,
-    incremental: false,
-    chunks: allChunks,
-  };
+  const enabled = await resolveEmbeddingsEnabled(rootDir, options.config);
+  return !enabled;
 }
 
 /**
@@ -702,6 +618,15 @@ async function performChunkOnlyIndex(
  * - Tries incremental indexing first (if not forced)
  * - Falls back to full indexing if needed
  * - Provides progress callbacks for UI integration
+ *
+ * When embeddings are disabled (explicitly via `skipEmbeddings: true`, or
+ * via the project config's `embeddings.enabled: false`), indexing still
+ * runs the normal chunking + persistence pipeline — it just substitutes a
+ * `NullEmbeddings` service that writes zero-vector placeholders instead of
+ * computing real embeddings. This is structural-only mode: no model
+ * download, no embedding worker, and every structural tool
+ * (`get_files_context`, `get_dependents`, `list_functions`,
+ * `get_complexity`) keeps working against the persisted index.
  *
  * @param options - Indexing options
  * @returns Indexing result with stats
@@ -721,30 +646,23 @@ async function performChunkOnlyIndex(
  * const embeddings = new WorkerEmbeddings();
  * await embeddings.initialize();
  * const result = await indexCodebase({ embeddings });
+ *
+ * // Structural-only mode (no embeddings)
+ * const result = await indexCodebase({ skipEmbeddings: true });
  * ```
  */
 export async function indexCodebase(options: IndexingOptions = {}): Promise<IndexingResult> {
   const rootDir = options.rootDir ?? process.cwd();
   const startTime = Date.now();
 
-  // Fast path: skip embeddings and VectorDB, return raw chunks
-  if (options.skipEmbeddings) {
-    try {
-      return await performChunkOnlyIndex(rootDir, options, startTime);
-    } catch (error) {
-      return {
-        success: false,
-        filesIndexed: 0,
-        chunksCreated: 0,
-        durationMs: Date.now() - startTime,
-        incremental: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
   try {
     options.onProgress?.({ phase: 'initializing', message: 'Loading configuration...' });
+
+    const skipEmbeddings = await resolveSkipEmbeddings(options, rootDir);
+    const effectiveOptions: IndexingOptions =
+      skipEmbeddings && !options.embeddings
+        ? { ...options, embeddings: new NullEmbeddings() }
+        : options;
 
     // Initialize vector database (use factory to select backend from global config)
     options.onProgress?.({ phase: 'initializing', message: 'Initializing vector database...' });
@@ -753,14 +671,19 @@ export async function indexCodebase(options: IndexingOptions = {}): Promise<Inde
 
     // Try incremental indexing first (unless forced)
     if (!options.force) {
-      const incrementalResult = await tryIncrementalIndex(rootDir, vectorDB, options, startTime);
+      const incrementalResult = await tryIncrementalIndex(
+        rootDir,
+        vectorDB,
+        effectiveOptions,
+        startTime,
+      );
       if (incrementalResult) {
         return incrementalResult;
       }
     }
 
     // Fall back to full index
-    return await performFullIndex(rootDir, vectorDB, options, startTime);
+    return await performFullIndex(rootDir, vectorDB, effectiveOptions, startTime);
   } catch (error) {
     return {
       success: false,


### PR DESCRIPTION
## Summary

Adds a **structural-only mode**: embeddings can be disabled so indexing and `lien serve` run on pure AST/structural analysis — no embedding computation, no model download, no embedding worker thread. This is step 1 toward a possible "structural-first" product direction (agents already lean on the structural tools — `get_files_context`, `get_dependents`, `list_functions`, `get_complexity` — far more than the semantic ones; the constant embed-on-save is what makes the machine run hot).

**Default stays ON.** This PR is purely additive — zero behavior change for existing users. Flipping the default is a separate future product decision.

## Design

### The seam
`packages/core/src/indexer/index.ts` already had `skipEmbeddings?: boolean` on `IndexingOptions`, wired to a private, **unexported**, in-memory-only code path (`performChunkOnlyIndex`/`chunkFileForCollection`). It turned out to be dead code — not the same function as `@liendev/parser`'s `performChunkOnlyIndex` used by `@liendev/review` (different package, different function, untouched here), and not called from anywhere else in the tree (verified via grep + `get_dependents`).

### Placeholder-vector vs. vector-optional schema
Went with **(a) placeholder vectors**, not a schema change:

- `NullEmbeddings` (new `EmbeddingService` implementation) returns zero-filled `Float32Array(384)` from `embed`/`embedBatch`, with `initialize()`/`dispose()` as no-ops.
- `indexCodebase()` now resolves `skipEmbeddings` (explicit option, or the project config's `embeddings.enabled`) and substitutes `NullEmbeddings` for `options.embeddings`, then runs the **exact same** incremental/full indexing pipeline as before (`ChunkBatchProcessor`, `insertBatch`, LanceDB schema, manifest, git state) — nothing about the persistence path changes.
- Since the LanceDB vector column is written normally (just zero-filled), `scanAll`/`scanWithFilter`/`querySymbols` are completely untouched. That's why `get_files_context`, `get_dependents`, `list_functions`, `get_complexity` — all column-scan based, never vector search — keep working unchanged against a structural-only index.
- `lien serve` mirrors this: `initializeDatabase()` constructs `NullEmbeddings` instead of `WorkerEmbeddings` when disabled, so **no worker thread spawns and no model downloads**. The same `embeddings` instance flows into file-watch-triggered incremental reindexing for free.

This kept the fix to swapping one `EmbeddingService` implementation rather than adding a second index-write code path or making the vector column optional in the schema — much smaller surface, and the structural read path is provably unchanged (same code executes).

**Dead-code cleanup**: deleted `performChunkOnlyIndex`/`chunkFileForCollection` (superseded by the above) and the now-always-`undefined` `IndexingOptions.filesToIndex` / `IndexingResult.chunks` fields they were the only consumers of.

### Config surface
- `embeddings.enabled: boolean` added to `LienConfig` (`.lien.config.json`), default `true`, validated in `ConfigService` the same way as `gitDetection`/`fileWatching`.
- **`.lien.config.json` was previously dead code** — `ConfigService.load()` was never called anywhere at runtime (confirmed via grep); `lien init` even printed "found but no longer used". This PR is what actually wires it up for the first time (via a new shared `resolveEmbeddingsEnabled(rootDir, preloadedConfig?)` helper in `@liendev/core`, used by `indexCodebase`, `lien serve`, and `lien status`). A malformed/missing config always falls back to `enabled: true` — never blocks indexing/serving.
- `lien config set embeddings.enabled false|true` — extended `lien config` (previously global-only, `~/.lien/config.json`) to also route **project**-scoped keys through `ConfigService`/`.lien.config.json`. `lien config get`/`list` follow the same split. This was necessary to make the semantic-tool "disabled" message's suggested re-enable command actually work.
- `lien index --no-embeddings` forces structural-only mode for one run (commander negatable flag; only forces `skipEmbeddings: true` when explicitly passed — otherwise falls through to the config).
- `lien status` reports `Embeddings: ✓ Enabled` / `✗ Disabled (structural-only mode)` in text output, and `embeddings: { enabled }` in JSON output.

### Semantic-tool UX when disabled
`semantic_search` and `find_similar` check a new `ToolContext.embeddingsEnabled` (optional, defaults to enabled so no test/call-site elsewhere needs updating) and return, e.g.:
> "Semantic search is disabled (structural-only mode). Re-enable with `lien config set embeddings.enabled true` and run `lien index --force` to compute embeddings."

Note the message says **`lien index --force`**, not a plain reindex — verified this matters: incremental indexing only reprocesses *changed* files, so toggling the flag alone does nothing to already-indexed (unchanged) files. A full reindex is required in either direction to actually flip vectors between real/placeholder. Documented in the config field's own doc comment too.

## `indexCodebase`/`IndexingOptions` impact check
Per CLAUDE.md, checked dependents before touching this exported symbol. Real call sites are only `packages/cli/src/cli/index-cmd.ts` (`lien index`) and `packages/cli/src/mcp/server.ts` (auto-indexing on first run) — both updated. `packages/core/src/index.ts`'s re-export is unaffected (same name/shape, `filesToIndex`/`chunks` were unused fields removed as dead-code cleanup). No `packages/review`/`packages/action` impact — they depend on `@liendev/parser` only, not `@liendev/core` (ADR-009), and parser's own `performChunkOnlyIndex` is a distinct, untouched function.

## Verification

- New unit/integration tests (all green):
  - `packages/core/src/embeddings/null-embeddings.test.ts` — zero-vector behavior.
  - `packages/core/src/config/embeddings-enabled.test.ts` — safe-default resolution incl. malformed config.
  - `packages/core/src/indexer/index.test.ts` — real `indexCodebase()` against a temp fixture: spies on `WorkerEmbeddings.prototype.initialize` and asserts it's **never called** when disabled (option or config), confirms real structural metadata (imports/exports/symbolName) is persisted, and confirms embeddings-enabled (default) behavior and precedence rules are unchanged.
  - `packages/cli/test/integration/embeddings-disabled.test.ts` — full real MCP client/server round trip (real LanceDB index, real handlers, `InMemoryTransport`) proving `get_files_context`, `get_dependents`, `list_functions`, `get_complexity` all return correct data against an embeddings-off index, `semantic_search`/`find_similar` return the disabled note (not an error, not a silent empty result), and the embedding worker is never initialized.
  - Handler/CLI unit tests updated: `semantic-search.test.ts`, `find-similar.test.ts`, `server.test.ts` (asserts `NullEmbeddings` used + `WorkerEmbeddings` never constructed when disabled), `config.test.ts`, `status.test.ts`, `index-cmd.test.ts`, `merge.test.ts`, `service.test.ts`.
- Full gates: `npm run format:check`, `npm run lint` (0 errors), `npm run typecheck`, `npm run build` all pass across parser/core/review/cli/action.
- Test counts: core 515/515, review 488/488, action 28/28, cli 706/710 (4 failures are pre-existing native tree-sitter Python-parsing issues in this worktree — zero diff to `packages/parser`, same root cause reproduces in parser's own suite; unrelated to this change). `worker-embeddings.test.ts` excluded per the known vitest-fork-crash issue noted in CLAUDE.md.

## Ship notes

- Changeset: minor bump for `@liendev/core` and `@liendev/lien`.
- No AI attribution.

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 2 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 4 | +85 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a clean structural-only mode by introducing a `NullEmbeddings` zero-vector stub and wiring `embeddings.enabled` project config through indexing, serving, and status. The default remains enabled, so existing behavior is unchanged. Callers of `indexCodebase` receive the same shape with only unused dead fields removed, and the read path for structural tools is untouched. Semantic tools correctly short-circuit with a disabled note rather than running meaningless vector searches.
>
> - Added `NullEmbeddings` and `resolveEmbeddingsEnabled`, with `indexCodebase` substituting the null stub when `skipEmbeddings` or config disables embeddings.
> - Extended CLI `config` commands and `lien index --no-embeddings` to support project-scoped `embeddings.enabled`.
> - `lien serve` now avoids constructing `WorkerEmbeddings` when disabled, and `semantic_search`/`find_similar` return an explicit disabled note.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 051d681. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structural-only mode that lets indexing and server tools run without embeddings.
  * Added a project-level `embeddings.enabled` setting and a one-time `--no-embeddings` indexing option.
  * Status output now shows whether embeddings are enabled, including JSON output.

* **Bug Fixes**
  * Semantic search and “find similar” now return a clear disabled-mode note instead of failing.
  * Structural context features continue working even when embeddings are turned off.

* **Documentation**
  * Updated CLI help and setup messages to explain global and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->