### PR TITLE
ci: smoke-test installs local sibling tarballs, not registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
     # lockfile -- the same resolution path an external `npm install
     # @liendev/lien` gets -- so a phantom dependency fails the PR instead of
     # shipping.
+    #
+    # It packs and installs all three PUBLISHED packages together (parser,
+    # core, lien), not just the CLI. A real release publishes them together
+    # (version-linked by changesets), so the CLI's @liendev/* sibling deps
+    # should resolve to those local tarballs, not whatever's currently live
+    # on the registry. Packing only the CLI made "new CLI + old published
+    # core/parser" -- a combination that can't happen in production -- the
+    # thing this job tested, which false-positived on any PR adding a new
+    # cross-package export (see #644: core shipped `NullEmbeddings` but the
+    # CLI resolved the older, still-published core without it). review,
+    # action, and site are private and intentionally excluded: if the CLI
+    # ever depends on one of them again, it still has to resolve from the
+    # registry and 404, preserving the #620 detection this job exists for.
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -128,18 +141,20 @@ jobs:
       - name: Build packages required for the CLI tarball
         run: npm run build:core && npm run build -w packages/cli
 
-      - name: Pack @liendev/lien tarball
-        run: npm pack -w @liendev/lien
+      - name: Pack published packages (parser, core, lien)
+        run: npm pack -w @liendev/parser -w @liendev/core -w @liendev/lien
 
-      - name: Install tarball as an external consumer
+      - name: Install tarballs together as an external consumer
         run: |
           set -euo pipefail
-          TARBALL="$(pwd)/$(ls liendev-lien-*.tgz)"
+          PARSER_TARBALL="$(pwd)/$(ls liendev-parser-*.tgz)"
+          CORE_TARBALL="$(pwd)/$(ls liendev-core-*.tgz)"
+          CLI_TARBALL="$(pwd)/$(ls liendev-lien-*.tgz)"
           SCRATCH="$(mktemp -d)"
           echo "SCRATCH_DIR=$SCRATCH" >> "$GITHUB_ENV"
           cd "$SCRATCH"
           npm init -y >/dev/null
-          npm install "$TARBALL"
+          npm install "$PARSER_TARBALL" "$CORE_TARBALL" "$CLI_TARBALL"
 
       - name: Run the installed CLI binary
         run: |


### PR DESCRIPTION
## The false positive

The \"Release smoke test (npm pack -> external install)\" job packed only the CLI tarball (\`npm pack -w @liendev/lien\`) and installed it alone into a scratch dir. With no sibling tarball present, npm resolved the CLI's \`@liendev/core\` and \`@liendev/parser\` dependencies from the **public npm registry** -- the currently-published versions, not the ones in this PR/build.

On #644, this threw at runtime:

```
SyntaxError: The requested module '@liendev/core' does not provide an export named 'NullEmbeddings'
```

because the CLI imported the new `NullEmbeddings` export, but the installed (published, older) `@liendev/core` didn't have it yet. This is a false positive: a real release publishes `parser`/`core`/`lien` together, version-linked by changesets, so "new CLI + old published core" can never happen in production. As written, the job blocked every PR that adds a cross-package export.

## The fix

Pack all three published workspace packages -- `@liendev/parser`, `@liendev/core`, `@liendev/lien` (verified via `package.json`: these three have no `private` field; `review`, `action`, and `site` are all `"private": true` and are never published) -- and install all three tarballs together in the scratch dir:

```
npm pack -w @liendev/parser -w @liendev/core -w @liendev/lien
...
npm install "$PARSER_TARBALL" "$CORE_TARBALL" "$CLI_TARBALL"
```

Because the three tarballs are version-linked and installed together, npm's dependency resolution satisfies the CLI's `@liendev/core`/`@liendev/parser` ranges from the local tarballs instead of fetching them from the registry -- this now tests the actual to-be-released set, not an impossible hybrid.

The job's `name:` is unchanged (`Release smoke test (npm pack -> external install)`) since branch protection requires that exact display name.

## Confirming the #620 detection is preserved

This job exists to catch the phantom/missing-dependency class of bug -- `@liendev/lien` once shipped a runtime dependency on the private, unpublishable `@liendev/review`, which broke `npm install` for real users until #620. That detection still works here: only the three genuinely-published siblings are packed and installed locally. Anything else the CLI might depend on (like `@liendev/review`) is *not* in the local tarball set, so npm still has to resolve it from the registry -- and since it was never published, that 404s and fails the job exactly as before.

Verified this directly: I built a throwaway package that declares a dependency on `@liendev/review` and installed it alongside the three real local tarballs. The install failed with:

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@liendev%2freview - Not found
```

confirming the fix doesn't weaken the check into an always-pass.

## Dry run

Built parser/core/cli locally, packed all three, and installed them together into a clean scratch dir with verbose/http logging:

- npm's dry-run resolution added exactly the local tarball versions with no duplicate/conflicting entries: `add @liendev/parser 0.50.0`, `add @liendev/core 0.50.1`, `add @liendev/lien 0.50.1`.
- npm does issue a registry GET for `@liendev/parser`'s packument (metadata only, for its own internal bookkeeping/dedup checks against the other packages that also depend on it) -- but the tarball content actually placed in `node_modules` is the local one, matching the versions above; no separate/older registry-published tarball is fetched or installed.
- A genuinely-missing/private dependency (simulated via `@liendev/review`) still fails resolution with a 404, as shown above.
- The final `lien --version`/`--help` step could not be exercised end-to-end on this machine: installing the full tarball set from scratch triggers native compilation of tree-sitter language bindings (e.g. `tree-sitter-kotlin`), which fails on this machine's local Clang/SDK toolchain (`no matching function for call to '__countl_zero'`) -- unrelated to this change. This is a known environment limitation (see worktree notes); CI runs on a clean Ubuntu runner where these bindings install from prebuilt binaries, so the runtime step will be validated there.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` -- parses cleanly, job name confirmed unchanged.
- `npx prettier --check .github/workflows/ci.yml` -- passes.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 78 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 5 high-risk file(s) with 118 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 9 | — |
| 🧠 mental load | 30 | — |
| ⏱️ time to understand | 37 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4897f2f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->