### PR TITLE
docs(action): dist sync needs a release tag, not workflow_dispatch

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -20,8 +20,12 @@ name: Publish Action
 # behavior for every private package, out of scope here.
 #
 # Caveat: an action-only change that doesn't also bump the CLI's version won't
-# trigger this automatically. Use workflow_dispatch to publish it manually
-# until/unless we add a dedicated tag (see the README runbook).
+# trigger this automatically. workflow_dispatch does NOT fill that gap — on
+# dispatch, "Resolve tags" below emits only the sha tag, and the dist-repo
+# sync step is gated to `push` only, so dispatch never syncs the dist repo or
+# moves :v1/:latest. It's useful only as an image-only smoke test. To ship an
+# action-only fix, include a changeset that bumps `@liendev/lien` so the next
+# release tag carries it (see the README runbook).
 
 on:
   push:
@@ -121,7 +125,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${GH_DIST_TOKEN:-}" ]; then
-            echo "::notice::GH_DIST_TOKEN is not set — skipping the getlien/lien-review dist-repo sync. The GHCR image was published above, but 'uses: getlien/lien-review@v1' will not resolve to it yet. See packages/action/README.md 'Publishing the Action' for the one-time human setup (create the dist repo + add the secret), then re-run this workflow via workflow_dispatch."
+            echo "::notice::GH_DIST_TOKEN is not set — skipping the getlien/lien-review dist-repo sync. The GHCR image was published above, but 'uses: getlien/lien-review@v1' will not resolve to it yet. See packages/action/README.md 'Publishing the Action' for the one-time human setup (create the dist repo + add the secret). Once that's done, this step runs automatically on the next @liendev/lien@* release tag push — not on workflow_dispatch, which skips this step entirely."
             exit 0
           fi
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -234,7 +234,11 @@ piggybacking on the CLI's tag avoids adding a dedicated tag scheme.
 **Caveat:** an action-only change that doesn't also bump `@liendev/lien`'s
 version won't auto-trigger a publish. Include a changeset that touches
 `@liendev/lien` (even a patch-level one) when you want a release to carry an
-action-only fix, or trigger `workflow_dispatch` manually.
+action-only fix. `workflow_dispatch` is not a substitute for that — it only
+publishes the immutable `sha-<commit>` image tag (see "One-time human setup"
+above and "What gets published where" below); the dist-repo sync and the
+`:v1`/`:latest` tag move are gated to tag pushes only, so dispatch never runs
+them.
 
 ### What gets published where
 


### PR DESCRIPTION
## Summary

Three spots in `publish-action.yml` / `packages/action/README.md` told the human to use `workflow_dispatch` to publish or "re-run this workflow" as if that completed the dist-repo sync — it never does, because the sync step ("Sync action.yml + README to dist repo and move v1 tag") is gated `if: github.event_name == 'push'`, i.e. it only runs on a `@liendev/lien@*` tag push (cutting a release). Docs/comments only — no workflow logic or step guards changed.

**Corrected mental model:**
- `workflow_dispatch` = image-only smoke test. On dispatch, the "Resolve tags" step emits only the immutable `sha-<commit>` tag; it never touches `:v1`/`:latest`/a version tag, and the dist-repo sync step never runs (wrong event).
- A `@liendev/lien@*` release tag push = full publish: image (version + `:v1` + `:latest` + sha tags) **and** the dist-repo sync + `v1`/`latest` tag move — the thing that makes `uses: getlien/lien-review@v1` resolve to the new release.

**What was misleading, now fixed:**
1. The `GH_DIST_TOKEN`-missing `::notice::` in the sync step said "...then re-run this workflow via workflow_dispatch." Re-running via dispatch skips the sync step entirely (wrong event), so following that advice would never sync the dist repo. Now points at the next `@liendev/lien@*` release tag push instead.
2. The header comment's caveat ("Use workflow_dispatch to publish it manually...") implied dispatch does a full publish. Now clarifies dispatch only publishes the sha-tagged image and that an action-only fix needs a changeset bumping `@liendev/lien` to ride the next release tag.
3. `packages/action/README.md`'s "Publishing the Action" runbook had the same "...or trigger `workflow_dispatch` manually" framing in its caveat. Now clarifies dispatch is not a substitute — it only publishes the sha tag, not the dist-repo sync or `:v1`/`:latest` move.

**Deliberately not done:** if we later want `workflow_dispatch` to do a full manual publish (e.g. for an action-only fix without waiting for a CLI release), that needs an actual behavior change — a version input plus letting the sync step run on dispatch. Out of scope for this docs-only fix.

## Test plan
- [x] `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/publish-action.yml'))"` — parses cleanly
- [x] `npx prettier --check .github/workflows/publish-action.yml packages/action/README.md` — passes
- [x] Diff confined to comments/prose only, no step guards or trigger logic touched

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 79 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 5 high-risk file(s) with 125 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 9 | — |
| 🧠 mental load | 30 | — |
| ⏱️ time to understand | 38 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b320dd2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->