### PR TITLE
fix(cli): pin @liendev sibling deps to a real range instead of "*"

### DIFF
--- a/.changeset/pin-cli-sibling-deps.md
+++ b/.changeset/pin-cli-sibling-deps.md
@@ -1,0 +1,16 @@
+---
+'@liendev/lien': patch
+'@liendev/core': patch
+'@liendev/review': patch
+'@liendev/action': patch
+---
+
+Pin `@liendev/*` sibling dependencies to a real semver range instead of `"*"`.
+
+`packages/cli/package.json` (published as `@liendev/lien`) declared `@liendev/core` and `@liendev/parser` as `"*"`, and `packages/core/package.json` declared `@liendev/parser` as `"*"`. Since `"*"` is never rewritten at publish time, npm installs of `@liendev/lien` could resolve to whatever `@liendev/core`/`@liendev/parser` happens to be latest on npm at install time — not the versions `lien` was actually built and tested against. This is the same `"*"`-in-published-package.json family as the earlier phantom `@liendev/review` dependency bug (#620).
+
+It worked so far mostly by luck (packages are usually published together in the same release), but the drift is real: `@liendev/parser` is currently stuck at `0.50.0` on npm while `@liendev/core`/`@liendev/lien` are at `0.51.0`.
+
+Fixed by replacing every `"*"` cross-package reference with the actual current semver range (e.g. `^0.51.0`), for both published packages (`cli`, `core`) and private ones (`review`, `action`) for consistency. `changeset`'s `updateInternalDependencies: "patch"` will now correctly keep these ranges in sync on future releases, since a `"*"` range is never considered "violated" and was silently defeating that mechanism.
+
+Note: `workspace:*` (the pnpm/yarn workspace protocol) is not usable here — this repo uses plain npm workspaces, and npm has no equivalent rewrite step; `npm install --package-lock-only` fails immediately with `EUNSUPPORTEDPROTOCOL` if you try it. A real pinned range is the correct fix for npm workspaces.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12841,7 +12841,10 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12976,8 +12979,8 @@
       "name": "@liendev/action",
       "version": "0.1.0",
       "dependencies": {
-        "@liendev/parser": "*",
-        "@liendev/review": "*"
+        "@liendev/parser": "^0.50.0",
+        "@liendev/review": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -13264,11 +13267,11 @@
     },
     "packages/cli": {
       "name": "@liendev/lien",
-      "version": "0.49.0",
+      "version": "0.51.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@liendev/core": "*",
-        "@liendev/parser": "*",
+        "@liendev/core": "^0.51.0",
+        "@liendev/parser": "^0.50.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/figlet": "1.7.0",
         "chalk": "5.3.0",
@@ -13360,12 +13363,12 @@
     },
     "packages/core": {
       "name": "@liendev/core",
-      "version": "0.49.0",
+      "version": "0.51.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@lancedb/lancedb": "^0.23.0",
-        "@liendev/parser": "*",
+        "@liendev/parser": "^0.50.0",
         "chalk": "^5.6.2",
         "collect.js": "^4.36.1",
         "p-limit": "5.0.0",
@@ -13683,7 +13686,7 @@
     },
     "packages/parser": {
       "name": "@liendev/parser",
-      "version": "0.48.2",
+      "version": "0.50.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "glob": "^10.5.0",
@@ -13727,7 +13730,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.61.0",
-        "@liendev/parser": "*",
+        "@liendev/parser": "^0.50.0",
         "@octokit/rest": "^21.1.1",
         "collect.js": "^4.36.1",
         "zod": "^3.23.0"

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -13,8 +13,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@liendev/parser": "*",
-    "@liendev/review": "*"
+    "@liendev/parser": "^0.50.0",
+    "@liendev/review": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,8 +67,8 @@
   "author": "Alf Henderson",
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "@liendev/core": "*",
-    "@liendev/parser": "*",
+    "@liendev/core": "^0.51.0",
+    "@liendev/parser": "^0.50.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/figlet": "1.7.0",
     "chalk": "5.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "@liendev/parser": "*",
+    "@liendev/parser": "^0.50.0",
     "@lancedb/lancedb": "^0.23.0",
     "chalk": "^5.6.2",
     "collect.js": "^4.36.1",

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.61.0",
-    "@liendev/parser": "*",
+    "@liendev/parser": "^0.50.0",
     "@octokit/rest": "^21.1.1",
     "collect.js": "^4.36.1",
     "zod": "^3.23.0"


### PR DESCRIPTION
## The bug

Published `@liendev/lien` (`packages/cli/package.json`) declared its sibling deps as unpinned wildcards:

```json
"@liendev/core": "*",
"@liendev/parser": "*"
```

`packages/core/package.json` had the same pattern for `@liendev/parser`. `"*"` is never rewritten at publish time, so npm installs of `@liendev/lien` can resolve `@liendev/core`/`@liendev/parser` to whatever is latest on npm at install time — not the versions `lien` was actually built and tested against. This is the same `"*"`-in-published-package.json family as the earlier phantom `@liendev/review` dependency bug (#620).

It has worked so far mostly by luck (packages are usually published together), but the drift is real and currently observable: **`@liendev/parser` is stuck at `0.50.0` on npm while `@liendev/core`/`@liendev/lien` are at `0.51.0`.**

## The fix

Replaced every `"*"` cross-package reference with the actual current semver range:

- `packages/cli/package.json` (published, `@liendev/lien`): `@liendev/core` and `@liendev/parser` → `^0.51.0` / `^0.50.0`
- `packages/core/package.json` (published): `@liendev/parser` → `^0.50.0`
- `packages/review/package.json` (private): `@liendev/parser` → `^0.50.0` (fixed for consistency)
- `packages/action/package.json` (private): `@liendev/parser`, `@liendev/review` → `^0.50.0` / `^0.1.0` (fixed for consistency)

`packages/parser/package.json` has no internal `@liendev/*` deps, so it needed no change.

### Why not `workspace:*`?

I initially reached for the pnpm/yarn `workspace:*` protocol, since that's what changesets rewrites to a pinned range at publish time. **It doesn't work here** — this repo uses plain npm workspaces (only a `package-lock.json`, no `yarn.lock`/`pnpm-lock.yaml`), and npm has no equivalent rewrite step at all:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

Per changesets' own source (`apply-release-plan/version-package.ts`) and docs: *"The `workspace:*` protocols in the packed tarballs are handled by the package manager, not by changeset."* Since npm doesn't implement that handling, a real pinned semver range (e.g. `^0.51.0`) is the correct fix for an npm-only workspace. Going forward, changesets' `updateInternalDependencies: "patch"` (already set in `.changeset/config.json`) will keep these ranges in sync automatically — something it could never do for a literal `"*"`, since a wildcard range is never "violated" by a new version.

## Repo convention finding

Before this PR, **every** `@liendev/*` cross-package reference in the repo was `"*"` — `cli`→core/parser, `core`→parser, `review`→parser, `action`→parser/review. There was no existing `workspace:*` (or pinned-range) precedent anywhere to follow; `"*"` was simply the uniform (broken) convention. This PR establishes real pinned ranges as the new convention.

## Changeset-linking finding (parser stuck at 0.50.0)

`.changeset/config.json` has:

```json
"linked": [["@liendev/parser", "@liendev/core", "@liendev/lien"]]
```

This is **not a config bug** — it's `linked` working as documented, and it's worth understanding why the drift happened. Per changesets docs: with `linked` (unlike `fixed`), *"only packages with changesets will be version-bumped and published"* — linked only syncs the **version number** among packages that actually release; it doesn't force every member to release together the way `fixed` does.

The most recent release (PR #647 / commit `543def2`) versioned from `.changeset/structural-only-mode.md`, which only bumped `@liendev/core` and `@liendev/lien` (minor) — it had no entry for `@liendev/parser`, because that change didn't touch parser's code. Since `linked` doesn't force unrelated members to bump, parser correctly stayed at `0.50.0`. This is expected behavior, not a gap — flagging it since the task called out the drift as suspicious. Separately: this same `"*"`-wildcard pattern was *also* silently defeating changesets' `updateInternalDependencies` dependency-cascade check (a `"*"` range is never "violated" by a version bump), which this PR's fix incidentally un-blocks for future releases.

I'm not touching `.changeset/config.json` — the `"*"` → pinned-range fix is the primary correction; the `linked`-vs-`fixed` question is a separate product decision (do `parser`/`core`/`lien` need to *always* release in lockstep, or just share version numbers when they do release?) that's worth a deliberate call from Alf, not a drive-by change here.

## Verification: packed tarball proof

`npm pack -w @liendev/lien`, tarball extracted, `package/package.json` inspected:

**Before** (packed from `main`, `@liendev/lien@0.50.0`):
```json
"dependencies": {
  "@liendev/core": "*",
  "@liendev/parser": "*",
  ...
}
```

**After** (packed from this branch, `@liendev/lien@0.51.0`):
```json
"dependencies": {
  "@liendev/core": "^0.51.0",
  "@liendev/parser": "^0.50.0",
  ...
}
```

The published artifact now pins its siblings to a real range instead of "any version on npm."

## Gates

- `npm run format:check` — pass
- `npm run lint` — pass (0 errors; pre-existing warnings only, unrelated to this change)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — pass (all 5 workspaces: parser, core, review, cli, action — 2,688 tests green)

## Changeset

Added `.changeset/pin-cli-sibling-deps.md` — patch bump for `@liendev/lien`, `@liendev/core`, `@liendev/review`, `@liendev/action` (the packages whose `package.json` changed). `@liendev/parser` needs no changeset since its own `package.json` wasn't touched.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 79 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 5 high-risk file(s) with 125 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 9 | — |
| 🧠 mental load | 30 | — |
| ⏱️ time to understand | 38 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 921ba7b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced broad dependency wildcards with pinned version ranges across several packages, improving install consistency.
  * Aligned related packages to the versions they were built against, reducing unexpected resolution issues.

* **Chores**
  * Updated release metadata to reflect patch-level dependency updates for affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->