### PR TITLE
feat(parser): exclude .claude/worktrees from indexing by default

### DIFF
--- a/.changeset/exclude-claude-worktrees.md
+++ b/.changeset/exclude-claude-worktrees.md
@@ -1,0 +1,13 @@
+---
+'@liendev/parser': patch
+'@liendev/lien': patch
+---
+
+Exclude `.claude/worktrees/**` from indexing by default. Claude Code agent
+worktrees are full nested repo clones used as scratch space — indexing them
+duplicates the entire project once per worktree (seen in production: ~30
+worktrees produced a 21 GB index and pegged 8 CPU cores). This directory is
+now added to `ALWAYS_IGNORE_PATTERNS`, the shared exclude list used by the
+scanner, watcher, and gitignore filter, so it's never indexed regardless of
+user configuration — the same treatment `node_modules/**` and `.lien/**`
+already get.

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,14 @@ coverage/
 # Claude Code (local settings are machine-specific)
 .claude/settings.local.json
 
+# Claude Code agent worktrees (full nested repo clones used as scratch
+# space by CC agents; never meant to be committed or indexed)
+.claude/worktrees/
+
+# Playwright MCP scratch output (screenshots, console/page captures from
+# browser-automation runs)
+.playwright-mcp/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/packages/parser/src/gitignore.test.ts
+++ b/packages/parser/src/gitignore.test.ts
@@ -83,10 +83,25 @@ describe('createGitignoreFilter', () => {
     expect(isIgnored('styles/main.min.css')).toBe(true);
   });
 
+  it('should always ignore Claude Code agent worktrees (.claude/worktrees)', async () => {
+    const isIgnored = await createGitignoreFilter(testDir);
+
+    // Direct child of the project root — the exact incident shape (full
+    // nested repo clone with source files under packages/*/src)
+    expect(isIgnored('.claude/worktrees/agent-x/packages/cli/src/foo.ts')).toBe(true);
+    expect(isIgnored('.claude/worktrees/agent-x/package.json')).toBe(true);
+    // Nested under a subdirectory (monorepo-in-monorepo scenario)
+    expect(isIgnored('packages/app/.claude/worktrees/agent-y/src/index.ts')).toBe(true);
+    // Sibling .claude paths that are NOT worktrees are unaffected — only
+    // the worktrees subdirectory (full repo clones) is excluded
+    expect(isIgnored('.claude/settings.json')).toBe(false);
+    expect(isIgnored('.claude/agents/reviewer.md')).toBe(false);
+  });
+
   it('should not allow .gitignore negations to override built-in patterns', async () => {
     await fs.writeFile(
       path.join(testDir, '.gitignore'),
-      '!node_modules/\n!.lien/\n!vendor/\n!.git/\n',
+      '!node_modules/\n!.lien/\n!vendor/\n!.git/\n!.claude/\n',
     );
 
     const isIgnored = await createGitignoreFilter(testDir);
@@ -95,6 +110,7 @@ describe('createGitignoreFilter', () => {
     expect(isIgnored('.lien/indices/abc123')).toBe(true);
     expect(isIgnored('vendor/autoload.php')).toBe(true);
     expect(isIgnored('.git/HEAD')).toBe(true);
+    expect(isIgnored('.claude/worktrees/agent-x/src/index.ts')).toBe(true);
   });
 
   it('should handle negation patterns', async () => {

--- a/packages/parser/src/gitignore.ts
+++ b/packages/parser/src/gitignore.ts
@@ -15,6 +15,12 @@ export const ALWAYS_IGNORE_PATTERNS = [
   '.git/**',
   '**/.git/**',
   '.lien/**',
+  // Claude Code agent worktrees: full nested repo clones used as scratch
+  // space by CC agents. Indexing them duplicates the entire project once
+  // per worktree (seen in production: ~30 worktrees -> 21 GB index, 8 CPU
+  // cores pegged). Never index these regardless of user config.
+  '.claude/worktrees/**',
+  '**/.claude/worktrees/**',
   'dist/**',
   '**/dist/**',
   'build/**',
@@ -98,8 +104,8 @@ function matchesScopedIgnore(normalized: string, prefix: string, ig: Ignore): bo
  * Create a filter function that checks if a file path is gitignored.
  * Discovers .gitignore files throughout the directory tree and applies
  * each at its appropriate scope, plus built-in exclusions (node_modules,
- * vendor, .git, .lien, dist, build, minified assets) to match the full scan
- * behavior in scanner.ts.
+ * vendor, .git, .lien, .claude/worktrees, dist, build, minified assets) to
+ * match the full scan behavior in scanner.ts.
  *
  * Limitation: scoped evaluation is OR across .gitignore files, so a nested
  * .gitignore cannot un-ignore a pattern from a parent. Cross-scope negation

--- a/packages/parser/src/scanner.test.ts
+++ b/packages/parser/src/scanner.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { detectFileType, detectLanguage } from './scanner.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { detectFileType, detectLanguage, scanCodebase } from './scanner.js';
 
 describe('detectFileType', () => {
   it('should export detectLanguage as a backwards-compat alias', () => {
@@ -119,5 +122,55 @@ describe('detectFileType', () => {
     expect(detectFileType('../src/index.ts')).toBe('typescript');
     expect(detectFileType('/usr/local/bin/script.py')).toBe('python');
     expect(detectFileType('./components/Button.tsx')).toBe('typescript');
+  });
+});
+
+describe('scanCodebase', () => {
+  let testDir: string;
+
+  afterEach(async () => {
+    if (!testDir) return;
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  // Regression test for the .claude/worktrees exclusion (ALWAYS_IGNORE_PATTERNS
+  // in gitignore.ts). That exclusion is matched against path.relative(rootDir, file),
+  // so it must only fire when .claude/worktrees is BELOW the scan root — never when
+  // a worktree itself IS the scan root. Guards against a future over-broad rewrite
+  // (e.g. absolute-path matching, or a wider '**/.claude/**' pattern) silently making
+  // Lien unable to index a repo checked out under .claude/worktrees/.
+  it('excludes a nested .claude/worktrees checkout when scanning the parent, but fully indexes it when scanned as its own root', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-worktrees-'));
+
+    const worktreeDir = path.join(testDir, '.claude', 'worktrees', 'agent-x');
+
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+    await fs.mkdir(path.join(worktreeDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(worktreeDir, 'src', 'foo.ts'), 'export const foo = true;\n');
+    await fs.writeFile(path.join(worktreeDir, 'package.json'), '{"name":"agent-x"}\n');
+
+    // 1. Scanning the parent repo excludes the nested worktree entirely.
+    const parentFiles = await scanCodebase({ rootDir: testDir });
+    const parentRelative = parentFiles.map(f => path.relative(testDir, f));
+
+    expect(parentRelative).toContain(path.join('src', 'real.ts'));
+    expect(parentRelative).not.toContain(
+      path.join('.claude', 'worktrees', 'agent-x', 'src', 'foo.ts'),
+    );
+    expect(parentRelative.some(f => f.includes('.claude'))).toBe(false);
+
+    // 2. Scanning the worktree AS ITS OWN ROOT is unaffected by the exclusion —
+    // relative paths from this root never contain '.claude/worktrees', so the
+    // pattern does not fire and the worktree is fully indexed.
+    const worktreeFiles = await scanCodebase({ rootDir: worktreeDir });
+    const worktreeRelative = worktreeFiles.map(f => path.relative(worktreeDir, f));
+
+    expect(worktreeRelative).toContain(path.join('src', 'foo.ts'));
   });
 });


### PR DESCRIPTION
## Incident

A user's laptop overheated because Lien's `serve`/watcher was indexing ~30 full repo copies sitting under `.claude/worktrees/` (Claude Code agent worktrees — CC agents each get an isolated git worktree, which is a full clone of the repo). This built a **21 GB index** and pegged **8 CPU cores**. Confirmed live in this repo while working on this very fix: `get_dependents` on `packages/parser/src/gitignore.ts` returned duplicate dependents from `.claude/worktrees/agent-ada9238d436758ed6/...` and `.claude/worktrees/agent-a9a2d98cb4757ce79/...` — the bug reproducing itself in the tool used to fix it.

`.claude/worktrees/` is agent scratch space (full repo clones), never project source, and must never be indexed — same treatment as `node_modules/` and `.lien/`.

## The fix

The single shared exclude list all scanning paths draw from is `ALWAYS_IGNORE_PATTERNS` in `packages/parser/src/gitignore.ts` — imported by `scanner.ts` (`scanCodebase`), the CLI watcher, and `createGitignoreFilter`. It already had `.lien/**` for exactly this "always exclude, regardless of user config" purpose. Added:

```ts
'.claude/worktrees/**',
'**/.claude/worktrees/**',
```

alongside it.

**Why not `.claude/**` broadly?** Being conservative per the request: `.claude/worktrees/` is unambiguously scratch (full repo clones — that's the entire incident). But `.claude/` also holds `agents/*.md`, `skills/*/SKILL.md`, and `commands/*.md` — markdown that describes project-specific agent/tooling behavior some users may genuinely want semantically searchable (e.g. "how does the code-reviewer agent work"). Excluding all of `.claude/` would silently remove that without a matching incident to justify it, so this PR only excludes the `worktrees/` subdirectory. Tests assert `.claude/settings.json` and `.claude/agents/reviewer.md` remain indexed while `.claude/worktrees/**` is fully excluded.

I did **not** touch `packages/parser/src/ecosystem-presets.ts`. That file's `excludePatterns` are per-ecosystem (nodejs/python/php/...) and gated behind marker-file detection — `.claude/worktrees` isn't nodejs-specific (CC is used with Python/Rust/Go projects too), so gating it behind ecosystem detection would be the wrong shape. `ALWAYS_IGNORE_PATTERNS` applies unconditionally, which is what this needs.

## Repo hygiene

- Added `.claude/worktrees/` and `.playwright-mcp/` to this repo's own `.gitignore` — both were untracked-but-not-ignored scratch dirs at the repo root.
- Left `.intent/` untouched: it ships its own nested `.gitignore` (`*` / `!config.json`) that appears to intentionally track `config.json` eventually. A root-level `.intent/` ignore would make that nested negation unreachable (git won't descend into a wholesale-ignored directory to evaluate nested un-ignores), so I didn't want to silently break that setup. Flagging it here rather than guessing.

## Verification

New test in `packages/parser/src/gitignore.test.ts` (mirrors the existing node_modules-exclusion test):

```
it('should always ignore Claude Code agent worktrees (.claude/worktrees)', ...)
```

Also ran a standalone proof against `scanCodebase` with a fixture tree shaped like the incident (`.claude/worktrees/agent-x/packages/cli/src/foo.ts` + a real `src/real.ts`):

```
Files that WOULD be indexed:
 - src/real.ts

PASS: .claude/worktrees/** fully excluded; real source file still indexed.
```

Gates, all green:
```
npm run format:check   ✓
npm run lint           ✓ (0 errors; pre-existing warnings unrelated to this change)
npm run typecheck      ✓
npm run build          ✓
npm run test -w @liendev/parser   ✓ 935/935 tests passed (29 files)
```

Changeset added: patch bump for `@liendev/parser` and `@liendev/lien`.

## Test plan

- [x] `npm run test -w @liendev/parser` passes (935/935, including 2 new assertions)
- [x] Fixture-tree proof script confirms `.claude/worktrees/**` files are excluded from `scanCodebase` output while sibling real source files are still indexed
- [ ] Manual: run `lien index` against a repo with an active `.claude/worktrees/` directory and confirm index size/CPU no longer scale with worktree count

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds `.claude/worktrees/**` and `**/.claude/worktrees/**` to the shared `ALWAYS_IGNORE_PATTERNS` list, the single source of truth used by `scanCodebase`, `createGitignoreFilter`, and (transitively) the CLI watcher. The change is narrow and correct: it prevents indexing of Claude Code agent worktrees while leaving sibling `.claude/` paths like `agents/*.md` and `settings.json` searchable. The new patterns mirror the existing shape of other always-ignore entries, and tests cover root-level, nested, and negation-resistant cases plus the important guard that a worktree scanned as its own root is still indexed.
>
> - Added `.claude/worktrees/**` and `**/.claude/worktrees/**` to `ALWAYS_IGNORE_PATTERNS`
> - Added parser tests asserting worktree exclusion and sibling `.claude/` inclusion
> - Added scanner regression test verifying a worktree is excluded when nested under a parent root but fully indexed when it is the scan root

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b89f6f6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->