### PR TITLE
fix(plugin): pin @liendev/lien@latest so npx isn't shadowed by local/global installs

### DIFF
--- a/packages/site/docs/guide/installation.md
+++ b/packages/site/docs/guide/installation.md
@@ -15,7 +15,7 @@ For Claude Code users, the simplest path is the one-time plugin install — no `
 /plugin install lien
 ```
 
-The plugin spawns Lien on demand via `npx -y @liendev/lien`, so it always pulls the latest release. To upgrade, restart Claude Code — the next spawn fetches the newest version automatically.
+The plugin spawns Lien on demand via `npx -y @liendev/lien@latest`, which resolves against the npm registry on every launch, so it always runs the latest published release — even if you have a local `npm link` or workspace copy of `@liendev/lien` on your machine. To upgrade, restart Claude Code — the next spawn fetches the newest version automatically.
 
 ::: tip Working on Lien itself?
 Contributors should NOT install the plugin in their dev environment — that points the MCP server at the npm-published binary, bypassing your local changes. See [CONTRIBUTING.md](https://github.com/getlien/lien/blob/main/CONTRIBUTING.md) for the dogfooding setup that points at your local build instead.
@@ -59,7 +59,7 @@ For frequent use, global installation gives better cold-start performance.
 
 ## Upgrading
 
-**Plugin users (Claude Code):** restart Claude Code. The plugin's `npx -y @liendev/lien` invocation re-resolves to the latest npm version on every cold start, so a restart is all you need.
+**Plugin users (Claude Code):** restart Claude Code. The plugin's `npx -y @liendev/lien@latest` invocation re-resolves to the latest npm version on every cold start, so a restart is all you need.
 
 **Global install users:** bump the package and restart your editor.
 

--- a/plugins/claude/.mcp.json
+++ b/plugins/claude/.mcp.json
@@ -1,6 +1,6 @@
 {
   "lien": {
     "command": "npx",
-    "args": ["-y", "@liendev/lien", "serve"]
+    "args": ["-y", "@liendev/lien@latest", "serve"]
   }
 }

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -1,0 +1,9 @@
+# Lien Claude Code Plugin
+
+Distribution files for the `/plugin install lien` flow (see the [root README](../../README.md) for the user-facing quick start).
+
+## Why `.mcp.json` pins `@liendev/lien@latest`
+
+`.mcp.json` launches the MCP server via `npx -y @liendev/lien@latest serve`. The version specifier is load-bearing: `npx` without one (`npx -y @liendev/lien`) does **not** force a registry check — it happily reuses any locally-resolvable copy (a global `npm link`, or this repo's own workspace symlink) ahead of npm. That let a months-old local dev build silently shadow the published release for weeks on one machine, with no error or warning. Appending `@latest` forces `npx` to resolve against the registry, so a stale link can no longer shadow the published version.
+
+If you're developing Lien itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md#dogfooding-lien-while-working-on-lien) for how to point the MCP server at your local build instead of installing this plugin.


### PR DESCRIPTION
## The bug (real incident)

The Claude Code plugin's `plugins/claude/.mcp.json` launches Lien via unpinned `npx`:

```json
{ "lien": { "command": "npx", "args": ["-y", "@liendev/lien", "serve"] } }
```

`npx -y @liendev/lien` (no version specifier) does **not** force a registry check — `npx` reuses any locally-resolvable copy (a global `npm link`, or a workspace symlink from this repo) ahead of consulting npm. On a dev machine, a months-old `npm link` plus the in-repo workspace symlink silently made the plugin run a stale local **0.50.0** dev build for weeks — never the published 0.51.0. That meant the newer embeddings-optional flag was silently ignored, and the machine overheated running old code. No error, no warning.

## The fix

`plugins/claude/.mcp.json`:

```diff
-    "args": ["-y", "@liendev/lien", "serve"]
+    "args": ["-y", "@liendev/lien@latest", "serve"]
```

A version/tag specifier forces `npx` to resolve against the registry — it resolves `@latest` to the real latest version and only reuses a local copy that **matches** it — so a stale link/workspace copy can no longer shadow the published release.

Also added `plugins/claude/README.md` documenting the footgun (`.mcp.json` is strict JSON, no comments, so the "why" needs to live next to it), and corrected two lines in `packages/site/docs/guide/installation.md` that previously claimed unpinned `npx -y @liendev/lien` "always pulls the latest release" / "re-resolves to the latest npm version" — that claim was the exact false premise behind the incident, and is only true now that `@latest` is pinned.

## Tradeoffs (maintainer decision)

1. **Lien devs lose accidental local-build dogfooding via the plugin.** With `@latest`, the plugin always runs the *published* version, even inside this repo. Arguably correct — the plugin should run what users run — but it means you can no longer `/plugin install lien` and incidentally test your local branch. `CONTRIBUTING.md` already documents (and this PR doesn't change) the supported way to dogfood a local build: point `.mcp.json`/`~/.claude.json` at `packages/cli/dist/index.js` directly instead of installing the plugin.

2. **Per-launch registry check.** `@latest` makes `npx` do a quick registry metadata lookup on every server start (it still reuses the cached tarball when the resolved version matches, and falls back to cache offline, so this is minor — but it is a network touch at startup that a bare unpinned/local invocation wouldn't necessarily make). If we'd rather avoid that, the alternative is pinning an exact version and bumping it via release automation (e.g., a release-script step that rewrites `.mcp.json`). Went with `@latest` here as the simpler, self-updating choice — flagging the alternative in case the maintainer prefers it.

## Verify

- [x] `plugins/claude/.mcp.json` is valid JSON (`python3 -c "import json;json.load(open('plugins/claude/.mcp.json'))"`) and `args` now contains `@liendev/lien@latest`
- [x] `npm run format:check` — passes (scope doesn't cover `plugins/`, but re-verified JSON formatting by hand)
- [x] `npm run lint` — passes, 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `npm run typecheck` — passes, 0 errors
- [x] `npm run build` — succeeds
- [x] No changeset — confirmed no `package.json` under `plugins/`, so it isn't a published npm package

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 79 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 5 high-risk file(s) with 125 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 9 | — |
| 🧠 mental load | 30 | — |
| ⏱️ time to understand | 38 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7620c14. Updates automatically on new commits.</sup>
<!-- /lien-stats -->