### PR TITLE
test: isolate + clean up index dirs so tests stop leaking ~/.lien/indices

### DIFF
--- a/.changeset/wire-up-lien-home-override.md
+++ b/.changeset/wire-up-lien-home-override.md
@@ -1,0 +1,11 @@
+---
+'@liendev/lien': patch
+'@liendev/core': patch
+'@liendev/parser': patch
+---
+
+Honor the `LIEN_HOME` environment variable for Lien's global store (`~/.lien/indices/*`, `~/.lien/config.json`), via a new `getLienHome()` helper in `@liendev/parser`.
+
+`LIEN_HOME` has been documented in the configuration guide ("Index location") since it was written, but nothing in the code ever read it — every store-path resolver (`VectorDB`, `loadGlobalConfig`/`saveGlobalConfig`/`mergeGlobalConfig`, `lien path --store`, `lien status`, `lien config`) called `os.homedir()` directly. This patch makes the documented override actually work, and falls back to `os.homedir()` when `LIEN_HOME` is unset, so behavior is unchanged for anyone not setting it.
+
+This was discovered while fixing a test-hygiene bug: test suites across `packages/core` and `packages/cli` were writing real indices into `~/.lien/indices/` on every run and never cleaning them up (thousands of leaked `test-*`/`lien-test-*`/`lien-bench-*` directories accumulate over time). Tests now set `LIEN_HOME` to a per-run temp directory via a new vitest `globalSetup` in both packages, so all index/config I/O during a test run is isolated and removed automatically in teardown — no more manual per-suite cleanup needed.

--- a/packages/cli/src/cli/config.ts
+++ b/packages/cli/src/cli/config.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import path from 'path';
-import os from 'os';
+import { getLienHome } from '@liendev/parser';
 import {
   loadGlobalConfig,
   mergeGlobalConfig,
@@ -9,7 +9,7 @@ import {
   type LienConfig,
 } from '@liendev/core';
 
-const GLOBAL_CONFIG_PATH = path.join(os.homedir(), '.lien', 'config.json');
+const GLOBAL_CONFIG_PATH = path.join(getLienHome(), '.lien', 'config.json');
 const PROJECT_CONFIG_FILENAME = '.lien.config.json';
 
 /**

--- a/packages/cli/src/cli/path-cmd.test.ts
+++ b/packages/cli/src/cli/path-cmd.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
-import os from 'os';
-import { extractRepoId } from '@liendev/parser';
+import { extractRepoId, getLienHome } from '@liendev/parser';
 import { pathCommand } from './path-cmd.js';
 import { resolveProjectRoot } from './project-root.js';
 
@@ -29,7 +28,7 @@ describe('pathCommand', () => {
     // getStoreRoot() normalizes to forward slashes for Windows compatibility,
     // so the test expectation has to do the same.
     const expected = path
-      .join(os.homedir(), '.lien', 'indices', extractRepoId(resolveProjectRoot(process.cwd())))
+      .join(getLienHome(), '.lien', 'indices', extractRepoId(resolveProjectRoot(process.cwd())))
       .replace(/\\/g, '/');
     expect(logSpy).toHaveBeenCalledWith(expected);
   });

--- a/packages/cli/src/cli/status.ts
+++ b/packages/cli/src/cli/status.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import type { Stats } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
-import os from 'os';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import {
@@ -15,7 +14,12 @@ import {
   DEFAULT_EMBEDDING_BATCH_SIZE,
   DEFAULT_GIT_POLL_INTERVAL_MS,
 } from '@liendev/core';
-import { extractRepoId, DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP } from '@liendev/parser';
+import {
+  extractRepoId,
+  getLienHome,
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_CHUNK_OVERLAP,
+} from '@liendev/parser';
 import { showCompactBanner } from '../utils/banner.js';
 
 const VALID_FORMATS = ['text', 'json'];
@@ -179,7 +183,7 @@ export async function statusCommand(options: { verbose?: boolean; format?: strin
 
   const rootDir = process.cwd();
   const repoId = extractRepoId(rootDir);
-  const indexPath = path.join(os.homedir(), '.lien', 'indices', repoId);
+  const indexPath = path.join(getLienHome(), '.lien', 'indices', repoId);
 
   if (format === 'json') {
     await outputJson(rootDir, indexPath);

--- a/packages/cli/src/cli/store-paths.ts
+++ b/packages/cli/src/cli/store-paths.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import os from 'os';
-import { extractRepoId } from '@liendev/parser';
+import { extractRepoId, getLienHome } from '@liendev/parser';
 import { resolveProjectRoot } from './project-root.js';
 
 /**
@@ -11,5 +10,5 @@ import { resolveProjectRoot } from './project-root.js';
  */
 export function getStoreRoot(cwd: string = process.cwd()): string {
   const repoId = extractRepoId(resolveProjectRoot(cwd));
-  return path.join(os.homedir(), '.lien', 'indices', repoId).replace(/\\/g, '/');
+  return path.join(getLienHome(), '.lien', 'indices', repoId).replace(/\\/g, '/');
 }

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -6,6 +6,7 @@ import os from 'os';
 import crypto from 'crypto';
 import { execSync } from 'child_process';
 import { VectorDB, LocalEmbeddings } from '@liendev/core';
+import { getLienHome } from '@liendev/parser';
 
 /**
  * E2E Tests with Real Open Source Projects
@@ -191,7 +192,11 @@ function getIndexPath(projectDir: string): string {
   const projectName = path.basename(realPath);
   const pathHash = crypto.createHash('md5').update(realPath).digest('hex').substring(0, 8);
 
-  return path.join(os.homedir(), '.lien', 'indices', `${projectName}-${pathHash}`);
+  // Matches getLienHome() from @liendev/parser: honors LIEN_HOME (set by
+  // vitest globalSetup during tests) so this never touches the real
+  // ~/.lien/indices/ store. The CLI subprocess spawned below inherits
+  // LIEN_HOME from process.env, so it writes to the same isolated location.
+  return path.join(getLienHome(), '.lien', 'indices', `${projectName}-${pathHash}`);
 }
 
 /**

--- a/packages/cli/test/global-setup.ts
+++ b/packages/cli/test/global-setup.ts
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Vitest globalSetup: redirect Lien's global store for the whole test run.
+ *
+ * Every code path that resolves `~/.lien/` (VectorDB indices, global config,
+ * `lien path --store`) goes through `getLienHome()` in `@liendev/parser`,
+ * which honors the `LIEN_HOME` environment variable. Setting it once here —
+ * before any test file or worker starts — means no individual test needs to
+ * remember to isolate or clean up its index directory: everything created
+ * during this run (including CLI subprocesses spawned by the e2e suite,
+ * which inherit `process.env`) lands under one throwaway temp dir that gets
+ * deleted in teardown.
+ *
+ * This also covers `test/e2e/real-projects.test.ts` and
+ * `test/benchmarks/performance.test.ts`, which shell out to the built CLI —
+ * the child process inherits `LIEN_HOME` from this process's environment.
+ */
+export default async function setup() {
+  const lienHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-home-'));
+  process.env.LIEN_HOME = lienHome;
+
+  return async () => {
+    delete process.env.LIEN_HOME;
+    await fs.rm(lienHome, { recursive: true, force: true });
+  };
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
+    globalSetup: ['./test/global-setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
@@ -19,4 +20,3 @@ export default defineConfig({
     testTimeout: 30000, // AI embeddings can be slow
   },
 });
-

--- a/packages/core/src/config/global-config.test.ts
+++ b/packages/core/src/config/global-config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
-import os from 'os';
+import { getLienHome } from '@liendev/parser';
 import { loadGlobalConfig, ConfigValidationError } from './global-config.js';
 
 describe('loadGlobalConfig', () => {
@@ -50,7 +50,7 @@ describe('loadGlobalConfig', () => {
   });
 
   describe('Config file parsing (parseConfigFile)', () => {
-    const configPath = path.join(os.homedir(), '.lien', 'config.json');
+    const configPath = path.join(getLienHome(), '.lien', 'config.json');
 
     beforeEach(() => {
       vi.clearAllMocks();

--- a/packages/core/src/config/global-config.ts
+++ b/packages/core/src/config/global-config.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import os from 'os';
+import { getLienHome } from '@liendev/parser';
 
 /**
  * Error thrown when config file exists but has invalid syntax or structure.
@@ -143,7 +143,7 @@ function parseConfigFile(content: string, configPath: string): RawGlobalConfig {
 export async function loadGlobalConfig(): Promise<GlobalConfig> {
   // 1. Load config file as base
   let fileConfig: GlobalConfig = {};
-  const configPath = path.join(os.homedir(), '.lien', 'config.json');
+  const configPath = path.join(getLienHome(), '.lien', 'config.json');
   try {
     const content = await fs.readFile(configPath, 'utf-8');
     const sanitized = stripRemovedQdrantConfig(parseConfigFile(content, configPath));
@@ -173,7 +173,7 @@ export async function loadGlobalConfig(): Promise<GlobalConfig> {
  * Creates the directory if it doesn't exist.
  */
 export async function saveGlobalConfig(config: GlobalConfig): Promise<void> {
-  const configDir = path.join(os.homedir(), '.lien');
+  const configDir = path.join(getLienHome(), '.lien');
   const configPath = path.join(configDir, 'config.json');
 
   await fs.mkdir(configDir, { recursive: true });
@@ -185,7 +185,7 @@ export async function saveGlobalConfig(config: GlobalConfig): Promise<void> {
  * Retired Qdrant settings in the existing file are dropped on save.
  */
 export async function mergeGlobalConfig(partial: Partial<GlobalConfig>): Promise<GlobalConfig> {
-  const configPath = path.join(os.homedir(), '.lien', 'config.json');
+  const configPath = path.join(getLienHome(), '.lien', 'config.json');
 
   let existing: RawGlobalConfig = {};
   try {

--- a/packages/core/src/test/global-setup.ts
+++ b/packages/core/src/test/global-setup.ts
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Vitest globalSetup: redirect Lien's global store for the whole test run.
+ *
+ * Every code path that resolves `~/.lien/` (VectorDB indices, global config)
+ * goes through `getLienHome()` in `@liendev/parser`, which honors the
+ * `LIEN_HOME` environment variable. Setting it once here — before any test
+ * file or worker starts — means no individual test needs to remember to
+ * isolate or clean up its index directory: everything created during this
+ * run lands under one throwaway temp dir that gets deleted in teardown.
+ *
+ * Without this, tests that construct `VectorDB`/`createVectorDB` against a
+ * tmp `projectRoot` still end up writing into the REAL `~/.lien/indices/`,
+ * because the store path is derived from `os.homedir()`, not from
+ * `projectRoot` itself — the tmp dir only supplies the name+hash used to
+ * build the leaf directory name.
+ */
+export default async function setup() {
+  const lienHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-home-'));
+  process.env.LIEN_HOME = lienHome;
+
+  return async () => {
+    delete process.env.LIEN_HOME;
+    await fs.rm(lienHome, { recursive: true, force: true });
+  };
+}

--- a/packages/core/src/vectordb/lancedb.ts
+++ b/packages/core/src/vectordb/lancedb.ts
@@ -1,10 +1,9 @@
 import * as lancedb from '@lancedb/lancedb';
 import path from 'path';
-import os from 'os';
 import type { SearchResult, VectorDBInterface } from './types.js';
 import type { LanceDBConnection, LanceDBTable } from './lancedb-types.js';
 import type { ChunkMetadata } from '@liendev/parser';
-import { extractRepoId } from '@liendev/parser';
+import { extractRepoId, getLienHome } from '@liendev/parser';
 import { EMBEDDING_DIMENSION } from '../embeddings/types.js';
 import { readVersionFile } from './version.js';
 import { DatabaseError, wrapError } from '../errors/index.js';
@@ -23,9 +22,11 @@ export class VectorDB implements VectorDBInterface {
 
   constructor(projectRoot: string) {
     // Store in user's home directory under ~/.lien/indices/{projectName-hash}
+    // (or LIEN_HOME, when set — used by tests to avoid writing into the
+    // real global store).
     const repoId = extractRepoId(projectRoot);
 
-    this.dbPath = path.join(os.homedir(), '.lien', 'indices', repoId);
+    this.dbPath = path.join(getLienHome(), '.lien', 'indices', repoId);
   }
 
   async initialize(): Promise<void> {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,13 +5,11 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    globalSetup: ['./src/test/global-setup.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/test/**',
-      ],
+      exclude: ['src/**/*.test.ts', 'src/test/**'],
       reporter: ['text', 'text-summary', 'lcov'],
     },
     testTimeout: 30000,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -32,6 +32,8 @@ export { normalizePath, matchesFile, getCanonicalPath, isTestFile } from './util
 
 export { extractRepoId } from './utils/repo-id.js';
 
+export { getLienHome } from './utils/lien-home.js';
+
 // =============================================================================
 // AST
 // =============================================================================

--- a/packages/parser/src/utils/lien-home.test.ts
+++ b/packages/parser/src/utils/lien-home.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import { getLienHome } from './lien-home.js';
+
+describe('getLienHome', () => {
+  const originalEnv = process.env.LIEN_HOME;
+
+  beforeEach(() => {
+    delete process.env.LIEN_HOME;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LIEN_HOME;
+    } else {
+      process.env.LIEN_HOME = originalEnv;
+    }
+  });
+
+  it('falls back to os.homedir() when LIEN_HOME is unset', () => {
+    expect(getLienHome()).toBe(os.homedir());
+  });
+
+  it('prefers LIEN_HOME when set', () => {
+    process.env.LIEN_HOME = '/tmp/fake-lien-home';
+    expect(getLienHome()).toBe('/tmp/fake-lien-home');
+  });
+
+  it('ignores an empty LIEN_HOME and falls back to os.homedir()', () => {
+    process.env.LIEN_HOME = '';
+    expect(getLienHome()).toBe(os.homedir());
+  });
+});

--- a/packages/parser/src/utils/lien-home.ts
+++ b/packages/parser/src/utils/lien-home.ts
@@ -1,0 +1,13 @@
+import os from 'os';
+
+/**
+ * Resolve the base directory Lien uses for its global state
+ * (`~/.lien/indices/*`, `~/.lien/config.json`).
+ *
+ * Honors the `LIEN_HOME` environment variable so test suites (and advanced
+ * users) can redirect Lien's global store to an isolated directory instead
+ * of the real home directory. Falls back to `os.homedir()` when unset.
+ */
+export function getLienHome(): string {
+  return process.env.LIEN_HOME || os.homedir();
+}


### PR DESCRIPTION
## Root cause

Test suites in `packages/core` and `packages/cli` construct `VectorDB`/CLI subprocesses against a tmp `projectRoot`, but the store base directory was **always** `os.homedir()` — only the leaf directory name (`{basename}-{md5hash}`) came from `projectRoot`. So every test run wrote a real index into `~/.lien/indices/` on the user's actual machine, not into the tmp dir. Per-suite `afterEach`/`afterAll` cleanup only ever removed the tmp `projectRoot` placeholder, never the real `dbPath`, so nothing was cleaned up.

Confirmed on the reporting machine: **19,737** leaked/real entries under `~/.lien/indices/` (12,868 visible + **6,869 hidden** `.lien-*` dirs — see "hidden leak class" below), of which only **160** are legitimate real-project indices (`tapwire-*`, `CA-102-*`, `anyhow-*`, `agent-*`, etc.).

Leak sources, all via the same root cause:
- `packages/core/src/vectordb/{boosting,intent-boosting,lancedb,factory}.test.ts` → `lien-boost-test-*`, `lien-intent-test-*`, `lien-test-*`
- `packages/core/src/test/helpers/test-db.ts` (shared helper) and its consumers (`indexer/{index,change-detector}.test.ts`) → `test-*`
- `packages/core/src/indexer/{incremental,branch-switch}.test.ts` → a **hidden** class: they build `indexPath = path.join(testDir, '.lien')` and pass that as `projectRoot`, so `basename()` is literally `.lien` → leaked dirs are named `.lien-<hash>` and don't show up in a plain `ls` (6,869 of them, the majority of the real leak by count)
- `packages/cli/test/benchmarks/performance.test.ts` → `lien-bench-*` (part of the default `npm test`, not just an opt-in benchmark run)
- `packages/cli/test/e2e/real-projects.test.ts` → `zod-*`, `requests-*`, `express-*`, `monolog-*`, etc. (one per cloned real-world project)

## Fix: wire up the (already-documented, never-implemented) `LIEN_HOME` override

`packages/site/docs/guide/configuration.md` has documented `LIEN_HOME` as an "Index location" override since it was written — but nothing in the code ever read it. Every resolver called `os.homedir()` directly: `VectorDB`, `loadGlobalConfig`/`saveGlobalConfig`/`mergeGlobalConfig`, `lien status`, `lien path --store`, `lien config`.

This PR:
1. Adds `getLienHome()` to `@liendev/parser` (`process.env.LIEN_HOME || os.homedir()`), exported alongside the existing `extractRepoId`.
2. Routes every one of those resolvers through it, making the documented env var actually work (no behavior change for anyone not setting it).
3. Adds a vitest `globalSetup` to `packages/core` and `packages/cli` that points `LIEN_HOME` at a fresh `mkdtemp` for the whole test run and removes it in teardown. This is the central fix: no individual test needs to remember to isolate or clean up its index directory anymore — everything created during a run (including the e2e suite's CLI subprocesses, which inherit `LIEN_HOME` via `process.env`, and the benchmark suite) lands under one throwaway dir that's deleted afterward.
4. Fixes the e2e suite's own hand-duplicated `getIndexPath()` helper to resolve via the same `getLienHome()` instead of a fourth independent `os.homedir()` copy, and updates two tests (`global-config.test.ts`, `path-cmd.test.ts`) that independently computed expected paths via raw `os.homedir()`.

I did not touch each leaking test file's cleanup logic individually — the global override makes that unnecessary (the two suites that already did correct manual cleanup via `vectorDB.dbPath`, `embeddings-disabled.test.ts` and `mcp-roundtrip.test.ts`, are now redundant-but-harmless).

## Verification: leak is fixed

Counted `~/.lien/indices/` before and after running the full affected surface (core, cli including the benchmark suite, review, action, parser):

| | visible | hidden (`.lien-*`) | total |
|---|---|---|---|
| Before | 12,868 | 6,869 | 19,737 |
| After `npm run test -w @liendev/parser` (937 tests) | 12,868 | 6,869 | 19,737 |
| After `npm run test -w @liendev/core -- --exclude '**/worker-embeddings.test.ts'` (522 tests) | 12,868 | 6,869 | 19,737 |
| After `npm run test -w packages/cli` (716 tests, includes the benchmark suite) | 12,868 | 6,869 | 19,737 |
| After `npm run test -w @liendev/review` (488 tests) + `npm run test -w @liendev/action` (28 tests) | 12,868 | 6,869 | 19,737 |

Zero growth. (e2e `real-projects.test.ts` was fixed analogously but not executed here — it clones real repos over the network and isn't part of the default gate.)

## One-time cleanup of the existing leak (documented only — NOT run)

This targets only the known test-pattern prefixes (including the hidden `.lien-*` class found above) and leaves everything else untouched:

```bash
# 1. Dry run — review the exact list first
find ~/.lien/indices -maxdepth 1 -mindepth 1 \( \
  -name 'test-*' -o \
  -name 'lien-test*' -o \
  -name 'lien-intent-test-*' -o \
  -name 'lien-boost-test-*' -o \
  -name 'lien-bench-*' -o \
  -name 'zod-*' -o \
  -name 'requests-*' -o \
  -name 'express-*' -o \
  -name 'monolog-*' -o \
  -name '.lien-*' \
\) -print

# 2. Count
find ~/.lien/indices -maxdepth 1 -mindepth 1 \( -name 'test-*' -o -name 'lien-test*' -o -name 'lien-intent-test-*' -o -name 'lien-boost-test-*' -o -name 'lien-bench-*' -o -name 'zod-*' -o -name 'requests-*' -o -name 'express-*' -o -name 'monolog-*' -o -name '.lien-*' \) -print | wc -l

# 3. Only after reviewing step 1's output, delete:
find ~/.lien/indices -maxdepth 1 -mindepth 1 \( \
  -name 'test-*' -o \
  -name 'lien-test*' -o \
  -name 'lien-intent-test-*' -o \
  -name 'lien-boost-test-*' -o \
  -name 'lien-bench-*' -o \
  -name 'zod-*' -o \
  -name 'requests-*' -o \
  -name 'express-*' -o \
  -name 'monolog-*' -o \
  -name '.lien-*' \
\) -print0 | xargs -0 rm -rf
```

`-maxdepth 1 -mindepth 1` restricts this to direct children of `~/.lien/indices` only. `find -name` matches dotfiles by default, so `.lien-*` is covered. This preserves `lien-e96f171e`, `tapwire-*`, `shopify-*`, `lancedb-project-*`, `review-action-*`, and everything else that doesn't match one of the listed test prefixes.

## Gates

- `npm run format:check` — pass
- `npm run lint` — pass (0 errors; pre-existing warnings only, none in touched files)
- `npm run typecheck` / `npm run build` — pass for parser, core, review, cli, action
- Tests — all green: parser 937, core 522 (excl. `worker-embeddings.test.ts`, the known onnxruntime teardown crash), cli 716, review 488, action 28

## Changeset

Included (`patch` for `@liendev/parser`, `@liendev/core`, `@liendev/lien`) — `getLienHome()` is a new exported symbol in `@liendev/parser`, and it changes real resolution behavior in `@liendev/core`/`@liendev/lien` for anyone who sets `LIEN_HOME` (previously silently ignored).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR wires up the previously-documented `LIEN_HOME` environment variable through a new `getLienHome()` helper in `@liendev/parser`, replacing all direct `os.homedir()` calls that resolve Lien's global store paths. It also adds per-package vitest global setups that redirect store I/O to a temp directory during tests and clean it up afterward. The change is additive and backward-compatible: when `LIEN_HOME` is unset, behavior is identical to before.
>
> - Centralizes global-store path resolution in `getLienHome()` (`process.env.LIEN_HOME || os.homedir()`)
> - Routes `VectorDB`, global config, `lien status`, `lien path --store`, and `lien config` through the new helper
> - Adds vitest `globalSetup` in `packages/core` and `packages/cli` to isolate and auto-clean test indices/configs

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 12e49a6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->