### PR TITLE
feat(core,cli): add opt-in SQLite structural backend behind the factory seam

### DIFF
--- a/.changeset/sqlite-structural-backend.md
+++ b/.changeset/sqlite-structural-backend.md
@@ -1,0 +1,6 @@
+---
+'@liendev/core': minor
+'@liendev/lien': minor
+---
+
+Add an opt-in SQLite structural backend behind the existing vector-DB factory seam. Set `backend: sqlite` in the global config (`~/.lien/config.json`) or `LIEN_BACKEND=sqlite` to store chunks in a better-sqlite3 database with an FTS5 lexical index instead of LanceDB; the SqliteBackend implements the same `VectorDBInterface`, so no handler or indexer changes are needed. The default backend is unchanged (`lancedb`), so this release is purely additive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3233,6 +3233,16 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4624,6 +4634,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4633,6 +4657,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/birpc": {
@@ -5954,6 +5987,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -5962,6 +6010,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -6160,6 +6217,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -6665,6 +6731,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -6869,6 +6944,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7009,6 +7090,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7115,6 +7202,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -7471,6 +7564,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/inquirer": {
       "version": "9.3.8",
@@ -8410,6 +8509,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -8422,6 +8533,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -8456,6 +8576,12 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
     "node_modules/mlly": {
@@ -8531,6 +8657,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8545,6 +8677,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -9252,6 +9396,33 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9324,6 +9495,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -9409,6 +9590,30 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/read-yaml-file": {
@@ -10070,6 +10275,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -10472,6 +10722,40 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/term-size": {
@@ -11524,6 +11808,18 @@
         "@esbuild/win32-arm64": "0.27.2",
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -13369,6 +13665,7 @@
         "@huggingface/transformers": "^3.8.1",
         "@lancedb/lancedb": "^0.23.0",
         "@liendev/parser": "^0.50.0",
+        "better-sqlite3": "^12.11.1",
         "chalk": "^5.6.2",
         "collect.js": "^4.36.1",
         "p-limit": "5.0.0",
@@ -13377,6 +13674,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^4.0.8",
         "typescript": "^5.3.0",

--- a/packages/cli/src/cli/config.test.ts
+++ b/packages/cli/src/cli/config.test.ts
@@ -52,6 +52,11 @@ describe('config command', () => {
       expect(mockMergeGlobalConfig).toHaveBeenCalledWith({ backend: 'lancedb' });
     });
 
+    it('should set the sqlite backend value', async () => {
+      await configSetCommand('backend', 'sqlite');
+      expect(mockMergeGlobalConfig).toHaveBeenCalledWith({ backend: 'sqlite' });
+    });
+
     it('should reject unknown keys', async () => {
       await expect(configSetCommand('unknown.key', 'value')).rejects.toThrow('process.exit');
     });

--- a/packages/cli/src/cli/config.ts
+++ b/packages/cli/src/cli/config.ts
@@ -23,8 +23,8 @@ const ALLOWED_KEYS: Record<
 > = {
   backend: {
     scope: 'global',
-    values: ['lancedb'],
-    description: 'Vector database backend',
+    values: ['lancedb', 'sqlite'],
+    description: 'Storage backend (lancedb = vector search; sqlite = structural store)',
   },
   'embeddings.enabled': {
     scope: 'project',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "@huggingface/transformers": "^3.8.1",
     "@liendev/parser": "^0.51.2",
     "@lancedb/lancedb": "^0.23.0",
+    "better-sqlite3": "^12.11.1",
     "chalk": "^5.6.2",
     "collect.js": "^4.36.1",
     "p-limit": "5.0.0",
@@ -35,6 +36,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^4.0.8",
     "typescript": "^5.3.0",

--- a/packages/core/src/config/global-config.test.ts
+++ b/packages/core/src/config/global-config.test.ts
@@ -39,6 +39,15 @@ describe('loadGlobalConfig', () => {
       expect(config).toEqual({ backend: 'lancedb' });
     });
 
+    it('should accept LIEN_BACKEND=sqlite', async () => {
+      process.env.LIEN_BACKEND = 'sqlite';
+      vi.spyOn(fs, 'readFile').mockRejectedValue({ code: 'ENOENT' } as NodeJS.ErrnoException);
+
+      const config = await loadGlobalConfig();
+
+      expect(config).toEqual({ backend: 'sqlite' });
+    });
+
     it('should throw ConfigValidationError when LIEN_BACKEND has an invalid value', async () => {
       process.env.LIEN_BACKEND = 'invalid';
       vi.spyOn(fs, 'readFile').mockRejectedValue({ code: 'ENOENT' } as NodeJS.ErrnoException);
@@ -106,6 +115,14 @@ describe('loadGlobalConfig', () => {
       const config = await loadGlobalConfig();
 
       expect(config).toEqual({ backend: 'lancedb' });
+    });
+
+    it('should pass validation for valid sqlite configuration', async () => {
+      vi.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify({ backend: 'sqlite' }));
+
+      const config = await loadGlobalConfig();
+
+      expect(config).toEqual({ backend: 'sqlite' });
     });
   });
 

--- a/packages/core/src/config/global-config.ts
+++ b/packages/core/src/config/global-config.ts
@@ -20,12 +20,15 @@ export class ConfigValidationError extends Error {
  * Global configuration for Lien.
  * Only contains what truly needs configuration: storage backend choice.
  *
- * LanceDB is the only supported backend. The field is kept so an
- * alternative backend can be reintroduced later without a config migration.
+ * 'lancedb' (default) is the vector backend; 'sqlite' is the opt-in structural
+ * store (better-sqlite3 + FTS5). The default remains 'lancedb'.
  */
 export interface GlobalConfig {
-  backend?: 'lancedb';
+  backend?: 'lancedb' | 'sqlite';
 }
+
+/** Backends the config layer accepts. */
+const VALID_BACKENDS: ReadonlySet<string> = new Set(['lancedb', 'sqlite']);
 
 /**
  * Raw shape of a parsed config file before sanitization.
@@ -85,14 +88,15 @@ function loadConfigFromEnv(): GlobalConfig | null {
     return { backend: 'lancedb' };
   }
 
-  if (backendEnv !== 'lancedb') {
+  if (!VALID_BACKENDS.has(backendEnv)) {
     throw new ConfigValidationError(
-      `Invalid LIEN_BACKEND environment variable: "${backendEnv}"\n` + `Valid value: 'lancedb'`,
+      `Invalid LIEN_BACKEND environment variable: "${backendEnv}"\n` +
+        `Valid values: 'lancedb', 'sqlite'`,
       '<environment>',
     );
   }
 
-  return { backend: 'lancedb' };
+  return { backend: backendEnv as GlobalConfig['backend'] };
 }
 
 /**
@@ -102,11 +106,11 @@ function validateConfig(
   config: RawGlobalConfig,
   configPath: string,
 ): asserts config is GlobalConfig {
-  if (config.backend && config.backend !== 'lancedb') {
+  if (config.backend && !VALID_BACKENDS.has(config.backend)) {
     throw new ConfigValidationError(
       `Invalid backend in global config: "${config.backend}"\n` +
         `Config file: ${configPath}\n` +
-        `Valid value: 'lancedb'`,
+        `Valid values: 'lancedb', 'sqlite'`,
       configPath,
     );
   }

--- a/packages/core/src/vectordb/factory.test.ts
+++ b/packages/core/src/vectordb/factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createVectorDB } from './factory.js';
 import { loadGlobalConfig } from '../config/global-config.js';
+import type * as globalConfigModule from '../config/global-config.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -9,6 +10,14 @@ import * as os from 'os';
 vi.mock('../config/global-config.js');
 vi.mock('./lancedb.js', () => ({
   VectorDB: class MockVectorDB {
+    backend = 'lancedb';
+    dbPath = '/test/path';
+    async initialize() {}
+  },
+}));
+vi.mock('./sqlite/sqlite-backend.js', () => ({
+  SqliteBackend: class MockSqliteBackend {
+    backend = 'sqlite';
     dbPath = '/test/path';
     async initialize() {}
   },
@@ -47,6 +56,36 @@ describe('createVectorDB', () => {
 
       const db = await createVectorDB(testDir);
       expect(db).toBeDefined();
+      expect((db as unknown as { backend: string }).backend).toBe('lancedb');
+    });
+  });
+
+  describe('SQLite backend', () => {
+    it('should create SqliteBackend when backend is sqlite', async () => {
+      vi.mocked(loadGlobalConfig).mockResolvedValue({ backend: 'sqlite' });
+
+      const db = await createVectorDB(testDir);
+      expect((db as unknown as { backend: string }).backend).toBe('sqlite');
+    });
+
+    it('should create SqliteBackend when LIEN_BACKEND=sqlite (real env-var path)', async () => {
+      // Exercise the genuine env→config→factory wiring: delegate to the real
+      // loadGlobalConfig so process.env.LIEN_BACKEND is actually parsed. Env has
+      // highest precedence, so it overrides any on-disk config file.
+      const actual = (await vi.importActual(
+        '../config/global-config.js',
+      )) as typeof globalConfigModule;
+      vi.mocked(loadGlobalConfig).mockImplementation(actual.loadGlobalConfig);
+
+      const prev = process.env.LIEN_BACKEND;
+      process.env.LIEN_BACKEND = 'sqlite';
+      try {
+        const db = await createVectorDB(testDir);
+        expect((db as unknown as { backend: string }).backend).toBe('sqlite');
+      } finally {
+        if (prev === undefined) delete process.env.LIEN_BACKEND;
+        else process.env.LIEN_BACKEND = prev;
+      }
     });
   });
 

--- a/packages/core/src/vectordb/factory.ts
+++ b/packages/core/src/vectordb/factory.ts
@@ -1,6 +1,11 @@
 import type { VectorDBInterface } from './types.js';
 import { VectorDB } from './lancedb.js';
-import { loadGlobalConfig, ConfigValidationError } from '../config/global-config.js';
+import { SqliteBackend } from './sqlite/sqlite-backend.js';
+import {
+  loadGlobalConfig,
+  ConfigValidationError,
+  type GlobalConfig,
+} from '../config/global-config.js';
 
 /**
  * Validate that a VectorDB instance has the required methods.
@@ -14,19 +19,20 @@ function validateVectorDBInterface(db: VectorDBInterface): void {
 /**
  * Factory function to create a VectorDB instance.
  *
- * LanceDB is the only supported backend. The factory (and the
- * VectorDBInterface seam) is deliberately kept so an alternative backend
- * can be reintroduced later without touching call sites.
+ * Selects the backend from GlobalConfig: 'sqlite' → SqliteBackend (opt-in
+ * structural store), otherwise the default LanceDB VectorDB. The
+ * VectorDBInterface seam means call sites don't change regardless of choice.
  *
  * Loading the global config here surfaces validation errors early and
  * emits the one-time warning for retired Qdrant settings.
  *
  * @param projectRoot - Root directory of the project
- * @returns VectorDBInterface instance (LanceDB)
+ * @returns VectorDBInterface instance for the configured backend
  */
 export async function createVectorDB(projectRoot: string): Promise<VectorDBInterface> {
+  let config: GlobalConfig = {};
   try {
-    await loadGlobalConfig();
+    config = await loadGlobalConfig();
   } catch (error) {
     // ConfigValidationError: Config file exists but has syntax/validation errors
     // This should fail hard with a clear error message
@@ -45,7 +51,8 @@ export async function createVectorDB(projectRoot: string): Promise<VectorDBInter
     }
   }
 
-  const db = new VectorDB(projectRoot);
+  const db: VectorDBInterface =
+    config.backend === 'sqlite' ? new SqliteBackend(projectRoot) : new VectorDB(projectRoot);
   validateVectorDBInterface(db);
   return db;
 }

--- a/packages/core/src/vectordb/filters.ts
+++ b/packages/core/src/vectordb/filters.ts
@@ -1,0 +1,176 @@
+import { SYMBOL_TYPE_MATCHES } from './types.js';
+import { safeRegex } from '../utils/safe-regex.js';
+
+/**
+ * Minimal record shape the shared filters read. Both the LanceDB `DBRecord`
+ * (query.ts, whose array columns may arrive as Arrow Vectors) and the SQLite
+ * backend's parsed row (plain JS arrays) structurally satisfy this — which is
+ * why `toPlainArray` tolerates both. This is the DRY seam both backends share.
+ */
+export interface FilterableRecord {
+  content?: string;
+  file?: string;
+  language?: string;
+  symbolName?: string;
+  symbolType?: string;
+  functionNames?: unknown;
+  classNames?: unknown;
+  interfaceNames?: unknown;
+}
+
+export interface SymbolQueryOptions {
+  language?: string;
+  pattern?: string;
+  symbolType?: 'function' | 'method' | 'class' | 'interface';
+}
+
+/**
+ * Convert an Arrow Vector to a plain array if needed.
+ * LanceDB returns Arrow Vector objects for array columns; the SQLite backend
+ * passes plain arrays through untouched.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toPlainArray<T>(arr: any): T[] | undefined {
+  if (!arr) return undefined;
+  // Arrow Vectors have a toArray() method
+  if (typeof arr.toArray === 'function') {
+    return arr.toArray();
+  }
+  if (Array.isArray(arr)) {
+    return arr;
+  }
+  return undefined;
+}
+
+/**
+ * Check if a string array has valid (non-empty) entries.
+ * LanceDB stores empty string arrays as [''] which we need to filter out.
+ */
+export function hasValidStringEntries(arr: string[] | undefined): boolean {
+  return Boolean(arr && arr.length > 0 && arr[0] !== '');
+}
+
+/**
+ * Get symbols for a specific type from a record.
+ * Consolidates the symbol extraction logic used across query functions.
+ */
+function getSymbolsForType(
+  r: FilterableRecord,
+  symbolType?: 'function' | 'method' | 'class' | 'interface',
+): string[] {
+  if (symbolType === 'function' || symbolType === 'method')
+    return toPlainArray<string>(r.functionNames) || [];
+  if (symbolType === 'class') return toPlainArray<string>(r.classNames) || [];
+  if (symbolType === 'interface') return toPlainArray<string>(r.interfaceNames) || [];
+  return [
+    ...(toPlainArray<string>(r.functionNames) || []),
+    ...(toPlainArray<string>(r.classNames) || []),
+    ...(toPlainArray<string>(r.interfaceNames) || []),
+  ];
+}
+
+/**
+ * Filter records by language (case-insensitive match).
+ */
+export function filterByLanguage<T extends FilterableRecord>(records: T[], language: string): T[] {
+  return records.filter(r => r.language && r.language.toLowerCase() === language.toLowerCase());
+}
+
+/**
+ * Filter records by regex pattern against content and file path.
+ */
+export function filterByPattern<T extends FilterableRecord>(records: T[], pattern: string): T[] {
+  const regex = safeRegex(pattern);
+  if (!regex) return records;
+  // Both fields may be `undefined` under column projection — coerce so the
+  // regex doesn't see the literal string "undefined" and match spuriously.
+  return records.filter(r => regex.test(r.content ?? '') || regex.test(r.file ?? ''));
+}
+
+/**
+ * Filter records by symbol type using SYMBOL_TYPE_MATCHES lookup.
+ */
+export function filterBySymbolType<T extends FilterableRecord>(
+  records: T[],
+  symbolType: 'function' | 'method' | 'class' | 'interface',
+): T[] {
+  const allowedTypes = SYMBOL_TYPE_MATCHES[symbolType];
+  if (!allowedTypes) {
+    return [];
+  }
+  return records.filter(r => r.symbolType != null && allowedTypes.has(r.symbolType));
+}
+
+/**
+ * Helper to check if a record matches the requested symbol type.
+ */
+function matchesSymbolType(
+  record: FilterableRecord,
+  symbolType: 'function' | 'method' | 'class' | 'interface',
+  symbols: string[],
+): boolean {
+  // If AST-based symbolType exists, use lookup table
+  if (record.symbolType) {
+    return SYMBOL_TYPE_MATCHES[symbolType]?.has(record.symbolType) ?? false;
+  }
+
+  // Fallback: check if pre-AST symbols array has valid entries
+  return symbols.length > 0 && symbols.some(s => s.length > 0 && s !== '');
+}
+
+/**
+ * Check if any symbol name matches the given regex pattern.
+ * Returns true if the pattern is invalid (graceful degradation) or if a name matches.
+ */
+function matchesPattern(pattern: string, symbols: string[], astSymbolName: string): boolean {
+  const regex = safeRegex(pattern);
+  if (!regex) return true;
+  return symbols.some(s => regex.test(s)) || regex.test(astSymbolName);
+}
+
+/**
+ * Check if a record matches the symbol query filters.
+ */
+export function matchesSymbolFilter(
+  r: FilterableRecord,
+  { language, pattern, symbolType }: SymbolQueryOptions,
+): boolean {
+  // Language filter
+  if (language && (!r.language || r.language.toLowerCase() !== language.toLowerCase())) {
+    return false;
+  }
+
+  const symbols = getSymbolsForType(r, symbolType);
+  const astSymbolName = r.symbolName || '';
+
+  // Must have at least one symbol (legacy or AST-based)
+  if (symbols.length === 0 && !astSymbolName) {
+    return false;
+  }
+
+  // Pattern filter (if provided)
+  if (pattern && !matchesPattern(pattern, symbols, astSymbolName)) {
+    return false;
+  }
+
+  // Symbol type filter (if provided)
+  if (symbolType) {
+    return matchesSymbolType(r, symbolType, symbols);
+  }
+
+  return true;
+}
+
+/**
+ * Build legacy symbols object for backwards compatibility.
+ */
+export function buildLegacySymbols(r: FilterableRecord) {
+  const functions = toPlainArray<string>(r.functionNames);
+  const classes = toPlainArray<string>(r.classNames);
+  const interfaces = toPlainArray<string>(r.interfaceNames);
+  return {
+    functions: hasValidStringEntries(functions) ? functions! : [],
+    classes: hasValidStringEntries(classes) ? classes! : [],
+    interfaces: hasValidStringEntries(interfaces) ? interfaces! : [],
+  };
+}

--- a/packages/core/src/vectordb/query.ts
+++ b/packages/core/src/vectordb/query.ts
@@ -1,7 +1,6 @@
 import type { LanceDBTable } from './lancedb-types.js';
 import type { SearchResult } from './types.js';
 import { EMBEDDING_DIMENSION } from '../embeddings/types.js';
-import { SYMBOL_TYPE_MATCHES } from './types.js';
 import { MAX_CHUNKS_PER_FILE } from '../constants.js';
 import { DatabaseError, wrapError } from '../errors/index.js';
 import { calculateRelevance } from './relevance.js';
@@ -12,8 +11,17 @@ import {
   FilenameBoostingStrategy,
   FileTypeBoostingStrategy,
 } from './boosting/index.js';
-import { safeRegex } from '../utils/safe-regex.js';
 import { CAPTURED_TRUE, CAPTURED_UNKNOWN } from './batch-insert.js';
+import {
+  toPlainArray,
+  hasValidStringEntries,
+  filterByLanguage,
+  filterByPattern,
+  filterBySymbolType,
+  matchesSymbolFilter,
+  buildLegacySymbols,
+  type SymbolQueryOptions,
+} from './filters.js';
 
 /**
  * Cached strategy instances to avoid repeated instantiation overhead.
@@ -111,15 +119,6 @@ function isValidRecord(r: DBRecord): boolean {
 }
 
 /**
- * Check if a string array has valid (non-empty) entries.
- * LanceDB stores empty string arrays as [''] which we need to filter out.
- * This is specifically for string arrays (cf. hasValidNumberEntries for number arrays).
- */
-function hasValidStringEntries(arr: string[] | undefined): boolean {
-  return Boolean(arr && arr.length > 0 && arr[0] !== '');
-}
-
-/**
  * Check if a number array has valid entries (filters out placeholder values).
  *
  * serializeCallSites() uses 0 as a sentinel meaning "no valid line number"
@@ -130,43 +129,6 @@ function hasValidStringEntries(arr: string[] | undefined): boolean {
  */
 function hasValidNumberEntries(arr: number[] | undefined): boolean {
   return Boolean(arr && arr.length > 0 && arr[0] !== 0);
-}
-
-/**
- * Get symbols for a specific type from a DB record.
- * Consolidates the symbol extraction logic used across query functions.
- */
-function getSymbolsForType(
-  r: DBRecord,
-  symbolType?: 'function' | 'method' | 'class' | 'interface',
-): string[] {
-  if (symbolType === 'function' || symbolType === 'method')
-    return toPlainArray<string>(r.functionNames) || [];
-  if (symbolType === 'class') return toPlainArray<string>(r.classNames) || [];
-  if (symbolType === 'interface') return toPlainArray<string>(r.interfaceNames) || [];
-  return [
-    ...(toPlainArray<string>(r.functionNames) || []),
-    ...(toPlainArray<string>(r.classNames) || []),
-    ...(toPlainArray<string>(r.interfaceNames) || []),
-  ];
-}
-
-/**
- * Convert Arrow Vector to plain array if needed.
- * LanceDB returns Arrow Vector objects for array columns.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toPlainArray<T>(arr: any): T[] | undefined {
-  if (!arr) return undefined;
-  // Arrow Vectors have a toArray() method
-  if (typeof arr.toArray === 'function') {
-    return arr.toArray();
-  }
-  // Already a plain array
-  if (Array.isArray(arr)) {
-    return arr;
-  }
-  return undefined;
 }
 
 /**
@@ -511,42 +473,6 @@ export async function search(
 }
 
 /**
- * Filter records by language (case-insensitive match).
- */
-function filterByLanguage(records: DBRecord[], language: string): DBRecord[] {
-  return records.filter(
-    (r: DBRecord) => r.language && r.language.toLowerCase() === language.toLowerCase(),
-  );
-}
-
-/**
- * Filter records by regex pattern against content and file path.
- */
-function filterByPattern(records: DBRecord[], pattern: string): DBRecord[] {
-  const regex = safeRegex(pattern);
-  if (!regex) return records;
-  // Both fields may be `undefined` under column projection — coerce so the
-  // regex doesn't see the literal string "undefined" and match spuriously.
-  // `applySelect` always injects `file`, but be defensive in case the
-  // helper changes.
-  return records.filter((r: DBRecord) => regex.test(r.content ?? '') || regex.test(r.file ?? ''));
-}
-
-/**
- * Filter records by symbol type using SYMBOL_TYPE_MATCHES lookup.
- */
-function filterBySymbolType(
-  records: DBRecord[],
-  symbolType: keyof typeof SYMBOL_TYPE_MATCHES,
-): DBRecord[] {
-  const allowedTypes = SYMBOL_TYPE_MATCHES[symbolType];
-  if (!allowedTypes) {
-    return [];
-  }
-  return records.filter((r: DBRecord) => r.symbolType != null && allowedTypes.has(r.symbolType));
-}
-
-/**
  * Convert DB records to unscored SearchResults (for scan/scroll operations).
  * Uses 'not_relevant' relevance to indicate results are unscored, not semantically irrelevant.
  */
@@ -647,87 +573,6 @@ export async function scanWithFilter(
   } catch (error) {
     throw wrapError(error, 'Failed to scan with filter');
   }
-}
-
-/**
- * Helper to check if a record matches the requested symbol type
- */
-function matchesSymbolType(
-  record: DBRecord,
-  symbolType: 'function' | 'method' | 'class' | 'interface',
-  symbols: string[],
-): boolean {
-  // If AST-based symbolType exists, use lookup table
-  if (record.symbolType) {
-    return SYMBOL_TYPE_MATCHES[symbolType]?.has(record.symbolType) ?? false;
-  }
-
-  // Fallback: check if pre-AST symbols array has valid entries
-  return symbols.length > 0 && symbols.some((s: string) => s.length > 0 && s !== '');
-}
-
-interface SymbolQueryOptions {
-  language?: string;
-  pattern?: string;
-  symbolType?: 'function' | 'method' | 'class' | 'interface';
-}
-
-/**
- * Check if any symbol name matches the given regex pattern.
- * Returns true if the pattern is invalid (graceful degradation) or if a name matches.
- */
-function matchesPattern(pattern: string, symbols: string[], astSymbolName: string): boolean {
-  const regex = safeRegex(pattern);
-  if (!regex) return true;
-  return symbols.some((s: string) => regex.test(s)) || regex.test(astSymbolName);
-}
-
-/**
- * Check if a record matches the symbol query filters.
- * Extracted to reduce complexity of querySymbols.
- */
-function matchesSymbolFilter(
-  r: DBRecord,
-  { language, pattern, symbolType }: SymbolQueryOptions,
-): boolean {
-  // Language filter
-  if (language && (!r.language || r.language.toLowerCase() !== language.toLowerCase())) {
-    return false;
-  }
-
-  const symbols = getSymbolsForType(r, symbolType);
-  const astSymbolName = r.symbolName || '';
-
-  // Must have at least one symbol (legacy or AST-based)
-  if (symbols.length === 0 && !astSymbolName) {
-    return false;
-  }
-
-  // Pattern filter (if provided)
-  if (pattern && !matchesPattern(pattern, symbols, astSymbolName)) {
-    return false;
-  }
-
-  // Symbol type filter (if provided)
-  if (symbolType) {
-    return matchesSymbolType(r, symbolType, symbols);
-  }
-
-  return true;
-}
-
-/**
- * Build legacy symbols object for backwards compatibility.
- */
-function buildLegacySymbols(r: DBRecord) {
-  const functions = toPlainArray<string>(r.functionNames);
-  const classes = toPlainArray<string>(r.classNames);
-  const interfaces = toPlainArray<string>(r.interfaceNames);
-  return {
-    functions: hasValidStringEntries(functions) ? functions! : [],
-    classes: hasValidStringEntries(classes) ? classes! : [],
-    interfaces: hasValidStringEntries(interfaces) ? interfaces! : [],
-  };
 }
 
 /**

--- a/packages/core/src/vectordb/sqlite/fts-search.test.ts
+++ b/packages/core/src/vectordb/sqlite/fts-search.test.ts
@@ -55,6 +55,7 @@ describe('SqliteBackend.search (FTS5)', () => {
   });
 
   afterEach(async () => {
+    db.close();
     await fs.rm(projectRoot, { recursive: true, force: true });
     await fs.rm(db.dbPath, { recursive: true, force: true });
   });

--- a/packages/core/src/vectordb/sqlite/fts-search.test.ts
+++ b/packages/core/src/vectordb/sqlite/fts-search.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import type { ChunkMetadata } from '@liendev/parser';
+import { SqliteBackend } from './sqlite-backend.js';
+import { orQuery } from './fts-search.js';
+
+const DIM = 384;
+const zeroVec = () => new Float32Array(DIM);
+
+function chunk(
+  file: string,
+  content: string,
+  extra: Partial<ChunkMetadata> = {},
+): { metadata: ChunkMetadata; content: string } {
+  return {
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: 5,
+      type: 'function',
+      language: 'typescript',
+      ...extra,
+    },
+    content,
+  };
+}
+
+async function insert(db: SqliteBackend, c: { metadata: ChunkMetadata; content: string }) {
+  await db.insertBatch([zeroVec()], [c.metadata], [c.content]);
+}
+
+describe('orQuery', () => {
+  it('OR-joins quoted whitespace-split terms and escapes quotes', () => {
+    expect(orQuery('parse import statement')).toBe('"parse" OR "import" OR "statement"');
+    expect(orQuery('  spaced   out ')).toBe('"spaced" OR "out"');
+    expect(orQuery('say "hi"')).toBe('"say" OR """hi"""');
+    expect(orQuery('   ')).toBe('');
+  });
+});
+
+describe('SqliteBackend.search (FTS5)', () => {
+  let db: SqliteBackend;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = path.join(
+      os.tmpdir(),
+      `lien-fts-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    );
+    await fs.mkdir(projectRoot, { recursive: true });
+    db = new SqliteBackend(projectRoot);
+    await db.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, { recursive: true, force: true });
+    await fs.rm(db.dbPath, { recursive: true, force: true });
+  });
+
+  it('returns a relevant chunk for a keyword query', async () => {
+    await insert(db, chunk('auth.ts', 'handles user authentication and session tokens'));
+    await insert(db, chunk('math.ts', 'adds two numbers together'));
+
+    const results = await db.search(zeroVec(), 5, 'authentication');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].metadata.file).toBe('auth.ts');
+  });
+
+  it('finds a camelCase symbol via the symbolTokens column', async () => {
+    // Content deliberately has no "parse" word — the match must come from
+    // symbolTokens ('parse import statement').
+    await insert(
+      db,
+      chunk('imports.ts', 'function x() { return 1; }', {
+        symbolName: 'parseImportStatement',
+      }),
+    );
+
+    const results = await db.search(zeroVec(), 5, 'parse');
+    expect(results).toHaveLength(1);
+    expect(results[0].metadata.symbolName).toBe('parseImportStatement');
+  });
+
+  it('orders by bm25 (best hit first) and the top hit is always highly_relevant', async () => {
+    await insert(db, chunk('strong.ts', 'cache cache cache invalidation cache layer'));
+    await insert(db, chunk('weak.ts', 'a cache and some unrelated words here'));
+
+    const results = await db.search(zeroVec(), 5, 'cache');
+    expect(results[0].metadata.file).toBe('strong.ts');
+    expect(results[0].relevance).toBe('highly_relevant');
+    expect(results[0].score).toBe(0);
+  });
+
+  it('forces highly_relevant when a query term exactly matches symbolName', async () => {
+    await insert(db, chunk('flow.ts', 'user login login login flow handler routine'));
+    await insert(db, chunk('def.ts', 'x', { symbolName: 'login' }));
+
+    const results = await db.search(zeroVec(), 5, 'login');
+    const exact = results.find(r => r.metadata.symbolName === 'login');
+    expect(exact?.relevance).toBe('highly_relevant');
+  });
+
+  it('returns [] when there is no query text', async () => {
+    await insert(db, chunk('a.ts', 'something searchable here'));
+    expect(await db.search(zeroVec(), 5, '')).toEqual([]);
+    expect(await db.search(zeroVec(), 5, '   ')).toEqual([]);
+    expect(await db.search(zeroVec(), 5, undefined)).toEqual([]);
+  });
+
+  it('over-fetches internally but trims to the requested limit', async () => {
+    for (let i = 0; i < 30; i++) {
+      await insert(db, chunk(`f${i}.ts`, `shared token number ${i}`));
+    }
+    const results = await db.search(zeroVec(), 5, 'shared');
+    expect(results).toHaveLength(5);
+  });
+
+  it('keeps the FTS index in sync through updateFile (triggers)', async () => {
+    await insert(db, chunk('a.ts', 'alpha zzztokenold marker'));
+    expect(await db.search(zeroVec(), 5, 'zzztokenold')).toHaveLength(1);
+
+    await db.updateFile(
+      'a.ts',
+      [zeroVec()],
+      [chunk('a.ts', 'beta zzztokennew marker').metadata],
+      ['beta zzztokennew marker'],
+    );
+
+    expect(await db.search(zeroVec(), 5, 'zzztokenold')).toEqual([]);
+    expect(await db.search(zeroVec(), 5, 'zzztokennew')).toHaveLength(1);
+  });
+
+  it('keeps the FTS index in sync through deleteByFile (triggers)', async () => {
+    await insert(db, chunk('a.ts', 'gone soon uniquetoken'));
+    expect(await db.search(zeroVec(), 5, 'uniquetoken')).toHaveLength(1);
+
+    await db.deleteByFile('a.ts');
+    expect(await db.search(zeroVec(), 5, 'uniquetoken')).toEqual([]);
+  });
+});

--- a/packages/core/src/vectordb/sqlite/fts-search.ts
+++ b/packages/core/src/vectordb/sqlite/fts-search.ts
@@ -96,8 +96,9 @@ export function keywordSearch(
   );
 
   const results = rows.map(row => {
-    // rankBest is the most-negative (best) rank; guard the degenerate 0 case.
-    const ratio = rankBest !== 0 ? row.rank / rankBest : 1;
+    // rankBest is the most-negative (best) rank. Clamp to [0, 1] so degenerate
+    // bm25 outputs (zero or positive ranks) can never invert the mapping.
+    const ratio = rankBest < 0 ? Math.min(1, Math.max(0, row.rank / rankBest)) : 1;
     const record = parseRow(row);
     const exactSymbolMatch = record.symbolName !== '' && terms.has(record.symbolName.toLowerCase());
     const relevance = exactSymbolMatch ? 'highly_relevant' : toRelevance(ratio);

--- a/packages/core/src/vectordb/sqlite/fts-search.ts
+++ b/packages/core/src/vectordb/sqlite/fts-search.ts
@@ -1,0 +1,113 @@
+import type Database from 'better-sqlite3';
+import type { SearchResult } from '../types.js';
+import type { RelevanceCategory } from '../relevance.js';
+import { parseRow, buildSearchResultMetadata } from './row-mapping.js';
+
+/**
+ * Over-fetch beyond the requested limit before trimming (parity with the
+ * LanceDB search path, which fetches limit+20). Gives the caller's dedup pass
+ * headroom without changing the top-ranked results.
+ */
+const FTS_OVERFETCH = 20;
+
+/** bm25 column weights: symbolName strongest, split tokens next, content least. */
+const BM25_WEIGHTS = { symbolName: 4.0, symbolTokens: 2.0, content: 1.0 };
+
+/**
+ * Build an FTS5 MATCH expression from free text: whitespace-split, quote each
+ * term (doubling embedded quotes), OR-join. FTS5 barewords are implicit-AND —
+ * too strict for short code chunks — so OR lets partial matches surface while
+ * bm25 still ranks multi-term hits highest.
+ */
+export function orQuery(text: string): string {
+  return text
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(w => `"${w.replace(/"/g, '""')}"`)
+    .join(' OR ');
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+/**
+ * Map a bm25 rank into the LanceDB-style score/relevance contract.
+ *
+ * bm25() is NEGATIVE (more negative = better), so ORDER BY rank ASC is correct.
+ * ratio = rank / rankBest lands in (0, 1] with the best hit = 1.0. Bands:
+ * >=0.75 highly_relevant, >=0.5 relevant, >=0.3 loosely_related, else
+ * not_relevant. An exact symbolName match against a query term is forced to
+ * highly_relevant. score = (1 - ratio) * 2 keeps lower-is-better ordering and
+ * lands in the familiar ~0..2 distance-like range consumers expect. The top
+ * hit is therefore always highly_relevant, so results always flow through the
+ * handlers' not_relevant pruning. Deliberately simple and tunable.
+ */
+function toRelevance(ratio: number): RelevanceCategory {
+  if (ratio >= 0.75) return 'highly_relevant';
+  if (ratio >= 0.5) return 'relevant';
+  if (ratio >= 0.3) return 'loosely_related';
+  return 'not_relevant';
+}
+
+interface FtsRow extends Record<string, unknown> {
+  rank: number;
+}
+
+/**
+ * FTS5 keyword search. Ignores vectors entirely — the meaningful input is the
+ * query text. Returns SearchResult[] ordered best-first, trimmed to `limit`.
+ */
+export function keywordSearch(
+  db: Database.Database,
+  queryText: string,
+  limit: number,
+): SearchResult[] {
+  const match = orQuery(queryText);
+  if (!match) return [];
+
+  const rows = db
+    .prepare(
+      `SELECT c.*, bm25(chunks_fts, ?, ?, ?) AS rank
+       FROM chunks_fts
+       JOIN chunks c ON c.id = chunks_fts.rowid
+       WHERE chunks_fts MATCH ?
+       ORDER BY rank
+       LIMIT ?`,
+    )
+    .all(
+      BM25_WEIGHTS.symbolName,
+      BM25_WEIGHTS.symbolTokens,
+      BM25_WEIGHTS.content,
+      match,
+      limit + FTS_OVERFETCH,
+    ) as FtsRow[];
+
+  if (rows.length === 0) return [];
+
+  const rankBest = rows[0].rank;
+  const terms = new Set(
+    queryText
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map(t => t.toLowerCase()),
+  );
+
+  const results = rows.map(row => {
+    // rankBest is the most-negative (best) rank; guard the degenerate 0 case.
+    const ratio = rankBest !== 0 ? row.rank / rankBest : 1;
+    const record = parseRow(row);
+    const exactSymbolMatch = record.symbolName !== '' && terms.has(record.symbolName.toLowerCase());
+    const relevance = exactSymbolMatch ? 'highly_relevant' : toRelevance(ratio);
+    return {
+      content: record.content,
+      metadata: buildSearchResultMetadata(record),
+      score: round4((1 - ratio) * 2),
+      relevance,
+    };
+  });
+
+  return results.slice(0, limit);
+}

--- a/packages/core/src/vectordb/sqlite/row-mapping.ts
+++ b/packages/core/src/vectordb/sqlite/row-mapping.ts
@@ -109,8 +109,14 @@ function parseJsonArray(value: unknown): string[] {
 function parseImportedSymbols(value: unknown): Record<string, string[]> | undefined {
   if (typeof value !== 'string') return undefined;
   try {
-    const parsed = JSON.parse(value);
-    if (parsed && typeof parsed === 'object' && Object.keys(parsed).length > 0) {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      Object.keys(parsed).length > 0 &&
+      Object.values(parsed).every(v => Array.isArray(v) && v.every(s => typeof s === 'string'))
+    ) {
       return parsed as Record<string, string[]>;
     }
   } catch {
@@ -177,8 +183,10 @@ export function parseRow(raw: Record<string, unknown>): SqliteChunkRecord {
 /**
  * Build a SearchResult's metadata from a parsed record, reproducing the
  * LanceDB read path (query.ts buildSearchResultMetadata) field-for-field:
- * empty arrays -> undefined, '' -> undefined for optional strings, `0`
- * complexity -> undefined, but Halstead 0 is preserved (explicit != null).
+ * empty arrays -> undefined, '' -> undefined for symbolName/parentClass/
+ * signature, `0` complexity -> undefined, Halstead 0 preserved (explicit
+ * != null). symbolType is a bare cast — query.ts passes '' through, so a
+ * `|| undefined` here would break parity.
  */
 function buildMetadata(r: SqliteChunkRecord): SearchResult['metadata'] {
   return {

--- a/packages/core/src/vectordb/sqlite/row-mapping.ts
+++ b/packages/core/src/vectordb/sqlite/row-mapping.ts
@@ -1,0 +1,225 @@
+import type { ChunkMetadata } from '@liendev/parser';
+import type { SearchResult } from '../types.js';
+import { hasValidStringEntries } from '../filters.js';
+
+/**
+ * A parsed structural row: scalars coerced, JSON columns deserialized to real
+ * JS values. Structurally satisfies `FilterableRecord`, so the shared filters
+ * in filters.ts operate on it directly.
+ */
+export interface SqliteChunkRecord {
+  file: string;
+  startLine: number;
+  endLine: number;
+  type: string;
+  language: string;
+  symbolName: string;
+  symbolType: string;
+  parentClass: string;
+  signature: string;
+  complexity: number;
+  cognitiveComplexity: number;
+  halsteadVolume: number;
+  halsteadDifficulty: number;
+  halsteadEffort: number;
+  halsteadBugs: number;
+  content: string;
+  functionNames: string[];
+  classNames: string[];
+  interfaceNames: string[];
+  parameters: string[];
+  imports: string[];
+  exports: string[];
+  importedSymbols?: Record<string, string[]>;
+  callSites?: Array<{ symbol: string; line: number; isResultCaptured?: boolean }>;
+}
+
+/** The row object bound to the INSERT prepared statement (keys = CHUNK_COLUMNS). */
+export type ChunkInsertRow = Record<string, string | number>;
+
+/**
+ * Split an identifier into space-separated lowercase tokens on camelCase
+ * boundaries, digit boundaries, `_` and `-`. Feeds the FTS `symbolTokens`
+ * column so a porter/unicode61 keyword search matches inside identifiers
+ * (e.g. 'parse' finds `parseImportStatement`). '' when there's no symbol.
+ */
+export function deriveSymbolTokens(symbolName: string): string {
+  if (!symbolName) return '';
+  const spaced = symbolName
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([a-zA-Z])([0-9])/g, '$1 $2')
+    .replace(/([0-9])([a-zA-Z])/g, '$1 $2');
+  return spaced
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map(t => t.toLowerCase())
+    .join(' ');
+}
+
+/**
+ * Serialize a chunk (content + metadata) to a flat insert row. Stores real
+ * empties (`[]` / `{}` / `''` / `0`) — no Arrow placeholders.
+ *
+ * `returnType` is not persisted (parser/src/types.ts). This matches the
+ * LanceDB backend, which also drops it — the round-trip stays intentionally
+ * lossy for parity.
+ */
+export function chunkToRow(content: string, metadata: ChunkMetadata): ChunkInsertRow {
+  const symbolName = metadata.symbolName || '';
+  return {
+    file: metadata.file,
+    startLine: metadata.startLine ?? 0,
+    endLine: metadata.endLine ?? 0,
+    type: metadata.type ?? '',
+    language: metadata.language ?? '',
+    symbolName,
+    symbolType: metadata.symbolType || '',
+    parentClass: metadata.parentClass || '',
+    signature: metadata.signature || '',
+    symbolTokens: deriveSymbolTokens(symbolName),
+    complexity: metadata.complexity || 0,
+    cognitiveComplexity: metadata.cognitiveComplexity || 0,
+    halsteadVolume: metadata.halsteadVolume || 0,
+    halsteadDifficulty: metadata.halsteadDifficulty || 0,
+    halsteadEffort: metadata.halsteadEffort || 0,
+    halsteadBugs: metadata.halsteadBugs || 0,
+    content: content ?? '',
+    functionNames: JSON.stringify(metadata.symbols?.functions ?? []),
+    classNames: JSON.stringify(metadata.symbols?.classes ?? []),
+    interfaceNames: JSON.stringify(metadata.symbols?.interfaces ?? []),
+    parameters: JSON.stringify(metadata.parameters ?? []),
+    imports: JSON.stringify(metadata.imports ?? []),
+    exports: JSON.stringify(metadata.exports ?? []),
+    importedSymbols: JSON.stringify(metadata.importedSymbols ?? {}),
+    callSites: JSON.stringify(metadata.callSites ?? []),
+  };
+}
+
+function parseJsonArray(value: unknown): string[] {
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseImportedSymbols(value: unknown): Record<string, string[]> | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object' && Object.keys(parsed).length > 0) {
+      return parsed as Record<string, string[]>;
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
+function parseCallSites(
+  value: unknown,
+): Array<{ symbol: string; line: number; isResultCaptured?: boolean }> | undefined {
+  if (typeof value !== 'string') return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed)) return undefined;
+  // line > 0 mirrors the LanceDB read path (0 is the missing-data sentinel).
+  const result = parsed
+    .filter(
+      (c): c is { symbol: string; line: number; isResultCaptured?: boolean } =>
+        c && typeof c.symbol === 'string' && typeof c.line === 'number' && c.line > 0,
+    )
+    .map(c =>
+      typeof c.isResultCaptured === 'boolean'
+        ? { symbol: c.symbol, line: c.line, isResultCaptured: c.isResultCaptured }
+        : { symbol: c.symbol, line: c.line },
+    );
+  return result.length > 0 ? result : undefined;
+}
+
+/** Parse a raw better-sqlite3 row into a normalized structural record. */
+export function parseRow(raw: Record<string, unknown>): SqliteChunkRecord {
+  return {
+    file: (raw.file as string) ?? '',
+    startLine: (raw.startLine as number) ?? 0,
+    endLine: (raw.endLine as number) ?? 0,
+    type: (raw.type as string) ?? '',
+    language: (raw.language as string) ?? '',
+    symbolName: (raw.symbolName as string) ?? '',
+    symbolType: (raw.symbolType as string) ?? '',
+    parentClass: (raw.parentClass as string) ?? '',
+    signature: (raw.signature as string) ?? '',
+    complexity: (raw.complexity as number) ?? 0,
+    cognitiveComplexity: (raw.cognitiveComplexity as number) ?? 0,
+    halsteadVolume: (raw.halsteadVolume as number) ?? 0,
+    halsteadDifficulty: (raw.halsteadDifficulty as number) ?? 0,
+    halsteadEffort: (raw.halsteadEffort as number) ?? 0,
+    halsteadBugs: (raw.halsteadBugs as number) ?? 0,
+    content: (raw.content as string) ?? '',
+    functionNames: parseJsonArray(raw.functionNames),
+    classNames: parseJsonArray(raw.classNames),
+    interfaceNames: parseJsonArray(raw.interfaceNames),
+    parameters: parseJsonArray(raw.parameters),
+    imports: parseJsonArray(raw.imports),
+    exports: parseJsonArray(raw.exports),
+    importedSymbols: parseImportedSymbols(raw.importedSymbols),
+    callSites: parseCallSites(raw.callSites),
+  };
+}
+
+/**
+ * Build a SearchResult's metadata from a parsed record, reproducing the
+ * LanceDB read path (query.ts buildSearchResultMetadata) field-for-field:
+ * empty arrays -> undefined, '' -> undefined for optional strings, `0`
+ * complexity -> undefined, but Halstead 0 is preserved (explicit != null).
+ */
+function buildMetadata(r: SqliteChunkRecord): SearchResult['metadata'] {
+  return {
+    file: r.file,
+    startLine: r.startLine,
+    endLine: r.endLine,
+    type: r.type as 'function' | 'class' | 'block',
+    language: r.language,
+    symbolName: r.symbolName || undefined,
+    symbolType: r.symbolType as 'function' | 'method' | 'class' | 'interface' | undefined,
+    parentClass: r.parentClass || undefined,
+    complexity: r.complexity || undefined,
+    cognitiveComplexity: r.cognitiveComplexity || undefined,
+    parameters: hasValidStringEntries(r.parameters) ? r.parameters : undefined,
+    signature: r.signature || undefined,
+    imports: hasValidStringEntries(r.imports) ? r.imports : undefined,
+    halsteadVolume: r.halsteadVolume != null ? r.halsteadVolume : undefined,
+    halsteadDifficulty: r.halsteadDifficulty != null ? r.halsteadDifficulty : undefined,
+    halsteadEffort: r.halsteadEffort != null ? r.halsteadEffort : undefined,
+    halsteadBugs: r.halsteadBugs != null ? r.halsteadBugs : undefined,
+    exports: hasValidStringEntries(r.exports) ? r.exports : undefined,
+    importedSymbols: r.importedSymbols,
+    callSites: r.callSites,
+  };
+}
+
+/** Convert a parsed record to an unscored SearchResult (scan/scroll paths). */
+export function recordToUnscoredResult(r: SqliteChunkRecord): SearchResult {
+  return {
+    content: r.content,
+    metadata: buildMetadata(r),
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
+
+/**
+ * Convert a parsed record to a scored SearchResult (FTS search path).
+ * Legacy symbols object is appended by querySymbols via buildLegacySymbols;
+ * this helper is used by search and querySymbols alike for the base metadata.
+ */
+export function buildSearchResultMetadata(r: SqliteChunkRecord): SearchResult['metadata'] {
+  return buildMetadata(r);
+}

--- a/packages/core/src/vectordb/sqlite/schema.ts
+++ b/packages/core/src/vectordb/sqlite/schema.ts
@@ -1,0 +1,129 @@
+import Database from 'better-sqlite3';
+
+/** File name of the SQLite structural store inside the index directory. */
+export const STRUCTURAL_DB_FILENAME = 'structural.db';
+
+/**
+ * Columns of the `chunks` table, in INSERT order. `id` (INTEGER PRIMARY KEY,
+ * a rowid alias) is omitted — it's what the external-content FTS5 table
+ * references via content_rowid.
+ */
+export const CHUNK_COLUMNS = [
+  'file',
+  'startLine',
+  'endLine',
+  'type',
+  'language',
+  'symbolName',
+  'symbolType',
+  'parentClass',
+  'signature',
+  'symbolTokens',
+  'complexity',
+  'cognitiveComplexity',
+  'halsteadVolume',
+  'halsteadDifficulty',
+  'halsteadEffort',
+  'halsteadBugs',
+  'content',
+  'functionNames',
+  'classNames',
+  'interfaceNames',
+  'parameters',
+  'imports',
+  'exports',
+  'importedSymbols',
+  'callSites',
+] as const;
+
+/**
+ * DDL for the structural store. startLine/endLine are INTEGER (not REAL — the
+ * spike stored line numbers as REAL, which round-trips floats; fixed here).
+ * JSON columns store real empties ([]/{}/'') — no Arrow placeholders.
+ *
+ * `chunks_fts` is an external-content FTS5 table (content='chunks'): it indexes
+ * the base table in place without duplicating storage. External-content tables
+ * do NOT auto-track base-table writes, so the sync triggers below are mandatory
+ * — without them incremental indexing / watcher updates silently drift the
+ * index. symbolTokens is an identifier-split copy of symbolName (e.g.
+ * 'parseImportStatement' -> 'parse import statement') so a porter/unicode61
+ * keyword search for 'parse' matches the symbol; it closes the spike's
+ * camelCase tokenizer gap.
+ */
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS chunks (
+  id INTEGER PRIMARY KEY,
+  file TEXT NOT NULL,
+  startLine INTEGER,
+  endLine INTEGER,
+  type TEXT,
+  language TEXT,
+  symbolName TEXT,
+  symbolType TEXT,
+  parentClass TEXT,
+  signature TEXT,
+  symbolTokens TEXT,
+  complexity INTEGER,
+  cognitiveComplexity INTEGER,
+  halsteadVolume REAL,
+  halsteadDifficulty REAL,
+  halsteadEffort REAL,
+  halsteadBugs REAL,
+  content TEXT NOT NULL DEFAULT '',
+  functionNames TEXT,
+  classNames TEXT,
+  interfaceNames TEXT,
+  parameters TEXT,
+  imports TEXT,
+  exports TEXT,
+  importedSymbols TEXT,
+  callSites TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_file ON chunks(file);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+  symbolName, symbolTokens, content,
+  content='chunks', content_rowid='id',
+  tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+  INSERT INTO chunks_fts(rowid, symbolName, symbolTokens, content)
+  VALUES (new.id, new.symbolName, new.symbolTokens, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+  INSERT INTO chunks_fts(chunks_fts, rowid, symbolName, symbolTokens, content)
+  VALUES ('delete', old.id, old.symbolName, old.symbolTokens, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
+  INSERT INTO chunks_fts(chunks_fts, rowid, symbolName, symbolTokens, content)
+  VALUES ('delete', old.id, old.symbolName, old.symbolTokens, old.content);
+  INSERT INTO chunks_fts(rowid, symbolName, symbolTokens, content)
+  VALUES (new.id, new.symbolName, new.symbolTokens, new.content);
+END;
+`;
+
+/**
+ * Deliberately OMITTED (YAGNI): the spike's `chunk_imports` child table +
+ * composite index (dependents-seed optimization no current consumer performs),
+ * the `chunks_symtri` trigram table (list_functions keeps its regex path), and
+ * indices on symbolType/complexity (no current query is selective on them).
+ * Add them when a feature that needs them lands.
+ */
+
+/**
+ * Open (creating if needed) the structural store and ensure schema exists.
+ * busy_timeout lets the MCP server watcher and a concurrent CLI index run
+ * both hold write handles without immediate SQLITE_BUSY failures.
+ */
+export function openDatabase(dbFilePath: string): Database.Database {
+  const db = new Database(dbFilePath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  db.pragma('busy_timeout = 5000');
+  db.exec(SCHEMA_SQL);
+  return db;
+}

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import type { ChunkMetadata } from '@liendev/parser';
+import { SqliteBackend } from './sqlite-backend.js';
+import { readVersionFile } from '../version.js';
+import { DatabaseError } from '../../errors/index.js';
+
+const DIM = 384;
+const zeroVec = () => new Float32Array(DIM);
+
+/** A metadata fixture exercising every persisted field. */
+function makeChunk(overrides: Partial<ChunkMetadata> = {}, content = 'function foo() {}') {
+  const metadata: ChunkMetadata = {
+    file: 'src/foo.ts',
+    startLine: 10,
+    endLine: 20,
+    type: 'function',
+    language: 'typescript',
+    symbols: { functions: ['foo'], classes: ['Bar'], interfaces: ['IBaz'] },
+    symbolName: 'foo',
+    symbolType: 'function',
+    parentClass: 'Bar',
+    complexity: 5,
+    cognitiveComplexity: 3,
+    parameters: ['a: string', 'b: number'],
+    signature: 'foo(a, b)',
+    returnType: 'void',
+    imports: ['./a', './b'],
+    exports: ['foo'],
+    importedSymbols: { './a': ['x', 'y'] },
+    callSites: [
+      { symbol: 'foo', line: 5, isResultCaptured: true },
+      { symbol: 'bar', line: 8, isResultCaptured: false },
+      { symbol: 'baz', line: 10 },
+    ],
+    halsteadVolume: 100,
+    halsteadDifficulty: 2,
+    halsteadEffort: 200,
+    halsteadBugs: 0.03,
+    ...overrides,
+  };
+  return { metadata, content };
+}
+
+async function insertOne(db: SqliteBackend, metadata: ChunkMetadata, content: string) {
+  await db.insertBatch([zeroVec()], [metadata], [content]);
+}
+
+describe('SqliteBackend', () => {
+  let db: SqliteBackend;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = path.join(
+      os.tmpdir(),
+      `lien-sqlite-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    );
+    await fs.mkdir(projectRoot, { recursive: true });
+    db = new SqliteBackend(projectRoot);
+    await db.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, { recursive: true, force: true });
+    await fs.rm(db.dbPath, { recursive: true, force: true });
+  });
+
+  describe('insert -> scan round-trip', () => {
+    it('round-trips every metadata field, coercing empties to undefined on read', async () => {
+      const { metadata, content } = makeChunk();
+      await insertOne(db, metadata, content);
+
+      const results = await db.scanWithFilter({ file: 'src/foo.ts' });
+      expect(results).toHaveLength(1);
+      const r = results[0];
+
+      expect(r.content).toBe(content);
+      expect(r.score).toBe(0);
+      expect(r.relevance).toBe('not_relevant');
+      expect(r.metadata).toEqual({
+        file: 'src/foo.ts',
+        startLine: 10,
+        endLine: 20,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'foo',
+        symbolType: 'function',
+        parentClass: 'Bar',
+        complexity: 5,
+        cognitiveComplexity: 3,
+        parameters: ['a: string', 'b: number'],
+        signature: 'foo(a, b)',
+        imports: ['./a', './b'],
+        halsteadVolume: 100,
+        halsteadDifficulty: 2,
+        halsteadEffort: 200,
+        halsteadBugs: 0.03,
+        exports: ['foo'],
+        importedSymbols: { './a': ['x', 'y'] },
+        callSites: [
+          { symbol: 'foo', line: 5, isResultCaptured: true },
+          { symbol: 'bar', line: 8, isResultCaptured: false },
+          { symbol: 'baz', line: 10 },
+        ],
+      });
+      // returnType is intentionally lossy (not persisted, matching LanceDB).
+      expect((r.metadata as ChunkMetadata).returnType).toBeUndefined();
+    });
+
+    it('maps empty arrays/objects to undefined on read', async () => {
+      const { metadata, content } = makeChunk({
+        symbols: { functions: [], classes: [], interfaces: [] },
+        parameters: [],
+        imports: [],
+        exports: [],
+        importedSymbols: {},
+        callSites: [],
+      });
+      await insertOne(db, metadata, content);
+
+      const [r] = await db.scanWithFilter({ file: 'src/foo.ts' });
+      expect(r.metadata.parameters).toBeUndefined();
+      expect(r.metadata.imports).toBeUndefined();
+      expect(r.metadata.exports).toBeUndefined();
+      expect(r.metadata.importedSymbols).toBeUndefined();
+      expect(r.metadata.callSites).toBeUndefined();
+    });
+
+    it('drops callSites with non-positive line numbers (missing-data sentinel)', async () => {
+      const { metadata, content } = makeChunk({
+        callSites: [
+          { symbol: 'kept', line: 3 },
+          { symbol: 'dropped', line: 0 },
+        ],
+      });
+      await insertOne(db, metadata, content);
+      const [r] = await db.scanWithFilter({ file: 'src/foo.ts' });
+      expect(r.metadata.callSites).toEqual([{ symbol: 'kept', line: 3 }]);
+    });
+  });
+
+  describe('scanWithFilter', () => {
+    beforeEach(async () => {
+      await insertOne(db, makeChunk({ file: 'a.ts', language: 'typescript' }).metadata, 'aaa');
+      await insertOne(db, makeChunk({ file: 'b.py', language: 'python' }).metadata, 'bbb');
+      await insertOne(db, makeChunk({ file: 'c.ts', language: 'typescript' }).metadata, 'ccc');
+    });
+
+    it('filters by exact file (single and IN-list)', async () => {
+      expect(await db.scanWithFilter({ file: 'a.ts' })).toHaveLength(1);
+      expect(await db.scanWithFilter({ file: ['a.ts', 'c.ts'] })).toHaveLength(2);
+    });
+
+    it('filters by language case-insensitively (JS-side)', async () => {
+      const r = await db.scanWithFilter({ language: 'TypeScript' });
+      expect(r).toHaveLength(2);
+    });
+
+    it('filters by pattern against content or file', async () => {
+      expect(await db.scanWithFilter({ pattern: 'bbb' })).toHaveLength(1);
+      expect(await db.scanWithFilter({ pattern: '\\.py$' })).toHaveLength(1);
+    });
+
+    it('applies limit last, after JS filters', async () => {
+      const r = await db.scanWithFilter({ language: 'typescript', limit: 1 });
+      expect(r).toHaveLength(1);
+    });
+
+    it('throws DatabaseError for a whitespace-only filepath', async () => {
+      await expect(db.scanWithFilter({ file: '   ' })).rejects.toThrow(DatabaseError);
+      await expect(db.scanWithFilter({ file: ['  ', ''] })).rejects.toThrow(DatabaseError);
+    });
+  });
+
+  describe('scanAll', () => {
+    it('returns all chunks with no filters', async () => {
+      await insertOne(db, makeChunk({ file: 'a.ts' }).metadata, 'aaa');
+      await insertOne(db, makeChunk({ file: 'b.ts' }).metadata, 'bbb');
+      expect(await db.scanAll()).toHaveLength(2);
+    });
+
+    it('honors language/pattern filters', async () => {
+      await insertOne(db, makeChunk({ file: 'a.ts', language: 'typescript' }).metadata, 'aaa');
+      await insertOne(db, makeChunk({ file: 'b.py', language: 'python' }).metadata, 'bbb');
+      expect(await db.scanAll({ language: 'python' })).toHaveLength(1);
+    });
+  });
+
+  describe('querySymbols', () => {
+    it('returns matching symbols with a legacy symbols object', async () => {
+      await insertOne(db, makeChunk({ symbolName: 'parseThing' }).metadata, 'code');
+      const results = await db.querySymbols({ pattern: 'parse' });
+      expect(results).toHaveLength(1);
+      expect(results[0].metadata.symbols).toEqual({
+        functions: ['foo'],
+        classes: ['Bar'],
+        interfaces: ['IBaz'],
+      });
+    });
+
+    it('matches symbolType function against method too', async () => {
+      await insertOne(db, makeChunk({ symbolName: 'm', symbolType: 'method' }).metadata, 'code');
+      const results = await db.querySymbols({ symbolType: 'function' });
+      expect(results).toHaveLength(1);
+    });
+
+    it('excludes empty-content chunks', async () => {
+      await insertOne(db, makeChunk({ symbolName: 'ghost' }).metadata, '');
+      expect(await db.querySymbols({})).toHaveLength(0);
+    });
+  });
+
+  describe('deleteByFile', () => {
+    it('deletes chunks for an exact file path and no-ops on non-matching paths', async () => {
+      await insertOne(db, makeChunk({ file: 'a.ts' }).metadata, 'aaa');
+      await insertOne(db, makeChunk({ file: 'b.ts' }).metadata, 'bbb');
+
+      await db.deleteByFile('does/not/exist.ts');
+      expect(await db.scanAll()).toHaveLength(2);
+
+      await db.deleteByFile('a.ts');
+      const remaining = await db.scanAll();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].metadata.file).toBe('b.ts');
+    });
+  });
+
+  describe('updateFile', () => {
+    it('replaces a file’s chunks in one transaction and bumps the version file', async () => {
+      await insertOne(db, makeChunk({ file: 'a.ts' }).metadata, 'old content');
+
+      await db.updateFile(
+        'a.ts',
+        [zeroVec()],
+        [makeChunk({ file: 'a.ts' }).metadata],
+        ['new content'],
+      );
+
+      const results = await db.scanWithFilter({ file: 'a.ts' });
+      expect(results).toHaveLength(1);
+      expect(results[0].content).toBe('new content');
+
+      const version = await readVersionFile(db.dbPath);
+      expect(version).toBeGreaterThan(0);
+    });
+  });
+
+  describe('hasData', () => {
+    it('is false when empty, true after a real insert, false for empty-content only', async () => {
+      expect(await db.hasData()).toBe(false);
+
+      await insertOne(db, makeChunk().metadata, 'real content');
+      expect(await db.hasData()).toBe(true);
+
+      await db.clear();
+      await insertOne(db, makeChunk().metadata, '');
+      expect(await db.hasData()).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the store but allows reinsertion', async () => {
+      await insertOne(db, makeChunk().metadata, 'content');
+      expect(await db.scanAll()).toHaveLength(1);
+
+      await db.clear();
+      expect(await db.scanAll()).toHaveLength(0);
+
+      await insertOne(db, makeChunk().metadata, 'content again');
+      expect(await db.scanAll()).toHaveLength(1);
+    });
+
+    it('leaves the version file intact', async () => {
+      await db.updateFile('a.ts', [zeroVec()], [makeChunk({ file: 'a.ts' }).metadata], ['c']);
+      const before = await readVersionFile(db.dbPath);
+      expect(before).toBeGreaterThan(0);
+
+      await db.clear();
+      const after = await readVersionFile(db.dbPath);
+      expect(after).toBe(before);
+    });
+  });
+
+  describe('checkVersion', () => {
+    it('detects a newer version once, then throttles for 1 second', async () => {
+      // updateFile writes a fresh version file (currentVersion starts at 0).
+      await db.updateFile('a.ts', [zeroVec()], [makeChunk({ file: 'a.ts' }).metadata], ['c']);
+
+      expect(await db.checkVersion()).toBe(true); // detects the bump
+      expect(await db.checkVersion()).toBe(false); // throttled within 1s
+    });
+  });
+
+  describe('scanPaginated', () => {
+    it('yields pages of the configured size', async () => {
+      for (let i = 0; i < 5; i++) {
+        await insertOne(db, makeChunk({ file: `f${i}.ts` }).metadata, `content ${i}`);
+      }
+      const pages: number[] = [];
+      for await (const page of db.scanPaginated({ pageSize: 2 })) {
+        pages.push(page.length);
+      }
+      expect(pages).toEqual([2, 2, 1]);
+    });
+
+    it('throws for a non-positive pageSize', async () => {
+      const gen = db.scanPaginated({ pageSize: 0 });
+      await expect(gen.next()).rejects.toThrow(DatabaseError);
+    });
+  });
+
+  describe('insertBatch edge cases', () => {
+    it('is a no-op for an empty batch', async () => {
+      await db.insertBatch([], [], []);
+      expect(await db.hasData()).toBe(false);
+    });
+
+    it('throws when array lengths mismatch', async () => {
+      await expect(db.insertBatch([zeroVec()], [], ['c'])).rejects.toThrow(DatabaseError);
+    });
+  });
+
+  describe('cross-repo stubs', () => {
+    it('reports no cross-repo support and returns [] from cross-repo methods', async () => {
+      expect(db.supportsCrossRepo).toBe(false);
+      expect(await db.searchCrossRepo(zeroVec())).toEqual([]);
+      expect(await db.scanCrossRepo({})).toEqual([]);
+    });
+  });
+
+  describe('version accessors', () => {
+    it('returns Unknown before any version and a date after', async () => {
+      expect(db.getVersionDate()).toBe('Unknown');
+      expect(db.getCurrentVersion()).toBe(0);
+
+      await db.updateFile('a.ts', [zeroVec()], [makeChunk({ file: 'a.ts' }).metadata], ['c']);
+      await db.checkVersion(); // bumps in-memory currentVersion from the file
+      expect(db.getCurrentVersion()).toBeGreaterThan(0);
+      expect(db.getVersionDate()).not.toBe('Unknown');
+    });
+  });
+});

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
+import Database from 'better-sqlite3';
 import type { ChunkMetadata } from '@liendev/parser';
 import { SqliteBackend } from './sqlite-backend.js';
 import { readVersionFile } from '../version.js';
@@ -63,6 +64,7 @@ describe('SqliteBackend', () => {
   });
 
   afterEach(async () => {
+    db.close();
     await fs.rm(projectRoot, { recursive: true, force: true });
     await fs.rm(db.dbPath, { recursive: true, force: true });
   });
@@ -339,6 +341,21 @@ describe('SqliteBackend', () => {
       await db.checkVersion(); // bumps in-memory currentVersion from the file
       expect(db.getCurrentVersion()).toBeGreaterThan(0);
       expect(db.getVersionDate()).not.toBe('Unknown');
+    });
+  });
+
+  describe('corrupt rows', () => {
+    it('degrades malformed importedSymbols JSON to undefined instead of crashing', async () => {
+      const { metadata, content } = makeChunk();
+      await insertOne(db, metadata, content);
+
+      const raw = new Database(path.join(db.dbPath, 'structural.db'));
+      raw.prepare(`UPDATE chunks SET importedSymbols = '{"mod": 123}'`).run();
+      raw.close();
+
+      const [result] = await db.scanWithFilter({ file: metadata.file });
+      expect(result.metadata.importedSymbols).toBeUndefined();
+      expect(result.metadata.imports).toEqual(metadata.imports);
     });
   });
 });

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.ts
@@ -1,0 +1,386 @@
+import fs from 'fs/promises';
+import path from 'path';
+import type DatabaseType from 'better-sqlite3';
+import type { ChunkMetadata } from '@liendev/parser';
+import { extractRepoId, getLienHome } from '@liendev/parser';
+import type { SearchResult, VectorDBInterface } from '../types.js';
+import { DatabaseError, wrapError } from '../../errors/index.js';
+import { readVersionFile, writeVersionFile } from '../version.js';
+import {
+  filterByLanguage,
+  filterByPattern,
+  filterBySymbolType,
+  matchesSymbolFilter,
+  buildLegacySymbols,
+} from '../filters.js';
+import { openDatabase, STRUCTURAL_DB_FILENAME, CHUNK_COLUMNS } from './schema.js';
+import {
+  chunkToRow,
+  parseRow,
+  recordToUnscoredResult,
+  buildSearchResultMetadata,
+  type SqliteChunkRecord,
+} from './row-mapping.js';
+import { keywordSearch } from './fts-search.js';
+
+const INSERT_SQL = `INSERT INTO chunks (${CHUNK_COLUMNS.join(', ')}) VALUES (${CHUNK_COLUMNS.map(
+  c => '@' + c,
+).join(', ')})`;
+
+/**
+ * A row identity requires a non-empty file and non-empty content. Mirrors
+ * query.ts:isValidRecord so scan paths drop empty-content rows identically to
+ * LanceDB (content is always a string here — the column is NOT NULL).
+ */
+function isValidRecord(r: SqliteChunkRecord): boolean {
+  if (!r.file || r.file.length === 0) return false;
+  if (r.content.trim().length === 0) return false;
+  return true;
+}
+
+/**
+ * Trim + validate a file filter into a list of exact-match paths. Empty or
+ * whitespace-only paths throw — matching query.ts buildFileWhereClause.
+ */
+function normalizeFileFilter(file: string | string[]): string[] {
+  if (typeof file === 'string') {
+    const trimmed = file.trim();
+    if (trimmed.length === 0) {
+      throw new DatabaseError('Invalid file filter: file path must be non-empty');
+    }
+    return [trimmed];
+  }
+  const cleaned = file.map(f => f.trim()).filter(f => f.length > 0);
+  if (cleaned.length === 0) {
+    throw new DatabaseError('Invalid file filter: at least one non-empty file path is required');
+  }
+  return cleaned;
+}
+
+function validateBatchLengths(
+  vectors: Float32Array[],
+  metadatas: ChunkMetadata[],
+  contents: string[],
+): void {
+  if (vectors.length !== metadatas.length || vectors.length !== contents.length) {
+    throw new DatabaseError('Vectors, metadatas, and contents arrays must have the same length', {
+      vectorsLength: vectors.length,
+      metadatasLength: metadatas.length,
+      contentsLength: contents.length,
+    });
+  }
+}
+
+/**
+ * SQLite + FTS5 structural backend implementing VectorDBInterface.
+ *
+ * Embeddings are ignored entirely: `vectors` arguments are accepted (for
+ * interface parity) but never stored, and `search` runs FTS5 keyword matching
+ * on the query text rather than a vector ANN. The `columns` projection is
+ * accepted and ignored everywhere — there's no fat vector column to skip, so
+ * full metadata is always returned (the interface doc permits this).
+ */
+export class SqliteBackend implements VectorDBInterface {
+  private db: DatabaseType.Database | null = null;
+  public readonly dbPath: string;
+  private readonly dbFilePath: string;
+  public readonly supportsCrossRepo = false;
+  private lastVersionCheck = 0;
+  private currentVersion = 0;
+
+  constructor(projectRoot: string) {
+    const repoId = extractRepoId(projectRoot);
+    // Same directory as LanceDB's table dir — the manifest and
+    // .lien-index-version file live here too and must stay put.
+    this.dbPath = path.join(getLienHome(), '.lien', 'indices', repoId);
+    this.dbFilePath = path.join(this.dbPath, STRUCTURAL_DB_FILENAME);
+  }
+
+  private requireDb(): DatabaseType.Database {
+    if (!this.db) {
+      throw new DatabaseError('Vector database not initialized');
+    }
+    return this.db;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      await fs.mkdir(this.dbPath, { recursive: true });
+      this.db = openDatabase(this.dbFilePath);
+      this.currentVersion = await readVersionFile(this.dbPath);
+    } catch (error: unknown) {
+      throw wrapError(error, 'Failed to initialize vector database', { dbPath: this.dbPath });
+    }
+  }
+
+  async insertBatch(
+    vectors: Float32Array[],
+    metadatas: ChunkMetadata[],
+    contents: string[],
+  ): Promise<void> {
+    const db = this.requireDb();
+    validateBatchLengths(vectors, metadatas, contents);
+    // Empty batch is a no-op.
+    if (metadatas.length === 0) return;
+
+    // Single transaction, one prepared statement. No adaptive half-split retry:
+    // that existed only for LanceDB/Arrow large-batch flakiness, which SQLite
+    // doesn't have.
+    const insert = db.prepare(INSERT_SQL);
+    const insertAll = db.transaction((rows: ReturnType<typeof chunkToRow>[]) => {
+      for (const row of rows) insert.run(row);
+    });
+    insertAll(metadatas.map((metadata, i) => chunkToRow(contents[i], metadata)));
+  }
+
+  async search(
+    _queryVector: Float32Array,
+    limit: number = 5,
+    query?: string,
+    _options: { columns?: string[] } = {},
+  ): Promise<SearchResult[]> {
+    const db = this.requireDb();
+    // No query text → no lexical search possible. LanceDB always had a vector,
+    // so this path has no current caller; keep it total anyway.
+    if (!query || query.trim().length === 0) return [];
+    return keywordSearch(db, query, limit);
+  }
+
+  async scanWithFilter(options: {
+    file?: string | string[];
+    language?: string;
+    pattern?: string;
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
+    limit?: number;
+    columns?: string[];
+  }): Promise<SearchResult[]> {
+    const db = this.requireDb();
+    const { file, language, pattern, symbolType, limit = 100 } = options;
+
+    let rawRows: Record<string, unknown>[];
+    // Truthy guard mirrors query.ts (`file ? ... : 'file != ""'`): an empty
+    // string is treated as no filter (full scan), while a non-empty array
+    // still routes through normalizeFileFilter.
+    if (file) {
+      const files = normalizeFileFilter(file);
+      const placeholders = files.map(() => '?').join(', ');
+      rawRows = db
+        .prepare(`SELECT * FROM chunks WHERE file IN (${placeholders}) ORDER BY id`)
+        .all(...files) as Record<string, unknown>[];
+    } else {
+      rawRows = db.prepare('SELECT * FROM chunks ORDER BY id').all() as Record<string, unknown>[];
+    }
+
+    let records = rawRows.map(parseRow).filter(isValidRecord);
+    if (language) records = filterByLanguage(records, language);
+    if (pattern) records = filterByPattern(records, pattern);
+    if (symbolType) records = filterBySymbolType(records, symbolType);
+
+    // slice LAST, after JS filters — same order as query.ts.
+    return records.slice(0, limit).map(recordToUnscoredResult);
+  }
+
+  async scanAll(
+    options: {
+      language?: string;
+      pattern?: string;
+      columns?: string[];
+    } = {},
+  ): Promise<SearchResult[]> {
+    const db = this.requireDb();
+    const { language, pattern } = options;
+
+    // Fast path: no filters → plain full read.
+    if (!language && !pattern) {
+      const rawRows = db.prepare('SELECT * FROM chunks ORDER BY id').all() as Record<
+        string,
+        unknown
+      >[];
+      return rawRows.map(parseRow).filter(isValidRecord).map(recordToUnscoredResult);
+    }
+
+    // Otherwise delegate to scanWithFilter with no result cap (parity with
+    // scanAll's max(totalRows, ...) limit).
+    return this.scanWithFilter({ language, pattern, limit: Number.MAX_SAFE_INTEGER });
+  }
+
+  async *scanPaginated(
+    options: {
+      pageSize?: number;
+      columns?: string[];
+    } = {},
+  ): AsyncGenerator<SearchResult[]> {
+    const db = this.requireDb();
+    const pageSize = options.pageSize ?? 1000;
+    if (pageSize <= 0) {
+      throw new DatabaseError('pageSize must be a positive number');
+    }
+
+    const stmt = db.prepare("SELECT * FROM chunks WHERE file != '' ORDER BY id LIMIT ? OFFSET ?");
+    let offset = 0;
+    while (true) {
+      const rawRows = stmt.all(pageSize, offset) as Record<string, unknown>[];
+      if (rawRows.length === 0) break;
+
+      const page = rawRows.map(parseRow).filter(isValidRecord).map(recordToUnscoredResult);
+      if (page.length > 0) yield page;
+
+      if (rawRows.length < pageSize) break;
+      offset += pageSize;
+    }
+  }
+
+  async querySymbols(options: {
+    language?: string;
+    pattern?: string;
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
+    limit?: number;
+    columns?: string[];
+  }): Promise<SearchResult[]> {
+    const db = this.requireDb();
+    const { language, pattern, symbolType, limit = 50 } = options;
+
+    // content != '' is a hard SQL prefilter (empty-content chunks excluded);
+    // matchesSymbolFilter stays authoritative for the rest (legacy symbol
+    // arrays can match with an empty symbolType).
+    const rawRows = db
+      .prepare("SELECT * FROM chunks WHERE content != '' ORDER BY id")
+      .all() as Record<string, unknown>[];
+
+    const records = rawRows
+      .map(parseRow)
+      .filter(r => isValidRecord(r) && matchesSymbolFilter(r, { language, pattern, symbolType }));
+
+    return records.slice(0, limit).map(r => ({
+      content: r.content,
+      metadata: { ...buildSearchResultMetadata(r), symbols: buildLegacySymbols(r) },
+      score: 0,
+      relevance: 'not_relevant' as const,
+    }));
+  }
+
+  async deleteByFile(filepath: string): Promise<void> {
+    const db = this.requireDb();
+    // Exact match, no normalization — caller normalizes. FTS stays in sync via
+    // the AFTER DELETE trigger.
+    db.prepare('DELETE FROM chunks WHERE file = ?').run(filepath);
+  }
+
+  async updateFile(
+    filepath: string,
+    vectors: Float32Array[],
+    metadatas: ChunkMetadata[],
+    contents: string[],
+  ): Promise<void> {
+    const db = this.requireDb();
+    validateBatchLengths(vectors, metadatas, contents);
+
+    // delete + insert in ONE transaction (an improvement over LanceDB's
+    // non-transactional two-step; same observable outcome).
+    const del = db.prepare('DELETE FROM chunks WHERE file = ?');
+    const insert = db.prepare(INSERT_SQL);
+    const apply = db.transaction((rows: ReturnType<typeof chunkToRow>[]) => {
+      del.run(filepath);
+      for (const row of rows) insert.run(row);
+    });
+    apply(metadatas.map((metadata, i) => chunkToRow(contents[i], metadata)));
+
+    // Bump the cross-process invalidation token. currentVersion is intentionally
+    // NOT bumped in-memory here — this matches LanceDB (maintenance.updateFile
+    // only writes the file); checkVersion picks the change up on its next poll.
+    await writeVersionFile(this.dbPath);
+  }
+
+  async hasData(): Promise<boolean> {
+    if (!this.db) return false;
+    try {
+      const row = this.db.prepare("SELECT 1 FROM chunks WHERE content != '' LIMIT 1").get();
+      return row !== undefined;
+    } catch {
+      return false;
+    }
+  }
+
+  async clear(): Promise<void> {
+    const db = this.requireDb();
+    // Close the handle to release the file, remove the db + WAL/SHM sidecars,
+    // then reopen a fresh empty store. Leaves .lien-index-version and the
+    // manifest untouched (LanceDB clear only removes the table dir).
+    db.close();
+    this.db = null;
+    await Promise.all(
+      [this.dbFilePath, `${this.dbFilePath}-wal`, `${this.dbFilePath}-shm`].map(f =>
+        fs.rm(f, { force: true }),
+      ),
+    );
+    this.db = openDatabase(this.dbFilePath);
+  }
+
+  async checkVersion(): Promise<boolean> {
+    const now = Date.now();
+    // Cache version checks for 1 second to minimize I/O.
+    if (now - this.lastVersionCheck < 1000) {
+      return false;
+    }
+    this.lastVersionCheck = now;
+
+    try {
+      const version = await readVersionFile(this.dbPath);
+      if (version > this.currentVersion) {
+        this.currentVersion = version;
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async reconnect(): Promise<void> {
+    try {
+      if (this.db) {
+        this.db.close();
+        this.db = null;
+      }
+      await this.initialize();
+    } catch (error) {
+      throw wrapError(error, 'Failed to reconnect to vector database');
+    }
+  }
+
+  getCurrentVersion(): number {
+    return this.currentVersion;
+  }
+
+  getVersionDate(): string {
+    if (this.currentVersion === 0) {
+      return 'Unknown';
+    }
+    return new Date(this.currentVersion).toLocaleString();
+  }
+
+  async searchCrossRepo(
+    _queryVector: Float32Array,
+    _limit?: number,
+    _options?: { repoIds?: string[]; branch?: string; columns?: string[] },
+  ): Promise<SearchResult[]> {
+    return [];
+  }
+
+  async scanCrossRepo(_options: {
+    language?: string;
+    pattern?: string;
+    limit?: number;
+    repoIds?: string[];
+    branch?: string;
+    columns?: string[];
+  }): Promise<SearchResult[]> {
+    return [];
+  }
+
+  static async load(projectRoot: string): Promise<SqliteBackend> {
+    const db = new SqliteBackend(projectRoot);
+    await db.initialize();
+    return db;
+  }
+}

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.ts
@@ -336,12 +336,19 @@ export class SqliteBackend implements VectorDBInterface {
     }
   }
 
+  /** Release the SQLite file handle. Not part of VectorDBInterface; callers
+   * that own the backend's lifecycle (tests, shutdown paths) use it to free
+   * file descriptors deterministically before removing the store. */
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
   async reconnect(): Promise<void> {
     try {
-      if (this.db) {
-        this.db.close();
-        this.db = null;
-      }
+      this.close();
       await this.initialize();
     } catch (error) {
       throw wrapError(error, 'Failed to reconnect to vector database');

--- a/packages/core/src/vectordb/sqlite/sqlite-lancedb-parity.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-lancedb-parity.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import type { ChunkMetadata } from '@liendev/parser';
+import type { SearchResult, VectorDBInterface } from '../types.js';
+import { SqliteBackend } from './sqlite-backend.js';
+import { VectorDB } from '../lancedb.js';
+
+// Consistency (parity) test — the spike's consistency.mjs methodology as a
+// cutover golden test: the SAME fixtures inserted into a real LanceDB and a
+// SqliteBackend must return identical result COUNTS and (order-insensitively)
+// identical (file,startLine,endLine,symbolName) tuples, plus deep-equal
+// metadata for a spot-checked chunk (score/relevance are 0/not_relevant on
+// both scan paths).
+
+const DIM = 384;
+const zeroVec = () => new Float32Array(DIM);
+
+const FIXTURES: Array<{ metadata: ChunkMetadata; content: string }> = [
+  {
+    metadata: {
+      file: 'a.ts',
+      startLine: 10,
+      endLine: 30,
+      type: 'function',
+      language: 'typescript',
+      symbols: { functions: ['fooHandler'], classes: [], interfaces: [] },
+      symbolName: 'fooHandler',
+      symbolType: 'function',
+      parentClass: 'Service',
+      complexity: 7,
+      cognitiveComplexity: 4,
+      parameters: ['req: Request', 'res: Response'],
+      signature: 'fooHandler(req, res)',
+      imports: ['./util', './types'],
+      exports: ['fooHandler'],
+      importedSymbols: { './util': ['helper', 'other'] },
+      callSites: [
+        { symbol: 'helper', line: 12, isResultCaptured: true },
+        { symbol: 'log', line: 15, isResultCaptured: false },
+        { symbol: 'noop', line: 18 },
+      ],
+      halsteadVolume: 120.5,
+      halsteadDifficulty: 3,
+      halsteadEffort: 361.5,
+      halsteadBugs: 0.04,
+    },
+    content: 'function fooHandler(req, res) { return helper(); }',
+  },
+  {
+    metadata: {
+      file: 'b.js',
+      startLine: 1,
+      endLine: 3,
+      type: 'block',
+      language: 'javascript',
+      symbols: { functions: ['b'], classes: [], interfaces: [] },
+    },
+    content: 'const b = 1;',
+  },
+  {
+    metadata: {
+      file: 'c.ts',
+      startLine: 5,
+      endLine: 40,
+      type: 'class',
+      language: 'typescript',
+      symbols: { functions: [], classes: ['Widget'], interfaces: [] },
+      symbolName: 'Widget',
+      symbolType: 'class',
+    },
+    content: 'class Widget {}',
+  },
+];
+
+async function seed(db: VectorDBInterface): Promise<void> {
+  const vectors = FIXTURES.map(zeroVec);
+  const metadatas = FIXTURES.map(f => f.metadata);
+  const contents = FIXTURES.map(f => f.content);
+  await db.insertBatch(vectors, metadatas, contents);
+}
+
+/** Order-insensitive identity tuples for a result set. */
+function tuples(results: SearchResult[]): string[] {
+  return results
+    .map(
+      r =>
+        `${r.metadata.file}|${r.metadata.startLine}|${r.metadata.endLine}|${r.metadata.symbolName ?? ''}`,
+    )
+    .sort();
+}
+
+describe('SqliteBackend / LanceDB parity', () => {
+  let sqlite: SqliteBackend;
+  let lance: VectorDB;
+  let sqliteRoot: string;
+  let lanceRoot: string;
+
+  beforeAll(async () => {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    sqliteRoot = path.join(os.tmpdir(), `lien-parity-sqlite-${stamp}`);
+    lanceRoot = path.join(os.tmpdir(), `lien-parity-lance-${stamp}`);
+    await fs.mkdir(sqliteRoot, { recursive: true });
+    await fs.mkdir(lanceRoot, { recursive: true });
+
+    sqlite = new SqliteBackend(sqliteRoot);
+    lance = new VectorDB(lanceRoot);
+    await sqlite.initialize();
+    await lance.initialize();
+    await seed(sqlite);
+    await seed(lance);
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      fs.rm(sqliteRoot, { recursive: true, force: true }),
+      fs.rm(lanceRoot, { recursive: true, force: true }),
+      fs.rm(sqlite.dbPath, { recursive: true, force: true }),
+      fs.rm(lance.dbPath, { recursive: true, force: true }),
+    ]);
+  });
+
+  it('scanWithFilter({file}) returns identical counts and tuples', async () => {
+    const s = await sqlite.scanWithFilter({ file: 'a.ts' });
+    const l = await lance.scanWithFilter({ file: 'a.ts' });
+    expect(s.length).toBe(l.length);
+    expect(tuples(s)).toEqual(tuples(l));
+  });
+
+  it('scanAll() returns identical counts and tuples', async () => {
+    const s = await sqlite.scanAll();
+    const l = await lance.scanAll();
+    expect(s.length).toBe(l.length);
+    expect(s.length).toBe(FIXTURES.length);
+    expect(tuples(s)).toEqual(tuples(l));
+  });
+
+  it('querySymbols({pattern}) returns identical counts and tuples', async () => {
+    const s = await sqlite.querySymbols({ pattern: 'foo' });
+    const l = await lance.querySymbols({ pattern: 'foo' });
+    expect(s.length).toBe(l.length);
+    expect(tuples(s)).toEqual(tuples(l));
+  });
+
+  it('produces deep-equal metadata for a spot-checked chunk', async () => {
+    const s = await sqlite.scanWithFilter({ file: 'a.ts' });
+    const l = await lance.scanWithFilter({ file: 'a.ts' });
+    expect(s).toHaveLength(1);
+    expect(l).toHaveLength(1);
+    // LanceDB leaks raw Arrow Vectors for the parameters/imports array columns
+    // (query.ts buildSearchResultMetadata only converts `exports`). Both are
+    // iterable, so normalize array-of-string fields to plain arrays before the
+    // deep-equal. score/relevance are 0/not_relevant on both scan paths.
+    expect(normalizeMeta(s[0].metadata)).toEqual(normalizeMeta(l[0].metadata));
+    expect(s[0].content).toBe(l[0].content);
+  });
+});
+
+/** Coerce iterable array-of-string metadata fields to plain arrays. */
+function normalizeMeta(metadata: ChunkMetadata): ChunkMetadata {
+  const out = { ...metadata } as Record<string, unknown>;
+  for (const key of ['parameters', 'imports', 'exports'] as const) {
+    const value = out[key];
+    if (value != null && typeof value !== 'string') {
+      out[key] = [...(value as Iterable<string>)];
+    }
+  }
+  return out as ChunkMetadata;
+}

--- a/packages/core/src/vectordb/sqlite/sqlite-lancedb-parity.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-lancedb-parity.test.ts
@@ -113,6 +113,7 @@ describe('SqliteBackend / LanceDB parity', () => {
   });
 
   afterAll(async () => {
+    sqlite.close();
     await Promise.all([
       fs.rm(sqliteRoot, { recursive: true, force: true }),
       fs.rm(lanceRoot, { recursive: true, force: true }),


### PR DESCRIPTION
## What

Adds `SqliteBackend` (better-sqlite3 + FTS5) implementing the existing `VectorDBInterface`, selectable via global config `backend: sqlite` or `LIEN_BACKEND=sqlite`. **Default stays `lancedb` — zero behavior change for existing users.**

PR 1 of 3 in the structural-first migration (next: flip the default + lexical search replaces semantic search; then: remove LanceDB + embeddings). Design validated in the structural-store benchmark spike (#645): get_files_context ~1000x faster, install footprint 93MB → 1.8MB.

## How

- **Structural store**: single `chunks` table + `file` index; `imports`/`exports`/`importedSymbols`/`callSites` stored as real JSON columns (no Arrow placeholder sentinels).
- **FTS5**: external-content index (porter tokenizer) over `symbolName`, camelCase-split `symbolTokens`, and `content`, kept in sync by AFTER INSERT/UPDATE/DELETE triggers — incremental indexing and the watcher can never drift the index (the spike's highest-risk trap, closed by construction).
- **search()**: ignores the vector argument and runs BM25 keyword search on the query text; a ratio-banded relevance mapping keeps the `SearchResult` score/relevance contract so handlers behave identically. `'parse import'` finds `parseImportStatement` via the split-identifier column — the spike's main tokenizer gap, closed.
- **filters.ts**: the pure JS filters (language/pattern/symbolType/symbol matching) extracted from query.ts and shared by both backends — no behavior change, existing query tests pass unchanged.
- **Parity test**: inserts the same fixture into a real LanceDB and SqliteBackend and asserts identical result counts, (file,startLine,endLine,symbolName) tuples, and deep-equal metadata — the spike's consistency methodology as a regression gate.
- Index path goes through `getLienHome()` (#653), so tests are sandboxed and leak nothing.

Deliberately omitted (YAGNI, documented in schema.ts): `chunk_imports` child table, trigram symbol index, extra indices — none has a consumer yet.

## Testing

- 38 new tests (backend contract 25, FTS 9, LanceDB parity 4); core suite 564 passed, full monorepo suite green.
- Driven end-to-end: indexed a fixture project with `LIEN_BACKEND=sqlite` via the built CLI; FTS search, scanWithFilter, and querySymbols all return correct results (`'password login'` → `verifyCredentials` via docstring).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional SQLite-backed storage/search mode alongside the existing default backend.
  * Users can now select it through configuration or an environment variable.
  * Search and symbol queries now work with SQLite FTS-based results.

* **Bug Fixes**
  * Improved validation for backend selection values.
  * Strengthened record filtering and result handling for blank, missing, or invalid fields.
  * Kept search and filtering behavior aligned across both backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +0 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it stopped unexpectedly while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a81c2e0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->