### PR TITLE
docs(core,plugin): fix stale embeddings wording from CodeRabbit review on #658

### DIFF
--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -55,13 +55,11 @@ export interface LienConfig {
   };
   embeddings: {
     /**
-     * Compute embeddings for semantic search (default: true).
-     * Set to false for structural-only mode: no model download, no
-     * embedding worker, no CPU cost on index/reindex. Structural tools
-     * (get_files_context, get_dependents, list_functions, get_complexity)
-     * keep working; search_code and find_similar report as disabled.
-     * Toggling this requires a full reindex (`lien index --force`) to take
-     * effect on already-indexed files.
+     * Retained for config compatibility; has no effect since the switch
+     * to lexical FTS5 search. Embeddings are never computed — no model
+     * download, no embedding worker — regardless of this value. search_code
+     * and find_similar run BM25 keyword search and work either way. Slated
+     * for removal together with the embeddings code.
      */
     enabled: boolean;
   };

--- a/plugins/claude/hooks/augment-explore-task.sh
+++ b/plugins/claude/hooks/augment-explore-task.sh
@@ -58,15 +58,15 @@ fi
 
 injection='
 
-[Lien] MCP tools are REQUIRED for meaning-based and structural codebase queries in this repo. Use Lien tools as your primary discovery mechanism — grep/glob/Read are fallbacks ONLY for exact-literal lookups (error strings, config keys, TODOs).
+[Lien] MCP tools are REQUIRED for keyword and structural codebase queries in this repo. Use Lien tools as your primary discovery mechanism — grep/glob/Read are fallbacks ONLY for exact-literal lookups (error strings, config keys, TODOs).
 
 Required tools:
-  • mcp__plugin_lien_lien__search_code — REQUIRED for meaning-based discovery. Full-text (BM25) search: phrase queries with concrete keywords/identifiers/domain terms that appear in the code ("chunk overlap config", "parse import statement"), NOT full natural-language questions — there are no embeddings, so paraphrase queries score worse.
+  • mcp__plugin_lien_lien__search_code — REQUIRED for keyword/full-text discovery. Full-text (BM25) search: phrase queries with concrete keywords/identifiers/domain terms that appear in the code ("chunk overlap config", "parse import statement"), NOT full natural-language questions — there are no embeddings, so paraphrase queries score worse.
   • mcp__plugin_lien_lien__list_functions — REQUIRED for "find all X" / pattern-based structural lookup (10× faster than grep).
   • mcp__plugin_lien_lien__get_files_context — REQUIRED before reporting on any file you exploratively read (returns imports, callers, test associations).
   • mcp__plugin_lien_lien__get_dependents — REQUIRED before reporting an exported symbol change is "safe" or complete.
 
-Grep/glob are only acceptable when the query is for an exact literal that semantic search cannot answer.'
+Grep/glob are only acceptable when the query is for an exact literal string.'
 
 new_prompt="${prompt}${injection}"
 


### PR DESCRIPTION
## What

Fixes the two relevant CodeRabbit comments from #658, plus one more instance of the same class it missed:

- `packages/core/src/config/schema.ts`: the `embeddings.enabled` doc comment claimed `search_code` and `find_similar` "report as disabled" when embeddings are off. Both run lexical BM25 since #657 and the flag is inert — the comment now says exactly that (CodeRabbit's narrower suggestion still described `find_similar` as embeddings-dependent, which is also no longer true).
- `plugins/claude/hooks/augment-explore-task.sh`: the Explore-agent injection called `search_code` "REQUIRED for meaning-based discovery" and its grep guidance referenced "semantic search". Both now say keyword/full-text.

Comment/string-only — no behavior change, no changeset.

## Testing

format ✓, lint 0 errors ✓, typecheck ✓, build ✓, `bash -n` on the hook ✓, core suite 572 passed (4 skipped), 38/39 files — the 39th is the known pre-existing worker-embeddings fork-timeout flake, passes standalone ✓.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR updates documentation comments and an agent prompt string to reflect that embeddings are no longer computed and search_code/find_similar use lexical BM25 search. There are no code behavior changes — only comment wording in `schema.ts` and prompt injection text in the Claude hook shell script. The listed changed functions (`isLegacyConfig`, `isModernConfig`) are not actually modified in the diff.
>
> - Updated `embeddings.enabled` doc comment to state the flag is inert and retained only for config compatibility
> - Updated Explore-agent prompt to describe `search_code` as keyword/full-text (BM25) rather than meaning-based/semantic

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 280e128. Updates automatically on new commits.</sup>
<!-- /lien-stats -->