### PR TITLE
feat(review): deterministic rename-sweep signals

### DIFF
--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -17,6 +17,7 @@ import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
+import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -178,6 +179,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderDeletedExports(context));
   appendIfPresent(sections, renderStaleLiteralSection(context));
   appendIfPresent(sections, renderUntrustedInputSection(context));
+  appendIfPresent(sections, renderRenameSweepSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/src/rename-sweep-signals.ts
+++ b/packages/review/src/rename-sweep-signals.ts
@@ -1,0 +1,625 @@
+/**
+ * Deterministic "rename sweep" signal for PR reviews.
+ *
+ * A mechanical rename (`semantic_search` → `search_code` across 40 files) is the
+ * failure mode that anesthetizes an LLM reviewer: the diff is huge, uniform, and
+ * "obviously fine", so the agent skims it and reports nothing. But a token-swap
+ * inside a comment, docstring, or string literal carries a CLAIM — "reports as
+ * disabled without embeddings", "meaning-based search" — that was renamed but
+ * never re-verified. PR #658 did exactly this; Lien Review found nothing while
+ * CodeRabbit caught two stale-prose claims that the rename silently invalidated.
+ *
+ * This module pre-computes the structural fact instead of hoping the agent
+ * reviews every file hard, mirroring the `<stale_literal_candidates>` /
+ * `<untrusted_input_sites>` precedents: infer the identifier substitution(s) the
+ * diff repeats across many files, then hand the agent two short, explicit
+ * worklists per mapping:
+ *   1. PROSE-TOUCHED LINES — changed lines where the swap landed inside a
+ *      comment/docstring/string; each frames "verify the claim still holds".
+ *   2. SURVIVORS — occurrences of the OLD name still present (the rename may be
+ *      incomplete).
+ *
+ * It injects FACTS (mapping + file:line + the post-image sentence), never a
+ * verdict — the agent still judges each item. Everything here is computed from
+ * the diff (and, when available, the indexed repo chunks); ZERO LLM calls.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** An identifier substitution A → B the diff repeats across the PR. */
+export interface RenameMapping {
+  /** Old identifier (removed side). */
+  from: string;
+  /** New identifier (added side). */
+  to: string;
+  /** How many changed lines carry this exact swap. */
+  occurrenceCount: number;
+  /** How many distinct files carry this swap. */
+  fileCount: number;
+}
+
+/** A changed line where the A → B swap landed inside prose. */
+export interface ProseTouchedLine {
+  file: string;
+  /** New-file line number of the (post-image) changed line. */
+  line: number;
+  /** Where the swap sits: 'doc' (prose file) | 'comment' | 'docstring' | 'string'. */
+  kind: ProseKind;
+  /** The post-image line text (trimmed, capped). */
+  sentence: string;
+}
+
+/** A surviving occurrence of the OLD name after the sweep. */
+export interface SurvivorSite {
+  file: string;
+  line: number;
+  snippet: string;
+  /** True when found repo-wide (an untouched file), false when in the diff post-image. */
+  repoWide: boolean;
+}
+
+/** The full signal for one detected rename mapping. */
+export interface RenameSweepSignal {
+  mapping: RenameMapping;
+  proseTouched: ProseTouchedLine[];
+  /** Prose lines dropped by the cap (0 when none). */
+  proseOverflow: number;
+  survivors: SurvivorSite[];
+  /** Survivor sites dropped by the cap (0 when none). */
+  survivorOverflow: number;
+}
+
+type ProseKind = 'doc' | 'comment' | 'docstring' | 'string';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * A rename is a "sweep" only when the SAME A → B substitution repeats at least
+ * this many times across at least this many files. Below either bound it's an
+ * ordinary edit the agent already reviews line-by-line — flagging it would be
+ * noise. Tuned deliberately conservative: a real codemod trips both easily.
+ */
+const MIN_OCCURRENCES = 5;
+const MIN_FILES = 3;
+
+/** Max mappings reported (most-repeated first) — keeps the prompt compact. */
+const MAX_MAPPINGS = 5;
+/** Max prose-touched lines listed per mapping. */
+const MAX_PROSE_LINES = 12;
+/** Max surviving old-name sites listed per mapping. */
+const MAX_SURVIVORS = 12;
+/** Snippet/sentence length cap. */
+const MAX_SNIPPET_CHARS = 160;
+
+/**
+ * Identifiers that are language keywords, not renameable symbols. A codemod like
+ * `let`→`const` or `func`→`fn` is a real sweep but carries no prose claims and
+ * its "survivors" (every remaining `let`) are pure noise, so such mappings are
+ * dropped. Kept small and cross-language; the occurrence/file threshold catches
+ * the rest.
+ */
+const KEYWORDS = new Set([
+  'let',
+  'const',
+  'var',
+  'def',
+  'func',
+  'fn',
+  'function',
+  'class',
+  'struct',
+  'interface',
+  'type',
+  'enum',
+  'int',
+  'str',
+  'bool',
+  'true',
+  'false',
+  'null',
+  'none',
+  'nil',
+  'undefined',
+  'if',
+  'else',
+  'elif',
+  'for',
+  'while',
+  'switch',
+  'case',
+  'return',
+  'import',
+  'export',
+  'from',
+  'as',
+  'new',
+  'this',
+  'self',
+  'async',
+  'await',
+  'public',
+  'private',
+  'static',
+  'void',
+]);
+
+/** Shortest identifier worth treating as a renamed symbol. */
+const MIN_TOKEN_LENGTH = 3;
+
+/** Splits a line into alternating [glue, identifier, glue, identifier, …]. */
+const IDENTIFIER_SPLIT_RE = /([A-Za-z_][A-Za-z0-9_]*)/;
+/** Quoted string spans (single/double/backtick), matching the stale-literal heuristic. */
+const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
+/** Leading comment / JSDoc / HTML-comment markers. */
+const LINE_COMMENT_LEAD_RE = /^\s*(\/\/|#|\*|\/\*|<!--|--)/;
+/** File extensions whose every line is prose. */
+const PROSE_FILE_RE = /\.(md|mdx|markdown|txt|rst|adoc)$/i;
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+// ---------------------------------------------------------------------------
+// Diff scanning
+// ---------------------------------------------------------------------------
+
+interface SwapOccurrence {
+  from: string;
+  to: string;
+  file: string;
+  /** New-file line of the added (post-image) side of the swap. */
+  line: number;
+  /** The post-image line text. */
+  addedText: string;
+}
+
+/** One post-image (context or added) line of a changed file. */
+interface PostImageLine {
+  line: number;
+  text: string;
+}
+
+interface DiffScan {
+  occurrences: SwapOccurrence[];
+  /** Post-image lines (context + added) per changed file — the survivor scan's source-1. */
+  postImageByFile: Map<string, PostImageLine[]>;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** True when `token` appears in `text` as a whole identifier (word-boundary). */
+function lineHasToken(text: string, token: string): boolean {
+  // Word boundaries via [A-Za-z0-9_] lookaround so `semantic_search` never
+  // matches inside `semantic_search_v2`.
+  const re = new RegExp(`(?<![A-Za-z0-9_])${escapeRegExp(token)}(?![A-Za-z0-9_])`);
+  return re.test(text);
+}
+
+/**
+ * Infer the single identifier substitution turning `removed` into `added`, or
+ * null when they differ by anything other than a consistent A → B token swap.
+ *
+ * Both lines are split into alternating glue/identifier segments. For a clean
+ * rename: the arrays are the same length, every glue segment is identical, and
+ * every differing identifier position is the SAME (from → to) pair. Anything
+ * else (glue changed, a number changed, two different mappings on one line)
+ * returns null — we only trust an unambiguous mechanical swap.
+ */
+export function inferSingleTokenSwap(
+  removed: string,
+  added: string,
+): { from: string; to: string } | null {
+  const rem = removed.split(IDENTIFIER_SPLIT_RE);
+  const add = added.split(IDENTIFIER_SPLIT_RE);
+  if (rem.length !== add.length) return null;
+
+  let from: string | null = null;
+  let to: string | null = null;
+
+  for (let i = 0; i < rem.length; i++) {
+    if (rem[i] === add[i]) continue;
+    // Even indices are glue (punctuation/whitespace/numbers); a difference there
+    // means this isn't a pure identifier swap.
+    if (i % 2 === 0) return null;
+    if (from === null) {
+      from = rem[i];
+      to = add[i];
+    } else if (from !== rem[i] || to !== add[i]) {
+      return null; // a second, different mapping on the same line — ambiguous
+    }
+  }
+
+  if (from === null || to === null || from === to) return null;
+  return { from, to };
+}
+
+/** Reject mappings that are keywords or too short to be meaningful symbols. */
+function isMeaningfulRename(from: string, to: string): boolean {
+  if (from.length < MIN_TOKEN_LENGTH || to.length < MIN_TOKEN_LENGTH) return false;
+  if (KEYWORDS.has(from) || KEYWORDS.has(to)) return false;
+  return true;
+}
+
+/**
+ * Pair the removed/added lines within each change block and record every
+ * consistent single-token swap, plus the post-image lines per file. A change
+ * block is a maximal run of `-`/`+` lines; unified diff emits all removals then
+ * all additions, so pairing removed[i] with added[i] recovers the swap.
+ */
+function scanDiff(patches: Map<string, string>): DiffScan {
+  const occurrences: SwapOccurrence[] = [];
+  const postImageByFile = new Map<string, PostImageLine[]>();
+
+  for (const [file, patch] of patches) {
+    const postImage: PostImageLine[] = [];
+    let removedBuf: string[] = [];
+    let addedBuf: PostImageLine[] = [];
+    let newLine = 0;
+
+    const flush = (): void => {
+      const pairs = Math.min(removedBuf.length, addedBuf.length);
+      for (let i = 0; i < pairs; i++) {
+        const swap = inferSingleTokenSwap(removedBuf[i], addedBuf[i].text);
+        if (swap && isMeaningfulRename(swap.from, swap.to)) {
+          occurrences.push({
+            from: swap.from,
+            to: swap.to,
+            file,
+            line: addedBuf[i].line,
+            addedText: addedBuf[i].text,
+          });
+        }
+      }
+      removedBuf = [];
+      addedBuf = [];
+    };
+
+    for (const raw of patch.split('\n')) {
+      const header = raw.match(HUNK_HEADER_RE);
+      if (header) {
+        flush();
+        newLine = parseInt(header[1], 10);
+        continue;
+      }
+      if (raw.startsWith('+++') || raw.startsWith('---')) continue;
+      if (raw.startsWith('\\')) continue; // "\ No newline at end of file"
+
+      if (raw.startsWith('+')) {
+        const text = raw.slice(1);
+        addedBuf.push({ line: newLine, text });
+        postImage.push({ line: newLine, text });
+        newLine++;
+      } else if (raw.startsWith('-')) {
+        removedBuf.push(raw.slice(1));
+        // a removed line does not advance the new-file counter
+      } else {
+        flush(); // context line ends the change block
+        postImage.push({ line: newLine, text: raw.startsWith(' ') ? raw.slice(1) : raw });
+        newLine++;
+      }
+    }
+    flush();
+
+    postImageByFile.set(file, postImage);
+  }
+
+  return { occurrences, postImageByFile };
+}
+
+// ---------------------------------------------------------------------------
+// Sweep detection
+// ---------------------------------------------------------------------------
+
+interface MappingGroup {
+  mapping: RenameMapping;
+  occurrences: SwapOccurrence[];
+}
+
+/** Group swap occurrences by (from,to) and keep those meeting the sweep threshold. */
+function groupSweeps(occurrences: SwapOccurrence[]): { groups: MappingGroup[]; capped: boolean } {
+  const byMapping = new Map<string, SwapOccurrence[]>();
+  for (const occ of occurrences) {
+    const key = `${occ.from} ${occ.to}`;
+    const list = byMapping.get(key);
+    if (list) list.push(occ);
+    else byMapping.set(key, [occ]);
+  }
+
+  const groups: MappingGroup[] = [];
+  for (const list of byMapping.values()) {
+    const fileCount = new Set(list.map(o => o.file)).size;
+    if (list.length < MIN_OCCURRENCES || fileCount < MIN_FILES) continue;
+    groups.push({
+      mapping: {
+        from: list[0].from,
+        to: list[0].to,
+        occurrenceCount: list.length,
+        fileCount,
+      },
+      occurrences: list,
+    });
+  }
+
+  groups.sort((a, b) => b.mapping.occurrenceCount - a.mapping.occurrenceCount);
+  const capped = groups.length > MAX_MAPPINGS;
+  return { groups: groups.slice(0, MAX_MAPPINGS), capped };
+}
+
+/**
+ * Detect rename sweeps from the diff alone. Exposed for testing — returns the
+ * mappings that meet the occurrence/file threshold, most-repeated first.
+ */
+export function detectRenameSweeps(patches: Map<string, string>): RenameMapping[] {
+  return groupSweeps(scanDiff(patches).occurrences).groups.map(g => g.mapping);
+}
+
+// ---------------------------------------------------------------------------
+// Prose classification
+// ---------------------------------------------------------------------------
+
+/** Character spans of quoted-string regions on a line. */
+function stringSpans(text: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  for (const m of text.matchAll(STRING_RE)) {
+    if (m.index === undefined) continue;
+    spans.push([m.index, m.index + m[0].length]);
+  }
+  return spans;
+}
+
+function indexInsideAnySpan(index: number, spans: Array<[number, number]>): boolean {
+  return spans.some(([start, end]) => index >= start && index < end);
+}
+
+/** Index of the first `//` or `#` line-comment marker not inside a string, or -1. */
+function commentMarkerIndex(text: string, spans: Array<[number, number]>): number {
+  let best = -1;
+  for (const marker of ['//', '#']) {
+    let from = 0;
+    for (;;) {
+      const idx = text.indexOf(marker, from);
+      if (idx === -1) break;
+      if (!indexInsideAnySpan(idx, spans)) {
+        if (best === -1 || idx < best) best = idx;
+        break;
+      }
+      from = idx + marker.length;
+    }
+  }
+  return best;
+}
+
+/**
+ * Classify whether the `token` swap on the post-image line `text` of `file`
+ * landed inside prose (comment / docstring / string / prose-file), and which.
+ * Returns null when the swap is in live code.
+ *
+ * Heuristics (documented, deliberately not a parser):
+ *  - a prose file extension (.md, .txt, …) → the whole line is prose ('doc');
+ *  - a triple-quote (`"""` / `'''`) enclosing the token → 'docstring';
+ *  - the token inside any quoted-string span → 'string';
+ *  - a leading `//` `#` `*` `/*` `<!--` `--`, or the token sitting after a
+ *    trailing `//`/`#` marker → 'comment'.
+ */
+export function classifyProseSwap(text: string, token: string, file: string): ProseKind | null {
+  if (PROSE_FILE_RE.test(file)) return 'doc';
+
+  const occ = new RegExp(`(?<![A-Za-z0-9_])${escapeRegExp(token)}(?![A-Za-z0-9_])`, 'g');
+  const indices: number[] = [];
+  for (let m = occ.exec(text); m !== null; m = occ.exec(text)) indices.push(m.index);
+  if (indices.length === 0) return null;
+
+  const spans = stringSpans(text);
+  const insideString = indices.some(i => indexInsideAnySpan(i, spans));
+  if (insideString) {
+    // A triple-quoted region reads as a docstring; a normal quote is a string.
+    return /"""|'''/.test(text) ? 'docstring' : 'string';
+  }
+
+  if (LINE_COMMENT_LEAD_RE.test(text)) return 'comment';
+
+  const marker = commentMarkerIndex(text, spans);
+  if (marker !== -1 && indices.some(i => i > marker)) return 'comment';
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Survivor scan
+// ---------------------------------------------------------------------------
+
+/**
+ * Find occurrences of the OLD name `from` still present after the sweep:
+ *  - source 1: the post-image (context + added) lines of changed files, from the
+ *    diff — always available. A renamed line carries `to`, not `from`, so any
+ *    `from` hit here is a genuine survivor (missed spot or stale context).
+ *  - source 2 (optional): repo chunks of files NOT in the diff — catches "swept
+ *    40 files, forgot the 41st". Skipped when no repo index is present. Changed
+ *    files are owned by source 1, so there's no double counting.
+ *
+ * Deduped by file:line. Capped, with the dropped count returned separately.
+ */
+function findSurvivors(
+  from: string,
+  postImageByFile: Map<string, PostImageLine[]>,
+  changedFiles: Set<string>,
+  repoChunks: CodeChunk[] | undefined,
+): { sites: SurvivorSite[]; overflow: number } {
+  const seen = new Set<string>();
+  const all: SurvivorSite[] = [];
+
+  const record = (file: string, line: number, text: string, repoWide: boolean): void => {
+    if (!lineHasToken(text, from)) return;
+    const key = `${file}:${line}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    all.push({ file, line, snippet: text.trim().slice(0, MAX_SNIPPET_CHARS), repoWide });
+  };
+
+  // Source 1: diff post-image of changed files.
+  for (const [file, lines] of postImageByFile) {
+    for (const { line, text } of lines) record(file, line, text, false);
+  }
+
+  // Source 2: repo-wide, untouched files only.
+  if (repoChunks) {
+    for (const chunk of repoChunks) {
+      const file = chunk.metadata.file;
+      if (changedFiles.has(file)) continue;
+      const lines = chunk.content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        record(file, chunk.metadata.startLine + i, lines[i], true);
+      }
+    }
+  }
+
+  const overflow = Math.max(0, all.length - MAX_SURVIVORS);
+  return { sites: all.slice(0, MAX_SURVIVORS), overflow };
+}
+
+// ---------------------------------------------------------------------------
+// Signal assembly
+// ---------------------------------------------------------------------------
+
+/** Collect the prose-touched lines for one mapping, deduped by file:line and capped. */
+function collectProseTouched(group: MappingGroup): {
+  lines: ProseTouchedLine[];
+  overflow: number;
+} {
+  const seen = new Set<string>();
+  const lines: ProseTouchedLine[] = [];
+  for (const occ of group.occurrences) {
+    const kind = classifyProseSwap(occ.addedText, occ.to, occ.file);
+    if (!kind) continue;
+    const key = `${occ.file}:${occ.line}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push({
+      file: occ.file,
+      line: occ.line,
+      kind,
+      sentence: occ.addedText.trim().slice(0, MAX_SNIPPET_CHARS),
+    });
+  }
+  const overflow = Math.max(0, lines.length - MAX_PROSE_LINES);
+  return { lines: lines.slice(0, MAX_PROSE_LINES), overflow };
+}
+
+/**
+ * Compute the rename-sweep signals from the review context. Returns [] when
+ * there's no diff or no detected sweep. Mappings whose sweep was fully clean
+ * (no prose claims touched, no surviving old name) are dropped — there's
+ * nothing for the agent to verify.
+ */
+export function computeRenameSweepSignals(context: ReviewContext): RenameSweepSignal[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+
+  const { occurrences, postImageByFile } = scanDiff(patches);
+  const { groups } = groupSweeps(occurrences);
+  if (groups.length === 0) return [];
+
+  const changedFiles = new Set(patches.keys());
+  const signals: RenameSweepSignal[] = [];
+
+  for (const group of groups) {
+    const prose = collectProseTouched(group);
+    const survivors = findSurvivors(
+      group.mapping.from,
+      postImageByFile,
+      changedFiles,
+      context.repoChunks,
+    );
+    if (prose.lines.length === 0 && survivors.sites.length === 0) continue;
+    signals.push({
+      mapping: group.mapping,
+      proseTouched: prose.lines,
+      proseOverflow: prose.overflow,
+      survivors: survivors.sites,
+      survivorOverflow: survivors.overflow,
+    });
+  }
+
+  return signals;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const LEAD = [
+  'Pre-computed by a deterministic diff scan (no grep needed — done for you). This PR applies one or',
+  'more MECHANICAL identifier renames across many files. The risk is not the code swaps (the agent',
+  'sees those) but token-swaps that landed inside comments, docstrings, or strings: those carry CLAIMS',
+  'that were renamed but never re-verified (the classic rename-sweep miss). For each mapping below:',
+  '(1) for every PROSE-TOUCHED line, read the post-image sentence and confirm the claim it now makes is',
+  'still TRUE of the new name — emit a finding if the sentence is now stale or false;',
+  '(2) for every SURVIVOR, decide whether that old-name reference should have been renamed too — emit a',
+  'finding if the rename is incomplete. Stay silent on an item only after checking it.',
+].join(' ');
+
+/**
+ * Render rename-sweep signals as a `<rename_sweep>` block for the agent's
+ * initial message. Returns '' when there are no signals so callers can append
+ * unconditionally.
+ */
+export function renderRenameSweepSignals(signals: RenameSweepSignal[]): string {
+  if (signals.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('<rename_sweep>');
+  lines.push(LEAD);
+
+  for (const s of signals) {
+    lines.push('');
+    lines.push(
+      `- Mapping \`${s.mapping.from}\` → \`${s.mapping.to}\` ` +
+        `(${s.mapping.occurrenceCount} occurrences across ${s.mapping.fileCount} files):`,
+    );
+
+    if (s.proseTouched.length > 0) {
+      lines.push(`  Prose-touched lines — verify each claim still holds of \`${s.mapping.to}\`:`);
+      for (const p of s.proseTouched) {
+        lines.push(`    - ${p.file}:${p.line} (${p.kind})  \`${p.sentence}\``);
+      }
+      if (s.proseOverflow > 0) {
+        lines.push(
+          `    - [+${s.proseOverflow} more prose-touched line(s) — scan the diff for the rest]`,
+        );
+      }
+    }
+
+    if (s.survivors.length > 0) {
+      lines.push(
+        `  Surviving \`${s.mapping.from}\` references — should these have been renamed too?`,
+      );
+      for (const v of s.survivors) {
+        const tag = v.repoWide ? ' (untouched file)' : '';
+        lines.push(`    - ${v.file}:${v.line}${tag}  \`${v.snippet}\``);
+      }
+      if (s.survivorOverflow > 0) {
+        lines.push(
+          `    - [+${s.survivorOverflow} more surviving reference(s) — grep \`${s.mapping.from}\` for the rest]`,
+        );
+      }
+    }
+  }
+
+  lines.push('</rename_sweep>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<rename_sweep>` section from the review context. Returns '' when
+ * there is no diff or no rename sweep worth flagging. Callers append
+ * unconditionally.
+ */
+export function renderRenameSweepSection(context: ReviewContext): string {
+  return renderRenameSweepSignals(computeRenameSweepSignals(context));
+}

--- a/packages/review/test/rename-sweep-signals.test.ts
+++ b/packages/review/test/rename-sweep-signals.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  inferSingleTokenSwap,
+  detectRenameSweeps,
+  classifyProseSwap,
+  computeRenameSweepSignals,
+  renderRenameSweepSignals,
+  renderRenameSweepSection,
+} from '../src/rename-sweep-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+  } as unknown as CodeChunk;
+}
+
+function ctx(opts: { patches?: Map<string, string>; repoChunks?: CodeChunk[] }): ReviewContext {
+  const pr = opts.patches ? { patches: opts.patches } : undefined;
+  return {
+    pr,
+    repoChunks: opts.repoChunks,
+    changedFiles: opts.patches ? [...opts.patches.keys()] : [],
+    chunks: [],
+  } as unknown as ReviewContext;
+}
+
+/** A single modification hunk swapping `removed`/`added` line-pairs (git emits all `-` then all `+`). */
+function hunk(startLine: number, pairs: Array<[string, string]>): string {
+  const removed = pairs.map(([r]) => `-${r}`).join('\n');
+  const added = pairs.map(([, a]) => `+${a}`).join('\n');
+  return `@@ -${startLine},${pairs.length} +${startLine},${pairs.length} @@\n${removed}\n${added}`;
+}
+
+/** A code line that calls `name` — differs from the same line under another name by only that token. */
+const call = (name: string, idx: number): string => `  results[${idx}] = ${name}(query);`;
+
+/** A swap-pair for the code line above (old → new). */
+const codeSwap = (from: string, to: string, idx: number): [string, string] => [
+  call(from, idx),
+  call(to, idx),
+];
+
+/**
+ * The canonical sweep shape: mapping `from`→`to` on 5 lines across 3 files
+ * (fileA:2, fileB:2, fileC:1) — meets MIN_OCCURRENCES(5) and MIN_FILES(3).
+ */
+function canonicalSweep(from = 'semantic_search', to = 'search_code'): Map<string, string> {
+  return new Map([
+    ['fileA.ts', hunk(1, [codeSwap(from, to, 0), codeSwap(from, to, 1)])],
+    ['fileB.ts', hunk(1, [codeSwap(from, to, 0), codeSwap(from, to, 1)])],
+    ['fileC.ts', hunk(1, [codeSwap(from, to, 0)])],
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// inferSingleTokenSwap
+// ---------------------------------------------------------------------------
+
+describe('inferSingleTokenSwap', () => {
+  it('detects a clean single-token identifier swap', () => {
+    expect(
+      inferSingleTokenSwap('const r = semantic_search(q);', 'const r = search_code(q);'),
+    ).toEqual({ from: 'semantic_search', to: 'search_code' });
+  });
+
+  it('detects a token swapped multiple times on one line (consistent mapping)', () => {
+    expect(inferSingleTokenSwap('f(old_name, old_name)', 'f(new_name, new_name)')).toEqual({
+      from: 'old_name',
+      to: 'new_name',
+    });
+  });
+
+  it('returns null when non-identifier glue also changed (e.g. a number)', () => {
+    // semantic_search→search_code AND 1→2: not a pure rename.
+    expect(inferSingleTokenSwap('a = semantic_search(1)', 'a = search_code(2)')).toBeNull();
+  });
+
+  it('returns null when two different mappings appear on one line', () => {
+    expect(inferSingleTokenSwap('foo(alpha, beta)', 'foo(gamma, delta)')).toBeNull();
+  });
+
+  it('returns null for identical lines', () => {
+    expect(inferSingleTokenSwap('const x = 1;', 'const x = 1;')).toBeNull();
+  });
+
+  it('treats an added suffix as a token swap (semantic_search → semantic_search_v2)', () => {
+    // The whole `[A-Za-z0-9_]+` run is one token, so this is a legitimate rename;
+    // the word-boundary guarantee lives in the survivor scan (see below).
+    expect(inferSingleTokenSwap('call(semantic_search)', 'call(semantic_search_v2)')).toEqual({
+      from: 'semantic_search',
+      to: 'semantic_search_v2',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectRenameSweeps — threshold, multi-mapping, keyword/short filters, cap
+// ---------------------------------------------------------------------------
+
+describe('detectRenameSweeps', () => {
+  it('detects a clean sweep meeting the occurrence/file threshold', () => {
+    const mappings = detectRenameSweeps(canonicalSweep());
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0]).toEqual({
+      from: 'semantic_search',
+      to: 'search_code',
+      occurrenceCount: 5,
+      fileCount: 3,
+    });
+  });
+
+  it('does NOT detect below the occurrence threshold (4 occurrences)', () => {
+    const patches = new Map([
+      ['a.ts', hunk(1, [codeSwap('semantic_search', 'search_code', 0)])],
+      ['b.ts', hunk(1, [codeSwap('semantic_search', 'search_code', 0)])],
+      [
+        'c.ts',
+        hunk(1, [
+          codeSwap('semantic_search', 'search_code', 0),
+          codeSwap('semantic_search', 'search_code', 1),
+        ]),
+      ],
+    ]);
+    expect(detectRenameSweeps(patches)).toEqual([]);
+  });
+
+  it('does NOT detect below the file threshold (5 occurrences, 2 files)', () => {
+    const patches = new Map([
+      [
+        'a.ts',
+        hunk(1, [
+          codeSwap('semantic_search', 'search_code', 0),
+          codeSwap('semantic_search', 'search_code', 1),
+          codeSwap('semantic_search', 'search_code', 2),
+        ]),
+      ],
+      [
+        'b.ts',
+        hunk(1, [
+          codeSwap('semantic_search', 'search_code', 0),
+          codeSwap('semantic_search', 'search_code', 1),
+        ]),
+      ],
+    ]);
+    expect(detectRenameSweeps(patches)).toEqual([]);
+  });
+
+  it('detects multiple concurrent mappings, most-repeated first', () => {
+    const patches = new Map<string, string>();
+    // mapping 1: get_deps→get_dependents, 6 occurrences across 3 files
+    patches.set(
+      'a.ts',
+      hunk(1, [
+        codeSwap('get_deps', 'get_dependents', 0),
+        codeSwap('get_deps', 'get_dependents', 1),
+      ]),
+    );
+    patches.set(
+      'b.ts',
+      hunk(1, [
+        codeSwap('get_deps', 'get_dependents', 0),
+        codeSwap('get_deps', 'get_dependents', 1),
+      ]),
+    );
+    patches.set(
+      'c.ts',
+      hunk(1, [
+        codeSwap('get_deps', 'get_dependents', 0),
+        codeSwap('get_deps', 'get_dependents', 1),
+      ]),
+    );
+    // mapping 2: semantic_search→search_code, 5 occurrences across 3 files
+    patches.set(
+      'd.ts',
+      hunk(1, [
+        codeSwap('semantic_search', 'search_code', 0),
+        codeSwap('semantic_search', 'search_code', 1),
+      ]),
+    );
+    patches.set(
+      'e.ts',
+      hunk(1, [
+        codeSwap('semantic_search', 'search_code', 0),
+        codeSwap('semantic_search', 'search_code', 1),
+      ]),
+    );
+    patches.set('f.ts', hunk(1, [codeSwap('semantic_search', 'search_code', 0)]));
+
+    const mappings = detectRenameSweeps(patches);
+    expect(mappings).toHaveLength(2);
+    expect(mappings[0].from).toBe('get_deps'); // 6 > 5, sorted first
+    expect(mappings[0].occurrenceCount).toBe(6);
+    expect(mappings[1].from).toBe('semantic_search');
+  });
+
+  it('drops keyword renames (let → const codemod carries no claims)', () => {
+    const line = (kw: string): string => `  ${kw} counter = compute();`;
+    const patches = new Map([
+      ['a.ts', hunk(1, [[line('let'), line('const')]])],
+      ['b.ts', hunk(1, [[line('let'), line('const')]])],
+      [
+        'c.ts',
+        hunk(1, [
+          [line('let'), line('const')],
+          [line('let'), line('const')],
+        ]),
+      ],
+      ['d.ts', hunk(1, [[line('let'), line('const')]])],
+    ] as Array<[string, string]>);
+    expect(detectRenameSweeps(patches)).toEqual([]);
+  });
+
+  it('drops too-short identifier renames', () => {
+    const patches = new Map([
+      ['a.ts', hunk(1, [['x = ab(1)', 'x = cd(1)']])],
+      ['b.ts', hunk(1, [['x = ab(1)', 'x = cd(1)']])],
+      [
+        'c.ts',
+        hunk(1, [
+          ['x = ab(1)', 'x = cd(1)'],
+          ['y = ab(2)', 'y = cd(2)'],
+        ]),
+      ],
+      ['d.ts', hunk(1, [['x = ab(1)', 'x = cd(1)']])],
+    ] as Array<[string, string]>);
+    expect(detectRenameSweeps(patches)).toEqual([]);
+  });
+
+  it('caps the number of reported mappings at 5', () => {
+    const patches = new Map<string, string>();
+    for (let k = 0; k < 7; k++) {
+      const from = `oldSymbolName${k}`;
+      const to = `newSymbolName${k}`;
+      patches.set(`m${k}a.ts`, hunk(1, [codeSwap(from, to, 0), codeSwap(from, to, 1)]));
+      patches.set(`m${k}b.ts`, hunk(1, [codeSwap(from, to, 0), codeSwap(from, to, 1)]));
+      patches.set(`m${k}c.ts`, hunk(1, [codeSwap(from, to, 0)]));
+    }
+    expect(detectRenameSweeps(patches)).toHaveLength(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyProseSwap — comment / block-comment / docstring / string / markdown
+// ---------------------------------------------------------------------------
+
+describe('classifyProseSwap', () => {
+  it('classifies a line comment', () => {
+    expect(classifyProseSwap('// uses search_code now', 'search_code', 'a.ts')).toBe('comment');
+  });
+
+  it('classifies a block-comment continuation line', () => {
+    expect(classifyProseSwap(' * search_code returns the top hits', 'search_code', 'a.ts')).toBe(
+      'comment',
+    );
+  });
+
+  it('classifies a trailing comment on a code line', () => {
+    expect(
+      classifyProseSwap(
+        'const x = compute(); // search_code is the new name',
+        'search_code',
+        'a.ts',
+      ),
+    ).toBe('comment');
+  });
+
+  it('classifies a Python docstring (triple-quoted)', () => {
+    expect(
+      classifyProseSwap('    """Runs search_code over the index."""', 'search_code', 'engine.py'),
+    ).toBe('docstring');
+  });
+
+  it('classifies a string literal', () => {
+    expect(classifyProseSwap("  const t = 'search_code is enabled';", 'search_code', 'a.ts')).toBe(
+      'string',
+    );
+  });
+
+  it('classifies every line of a markdown/prose file as doc', () => {
+    expect(
+      classifyProseSwap('Use search_code for lexical search.', 'search_code', 'guide.md'),
+    ).toBe('doc');
+  });
+
+  it('returns null for live code (not prose)', () => {
+    expect(classifyProseSwap('  return search_code(query);', 'search_code', 'a.ts')).toBeNull();
+  });
+
+  it('does not mistake a # inside a string for a trailing comment', () => {
+    // The `#fff` marker is inside the string span; the swap is in live code → null.
+    expect(
+      classifyProseSwap("  const c = '#fff'; foo(search_code);", 'search_code', 'a.ts'),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRenameSweepSignals — prose-touched, survivors, word-boundary, drop-clean
+// ---------------------------------------------------------------------------
+
+describe('computeRenameSweepSignals', () => {
+  it('returns [] when there is no diff', () => {
+    expect(computeRenameSweepSignals(ctx({}))).toEqual([]);
+  });
+
+  it('returns [] when a sweep is clean (no prose touched, no survivor)', () => {
+    // canonicalSweep touches only live-code call sites and leaves no old-name behind.
+    expect(computeRenameSweepSignals(ctx({ patches: canonicalSweep() }))).toEqual([]);
+  });
+
+  it('emits a prose-touched line when the swap lands in a comment', () => {
+    const patches = canonicalSweep();
+    // Replace fileC with a hunk whose swap is inside a doc comment.
+    patches.set(
+      'schema.ts',
+      '@@ -10,1 +10,1 @@\n' +
+        '-// semantic_search reports as disabled without embeddings\n' +
+        '+// search_code reports as disabled without embeddings',
+    );
+    const signals = computeRenameSweepSignals(ctx({ patches }));
+    expect(signals).toHaveLength(1);
+    const prose = signals[0].proseTouched;
+    expect(prose).toContainEqual({
+      file: 'schema.ts',
+      line: 10,
+      kind: 'comment',
+      sentence: '// search_code reports as disabled without embeddings',
+    });
+  });
+
+  it('emits a post-image survivor (old name left on a context line of a changed file)', () => {
+    const patches = canonicalSweep();
+    patches.set(
+      'legacy.ts',
+      '@@ -5,3 +5,3 @@\n' +
+        '   // NOTE: semantic_search is still referenced here\n' +
+        '-  a = semantic_search(0);\n' +
+        '+  a = search_code(0);',
+    );
+    const signals = computeRenameSweepSignals(ctx({ patches }));
+    const survivors = signals[0].survivors;
+    expect(survivors).toContainEqual({
+      file: 'legacy.ts',
+      line: 5,
+      snippet: '// NOTE: semantic_search is still referenced here',
+      repoWide: false,
+    });
+  });
+
+  it('emits a repo-wide survivor in an untouched file, skipping changed files', () => {
+    const patches = canonicalSweep();
+    const repoChunks = [
+      // untouched file — the sweep forgot this reference
+      makeChunk('other.ts', 40, 'export function old() {\n  return semantic_search(x);\n}'),
+      // a changed file: must NOT be re-scanned repo-wide (owned by the diff post-image)
+      makeChunk('fileA.ts', 100, '  legacy = semantic_search(z);'),
+    ];
+    const signals = computeRenameSweepSignals(ctx({ patches, repoChunks }));
+    const survivors = signals[0].survivors;
+    expect(survivors).toContainEqual({
+      file: 'other.ts',
+      line: 41,
+      snippet: 'return semantic_search(x);',
+      repoWide: true,
+    });
+    // fileA.ts is a changed file — never reported via the repo-wide source.
+    expect(survivors.some(s => s.file === 'fileA.ts')).toBe(false);
+  });
+
+  it('respects word boundaries: semantic_search does not match semantic_search_v2', () => {
+    const patches = canonicalSweep();
+    const repoChunks = [
+      makeChunk('other.ts', 1, 'const a = semantic_search_v2(x);\nconst b = semantic_search(y);'),
+    ];
+    const signals = computeRenameSweepSignals(ctx({ patches, repoChunks }));
+    const survivors = signals[0].survivors;
+    // line 2 (exact token) is a survivor; line 1 (semantic_search_v2) is NOT.
+    expect(survivors.some(s => s.file === 'other.ts' && s.line === 2)).toBe(true);
+    expect(survivors.some(s => s.file === 'other.ts' && s.line === 1)).toBe(false);
+  });
+
+  it('caps survivors per mapping and reports the overflow count', () => {
+    const patches = canonicalSweep();
+    // 15 surviving references in an untouched file → capped at 12, overflow 3.
+    const content = Array.from({ length: 15 }, (_, i) => `  ref${i} = semantic_search(${i});`).join(
+      '\n',
+    );
+    const repoChunks = [makeChunk('survivors.ts', 1, content)];
+    const signals = computeRenameSweepSignals(ctx({ patches, repoChunks }));
+    expect(signals[0].survivors).toHaveLength(12);
+    expect(signals[0].survivorOverflow).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('renderRenameSweepSignals', () => {
+  it('returns "" for no signals', () => {
+    expect(renderRenameSweepSignals([])).toBe('');
+  });
+
+  it('renders the block with the mapping, prose-touched, and survivor lines', () => {
+    const md = renderRenameSweepSignals([
+      {
+        mapping: { from: 'semantic_search', to: 'search_code', occurrenceCount: 40, fileCount: 12 },
+        proseTouched: [
+          {
+            file: 'schema.ts',
+            line: 10,
+            kind: 'comment',
+            sentence: '// search_code reports as disabled without embeddings',
+          },
+        ],
+        proseOverflow: 0,
+        survivors: [
+          { file: 'other.ts', line: 41, snippet: 'return semantic_search(x);', repoWide: true },
+        ],
+        survivorOverflow: 0,
+      },
+    ]);
+    expect(md).toContain('<rename_sweep>');
+    expect(md).toContain('</rename_sweep>');
+    expect(md).toContain('`semantic_search` → `search_code`');
+    expect(md).toContain('40 occurrences across 12 files');
+    expect(md).toContain('schema.ts:10 (comment)');
+    expect(md).toContain('other.ts:41 (untouched file)');
+  });
+
+  it('notes overflow instead of dropping silently', () => {
+    const md = renderRenameSweepSignals([
+      {
+        mapping: { from: 'a_symbol', to: 'b_symbol', occurrenceCount: 5, fileCount: 3 },
+        proseTouched: [],
+        proseOverflow: 0,
+        survivors: [{ file: 'x.ts', line: 1, snippet: 'a_symbol', repoWide: true }],
+        survivorOverflow: 7,
+      },
+    ]);
+    expect(md).toContain('[+7 more surviving reference(s)');
+  });
+});
+
+describe('renderRenameSweepSection', () => {
+  it('returns "" when there is no diff', () => {
+    expect(renderRenameSweepSection(ctx({}))).toBe('');
+  });
+
+  // Synthetic mini-#658: the exact failure CodeRabbit caught and Lien Review missed.
+  it('surfaces the #658 schema.ts stale-claim comment with file:line and the sentence', () => {
+    const patches = canonicalSweep();
+    patches.set(
+      'packages/core/src/config/schema.ts',
+      '@@ -12,1 +12,1 @@\n' +
+        '-  // When embeddings are off, semantic_search reports as disabled.\n' +
+        '+  // When embeddings are off, search_code reports as disabled.',
+    );
+    const section = renderRenameSweepSection(ctx({ patches }));
+    expect(section).toContain('<rename_sweep>');
+    expect(section).toContain('packages/core/src/config/schema.ts:12');
+    expect(section).toContain('When embeddings are off, search_code reports as disabled.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage rename-sweep injection', () => {
+  it('includes the <rename_sweep> block when a sweep touches prose', () => {
+    const patches = canonicalSweep();
+    patches.set(
+      'docs.md',
+      '@@ -1,1 +1,1 @@\n-Use semantic_search for retrieval.\n+Use search_code for retrieval.',
+    );
+    const message = buildInitialMessage(ctx({ patches }), { blastRadius: null });
+    expect(message).toContain('<rename_sweep>');
+    expect(message).toContain('docs.md:1 (doc)');
+  });
+
+  it('omits the block when there is no rename sweep', () => {
+    const patches = new Map([['a.ts', '@@ -1,1 +1,2 @@\n const x = 1;\n+const y = x + 1;']]);
+    const message = buildInitialMessage(ctx({ patches }), { blastRadius: null });
+    expect(message).not.toContain('<rename_sweep>');
+  });
+});


### PR DESCRIPTION
## Motivation — the PR #658 miss

PR #658 was a 40-file mechanical rename (`semantic_search` → `search_code`). Lien Review found nothing and asserted the sweep was "consistent". CodeRabbit caught two stale-**prose** findings the rename silently invalidated:

- a doc comment in `packages/core/src/config/schema.ts` still claiming `search_code` "reports as disabled" without embeddings (false since #657), and
- guidance text calling the tool "meaning-based" (it's lexical BM25).

The failure mode: a rename sweep **anesthetizes** the reviewer. The diff is huge and uniform, so the agent skims it — but token-swaps inside comments/docstrings/strings carry **claims** that were mechanically renamed and never re-verified.

The fix (following the shipped `stale-literal-signals` / `untrusted-input-signals` pattern): detect the sweep deterministically and hand the agent a short, explicit "verify these" worklist instead of hoping it reviews 40 files hard.

## Detection (zero LLM, from the diff)

- Within each hunk, pair removed/added lines (unified diff emits all `-` then all `+`) and infer a **single consistent identifier substitution** A→B: split each line into `[glue, identifier, glue, …]` on `/[A-Za-z_][A-Za-z0-9_]*/`; require identical glue and one consistent (A→B) at the differing identifier position. Number/glue changes or a second mapping on the line → rejected.
- A **rename sweep** = the SAME mapping repeated **≥ 5 occurrences across ≥ 3 files** (named constants `MIN_OCCURRENCES` / `MIN_FILES`). Multiple concurrent mappings supported, capped at `MAX_MAPPINGS` (5).
- Keyword renames (`let`→`const`) and sub-3-char tokens are dropped — real codemods with no prose claims and pure-noise survivors.

## What gets emitted — `<rename_sweep>` block, per mapping

1. **PROSE-TOUCHED LINES** — every changed line where the swap landed inside prose (cheap documented heuristics, not a parser): prose file ext (`.md`, …), triple-quote docstring, quoted-string span, leading/trailing `//` `#` `*` `/*` `<!--` `--`. Framed: file:line + the post-image sentence + "verify the claim it makes is still true of the new name."
2. **SURVIVORS** — occurrences of the OLD name A still present: (a) the diff **post-image** of changed files (always), and (b) when a repo index is present, **repo-wide untouched files** via `context.repoChunks` (the seam `stale-literal-signals` already uses; blind grep is avoided — computed from chunk data). Whole-token word-boundary match, so `semantic_search` never matches `semantic_search_v2`. Deduped, capped (`MAX_SURVIVORS` 12), overflow reported, never silently truncated.

Mappings whose sweep was fully clean (no prose touched, no survivor) are dropped — nothing to verify.

## Injection seam

`renderRenameSweepSection(context)` is appended in `packages/review/src/plugins/agent/system-prompt.ts::buildInitialMessage` via the existing `appendIfPresent(...)` line, exactly like `<stale_literal_candidates>` and `<untrusted_input_sites>`. **No rule prompts in `plugins/agent/` were touched** (brevity/keyword regressions there are a known hazard).

## Tests — pure functions, zero LLM/network (35 new)

`inferSingleTokenSwap` (clean/multi/glue-change/two-mappings/identical/suffix); `detectRenameSweeps` (clean sweep, below occurrence threshold, below file threshold, multi-mapping ordering, keyword drop, short-token drop, mapping cap); `classifyProseSwap` (line comment, block-comment continuation, trailing comment, Python docstring, string literal, markdown, live-code null, `#`-in-string not a comment); `computeRenameSweepSignals` (no diff, clean-sweep drop, comment prose-touched, post-image survivor, repo-wide survivor + changed-file exclusion, word-boundary `semantic_search` vs `_v2`, survivor cap+overflow); rendering (`''` empty, block shape, overflow note); a **synthetic mini-#658** asserting the emitted block contains `schema.ts:12` and the stale-claim sentence; `buildInitialMessage` wiring (present/absent).

## Gate

- `npm test -w @liendev/review`: **523 passed** (28 files), incl. 35 new.
- `format:check`: pass. `lint`: **0 errors** (only pre-existing warnings). `@liendev/review` typecheck + build (incl. DTS): pass.
- Pre-existing, out-of-scope: `packages/cli` typecheck is red on origin/main (a half-migrated lancedb-embeddings removal: `search_code` handler passes `string` where `Float32Array` is expected; integration tests call with wrong arg count). This PR's diff touches **zero** CLI/core files.

No config surface, no new dependencies, no AI attribution.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 6 new functions are too complex.
🔗 **Impact**: 1 high-risk file(s) with 3 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 4 | +64 |
| ⏱️ time to understand | 3 | +270 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic rename-sweep signal generator for the review agent. It introduces a new module that infers repeated identifier substitutions from unified diffs, flags swaps that landed in prose (comments/docstrings/strings), and reports surviving old-name references. The module is wired into the existing system prompt builder alongside the stale-literal and untrusted-input sections. The implementation is pure, well-tested, capped at reasonable limits, and returns empty output when there is nothing to flag. No breaking changes or wrong-output paths were identified.
>
> - Added packages/review/src/rename-sweep-signals.ts with diff-scanning, prose classification, survivor detection, and rendering functions.
> - Wired renderRenameSweepSection into buildInitialMessage via appendIfPresent.
> - Added 35 unit tests covering token-swap inference, sweep thresholds, prose classification, survivor scanning, rendering, and system-prompt injection.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6a22d88. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review summaries now include rename-related context when relevant, helping surface important wording changes in comments, docs, and other prose.
* **Bug Fixes**
  * Improved detection of rename patterns so unrelated changes are less likely to be flagged.
  * Added better handling for overflow and matching behavior, reducing noisy or incomplete review output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Harness evidence

This PR adds a deterministic signal (35 zero-LLM unit tests) and one prompt-section wire-up; no agent rule prompts are modified. Behavioral evidence: the sibling doc-truth rule calibrated 10/10 + 10/10 (`--rule doc-truth --calibrate 10`, kimi, 2026-07-04) with this same signal architecture, and a maintainer-approved full 1-pass harness sweep of every rule runs post-merge to confirm no regression (will be linked here).