### PR TITLE
test(review): capture PR #658 rename-sweep fixture

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -94,6 +94,29 @@ npx tsx packages/review/test/harness/capture-pr.ts 574 "$ROOT/error-swallowing/s
 npx tsx packages/review/test/harness/capture-pr.ts 575 "$ROOT/error-swallowing/harness-gitignore-convention-fp.fixture.json" --sha b1e36fc
 ```
 
+## Documented-miss fixtures (real bugs, not yet reliably caught)
+
+These capture a real bug from a merged PR that another reviewer (CodeRabbit)
+caught but Lien Review missed — filed under the existing rule whose mandate
+is the closest match, so the fixture is ready the moment someone iterates on
+that rule's prompt. Unlike the canary corpus, these are **not** claimed to
+pass `--calibrate 10` today; that's the point of capturing them. Not tagged
+`canary` (no green baseline to protect from drift yet) — see each fixture's
+own doc comment for exactly which mechanism (deterministic-scan gap,
+diff-render truncation, missing parser support, etc.) keeps the current
+prompt/pipeline from reaching it.
+
+| Rule | PR | Fixture | Why |
+|---|---|---|---|
+| `stale-duplicate` | #658 | `stale-duplicate/pr658-search-code-rename` | `schema.ts:62`'s `embeddings.enabled` doc comment claims `search_code` "reports as disabled" — stale since #657 made `search_code` lexical/BM25 with no embeddings dependency. The pre-computed `<stale_literal_candidates>` scan only matches quoted string literals, not bare identifiers in prose comments, so this shape needs either a prompt change or a pre-scan extension. A second real finding on the same PR (`plugins/claude/hooks/augment-explore-task.sh:64`, [thread](https://github.com/getlien/lien/pull/658#discussion_r3522630331)) is documented in the fixture's `.assertions.ts` but intentionally not asserted — `.sh` has no parser support, so it produces zero chunks regardless of prompt quality; that's a visibility gap, not something a rule/prompt change can fix. |
+
+Regenerate:
+
+```bash
+npx tsx packages/review/test/harness/capture-pr.ts 658 \
+  packages/review/test/harness/fixtures/stale-duplicate/pr658-search-code-rename.fixture.json
+```
+
 Run the full multi-model sweep:
 
 ```bash

--- a/packages/review/test/harness/fixtures/stale-duplicate/pr658-search-code-rename.assertions.ts
+++ b/packages/review/test/harness/fixtures/stale-duplicate/pr658-search-code-rename.assertions.ts
@@ -1,0 +1,139 @@
+/**
+ * Snapshot from PR #658 (merged, squash commit 7318371, PR head b24fa33) —
+ * a 40-file mechanical rename sweep: `semantic_search` -> `search_code`
+ * (per #657, which made embeddings inert and search purely lexical/BM25),
+ * plus removal of the now-dishonest embedding-themed indexing spinner copy.
+ *
+ * Lien Review reported ZERO findings on this PR and its own summary
+ * asserted "user-facing docs were updated consistently". CodeRabbit's
+ * review on the same PR caught two real findings that Lien Review missed:
+ *
+ * Finding A (asserted below, Tier 1 + Tier 2):
+ *   `packages/core/src/config/schema.ts:62`, the `embeddings.enabled` doc
+ *   comment. The diff mechanically renamed the identifier in place:
+ *     - "...keep working; semantic_search and find_similar report as disabled."
+ *     + "...keep working; search_code and find_similar report as disabled."
+ *   The rename is textually correct but the underlying CLAIM is now false:
+ *   since #657, `search_code` is the lexical BM25 path and does NOT depend
+ *   on embeddings. CodeRabbit's own suggested fix narrows the claim to
+ *   "only find_similar reports as disabled" — but that's ALSO stale: an
+ *   audit of `handleFindSimilar` at this PR's head commit
+ *   (packages/cli/src/mcp/handlers/find-similar.ts) shows it runs the same
+ *   lexical FTS5/BM25 `vectorDB.search` with a vestigial zero-vector as
+ *   `search_code`, with no `embeddings.enabled` check anywhere in either
+ *   handler. Repo-wide grep at the PR head confirms zero runtime references
+ *   to a "disabled" search state outside these two doc comments
+ *   (`schema.ts` and `null-embeddings.ts:20`, which has the identical
+ *   stale claim baked into the same PR's rename and wasn't flagged by
+ *   either reviewer). The accurate fix is that NEITHER tool reports as
+ *   disabled any more — the disabled-status behavior described here was
+ *   fully retired, not partially. This is exactly the shape the
+ *   `stale-duplicate` rule exists to catch: a site the diff touched still
+ *   asserts something that no longer tracks reality. Corroborating GitHub
+ *   thread: https://github.com/getlien/lien/pull/658#discussion_r3522630327
+ *
+ * Finding B (documented, NOT asserted — see below):
+ *   `plugins/claude/hooks/augment-explore-task.sh:64` described
+ *   `search_code` as "REQUIRED for meaning-based discovery" — the tool is
+ *   keyword/BM25 search, not meaning-based, so the hook's own guidance
+ *   contradicts the tool's real behavior post-#657.
+ *   https://github.com/getlien/lien/pull/658#discussion_r3522630331
+ *
+ *   This finding is intentionally left unasserted because it is currently
+ *   IMPOSSIBLE for the agent-review pipeline to reach, not merely
+ *   model-dependent — a visibility gap, not a prompt-quality gap. Verified
+ *   empirically against this exact fixture via
+ *   `npx tsx packages/review/test/harness/build-prompts.ts <fixture>`
+ *   (no LLM call — pure prompt assembly):
+ *     1. `.sh` is not in any `LanguageDefinition.extensions` in
+ *        `packages/parser/src/ast/languages/*.ts`, so the parser never
+ *        chunks it: this fixture's `chunks`/`repoChunks` have 0 entries for
+ *        `plugins/claude/hooks/augment-explore-task.sh`. Every content-based
+ *        tool the rules mandate — `get_files_context`, `list_functions`,
+ *        `get_complexity` — has nothing to return for this path, full stop.
+ *        (In production, `filterAnalyzableFiles()`,
+ *        packages/review/src/analysis.ts, additionally drops the path from
+ *        `ctx.changedFiles` entirely before the agent runs, since
+ *        `review-pr.ts` passes the *filtered* `filesToAnalyze` as
+ *        `changedFiles`. `capture-pr.ts` does not reproduce that filter —
+ *        it captures the raw unfiltered file list — so this fixture's
+ *        `<changed_files>` block, unlike production's, does still name the
+ *        path textually. That's a known fixture/production divergence, not
+ *        a reason to expect a different outcome: chunk emptiness is the
+ *        operative cause either way.)
+ *     2. Even the raw diff text can't compensate: `renderDiff()` in
+ *        `packages/review/src/plugins/agent/system-prompt.ts` truncates the
+ *        concatenated `<diff>` block at `MAX_DIFF_CHARS` (50,000 chars).
+ *        Confirmed by inspecting this fixture's rendered initial message —
+ *        the `<diff>` section truncates mid-way through
+ *        `packages/cli/src/mcp/server.error-handling.test.ts`, which comes
+ *        BEFORE `packages/core/src/config/schema.ts` in diff order, and
+ *        well before `augment-explore-task.sh` (the last file in the diff,
+ *        starting at ~76KB of this PR's ~77.7KB raw diff). Finding A
+ *        survives this same truncation only because `schema.ts` has chunks
+ *        (case 1 above) — `get_files_context` on it returns the doc comment
+ *        independent of the diff render. Finding B has no such fallback.
+ *   Fixing this needs infra work — extending `filterAnalyzableFiles`'s
+ *   extension allowlist / adding a lightweight non-AST prose path for
+ *   shell/config/doc files — not a `stale-duplicate` prompt tweak. Tracked
+ *   here as a documented gap rather than a red assertion so it doesn't get
+ *   silently "fixed" by prompt-only iteration that can't actually address
+ *   it.
+ *
+ * Capture command:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 658 \
+ *     packages/review/test/harness/fixtures/stale-duplicate/pr658-search-code-rename.fixture.json
+ *
+ * Calibration status: NOT YET RUN. This fixture was captured and validated
+ * structurally (fixture-loader round-trip, build-prompts render) only —
+ * no OpenRouter/paid run has been made against it. Given the deterministic
+ * `<stale_literal_candidates>` pre-scan (packages/review/src/stale-literal-signals.ts)
+ * only extracts QUOTED string literals from diff lines
+ * (`extractQuotedValues` requires a quote character), and the offending
+ * text here is a bare identifier inside a JSDoc-style block comment with
+ * no quotes, the pre-scan will NOT surface this candidate — the agent would
+ * have to notice the stale claim through general investigation alone, with
+ * no deterministic assist. Expect this to need prompt work (or a pre-scan
+ * extension to comment-embedded identifiers) before it reliably clears the
+ * 9/10 bar; that calibration is a follow-up, human-approved step, not part
+ * of this capture.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #658 b24fa33 — schema.ts embeddings.enabled doc comment falsely claims search_code reports as disabled (stale since #657); CodeRabbit caught it, Lien Review did not',
+  rule: 'stale-duplicate',
+  expect: (result, h) => {
+    h.expectRuleFired('stale-duplicate', result);
+    h.expectFindingMentions(
+      [
+        // File / symbol anchors
+        'schema.ts',
+        'embeddings.enabled',
+        'embeddings',
+        // The specific stale claim and its correction
+        'search_code',
+        'find_similar',
+        'report as disabled',
+        'reports as disabled',
+        'lexical',
+        'bm25',
+        'full-text',
+        // Vocabulary the model reaches for when describing the drift
+        'stale',
+        'no longer',
+        'disabled when embeddings',
+        'does not depend on embeddings',
+        "doesn't depend on embeddings",
+        '#657',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+};
+
+export default assertions;


### PR DESCRIPTION
## What

Captures merged PR #658 (`feat(mcp)!: rename semantic_search to search_code + honest indexing spinner`, squash commit 7318371, PR head b24fa33) as an offline agent-review test-harness fixture under `stale-duplicate/`.

Lien Review reported **zero findings** on PR #658 and its own summary claimed "user-facing docs were updated consistently". CodeRabbit's review on the same PR caught two real findings that were false:

- **Finding A** (asserted, Tier 1 + Tier 2) — `packages/core/src/config/schema.ts:62`. The diff mechanically renamed `semantic_search` → `search_code` in the `embeddings.enabled` doc comment ("...keep working; search_code and find_similar report as disabled."), but the underlying claim is stale: since #657, `search_code` runs lexical BM25 with no embeddings dependency. An audit at the PR's head commit shows neither `search_code` nor `find_similar`'s handlers check `embeddings.enabled` any more (both run the same vestigial-vector lexical search) — so even CodeRabbit's own suggested fix ("only find_similar reports as disabled") is incomplete. The identical stale phrase also exists, untouched by either reviewer, in `null-embeddings.ts:20`. ([CodeRabbit thread](https://github.com/getlien/lien/pull/658#discussion_r3522630327))

- **Finding B** (documented, *not* asserted) — `plugins/claude/hooks/augment-explore-task.sh:64` describes `search_code` as "REQUIRED for meaning-based discovery," but the tool is keyword/BM25, not meaning-based. ([CodeRabbit thread](https://github.com/getlien/lien/pull/658#discussion_r3522630331)) This is left unasserted because it's currently **impossible** for the pipeline to reach, not merely a prompt-quality gap: `.sh` has no parser/AST support, so the file produces zero chunks regardless of what `changedFiles` says, and every content-based tool (`get_files_context`, `list_functions`, `get_complexity`) has nothing to return for it. Verified empirically (no LLM call) that this PR's raw `<diff>` block also truncates at `MAX_DIFF_CHARS` well before reaching either file's hunk — Finding A only survives because `schema.ts` has real chunks to fall back on; Finding B has no such fallback. Fixing this needs `filterAnalyzableFiles`/parser-support work, not a rule prompt tweak.

## Why `stale-duplicate`

No existing rule targets "a prose claim in a comment invalidated by an earlier, unrelated PR" precisely, but `stale-duplicate` is the closest existing mandate (a site the diff touched should track reality elsewhere). Filed as a **documented-miss fixture** (new README section), not a canary — the deterministic `<stale_literal_candidates>` pre-scan only matches quoted string literals, not bare identifiers in prose comments, so this fixture is not currently expected to pass `--calibrate 10`. That calibration is an intentional follow-up, not part of this PR.

## Testing

- `npx tsx packages/review/test/harness/capture-pr.ts 658 <fixture>` — capture succeeded (4401 repo chunks, 190 changed-file chunks, 43 changed files).
- `npx tsx packages/review/test/harness/build-prompts.ts <fixture>` — free/offline structural replay: fixture loads, `stale-duplicate` is selected as active for this PR, initial message renders deterministically (byte-identical across two runs).
- `npx tsx packages/review/test/harness/assert-cli.ts <assertions> <mock-result>` — validated the assertions module itself against a synthetic passing result (matching finding → exit 0) and a synthetic empty result (Tier 1 failure, correct error message → exit 1).
- `npm run typecheck:harness -w @liendev/review` — clean.
- Full gate: `format:check` ✓, `lint` 0 errors ✓, `typecheck` ✓, `build` ✓, `npm test -w @liendev/review` — 27 files / 488 tests passed.
- **No OpenRouter/paid calibration run** — per the harness's documented workflow, that's a separate, human-approved step (this fixture is explicitly not claimed to clear the 9/10 bar yet).

## Test plan

- [ ] Human review of the fixture's `.assertions.ts` framing and keyword set
- [ ] Follow-up: run `--calibrate 10` against `stale-duplicate` once someone iterates on the rule prompt (or the pre-scan) to handle prose-embedded identifiers
- [ ] Separate follow-up: `.sh`/non-AST file visibility gap (`filterAnalyzableFiles` + diff-truncation interaction) tracked independently

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a documented-miss test fixture and README entry for PR #658 under the `stale-duplicate` rule. It contains no production code changes — only a new `.assertions.ts` fixture file and documentation. The assertions describe a real stale-doc bug that Lien Review missed and that the current deterministic pre-scan cannot surface, and the fixture is explicitly not claimed to pass calibration yet. No callers, runtime behavior, or exported APIs are affected.
>
> - Added `stale-duplicate/pr658-search-code-rename.assertions.ts` fixture capturing the `search_code` rename stale-doc finding from PR #658
> - Added README section documenting the documented-miss fixture corpus and why this case is not currently reachable by the deterministic pre-scan

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2a75197. Updates automatically on new commits.</sup>
<!-- /lien-stats -->