### PR TITLE
feat(review): guidance-surface passthrough + doc-truth rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,9 @@ coverage/
 # placeholder fixtures stay committed via the negation rule below.
 packages/review/test/harness/fixtures/**/*.fixture.json
 !packages/review/test/harness/fixtures/**/placeholder*.fixture.json
+# doc-truth fixtures are hand-authored (small, self-contained) — they can't be
+# regenerated via capture-pr.ts, so they're committed like placeholders. The
+# real-PR calibration fixture (PR #658) still lands under the ignore rule above.
+!packages/review/test/harness/fixtures/doc-truth/*.fixture.json
 
 packages/cli/README.md

--- a/packages/review/src/guidance-surface-signals.ts
+++ b/packages/review/src/guidance-surface-signals.ts
@@ -1,0 +1,159 @@
+/**
+ * Guidance-surface passthrough for PR reviews.
+ *
+ * The review pipeline only chunks/analyzes files whose extension is in the
+ * parser-supported set (see `filterAnalyzableFiles` in analysis.ts). That drops
+ * the agent-guidance surfaces — shell hooks, `.mdc` rules, CLAUDE.md — from the
+ * material the reviewer reasons about. For a tool whose *product* is agent
+ * guidance, that is exactly the wrong thing to hide: a hook that calls a
+ * keyword search "meaning-based discovery", or a CLAUDE.md that describes a flag
+ * the code no longer honors, actively misroutes the agents that read it. Stale
+ * guidance is a functional bug, not a style nit (see PR #658).
+ *
+ * This module widens the review INPUT without touching the parser: it collects
+ * the raw unified-diff hunks of any changed file that is a guidance surface and
+ * injects them as a clearly-labeled `<guidance_surface_changes>` block, so the
+ * prose reaches the model (and the `doc-truth` rule) instead of being silently
+ * dropped. It is a deterministic, zero-LLM pass over the existing patches —
+ * mirroring the `<untrusted_input_sites>` / `<stale_literal_candidates>`
+ * precedents (a focused view derived from the diff, appended unconditionally).
+ *
+ * Scope is deliberately tight (KISS): NOT every `.md`/`.json` in the repo — only
+ * surfaces whose prose steers an agent. The passthrough is byte-capped; when the
+ * cap is hit it says so rather than truncating silently.
+ */
+
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A changed guidance-surface file and its raw unified-diff hunk(s). */
+export interface GuidanceSurfaceChange {
+  file: string;
+  /** Raw unified-diff patch text for this file, as returned by the GitHub API. */
+  patch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Guidance-surface definition
+// ---------------------------------------------------------------------------
+
+/**
+ * A changed file is a "guidance surface" when its prose steers an agent rather
+ * than being executable source the parser can analyze. Kept tight on purpose —
+ * this is NOT "every doc/config file", only:
+ *  - CLAUDE.md at any depth (agent memory / project instructions);
+ *  - shell hooks and `.mdc` rule files under an agent-guidance root
+ *    (`plugins/**` for Claude Code plugins, `.cursor/**` for Cursor rules).
+ * Paths are repo-relative (no leading `./`), matching GitHub's file list.
+ */
+const GUIDANCE_SURFACE_MATCHERS: readonly RegExp[] = [
+  /(?:^|\/)CLAUDE\.md$/,
+  /^(?:plugins|\.cursor)\/.*\.(?:sh|mdc)$/,
+];
+
+/** True when `file` is an agent-guidance surface (see GUIDANCE_SURFACE_MATCHERS). */
+export function isGuidanceSurface(file: string): boolean {
+  return GUIDANCE_SURFACE_MATCHERS.some(re => re.test(file));
+}
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect the changed guidance-surface files and their raw diff hunks from the
+ * PR patches, preserving the patches' iteration order. Exposed for testing.
+ */
+export function collectGuidanceSurfaceChanges(
+  patches: Map<string, string>,
+): GuidanceSurfaceChange[] {
+  const changes: GuidanceSurfaceChange[] = [];
+  for (const [file, patch] of patches) {
+    if (isGuidanceSurface(file)) changes.push({ file, patch });
+  }
+  return changes;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Total budget for the passed-through hunks. Deliberately modest: input-budget
+ * bloat measurably degrades finding quality (PR #613), and guidance surfaces are
+ * usually small (a hook, a rule file, a CLAUDE.md section). When the budget is
+ * exhausted the block says how much was omitted — never a silent drop.
+ */
+const MAX_GUIDANCE_CHARS = 6_000;
+
+const HEADER = `<guidance_surface_changes>
+The diffs below are AGENT-GUIDANCE surfaces this PR changed (Claude/Cursor hooks, \`.mdc\` rules, CLAUDE.md). They are guidance-surface changes, NOT code-analyzed — no AST, chunks, or signals are computed for them, so their raw hunks are passed through here. For a tool whose product is agent guidance, prose that mis-describes behavior is a functional bug (a hook calling a keyword search "meaning-based", a doc claiming a flag is "disabled when X" the code contradicts). Apply the doc-truth check to behavioral claims in these hunks; do NOT report pure wording/style nits.`;
+
+/** Render one file's hunk as a fenced, labeled block. */
+function renderFileBlock(file: string, patch: string): string {
+  return `### ${file} (guidance-surface change — not code-analyzed)\n\`\`\`diff\n${patch}\n\`\`\``;
+}
+
+/**
+ * Render the collected guidance-surface changes as a `<guidance_surface_changes>`
+ * block for the agent's initial message. Returns '' when there are none, so
+ * callers can append unconditionally. Caps the total passed-through bytes and,
+ * if the cap is hit, states what was truncated/omitted rather than dropping
+ * content silently.
+ */
+export function renderGuidanceSurfaceChanges(changes: GuidanceSurfaceChange[]): string {
+  if (changes.length === 0) return '';
+
+  const blocks: string[] = [];
+  let used = 0;
+  let omittedFiles = 0;
+
+  for (let i = 0; i < changes.length; i++) {
+    const { file, patch } = changes[i];
+    const remaining = MAX_GUIDANCE_CHARS - used;
+    if (remaining <= 0) {
+      omittedFiles = changes.length - i;
+      break;
+    }
+    const block = renderFileBlock(file, patch);
+    if (block.length <= remaining) {
+      blocks.push(block);
+      used += block.length;
+      continue;
+    }
+    // The patch doesn't fit whole: include as much as the budget allows and
+    // mark this file's hunk as truncated, then stop (subsequent files omitted).
+    const truncatedPatch = patch.slice(
+      0,
+      Math.max(0, remaining - renderFileBlock(file, '').length),
+    );
+    const cut = patch.length - truncatedPatch.length;
+    blocks.push(
+      `${renderFileBlock(file, truncatedPatch)}\n[hunk truncated to respect the input budget — ${cut} more char(s) for this file; use read_file for the full contents]`,
+    );
+    omittedFiles = changes.length - i - 1;
+    break;
+  }
+
+  const parts = [HEADER, ...blocks];
+  if (omittedFiles > 0) {
+    parts.push(
+      `[+${omittedFiles} more changed guidance-surface file(s) omitted to respect the input budget — inspect them with read_file if a behavioral claim is at stake]`,
+    );
+  }
+  parts.push('</guidance_surface_changes>');
+  return parts.join('\n\n');
+}
+
+/**
+ * Build the `<guidance_surface_changes>` section from the review context.
+ * Returns '' when there is no diff or no changed guidance surface.
+ */
+export function renderGuidanceSurfaceSection(context: ReviewContext): string {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return '';
+  return renderGuidanceSurfaceChanges(collectGuidanceSurfaceChanges(patches));
+}

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -665,6 +665,110 @@ matches.`,
   source: 'builtin',
 };
 
+const DOC_TRUTH: ReviewRule = {
+  id: 'doc-truth',
+  name: 'Documentation / Guidance Truthfulness',
+  description:
+    'Flag doc comments, docstrings, tool descriptions, and agent-guidance prose whose behavioral claims are contradicted by the code the diff touches',
+  prompt: `### Documentation / Guidance Truthfulness Check
+
+**This rule is a deliberate exception to the general "do NOT report
+documentation" policy.** A doc comment, docstring, tool description, or
+agent-guidance file (CLAUDE.md, a plugin hook, a \`.mdc\` rule) that makes a
+FALSE behavioral claim is a real bug, not a style nit — especially for a
+tool whose product IS agent guidance, where wrong guidance actively
+misroutes the agents that read it. Silence is not a safe default here: if
+the diff touches prose making a behavioral claim, verify the claim before
+staying quiet.
+
+Scope: only prose the diff TOUCHED — comments, docstrings, string/Markdown
+descriptions, or shell \`echo\`/comment text on \`+\` (or removed \`-\`)
+lines — INCLUDING any \`<guidance_surface_changes>\` block in your initial
+message (those files are not code-analyzed, so their prose is reviewed only
+here). Ignore prose the diff did not touch, and ignore pure wording/style
+preferences.
+
+Concrete claim shapes to check — report ONLY when the code contradicts the
+claim (or the diff itself just changed the described behavior and left the
+prose describing the OLD behavior):
+- **State claim** — "X is disabled/enabled/inactive/inert when Y",
+  "reports as disabled without Z". Falsified when the code path shows the
+  opposite (e.g. the feature still runs / still reports as active).
+- **Mechanism claim** — "X is meaning-based / semantic / embedding-based"
+  when the implementation is lexical/keyword/substring (or the reverse).
+- **Requirement claim** — "X requires Z", "X never does Z", "always
+  returns …". Falsified when the code imposes no such requirement or does
+  the forbidden thing.
+- **Default claim** — "default: true", "defaults to N". Falsified when the
+  schema / constructor / config default in the code is a different value.
+
+MANDATORY protocol when this rule is active:
+
+1. List every claim-bearing line the diff touched (from \`<diff>\` and from
+   \`<guidance_surface_changes>\`). If there are none, the rule has nothing
+   to do — that is the only clean way to finish with zero findings.
+2. For EACH claim, locate the code it describes using material ALREADY in
+   your prompt: the diff hunks, \`<changed_functions>\`, and — for symbols in
+   changed code — \`get_files_context\` (it reads the indexed chunks). Do
+   NOT depend on \`grep_codebase\` / \`read_file\` alone to confirm a claim:
+   in some review modes those tools return no content, so a claim you cannot
+   otherwise check is "unverified", not "fine".
+3. Emit a finding when the claim is CONTRADICTED by the code you can see, OR
+   when the diff changed the described behavior and left the prose describing
+   the old behavior (a mechanical rename/refactor that made a neighbouring
+   comment stale is the canonical case). The \`message\` must QUOTE the
+   stale/false claim and state the actual behavior; the \`evidence\` must
+   cite the code fact that falsifies it (file:line, signature, return value,
+   or the specific diff hunk) — not "the comment looks wrong".
+4. Stay silent on a claim only after locating the code and confirming it
+   still matches. A claim you genuinely could not locate is reported as a
+   \`warning\` "unverifiable behavioral claim in touched prose" — do not
+   silently pass it.`,
+  example: `### Good finding — mechanical rename left a doc comment describing removed behavior:
+{
+  "filepath": "packages/core/src/config/schema.ts",
+  "line": 42,
+  "symbolName": "embeddingsConfig",
+  "severity": "warning",
+  "category": "bug",
+  "ruleId": "doc-truth",
+  "message": "The touched doc comment claims code search \\"reports as disabled\\" when embeddings are absent, but the code no longer disables it: without embeddings, search falls back to lexical BM25 and still reports as active. The comment describes pre-refactor behavior the code path no longer has.",
+  "suggestion": "Reword to: without embeddings, search falls back to lexical BM25 (it does not report as disabled).",
+  "evidence": "Doc-truth check — comment at line 42 says 'reports as disabled'; the resolver in the same file returns 'lexical', never 'disabled', so the claim is falsified by the code."
+}
+
+### Good finding — guidance-surface hook mislabels a lexical tool as semantic:
+{
+  "filepath": "plugins/claude/hooks/augment-explore-task.sh",
+  "line": 12,
+  "severity": "warning",
+  "category": "bug",
+  "ruleId": "doc-truth",
+  "message": "The hook's guidance text calls search_code \\"meaning-based discovery\\", but the tool now performs lexical keyword (BM25) search. Agents reading this hook will expect semantic ranking and mis-use the tool.",
+  "suggestion": "Reword to 'keyword-based code search (BM25)' to match the tool's actual behavior.",
+  "evidence": "Doc-truth check — the <guidance_surface_changes> hunk describes 'meaning-based'; the tool is lexical per this PR's rename and the search implementation."
+}`,
+  triggers: {
+    // Guidance surfaces (matched against allChangedFiles, so the invisible
+    // .sh/.mdc/CLAUDE.md cases still activate the rule)...
+    filePatterns: ['**/CLAUDE.md', 'plugins/**', '.cursor/**', '**/*.mdc'],
+    // ...OR claim-shaped prose anywhere in the diff (doc comments/docstrings in
+    // otherwise-analyzable code, e.g. the schema.ts miss on PR #658).
+    keywords: [
+      'reports?\\s+as\\s+(disabled|enabled|inactive|unavailable)',
+      '(disabled|enabled|inactive|inert|no-?op|ignored)\\s+(when|unless|if|without)',
+      'meaning-based',
+      'semantic(ally)?\\s+(search|match|matching|similar|discovery)',
+      'default:\\s*(true|false|\\d)',
+      '(always|never)\\s+(returns?|throws?|requires?|uses?|does|disables?|enables?)',
+    ],
+  },
+  severity: 'warning',
+  category: 'bug',
+  enabled: true,
+  source: 'builtin',
+};
+
 /** All built-in review rules. */
 export const BUILTIN_RULES: ReviewRule[] = [
   STRUCTURAL_ANALYSIS,
@@ -675,4 +779,5 @@ export const BUILTIN_RULES: ReviewRule[] = [
   BOUNDARY_CHANGE,
   STALE_DUPLICATE,
   UNTRUSTED_INPUT_VALIDATION,
+  DOC_TRUTH,
 ];

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -17,6 +17,7 @@ import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
+import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -178,6 +179,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderDeletedExports(context));
   appendIfPresent(sections, renderStaleLiteralSection(context));
   appendIfPresent(sections, renderUntrustedInputSection(context));
+  appendIfPresent(sections, renderGuidanceSurfaceSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/test/guidance-surface-signals.test.ts
+++ b/packages/review/test/guidance-surface-signals.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  isGuidanceSurface,
+  collectGuidanceSurfaceChanges,
+  renderGuidanceSurfaceChanges,
+  renderGuidanceSurfaceSection,
+  type GuidanceSurfaceChange,
+} from '../src/guidance-surface-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+function ctxWithPatches(patches?: Map<string, string>): ReviewContext {
+  return {
+    pr: patches ? { patches } : undefined,
+    changedFiles: patches ? [...patches.keys()] : [],
+    chunks: [],
+  } as unknown as ReviewContext;
+}
+
+// Mirrors the PR #658 miss: a hook whose guidance text calls a keyword search
+// "meaning-based discovery".
+const HOOK_PATCH =
+  '@@ -10,3 +10,3 @@\n' +
+  ' # Suggest the right tool for exploration\n' +
+  '-echo "Use search_code for meaning-based discovery of relevant code"\n' +
+  '+echo "Use search_code for meaning-based discovery of relevant code (renamed)"\n' +
+  ' exit 0';
+
+const CLAUDE_MD_PATCH =
+  '@@ -1,2 +1,2 @@\n' +
+  ' ## Search\n' +
+  '-Semantic search finds code by meaning.\n' +
+  '+Semantic search finds code by meaning (via embeddings).';
+
+// ---------------------------------------------------------------------------
+// isGuidanceSurface
+// ---------------------------------------------------------------------------
+
+describe('isGuidanceSurface', () => {
+  it('matches CLAUDE.md at the root and at any depth', () => {
+    expect(isGuidanceSurface('CLAUDE.md')).toBe(true);
+    expect(isGuidanceSurface('packages/core/CLAUDE.md')).toBe(true);
+  });
+
+  it('matches shell hooks and .mdc rules under plugins/ and .cursor/', () => {
+    expect(isGuidanceSurface('plugins/claude/hooks/augment-explore-task.sh')).toBe(true);
+    expect(isGuidanceSurface('plugins/claude/rules/foo.mdc')).toBe(true);
+    expect(isGuidanceSurface('.cursor/rules/lien.mdc')).toBe(true);
+    expect(isGuidanceSurface('.cursor/hooks/setup.sh')).toBe(true);
+  });
+
+  it('does NOT match ordinary code, docs, config, or out-of-scope .sh/.mdc', () => {
+    // Parser-analyzable source is reviewed the normal way, not passed through.
+    expect(isGuidanceSurface('packages/core/src/config/schema.ts')).toBe(false);
+    // Tight scope: not every markdown/json, and .sh/.mdc only under the two roots.
+    expect(isGuidanceSurface('README.md')).toBe(false);
+    expect(isGuidanceSurface('docs/guide.md')).toBe(false);
+    expect(isGuidanceSurface('package.json')).toBe(false);
+    expect(isGuidanceSurface('scripts/build.sh')).toBe(false);
+    expect(isGuidanceSurface('src/rules/foo.mdc')).toBe(false);
+    // Must be the full basename, not a suffix.
+    expect(isGuidanceSurface('NOTCLAUDE.md')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectGuidanceSurfaceChanges
+// ---------------------------------------------------------------------------
+
+describe('collectGuidanceSurfaceChanges', () => {
+  it('keeps only guidance surfaces and preserves patch order', () => {
+    const patches = new Map<string, string>([
+      ['packages/core/src/config/schema.ts', '@@ -1 +1 @@\n-a\n+b'],
+      ['plugins/claude/hooks/augment-explore-task.sh', HOOK_PATCH],
+      ['README.md', '@@ -1 +1 @@\n-x\n+y'],
+      ['CLAUDE.md', CLAUDE_MD_PATCH],
+    ]);
+    const changes = collectGuidanceSurfaceChanges(patches);
+    expect(changes.map(c => c.file)).toEqual([
+      'plugins/claude/hooks/augment-explore-task.sh',
+      'CLAUDE.md',
+    ]);
+    expect(changes[0].patch).toBe(HOOK_PATCH);
+  });
+
+  it('returns [] when no changed file is a guidance surface', () => {
+    const patches = new Map<string, string>([['src/index.ts', '@@ -1 +1 @@\n-a\n+b']]);
+    expect(collectGuidanceSurfaceChanges(patches)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderGuidanceSurfaceChanges
+// ---------------------------------------------------------------------------
+
+describe('renderGuidanceSurfaceChanges', () => {
+  it('returns "" for no changes', () => {
+    expect(renderGuidanceSurfaceChanges([])).toBe('');
+  });
+
+  it('renders a labeled, fenced block with the raw hunk and the doc-truth framing', () => {
+    const md = renderGuidanceSurfaceChanges([
+      { file: 'plugins/claude/hooks/augment-explore-task.sh', patch: HOOK_PATCH },
+    ]);
+    expect(md).toContain('<guidance_surface_changes>');
+    expect(md).toContain('</guidance_surface_changes>');
+    expect(md).toContain(
+      'plugins/claude/hooks/augment-explore-task.sh (guidance-surface change — not code-analyzed)',
+    );
+    expect(md).toContain('```diff');
+    expect(md).toContain('meaning-based discovery');
+    expect(md).toContain('doc-truth');
+  });
+
+  it('caps total bytes and notes the omitted files rather than dropping silently', () => {
+    const big = 'x'.repeat(5_000);
+    const changes: GuidanceSurfaceChange[] = [
+      { file: 'plugins/a/hooks/one.sh', patch: `@@ -1 +1 @@\n+${big}` },
+      { file: 'plugins/a/hooks/two.sh', patch: `@@ -1 +1 @@\n+${big}` },
+      { file: 'plugins/a/hooks/three.sh', patch: `@@ -1 +1 @@\n+${big}` },
+    ];
+    const md = renderGuidanceSurfaceChanges(changes);
+    expect(md).toContain('plugins/a/hooks/one.sh');
+    // Budget (6000) fits the first file whole; the second overflows and is
+    // truncated in place; the third is omitted with an explicit note.
+    expect(md).toMatch(/hunk truncated to respect the input budget/);
+    expect(md).toMatch(/\+1 more changed guidance-surface file\(s\) omitted/);
+    // Passed-through hunk content stays within budget; only the fixed framing
+    // (header + notes + closing tag) sits on top. Bounded, not runaway
+    // (all three 5 KB hunks would be ~15 KB uncapped).
+    expect(md.length).toBeLessThan(6_000 + 2_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderGuidanceSurfaceSection
+// ---------------------------------------------------------------------------
+
+describe('renderGuidanceSurfaceSection', () => {
+  it('returns "" when there is no diff', () => {
+    expect(renderGuidanceSurfaceSection(ctxWithPatches())).toBe('');
+  });
+
+  it('renders the block from context patches, skipping non-guidance files', () => {
+    const section = renderGuidanceSurfaceSection(
+      ctxWithPatches(
+        new Map([
+          ['src/index.ts', '@@ -1 +1 @@\n-a\n+b'],
+          ['plugins/claude/hooks/augment-explore-task.sh', HOOK_PATCH],
+        ]),
+      ),
+    );
+    expect(section).toContain('<guidance_surface_changes>');
+    expect(section).toContain('plugins/claude/hooks/augment-explore-task.sh');
+    expect(section).not.toContain('src/index.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage guidance-surface injection', () => {
+  it('includes the <guidance_surface_changes> block when a guidance surface changed', () => {
+    const ctx = ctxWithPatches(
+      new Map([['plugins/claude/hooks/augment-explore-task.sh', HOOK_PATCH]]),
+    );
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).toContain('<guidance_surface_changes>');
+    expect(message).toContain('plugins/claude/hooks/augment-explore-task.sh');
+  });
+
+  it('omits the block when no guidance surface changed', () => {
+    const ctx = ctxWithPatches(new Map([['src/index.ts', '@@ -1 +1 @@\n-a\n+b']]));
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).not.toContain('<guidance_surface_changes>');
+  });
+});

--- a/packages/review/test/harness/fixtures/doc-truth/accurate-doc.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/accurate-doc.assertions.ts
@@ -1,0 +1,33 @@
+/**
+ * Hand-authored precision guard for the doc-truth rule — the no-finding case.
+ *
+ * The touched doc comment ("Search is disabled when the index is missing or
+ * empty") makes a behavioral claim of exactly the shape doc-truth targets
+ * ("disabled when …"), so the rule ACTIVATES — but the claim is TRUE: the code
+ * in the same hunk returns `{ mode: 'disabled' }` when `!index || index.size ===
+ * 0`. A correct reviewer verifies the claim against the visible code and stays
+ * silent. This guards against the rule flagging accurate prose (precision), the
+ * failure mode that makes a doc rule noisy.
+ *
+ * The diff touches only comment lines (no changed logic, no changed string
+ * literals, no removed exports), so the always-on rules — edge-case-sweep,
+ * structural-analysis, stale-duplicate — have nothing to fire on either.
+ * `expectEmpty` therefore holds for the whole result, not just doc-truth.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'Accurate doc comment ("disabled when the index is missing or empty") that matches ' +
+    'the code — doc-truth activates but must stay silent',
+  rule: 'doc-truth',
+  expect: (result, h) => {
+    h.expectEmpty(result);
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['doc-truth', 'hand-authored', 'precision'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/accurate-doc.fixture.json
+++ b/packages/review/test/harness/fixtures/doc-truth/accurate-doc.fixture.json
@@ -1,0 +1,79 @@
+{
+  "chunks": [
+    {
+      "content": "export function getSearchStatus(index: Index | null): SearchStatus {\n  if (!index || index.isEmpty()) {\n    return { mode: 'disabled' };\n  }\n  return { mode: 'active' };\n}",
+      "metadata": {
+        "file": "packages/core/src/search/status.ts",
+        "startLine": 18,
+        "endLine": 23,
+        "type": "function",
+        "language": "typescript",
+        "symbolName": "getSearchStatus",
+        "symbolType": "function",
+        "complexity": 2,
+        "parameters": ["index: Index | null"],
+        "signature": "function getSearchStatus(index: Index | null): SearchStatus",
+        "returnType": "SearchStatus",
+        "exports": ["getSearchStatus"]
+      }
+    }
+  ],
+  "changedFiles": ["packages/core/src/search/status.ts"],
+  "allChangedFiles": ["packages/core/src/search/status.ts"],
+  "complexityReport": {
+    "summary": {
+      "filesAnalyzed": 1,
+      "totalViolations": 0,
+      "bySeverity": { "error": 0, "warning": 0 },
+      "avgComplexity": 2,
+      "maxComplexity": 2
+    },
+    "files": {}
+  },
+  "baselineReport": null,
+  "deltas": null,
+  "pluginConfigs": {},
+  "config": {},
+  "pr": {
+    "owner": "getlien",
+    "repo": "lien",
+    "pullNumber": 9003,
+    "title": "docs: clarify when search status is disabled",
+    "body": "Expand the doc comment to note the empty-index case. No behavior change.",
+    "baseSha": "0000000000000000000000000000000000000000",
+    "headSha": "1111111111111111111111111111111111111111",
+    "patches": {
+      "__type": "Map",
+      "entries": [
+        [
+          "packages/core/src/search/status.ts",
+          "@@ -14,10 +14,10 @@ export interface SearchStatus {\n   mode: 'disabled' | 'active';\n }\n \n /**\n- * Search is disabled when the index is missing.\n+ * Search is disabled when the index is missing or empty.\n  */\n export function getSearchStatus(index: Index | null): SearchStatus {\n   if (!index || index.isEmpty()) {\n     return { mode: 'disabled' };\n   }\n   return { mode: 'active' };\n }"
+        ]
+      ]
+    },
+    "diffLines": {
+      "__type": "Map",
+      "entries": [["packages/core/src/search/status.ts", { "__type": "Set", "values": [18] }]]
+    }
+  },
+  "repoChunks": [
+    {
+      "content": "export function getSearchStatus(index: Index | null): SearchStatus {\n  if (!index || index.isEmpty()) {\n    return { mode: 'disabled' };\n  }\n  return { mode: 'active' };\n}",
+      "metadata": {
+        "file": "packages/core/src/search/status.ts",
+        "startLine": 18,
+        "endLine": 23,
+        "type": "function",
+        "language": "typescript",
+        "symbolName": "getSearchStatus",
+        "symbolType": "function",
+        "complexity": 2,
+        "parameters": ["index: Index | null"],
+        "signature": "function getSearchStatus(index: Index | null): SearchStatus",
+        "returnType": "SearchStatus",
+        "exports": ["getSearchStatus"]
+      }
+    }
+  ],
+  "repoRootDir": "/repo"
+}

--- a/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.assertions.ts
@@ -1,0 +1,60 @@
+/**
+ * Hand-authored fixture for the doc-truth rule — the falsified-claim case.
+ *
+ * Models the PR #658 miss on `packages/core/src/config/schema.ts`: a mechanical
+ * rename (`semantic_search` → `search_code`) TOUCHES a doc comment whose
+ * behavioral claim ("reports as disabled and returns no results" without
+ * embeddings) is contradicted by the code visible in the same hunk —
+ * `resolveSearchMode` falls back to lexical BM25 (active, returns results) when
+ * `hasEmbeddings` is false. The contradiction is fully in-prompt (diff context),
+ * so the case is verifiable in free/offline (CC-replay) mode without any
+ * grep/read of a capture-time repo — which are blind in fixture replay.
+ *
+ * Tier 1: the doc-truth rule fires.
+ * Tier 2: the finding names the contradiction (comment says "disabled" while the
+ * code returns "lexical" / BM25). The keyword set is wide because a correct
+ * rendering can lead with either the false claim or the true behavior.
+ *
+ * Real-PR calibration target: the captured PR #658 fixture landing on the
+ * sibling branch `test/capture-pr658-fixture` is the fixture to run
+ * `--calibrate 10` against on kimi before shipping (≥ 9/10). This hand-authored
+ * fixture is the free CC-mode smoke test, NOT the calibration gate.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #658-style rename — schema.ts doc comment claims search "reports as disabled" ' +
+    'without embeddings, but the code falls back to lexical BM25 (still active)',
+  rule: 'doc-truth',
+  expect: (result, h) => {
+    h.expectRuleFired('doc-truth', result);
+    h.expectFindingMentions(
+      [
+        // The true behavior the claim contradicts
+        'lexical',
+        'bm25',
+        'fall back',
+        'fallback',
+        // The false claim being flagged
+        'disabled',
+        'reports as',
+        'no results',
+        // Framing a correct finding tends to use
+        'resolvesearchmode',
+        'stale',
+        'contradict',
+        'falsif',
+        'still',
+        'outdated',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['doc-truth', 'hand-authored'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.fixture.json
+++ b/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.fixture.json
@@ -1,0 +1,79 @@
+{
+  "chunks": [
+    {
+      "content": "export function resolveSearchMode(hasEmbeddings: boolean): SearchMode {\n  // No embeddings: fall back to lexical BM25 keyword search.\n  return hasEmbeddings ? 'semantic' : 'lexical';\n}",
+      "metadata": {
+        "file": "packages/core/src/config/schema.ts",
+        "startLine": 40,
+        "endLine": 43,
+        "type": "function",
+        "language": "typescript",
+        "symbolName": "resolveSearchMode",
+        "symbolType": "function",
+        "complexity": 1,
+        "parameters": ["hasEmbeddings: boolean"],
+        "signature": "function resolveSearchMode(hasEmbeddings: boolean): SearchMode",
+        "returnType": "SearchMode",
+        "exports": ["resolveSearchMode"]
+      }
+    }
+  ],
+  "changedFiles": ["packages/core/src/config/schema.ts"],
+  "allChangedFiles": ["packages/core/src/config/schema.ts"],
+  "complexityReport": {
+    "summary": {
+      "filesAnalyzed": 1,
+      "totalViolations": 0,
+      "bySeverity": { "error": 0, "warning": 0 },
+      "avgComplexity": 1,
+      "maxComplexity": 1
+    },
+    "files": {}
+  },
+  "baselineReport": null,
+  "deltas": null,
+  "pluginConfigs": {},
+  "config": {},
+  "pr": {
+    "owner": "getlien",
+    "repo": "lien",
+    "pullNumber": 9002,
+    "title": "refactor: rename semantic_search tool to search_code",
+    "body": "Mechanical rename of the MCP tool across the codebase and its docs. No behavior change.",
+    "baseSha": "0000000000000000000000000000000000000000",
+    "headSha": "1111111111111111111111111111111111111111",
+    "patches": {
+      "__type": "Map",
+      "entries": [
+        [
+          "packages/core/src/config/schema.ts",
+          "@@ -32,13 +32,13 @@ export type SearchMode = 'semantic' | 'lexical';\n \n export interface EmbeddingsConfig {\n   enabled: boolean;\n }\n \n /**\n- * When embeddings are absent, semantic_search reports as disabled\n- * and returns no results.\n+ * When embeddings are absent, search_code reports as disabled\n+ * and returns no results.\n  */\n export function resolveSearchMode(hasEmbeddings: boolean): SearchMode {\n   // No embeddings: fall back to lexical BM25 keyword search.\n   return hasEmbeddings ? 'semantic' : 'lexical';\n }"
+        ]
+      ]
+    },
+    "diffLines": {
+      "__type": "Map",
+      "entries": [["packages/core/src/config/schema.ts", { "__type": "Set", "values": [38, 39] }]]
+    }
+  },
+  "repoChunks": [
+    {
+      "content": "export function resolveSearchMode(hasEmbeddings: boolean): SearchMode {\n  // No embeddings: fall back to lexical BM25 keyword search.\n  return hasEmbeddings ? 'semantic' : 'lexical';\n}",
+      "metadata": {
+        "file": "packages/core/src/config/schema.ts",
+        "startLine": 40,
+        "endLine": 43,
+        "type": "function",
+        "language": "typescript",
+        "symbolName": "resolveSearchMode",
+        "symbolType": "function",
+        "complexity": 1,
+        "parameters": ["hasEmbeddings: boolean"],
+        "signature": "function resolveSearchMode(hasEmbeddings: boolean): SearchMode",
+        "returnType": "SearchMode",
+        "exports": ["resolveSearchMode"]
+      }
+    }
+  ],
+  "repoRootDir": "/repo"
+}

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -257,6 +257,37 @@ describe('selectRules', () => {
     expect(selectRules([rule], match).active.map(r => r.id)).toContain('test-lang');
   });
 
+  it('activates doc-truth when a guidance surface changed (invisible-file case)', () => {
+    // The .sh hook is not analyzable, so it only reaches the rule via
+    // allChangedFiles → filePatterns. It must still activate the rule.
+    const hookOnly = makeTriggerContext({
+      changedFiles: ['plugins/claude/hooks/augment-explore-task.sh'],
+      diffText: '+echo "run the tool"',
+    });
+    expect(selectRules(BUILTIN_RULES, hookOnly).active.map(r => r.id)).toContain('doc-truth');
+
+    const claudeMd = makeTriggerContext({ changedFiles: ['packages/core/CLAUDE.md'] });
+    expect(selectRules(BUILTIN_RULES, claudeMd).active.map(r => r.id)).toContain('doc-truth');
+  });
+
+  it('activates doc-truth on claim-shaped prose in an otherwise-analyzable diff', () => {
+    // The schema.ts miss: a doc comment making a falsifiable "reports as
+    // disabled" claim, in a code file (no guidance-surface path match).
+    const ctx = makeTriggerContext({
+      changedFiles: ['packages/core/src/config/schema.ts'],
+      diffText: '+  /** Without embeddings, code search reports as disabled. */',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).active.map(r => r.id)).toContain('doc-truth');
+  });
+
+  it('skips doc-truth for a plain code change with no guidance surface or claim prose', () => {
+    const ctx = makeTriggerContext({
+      changedFiles: ['src/utils/math.ts'],
+      diffText: 'const total = a + b;\nreturn total;',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('doc-truth');
+  });
+
   it('matches filePatterns triggers', () => {
     const rule: ReviewRule = {
       id: 'test-patterns',


### PR DESCRIPTION
## Motivation — two PR #658 misses

PR #658 was a mechanical rename (`semantic_search` → `search_code`). Lien Review reported **zero findings**, while CodeRabbit caught two stale-prose claims that the earlier PR #657 had falsified (embeddings became inert; code search became lexical BM25):

1. **`packages/core/src/config/schema.ts`** — a doc comment claimed the tool "reports as disabled" without embeddings. False (search falls back to lexical), and the file **was** reviewable — a straight model miss.
2. **`plugins/claude/hooks/augment-explore-task.sh`** — called the tool "meaning-based discovery" when it's keyword search. This file was **invisible** to the review: `filterAnalyzableFiles` drops any extension outside the parser-supported set, so agent-guidance surfaces (`.sh` hooks, `.mdc` rules, CLAUDE.md) never reach the model.

For Lien — whose product *is* agent guidance — wrong guidance actively misroutes the agents that read it. Stale guidance is a functional bug, not a style nit. This PR closes both gaps.

## Part 1 — guidance-surface passthrough (deterministic, zero-LLM)

`packages/review/src/guidance-surface-signals.ts`: a pure pass over the existing PR patches (no parser change, no new fetch) that collects the raw diff hunks of any changed guidance surface and injects them as a clearly-labeled `<guidance_surface_changes>` block, appended at the same seam as the other signals in `buildInitialMessage`.

- **Scope (tight, named matchers — NOT every `.md`/`.json`):** `CLAUDE.md` at any depth; `.sh` / `.mdc` under `plugins/**` or `.cursor/**`. MCP tool descriptions live in `.ts` source (already analyzable), so they need no passthrough — the doc-truth rule catches them directly.
- **Cap:** 6 KB total. Guidance surfaces are small, and input-budget bloat measurably degrades findings (PR #613). When the budget is hit, the block **says** what it truncated/omitted (per-file "hunk truncated" + "+N more file(s) omitted") — never a silent drop.
- Pure functions (`isGuidanceSurface`, `collectGuidanceSurfaceChanges`, `renderGuidanceSurfaceChanges`, `renderGuidanceSurfaceSection`) with 12 zero-LLM unit tests.

## Part 2 — the `doc-truth` agent rule

New rule `doc-truth` in `packages/review/src/plugins/agent/rules.ts`. A **deliberate exception** to the general "do NOT report documentation" policy (framed the same way `boundary-change` / `stale-duplicate` are exceptions to "silence means approval"): a doc comment, docstring, tool description, or guidance file that makes a FALSE behavioral claim is a real bug.

**Claim shapes it anchors on** (report only when the code contradicts the claim, or the diff just changed the described behavior and left the prose stale):
- **State** — "X is disabled/enabled/inactive when Y", "reports as disabled without Z"
- **Mechanism** — "X is meaning-based / semantic" vs a lexical/keyword implementation
- **Requirement** — "X requires Z", "X never does Z", "always returns …"
- **Default** — "default: true", "defaults to N" contradicting the schema/constructor default

**Evidence discipline (hard-won repo lessons respected):** the rule takes evidence only from the diff, `<changed_functions>`, injected signals, and `get_files_context` (which reads in-memory chunks). It explicitly does **not** depend on `grep_codebase` / `read_file` — those are blind in harness fixture replay. It reads Part 1's `<guidance_surface_changes>` block so guidance prose is in scope. Instructions are concrete and example-anchored (two worked examples mirroring the schema.ts and `.sh` misses) to counter kimi's silent zero-finding failure mode. No other rule's prompt was reworded; no global brevity instructions were added.

Triggers: guidance-surface `filePatterns` (so the invisible `.sh`/`.mdc`/CLAUDE.md cases activate via `allChangedFiles`) **OR** claim-shaped keywords in the diff (so an in-code doc comment like the schema.ts miss activates).

## Fixture coverage & free validation

Two hand-authored, self-contained harness fixtures under `test/harness/fixtures/doc-truth/` (committed via a scoped `.gitignore` negation — they're synthetic, so `capture-pr.ts` can't regenerate them):

- **`renamed-stale-claim`** (must fire) — mirrors the schema.ts miss: a mechanical rename touches a doc comment claiming search "reports as disabled and returns no results" while the code in the same hunk returns `'lexical'` (BM25 fallback). Contradiction fully in-prompt, so it's verifiable offline.
- **`accurate-doc`** (must stay silent) — a "disabled when …" claim that **matches** the code; the rule activates but must not fire. Precision guard.

Plus 4 trigger unit tests in `plugins-agent-rules.test.ts` (guidance-surface + in-code claim activate; a plain code change does not).

**Validated for free** via CC-subagent replay of the exact production prompts (`build-prompts.ts` → subagents → `assert-cli.ts`), 3 votes each:
- `renamed-stale-claim`: **3/3** fired `doc-truth`, each citing the contradiction (lexical / BM25 / disabled / `resolveSearchMode`).
- `accurate-doc`: **3/3** stayed silent (empty findings).

## ⚠️ Calibration gate — PENDING (not done in this PR)

CC-mode is necessary but **not sufficient** to ship (Claude is materially smarter than the prod default). The `≥ 9/10` OpenRouter calibration on the prod model (`moonshotai/kimi-k2.7-code`) is a separate, human-approved step and has **not** been run here (no OpenRouter spend in this PR). The real-PR calibration target is the **captured PR #658 fixture** landing on the sibling branch `test/capture-pr658-fixture` — run `--calibrate 10 --rule doc-truth` against it (and confirm no regression on the existing canary corpus) before merging/relying on this rule in production.

## Sibling-branch coordination

- **`test/capture-pr658-fixture`** — captures the real #658 fixture. This PR does **not** duplicate that capture; it names it as the future calibration target (above).
- **`feat/rename-sweep-signal` (PR #663)** — adds a deterministic rename-sweep signal wired into `buildInitialMessage` via `appendIfPresent(sections, renderRenameSweepSection(context))` right after the stale-literal section. My guidance-surface wiring adds `appendIfPresent(sections, renderGuidanceSurfaceSection(context))` a couple of lines below (after untrusted-input), plus a new import. The two are logically independent, but they touch the **same region** of `system-prompt.ts` (import block + the `appendIfPresent` sequence), so expect a small, trivially-resolved merge overlap depending on merge order.

## Gate (all green)

`npm run format:check` ✓ · `npm run lint` (0 errors) ✓ · `npm run typecheck` ✓ · `npm run typecheck:harness` ✓ · `npm run build` ✓ · `npm test -w @liendev/review` (509 passed) ✓

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic guidance-surface passthrough and a new `doc-truth` review rule. The passthrough correctly scopes agent-guidance files, caps passed-through bytes at 6 KB, and reports truncation explicitly. The `doc-truth` rule is wired into the dynamic rule set with appropriate triggers and a precise prompt limited to contradicted behavioral claims. No exports are removed, no callers are broken, and the new code handles empty inputs and budget exhaustion gracefully.
>
> - New zero-LLM guidance-surface passthrough module with 6 KB hunk budget and explicit truncation notices
> - New `doc-truth` built-in rule activated by guidance-surface changes or claim-shaped diff keywords
> - System prompt appends `<guidance_surface_changes>` after existing signal sections

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 321037a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

## Harness evidence (calibration run 2026-07-04)

`npm run test:harness -w @liendev/review -- --rule doc-truth --calibrate 10` against the prod default model (kimi-k2.7-code, OpenRouter):

- `doc-truth/renamed-stale-claim` — **10/10 passed** (fired, citing the lexical/BM25-vs-disabled contradiction)
- `doc-truth/accurate-doc` — **10/10 passed** (stayed silent — precision guard)
- Total cost: $0.16

Clears the ≥9/10 shipping bar with no prompt iteration.