### PR TITLE
test(review): retarget pr658 fixture to doc-truth after sweep proved detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,9 +99,11 @@ coverage/
 # placeholder fixtures stay committed via the negation rule below.
 packages/review/test/harness/fixtures/**/*.fixture.json
 !packages/review/test/harness/fixtures/**/placeholder*.fixture.json
-# doc-truth fixtures are hand-authored (small, self-contained) — they can't be
-# regenerated via capture-pr.ts, so they're committed like placeholders. The
-# real-PR calibration fixture (PR #658) still lands under the ignore rule above.
-!packages/review/test/harness/fixtures/doc-truth/*.fixture.json
+# The two synthetic doc-truth fixtures are hand-authored (small,
+# self-contained) — they can't be regenerated via capture-pr.ts, so they're
+# committed by name. The real-PR calibration fixture (PR #658) lives in the
+# same directory but stays under the ignore rule above (10MB+, regenerable).
+!packages/review/test/harness/fixtures/doc-truth/accurate-doc.fixture.json
+!packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.fixture.json
 
 packages/cli/README.md

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -108,13 +108,13 @@ prompt/pipeline from reaching it.
 
 | Rule | PR | Fixture | Why |
 |---|---|---|---|
-| `stale-duplicate` | #658 | `stale-duplicate/pr658-search-code-rename` | `schema.ts:62`'s `embeddings.enabled` doc comment claims `search_code` "reports as disabled" — stale since #657 made `search_code` lexical/BM25 with no embeddings dependency. The pre-computed `<stale_literal_candidates>` scan only matches quoted string literals, not bare identifiers in prose comments, so this shape needs either a prompt change or a pre-scan extension. A second real finding on the same PR (`plugins/claude/hooks/augment-explore-task.sh:64`, [thread](https://github.com/getlien/lien/pull/658#discussion_r3522630331)) is documented in the fixture's `.assertions.ts` but intentionally not asserted — `.sh` has no parser support, so it produces zero chunks regardless of prompt quality; that's a visibility gap, not something a rule/prompt change can fix. |
+| `doc-truth` | #658 | `doc-truth/pr658-search-code-rename` | `schema.ts:62`'s `embeddings.enabled` doc comment claims `search_code` "reports as disabled" — stale since #657 made `search_code` lexical/BM25 with no embeddings dependency. Originally captured under `stale-duplicate` (the nearest rule at the time) as a documented miss: the `<stale_literal_candidates>` scan only matches quoted string literals, so bare identifiers in prose comments got no deterministic assist. RESOLVED by the `<rename_sweep>` signal (#663) + the `doc-truth` rule (#665): the 2026-07-04 post-merge sweep caught this finding on 3/3 votes, all attributed to `doc-truth` — the fixture was retargeted and relocated accordingly. A second real finding on the same PR (`plugins/claude/hooks/augment-explore-task.sh:64`, [thread](https://github.com/getlien/lien/pull/658#discussion_r3522630331)) is documented in the fixture's `.assertions.ts` but still not asserted — `.sh` has no parser support so it produces zero chunks; #665's guidance-surface passthrough now surfaces its raw hunks, so asserting it is a candidate follow-up once evidence shows it fires reliably. |
 
 Regenerate:
 
 ```bash
 npx tsx packages/review/test/harness/capture-pr.ts 658 \
-  packages/review/test/harness/fixtures/stale-duplicate/pr658-search-code-rename.fixture.json
+  packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.fixture.json
 ```
 
 Run the full multi-model sweep:

--- a/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
@@ -27,9 +27,12 @@
  *   stale claim baked into the same PR's rename and wasn't flagged by
  *   either reviewer). The accurate fix is that NEITHER tool reports as
  *   disabled any more — the disabled-status behavior described here was
- *   fully retired, not partially. This is exactly the shape the
- *   `stale-duplicate` rule exists to catch: a site the diff touched still
- *   asserts something that no longer tracks reality. Corroborating GitHub
+ *   fully retired, not partially. This is exactly the shape the `doc-truth`
+ *   rule (#665) exists to catch: a prose claim the diff touched that no
+ *   longer tracks the code's real behavior. (This fixture was originally
+ *   captured under stale-duplicate — the nearest rule at the time — and
+ *   retargeted after the 2026-07-04 post-merge sweep showed all 3 votes
+ *   catching this finding via doc-truth.) Corroborating GitHub
  *   thread: https://github.com/getlien/lien/pull/658#discussion_r3522630327
  *
  * Finding B (documented, NOT asserted — see below):
@@ -82,31 +85,30 @@
  *
  * Capture command:
  *   npx tsx packages/review/test/harness/capture-pr.ts 658 \
- *     packages/review/test/harness/fixtures/stale-duplicate/pr658-search-code-rename.fixture.json
+ *     packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.fixture.json
  *
- * Calibration status: NOT YET RUN. This fixture was captured and validated
- * structurally (fixture-loader round-trip, build-prompts render) only —
- * no OpenRouter/paid run has been made against it. Given the deterministic
- * `<stale_literal_candidates>` pre-scan (packages/review/src/stale-literal-signals.ts)
- * only extracts QUOTED string literals from diff lines
- * (`extractQuotedValues` requires a quote character), and the offending
- * text here is a bare identifier inside a JSDoc-style block comment with
- * no quotes, the pre-scan will NOT surface this candidate — the agent would
- * have to notice the stale claim through general investigation alone, with
- * no deterministic assist. Expect this to need prompt work (or a pre-scan
- * extension to comment-embedded identifiers) before it reliably clears the
- * 9/10 bar; that calibration is a follow-up, human-approved step, not part
- * of this capture.
+ * Calibration status: post-merge sweep 2026-07-04, after the rename-sweep
+ * signal (#663) and the doc-truth rule + guidance passthrough (#665)
+ * merged: 3/3 votes caught Finding A — every vote attributed it to
+ * `doc-truth` (the original `stale-duplicate` Tier-1 expectation written
+ * before #665 existed failed only on rule attribution, never on detection).
+ * The concern documented at capture time — that the
+ * `<stale_literal_candidates>` pre-scan only extracts QUOTED literals and
+ * would give no deterministic assist for a bare identifier in a JSDoc
+ * comment — was addressed by #663's `<rename_sweep>` signal, which lists
+ * exactly these prose-touched renamed lines. Retargeted to doc-truth
+ * accordingly; kept at votes-based assertion (not yet canary) pending a
+ * dedicated calibrate-10.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
 
 const assertions: FixtureAssertions = {
   description:
-    'PR #658 b24fa33 — schema.ts embeddings.enabled doc comment falsely claims search_code reports as disabled (stale since #657); CodeRabbit caught it, Lien Review did not',
-  rule: 'stale-duplicate',
+    'PR #658 b24fa33 — schema.ts embeddings.enabled doc comment falsely claims search_code reports as disabled (stale since #657); CodeRabbit caught it, Lien Review did not (pre-#663/#665)',
+  rule: 'doc-truth',
   expect: (result, h) => {
-    h.expectRuleFired('stale-duplicate', result);
+    h.expectRuleFired('doc-truth', result);
     h.expectFindingMentions(
       [
         // File / symbol anchors


### PR DESCRIPTION
## What

Closes the loop on the #658 review-miss campaign (#663 + #664 + #665).

The post-merge one-pass sweep (2026-07-04, $1.12, 12/14 fixtures green) showed `stale-duplicate/pr658-search-code-rename` failing 0/3 — but only on **rule attribution**: all three votes caught the schema.ts stale-claim finding and attributed it to `doc-truth`, which didn't exist when the assertion was written. The miss that started the campaign is now detected every vote.

Changes:
- Move the fixture pair to `fixtures/doc-truth/` — the harness scopes `--rule` runs by directory.
- Retarget Tier 1 to `expectRuleFired('doc-truth')`; header prose updated to record the resolution (the capture-time concern about the quoted-literals-only pre-scan was addressed by #663's `<rename_sweep>` signal).
- Narrow the `.gitignore` doc-truth negation to the two hand-authored synthetic fixtures by name, so the regenerable 12MB pr658 fixture stays ignored in its new home.
- Update the README documented-miss table entry; note the `.sh` Finding B is now potentially reachable via #665's guidance passthrough — asserting it is a follow-up pending evidence.

## Harness evidence

Post-retarget validation: `--fixture doc-truth/pr658-search-code-rename --votes 3` against kimi (OpenRouter) — **3/3 passed**, $0.11. Full-sweep context: 12/14 green; one unrelated flaky (`error-swallowing/scanall-null-guard-fp` 2/3). Not yet promoted to canary — a dedicated calibrate-10 can do that as a follow-up.

## Testing

format ✓ · lint 0 errors ✓ · typecheck ✓ · review suite 29/29 files ✓

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a test-harness cleanup: it relocates the PR #658 calibration fixture from `stale-duplicate/` to `doc-truth/`, retargets its Tier-1 assertion to the new `doc-truth` rule, narrows `.gitignore` negations to the two small hand-authored synthetic fixtures, and updates the README documented-miss table. No production code or public API is changed. The remaining `stale-duplicate` references in the codebase are the still-existing rule definition, unrelated fixtures, and intentional historical commentary in the retargeted fixture — none are stale duplicates that should track the changed site.
>
> - Retargeted PR #658 fixture assertions from `stale-duplicate` to `doc-truth`
> - Moved fixture metadata to `fixtures/doc-truth/` and scoped `.gitignore` negations to the two synthetic fixtures by name
> - Updated README documented-miss table to reflect resolution via `<rename_sweep>` + `doc-truth`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6362033. Updates automatically on new commits.</sup>
<!-- /lien-stats -->