### PR TITLE
feat(core): worktree-aware indexing (shared base + per-worktree overlay)

### DIFF
--- a/.changeset/worktree-aware-indexing.md
+++ b/.changeset/worktree-aware-indexing.md
@@ -1,0 +1,14 @@
+---
+'@liendev/core': minor
+'@liendev/lien': minor
+---
+
+Add worktree-aware indexing: when Lien's root is a linked git worktree, it now shares the main checkout's index as a read-only base and stores only a small per-worktree overlay, instead of building a full independent index per worktree.
+
+- **Detection** is state-based: a root is a linked worktree when `git rev-parse --git-dir` differs from `--git-common-dir`; the main checkout is located via `git worktree list --porcelain`.
+- **Reads** union the writable overlay with the read-only base, suppressing base rows for files the worktree changed or deleted (a per-overlay mask). The base is opened `{ readonly: true }` and is never written by a worktree process.
+- **The overlay** holds full chunk rows only for files whose current content differs from what the base indexed (diff via the parser content-hash vs the base manifest), plus new files. It is rebuilt automatically when the base is reindexed.
+- **Fallbacks never error**: if the main checkout has no index, its index format is incompatible, or the base is otherwise unavailable, Lien uses a standalone index as before. Set `LIEN_WORKTREE_STANDALONE=1` to force standalone behavior.
+- **FTS caveat**: BM25 scores from the base and overlay corpora are merged approximately (documented as a v1 limitation).
+
+This eliminates the N× index duplication that produced a 21 GB index pile across ~30 agent worktrees of one repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,11 @@ packages/core/src/          # Structural store, config, git — depends on parse
 ├── vectordb/    # Storage backend behind VectorDBInterface + createVectorDB factory;
 │   └── sqlite/  #   SqliteBackend — SQLite structural store + FTS5/BM25 lexical search
 │                #   (LanceDB + embeddings removed — see ADR-0011)
+│                #   OverlayBackend shares a linked worktree's index with its main
+│                #   checkout (read-only base + writable overlay) — see
+│                #   docs/architecture/worktree-aware-indexing.md
 ├── config/      # Config management & migration (GlobalConfig + per-project ConfigService)
-├── git/         # Git state tracking
+├── git/         # Git state tracking, linked-worktree detection (git/worktree.ts)
 └── insights/    # ComplexityAnalyzer + formatters (text/JSON/SARIF)
 
 packages/cli/src/           # CLI + MCP server — depends on core and parser

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ That single `uses:` line is the whole integration — Lien self-clones the PR by
 
 **👉 [Lien Review guide](https://lien.dev/guide/lien-review)** · [Action reference](./packages/action/README.md)
 
+## Git Worktrees
+
+A linked git worktree (`git worktree add`) automatically shares the main
+checkout's index instead of building a full independent copy — a read-only
+base plus a small per-worktree overlay for whatever's actually changed. No
+setup required; set `LIEN_WORKTREE_STANDALONE=1` to opt out and get a fully
+independent index for that worktree.
+
+**👉 [How it works](https://lien.dev/how-it-works#git-worktree-support)**
+
 ## Documentation
 
 - **[Installation](https://lien.dev/guide/installation)** - npm, npx, or local setup

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -297,11 +297,23 @@ diverged files — e.g. this exact worktree, which had been used standalone
 during Phase 1 development — kept that high-water-mark file size forever even
 after shrinking back down to a handful of live rows. On the real repo this
 made the "small" overlay 11 MB, nearly the size of the 11.5 MB base, defeating
-the feature's point. Fixed by mirroring `SqliteBackend.clear()`'s existing
-pattern (close the handle, delete the db + WAL/SHM files, reopen fresh)
-instead of an in-place `DELETE`; confirmed the same worktree's overlay dropped
-to 1.0 MB after the fix. See `packages/core/src/vectordb/overlay-backend.ts`
-and its new disk-space regression test.
+the feature's point.
+
+The first fix attempt mirrored `SqliteBackend.clear()`'s existing pattern
+(close the handle, delete the db + WAL/SHM files, reopen fresh), which did
+shrink the file (11 MB → 1.0 MB) but turned out to be unsafe: it swaps the
+overlay file's identity out from under any other process that has it open, and
+a 20–30-way concurrent `lien index` stress test on one worktree reproduced
+real `disk I/O error` / "Failed to initialize overlay database" failures in
+roughly half the runs. The same stress test against the original DELETE-only
+code, and against `SqliteBackend`'s own close+delete+recreate path on a
+*standalone* index, produced zero failures — so the hazard is specific to
+swapping the overlay's file identity while multiple processes hold it open
+concurrently. The shipped fix instead does `DELETE` + `VACUUM` + a WAL
+checkpoint: same file identity throughout, same disk-space reclamation
+(confirmed 1.1 MB on the real repo), and zero failures across repeated 20- and
+30-way concurrent runs. See `packages/core/src/vectordb/overlay-backend.ts`
+and its disk-space regression test.
 
 See PR #667's "Verification findings" section for the full scenario matrix,
 including one documented-but-not-fixed edge case (transient state mixing when

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -170,18 +170,33 @@ The base manifest is read-only input for the diff.
 
 ## Incremental / watcher updates (overlay only)
 
-The watcher and `indexMultipleFiles` call `updateFile` / `deleteByFile` on the
-`OverlayBackend`, which **reconciles the mask against base** so the union stays
-correct without the caller knowing about base:
+The watcher and `indexMultipleFiles` write to the `OverlayBackend`, which
+**reconciles the mask against base** so the union stays correct without the
+caller knowing about the base.
 
-- `updateFile(file, …)`: if `file` exists in the base manifest, re-hash the
-  current worktree file; if it now **equals** base → drop overlay rows +
-  un-mask (the edit was reverted to base state); else → mask + write overlay
-  rows. If `file` is not in base → just write overlay rows (added file).
-- `deleteByFile(file)`: drop overlay rows; if `file` ∈ base manifest → mask it
-  (base still has stale rows we must suppress); else → nothing more.
+**Implementation note (deviation from the first-draft reconcile rule):** the
+incremental write path is `deleteByFile(f)` **then** `insertBatch(...)` (see
+`incremental.ts` `handleNonEmptyFile`), not a single `updateFile`. So the mask
+rule hinges on one cheap fact — *is `f` present in the base manifest?* — with no
+per-file re-hashing in the backend:
 
-This makes correctness a property of the backend, not of every call site.
+- `deleteByFile(f)`: drop overlay rows; if `f ∈ base` → mask it. This one rule
+  covers both a real deletion (no insert follows) and the delete-old-chunks step
+  that precedes an incremental `insertBatch` (the file diverged from base, so it
+  must stay masked while its new overlay rows are written).
+- `insertBatch(...)`: write overlay rows only (the preceding `deleteByFile`
+  already set the mask when needed; added files are never in base, so never
+  masked).
+- `updateFile(f, …)` (used by `indexSingleFile`): write overlay rows; mask `f`
+  when `f ∈ base`.
+
+The first draft proposed *un-masking* a file whose content was reverted to
+exactly match base. We drop that: it would require re-hashing every written file
+against base, and the win is only reclaiming a redundant overlay copy. Instead,
+a revert-to-base leaves a correct-but-redundant overlay copy (the union still
+returns the right content because base is masked); the next full overlay
+rebuild — which happens whenever the base is reindexed — reclaims it. Simpler,
+and correctness is a property of the backend, not of every call site.
 
 ## Staleness & revalidation
 

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -217,8 +217,8 @@ and correctness is a property of the backend, not of every call site.
 |---|---|
 | Not a linked worktree | Standalone (unchanged). |
 | `LIEN_WORKTREE_STANDALONE=1` | Standalone (forced). |
-| Main checkout has **no index** | Standalone + one-line hint: run `lien index` in the main checkout to enable shared-base mode. |
-| Base `formatVersion` ≠ current | Standalone + warn once (schema mismatch — can't safely read base rows). |
+| Main checkout has **no index** | Standalone. `serve` emits a one-line hint (run `lien index` in the main checkout to enable shared-base mode); other commands stay silent — `resolveIndexStrategy` is silent by default and callers opt into the hint via `createVectorDB(root, { warn })`. |
+| Base `formatVersion` ≠ current | Standalone + (opt-in) warn once (schema mismatch — can't safely read base rows). |
 | Base db file missing **mid-serve** | Reads degrade: base connection errors are caught and treated as "base returned nothing"; overlay still serves. Next serve start re-resolves and falls back to standalone cleanly. |
 | Main indexed from a **different path string** than git reports (e.g. a symlinked checkout: `/var/...` vs `/private/var/...`) | The base index dir is keyed by `md5(path)` (`extractRepoId`). If the path string the main checkout was indexed under differs from the canonical path `git worktree list` reports, the base-dir hash misses and we fall back to standalone (safe, no error). Normal for repos under a real (non-symlinked) path; a known limitation otherwise, inherited from `extractRepoId`. |
 

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -270,3 +270,40 @@ and correctness is a property of the backend, not of every call site.
 - **Integration**: fixture repo + real `git worktree add`; assert shared-base
   reads (unchanged files resolve from base) and overlay divergence (edited file
   returns worktree content, not base content).
+
+## Verified (2026-07-04)
+
+Independent adversarial verification against the built CLI (`packages/cli/dist/index.js`)
+and MCP over stdio, using scratch `git worktree add` repos plus the real lien
+repo's own worktree/base pair. All scenarios below passed:
+
+- Happy path: modified/added/deleted/unchanged/renamed files each resolve
+  correctly through `get_files_context` over a real MCP stdio round-trip.
+- Churn + revert-to-base: re-diffing after further edits correctly reclassifies
+  a reverted file back to "shared with base" with no stale or duplicate content.
+- Fallbacks: main-has-no-index → standalone + hint; `LIEN_WORKTREE_STANDALONE=1`
+  → forced standalone; base db deleted mid-serve → graceful degrade, no crash.
+- Concurrency: two worktree serves reading while the base was force-reindexed
+  five times in a loop — no `SQLITE_BUSY`, no crashes, correct isolated reads.
+- Real repo: `lien-e96f171e` (base, ~420 files) vs this feature's own
+  development worktree — overlay correctly held only the ~23 files that
+  actually diverged.
+
+**Bug found and fixed**: `OverlayBackend.clear()` used an in-place
+`DELETE FROM chunks` (and mask/meta tables), which leaves freed pages in
+SQLite's freelist instead of shrinking the file. Since `buildOverlay` calls
+`clear()` at the start of every rebuild, an overlay that once held many
+diverged files — e.g. this exact worktree, which had been used standalone
+during Phase 1 development — kept that high-water-mark file size forever even
+after shrinking back down to a handful of live rows. On the real repo this
+made the "small" overlay 11 MB, nearly the size of the 11.5 MB base, defeating
+the feature's point. Fixed by mirroring `SqliteBackend.clear()`'s existing
+pattern (close the handle, delete the db + WAL/SHM files, reopen fresh)
+instead of an in-place `DELETE`; confirmed the same worktree's overlay dropped
+to 1.0 MB after the fix. See `packages/core/src/vectordb/overlay-backend.ts`
+and its new disk-space regression test.
+
+See PR #667's "Verification findings" section for the full scenario matrix,
+including one documented-but-not-fixed edge case (transient state mixing when
+toggling the `LIEN_WORKTREE_STANDALONE=1` escape hatch on and off for the same
+worktree, which self-heals on the next normal-mode `lien index`/`lien serve`).

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -1,0 +1,256 @@
+# Worktree-Aware Indexing
+
+Status: In development (`feat/worktree-aware-indexing`)
+Package impact: `@liendev/core` (new backend + build), `@liendev/lien` (wiring)
+
+## Problem
+
+Today, every project root gets its own fully independent index at
+`~/.lien/indices/<repoId>` where `repoId = <basename>-<md5(path).slice(8)>`
+(`packages/parser/src/utils/repo-id.ts`). A linked git worktree has a distinct
+absolute path, so it hashes to a distinct `repoId` and gets a **complete,
+independent copy** of the index.
+
+Claude Code agent worktrees make this pathological: ~30 worktrees of one repo
+produced a **21 GB** pile of near-identical indexes (the incident that motivated
+[PR #651](https://github.com/getlien/lien/pull/651), which blunt-excluded
+`.claude/worktrees/**` from being indexed *as a subtree of main*). That exclude
+does not help when Lien's root **is** a worktree — the case this feature covers.
+
+The insight: a worktree differs from its main checkout by only a handful of
+files. We should index those, and **share** everything else.
+
+## Solution overview
+
+When Lien's root is a **linked git worktree**, share the main checkout's index
+as a **read-only base** and store only a small per-worktree **overlay**:
+
+```
+~/.lien/indices/<main-repoId>/structural.db      ← BASE  (read-only, owned by main)
+~/.lien/indices/<worktree-repoId>/structural.db  ← OVERLAY (rows for diverged files)
+~/.lien/indices/<worktree-repoId>/overlay.db     ← (see "One overlay DB" below)
+```
+
+Reads = overlay rows **UNION** base rows whose file is **not masked**. Writes
+(index/watcher) touch the overlay only. The base is never written by a worktree
+process.
+
+### Detection
+
+A root is a linked worktree iff:
+
+```
+git rev-parse --git-dir  !=  git rev-parse --git-common-dir
+```
+
+(verified: in a linked worktree `--git-dir` is `<main>/.git/worktrees/<name>`
+while `--git-common-dir` is `<main>/.git`; in the main checkout they're equal).
+
+The **main checkout root** is taken from the first `worktree <path>` line of
+`git worktree list --porcelain` — this is authoritative and also correct for
+bare-repo topologies (where deriving `dirname(commonDir)` would be wrong). We
+additionally require that the resolved main root is **not** the current root and
+that it **has an index** (`structural.db` exists). If either fails we fall back
+to standalone.
+
+### Escape hatch
+
+`LIEN_WORKTREE_STANDALONE=1` forces today's standalone behavior (a full,
+independent index for the worktree). Chosen as an env var (not a config key) for
+KISS and to match existing `LIEN_HOME` / `LIEN_FORCE_INDEX` conventions. No
+config-schema change.
+
+## Storage & schema
+
+The overlay reuses the **exact `chunks` + `chunks_fts` schema** from
+`packages/core/src/vectordb/sqlite/schema.ts` (full chunk rows, same columns,
+same external-content FTS5, same `porter unicode61` tokenizer). Diverged and
+added files are chunked and inserted exactly as a standalone index would store
+them — so all existing row-mapping / FTS / filter code works unchanged on the
+overlay side.
+
+Two small extra tables live in the overlay's index directory:
+
+```sql
+-- Paths (relative, forward-slash) of BASE files suppressed from base reads.
+-- Populated for files that are modified-in-worktree (also present in overlay)
+-- and deleted-in-worktree (absent from overlay).
+CREATE TABLE IF NOT EXISTS overlay_mask (
+  file TEXT PRIMARY KEY
+);
+
+-- Single-row metadata: which base build this overlay was diffed against.
+CREATE TABLE IF NOT EXISTS overlay_meta (
+  k TEXT PRIMARY KEY,
+  v TEXT
+);
+-- keys: baseIndexDir, baseStamp (base's .lien-index-version value at build time),
+--       baseFormatVersion
+```
+
+### One overlay DB vs a separate `overlay.db`
+
+**Decision:** the mask/meta tables live in the **same** SQLite file as the
+overlay `chunks` table (`structural.db` inside the worktree's index dir). One
+file, one connection, one WAL. A separate `overlay.db` would buy nothing and
+add a second handle. The two extra tables are inert in a standalone index, so
+sharing the file is safe.
+
+## Deviation from the brief: two connections, not `ATTACH`
+
+The brief specified ATTACHing the base read-only. **We use two independent
+better-sqlite3 connections instead** and merge in application code:
+
+- **Base**: opened with `{ readonly: true, fileMustExist: true }`. This is the
+  only way to *guarantee* the worktree process cannot mutate the base — SQLite's
+  `ATTACH` has no per-database read-only flag, so an attached base would inherit
+  the overlay connection's read-write mode, violating "NEVER written by the
+  worktree process" and endangering a concurrent `main` serve.
+- **Overlay**: opened read-write via the normal `openDatabase()`.
+
+`ATTACH` also would not have simplified FTS: `bm25()` ranks from two separate
+external-content FTS5 tables are computed per-corpus and cannot be fused into a
+single ranked SQL query anyway — the merge has to happen in application code
+regardless. Two connections make that explicit and keep the base immutable.
+
+**Performance:** today's standalone `scanAll` already reads *all* rows into JS
+(`SELECT * FROM chunks`). The overlay's base read is no worse; the overlay side
+is tiny; masking is a `Set` membership test. So read cost stays at parity with
+standalone.
+
+## Read paths (union + mask)
+
+`OverlayBackend implements VectorDBInterface`. For every read it queries the
+overlay and the base, drops base results whose `file` is in the mask, and merges:
+
+| Method | Strategy |
+|---|---|
+| `scanAll` / `scanWithFilter` / `querySymbols` / `scanPaginated` | overlay rows ∪ (base rows where `file ∉ mask`); existing filters/limits applied to the merged set |
+| `search` (FTS/BM25) | run `keywordSearch` on each connection independently, mask base hits, merge, re-sort by `score` ascending, trim to `limit` |
+
+Because the overlay contains exactly the diverged/added files and those files
+are exactly what's masked from base, a file is served from **one** side only —
+no duplication:
+
+| File state in worktree | In overlay? | Masked from base? | Served from |
+|---|---|---|---|
+| unchanged | no | no | base |
+| modified | yes | yes | overlay |
+| added (new) | yes | no (not in base) | overlay |
+| deleted | no | yes | (nothing) |
+| renamed | new path: yes | old path: yes | overlay (new), suppressed (old) |
+
+### FTS caveat (v1)
+
+BM25 scores are corpus-relative. Merging ranked hits from two corpora
+(base + overlay) yields an approximate global ordering, not a true one. This is
+accepted for v1 and documented here; in practice the overlay is small and top
+hits are dominated by exact-symbol boosting, which is corpus-independent.
+
+## Overlay build (hash-diff scan)
+
+State-based, **not** git-history-based (robust to divergence, rebases, dirty
+trees). Given `worktreeRoot`, the base index dir, and the overlay backend:
+
+1. Load the **base manifest** (`<baseIndexDir>/manifest.json`) → map
+   `relPath → contentHash`. (The manifest is the source of base per-file
+   hashes; the `chunks` table does not store hashes.)
+2. Scan the worktree (`scanFilesToIndex(worktreeRoot)`) → current relative paths.
+3. For each current file, compute `computeContentHash` and compare to base:
+   - **not in base** → *added* → chunk + insert into overlay (no mask).
+   - **in base, hash differs** → *modified* → mask + chunk + insert into overlay.
+   - **in base, hash equal** → *unchanged* → skip (served from base).
+4. **deleted** = base-manifest paths ∉ current set → mask (no overlay rows).
+5. Stamp `overlay_meta`: `baseIndexDir`, `baseStamp` (base's
+   `.lien-index-version`), `baseFormatVersion`.
+
+The overlay keeps its **own** manifest (in the worktree index dir) tracking only
+the files it indexed — this drives the overlay's own incremental/watcher path.
+The base manifest is read-only input for the diff.
+
+## Incremental / watcher updates (overlay only)
+
+The watcher and `indexMultipleFiles` call `updateFile` / `deleteByFile` on the
+`OverlayBackend`, which **reconciles the mask against base** so the union stays
+correct without the caller knowing about base:
+
+- `updateFile(file, …)`: if `file` exists in the base manifest, re-hash the
+  current worktree file; if it now **equals** base → drop overlay rows +
+  un-mask (the edit was reverted to base state); else → mask + write overlay
+  rows. If `file` is not in base → just write overlay rows (added file).
+- `deleteByFile(file)`: drop overlay rows; if `file` ∈ base manifest → mask it
+  (base still has stale rows we must suppress); else → nothing more.
+
+This makes correctness a property of the backend, not of every call site.
+
+## Staleness & revalidation
+
+- **Overlay stamped with base's version.** On serve start (overlay mode) compare
+  the base's current `.lien-index-version` to `overlay_meta.baseStamp`.
+  - unchanged → overlay is valid; rely on the overlay's own incremental for
+    worktree-local edits since last run.
+  - **moved** (main was reindexed) → the base hashes the overlay was diffed
+    against changed → **rebuild the overlay** (clear overlay rows + mask, re-run
+    the hash-diff scan). This is bounded by the worktree file count (hashing) +
+    chunking only the still-diverged files — cheap.
+- **Base staleness is out of scope.** Keeping the base fresh is main's own
+  serve/watcher responsibility.
+
+## Fallbacks (never error)
+
+| Condition | Behavior |
+|---|---|
+| Not a linked worktree | Standalone (unchanged). |
+| `LIEN_WORKTREE_STANDALONE=1` | Standalone (forced). |
+| Main checkout has **no index** | Standalone + one-line hint: run `lien index` in the main checkout to enable shared-base mode. |
+| Base `formatVersion` ≠ current | Standalone + warn once (schema mismatch — can't safely read base rows). |
+| Base db file missing **mid-serve** | Reads degrade: base connection errors are caught and treated as "base returned nothing"; overlay still serves. Next serve start re-resolves and falls back to standalone cleanly. |
+
+## Edge cases
+
+- **File added / deleted / renamed in worktree** — covered by the build table
+  and the reconcile rules above.
+- **Overlay invalidation on base reindex** — base-stamp compare on serve start
+  triggers a rebuild.
+- **Base db file missing mid-serve** — graceful degrade; base read errors are
+  swallowed to `[]`. Full re-resolution on next start.
+- **Two worktree serves reading the same base concurrently** — both open the
+  base `{ readonly: true }`; WAL mode + `busy_timeout` already configured in
+  `openDatabase`; read-only handles don't contend for the write lock. Safe.
+- **Base opened while main is mid-write** — WAL readers see the last committed
+  snapshot; no torn reads.
+
+## Wiring
+
+- `createVectorDB(projectRoot)` (`vectordb/factory.ts`) is the seam: it resolves
+  worktree mode and returns an `OverlayBackend` (composing base reader +
+  overlay `SqliteBackend`) or a plain `SqliteBackend`. All read call sites become
+  overlay-aware for free.
+- `VectorDBInterface.dbPath` for an overlay is the **worktree** index dir, so
+  `ManifestManager` and `GitStateTracker` operate on the worktree's own state.
+- `hasData()` returns true if base **or** overlay has data — so the serve
+  auto-index gate does not full-index a worktree.
+- Because `hasData()` is true in overlay mode, the serve/index path must
+  **explicitly** build/refresh the overlay. `indexCodebase` detects overlay mode
+  (typed discriminator on the backend) and routes to the overlay build instead
+  of `performFullIndex`; the MCP server's auto-index step triggers an overlay
+  refresh regardless of `hasData()`.
+
+## Non-goals (YAGNI)
+
+- No cross-worktree dedup beyond base+overlay (no global content-addressed store).
+- No writing to / refreshing the base from a worktree.
+- No merging BM25 corpora into a single statistically-correct ranking.
+
+## Test plan
+
+- **Detection + path resolution** (unit): linked-worktree vs main vs non-git;
+  escape hatch; main-has-no-index fallback; bare-repo fallback.
+- **Overlay build** (unit): added / modified / unchanged / deleted classification
+  → correct overlay rows + mask; base stamp recorded.
+- **Read union** (unit): mask correctness (modified file served from overlay not
+  base; deleted file served from neither; unchanged from base); FTS merge.
+- **Reconcile** (unit): edit→diverge→mask, revert→un-mask, delete→mask.
+- **Integration**: fixture repo + real `git worktree add`; assert shared-base
+  reads (unchanged files resolve from base) and overlay divergence (edited file
+  returns worktree content, not base content).

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -220,6 +220,7 @@ and correctness is a property of the backend, not of every call site.
 | Main checkout has **no index** | Standalone + one-line hint: run `lien index` in the main checkout to enable shared-base mode. |
 | Base `formatVersion` ≠ current | Standalone + warn once (schema mismatch — can't safely read base rows). |
 | Base db file missing **mid-serve** | Reads degrade: base connection errors are caught and treated as "base returned nothing"; overlay still serves. Next serve start re-resolves and falls back to standalone cleanly. |
+| Main indexed from a **different path string** than git reports (e.g. a symlinked checkout: `/var/...` vs `/private/var/...`) | The base index dir is keyed by `md5(path)` (`extractRepoId`). If the path string the main checkout was indexed under differs from the canonical path `git worktree list` reports, the base-dir hash misses and we fall back to standalone (safe, no error). Normal for repos under a real (non-symlinked) path; a known limitation otherwise, inherited from `extractRepoId`. |
 
 ## Edge cases
 

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -162,7 +162,9 @@ describe('startMCPServer', () => {
   it('should initialize the vector database (structural store, no embeddings)', async () => {
     await startMCPServer({ rootDir: '/test/project' });
 
-    expect(createVectorDB).toHaveBeenCalledWith('/test/project');
+    expect(createVectorDB).toHaveBeenCalledWith('/test/project', {
+      warn: expect.any(Function),
+    });
     expect(mockVectorDB.initialize).toHaveBeenCalledOnce();
   });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -89,8 +89,11 @@ async function handleAutoIndexing(
   rootDir: string,
   log: LogFn,
 ): Promise<void> {
+  // Overlay mode: hasData() is true whenever the shared base has data, so the
+  // usual gate would never (re)build the overlay. Always refresh it in the
+  // background — buildOverlay is cheap when the worktree matches main.
   const hasIndex = await vectorDB.hasData();
-  if (hasIndex) return;
+  if (hasIndex && !vectorDB.isOverlay) return;
 
   const forceIndex = process.env.LIEN_FORCE_INDEX === '1';
   if (!forceIndex && !(await isInsideGitWorkTree(rootDir))) {
@@ -102,7 +105,11 @@ async function handleAutoIndexing(
     return;
   }
 
-  log('📦 No index found - running initial indexing in the background...');
+  if (vectorDB.isOverlay) {
+    log('📦 Linked worktree - refreshing the overlay against the shared base index...');
+  } else {
+    log('📦 No index found - running initial indexing in the background...');
+  }
   log('⏱️  Server is ready; tools will return empty results until indexing completes.');
 
   const { indexCodebase } = await import('@liendev/core');

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -43,7 +43,7 @@ async function initializeDatabase(
 }> {
   // Create the structural store using global config (auto-detects backend and orgId)
   log('Creating structural store...');
-  const vectorDB = await createVectorDB(rootDir);
+  const vectorDB = await createVectorDB(rootDir, { warn: message => log(message, 'warning') });
 
   // Verify we got a valid instance
   if (!vectorDB) {

--- a/packages/core/src/git/worktree.test.ts
+++ b/packages/core/src/git/worktree.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { detectLinkedWorktree } from './worktree.js';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd });
+}
+
+describe('detectLinkedWorktree', () => {
+  let mainRoot: string;
+  let worktreeRoot: string;
+
+  beforeEach(async () => {
+    mainRoot = await createTestDir();
+    await git(mainRoot, 'init', '-q', '-b', 'main');
+    await git(mainRoot, 'config', 'user.email', 'test@lien.dev');
+    await git(mainRoot, 'config', 'user.name', 'Lien Test');
+    await git(mainRoot, 'config', 'commit.gpgsign', 'false');
+    await fs.writeFile(path.join(mainRoot, 'a.txt'), 'hello\n');
+    await git(mainRoot, 'add', '.');
+    await git(mainRoot, 'commit', '-q', '-m', 'init');
+
+    worktreeRoot = path.join(mainRoot, '..', `wt-${Date.now()}`);
+    await git(mainRoot, 'worktree', 'add', '-q', worktreeRoot, '-b', 'feature');
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(mainRoot);
+    await cleanupTestDir(worktreeRoot);
+  });
+
+  it('flags a linked worktree and resolves the main checkout', async () => {
+    const info = await detectLinkedWorktree(worktreeRoot);
+    expect(info.isLinkedWorktree).toBe(true);
+    // git may canonicalize (e.g. /var -> /private/var); compare by realpath.
+    const resolvedMain = await fs.realpath(info.mainRoot!);
+    expect(resolvedMain).toBe(await fs.realpath(mainRoot));
+  });
+
+  it('does NOT flag the main checkout as a linked worktree', async () => {
+    const info = await detectLinkedWorktree(mainRoot);
+    expect(info.isLinkedWorktree).toBe(false);
+    expect(info.mainRoot).toBeNull();
+  });
+
+  it('returns standalone for a non-git directory', async () => {
+    const plain = await createTestDir();
+    try {
+      const info = await detectLinkedWorktree(plain);
+      expect(info.isLinkedWorktree).toBe(false);
+      expect(info.mainRoot).toBeNull();
+    } finally {
+      await cleanupTestDir(plain);
+    }
+  });
+});

--- a/packages/core/src/git/worktree.ts
+++ b/packages/core/src/git/worktree.ts
@@ -1,0 +1,68 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Result of probing whether a directory is a linked git worktree. */
+export interface WorktreeInfo {
+  /** True when `rootDir` is a linked worktree (its git-dir differs from the
+   *  shared git-common-dir). False for the main checkout or a non-git dir. */
+  isLinkedWorktree: boolean;
+  /** Absolute path of the main checkout's working tree, or null when unknown
+   *  (not a linked worktree, or a bare-repo topology with no main working tree). */
+  mainRoot: string | null;
+}
+
+/**
+ * Detect whether `rootDir` is a *linked* git worktree and, if so, locate the
+ * main checkout.
+ *
+ * Detection rule (verified against `git worktree`): a linked worktree's
+ * `--git-dir` (`<main>/.git/worktrees/<name>`) differs from its
+ * `--git-common-dir` (`<main>/.git`); in the main checkout the two are equal.
+ *
+ * The main working-tree path is read from the first `worktree <path>` line of
+ * `git worktree list --porcelain` — authoritative, and correct for bare-repo
+ * topologies (where deriving it from the common dir would be wrong).
+ *
+ * Never throws: any git failure (not installed, not a repo) resolves to
+ * `{ isLinkedWorktree: false, mainRoot: null }` so callers fall back to
+ * standalone behavior.
+ */
+export async function detectLinkedWorktree(rootDir: string): Promise<WorktreeInfo> {
+  const standalone: WorktreeInfo = { isLinkedWorktree: false, mainRoot: null };
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-dir', '--git-common-dir'],
+      { cwd: rootDir, timeout: 5000 },
+    );
+    const [gitDir, commonDir] = stdout.trim().split('\n');
+    if (!gitDir || !commonDir || gitDir === commonDir) {
+      return standalone;
+    }
+
+    const mainRoot = await findMainWorktreeRoot(rootDir);
+    return { isLinkedWorktree: true, mainRoot };
+  } catch {
+    return standalone;
+  }
+}
+
+/**
+ * Return the main checkout's working-tree path — the first entry of
+ * `git worktree list --porcelain`. Returns null on any failure.
+ */
+async function findMainWorktreeRoot(rootDir: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: rootDir,
+      timeout: 5000,
+    });
+    const firstLine = stdout.split('\n').find(line => line.startsWith('worktree '));
+    if (!firstLine) return null;
+    return firstLine.slice('worktree '.length).trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,8 @@
 
 export { indexCodebase } from './indexer/index.js';
 export type { IndexingOptions, IndexingProgress, IndexingResult } from './indexer/index.js';
+export { buildOverlay } from './indexer/overlay-index.js';
+export type { OverlayBuildResult } from './indexer/overlay-index.js';
 export { ManifestManager } from './indexer/manifest.js';
 export type { IndexManifest, FileEntry } from './indexer/manifest.js';
 export {
@@ -64,6 +66,9 @@ export {
 // =============================================================================
 
 export { createVectorDB } from './vectordb/factory.js';
+export { OverlayBackend } from './vectordb/overlay-backend.js';
+export { resolveIndexStrategy } from './vectordb/overlay-resolution.js';
+export type { IndexStrategy } from './vectordb/overlay-resolution.js';
 export type { VectorDBInterface, SearchResult } from './vectordb/types.js';
 export { SYMBOL_TYPE_MATCHES } from './vectordb/types.js';
 export type { RelevanceCategory } from './vectordb/relevance.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,6 +120,9 @@ export {
 export { GitStateTracker } from './git/tracker.js';
 export type { GitState } from './git/tracker.js';
 
+export { detectLinkedWorktree } from './git/worktree.js';
+export type { WorktreeInfo } from './git/worktree.js';
+
 // =============================================================================
 // FRAMEWORK DETECTION (DEPRECATED - replaced by ecosystem presets)
 // =============================================================================

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -23,7 +23,9 @@ import { detectChanges } from './change-detector.js';
 import type { ChangeDetectionResult } from './change-detector.js';
 import { indexMultipleFiles, normalizeToRelativePath } from './incremental.js';
 import { ChunkBatchProcessor } from './chunk-batch-processor.js';
+import { buildOverlay } from './overlay-index.js';
 import type { VectorDBInterface } from '../vectordb/types.js';
+import type { OverlayBackend } from '../vectordb/overlay-backend.js';
 import {
   extractRepoId,
   scanCodebase,
@@ -449,6 +451,45 @@ async function batchProcessFiles(
 }
 
 /**
+ * Build/refresh a worktree overlay instead of full-indexing the whole tree.
+ *
+ * buildOverlay is idempotent and cheap (hash every worktree file, chunk only
+ * the files that diverge from the shared base), so it doubles as the refresh
+ * path — no separate incremental branch is needed here. The watcher keeps the
+ * overlay current within a serve session via `indexMultipleFiles`.
+ */
+async function performOverlayIndex(
+  overlay: OverlayBackend,
+  options: IndexingOptions,
+  startTime: number,
+): Promise<IndexingResult> {
+  options.onProgress?.({
+    phase: 'scanning',
+    message: 'Diffing worktree against the shared base index...',
+  });
+
+  const res = await buildOverlay(overlay, { verbose: options.verbose });
+  const filesIndexed = res.added + res.modified;
+
+  options.onProgress?.({
+    phase: 'complete',
+    message:
+      `Overlay ready: ${res.added} added, ${res.modified} modified, ` +
+      `${res.deleted} deleted, ${res.unchanged} shared with base`,
+    filesTotal: filesIndexed,
+    filesProcessed: filesIndexed,
+  });
+
+  return {
+    success: true,
+    filesIndexed,
+    chunksCreated: 0,
+    durationMs: Date.now() - startTime,
+    incremental: false,
+  };
+}
+
+/**
  * Perform full indexing of the codebase
  */
 async function performFullIndex(
@@ -565,6 +606,12 @@ export async function indexCodebase(options: IndexingOptions = {}): Promise<Inde
     options.onProgress?.({ phase: 'initializing', message: 'Initializing structural store...' });
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
+
+    // Worktree overlay mode: (re)build the small per-worktree overlay against
+    // the shared base instead of full-indexing the whole tree.
+    if (vectorDB.isOverlay) {
+      return await performOverlayIndex(vectorDB as OverlayBackend, options, startTime);
+    }
 
     // Try incremental indexing first (unless forced)
     if (!options.force) {

--- a/packages/core/src/indexer/overlay-index.test.ts
+++ b/packages/core/src/indexer/overlay-index.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+import { indexCodebase } from './index.js';
+import { buildOverlay } from './overlay-index.js';
+import { OverlayBackend } from '../vectordb/overlay-backend.js';
+import { writeVersionFile } from '../vectordb/version.js';
+
+/** Files (relative path -> content) for the base checkout. */
+const BASE_FILES: Record<string, string> = {
+  'a.ts': 'export function alpha() {\n  return 1;\n}\n',
+  'b.ts': 'export function bravo() {\n  return 2;\n}\n',
+  'c.ts': 'export function charlie() {\n  return 3;\n}\n',
+};
+
+async function writeFiles(root: string, files: Record<string, string>): Promise<void> {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+}
+
+/** File set covered by scanAll (union of base + overlay, mask applied). */
+async function filesInIndex(overlay: OverlayBackend): Promise<Set<string>> {
+  const results = await overlay.scanAll();
+  return new Set(results.map(r => r.metadata.file));
+}
+
+describe('buildOverlay', () => {
+  let baseDir: string;
+  let worktreeDir: string;
+  let overlay: OverlayBackend;
+
+  beforeEach(async () => {
+    baseDir = await createTestDir();
+    worktreeDir = await createTestDir();
+    await writeFiles(baseDir, BASE_FILES);
+
+    // Build a real, standalone base index (baseDir is not a worktree).
+    const result = await indexCodebase({ rootDir: baseDir });
+    expect(result.success).toBe(true);
+
+    // Worktree starts as a copy of base, then diverges: modify b, delete c, add d.
+    await writeFiles(worktreeDir, BASE_FILES);
+    await fs.writeFile(
+      path.join(worktreeDir, 'b.ts'),
+      'export function bravo() {\n  return 22222;\n}\n',
+    );
+    await fs.rm(path.join(worktreeDir, 'c.ts'));
+    await fs.writeFile(
+      path.join(worktreeDir, 'd.ts'),
+      'export function delta() {\n  return 4;\n}\n',
+    );
+
+    overlay = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await overlay.initialize();
+  });
+
+  afterEach(async () => {
+    overlay.close();
+    await cleanupTestDir(baseDir);
+    await cleanupTestDir(worktreeDir);
+  });
+
+  it('classifies added / modified / unchanged / deleted correctly', async () => {
+    const res = await buildOverlay(overlay);
+    expect(res).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1 });
+  });
+
+  it('serves unchanged files from base, diverged from overlay, and drops deleted', async () => {
+    await buildOverlay(overlay);
+    const files = await filesInIndex(overlay);
+    expect(files.has('a.ts')).toBe(true); // unchanged -> base
+    expect(files.has('b.ts')).toBe(true); // modified -> overlay
+    expect(files.has('d.ts')).toBe(true); // added -> overlay
+    expect(files.has('c.ts')).toBe(false); // deleted -> masked
+  });
+
+  it('serves the worktree content for a modified file, not the base content', async () => {
+    await buildOverlay(overlay);
+    const results = await overlay.scanWithFilter({ file: 'b.ts' });
+    const joined = results.map(r => r.content).join('\n');
+    expect(joined).toContain('22222');
+    expect(joined).not.toContain('return 2;');
+  });
+
+  it('records the base build stamp; needsRebuild flips when the base moves', async () => {
+    await buildOverlay(overlay);
+    expect(await overlay.needsRebuild()).toBe(false);
+
+    // Simulate a base reindex bumping its version stamp.
+    await new Promise(r => setTimeout(r, 5));
+    await writeVersionFile(getIndexDir(baseDir));
+    expect(await overlay.needsRebuild()).toBe(true);
+  });
+
+  it('needsRebuild is true before the first build', async () => {
+    expect(await overlay.needsRebuild()).toBe(true);
+  });
+
+  it('is idempotent — a rebuild yields the same classification', async () => {
+    await buildOverlay(overlay);
+    const second = await buildOverlay(overlay);
+    expect(second).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1 });
+    const files = await filesInIndex(overlay);
+    expect(files).toEqual(new Set(['a.ts', 'b.ts', 'd.ts']));
+  });
+});

--- a/packages/core/src/indexer/overlay-index.ts
+++ b/packages/core/src/indexer/overlay-index.ts
@@ -1,0 +1,99 @@
+import path from 'path';
+import pLimit from 'p-limit';
+import { computeContentHash } from '@liendev/parser';
+import { DEFAULT_CONCURRENCY } from '../constants.js';
+import type { OverlayBackend } from '../vectordb/overlay-backend.js';
+import { scanFilesToIndex } from './index.js';
+import { indexMultipleFiles, normalizeToRelativePath } from './incremental.js';
+
+/** Per-classification counts from an overlay build. */
+export interface OverlayBuildResult {
+  /** Files present in the worktree but not in the base index. */
+  added: number;
+  /** Files present in both but with different content. */
+  modified: number;
+  /** Files present in the base index but gone from the worktree. */
+  deleted: number;
+  /** Files identical to the base — served from the base, not the overlay. */
+  unchanged: number;
+}
+
+/**
+ * (Re)build a worktree overlay by diffing the worktree's current content
+ * against the base index's per-file content hashes (state-based, not
+ * git-history-based).
+ *
+ * Only files that diverge from the base (added + modified) are chunked into the
+ * overlay; unchanged files are served from the base. Deleted files (in base,
+ * gone from the worktree) are masked. Modified files are masked implicitly by
+ * `OverlayBackend.deleteByFile`, which the incremental write path calls before
+ * inserting the new rows.
+ *
+ * Idempotent: clears the overlay's chunks + mask first, so it doubles as the
+ * staleness-revalidation path when the base has been reindexed.
+ */
+export async function buildOverlay(
+  overlay: OverlayBackend,
+  options: { verbose?: boolean } = {},
+): Promise<OverlayBuildResult> {
+  const rootDir = overlay.worktreeRoot;
+  const baseHashes = overlay.getBaseHashes();
+
+  // Start from a clean slate so a rebuild after a base reindex can't leave stale
+  // overlay rows or mask entries behind.
+  await overlay.clear();
+
+  const files = await scanFilesToIndex(rootDir);
+
+  const currentPaths = new Set<string>();
+  const diverged: string[] = []; // absolute paths to (re)index into the overlay
+  let added = 0;
+  let modified = 0;
+
+  const limit = pLimit(DEFAULT_CONCURRENCY);
+  await Promise.all(
+    files.map(file =>
+      limit(async () => {
+        const rel = normalizeToRelativePath(file, rootDir);
+        const abs = path.isAbsolute(file) ? file : path.join(rootDir, file);
+        currentPaths.add(rel);
+
+        const baseHash = baseHashes.get(rel);
+        if (baseHash === undefined) {
+          added++;
+          diverged.push(abs);
+          return;
+        }
+        const currentHash = await computeContentHash(abs);
+        if (currentHash !== baseHash) {
+          modified++;
+          diverged.push(abs);
+        }
+      }),
+    ),
+  );
+
+  // Deleted: in the base manifest but no longer in the worktree → mask only.
+  let deleted = 0;
+  for (const baseFile of baseHashes.keys()) {
+    if (!currentPaths.has(baseFile)) {
+      overlay.maskBasePath(baseFile);
+      deleted++;
+    }
+  }
+
+  // Chunk + persist the diverged files. indexMultipleFiles calls deleteByFile
+  // (which masks modified files that exist in the base) then insertBatch.
+  if (diverged.length > 0) {
+    await indexMultipleFiles(diverged, overlay, { verbose: options.verbose, rootDir });
+  }
+
+  await overlay.recordBaseBuild();
+
+  return {
+    added,
+    modified,
+    deleted,
+    unchanged: currentPaths.size - added - modified,
+  };
+}

--- a/packages/core/src/vectordb/factory.ts
+++ b/packages/core/src/vectordb/factory.ts
@@ -1,5 +1,7 @@
 import type { VectorDBInterface } from './types.js';
 import { SqliteBackend } from './sqlite/sqlite-backend.js';
+import { OverlayBackend } from './overlay-backend.js';
+import { resolveIndexStrategy } from './overlay-resolution.js';
 import { loadGlobalConfig, ConfigValidationError } from '../config/global-config.js';
 
 /**
@@ -50,7 +52,15 @@ export async function createVectorDB(projectRoot: string): Promise<VectorDBInter
     }
   }
 
-  const db: VectorDBInterface = new SqliteBackend(projectRoot);
+  // Worktree-aware: when projectRoot is a linked git worktree with a usable
+  // main-checkout index, back it with an OverlayBackend (shared read-only base
+  // + small writable overlay) instead of a full independent index. Every
+  // uncertain condition resolves to standalone.
+  const strategy = await resolveIndexStrategy(projectRoot);
+  const db: VectorDBInterface =
+    strategy.mode === 'overlay'
+      ? new OverlayBackend(projectRoot, strategy.baseIndexDir)
+      : new SqliteBackend(projectRoot);
   validateVectorDBInterface(db);
   return db;
 }

--- a/packages/core/src/vectordb/factory.ts
+++ b/packages/core/src/vectordb/factory.ts
@@ -26,9 +26,14 @@ function validateVectorDBInterface(db: VectorDBInterface): void {
  * the one-time warning for retired backend settings.
  *
  * @param projectRoot - Root directory of the project
+ * @param options.warn - Optional sink for worktree-fallback hints (e.g. "main
+ *   checkout has no index"). Silent when omitted; `serve`/`index` pass a logger.
  * @returns VectorDBInterface instance for the configured backend
  */
-export async function createVectorDB(projectRoot: string): Promise<VectorDBInterface> {
+export async function createVectorDB(
+  projectRoot: string,
+  options: { warn?: (message: string) => void } = {},
+): Promise<VectorDBInterface> {
   // Load the global config for its side effects only: surface validation
   // errors early and emit the one-time retired-backend warning. The backend
   // choice itself is fixed — sqlite is the only reachable backend.
@@ -56,7 +61,7 @@ export async function createVectorDB(projectRoot: string): Promise<VectorDBInter
   // main-checkout index, back it with an OverlayBackend (shared read-only base
   // + small writable overlay) instead of a full independent index. Every
   // uncertain condition resolves to standalone.
-  const strategy = await resolveIndexStrategy(projectRoot);
+  const strategy = await resolveIndexStrategy(projectRoot, { warn: options.warn });
   const db: VectorDBInterface =
     strategy.mode === 'overlay'
       ? new OverlayBackend(projectRoot, strategy.baseIndexDir)

--- a/packages/core/src/vectordb/overlay-backend.test.ts
+++ b/packages/core/src/vectordb/overlay-backend.test.ts
@@ -119,6 +119,75 @@ describe('OverlayBackend read union', () => {
   });
 });
 
+describe('OverlayBackend.clear() reclaims disk space', () => {
+  let baseDir: string;
+  let worktreeDir: string;
+  let overlay: OverlayBackend;
+
+  beforeEach(async () => {
+    baseDir = await createTestDir();
+    worktreeDir = await createTestDir();
+    await writeFiles(baseDir, BASE_FILES);
+    const result = await indexCodebase({ rootDir: baseDir });
+    expect(result.success).toBe(true);
+
+    overlay = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await overlay.initialize();
+  });
+
+  afterEach(async () => {
+    overlay.close();
+    await cleanupTestDir(baseDir);
+    await cleanupTestDir(worktreeDir);
+  });
+
+  it('shrinks the overlay db file after clearing a large number of rows', async () => {
+    // A prior standalone index, or a since-shrunk overlay, can leave the
+    // overlay holding many more rows than it currently needs. `clear()` must
+    // physically reclaim that space, not just mark it free in SQLite's
+    // freelist (which leaves the file at its high-water-mark size forever —
+    // exactly the bloat this feature exists to avoid).
+    const bigContent = 'x'.repeat(2000);
+    const metadatas = Array.from({ length: 500 }, (_, i) => ({
+      file: `synthetic-${i}.ts`,
+      startLine: 1,
+      endLine: 1,
+      type: 'block' as const,
+      language: 'typescript',
+    }));
+    const contents = metadatas.map(() => bigContent);
+    await overlay.insertBatch(metadatas, contents);
+
+    // WAL mode: writes may sit in the `-wal` sidecar rather than the main
+    // file until a checkpoint, so measure the pair together.
+    const dbFilePath = path.join(getIndexDir(worktreeDir), 'structural.db');
+    const totalSize = async () => {
+      const sizes = await Promise.all(
+        [dbFilePath, `${dbFilePath}-wal`].map(async f => {
+          try {
+            return (await fs.stat(f)).size;
+          } catch {
+            return 0;
+          }
+        }),
+      );
+      return sizes.reduce((a, b) => a + b, 0);
+    };
+
+    const sizeBeforeClear = await totalSize();
+    expect(sizeBeforeClear).toBeGreaterThan(100_000); // sanity: rows actually landed on disk
+
+    await overlay.clear();
+
+    const sizeAfterClear = await totalSize();
+    expect(sizeAfterClear).toBeLessThan(sizeBeforeClear / 4);
+    // clear() resets the overlay only — base rows (keep.ts, change.ts, gone.ts
+    // were indexed into baseDir in beforeEach) are untouched and still union in.
+    const files = new Set((await overlay.scanAll()).map(r => r.metadata.file));
+    expect([...files].some(f => f.startsWith('synthetic-'))).toBe(false);
+  });
+});
+
 describe('OverlayBackend degrades gracefully when the base is unavailable', () => {
   let bogusBaseDir: string;
   let worktreeDir: string;

--- a/packages/core/src/vectordb/overlay-backend.test.ts
+++ b/packages/core/src/vectordb/overlay-backend.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+import { indexCodebase } from '../indexer/index.js';
+import { buildOverlay } from '../indexer/overlay-index.js';
+import { indexMultipleFiles } from '../indexer/incremental.js';
+import { OverlayBackend } from './overlay-backend.js';
+
+const BASE_FILES: Record<string, string> = {
+  'keep.ts': 'export function keepUnchangedSymbol() {\n  return 1;\n}\n',
+  'change.ts': 'export function changedSymbol() {\n  return 2;\n}\n',
+  'gone.ts': 'export function goneSymbol() {\n  return 3;\n}\n',
+};
+
+async function writeFiles(root: string, files: Record<string, string>): Promise<void> {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+}
+
+async function symbolNames(overlay: OverlayBackend): Promise<Set<string>> {
+  const results = await overlay.querySymbols({ limit: 100 });
+  return new Set(results.map(r => r.metadata.symbolName).filter((s): s is string => !!s));
+}
+
+describe('OverlayBackend read union', () => {
+  let baseDir: string;
+  let worktreeDir: string;
+  let overlay: OverlayBackend;
+
+  beforeEach(async () => {
+    baseDir = await createTestDir();
+    worktreeDir = await createTestDir();
+    await writeFiles(baseDir, BASE_FILES);
+    const result = await indexCodebase({ rootDir: baseDir });
+    expect(result.success).toBe(true);
+
+    // Worktree: keep.ts unchanged, change.ts modified (new symbol), gone.ts
+    // deleted, fresh.ts added.
+    await writeFiles(worktreeDir, BASE_FILES);
+    await fs.writeFile(
+      path.join(worktreeDir, 'change.ts'),
+      'export function changedSymbolV2() {\n  return 222;\n}\n',
+    );
+    await fs.rm(path.join(worktreeDir, 'gone.ts'));
+    await fs.writeFile(
+      path.join(worktreeDir, 'fresh.ts'),
+      'export function freshSymbol() {\n  return 4;\n}\n',
+    );
+
+    overlay = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await overlay.initialize();
+    await buildOverlay(overlay);
+  });
+
+  afterEach(async () => {
+    overlay.close();
+    await cleanupTestDir(baseDir);
+    await cleanupTestDir(worktreeDir);
+  });
+
+  it('querySymbols merges base + overlay and honors the mask', async () => {
+    const names = await symbolNames(overlay);
+    expect(names.has('keepUnchangedSymbol')).toBe(true); // unchanged -> base
+    expect(names.has('changedSymbolV2')).toBe(true); // modified -> overlay
+    expect(names.has('freshSymbol')).toBe(true); // added -> overlay
+    expect(names.has('goneSymbol')).toBe(false); // deleted -> masked
+    expect(names.has('changedSymbol')).toBe(false); // superseded base row masked
+  });
+
+  it('FTS search returns base hits (unchanged) through the union', async () => {
+    const hits = await overlay.search('keepUnchangedSymbol', 10);
+    expect(hits.some(h => h.metadata.file === 'keep.ts')).toBe(true);
+  });
+
+  it('FTS search returns overlay hits (added)', async () => {
+    const hits = await overlay.search('freshSymbol', 10);
+    expect(hits.some(h => h.metadata.file === 'fresh.ts')).toBe(true);
+  });
+
+  it('FTS search suppresses masked base hits (deleted file)', async () => {
+    const hits = await overlay.search('goneSymbol', 10);
+    expect(hits.some(h => h.metadata.file === 'gone.ts')).toBe(false);
+  });
+
+  it('scanPaginated yields the full union (no masked/deleted paths)', async () => {
+    const seen = new Set<string>();
+    for await (const page of overlay.scanPaginated({ pageSize: 1 })) {
+      for (const r of page) seen.add(r.metadata.file);
+    }
+    expect(seen).toEqual(new Set(['keep.ts', 'change.ts', 'fresh.ts']));
+  });
+
+  it('reconciles an incremental edit of a base file: masks base, serves overlay', async () => {
+    // Edit a previously-unchanged base file in the worktree, then run the
+    // incremental write path (deleteByFile + insertBatch).
+    await fs.writeFile(
+      path.join(worktreeDir, 'keep.ts'),
+      'export function keepUnchangedSymbol() {\n  return 99999;\n}\n',
+    );
+    await indexMultipleFiles([path.join(worktreeDir, 'keep.ts')], overlay, {
+      rootDir: worktreeDir,
+    });
+
+    const results = await overlay.scanWithFilter({ file: 'keep.ts' });
+    const joined = results.map(r => r.content).join('\n');
+    expect(joined).toContain('99999'); // overlay content
+    expect(joined).not.toContain('return 1;'); // base row suppressed
+  });
+
+  it('reconciles an incremental delete of a base file: nothing served', async () => {
+    await overlay.deleteByFile('keep.ts');
+    const results = await overlay.scanWithFilter({ file: 'keep.ts' });
+    expect(results).toEqual([]);
+  });
+});
+
+describe('OverlayBackend degrades gracefully when the base is unavailable', () => {
+  let bogusBaseDir: string;
+  let worktreeDir: string;
+  let overlay: OverlayBackend;
+
+  beforeEach(async () => {
+    bogusBaseDir = await createTestDir(); // exists but has no structural.db / manifest
+    worktreeDir = await createTestDir();
+    await writeFiles(worktreeDir, {
+      'only.ts': 'export function onlySymbol() {\n  return 1;\n}\n',
+    });
+    overlay = new OverlayBackend(worktreeDir, getIndexDir(bogusBaseDir));
+    await overlay.initialize();
+  });
+
+  afterEach(async () => {
+    overlay.close();
+    await cleanupTestDir(bogusBaseDir);
+    await cleanupTestDir(worktreeDir);
+  });
+
+  it('initializes and serves overlay-only reads without throwing', async () => {
+    const res = await buildOverlay(overlay);
+    // No base manifest => every worktree file is "added".
+    expect(res.added).toBe(1);
+    const files = new Set((await overlay.scanAll()).map(r => r.metadata.file));
+    expect(files).toEqual(new Set(['only.ts']));
+    // FTS still works against the overlay alone.
+    const hits = await overlay.search('onlySymbol', 10);
+    expect(hits.some(h => h.metadata.file === 'only.ts')).toBe(true);
+  });
+});

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -258,9 +258,27 @@ export class OverlayBackend implements VectorDBInterface {
   }
 
   async clear(): Promise<void> {
-    // Reset the OVERLAY only — never the base.
-    const db = this.requireOverlay();
-    db.exec('DELETE FROM chunks; DELETE FROM overlay_mask; DELETE FROM overlay_meta;');
+    // Reset the OVERLAY only — never the base. Close the handle, remove the
+    // db + WAL/SHM sidecars, then reopen a fresh empty store — mirrors
+    // SqliteBackend.clear(). An in-place `DELETE FROM chunks` leaves the
+    // freed pages in SQLite's freelist rather than shrinking the file, and
+    // buildOverlay calls clear() at the start of every rebuild: an overlay
+    // that once held many diverged files (e.g. a branch that has since been
+    // merged back, or a worktree indexed standalone before this feature
+    // existed) would keep that high-water-mark file size forever even after
+    // shrinking back to a handful of rows — defeating the point of the
+    // overlay staying small.
+    this.requireOverlay();
+    this.overlayDb?.close();
+    this.overlayDb = null;
+    await Promise.all(
+      [
+        this.overlayDbFilePath,
+        `${this.overlayDbFilePath}-wal`,
+        `${this.overlayDbFilePath}-shm`,
+      ].map(f => fs.rm(f, { force: true })),
+    );
+    this.overlayDb = openOverlayDatabase(this.overlayDbFilePath);
   }
 
   async hasData(): Promise<boolean> {

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -1,0 +1,392 @@
+import fs from 'fs/promises';
+import path from 'path';
+import Database from 'better-sqlite3';
+import type DatabaseType from 'better-sqlite3';
+import type { ChunkMetadata } from '@liendev/parser';
+import { getIndexDir } from '@liendev/parser';
+import type { SearchResult, VectorDBInterface } from './types.js';
+import { wrapError } from '../errors/index.js';
+import { readVersionFile, writeVersionFile } from './version.js';
+import {
+  filterByLanguage,
+  filterByPattern,
+  filterBySymbolType,
+  matchesSymbolFilter,
+  buildLegacySymbols,
+} from './filters.js';
+import type { SqliteChunkRecord } from './sqlite/row-mapping.js';
+import { recordToUnscoredResult, buildSearchResultMetadata } from './sqlite/row-mapping.js';
+import {
+  normalizeFileFilter,
+  readAllRecords,
+  readRecordsByFiles,
+  readSymbolRecords,
+  paginateRecords,
+} from './sqlite/read-ops.js';
+import {
+  insertChunks,
+  replaceFileChunks,
+  deleteFileChunks,
+  validateBatchLengths,
+} from './sqlite/write-ops.js';
+import { keywordSearch } from './sqlite/fts-search.js';
+import {
+  openOverlayDatabase,
+  OVERLAY_META,
+  STRUCTURAL_DB_FILENAME,
+} from './sqlite/overlay-schema.js';
+
+const MANIFEST_FILE = 'manifest.json';
+
+/**
+ * Worktree overlay backend: reads = writable overlay UNION read-only base
+ * (minus masked base files); writes touch the overlay only.
+ *
+ * The overlay stores full chunk rows (same schema as a standalone index) for
+ * files that differ from the base checkout, plus a `overlay_mask` table naming
+ * base files to suppress (modified + deleted). The base is opened
+ * `{ readonly: true }` so a worktree process can NEVER mutate the main
+ * checkout's index. See docs/architecture/worktree-aware-indexing.md.
+ *
+ * Mask reconciliation hinges on one fact — is a file present in the base
+ * manifest? — so it needs no re-hashing:
+ *   - `deleteByFile(f)`: drop overlay rows; if `f ∈ base` → mask it. This covers
+ *     both a plain deletion and the "delete old chunks" step that precedes an
+ *     `insertBatch` on the incremental write path.
+ *   - `insertBatch` / `updateFile`: write overlay rows; `updateFile` also masks
+ *     `f` when `f ∈ base`.
+ */
+export class OverlayBackend implements VectorDBInterface {
+  public readonly dbPath: string;
+  public readonly supportsCrossRepo = false;
+  public readonly isOverlay = true;
+  public readonly worktreeRoot: string;
+  public readonly baseIndexDir: string;
+
+  private readonly overlayDbFilePath: string;
+  private readonly baseDbFilePath: string;
+  private overlayDb: DatabaseType.Database | null = null;
+  private baseDb: DatabaseType.Database | null = null;
+  /** Base per-file content hashes (relative path -> hash), loaded from the base
+   *  manifest at initialize; drives mask reconciliation and the build diff. */
+  private baseHashes = new Map<string, string>();
+  private lastVersionCheck = 0;
+  private currentVersion = 0;
+
+  constructor(projectRoot: string, baseIndexDir: string) {
+    this.worktreeRoot = projectRoot;
+    this.baseIndexDir = baseIndexDir;
+    this.dbPath = getIndexDir(projectRoot);
+    this.overlayDbFilePath = path.join(this.dbPath, STRUCTURAL_DB_FILENAME);
+    this.baseDbFilePath = path.join(baseIndexDir, STRUCTURAL_DB_FILENAME);
+  }
+
+  private requireOverlay(): DatabaseType.Database {
+    if (!this.overlayDb) {
+      throw wrapError(new Error('not initialized'), 'Overlay database not initialized');
+    }
+    return this.overlayDb;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      await fs.mkdir(this.dbPath, { recursive: true });
+      this.overlayDb = openOverlayDatabase(this.overlayDbFilePath);
+      this.openBase();
+      this.baseHashes = await this.loadBaseHashes();
+      this.currentVersion = await readVersionFile(this.dbPath);
+    } catch (error: unknown) {
+      throw wrapError(error, 'Failed to initialize overlay database', { dbPath: this.dbPath });
+    }
+  }
+
+  /** Open the base read-only. Failure (missing/locked) is non-fatal: reads then
+   *  serve overlay-only and the next serve start re-resolves to standalone. */
+  private openBase(): void {
+    try {
+      const db = new Database(this.baseDbFilePath, { readonly: true, fileMustExist: true });
+      db.pragma('busy_timeout = 5000');
+      this.baseDb = db;
+    } catch {
+      this.baseDb = null;
+    }
+  }
+
+  private async loadBaseHashes(): Promise<Map<string, string>> {
+    const hashes = new Map<string, string>();
+    try {
+      const raw = await fs.readFile(path.join(this.baseIndexDir, MANIFEST_FILE), 'utf-8');
+      const parsed = JSON.parse(raw) as {
+        files?: Record<string, { contentHash?: string }>;
+      };
+      for (const [filepath, entry] of Object.entries(parsed.files ?? {})) {
+        if (entry.contentHash) hashes.set(filepath, entry.contentHash);
+      }
+    } catch {
+      // No/unreadable base manifest — mask reconciliation degrades to "never
+      // mask" (base rows always visible). Resolution normally prevents this.
+    }
+    return hashes;
+  }
+
+  /** Run a read against the base, swallowing errors to [] (base may vanish
+   *  mid-serve). Returns [] when there is no base connection. */
+  private baseRead<T>(fn: (db: DatabaseType.Database) => T[]): T[] {
+    if (!this.baseDb) return [];
+    try {
+      return fn(this.baseDb);
+    } catch {
+      return [];
+    }
+  }
+
+  private loadMask(): Set<string> {
+    const db = this.requireOverlay();
+    const rows = db.prepare('SELECT file FROM overlay_mask').all() as { file: string }[];
+    return new Set(rows.map(r => r.file));
+  }
+
+  /** Overlay records ∪ (base records not in the mask). */
+  private unionRecords(
+    read: (db: DatabaseType.Database) => SqliteChunkRecord[],
+  ): SqliteChunkRecord[] {
+    const overlayRecords = read(this.requireOverlay());
+    const mask = this.loadMask();
+    const baseRecords = this.baseRead(read).filter(r => !mask.has(r.file));
+    return [...overlayRecords, ...baseRecords];
+  }
+
+  // ── Reads ──────────────────────────────────────────────────────────────
+
+  async search(query: string, limit = 5): Promise<SearchResult[]> {
+    if (!query || query.trim().length === 0) return [];
+    const overlayHits = keywordSearch(this.requireOverlay(), query, limit);
+    const mask = this.loadMask();
+    const baseHits = this.baseRead(db => keywordSearch(db, query, limit)).filter(
+      h => !mask.has(h.metadata.file),
+    );
+    // BM25 ranks are corpus-relative; merging two corpora yields an approximate
+    // global order (documented v1 caveat). score is lower-is-better.
+    return [...overlayHits, ...baseHits].sort((a, b) => a.score - b.score).slice(0, limit);
+  }
+
+  async scanWithFilter(options: {
+    file?: string | string[];
+    language?: string;
+    pattern?: string;
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
+    limit?: number;
+  }): Promise<SearchResult[]> {
+    const { file, language, pattern, symbolType, limit = 100 } = options;
+
+    let records = file
+      ? this.unionRecords(db => readRecordsByFiles(db, normalizeFileFilter(file)))
+      : this.unionRecords(readAllRecords);
+    if (language) records = filterByLanguage(records, language);
+    if (pattern) records = filterByPattern(records, pattern);
+    if (symbolType) records = filterBySymbolType(records, symbolType);
+
+    return records.slice(0, limit).map(recordToUnscoredResult);
+  }
+
+  async scanAll(options: { language?: string; pattern?: string } = {}): Promise<SearchResult[]> {
+    const { language, pattern } = options;
+    if (!language && !pattern) {
+      return this.unionRecords(readAllRecords).map(recordToUnscoredResult);
+    }
+    return this.scanWithFilter({ language, pattern, limit: Number.MAX_SAFE_INTEGER });
+  }
+
+  async querySymbols(options: {
+    language?: string;
+    pattern?: string;
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
+    limit?: number;
+  }): Promise<SearchResult[]> {
+    const { language, pattern, symbolType, limit = 50 } = options;
+    const records = this.unionRecords(readSymbolRecords).filter(r =>
+      matchesSymbolFilter(r, { language, pattern, symbolType }),
+    );
+    return records.slice(0, limit).map(r => ({
+      content: r.content,
+      metadata: { ...buildSearchResultMetadata(r), symbols: buildLegacySymbols(r) },
+      score: 0,
+      relevance: 'not_relevant' as const,
+    }));
+  }
+
+  async *scanPaginated(options: { pageSize?: number } = {}): AsyncGenerator<SearchResult[]> {
+    const pageSize = options.pageSize ?? 1000;
+    // Overlay pages first, then masked base pages — each store paginated
+    // independently so neither is fully materialized in memory.
+    for (const page of paginateRecords(this.requireOverlay(), pageSize)) {
+      yield page.map(recordToUnscoredResult);
+    }
+    if (this.baseDb) {
+      const mask = this.loadMask();
+      for (const page of paginateRecords(this.baseDb, pageSize)) {
+        const kept = page.filter(r => !mask.has(r.file)).map(recordToUnscoredResult);
+        if (kept.length > 0) yield kept;
+      }
+    }
+  }
+
+  // ── Writes (overlay only) ─────────────────────────────────────────────
+
+  async insertBatch(metadatas: ChunkMetadata[], contents: string[]): Promise<void> {
+    validateBatchLengths(metadatas, contents);
+    insertChunks(this.requireOverlay(), metadatas, contents);
+  }
+
+  async updateFile(
+    filepath: string,
+    metadatas: ChunkMetadata[],
+    contents: string[],
+  ): Promise<void> {
+    validateBatchLengths(metadatas, contents);
+    replaceFileChunks(this.requireOverlay(), filepath, metadatas, contents);
+    if (this.baseHashes.has(filepath)) this.maskBasePath(filepath);
+    await writeVersionFile(this.dbPath);
+  }
+
+  async deleteByFile(filepath: string): Promise<void> {
+    deleteFileChunks(this.requireOverlay(), filepath);
+    // Suppress the (still present) base rows for this path. Covers a real
+    // deletion AND the delete-old-chunks step before an incremental insertBatch
+    // (in which case the file diverged from base and must stay masked).
+    if (this.baseHashes.has(filepath)) this.maskBasePath(filepath);
+  }
+
+  async clear(): Promise<void> {
+    // Reset the OVERLAY only — never the base.
+    const db = this.requireOverlay();
+    db.exec('DELETE FROM chunks; DELETE FROM overlay_mask; DELETE FROM overlay_meta;');
+  }
+
+  async hasData(): Promise<boolean> {
+    if (this.overlayHasRows()) return true;
+    return (
+      this.baseRead(db => {
+        const row = db.prepare("SELECT 1 FROM chunks WHERE content != '' LIMIT 1").get();
+        return row !== undefined ? [true] : [];
+      }).length > 0
+    );
+  }
+
+  private overlayHasRows(): boolean {
+    if (!this.overlayDb) return false;
+    try {
+      const row = this.overlayDb.prepare("SELECT 1 FROM chunks WHERE content != '' LIMIT 1").get();
+      return row !== undefined;
+    } catch {
+      return false;
+    }
+  }
+
+  // ── Overlay build support (driven by indexer/overlay-index.ts) ─────────
+
+  /** Base per-file content hashes (relative path -> hash). */
+  getBaseHashes(): ReadonlyMap<string, string> {
+    return this.baseHashes;
+  }
+
+  /** Add a base file path to the suppression mask (idempotent). */
+  maskBasePath(filepath: string): void {
+    this.requireOverlay()
+      .prepare('INSERT OR IGNORE INTO overlay_mask(file) VALUES (?)')
+      .run(filepath);
+  }
+
+  private setMeta(key: string, value: string): void {
+    this.requireOverlay()
+      .prepare(
+        'INSERT INTO overlay_meta(k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v',
+      )
+      .run(key, value);
+  }
+
+  private getMeta(key: string): string | null {
+    const row = this.requireOverlay().prepare('SELECT v FROM overlay_meta WHERE k = ?').get(key) as
+      | { v: string }
+      | undefined;
+    return row ? row.v : null;
+  }
+
+  /** Record which base build this overlay was diffed against + stamp the
+   *  overlay version file. Called at the end of a build. */
+  async recordBaseBuild(): Promise<void> {
+    const stamp = await readVersionFile(this.baseIndexDir);
+    this.setMeta(OVERLAY_META.BASE_INDEX_DIR, this.baseIndexDir);
+    this.setMeta(OVERLAY_META.BASE_STAMP, String(stamp));
+    await writeVersionFile(this.dbPath);
+  }
+
+  /**
+   * True when the overlay must be rebuilt against the base: it was never built,
+   * or the base has been reindexed since (its version stamp moved). Cheap —
+   * two small reads.
+   */
+  async needsRebuild(): Promise<boolean> {
+    const recorded = this.getMeta(OVERLAY_META.BASE_STAMP);
+    if (recorded === null) return true;
+    const currentBaseStamp = await readVersionFile(this.baseIndexDir);
+    return String(currentBaseStamp) !== recorded;
+  }
+
+  // ── Lifecycle / version plumbing (over the overlay dir) ────────────────
+
+  async checkVersion(): Promise<boolean> {
+    const now = Date.now();
+    if (now - this.lastVersionCheck < 1000) return false;
+    this.lastVersionCheck = now;
+    try {
+      const version = await readVersionFile(this.dbPath);
+      if (version > this.currentVersion) {
+        this.currentVersion = version;
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  close(): void {
+    if (this.overlayDb) {
+      this.overlayDb.close();
+      this.overlayDb = null;
+    }
+    if (this.baseDb) {
+      this.baseDb.close();
+      this.baseDb = null;
+    }
+  }
+
+  async reconnect(): Promise<void> {
+    try {
+      this.close();
+      await this.initialize();
+    } catch (error) {
+      throw wrapError(error, 'Failed to reconnect to overlay database');
+    }
+  }
+
+  getCurrentVersion(): number {
+    return this.currentVersion;
+  }
+
+  getVersionDate(): string {
+    if (this.currentVersion === 0) return 'Unknown';
+    return new Date(this.currentVersion).toLocaleString();
+  }
+
+  async scanCrossRepo(_options: {
+    language?: string;
+    pattern?: string;
+    limit?: number;
+    repoIds?: string[];
+    branch?: string;
+  }): Promise<SearchResult[]> {
+    return [];
+  }
+}

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -258,27 +258,25 @@ export class OverlayBackend implements VectorDBInterface {
   }
 
   async clear(): Promise<void> {
-    // Reset the OVERLAY only — never the base. Close the handle, remove the
-    // db + WAL/SHM sidecars, then reopen a fresh empty store — mirrors
-    // SqliteBackend.clear(). An in-place `DELETE FROM chunks` leaves the
-    // freed pages in SQLite's freelist rather than shrinking the file, and
-    // buildOverlay calls clear() at the start of every rebuild: an overlay
-    // that once held many diverged files (e.g. a branch that has since been
-    // merged back, or a worktree indexed standalone before this feature
-    // existed) would keep that high-water-mark file size forever even after
-    // shrinking back to a handful of rows — defeating the point of the
-    // overlay staying small.
-    this.requireOverlay();
-    this.overlayDb?.close();
-    this.overlayDb = null;
-    await Promise.all(
-      [
-        this.overlayDbFilePath,
-        `${this.overlayDbFilePath}-wal`,
-        `${this.overlayDbFilePath}-shm`,
-      ].map(f => fs.rm(f, { force: true })),
-    );
-    this.overlayDb = openOverlayDatabase(this.overlayDbFilePath);
+    // Reset the OVERLAY only — never the base. A plain `DELETE FROM chunks`
+    // leaves the freed pages in SQLite's freelist rather than shrinking the
+    // file, and buildOverlay calls clear() at the start of every rebuild: an
+    // overlay that once held many diverged files (e.g. a worktree previously
+    // indexed standalone, or a branch that has since been merged back) would
+    // keep that high-water-mark file size forever even after shrinking back
+    // to a handful of rows — defeating the point of the overlay staying
+    // small. VACUUM reclaims that space in place.
+    //
+    // Deliberately NOT close+delete+recreate-the-file (as SqliteBackend.clear()
+    // does): that swaps the file's identity out from under any other process
+    // with the same overlay open (e.g. two `lien index` runs racing on one
+    // worktree), which reproduced real `SQLITE_IOERR` failures under
+    // concurrent load in testing. VACUUM + a WAL checkpoint keep the same
+    // file identity throughout and proved safe under the same stress test.
+    const db = this.requireOverlay();
+    db.exec('DELETE FROM chunks; DELETE FROM overlay_mask; DELETE FROM overlay_meta;');
+    db.exec('VACUUM');
+    db.pragma('wal_checkpoint(TRUNCATE)');
   }
 
   async hasData(): Promise<boolean> {

--- a/packages/core/src/vectordb/overlay-integration.test.ts
+++ b/packages/core/src/vectordb/overlay-integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+import { indexCodebase } from '../indexer/index.js';
+import { createVectorDB } from './factory.js';
+import { _resetWarnMemo } from './overlay-resolution.js';
+import type { VectorDBInterface } from './types.js';
+
+const execFileAsync = promisify(execFile);
+const git = (cwd: string, ...args: string[]) => execFileAsync('git', args, { cwd });
+
+/** File set covered by scanAll on a freshly-opened backend. */
+async function unionFiles(db: VectorDBInterface): Promise<Set<string>> {
+  const results = await db.scanAll();
+  return new Set(results.map(r => r.metadata.file));
+}
+
+function close(db: VectorDBInterface): void {
+  (db as unknown as { close?: () => void }).close?.();
+}
+
+/**
+ * Full-chain integration: a real `git worktree add`, driven through the public
+ * factory + indexer (not by constructing OverlayBackend directly).
+ */
+describe('worktree-aware indexing (integration)', () => {
+  let mainRoot: string;
+  let worktreeRoot: string;
+
+  beforeEach(async () => {
+    _resetWarnMemo();
+    delete process.env.LIEN_WORKTREE_STANDALONE;
+
+    // realpath so git's canonical worktree path matches the path main is
+    // indexed under (macOS /var -> /private/var).
+    mainRoot = await fs.realpath(await createTestDir());
+    await git(mainRoot, 'init', '-q', '-b', 'main');
+    await git(mainRoot, 'config', 'user.email', 't@lien.dev');
+    await git(mainRoot, 'config', 'user.name', 'Lien Test');
+    await git(mainRoot, 'config', 'commit.gpgsign', 'false');
+    await fs.writeFile(
+      path.join(mainRoot, 'shared.ts'),
+      'export function sharedFn() {\n  return 1;\n}\n',
+    );
+    await fs.writeFile(
+      path.join(mainRoot, 'edited.ts'),
+      'export function editedFn() {\n  return 2;\n}\n',
+    );
+    await git(mainRoot, 'add', '.');
+    await git(mainRoot, 'commit', '-q', '-m', 'init');
+
+    // Index the main checkout (standalone).
+    const r = await indexCodebase({ rootDir: mainRoot });
+    expect(r.success).toBe(true);
+
+    // Linked worktree that diverges: edit edited.ts, delete nothing, add added.ts.
+    worktreeRoot = await fs.realpath(
+      await (async () => {
+        const wt = path.join(
+          mainRoot,
+          '..',
+          `wt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        );
+        await git(mainRoot, 'worktree', 'add', '-q', wt, '-b', 'feature');
+        return wt;
+      })(),
+    );
+    await fs.writeFile(
+      path.join(worktreeRoot, 'edited.ts'),
+      'export function editedFnV2() {\n  return 999;\n}\n',
+    );
+    await fs.writeFile(
+      path.join(worktreeRoot, 'added.ts'),
+      'export function addedFn() {\n  return 3;\n}\n',
+    );
+  });
+
+  afterEach(async () => {
+    delete process.env.LIEN_WORKTREE_STANDALONE;
+    await cleanupTestDir(mainRoot);
+    await cleanupTestDir(worktreeRoot);
+  });
+
+  it('the factory backs the worktree with an overlay and the main checkout without one', async () => {
+    const mainDb = await createVectorDB(mainRoot);
+    const wtDb = await createVectorDB(worktreeRoot);
+    expect(mainDb.isOverlay).toBe(false);
+    expect(wtDb.isOverlay).toBe(true);
+    close(mainDb);
+    close(wtDb);
+  });
+
+  it('indexes only diverged files, then reads base ∪ overlay with divergence applied', async () => {
+    const result = await indexCodebase({ rootDir: worktreeRoot });
+    expect(result.success).toBe(true);
+    // edited (modified) + added — shared.ts is served from the base.
+    expect(result.filesIndexed).toBe(2);
+
+    const wtDb = await createVectorDB(worktreeRoot);
+    await wtDb.initialize();
+    const files = await unionFiles(wtDb);
+    expect(files).toEqual(new Set(['shared.ts', 'edited.ts', 'added.ts']));
+
+    const edited = (await wtDb.scanWithFilter({ file: 'edited.ts' })).map(r => r.content).join('');
+    expect(edited).toContain('999'); // worktree content
+    expect(edited).not.toContain('return 2;'); // base row masked
+
+    const shared = (await wtDb.scanWithFilter({ file: 'shared.ts' })).map(r => r.content).join('');
+    expect(shared).toContain('sharedFn'); // served from the shared base
+    close(wtDb);
+  });
+
+  it('honors the LIEN_WORKTREE_STANDALONE escape hatch through the factory', async () => {
+    process.env.LIEN_WORKTREE_STANDALONE = '1';
+    const wtDb = await createVectorDB(worktreeRoot);
+    expect(wtDb.isOverlay).toBe(false);
+    close(wtDb);
+  });
+});

--- a/packages/core/src/vectordb/overlay-resolution.test.ts
+++ b/packages/core/src/vectordb/overlay-resolution.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { getIndexDir } from '@liendev/parser';
+import { INDEX_FORMAT_VERSION } from '../constants.js';
+import { STRUCTURAL_DB_FILENAME } from './sqlite/schema.js';
+import { resolveIndexStrategy, _resetWarnMemo } from './overlay-resolution.js';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd });
+}
+
+/** Seed a base index dir (existence-only content) for the given main root. */
+async function seedBaseIndex(mainRoot: string, formatVersion: number): Promise<string> {
+  const baseIndexDir = getIndexDir(mainRoot);
+  await fs.mkdir(baseIndexDir, { recursive: true });
+  await fs.writeFile(path.join(baseIndexDir, STRUCTURAL_DB_FILENAME), '');
+  await fs.writeFile(
+    path.join(baseIndexDir, 'manifest.json'),
+    JSON.stringify({ formatVersion, files: {} }),
+  );
+  return baseIndexDir;
+}
+
+describe('resolveIndexStrategy', () => {
+  let mainRoot: string;
+  let worktreeRoot: string;
+
+  beforeEach(async () => {
+    _resetWarnMemo();
+    delete process.env.LIEN_WORKTREE_STANDALONE;
+
+    mainRoot = await createTestDir();
+    await git(mainRoot, 'init', '-q', '-b', 'main');
+    await git(mainRoot, 'config', 'user.email', 'test@lien.dev');
+    await git(mainRoot, 'config', 'user.name', 'Lien Test');
+    await git(mainRoot, 'config', 'commit.gpgsign', 'false');
+    await fs.writeFile(path.join(mainRoot, 'a.txt'), 'hello\n');
+    await git(mainRoot, 'add', '.');
+    await git(mainRoot, 'commit', '-q', '-m', 'init');
+
+    worktreeRoot = path.join(
+      mainRoot,
+      '..',
+      `wt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    );
+    await git(mainRoot, 'worktree', 'add', '-q', worktreeRoot, '-b', 'feature');
+
+    // `git worktree list` reports canonical (realpath'd) paths, so align the
+    // test's roots with what resolution derives — otherwise macOS's
+    // /var -> /private/var symlink makes the seeded base index dir (keyed by
+    // path hash) miss the one resolution computes.
+    mainRoot = await fs.realpath(mainRoot);
+    worktreeRoot = await fs.realpath(worktreeRoot);
+  });
+
+  afterEach(async () => {
+    delete process.env.LIEN_WORKTREE_STANDALONE;
+    await cleanupTestDir(mainRoot);
+    await cleanupTestDir(worktreeRoot);
+  });
+
+  it('returns overlay when the worktree has a complete, compatible base index', async () => {
+    const baseIndexDir = await seedBaseIndex(mainRoot, INDEX_FORMAT_VERSION);
+    const strategy = await resolveIndexStrategy(worktreeRoot);
+    expect(strategy.mode).toBe('overlay');
+    if (strategy.mode !== 'overlay') throw new Error('unreachable');
+    expect(strategy.baseIndexDir).toBe(baseIndexDir);
+    expect(strategy.overlayIndexDir).toBe(getIndexDir(worktreeRoot));
+    expect(await fs.realpath(strategy.mainRoot)).toBe(await fs.realpath(mainRoot));
+  });
+
+  it('falls back to standalone when the main checkout has no index (with a hint)', async () => {
+    const warn = vi.fn();
+    const strategy = await resolveIndexStrategy(worktreeRoot, { warn });
+    expect(strategy.mode).toBe('standalone');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/no complete index/i);
+  });
+
+  it('falls back to standalone on base format mismatch (with a warning)', async () => {
+    await seedBaseIndex(mainRoot, INDEX_FORMAT_VERSION - 1);
+    const warn = vi.fn();
+    const strategy = await resolveIndexStrategy(worktreeRoot, { warn });
+    expect(strategy.mode).toBe('standalone');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/incompatible/i);
+  });
+
+  it('honors the LIEN_WORKTREE_STANDALONE escape hatch even with a valid base', async () => {
+    await seedBaseIndex(mainRoot, INDEX_FORMAT_VERSION);
+    process.env.LIEN_WORKTREE_STANDALONE = '1';
+    const strategy = await resolveIndexStrategy(worktreeRoot);
+    expect(strategy.mode).toBe('standalone');
+  });
+
+  it('returns standalone for the main checkout itself', async () => {
+    await seedBaseIndex(mainRoot, INDEX_FORMAT_VERSION);
+    const strategy = await resolveIndexStrategy(mainRoot);
+    expect(strategy.mode).toBe('standalone');
+  });
+
+  it('warns only once per base index dir', async () => {
+    const warn = vi.fn();
+    await resolveIndexStrategy(worktreeRoot, { warn });
+    await resolveIndexStrategy(worktreeRoot, { warn });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/vectordb/overlay-resolution.ts
+++ b/packages/core/src/vectordb/overlay-resolution.ts
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import { INDEX_FORMAT_VERSION } from '../constants.js';
+import { detectLinkedWorktree } from '../git/worktree.js';
+import { STRUCTURAL_DB_FILENAME } from './sqlite/schema.js';
+
+const MANIFEST_FILE = 'manifest.json';
+
+/** How `createVectorDB` should back a given project root. */
+export type IndexStrategy =
+  | { mode: 'standalone' }
+  | {
+      mode: 'overlay';
+      /** Main checkout working-tree path. */
+      mainRoot: string;
+      /** `~/.lien/indices/<main-repoId>` — read-only base. */
+      baseIndexDir: string;
+      /** `~/.lien/indices/<worktree-repoId>` — writable overlay. */
+      overlayIndexDir: string;
+    };
+
+/** Injectable logger so the fallback hints are testable; defaults to stderr. */
+export interface ResolveOptions {
+  warn?: (message: string) => void;
+}
+
+// "warn once" per base index dir, process-wide. Keyed by baseIndexDir so two
+// worktrees of different repos each get their own single warning.
+const warnedKeys = new Set<string>();
+
+function warnOnce(warn: (m: string) => void, key: string, message: string): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  warn(message);
+}
+
+/** @internal reset the once-warned memo (tests only). */
+export function _resetWarnMemo(): void {
+  warnedKeys.clear();
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function realpathSafe(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/** Read the base manifest's formatVersion, or null if unreadable/absent. */
+async function readBaseFormatVersion(baseIndexDir: string): Promise<number | null> {
+  try {
+    const raw = await fs.readFile(path.join(baseIndexDir, MANIFEST_FILE), 'utf-8');
+    const parsed = JSON.parse(raw) as { formatVersion?: number };
+    return typeof parsed.formatVersion === 'number' ? parsed.formatVersion : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether a project root should use a standalone index or a shared-base
+ * overlay. Never throws — every uncertain condition degrades to standalone.
+ *
+ * Overlay mode requires ALL of:
+ *  - `LIEN_WORKTREE_STANDALONE` is not set to `1` (escape hatch),
+ *  - the root is a linked worktree with a resolvable, distinct main checkout,
+ *  - the main checkout has a `structural.db` AND a `manifest.json` (the base
+ *    per-file content hashes the overlay diff relies on),
+ *  - the base manifest's `formatVersion` matches the current schema.
+ */
+export async function resolveIndexStrategy(
+  projectRoot: string,
+  opts: ResolveOptions = {},
+): Promise<IndexStrategy> {
+  const warn = opts.warn ?? ((m: string) => console.error(m));
+
+  if (process.env.LIEN_WORKTREE_STANDALONE === '1') {
+    return { mode: 'standalone' };
+  }
+
+  const { isLinkedWorktree, mainRoot } = await detectLinkedWorktree(projectRoot);
+  if (!isLinkedWorktree || !mainRoot) {
+    return { mode: 'standalone' };
+  }
+
+  // Defensive: a main root that resolves to the current root offers no base.
+  const [realMain, realRoot] = await Promise.all([
+    realpathSafe(mainRoot),
+    realpathSafe(projectRoot),
+  ]);
+  if (realMain === realRoot) {
+    return { mode: 'standalone' };
+  }
+
+  const baseIndexDir = getIndexDir(mainRoot);
+  const hasDb = await fileExists(path.join(baseIndexDir, STRUCTURAL_DB_FILENAME));
+  const hasManifest = await fileExists(path.join(baseIndexDir, MANIFEST_FILE));
+  if (!hasDb || !hasManifest) {
+    warnOnce(
+      warn,
+      baseIndexDir,
+      `[Lien] Worktree detected but the main checkout at ${mainRoot} has no complete index — ` +
+        `using a standalone index. Run \`lien index\` in the main checkout to share its index across worktrees.`,
+    );
+    return { mode: 'standalone' };
+  }
+
+  const baseFormat = await readBaseFormatVersion(baseIndexDir);
+  if (baseFormat !== null && baseFormat !== INDEX_FORMAT_VERSION) {
+    warnOnce(
+      warn,
+      baseIndexDir,
+      `[Lien] Main checkout index format v${baseFormat} is incompatible with current v${INDEX_FORMAT_VERSION} — ` +
+        `using a standalone worktree index until the main checkout is reindexed.`,
+    );
+    return { mode: 'standalone' };
+  }
+
+  return {
+    mode: 'overlay',
+    mainRoot,
+    baseIndexDir,
+    overlayIndexDir: getIndexDir(projectRoot),
+  };
+}

--- a/packages/core/src/vectordb/overlay-resolution.ts
+++ b/packages/core/src/vectordb/overlay-resolution.ts
@@ -20,7 +20,9 @@ export type IndexStrategy =
       overlayIndexDir: string;
     };
 
-/** Injectable logger so the fallback hints are testable; defaults to stderr. */
+/** Injectable logger for the fallback hints. Silent by default so library-level
+ *  `createVectorDB` calls (status, complexity, annotate, …) don't nag on every
+ *  invocation; `serve` and `index` opt in, where the hint is actionable. */
 export interface ResolveOptions {
   warn?: (message: string) => void;
 }
@@ -83,7 +85,7 @@ export async function resolveIndexStrategy(
   projectRoot: string,
   opts: ResolveOptions = {},
 ): Promise<IndexStrategy> {
-  const warn = opts.warn ?? ((m: string) => console.error(m));
+  const warn = opts.warn ?? (() => {});
 
   if (process.env.LIEN_WORKTREE_STANDALONE === '1') {
     return { mode: 'standalone' };

--- a/packages/core/src/vectordb/sqlite/overlay-schema.ts
+++ b/packages/core/src/vectordb/sqlite/overlay-schema.ts
@@ -1,0 +1,46 @@
+import type Database from 'better-sqlite3';
+import { openDatabase } from './schema.js';
+
+/** File name of the overlay's structural store (same layout as a standalone
+ *  index — the overlay reuses the exact `chunks` + `chunks_fts` schema). */
+export { STRUCTURAL_DB_FILENAME } from './schema.js';
+
+/** overlay_meta keys. */
+export const OVERLAY_META = {
+  /** Absolute path of the base index dir this overlay was diffed against. */
+  BASE_INDEX_DIR: 'baseIndexDir',
+  /** Base `.lien-index-version` value captured at overlay build time. */
+  BASE_STAMP: 'baseStamp',
+  /** Base index format version captured at overlay build time. */
+  BASE_FORMAT_VERSION: 'baseFormatVersion',
+} as const;
+
+/**
+ * Overlay-only tables, layered on top of the standard chunks schema:
+ *  - `overlay_mask`: base file paths (relative, forward-slash) suppressed from
+ *    base reads — the modified-in-worktree and deleted-in-worktree files.
+ *  - `overlay_meta`: single-key/value rows recording which base build this
+ *    overlay was diffed against (for staleness detection on serve start).
+ *
+ * Both are inert in a standalone index, so sharing `structural.db` is safe.
+ */
+const OVERLAY_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS overlay_mask (
+  file TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS overlay_meta (
+  k TEXT PRIMARY KEY,
+  v TEXT
+);
+`;
+
+/**
+ * Open (creating if needed) the overlay's structural store: the standard
+ * `chunks` + `chunks_fts` schema plus the overlay mask/meta tables.
+ */
+export function openOverlayDatabase(dbFilePath: string): Database.Database {
+  const db = openDatabase(dbFilePath);
+  db.exec(OVERLAY_SCHEMA_SQL);
+  return db;
+}

--- a/packages/core/src/vectordb/sqlite/read-ops.ts
+++ b/packages/core/src/vectordb/sqlite/read-ops.ts
@@ -1,0 +1,86 @@
+import type Database from 'better-sqlite3';
+import { parseRow, type SqliteChunkRecord } from './row-mapping.js';
+import { DatabaseError } from '../../errors/index.js';
+
+/**
+ * Trim + validate a file filter into a list of exact-match paths. Empty or
+ * whitespace-only paths throw — matching query.ts buildFileWhereClause.
+ */
+export function normalizeFileFilter(file: string | string[]): string[] {
+  if (typeof file === 'string') {
+    const trimmed = file.trim();
+    if (trimmed.length === 0) {
+      throw new DatabaseError('Invalid file filter: file path must be non-empty');
+    }
+    return [trimmed];
+  }
+  const cleaned = file.map(f => f.trim()).filter(f => f.length > 0);
+  if (cleaned.length === 0) {
+    throw new DatabaseError('Invalid file filter: at least one non-empty file path is required');
+  }
+  return cleaned;
+}
+
+/**
+ * Low-level read primitives over a `chunks` table, shared by `SqliteBackend`
+ * (single store) and `OverlayBackend` (base + overlay union). Keeping the scan
+ * SQL + parse + validate in one place stops the two backends from drifting.
+ */
+
+/**
+ * A row identity requires a non-empty file and non-empty content. Scan paths
+ * drop empty-content rows (content is always a string here — NOT NULL).
+ */
+export function isValidRecord(r: SqliteChunkRecord): boolean {
+  if (!r.file || r.file.length === 0) return false;
+  if (r.content.trim().length === 0) return false;
+  return true;
+}
+
+/** All valid chunk records, ordered by rowid. */
+export function readAllRecords(db: Database.Database): SqliteChunkRecord[] {
+  const rows = db.prepare('SELECT * FROM chunks ORDER BY id').all() as Record<string, unknown>[];
+  return rows.map(parseRow).filter(isValidRecord);
+}
+
+/** Valid chunk records whose `file` is in the exact-match list, ordered by rowid. */
+export function readRecordsByFiles(db: Database.Database, files: string[]): SqliteChunkRecord[] {
+  if (files.length === 0) return [];
+  const placeholders = files.map(() => '?').join(', ');
+  const rows = db
+    .prepare(`SELECT * FROM chunks WHERE file IN (${placeholders}) ORDER BY id`)
+    .all(...files) as Record<string, unknown>[];
+  return rows.map(parseRow).filter(isValidRecord);
+}
+
+/** Valid chunk records with non-empty content (symbol-query prefilter), by rowid. */
+export function readSymbolRecords(db: Database.Database): SqliteChunkRecord[] {
+  const rows = db.prepare("SELECT * FROM chunks WHERE content != '' ORDER BY id").all() as Record<
+    string,
+    unknown
+  >[];
+  return rows.map(parseRow).filter(isValidRecord);
+}
+
+/**
+ * Yield pages of valid chunk records via LIMIT/OFFSET iteration, so callers
+ * never load the whole table into memory. Stops after the first short page.
+ */
+export function* paginateRecords(
+  db: Database.Database,
+  pageSize: number,
+): Generator<SqliteChunkRecord[]> {
+  if (pageSize <= 0) {
+    throw new DatabaseError('pageSize must be a positive number');
+  }
+  const stmt = db.prepare("SELECT * FROM chunks WHERE file != '' ORDER BY id LIMIT ? OFFSET ?");
+  let offset = 0;
+  while (true) {
+    const rawRows = stmt.all(pageSize, offset) as Record<string, unknown>[];
+    if (rawRows.length === 0) break;
+    const page = rawRows.map(parseRow).filter(isValidRecord);
+    if (page.length > 0) yield page;
+    if (rawRows.length < pageSize) break;
+    offset += pageSize;
+  }
+}

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.ts
@@ -13,57 +13,22 @@ import {
   matchesSymbolFilter,
   buildLegacySymbols,
 } from '../filters.js';
-import { openDatabase, STRUCTURAL_DB_FILENAME, CHUNK_COLUMNS } from './schema.js';
+import { openDatabase, STRUCTURAL_DB_FILENAME } from './schema.js';
+import { recordToUnscoredResult, buildSearchResultMetadata } from './row-mapping.js';
 import {
-  chunkToRow,
-  parseRow,
-  recordToUnscoredResult,
-  buildSearchResultMetadata,
-  type SqliteChunkRecord,
-} from './row-mapping.js';
+  normalizeFileFilter,
+  readAllRecords,
+  readRecordsByFiles,
+  readSymbolRecords,
+  paginateRecords,
+} from './read-ops.js';
+import {
+  insertChunks,
+  replaceFileChunks,
+  deleteFileChunks,
+  validateBatchLengths,
+} from './write-ops.js';
 import { keywordSearch } from './fts-search.js';
-
-const INSERT_SQL = `INSERT INTO chunks (${CHUNK_COLUMNS.join(', ')}) VALUES (${CHUNK_COLUMNS.map(
-  c => '@' + c,
-).join(', ')})`;
-
-/**
- * A row identity requires a non-empty file and non-empty content. Scan paths
- * drop empty-content rows (content is always a string here — NOT NULL).
- */
-function isValidRecord(r: SqliteChunkRecord): boolean {
-  if (!r.file || r.file.length === 0) return false;
-  if (r.content.trim().length === 0) return false;
-  return true;
-}
-
-/**
- * Trim + validate a file filter into a list of exact-match paths. Empty or
- * whitespace-only paths throw — matching query.ts buildFileWhereClause.
- */
-function normalizeFileFilter(file: string | string[]): string[] {
-  if (typeof file === 'string') {
-    const trimmed = file.trim();
-    if (trimmed.length === 0) {
-      throw new DatabaseError('Invalid file filter: file path must be non-empty');
-    }
-    return [trimmed];
-  }
-  const cleaned = file.map(f => f.trim()).filter(f => f.length > 0);
-  if (cleaned.length === 0) {
-    throw new DatabaseError('Invalid file filter: at least one non-empty file path is required');
-  }
-  return cleaned;
-}
-
-function validateBatchLengths(metadatas: ChunkMetadata[], contents: string[]): void {
-  if (metadatas.length !== contents.length) {
-    throw new DatabaseError('Metadatas and contents arrays must have the same length', {
-      metadatasLength: metadatas.length,
-      contentsLength: contents.length,
-    });
-  }
-}
 
 /**
  * SQLite + FTS5 structural backend implementing VectorDBInterface.
@@ -77,6 +42,7 @@ export class SqliteBackend implements VectorDBInterface {
   public readonly dbPath: string;
   private readonly dbFilePath: string;
   public readonly supportsCrossRepo = false;
+  public readonly isOverlay = false;
   private lastVersionCheck = 0;
   private currentVersion = 0;
 
@@ -108,15 +74,7 @@ export class SqliteBackend implements VectorDBInterface {
   async insertBatch(metadatas: ChunkMetadata[], contents: string[]): Promise<void> {
     const db = this.requireDb();
     validateBatchLengths(metadatas, contents);
-    // Empty batch is a no-op.
-    if (metadatas.length === 0) return;
-
-    // Single transaction, one prepared statement.
-    const insert = db.prepare(INSERT_SQL);
-    const insertAll = db.transaction((rows: ReturnType<typeof chunkToRow>[]) => {
-      for (const row of rows) insert.run(row);
-    });
-    insertAll(metadatas.map((metadata, i) => chunkToRow(contents[i], metadata)));
+    insertChunks(db, metadatas, contents);
   }
 
   async search(query: string, limit: number = 5): Promise<SearchResult[]> {
@@ -135,21 +93,10 @@ export class SqliteBackend implements VectorDBInterface {
     const db = this.requireDb();
     const { file, language, pattern, symbolType, limit = 100 } = options;
 
-    let rawRows: Record<string, unknown>[];
     // Truthy guard mirrors query.ts (`file ? ... : 'file != ""'`): an empty
     // string is treated as no filter (full scan), while a non-empty array
     // still routes through normalizeFileFilter.
-    if (file) {
-      const files = normalizeFileFilter(file);
-      const placeholders = files.map(() => '?').join(', ');
-      rawRows = db
-        .prepare(`SELECT * FROM chunks WHERE file IN (${placeholders}) ORDER BY id`)
-        .all(...files) as Record<string, unknown>[];
-    } else {
-      rawRows = db.prepare('SELECT * FROM chunks ORDER BY id').all() as Record<string, unknown>[];
-    }
-
-    let records = rawRows.map(parseRow).filter(isValidRecord);
+    let records = file ? readRecordsByFiles(db, normalizeFileFilter(file)) : readAllRecords(db);
     if (language) records = filterByLanguage(records, language);
     if (pattern) records = filterByPattern(records, pattern);
     if (symbolType) records = filterBySymbolType(records, symbolType);
@@ -169,11 +116,7 @@ export class SqliteBackend implements VectorDBInterface {
 
     // Fast path: no filters → plain full read.
     if (!language && !pattern) {
-      const rawRows = db.prepare('SELECT * FROM chunks ORDER BY id').all() as Record<
-        string,
-        unknown
-      >[];
-      return rawRows.map(parseRow).filter(isValidRecord).map(recordToUnscoredResult);
+      return readAllRecords(db).map(recordToUnscoredResult);
     }
 
     // Otherwise delegate to scanWithFilter with no result cap (parity with
@@ -188,21 +131,8 @@ export class SqliteBackend implements VectorDBInterface {
   ): AsyncGenerator<SearchResult[]> {
     const db = this.requireDb();
     const pageSize = options.pageSize ?? 1000;
-    if (pageSize <= 0) {
-      throw new DatabaseError('pageSize must be a positive number');
-    }
-
-    const stmt = db.prepare("SELECT * FROM chunks WHERE file != '' ORDER BY id LIMIT ? OFFSET ?");
-    let offset = 0;
-    while (true) {
-      const rawRows = stmt.all(pageSize, offset) as Record<string, unknown>[];
-      if (rawRows.length === 0) break;
-
-      const page = rawRows.map(parseRow).filter(isValidRecord).map(recordToUnscoredResult);
-      if (page.length > 0) yield page;
-
-      if (rawRows.length < pageSize) break;
-      offset += pageSize;
+    for (const page of paginateRecords(db, pageSize)) {
+      yield page.map(recordToUnscoredResult);
     }
   }
 
@@ -218,13 +148,9 @@ export class SqliteBackend implements VectorDBInterface {
     // content != '' is a hard SQL prefilter (empty-content chunks excluded);
     // matchesSymbolFilter stays authoritative for the rest (legacy symbol
     // arrays can match with an empty symbolType).
-    const rawRows = db
-      .prepare("SELECT * FROM chunks WHERE content != '' ORDER BY id")
-      .all() as Record<string, unknown>[];
-
-    const records = rawRows
-      .map(parseRow)
-      .filter(r => isValidRecord(r) && matchesSymbolFilter(r, { language, pattern, symbolType }));
+    const records = readSymbolRecords(db).filter(r =>
+      matchesSymbolFilter(r, { language, pattern, symbolType }),
+    );
 
     return records.slice(0, limit).map(r => ({
       content: r.content,
@@ -238,7 +164,7 @@ export class SqliteBackend implements VectorDBInterface {
     const db = this.requireDb();
     // Exact match, no normalization — caller normalizes. FTS stays in sync via
     // the AFTER DELETE trigger.
-    db.prepare('DELETE FROM chunks WHERE file = ?').run(filepath);
+    deleteFileChunks(db, filepath);
   }
 
   async updateFile(
@@ -250,13 +176,7 @@ export class SqliteBackend implements VectorDBInterface {
     validateBatchLengths(metadatas, contents);
 
     // delete + insert in ONE transaction.
-    const del = db.prepare('DELETE FROM chunks WHERE file = ?');
-    const insert = db.prepare(INSERT_SQL);
-    const apply = db.transaction((rows: ReturnType<typeof chunkToRow>[]) => {
-      del.run(filepath);
-      for (const row of rows) insert.run(row);
-    });
-    apply(metadatas.map((metadata, i) => chunkToRow(contents[i], metadata)));
+    replaceFileChunks(db, filepath, metadatas, contents);
 
     // Bump the cross-process invalidation token. currentVersion is intentionally
     // NOT bumped in-memory here — only the file is written; checkVersion picks

--- a/packages/core/src/vectordb/sqlite/write-ops.ts
+++ b/packages/core/src/vectordb/sqlite/write-ops.ts
@@ -1,0 +1,61 @@
+import type Database from 'better-sqlite3';
+import type { ChunkMetadata } from '@liendev/parser';
+import { CHUNK_COLUMNS } from './schema.js';
+import { chunkToRow } from './row-mapping.js';
+import { DatabaseError } from '../../errors/index.js';
+
+/** Assert metadatas/contents arrays are the same length before a batch write. */
+export function validateBatchLengths(metadatas: ChunkMetadata[], contents: string[]): void {
+  if (metadatas.length !== contents.length) {
+    throw new DatabaseError('Metadatas and contents arrays must have the same length', {
+      metadatasLength: metadatas.length,
+      contentsLength: contents.length,
+    });
+  }
+}
+
+/**
+ * Low-level write primitives over a `chunks` table, shared by `SqliteBackend`
+ * and `OverlayBackend`. The external-content FTS5 table stays in sync via the
+ * schema's triggers, so callers never touch `chunks_fts` directly.
+ */
+
+/** `INSERT INTO chunks (...) VALUES (@...)` bound to CHUNK_COLUMNS order. */
+export const INSERT_SQL = `INSERT INTO chunks (${CHUNK_COLUMNS.join(', ')}) VALUES (${CHUNK_COLUMNS.map(
+  c => '@' + c,
+).join(', ')})`;
+
+/** Insert a batch of chunks in a single transaction. Empty batch is a no-op. */
+export function insertChunks(
+  db: Database.Database,
+  metadatas: ChunkMetadata[],
+  contents: string[],
+): void {
+  if (metadatas.length === 0) return;
+  const insert = db.prepare(INSERT_SQL);
+  const insertAll = db.transaction((rows: ReturnType<typeof chunkToRow>[]) => {
+    for (const row of rows) insert.run(row);
+  });
+  insertAll(metadatas.map((metadata, i) => chunkToRow(contents[i], metadata)));
+}
+
+/** Replace all chunks for one file (delete + insert) in a single transaction. */
+export function replaceFileChunks(
+  db: Database.Database,
+  filepath: string,
+  metadatas: ChunkMetadata[],
+  contents: string[],
+): void {
+  const del = db.prepare('DELETE FROM chunks WHERE file = ?');
+  const insert = db.prepare(INSERT_SQL);
+  const apply = db.transaction((rows: ReturnType<typeof chunkToRow>[]) => {
+    del.run(filepath);
+    for (const row of rows) insert.run(row);
+  });
+  apply(metadatas.map((metadata, i) => chunkToRow(contents[i], metadata)));
+}
+
+/** Delete all chunks for one file. FTS stays in sync via the AFTER DELETE trigger. */
+export function deleteFileChunks(db: Database.Database, filepath: string): void {
+  db.prepare('DELETE FROM chunks WHERE file = ?').run(filepath);
+}

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -59,6 +59,10 @@ export interface VectorDBInterface {
   getVersionDate(): string;
   /** Whether this backend supports cross-repo operations. */
   readonly supportsCrossRepo: boolean;
+  /** True for the worktree overlay backend (shared read-only base + writable
+   *  overlay). Lets the indexer route to the overlay build instead of a full
+   *  reindex of the worktree. */
+  readonly isOverlay: boolean;
   /** Scan across all repos in the organization. Returns [] if unsupported. */
   scanCrossRepo(options: {
     language?: string;

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -34,6 +34,8 @@ export { extractRepoId } from './utils/repo-id.js';
 
 export { getLienHome } from './utils/lien-home.js';
 
+export { getIndexDir } from './utils/index-dir.js';
+
 // =============================================================================
 // AST
 // =============================================================================

--- a/packages/parser/src/utils/index-dir.ts
+++ b/packages/parser/src/utils/index-dir.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { getLienHome } from './lien-home.js';
+import { extractRepoId } from './repo-id.js';
+
+/**
+ * Resolve the per-project index directory: `<LIEN_HOME>/.lien/indices/<repoId>`.
+ *
+ * This is the single source of truth for where a project's structural store,
+ * manifest, and version file live. `SqliteBackend` and the worktree overlay
+ * resolution both derive their paths from here so a project root and its index
+ * dir never drift apart.
+ */
+export function getIndexDir(projectRoot: string): string {
+  return path.join(getLienHome(), '.lien', 'indices', extractRepoId(projectRoot));
+}

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -139,13 +139,56 @@ Lien tracks four complementary complexity metrics:
 
 All metrics are calculated during indexing using Tree-sitter AST parsing. Cognitive complexity is based on [SonarSource's specification](https://www.sonarsource.com/docs/CognitiveComplexity.pdf), Halstead metrics are based on Maurice Halstead's "Elements of Software Science" (1977).
 
+## Git Worktree Support
+
+A linked git worktree (`git worktree add`) shares the main checkout's index
+instead of building its own full copy. When Lien's root is a linked worktree,
+it opens the main checkout's index as a read-only **base** and stores only a
+small **overlay** at the worktree's own index location — chunk rows for
+whatever files differ from the base (edited or new), plus a small "mask" that
+suppresses base rows for files the worktree changed or deleted. Reads merge
+the two: an unchanged file resolves from the base, a changed or new file
+resolves from the overlay, and a file deleted in the worktree resolves from
+neither.
+
+This is automatic — `lien index` and `lien serve` detect a linked worktree
+(`git rev-parse --git-dir` differs from `--git-common-dir`) and locate the
+main checkout via `git worktree list`, no configuration needed. It's also safe
+by construction: the base is opened read-only, so a worktree process can never
+write to the main checkout's index. Every uncertain case — the main checkout
+has no index yet, its index format doesn't match, or the base becomes
+unavailable mid-session — falls back to a full, independent index rather than
+erroring.
+
+**Escape hatch:** set `LIEN_WORKTREE_STANDALONE=1` to force the old,
+fully-independent behavior for a worktree.
+
+**Known v1 limitations:**
+- Full-text search ranks are merged approximately across the base and overlay
+  corpora — BM25 scores are corpus-relative, so this isn't a single
+  statistically correct ranking. In practice the overlay is small and
+  exact-symbol matches dominate, so this rarely changes what you see.
+- The base index is located by the exact path string the main checkout was
+  indexed under. If that checkout lives behind a symlink and was indexed under
+  a different path spelling than `git worktree list` reports, its worktrees
+  fall back to a standalone index instead of sharing (safe, just not shared).
+
+**Why this matters:** without this, every linked worktree got its own
+complete index. A ~30-worktree agent setup on one repo produced a 21 GB pile
+of near-identical indexes before this existed
+([#651](https://github.com/getlien/lien/pull/651)). Sharing cuts that down to
+the base size once, plus a typically kilobytes-to-low-megabytes overlay per
+worktree.
+
 ## Performance
 
 - **File context lookup:** sub-millisecond (indexed lookup by file)
 - **Small projects** (1k files): minutes to index
 - **Medium projects** (10k files): ~15-20 minutes to index
 - **Native install:** ~1.8MB (SQLite binding) — no model download
-- **Disk usage:** roughly comparable to the source it indexes
+- **Disk usage:** roughly comparable to the source it indexes for a standalone
+  index; a linked git worktree instead pays only for its overlay (see
+  [Git Worktree Support](#git-worktree-support) above)
 
 ---
 


### PR DESCRIPTION
## Worktree-aware indexing

Today `N` linked git worktrees of one repo = `N` full independent indexes
(a ~30-worktree checkout produced a **21 GB** index pile — the incident that
motivated #651's blunt `.claude/worktrees/**` exclude). This feature makes a
worktree share the main checkout's index as a **read-only base** and store only
a small per-worktree **overlay** (rows for diverged/added files + a mask that
suppresses stale base rows).

Design doc: [`docs/architecture/worktree-aware-indexing.md`](docs/architecture/worktree-aware-indexing.md)

### Key decisions
- **Detection**: `git rev-parse --git-dir != --git-common-dir` ⇒ linked worktree; main root from `git worktree list --porcelain`.
- **Two read-only connections, not `ATTACH`** (documented deviation): `ATTACH` can't enforce a per-db read-only mode, and BM25 across two FTS corpora must be merged in app code regardless. Base opened `{ readonly: true }` — physically immutable from the worktree.
- **State-based diff** (parser content-hash vs base manifest), not git-history-based — robust to divergence.
- **Mask model**: reconcile hinges on "is the file in the base manifest?"; `deleteByFile` masks modified/deleted base paths — no re-hashing (documented deviation from the first-draft un-mask rule).
- **Escape hatch**: `LIEN_WORKTREE_STANDALONE=1`.
- **Never errors**: main-has-no-index / schema-mismatch / base-missing-mid-serve / path-hash-mismatch all degrade to standalone (hint is opt-in, silent for non-serve commands).

### Milestones — all complete
- [x] 1. Design doc committed + draft PR open
- [x] 2. Worktree detection + index-path resolution (+ escape hatch) — `git/worktree.ts`, `overlay-resolution.ts`, parser `getIndexDir`; 9 unit tests
- [x] 3. Overlay schema + hash-diff build → overlay rows + mask — `overlay-backend.ts`, `sqlite/overlay-schema.ts`, `indexer/overlay-index.ts`, shared `read-ops`/`write-ops`; factory wired; 6 tests
- [x] 4. Read-path union (scan/query/FTS/paginate) + mask + reconcile + graceful degrade — 8 tests
- [x] 5. Wiring: `indexCodebase` routes overlay→buildOverlay; MCP auto-index always refreshes overlay; watcher reconciles via the backend. Verified E2E on a real `git worktree add`.
- [x] 6. Integration test (real `git worktree add`, through the factory) — 3 tests; changeset (minor, core + lien); full monorepo gate green (format, lint 0-errors, typecheck, build, test 2511 passing).
- [x] 7. Phase 2: independent adversarial verification (real CLI + MCP stdio) and user-facing docs — see "Verification findings" below.

### Gate
`format:check` ✓ · `lint` 0 errors ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ (parser 939, core 318, review 544, cli 683, action 28) · `docs:build` ✓

---

## Verification findings (Phase 2)

Independent adversarial pass against the built CLI (`packages/cli/dist/index.js`)
and MCP over stdio (via the real `@modelcontextprotocol/sdk` client), using
scratch `git worktree add` repos plus the real lien repo's own worktree/base
pair (this feature's own development worktree vs. `lien-e96f171e`).

### Scenario matrix

| Scenario | Result |
|---|---|
| Happy path (edit / add / delete a file in the worktree) | ✅ `get_files_context` correctly returns worktree content for edited/added files, base content for the unchanged file, nothing for the deleted file |
| Renamed file (old path deleted, new path added) | ✅ new path resolves to worktree content exactly once; old path returns nothing |
| Churn + revert-to-base | ✅ re-diffing after further edits correctly reclassifies a reverted file back to "shared with base"; no stale or duplicate content |
| Fallback: main checkout has no index | ✅ standalone + one-line hint on `serve` |
| Fallback: `LIEN_WORKTREE_STANDALONE=1` | ✅ forces standalone as designed (see caveat below) |
| Fallback: base db deleted mid-serve | ✅ graceful degrade (base reads return nothing), no crash, unaffected overlay-only files still serve correctly |
| Concurrency: 2 worktree serves reading while the base is force-reindexed 5× in a loop | ✅ no `SQLITE_BUSY`, no crashes, correct isolated reads throughout |
| Concurrency: 20–30 truly parallel `lien index` runs racing on **one** worktree's overlay | ✅ after fix (see below); ❌ before fix |
| Real repo (`lien-e96f171e`, ~420 files, vs. this worktree) | ✅ overlay correctly held only the ~23–26 files that actually diverged |

### Bugs found and fixed

1. **`OverlayBackend.clear()` never reclaimed disk space.** It used an in-place
   `DELETE FROM chunks` (+ mask/meta tables), which leaves freed pages in
   SQLite's freelist instead of shrinking the file. Since `buildOverlay` calls
   `clear()` at the start of *every* rebuild, an overlay that once held many
   diverged files (e.g. this exact worktree, used standalone during Phase 1
   development) kept that high-water-mark size forever even after shrinking
   back to a handful of live rows. On the real repo this made the "small"
   overlay **11 MB — nearly the size of the 11.5 MB base**, defeating the
   feature's point. (`freelist_count` was 2111 of 2554 total pages — 82% dead
   space.)

2. **Fix-of-the-fix: the first repair was itself unsafe under concurrency.**
   The obvious fix mirrors `SqliteBackend.clear()`'s existing pattern (close
   the handle, delete the db + WAL/SHM files, reopen fresh) — verified to
   shrink the overlay to 1.0 MB. But stress-testing it with 20–30 truly
   concurrent `lien index` processes racing on the *same* worktree reproduced
   real `disk I/O error` / "Failed to initialize overlay database" failures in
   roughly half the runs. The identical stress test against the original
   DELETE-only code, and against `SqliteBackend`'s own close+delete+recreate
   path on a *standalone* index, produced **zero** failures — so the hazard is
   specifically swapping the overlay file's identity while other processes
   hold it open, not the close+delete+recreate pattern in general (standalone
   indexes aren't rebuilt on every single `lien index` invocation the way
   overlays are, so they're far less exposed).
   Shipped fix: `DELETE` + `VACUUM` + a WAL checkpoint — same file identity
   throughout, same disk-space reclamation (confirmed 1.1 MB on the real
   repo), zero failures across repeated 20- and 30-way concurrent stress runs.

Both are in `packages/core/src/vectordb/overlay-backend.ts`, with a new
disk-space regression test in `overlay-backend.test.ts`.

### Reviewed but not changed (automated Lien Review findings)

- *"Reports zero created chunks despite creating them"* — true, but
  `performOverlayIndex` reporting `chunksCreated: 0` is consistent with the
  pre-existing incremental-indexing path (`indexer/index.ts:315`, already
  commented `// Not tracked in incremental mode`), not a regression this PR
  introduces. It's also never surfaced to CLI users in practice: both paths
  always emit a descriptive `'complete'` progress event, which short-circuits
  the generic `chunksCreated` display in `index-cmd.ts`.
- *"Clears the overlay database/mask before rebuilding, creating a race
  window"* — correct in spirit; see bug #2 above, which this same review
  comment prompted us to stress-test and fix directly.

### Documented, not fixed (structural — out of scope for a surgical fix)

- **`LIEN_WORKTREE_STANDALONE=1` and default overlay mode share one physical
  index directory per worktree.** Toggling the escape hatch on, indexing, then
  toggling it back off can leave the shared `structural.db` in a transiently
  mixed state (e.g. a file that matches base sitting in the overlay
  unmasked, alongside its unmasked base row = duplicate reads) until the next
  *normal-mode* `lien index` or `lien serve` runs — `buildOverlay` always
  starts with a full `clear()` + hash-diff rebuild, so it self-heals
  automatically on the very next such run. Verified: reproduced the mixed
  state, confirmed it self-heals, found no case where it persists across a
  subsequent normal-mode index/serve. Not fixed here because a real fix (e.g.
  a separate physical directory for the escape hatch) is a storage-layout
  decision, not a bug in the shipped design.
- **`lien status` doesn't report worktree/overlay mode at all.** It computes
  its index path directly (`extractRepoId` + path join) rather than through
  `resolveIndexStrategy`, so a user in a worktree gets no indication they're
  in shared-base mode, no base index location, nothing — `lien index`'s
  progress output is currently the only place this surfaces. Worth a
  follow-up; skipped here to avoid rushing a change to `status.ts`'s test
  mocking (the command would need to call `detectLinkedWorktree`, which
  shells out to real `git` — the existing test file's `@liendev/core` mock is
  partial, and hardening it properly is more than a drive-by fix warrants
  under this PR's scope).

### Real-repo numbers

- Base (`lien-e96f171e`, main checkout, ~420 files): **11 MB** `structural.db`.
- This feature's own development worktree, 23–26 files actually diverged:
  overlay **1.0–1.1 MB** after the fix (was 11 MB before, due to bug #1 above).

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 1 new function is more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +63 |


> [!WARNING]
> **2 issues found** · Medium Risk
>
> This PR introduces worktree-aware indexing using a shared read-only base index and a per-worktree writable overlay, with conservative standalone fallback when the base is unavailable. The design is sound, but the overlay build path has two concrete issues: it misreports chunk creation statistics, and it clears the overlay before rebuilding, creating a temporary inconsistency window for concurrent readers.
>
> - createVectorDB resolves standalone vs overlay mode via detectLinkedWorktree and base-index validation.
> - buildOverlay diffs the worktree against the base manifest and writes only added/modified files into the overlay, masking deleted/modified base paths.
> - OverlayBackend unions overlay and unmasked base rows for reads, and exposes isOverlay so the MCP server can refresh the overlay on every auto-index.
> - Two real bugs: overlay builds report zero chunks created despite creating chunks, and rebuilds clear the mask/rows before repopulating them, exposing stale base content to concurrent reads.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1882b38. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
