### PR TITLE
fix(review): line-drift-tolerant comment dedup + log skip counts

### DIFF
--- a/packages/review/src/analysis.ts
+++ b/packages/review/src/analysis.ts
@@ -127,8 +127,12 @@ export async function runComplexityAnalysis(
     try {
       await access(join(rootDir, file));
       present.push(file);
-    } catch {
-      // absent in this checkout
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        // Not "absent" — a real filesystem problem (EACCES, EMFILE, ...).
+        // Keep the file so the parser surfaces the actual error loudly.
+        present.push(file);
+      }
     }
   }
   const absentCount = files.length - present.length;

--- a/packages/review/src/analysis.ts
+++ b/packages/review/src/analysis.ts
@@ -5,7 +5,7 @@
  * from that module still used at runtime.
  */
 
-import { readdir } from 'node:fs/promises';
+import { access, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
@@ -118,7 +118,28 @@ export async function runComplexityAnalysis(
   rootDir: string,
   logger: Logger,
 ): Promise<{ report: ComplexityReport; chunks: CodeChunk[] } | null> {
-  if (files.length === 0) {
+  // This runs against both the PR-head clone and the baseline clone with the
+  // same changed-file list. Files the PR adds don't exist in the baseline
+  // checkout, and the parser logs a per-file ENOENT "error" for each. Filter
+  // to files present in this checkout and say so once, honestly.
+  const present: string[] = [];
+  for (const file of files) {
+    try {
+      await access(join(rootDir, file));
+      present.push(file);
+    } catch {
+      // absent in this checkout
+    }
+  }
+  const absentCount = files.length - present.length;
+  if (absentCount > 0) {
+    logger.info(
+      `${absentCount} of ${files.length} file(s) not present in this checkout ` +
+        `(expected when analyzing the baseline of a PR that adds files) — skipped`,
+    );
+  }
+
+  if (present.length === 0) {
     logger.info('No files to analyze');
     return null;
   }
@@ -126,8 +147,8 @@ export async function runComplexityAnalysis(
   try {
     // Use performChunkOnlyIndex for fast chunk-only indexing (no VectorDB needed)
     // Pass filesToIndex to skip full repo scan — only chunk the changed files
-    logger.info(`Indexing ${files.length} files (chunk-only)...`);
-    const indexResult = await performChunkOnlyIndex(rootDir, { filesToIndex: files });
+    logger.info(`Indexing ${present.length} files (chunk-only)...`);
+    const indexResult = await performChunkOnlyIndex(rootDir, { filesToIndex: present });
 
     logger.info(
       `Indexing complete: ${indexResult.chunksCreated} chunks from ${indexResult.filesIndexed} files (success: ${indexResult.success})`,
@@ -142,7 +163,7 @@ export async function runComplexityAnalysis(
     const thresholdNum = parseInt(threshold, 10);
     const report = analyzeComplexityFromChunks(
       indexResult.chunks,
-      files,
+      present,
       !isNaN(thresholdNum) ? { testPaths: thresholdNum, mentalLoad: thresholdNum } : undefined,
     );
     logger.info(`Found ${report.summary.totalViolations} violations`);

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -571,7 +571,13 @@ async function postPluginInlineComments(
   const markerPrefix = `${PLUGIN_MARKER_PREFIX}${pluginId}:`;
 
   const diffResult = await filterToDiffLines(octokit, pr, findings, logger);
-  if (!diffResult) return { posted: 0, skipped: findings.length };
+  if (!diffResult) {
+    logger.info(
+      `postInlineComments(${pluginId}): posting 0 of ${findings.length} finding(s) ` +
+        `(diff fetch failed — see warning above)`,
+    );
+    return { posted: 0, skipped: findings.length };
+  }
 
   const { inDiff, outOfDiffCount } = diffResult;
 
@@ -889,6 +895,11 @@ function extractPluginCommentKey(body: string, markerPrefix: string): string | n
  * 461, 483, and 486 by three consecutive runs), so exact-line keys re-post
  * near-duplicates. Same file + same category within this many lines counts
  * as the same finding.
+ *
+ * Deliberate tradeoff: two genuinely distinct same-category findings within
+ * this window in one file are collapsed into one comment. That costs less
+ * than re-posting the same finding on every run — the surviving comment
+ * still points a reviewer at the right region.
  */
 export const DEDUP_LINE_TOLERANCE = 30;
 

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -574,24 +574,31 @@ async function postPluginInlineComments(
   if (!diffResult) return { posted: 0, skipped: findings.length };
 
   const { inDiff, outOfDiffCount } = diffResult;
-  if (inDiff.length === 0) return { posted: 0, skipped: findings.length };
 
-  const comments: LineComment[] = inDiff.map(f => ({
-    path: f.filepath,
-    line: f.line,
-    body: buildPluginCommentBody(f, markerPrefix),
-  }));
+  let toPost: LineComment[] = [];
+  let dedupSkipped = 0;
+  if (inDiff.length > 0) {
+    const comments: LineComment[] = inDiff.map(f => ({
+      path: f.filepath,
+      line: f.line,
+      body: buildPluginCommentBody(f, markerPrefix),
+    }));
 
-  const { toPost, dedupSkipped } = await deduplicateComments(
-    octokit,
-    pr,
-    pluginId,
-    comments,
-    markerPrefix,
-    logger,
-  );
+    ({ toPost, dedupSkipped } = await deduplicateComments(
+      octokit,
+      pr,
+      pluginId,
+      comments,
+      markerPrefix,
+      logger,
+    ));
+  }
 
   const skipped = outOfDiffCount + dedupSkipped;
+  logger.info(
+    `postInlineComments(${pluginId}): posting ${toPost.length} of ${findings.length} finding(s) ` +
+      `(${outOfDiffCount} outside diff, ${dedupSkipped} already commented)`,
+  );
   if (toPost.length === 0) return { posted: 0, skipped };
 
   await postPRReview(octokit, pr, toPost, summaryBody, logger, 'COMMENT');
@@ -630,7 +637,7 @@ async function deduplicateComments(
     let dedupSkipped = 0;
     const toPost = comments.filter(c => {
       const key = extractPluginCommentKey(c.body, markerPrefix);
-      if (key && existingKeys.has(key)) {
+      if (key && isDuplicateOfExistingComment(key, existingKeys)) {
         dedupSkipped++;
         return false;
       }
@@ -873,4 +880,60 @@ function extractPluginCommentKey(body: string, markerPrefix: string): string | n
   const end = body.indexOf(' -->', keyStart);
   if (end === -1) return null;
   return body.slice(keyStart, end);
+}
+
+/**
+ * Line drift tolerance when matching a finding against an existing comment's
+ * dedup key. Agent line attribution drifts between runs on unchanged code
+ * (observed on PR #667: the same chunksCreated finding was posted at lines
+ * 461, 483, and 486 by three consecutive runs), so exact-line keys re-post
+ * near-duplicates. Same file + same category within this many lines counts
+ * as the same finding.
+ */
+export const DEDUP_LINE_TOLERANCE = 30;
+
+interface PluginCommentKey {
+  filepath: string;
+  line: number;
+  category: string;
+}
+
+/** Parse a `filepath::line::category` dedup key. Null if malformed. */
+export function parsePluginCommentKey(key: string): PluginCommentKey | null {
+  const parts = key.split('::');
+  if (parts.length < 3) return null;
+  const category = parts[parts.length - 1];
+  const line = Number(parts[parts.length - 2]);
+  const filepath = parts.slice(0, -2).join('::');
+  if (!filepath || !category || !Number.isInteger(line)) return null;
+  return { filepath, line, category };
+}
+
+/**
+ * True if a candidate dedup key matches an existing comment's key exactly,
+ * or matches one on the same file + category within DEDUP_LINE_TOLERANCE
+ * lines (line-drift tolerant dedup).
+ */
+export function isDuplicateOfExistingComment(
+  candidateKey: string,
+  existingKeys: ReadonlySet<string>,
+  tolerance: number = DEDUP_LINE_TOLERANCE,
+): boolean {
+  if (existingKeys.has(candidateKey)) return true;
+
+  const candidate = parsePluginCommentKey(candidateKey);
+  if (!candidate) return false;
+
+  for (const existingKey of existingKeys) {
+    const existing = parsePluginCommentKey(existingKey);
+    if (!existing) continue;
+    if (
+      existing.filepath === candidate.filepath &&
+      existing.category === candidate.category &&
+      Math.abs(existing.line - candidate.line) <= tolerance
+    ) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/review/test/analysis.test.ts
+++ b/packages/review/test/analysis.test.ts
@@ -103,4 +103,30 @@ describe('runComplexityAnalysis', () => {
     expect(result).not.toBeNull();
     expect(result!.report).toBeDefined();
   });
+
+  it('skips files absent from the checkout (baseline pass of a PR that adds files)', async () => {
+    const result = await runComplexityAnalysis(
+      ['src/analysis.ts', 'src/added-by-the-pr-does-not-exist.ts'],
+      '15',
+      process.cwd(),
+      silentLogger,
+    );
+
+    // The existing file is analyzed; the absent one is skipped without a
+    // per-file parser error and without appearing in the report.
+    expect(result).not.toBeNull();
+    expect(result!.chunks.length).toBeGreaterThan(0);
+    expect(result!.report.files['src/added-by-the-pr-does-not-exist.ts']).toBeUndefined();
+  });
+
+  it('returns null when no listed file exists in the checkout', async () => {
+    const result = await runComplexityAnalysis(
+      ['src/nope-1.ts', 'src/nope-2.ts'],
+      '15',
+      process.cwd(),
+      silentLogger,
+    );
+
+    expect(result).toBeNull();
+  });
 });

--- a/packages/review/test/engine-comment-dedup.test.ts
+++ b/packages/review/test/engine-comment-dedup.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePluginCommentKey,
+  isDuplicateOfExistingComment,
+  DEDUP_LINE_TOLERANCE,
+} from '../src/engine.js';
+
+describe('parsePluginCommentKey', () => {
+  it('parses a well-formed key', () => {
+    expect(parsePluginCommentKey('packages/core/src/indexer/index.ts::461::logic_error')).toEqual({
+      filepath: 'packages/core/src/indexer/index.ts',
+      line: 461,
+      category: 'logic_error',
+    });
+  });
+
+  it('returns null for keys with too few segments', () => {
+    expect(parsePluginCommentKey('just-a-string')).toBeNull();
+    expect(parsePluginCommentKey('file.ts::12')).toBeNull();
+  });
+
+  it('returns null for a non-integer line segment', () => {
+    expect(parsePluginCommentKey('file.ts::abc::logic_error')).toBeNull();
+  });
+
+  it('returns null for an empty filepath or category', () => {
+    expect(parsePluginCommentKey('::12::logic_error')).toBeNull();
+    expect(parsePluginCommentKey('file.ts::12::')).toBeNull();
+  });
+});
+
+describe('isDuplicateOfExistingComment', () => {
+  const key = (file: string, line: number, category = 'logic_error') =>
+    `${file}::${line}::${category}`;
+
+  it('matches an identical key exactly', () => {
+    const existing = new Set([key('src/a.ts', 10)]);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 10), existing)).toBe(true);
+  });
+
+  it('matches the same file + category within the line tolerance', () => {
+    const existing = new Set([key('src/a.ts', 10)]);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 10 + DEDUP_LINE_TOLERANCE), existing)).toBe(
+      true,
+    );
+  });
+
+  it('does not match beyond the line tolerance', () => {
+    const existing = new Set([key('src/a.ts', 10)]);
+    expect(
+      isDuplicateOfExistingComment(key('src/a.ts', 10 + DEDUP_LINE_TOLERANCE + 1), existing),
+    ).toBe(false);
+  });
+
+  it('does not match a different category on the same line', () => {
+    const existing = new Set([key('src/a.ts', 10, 'logic_error')]);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 10, 'error_swallowing'), existing)).toBe(
+      false,
+    );
+  });
+
+  it('does not match a different file', () => {
+    const existing = new Set([key('src/a.ts', 10)]);
+    expect(isDuplicateOfExistingComment(key('src/b.ts', 10), existing)).toBe(false);
+  });
+
+  it('ignores malformed existing keys instead of throwing', () => {
+    const existing = new Set(['not-a-key', key('src/a.ts', 10)]);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 12), existing)).toBe(true);
+    expect(isDuplicateOfExistingComment('also-not-a-key', existing)).toBe(false);
+  });
+
+  it('collapses the PR #667 line-drift incident: 461 → 483 → 486', () => {
+    // Three consecutive review runs posted the same chunksCreated finding
+    // at drifting lines; each later key must dedup against the earlier ones.
+    const file = 'packages/core/src/indexer/index.ts';
+    const afterRun1 = new Set([key(file, 461)]);
+    expect(isDuplicateOfExistingComment(key(file, 483), afterRun1)).toBe(true);
+    expect(isDuplicateOfExistingComment(key(file, 486), afterRun1)).toBe(true);
+  });
+
+  it('respects a custom tolerance argument', () => {
+    const existing = new Set([key('src/a.ts', 10)]);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 15), existing, 4)).toBe(false);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 15), existing, 5)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Three papercuts surfaced while diagnosing why PR #667's latest review run reported '2 issues found' with no visible comment activity (the comments existed — earlier runs had posted them, and the new run deduplicated silently):

1. **Silent dedup skips.** `postInlineComments` returned early with no logging when everything was filtered or deduplicated. It now always logs one line: `posting N of M finding(s) (X outside diff, Y already commented)` — so a run that posts nothing says why.
2. **Line-drift near-duplicates.** The dedup key is `filepath::line::category`, but agent line attribution drifts between runs on unchanged code: PR #667 accumulated three comments for the same `chunksCreated` finding at lines 461, 483, and 486. Dedup now treats same file + same category within `DEDUP_LINE_TOLERANCE` (30 lines) as the same finding, with exact-match as the fast path. Helpers are exported pure functions.

Not addressed here (observed, separate concern): multiple review runs executing against the same head SHA.

## Testing

12 new unit tests (`engine-comment-dedup.test.ts`) covering key parsing, exact/tolerant/boundary matching, category and file mismatches, malformed-key resilience, and a regression case encoding the exact 461→483→486 incident. Full review suite 30 files / 556 tests green; format/lint/typecheck/build clean.

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 2 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +151 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it ended without emitting a parseable JSON verdict while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fece6ba. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline comment deduplication so repeated findings are recognized even if line numbers shift slightly.
  * Reduced duplicate comments by matching on the same file and category within a safe line-range tolerance.
  * Added more informative logging for review results, including findings outside the diff and already-commented items.

* **Tests**
  * Added coverage for comment key parsing and duplicate detection, including edge cases and line-drift behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

3. **Baseline ENOENT noise.** `runComplexityAnalysis` runs against both the PR-head clone and the baseline clone with the same changed-file list, so every file a PR *adds* produced a `[parser] Failed to process <file>: ENOENT` error line in the baseline pass (12 of them on PR #667's runs) despite being harmless — added files correctly count as all-new complexity. Files absent from the checkout are now filtered up front with one honest info line. +2 tests (absent-file skip, all-absent returns null); review suite now 30 files / 558 tests.