### PR TITLE
fix(review): recover verdicts from the reasoning channel

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -118,6 +118,42 @@ export function extractFindingsFromText(text: string): {
   return fallback ?? { findings: [] };
 }
 
+/**
+ * Extract a verdict from a turn's content, falling back to its reasoning
+ * channel when content yields nothing. Kimi (via OpenRouter) sometimes emits
+ * the entire verdict JSON into `message.reasoning` with empty content —
+ * observed twice on PR #668 (run 28705034445, attempts 1 and 2): the full
+ * verdict was visible in the turn log under "Turn 5 reasoning:" while
+ * content-only extraction found nothing, so the review bailed as incomplete
+ * and discarded real findings, surviving even the summary-retry (which hit
+ * the same channel mismatch).
+ *
+ * Content always wins when it carries a summary or findings; reasoning is
+ * consulted only when content produced neither. Both channels go through the
+ * same fence-priority pipeline, so the summary-preference guard against
+ * few-shot example JSON applies to reasoning too.
+ */
+export function extractFindingsWithReasoningFallback(
+  content: string | null | undefined,
+  reasoning: string | null | undefined,
+  logger?: Logger,
+): { findings: AgentFinding[]; summary?: AgentSummary } {
+  const fromContent = content
+    ? extractFindingsFromText(content)
+    : { findings: [] as AgentFinding[], summary: undefined };
+  if (fromContent.summary || fromContent.findings.length > 0) return fromContent;
+
+  const fromReasoning = reasoning
+    ? extractFindingsFromText(reasoning)
+    : { findings: [] as AgentFinding[], summary: undefined };
+  if (fromReasoning.summary || fromReasoning.findings.length > 0) {
+    logger?.info('[agent] Verdict recovered from the reasoning channel (content had none)');
+    return fromReasoning;
+  }
+
+  return { findings: [] };
+}
+
 /** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
 export function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
   const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -22,7 +22,7 @@ import {
   truncate,
   envDisabled,
   logTurn,
-  extractFindingsFromText,
+  extractFindingsWithReasoningFallback,
 } from './agent-client-shared.js';
 
 // `envDisabled` is re-exported so its existing test import path
@@ -391,7 +391,7 @@ export class OpenAIAgentClient {
     // its own (reasoning-less) trace — that's what we want to surface on bail.
     const lastLoopTurn = turnTraces[turnTraces.length - 1];
 
-    let parsed = extractResponse(lastContent);
+    let parsed = extractResponse(lastContent, lastLoopTurn?.reasoning, this.logger);
     // Fire the summary-retry whenever we have *any* loop history but no
     // findings JSON. The previous guard `lastContent !== null` skipped
     // retry whenever the model emitted reasoning but null content — the
@@ -527,7 +527,11 @@ export class OpenAIAgentClient {
         inputTokens,
         outputTokens,
       };
-      const parsed = extractResponse(choice?.message.content);
+      const parsed = extractResponse(
+        choice?.message.content ?? null,
+        choice?.message.reasoning,
+        this.logger,
+      );
       return { parsed, traceTurn, inputTokens, outputTokens };
     } catch (err) {
       this.logger.warning(
@@ -714,13 +718,18 @@ export function toOpenAITools(
 // ---------------------------------------------------------------------------
 
 /**
- * Extract findings from a chat completion's message content, delegating to the
- * shared fence-priority recovery pipeline (see `extractFindingsFromText`). A
- * null/empty content (e.g. a tool-calls turn) yields no findings.
+ * Extract findings from a chat completion's message, delegating to the shared
+ * fence-priority recovery pipeline. Content is authoritative; the reasoning
+ * channel is a fallback for models (Kimi via OpenRouter) that emit their
+ * verdict there with empty content — see extractFindingsWithReasoningFallback.
  */
-function extractResponse(content: string | null): {
+function extractResponse(
+  content: string | null,
+  reasoning: string | null | undefined,
+  logger?: Logger,
+): {
   findings: AgentFinding[];
   summary?: AgentSummary;
 } {
-  return content ? extractFindingsFromText(content) : { findings: [] };
+  return extractFindingsWithReasoningFallback(content, reasoning, logger);
 }

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -4,12 +4,14 @@ import {
   envDisabled,
   logTurn,
   extractFindingsFromText,
+  extractFindingsWithReasoningFallback,
   readVerdict,
   embeddedJsonObject,
   isValidSummary,
   isValidFinding,
   AGENT_LOG_MAX,
 } from '../src/plugins/agent/agent-client-shared.js';
+import { silentLogger } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
 import type { TurnTrace } from '../src/plugins/agent/types.js';
 
@@ -244,5 +246,58 @@ describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
     const good = fence({ findings: [], summary });
     const out = extractFindingsFromText(`${good}\n${broken}`);
     expect(out.summary).toEqual(summary);
+  });
+});
+
+describe('extractFindingsWithReasoningFallback (reasoning-channel verdict recovery)', () => {
+  it('content wins when it carries a verdict, even if reasoning has one too', () => {
+    const contentVerdict = fence({ findings: [], summary: { ...summary, overview: 'CONTENT' } });
+    const reasoningVerdict = fence({
+      findings: [],
+      summary: { ...summary, overview: 'REASONING' },
+    });
+    const out = extractFindingsWithReasoningFallback(contentVerdict, reasoningVerdict);
+    expect(out.summary?.overview).toBe('CONTENT');
+  });
+
+  it('content wins with findings-only output (content stays authoritative)', () => {
+    const contentFindings = fence({ findings: [finding] });
+    const reasoningVerdict = fence({ findings: [], summary });
+    const out = extractFindingsWithReasoningFallback(contentFindings, reasoningVerdict);
+    expect(out.findings).toHaveLength(1);
+    expect(out.summary).toBeUndefined();
+  });
+
+  it('recovers a fenced verdict from reasoning when content is null', () => {
+    const out = extractFindingsWithReasoningFallback(null, fence({ findings: [finding], summary }));
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(1);
+  });
+
+  it('recovers a raw JSON verdict embedded in reasoning prose (the PR #668 incident shape)', () => {
+    const reasoning =
+      'We need output findings JSON now. We have already read key files. ' +
+      JSON.stringify({ findings: [finding], summary });
+    const out = extractFindingsWithReasoningFallback('', reasoning);
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(1);
+  });
+
+  it('returns empty when neither channel has a verdict', () => {
+    const out = extractFindingsWithReasoningFallback('just prose', 'more prose');
+    expect(out.findings).toHaveLength(0);
+    expect(out.summary).toBeUndefined();
+  });
+
+  it('returns empty when both channels are absent', () => {
+    const out = extractFindingsWithReasoningFallback(null, undefined);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('logs the recovery when falling back to reasoning', () => {
+    const infos: string[] = [];
+    const logger = { ...silentLogger, info: (m: string) => void infos.push(m) };
+    extractFindingsWithReasoningFallback(null, fence({ findings: [], summary }), logger);
+    expect(infos.some(m => m.includes('recovered from the reasoning channel'))).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Fixes the failure that ate today's review of #668 twice in a row: https://github.com/getlien/lien/actions/runs/28705034445 (attempts 1 and 2 both ended with "Lien Review did not finish — no parseable JSON verdict").

**Root cause:** kimi (via OpenRouter) emitted its complete verdict JSON into `message.reasoning` with empty `content`. Both extraction points (`openai-client.ts` end-of-loop and the summary-retry) parse content only — the retry re-hit the same channel mismatch, so the #612-era mitigation couldn't recover it. The log shows the full three-finding verdict under "Turn 5 reasoning:" while the engine reported 0 findings, `finish_reason=stop` (not truncation).

**Fix:** `extractFindingsWithReasoningFallback` in `agent-client-shared.ts` — content stays authoritative; the reasoning channel is consulted only when content yields neither summary nor findings, through the same fence-priority pipeline (summary-preference guard against few-shot examples applies), with an `[agent] Verdict recovered from the reasoning channel` info log. Wired at both extraction points. Anthropic client deliberately untouched.

## Testing

- 7 new zero-LLM unit tests: content-wins (full and findings-only), fenced + raw-embedded recovery from reasoning (the exact incident shape, including the "We need output findings JSON now…" prose prefix), empty-both, and the recovery log.
- Full review suite 29 files / 551 tests green; format/lint/typecheck/build clean.
- Live behavioral check through the patched client: `doc-truth/renamed-stale-claim` 3/3 passed on kimi ($0.04) — normal content-channel extraction unregressed.

## Harness evidence

No rule prompts changed — this is parsing/recovery logic. Evidence: the incident run above, the zero-LLM test suite, and the live 3-vote fixture pass; the doc-truth rule's 10/10+10/10 calibrate baseline from #665 is unaffected by this change.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 7 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 2 | +6 |
| 🐛 estimated bugs | 1 | +0.019 |


> [!NOTE]
> **Low Risk**
>
> The PR adds a reasoning-channel fallback for verdict extraction when OpenRouter/Kimi emits the verdict JSON into `message.reasoning` with empty `content`. The implementation is straightforward: `extractFindingsWithReasoningFallback` tries content first, then reasoning, using the same fence-priority pipeline, and logs when recovery happens. Both extraction points in `openai-client.ts` (end-of-loop and summary-retry) are wired correctly, and the Anthropic client is intentionally left unchanged. The new unit tests cover content-wins, reasoning recovery (fenced and raw-embedded), empty-both, and the recovery log. No bugs, breaking changes, or silent error swallowing were found.
>
> - Added `extractFindingsWithReasoningFallback` in `agent-client-shared.ts` with content-authoritative, reasoning-fallback semantics
> - Updated `openai-client.ts` end-of-loop extraction and summary-retry extraction to pass `message.reasoning` through the new fallback
> - Added 7 zero-LLM unit tests covering the incident shape and recovery log

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1a93509. Updates automatically on new commits.</sup>
<!-- /lien-stats -->