### PR TITLE
feat(cli): report worktree-aware indexing status in lien status

### DIFF
--- a/.changeset/status-worktree-mode.md
+++ b/.changeset/status-worktree-mode.md
@@ -1,0 +1,5 @@
+---
+'@liendev/lien': minor
+---
+
+`lien status` now reports worktree-aware indexing status when run inside a linked git worktree: the resolved mode (overlay vs standalone, with the reason for a standalone fallback), the main checkout and base index location and whether it was found, the overlay index location and file count, and whether the `LIEN_WORKTREE_STANDALONE=1` escape hatch forced standalone. Output in a normal checkout is unchanged.

--- a/packages/cli/src/cli/status.test.ts
+++ b/packages/cli/src/cli/status.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock @liendev/core
+//
+// `detectLinkedWorktree` and `resolveIndexStrategy` are mocked here (not left
+// to the `...actual` spread) because `detectLinkedWorktree` shells out to real
+// `git` — running the actual implementation in tests would make status.test.ts
+// behave differently depending on whether it happens to run inside a linked
+// worktree (true for e.g. Claude Code agent worktrees). Default to "not a
+// worktree" so every pre-existing test keeps seeing today's output unchanged.
 vi.mock('@liendev/core', async () => {
   const actual = await vi.importActual<typeof import('@liendev/core')>('@liendev/core');
   return {
@@ -10,6 +17,8 @@ vi.mock('@liendev/core', async () => {
     getCurrentCommit: vi.fn().mockResolvedValue('abc12345def67890'),
     readVersionFile: vi.fn().mockResolvedValue(0),
     loadGlobalConfig: vi.fn().mockResolvedValue({ backend: 'sqlite' }),
+    detectLinkedWorktree: vi.fn().mockResolvedValue({ isLinkedWorktree: false, mainRoot: null }),
+    resolveIndexStrategy: vi.fn().mockResolvedValue({ mode: 'standalone' }),
   };
 });
 
@@ -42,6 +51,8 @@ import {
   getCurrentCommit,
   readVersionFile,
   loadGlobalConfig,
+  detectLinkedWorktree,
+  resolveIndexStrategy,
 } from '@liendev/core';
 import fs from 'fs/promises';
 
@@ -55,10 +66,13 @@ describe('statusCommand', () => {
     vi.mocked(fs.readdir).mockResolvedValue([]);
     vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
     vi.mocked(loadGlobalConfig).mockResolvedValue({ backend: 'sqlite' });
+    vi.mocked(detectLinkedWorktree).mockResolvedValue({ isLinkedWorktree: false, mainRoot: null });
+    vi.mocked(resolveIndexStrategy).mockResolvedValue({ mode: 'standalone' });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env.LIEN_WORKTREE_STANDALONE;
   });
 
   it('should show "Not indexed" for project without index', async () => {
@@ -211,5 +225,83 @@ describe('statusCommand', () => {
 
     const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
     expect(allOutput).toContain('3');
+  });
+
+  describe('worktree-aware indexing status', () => {
+    it('should not show a Worktree section in a normal checkout', async () => {
+      // beforeEach already defaults detectLinkedWorktree to { isLinkedWorktree: false }
+      await statusCommand();
+
+      const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(allOutput).not.toContain('Worktree:');
+    });
+
+    it('should report overlay mode with base and overlay index locations', async () => {
+      vi.mocked(detectLinkedWorktree).mockResolvedValue({
+        isLinkedWorktree: true,
+        mainRoot: '/repo/main',
+      });
+      vi.mocked(resolveIndexStrategy).mockResolvedValue({
+        mode: 'overlay',
+        mainRoot: '/repo/main',
+        baseIndexDir: '/lien-home/.lien/indices/main-repo-id',
+        overlayIndexDir: '/lien-home/.lien/indices/worktree-repo-id',
+      });
+      vi.mocked(fs.stat).mockResolvedValue({
+        mtime: new Date('2025-01-01'),
+        isDirectory: () => true,
+      } as any);
+      vi.mocked(fs.readdir).mockResolvedValue(['a', 'b'] as any);
+
+      await statusCommand();
+
+      const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(allOutput).toContain('Worktree:');
+      expect(allOutput).toContain('Overlay');
+      expect(allOutput).toContain('/repo/main');
+      expect(allOutput).toContain('Base index:');
+      expect(allOutput).toContain('/lien-home/.lien/indices/main-repo-id');
+      expect(allOutput).toContain('Found');
+      expect(allOutput).toContain('Overlay index:');
+      expect(allOutput).toContain('/lien-home/.lien/indices/worktree-repo-id');
+    });
+
+    it('should report standalone mode with the reason when the main checkout has no usable index', async () => {
+      vi.mocked(detectLinkedWorktree).mockResolvedValue({
+        isLinkedWorktree: true,
+        mainRoot: '/repo/main',
+      });
+      vi.mocked(resolveIndexStrategy).mockResolvedValue({ mode: 'standalone' });
+      vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+      await statusCommand();
+
+      const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(allOutput).toContain('Worktree:');
+      expect(allOutput).toContain('Standalone');
+      expect(allOutput).toContain('main checkout has no index yet');
+      expect(allOutput).toContain('/repo/main');
+      expect(allOutput).toContain('Base index:');
+      expect(allOutput).toContain('Not found');
+      expect(allOutput).not.toContain('Escape hatch:');
+    });
+
+    it('should report the LIEN_WORKTREE_STANDALONE escape hatch when it forced standalone mode', async () => {
+      process.env.LIEN_WORKTREE_STANDALONE = '1';
+      vi.mocked(detectLinkedWorktree).mockResolvedValue({
+        isLinkedWorktree: true,
+        mainRoot: '/repo/main',
+      });
+      vi.mocked(resolveIndexStrategy).mockResolvedValue({ mode: 'standalone' });
+
+      await statusCommand();
+
+      const allOutput = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(allOutput).toContain('Worktree:');
+      expect(allOutput).toContain('Standalone');
+      expect(allOutput).toContain('escape hatch forced standalone');
+      expect(allOutput).toContain('Escape hatch:');
+      expect(allOutput).toContain('LIEN_WORKTREE_STANDALONE=1');
+    });
   });
 });

--- a/packages/cli/src/cli/status.ts
+++ b/packages/cli/src/cli/status.ts
@@ -10,12 +10,15 @@ import {
   getCurrentCommit,
   readVersionFile,
   loadGlobalConfig,
+  detectLinkedWorktree,
+  resolveIndexStrategy,
   DEFAULT_CONCURRENCY,
   DEFAULT_GIT_POLL_INTERVAL_MS,
 } from '@liendev/core';
 import {
   extractRepoId,
   getLienHome,
+  getIndexDir,
   DEFAULT_CHUNK_SIZE,
   DEFAULT_CHUNK_OVERLAP,
 } from '@liendev/parser';
@@ -147,6 +150,78 @@ async function printGitStatus(rootDir: string, indexPath: string) {
   }
 }
 
+/**
+ * Report worktree-aware indexing status. A no-op (prints nothing) outside a
+ * linked git worktree, so a normal checkout's output is unchanged.
+ *
+ * Reuses `resolveIndexStrategy` as the sole source of truth for the mode
+ * (overlay vs standalone) — this only adds display-only facts (does the base
+ * index dir exist, how big is the overlay) on top of that decision.
+ */
+async function printWorktreeStatus(rootDir: string) {
+  const { isLinkedWorktree, mainRoot } = await detectLinkedWorktree(rootDir);
+  if (!isLinkedWorktree) return;
+
+  const strategy = await resolveIndexStrategy(rootDir);
+  const escapeHatchOn = process.env.LIEN_WORKTREE_STANDALONE === '1';
+
+  const effectiveMainRoot = strategy.mode === 'overlay' ? strategy.mainRoot : mainRoot;
+  const baseIndexDir =
+    strategy.mode === 'overlay'
+      ? strategy.baseIndexDir
+      : effectiveMainRoot
+        ? getIndexDir(effectiveMainRoot)
+        : null;
+  const baseFound = baseIndexDir ? (await getFileStats(baseIndexDir)) !== null : false;
+
+  console.log(chalk.bold('\nWorktree:'));
+
+  if (strategy.mode === 'overlay') {
+    console.log(
+      chalk.dim('Mode:'),
+      chalk.green('✓ Overlay'),
+      chalk.dim('(sharing base index from main checkout)'),
+    );
+  } else {
+    const reason = escapeHatchOn
+      ? 'escape hatch forced standalone'
+      : !effectiveMainRoot
+        ? 'main checkout could not be located'
+        : !baseFound
+          ? 'main checkout has no index yet — run `lien index` there'
+          : 'main checkout index is incompatible with this version';
+    console.log(chalk.dim('Mode:'), chalk.yellow('✗ Standalone'), chalk.dim(`(${reason})`));
+  }
+
+  if (effectiveMainRoot) {
+    console.log(chalk.dim('Main checkout:'), effectiveMainRoot);
+  }
+
+  if (baseIndexDir) {
+    console.log(chalk.dim('Base index:'), baseIndexDir);
+    console.log(
+      chalk.dim('  Status:'),
+      baseFound ? chalk.green('✓ Found') : chalk.yellow('✗ Not found'),
+    );
+  }
+
+  if (strategy.mode === 'overlay') {
+    console.log(chalk.dim('Overlay index:'), strategy.overlayIndexDir);
+    const overlayFileCount = await getFileCount(strategy.overlayIndexDir);
+    if (overlayFileCount !== null) {
+      console.log(chalk.dim('  Files:'), overlayFileCount);
+    }
+  }
+
+  if (escapeHatchOn) {
+    console.log(
+      chalk.dim('Escape hatch:'),
+      chalk.yellow('ON'),
+      chalk.dim('(LIEN_WORKTREE_STANDALONE=1)'),
+    );
+  }
+}
+
 function printWatchStatus() {
   console.log(chalk.dim('File watching:'), chalk.green('✓ Enabled (default)'));
   console.log(chalk.dim('  Batch window:'), '500ms (collects rapid changes, force-flush after 5s)');
@@ -192,6 +267,7 @@ export async function statusCommand(options: { verbose?: boolean; format?: strin
   console.log(chalk.dim('Backend:'), backend);
 
   await printIndexStatus(indexPath);
+  await printWorktreeStatus(rootDir);
 
   console.log(chalk.bold('\nFeatures:'));
   await printGitStatus(rootDir, indexPath);


### PR DESCRIPTION
## Summary

- `lien status` never called `resolveIndexStrategy`, so worktree overlay/standalone mode was only visible via `lien index`'s progress output — a gap explicitly called out in #667's verification notes.
- When run inside a **linked git worktree**, `status` now prints a `Worktree:` section: resolved mode (overlay vs standalone, with the reason for a standalone fallback), the main checkout + base index location and whether it was found, the overlay index location + file count, and whether `LIEN_WORKTREE_STANDALONE=1` forced standalone.
- In a **normal checkout**, `printWorktreeStatus` is a no-op (returns immediately after `detectLinkedWorktree` reports `isLinkedWorktree: false`) — output is byte-for-byte unchanged from before this PR.
- Reuses `resolveIndexStrategy` (already exported from `@liendev/core`) as the sole source of truth for the mode decision; the extra display-only facts (does the base dir exist, how many files in the overlay) are simple `fs.stat`/`fs.readdir` checks using the same helpers `status.ts` already had for the local index.

## Test mock hardening

`status.test.ts`'s `@liendev/core` mock now explicitly mocks `detectLinkedWorktree` (default: `{ isLinkedWorktree: false, mainRoot: null }`) and `resolveIndexStrategy` (default: `{ mode: 'standalone' }'`), reset in `beforeEach` — matching the existing pattern for `isGitRepo`/`loadGlobalConfig`. This was required because `detectLinkedWorktree` shells out to real `git`; leaving it un-mocked (falling through the `...actual` spread) would make the test suite's behavior depend on whether it happens to run inside a linked worktree (true today for Claude Code agent worktrees). Four new tests cover: no `Worktree:` section in a normal checkout, overlay mode, standalone-with-reason (main has no index), and the escape hatch flag.

`status.ts` continues to let `loadGlobalConfig`/config errors propagate (no new silent-catch introduced) — `resolveIndexStrategy`/`detectLinkedWorktree` are documented as "never throw", so no additional error handling was needed there.

## Verified against the built CLI

Ran `node packages/cli/dist/index.js status` (built from this branch) against scratch `git worktree add` repos plus a normal checkout, with `LIEN_HOME` pointed at a scratch dir.

**Normal checkout (not a worktree) — unchanged, no Worktree section:**
```
Status

Backend: sqlite
Index status: ✗ Not indexed

Run lien index to index your codebase

Features:
Git detection: ✓ Enabled
  Poll interval: 10s
  Current branch: master
  Current commit: d1c7719b
File watching: ✓ Enabled (default)
  Batch window: 500ms (collects rapid changes, force-flush after 5s)
  Disable with: lien serve --no-watch
Search: ✓ Lexical (FTS5 full-text, BM25)
  No embeddings are computed — nothing is downloaded.
```

**Linked worktree, main checkout indexed → overlay mode:**
```
Status

Backend: sqlite
Index location: /tmp/lien-verify-home/.lien/indices/lien-verify-wt-overlay-8fac450e
Index status: ✓ Exists
Index files: 3
Last modified: 7/4/2026, 2:32:00 PM
Last reindex: 7/4/2026, 2:32:00 PM

Worktree:
Mode: ✓ Overlay (sharing base index from main checkout)
Main checkout: /private/tmp/lien-verify-repo
Base index: /tmp/lien-verify-home/.lien/indices/lien-verify-repo-6aab2ccc
  Status: ✓ Found
Overlay index: /tmp/lien-verify-home/.lien/indices/lien-verify-wt-overlay-8fac450e
  Files: 3

Features:
Git detection: ✓ Enabled
  Poll interval: 10s
  Current branch: wt-overlay-branch
  Current commit: d1c7719b
File watching: ✓ Enabled (default)
  Batch window: 500ms (collects rapid changes, force-flush after 5s)
  Disable with: lien serve --no-watch
Search: ✓ Lexical (FTS5 full-text, BM25)
  No embeddings are computed — nothing is downloaded.
```

**Linked worktree, main checkout NOT indexed → standalone fallback with reason:**
```
Worktree:
Mode: ✗ Standalone (main checkout has no index yet — run `lien index` there)
Main checkout: /private/tmp/lien-verify-repo2
Base index: /tmp/lien-verify-home2/.lien/indices/lien-verify-repo2-62c4b606
  Status: ✗ Not found
```

**Linked worktree with a valid base index, `LIEN_WORKTREE_STANDALONE=1` set → escape hatch:**
```
Worktree:
Mode: ✗ Standalone (escape hatch forced standalone)
Main checkout: /private/tmp/lien-verify-repo
Base index: /tmp/lien-verify-home/.lien/indices/lien-verify-repo-6aab2ccc
  Status: ✓ Found
Escape hatch: ON (LIEN_WORKTREE_STANDALONE=1)
```

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; pre-existing warning count unchanged)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (full monorepo — parser 939, core 318, review 565, cli 687 incl. 4 new worktree-status tests, action 28 — all passing)
- [x] Manual verification against the built CLI in scratch worktrees (see above) — normal checkout, overlay mode, standalone fallback, escape hatch

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 2 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +16 |
| 🧠 mental load | 1 | +17 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a worktree-aware status section to `lien status` by reusing `resolveIndexStrategy` from `@liendev/core`. In a normal checkout the new code returns early and leaves output unchanged; in a linked worktree it prints the resolved overlay/standalone mode, base/overlay index locations, and escape-hatch state. The implementation correctly delegates the mode decision to `resolveIndexStrategy`, swallows only expected filesystem errors, and hardens the test mocks so the suite is deterministic outside a worktree. No breaking changes or incorrect output paths were found.
>
> - `statusCommand` now calls `printWorktreeStatus` after `printIndexStatus` for text output.
> - `printWorktreeStatus` uses `detectLinkedWorktree` and `resolveIndexStrategy` as the source of truth, then computes display-only filesystem facts with existing helpers.
> - Test mocks now explicitly default `detectLinkedWorktree` and `resolveIndexStrategy` and reset `LIEN_WORKTREE_STANDALONE` after each test.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a72092b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->