### PR TITLE
feat(delta): lien delta — complexity accounting before commit (Phase 1)

### DIFF
--- a/.changeset/lien-delta.md
+++ b/.changeset/lien-delta.md
@@ -1,0 +1,11 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': minor
+---
+
+Add `lien delta` — flag NEW complexity threshold crossings before commit.
+
+Lien already scores per-function complexity and reports threshold violations in PR review, but only *after* code is pushed. `lien delta` moves that signal to edit time: a ~50 ms deterministic check that compares the working tree against `HEAD` and fails only when a change pushes a function's complexity over a threshold it was under before (a new-over-threshold or crossed function). Improving, or merely touching, a pre-existing violation never fails.
+
+- **Shared primitive** `computeComplexityDelta` in `@liendev/parser` computes per-function before/after verdicts (`crossed`, `new-over-threshold`, `worsened`, `pre-existing`, `improved`, `unchanged`, `new-under-threshold`, `removed`) from two content strings, reusing the existing complexity machinery (`chunkFile` + cyclomatic/cognitive/Halstead metrics). Because the PR-review engine depends on parser only, it can adopt the same primitive so write-time and review-time verdicts never structurally disagree.
+- **`lien delta` CLI** compares the working tree vs `HEAD` across changed files (staged + unstaged + untracked, with rename and unborn-HEAD handling), prints a concise per-function crossing table, and uses gate-friendly exit codes: `0` clean (or `--soft`), `1` on new crossings, `2` on operational failure. Thresholds come from `.lien.config.json`'s `complexity.thresholds` (the same source PR review reads), overridable with `--threshold`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,9 +274,17 @@ npm run lint          # ESLint must pass with 0 errors
 npm run typecheck     # Must pass with 0 errors
 npm run build         # Must compile successfully
 npm test              # All tests must pass
+lien delta            # No NEW complexity threshold crossings vs HEAD (exit 0)
 ```
 
 **No exceptions.** This prevents broken builds.
+
+**`lien delta`** is the sixth gate: a ~50 ms deterministic check that fails
+(exit 1) only when your working-tree changes push a function's complexity over a
+threshold it was under at `HEAD` (a new-over-threshold or crossed function).
+Improving, or merely touching a pre-existing violation, never fails. If it
+flags a crossing, simplify the function before committing — do not reach for
+`--soft` (advisory, always exit 0) to silence it.
 
 **Tip:** Run `npm run fix` to auto-fix both ESLint and Prettier issues.
 

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -166,7 +166,7 @@ Given a metric's `before` value `b`, `after` value `a`, and threshold `t`
 a === null                 -> 'removed'
 b === null                 -> a >= t ? 'new-over-threshold' : 'new-under-threshold'
 b <  t && a >= t           -> 'crossed'
-b >= t                     -> a <  b ? 'improved' : 'pre-existing'   // pre-existing violation
+b >= t                     -> a < b ? 'improved' : a > b ? 'pre-existing' : 'unchanged'
 otherwise (both < t)       -> a > b ? 'worsened' : a < b ? 'improved' : 'unchanged'
 ```
 

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -1,0 +1,337 @@
+# lien delta — complexity accounting before the commit
+
+Status: **Phase 1 (in progress)** — mechanisms 1 + 4 of a 5-mechanism plan.
+
+## Motivation
+
+An agent shipped a PR that passed every gate — format, lint, typecheck, build,
+test — but raised a function's cognitive complexity from under the threshold to
+**29 against a threshold of 15**. Nothing at edit time noticed. The PR-review
+engine caught it *after the fact*, which cost a full extra fixer-agent run for
+something a ~50 ms deterministic check could have flagged while the agent still
+had the change in hand.
+
+Lien already computes cognitive/cyclomatic/Halstead complexity per function and
+already surfaces threshold violations in PR review. The gap is purely one of
+**timing**: the signal exists, but only *after* the code is pushed. `lien delta`
+moves that signal to before the commit.
+
+This is the product thesis in miniature — Lien is the tool that stops agents
+from writing AI-shaped code. A blunt "your function is too complex" at review
+time is a slap on the wrist. The same verdict at edit time is a course
+correction the agent can act on for free.
+
+## Scope
+
+Phase 1 delivers two of the five planned mechanisms:
+
+- **Mechanism 4 — the shared primitive** (build first; it shapes everything).
+  A complexity-delta computation that lives in `@liendev/parser`. It takes two
+  versions of a file's content and emits per-function verdicts. Because the PR
+  review engine (`packages/review`) depends on parser *only* (not core), review
+  can adopt the exact same primitive later — so write-time and review-time
+  verdicts can never structurally disagree.
+- **Mechanism 1 — the `lien delta` CLI command.** Compares the working tree
+  against `HEAD` across changed files and prints a concise per-function table of
+  crossings plus a summary line, with exit codes designed for a commit gate.
+
+Explicitly **out of Phase 1** (later phases): the annotate-hook crossing
+warnings (mechanism 2), `get_files_context` complexity priming (mechanism 3),
+and any commit-*blocking* / soft-block behaviour (mechanism 5). Phase 1 builds
+**no hooks and blocks no commits** — `lien delta` is a gate an agent *chooses*
+to run, exactly like `npm test`.
+
+## A. The shared primitive (`@liendev/parser`)
+
+### Where it lives
+
+`packages/parser/src/insights/complexity-delta.ts`, exported from
+`packages/parser/src/index.ts`. It sits *beside* `analyzeComplexityFromChunks`
+(same directory, same metric machinery) rather than reimplementing anything.
+
+### How it reuses existing machinery
+
+The primitive does not invent metrics. It calls the existing
+`chunkFile(filepath, content, opts)` (from `chunker.ts`) which already:
+
+1. parses content via tree-sitter (`chunkByAST`),
+2. emits one chunk per function/method with
+   `complexity` (cyclomatic), `cognitiveComplexity`, `halsteadEffort`,
+   `halsteadBugs`, `symbolName`, `parentClass`, `signature`, `startLine`.
+
+`chunkFile` takes a **content string**, not a path on disk — so the primitive
+can chunk a "before" image (`git show HEAD:file`) and an "after" image (working
+tree) purely in memory, with no second checkout. This is the key difference from
+the existing review-side delta (see "Relationship to review" below).
+
+Halstead-effort thresholds are expressed in minutes in config; the primitive
+converts via the existing `minutesToEffort()` helper, exactly as
+`findViolations` does.
+
+### API
+
+```ts
+export interface ComplexityDeltaThresholds {
+  testPaths: number;               // cyclomatic  — matches config complexity.thresholds
+  mentalLoad: number;              // cognitive
+  timeToUnderstandMinutes: number; // halstead effort (converted to effort units)
+  estimatedBugs: number;           // halstead bugs
+}
+
+export type ComplexityDeltaVerdict =
+  | 'new-over-threshold'   // FAILS gate: function added and already over threshold
+  | 'crossed'              // FAILS gate: existed under threshold, now over it
+  | 'worsened'             // advisory: increased but still under threshold
+  | 'pre-existing'         // advisory: was over before, still over (no NEW crossing)
+  | 'improved'             // complexity decreased (may still be over — that's fine)
+  | 'unchanged'
+  | 'new-under-threshold'  // function added, under threshold
+  | 'removed';             // function deleted
+
+export interface MetricComplexityDelta {
+  metricType: ComplexityMetricType; // 'cyclomatic' | 'cognitive' | 'halstead_effort' | 'halstead_bugs'
+  before: number | null;            // null => function is newly added
+  after: number | null;             // null => function was removed
+  threshold: number;
+  verdict: ComplexityDeltaVerdict;
+}
+
+export interface FunctionComplexityDelta {
+  key: string;            // qualified match key, e.g. "MyClass::doThing"
+  symbolName: string;
+  parentClass?: string;
+  filepath: string;
+  language: string;
+  startLine: number;      // location in the "after" image (or "before" if removed)
+  verdict: ComplexityDeltaVerdict;  // worst verdict across the function's metrics
+  isRegression: boolean;            // verdict is 'crossed' | 'new-over-threshold'
+  metrics: MetricComplexityDelta[];
+}
+
+export interface FileComplexityDelta {
+  filepath: string;
+  oldPath?: string;       // set when the file was renamed
+  status: 'added' | 'deleted' | 'modified' | 'renamed';
+  functions: FunctionComplexityDelta[];
+}
+
+export interface ComplexityDeltaResult {
+  files: FileComplexityDelta[];
+  regressions: FunctionComplexityDelta[]; // flattened convenience view of failing functions
+  summary: {
+    filesChanged: number;
+    functionsAnalyzed: number;
+    regressions: number;      // functions with a failing verdict
+    crossed: number;
+    newOverThreshold: number;
+    worsened: number;
+    improved: number;
+  };
+  thresholds: ComplexityDeltaThresholds;   // the resolved thresholds actually applied
+}
+
+export interface FileContentChange {
+  filepath: string;       // path in the "after" tree (or the deleted path)
+  before: string | null;  // HEAD content; null = file added
+  after: string | null;   // working-tree content; null = file deleted
+  oldPath?: string;       // previous path, when renamed
+}
+
+// One file:
+export function computeFileComplexityDelta(
+  change: FileContentChange,
+  thresholds?: Partial<ComplexityDeltaThresholds>,
+): FileComplexityDelta;
+
+// Many files, aggregated with a summary:
+export function computeComplexityDelta(
+  changes: FileContentChange[],
+  thresholds?: Partial<ComplexityDeltaThresholds>,
+): ComplexityDeltaResult;
+
+// Gate helper:
+export function hasRegressions(result: ComplexityDeltaResult): boolean;
+```
+
+Thresholds default to the same constants `analyzeComplexityFromChunks` uses
+(`testPaths: 15, mentalLoad: 15, timeToUnderstandMinutes: 60, estimatedBugs:
+1.5`); a partial override is deep-merged over the defaults.
+
+### Per-metric classification
+
+Given a metric's `before` value `b`, `after` value `a`, and threshold `t`
+(`b`/`a` are `null` when the function is absent on that side):
+
+```
+a === null                 -> 'removed'
+b === null                 -> a >= t ? 'new-over-threshold' : 'new-under-threshold'
+b <  t && a >= t           -> 'crossed'
+b >= t                     -> a <  b ? 'improved' : 'pre-existing'   // pre-existing violation
+otherwise (both < t)       -> a > b ? 'worsened' : a < b ? 'improved' : 'unchanged'
+```
+
+A function's overall `verdict` is the **worst** of its per-metric verdicts,
+ordered `crossed > new-over-threshold > pre-existing > worsened >
+new-under-threshold > improved > unchanged > removed`.
+`isRegression` is true iff that verdict is `crossed` or `new-over-threshold`.
+
+**Which metrics gate.** All four metrics can produce a regression. This is
+deliberate: it is exactly the set `analyzeComplexityFromChunks` (and therefore
+PR review) already scores, so a delta regression and a review violation are the
+same event computed the same way. Metric-selection policy (e.g. "only cognitive
+gates, Halstead is advisory") is a plausible future knob, but it would then be
+tuned in this one shared primitive and both engines would move together. It is
+**not** a Phase-1 config surface (YAGNI).
+
+### Function matching across versions
+
+Functions are matched by **qualified name**: `` `${parentClass ?? ''}::${symbolName}` ``.
+When a key has multiple functions on one side (overloads, or same-named methods),
+they are paired positionally by ascending `startLine`; any extra on the "after"
+side are `added`, any extra on the "before" side are `removed`.
+
+Honest limitations (documented, not solved in Phase 1):
+
+- **Renames are not tracked at the function level.** Renaming `foo` to `bar`
+  reads as `foo` removed + `bar` added. If `bar` is over threshold it surfaces
+  as `new-over-threshold`. This is defensible (a new over-threshold function
+  *did* appear) but can nag on pure renames. File-level rename detection
+  (`--find-renames`) still lets us diff the *body*, so a renamed-but-unchanged
+  file produces no function-level noise; only function *identifier* renames are
+  affected.
+- **Signature changes do not break matching** — the key is name + parent, not
+  the full signature, so changing parameters or return type still matches the
+  same function (which is what we want: that is the common "edited a function"
+  case).
+- **Overload disambiguation is positional**, best-effort. TypeScript overloads
+  that reorder could mis-pair; rare enough to accept for Phase 1.
+
+## B. The `lien delta` CLI command
+
+`packages/cli/src/cli/delta-cmd.ts`, registered in `packages/cli/src/cli/index.ts`.
+
+### Behaviour
+
+1. Resolve the project root (walk up to `.git`, mirroring existing commands).
+2. Load thresholds from `.lien.config.json` via `configService.load()`
+   (`@liendev/core`) — the *same* source the review reads — falling back to
+   built-in defaults when the file or the `complexity` block is absent.
+   `--threshold <n>` overrides `testPaths` + `mentalLoad` (parity with the
+   review's single `--threshold`).
+3. Discover changed files (working tree vs `HEAD`):
+   - `git diff --name-status --find-renames HEAD` for tracked changes
+     (this already unions staged + unstaged, since it compares HEAD to the
+     working tree),
+   - plus `git ls-files --others --exclude-standard` for untracked new files
+     (treated as `added`).
+   - Filter to parser-supported code extensions (`getSupportedExtensions()`).
+4. For each changed file, build a `FileContentChange`:
+   - modified → `before = git show HEAD:path`, `after = read(worktree)`;
+   - added / untracked → `before = null`, `after = read(worktree)`;
+   - deleted → `before = git show HEAD:path`, `after = null`;
+   - renamed → `before = git show HEAD:oldPath`, `after = read(worktree:newPath)`,
+     `oldPath` set.
+5. Call `computeComplexityDelta(changes, thresholds)`.
+6. Print the table + summary; exit per the codes below.
+
+### Git edge cases
+
+- **Unborn HEAD** (no commits yet): `git rev-parse --verify HEAD` fails →
+  every changed/tracked/untracked file is treated as `added` (`before = null`).
+- **Not a git repo**: operational error, exit 2 (see below).
+- **Worktrees** (post-#667): `HEAD` and `git show HEAD:path` resolve against the
+  current worktree's HEAD — no special handling needed.
+
+### Output
+
+Concise, one row per function with a non-trivial verdict, grouped by file:
+
+```
+lien delta — complexity vs HEAD
+
+  packages/cli/src/cli/foo.ts
+    ✗ crossed     processRequest      cognitive 12 → 18  (threshold 15)
+    ⚠ worsened    helper              cognitive  8 → 11
+    ✓ improved    legacyThing         cognitive 24 → 9
+
+  ✗ 1 new crossing · ⚠ 1 worsened · ✓ 1 improved · 1 file · 41 ms
+```
+
+Clean changeset prints a single reassuring line and exits 0. `--format json`
+emits the `ComplexityDeltaResult` for tooling.
+
+### Exit-code semantics (designed for the gate liturgy)
+
+| Code | Meaning |
+|------|---------|
+| **0** | No new threshold crossings (or `--soft`). Improved / pre-existing / worsened-but-under do **not** fail. |
+| **1** | At least one regression: `new-over-threshold` or `crossed`. |
+| **2** | Operational failure — not a git repo, git missing, unreadable file. (Distinct from 1 so a gate can tell "found problems" from "couldn't run".) |
+
+`--soft` forces exit 0 always (advisory mode) while still printing the table —
+for agents that want the signal without the gate teeth during exploration.
+
+The asymmetry is the whole point: you are punished only for **making things
+worse than HEAD**, never for pre-existing debt you happened to touch. This keeps
+the gate honest and prevents it from blocking unrelated work in a hot file.
+
+### Optional MCP variant — deferred
+
+`get_complexity({ diff: true })` is attractive but does **not** fall out of A+B
+for free: the existing `get_complexity` handler reads the persisted index, while
+the delta primitive is content-based against `HEAD`. Wiring it means a new MCP
+schema field + a handler path that shells out to git. Deferred to a later phase
+with this note; the CLI is the Phase-1 surface.
+
+## Relationship to PR review (integration path — follow-up, NOT this PR)
+
+`packages/review/src/delta.ts` already computes a complexity delta, but at the
+**report** level: it diffs two `ComplexityReport`s (base clone vs head clone),
+so it only sees functions that *violate* on one side — it cannot observe a
+function that worsened while staying under threshold, and it requires the review
+engine's two full checkouts.
+
+The Phase-1 primitive is strictly more capable (function-level, sees
+under-threshold movement, needs only content strings). The intended follow-up —
+**not done in this PR** — is to have `packages/review` call
+`computeComplexityDelta` on the before/after content it already has from its two
+clones, and retire the report-diffing logic in `review/src/delta.ts`. That is
+what structurally guarantees write-time and review-time verdicts agree: one
+function, one classification table, two callers. This PR only adds the primitive
+and the CLI; review is left untouched.
+
+## C. Gate liturgy
+
+Agents follow gate lists religiously, so `lien delta` is added as the **sixth
+gate**:
+
+1. `CLAUDE.md` → "Before EVERY Commit (MANDATORY)" gains
+   `lien delta` after `npm test`.
+2. `lien init` templates: init currently writes no project-level commit-gate
+   file — its only agent artifact is the read-only Explore agent
+   (`packages/cli/src/cli/agents/explore-agent.ts`). Phase 1 surfaces
+   `lien delta` guidance there (under the "Safe to change? / tech-debt" framing
+   the Explore agent already uses). A dedicated project-scoped gate template
+   emitted by `lien init` is a new output surface and is deferred (YAGNI).
+
+## Deviations from the brief
+
+- **init gate template**: the brief anticipated an init-written gate template to
+  edit; none exists today (init only installs the Explore agent). Documented
+  above; the concrete Phase-1 edits are repo `CLAUDE.md` + the Explore agent
+  template.
+- **Metric gating**: the brief centres the cognitive-complexity incident, but
+  the primitive gates on all four metrics for structural parity with review
+  (rationale above). The CLI table leads with the crossed metric so the cognitive
+  case still reads front-and-centre.
+- **Exit code 2**: the brief specified non-zero only on new crossings; we split
+  that non-zero space into 1 (found crossings) vs 2 (couldn't run) so a gate can
+  distinguish the two. Exit 1 remains "new crossings," as specified.
+
+## Milestones
+
+- [ ] 1. Design doc + draft PR
+- [ ] 2. Shared delta primitive in parser + unit tests
+- [ ] 3. `lien delta` CLI + tests (git edge cases: staged/unstaged, unborn HEAD, renames)
+- [ ] 4. Gate liturgy docs (CLAUDE.md + init templates) + changeset
+- [ ] 5. Full gate green + real-repo & worsened-function demos with timing

--- a/packages/cli/src/cli/agents/explore-agent.ts
+++ b/packages/cli/src/cli/agents/explore-agent.ts
@@ -29,6 +29,7 @@ Choose the right tool for each query type:
 | "What does this file do?" / "What tests cover this?" | \`get_files_context\` |
 | "What depends on this?" / "Safe to change?" | \`get_dependents\` |
 | "Most complex functions?" / "Tech debt hotspots?" | \`get_complexity\` |
+| "Did my change add complexity?" / "Safe to commit?" | \`lien delta\` (via \`Bash\`) — new complexity crossings in the working tree vs HEAD |
 | "Find similar code to this pattern" | \`find_similar\` |
 
 ### Fallback Tools (when Lien tools are insufficient)

--- a/packages/cli/src/cli/delta-cmd.test.ts
+++ b/packages/cli/src/cli/delta-cmd.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeComplexityDelta,
+  DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
+  type ComplexityDeltaThresholds,
+} from '@liendev/parser';
+import { resolveDeltaThresholds, deltaExitCode, formatDeltaText } from './delta-cmd.js';
+
+const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*m/g, '');
+
+const BODY = {
+  oneIf: 'function target(x){ if(x){return 1;} return 2; }', // cog 1
+  twoNest: 'function target(x){ if(x){ if(x>1){ return 1; } } return 2; }', // cog 3
+  threeNest: 'function target(x){ if(x){ if(x>1){ if(x>2){ return 1; } } } return 2; }', // cog 6
+} as const;
+
+const COG_ONLY: ComplexityDeltaThresholds = {
+  testPaths: 1000,
+  mentalLoad: 5,
+  timeToUnderstandMinutes: 100000,
+  estimatedBugs: 1000,
+};
+
+describe('resolveDeltaThresholds', () => {
+  it('returns defaults when no config and no flag', () => {
+    expect(resolveDeltaThresholds(undefined, undefined)).toEqual(
+      DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
+    );
+  });
+
+  it('takes defined config values and ignores missing ones (no undefined clobber)', () => {
+    const resolved = resolveDeltaThresholds({ testPaths: 20, mentalLoad: 25 }, undefined);
+    expect(resolved.testPaths).toBe(20);
+    expect(resolved.mentalLoad).toBe(25);
+    // untouched keys keep their defaults
+    expect(resolved.timeToUnderstandMinutes).toBe(
+      DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.timeToUnderstandMinutes,
+    );
+    expect(resolved.estimatedBugs).toBe(DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.estimatedBugs);
+  });
+
+  it('--threshold overrides cyclomatic + cognitive only', () => {
+    const resolved = resolveDeltaThresholds({ testPaths: 20, mentalLoad: 20 }, '7');
+    expect(resolved.testPaths).toBe(7);
+    expect(resolved.mentalLoad).toBe(7);
+    expect(resolved.timeToUnderstandMinutes).toBe(
+      DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.timeToUnderstandMinutes,
+    );
+  });
+
+  it('ignores a non-numeric --threshold', () => {
+    const resolved = resolveDeltaThresholds({ testPaths: 20, mentalLoad: 20 }, 'abc');
+    expect(resolved.testPaths).toBe(20);
+    expect(resolved.mentalLoad).toBe(20);
+  });
+});
+
+describe('deltaExitCode', () => {
+  const withRegression = computeComplexityDelta(
+    [{ filepath: 'a.ts', before: BODY.twoNest, after: BODY.threeNest }],
+    COG_ONLY,
+  );
+  const clean = computeComplexityDelta(
+    [{ filepath: 'a.ts', before: BODY.threeNest, after: BODY.oneIf }],
+    COG_ONLY,
+  );
+
+  it('exits 1 on a regression', () => {
+    expect(deltaExitCode(withRegression, false)).toBe(1);
+  });
+
+  it('exits 0 when clean', () => {
+    expect(deltaExitCode(clean, false)).toBe(0);
+  });
+
+  it('--soft forces exit 0 even with a regression', () => {
+    expect(deltaExitCode(withRegression, true)).toBe(0);
+  });
+});
+
+describe('formatDeltaText', () => {
+  it('renders a crossing with the metric, values, limit and a call-to-action footer', () => {
+    const result = computeComplexityDelta(
+      [{ filepath: 'src/foo.ts', before: BODY.twoNest, after: BODY.threeNest }],
+      COG_ONLY,
+    );
+    const text = stripAnsi(formatDeltaText(result, 42));
+    expect(text).toContain('src/foo.ts');
+    expect(text).toContain('crossed');
+    expect(text).toContain('target');
+    expect(text).toContain('cognitive 3 → 6');
+    expect(text).toContain('(limit 5)');
+    expect(text).toContain('1 new crossing');
+    expect(text).toContain('42 ms');
+    expect(text).toContain('Simplify before committing');
+  });
+
+  it('renders improvements without a failure footer', () => {
+    const result = computeComplexityDelta(
+      [{ filepath: 'src/foo.ts', before: BODY.threeNest, after: BODY.oneIf }],
+      COG_ONLY,
+    );
+    const text = stripAnsi(formatDeltaText(result, 10));
+    expect(text).toContain('improved');
+    expect(text).toContain('1 improved');
+    expect(text).not.toContain('Simplify before committing');
+  });
+
+  it('reports a clean line when there are no changes', () => {
+    const text = stripAnsi(formatDeltaText(computeComplexityDelta([], COG_ONLY), 5));
+    expect(text).toContain('no complexity-affecting changes vs HEAD');
+    expect(text).toContain('5 ms');
+  });
+
+  it('labels renamed files', () => {
+    const result = computeComplexityDelta(
+      [{ filepath: 'new.ts', oldPath: 'old.ts', before: BODY.twoNest, after: BODY.threeNest }],
+      COG_ONLY,
+    );
+    const text = stripAnsi(formatDeltaText(result, 1));
+    expect(text).toContain('new.ts');
+    expect(text).toContain('renamed from old.ts');
+  });
+});

--- a/packages/cli/src/cli/delta-cmd.ts
+++ b/packages/cli/src/cli/delta-cmd.ts
@@ -1,0 +1,198 @@
+/**
+ * `lien delta` — flag NEW complexity threshold crossings in the working tree
+ * before they are committed. The sixth commit gate: cheap, deterministic, and
+ * it fails only on regressions you introduce (never on pre-existing debt).
+ */
+
+import chalk from 'chalk';
+import { configService } from '@liendev/core';
+import {
+  computeComplexityDelta,
+  resolveComplexityDeltaThresholds,
+  hasRegressions,
+  type ComplexityDeltaResult,
+  type ComplexityDeltaThresholds,
+  type FunctionComplexityDelta,
+  type MetricComplexityDelta,
+  type ComplexityDeltaVerdict,
+} from '@liendev/parser';
+import { getRepoRoot, collectFileChanges } from './delta-git.js';
+
+export interface DeltaOptions {
+  soft?: boolean;
+  format: 'text' | 'json';
+  threshold?: string;
+}
+
+const VALID_FORMATS = ['text', 'json'];
+
+/** Merge config thresholds (+ optional --threshold override) over the defaults. */
+export function resolveDeltaThresholds(
+  configThresholds: Partial<ComplexityDeltaThresholds> | undefined,
+  thresholdFlag: string | undefined,
+): ComplexityDeltaThresholds {
+  const overrides: Partial<ComplexityDeltaThresholds> = {};
+  if (configThresholds) {
+    // Copy only defined numeric values — an explicit `undefined` would otherwise
+    // clobber the default when spread.
+    for (const key of [
+      'testPaths',
+      'mentalLoad',
+      'timeToUnderstandMinutes',
+      'estimatedBugs',
+    ] as const) {
+      const value = configThresholds[key];
+      if (typeof value === 'number') overrides[key] = value;
+    }
+  }
+  if (thresholdFlag !== undefined) {
+    const n = Number.parseInt(thresholdFlag, 10);
+    if (!Number.isNaN(n)) {
+      overrides.testPaths = n;
+      overrides.mentalLoad = n;
+    }
+  }
+  return resolveComplexityDeltaThresholds(overrides);
+}
+
+/** Exit code: 0 clean/soft, 1 regressions, (2 is reserved for operational errors). */
+export function deltaExitCode(result: ComplexityDeltaResult, soft: boolean | undefined): number {
+  if (soft) return 0;
+  return hasRegressions(result) ? 1 : 0;
+}
+
+const VERDICT_DISPLAY: Record<
+  ComplexityDeltaVerdict,
+  { marker: string; label: string; color: (s: string) => string }
+> = {
+  crossed: { marker: '✗', label: 'crossed', color: chalk.red },
+  'new-over-threshold': { marker: '✗', label: 'new>limit', color: chalk.red },
+  'pre-existing': { marker: '⚠', label: 'pre-exist', color: chalk.yellow },
+  worsened: { marker: '⚠', label: 'worsened', color: chalk.yellow },
+  'new-under-threshold': { marker: '·', label: 'new', color: chalk.dim },
+  improved: { marker: '✓', label: 'improved', color: chalk.green },
+  unchanged: { marker: '·', label: 'unchanged', color: chalk.dim },
+  removed: { marker: '·', label: 'removed', color: chalk.dim },
+};
+
+const METRIC_LABEL: Record<MetricComplexityDelta['metricType'], string> = {
+  cyclomatic: 'cyclomatic',
+  cognitive: 'cognitive',
+  halstead_effort: 'time',
+  halstead_bugs: 'bugs',
+};
+
+/** Pick the metric that best explains a function's overall verdict. */
+function displayMetric(fn: FunctionComplexityDelta): MetricComplexityDelta | undefined {
+  const matching = fn.metrics.filter(m => m.verdict === fn.verdict);
+  const pool = matching.length > 0 ? matching : fn.metrics;
+  const order: MetricComplexityDelta['metricType'][] = [
+    'cognitive',
+    'cyclomatic',
+    'halstead_effort',
+    'halstead_bugs',
+  ];
+  return [...pool].sort((a, b) => order.indexOf(a.metricType) - order.indexOf(b.metricType))[0];
+}
+
+function fmtValue(v: number | null, metricType: MetricComplexityDelta['metricType']): string {
+  if (v === null) return '–';
+  if (metricType === 'halstead_bugs') return v.toFixed(2);
+  if (metricType === 'halstead_effort') return `${Math.round(v)}m`;
+  return String(v);
+}
+
+function fmtFunction(fn: FunctionComplexityDelta): string {
+  const d = VERDICT_DISPLAY[fn.verdict];
+  const name = fn.parentClass ? `${fn.parentClass}.${fn.symbolName}` : fn.symbolName;
+  const head = `    ${d.color(`${d.marker} ${d.label.padEnd(9)}`)} ${name.padEnd(24)}`;
+  const m = displayMetric(fn);
+  if (!m) return head;
+  const showLimit = fn.verdict === 'crossed' || fn.verdict === 'new-over-threshold';
+  const limit = showLimit ? chalk.dim(` (limit ${fmtValue(m.threshold, m.metricType)})`) : '';
+  return `${head} ${chalk.dim(METRIC_LABEL[m.metricType])} ${fmtValue(m.before, m.metricType)} → ${fmtValue(m.after, m.metricType)}${limit}`;
+}
+
+/** Render the human-readable report. Pure — no I/O, no process state. */
+export function formatDeltaText(result: ComplexityDeltaResult, elapsedMs: number): string {
+  const { summary, files } = result;
+  const filesWithFindings = files.filter(f => f.functions.length > 0);
+
+  if (summary.functionsAnalyzed === 0) {
+    const what =
+      summary.filesChanged === 0
+        ? 'no complexity-affecting changes'
+        : `no complexity changes across ${summary.filesChanged} file(s)`;
+    return chalk.dim(`lien delta — ${what} vs HEAD (${elapsedMs} ms)`);
+  }
+
+  const lines: string[] = [chalk.bold('lien delta — complexity vs HEAD'), ''];
+  for (const file of filesWithFindings) {
+    const tag =
+      file.status === 'renamed' && file.oldPath ? chalk.dim(` (renamed from ${file.oldPath})`) : '';
+    lines.push(`  ${chalk.cyan(file.filepath)}${tag}`);
+    for (const fn of file.functions) lines.push(fmtFunction(fn));
+    lines.push('');
+  }
+
+  const parts: string[] = [];
+  const crossings = summary.crossed + summary.newOverThreshold;
+  if (crossings > 0)
+    parts.push(chalk.red(`✗ ${crossings} new crossing${crossings === 1 ? '' : 's'}`));
+  if (summary.worsened > 0) parts.push(chalk.yellow(`⚠ ${summary.worsened} worsened`));
+  if (summary.improved > 0) parts.push(chalk.green(`✓ ${summary.improved} improved`));
+  parts.push(`${summary.filesChanged} file${summary.filesChanged === 1 ? '' : 's'}`);
+  parts.push(`${elapsedMs} ms`);
+  lines.push(`  ${parts.join(chalk.dim(' · '))}`);
+
+  if (crossings > 0) {
+    lines.push('');
+    lines.push(
+      chalk.red('  → new complexity crossings introduced.') +
+        chalk.dim(' Simplify before committing, or re-run with --soft to advise only.'),
+    );
+  }
+  return lines.join('\n');
+}
+
+/** Analyze the working tree's complexity delta vs HEAD. */
+export async function deltaCommand(options: DeltaOptions): Promise<void> {
+  const start = Date.now();
+
+  if (!VALID_FORMATS.includes(options.format)) {
+    console.error(chalk.red(`Error: Invalid --format "${options.format}". Must be text or json.`));
+    process.exit(2);
+  }
+
+  const rootDir = await getRepoRoot(process.cwd());
+  if (!rootDir) {
+    console.error(chalk.red('lien delta: not a git repository (or git is not installed)'));
+    process.exit(2);
+  }
+
+  const config = await configService.load(rootDir);
+  const thresholds = resolveDeltaThresholds(config.complexity?.thresholds, options.threshold);
+
+  let changes;
+  try {
+    changes = await collectFileChanges(rootDir);
+  } catch (error) {
+    console.error(
+      chalk.red(
+        `lien delta: failed to read git changes: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+    process.exit(2);
+  }
+
+  const result = computeComplexityDelta(changes, thresholds);
+  const elapsedMs = Date.now() - start;
+
+  if (options.format === 'json') {
+    console.log(JSON.stringify({ ...result, elapsedMs }, null, 2));
+  } else {
+    console.log(formatDeltaText(result, elapsedMs));
+  }
+
+  process.exit(deltaExitCode(result, options.soft));
+}

--- a/packages/cli/src/cli/delta-git.test.ts
+++ b/packages/cli/src/cli/delta-git.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { getRepoRoot, collectFileChanges } from './delta-git.js';
+import type { FileContentChange } from '@liendev/parser';
+
+const execFileAsync = promisify(execFile);
+
+const SIMPLE = 'export function target(x) {\n  return x + 1;\n}\n';
+const COMPLEX =
+  'export function target(x) {\n  if (x) { if (x > 1) { if (x > 2) { return 1; } } }\n  return 2;\n}\n';
+
+function byPath(changes: FileContentChange[], filepath: string): FileContentChange | undefined {
+  return changes.find(c => c.filepath === filepath);
+}
+
+describe('delta-git', () => {
+  let dir: string;
+
+  async function git(...args: string[]): Promise<void> {
+    await execFileAsync('git', args, { cwd: dir });
+  }
+
+  async function write(rel: string, content: string): Promise<void> {
+    const full = path.join(dir, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, 'utf-8');
+  }
+
+  async function initRepo(): Promise<void> {
+    await git('init', '-q');
+    await git('config', 'user.email', 'test@example.com');
+    await git('config', 'user.name', 'Test');
+    await git('config', 'commit.gpgsign', 'false');
+  }
+
+  async function commitAll(msg: string): Promise<void> {
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', msg);
+  }
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-delta-git-'));
+    // Resolve symlinked tmp dirs (macOS /var → /private/var) so paths compare cleanly.
+    dir = await fs.realpath(dir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('getRepoRoot returns null outside a repo and the toplevel inside one', async () => {
+    expect(await getRepoRoot(dir)).toBeNull();
+    await initRepo();
+    expect(await getRepoRoot(dir)).toBe(dir);
+  });
+
+  it('detects a modified file (before = HEAD, after = working tree)', async () => {
+    await initRepo();
+    await write('a.ts', SIMPLE);
+    await commitAll('init');
+    await write('a.ts', COMPLEX);
+
+    const changes = await collectFileChanges(dir);
+    const c = byPath(changes, 'a.ts')!;
+    expect(c.before).toBe(SIMPLE);
+    expect(c.after).toBe(COMPLEX);
+    expect(c.oldPath).toBeUndefined();
+  });
+
+  it('detects a staged modification the same as an unstaged one', async () => {
+    await initRepo();
+    await write('a.ts', SIMPLE);
+    await commitAll('init');
+    await write('a.ts', COMPLEX);
+    await git('add', 'a.ts'); // stage it
+
+    const c = byPath(await collectFileChanges(dir), 'a.ts')!;
+    expect(c.before).toBe(SIMPLE);
+    expect(c.after).toBe(COMPLEX);
+  });
+
+  it('reflects unstaged edits on top of a staged change in the after image', async () => {
+    await initRepo();
+    await write('a.ts', SIMPLE);
+    await commitAll('init');
+    await write('a.ts', COMPLEX);
+    await git('add', 'a.ts');
+    await write('a.ts', COMPLEX + '// trailing edit\n'); // further unstaged edit
+
+    const c = byPath(await collectFileChanges(dir), 'a.ts')!;
+    expect(c.after).toContain('trailing edit');
+  });
+
+  it('treats an untracked new file as added (before = null)', async () => {
+    await initRepo();
+    await write('a.ts', SIMPLE);
+    await commitAll('init');
+    await write('b.ts', COMPLEX); // untracked
+
+    const c = byPath(await collectFileChanges(dir), 'b.ts')!;
+    expect(c.before).toBeNull();
+    expect(c.after).toBe(COMPLEX);
+  });
+
+  it('treats a deleted file as removed (after = null)', async () => {
+    await initRepo();
+    await write('a.ts', COMPLEX);
+    await commitAll('init');
+    await fs.rm(path.join(dir, 'a.ts'));
+
+    const c = byPath(await collectFileChanges(dir), 'a.ts')!;
+    expect(c.before).toBe(COMPLEX);
+    expect(c.after).toBeNull();
+  });
+
+  it('detects a rename and records the old path', async () => {
+    await initRepo();
+    await write('a.ts', COMPLEX);
+    await commitAll('init');
+    await git('mv', 'a.ts', 'b.ts'); // staged rename
+
+    const c = byPath(await collectFileChanges(dir), 'b.ts')!;
+    expect(c.oldPath).toBe('a.ts');
+    expect(c.before).toBe(COMPLEX);
+    expect(c.after).toBe(COMPLEX);
+  });
+
+  it('handles an unborn HEAD (repo with no commits) — all files are added', async () => {
+    await initRepo();
+    await write('a.ts', COMPLEX);
+    await git('add', 'a.ts'); // staged, never committed
+    await write('b.ts', SIMPLE); // untracked
+
+    const changes = await collectFileChanges(dir);
+    const a = byPath(changes, 'a.ts')!;
+    const b = byPath(changes, 'b.ts')!;
+    expect(a.before).toBeNull();
+    expect(a.after).toBe(COMPLEX);
+    expect(b.before).toBeNull();
+    expect(b.after).toBe(SIMPLE);
+  });
+
+  it('ignores files whose extension the parser does not support', async () => {
+    await initRepo();
+    await write('a.ts', SIMPLE);
+    await commitAll('init');
+    await write('notes.txt', 'hello');
+    await write('data.lock', 'x');
+
+    const changes = await collectFileChanges(dir);
+    expect(byPath(changes, 'notes.txt')).toBeUndefined();
+    expect(byPath(changes, 'data.lock')).toBeUndefined();
+  });
+
+  it('returns an empty array for a clean working tree', async () => {
+    await initRepo();
+    await write('a.ts', SIMPLE);
+    await commitAll('init');
+    expect(await collectFileChanges(dir)).toEqual([]);
+  });
+});

--- a/packages/cli/src/cli/delta-git.ts
+++ b/packages/cli/src/cli/delta-git.ts
@@ -1,0 +1,159 @@
+/**
+ * Git change discovery for `lien delta`.
+ *
+ * Builds the before/after content pairs the complexity-delta primitive
+ * consumes, comparing the working tree against HEAD. Handles staged + unstaged
+ * changes (via `git diff HEAD`), untracked new files, renames, deletions, and
+ * an unborn HEAD (a repo with no commits yet).
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { getSupportedExtensions, type FileContentChange } from '@liendev/parser';
+
+const execFileAsync = promisify(execFile);
+
+// git show of a large blob can exceed the default 1 MB stdout buffer.
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+async function git(rootDir: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: rootDir, maxBuffer: MAX_BUFFER });
+  return stdout;
+}
+
+/** Resolve the git repository root for `cwd`, or null if not a git repo. */
+export async function getRepoRoot(cwd: string): Promise<string | null> {
+  try {
+    const out = await git(cwd, ['rev-parse', '--show-toplevel']);
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function hasCommits(rootDir: string): Promise<boolean> {
+  try {
+    await git(rootDir, ['rev-parse', '--verify', 'HEAD']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface RawChange {
+  status: 'A' | 'M' | 'D' | 'R';
+  path: string;
+  oldPath?: string;
+}
+
+/**
+ * Parse `git diff --name-status --find-renames -z` output. The `-z` stream is a
+ * flat NUL-separated token list: a status token, then one path (or, for renames
+ * and copies, an old path followed by a new path).
+ */
+function parseNameStatusZ(out: string): RawChange[] {
+  const tokens = out.split('\0').filter(t => t.length > 0);
+  const changes: RawChange[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const status = tokens[i++];
+    const code = status[0];
+    if (code === 'R' || code === 'C') {
+      const oldPath = tokens[i++];
+      const newPath = tokens[i++];
+      changes.push({ status: 'R', path: newPath, oldPath });
+    } else if (code === 'A' || code === 'M' || code === 'D') {
+      changes.push({ status: code, path: tokens[i++] });
+    } else {
+      // Unknown status (T type change, U unmerged, …) — treat as modified.
+      changes.push({ status: 'M', path: tokens[i++] });
+    }
+  }
+  return changes;
+}
+
+function splitZ(out: string): string[] {
+  return out.split('\0').filter(t => t.length > 0);
+}
+
+function isSupported(filepath: string, supported: ReadonlySet<string>): boolean {
+  const dot = filepath.lastIndexOf('.');
+  if (dot < 0) return false;
+  return supported.has(filepath.slice(dot));
+}
+
+async function showHead(rootDir: string, gitPath: string): Promise<string | null> {
+  try {
+    return await git(rootDir, ['show', `HEAD:${gitPath}`]);
+  } catch {
+    return null;
+  }
+}
+
+async function readWorktree(rootDir: string, gitPath: string): Promise<string | null> {
+  try {
+    return await readFile(path.join(rootDir, gitPath), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Turn a raw git change into a before/after content pair. */
+async function toContentChange(
+  rootDir: string,
+  raw: RawChange,
+  unborn: boolean,
+): Promise<FileContentChange> {
+  if (unborn || raw.status === 'A') {
+    return { filepath: raw.path, before: null, after: await readWorktree(rootDir, raw.path) };
+  }
+  if (raw.status === 'D') {
+    return { filepath: raw.path, before: await showHead(rootDir, raw.path), after: null };
+  }
+  if (raw.status === 'R') {
+    const oldPath = raw.oldPath ?? raw.path;
+    return {
+      filepath: raw.path,
+      oldPath,
+      before: await showHead(rootDir, oldPath),
+      after: await readWorktree(rootDir, raw.path),
+    };
+  }
+  // Modified
+  return {
+    filepath: raw.path,
+    before: await showHead(rootDir, raw.path),
+    after: await readWorktree(rootDir, raw.path),
+  };
+}
+
+/**
+ * Collect before/after content pairs for every changed, parser-supported file
+ * (working tree vs HEAD). Returns an empty array when there are no changes.
+ */
+export async function collectFileChanges(rootDir: string): Promise<FileContentChange[]> {
+  const supported = new Set(getSupportedExtensions().map(ext => `.${ext}`));
+  const born = await hasCommits(rootDir);
+
+  let raw: RawChange[];
+  if (born) {
+    raw = parseNameStatusZ(
+      await git(rootDir, ['diff', '--name-status', '--find-renames', '-z', 'HEAD']),
+    );
+  } else {
+    // Unborn HEAD: everything staged is "added"; nothing has a HEAD baseline.
+    const staged = splitZ(await git(rootDir, ['diff', '--cached', '--name-only', '-z']));
+    raw = staged.map(p => ({ status: 'A' as const, path: p }));
+  }
+
+  // Untracked files are additions regardless of HEAD state.
+  const untracked = splitZ(
+    await git(rootDir, ['ls-files', '--others', '--exclude-standard', '-z']),
+  );
+  for (const p of untracked) raw.push({ status: 'A', path: p });
+
+  const filtered = raw.filter(r => isSupported(r.path, supported));
+  return Promise.all(filtered.map(r => toContentChange(rootDir, r, !born)));
+}

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -7,6 +7,7 @@ import { statusCommand } from './status.js';
 import { indexCommand } from './index-cmd.js';
 import { serveCommand } from './serve.js';
 import { complexityCommand } from './complexity.js';
+import { deltaCommand } from './delta-cmd.js';
 import { configSetCommand, configGetCommand, configListCommand } from './config.js';
 import { pathCommand } from './path-cmd.js';
 import { annotateCommand } from './annotate-cmd.js';
@@ -84,6 +85,16 @@ program
   .option('--format <type>', 'Output format: text, json, sarif', 'text')
   .option('--fail-on <severity>', 'Exit 1 if violations: error, warning')
   .action(complexityCommand);
+
+program
+  .command('delta')
+  .description(
+    'Flag NEW complexity threshold crossings in the working tree (vs HEAD) before commit',
+  )
+  .option('--format <type>', 'Output format: text, json', 'text')
+  .option('--threshold <n>', 'Override cyclomatic + cognitive thresholds (default: from config)')
+  .option('--soft', 'Advisory mode: always exit 0 (still prints the report)')
+  .action(deltaCommand);
 
 const configCmd = program
   .command('config')

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -139,6 +139,26 @@ export type { FileComplexityInfo, DependencyAnalysisResult } from './dependency-
 
 export { analyzeComplexityFromChunks } from './insights/chunk-complexity.js';
 
+// Complexity delta (before/after content → per-function verdicts) — shared by
+// the `lien delta` CLI and (as a follow-up) the PR-review engine.
+export {
+  computeComplexityDelta,
+  computeFileComplexityDelta,
+  resolveComplexityDeltaThresholds,
+  hasRegressions,
+  DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
+} from './insights/complexity-delta.js';
+export type {
+  ComplexityDeltaThresholds,
+  ComplexityDeltaVerdict,
+  MetricComplexityDelta,
+  FunctionComplexityDelta,
+  FileComplexityDelta,
+  ComplexityDeltaSummary,
+  ComplexityDeltaResult,
+  FileContentChange,
+} from './insights/complexity-delta.js';
+
 // =============================================================================
 // CHUNK-ONLY INDEXING (no embeddings or VectorDB)
 // =============================================================================

--- a/packages/parser/src/insights/complexity-delta.test.ts
+++ b/packages/parser/src/insights/complexity-delta.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeComplexityDelta,
+  computeFileComplexityDelta,
+  resolveComplexityDeltaThresholds,
+  hasRegressions,
+  DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
+  type ComplexityDeltaThresholds,
+  type FunctionComplexityDelta,
+  type MetricComplexityDelta,
+} from './complexity-delta.js';
+
+// Fixture bodies with known metrics (measured against the real chunker):
+//   trivial   cyclo 1  cog 0
+//   oneIf     cyclo 2  cog 1
+//   twoNest   cyclo 3  cog 3
+//   threeNest cyclo 4  cog 6
+//   deep      cyclo 6  cog 15
+const BODY = {
+  trivial: 'function target(x){ return x+1; }',
+  oneIf: 'function target(x){ if(x){return 1;} return 2; }',
+  twoNest: 'function target(x){ if(x){ if(x>1){ return 1; } } return 2; }',
+  threeNest: 'function target(x){ if(x){ if(x>1){ if(x>2){ return 1; } } } return 2; }',
+  deep: 'function target(x){ if(x){ for(const i of x){ if(i){ while(i){ i--; if(i>5){break;} } } } } return 0; }',
+} as const;
+
+// Isolate the cognitive metric: only `mentalLoad` is small enough to be crossed;
+// the other metrics stay far below their thresholds so they never gate.
+const COG_ONLY: ComplexityDeltaThresholds = {
+  testPaths: 1000,
+  mentalLoad: 5,
+  timeToUnderstandMinutes: 100000,
+  estimatedBugs: 1000,
+};
+
+function fnByName(
+  functions: FunctionComplexityDelta[],
+  name: string,
+): FunctionComplexityDelta | undefined {
+  return functions.find(f => f.symbolName === name);
+}
+
+function cognitive(fn: FunctionComplexityDelta): MetricComplexityDelta {
+  const m = fn.metrics.find(x => x.metricType === 'cognitive');
+  if (!m) throw new Error('no cognitive metric on function delta');
+  return m;
+}
+
+describe('computeFileComplexityDelta — verdict matrix (cognitive-isolated)', () => {
+  it('crossed: under-threshold → over-threshold fails the gate', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: BODY.twoNest, after: BODY.threeNest },
+      COG_ONLY,
+    );
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('crossed');
+    expect(fn.isRegression).toBe(true);
+    const cog = cognitive(fn);
+    expect(cog.before).toBe(3);
+    expect(cog.after).toBe(6);
+    expect(cog.threshold).toBe(5);
+    expect(cog.verdict).toBe('crossed');
+  });
+
+  it('worsened: increased but still under threshold does not fail', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: BODY.oneIf, after: BODY.twoNest },
+      COG_ONLY,
+    );
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('worsened');
+    expect(fn.isRegression).toBe(false);
+    expect(cognitive(fn).verdict).toBe('worsened');
+  });
+
+  it('improved: decreased complexity does not fail', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: BODY.threeNest, after: BODY.oneIf },
+      COG_ONLY,
+    );
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('improved');
+    expect(fn.isRegression).toBe(false);
+    // dropped from over-threshold (6) back under (1) — still classified improved
+    expect(cognitive(fn).verdict).toBe('improved');
+  });
+
+  it('pre-existing: worsening an already-over-threshold function does not fail', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: BODY.threeNest, after: BODY.deep },
+      COG_ONLY,
+    );
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('pre-existing');
+    expect(fn.isRegression).toBe(false);
+    const cog = cognitive(fn);
+    expect(cog.before).toBe(6);
+    expect(cog.after).toBe(15);
+    expect(cog.verdict).toBe('pre-existing');
+  });
+
+  it('unchanged functions are omitted from the file result', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: BODY.twoNest, after: BODY.twoNest },
+      COG_ONLY,
+    );
+    expect(file.functions).toHaveLength(0);
+    expect(file.status).toBe('modified');
+  });
+
+  it('added file: new function over threshold → new-over-threshold (fails)', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: null, after: BODY.deep },
+      COG_ONLY,
+    );
+    expect(file.status).toBe('added');
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('new-over-threshold');
+    expect(fn.isRegression).toBe(true);
+    const cog = cognitive(fn);
+    expect(cog.before).toBeNull();
+    expect(cog.after).toBe(15);
+  });
+
+  it('added file: new function under threshold → new-under-threshold (advisory)', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: null, after: BODY.oneIf },
+      COG_ONLY,
+    );
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('new-under-threshold');
+    expect(fn.isRegression).toBe(false);
+  });
+
+  it('deleted file: functions are marked removed (advisory)', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'a.ts', before: BODY.deep, after: null },
+      COG_ONLY,
+    );
+    expect(file.status).toBe('deleted');
+    const fn = fnByName(file.functions, 'target')!;
+    expect(fn.verdict).toBe('removed');
+    expect(fn.isRegression).toBe(false);
+    expect(cognitive(fn).after).toBeNull();
+  });
+});
+
+describe('computeFileComplexityDelta — renames', () => {
+  it('renamed file with an unchanged function body produces no noise', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'new/path.ts', oldPath: 'old/path.ts', before: BODY.deep, after: BODY.deep },
+      COG_ONLY,
+    );
+    expect(file.status).toBe('renamed');
+    expect(file.oldPath).toBe('old/path.ts');
+    expect(file.functions).toHaveLength(0);
+  });
+
+  it('renamed file where a function crosses is reported', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'new.ts', oldPath: 'old.ts', before: BODY.twoNest, after: BODY.threeNest },
+      COG_ONLY,
+    );
+    expect(file.status).toBe('renamed');
+    expect(fnByName(file.functions, 'target')!.verdict).toBe('crossed');
+  });
+
+  it('documented limit: renaming a function identifier reads as remove + add', () => {
+    // `target` (deep, over threshold) renamed to `renamed` (same body).
+    const before = BODY.deep;
+    const after = BODY.deep.replace(/target/g, 'renamed');
+    const file = computeFileComplexityDelta({ filepath: 'a.ts', before, after }, COG_ONLY);
+
+    const removed = fnByName(file.functions, 'target')!;
+    const added = fnByName(file.functions, 'renamed')!;
+    expect(removed.verdict).toBe('removed');
+    expect(added.verdict).toBe('new-over-threshold');
+    expect(added.isRegression).toBe(true);
+  });
+});
+
+describe('thresholds', () => {
+  it('resolveComplexityDeltaThresholds fills defaults and applies overrides', () => {
+    expect(resolveComplexityDeltaThresholds()).toEqual(DEFAULT_COMPLEXITY_DELTA_THRESHOLDS);
+    expect(resolveComplexityDeltaThresholds({ mentalLoad: 3 })).toEqual({
+      ...DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
+      mentalLoad: 3,
+    });
+  });
+
+  it('default thresholds gate cognitive at 15 (the motivating incident)', () => {
+    // deep has cognitive 15 == default mentalLoad 15 → over threshold.
+    const file = computeFileComplexityDelta({ filepath: 'a.ts', before: null, after: BODY.deep });
+    const fn = fnByName(file.functions, 'target')!;
+    expect(cognitive(fn).threshold).toBe(15);
+    expect(fn.verdict).toBe('new-over-threshold');
+  });
+
+  it('a lower threshold turns a previously-passing change into a crossing', () => {
+    const change = { filepath: 'a.ts', before: BODY.oneIf, after: BODY.twoNest };
+    // cognitive 1 → 3
+    expect(computeFileComplexityDelta(change, COG_ONLY).functions[0].verdict).toBe('worsened');
+    expect(
+      computeFileComplexityDelta(change, { ...COG_ONLY, mentalLoad: 3 }).functions[0].verdict,
+    ).toBe('crossed');
+  });
+});
+
+describe('methods and multiple functions', () => {
+  it('matches methods by parentClass::name and only reports the changed one', () => {
+    const before = `
+class Svc {
+  keep(x){ if(x){ if(x>1){ return 1; } } return 2; }
+  edit(x){ if(x){ return 1; } return 2; }
+}`;
+    const after = `
+class Svc {
+  keep(x){ if(x){ if(x>1){ return 1; } } return 2; }
+  edit(x){ if(x){ if(x>1){ if(x>2){ return 1; } } } return 2; }
+}`;
+    const file = computeFileComplexityDelta({ filepath: 'svc.ts', before, after }, COG_ONLY);
+    // keep unchanged (hidden); edit worsened cognitive 1 → 6, crosses threshold 5
+    expect(fnByName(file.functions, 'keep')).toBeUndefined();
+    const edit = fnByName(file.functions, 'edit')!;
+    expect(edit.parentClass).toBe('Svc');
+    expect(edit.key).toBe('Svc::edit');
+    expect(edit.verdict).toBe('crossed');
+  });
+});
+
+describe('files with no analyzable functions', () => {
+  it('produces an empty function list for content without functions', () => {
+    const file = computeFileComplexityDelta(
+      { filepath: 'notes.md', before: '# hello', after: '# hello world' },
+      COG_ONLY,
+    );
+    expect(file.functions).toHaveLength(0);
+  });
+});
+
+describe('computeComplexityDelta — aggregation', () => {
+  it('summarizes crossings, new-over, worsened and improved across files', () => {
+    const result = computeComplexityDelta(
+      [
+        { filepath: 'crossed.ts', before: BODY.twoNest, after: BODY.threeNest }, // crossed
+        { filepath: 'newover.ts', before: null, after: BODY.deep }, // new-over-threshold
+        { filepath: 'worse.ts', before: BODY.oneIf, after: BODY.twoNest }, // worsened
+        { filepath: 'better.ts', before: BODY.threeNest, after: BODY.oneIf }, // improved
+        { filepath: 'same.ts', before: BODY.twoNest, after: BODY.twoNest }, // unchanged (hidden)
+      ],
+      COG_ONLY,
+    );
+
+    expect(result.summary.filesChanged).toBe(5);
+    expect(result.summary.crossed).toBe(1);
+    expect(result.summary.newOverThreshold).toBe(1);
+    expect(result.summary.worsened).toBe(1);
+    expect(result.summary.improved).toBe(1);
+    expect(result.summary.regressions).toBe(2);
+    expect(result.regressions).toHaveLength(2);
+    expect(result.regressions.map(r => r.verdict).sort()).toEqual([
+      'crossed',
+      'new-over-threshold',
+    ]);
+    expect(hasRegressions(result)).toBe(true);
+    expect(result.thresholds).toEqual(COG_ONLY);
+  });
+
+  it('reports no regressions for an all-improved / unchanged changeset', () => {
+    const result = computeComplexityDelta(
+      [
+        { filepath: 'better.ts', before: BODY.threeNest, after: BODY.oneIf },
+        { filepath: 'same.ts', before: BODY.twoNest, after: BODY.twoNest },
+      ],
+      COG_ONLY,
+    );
+    expect(result.summary.regressions).toBe(0);
+    expect(hasRegressions(result)).toBe(false);
+  });
+
+  it('functions within a file are sorted worst-first', () => {
+    const before = `
+function a(x){ if(x){ if(x>1){ return 1; } } return 2; }
+function b(x){ if(x){ return 1; } return 2; }`;
+    const after = `
+function a(x){ if(x){ if(x>1){ if(x>2){ return 1; } } } return 2; }
+function b(x){ if(x){ if(x>1){ return 1; } } return 2; }`;
+    // a: cog 3 → 6 crossed; b: cog 1 → 3 worsened
+    const file = computeFileComplexityDelta({ filepath: 'm.ts', before, after }, COG_ONLY);
+    expect(file.functions.map(f => f.verdict)).toEqual(['crossed', 'worsened']);
+  });
+});

--- a/packages/parser/src/insights/complexity-delta.ts
+++ b/packages/parser/src/insights/complexity-delta.ts
@@ -1,0 +1,363 @@
+/**
+ * Complexity-delta primitive.
+ *
+ * Compares two versions of a file's content (before/after) and reports, per
+ * function, whether a complexity metric newly crossed a threshold, worsened,
+ * improved, or is unchanged. It is the single source of truth for both the
+ * `lien delta` CLI (write-time) and — as a documented follow-up — the PR-review
+ * engine (review-time), so the two can never structurally disagree.
+ *
+ * It reuses the existing complexity machinery end to end: `chunkFile` produces
+ * one chunk per function/method carrying cyclomatic / cognitive / Halstead
+ * metrics, and thresholds mirror `analyzeComplexityFromChunks`. No new metrics
+ * are invented here.
+ *
+ * See docs/architecture/lien-delta.md for the design and honest limitations
+ * (function-level renames are not tracked; overloads are paired positionally).
+ */
+
+import { chunkFile } from '../chunker.js';
+import type { ChunkMetadata } from '../types.js';
+import type { ComplexityMetricType } from './types.js';
+import { effortToMinutes } from './chunk-complexity.js';
+
+/**
+ * Complexity thresholds — same shape and defaults as the config
+ * `complexity.thresholds` block that `analyzeComplexityFromChunks` reads.
+ */
+export interface ComplexityDeltaThresholds {
+  /** Cyclomatic complexity (config: testPaths). */
+  testPaths: number;
+  /** Cognitive complexity (config: mentalLoad). */
+  mentalLoad: number;
+  /** Halstead effort, expressed as minutes-to-understand (config: timeToUnderstandMinutes). */
+  timeToUnderstandMinutes: number;
+  /** Halstead estimated bugs (config: estimatedBugs). */
+  estimatedBugs: number;
+}
+
+/** Default thresholds — mirror `DEFAULT_THRESHOLDS` in chunk-complexity.ts. */
+export const DEFAULT_COMPLEXITY_DELTA_THRESHOLDS: ComplexityDeltaThresholds = {
+  testPaths: 15,
+  mentalLoad: 15,
+  timeToUnderstandMinutes: 60,
+  estimatedBugs: 1.5,
+};
+
+export type ComplexityDeltaVerdict =
+  /** FAILS gate: function added and already over threshold. */
+  | 'new-over-threshold'
+  /** FAILS gate: function existed under threshold and is now over it. */
+  | 'crossed'
+  /** Advisory: increased but still under threshold. */
+  | 'worsened'
+  /** Advisory: was over threshold before and still is (no NEW crossing). */
+  | 'pre-existing'
+  /** Complexity decreased (may still be over threshold — that is fine). */
+  | 'improved'
+  /** No change. */
+  | 'unchanged'
+  /** Function added, under threshold. */
+  | 'new-under-threshold'
+  /** Function deleted. */
+  | 'removed';
+
+export interface MetricComplexityDelta {
+  metricType: ComplexityMetricType;
+  /** null => function is newly added (absent in "before"). */
+  before: number | null;
+  /** null => function was removed (absent in "after"). */
+  after: number | null;
+  threshold: number;
+  verdict: ComplexityDeltaVerdict;
+}
+
+export interface FunctionComplexityDelta {
+  /** Qualified match key, e.g. "MyClass::doThing". */
+  key: string;
+  symbolName: string;
+  parentClass?: string;
+  filepath: string;
+  language: string;
+  /** Location in the "after" image (or "before" if the function was removed). */
+  startLine: number;
+  /** Worst verdict across the function's metrics. */
+  verdict: ComplexityDeltaVerdict;
+  /** True iff the verdict is a failing verdict ('crossed' | 'new-over-threshold'). */
+  isRegression: boolean;
+  metrics: MetricComplexityDelta[];
+}
+
+export interface FileComplexityDelta {
+  filepath: string;
+  /** Set when the file was renamed. */
+  oldPath?: string;
+  status: 'added' | 'deleted' | 'modified' | 'renamed';
+  /** Functions whose verdict is not 'unchanged', sorted worst-first. */
+  functions: FunctionComplexityDelta[];
+}
+
+export interface ComplexityDeltaSummary {
+  filesChanged: number;
+  functionsAnalyzed: number;
+  regressions: number;
+  crossed: number;
+  newOverThreshold: number;
+  worsened: number;
+  improved: number;
+}
+
+export interface ComplexityDeltaResult {
+  files: FileComplexityDelta[];
+  /** Flattened convenience view of functions with a failing verdict. */
+  regressions: FunctionComplexityDelta[];
+  summary: ComplexityDeltaSummary;
+  /** The resolved thresholds actually applied. */
+  thresholds: ComplexityDeltaThresholds;
+}
+
+export interface FileContentChange {
+  /** Path in the "after" tree (or the deleted path). */
+  filepath: string;
+  /** HEAD content; null = file added. */
+  before: string | null;
+  /** Working-tree content; null = file deleted. */
+  after: string | null;
+  /** Previous path, when renamed. */
+  oldPath?: string;
+}
+
+/** Verdicts that fail a gate. */
+const FAILING_VERDICTS: ReadonlySet<ComplexityDeltaVerdict> = new Set([
+  'crossed',
+  'new-over-threshold',
+]);
+
+/** Severity ordering — higher is worse; used to pick a function's overall verdict. */
+const VERDICT_SEVERITY: Record<ComplexityDeltaVerdict, number> = {
+  crossed: 7,
+  'new-over-threshold': 6,
+  'pre-existing': 5,
+  worsened: 4,
+  'new-under-threshold': 3,
+  improved: 2,
+  unchanged: 1,
+  removed: 0,
+};
+
+interface MetricSpec {
+  metricType: ComplexityMetricType;
+  /** Raw metric value from chunk metadata, in the same unit as the threshold. */
+  value: (m: ChunkMetadata) => number | undefined;
+  threshold: (t: ComplexityDeltaThresholds) => number;
+}
+
+/**
+ * The four metrics scored by `analyzeComplexityFromChunks`. Halstead effort is
+ * converted to minutes so it is compared against `timeToUnderstandMinutes`
+ * directly (equivalent to the review's effort-unit comparison, more readable).
+ */
+const METRIC_SPECS: readonly MetricSpec[] = [
+  { metricType: 'cyclomatic', value: m => m.complexity, threshold: t => t.testPaths },
+  { metricType: 'cognitive', value: m => m.cognitiveComplexity, threshold: t => t.mentalLoad },
+  {
+    metricType: 'halstead_effort',
+    value: m => (m.halsteadEffort === undefined ? undefined : effortToMinutes(m.halsteadEffort)),
+    threshold: t => t.timeToUnderstandMinutes,
+  },
+  { metricType: 'halstead_bugs', value: m => m.halsteadBugs, threshold: t => t.estimatedBugs },
+];
+
+export function resolveComplexityDeltaThresholds(
+  overrides?: Partial<ComplexityDeltaThresholds>,
+): ComplexityDeltaThresholds {
+  return { ...DEFAULT_COMPLEXITY_DELTA_THRESHOLDS, ...overrides };
+}
+
+/** Whether any function in the result is a gate-failing regression. */
+export function hasRegressions(result: ComplexityDeltaResult): boolean {
+  return result.summary.regressions > 0;
+}
+
+/** Classify one metric given before/after values and a threshold. */
+function classifyMetric(
+  before: number | null,
+  after: number | null,
+  threshold: number,
+): ComplexityDeltaVerdict {
+  if (after === null) return 'removed';
+  if (before === null) return after >= threshold ? 'new-over-threshold' : 'new-under-threshold';
+  if (before < threshold && after >= threshold) return 'crossed';
+  if (before >= threshold) {
+    // Standing violation: improved if it dropped, pre-existing if it worsened,
+    // unchanged (hidden) if the metric did not move.
+    if (after < before) return 'improved';
+    if (after > before) return 'pre-existing';
+    return 'unchanged';
+  }
+  // both under threshold
+  if (after > before) return 'worsened';
+  if (after < before) return 'improved';
+  return 'unchanged';
+}
+
+/** Effective metric value for a side; null = function absent, present-but-unmeasured => 0. */
+function metricValue(meta: ChunkMetadata | undefined, spec: MetricSpec): number | null {
+  if (!meta) return null;
+  const v = spec.value(meta);
+  return v === undefined ? 0 : v;
+}
+
+/** Qualified match key: parentClass::symbolName (parentClass omitted when absent). */
+function functionKey(meta: ChunkMetadata): string {
+  return `${meta.parentClass ?? ''}::${meta.symbolName ?? ''}`;
+}
+
+/**
+ * Chunk content into function/method metadata, grouped by qualified key and
+ * sorted by startLine so same-keyed functions (overloads) pair positionally.
+ */
+function functionMetadataByKey(
+  filepath: string,
+  content: string | null,
+): Map<string, ChunkMetadata[]> {
+  const byKey = new Map<string, ChunkMetadata[]>();
+  if (content === null) return byKey;
+
+  const chunks = chunkFile(filepath, content, { useAST: true, astFallback: 'line-based' });
+  for (const { metadata } of chunks) {
+    if (metadata.symbolType !== 'function' && metadata.symbolType !== 'method') continue;
+    if (!metadata.symbolName) continue;
+    const key = functionKey(metadata);
+    const list = byKey.get(key) ?? [];
+    list.push(metadata);
+    byKey.set(key, list);
+  }
+  for (const list of byKey.values()) {
+    list.sort((a, b) => a.startLine - b.startLine);
+  }
+  return byKey;
+}
+
+/** Build the per-function delta for a matched (before?, after?) pair. */
+function buildFunctionDelta(
+  before: ChunkMetadata | undefined,
+  after: ChunkMetadata | undefined,
+  filepath: string,
+  thresholds: ComplexityDeltaThresholds,
+): FunctionComplexityDelta | null {
+  const anchor = after ?? before;
+  if (!anchor) return null;
+
+  const metrics: MetricComplexityDelta[] = [];
+  for (const spec of METRIC_SPECS) {
+    const b = metricValue(before, spec);
+    const a = metricValue(after, spec);
+    // Skip metrics with no signal on either present side (e.g. absent Halstead).
+    if ((b ?? 0) === 0 && (a ?? 0) === 0) continue;
+    const threshold = spec.threshold(thresholds);
+    metrics.push({
+      metricType: spec.metricType,
+      before: b,
+      after: a,
+      threshold,
+      verdict: classifyMetric(b, a, threshold),
+    });
+  }
+
+  if (metrics.length === 0) return null;
+
+  const verdict = metrics.reduce<ComplexityDeltaVerdict>(
+    (worst, m) => (VERDICT_SEVERITY[m.verdict] > VERDICT_SEVERITY[worst] ? m.verdict : worst),
+    'removed',
+  );
+
+  return {
+    key: functionKey(anchor),
+    symbolName: anchor.symbolName ?? '',
+    parentClass: anchor.parentClass,
+    filepath,
+    language: anchor.language,
+    startLine: anchor.startLine,
+    verdict,
+    isRegression: FAILING_VERDICTS.has(verdict),
+    metrics,
+  };
+}
+
+function fileStatus(change: FileContentChange): FileComplexityDelta['status'] {
+  if (change.oldPath && change.oldPath !== change.filepath) return 'renamed';
+  if (change.before === null) return 'added';
+  if (change.after === null) return 'deleted';
+  return 'modified';
+}
+
+/** Compute the complexity delta for a single file's before/after content. */
+export function computeFileComplexityDelta(
+  change: FileContentChange,
+  thresholds?: Partial<ComplexityDeltaThresholds>,
+): FileComplexityDelta {
+  const resolved = resolveComplexityDeltaThresholds(thresholds);
+  const beforePath = change.oldPath ?? change.filepath;
+
+  const beforeByKey = functionMetadataByKey(beforePath, change.before);
+  const afterByKey = functionMetadataByKey(change.filepath, change.after);
+
+  const allKeys = new Set<string>([...beforeByKey.keys(), ...afterByKey.keys()]);
+  const functions: FunctionComplexityDelta[] = [];
+
+  for (const key of allKeys) {
+    const beforeList = beforeByKey.get(key) ?? [];
+    const afterList = afterByKey.get(key) ?? [];
+    const pairs = Math.max(beforeList.length, afterList.length);
+    for (let i = 0; i < pairs; i++) {
+      const delta = buildFunctionDelta(beforeList[i], afterList[i], change.filepath, resolved);
+      if (delta && delta.verdict !== 'unchanged') functions.push(delta);
+    }
+  }
+
+  functions.sort((a, b) => VERDICT_SEVERITY[b.verdict] - VERDICT_SEVERITY[a.verdict]);
+
+  return {
+    filepath: change.filepath,
+    ...(change.oldPath && change.oldPath !== change.filepath ? { oldPath: change.oldPath } : {}),
+    status: fileStatus(change),
+    functions,
+  };
+}
+
+/** Compute the aggregated complexity delta across many files' before/after content. */
+export function computeComplexityDelta(
+  changes: FileContentChange[],
+  thresholds?: Partial<ComplexityDeltaThresholds>,
+): ComplexityDeltaResult {
+  const resolved = resolveComplexityDeltaThresholds(thresholds);
+  const files = changes.map(change => computeFileComplexityDelta(change, resolved));
+
+  const regressions: FunctionComplexityDelta[] = [];
+  const summary: ComplexityDeltaSummary = {
+    filesChanged: files.length,
+    functionsAnalyzed: 0,
+    regressions: 0,
+    crossed: 0,
+    newOverThreshold: 0,
+    worsened: 0,
+    improved: 0,
+  };
+
+  for (const file of files) {
+    for (const fn of file.functions) {
+      summary.functionsAnalyzed++;
+      if (fn.verdict === 'crossed') summary.crossed++;
+      if (fn.verdict === 'new-over-threshold') summary.newOverThreshold++;
+      if (fn.verdict === 'worsened') summary.worsened++;
+      if (fn.verdict === 'improved') summary.improved++;
+      if (fn.isRegression) {
+        summary.regressions++;
+        regressions.push(fn);
+      }
+    }
+  }
+
+  return { files, regressions, summary, thresholds: resolved };
+}


### PR DESCRIPTION
## lien delta — Phase 1 (mechanisms 1 + 4)

Moves Lien's complexity signal from **PR-review time** to **edit time**. An agent recently shipped a PR that passed every gate but raised a function's cognitive complexity to 29 (threshold 15) — caught only afterward, costing a full extra fixer-agent run. `lien delta` is a ~30 ms deterministic check that flags new threshold crossings against `HEAD` *before* the commit.

Full design: [`docs/architecture/lien-delta.md`](docs/architecture/lien-delta.md).

### What Phase 1 ships
- **Shared primitive** in `@liendev/parser` (`computeComplexityDelta`) — function-level before/after verdicts from raw content, reusing the existing complexity machinery (`chunkFile` + cyclomatic/cognitive/Halstead). Review depends on parser only, so it can adopt the same primitive later (write-time & review-time verdicts can never structurally disagree).
- **`lien delta` CLI** — working tree vs `HEAD` across changed files; concise per-function crossing table; exit codes for a commit gate.
- **Gate liturgy** — `lien delta` added as the 6th "Before EVERY Commit" gate in `CLAUDE.md` + surfaced in the Explore agent template.

### Exit-code semantics
| Code | Meaning |
|------|---------|
| 0 | No new crossings (or `--soft`). Improved / pre-existing / worsened-under do not fail. |
| 1 | New regression: `new-over-threshold` or `crossed`. |
| 2 | Operational failure (not a git repo, git missing, unreadable file). |

### Not in Phase 1
No hooks, no commit-blocking (mechanisms 2/3/5). Review is **not** rewired here — the integration path is documented as a follow-up.

### Milestones
- [x] 1. Design doc + draft PR
- [x] 2. Shared delta primitive in parser + unit tests (crossings / new / improved / renamed / added / deleted)
- [x] 3. `lien delta` CLI + tests (staged vs unstaged, unborn HEAD, renames)
- [x] 4. Gate liturgy docs (CLAUDE.md + init templates) + changeset (minor: `@liendev/parser`, `@liendev/lien`)
- [x] 5. Full gate green + real-repo & deliberately-worsened-function demos with timing

---

## Gate results (all green)
- `npm run format:check` — clean
- `npm run lint` — **0 errors** (20 pre-existing warnings in `review/`, none in new files)
- `npm run typecheck` — clean (parser, core, review, cli, action)
- `npm run build` — clean
- `npm test` — **all passing**; new tests: parser `complexity-delta` **19**, cli `delta-cmd` **11**, cli `delta-git` **10** (integration: modified/staged/unstaged/untracked/deleted/renamed/unborn-HEAD/ext-filter). Full CLI suite 704, action 28.

## Demo 1 — scratch repo (worsen a function + add a complex new one)
```
lien delta — complexity vs HEAD

  svc.ts
    ✗ crossed   tidy                     cognitive 0 → 15 (limit 15)
    · new       brandNew                 cognitive – → 10

  ✗ 1 new crossing · 1 file · 34 ms

  → new complexity crossings introduced. Simplify before committing, or re-run with --soft to advise only.
exit=1
```
`--soft` → exit 0. `--format json` summary: `{"filesChanged":1,"functionsAnalyzed":2,"regressions":1,"crossed":1,...}`, `elapsedMs: 31`.

## Demo 2 — this repo, deliberately-worsened function (then reverted)
Bloated `deltaExitCode` with absurd nesting, ran the built CLI, then `git checkout`:
```
lien delta — complexity vs HEAD

  packages/cli/src/cli/delta-cmd.ts
    ✗ crossed   deltaExitCode            cognitive 2 → 56 (limit 15)

  ✗ 1 new crossing · 1 file · 61 ms

  → new complexity crossings introduced. Simplify before committing, or re-run with --soft to advise only.
exit=1
```
After revert, clean tree: `lien delta — no complexity-affecting changes vs HEAD (27 ms)`, exit 0.

**Timing: 27–61 ms** across runs — comfortably under the <1 s target.

---

<!-- lien-stats -->
### Lien Review

⚠️ **Needs attention** - 3 new functions are more complex than recommended.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +18 |
| ⏱️ time to understand | 2 | +141 |


> [!WARNING]
> **3 issues found** · Medium Risk
>
> Phase 1 introduces a useful new CLI gate and a shared parser primitive. The new git-discovery layer has the most serious defect: it swallows read/git errors and converts them into wrong file statuses, which can turn a modified file into a reported deletion and vice versa. There is also an unbounded parse in rename handling and no validation that --threshold is positive. The core classification logic matches its documented semantics, and the blast radius is limited to the new lien delta surface.
>
> - New computeComplexityDelta primitive in @liendev/parser for before/after content comparison
> - New lien delta CLI registered in packages/cli/src/cli/index.ts
> - Git change discovery in delta-git.ts with error-swallowing that misclassifies unreadable files

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a1e42a8. Updates automatically on new commits.</sup>
<!-- /lien-stats -->