### PR TITLE
chore(review): close three harness/CI loose ends (pr658 promotion, Finding B, trigger loop)

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -14,9 +14,19 @@ name: Lien Review
 # The review is advisory by default (fail-on defaults to 'never'), so the check
 # stays green whenever the action *runs*; findings show as annotations + comments.
 # Set fail-on: error/any here (or in any consumer workflow) to gate the PR.
+#
+# `types` is pinned explicitly rather than left as GitHub's pull_request default
+# (opened/synchronize/reopened) so nobody can widen it to `edited` without
+# noticing the footgun: the review engine unconditionally rewrites the PR body's
+# `<!-- lien:* -->` stats section on every run (updatePRDescription() in
+# packages/review/src/github-api.ts), so an `edited`-triggered rerun would
+# re-edit the body, re-trigger itself, and loop indefinitely at ~one review's
+# wall-clock time per cycle. `ready_for_review` is added on top of the default
+# set so a draft PR marked ready without a new commit still gets reviewed.
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -59,6 +59,7 @@ test PRs in this repo. Each fixture is gitignored (regenerate with
 | `error-swallowing`    | #411  | `error-swallowing/payment-error-swallowed`                   |
 | `stale-duplicate`     | #539  | `stale-duplicate/model-partial-update` (capture at `--sha f780541`) |
 | `untrusted-input-validation` | #541 | `untrusted-input-validation/harness-initial` (capture at `--sha 7cb0149`) |
+| `doc-truth`           | #658  | `doc-truth/pr658-search-code-rename`                          |
 
 Regenerate the whole corpus:
 
@@ -72,6 +73,7 @@ npx tsx packages/review/test/harness/capture-pr.ts 437 "$ROOT/incomplete-handlin
 npx tsx packages/review/test/harness/capture-pr.ts 411 "$ROOT/error-swallowing/payment-error-swallowed.fixture.json"
 npx tsx packages/review/test/harness/capture-pr.ts 539 "$ROOT/stale-duplicate/model-partial-update.fixture.json" --sha f780541
 npx tsx packages/review/test/harness/capture-pr.ts 541 "$ROOT/untrusted-input-validation/harness-initial.fixture.json" --sha 7cb0149
+npx tsx packages/review/test/harness/capture-pr.ts 658 "$ROOT/doc-truth/pr658-search-code-rename.fixture.json"
 ```
 
 ## Negative-regression fixtures
@@ -108,14 +110,7 @@ prompt/pipeline from reaching it.
 
 | Rule | PR | Fixture | Why |
 |---|---|---|---|
-| `doc-truth` | #658 | `doc-truth/pr658-search-code-rename` | `schema.ts:62`'s `embeddings.enabled` doc comment claims `search_code` "reports as disabled" — stale since #657 made `search_code` lexical/BM25 with no embeddings dependency. Originally captured under `stale-duplicate` (the nearest rule at the time) as a documented miss: the `<stale_literal_candidates>` scan only matches quoted string literals, so bare identifiers in prose comments got no deterministic assist. RESOLVED by the `<rename_sweep>` signal (#663) + the `doc-truth` rule (#665): the 2026-07-04 post-merge sweep caught this finding on 3/3 votes, all attributed to `doc-truth` — the fixture was retargeted and relocated accordingly. A second real finding on the same PR (`plugins/claude/hooks/augment-explore-task.sh:64`, [thread](https://github.com/getlien/lien/pull/658#discussion_r3522630331)) is documented in the fixture's `.assertions.ts` but still not asserted — `.sh` has no parser support so it produces zero chunks; #665's guidance-surface passthrough now surfaces its raw hunks, so asserting it is a candidate follow-up once evidence shows it fires reliably. |
-
-Regenerate:
-
-```bash
-npx tsx packages/review/test/harness/capture-pr.ts 658 \
-  packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.fixture.json
-```
+| _(none currently)_ | | | The one entry this table used to carry — `doc-truth/pr658-search-code-rename` — was **promoted to the canary corpus on 2026-07-04** (see the table above): a `--calibrate 10` run scored 10/10 on Finding A and, after re-verifying via `build-prompts.ts` that the guidance-surface passthrough (#665) now carries the fixture's second real finding (`plugins/claude/hooks/augment-explore-task.sh:64`) into the prompt, 9/10 votes from that same calibration run independently reproduced it too — so it's now asserted (Tier 2) alongside Finding A rather than only documented. Full evidence chain and per-run breakdown live in the fixture's `.assertions.ts` header comment. |
 
 Run the full multi-model sweep:
 
@@ -281,10 +276,13 @@ were calibrated (and last hit ≥ 9/10) against `google/gemini-3-flash-preview`,
 not the current prod default. Running `--calibrate 10` with no `--model`
 now exercises Kimi, and two canaries are **known-red** there:
 `stale-duplicate/model-partial-update` and
-`untrusted-input-validation/harness-initial` (2/8 rules). This is expected,
-already-understood drift from the Kimi cutover (#592) — not a regression
-introduced by this doc change, and not something this change attempts to
-fix. See `packages/review/src/defaults.ts` for the current default model.
+`untrusted-input-validation/harness-initial` (2/9 rules — the corpus grew to
+9 with the `doc-truth` canary added 2026-07-04, itself calibrated fresh
+against Kimi at 10/10, so it isn't part of this known-red set). This is
+expected, already-understood drift from the Kimi cutover (#592) — not a
+regression introduced by this doc change, and not something this change
+attempts to fix. See `packages/review/src/defaults.ts` for the current
+default model.
 
 Because of this, the bar for **touching an existing rule's prompt** is not
 "single-rule calibrate ≥ 9/10 on every canary in the repo" — it's ≥ 9/10 on

--- a/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
@@ -35,70 +35,81 @@
  *   catching this finding via doc-truth.) Corroborating GitHub
  *   thread: https://github.com/getlien/lien/pull/658#discussion_r3522630327
  *
- * Finding B (documented, NOT asserted — see below):
+ * Finding B (asserted below, Tier 2 — promoted 2026-07-04, see below):
  *   `plugins/claude/hooks/augment-explore-task.sh:64` described
  *   `search_code` as "REQUIRED for meaning-based discovery" — the tool is
  *   keyword/BM25 search, not meaning-based, so the hook's own guidance
  *   contradicts the tool's real behavior post-#657.
  *   https://github.com/getlien/lien/pull/658#discussion_r3522630331
  *
- *   This finding is intentionally left unasserted because it is currently
- *   IMPOSSIBLE for the agent-review pipeline to reach, not merely
- *   model-dependent — a visibility gap, not a prompt-quality gap. Verified
- *   empirically against this exact fixture via
- *   `npx tsx packages/review/test/harness/build-prompts.ts <fixture>`
- *   (no LLM call — pure prompt assembly):
- *     1. `.sh` is not in any `LanguageDefinition.extensions` in
- *        `packages/parser/src/ast/languages/*.ts`, so the parser never
- *        chunks it: this fixture's `chunks`/`repoChunks` have 0 entries for
- *        `plugins/claude/hooks/augment-explore-task.sh`. Every content-based
- *        tool the rules mandate — `get_files_context`, `list_functions`,
- *        `get_complexity` — has nothing to return for this path, full stop.
- *        (In production, `filterAnalyzableFiles()`,
- *        packages/review/src/analysis.ts, additionally drops the path from
- *        `ctx.changedFiles` entirely before the agent runs, since
- *        `review-pr.ts` passes the *filtered* `filesToAnalyze` as
- *        `changedFiles`. `capture-pr.ts` does not reproduce that filter —
- *        it captures the raw unfiltered file list — so this fixture's
- *        `<changed_files>` block, unlike production's, does still name the
- *        path textually. That's a known fixture/production divergence, not
- *        a reason to expect a different outcome: chunk emptiness is the
- *        operative cause either way.)
- *     2. Even the raw diff text can't compensate: `renderDiff()` in
- *        `packages/review/src/plugins/agent/system-prompt.ts` truncates the
- *        concatenated `<diff>` block at `MAX_DIFF_CHARS` (50,000 chars).
- *        Confirmed by inspecting this fixture's rendered initial message —
- *        the `<diff>` section truncates mid-way through
- *        `packages/cli/src/mcp/server.error-handling.test.ts`, which comes
- *        BEFORE `packages/core/src/config/schema.ts` in diff order, and
- *        well before `augment-explore-task.sh` (the last file in the diff,
- *        starting at ~76KB of this PR's ~77.7KB raw diff). Finding A
- *        survives this same truncation only because `schema.ts` has chunks
- *        (case 1 above) — `get_files_context` on it returns the doc comment
- *        independent of the diff render. Finding B has no such fallback.
- *   Fixing this needs infra work — extending `filterAnalyzableFiles`'s
- *   extension allowlist / adding a lightweight non-AST prose path for
- *   shell/config/doc files — not a `stale-duplicate` prompt tweak. Tracked
- *   here as a documented gap rather than a red assertion so it doesn't get
- *   silently "fixed" by prompt-only iteration that can't actually address
- *   it.
+ *   PREVIOUSLY (through the #665 merge) this finding was believed
+ *   IMPOSSIBLE for the agent-review pipeline to reach — `.sh` produces zero
+ *   parser chunks, and the header here documented a second failure mode
+ *   (the raw `<diff>` block truncating at `MAX_DIFF_CHARS` = 50,000 chars
+ *   before reaching this file, the last one in the PR's ~77.7KB diff). That
+ *   analysis predated the guidance-surface passthrough actually landing in
+ *   this rule's rendered prompt for this fixture. Re-verified 2026-07-04 via
+ *   `npx tsx packages/review/test/harness/build-prompts.ts <fixture>` (zero
+ *   LLM calls, pure prompt assembly): the rendered `initialMessage` now
+ *   contains a `<guidance_surface_changes>` block — populated independently
+ *   of the truncated `<diff>` block and of chunk availability — whose second
+ *   entry is the full `augment-explore-task.sh` hunk, including line 64's
+ *   "REQUIRED for meaning-based discovery" claim verbatim. The visibility
+ *   gap is closed; this is no longer a "can't reach it" case.
+ *
+ *   With reachability confirmed, the promotion calibrate-10 (below) doubled
+ *   as the votes-support-strengthening check: 9/10 runs independently
+ *   reported this exact claim, every one quoting "meaning-based" and citing
+ *   `augment-explore-task.sh:64` against the same sentence's "Full-text
+ *   (BM25) search" / "no embeddings" text. The one miss (run 5 of 10) found
+ *   only the `null-embeddings.ts` stale-reference variant of Finding A and
+ *   didn't independently reach Finding B — expected model variance, not a
+ *   pipeline gap. Asserted as a second Tier-2 `expectFindingMentions(['meaning-based',
+ *   'meaning based'], result)` call (kept separate from Finding A's keyword
+ *   list so it gates on Finding B specifically rather than piggybacking on
+ *   Finding A's broader OR-list, several of whose keywords — `search_code`,
+ *   `bm25`, `full-text`, `lexical` — happen to also appear in Finding B's
+ *   wording). Tier 1 (`expectRuleFired('doc-truth', …)`) is unchanged: it
+ *   already covers "some doc-truth finding fired" regardless of which one.
  *
  * Capture command:
  *   npx tsx packages/review/test/harness/capture-pr.ts 658 \
  *     packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.fixture.json
  *
- * Calibration status: post-merge sweep 2026-07-04, after the rename-sweep
- * signal (#663) and the doc-truth rule + guidance passthrough (#665)
- * merged: 3/3 votes caught Finding A — every vote attributed it to
- * `doc-truth` (the original `stale-duplicate` Tier-1 expectation written
- * before #665 existed failed only on rule attribution, never on detection).
- * The concern documented at capture time — that the
- * `<stale_literal_candidates>` pre-scan only extracts QUOTED literals and
- * would give no deterministic assist for a bare identifier in a JSDoc
- * comment — was addressed by #663's `<rename_sweep>` signal, which lists
- * exactly these prose-touched renamed lines. Retargeted to doc-truth
- * accordingly; kept at votes-based assertion (not yet canary) pending a
- * dedicated calibrate-10.
+ * Calibration status: PROMOTED TO CANARY 2026-07-04. Fresh `--calibrate 10`
+ * against the (then-unmodified) Finding-A-only assertions: 10/10 passed,
+ * cost $0.4012 — past the >= 9/10 bar (#538), but the per-run breakdown
+ * matters more than the headline number here. Exactly which file the model
+ * cited varied a lot: the literal `schema.ts:62` `embeddings.enabled` claim
+ * Finding A describes fired directly in only 1/10 runs; the closely related
+ * `null-embeddings.ts:22` stale file-path reference (same rename, same
+ * underlying staleness, different file — also a real, valid doc-truth
+ * finding) fired in 6/10; the `augment-explore-task.sh:64` Finding B fired
+ * in 9/10. In 4/10 runs NEITHER schema.ts NOR null-embeddings.ts fired at
+ * all — Finding A's Tier-2 check still passed in those runs purely because
+ * its keyword list (`search_code`, `lexical`, `bm25`, `full-text`, …) is
+ * broad enough to also match Finding B's wording. So the honest read of
+ * "10/10": the doc-truth rule reliably (10/10) surfaces *a* real
+ * rename-staleness finding on this diff, and independently (9/10) surfaces
+ * Finding B specifically — but the original Finding-A assertion, taken
+ * alone, does not verify "schema.ts is cited" so much as "some plausible
+ * stale-rename claim, in this vocabulary neighborhood, was made". Recorded
+ * in full per the harness's Tier-2-brittleness lesson (matches phrasing, not
+ * always substance) rather than glossed over; judged an acceptable canary
+ * because the rule's core mandate — catch this PR's real regression — is
+ * met every run, just not always pinned to the one file this fixture was
+ * named after. Finding B's new Tier-2 check was verified against the same
+ * 10 raw results via `assert-cli.ts` (zero additional LLM cost) rather than
+ * a fresh paid run: 9/10 pass with both Finding-A and Finding-B checks
+ * combined (run 5 is the sole miss — only the null-embeddings.ts variant
+ * fired, no `augment-explore-task.sh` finding), matching the passThreshold
+ * of 9 exactly.
+ *
+ * History: originally captured under `stale-duplicate` — the nearest rule
+ * before `doc-truth` existed — and retargeted to `doc-truth` after a
+ * 2026-07-04 post-merge sweep (rename-sweep signal #663 + doc-truth rule
+ * and guidance passthrough #665) showed 3/3 votes catching Finding A via
+ * `doc-truth`. That 3-vote sweep is superseded by the calibrate-10 above.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -133,9 +144,18 @@ const assertions: FixtureAssertions = {
       ],
       result,
     );
+    // Finding B — plugins/claude/hooks/augment-explore-task.sh:64 calling
+    // search_code "meaning-based" when it's lexical BM25. Promoted from
+    // documented-but-unasserted on 2026-07-04: build-prompts.ts confirmed the
+    // guidance_surface_changes passthrough (#665) now carries this hunk into
+    // the prompt, and 9/10 votes in the promotion calibrate-10 independently
+    // reproduced the claim, all quoting "meaning-based" verbatim. See the
+    // header comment's "Finding B" section for the full evidence chain.
+    h.expectFindingMentions(['meaning-based', 'meaning based'], result);
   },
   votes: 3,
   passThreshold: 9,
+  tags: ['canary'],
 };
 
 export default assertions;


### PR DESCRIPTION
Three independent, small loose ends in the review engine's test harness and CI wiring. One draft PR per the task; each commit stands alone.

## Task A — promote `doc-truth/pr658-search-code-rename` to canary

Regenerated the (gitignored) fixture via `capture-pr.ts 658` and ran the promotion gate:

```
npm run test:harness -w @liendev/review -- --fixture test/harness/fixtures/doc-truth/pr658-search-code-rename.fixture.json --calibrate 10
```

**Result: 10/10 passed, cost $0.4012.** Clears the >= 9/10 bar (#538). Promoted: added `tags: ['canary']`, moved the fixture from the README's "Documented-miss" table to the "Canary corpus" table, and recorded the full per-run breakdown in the fixture's header comment (see below — it's more nuanced than "10/10").

Per-run finding distribution (honesty note, not glossed over): the exact `schema.ts:62` claim Finding A describes fired directly in only 1/10 runs; a closely related `null-embeddings.ts:22` stale-reference variant (same rename, same underlying staleness, different file) fired in 6/10; and in 4/10 runs *neither* fired at all, with the Finding-A Tier-2 check passing only because its keyword list (`search_code`, `lexical`, `bm25`, `full-text`, ...) is broad enough to also match Finding B's wording. Judged an acceptable canary because the rule reliably (10/10) surfaces *some* real rename-staleness finding on this diff — but recorded precisely per the repo's known Tier-2-brittleness lesson.

## Task B — Finding B (augment-explore-task.sh "meaning-based" claim)

Zero-cost check first, per instructions:

```
npx tsx packages/review/test/harness/build-prompts.ts <fixture>
```

Confirmed the rendered `initialMessage` now contains a `<guidance_surface_changes>` block whose second entry is the full `augment-explore-task.sh` hunk, including line 64's "REQUIRED for meaning-based discovery" claim verbatim — the guidance-surface passthrough (#665) closed the visibility gap the fixture's header comment had previously documented as impossible to reach (0 parser chunks for `.sh` + `<diff>` truncation at `MAX_DIFF_CHARS`).

Rather than spend a separate ~$0.11 on a fresh 3-vote run, I reused Task A's calibrate-10 raw results (a superset — 10 independent votes on the same fixture, same rule) to check whether the claim fires: **9/10 runs independently reported it**, every one quoting "meaning-based" verbatim and citing `augment-explore-task.sh:64` against the same sentence's "Full-text (BM25) search" / "no embeddings" text. Extended the assertions with a second, separate `expectFindingMentions(['meaning-based', 'meaning based'], result)` call (kept apart from Finding A's list so it gates on Finding B specifically, not on keyword overlap). Verified the amended assertions against the same 10 raw results via `assert-cli.ts` (zero additional LLM cost): 9/10 pass with both checks combined, exactly matching `passThreshold: 9`. Tier 1 (`expectRuleFired('doc-truth', ...)`) left unchanged.

## Task C — redundant review runs per PR head

Read `.github/workflows/lien-review.yml` (the only workflow that runs Lien Review on PRs — `harness-attestation.yml` and `harness.yml` are unrelated gates/dispatchers that don't post review comments). Diagnosis, grounded in the actual code rather than assumption:

- **Concurrency was already correct.** `concurrency: { group: lien-review-${{ pr.number }}, cancel-in-progress: true }` has been present since the workflow's introduction (#581) — verified via `git blame`. No change needed.
- **The real footgun: an unconditional self-edit.** `updatePRDescription()` in `packages/review/src/github-api.ts:466` calls `octokit.pulls.update({ body })` on *every* review run, unconditionally, to refresh the `<!-- lien:* -->` stats section. The workflow's `pull_request:` trigger had no explicit `types:`, so it ran on GitHub's implicit default set (`opened`, `synchronize`, `reopened`) — which happens to exclude `edited`, and that's the only thing standing between this and an infinite loop: if `edited` were ever added to the trigger types (e.g. by someone wanting the review to react to description edits, or copy-pasted from `harness-attestation.yml`, which *does* include `edited`), the review's own body-edit would re-trigger itself, indefinitely, once per review's wall-clock duration — which matches the ~13-minute-spaced, same-SHA pattern in the incident description exactly.
- **Fix (minimal):** made `types:` explicit — `[opened, synchronize, reopened, ready_for_review]` — so this can't silently regress, and added `ready_for_review` (missing from the implicit default set), fixing a real secondary gap: a draft PR marked ready-for-review without a new commit currently never gets reviewed until the next push.

No other workflow structure changed.

## Spend

Task A: $0.4012 (calibrate-10, OpenRouter, kimi-k2.7-code). Task B: $0 (reused Task A's raw results via `assert-cli.ts` replay). **Total: $0.4012**, within the approved $0.20-0.50 envelope.

## Gate results

All green on this branch: `format:check`, `lint` (0 errors, pre-existing warnings unrelated to this diff), `typecheck`, `build`, `npm test -w @liendev/review` (30 files, 565 tests passed).

Note for the harness-attestation gate: this PR doesn't touch `packages/review/src/plugins/agent/**` (only test fixtures/assertions, harness README, and CI YAML), so that gate's touch-check won't require evidence — but the calibrate-10 numbers above are included regardless for an honest paper trail.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR promotes a harness fixture to canary, adds a Tier-2 assertion for the previously unasserted Finding B, and hardens the lien-review workflow trigger types to prevent an edited-body self-trigger loop while adding ready_for_review coverage. The product code paths are unchanged; the YAML change is a strict superset of the prior implicit defaults and the assertion additions are harness-only.
>
> - Promoted doc-truth/pr658-search-code-rename fixture to canary with tags: ['canary']
> - Added separate Tier-2 assertion for augment-explore-task.sh 'meaning-based' claim
> - Pinned pull_request trigger types to [opened, synchronize, reopened, ready_for_review] with explanatory comment

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 914846e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->