### PR TITLE
feat(delta): Phase 2 — edit-time complexity hooks (detection + prevention)

### DIFF
--- a/.changeset/lien-delta-phase2.md
+++ b/.changeset/lien-delta-phase2.md
@@ -1,0 +1,13 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': minor
+---
+
+`lien delta` Phase 2 — surface the complexity-delta verdict at the moment of the edit.
+
+Phase 1 made the verdict available as a gate the agent chooses to run. Phase 2 moves it to edit time via two advisory (non-blocking) mechanisms, plus fixes for five review findings on the Phase-1 code.
+
+- **PostToolUse edit hook** (`plugins/claude/hooks/delta-write.sh`, registered in the Claude Code plugin): after an `Edit`/`Write`/`MultiEdit`, computes the complexity delta for just that file and emits an `additionalContext` warning **only** when the edit introduces a NEW threshold crossing. Silent otherwise. Driven by a new single-file fast path.
+- **`lien delta --file <path>`**: analyze one file vs `HEAD` (instead of scanning the whole working tree) — bounds the per-edit hook to the file that changed. Resolves absolute-or-relative paths and canonicalizes symlinked segments; out-of-repo, unsupported, or absent files produce no output.
+- **`get_files_context` complexity headroom**: the response now includes a lean `complexityHeadroom` array listing functions at ≥ 80% of a cyclomatic/cognitive budget (worst-first, capped, with an overflow count), computed from complexity metrics already stored in the index (no re-parse). It lets an agent steer around near-budget functions before editing. Omitted entirely when nothing is near budget.
+- **Phase-1 review-finding fixes** in the shared primitive and CLI: a still-over-threshold decrease is now `pre-existing` rather than `improved` (`classifyMetric` is exported for testing); `--threshold` requires a positive integer (rejects negatives/floats/zero → exit 2); a config-load failure exits 2 instead of crashing; single-file reads only treat `ENOENT` as "deleted"; and Halstead-effort display floors rather than rounds so it can never overstate past a limit.

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -1,6 +1,7 @@
 # lien delta — complexity accounting before the commit
 
-Status: **Phase 1 (in progress)** — mechanisms 1 + 4 of a 5-mechanism plan.
+Status: **Phase 1 shipped** (mechanisms 1 + 4, PR #672) · **Phase 2 in progress**
+(mechanisms 2 + 3 — see "Phase 2" below) of a 5-mechanism plan.
 
 ## Motivation
 
@@ -328,10 +329,206 @@ gate**:
   that non-zero space into 1 (found crossings) vs 2 (couldn't run) so a gate can
   distinguish the two. Exit 1 remains "new crossings," as specified.
 
-## Milestones
+## Milestones (Phase 1 — shipped in #672)
 
-- [ ] 1. Design doc + draft PR
-- [ ] 2. Shared delta primitive in parser + unit tests
-- [ ] 3. `lien delta` CLI + tests (git edge cases: staged/unstaged, unborn HEAD, renames)
-- [ ] 4. Gate liturgy docs (CLAUDE.md + init templates) + changeset
-- [ ] 5. Full gate green + real-repo & worsened-function demos with timing
+- [x] 1. Design doc + draft PR
+- [x] 2. Shared delta primitive in parser + unit tests
+- [x] 3. `lien delta` CLI + tests (git edge cases: staged/unstaged, unborn HEAD, renames)
+- [x] 4. Gate liturgy docs (CLAUDE.md + init templates) + changeset
+- [x] 5. Full gate green + real-repo & worsened-function demos with timing
+
+---
+
+# Phase 2 — the signal at the moment of the edit
+
+Phase 1 made the verdict *available* (`lien delta`, a gate the agent chooses to
+run). Phase 2 moves it from "when the agent runs the gates" to "the moment the
+agent edits" — **detection** (mechanism 2) plus **prevention** (mechanism 3).
+Neither blocks anything; both are advisory nudges on channels the agent already
+consumes. Mechanism 5 (commit *soft-block*) and the review-engine adoption of
+the shared primitive remain explicitly out of scope.
+
+Both mechanisms reuse Phase-1 machinery unchanged. Mechanism 2 shells out to the
+same `lien delta` command (so write-time and hook verdicts are byte-identical);
+mechanism 3 reads complexity metrics **already stored in the index** (no
+re-parse) and compares them against the same default thresholds the primitive
+uses.
+
+## D. Mechanism 2 — PostToolUse hook on Edit/Write (detection)
+
+A Claude Code plugin hook (`plugins/claude/hooks/delta-write.sh`, registered in
+`plugins/claude/hooks/hooks.json`) that fires **after** every `Edit`, `Write`,
+and `MultiEdit` tool call and warns — once, concisely — only when *that edit*
+introduced a **new** complexity threshold crossing.
+
+### How it locates and drives the CLI
+
+It mirrors `annotate-read.sh` exactly:
+
+- `command -v jq` and `command -v lien` — exit 0 (silent) if either is missing.
+  The hook never assumes a bundled binary; it uses whatever `lien` is on `PATH`,
+  same as every other Lien hook.
+- Reads the PostToolUse payload from stdin, pulls `tool_name`, `tool_input.file_path`,
+  and `cwd` with `jq`, and runs the delta **from `cwd`** so `resolveProjectRoot`
+  and `git` resolve against the session's repo (multi-repo safe).
+
+### hook → CLI invocation (the key decision)
+
+The hook drives the Phase-1 primitive through a **new `--file <path>` flag** on
+`lien delta` rather than running the full working-tree scan and filtering the
+JSON. Rationale:
+
+- The full scan runs `git diff HEAD` across **every** changed file, reads each,
+  and chunks each — wasteful when this hook fires on *every* edit and cares
+  about exactly one file. `--file` bounds the work to a single `git show
+  HEAD:<path>` + one working-tree read + one before/after chunk pair.
+- It is the same code path and the same `computeComplexityDelta` call, so the
+  hook's verdict and `lien delta`'s verdict cannot diverge.
+
+`lien delta --file <path> --format json` semantics:
+
+- Resolves `<path>` (absolute or relative) to a repo-relative path against the
+  git root. Path outside the repo, or a non-code / unsupported extension →
+  empty result, exit 0 (the hook stays silent).
+- `before = git show HEAD:<relpath>` (null when the file is untracked/new or
+  HEAD is unborn → absolute-threshold classification); `after` = working-tree
+  content (null when deleted).
+- Exit codes are unchanged from Phase 1 (0 clean, 1 regression, 2 operational).
+  The hook **ignores** the exit code and inspects the JSON `regressions[]`
+  array — it emits a warning *iff* that array is non-empty, i.e. only for
+  `crossed` / `new-over-threshold` verdicts. Worsened-but-under, pre-existing,
+  and improved are all silent by design (an always-on hook that fires on
+  advisory movement becomes wallpaper and burns context).
+
+### Output channel (hard-won)
+
+The hook emits, on stdout, exactly the JSON shape `annotate-read.sh` uses —
+`additionalContext` is the **only** field that reaches the model on the next
+turn (verified in CC 2.1.142; a bare `systemMessage` does not):
+
+```json
+{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"⚠ lien delta: extractSymbols cognitive 12→29 (threshold 15) — consider simplifying before you commit."}}
+```
+
+The message lists up to the top 3 regressing functions (worst-first, as the
+primitive already sorts them), each rendered `name metric before→after
+(threshold N)`; a `(+N more)` suffix when there are more. A newly-added
+over-threshold function renders its `before` as `new`. **Silence** (exit 0, no
+stdout) in every other case: no regression, non-code file, file outside a git
+repo, unreadable payload, missing `jq`/`lien`. The hook never fails the user's
+edit (`set -u`, best-effort throughout, always `exit 0`).
+
+Kill switch: `LIEN_DELTA_HOOK=off`.
+
+### Performance
+
+The hook cost is dominated by **CLI process startup** (Node + loading the bundled
+`@liendev/lien` image), not the delta compute — the single-file delta itself is a
+few ms. Measured end-to-end on this repo (see PR body for the transcript);
+target is well under 1 s and it clears it comfortably. Because the cost is
+startup, not work, the honest optimisation levers (if it ever matters) are a
+persistent/daemon `lien` or a slimmer entrypoint — **not** pursued now (YAGNI;
+the measured number is already inside budget).
+
+### Subagent caveat (dogfooding item for the maintainer)
+
+Whether a plugin PostToolUse hook fires for `Edit`/`Write` performed *inside a
+subagent session* cannot be verified outside a live Claude Code run (it is the
+same `Agent`-vs-`Task` tool-name matcher subtlety the explore hook already
+navigates). This is flagged as the one explicit live-CC dogfooding check before
+Phase 2 is considered fully proven; the offline drive-the-script tests below
+cover everything else.
+
+## E. Mechanism 3 — `get_files_context` headroom priming (prevention)
+
+`get_files_context` is MANDATORY before any edit. That makes it the natural place
+to *prevent* a crossing: when the agent asks for a file's context, tell it which
+functions are already near or over their complexity budget, so it steers around
+them before writing a line.
+
+### Zero re-parse
+
+The complexity metrics (`complexity` = cyclomatic, `cognitiveComplexity`) are
+**already stored per chunk** in the structural index (`chunks` table columns;
+`SELECT *` in `read-ops.ts` projects them, `buildMetadata` maps them back onto
+`SearchResult.metadata`). The handler already fetches the file's own chunks via
+`searchFileChunks`. So headroom is computed from data in hand — **no second
+parse, no extra query.**
+
+### Shape
+
+A new optional `complexityHeadroom` per file — an array of the functions at
+≥ 80 % of a threshold (near) or over it, worst-first:
+
+```jsonc
+"complexityHeadroom": [
+  { "symbol": "scanPatches", "metric": "cognitive", "value": 14, "threshold": 15 }
+]
+```
+
+- One element **per function** — the single metric closest to (or furthest over)
+  its threshold, by `value / threshold` ratio — never two rows for one function.
+- Metrics considered: **cyclomatic + cognitive** only. These are the integer,
+  intuitive, agent-actionable ones and the ones `--threshold` tunes. Halstead
+  effort/bugs are deliberately left out of the *headroom hint* to keep the
+  payload lean (a prior tuning pass showed response bloat degrades agent
+  behaviour); the write-time `lien delta` gate still scores all four.
+- Thresholds are the primitive's defaults (`DEFAULT_COMPLEXITY_DELTA_THRESHOLDS`:
+  cyclomatic 15, cognitive 15). The handler stays **zero-I/O** — it does not load
+  per-project `.lien.config.json`. Documented limitation: a project that
+  customises `complexity.thresholds` heavily will see headroom computed against
+  defaults; wiring config into `ToolContext` is a deferred follow-up (YAGNI).
+- **Cap 5 per file**, sorted worst-first. Overflow is noted with a sibling
+  `complexityHeadroomMore: <N>` (count of near/over functions beyond the 5 shown),
+  present only when truncated.
+- The field (and its `More` sibling) is **omitted entirely** when nothing is near
+  budget — the overwhelmingly common case — so quiet files pay zero bytes.
+
+### Discoverability
+
+One sentence added to the `get_files_context` tool description and one to the
+server instructions, naming the field. No other tool guidance is reworded.
+
+## F. Phase-1 review findings (fixed on this branch)
+
+Lien Review flagged five legitimate issues on the merged Phase-1 code, all in the
+files Phase 2 touches. They are fixed here (commit `fix(delta): address Phase-1
+review findings`) so they ship before Phase 1 reaches users:
+
+1. **`classifyMetric` "improved" semantics** (`complexity-delta.ts`). A function
+   that drops but stays over threshold (e.g. 20→18 @ 15) was reported `improved`,
+   which reads as "this is fine" for a still-violating function. **Decision:**
+   `improved` is reserved for drops that land **strictly below** threshold; a
+   still-over-threshold decrease is `pre-existing` (the violation persists). Exit
+   code is unaffected either way (neither is a regression), but the report must
+   not imply a still-violating function is healthy. Boundary tests: 20→18@15
+   (`pre-existing`), 20→14@15 (`improved`), 20→15@15 (`pre-existing`).
+2. **`--threshold` validation** (`delta-cmd.ts`). Parsed with
+   `parseInt`+`isNaN` only, so `-5` (turns every function into a regression) and
+   `5.7` (silently truncated) were accepted. Now requires a **positive integer**
+   or exits 2 with a clear message. Tests: `-5`, `5.7`, `0`.
+3. **`configService.load` rejection** (`delta-cmd.ts`). A malformed
+   `.lien.config.json` produced a Node uncaught-exception exit instead of the
+   operational exit-2 path. Now wrapped: clear message + exit 2.
+4. **`readWorktree` swallowing all errors as null** (`delta-git.ts`). `null`
+   downstream means "deleted", so an `EACCES`/`EISDIR` read masqueraded as a
+   deletion. Now **only `ENOENT` → null** (genuinely absent); any other errno is
+   re-thrown to the operational (exit 2) path. Same treatment applied wherever
+   the file maps read errors to null.
+5. **Halstead-effort display vs classification** (`complexity-delta.ts` /
+   `delta-cmd.ts`). The table `Math.round`ed effort-minutes (`60m` for 59.7)
+   while classification used the raw value, so an under-limit function could
+   render at-the-limit. **Decision:** display **floors** effort-minutes, so the
+   shown number can never round *up* past a limit the classifier treats as under.
+
+These interact cleanly with Phase 2: the hook and headroom both surface the
+*corrected* verdicts, and finding #1's `improved`/`pre-existing` split is exactly
+the distinction the hook relies on to stay silent on non-regressions.
+
+## Phase 2 milestones
+
+- [ ] 1. Phase-2 design doc section + draft PR (this section)
+- [ ] 2. Fix Phase-1 review findings (5) + tests — separate commit
+- [ ] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
+- [ ] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
+- [ ] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -530,5 +530,5 @@ the distinction the hook relies on to stay silent on non-regressions.
 - [x] 1. Phase-2 design doc section + draft PR (this section)
 - [x] 2. Fix Phase-1 review findings (5) + tests — separate commit
 - [x] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
-- [ ] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
+- [x] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
 - [ ] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -527,8 +527,8 @@ the distinction the hook relies on to stay silent on non-regressions.
 
 ## Phase 2 milestones
 
-- [ ] 1. Phase-2 design doc section + draft PR (this section)
-- [ ] 2. Fix Phase-1 review findings (5) + tests — separate commit
+- [x] 1. Phase-2 design doc section + draft PR (this section)
+- [x] 2. Fix Phase-1 review findings (5) + tests — separate commit
 - [ ] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
 - [ ] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
 - [ ] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -529,6 +529,6 @@ the distinction the hook relies on to stay silent on non-regressions.
 
 - [x] 1. Phase-2 design doc section + draft PR (this section)
 - [x] 2. Fix Phase-1 review findings (5) + tests — separate commit
-- [ ] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
+- [x] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
 - [ ] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
 - [ ] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -424,11 +424,12 @@ Kill switch: `LIEN_DELTA_HOOK=off`.
 
 The hook cost is dominated by **CLI process startup** (Node + loading the bundled
 `@liendev/lien` image), not the delta compute — the single-file delta itself is a
-few ms. Measured end-to-end on this repo (see PR body for the transcript);
-target is well under 1 s and it clears it comfortably. Because the cost is
-startup, not work, the honest optimisation levers (if it ever matters) are a
-persistent/daemon `lien` or a slimmer entrypoint — **not** pursued now (YAGNI;
-the measured number is already inside budget).
+few ms. Measured end-to-end (hook script + `lien delta --file` incl. CLI
+startup): **~215 ms warm, ~410 ms cold** — well under the 1 s aim and the 5 s
+hook timeout. Because the cost is startup, not work, the honest optimisation
+levers (if it ever matters) are a persistent/daemon `lien` or a slimmer
+entrypoint — **not** pursued now (YAGNI; the measured number is already inside
+budget).
 
 ### Subagent caveat (dogfooding item for the maintainer)
 
@@ -531,4 +532,4 @@ the distinction the hook relies on to stay silent on non-regressions.
 - [x] 2. Fix Phase-1 review findings (5) + tests — separate commit
 - [x] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
 - [x] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
-- [ ] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset
+- [x] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset

--- a/packages/cli/src/cli/delta-cmd.test.ts
+++ b/packages/cli/src/cli/delta-cmd.test.ts
@@ -10,6 +10,7 @@ import {
   parseThresholdFlag,
   deltaExitCode,
   formatDeltaText,
+  fmtValue,
   deltaCommand,
 } from './delta-cmd.js';
 
@@ -151,6 +152,28 @@ describe('formatDeltaText', () => {
   });
 });
 
+describe('fmtValue — display formatting guards', () => {
+  it('renders null as an em-dash', () => {
+    expect(fmtValue(null, 'cognitive')).toBe('–');
+  });
+
+  it('renders NaN and Infinity as an em-dash, never "NaNm"/"Infinitym"', () => {
+    expect(fmtValue(Number.NaN, 'halstead_effort')).toBe('–');
+    expect(fmtValue(Number.POSITIVE_INFINITY, 'halstead_effort')).toBe('–');
+    expect(fmtValue(Number.NaN, 'cognitive')).toBe('–');
+    expect(fmtValue(Number.NaN, 'halstead_bugs')).toBe('–');
+  });
+
+  it('floors halstead effort minutes so display never overstates past a limit', () => {
+    expect(fmtValue(59.7, 'halstead_effort')).toBe('59m');
+  });
+
+  it('formats bugs with two decimals and integers verbatim', () => {
+    expect(fmtValue(1.5, 'halstead_bugs')).toBe('1.50');
+    expect(fmtValue(12, 'cognitive')).toBe('12');
+  });
+});
+
 describe('deltaCommand — operational failures exit 2 (Phase-1 findings #2, #3)', () => {
   let errSpy: ReturnType<typeof vi.spyOn>;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -177,6 +200,15 @@ describe('deltaCommand — operational failures exit 2 (Phase-1 findings #2, #3)
 
   it('exits 2 on a float --threshold', async () => {
     await expect(deltaCommand({ format: 'text', threshold: '5.7' })).rejects.toThrow('__exit__:2');
+  });
+
+  it('exits 2 on an empty --file (usage error, not silence)', async () => {
+    await expect(deltaCommand({ format: 'text', file: '' })).rejects.toThrow('__exit__:2');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('non-empty path'));
+  });
+
+  it('exits 2 on a whitespace-only --file', async () => {
+    await expect(deltaCommand({ format: 'text', file: '   ' })).rejects.toThrow('__exit__:2');
   });
 
   it('exits 2 when config fails to load (malformed .lien.config.json)', async () => {

--- a/packages/cli/src/cli/delta-cmd.test.ts
+++ b/packages/cli/src/cli/delta-cmd.test.ts
@@ -152,16 +152,16 @@ describe('formatDeltaText', () => {
 });
 
 describe('deltaCommand — operational failures exit 2 (Phase-1 findings #2, #3)', () => {
-  let exitSpy: ReturnType<typeof vi.spyOn>;
   let errSpy: ReturnType<typeof vi.spyOn>;
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // Throw a sentinel so a mocked process.exit actually halts deltaCommand,
-    // exactly as the real one would (rather than letting it run on).
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    // Throw a sentinel encoding the exit code so a mocked process.exit actually
+    // halts deltaCommand (as the real one would) — the sentinel `__exit__:2`
+    // asserted below is what proves exit(2) was reached.
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`__exit__:${code}`);
     }) as never);
   });

--- a/packages/cli/src/cli/delta-cmd.test.ts
+++ b/packages/cli/src/cli/delta-cmd.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   computeComplexityDelta,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
   type ComplexityDeltaThresholds,
 } from '@liendev/parser';
-import { resolveDeltaThresholds, deltaExitCode, formatDeltaText } from './delta-cmd.js';
+import * as core from '@liendev/core';
+import {
+  resolveDeltaThresholds,
+  parseThresholdFlag,
+  deltaExitCode,
+  formatDeltaText,
+  deltaCommand,
+} from './delta-cmd.js';
 
 const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*m/g, '');
 
@@ -39,19 +46,40 @@ describe('resolveDeltaThresholds', () => {
     expect(resolved.estimatedBugs).toBe(DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.estimatedBugs);
   });
 
-  it('--threshold overrides cyclomatic + cognitive only', () => {
-    const resolved = resolveDeltaThresholds({ testPaths: 20, mentalLoad: 20 }, '7');
+  it('--threshold override applies to cyclomatic + cognitive only', () => {
+    const resolved = resolveDeltaThresholds({ testPaths: 20, mentalLoad: 20 }, 7);
     expect(resolved.testPaths).toBe(7);
     expect(resolved.mentalLoad).toBe(7);
     expect(resolved.timeToUnderstandMinutes).toBe(
       DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.timeToUnderstandMinutes,
     );
   });
+});
 
-  it('ignores a non-numeric --threshold', () => {
-    const resolved = resolveDeltaThresholds({ testPaths: 20, mentalLoad: 20 }, 'abc');
-    expect(resolved.testPaths).toBe(20);
-    expect(resolved.mentalLoad).toBe(20);
+describe('parseThresholdFlag', () => {
+  it('returns undefined when the flag is absent', () => {
+    expect(parseThresholdFlag(undefined)).toBeUndefined();
+  });
+
+  it('parses a positive integer', () => {
+    expect(parseThresholdFlag('7')).toBe(7);
+    expect(parseThresholdFlag(' 12 ')).toBe(12); // tolerant of surrounding whitespace
+  });
+
+  it('rejects a negative value (would make every function a regression)', () => {
+    expect(() => parseThresholdFlag('-5')).toThrow(/positive integer/);
+  });
+
+  it('rejects a float (parseInt would silently truncate it)', () => {
+    expect(() => parseThresholdFlag('5.7')).toThrow(/positive integer/);
+  });
+
+  it('rejects zero', () => {
+    expect(() => parseThresholdFlag('0')).toThrow(/greater than 0/);
+  });
+
+  it('rejects a non-numeric value', () => {
+    expect(() => parseThresholdFlag('abc')).toThrow(/positive integer/);
   });
 });
 
@@ -120,5 +148,44 @@ describe('formatDeltaText', () => {
     const text = stripAnsi(formatDeltaText(result, 1));
     expect(text).toContain('new.ts');
     expect(text).toContain('renamed from old.ts');
+  });
+});
+
+describe('deltaCommand — operational failures exit 2 (Phase-1 findings #2, #3)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Throw a sentinel so a mocked process.exit actually halts deltaCommand,
+    // exactly as the real one would (rather than letting it run on).
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 2 on a negative --threshold (validated before any git/config work)', async () => {
+    await expect(deltaCommand({ format: 'text', threshold: '-5' })).rejects.toThrow('__exit__:2');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('positive integer'));
+  });
+
+  it('exits 2 on a float --threshold', async () => {
+    await expect(deltaCommand({ format: 'text', threshold: '5.7' })).rejects.toThrow('__exit__:2');
+  });
+
+  it('exits 2 when config fails to load (malformed .lien.config.json)', async () => {
+    vi.spyOn(core.configService, 'load').mockRejectedValue(
+      new SyntaxError('Unexpected token } in JSON'),
+    );
+    await expect(deltaCommand({ format: 'text' })).rejects.toThrow('__exit__:2');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('failed to load config'));
+    // No report is printed on the error path.
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/cli/delta-cmd.ts
+++ b/packages/cli/src/cli/delta-cmd.ts
@@ -26,10 +26,38 @@ export interface DeltaOptions {
 
 const VALID_FORMATS = ['text', 'json'];
 
-/** Merge config thresholds (+ optional --threshold override) over the defaults. */
+/**
+ * Parse and validate the `--threshold` flag. Returns `undefined` when the flag
+ * is absent; otherwise the parsed value, which MUST be a positive integer.
+ *
+ * Throws on malformed input (non-numeric, negative, zero, or a float) so the
+ * command can report it and exit 2. A negative threshold would turn every
+ * function into a regression; a float would be silently truncated by parseInt —
+ * both are user errors we refuse rather than guess at.
+ */
+export function parseThresholdFlag(thresholdFlag: string | undefined): number | undefined {
+  if (thresholdFlag === undefined) return undefined;
+  const trimmed = thresholdFlag.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(
+      `Invalid --threshold "${thresholdFlag}": must be a positive integer (whole number > 0).`,
+    );
+  }
+  const n = Number.parseInt(trimmed, 10);
+  if (n <= 0) {
+    throw new Error(`Invalid --threshold "${thresholdFlag}": must be greater than 0.`);
+  }
+  return n;
+}
+
+/**
+ * Merge config thresholds (+ optional validated --threshold override) over the
+ * defaults. `thresholdOverride`, when provided, is an already-validated positive
+ * integer (see `parseThresholdFlag`) and overrides cyclomatic + cognitive.
+ */
 export function resolveDeltaThresholds(
   configThresholds: Partial<ComplexityDeltaThresholds> | undefined,
-  thresholdFlag: string | undefined,
+  thresholdOverride: number | undefined,
 ): ComplexityDeltaThresholds {
   const overrides: Partial<ComplexityDeltaThresholds> = {};
   if (configThresholds) {
@@ -45,12 +73,9 @@ export function resolveDeltaThresholds(
       if (typeof value === 'number') overrides[key] = value;
     }
   }
-  if (thresholdFlag !== undefined) {
-    const n = Number.parseInt(thresholdFlag, 10);
-    if (!Number.isNaN(n)) {
-      overrides.testPaths = n;
-      overrides.mentalLoad = n;
-    }
+  if (thresholdOverride !== undefined) {
+    overrides.testPaths = thresholdOverride;
+    overrides.mentalLoad = thresholdOverride;
   }
   return resolveComplexityDeltaThresholds(overrides);
 }
@@ -98,7 +123,12 @@ function displayMetric(fn: FunctionComplexityDelta): MetricComplexityDelta | und
 function fmtValue(v: number | null, metricType: MetricComplexityDelta['metricType']): string {
   if (v === null) return '–';
   if (metricType === 'halstead_bugs') return v.toFixed(2);
-  if (metricType === 'halstead_effort') return `${Math.round(v)}m`;
+  // Floor (not round) effort-minutes: classification compares the RAW value to
+  // the threshold, so a rounded display could show an at/over-limit number for a
+  // value the classifier treats as under-limit (e.g. 59.7 → "60m" against a 60m
+  // limit). Flooring guarantees the shown number is never larger than the real
+  // one, so display can only ever understate, never falsely cross the limit.
+  if (metricType === 'halstead_effort') return `${Math.floor(v)}m`;
   return String(v);
 }
 
@@ -164,14 +194,37 @@ export async function deltaCommand(options: DeltaOptions): Promise<void> {
     process.exit(2);
   }
 
+  // Validate --threshold before doing any work, so a bad flag fails fast (exit 2).
+  let thresholdOverride: number | undefined;
+  try {
+    thresholdOverride = parseThresholdFlag(options.threshold);
+  } catch (error) {
+    console.error(
+      chalk.red(`lien delta: ${error instanceof Error ? error.message : String(error)}`),
+    );
+    process.exit(2);
+  }
+
   const rootDir = await getRepoRoot(process.cwd());
   if (!rootDir) {
     console.error(chalk.red('lien delta: not a git repository (or git is not installed)'));
     process.exit(2);
   }
 
-  const config = await configService.load(rootDir);
-  const thresholds = resolveDeltaThresholds(config.complexity?.thresholds, options.threshold);
+  let config;
+  try {
+    config = await configService.load(rootDir);
+  } catch (error) {
+    // A malformed .lien.config.json (or any config-load failure) is an
+    // operational error, not a complexity regression — exit 2, don't crash.
+    console.error(
+      chalk.red(
+        `lien delta: failed to load config: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+    process.exit(2);
+  }
+  const thresholds = resolveDeltaThresholds(config.complexity?.thresholds, thresholdOverride);
 
   let changes;
   try {

--- a/packages/cli/src/cli/delta-cmd.ts
+++ b/packages/cli/src/cli/delta-cmd.ts
@@ -16,12 +16,18 @@ import {
   type MetricComplexityDelta,
   type ComplexityDeltaVerdict,
 } from '@liendev/parser';
-import { getRepoRoot, collectFileChanges } from './delta-git.js';
+import { getRepoRoot, collectFileChanges, collectFileChange } from './delta-git.js';
 
 export interface DeltaOptions {
   soft?: boolean;
   format: 'text' | 'json';
   threshold?: string;
+  /**
+   * Restrict analysis to a single file (working tree vs HEAD). The fast path
+   * the PostToolUse edit hook uses — bounds the work to the one edited file
+   * instead of scanning the whole working tree on every keystroke.
+   */
+  file?: string;
 }
 
 const VALID_FORMATS = ['text', 'json'];
@@ -228,7 +234,14 @@ export async function deltaCommand(options: DeltaOptions): Promise<void> {
 
   let changes;
   try {
-    changes = await collectFileChanges(rootDir);
+    if (options.file !== undefined) {
+      // Single-file fast path (the edit hook). An out-of-repo / unsupported /
+      // absent file yields no change → empty result → clean exit 0.
+      const single = await collectFileChange(rootDir, options.file);
+      changes = single ? [single] : [];
+    } else {
+      changes = await collectFileChanges(rootDir);
+    }
   } catch (error) {
     console.error(
       chalk.red(

--- a/packages/cli/src/cli/delta-cmd.ts
+++ b/packages/cli/src/cli/delta-cmd.ts
@@ -126,8 +126,15 @@ function displayMetric(fn: FunctionComplexityDelta): MetricComplexityDelta | und
   return [...pool].sort((a, b) => order.indexOf(a.metricType) - order.indexOf(b.metricType))[0];
 }
 
-function fmtValue(v: number | null, metricType: MetricComplexityDelta['metricType']): string {
+// Exported for unit testing (Phase-2 review finding: non-finite guard).
+export function fmtValue(
+  v: number | null,
+  metricType: MetricComplexityDelta['metricType'],
+): string {
   if (v === null) return '–';
+  // Malformed metrics (NaN/Infinity) must not leak "NaNm"/"Infinitym" into the
+  // report — render them as absent, same as null.
+  if (!Number.isFinite(v)) return '–';
   if (metricType === 'halstead_bugs') return v.toFixed(2);
   // Floor (not round) effort-minutes: classification compares the RAW value to
   // the threshold, so a rounded display could show an at/over-limit number for a
@@ -197,6 +204,14 @@ export async function deltaCommand(options: DeltaOptions): Promise<void> {
 
   if (!VALID_FORMATS.includes(options.format)) {
     console.error(chalk.red(`Error: Invalid --format "${options.format}". Must be text or json.`));
+    process.exit(2);
+  }
+
+  // Validate --file before doing any work: an empty value is a usage error
+  // (exit 2), not a silent no-op — silence is reserved for genuinely
+  // out-of-scope files (non-code, outside the repo), never malformed input.
+  if (options.file !== undefined && options.file.trim() === '') {
+    console.error(chalk.red('lien delta: --file requires a non-empty path.'));
     process.exit(2);
   }
 

--- a/packages/cli/src/cli/delta-git.test.ts
+++ b/packages/cli/src/cli/delta-git.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { getRepoRoot, collectFileChanges, readWorktree } from './delta-git.js';
+import { getRepoRoot, collectFileChanges, collectFileChange, readWorktree } from './delta-git.js';
 import type { FileContentChange } from '@liendev/parser';
 
 const execFileAsync = promisify(execFile);
@@ -161,6 +161,73 @@ describe('delta-git', () => {
     await write('a.ts', SIMPLE);
     await commitAll('init');
     expect(await collectFileChanges(dir)).toEqual([]);
+  });
+
+  describe('collectFileChange — single-file fast path (edit hook)', () => {
+    it('builds before/after for a modified file (relative path)', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      await write('a.ts', COMPLEX);
+
+      const c = await collectFileChange(dir, 'a.ts');
+      expect(c).not.toBeNull();
+      expect(c!.filepath).toBe('a.ts');
+      expect(c!.before).toBe(SIMPLE);
+      expect(c!.after).toBe(COMPLEX);
+    });
+
+    it('accepts an absolute path (the shape Claude Code sends) and maps it repo-relative', async () => {
+      await initRepo();
+      await write('src/a.ts', SIMPLE);
+      await commitAll('init');
+      await write('src/a.ts', COMPLEX);
+
+      const c = await collectFileChange(dir, path.join(dir, 'src/a.ts'));
+      expect(c).not.toBeNull();
+      expect(c!.filepath).toBe('src/a.ts');
+      expect(c!.after).toBe(COMPLEX);
+    });
+
+    it('treats an untracked new file as added (before = null)', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      await write('b.ts', COMPLEX);
+
+      const c = await collectFileChange(dir, 'b.ts');
+      expect(c!.before).toBeNull();
+      expect(c!.after).toBe(COMPLEX);
+    });
+
+    it('handles a deleted file (after = null, before = HEAD)', async () => {
+      await initRepo();
+      await write('a.ts', COMPLEX);
+      await commitAll('init');
+      await fs.rm(path.join(dir, 'a.ts'));
+
+      const c = await collectFileChange(dir, 'a.ts');
+      expect(c!.before).toBe(COMPLEX);
+      expect(c!.after).toBeNull();
+    });
+
+    it('returns null for an unsupported extension (non-code file → hook silent)', async () => {
+      await initRepo();
+      await write('notes.txt', 'hello');
+      expect(await collectFileChange(dir, 'notes.txt')).toBeNull();
+    });
+
+    it('returns null for a path outside the repo', async () => {
+      await initRepo();
+      expect(await collectFileChange(dir, '/etc/hosts')).toBeNull();
+    });
+
+    it('returns null when the file exists on neither side', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      expect(await collectFileChange(dir, 'ghost.ts')).toBeNull();
+    });
   });
 
   describe('readWorktree — only ENOENT maps to null (Phase-1 finding #4)', () => {

--- a/packages/cli/src/cli/delta-git.test.ts
+++ b/packages/cli/src/cli/delta-git.test.ts
@@ -228,6 +228,52 @@ describe('delta-git', () => {
       await commitAll('init');
       expect(await collectFileChange(dir, 'ghost.ts')).toBeNull();
     });
+
+    it('accepts the repo root through a symlinked ancestor, even for a deleted file in a deleted dir', async () => {
+      // Regression (Phase-2 review finding #1): with a symlinked ANCESTOR of
+      // the repo root, a target whose file AND parent dir no longer exist hits
+      // canonicalize()'s identity fallback. Resolving against the raw rootDir
+      // then left the symlinked prefix in place, and the lexical
+      // path.relative(canonRoot, …) falsely escaped the repo → null.
+      await initRepo();
+      await write('sub/dir/a.ts', COMPLEX);
+      await commitAll('init');
+      await fs.rm(path.join(dir, 'sub'), { recursive: true }); // file AND parent dir gone
+
+      // Symlink an ancestor: linkParent/repo → dir. dir is already realpath'd,
+      // so every path through linkParent has a symlinked ancestor.
+      const linkParent = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-delta-link-'));
+      const linkedRoot = path.join(linkParent, 'repo');
+      await fs.symlink(dir, linkedRoot);
+      try {
+        const c = await collectFileChange(linkedRoot, 'sub/dir/a.ts');
+        expect(c).not.toBeNull();
+        expect(c!.filepath).toBe('sub/dir/a.ts');
+        expect(c!.before).toBe(COMPLEX);
+        expect(c!.after).toBeNull(); // deleted
+      } finally {
+        await fs.rm(linkParent, { recursive: true, force: true });
+      }
+    });
+
+    it('accepts a relative path when the repo root itself is reached via a symlink (file present)', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      await write('a.ts', COMPLEX);
+
+      const linkParent = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-delta-link-'));
+      const linkedRoot = path.join(linkParent, 'repo');
+      await fs.symlink(dir, linkedRoot);
+      try {
+        const c = await collectFileChange(linkedRoot, 'a.ts');
+        expect(c).not.toBeNull();
+        expect(c!.before).toBe(SIMPLE);
+        expect(c!.after).toBe(COMPLEX);
+      } finally {
+        await fs.rm(linkParent, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('readWorktree — only ENOENT maps to null (Phase-1 finding #4)', () => {

--- a/packages/cli/src/cli/delta-git.test.ts
+++ b/packages/cli/src/cli/delta-git.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { getRepoRoot, collectFileChanges } from './delta-git.js';
+import { getRepoRoot, collectFileChanges, readWorktree } from './delta-git.js';
 import type { FileContentChange } from '@liendev/parser';
 
 const execFileAsync = promisify(execFile);
@@ -161,5 +161,22 @@ describe('delta-git', () => {
     await write('a.ts', SIMPLE);
     await commitAll('init');
     expect(await collectFileChanges(dir)).toEqual([]);
+  });
+
+  describe('readWorktree — only ENOENT maps to null (Phase-1 finding #4)', () => {
+    it('reads an existing file', async () => {
+      await write('a.ts', SIMPLE);
+      expect(await readWorktree(dir, 'a.ts')).toBe(SIMPLE);
+    });
+
+    it('returns null for a genuinely absent file (ENOENT)', async () => {
+      expect(await readWorktree(dir, 'does-not-exist.ts')).toBeNull();
+    });
+
+    it('throws (does NOT return null) when the path is a directory (EISDIR)', async () => {
+      // A directory where a file is expected must NOT masquerade as a deletion.
+      await fs.mkdir(path.join(dir, 'a-dir'), { recursive: true });
+      await expect(readWorktree(dir, 'a-dir')).rejects.toThrow();
+    });
   });
 });

--- a/packages/cli/src/cli/delta-git.ts
+++ b/packages/cli/src/cli/delta-git.ts
@@ -88,15 +88,25 @@ async function showHead(rootDir: string, gitPath: string): Promise<string | null
   try {
     return await git(rootDir, ['show', `HEAD:${gitPath}`]);
   } catch {
+    // `null` here means "no version of this path in HEAD" — i.e. the file is
+    // added/untracked. That is the intended, correct meaning of a `git show`
+    // failure for this path (unlike readWorktree below, where null must be
+    // reserved for genuine absence), so all errors legitimately map to null.
     return null;
   }
 }
 
-async function readWorktree(rootDir: string, gitPath: string): Promise<string | null> {
+// Exported for unit testing of the ENOENT-only null-mapping (Phase-1 finding #4).
+export async function readWorktree(rootDir: string, gitPath: string): Promise<string | null> {
   try {
     return await readFile(path.join(rootDir, gitPath), 'utf-8');
-  } catch {
-    return null;
+  } catch (error) {
+    // Downstream, a null `after` is read as "file deleted". Only a genuinely
+    // absent file (ENOENT) means that. Any other failure — EACCES, EISDIR, an
+    // I/O error — must NOT masquerade as a deletion; surface it as an
+    // operational error (the caller maps thrown errors to exit 2).
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+    throw error;
   }
 }
 

--- a/packages/cli/src/cli/delta-git.ts
+++ b/packages/cli/src/cli/delta-git.ts
@@ -205,8 +205,18 @@ export async function collectFileChange(
   // Canonicalize symlinked path segments on BOTH sides first — otherwise a
   // symlinked ancestor (macOS /tmp → /private/tmp, or a symlinked project dir)
   // makes an absolute input path lexically "escape" the repo and get rejected.
+  //
+  // Resolve filePath against the CANONICAL root, not the raw rootDir: when the
+  // repo root itself sits behind a symlinked ancestor AND the target no longer
+  // exists on disk (deleted file in a deleted directory), canonicalize() falls
+  // back to the identity — resolving against the raw root would then leave the
+  // symlinked prefix in place and path.relative(canonRoot, …) would falsely
+  // escape. Residual (accepted) edge: an *absolute* input path through a
+  // symlinked ancestor whose file AND parent dir are both gone can still hit
+  // the identity fallback and be rejected — that fails silent-safe, and hook
+  // payloads reference files that were just edited (they exist).
   const canonRoot = await canonicalize(rootDir);
-  const abs = await canonicalize(path.resolve(rootDir, filePath));
+  const abs = await canonicalize(path.resolve(canonRoot, filePath));
   const rel = path.relative(canonRoot, abs);
   if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return null;
   const relPosix = rel.split(path.sep).join('/');

--- a/packages/cli/src/cli/delta-git.ts
+++ b/packages/cli/src/cli/delta-git.ts
@@ -9,7 +9,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import path from 'node:path';
 import { getSupportedExtensions, type FileContentChange } from '@liendev/parser';
 
@@ -166,4 +166,57 @@ export async function collectFileChanges(rootDir: string): Promise<FileContentCh
 
   const filtered = raw.filter(r => isSupported(r.path, supported));
   return Promise.all(filtered.map(r => toContentChange(rootDir, r, !born)));
+}
+
+/**
+ * Resolve symlinked path segments so lexical `path.relative` comparisons are
+ * sound. Falls back gracefully when the target does not exist yet (e.g. a
+ * deleted file): realpath the parent directory and re-attach the basename;
+ * failing that, return the input unchanged.
+ */
+async function canonicalize(p: string): Promise<string> {
+  try {
+    return await realpath(p);
+  } catch {
+    try {
+      return path.join(await realpath(path.dirname(p)), path.basename(p));
+    } catch {
+      return p;
+    }
+  }
+}
+
+/**
+ * Build the before/after content pair for a SINGLE file (working tree vs HEAD).
+ * This is the fast path for the per-edit hook: it avoids the full `git diff`
+ * scan and touches only the one file that was just edited.
+ *
+ * `filePath` may be absolute or relative to `rootDir`. Returns `null` — meaning
+ * "nothing to analyze, stay silent" — when the path is outside the repo, its
+ * extension is not parser-supported, or it exists on neither side (before and
+ * after both absent). Read errors other than ENOENT propagate (operational
+ * failure), matching `readWorktree`'s contract.
+ */
+export async function collectFileChange(
+  rootDir: string,
+  filePath: string,
+): Promise<FileContentChange | null> {
+  // Resolve to a repo-relative POSIX path; reject anything outside the repo.
+  // Canonicalize symlinked path segments on BOTH sides first — otherwise a
+  // symlinked ancestor (macOS /tmp → /private/tmp, or a symlinked project dir)
+  // makes an absolute input path lexically "escape" the repo and get rejected.
+  const canonRoot = await canonicalize(rootDir);
+  const abs = await canonicalize(path.resolve(rootDir, filePath));
+  const rel = path.relative(canonRoot, abs);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  const relPosix = rel.split(path.sep).join('/');
+
+  const supported = new Set(getSupportedExtensions().map(ext => `.${ext}`));
+  if (!isSupported(relPosix, supported)) return null;
+
+  const before = await showHead(rootDir, relPosix); // null => not in HEAD (added/new)
+  const after = await readWorktree(rootDir, relPosix); // null => deleted (ENOENT only)
+  if (before === null && after === null) return null;
+
+  return { filepath: relPosix, before, after };
 }

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -94,6 +94,7 @@ program
   .option('--format <type>', 'Output format: text, json', 'text')
   .option('--threshold <n>', 'Override cyclomatic + cognitive thresholds (default: from config)')
   .option('--soft', 'Advisory mode: always exit 0 (still prints the report)')
+  .option('--file <path>', 'Analyze only this file vs HEAD (fast path for edit hooks)')
   .action(deltaCommand);
 
 const configCmd = program

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -4,9 +4,40 @@ import {
   findRelatedChunks,
   handleGetFilesContext,
   clearTestAssociationScanCache,
+  computeComplexityHeadroom,
 } from './get-files-context.js';
 import type { ToolContext } from '../types.js';
 import type { SearchResult } from '@liendev/core';
+
+/** Build a function/method chunk carrying stored complexity metrics. */
+function makeFnChunk(
+  symbolName: string,
+  opts: {
+    cyclomatic?: number;
+    cognitive?: number;
+    parentClass?: string;
+    symbolType?: 'function' | 'method' | 'class' | 'block';
+    file?: string;
+  } = {},
+): SearchResult {
+  return {
+    content: '',
+    metadata: {
+      file: opts.file ?? 'src/target.ts',
+      startLine: 1,
+      endLine: 20,
+      type: 'function',
+      language: 'typescript',
+      symbolName,
+      symbolType: opts.symbolType ?? 'function',
+      parentClass: opts.parentClass,
+      complexity: opts.cyclomatic,
+      cognitiveComplexity: opts.cognitive,
+    },
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
 
 describe('searchFileChunks', () => {
   const mockLog = vi.fn();
@@ -273,5 +304,127 @@ describe('handleGetFilesContext - test-association scan (scanAll fast path + cac
     await handleGetFilesContext({ filepaths: 'src/b.ts', includeRelated: false }, ctx);
 
     expect(scanAll).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('computeComplexityHeadroom (Mechanism 3)', () => {
+  // Default thresholds: cyclomatic 15, cognitive 15. Near-budget = >= 80% (>=12).
+
+  it('flags a function over threshold', () => {
+    const { entries, overflow } = computeComplexityHeadroom([
+      makeFnChunk('over', { cognitive: 18 }),
+    ]);
+    expect(overflow).toBe(0);
+    expect(entries).toEqual([{ symbol: 'over', metric: 'cognitive', value: 18, threshold: 15 }]);
+  });
+
+  it('flags a function at/near budget (>= 80%) and excludes one below', () => {
+    const { entries } = computeComplexityHeadroom([
+      makeFnChunk('near', { cognitive: 12 }), // 12/15 = 0.80 → included
+      makeFnChunk('comfortable', { cognitive: 11 }), // 11/15 = 0.73 → excluded
+    ]);
+    expect(entries.map(e => e.symbol)).toEqual(['near']);
+  });
+
+  it('returns nothing when every function is comfortably under budget', () => {
+    const { entries, overflow } = computeComplexityHeadroom([
+      makeFnChunk('a', { cognitive: 5, cyclomatic: 4 }),
+      makeFnChunk('b', { cognitive: 8 }),
+    ]);
+    expect(entries).toEqual([]);
+    expect(overflow).toBe(0);
+  });
+
+  it('emits ONE entry per function — its worst metric by value/threshold ratio', () => {
+    // cyclomatic 13 (0.87) vs cognitive 16 (1.07) → cognitive wins.
+    const { entries } = computeComplexityHeadroom([
+      makeFnChunk('mixed', { cyclomatic: 13, cognitive: 16 }),
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({ symbol: 'mixed', metric: 'cognitive', value: 16, threshold: 15 });
+  });
+
+  it('qualifies methods with their parent class', () => {
+    const { entries } = computeComplexityHeadroom([
+      makeFnChunk('doThing', { cognitive: 20, parentClass: 'MyService', symbolType: 'method' }),
+    ]);
+    expect(entries[0].symbol).toBe('MyService.doThing');
+  });
+
+  it('ignores non-function chunks (blocks, classes, unnamed)', () => {
+    const { entries } = computeComplexityHeadroom([
+      makeFnChunk('blockish', { cognitive: 30, symbolType: 'block' }),
+      makeFnChunk('classish', { cognitive: 30, symbolType: 'class' }),
+    ]);
+    expect(entries).toEqual([]);
+  });
+
+  it('sorts worst-first and caps at 5 with an overflow count', () => {
+    const chunks = [
+      makeFnChunk('f1', { cognitive: 13 }),
+      makeFnChunk('f2', { cognitive: 14 }),
+      makeFnChunk('f3', { cognitive: 15 }),
+      makeFnChunk('f4', { cognitive: 16 }),
+      makeFnChunk('f5', { cognitive: 17 }),
+      makeFnChunk('f6', { cognitive: 18 }),
+      makeFnChunk('f7', { cognitive: 19 }),
+    ];
+    const { entries, overflow } = computeComplexityHeadroom(chunks);
+    expect(entries).toHaveLength(5);
+    expect(entries.map(e => e.symbol)).toEqual(['f7', 'f6', 'f5', 'f4', 'f3']); // worst-first
+    expect(overflow).toBe(2);
+  });
+});
+
+describe('handleGetFilesContext — complexityHeadroom in the response', () => {
+  const mockLog = vi.fn();
+
+  function ctxReturning(chunks: SearchResult[]): ToolContext {
+    return {
+      vectorDB: {
+        scanWithFilter: vi.fn().mockResolvedValue(chunks),
+        scanAll: vi.fn().mockResolvedValue([]),
+        search: vi.fn().mockResolvedValue([]),
+      } as any,
+      rootDir: process.cwd(),
+      log: mockLog,
+      checkAndReconnect: vi.fn().mockResolvedValue(undefined),
+      getIndexMetadata: vi.fn(() => ({ indexVersion: 1, indexDate: '2026-07-01' })),
+      getReindexState: vi.fn(() => ({
+        inProgress: false,
+        pendingFiles: [],
+        lastReindexTimestamp: null,
+        lastReindexDurationMs: null,
+      })),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTestAssociationScanCache();
+  });
+
+  it('includes complexityHeadroom for a file with a near/over-budget function', async () => {
+    const ctx = ctxReturning([makeFnChunk('extractSymbols', { cognitive: 18, file: 'src/a.ts' })]);
+    const result = await handleGetFilesContext(
+      { filepaths: 'src/a.ts', includeRelated: false },
+      ctx,
+    );
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed.complexityHeadroom).toEqual([
+      { symbol: 'extractSymbols', metric: 'cognitive', value: 18, threshold: 15 },
+    ]);
+    expect(parsed.complexityHeadroomMore).toBeUndefined();
+  });
+
+  it('omits complexityHeadroom entirely when nothing is near budget', async () => {
+    const ctx = ctxReturning([makeFnChunk('tidy', { cognitive: 4, file: 'src/a.ts' })]);
+    const result = await handleGetFilesContext(
+      { filepaths: 'src/a.ts', includeRelated: false },
+      ctx,
+    );
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed).not.toHaveProperty('complexityHeadroom');
+    expect(parsed).not.toHaveProperty('complexityHeadroomMore');
   });
 });

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -374,6 +374,23 @@ describe('computeComplexityHeadroom (Mechanism 3)', () => {
     expect(entries.map(e => e.symbol)).toEqual(['Svc.constructor', 'arrowFn']);
   });
 
+  it('skips non-finite metric values — NaN and Infinity never reach the payload', () => {
+    // Mirrors fmtValue's display guard: NaN slips past `ratio < 0.8` (NaN
+    // comparisons are false) and Infinity passes it outright — without the
+    // explicit guard either would leak into the MCP response.
+    const { entries, overflow } = computeComplexityHeadroom([
+      makeFnChunk('nanFn', { cognitive: Number.NaN }),
+      makeFnChunk('infFn', { cyclomatic: Number.POSITIVE_INFINITY }),
+      // Mixed: one corrupt metric, one valid over-budget metric — the valid one
+      // must still be reported.
+      makeFnChunk('mixedFn', { cognitive: Number.NaN, cyclomatic: 18 }),
+    ]);
+    expect(entries).toEqual([
+      { symbol: 'mixedFn', metric: 'cyclomatic', value: 18, threshold: 15 },
+    ]);
+    expect(overflow).toBe(0);
+  });
+
   it('sorts worst-first and caps at 5 with an overflow count', () => {
     const chunks = [
       makeFnChunk('f1', { cognitive: 13 }),

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -359,6 +359,21 @@ describe('computeComplexityHeadroom (Mechanism 3)', () => {
     expect(entries).toEqual([]);
   });
 
+  it('includes over-budget constructors (chunked as symbolType "method", name "constructor")', () => {
+    // Regression lock for a review finding that suggested 'constructor' /
+    // 'arrow_function' symbolTypes escape headroom: neither exists in the
+    // parser's symbolType vocabulary. Verified against the real chunker —
+    // constructors chunk as { symbolName: 'constructor', symbolType: 'method',
+    // parentClass: <Class> } and arrow functions as symbolType 'function', so
+    // the function|method filter (identical to the delta primitive's) covers
+    // every callable kind the chunker emits.
+    const { entries } = computeComplexityHeadroom([
+      makeFnChunk('constructor', { cognitive: 18, parentClass: 'Svc', symbolType: 'method' }),
+      makeFnChunk('arrowFn', { cognitive: 16, symbolType: 'function' }),
+    ]);
+    expect(entries.map(e => e.symbol)).toEqual(['Svc.constructor', 'arrowFn']);
+  });
+
   it('sorts worst-first and caps at 5 with an overflow count', () => {
     const chunks = [
       makeFnChunk('f1', { cognitive: 13 }),

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -16,7 +16,7 @@ function makeFnChunk(
     cyclomatic?: number;
     cognitive?: number;
     parentClass?: string;
-    symbolType?: 'function' | 'method' | 'class' | 'block';
+    symbolType?: 'function' | 'method' | 'class' | 'interface';
     file?: string;
   } = {},
 ): SearchResult {
@@ -351,10 +351,10 @@ describe('computeComplexityHeadroom (Mechanism 3)', () => {
     expect(entries[0].symbol).toBe('MyService.doThing');
   });
 
-  it('ignores non-function chunks (blocks, classes, unnamed)', () => {
+  it('ignores non-function chunks (classes, interfaces)', () => {
     const { entries } = computeComplexityHeadroom([
-      makeFnChunk('blockish', { cognitive: 30, symbolType: 'block' }),
-      makeFnChunk('classish', { cognitive: 30, symbolType: 'class' }),
+      makeFnChunk('SomeClass', { cognitive: 30, symbolType: 'class' }),
+      makeFnChunk('SomeInterface', { cognitive: 30, symbolType: 'interface' }),
     ]);
     expect(entries).toEqual([]);
   });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -326,7 +326,11 @@ export function computeComplexityHeadroom(chunks: SearchResult[]): {
     let best: (ComplexityHeadroomEntry & { ratio: number }) | null = null;
     for (const spec of HEADROOM_METRICS) {
       const value = spec.value(m);
-      if (value === undefined || spec.threshold <= 0) continue;
+      // Skip non-finite values explicitly (mirrors fmtValue's display guard):
+      // NaN would slip past the `ratio < NEAR_BUDGET_RATIO` skip (NaN
+      // comparisons are false) and Infinity would pass it outright — either
+      // would leak a nonsensical value into the MCP payload.
+      if (value === undefined || !Number.isFinite(value) || spec.threshold <= 0) continue;
       const ratio = value / spec.threshold;
       if (ratio < NEAR_BUDGET_RATIO) continue;
       if (!best || ratio > best.ratio) {

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -8,6 +8,7 @@ import {
   getCanonicalPath,
   isTestFile,
   MAX_CHUNKS_PER_FILE,
+  DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
 } from '@liendev/parser';
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 
@@ -28,10 +29,22 @@ interface HandlerContext {
   workspaceRoot: string;
 }
 
-/** File data with chunks and test associations */
+/** A single near-or-over-budget function, as surfaced to the agent. */
+export interface ComplexityHeadroomEntry {
+  symbol: string;
+  metric: 'cyclomatic' | 'cognitive';
+  value: number;
+  threshold: number;
+}
+
+/** File data with chunks, test associations, and complexity headroom. */
 interface FileData {
   chunks: SearchResult[];
   testAssociations: string[];
+  /** Functions at >= 80% of a threshold, worst-first, capped. May be empty. */
+  headroom: ComplexityHeadroomEntry[];
+  /** Count of near/over-budget functions beyond the capped list. */
+  headroomOverflow: number;
 }
 
 /** Path cache for normalized path lookups */
@@ -257,6 +270,87 @@ export function findTestAssociations(
   });
 }
 
+// ============================================================================
+// Complexity headroom (Mechanism 3 — prevention)
+// ============================================================================
+
+/** A function is "near budget" once it reaches this fraction of a threshold. */
+const NEAR_BUDGET_RATIO = 0.8;
+/** Cap the per-file headroom list so the payload stays lean. */
+const MAX_HEADROOM_PER_FILE = 5;
+
+/**
+ * The metrics surfaced as headroom. Deliberately just cyclomatic + cognitive —
+ * the integer, intuitive, agent-actionable ones (and the pair `--threshold`
+ * tunes). Halstead is left out to keep the payload lean; the write-time
+ * `lien delta` gate still scores all four. Thresholds are the delta primitive's
+ * defaults (handler stays zero-I/O; it does not load per-project config).
+ */
+const HEADROOM_METRICS: ReadonlyArray<{
+  metric: ComplexityHeadroomEntry['metric'];
+  value: (m: SearchResult['metadata']) => number | undefined;
+  threshold: number;
+}> = [
+  {
+    metric: 'cyclomatic',
+    value: m => m.complexity,
+    threshold: DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.testPaths,
+  },
+  {
+    metric: 'cognitive',
+    value: m => m.cognitiveComplexity,
+    threshold: DEFAULT_COMPLEXITY_DELTA_THRESHOLDS.mentalLoad,
+  },
+];
+
+/**
+ * Compute the complexity headroom for a file from its already-fetched chunks.
+ *
+ * No re-parse: cyclomatic/cognitive metrics are stored per chunk in the index
+ * and are carried on `SearchResult.metadata`. For each function/method at
+ * >= 80% of a threshold, emit its single worst metric (highest value/threshold
+ * ratio) — one entry per function, never two. Sorted worst-first and capped at
+ * MAX_HEADROOM_PER_FILE, with an overflow count for the remainder.
+ */
+export function computeComplexityHeadroom(chunks: SearchResult[]): {
+  entries: ComplexityHeadroomEntry[];
+  overflow: number;
+} {
+  const bySymbol = new Map<string, ComplexityHeadroomEntry & { ratio: number }>();
+
+  for (const { metadata: m } of chunks) {
+    if (m.symbolType !== 'function' && m.symbolType !== 'method') continue;
+    if (!m.symbolName) continue;
+    const symbol = m.parentClass ? `${m.parentClass}.${m.symbolName}` : m.symbolName;
+
+    let best: (ComplexityHeadroomEntry & { ratio: number }) | null = null;
+    for (const spec of HEADROOM_METRICS) {
+      const value = spec.value(m);
+      if (value === undefined || spec.threshold <= 0) continue;
+      const ratio = value / spec.threshold;
+      if (ratio < NEAR_BUDGET_RATIO) continue;
+      if (!best || ratio > best.ratio) {
+        best = { symbol, metric: spec.metric, value, threshold: spec.threshold, ratio };
+      }
+    }
+    if (!best) continue;
+
+    // A function normally maps to one chunk; if it somehow appears twice, keep
+    // the worst reading.
+    const existing = bySymbol.get(symbol);
+    if (!existing || best.ratio > existing.ratio) bySymbol.set(symbol, best);
+  }
+
+  const sorted = [...bySymbol.values()].sort((a, b) => b.ratio - a.ratio);
+  const entries = sorted
+    .slice(0, MAX_HEADROOM_PER_FILE)
+    // Drop the internal ratio — keep the payload minimal.
+    .map(({ symbol, metric, value, threshold }) => ({ symbol, metric, value, threshold }));
+  const overflow = Math.max(0, sorted.length - MAX_HEADROOM_PER_FILE);
+
+  return { entries, overflow };
+}
+
 /**
  * Deduplicate chunks by file path and line range.
  *
@@ -297,10 +391,16 @@ export function buildFilesData(
 
   filepaths.forEach((filepath, i) => {
     const dedupedChunks = deduplicateChunks(fileChunksMap[i], relatedChunksMap[i] || []);
+    // Headroom is computed from the file's OWN chunks (fileChunksMap[i]), not the
+    // deduped set — related chunks belong to other files and must not leak into
+    // this file's budget view.
+    const { entries, overflow } = computeComplexityHeadroom(fileChunksMap[i]);
 
     filesData[filepath] = {
       chunks: dedupedChunks,
       testAssociations: testAssociationsMap[i],
+      headroom: entries,
+      headroomOverflow: overflow,
     };
   });
 
@@ -328,6 +428,9 @@ function buildSingleFileResponse(
     file: filepath,
     chunks: shapeResults(data.chunks, 'get_files_context'),
     testAssociations: data.testAssociations,
+    // Omit entirely when nothing is near budget (the common case → zero bytes).
+    ...(data.headroom.length > 0 && { complexityHeadroom: data.headroom }),
+    ...(data.headroomOverflow > 0 && { complexityHeadroomMore: data.headroomOverflow }),
     ...(note && { note }),
   };
 }
@@ -342,12 +445,19 @@ function buildMultiFileResponse(
 ) {
   const shaped: Record<
     string,
-    { chunks: ReturnType<typeof shapeResults>; testAssociations: string[] }
+    {
+      chunks: ReturnType<typeof shapeResults>;
+      testAssociations: string[];
+      complexityHeadroom?: ComplexityHeadroomEntry[];
+      complexityHeadroomMore?: number;
+    }
   > = {};
   for (const [filepath, data] of Object.entries(filesData)) {
     shaped[filepath] = {
       chunks: shapeResults(data.chunks, 'get_files_context'),
       testAssociations: data.testAssociations,
+      ...(data.headroom.length > 0 && { complexityHeadroom: data.headroom }),
+      ...(data.headroomOverflow > 0 && { complexityHeadroomMore: data.headroomOverflow }),
     };
   }
   return {

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -13,6 +13,8 @@ REQUIRED before Edit/Write on any file:
   get_files_context({ filepaths }) — returns imports, callSites, and test
   associations. Batch form: { filepaths: [...] } for multi-file edits.
   Always check testAssociations and run those tests after changes.
+  If it returns complexityHeadroom, those functions are at/near their
+  complexity budget — avoid adding complexity to them.
 
 REQUIRED before renaming, removing, or changing the signature of any exported
 symbol:

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -96,6 +96,8 @@ Returns for each file:
 ALWAYS check testAssociations before modifying source code.
 After changes, remind the user to run the associated tests.
 
+May include complexityHeadroom: functions already at/near their complexity budget (cyclomatic/cognitive) — steer clear of adding to them.
+
 Batch calls are more efficient than multiple single-file calls.`,
   ),
   toMCPToolSchema(

--- a/packages/cli/test/delta-write-hook.test.ts
+++ b/packages/cli/test/delta-write-hook.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the PostToolUse edit hook `plugins/claude/hooks/delta-write.sh`.
+ *
+ * The hook's own logic — payload parsing, tool-name matching, the jq transform
+ * of the delta JSON into a one-line warning, and the silence conditions — is
+ * tested in isolation by stubbing `lien` on PATH with a shim that prints a
+ * canned `lien delta --file … --format json` payload. Real `jq` is used. No git,
+ * no real CLI: this exercises exactly the hook script, fed realistic
+ * PostToolUse payloads synthesized from the Claude Code hook schema.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import os from 'node:os';
+
+const HOOK = fileURLToPath(
+  new URL('../../../plugins/claude/hooks/delta-write.sh', import.meta.url),
+);
+
+let shimDir: string;
+let fakeJsonFile: string;
+let hookPath: string; // PATH with the lien shim prepended (real jq stays resolvable)
+
+beforeAll(() => {
+  shimDir = mkdtempSync(path.join(os.tmpdir(), 'lien-hook-shim-'));
+  fakeJsonFile = path.join(shimDir, 'delta.json');
+  // `lien` shim: ignore all args, print the canned delta JSON. Empty file → the
+  // shim prints nothing, mimicking an operational failure / no output.
+  const shim = path.join(shimDir, 'lien');
+  writeFileSync(shim, `#!/usr/bin/env bash\ncat "${fakeJsonFile}" 2>/dev/null\n`, 'utf-8');
+  chmodSync(shim, 0o755);
+  hookPath = `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`;
+});
+
+afterAll(() => {
+  rmSync(shimDir, { recursive: true, force: true });
+});
+
+/** A regression function entry as the primitive emits it in JSON. */
+function regression(
+  symbolName: string,
+  metricType: string,
+  before: number | null,
+  after: number,
+  threshold: number,
+  parentClass = '',
+) {
+  const verdict = before === null ? 'new-over-threshold' : 'crossed';
+  return {
+    key: `${parentClass}::${symbolName}`,
+    symbolName,
+    parentClass,
+    filepath: 'a.ts',
+    language: 'typescript',
+    startLine: 1,
+    verdict,
+    isRegression: true,
+    metrics: [{ metricType, before, after, threshold, verdict }],
+  };
+}
+
+/** Build a canned `lien delta --format json` result with the given regressions. */
+function deltaJson(regressions: ReturnType<typeof regression>[]): string {
+  return JSON.stringify({
+    files: [],
+    regressions,
+    summary: {
+      filesChanged: 1,
+      functionsAnalyzed: regressions.length,
+      regressions: regressions.length,
+      crossed: regressions.length,
+      newOverThreshold: 0,
+      worsened: 0,
+      improved: 0,
+    },
+    thresholds: { testPaths: 15, mentalLoad: 15, timeToUnderstandMinutes: 60, estimatedBugs: 1.5 },
+    elapsedMs: 5,
+  });
+}
+
+/** Run the hook with a payload + canned JSON, returning trimmed stdout. */
+function runHook(
+  payload: Record<string, unknown>,
+  cannedJson: string,
+  extraEnv: Record<string, string> = {},
+): { stdout: string; status: number | null } {
+  writeFileSync(fakeJsonFile, cannedJson, 'utf-8');
+  const res = spawnSync('bash', [HOOK], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: { ...process.env, PATH: hookPath, ...extraEnv },
+  });
+  return { stdout: res.stdout.trim(), status: res.status };
+}
+
+/** Extract the additionalContext string from the hook's JSON stdout. */
+function additionalContext(stdout: string): string {
+  expect(stdout, 'hook should emit JSON').not.toBe('');
+  const parsed = JSON.parse(stdout);
+  return parsed.hookSpecificOutput.additionalContext as string;
+}
+
+const editPayload = (filePath: string, tool = 'Edit') => ({
+  session_id: 's1',
+  tool_name: tool,
+  cwd: shimDir,
+  tool_input: { file_path: filePath },
+});
+
+describe('delta-write.sh — emits additionalContext only on a crossing', () => {
+  it('renders a crossed function as "name metric before→after (threshold N)"', () => {
+    const { stdout, status } = runHook(
+      editPayload('a.ts'),
+      deltaJson([regression('extractSymbols', 'cognitive', 12, 29, 15)]),
+    );
+    expect(status).toBe(0);
+    const ctx = additionalContext(stdout);
+    expect(ctx).toContain('lien delta:');
+    expect(ctx).toContain('extractSymbols cognitive 12→29 (threshold 15)');
+    expect(ctx).toContain('consider simplifying before you commit');
+  });
+
+  it('renders a newly-added over-threshold function with "new" as the before value', () => {
+    const { stdout } = runHook(
+      editPayload('a.ts', 'Write'),
+      deltaJson([regression('freshFn', 'cyclomatic', null, 20, 15)]),
+    );
+    expect(additionalContext(stdout)).toContain('freshFn cyclomatic new→20 (threshold 15)');
+  });
+
+  it('qualifies a method with its parent class', () => {
+    const { stdout } = runHook(
+      editPayload('a.ts'),
+      deltaJson([regression('doThing', 'cognitive', 10, 18, 15, 'MyService')]),
+    );
+    expect(additionalContext(stdout)).toContain('MyService.doThing cognitive 10→18');
+  });
+
+  it('lists up to 3 functions and notes overflow with "(+N more)"', () => {
+    const { stdout } = runHook(
+      editPayload('a.ts'),
+      deltaJson([
+        regression('f1', 'cognitive', 10, 20, 15),
+        regression('f2', 'cognitive', 10, 21, 15),
+        regression('f3', 'cognitive', 10, 22, 15),
+        regression('f4', 'cognitive', 10, 23, 15),
+        regression('f5', 'cognitive', 10, 24, 15),
+      ]),
+    );
+    const ctx = additionalContext(stdout);
+    expect(ctx).toContain('f1 cognitive');
+    expect(ctx).toContain('f3 cognitive');
+    expect(ctx).not.toContain('f4 cognitive'); // capped at 3
+    expect(ctx).toContain('(+2 more)');
+  });
+
+  it('produces valid JSON with a well-formed hookSpecificOutput envelope', () => {
+    const { stdout } = runHook(
+      editPayload('a.ts'),
+      deltaJson([regression('extractSymbols', 'cognitive', 12, 29, 15)]),
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PostToolUse');
+    expect(typeof parsed.hookSpecificOutput.additionalContext).toBe('string');
+  });
+});
+
+describe('delta-write.sh — stays silent (exit 0, no stdout)', () => {
+  it('when there are no regressions (advisory-only or clean change)', () => {
+    const { stdout, status } = runHook(editPayload('a.ts'), deltaJson([]));
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+  });
+
+  it('when the tool is not an edit (e.g. Bash)', () => {
+    const { stdout, status } = runHook(
+      { tool_name: 'Bash', cwd: shimDir, tool_input: { command: 'ls' } },
+      deltaJson([regression('x', 'cognitive', 12, 29, 15)]),
+    );
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+  });
+
+  it('when file_path is missing from the payload', () => {
+    const { stdout } = runHook(
+      { tool_name: 'Edit', cwd: shimDir, tool_input: {} },
+      deltaJson([regression('x', 'cognitive', 12, 29, 15)]),
+    );
+    expect(stdout).toBe('');
+  });
+
+  it('when the kill switch LIEN_DELTA_HOOK=off is set, even on a crossing', () => {
+    const { stdout } = runHook(
+      editPayload('a.ts'),
+      deltaJson([regression('x', 'cognitive', 12, 29, 15)]),
+      { LIEN_DELTA_HOOK: 'off' },
+    );
+    expect(stdout).toBe('');
+  });
+
+  it('when the CLI produces no output (empty stdout, e.g. exit 2)', () => {
+    const { stdout, status } = runHook(editPayload('a.ts'), '');
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+  });
+
+  it('when the CLI emits malformed JSON', () => {
+    const { stdout, status } = runHook(editPayload('a.ts'), 'not json at all');
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+  });
+
+  it('accepts MultiEdit as an edit tool (emits on a crossing)', () => {
+    const { stdout } = runHook(
+      editPayload('a.ts', 'MultiEdit'),
+      deltaJson([regression('extractSymbols', 'cognitive', 12, 29, 15)]),
+    );
+    expect(additionalContext(stdout)).toContain('extractSymbols cognitive 12→29');
+  });
+});

--- a/packages/cli/test/delta-write-hook.test.ts
+++ b/packages/cli/test/delta-write-hook.test.ts
@@ -95,11 +95,26 @@ function runHook(
   return { stdout: res.stdout.trim(), status: res.status };
 }
 
-/** Extract the additionalContext string from the hook's JSON stdout. */
+/**
+ * Extract the additionalContext string from the hook's JSON stdout, failing
+ * with a readable message (rather than a bare JSON.parse stack) when the hook
+ * unexpectedly printed nothing or printed non-JSON.
+ */
 function additionalContext(stdout: string): string {
-  expect(stdout, 'hook should emit JSON').not.toBe('');
-  const parsed = JSON.parse(stdout);
-  return parsed.hookSpecificOutput.additionalContext as string;
+  if (stdout === '') {
+    throw new Error('hook produced no stdout — expected an additionalContext JSON envelope');
+  }
+  let parsed: { hookSpecificOutput?: { additionalContext?: unknown } };
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(`hook stdout is not valid JSON: ${stdout}`);
+  }
+  const ctx = parsed.hookSpecificOutput?.additionalContext;
+  if (typeof ctx !== 'string') {
+    throw new Error(`hook JSON has no string additionalContext: ${stdout}`);
+  }
+  return ctx;
 }
 
 const editPayload = (filePath: string, tool = 'Edit') => ({

--- a/packages/parser/src/insights/complexity-delta.test.ts
+++ b/packages/parser/src/insights/complexity-delta.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   computeComplexityDelta,
   computeFileComplexityDelta,
+  classifyMetric,
   resolveComplexityDeltaThresholds,
   hasRegressions,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
@@ -45,6 +46,40 @@ function cognitive(fn: FunctionComplexityDelta): MetricComplexityDelta {
   if (!m) throw new Error('no cognitive metric on function delta');
   return m;
 }
+
+describe('classifyMetric — standing-violation semantics (Phase-1 finding #1)', () => {
+  const t = 15;
+
+  it('a decrease that stays over threshold is pre-existing, not improved (20→18@15)', () => {
+    // The violation persists — the report must not imply the function is now fine.
+    expect(classifyMetric(20, 18, t)).toBe('pre-existing');
+  });
+
+  it('a decrease that lands exactly on the threshold is still pre-existing (20→15@15)', () => {
+    // >= threshold counts as over (consistent with the crossing rule), so 15 is
+    // still a violation.
+    expect(classifyMetric(20, 15, t)).toBe('pre-existing');
+  });
+
+  it('a decrease that clears the threshold is improved (20→14@15)', () => {
+    expect(classifyMetric(20, 14, t)).toBe('improved');
+  });
+
+  it('an increase while already over threshold is pre-existing (18→20@15)', () => {
+    expect(classifyMetric(18, 20, t)).toBe('pre-existing');
+  });
+
+  it('classic gate verdicts are unaffected', () => {
+    expect(classifyMetric(10, 20, t)).toBe('crossed'); // under → over
+    expect(classifyMetric(null, 20, t)).toBe('new-over-threshold');
+    expect(classifyMetric(null, 5, t)).toBe('new-under-threshold');
+    expect(classifyMetric(5, 20, t)).toBe('crossed');
+    expect(classifyMetric(20, null, t)).toBe('removed');
+    expect(classifyMetric(5, 8, t)).toBe('worsened'); // both under
+    expect(classifyMetric(8, 5, t)).toBe('improved'); // both under, dropped
+    expect(classifyMetric(8, 8, t)).toBe('unchanged');
+  });
+});
 
 describe('computeFileComplexityDelta — verdict matrix (cognitive-isolated)', () => {
   it('crossed: under-threshold → over-threshold fails the gate', () => {

--- a/packages/parser/src/insights/complexity-delta.ts
+++ b/packages/parser/src/insights/complexity-delta.ts
@@ -179,8 +179,20 @@ export function hasRegressions(result: ComplexityDeltaResult): boolean {
   return result.summary.regressions > 0;
 }
 
-/** Classify one metric given before/after values and a threshold. */
-function classifyMetric(
+/**
+ * Classify one metric given before/after values and a threshold.
+ *
+ * Semantics note (`improved` vs `pre-existing` for a standing violation):
+ * `improved` is reserved for a decrease that lands **strictly below** the
+ * threshold. A function that was over threshold and drops but is *still* over
+ * threshold (e.g. 20 → 18 against 15) is `pre-existing`, NOT `improved` — the
+ * violation persists, and the report must never imply a still-violating
+ * function is healthy. Neither verdict is a gate regression, so the exit code
+ * is unaffected either way; this is purely about the honesty of the label.
+ *
+ * Exported for unit testing of the boundary cases.
+ */
+export function classifyMetric(
   before: number | null,
   after: number | null,
   threshold: number,
@@ -189,11 +201,14 @@ function classifyMetric(
   if (before === null) return after >= threshold ? 'new-over-threshold' : 'new-under-threshold';
   if (before < threshold && after >= threshold) return 'crossed';
   if (before >= threshold) {
-    // Standing violation: improved if it dropped, pre-existing if it worsened,
-    // unchanged (hidden) if the metric did not move.
-    if (after < before) return 'improved';
+    // Standing violation.
+    if (after < before) {
+      // Dropped. Only call it 'improved' if it cleared the threshold; a decrease
+      // that is still over threshold is 'pre-existing' (violation persists).
+      return after < threshold ? 'improved' : 'pre-existing';
+    }
     if (after > before) return 'pre-existing';
-    return 'unchanged';
+    return 'unchanged'; // unchanged and still over threshold — hidden from the report
   }
   // both under threshold
   if (after > before) return 'worsened';

--- a/plugins/claude/hooks/delta-write.sh
+++ b/plugins/claude/hooks/delta-write.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Edit|Write|MultiEdit: compute the complexity delta for the
+# file just edited and, ONLY when the edit introduced a NEW threshold crossing,
+# surface a one-line warning via additionalContext. Silent in every other case.
+#
+# Drives the same Phase-1 primitive as `lien delta`, through the single-file
+# fast path `lien delta --file <path> --format json`, so the hook's verdict and
+# the CLI's verdict can never diverge. An always-on hook that fired on advisory
+# movement (worsened-but-under, pre-existing) would become wallpaper and burn
+# context, so it emits ONLY for gate-failing verdicts (crossed / new-over).
+#
+# Best-effort throughout — never fails the user's edit. Disable via
+# LIEN_DELTA_HOOK=off.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+# Env kill switch.
+if [ "${LIEN_DELTA_HOOK:-}" = "off" ]; then
+  exit 0
+fi
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+case "$tool_name" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+[ -n "$file_path" ] || exit 0
+
+# Run the single-file delta as JSON, from the session's cwd so the git root and
+# project root resolve against the right repo (multi-repo safe). Any failure
+# (not a git repo, unsupported file, git error → exit 2) yields empty/non-JSON
+# output and we stay silent.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  json="$(cd "$cwd" && lien delta --file "$file_path" --format json 2>/dev/null)"
+else
+  json="$(lien delta --file "$file_path" --format json 2>/dev/null)"
+fi
+[ -n "$json" ] || exit 0
+
+# Build the warning from the regressions[] array ONLY (crossed / new-over).
+# Empty array → jq emits nothing → we stay silent. Lists up to the top 3
+# functions (already sorted worst-first by the primitive), each as
+# "name metric before→after (threshold N)"; a newly-added over-threshold
+# function shows its "before" as "new".
+msg="$(printf '%s' "$json" | jq -r '
+  (.regressions // []) as $r
+  | ($r | length) as $n
+  | if $n == 0 then empty else
+      ( [ $r[0:3][]
+          | ( [ .metrics[] | select(.verdict == "crossed" or .verdict == "new-over-threshold") ][0] ) as $m
+          | select($m != null)
+          | (if (.parentClass // "") != "" then .parentClass + "." + .symbolName else .symbolName end) as $name
+          | $name + " " + $m.metricType + " "
+            + (if $m.before == null then "new" else ($m.before | tostring) end)
+            + "→" + ($m.after | tostring)
+            + " (threshold " + ($m.threshold | tostring) + ")"
+        ] | join("; ") )
+      + (if $n > 3 then " (+\($n - 3) more)" else "" end)
+    end
+')"
+[ -n "$msg" ] || exit 0
+
+text="⚠ lien delta: ${msg} — consider simplifying before you commit."
+
+# additionalContext is the only field that reaches the model on the next turn
+# (verified in CC 2.1.142; a bare systemMessage does not). Match annotate-read.sh.
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' \
+  "$(printf '%s' "$text" | jq -Rs .)"
+
+exit 0

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Suppresses repeats per session for 5 minutes.",
+  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Plus a write-time delta warning: after an Edit/Write, flags any function whose complexity newly crossed a threshold. Suppresses repeats per session for 5 minutes.",
   "hooks": {
     "PreToolUse": [
       {
@@ -20,6 +20,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-read.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/delta-write.sh",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
## lien delta — Phase 2: the signal at the moment of the edit

Phase 1 (#672) made the complexity-delta verdict *available* as a gate the agent
chooses to run. Phase 2 moves it to **edit time** — detection + prevention — on
channels the agent already consumes. Nothing blocks; both mechanisms are
advisory. Full design + honest limitations: `docs/architecture/lien-delta.md`
(Phase 2 section).

### Mechanisms

**M2 — PostToolUse edit hook** (`plugins/claude/hooks/delta-write.sh`, registered
in the plugin's `hooks.json`). Fires after `Edit`/`Write`/`MultiEdit`, drives a
new **`lien delta --file <path>`** single-file fast path, and emits
`additionalContext` **only** on a new threshold crossing. Mirrors
`annotate-read.sh` (jq + `command -v lien`, cwd-scoped, best-effort, always exit
0). Kill switch `LIEN_DELTA_HOOK=off`.

- **hook → CLI decision:** a new `--file` flag rather than filtering the full-tree
  JSON — bounds per-edit work to one `git show HEAD:<path>` + one read + one
  chunk pair, and reuses the exact `computeComplexityDelta` call so hook and CLI
  verdicts can't diverge.
- **measured latency (end-to-end, incl. CLI startup): ~215 ms warm / ~410 ms
  cold** — well under the 1 s aim and the 5 s hook timeout. Cost is process
  startup, not the delta (a few ms); daemon/slim-entrypoint deferred (YAGNI).

**M3 — `get_files_context` complexity headroom.** The MANDATORY-before-edit tool
now returns a lean `complexityHeadroom` array of functions at ≥ 80 % of a
cyclomatic/cognitive budget (worst-first, one entry per function, capped at 5 +
`complexityHeadroomMore` overflow). Computed from complexity metrics **already
stored per chunk** in the index — zero re-parse, zero extra query. Omitted
entirely when nothing is near budget. Tool description + server instructions each
gain one sentence.

### Scope addition — Phase-1 review findings (commit `65e3eca`)

Five legitimate issues Lien Review flagged on #672, fixed here so they ship
before Phase 1 reaches users:
1. `classifyMetric` — a decrease that stays over threshold (20→18@15) was
   `improved`; now `pre-existing` (violation persists). `classifyMetric`
   exported; boundary tests 20→18/20→15/20→14 @15 added.
2. `--threshold` now requires a positive integer (rejects `-5`, `5.7`, `0` → exit 2).
3. `configService.load` failure wrapped → exit 2 (was an uncaught crash).
4. `readWorktree` only maps `ENOENT`→null; `EISDIR`/`EACCES` rethrow (null meant "deleted").
5. Halstead-effort display floors (was `Math.round`) so it can't overstate past a limit.

### Verification

**Hook driven directly** (real `delta-write.sh`, `lien` shim → built CLI, temp git repo):

```
(a) crossing edit (a.ts: cognitive 0→15) → EMITS:
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"⚠ lien delta: extractSymbols cognitive 0→15 (threshold 15) — consider simplifying before you commit."}}   [exit 0]

(b) harmless edit (b.ts: adds one if, no crossing)  → stdout=[]  [exit 0]  (silent)
(c) non-code file (notes.txt, unsupported ext)      → stdout=[]  [exit 0]  (silent)
(d) non-edit tool (Bash)                            → stdout=[]  [exit 0]  (silent)
(e) LIEN_DELTA_HOOK=off on the crossing case        → stdout=[]  [exit 0]  (silent)
```

**`get_files_context` over real MCP stdio** (built CLI serving an indexed temp repo, `tangled` = cognitive 41, `tidy` = trivial):

```json
{
  "file": "messy.ts",
  "complexityHeadroom": [
    { "symbol": "tangled", "metric": "cognitive", "value": 41, "threshold": 15 }
  ]
}
```
`tidy` correctly absent; `complexityHeadroomMore` omitted (only one entry).

**Full monorepo gate — all green:**
- `format:check` ✓ · `lint` ✓ (0 errors) · `typecheck` ✓ · `build` ✓
- `npm test` ✓ — parser 963, core 318, review 565, cli 747, action 28 (all passing)

**New tests:** parser +5 (`classifyMetric` boundaries) · cli +6 `parseThresholdFlag`
· +3 `deltaCommand` exit-2 · +3 `readWorktree` · +7 `collectFileChange` · +12
hook-logic (stubbed `lien` + real `jq`, synthesized PostToolUse payloads) · +8
`computeComplexityHeadroom` · +2 handler response-shape.

### Milestones
- [x] 1. Phase-2 design doc section + draft PR
- [x] 2. Fix Phase-1 review findings (5) + tests — `fix(delta): address Phase-1 review findings`
- [x] 3. M2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
- [x] 4. M3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
- [x] 5. Verification: hook transcripts (3+) + MCP headroom response + latency; full gate green; changeset

### Out of scope
Mechanism 5 (commit soft-block); review-engine adoption of the primitive; rule
prompts in `packages/review` (CI-guarded — untouched, verified via `git diff`).

### Review findings triage (commit `a2c5847`)

Lien Review posted 5 inline findings; 4 fixed, 1 rebutted:

1. 🔴 **`collectFileChange` symlinked-ancestor rejection — FIXED.** The path was
   resolved against the raw `rootDir` but compared against the canonical root, so
   a repo behind a symlinked ancestor falsely rejected a deleted file in a
   deleted directory (`canonicalize`'s identity fallback kept the symlinked
   prefix and `path.relative` escaped). Now resolves against `canonRoot`.
   Regression test with a symlinked parent of the repo root added — **verified
   to fail on the old code**. Residual accepted edge documented in a comment
   (absolute input path whose file AND parent dir are gone, under a symlinked
   ancestor → silent-safe null).
2. 🟡 **Empty `--file` silence — FIXED.** `--file ''` (or whitespace) is now a
   usage error: clear message + exit 2, validated before any git/config work.
   `rel === ''` inside `collectFileChange` (path resolving to the repo root
   directory) keeps its silent-null semantics — that case is a directory, not
   malformed input, and cannot arise from hook payloads. Tests for `''` and `'   '`.
3. 🔴 **Constructors escaping `computeComplexityHeadroom` — REBUTTED (false
   positive).** `'constructor'` and `'arrow_function'` do not exist in the
   parser's `symbolType` vocabulary (`function | method | class | interface |
   schema | style | javascript | template` — `packages/parser/src/types.ts`).
   Verified against the real chunker: a class constructor chunks as
   `{ symbolName: 'constructor', symbolType: 'method', parentClass: <Class> }`
   and an arrow function as `symbolType: 'function'`, both carrying complexity
   metrics. The `function|method` filter therefore already covers every callable
   kind the chunker emits, and is **identical** to the delta primitive's filter
   (`complexity-delta.ts` — the exact alignment the finding suggested). Added a
   constructor-heavy regression test locking `Svc.constructor` into the headroom
   output.
4. 🟡 **`fmtValue` NaN/Infinity — FIXED.** Non-finite values render as `–`
   (same as null), never `NaNm`; `fmtValue` exported with unit tests
   (NaN/Infinity/floor/null).
5. 🟡 **Hook-test helper JSON.parse — FIXED.** `additionalContext` now fails
   with a readable message on empty stdout, non-JSON stdout, or a missing
   `additionalContext` string, instead of a bare parse stack.

6. 🟡 **Round 2 — non-finite metrics in headroom — FIXED (commit `5adc83d`).**
   `computeComplexityHeadroom` now skips NaN/Infinity metric values explicitly
   (mirroring `fmtValue`'s display guard); test asserts neither can reach the
   `complexityHeadroom` payload while a valid metric on the same function still
   reports. Gate re-run green (cli 757).

**Gate re-run after fixes — all green:** `format:check` ✓ · `lint` ✓ (0 errors) ·
`typecheck` ✓ · `build` ✓ · `npm test` ✓ (parser 963, core 318, review 565,
cli **756** (+9), action 28).

### ⚠ Live-CC dogfooding item (maintainer)
Whether this PostToolUse hook fires for `Edit`/`Write` performed **inside a
subagent session** cannot be verified outside a live Claude Code run (the same
`Agent`-vs-`Task` tool-name matcher subtlety the explore hook navigates). This is
the one explicit manual check before Phase 2 is fully proven; everything else is
covered by the offline drive-the-script tests above.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 5 new functions are too complex.
🔗 **Impact**: 1 high-risk file(s) with 4 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +16 |
| 🧠 mental load | 3 | +40 |
| ⏱️ time to understand | 4 | +243 |


> [!WARNING]
> **2 issues found** · Low Risk
>
> This PR adds a PostToolUse edit-time complexity hook (driven by a new `lien delta --file` fast path) and surfaces `complexityHeadroom` in `get_files_context`, plus fixes five Phase-1 review findings. The changes are well-tested and conservative. The only material concerns are minor: a missing guard for negative metric values in headroom computation and precision loss for extremely large `--threshold` inputs. Neither blocks users under normal conditions, and the updated classification/validation paths behave correctly for realistic inputs.
>
> - Added `lien delta --file <path>` single-file fast path and `delta-write.sh` hook
> - Added `complexityHeadroom` / `complexityHeadroomMore` to `get_files_context` responses
> - Fixed Phase-1 findings: threshold validation, config-load exit 2, ENOENT-only deletion mapping, improved/pre-existing classification, Halstead-effort flooring

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5adc83d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster file-level complexity check for edits, with write-time warnings when a function newly crosses a complexity threshold.
  * Enhanced file context results with “complexity headroom” guidance for near-budget functions.
  * Added stricter input handling for the delta command, including clearer validation for file and threshold options.

* **Bug Fixes**
  * Improved delta reporting accuracy for threshold boundary cases and file-read errors.
  * Refined displayed metric values to avoid misleading rounding and invalid number output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**7. Dismissed (maintainer triage): parseThresholdFlag leading-zeros / huge-number acceptance (🟡, delta-cmd.ts:44).** `'007'`→7 is harmless normalization. An absurdly large `--threshold` does effectively disable the gate — but `--threshold` is a deliberate, human-only override flag and `--soft` already exists as the sanctioned disable; agents run bare `lien delta` and never pass it. Bounding the accepted range (e.g. 1–1000) is filed as a nice-to-have follow-up rather than a merge blocker.