### PR TITLE
fix(plugin): resolve lien via npx fallback so hooks actually run

### DIFF
--- a/plugins/claude/hooks/annotate-clean.sh
+++ b/plugins/claude/hooks/annotate-clean.sh
@@ -6,15 +6,15 @@
 set -u
 
 command -v jq >/dev/null 2>&1 || exit 0
-command -v lien >/dev/null 2>&1 || exit 0
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
 
 input="$(cat)"
 cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
-  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+  store="$(cd "$cwd" && "${LIEN_CMD[@]}" path --store 2>/dev/null)"
 else
-  store="$(lien path --store 2>/dev/null)"
+  store="$("${LIEN_CMD[@]}" path --store 2>/dev/null)"
 fi
 [ -n "$store" ] || exit 0
 
@@ -25,5 +25,11 @@ sessions_root="$store/annotated-sessions"
 if [ -d "$sessions_root" ]; then
   find "$sessions_root" -mindepth 1 -maxdepth 1 -type d -mmin +1440 -exec rm -rf {} + 2>/dev/null
 fi
+
+# Pre-warm the resolver's npx fallback in the background (detached, so this
+# SessionStart hook returns immediately). Without a global lien install the
+# first real hook invocation would otherwise pay npx's cold package install
+# and blow its timeout; after this warm-up every later call is ~300ms.
+("${LIEN_CMD[@]}" --version >/dev/null 2>&1 &)
 
 exit 0

--- a/plugins/claude/hooks/annotate-end.sh
+++ b/plugins/claude/hooks/annotate-end.sh
@@ -6,7 +6,7 @@
 set -u
 
 command -v jq >/dev/null 2>&1 || exit 0
-command -v lien >/dev/null 2>&1 || exit 0
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
 
 input="$(cat)"
 session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
@@ -21,9 +21,9 @@ case "$session_id" in
 esac
 
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
-  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+  store="$(cd "$cwd" && "${LIEN_CMD[@]}" path --store 2>/dev/null)"
 else
-  store="$(lien path --store 2>/dev/null)"
+  store="$("${LIEN_CMD[@]}" path --store 2>/dev/null)"
 fi
 [ -n "$store" ] || exit 0
 

--- a/plugins/claude/hooks/annotate-read.sh
+++ b/plugins/claude/hooks/annotate-read.sh
@@ -10,7 +10,7 @@
 set -u
 
 command -v jq >/dev/null 2>&1 || exit 0
-command -v lien >/dev/null 2>&1 || exit 0
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
 
 input="$(cat)"
 file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
@@ -29,9 +29,9 @@ esac
 
 # Resolve store from the session's cwd so multi-repo setups work correctly.
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
-  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+  store="$(cd "$cwd" && "${LIEN_CMD[@]}" path --store 2>/dev/null)"
 else
-  store="$(lien path --store 2>/dev/null)"
+  store="$("${LIEN_CMD[@]}" path --store 2>/dev/null)"
 fi
 [ -n "$store" ] || exit 0
 
@@ -41,7 +41,7 @@ if [ "$ext" = "$file_path" ]; then
   # No extension at all.
   exit 0
 fi
-if ! lien path --extensions 2>/dev/null | grep -Fxq "$ext"; then
+if ! "${LIEN_CMD[@]}" path --extensions 2>/dev/null | grep -Fxq "$ext"; then
   exit 0
 fi
 
@@ -75,12 +75,12 @@ fi
 
 # Invoke from cwd so resolveProjectRoot works under subdirectory cwds.
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
-  annotation="$(cd "$cwd" && lien annotate "$file_path" 2>/dev/null)"
+  annotation="$(cd "$cwd" && "${LIEN_CMD[@]}" annotate "$file_path" 2>/dev/null)"
 else
-  annotation="$(lien annotate "$file_path" 2>/dev/null)"
+  annotation="$("${LIEN_CMD[@]}" annotate "$file_path" 2>/dev/null)"
 fi
 
-# Trivial impact → lien annotate prints nothing → stay silent.
+# Trivial impact → `lien annotate` prints nothing → stay silent.
 [ -n "$annotation" ] || exit 0
 
 # Record the annotation so suppression kicks in next time. Truncating an

--- a/plugins/claude/hooks/augment-explore-task.sh
+++ b/plugins/claude/hooks/augment-explore-task.sh
@@ -48,11 +48,12 @@ esac
 # point the subagent at tools that return empty for everything and
 # burn calls on dead ends. The sqlite structural.db file is the canonical
 # "is this repo indexed?" signal.
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
 cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
-  store="$(cd "$cwd" && lien path --store 2>/dev/null)"
+  store="$(cd "$cwd" && "${LIEN_CMD[@]}" path --store 2>/dev/null)"
 else
-  store="$(lien path --store 2>/dev/null)"
+  store="$("${LIEN_CMD[@]}" path --store 2>/dev/null)"
 fi
 [ -n "$store" ] && [ -f "$store/structural.db" ] || exit 0
 

--- a/plugins/claude/hooks/delta-write.sh
+++ b/plugins/claude/hooks/delta-write.sh
@@ -15,7 +15,7 @@
 set -u
 
 command -v jq >/dev/null 2>&1 || exit 0
-command -v lien >/dev/null 2>&1 || exit 0
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
 
 # Env kill switch.
 if [ "${LIEN_DELTA_HOOK:-}" = "off" ]; then
@@ -39,9 +39,9 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 # (not a git repo, unsupported file, git error → exit 2) yields empty/non-JSON
 # output and we stay silent.
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
-  json="$(cd "$cwd" && lien delta --file "$file_path" --format json 2>/dev/null)"
+  json="$(cd "$cwd" && "${LIEN_CMD[@]}" delta --file "$file_path" --format json 2>/dev/null)"
 else
-  json="$(lien delta --file "$file_path" --format json 2>/dev/null)"
+  json="$("${LIEN_CMD[@]}" delta --file "$file_path" --format json 2>/dev/null)"
 fi
 [ -n "$json" ] || exit 0
 

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -41,7 +41,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-clean.sh",
-            "timeout": 30
+            "timeout": 5000
           }
         ]
       }
@@ -52,7 +52,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/annotate-end.sh",
-            "timeout": 30
+            "timeout": 5000
           }
         ]
       }

--- a/plugins/claude/hooks/lien-resolve.sh
+++ b/plugins/claude/hooks/lien-resolve.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Shared lien resolver for plugin hooks. A global `lien` install is NOT
+# guaranteed — the plugin's own MCP server invokes `npx -y @liendev/lien@latest`
+# for exactly that reason — so hooks must not hard-require one. Before this
+# resolver existed, every hook opened with `command -v lien || exit 0`, which
+# made the entire hook suite a silent no-op on machines without a global
+# install (i.e. the default plugin setup).
+#
+# Usage (from a sibling hook script):
+#   . "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
+#   "${LIEN_CMD[@]}" path --store
+#
+# Resolution order: global `lien` (fastest) → `npx -y @liendev/lien@latest`
+# (warm npx adds ~300ms; the SessionStart hook pre-warms the cache so real
+# hook invocations never pay the cold install). Fails the source (caller
+# exits 0, staying silent) only when neither is available.
+
+if command -v lien >/dev/null 2>&1; then
+  LIEN_CMD=(lien)
+elif command -v npx >/dev/null 2>&1; then
+  LIEN_CMD=(npx -y @liendev/lien@latest)
+else
+  return 1
+fi


### PR DESCRIPTION
## What

Dogfooding discovery (critical): **the plugin's entire hook suite has never fired in a real session.** Every hook gates on `command -v lien || exit 0` (the explore hook had no guard — its bare `lien` calls failed into silence), but the plugin never establishes a global `lien`: its own MCP server invokes `npx -y @liendev/lien@latest` for exactly that reason. On a default setup (no global install), annotate-read, delta-write, session cleanup, and the Explore mandate all silently no-op. Every hook test transcript to date had `node_modules/.bin` injected into PATH, masking this.

## How

- **`hooks/lien-resolve.sh`** (new, shared): resolves `LIEN_CMD` as global `lien` when present, else `npx -y @liendev/lien@latest`; sourcing fails (hook exits 0, silent) only when neither exists. All five hooks source it and invoke `"${LIEN_CMD[@]}"`.
- **SessionStart pre-warm**: `annotate-clean.sh` kicks a detached background `--version` so the npx cache is warm before any real hook fires (cold npx would blow the 5s timeout on its first-ever run).
- **hooks.json**: SessionStart/SessionEnd timeouts `30` → `5000` (30ms was surely a units mistake — more evidence these never meaningfully ran).

## Testing

Real conditions (verified `command -v lien` absent, no PATH injection):
- Crossing edit → `⚠ lien delta: labyrinth cyclomatic new→20 (threshold 15)…` in **0.95s** (within the 5s budget, warm npx)
- Harmless edit / non-code file → silent, exit 0
- Explore Task payload → Lien mandate injected with correct wording
- `bash -n` on all six scripts; full monorepo gate green (31/29/30/43/4 test files)

After merge: reinstall the plugin (`/plugin uninstall lien@lien` + `install`) to re-snapshot — then the first-ever live-session hook run happens, including the still-open question of hook firing inside subagents.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 7 high-risk file(s) with 135 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 425ef6d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook reliability when the expected CLI isn’t installed locally by automatically using an available fallback.
  * Reduced the chance of hook failures by giving key session start/end actions much longer timeouts.
  * Added a lightweight warm-up step to help first-run commands start faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->