### PR TITLE
fix(cli): join complexity metrics against resolved dependents only

### DIFF
--- a/.changeset/dependents-complexity-join-fix.md
+++ b/.changeset/dependents-complexity-join-fix.md
@@ -1,0 +1,5 @@
+---
+'@liendev/lien': patch
+---
+
+Fix `get_dependents` reporting complexity metrics for files that aren't actually dependents. For symbol-level queries, `complexityMetrics`/`highComplexityDependents`/`riskReasoning` were computed from the pre-symbol-filter candidate set (every file that imports the target file) instead of the resolved `dependents` list, so an unrelated file that merely imports the target — without using the requested symbol — could inflate the reported risk even when zero real dependents were found. Complexity is now joined against exactly the resolved dependents.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -273,6 +273,67 @@ describe('findDependents', () => {
       expect(result.complexityMetrics.filesWithComplexityData).toBe(0);
       expect(result.complexityMetrics.complexityRiskBoost).toBe('low');
     });
+
+    // Regression: a file can import the target file (landing in the
+    // pre-symbol-filter candidate set) without importing the requested
+    // symbol, so `buildDependentsList` correctly drops it from `dependents`.
+    // Complexity metrics used to be computed from that wider candidate set
+    // instead of the resolved `dependents`, so an unrelated high-complexity
+    // file could inflate `complexityMetrics`/`complexityRiskBoost` even when
+    // zero dependents were returned.
+    it('should return neutral complexity metrics when the symbol filter leaves zero dependents', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/target.ts', { exports: ['Foo', 'Bar'] }),
+        createChunk('src/unrelated.ts', {
+          imports: ['src/target.ts'],
+          importedSymbols: { 'src/target': ['Bar'] }, // does not import 'Foo'
+          complexity: 17,
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'Foo');
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.fileComplexities).toHaveLength(0);
+      expect(result.complexityMetrics).toEqual({
+        averageComplexity: 0,
+        maxComplexity: 0,
+        filesWithComplexityData: 0,
+        highComplexityDependents: [],
+        complexityRiskBoost: 'low',
+      });
+    });
+
+    // Regression: when some (but not all) files pass the symbol filter,
+    // complexity metrics must be restricted to exactly those files — not the
+    // wider import-graph candidate set that also matched the target file.
+    it('should restrict complexity metrics to exactly the resolved symbol dependents', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/target.ts', { exports: ['Foo', 'Bar'] }),
+        createChunk('src/uses-foo.ts', {
+          imports: ['src/target.ts'],
+          importedSymbols: { 'src/target': ['Foo'] },
+          complexity: 4,
+        }),
+        createChunk('src/uses-bar.ts', {
+          imports: ['src/target.ts'],
+          importedSymbols: { 'src/target': ['Bar'] }, // does not import 'Foo'
+          complexity: 20, // high complexity, but must not leak into the result
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'Foo');
+
+      expect(result.dependents).toHaveLength(1);
+      expect(result.dependents[0].filepath).toBe('src/uses-foo.ts');
+
+      expect(result.fileComplexities).toHaveLength(1);
+      expect(result.fileComplexities[0].filepath).toBe('src/uses-foo.ts');
+
+      expect(result.complexityMetrics.filesWithComplexityData).toBe(1);
+      expect(result.complexityMetrics.maxComplexity).toBe(4);
+      expect(result.complexityMetrics.highComplexityDependents).toHaveLength(0);
+    });
   });
 
   describe('production vs test split', () => {

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -634,9 +634,6 @@ export async function findDependents(
     maxNodes,
   });
 
-  const fileComplexities = calculateFileComplexities(chunksByFile);
-  const complexityMetrics = calculateOverallComplexityMetrics(fileComplexities);
-
   const targetFileChunks = symbol ? (allChunksByFile.get(normalizedTarget) ?? []) : [];
   const { dependents, totalUsageCount } = buildDependentsList(
     chunksByFile,
@@ -649,6 +646,18 @@ export async function findDependents(
     reExporterPaths,
   );
   stampHopsAndSort(dependents, hopsByFile);
+
+  // Complexity metrics must be joined against the *resolved* dependents, not
+  // the broader import-graph candidate set (`chunksByFile`) considered before
+  // symbol filtering. For file-level queries the two are identical, but for
+  // symbol queries `chunksByFile` can contain files that import the target
+  // file yet don't use the requested symbol — `buildDependentsList` drops
+  // those. Reading complexity from `chunksByFile` directly let an unrelated
+  // file's complexity leak into `complexityMetrics`/`riskReasoning` even when
+  // `dependents` came back empty.
+  const dependentChunksByFile = restrictToDependents(chunksByFile, dependents);
+  const fileComplexities = calculateFileComplexities(dependentChunksByFile);
+  const complexityMetrics = calculateOverallComplexityMetrics(fileComplexities);
 
   const testDependentCount = dependents.filter(f => f.isTestFile).length;
   const productionDependentCount = dependents.length - testDependentCount;
@@ -942,6 +951,25 @@ function findDependentChunks(
   }
 
   return dependentChunks;
+}
+
+/**
+ * Restrict a file-level chunk map down to exactly the resolved dependent
+ * filepaths. Used to join complexity metrics against `dependents` rather
+ * than the wider pre-symbol-filter candidate set (see `findDependents`).
+ */
+function restrictToDependents(
+  chunksByFile: Map<string, SearchResult[]>,
+  dependents: DependentInfo[],
+): Map<string, SearchResult[]> {
+  const dependentPaths = new Set(dependents.map(d => d.filepath));
+  const restricted = new Map<string, SearchResult[]>();
+  for (const [filepath, chunks] of chunksByFile.entries()) {
+    if (dependentPaths.has(filepath)) {
+      restricted.set(filepath, chunks);
+    }
+  }
+  return restricted;
 }
 
 /**


### PR DESCRIPTION
## Root cause

`findDependents` (`packages/cli/src/mcp/handlers/dependency-analyzer.ts`) computed `complexityMetrics`/`fileComplexities` from `chunksByFile` — the pre-symbol-filter, file-level import-graph candidate set (every file that imports the target file) — instead of from the resolved `dependents` list.

For file-level queries these two sets are identical, so the bug is invisible there. For **symbol** queries, `buildDependentsList` narrows `chunksByFile` down via `findSymbolUsages`, dropping any file that imports the target file but doesn't actually use the requested symbol. `complexityMetrics` never got that narrowing — it kept reading the wider `chunksByFile` — so a completely unrelated file could leak its complexity into `complexityMetrics`, `highComplexityDependents`, `complexityRiskBoost`, and (via `computeRisk` in `get-dependents.ts`) into `riskReasoning`/`riskLevel`, even when it wasn't a real dependent.

In this repo, `lien-review-testbed/rust/src/analyzer.rs` contains `use crate::parser::{self, ParsedInput};`. The Rust extractor strips `crate::`, storing the import as the bare token `parser`, which fuzzy-matches any target path with a `parser` path segment (`packages/parser/src/...`) via `matchesFile`'s boundary-match strategy. That's a legitimate file-level dependency match (out of scope for this PR — see "Not touched" below) — the bug is that it kept counting toward complexity even after being correctly excluded from the symbol-level `dependents` list.

## Fix

`packages/cli/src/mcp/handlers/dependency-analyzer.ts`: moved the complexity computation to run *after* `buildDependentsList`, and added a small `restrictToDependents` helper that filters `chunksByFile` down to exactly the filepaths in the resolved `dependents` array before computing `fileComplexities`/`complexityMetrics`. File-level queries are unaffected (dependents already equals `chunksByFile`'s keys there). The target file itself is not included in `dependents` by design (see existing test "should not include the target file itself as a dependent"), so it's correctly excluded from complexity metrics too — no design change needed there.

No changes to import/dependency *resolution* (`findDependentChunks`, `matchesFile`, `seedDepth1Dependents`, BFS) — that's the cross-language fuzzy-match behavior owned separately, and is a legitimate file-level result, not this bug.

## Before / after (real MCP stdio, this repo)

Reproduced by spawning the built CLI's `lien serve` over the real MCP stdio transport and calling `get_dependents` with the exact args from the dogfooding report, against a real index of this repo (base+overlay), toggling only this fix via `git stash`/`pop` + rebuild between runs (same index both times).

**Before (bug):** `dependents` correctly has 2 real entries (`packages/parser/src/index.ts`, `complexity-delta.test.ts`) — `analyzer.rs` is not one of them — yet `complexityMetrics` reports `analyzer.rs` as a high-complexity dependent and escalates risk to `high`:

```json
{
  "dependentCount": 2,
  "riskLevel": "high",
  "riskReasoning": ["1 caller", "1 untested", "max complexity 17", "untested high-complexity dependent"],
  "dependents": [
    { "filepath": "packages/parser/src/index.ts", "isTestFile": false, "hops": 1 },
    { "filepath": "packages/parser/src/insights/complexity-delta.test.ts", "isTestFile": true, "hops": 1 }
  ],
  "complexityMetrics": {
    "averageComplexity": 4.9,
    "maxComplexity": 17,
    "filesWithComplexityData": 3,
    "highComplexityDependents": [
      { "filepath": "lien-review-testbed/rust/src/analyzer.rs", "maxComplexity": 17, "avgComplexity": 9.5 }
    ],
    "complexityRiskBoost": "medium"
  }
}
```

**After (fixed):** same 2 resolved dependents, but `complexityMetrics` now derives only from them:

```json
{
  "dependentCount": 2,
  "riskLevel": "medium",
  "riskReasoning": ["1 caller", "1 untested", "max complexity 2"],
  "dependents": [
    { "filepath": "packages/parser/src/index.ts", "isTestFile": false, "hops": 1 },
    { "filepath": "packages/parser/src/insights/complexity-delta.test.ts", "isTestFile": true, "hops": 1 }
  ],
  "complexityMetrics": {
    "averageComplexity": 1.5,
    "maxComplexity": 2,
    "filesWithComplexityData": 1,
    "highComplexityDependents": [],
    "complexityRiskBoost": "low"
  }
}
```

(Note: the original dogfooding report saw `dependentCount: 0` at the time it was filed; this repo's `packages/parser/src/index.ts` and `complexity-delta.test.ts` now reference `computeComplexityDelta` directly, so the live symbol-level candidate set is non-empty today. The exact zero-dependents case from the report is covered deterministically by the new regression test below, and the leak mechanism reproduced above is identical.)

## Tests

Added to `packages/cli/src/mcp/handlers/dependency-analyzer.test.ts` (`complexity metrics` describe block):
- **`should return neutral complexity metrics when the symbol filter leaves zero dependents`** — reproduces the exact reported shape: an unrelated file imports the target file but not the requested symbol; `dependents` is empty and `complexityMetrics` is asserted to equal the fully neutral shape (all zeros, empty arrays, `low` boost).
- **`should restrict complexity metrics to exactly the resolved symbol dependents`** — one file matches the symbol (low complexity), a second imports the target but not the symbol (high complexity, 20); asserts `fileComplexities`/`complexityMetrics` reflect only the matching file.

Existing complexity-metrics tests (file-level, matching `chunksByFile`) still pass unchanged.

## Gate

- `npm run format:check` — pass
- `npm run lint` — 0 errors (20 pre-existing warnings, unrelated to this change)
- `npm run typecheck` — pass (all packages)
- `npm run build` — pass (all packages)
- `npm test` — pass: parser 963/963, core 318/318, review 565/565, cli 759/759 (incl. 2 new regression tests), action 28/28

## Not touched (per scope)

- `overlay`/`vectordb` files
- `packages/cli/src/mcp/handlers/dependency-analyzer.ts` import-*resolution* logic (`findDependentChunks`, `matchesFile`, `seedDepth1Dependents`, BFS) — the Rust `crate::parser` fuzzy-match collision that puts `analyzer.rs`/`reporter.rs` in the file-level candidate set at all is real and reproducible (see file-level query in testing above), but it's a legitimate file-level dependency match, not this bug, and resolution logic is owned separately.
- `packages/parser/src/dependency-analyzer.ts` (the unrelated, AST-based `analyzeDependencies` used by the `lien complexity` CLI/insights path) — different file, not implicated in this MCP-tool bug.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real bug in symbol-level `get_dependents` where complexity metrics were computed from the pre-symbol-filter import-graph candidate set (`chunksByFile`) instead of the resolved `dependents` list, allowing unrelated files that import the target but don't use the requested symbol to leak into `complexityMetrics`, `highComplexityDependents`, and downstream risk reasoning. The fix moves complexity calculation after `buildDependentsList` and adds a `restrictToDependents` helper that filters the chunk map to exactly the resolved dependent filepaths. File-level queries are unaffected, and two regression tests cover the zero-dependents and partial-filter cases. No breaking changes or new logic errors were introduced.
>
> - Complexity metrics now derive from resolved dependents via `restrictToDependents` rather than the broader pre-symbol-filter candidate set
> - Added two regression tests for symbol-filtered complexity metric behavior
> - File-level `get_dependents` behavior is unchanged because `dependents` already equals `chunksByFile`'s keys

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1921857. Updates automatically on new commits.</sup>
<!-- /lien-stats -->