### PR TITLE
fix(parser): resolve workspace package specifiers for cross-package dependents

### DIFF
--- a/.changeset/workspace-import-resolution.md
+++ b/.changeset/workspace-import-resolution.md
@@ -1,0 +1,8 @@
+---
+'@liendev/parser': minor
+'@liendev/core': patch
+---
+
+Resolve workspace package specifiers (`import { X } from '@scope/pkg'`) to the package's source entry file during chunking, closing a monorepo blind spot in dependency analysis. Previously, imports written as a workspace package specifier (rather than a relative path) were stored raw and never matched any indexed file, so `get_dependents` couldn't see across package boundaries in npm-workspaces monorepos — e.g. a CLI package consuming a symbol from a sibling library package showed 0 dependents.
+
+Workspace packages are now detected generically from the root `package.json`'s `workspaces` globs (supporting nested globs and negated excludes) and each member's declared source entry (`main`/`module`, falling back to the `src/index.<ext>` convention) — nothing is hardcoded to `@liendev`. The resulting map is applied the same way `./`/`../` specifiers already are, so file-level dependents, the transitive re-export BFS, and symbol-level usage tracking all pick up cross-package edges automatically. Deep/subpath imports (`@scope/pkg/subpath`) are out of scope for this pass and continue to pass through unresolved. Non-monorepo projects and external npm packages are unaffected.

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -99,6 +99,7 @@ async function processFileContent(
     astFallback,
     repoId,
     orgId,
+    workspaceRoot: rootDir,
   });
 
   if (chunks.length === 0) {

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -348,6 +348,7 @@ async function processFileForIndexing(
       astFallback: indexConfig.astFallback,
       repoId: indexConfig.repoId,
       orgId: indexConfig.orgId,
+      workspaceRoot: rootDir,
     });
 
     if (chunks.length === 0) {

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import { chunkByAST, shouldUseAST } from './chunker.js';
+import { clearWorkspacePackageCache } from '../workspace-packages.js';
 
 describe('AST Chunker', () => {
   describe('shouldUseAST', () => {
@@ -191,6 +195,119 @@ pub fn run() {
       expect(funcChunk?.metadata.imports).toContain('../utils/helper');
       // Explicitly NOT resolved against crates/app/src/foo.rs.
       expect(funcChunk?.metadata.imports).not.toContain('crates/app/utils/helper');
+    });
+
+    describe('cross-package workspace imports', () => {
+      let testDir: string;
+
+      beforeEach(async () => {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-chunker-workspace-'));
+      });
+
+      afterEach(async () => {
+        clearWorkspacePackageCache();
+        await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+      });
+
+      async function writeJson(relPath: string, data: unknown): Promise<void> {
+        const abs = path.join(testDir, relPath);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, JSON.stringify(data, null, 2));
+      }
+
+      async function writeFile(relPath: string, content = ''): Promise<void> {
+        const abs = path.join(testDir, relPath);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+
+      it('resolves a bare workspace-package import to the package source entry (monorepo fixture)', async () => {
+        // Reproduces the dogfooding gap: a consumer package imports a symbol
+        // from a sibling workspace package by its package specifier, not a
+        // relative path.
+        await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+        await writeJson('packages/parser/package.json', {
+          name: '@liendev/parser',
+          main: './dist/index.js',
+        });
+        await writeFile(
+          'packages/parser/src/index.ts',
+          "export { computeComplexityDelta } from './insights/complexity-delta.js';",
+        );
+
+        const content = `
+import { computeComplexityDelta } from '@liendev/parser';
+
+function run() {
+  return computeComplexityDelta();
+}
+        `.trim();
+
+        const chunks = chunkByAST('packages/cli/src/delta-cmd.ts', content, {
+          workspaceRoot: testDir,
+        });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
+
+        expect(funcChunk?.metadata.imports).toContain('packages/parser/src/index.ts');
+        expect(funcChunk?.metadata.importedSymbols).toMatchObject({
+          'packages/parser/src/index.ts': ['computeComplexityDelta'],
+        });
+      });
+
+      it('leaves external package specifiers untouched even when workspaceRoot is set', async () => {
+        await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+        await writeJson('packages/parser/package.json', { name: '@liendev/parser' });
+        await writeFile('packages/parser/src/index.ts', 'export const x = 1;');
+
+        const content = `
+import chalk from 'chalk';
+
+function run() {
+  return chalk.red('x');
+}
+        `.trim();
+
+        const chunks = chunkByAST('packages/cli/src/delta-cmd.ts', content, {
+          workspaceRoot: testDir,
+        });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
+
+        expect(funcChunk?.metadata.imports).toContain('chalk');
+      });
+
+      it('leaves imports unresolved for a non-workspace repo (no workspaces field)', async () => {
+        await writeJson('package.json', { name: 'standalone-app' });
+
+        const content = `
+import { computeComplexityDelta } from '@liendev/parser';
+
+function run() {
+  return computeComplexityDelta();
+}
+        `.trim();
+
+        const chunks = chunkByAST('src/delta-cmd.ts', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
+
+        // No workspaces field → resolveWorkspacePackageEntries returns an
+        // empty map → zero behavior change from the pre-fix raw specifier.
+        expect(funcChunk?.metadata.imports).toContain('@liendev/parser');
+      });
+
+      it('is a no-op when workspaceRoot is omitted (existing callers unaffected)', () => {
+        const content = `
+import { computeComplexityDelta } from '@liendev/parser';
+
+function run() {
+  return computeComplexityDelta();
+}
+        `.trim();
+
+        const chunks = chunkByAST('packages/cli/src/delta-cmd.ts', content);
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
+
+        expect(funcChunk?.metadata.imports).toContain('@liendev/parser');
+      });
     });
 
     it('should calculate cyclomatic complexity', () => {

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -10,6 +10,7 @@ import {
 } from './symbols.js';
 import { calculateCognitiveComplexity, calculateHalstead } from './complexity/index.js';
 import { getTraverser } from './traversers/index.js';
+import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
 
 export interface ASTChunkOptions {
   maxChunkSize?: number; // Reserved for future use (smart splitting of large functions)
@@ -17,6 +18,15 @@ export interface ASTChunkOptions {
   // Multi-tenant fields (optional for backward compatibility)
   repoId?: string; // Repository identifier for multi-tenant scenarios
   orgId?: string; // Organization identifier for multi-tenant scenarios
+  /**
+   * Absolute path to the workspace/monorepo root. When provided (and the
+   * root has an npm `workspaces` field), bare package specifiers that name a
+   * sibling workspace package (e.g. `@scope/pkg`) are resolved to that
+   * package's source entry file, so cross-package imports participate in
+   * dependency analysis. Omit for non-monorepo projects — behavior is
+   * unchanged.
+   */
+  workspaceRoot?: string;
 }
 
 /**
@@ -74,18 +84,30 @@ const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
  * specifiers (`./foo`, `../bar`) are resolved to workspace-relative paths at
  * index time. This prevents cross-package basename collisions in the downstream
  * dependency analysis (see #525).
+ *
+ * When `workspaceRoot` is also provided, bare package specifiers naming a
+ * sibling workspace package (`@scope/pkg`) are resolved the same way, to that
+ * package's source entry file — closing the monorepo cross-package blind
+ * spot in `get_dependents`. Gated to the same JS/TS language set as relative
+ * import resolution: npm workspaces is a JS-ecosystem mechanism, and other
+ * languages' import syntax could otherwise coincidentally collide with a
+ * workspace package name.
  */
 function prepareASTContext(
   content: string,
   rootNode: Parser.SyntaxNode,
   language: SupportedLanguage,
   filepath: string,
+  workspaceRoot?: string,
 ): ASTContext {
-  const resolutionPath = RESOLVE_RELATIVE_IMPORTS.has(language) ? filepath : undefined;
+  const resolvesImports = RESOLVE_RELATIVE_IMPORTS.has(language);
+  const resolutionPath = resolvesImports ? filepath : undefined;
+  const workspacePackages =
+    resolvesImports && workspaceRoot ? resolveWorkspacePackageEntries(workspaceRoot) : undefined;
   return {
     lines: content.split('\n'),
-    fileImports: extractImports(rootNode, language, resolutionPath),
-    importedSymbols: extractImportedSymbols(rootNode, language, resolutionPath),
+    fileImports: extractImports(rootNode, language, resolutionPath, workspacePackages),
+    importedSymbols: extractImportedSymbols(rootNode, language, resolutionPath, workspacePackages),
     fileExports: extractExports(rootNode, language),
     traverser: getTraverser(language),
   };
@@ -169,14 +191,14 @@ export function chunkByAST(
   content: string,
   options: ASTChunkOptions = {},
 ): ASTChunk[] {
-  const { minChunkSize = 5, repoId, orgId } = options;
+  const { minChunkSize = 5, repoId, orgId, workspaceRoot } = options;
   const tenantContext = { repoId, orgId };
 
   // Parse and validate
   const { language, rootNode } = parseAndValidate(filepath, content);
 
   // Prepare context
-  const context = prepareASTContext(content, rootNode, language, filepath);
+  const context = prepareASTContext(content, rootNode, language, filepath, workspaceRoot);
 
   // Find and process top-level nodes
   const topLevelNodes = findTopLevelNodes(rootNode, context.traverser);

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -4,7 +4,7 @@ import type { LanguageSymbolExtractor } from './extractors/types.js';
 import { getExtractor, getImportExtractor, getSymbolExtractor } from './extractors/index.js';
 import { getLanguage } from './languages/registry.js';
 
-import { resolveRelativeImport } from '../utils/path-matching.js';
+import { resolveRelativeImport, resolveWorkspaceImport } from '../utils/path-matching.js';
 
 /**
  * Extract symbol information from an AST node using language-specific extractors.
@@ -58,17 +58,36 @@ function collectImportNodes(
 }
 
 /**
+ * Resolve a single raw import specifier: relative specifiers first (against
+ * the importer's directory), then workspace package specifiers (against the
+ * `workspacePackages` map). Both steps are no-ops when their respective
+ * input isn't provided, so behavior for existing callers is unchanged.
+ */
+function resolveImportSpecifier(
+  specifier: string,
+  filepath: string | undefined,
+  workspacePackages: ReadonlyMap<string, string> | undefined,
+): string {
+  const relResolved = filepath ? resolveRelativeImport(filepath, specifier) : specifier;
+  return workspacePackages ? resolveWorkspaceImport(relResolved, workspacePackages) : relResolved;
+}
+
+/**
  * Extract import paths using the language-specific extractor.
  *
  * When `filepath` is provided, relative specifiers (`./foo`, `../bar`) are
  * resolved against the importer's directory so that cross-package files with
- * the same basename don't collide downstream. Non-relative specifiers pass
- * through unchanged.
+ * the same basename don't collide downstream. When `workspacePackages` is
+ * also provided, bare specifiers naming a workspace package (`@scope/pkg`)
+ * resolve to that package's source entry file, enabling cross-package
+ * dependency analysis in monorepos. Everything else passes through
+ * unchanged.
  */
 function extractImportPaths(
   rootNode: Parser.SyntaxNode,
   importExtractor: ReturnType<typeof getImportExtractor>,
   filepath?: string,
+  workspacePackages?: ReadonlyMap<string, string>,
 ): string[] {
   if (!importExtractor) return [];
 
@@ -77,7 +96,7 @@ function extractImportPaths(
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
     const result = importExtractor.extractImportPath(node);
-    if (result) imports.push(filepath ? resolveRelativeImport(filepath, result) : result);
+    if (result) imports.push(resolveImportSpecifier(result, filepath, workspacePackages));
   }
 
   return imports;
@@ -92,14 +111,18 @@ function extractImportPaths(
  * @param filepath - Optional path of the file being chunked. Enables resolution
  *   of `./` / `../` specifiers so they store workspace-relative paths instead
  *   of bare basenames.
+ * @param workspacePackages - Optional map of workspace package name -> source
+ *   entry file (see `resolveWorkspacePackageEntries`). Enables resolution of
+ *   bare `@scope/pkg` specifiers that reference sibling workspace packages.
  */
 export function extractImports(
   rootNode: Parser.SyntaxNode,
   language?: SupportedLanguage,
   filepath?: string,
+  workspacePackages?: ReadonlyMap<string, string>,
 ): string[] {
   if (!language) return [];
-  return extractImportPaths(rootNode, getImportExtractor(language), filepath);
+  return extractImportPaths(rootNode, getImportExtractor(language), filepath, workspacePackages);
 }
 
 /**
@@ -123,11 +146,14 @@ function addSymbolsToMap(
  *
  * When `filepath` is provided, relative import paths in the returned map's
  * keys are resolved to workspace-relative paths via `resolveRelativeImport`.
+ * When `workspacePackages` is also provided, bare workspace-package keys are
+ * further resolved to their source entry file (see `extractImportPaths`).
  */
 function extractSymbolsWithExtractor(
   rootNode: Parser.SyntaxNode,
   importExtractor: ReturnType<typeof getImportExtractor>,
   filepath?: string,
+  workspacePackages?: ReadonlyMap<string, string>,
 ): Record<string, string[]> {
   if (!importExtractor) return {};
 
@@ -137,7 +163,7 @@ function extractSymbolsWithExtractor(
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
     const result = importExtractor.processImportSymbols(node);
     if (result) {
-      const key = filepath ? resolveRelativeImport(filepath, result.importPath) : result.importPath;
+      const key = resolveImportSpecifier(result.importPath, filepath, workspacePackages);
       addSymbolsToMap(importedSymbols, key, result.symbols);
     }
   }
@@ -154,14 +180,22 @@ function extractSymbolsWithExtractor(
  *
  * @param filepath - Optional path of the file being chunked. Enables resolution
  *   of `./` / `../` specifiers into workspace-relative keys.
+ * @param workspacePackages - Optional map of workspace package name -> source
+ *   entry file. Enables resolution of bare `@scope/pkg` keys.
  */
 export function extractImportedSymbols(
   rootNode: Parser.SyntaxNode,
   language?: SupportedLanguage,
   filepath?: string,
+  workspacePackages?: ReadonlyMap<string, string>,
 ): Record<string, string[]> {
   if (!language) return {};
-  return extractSymbolsWithExtractor(rootNode, getImportExtractor(language), filepath);
+  return extractSymbolsWithExtractor(
+    rootNode,
+    getImportExtractor(language),
+    filepath,
+    workspacePackages,
+  );
 }
 
 /**

--- a/packages/parser/src/chunk-only-index.ts
+++ b/packages/parser/src/chunk-only-index.ts
@@ -75,6 +75,7 @@ async function chunkFileForCollection(
       useAST: true,
       astFallback: 'line-based',
       repoId: config.repoId,
+      workspaceRoot: rootDir,
     });
 
     if (chunks.length > 0) {

--- a/packages/parser/src/chunker.ts
+++ b/packages/parser/src/chunker.ts
@@ -13,6 +13,12 @@ export interface ChunkOptions {
   // Multi-tenant fields (optional for backward compatibility)
   repoId?: string; // Repository identifier for multi-tenant scenarios
   orgId?: string; // Organization identifier for multi-tenant scenarios
+  /**
+   * Absolute path to the workspace/monorepo root. Enables cross-package
+   * import resolution for JS/TS monorepos — see `ASTChunkOptions.workspaceRoot`.
+   * Optional; omit for non-monorepo projects (zero behavior change).
+   */
+  workspaceRoot?: string;
 }
 
 export function chunkFile(
@@ -27,6 +33,7 @@ export function chunkFile(
     astFallback = 'line-based',
     repoId,
     orgId,
+    workspaceRoot,
   } = options;
 
   // Special handling for Liquid files
@@ -49,6 +56,7 @@ export function chunkFile(
         minChunkSize: Math.floor(chunkSize / 10),
         repoId,
         orgId,
+        workspaceRoot,
       });
     } catch (error) {
       // Handle AST errors based on configuration

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { normalizePath, matchesFile, isTestFile, resolveRelativeImport } from './path-matching.js';
+import {
+  normalizePath,
+  matchesFile,
+  isTestFile,
+  resolveRelativeImport,
+  resolveWorkspaceImport,
+} from './path-matching.js';
 
 /**
  * Test cases for path matching logic in get_dependents tool.
@@ -458,5 +464,43 @@ describe('resolveRelativeImport', () => {
     expect(aResolved).toBe('packages/cli/src/mcp/handlers/dependency-analyzer');
     expect(bResolved).toBe('packages/parser/src/dependency-analyzer');
     expect(aResolved).not.toBe(bResolved);
+  });
+});
+
+describe('resolveWorkspaceImport', () => {
+  const workspacePackages = new Map([
+    ['@liendev/parser', 'packages/parser/src/index.ts'],
+    ['@liendev/core', 'packages/core/src/index.ts'],
+  ]);
+
+  it('resolves a bare specifier that matches a known workspace package', () => {
+    expect(resolveWorkspaceImport('@liendev/parser', workspacePackages)).toBe(
+      'packages/parser/src/index.ts',
+    );
+  });
+
+  it('leaves external (non-workspace) package specifiers untouched', () => {
+    expect(resolveWorkspaceImport('lodash', workspacePackages)).toBe('lodash');
+    expect(resolveWorkspaceImport('react', workspacePackages)).toBe('react');
+  });
+
+  it('leaves an empty map (non-monorepo project) fully unaffected', () => {
+    const empty = new Map<string, string>();
+    expect(resolveWorkspaceImport('@liendev/parser', empty)).toBe('@liendev/parser');
+    expect(resolveWorkspaceImport('./relative/path', empty)).toBe('./relative/path');
+  });
+
+  it('does not resolve deep/subpath imports into a workspace package (v1 scope)', () => {
+    // Only the bare specifier is a map key; a subpath is a different string
+    // and deliberately passes through unresolved.
+    expect(resolveWorkspaceImport('@liendev/parser/dist/index', workspacePackages)).toBe(
+      '@liendev/parser/dist/index',
+    );
+  });
+
+  it('leaves already-relative-resolved specifiers untouched', () => {
+    expect(resolveWorkspaceImport('packages/parser/src/foo', workspacePackages)).toBe(
+      'packages/parser/src/foo',
+    );
   });
 });

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -287,6 +287,31 @@ export function resolveRelativeImport(importerFile: string, specifier: string): 
 }
 
 /**
+ * Resolve a bare workspace package specifier (`@scope/pkg`, `pkg`) to that
+ * package's workspace-relative source entry file, when `workspacePackages`
+ * has an entry for it. See `resolveWorkspacePackageEntries` in
+ * `../workspace-packages.ts` for how the map is built.
+ *
+ * Only exact bare-specifier matches resolve — deep imports into a package's
+ * subpath (`@scope/pkg/subpath`) pass through unchanged (see that module's
+ * doc comment for why this is the deliberate v1 scope). Specifiers with no
+ * matching workspace package (external npm deps, or an empty/absent map for
+ * non-monorepo projects) also pass through unchanged, so this is a no-op
+ * everywhere it doesn't apply.
+ *
+ * @param specifier - The raw (or already relative-resolved) import specifier
+ * @param workspacePackages - Map of package name -> workspace-relative entry file
+ * @returns The resolved entry file path, or `specifier` unchanged
+ */
+export function resolveWorkspaceImport(
+  specifier: string,
+  workspacePackages: ReadonlyMap<string, string>,
+): string {
+  if (workspacePackages.size === 0) return specifier;
+  return workspacePackages.get(specifier) ?? specifier;
+}
+
+/**
  * Gets a canonical path representation (relative to workspace, with extension).
  *
  * @param filepath - The file path to canonicalize

--- a/packages/parser/src/workspace-packages.test.ts
+++ b/packages/parser/src/workspace-packages.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  resolveWorkspacePackageEntries,
+  clearWorkspacePackageCache,
+} from './workspace-packages.js';
+
+describe('resolveWorkspacePackageEntries', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-workspace-packages-'));
+  });
+
+  afterEach(async () => {
+    clearWorkspacePackageCache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeJson(relPath: string, data: unknown): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, JSON.stringify(data, null, 2));
+  }
+
+  async function writeFile(relPath: string, content = ''): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it('returns an empty map for a non-workspace repo (no workspaces field)', async () => {
+    await writeJson('package.json', { name: 'solo-app' });
+    await writeFile('src/index.ts', 'export const x = 1;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('returns an empty map when there is no root package.json at all', () => {
+    const map = resolveWorkspacePackageEntries(testDir);
+    expect(map.size).toBe(0);
+  });
+
+  it('resolves a simple npm workspaces glob to each member source entry', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+    await writeJson('packages/parser/package.json', {
+      name: '@liendev/parser',
+      main: './dist/index.js',
+    });
+    await writeFile('packages/parser/src/index.ts', 'export const parser = true;');
+    await writeJson('packages/core/package.json', {
+      name: '@liendev/core',
+      main: './dist/index.js',
+    });
+    await writeFile('packages/core/src/index.ts', 'export const core = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.get('@liendev/parser')).toBe('packages/parser/src/index.ts');
+    expect(map.get('@liendev/core')).toBe('packages/core/src/index.ts');
+    expect(map.size).toBe(2);
+  });
+
+  it('resolves nested workspace globs', async () => {
+    await writeJson('package.json', {
+      name: 'root',
+      workspaces: ['packages/*', 'tools/*/plugins/*'],
+    });
+    await writeJson('packages/core/package.json', { name: '@scope/core' });
+    await writeFile('packages/core/src/index.ts', 'export const core = true;');
+    await writeJson('tools/build/plugins/logger/package.json', { name: '@scope/logger-plugin' });
+    await writeFile('tools/build/plugins/logger/src/index.ts', 'export const logger = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.get('@scope/core')).toBe('packages/core/src/index.ts');
+    expect(map.get('@scope/logger-plugin')).toBe('tools/build/plugins/logger/src/index.ts');
+  });
+
+  it('supports the { workspaces: { packages: [...] } } object form', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: { packages: ['packages/*'] } });
+    await writeJson('packages/widget/package.json', { name: '@scope/widget' });
+    await writeFile('packages/widget/src/index.ts', 'export const widget = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.get('@scope/widget')).toBe('packages/widget/src/index.ts');
+  });
+
+  it('honors negated exclude globs', async () => {
+    await writeJson('package.json', {
+      name: 'root',
+      workspaces: ['packages/*', '!packages/excluded'],
+    });
+    await writeJson('packages/included/package.json', { name: '@scope/included' });
+    await writeFile('packages/included/src/index.ts', 'export const included = true;');
+    await writeJson('packages/excluded/package.json', { name: '@scope/excluded' });
+    await writeFile('packages/excluded/src/index.ts', 'export const excluded = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.has('@scope/included')).toBe(true);
+    expect(map.has('@scope/excluded')).toBe(false);
+  });
+
+  it('falls back to the src/index.<ext> convention when main is absent', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+    await writeJson('packages/noentry/package.json', { name: '@scope/noentry' });
+    await writeFile('packages/noentry/src/index.tsx', 'export const noentry = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.get('@scope/noentry')).toBe('packages/noentry/src/index.tsx');
+  });
+
+  it('derives the source entry from a dist-style main field', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+    await writeJson('packages/action/package.json', {
+      name: '@scope/action',
+      main: './dist/cli.js',
+    });
+    await writeFile('packages/action/src/cli.ts', 'export const cli = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.get('@scope/action')).toBe('packages/action/src/cli.ts');
+  });
+
+  it('skips a matched directory that has no package.json', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+    await fs.mkdir(path.join(testDir, 'packages/not-a-package'), { recursive: true });
+    await writeJson('packages/real/package.json', { name: '@scope/real' });
+    await writeFile('packages/real/src/index.ts', 'export const real = true;');
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.size).toBe(1);
+    expect(map.get('@scope/real')).toBe('packages/real/src/index.ts');
+  });
+
+  it('skips a matched package whose entry file cannot be resolved on disk', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+    // Package exists, declares a main, but neither that file nor the
+    // src/index.* convention exists on disk.
+    await writeJson('packages/ghost/package.json', {
+      name: '@scope/ghost',
+      main: './dist/index.js',
+    });
+
+    const map = resolveWorkspacePackageEntries(testDir);
+
+    expect(map.has('@scope/ghost')).toBe(false);
+  });
+
+  it('caches the resolved map per workspace root', async () => {
+    await writeJson('package.json', { name: 'root', workspaces: ['packages/*'] });
+    await writeJson('packages/a/package.json', { name: '@scope/a' });
+    await writeFile('packages/a/src/index.ts', 'export const a = true;');
+
+    const first = resolveWorkspacePackageEntries(testDir);
+
+    // Add a second package after the first resolution — the cached map
+    // should be returned unchanged until the cache is explicitly cleared.
+    await writeJson('packages/b/package.json', { name: '@scope/b' });
+    await writeFile('packages/b/src/index.ts', 'export const b = true;');
+
+    const second = resolveWorkspacePackageEntries(testDir);
+    expect(second).toBe(first);
+    expect(second.has('@scope/b')).toBe(false);
+
+    clearWorkspacePackageCache();
+
+    const third = resolveWorkspacePackageEntries(testDir);
+    expect(third.has('@scope/b')).toBe(true);
+  });
+});

--- a/packages/parser/src/workspace-packages.ts
+++ b/packages/parser/src/workspace-packages.ts
@@ -1,0 +1,179 @@
+import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
+
+/**
+ * Resolves npm-style `workspaces` globs (root `package.json`) to a map of
+ * workspace package name -> workspace-relative source entry file.
+ *
+ * This closes the monorepo cross-package blind spot in dependency analysis:
+ * imports like `import { X } from '@scope/pkg'` are stored RAW by the import
+ * extractors (see `resolveRelativeImport` in `./utils/path-matching.ts`,
+ * which only rewrites `./`/`../` specifiers). Without this map, a bare
+ * package specifier never matches any indexed file, so `get_dependents`
+ * can't see across package boundaries.
+ *
+ * v1 scope (deliberately KISS/YAGNI):
+ * - Only the npm `workspaces: string[]` form is read (also accepts the
+ *   `{ workspaces: { packages: string[] } }` shape some tooling emits).
+ *   Yarn/pnpm-specific workspace config files (`pnpm-workspace.yaml`) are
+ *   out of scope — add if/when a real repo needs it.
+ * - Only the BARE package specifier is resolved (`@scope/pkg`), mapped to
+ *   the package's SOURCE entry (e.g. `packages/parser/src/index.ts`), not
+ *   its built `main` (`dist/index.js` isn't indexed). Deep/subpath imports
+ *   (`@scope/pkg/subpath`) pass through unresolved — no cross-package
+ *   import in this codebase uses that form, and honoring package.json
+ *   `exports` maps for arbitrary subpaths is real complexity for no
+ *   observed benefit.
+ * - Entry file detection tries `main`/`module` (rewriting a leading
+ *   `dist|build|lib|out/` segment to `src/` and swapping the compiled
+ *   extension for a source one), then falls back to the `src/index.<ext>`
+ *   convention. No `package.json#exports` map resolution.
+ */
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+/** A minimal shape for the fields of package.json this module reads. */
+interface PackageJsonShape {
+  name?: unknown;
+  main?: unknown;
+  module?: unknown;
+  workspaces?: unknown;
+}
+
+/** Per-workspace-root cache so repeated calls during a single index run are O(1) map lookups. */
+const workspaceMapCache = new Map<string, Map<string, string>>();
+
+/** Clears the cached workspace package maps. Exported for test isolation. */
+export function clearWorkspacePackageCache(): void {
+  workspaceMapCache.clear();
+}
+
+function readPackageJson(filePath: string): PackageJsonShape | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as PackageJsonShape) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Extract the `workspaces` globs, supporting both the array and `{ packages }` shapes. */
+function getWorkspaceGlobs(rootPackageJson: PackageJsonShape): string[] {
+  const { workspaces } = rootPackageJson;
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter((g): g is string => typeof g === 'string');
+  }
+  if (workspaces && typeof workspaces === 'object' && 'packages' in workspaces) {
+    const packages = (workspaces as { packages?: unknown }).packages;
+    if (Array.isArray(packages)) {
+      return packages.filter((g): g is string => typeof g === 'string');
+    }
+  }
+  return [];
+}
+
+/**
+ * Resolve workspace globs to member directories (workspace-relative, POSIX
+ * separators). Negated patterns (`!packages/excluded`) filter out matches
+ * from earlier patterns, mirroring npm's own workspace resolution.
+ */
+function resolveMemberDirs(workspaceRoot: string, globs: string[]): string[] {
+  const includePatterns = globs.filter(g => !g.startsWith('!'));
+  const excludePatterns = globs.filter(g => g.startsWith('!')).map(g => g.slice(1));
+
+  const matched = new Set<string>();
+  for (const pattern of includePatterns) {
+    const results = globSync(pattern, { cwd: workspaceRoot, ignore: excludePatterns });
+    for (const result of results) {
+      const relDir = result.replace(/\\/g, '/');
+      const absDir = path.join(workspaceRoot, relDir);
+      if (isDirectory(absDir)) {
+        matched.add(relDir);
+      }
+    }
+  }
+  return Array.from(matched);
+}
+
+function isDirectory(absPath: string): boolean {
+  try {
+    return fs.statSync(absPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Strip a leading build-output directory segment and swap it for `src/`. */
+function toSourceDir(compiledPath: string): string {
+  return compiledPath.replace(/^(?:\.\/)?(dist|build|lib|out)\//, 'src/');
+}
+
+/**
+ * Candidate source entry paths for a package, in priority order: derived
+ * from `main`/`module` first, falling back to the `src/index.<ext>`
+ * convention. The first candidate that exists on disk wins.
+ */
+function deriveEntryCandidates(pkg: PackageJsonShape): string[] {
+  const candidates: string[] = [];
+
+  const addFromField = (value: unknown): void => {
+    if (typeof value !== 'string' || value.length === 0) return;
+    const cleaned = value.replace(/^\.\//, '');
+    const sourceDir = toSourceDir(cleaned);
+    const base = sourceDir.replace(/\.[cm]?[jt]sx?$/, '');
+    for (const ext of SOURCE_EXTENSIONS) candidates.push(`${base}${ext}`);
+  };
+
+  addFromField(pkg.main);
+  addFromField(pkg.module);
+  for (const ext of SOURCE_EXTENSIONS) candidates.push(`src/index${ext}`);
+
+  return candidates;
+}
+
+function findEntryFile(pkgDirAbs: string, pkg: PackageJsonShape): string | null {
+  for (const candidate of deriveEntryCandidates(pkg)) {
+    if (fs.existsSync(path.join(pkgDirAbs, candidate))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build (or retrieve from cache) the workspace package name -> source entry
+ * file map for a workspace root.
+ *
+ * Returns an empty map for non-monorepo projects (no root `package.json`, or
+ * no `workspaces` field) — callers can pass the result straight through with
+ * zero behavior change.
+ *
+ * @param workspaceRoot - Absolute path to the workspace/monorepo root.
+ */
+export function resolveWorkspacePackageEntries(workspaceRoot: string): Map<string, string> {
+  const normalizedRoot = workspaceRoot.replace(/\\/g, '/').replace(/\/$/, '');
+
+  const cached = workspaceMapCache.get(normalizedRoot);
+  if (cached) return cached;
+
+  const map = new Map<string, string>();
+  const rootPackageJson = readPackageJson(path.join(normalizedRoot, 'package.json'));
+  const globs = rootPackageJson ? getWorkspaceGlobs(rootPackageJson) : [];
+
+  if (globs.length > 0) {
+    for (const memberDir of resolveMemberDirs(normalizedRoot, globs)) {
+      const memberPkg = readPackageJson(path.join(normalizedRoot, memberDir, 'package.json'));
+      if (!memberPkg || typeof memberPkg.name !== 'string') continue;
+
+      const entry = findEntryFile(path.join(normalizedRoot, memberDir), memberPkg);
+      if (!entry) continue;
+
+      map.set(memberPkg.name, path.posix.join(memberDir, entry));
+    }
+  }
+
+  workspaceMapCache.set(normalizedRoot, map);
+  return map;
+}


### PR DESCRIPTION
## Summary

Closes a monorepo dependency-analysis blind spot found while dogfooding: `get_dependents` couldn't see across package boundaries when a consumer imports via a workspace package specifier (`import { X } from '@scope/pkg'`) instead of a relative path.

**Root cause**: import extractors already resolve `./`/`../` specifiers to workspace-relative paths at index time (`resolveRelativeImport`, #525), but non-relative specifiers — including bare workspace package names — passed through unchanged. A bare `@liendev/parser` specifier never matched any indexed file, so any downstream consumer of a symbol re-exported through that package's barrel showed up as 0 dependents.

**Fix**: detect workspace packages generically from the root `package.json`'s npm `workspaces` globs (nested globs and negated excludes supported — nothing hardcoded to `@liendev`), and map each member's declared source entry (`main`/`module`, rewriting a `dist|build|lib|out/` prefix to `src/` and swapping the extension; falling back to the `src/index.<ext>` convention) to its workspace-relative path. The map is cached per workspace root. Bare package specifiers are resolved through the same code path as relative specifiers (`resolveImportSpecifier` in `symbols.ts`), so:
- File-level dependents work across packages
- The existing transitive re-export BFS (barrel chasing, up to depth 3) works across packages
- Symbol-level usage tracking (`importedSymbols` + call sites) works with **zero changes** to that logic — once the import path resolves to a real file, the existing symbol-key matching just works

**v1 scope (documented, not built)**: only bare/exact package specifiers resolve. Deep/subpath imports (`@scope/pkg/subpath`) pass through unresolved — no cross-package import in this repo uses that form, and honoring `package.json#exports` maps for arbitrary subpaths is real complexity for no observed benefit (YAGNI). Symbol-level tracking through re-exports remains 1-hop-limited, same pre-existing limitation as same-package barrels.

Zero behavior change for non-workspace repos (empty `workspaces` field → empty map, passthrough) and for external npm packages (never in the map, passthrough).

## Design decisions

- **New module**: `packages/parser/src/workspace-packages.ts` — `resolveWorkspacePackageEntries(workspaceRoot)` does the npm-workspaces-glob → member-package → source-entry resolution, with a per-workspace-root in-memory cache (module-level `Map`, cleared via `clearWorkspacePackageCache()` for tests). Uses sync fs (`readFileSync`/`existsSync`/`statSync`) + `globSync` from the already-installed `glob` dependency, since the whole `chunkFile` → `chunkByAST` call chain is synchronous.
- **Extension point**: `resolveWorkspaceImport(specifier, workspacePackages)` added beside `resolveRelativeImport` in `utils/path-matching.ts`. `symbols.ts` chains both (`resolveImportSpecifier`) so a specifier is first relative-resolved, then workspace-package-resolved — both are no-ops on their own when their respective input isn't provided.
- **Threading**: `workspaceRoot?: string` added to `ASTChunkOptions` and `ChunkOptions`, gated to the same JS/TS language set as relative-import resolution (`RESOLVE_RELATIVE_IMPORTS`) since npm workspaces is a JS-ecosystem mechanism. Wired through `packages/core/src/indexer/index.ts`, `incremental.ts`, and `packages/parser/src/chunk-only-index.ts` (all already had `rootDir` in scope).
- **Untouched**: `dependency-analyzer.ts` (both the parser-side and CLI-side implementations), the re-export/barrel BFS, and all matching logic — the fix is entirely upstream, at import-extraction time. Did not touch `packages/review` or overlay/vectordb files per scope.

## MCP acceptance evidence

Reproduced the gap first (pre-fix, on `origin/main`): `get_dependents({ filepath: 'packages/parser/src/insights/complexity-delta.ts', symbol: 'computeComplexityDelta' })` → `dependentCount: 0`, despite `packages/cli/src/cli/delta-cmd.ts` genuinely calling it via `import { computeComplexityDelta } from '@liendev/parser'`.

Verified the fix by building the CLI on this branch, doing a full reindex of a plain (non-worktree) export of this repo, and driving `get_dependents` over real MCP stdio (`@modelcontextprotocol/sdk` `Client` + `StdioClientTransport` against `lien serve`):

**File-level** (`filepath` only):
```
dependentCount: 128
includes delta-cmd.ts: true
includes delta-git.ts: true
```
(128 is expected, not a regression — `packages/parser/src/index.ts` is now correctly resolved as the target of the `@liendev/parser` specifier, and it's a re-exporter of `complexity-delta.ts`, so every consumer of the parser package's barrel becomes a file-level dependent via the pre-existing transitive re-export BFS — the same barrel semantics that already applied within a single package now correctly extend across the package boundary.)

**Symbol-level** (`symbol: 'computeComplexityDelta'`) — precise, not broadened by the barrel:
```json
{
  "dependentCount": 4,
  "dependents": [
    { "filepath": "packages/parser/src/index.ts", "isTestFile": false, "hops": 1 },
    { "filepath": "packages/cli/src/cli/delta-cmd.ts", "isTestFile": false, "hops": 1 },
    { "filepath": "packages/parser/src/insights/complexity-delta.test.ts", "isTestFile": true, "hops": 1 },
    { "filepath": "packages/cli/src/cli/delta-cmd.test.ts", "isTestFile": true, "hops": 1 }
  ]
}
```
`delta-git.ts` correctly does **not** appear at symbol level — it only imports `getSupportedExtensions` from `@liendev/parser`, never `computeComplexityDelta`. This confirms the existing symbol-usage matching in `packages/cli/src/mcp/handlers/dependency-analyzer.ts` needed zero changes.

## Tests

- `packages/parser/src/workspace-packages.test.ts` (11 tests, new): npm `workspaces` array + `{ packages: [...] }` object form, nested globs, negated excludes, `main`/`module`-derived entries, `src/index.<ext>` fallback, non-workspace repo → empty map, no root package.json → empty map, unresolvable entry skipped, per-root caching.
- `packages/parser/src/utils/path-matching.test.ts` (+5 tests): `resolveWorkspaceImport` — resolves known package, external packages untouched, empty map (non-monorepo) untouched, deep/subpath imports untouched, already-resolved paths untouched.
- `packages/parser/src/ast/chunker.test.ts` (+4 tests, real fixture monorepo via `fs.mkdtemp`): bare workspace-package import resolves to source entry end-to-end through `chunkByAST` (the `complexity-delta.ts`/`delta-cmd.ts` scenario), external package untouched even with `workspaceRoot` set, non-workspace repo unaffected, no-op when `workspaceRoot` omitted (back-compat for existing callers).

Full monorepo test suite: **2,651 tests passing** (parser 983, core 318, review 565, cli 757, action 28) — zero regressions.

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass (all 5 packages)
- [x] `npm test` — 2,651/2,651 passing
- [x] Changeset added: minor `@liendev/parser`, patch `@liendev/core` (touched to thread `workspaceRoot` through indexing; `@liendev/lien`/cli not touched)
- [x] Live MCP stdio verification against a real built CLI (see above)

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds workspace package specifier resolution for npm-workspaces monorepos by detecting workspace members from the root package.json, deriving each member's source entry, and resolving bare package imports to workspace-relative paths during chunking. The change is narrowly scoped to JS/TS import extraction, falls back cleanly for non-monorepos and external packages, and is well covered by new tests. The cache isolation helper and guarded JSON parsing avoid cross-test contamination and runtime crashes on malformed package.json files.
>
> - Added workspace-packages.ts to build package-name -> source-entry maps from npm workspaces globs with per-root caching
> - Added resolveWorkspaceImport and chained it after relative import resolution in symbols.ts
> - Threaded workspaceRoot through chunkByAST, chunkFile, chunk-only-index, and both core indexers

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 97cb349. Updates automatically on new commits.</sup>
<!-- /lien-stats -->