### PR TITLE
fix(core): make worktree overlay rebuilds reader-atomic and livelock-free

### DIFF
--- a/.changeset/overlay-atomic-rebuild.md
+++ b/.changeset/overlay-atomic-rebuild.md
@@ -1,0 +1,30 @@
+---
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+fix(core): make worktree overlay rebuilds reader-atomic and livelock-free
+
+Two composing concurrency bugs in worktree overlay indexing (shipped in #667)
+could make `list_functions` / `querySymbols` intermittently return 0 results for
+a file that exists, while the overlay's `indexVersion` churned with zero file
+edits when more than one `lien serve` had the worktree as cwd.
+
+- **Reader atomicity.** `buildOverlay` no longer clears then repopulates the
+  overlay across many autocommitted statements. It now does all scan/hash/chunk
+  work up front, then applies the whole swap (delete + insert of chunks and
+  mask, plus metadata) in ONE `BEGIN IMMEDIATE` transaction via
+  `OverlayBackend.applyRebuild`, so other connections observe the rebuild
+  all-or-nothing under WAL snapshot isolation — never a base file masked with no
+  replacement rows. Disk reclamation moves to a best-effort post-commit
+  `VACUUM` + WAL checkpoint (same file identity, preserving #667's multi-process
+  safety fix). Union reads (`unionRecords`, `search`, `scanPaginated`) now read
+  overlay rows + mask inside one deferred snapshot so a commit landing between
+  the two statements can't be seen half-applied.
+
+- **Rebuild livelock.** A rebuild that reproduces a byte-identical overlay
+  (same diverged-file/hash set + mask) no longer bumps the version stamp — a
+  cheap content signature, checked inside the swap transaction, makes redundant
+  rebuilds silent. So piled-up serves stop mutually re-triggering reconnects and
+  rebuilds; genuine content changes still bump. A `SQLITE_BUSY` busy-skip lets a
+  peer's in-flight rebuild serve everyone rather than contending.

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -364,6 +364,34 @@ both statements inside **one deferred read transaction**, pinning a single WAL
 snapshot. Without this, an atomic writer commit landing *between* the reader's
 two statements would still be observed half-applied.
 
+**Accepted limitation: the base read is a separate snapshot.** A union read is
+overlay-rows + mask from one overlay snapshot `S`, merged with base rows read
+afterwards on the base connection (a *different database file*). SQLite
+transactions are per-connection, so no code structure can extend `S` across the
+base — true cross-database snapshot atomicity is impossible in the
+two-connection design (and `ATTACH` was rejected above to keep the base
+provably read-only). This window is accepted, not mitigated, because it cannot
+produce the mask-without-replacement bug or duplicates:
+
+- Base hits are filtered against the mask from the **same** snapshot `S` as the
+  overlay hits. Per `S`'s build invariant, any file with overlay rows that also
+  exists in base is masked in `S` — so its base row is dropped no matter when
+  the base read runs, including across a concurrent `applyRebuild` commit.
+  A rebuild un-masking a file (revert-to-base) also removes its overlay rows in
+  the same transaction, so a reader on `S` serves the old overlay row and drops
+  the base row (consistent old state); a reader on the new snapshot drops the
+  overlay row and serves the base row (consistent new state). No interleaving
+  yields both.
+- The only residual effect is that base rows may come from a base commit that
+  landed mid-query: the result is overlay@`S` ∪ base@now, each side internally
+  consistent, per-file single-source preserved. But a mid-serve base write
+  already implies the overlay is stale-until-rebuild *regardless of intra-query
+  timing* (see "Staleness & revalidation" — the base-stamp compare triggers the
+  reconciling rebuild). A retry-on-base-stamp-change would re-run the query into
+  the same stale-until-rebuild state, buying nothing for two extra fs reads per
+  query. Cross-corpus BM25 ranking is likewise already approximate by design
+  (see "FTS caveat (v1)").
+
 ### 2. Rebuild livelock → identical rebuilds churned the version stamp
 
 `recordBaseBuild` bumped `.lien-index-version` on **every** rebuild. The only
@@ -375,8 +403,11 @@ other** serves' version poll reconnect; restart/re-spawn churn kept new serves
 rebuilding — a self-amplifying reconnect/rebuild storm with no file edits.
 
 **Fix (no-op → no bump).** `buildOverlay` computes a cheap **content
-signature** — a hash over the sorted (diverged file → content hash) pairs plus
-the sorted mask set, reusing hashes already computed during the diff. If it
+signature** — a hash over an indexing-format salt (`INDEX_FORMAT_VERSION` +
+chunk size/overlap, so a Lien upgrade that changes the chunking contract forces
+one real rebuild instead of skipping forever) plus the sorted (diverged file →
+content hash) pairs plus the sorted mask set, reusing hashes already computed
+during the diff. If it
 matches the signature stored at the last build, the rebuild is a no-op: it
 refreshes only the base stamp (so `needsRebuild()` still settles after a base
 reindex) and returns `changed: false` **without bumping**. So once any serve has

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -319,3 +319,110 @@ See PR #667's "Verification findings" section for the full scenario matrix,
 including one documented-but-not-fixed edge case (transient state mixing when
 toggling the `LIEN_WORKTREE_STANDALONE=1` escape hatch on and off for the same
 worktree, which self-heals on the next normal-mode `lien index`/`lien serve`).
+
+## Concurrency hardening (2026-07-04)
+
+PR #667 shipped `buildOverlay` as: `clear()` (DELETE + VACUUM + checkpoint) →
+scan → hash → `maskBasePath` for deletions → `indexMultipleFiles` (per-file
+`deleteByFile` then `insertBatch`) → `recordBaseBuild` (which always bumped the
+version stamp). Lien Review flagged the rebuild window on #667; it was
+documented but not fixed. Live dogfooding then reproduced it: in a worktree
+serve, `list_functions` / `querySymbols` intermittently returned **0 results**
+for a class that exists, for minutes. Single-transaction snapshots of the
+overlay db repeatedly caught `overlay_mask` containing the diverged file while
+`chunks` held **zero rows** for it — the file suppressed from base with no
+replacement, invisible to every read path — with the overlay's `indexVersion`
+churning (multiple bumps in minutes with **zero file edits**) while more than
+one serve process had the worktree as cwd.
+
+Two composing root causes, both now fixed:
+
+### 1. Non-atomic rebuild → reader could see mask-without-replacement
+
+The old rebuild mutated the mask and chunks across many autocommitted
+statements spread over async ticks. Between `clear()` and the final
+`insertBatch`, an **added** file had no overlay rows and no base fallback for
+the entire scan/chunk phase; between a **modified** file's `deleteByFile` (which
+sets the mask) and its `insertBatch`, the file was masked with no rows. A
+concurrent reader on another connection (another serve) observed those states.
+
+**Fix (reader-atomic swap).** All async work (scan, hash, chunk) now happens in
+`buildOverlay` *before* any write, producing in-memory chunk batches + the mask
+set. `OverlayBackend.applyRebuild` then applies the **entire swap** — delete old
+chunks + mask, insert new chunks + mask, update meta — in **one
+`BEGIN IMMEDIATE` transaction**. WAL snapshot isolation means another connection
+sees the complete old overlay or the complete new one, never a half-applied
+state. `buildOverlay` no longer calls `clear()`; the transaction's `DELETE`
+reclaims logically and a **post-commit** `VACUUM` + `wal_checkpoint(TRUNCATE)`
+(VACUUM cannot run inside a transaction) reclaim on disk — **same file identity
+throughout**, preserving #667's multi-process safety fix (close+delete+recreate
+stays banned).
+
+The reader side is snapshotted too: overlay reads pair a chunk scan with a mask
+read, so each union read (`unionRecords`, `search`, `scanPaginated`) now runs
+both statements inside **one deferred read transaction**, pinning a single WAL
+snapshot. Without this, an atomic writer commit landing *between* the reader's
+two statements would still be observed half-applied.
+
+### 2. Rebuild livelock → identical rebuilds churned the version stamp
+
+`recordBaseBuild` bumped `.lien-index-version` on **every** rebuild. The only
+overlay-rebuild trigger is each serve's **startup** `handleAutoIndexing`
+(tool handlers and the version/git polls only *reconnect*, never rebuild) — but
+multiple serves per root is a known operational reality (they pile up, three
+install paths). Every startup rebuild bumped the stamp; every bump made **all
+other** serves' version poll reconnect; restart/re-spawn churn kept new serves
+rebuilding — a self-amplifying reconnect/rebuild storm with no file edits.
+
+**Fix (no-op → no bump).** `buildOverlay` computes a cheap **content
+signature** — a hash over the sorted (diverged file → content hash) pairs plus
+the sorted mask set, reusing hashes already computed during the diff. If it
+matches the signature stored at the last build, the rebuild is a no-op: it
+refreshes only the base stamp (so `needsRebuild()` still settles after a base
+reindex) and returns `changed: false` **without bumping**. So once any serve has
+built the overlay, further startups on an unchanged worktree are silent — the
+storm cannot form. A genuine content change still bumps, so real edits
+propagate. `applyRebuild` re-checks the signature **inside** its `IMMEDIATE`
+transaction, so even under a true race the swap is serialized and only the first
+writer bumps; a peer that already applied the identical overlay makes this a
+no-op.
+
+### Cross-process single-rebuilder guard: what we chose
+
+The brief asked to *consider* a dedicated single-rebuilder advisory lock (e.g.
+`BEGIN IMMEDIATE` held for the whole build with busy-skip, "its result serves
+both"). We chose **not** to hold a long-lived lock, and instead rely on:
+
+- the **in-transaction signature test-and-set** under `BEGIN IMMEDIATE`, which
+  already guarantees a single effective rebuild (one bump, silent no-ops) across
+  any number of concurrent writers, and
+- a lightweight **busy-skip**: if a peer holds the overlay's write lock past the
+  busy timeout, `applyRebuild` catches `SQLITE_BUSY` and returns
+  `changed: false` — the peer's atomic swap serves everyone.
+
+Rejected: a held advisory lock (or a lease row with a staleness timeout) would
+have to span the async chunking phase, blocking the watcher's incremental
+writes for the whole build, and needs fragile cross-async transaction handling
+plus stale-lock/lease heuristics and their own tests. Its only remaining benefit
+over the chosen design is de-duplicating concurrent *chunking CPU* — negligible,
+because the overlay only covers the handful of diverged files and the build is
+already cheap (KISS/YAGNI). Multiple serves are therefore **tolerated** (atomic,
+single-bump, busy-skip), not assumed away.
+
+### Verified
+
+- **Reproduction-first stress test** (`overlay-concurrency.test.ts`): two
+  `OverlayBackend` connections on one overlay db — a writer rebuilding in a loop
+  while a reader polls `querySymbols` for diverged files. Against origin/main it
+  **fails** (the reader observes an added file missing many times; the no-op
+  tests fail because every rebuild bumped); with the fix all four pass. A second
+  case toggles a file between two bodies each iteration so every rebuild is a
+  genuine atomic swap, exercising the reader-snapshot path.
+- No-op-doesn't-bump and two-writers-don't-re-trigger (but a real change still
+  bumps) are asserted directly against the version stamp.
+- Full suite green: parser 963, core 322, review 565, cli 757, action 28.
+
+See `packages/core/src/vectordb/overlay-backend.ts` (`applyRebuild`,
+`overlaySnapshot`, `refreshBaseStamp`), `packages/core/src/indexer/overlay-index.ts`
+(`buildOverlay`, `computeOverlaySignature`), and
+`packages/core/src/vectordb/overlay-concurrency.test.ts`.

--- a/packages/core/src/indexer/overlay-index.test.ts
+++ b/packages/core/src/indexer/overlay-index.test.ts
@@ -67,7 +67,7 @@ describe('buildOverlay', () => {
 
   it('classifies added / modified / unchanged / deleted correctly', async () => {
     const res = await buildOverlay(overlay);
-    expect(res).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1 });
+    expect(res).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1, changed: true });
   });
 
   it('serves unchanged files from base, diverged from overlay, and drops deleted', async () => {
@@ -101,10 +101,11 @@ describe('buildOverlay', () => {
     expect(await overlay.needsRebuild()).toBe(true);
   });
 
-  it('is idempotent — a rebuild yields the same classification', async () => {
+  it('is idempotent — a rebuild yields the same classification without a bump', async () => {
     await buildOverlay(overlay);
     const second = await buildOverlay(overlay);
-    expect(second).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1 });
+    // Same classification, but an identical overlay must NOT re-bump the stamp.
+    expect(second).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1, changed: false });
     const files = await filesInIndex(overlay);
     expect(files).toEqual(new Set(['a.ts', 'b.ts', 'd.ts']));
   });

--- a/packages/core/src/indexer/overlay-index.test.ts
+++ b/packages/core/src/indexer/overlay-index.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
+import Database from 'better-sqlite3';
 import { getIndexDir } from '@liendev/parser';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
 import { indexCodebase } from './index.js';
-import { buildOverlay } from './overlay-index.js';
+import { buildOverlay, computeOverlaySignature } from './overlay-index.js';
 import { OverlayBackend } from '../vectordb/overlay-backend.js';
 import { writeVersionFile } from '../vectordb/version.js';
 
@@ -108,5 +109,55 @@ describe('buildOverlay', () => {
     expect(second).toEqual({ added: 1, modified: 1, deleted: 1, unchanged: 1, changed: false });
     const files = await filesInIndex(overlay);
     expect(files).toEqual(new Set(['a.ts', 'b.ts', 'd.ts']));
+  });
+
+  it('rebuilds when the stored signature predates a format change (no eternal skip)', async () => {
+    await buildOverlay(overlay);
+
+    // Simulate a signature recorded under a previous indexing format (older
+    // INDEX_FORMAT_VERSION / different chunk params): overwrite the stored
+    // value so it can no longer match the currently computed signature.
+    const dbFile = path.join(getIndexDir(worktreeDir), 'structural.db');
+    const raw = new Database(dbFile);
+    raw
+      .prepare('UPDATE overlay_meta SET v = ? WHERE k = ?')
+      .run('signature-from-older-format', 'overlaySignature');
+    raw.close();
+
+    // Same worktree content — but the format mismatch must force a real swap.
+    const res = await buildOverlay(overlay);
+    expect(res.changed).toBe(true);
+
+    // And the fast path resumes once the current-format signature is stored.
+    const again = await buildOverlay(overlay);
+    expect(again.changed).toBe(false);
+  });
+});
+
+describe('computeOverlaySignature format salt', () => {
+  const diverged = [
+    { rel: 'b.ts', hash: 'hash-b' },
+    { rel: 'd.ts', hash: 'hash-d' },
+  ];
+  const masks = ['b.ts', 'c.ts'];
+  const format = { formatVersion: 5, chunkSize: 75, chunkOverlap: 10 };
+
+  it('is stable for identical content + format inputs', () => {
+    expect(computeOverlaySignature(diverged, masks, format)).toBe(
+      computeOverlaySignature([...diverged].reverse(), [...masks].reverse(), { ...format }),
+    );
+  });
+
+  it('differs when content differs', () => {
+    const sig = computeOverlaySignature(diverged, masks, format);
+    expect(computeOverlaySignature([{ rel: 'b.ts', hash: 'other' }], masks, format)).not.toBe(sig);
+    expect(computeOverlaySignature(diverged, ['b.ts'], format)).not.toBe(sig);
+  });
+
+  it('differs when any format input changes (forces one rebuild after an upgrade)', () => {
+    const sig = computeOverlaySignature(diverged, masks, format);
+    expect(computeOverlaySignature(diverged, masks, { ...format, formatVersion: 6 })).not.toBe(sig);
+    expect(computeOverlaySignature(diverged, masks, { ...format, chunkSize: 100 })).not.toBe(sig);
+    expect(computeOverlaySignature(diverged, masks, { ...format, chunkOverlap: 20 })).not.toBe(sig);
   });
 });

--- a/packages/core/src/indexer/overlay-index.ts
+++ b/packages/core/src/indexer/overlay-index.ts
@@ -1,10 +1,14 @@
+import fs from 'fs/promises';
 import path from 'path';
+import { createHash } from 'crypto';
 import pLimit from 'p-limit';
-import { computeContentHash } from '@liendev/parser';
-import { DEFAULT_CONCURRENCY } from '../constants.js';
+import { chunkFile, computeContentHash, extractRepoId } from '@liendev/parser';
+import type { ChunkMetadata } from '@liendev/parser';
+import { DEFAULT_CONCURRENCY, DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP } from '../constants.js';
 import type { OverlayBackend } from '../vectordb/overlay-backend.js';
+import { ManifestManager, type FileEntry } from './manifest.js';
 import { scanFilesToIndex } from './index.js';
-import { indexMultipleFiles, normalizeToRelativePath } from './incremental.js';
+import { normalizeToRelativePath } from './incremental.js';
 
 /** Per-classification counts from an overlay build. */
 export interface OverlayBuildResult {
@@ -16,6 +20,34 @@ export interface OverlayBuildResult {
   deleted: number;
   /** Files identical to the base — served from the base, not the overlay. */
   unchanged: number;
+  /**
+   * Whether this build changed the overlay's content (and therefore bumped the
+   * version stamp). `false` when the rebuild reproduced a byte-identical overlay
+   * — the guard that stops multiple `lien serve` processes from mutually
+   * re-triggering rebuilds forever (see the concurrency notes in
+   * docs/architecture/worktree-aware-indexing.md).
+   */
+  changed: boolean;
+}
+
+/** One diverged (added or modified) worktree file. */
+interface DivergedFile {
+  rel: string; // relative, forward-slash path (storage + mask key)
+  abs: string; // absolute path (filesystem reads)
+  hash: string; // current content hash (drives the content signature)
+}
+
+/**
+ * Content signature of an overlay: a hash over the sorted (diverged file →
+ * content hash) pairs plus the sorted mask set. Two builds with the same
+ * signature would produce a byte-identical overlay, so the second can skip the
+ * swap + version bump. Cheap: reuses hashes already computed during the diff.
+ */
+function computeOverlaySignature(diverged: DivergedFile[], maskFiles: string[]): string {
+  const files = diverged.map(d => `${d.rel}\t${d.hash}`).sort();
+  const masks = [...maskFiles].sort();
+  const canonical = `${files.join('\n')}\n--mask--\n${masks.join('\n')}`;
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 32);
 }
 
 /**
@@ -24,13 +56,19 @@ export interface OverlayBuildResult {
  * git-history-based).
  *
  * Only files that diverge from the base (added + modified) are chunked into the
- * overlay; unchanged files are served from the base. Deleted files (in base,
- * gone from the worktree) are masked. Modified files are masked implicitly by
- * `OverlayBackend.deleteByFile`, which the incremental write path calls before
- * inserting the new rows.
+ * overlay; unchanged files are served from the base; deleted files (in base,
+ * gone from the worktree) are masked. Modified files are both masked (base row
+ * suppressed) and chunked (overlay row served).
  *
- * Idempotent: clears the overlay's chunks + mask first, so it doubles as the
- * staleness-revalidation path when the base has been reindexed.
+ * Concurrency-hardened (see docs/architecture/worktree-aware-indexing.md):
+ *   - The overlay swap (clear + repopulate mask & chunks) is applied in ONE
+ *     transaction via `OverlayBackend.applyRebuild`, so concurrent readers on
+ *     other connections never observe a masked-but-unreplaced file.
+ *   - A rebuild that reproduces the identical overlay does NOT bump the version
+ *     stamp (`changed: false`), so peer serves don't see a phantom change and
+ *     re-trigger their own rebuilds. All the async file I/O (scan, hash, chunk)
+ *     happens here, OUTSIDE the write transaction, because better-sqlite3
+ *     transactions must be synchronous.
  */
 export async function buildOverlay(
   overlay: OverlayBackend,
@@ -39,14 +77,10 @@ export async function buildOverlay(
   const rootDir = overlay.worktreeRoot;
   const baseHashes = overlay.getBaseHashes();
 
-  // Start from a clean slate so a rebuild after a base reindex can't leave stale
-  // overlay rows or mask entries behind.
-  await overlay.clear();
-
+  // ── Diff the worktree against the base (hash every file once) ───────────
   const files = await scanFilesToIndex(rootDir);
-
   const currentPaths = new Set<string>();
-  const diverged: string[] = []; // absolute paths to (re)index into the overlay
+  const diverged: DivergedFile[] = [];
   let added = 0;
   let modified = 0;
 
@@ -59,41 +93,101 @@ export async function buildOverlay(
         currentPaths.add(rel);
 
         const baseHash = baseHashes.get(rel);
+        const currentHash = await computeContentHash(abs);
         if (baseHash === undefined) {
           added++;
-          diverged.push(abs);
-          return;
-        }
-        const currentHash = await computeContentHash(abs);
-        if (currentHash !== baseHash) {
+          diverged.push({ rel, abs, hash: currentHash });
+        } else if (currentHash !== baseHash) {
           modified++;
-          diverged.push(abs);
+          diverged.push({ rel, abs, hash: currentHash });
         }
       }),
     ),
   );
 
-  // Deleted: in the base manifest but no longer in the worktree → mask only.
+  // Masked base paths: modified (in base AND diverged) + deleted (in base, gone
+  // from the worktree). Added files are never in base, so never masked.
+  const maskFiles: string[] = [];
   let deleted = 0;
   for (const baseFile of baseHashes.keys()) {
     if (!currentPaths.has(baseFile)) {
-      overlay.maskBasePath(baseFile);
+      maskFiles.push(baseFile);
       deleted++;
     }
   }
-
-  // Chunk + persist the diverged files. indexMultipleFiles calls deleteByFile
-  // (which masks modified files that exist in the base) then insertBatch.
-  if (diverged.length > 0) {
-    await indexMultipleFiles(diverged, overlay, { verbose: options.verbose, rootDir });
+  for (const d of diverged) {
+    if (baseHashes.has(d.rel)) maskFiles.push(d.rel);
   }
 
-  await overlay.recordBaseBuild();
-
-  return {
+  const counts = {
     added,
     modified,
     deleted,
     unchanged: currentPaths.size - added - modified,
   };
+  const signature = computeOverlaySignature(diverged, maskFiles);
+  const baseIndexDir = overlay.baseIndexDir;
+  const baseStamp = await overlay.getBaseStamp();
+
+  // ── Fast path: overlay already matches → no swap, no bump ───────────────
+  // Refresh only the base stamp so needsRebuild() settles, then bail. This is
+  // the common case for a serve (re)starting on an unchanged worktree, and is
+  // what keeps piled-up serves from churning the version stamp.
+  if (overlay.overlaySignatureMatches(signature)) {
+    overlay.refreshBaseStamp(baseIndexDir, baseStamp);
+    return { ...counts, changed: false };
+  }
+
+  // ── Chunk the diverged files into in-memory batches (async I/O) ─────────
+  const repoId = extractRepoId(rootDir);
+  const chunkBatches: Array<{ metadatas: ChunkMetadata[]; contents: string[] }> = [];
+  const manifestEntries: FileEntry[] = [];
+  await Promise.all(
+    diverged.map(d =>
+      limit(async () => {
+        const content = await fs.readFile(d.abs, 'utf-8');
+        const chunks = chunkFile(d.rel, content, {
+          chunkSize: DEFAULT_CHUNK_SIZE,
+          chunkOverlap: DEFAULT_CHUNK_OVERLAP,
+          useAST: true,
+          astFallback: 'line-based',
+          repoId,
+        });
+        const stats = await fs.stat(d.abs);
+        if (chunks.length > 0) {
+          chunkBatches.push({
+            metadatas: chunks.map(c => c.metadata),
+            contents: chunks.map(c => c.content),
+          });
+        }
+        manifestEntries.push({
+          filepath: d.rel,
+          lastModified: stats.mtimeMs,
+          chunkCount: chunks.length,
+          contentHash: d.hash,
+        });
+        if (options.verbose) {
+          console.error(`[Lien] overlay: staged ${d.rel} (${chunks.length} chunks)`);
+        }
+      }),
+    ),
+  );
+
+  // ── Apply atomically; bump + persist manifest only on a real change ─────
+  const { changed } = overlay.applyRebuild({
+    chunkBatches,
+    maskFiles,
+    baseIndexDir,
+    baseStamp,
+    signature,
+  });
+
+  if (changed) {
+    if (manifestEntries.length > 0) {
+      await new ManifestManager(overlay.dbPath).updateFiles(manifestEntries);
+    }
+    await overlay.bumpVersion();
+  }
+
+  return { ...counts, changed };
 }

--- a/packages/core/src/indexer/overlay-index.ts
+++ b/packages/core/src/indexer/overlay-index.ts
@@ -4,7 +4,12 @@ import { createHash } from 'crypto';
 import pLimit from 'p-limit';
 import { chunkFile, computeContentHash, extractRepoId } from '@liendev/parser';
 import type { ChunkMetadata } from '@liendev/parser';
-import { DEFAULT_CONCURRENCY, DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP } from '../constants.js';
+import {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_CHUNK_OVERLAP,
+  INDEX_FORMAT_VERSION,
+} from '../constants.js';
 import type { OverlayBackend } from '../vectordb/overlay-backend.js';
 import { ManifestManager, type FileEntry } from './manifest.js';
 import { scanFilesToIndex } from './index.js';
@@ -37,16 +42,36 @@ interface DivergedFile {
   hash: string; // current content hash (drives the content signature)
 }
 
+/** Indexing-format inputs baked into the overlay signature. If any of these
+ *  change (a Lien upgrade bumps `INDEX_FORMAT_VERSION`, or the chunking
+ *  parameters move), the same worktree content chunks differently — so the
+ *  signature must differ and force one real rebuild, or the no-op fast path
+ *  would keep serving stale-format chunk rows forever. */
+export interface OverlaySignatureFormat {
+  formatVersion: number;
+  chunkSize: number;
+  chunkOverlap: number;
+}
+
 /**
- * Content signature of an overlay: a hash over the sorted (diverged file →
- * content hash) pairs plus the sorted mask set. Two builds with the same
- * signature would produce a byte-identical overlay, so the second can skip the
- * swap + version bump. Cheap: reuses hashes already computed during the diff.
+ * Content signature of an overlay: a hash over the indexing-format salt plus
+ * the sorted (diverged file → content hash) pairs plus the sorted mask set.
+ * Two builds with the same signature would produce a byte-identical overlay,
+ * so the second can skip the swap + version bump. Cheap: reuses hashes already
+ * computed during the diff.
+ *
+ * Exported for tests; production callers go through `buildOverlay`, which
+ * supplies the real format constants.
  */
-function computeOverlaySignature(diverged: DivergedFile[], maskFiles: string[]): string {
+export function computeOverlaySignature(
+  diverged: Array<{ rel: string; hash: string }>,
+  maskFiles: readonly string[],
+  format: OverlaySignatureFormat,
+): string {
+  const salt = `format=${format.formatVersion};chunk=${format.chunkSize}/${format.chunkOverlap}`;
   const files = diverged.map(d => `${d.rel}\t${d.hash}`).sort();
   const masks = [...maskFiles].sort();
-  const canonical = `${files.join('\n')}\n--mask--\n${masks.join('\n')}`;
+  const canonical = `${salt}\n${files.join('\n')}\n--mask--\n${masks.join('\n')}`;
   return createHash('sha256').update(canonical).digest('hex').slice(0, 32);
 }
 
@@ -125,7 +150,11 @@ export async function buildOverlay(
     deleted,
     unchanged: currentPaths.size - added - modified,
   };
-  const signature = computeOverlaySignature(diverged, maskFiles);
+  const signature = computeOverlaySignature(diverged, maskFiles, {
+    formatVersion: INDEX_FORMAT_VERSION,
+    chunkSize: DEFAULT_CHUNK_SIZE,
+    chunkOverlap: DEFAULT_CHUNK_OVERLAP,
+  });
   const baseIndexDir = overlay.baseIndexDir;
   const baseStamp = await overlay.getBaseStamp();
 

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -38,6 +38,14 @@ import {
 
 const MANIFEST_FILE = 'manifest.json';
 
+/** True for the lock-contention error codes BEGIN IMMEDIATE can raise when a
+ *  peer process holds the overlay's write lock past the busy timeout. */
+function isSqliteBusy(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  const code = (error as { code: unknown }).code;
+  return code === 'SQLITE_BUSY' || code === 'SQLITE_BUSY_SNAPSHOT';
+}
+
 /**
  * Worktree overlay backend: reads = writable overlay UNION read-only base
  * (minus masked base files); writes touch the overlay only.
@@ -146,12 +154,31 @@ export class OverlayBackend implements VectorDBInterface {
     return new Set(rows.map(r => r.file));
   }
 
-  /** Overlay records ∪ (base records not in the mask). */
+  /**
+   * Run `fn` against the overlay inside one deferred (read-only) transaction so
+   * every statement it issues sees the SAME WAL snapshot. Overlay reads pair a
+   * chunk scan with a mask read; without a shared snapshot a concurrent atomic
+   * rebuild committing between the two statements could be observed half-applied
+   * (rows from the old snapshot, mask from the new — or vice versa), which is
+   * exactly the masked-but-unreplaced window this backend must never expose.
+   * A deferred transaction pins the snapshot at its first read and never blocks
+   * (or is blocked by) the single WAL writer.
+   */
+  private overlaySnapshot<T>(fn: (db: DatabaseType.Database) => T): T {
+    const db = this.requireOverlay();
+    return db.transaction(fn)(db);
+  }
+
+  /** Overlay records ∪ (base records not in the mask). Overlay rows + mask are
+   *  read from one snapshot; the base read is on a separate, immutable-from-here
+   *  connection. */
   private unionRecords(
     read: (db: DatabaseType.Database) => SqliteChunkRecord[],
   ): SqliteChunkRecord[] {
-    const overlayRecords = read(this.requireOverlay());
-    const mask = this.loadMask();
+    const { overlayRecords, mask } = this.overlaySnapshot(db => ({
+      overlayRecords: read(db),
+      mask: this.loadMask(),
+    }));
     const baseRecords = this.baseRead(read).filter(r => !mask.has(r.file));
     return [...overlayRecords, ...baseRecords];
   }
@@ -160,8 +187,10 @@ export class OverlayBackend implements VectorDBInterface {
 
   async search(query: string, limit = 5): Promise<SearchResult[]> {
     if (!query || query.trim().length === 0) return [];
-    const overlayHits = keywordSearch(this.requireOverlay(), query, limit);
-    const mask = this.loadMask();
+    const { overlayHits, mask } = this.overlaySnapshot(db => ({
+      overlayHits: keywordSearch(db, query, limit),
+      mask: this.loadMask(),
+    }));
     const baseHits = this.baseRead(db => keywordSearch(db, query, limit)).filter(
       h => !mask.has(h.metadata.file),
     );
@@ -217,13 +246,18 @@ export class OverlayBackend implements VectorDBInterface {
 
   async *scanPaginated(options: { pageSize?: number } = {}): AsyncGenerator<SearchResult[]> {
     const pageSize = options.pageSize ?? 1000;
-    // Overlay pages first, then masked base pages — each store paginated
-    // independently so neither is fully materialized in memory.
-    for (const page of paginateRecords(this.requireOverlay(), pageSize)) {
-      yield page.map(recordToUnscoredResult);
+    // Snapshot the overlay rows + mask together (one WAL snapshot) so the mask
+    // matches the rows even if a rebuild commits mid-iteration. The overlay is
+    // small by design (only diverged files), so materializing it is cheap; the
+    // large base side stays paginated to bound memory.
+    const { overlayRecords, mask } = this.overlaySnapshot(db => ({
+      overlayRecords: readAllRecords(db),
+      mask: this.loadMask(),
+    }));
+    for (let i = 0; i < overlayRecords.length; i += pageSize) {
+      yield overlayRecords.slice(i, i + pageSize).map(recordToUnscoredResult);
     }
     if (this.baseDb) {
-      const mask = this.loadMask();
       for (const page of paginateRecords(this.baseDb, pageSize)) {
         const kept = page.filter(r => !mask.has(r.file)).map(recordToUnscoredResult);
         if (kept.length > 0) yield kept;
@@ -328,13 +362,105 @@ export class OverlayBackend implements VectorDBInterface {
     return row ? row.v : null;
   }
 
-  /** Record which base build this overlay was diffed against + stamp the
-   *  overlay version file. Called at the end of a build. */
-  async recordBaseBuild(): Promise<void> {
-    const stamp = await readVersionFile(this.baseIndexDir);
-    this.setMeta(OVERLAY_META.BASE_INDEX_DIR, this.baseIndexDir);
-    this.setMeta(OVERLAY_META.BASE_STAMP, String(stamp));
+  /** True when the given content signature matches the one recorded at the last
+   *  build — i.e. a rebuild would reproduce the identical overlay. */
+  overlaySignatureMatches(signature: string): boolean {
+    return this.getMeta(OVERLAY_META.SIGNATURE) === signature;
+  }
+
+  /** Base `.lien-index-version` stamp as a string (for staleness comparison). */
+  async getBaseStamp(): Promise<string> {
+    return String(await readVersionFile(this.baseIndexDir));
+  }
+
+  /** Refresh only the base-build stamp — no content change, no version bump.
+   *  Used on the no-op rebuild path so `needsRebuild()` settles after a base
+   *  reindex that left the overlay content identical. */
+  refreshBaseStamp(baseIndexDir: string, baseStamp: string): void {
+    const db = this.requireOverlay();
+    db.transaction(() => {
+      this.setMeta(OVERLAY_META.BASE_INDEX_DIR, baseIndexDir);
+      this.setMeta(OVERLAY_META.BASE_STAMP, baseStamp);
+    })();
+  }
+
+  /** Bump the overlay's version stamp so other connections reconnect. */
+  async bumpVersion(): Promise<void> {
     await writeVersionFile(this.dbPath);
+  }
+
+  /**
+   * Atomically replace the overlay's entire content — chunk rows, suppression
+   * mask, and base-build metadata — in ONE transaction, so other connections
+   * observe the swap all-or-nothing (WAL snapshot isolation): a reader sees the
+   * complete old overlay or the complete new one, never a base file masked with
+   * no replacement rows yet (the bug this method exists to kill).
+   *
+   * The transaction is `BEGIN IMMEDIATE` and re-reads the stored signature
+   * INSIDE the write lock: if a concurrent writer (another `lien serve` on the
+   * same worktree) already applied the identical overlay, this is a no-op that
+   * reports `changed: false`, so the caller skips the version bump — no
+   * reconnect / rebuild cascade forms. If a peer holds the write lock past the
+   * busy timeout we skip as well (busy-skip: the peer's swap serves us).
+   *
+   * VACUUM + a WAL checkpoint run AFTER commit (VACUUM cannot run inside a
+   * transaction) to reclaim pages freed by the DELETE — keeping the same file
+   * identity throughout (never close+delete+recreate, which is unsafe when
+   * other processes hold the overlay open). Correctness never depends on them.
+   */
+  applyRebuild(plan: {
+    chunkBatches: ReadonlyArray<{ metadatas: ChunkMetadata[]; contents: string[] }>;
+    maskFiles: readonly string[];
+    baseIndexDir: string;
+    baseStamp: string;
+    signature: string;
+  }): { changed: boolean } {
+    const db = this.requireOverlay();
+
+    const swap = db.transaction((): boolean => {
+      // Always keep the base-build stamp current so needsRebuild() settles even
+      // when the content itself is unchanged.
+      this.setMeta(OVERLAY_META.BASE_INDEX_DIR, plan.baseIndexDir);
+      this.setMeta(OVERLAY_META.BASE_STAMP, plan.baseStamp);
+      if (this.getMeta(OVERLAY_META.SIGNATURE) === plan.signature) {
+        return false; // identical overlay already applied (possibly by a peer)
+      }
+      db.exec('DELETE FROM chunks; DELETE FROM overlay_mask;');
+      for (const batch of plan.chunkBatches) {
+        insertChunks(db, batch.metadatas, batch.contents);
+      }
+      const maskInsert = db.prepare('INSERT OR IGNORE INTO overlay_mask(file) VALUES (?)');
+      for (const file of plan.maskFiles) maskInsert.run(file);
+      this.setMeta(OVERLAY_META.SIGNATURE, plan.signature);
+      return true;
+    });
+
+    let changed: boolean;
+    try {
+      changed = swap.immediate();
+    } catch (error) {
+      if (isSqliteBusy(error)) return { changed: false }; // a peer is rebuilding
+      throw error;
+    }
+
+    if (changed) this.reclaimSpace();
+    return { changed };
+  }
+
+  /** Best-effort in-place disk reclamation after a content swap (same file
+   *  identity — see applyRebuild). */
+  private reclaimSpace(): void {
+    const db = this.requireOverlay();
+    try {
+      db.exec('VACUUM');
+    } catch {
+      // A concurrent connection may hold a lock; the next rebuild reclaims.
+    }
+    try {
+      db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch {
+      // best-effort
+    }
   }
 
   /**

--- a/packages/core/src/vectordb/overlay-concurrency.test.ts
+++ b/packages/core/src/vectordb/overlay-concurrency.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+import { indexCodebase } from '../indexer/index.js';
+import { buildOverlay } from '../indexer/overlay-index.js';
+import { OverlayBackend } from './overlay-backend.js';
+import { readVersionFile } from './version.js';
+
+/**
+ * Regression tests for the worktree-overlay rebuild concurrency bug
+ * (see docs/architecture/worktree-aware-indexing.md, "Concurrency hardening").
+ *
+ * Two failure modes, reproduced here with two separate connections against one
+ * overlay db — the shape of "multiple `lien serve` processes on one worktree":
+ *
+ *   1. Non-atomic rebuild window: a rebuild `clear()`ed the overlay then
+ *      repopulated it over many async ticks, so a concurrent reader could
+ *      observe a diverged file with neither overlay rows nor a base fallback —
+ *      the file vanishing from `querySymbols` / `list_functions` entirely.
+ *   2. Rebuild livelock: every rebuild bumped the version stamp even when the
+ *      overlay was byte-identical, so each serve's version poll saw a bump and
+ *      reconnected / re-triggered — churning forever with zero file edits.
+ */
+
+const BASE_FILES: Record<string, string> = {
+  'target.ts': 'export function targetSymbol() {\n  return 1;\n}\n',
+  'keep-a.ts': 'export function keepA() {\n  return 10;\n}\n',
+  'keep-b.ts': 'export function keepB() {\n  return 20;\n}\n',
+};
+
+/** target.ts modified in the worktree: SAME symbol name, different body → it
+ *  diverges from base (masked from base AND stored in the overlay). */
+const WORKTREE_TARGET = 'export function targetSymbol() {\n  return 22222;\n}\n';
+/** A worktree-only file (absent from base). During a non-atomic rebuild it has
+ *  no overlay rows AND no base fallback for the entire scan/chunk phase — the
+ *  deterministic, macro-task-spanning "disappears entirely" window. */
+const WORKTREE_ADDED = 'export function addedSymbol() {\n  return 7;\n}\n';
+
+async function writeFiles(root: string, files: Record<string, string>): Promise<void> {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+}
+
+const nextTick = (): Promise<void> => new Promise(resolve => setImmediate(resolve));
+
+async function seenFiles(overlay: OverlayBackend): Promise<Set<string>> {
+  const results = await overlay.querySymbols({ limit: 1000 });
+  return new Set(results.map(r => r.metadata.file));
+}
+
+describe('OverlayBackend rebuild concurrency', () => {
+  let baseDir: string;
+  let worktreeDir: string;
+
+  beforeEach(async () => {
+    baseDir = await createTestDir();
+    worktreeDir = await createTestDir();
+    await writeFiles(baseDir, BASE_FILES);
+    const result = await indexCodebase({ rootDir: baseDir });
+    expect(result.success).toBe(true);
+
+    // Worktree = base + a modified file (target.ts) + an added file (added.ts).
+    await writeFiles(worktreeDir, BASE_FILES);
+    await fs.writeFile(path.join(worktreeDir, 'target.ts'), WORKTREE_TARGET);
+    await fs.writeFile(path.join(worktreeDir, 'added.ts'), WORKTREE_ADDED);
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(baseDir);
+    await cleanupTestDir(worktreeDir);
+  });
+
+  it('never exposes a masked-but-unreplaced window to a concurrent reader', async () => {
+    const writer = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    const reader = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await writer.initialize();
+    await reader.initialize();
+
+    try {
+      // Prime the overlay so both diverged files are present before racing.
+      await buildOverlay(writer);
+      const primed = await seenFiles(reader);
+      expect(primed.has('target.ts')).toBe(true); // modified → overlay
+      expect(primed.has('added.ts')).toBe(true); // added → overlay
+
+      const missing: string[] = [];
+      let done = false;
+
+      const writerLoop = (async () => {
+        for (let i = 0; i < 50; i++) {
+          await buildOverlay(writer);
+        }
+        done = true;
+      })();
+
+      const readerLoop = (async () => {
+        while (!done) {
+          const files = await seenFiles(reader);
+          // Both diverged files exist in the worktree at every instant — a
+          // concurrent rebuild must never make them momentarily invisible.
+          if (!files.has('target.ts')) missing.push('target.ts');
+          if (!files.has('added.ts')) missing.push('added.ts');
+          await nextTick();
+        }
+      })();
+
+      await Promise.all([writerLoop, readerLoop]);
+
+      expect(missing, `reader observed missing files: ${missing.join(', ')}`).toEqual([]);
+    } finally {
+      writer.close();
+      reader.close();
+    }
+  });
+
+  it('serves a consistent snapshot across genuine rebuild swaps', async () => {
+    const writer = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    const reader = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await writer.initialize();
+    await reader.initialize();
+
+    try {
+      await buildOverlay(writer);
+
+      const missing: string[] = [];
+      let done = false;
+
+      // Toggle keep-a.ts between two divergent bodies BETWEEN builds (never
+      // during a scan) so every rebuild is a real atomic swap, not a no-op.
+      const variants = [
+        'export function keepA() {\n  return 111;\n}\n',
+        'export function keepA() {\n  return 222;\n}\n',
+      ];
+
+      const writerLoop = (async () => {
+        for (let i = 0; i < 40; i++) {
+          await fs.writeFile(path.join(worktreeDir, 'keep-a.ts'), variants[i % 2]);
+          await buildOverlay(writer);
+        }
+        done = true;
+      })();
+
+      const readerLoop = (async () => {
+        while (!done) {
+          const files = await seenFiles(reader);
+          // added.ts is stable across every swap; it must be visible always.
+          if (!files.has('added.ts')) missing.push('added.ts');
+          // keep-a.ts diverges in every variant, so it is always present too.
+          if (!files.has('keep-a.ts')) missing.push('keep-a.ts');
+          await nextTick();
+        }
+      })();
+
+      await Promise.all([writerLoop, readerLoop]);
+
+      expect(missing, `reader observed missing files: ${missing.join(', ')}`).toEqual([]);
+    } finally {
+      writer.close();
+      reader.close();
+    }
+  });
+
+  it('does not bump the version stamp when a rebuild produces an identical overlay', async () => {
+    const overlay = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await overlay.initialize();
+    try {
+      const first = await buildOverlay(overlay);
+      expect(first.changed).toBe(true); // first build is a real change
+      const v1 = await readVersionFile(getIndexDir(worktreeDir));
+      expect(v1).toBeGreaterThan(0);
+
+      // Any bump would be observable as a strictly greater timestamp.
+      await new Promise(r => setTimeout(r, 5));
+
+      const second = await buildOverlay(overlay);
+      expect(second.changed).toBe(false); // identical overlay → no-op
+      const v2 = await readVersionFile(getIndexDir(worktreeDir));
+      expect(v2).toBe(v1); // version stamp unchanged
+    } finally {
+      overlay.close();
+    }
+  });
+
+  it('two writers on one overlay do not re-trigger each other, but a real change still bumps', async () => {
+    const w1 = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    const w2 = new OverlayBackend(worktreeDir, getIndexDir(baseDir));
+    await w1.initialize();
+    await w2.initialize();
+
+    try {
+      await buildOverlay(w1);
+      const v1 = await readVersionFile(getIndexDir(worktreeDir));
+
+      await new Promise(r => setTimeout(r, 5));
+
+      // Second serve rebuilds the identical overlay → MUST NOT bump (no cascade).
+      const w2res = await buildOverlay(w2);
+      expect(w2res.changed).toBe(false);
+      const v2 = await readVersionFile(getIndexDir(worktreeDir));
+      expect(v2).toBe(v1);
+
+      // But a genuine worktree change still bumps, so real edits propagate.
+      await new Promise(r => setTimeout(r, 5));
+      await fs.writeFile(
+        path.join(worktreeDir, 'keep-b.ts'),
+        'export function keepB() {\n  return 999999;\n}\n',
+      );
+      const w2res2 = await buildOverlay(w2);
+      expect(w2res2.changed).toBe(true);
+      const v3 = await readVersionFile(getIndexDir(worktreeDir));
+      expect(v3).toBeGreaterThan(v1);
+    } finally {
+      w1.close();
+      w2.close();
+    }
+  });
+});

--- a/packages/core/src/vectordb/sqlite/overlay-schema.ts
+++ b/packages/core/src/vectordb/sqlite/overlay-schema.ts
@@ -13,6 +13,11 @@ export const OVERLAY_META = {
   BASE_STAMP: 'baseStamp',
   /** Base index format version captured at overlay build time. */
   BASE_FORMAT_VERSION: 'baseFormatVersion',
+  /** Content signature of the overlay (diverged file→hash set + mask set) at
+   *  the last build. Lets a rebuild that reproduces the identical overlay skip
+   *  the version-stamp bump — the guard that breaks the multi-serve rebuild
+   *  livelock. */
+  SIGNATURE: 'overlaySignature',
 } as const;
 
 /**


### PR DESCRIPTION
## The bug (reproduced with atomic reads)

In a worktree serve, `list_functions` / `querySymbols` intermittently returned **0 results** for `OverlayBackend` — a class that exists — across many attempts over several minutes. Single-transaction snapshots of the overlay db repeatedly caught `overlay_mask` containing `packages/core/src/vectordb/overlay-backend.ts` (correct — the file diverges from base) while `chunks` held **zero rows** for it: the file suppressed from base with *no replacement*, invisible to every read path. Moments later another snapshot showed rows present. Meanwhile the overlay's `indexVersion` churned continuously (3 bumps in ~4 minutes with **zero file edits**) while more than one serve process had the worktree as cwd.

## Root causes (confirmed in code)

**1. Non-atomic rebuild window** (flagged by Lien Review on #667, documented-not-fixed). `buildOverlay` did `clear()` → scan → hash → `maskBasePath` → `indexMultipleFiles` (per-file `deleteByFile` then `insertBatch`), mutating the mask and chunks across many autocommitted statements spread over async ticks. A concurrent reader on another connection could observe:
- an **added** file with no overlay rows and no base fallback for the entire scan/chunk phase, or
- a **modified** file masked (by `deleteByFile`) with its overlay rows not yet inserted.

**2. Rebuild livelock.** `recordBaseBuild` bumped `.lien-index-version` on **every** rebuild. The only rebuild trigger is each serve's *startup* `handleAutoIndexing` (tool handlers and the version/git polls only reconnect, never rebuild) — but multiple serves per root is a known reality (they pile up, three install paths). Every startup rebuild bumped the stamp; every bump made all other serves' version poll reconnect; restart/re-spawn churn kept new serves rebuilding — a self-amplifying reconnect/rebuild storm with zero file edits.

## The fix

**Reader atomicity.** All async work (scan/hash/chunk) now happens in `buildOverlay` *before* any write, producing in-memory chunk batches + the mask set. `OverlayBackend.applyRebuild` applies the **entire swap** — delete old chunks + mask, insert new chunks + mask, update meta — in **one `BEGIN IMMEDIATE` transaction**. WAL snapshot isolation means another connection sees the complete old overlay or the complete new one, never a half-applied state. `buildOverlay` no longer calls `clear()`; a **post-commit** `VACUUM` + `wal_checkpoint(TRUNCATE)` reclaim disk (VACUUM can't run inside a txn) with the **same file identity** throughout — preserving #667's multi-process safety fix (close+delete+recreate stays banned). The reader side is snapshotted too: `unionRecords` / `search` / `scanPaginated` read overlay rows + mask inside **one deferred read transaction**, so an atomic writer commit landing between the two statements can't be observed half-applied.

**Livelock guard.** `buildOverlay` computes a cheap **content signature** (hash over sorted diverged-file→hash pairs + sorted mask set, reusing hashes from the diff). If it matches the last build's signature, the rebuild is a no-op: it refreshes only the base stamp (so `needsRebuild()` still settles) and returns `changed: false` **without bumping**. So once any serve builds the overlay, further startups on an unchanged worktree are silent and the storm can't form. `applyRebuild` re-checks the signature **inside** its `IMMEDIATE` transaction, so under a true race only the first writer bumps.

**Cross-process single-rebuilder guard — what I chose.** Rather than a held advisory lock (which would span the async chunking phase, block the watcher's incremental writes, and need fragile cross-async handling + lease/stale-lock heuristics), I rely on the **in-transaction signature test-and-set** (guarantees one effective rebuild / one bump across any number of concurrent writers) plus a lightweight **`SQLITE_BUSY` busy-skip** (if a peer holds the write lock past the busy timeout, `applyRebuild` returns `changed: false` — the peer's swap serves everyone). Its only lost benefit vs. a held lock is de-duplicating concurrent chunking CPU — negligible, since the overlay only covers the handful of diverged files (KISS/YAGNI). Multiple serves are *tolerated*, not assumed away. Full rationale in `docs/architecture/worktree-aware-indexing.md` → "Concurrency hardening".

## Stress test — reproduction first (before-fail / after-pass)

`packages/core/src/vectordb/overlay-concurrency.test.ts`: two `OverlayBackend` connections on one overlay db (the shape of multiple serves on one worktree) — a writer rebuilding in a loop while a reader polls `querySymbols`.

Same test file, run against `origin/main` source vs. the fix:

```
=== BEFORE (origin/main source, same stress test) ===
  × never exposes a masked-but-unreplaced window to a concurrent reader
  × serves a consistent snapshot across genuine rebuild swaps
  × does not bump the version stamp when a rebuild produces an identical overlay
  × two writers on one overlay do not re-trigger each other, but a real change still bumps
  Tests  4 failed (4)

=== AFTER (with fix) ===
  ✓ (4 tests)
  Tests  4 passed (4)
```

(The reader-observable window is deterministic on an **added** file — absent for the whole scan/chunk phase after `clear()` — which is the single-process manifestation of the same masked/absent-without-replacement bug that a separate serve process hits on a modified file too. A second case toggles a file between two bodies each iteration so every rebuild is a genuine atomic swap, exercising the reader-snapshot path.)

## Gate

`format:check` ✓ · `lint` 0 errors ✓ · `typecheck` ✓ · `build` ✓ · `test`: parser 963, core 322, review 565, cli 757, action 28 — all pass.

Changeset: patch `@liendev/core` + `@liendev/lien`. Does not touch `packages/review`.

---

<!-- lien-stats -->
### Lien Review

🔴 **Review required** - 1 new function is too complex.
🔗 **Impact**: 1 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +19 |
| ⏱️ time to understand | 1 | +121 |


> [!WARNING]
> **2 issues found** · Medium Risk
>
> The PR makes overlay rebuilds atomic and suppresses no-op version bumps, which directly fixes the reported masked-but-unreplaced and livelock bugs. The main residual risks are a stale manifest after files revert to base and a busy-skip path that can silently drop a newer rebuild plan when two serves race.
>
> - Overlay swap (delete + insert + mask + meta) moved into a single BEGIN IMMEDIATE transaction
> - Content signature short-circuits identical rebuilds and prevents version-stamp churn
> - Overlay reads now pin rows + mask in one deferred snapshot

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 23d0f41. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

## Review findings triage (commit 23d0f41)

**1. 🟡 `overlay-index.ts` — signature excludes chunking/format inputs → FIXED.**
Valid finding. `overlay-resolution` guards only the *base's* format version; once the main checkout is reindexed at a new format, the worktree resolves to overlay mode, `needsRebuild()` fires, but the signature fast path saw unchanged file content and skipped the swap — leaving the overlay's own chunk rows in the old chunking format forever. `computeOverlaySignature` now bakes in a format salt (`INDEX_FORMAT_VERSION` + effective chunk size/overlap), so any change to the chunking contract forces exactly one real rebuild, after which the no-op fast path resumes. Deliberately **not** salted with the package version: that would force a rebuild-and-bump on every release even when nothing chunking-related changed, and `INDEX_FORMAT_VERSION` is already this repo's bump-on-indexing-format-change contract (`constants.ts`). Tests added: unit (each format input independently alters the signature; stable under input reordering) and integration (a stored signature from an older format ⇒ `changed: true`, then `changed: false` again).

**2. 🟡 `overlay-backend.ts:186` — `search` base hits outside the overlay snapshot → REBUTTED (documented limitation, no code change).**
The suggested fix ("read base hits inside the same `overlaySnapshot` block") is structurally a no-op: SQLite transactions are per-connection, and the base is a **separate connection to a different database file** — lexically nesting the base read inside the overlay transaction cannot extend WAL snapshot isolation across them. True cross-DB snapshot atomicity is impossible in the two-connection design (ATTACH was rejected in #667 to keep the base provably read-only).

The specific anomaly claimed — duplicates when a concurrent `applyRebuild` unmasks a file between the two reads — cannot occur: base hits are filtered against the mask captured in the **same** snapshot `S` as the overlay hits. Per `S`'s build invariant, any file with overlay rows that also exists in base is masked in `S`, so its base row is dropped regardless of when the base read runs; and a rebuild that unmasks a file removes its overlay rows in the same transaction, so a reader sees consistent-old or consistent-new, never both. The residual window is only that base rows may reflect a base commit landing mid-query — each side internally consistent, per-file single-source preserved — and a mid-serve base write already implies the overlay is stale-until-rebuild *regardless of intra-query timing* (documented base-staleness semantics; the base-stamp compare triggers the reconciling rebuild). A retry-on-base-stamp-change mitigation would re-run into the same stale-until-rebuild state, buying nothing for two extra fs reads per query. Cross-corpus BM25 ranking is already documented as approximate (v1 FTS caveat). Full reasoning recorded in `docs/architecture/worktree-aware-indexing.md` → "Accepted limitation: the base read is a separate snapshot".

Gate re-run after triage: `format:check` ✓ · `lint` 0 errors ✓ · `typecheck` ✓ · `build` ✓ · tests all pass (parser 963, **core 326** (+4), review 565, cli 757, action 28).
