### PR TITLE
feat(gc): index garbage collection (lien gc + serve auto-GC)

### DIFF
--- a/.changeset/lien-index-gc.md
+++ b/.changeset/lien-index-gc.md
@@ -1,0 +1,34 @@
+---
+'@liendev/core': minor
+'@liendev/lien': minor
+---
+
+feat(gc): garbage-collect stale and orphaned index directories
+
+`~/.lien/indices` accumulated one directory per project root ever opened —
+repos, worktrees, clones, scratch dirs — and nothing ever removed them. This
+adds index garbage collection.
+
+New `lien gc` command:
+
+- **Orphan GC (default):** removes indices whose recorded source root no longer
+  exists on disk. The core indexer now records `sourceRoot` in `manifest.json`
+  at index time; legacy indices lacking it are reported as "unknown provenance"
+  and removed only via `--stale`. Missing roots on an offline `/Volumes` mount
+  (unplugged external drive) are skipped, not treated as orphans.
+- **Legacy lance sweep (default):** removes dead `code_chunks.lance` directories
+  left inside surviving index dirs after the LanceDB removal (#661).
+- **`--stale [days]` (opt-in, default 60):** removes indices not accessed within
+  N days, using a new `.lien-accessed` stamp touched on serve start.
+- **`--dry-run`** previews every candidate with size and reason and deletes
+  nothing; a summary (removed / freed / skipped) always prints. `--format json`
+  is available for scripting.
+- **Safety rails:** never deletes the current project's index, and skips any
+  index a live process holds open (probed via a `BEGIN IMMEDIATE` busy-check on
+  its `structural.db`). Deletions happen one directory at a time.
+
+Auto-GC on serve start: after the MCP server is up, a background, non-blocking
+pass runs orphan GC + the lance sweep (never stale GC), throttled machine-wide
+to at most once per 24h via a stamp + atomic lock so piled-up serves don't
+stampede. It logs a single line only when something was collected. Opt out with
+`LIEN_AUTO_GC=off`.

--- a/packages/cli/src/cli/gc.test.ts
+++ b/packages/cli/src/cli/gc.test.ts
@@ -124,4 +124,23 @@ describe('gcCommand', () => {
     expect(errorSpy).toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it('does not run GC when --format is invalid, even with process.exit mocked as a no-op', async () => {
+    // Regression test: process.exit(1) wasn't followed by a `return`, so with
+    // process.exit mocked (as in this test file), execution fell through into
+    // a real, non-dry-run GC pass despite the format being rejected.
+    const dir = await makeOrphan('orphan-invalid-format');
+
+    await gcCommand({ format: 'yaml' });
+
+    expect(fsSync.existsSync(dir)).toBe(true);
+  });
+
+  it('does not run GC when --stale is invalid, even with process.exit mocked as a no-op', async () => {
+    const dir = await makeOrphan('orphan-invalid-stale');
+
+    await gcCommand({ stale: 'not-a-number' });
+
+    expect(fsSync.existsSync(dir)).toBe(true);
+  });
 });

--- a/packages/cli/src/cli/gc.test.ts
+++ b/packages/cli/src/cli/gc.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+import { gcCommand } from './gc.js';
+
+let originalHome: string | undefined;
+let home: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+function indicesRoot(): string {
+  return path.join(home, '.lien', 'indices');
+}
+
+async function makeOrphan(name: string): Promise<string> {
+  const dir = path.join(indicesRoot(), name);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, 'manifest.json'),
+    JSON.stringify({
+      formatVersion: 5,
+      lienVersion: 'test',
+      lastIndexed: Date.now(),
+      files: {},
+      sourceRoot: path.join(home, 'gone', name),
+    }),
+    'utf-8',
+  );
+  return dir;
+}
+
+/** Concatenate everything printed to stdout during a command. */
+function loggedText(): string {
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+}
+
+beforeEach(async () => {
+  originalHome = process.env.LIEN_HOME;
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-gc-cli-test-'));
+  process.env.LIEN_HOME = home;
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.LIEN_HOME;
+  else process.env.LIEN_HOME = originalHome;
+  vi.restoreAllMocks();
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+describe('gcCommand', () => {
+  it('--dry-run lists the orphan candidate and deletes nothing', async () => {
+    const dir = await makeOrphan('orphan-cli');
+
+    await gcCommand({ dryRun: true });
+
+    const out = loggedText();
+    expect(out).toContain('orphan-cli');
+    expect(out).toContain('orphan');
+    expect(out).toContain('dry run');
+    expect(fsSync.existsSync(dir)).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('deletes the orphan on a real run and prints a summary', async () => {
+    const dir = await makeOrphan('orphan-cli-real');
+
+    await gcCommand({});
+
+    expect(fsSync.existsSync(dir)).toBe(false);
+    expect(loggedText()).toMatch(/Removed 1 index/);
+  });
+
+  it('--format json emits machine-readable plan + summary', async () => {
+    await makeOrphan('orphan-json');
+
+    await gcCommand({ dryRun: true, format: 'json' });
+
+    const parsed = JSON.parse(loggedText());
+    expect(parsed.plan.removals).toHaveLength(1);
+    expect(parsed.plan.removals[0].kind).toBe('orphan');
+    expect(parsed.summary.dryRun).toBe(true);
+  });
+
+  it('rejects an invalid --stale value', async () => {
+    await gcCommand({ stale: 'not-a-number' });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects an invalid --format', async () => {
+    await gcCommand({ format: 'yaml' });
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/cli/gc.test.ts
+++ b/packages/cli/src/cli/gc.test.ts
@@ -87,10 +87,35 @@ describe('gcCommand', () => {
     expect(parsed.summary.dryRun).toBe(true);
   });
 
-  it('rejects an invalid --stale value', async () => {
+  it('rejects a non-numeric --stale value', async () => {
     await gcCommand({ stale: 'not-a-number' });
 
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('rejects --stale 0 — it would make every index an immediate candidate', async () => {
+    await gcCommand({ stale: '0' });
+
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('rejects a negative --stale value', async () => {
+    await gcCommand({ stale: '-1' });
+
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('rejects a fractional --stale value', async () => {
+    await gcCommand({ stale: '1.5' });
+
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('accepts --stale 1', async () => {
+    await gcCommand({ stale: '1', dryRun: true });
+
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('rejects an invalid --format', async () => {

--- a/packages/cli/src/cli/gc.ts
+++ b/packages/cli/src/cli/gc.ts
@@ -25,6 +25,7 @@ const VALID_FORMATS = ['text', 'json'];
 const SKIP_LABELS: Record<GcSkipReason, string> = {
   'current-project': 'current project',
   'in-use': 'in use by a live process',
+  unprobeable: 'could not verify (skipped for safety)',
   'volume-offline': 'source volume offline',
   'unknown-provenance': 'unknown provenance (legacy)',
   present: 'source root present',
@@ -32,14 +33,16 @@ const SKIP_LABELS: Record<GcSkipReason, string> = {
 
 /**
  * Resolve the `--stale [days]` flag into a day count, or undefined when the flag
- * was not passed. `--stale` alone means the default window.
+ * was not passed. `--stale` alone means the default window. Requires an
+ * integer >= 1 — `--stale 0` would make every index (including ones accessed
+ * moments ago) an immediate removal candidate, which is never what's meant.
  */
 function parseStaleDays(stale: string | boolean | undefined): number | undefined {
   if (stale === undefined) return undefined;
   if (stale === true) return DEFAULT_STALE_DAYS;
-  const days = parseInt(String(stale), 10);
-  if (Number.isNaN(days) || days < 0) {
-    throw new Error(`--stale expects a non-negative number of days, got "${String(stale)}"`);
+  const days = Number(stale);
+  if (!Number.isInteger(days) || days < 1) {
+    throw new Error(`--stale expects a whole number of days >= 1, got "${String(stale)}"`);
   }
   return days;
 }
@@ -127,8 +130,15 @@ export async function gcCommand(options: GcCommandOptions = {}): Promise<void> {
     process.exit(1);
   }
 
+  let staleDays: number | undefined;
   try {
-    const staleDays = parseStaleDays(options.stale);
+    staleDays = parseStaleDays(options.stale);
+  } catch (error) {
+    console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+    process.exit(2);
+  }
+
+  try {
     const currentIndexDir = getIndexDir(resolveProjectRoot(process.cwd()));
     const dryRun = options.dryRun ?? false;
 

--- a/packages/cli/src/cli/gc.ts
+++ b/packages/cli/src/cli/gc.ts
@@ -128,6 +128,7 @@ export async function gcCommand(options: GcCommandOptions = {}): Promise<void> {
   if (!VALID_FORMATS.includes(format)) {
     console.error(chalk.red(`Invalid format: ${format}. Valid: ${VALID_FORMATS.join(', ')}`));
     process.exit(1);
+    return;
   }
 
   let staleDays: number | undefined;
@@ -136,6 +137,7 @@ export async function gcCommand(options: GcCommandOptions = {}): Promise<void> {
   } catch (error) {
     console.error(chalk.red(error instanceof Error ? error.message : String(error)));
     process.exit(2);
+    return;
   }
 
   try {

--- a/packages/cli/src/cli/gc.ts
+++ b/packages/cli/src/cli/gc.ts
@@ -1,0 +1,150 @@
+import chalk from 'chalk';
+import { getIndexDir } from '@liendev/parser';
+import {
+  planGc,
+  executeGc,
+  formatBytes,
+  DEFAULT_STALE_DAYS,
+  type GcPlan,
+  type GcSummary,
+  type GcSkipReason,
+} from '@liendev/core';
+import { resolveProjectRoot } from './project-root.js';
+import { handleCommandError } from './utils.js';
+
+interface GcCommandOptions {
+  dryRun?: boolean;
+  stale?: string | boolean;
+  format?: string;
+  verbose?: boolean;
+}
+
+const VALID_FORMATS = ['text', 'json'];
+
+/** Human-readable label per skip reason for the report. */
+const SKIP_LABELS: Record<GcSkipReason, string> = {
+  'current-project': 'current project',
+  'in-use': 'in use by a live process',
+  'volume-offline': 'source volume offline',
+  'unknown-provenance': 'unknown provenance (legacy)',
+  present: 'source root present',
+};
+
+/**
+ * Resolve the `--stale [days]` flag into a day count, or undefined when the flag
+ * was not passed. `--stale` alone means the default window.
+ */
+function parseStaleDays(stale: string | boolean | undefined): number | undefined {
+  if (stale === undefined) return undefined;
+  if (stale === true) return DEFAULT_STALE_DAYS;
+  const days = parseInt(String(stale), 10);
+  if (Number.isNaN(days) || days < 0) {
+    throw new Error(`--stale expects a non-negative number of days, got "${String(stale)}"`);
+  }
+  return days;
+}
+
+function reasonColor(kind: 'orphan' | 'stale'): (s: string) => string {
+  return kind === 'orphan' ? chalk.red : chalk.yellow;
+}
+
+/** Print the removal candidates + lance sweeps (or a "nothing to collect" line). */
+function printCandidates(plan: GcPlan): void {
+  if (plan.removals.length === 0 && plan.lanceSweeps.length === 0) {
+    console.log(chalk.green('Nothing to collect — no orphaned, stale, or legacy data found.\n'));
+    return;
+  }
+  console.log(chalk.bold('Candidates:'));
+  for (const r of plan.removals) {
+    const color = reasonColor(r.kind);
+    const size = chalk.dim(formatBytes(r.sizeBytes));
+    console.log(
+      `  ${color('✗')} ${chalk.cyan(r.repoId)}  ${size}  ${color(r.kind)} — ${chalk.dim(r.detail)}`,
+    );
+  }
+  for (const s of plan.lanceSweeps) {
+    const size = chalk.dim(formatBytes(s.sizeBytes));
+    console.log(
+      `  ${chalk.magenta('🧹')} ${chalk.cyan(s.repoId)}/code_chunks.lance  ${size}  ${chalk.magenta('legacy lance sweep')}`,
+    );
+  }
+  console.log('');
+}
+
+/** Print the grouped skip breakdown. */
+function printSkips(plan: GcPlan): void {
+  if (plan.skipped.length === 0) return;
+  const counts = new Map<GcSkipReason, number>();
+  for (const s of plan.skipped) counts.set(s.reason, (counts.get(s.reason) ?? 0) + 1);
+  const parts = [...counts.entries()].map(([reason, n]) => `${n} ${SKIP_LABELS[reason]}`);
+  console.log(chalk.dim(`Skipped ${plan.skipped.length}: ${parts.join(', ')}`));
+}
+
+/** Print the candidate list, skip breakdown, and a --stale hint. */
+function printPlanText(plan: GcPlan, staleDays: number | undefined): void {
+  console.log(chalk.dim(`Indices root: ${plan.indicesRoot}\n`));
+  printCandidates(plan);
+  printSkips(plan);
+  if (staleDays === undefined) {
+    console.log(
+      chalk.dim(
+        `Tip: add --stale [days] to also remove indices not accessed recently (default ${DEFAULT_STALE_DAYS}d).`,
+      ),
+    );
+  }
+}
+
+/** Print the final one-line summary. Always printed. */
+function printSummaryText(summary: GcSummary): void {
+  const verb = summary.dryRun ? 'Would remove' : 'Removed';
+  const freed = summary.dryRun ? 'would free' : 'freed';
+  const lance = summary.sweptLanceDirs > 0 ? ` + ${summary.sweptLanceDirs} lance dir(s)` : '';
+  console.log(
+    '\n' +
+      chalk.bold(
+        `${verb} ${summary.removedIndices} ${summary.removedIndices === 1 ? 'index' : 'indices'}${lance}, ` +
+          `${freed} ${formatBytes(summary.freedBytes)}, skipped ${summary.skipped}` +
+          (summary.dryRun ? chalk.dim('  (dry run — nothing deleted)') : ''),
+      ),
+  );
+}
+
+function outputJson(plan: GcPlan, summary: GcSummary): void {
+  console.log(JSON.stringify({ plan, summary }, null, 2));
+}
+
+/**
+ * `lien gc` — reclaim `~/.lien/indices` space. Default action removes orphaned
+ * indices (source root gone) and sweeps legacy `code_chunks.lance` dirs; opt in
+ * to time-based cleanup with `--stale [days]`. `--dry-run` previews without
+ * deleting. Never touches the current project's index or one a live process
+ * holds open.
+ */
+export async function gcCommand(options: GcCommandOptions = {}): Promise<void> {
+  const format = options.format ?? 'text';
+  if (!VALID_FORMATS.includes(format)) {
+    console.error(chalk.red(`Invalid format: ${format}. Valid: ${VALID_FORMATS.join(', ')}`));
+    process.exit(1);
+  }
+
+  try {
+    const staleDays = parseStaleDays(options.stale);
+    const currentIndexDir = getIndexDir(resolveProjectRoot(process.cwd()));
+    const dryRun = options.dryRun ?? false;
+
+    const plan = await planGc({ staleDays, protectedDirs: [currentIndexDir], dryRun });
+    const summary = await executeGc(plan, { dryRun });
+
+    if (format === 'json') {
+      outputJson(plan, summary);
+      return;
+    }
+
+    console.log(chalk.bold(`\nLien index GC${dryRun ? chalk.dim('  (dry run)') : ''}\n`));
+    printPlanText(plan, staleDays);
+    printSummaryText(summary);
+  } catch (error) {
+    handleCommandError(error, options.verbose ?? false);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from 'commander';
+import { DEFAULT_STALE_DAYS } from '@liendev/core';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -11,6 +12,7 @@ import { deltaCommand } from './delta-cmd.js';
 import { configSetCommand, configGetCommand, configListCommand } from './config.js';
 import { pathCommand } from './path-cmd.js';
 import { annotateCommand } from './annotate-cmd.js';
+import { gcCommand } from './gc.js';
 
 // Get version from package.json dynamically
 const __filename = fileURLToPath(import.meta.url);
@@ -122,6 +124,18 @@ program
   .command('annotate <file>')
   .description('Print a short impact summary for a single file (for hook annotation)')
   .action(annotateCommand);
+
+program
+  .command('gc')
+  .description('Garbage-collect stale/orphaned index directories under ~/.lien/indices')
+  .option('--dry-run', 'List candidates with size and reason; delete nothing')
+  .option(
+    '--stale [days]',
+    `Also remove indices not accessed in N days (default ${DEFAULT_STALE_DAYS})`,
+  )
+  .option('--format <type>', 'Output format: text, json', 'text')
+  .option('-v, --verbose', 'Show detailed error output')
+  .action(gcCommand);
 
 program.action(() => {
   program.help();

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -10,6 +10,8 @@ const {
   mockSetupCleanupHandlers,
   mockIsGitRepo,
   mockIndexCodebase,
+  mockWriteAccessStamp,
+  mockRunAutoGc,
 } = vi.hoisted(() => ({
   mockServerInstance: {
     connect: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +36,8 @@ const {
   mockSetupCleanupHandlers: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(undefined)),
   mockIsGitRepo: vi.fn(async (_dir: string) => true),
   mockIndexCodebase: vi.fn(async (_opts: { rootDir: string; verbose?: boolean }) => undefined),
+  mockWriteAccessStamp: vi.fn(async (_dir: string) => undefined),
+  mockRunAutoGc: vi.fn(async () => ({ ran: false, reason: 'throttled' as const })),
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
@@ -53,6 +57,8 @@ vi.mock('@liendev/core', () => ({
   VERSION_CHECK_INTERVAL_MS: 60000,
   isGitRepo: mockIsGitRepo,
   indexCodebase: mockIndexCodebase,
+  writeAccessStamp: mockWriteAccessStamp,
+  runAutoGc: mockRunAutoGc,
 }));
 
 vi.mock('../watcher/index.js', () => ({
@@ -112,7 +118,7 @@ vi.mock('url', () => ({
 import { startMCPServer } from './server.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { createVectorDB } from '@liendev/core';
+import { createVectorDB, writeAccessStamp, runAutoGc } from '@liendev/core';
 import { FileWatcher } from '../watcher/index.js';
 import { createMCPServerConfig, registerMCPHandlers } from './server-config.js';
 import { setupCleanupHandlers } from './cleanup.js';
@@ -187,6 +193,26 @@ describe('startMCPServer', () => {
     await startMCPServer({ rootDir: '/test/project' });
 
     expect(StdioServerTransport).toHaveBeenCalledOnce();
+    expect(mockServerInstance.connect).toHaveBeenCalledOnce();
+  });
+
+  it('touches the access stamp and kicks off auto-GC once the server is ready', async () => {
+    await startMCPServer({ rootDir: '/test/project' });
+
+    // Access stamp is written for the serving index dir.
+    expect(writeAccessStamp).toHaveBeenCalledWith('/test/.lien');
+    // Auto-GC runs in the background, protecting the serving index dir.
+    expect(runAutoGc).toHaveBeenCalledWith(
+      expect.objectContaining({ protectedDirs: ['/test/.lien'], log: expect.any(Function) }),
+    );
+  });
+
+  it('does not block serve readiness on background maintenance', async () => {
+    // Maintenance is fire-and-forget: even if auto-GC never settles, startMCPServer
+    // resolves (connect completed) without awaiting it.
+    vi.mocked(runAutoGc).mockReturnValueOnce(new Promise(() => {}) as never);
+
+    await expect(startMCPServer({ rootDir: '/test/project' })).resolves.toBeUndefined();
     expect(mockServerInstance.connect).toHaveBeenCalledOnce();
   });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -4,7 +4,13 @@ import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
 import type { VectorDBInterface, GitState } from '@liendev/core';
-import { VERSION_CHECK_INTERVAL_MS, createVectorDB, isGitRepo } from '@liendev/core';
+import {
+  VERSION_CHECK_INTERVAL_MS,
+  createVectorDB,
+  isGitRepo,
+  writeAccessStamp,
+  runAutoGc,
+} from '@liendev/core';
 import { FileWatcher } from '../watcher/index.js';
 import { createMCPServerConfig, registerMCPHandlers } from './server-config.js';
 import { createReindexStateManager } from './reindex-state-manager.js';
@@ -326,6 +332,18 @@ function createMCPServer(): Server {
 /**
  * Setup server features and connect transport.
  */
+/**
+ * Fire-and-forget maintenance kicked off once the server is up. NEVER awaited —
+ * it must not delay serve readiness (mirrors handleAutoIndexing's rationale):
+ *  1. Touch the index's access stamp so `lien gc --stale` sees a fresh use.
+ *  2. Run throttled orphan GC + legacy lance sweep (at most once/24h across all
+ *     serves; opt out with LIEN_AUTO_GC=off). Protects the serving index.
+ */
+function startBackgroundMaintenance(vectorDB: VectorDBInterface, log: LogFn): void {
+  void writeAccessStamp(vectorDB.dbPath).catch(() => {});
+  void runAutoGc({ protectedDirs: [vectorDB.dbPath], log }).catch(() => {});
+}
+
 async function setupAndConnectServer(
   server: Server,
   toolContext: ToolContext,
@@ -388,6 +406,8 @@ async function setupAndConnectServer(
   try {
     await server.connect(transport);
     log('MCP server started and listening on stdio');
+    // Server is ready and listening — kick off non-blocking maintenance.
+    startBackgroundMaintenance(vectorDB, log);
   } catch (error) {
     console.error(`Failed to connect MCP transport: ${error}`);
     process.exit(1);

--- a/packages/core/src/gc/access-stamp.ts
+++ b/packages/core/src/gc/access-stamp.ts
@@ -1,0 +1,47 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Name of the access-stamp file inside an index directory. Its content is an
+ * epoch-ms timestamp recording when a `lien serve` last opened this index.
+ *
+ * This is deliberately distinct from `.lien-index-version` (which tracks the
+ * last write / reindex) — the stamp tracks last use so `lien gc --stale` can
+ * reclaim indices for repos nobody has served in a while. It is touched on
+ * serve start only (a single cheap write), NOT on every query.
+ */
+export const ACCESS_STAMP_FILE = '.lien-accessed';
+
+/**
+ * Record that this index was just accessed (opened by a serve). Best-effort:
+ * failures are swallowed since the stamp is a convenience for GC, not critical.
+ *
+ * @param indexDir - Path to the index directory
+ */
+export async function writeAccessStamp(indexDir: string): Promise<void> {
+  try {
+    await fs.mkdir(indexDir, { recursive: true });
+    const stampPath = path.join(indexDir, ACCESS_STAMP_FILE);
+    await fs.writeFile(stampPath, Date.now().toString(), 'utf-8');
+  } catch {
+    // Best-effort — a missing access stamp only makes an index look older to
+    // `lien gc --stale`, which falls back to other timestamps.
+  }
+}
+
+/**
+ * Read the last-access timestamp from an index directory.
+ *
+ * @param indexDir - Path to the index directory
+ * @returns Epoch-ms timestamp, or null if the stamp is absent/unreadable
+ */
+export async function readAccessStamp(indexDir: string): Promise<number | null> {
+  try {
+    const stampPath = path.join(indexDir, ACCESS_STAMP_FILE);
+    const content = await fs.readFile(stampPath, 'utf-8');
+    const timestamp = parseInt(content.trim(), 10);
+    return Number.isNaN(timestamp) ? null : timestamp;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/gc/auto-gc.test.ts
+++ b/packages/core/src/gc/auto-gc.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+import { openDatabase, STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
+import { getIndicesRoot, LEGACY_LANCE_DIRNAME } from './gc.js';
+import { runAutoGc, GC_STAMP_FILE, GC_LOCK_FILE } from './auto-gc.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+let originalHome: string | undefined;
+let home: string;
+
+async function makeIndex(
+  name: string,
+  opts: { sourceRoot?: string; withDb?: boolean; lance?: boolean; accessMs?: number } = {},
+): Promise<string> {
+  const dir = path.join(getIndicesRoot(), name);
+  await fs.mkdir(dir, { recursive: true });
+  const manifest: Record<string, unknown> = {
+    formatVersion: 5,
+    lienVersion: 'test',
+    lastIndexed: Date.now(),
+    files: {},
+  };
+  if (opts.sourceRoot) manifest.sourceRoot = opts.sourceRoot;
+  await fs.writeFile(path.join(dir, 'manifest.json'), JSON.stringify(manifest), 'utf-8');
+  if (opts.withDb) {
+    const db = openDatabase(path.join(dir, STRUCTURAL_DB_FILENAME));
+    db.close();
+  }
+  if (opts.lance) await fs.mkdir(path.join(dir, LEGACY_LANCE_DIRNAME), { recursive: true });
+  if (opts.accessMs !== undefined) {
+    await fs.writeFile(path.join(dir, '.lien-accessed'), String(opts.accessMs), 'utf-8');
+  }
+  return dir;
+}
+
+beforeEach(async () => {
+  originalHome = process.env.LIEN_HOME;
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-autogc-test-'));
+  process.env.LIEN_HOME = home;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.LIEN_HOME;
+  else process.env.LIEN_HOME = originalHome;
+  delete process.env.LIEN_AUTO_GC;
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+describe('runAutoGc', () => {
+  it('runs orphan GC on the first invocation and throttles the immediate second', async () => {
+    const dir = await makeIndex('orphan-auto', {
+      sourceRoot: path.join(home, 'gone', 'auto'),
+      withDb: true,
+    });
+
+    const first = await runAutoGc();
+    expect(first.ran).toBe(true);
+    expect(first.summary?.removedIndices).toBe(1);
+    expect(fsSync.existsSync(dir)).toBe(false);
+    expect(fsSync.existsSync(path.join(home, '.lien', GC_STAMP_FILE))).toBe(true);
+
+    const second = await runAutoGc();
+    expect(second.ran).toBe(false);
+    expect(second.reason).toBe('throttled');
+  });
+
+  it('sweeps legacy lance dirs from surviving indices', async () => {
+    const root = path.join(home, 'roots', 'keep');
+    await fs.mkdir(root, { recursive: true });
+    const dir = await makeIndex('keep-auto', { sourceRoot: root, withDb: true, lance: true });
+
+    const res = await runAutoGc();
+
+    expect(res.ran).toBe(true);
+    expect(res.summary?.sweptLanceDirs).toBe(1);
+    expect(fsSync.existsSync(path.join(dir, LEGACY_LANCE_DIRNAME))).toBe(false);
+    expect(fsSync.existsSync(dir)).toBe(true);
+  });
+
+  it('never stale-GCs automatically — an old present-root index survives', async () => {
+    const root = path.join(home, 'roots', 'old');
+    await fs.mkdir(root, { recursive: true });
+    const dir = await makeIndex('old-present', {
+      sourceRoot: root,
+      withDb: true,
+      accessMs: Date.now() - 400 * DAY,
+    });
+
+    const res = await runAutoGc();
+
+    expect(res.ran).toBe(true);
+    expect(fsSync.existsSync(dir)).toBe(true); // stale is opt-in only, never automatic
+  });
+
+  it('is disabled by LIEN_AUTO_GC=off', async () => {
+    process.env.LIEN_AUTO_GC = 'off';
+
+    const res = await runAutoGc();
+
+    expect(res).toEqual({ ran: false, reason: 'disabled' });
+  });
+
+  it('no-ops when another serve holds the lock', async () => {
+    await fs.mkdir(path.join(home, '.lien'), { recursive: true });
+    await fs.writeFile(path.join(home, '.lien', GC_LOCK_FILE), 'peer', 'utf-8');
+
+    const res = await runAutoGc();
+
+    expect(res.ran).toBe(false);
+    expect(res.reason).toBe('locked');
+  });
+});

--- a/packages/core/src/gc/auto-gc.test.ts
+++ b/packages/core/src/gc/auto-gc.test.ts
@@ -5,7 +5,10 @@ import os from 'os';
 import path from 'path';
 import { openDatabase, STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
 import { getIndicesRoot, LEGACY_LANCE_DIRNAME } from './gc.js';
-import { runAutoGc, GC_STAMP_FILE, GC_LOCK_FILE } from './auto-gc.js';
+import { runAutoGc, acquireLock, GC_STAMP_FILE, GC_LOCK_FILE } from './auto-gc.js';
+
+/** Older than auto-gc's internal STALE_LOCK_MS (1h), so reclaim kicks in. */
+const STALE_LOCK_AGE_MS = 2 * 60 * 60 * 1000;
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -112,5 +115,41 @@ describe('runAutoGc', () => {
 
     expect(res.ran).toBe(false);
     expect(res.reason).toBe('locked');
+  });
+});
+
+describe('acquireLock — concurrent stale reclaim', () => {
+  it('exactly one of two racing acquires wins a stale lock', async () => {
+    const lienDir = path.join(home, '.lien');
+    await fs.mkdir(lienDir, { recursive: true });
+    const lockPath = path.join(lienDir, GC_LOCK_FILE);
+    await fs.writeFile(lockPath, 'stale', 'utf-8');
+    const staleTime = new Date(Date.now() - STALE_LOCK_AGE_MS);
+    await fs.utimes(lockPath, staleTime, staleTime);
+
+    const [a, b] = await Promise.all([acquireLock(lockPath), acquireLock(lockPath)]);
+    const winners = [a, b].filter((handle): handle is fs.FileHandle => handle !== null);
+
+    expect(winners).toHaveLength(1);
+    await winners[0].close();
+    // No leftover reclaim artifact from either racer.
+    const entries = await fs.readdir(lienDir);
+    expect(entries.filter(name => name.startsWith(`${GC_LOCK_FILE}.reclaim-`))).toHaveLength(0);
+  });
+
+  it('reclaims a stale lock and lets a fresh acquire proceed afterward', async () => {
+    const lienDir = path.join(home, '.lien');
+    await fs.mkdir(lienDir, { recursive: true });
+    const lockPath = path.join(lienDir, GC_LOCK_FILE);
+    await fs.writeFile(lockPath, 'stale', 'utf-8');
+    const staleTime = new Date(Date.now() - STALE_LOCK_AGE_MS);
+    await fs.utimes(lockPath, staleTime, staleTime);
+
+    const handle = await acquireLock(lockPath);
+    expect(handle).not.toBeNull();
+    await handle?.close();
+
+    // A fresh (non-stale) lock is respected, not reclaimed.
+    expect(await acquireLock(lockPath)).toBeNull();
   });
 });

--- a/packages/core/src/gc/auto-gc.test.ts
+++ b/packages/core/src/gc/auto-gc.test.ts
@@ -5,7 +5,13 @@ import os from 'os';
 import path from 'path';
 import { openDatabase, STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
 import { getIndicesRoot, LEGACY_LANCE_DIRNAME } from './gc.js';
-import { runAutoGc, acquireLock, GC_STAMP_FILE, GC_LOCK_FILE } from './auto-gc.js';
+import {
+  runAutoGc,
+  acquireLock,
+  startLockHeartbeat,
+  GC_STAMP_FILE,
+  GC_LOCK_FILE,
+} from './auto-gc.js';
 
 /** Older than auto-gc's internal STALE_LOCK_MS (1h), so reclaim kicks in. */
 const STALE_LOCK_AGE_MS = 2 * 60 * 60 * 1000;
@@ -151,5 +157,31 @@ describe('acquireLock — concurrent stale reclaim', () => {
 
     // A fresh (non-stale) lock is respected, not reclaimed.
     expect(await acquireLock(lockPath)).toBeNull();
+  });
+});
+
+describe('startLockHeartbeat', () => {
+  it('refreshes the lock mtime on each tick, and stops once cleared', async () => {
+    // Regression test: without a heartbeat, a live-but-slow GC run's lock
+    // mtime never advances past acquisition time, so a peer could mistake it
+    // for a crashed holder's stale lock once STALE_LOCK_MS elapses.
+    const lienDir = path.join(home, '.lien');
+    await fs.mkdir(lienDir, { recursive: true });
+    const lockPath = path.join(lienDir, GC_LOCK_FILE);
+    await fs.writeFile(lockPath, '', 'utf-8');
+    const past = new Date(Date.now() - 60 * 60 * 1000);
+    await fs.utimes(lockPath, past, past);
+
+    const timer = startLockHeartbeat(lockPath, 20);
+    await new Promise(resolve => setTimeout(resolve, 80));
+
+    const refreshedMtime = (await fs.stat(lockPath)).mtimeMs;
+    expect(refreshedMtime).toBeGreaterThan(past.getTime());
+
+    clearInterval(timer);
+    const mtimeAfterStop = (await fs.stat(lockPath)).mtimeMs;
+    await new Promise(resolve => setTimeout(resolve, 80));
+
+    expect((await fs.stat(lockPath)).mtimeMs).toBe(mtimeAfterStop);
   });
 });

--- a/packages/core/src/gc/auto-gc.ts
+++ b/packages/core/src/gc/auto-gc.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { getLienHome } from '@liendev/parser';
 import { runGc, type GcSummary } from './gc.js';
 
@@ -12,6 +13,11 @@ export const GC_LOCK_FILE = 'gc.lock';
 export const AUTO_GC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 /** A lock older than this is assumed abandoned by a crashed serve and reclaimed. */
 const STALE_LOCK_MS = 60 * 60 * 1000;
+/** How often the lock holder refreshes its mtime while GC runs, so a live but
+ *  unusually slow run is never mistaken for a crashed one and reclaimed out
+ *  from under it. Well under STALE_LOCK_MS. The lock is otherwise held only
+ *  for the duration of a single GC run. */
+const LOCK_HEARTBEAT_MS = 5 * 60 * 1000;
 
 export interface AutoGcOptions {
   /** Index dirs to never touch (absolute paths; e.g. the serving project's). */
@@ -40,6 +46,27 @@ async function readStampMs(stampPath: string): Promise<number> {
 }
 
 /**
+ * After renaming a presumed-stale lock aside, confirm we moved the SAME file
+ * we inspected (by inode) rather than a fresh lock a peer recreated in the
+ * gap between our stat and our rename. Restores the file on a mismatch so we
+ * don't clobber a peer's live lock.
+ */
+async function verifyReclaimedLock(
+  reclaimPath: string,
+  lockPath: string,
+  originalIno: number,
+): Promise<boolean> {
+  try {
+    const moved = await fs.stat(reclaimPath);
+    if (moved.ino === originalIno) return true;
+  } catch {
+    return false;
+  }
+  await fs.rename(reclaimPath, lockPath).catch(() => {});
+  return false;
+}
+
+/**
  * Try to grab the machine-wide GC lock via exclusive create. Returns a handle
  * on success, or null when a peer holds it. Reclaims a lock left behind by a
  * crashed serve once it is older than STALE_LOCK_MS.
@@ -53,6 +80,15 @@ async function readStampMs(stampPath: string): Promise<number> {
  * that loses the rename (or the subsequent open, if it's beaten to that too)
  * treats the lock as held.
  *
+ * That alone isn't sufficient: a rename doesn't check WHICH file is at
+ * `lockPath`, only that something is. If caller A reclaims, recreates a fresh
+ * lock, and finishes before caller B's own (later) rename runs, B's rename
+ * would yank A's brand-new live lock out from under it and both would end up
+ * holding a handle. Comparing the inode captured by the initial stat against
+ * the inode actually moved detects this: a mismatch means a peer replaced the
+ * file between our stat and our rename, so we restore it (rename back) and
+ * treat the lock as held rather than stealing a live one.
+ *
  * Exported for the concurrency test — not part of the public GC surface.
  */
 export async function acquireLock(lockPath: string): Promise<fs.FileHandle | null> {
@@ -60,36 +96,67 @@ export async function acquireLock(lockPath: string): Promise<fs.FileHandle | nul
     return await fs.open(lockPath, 'wx');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') return null;
-
-    let stat;
-    try {
-      stat = await fs.stat(lockPath);
-    } catch {
-      // A peer released it between our open and this stat — retry once.
-      try {
-        return await fs.open(lockPath, 'wx');
-      } catch {
-        return null;
-      }
-    }
-    if (Date.now() - stat.mtimeMs <= STALE_LOCK_MS) return null; // held, not stale
-
-    const reclaimPath = `${lockPath}.reclaim-${process.pid}`;
-    try {
-      await fs.rename(lockPath, reclaimPath);
-    } catch {
-      return null; // lost the reclaim race — a peer now owns the lock
-    }
-
-    try {
-      return await fs.open(lockPath, 'wx');
-    } catch {
-      // A peer's fresh acquire (or reclaim) beat us to recreating the file.
-      return null;
-    } finally {
-      await fs.rm(reclaimPath, { force: true });
-    }
+    return await reclaimIfStale(lockPath);
   }
+}
+
+/** The EEXIST branch of {@link acquireLock}, split out to keep each function's
+ *  branching manageable. */
+async function reclaimIfStale(lockPath: string): Promise<fs.FileHandle | null> {
+  let stat;
+  try {
+    stat = await fs.stat(lockPath);
+  } catch {
+    // A peer released it between our open and this stat — retry once.
+    return await fs.open(lockPath, 'wx').catch(() => null);
+  }
+  if (Date.now() - stat.mtimeMs <= STALE_LOCK_MS) return null; // held, not stale
+
+  // Unique per call, not just per pid — two racing reclaims from the SAME
+  // process (e.g. concurrent runAutoGc invocations) would otherwise compute
+  // an identical reclaim path and could both end up believing they hold the
+  // lock (one renames the other's freshly-created lock file out from under it).
+  const reclaimPath = `${lockPath}.reclaim-${process.pid}-${randomUUID()}`;
+  try {
+    await fs.rename(lockPath, reclaimPath);
+  } catch {
+    return null; // lost the reclaim race — a peer now owns the lock
+  }
+
+  // Verify we actually moved the file we inspected, not a fresh lock a peer
+  // recreated in the gap between our stat and our rename.
+  if (!(await verifyReclaimedLock(reclaimPath, lockPath, stat.ino))) return null;
+
+  try {
+    return await fs.open(lockPath, 'wx');
+  } catch {
+    // A peer's fresh acquire (or reclaim) beat us to recreating the file.
+    return null;
+  } finally {
+    await fs.rm(reclaimPath, { force: true });
+  }
+}
+
+/**
+ * Periodically refresh the lock's mtime so a live GC run isn't reclaimed
+ * mid-run by a peer that only sees an old mtime. Unref'd so it can never keep
+ * the process alive if `clearInterval` is somehow skipped.
+ *
+ * Exported (with a configurable interval) for the heartbeat test — not part
+ * of the public GC surface.
+ */
+export function startLockHeartbeat(
+  lockPath: string,
+  intervalMs: number = LOCK_HEARTBEAT_MS,
+): NodeJS.Timeout {
+  const timer = setInterval(() => {
+    const now = new Date();
+    fs.utimes(lockPath, now, now).catch(() => {
+      // Best-effort — if this fails the lock just ages normally.
+    });
+  }, intervalMs);
+  timer.unref?.();
+  return timer;
 }
 
 async function releaseLock(handle: fs.FileHandle, lockPath: string): Promise<void> {
@@ -151,6 +218,7 @@ export async function runAutoGc(options: AutoGcOptions = {}): Promise<AutoGcResu
     const lock = await acquireLock(lockPath);
     if (!lock) return { ran: false, reason: 'locked' };
 
+    const heartbeat = startLockHeartbeat(lockPath);
     try {
       // Re-check under the lock: a peer may have just finished.
       if (await isThrottled(stampPath)) return { ran: false, reason: 'throttled' };
@@ -161,6 +229,7 @@ export async function runAutoGc(options: AutoGcOptions = {}): Promise<AutoGcResu
       logCollected(summary, options.log);
       return { ran: true, summary };
     } finally {
+      clearInterval(heartbeat);
       await releaseLock(lock, lockPath);
     }
   } catch {

--- a/packages/core/src/gc/auto-gc.ts
+++ b/packages/core/src/gc/auto-gc.ts
@@ -43,22 +43,52 @@ async function readStampMs(stampPath: string): Promise<number> {
  * Try to grab the machine-wide GC lock via exclusive create. Returns a handle
  * on success, or null when a peer holds it. Reclaims a lock left behind by a
  * crashed serve once it is older than STALE_LOCK_MS.
+ *
+ * Reclaiming is race-prone: two peers can both stat the same stale lock and
+ * decide to reclaim it. An unconditional rm+open lets the second peer's rm
+ * delete the first peer's brand-new lock, so both end up believing they hold
+ * it. Renaming the stale file aside instead of removing it is atomic — the
+ * rename only succeeds for whichever caller finds the file still at
+ * `lockPath`, so at most one caller proceeds to recreate the lock. A caller
+ * that loses the rename (or the subsequent open, if it's beaten to that too)
+ * treats the lock as held.
+ *
+ * Exported for the concurrency test — not part of the public GC surface.
  */
-async function acquireLock(lockPath: string): Promise<fs.FileHandle | null> {
+export async function acquireLock(lockPath: string): Promise<fs.FileHandle | null> {
   try {
     return await fs.open(lockPath, 'wx');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') return null;
+
+    let stat;
     try {
-      const stat = await fs.stat(lockPath);
-      if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
-        await fs.rm(lockPath, { force: true });
-        return await fs.open(lockPath, 'wx'); // reclaim: retry once
-      }
+      stat = await fs.stat(lockPath);
     } catch {
-      // lost a race with a peer that grabbed/removed it — treat as locked
+      // A peer released it between our open and this stat — retry once.
+      try {
+        return await fs.open(lockPath, 'wx');
+      } catch {
+        return null;
+      }
     }
-    return null;
+    if (Date.now() - stat.mtimeMs <= STALE_LOCK_MS) return null; // held, not stale
+
+    const reclaimPath = `${lockPath}.reclaim-${process.pid}`;
+    try {
+      await fs.rename(lockPath, reclaimPath);
+    } catch {
+      return null; // lost the reclaim race — a peer now owns the lock
+    }
+
+    try {
+      return await fs.open(lockPath, 'wx');
+    } catch {
+      // A peer's fresh acquire (or reclaim) beat us to recreating the file.
+      return null;
+    } finally {
+      await fs.rm(reclaimPath, { force: true });
+    }
   }
 }
 

--- a/packages/core/src/gc/auto-gc.ts
+++ b/packages/core/src/gc/auto-gc.ts
@@ -1,0 +1,140 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getLienHome } from '@liendev/parser';
+import { runGc, type GcSummary } from './gc.js';
+
+/** Stamp file recording the epoch-ms of the last machine-wide auto-GC run. */
+export const GC_STAMP_FILE = 'gc-last-run';
+/** Exclusive-create lock so piled-up serves don't stampede or double-delete. */
+export const GC_LOCK_FILE = 'gc.lock';
+
+/** At most one auto-GC across ALL serves per this window. */
+export const AUTO_GC_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/** A lock older than this is assumed abandoned by a crashed serve and reclaimed. */
+const STALE_LOCK_MS = 60 * 60 * 1000;
+
+export interface AutoGcOptions {
+  /** Index dirs to never touch (absolute paths; e.g. the serving project's). */
+  protectedDirs?: string[];
+  /** One-line logger used only when something was actually collected. */
+  log?: (message: string) => void;
+}
+
+/** Outcome of an auto-GC attempt (returned mainly for tests). */
+export interface AutoGcResult {
+  /** True if this call actually ran GC (acquired the lock, past the throttle). */
+  ran: boolean;
+  /** Why it did not run, when `ran` is false. */
+  reason?: 'disabled' | 'throttled' | 'locked';
+  summary?: GcSummary;
+}
+
+async function readStampMs(stampPath: string): Promise<number> {
+  try {
+    const raw = await fs.readFile(stampPath, 'utf-8');
+    const value = parseInt(raw.trim(), 10);
+    return Number.isNaN(value) ? 0 : value;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Try to grab the machine-wide GC lock via exclusive create. Returns a handle
+ * on success, or null when a peer holds it. Reclaims a lock left behind by a
+ * crashed serve once it is older than STALE_LOCK_MS.
+ */
+async function acquireLock(lockPath: string): Promise<fs.FileHandle | null> {
+  try {
+    return await fs.open(lockPath, 'wx');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') return null;
+    try {
+      const stat = await fs.stat(lockPath);
+      if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
+        await fs.rm(lockPath, { force: true });
+        return await fs.open(lockPath, 'wx'); // reclaim: retry once
+      }
+    } catch {
+      // lost a race with a peer that grabbed/removed it — treat as locked
+    }
+    return null;
+  }
+}
+
+async function releaseLock(handle: fs.FileHandle, lockPath: string): Promise<void> {
+  try {
+    await handle.close();
+  } catch {
+    // ignore
+  }
+  try {
+    await fs.rm(lockPath, { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+/** True when the throttle window has not yet elapsed since the last run. */
+async function isThrottled(stampPath: string): Promise<boolean> {
+  return Date.now() - (await readStampMs(stampPath)) < AUTO_GC_INTERVAL_MS;
+}
+
+/** Emit the single summary line, only when something was actually collected. */
+function logCollected(summary: GcSummary, log?: (message: string) => void): void {
+  if (summary.removedIndices === 0 && summary.sweptLanceDirs === 0) return;
+  const indices = `${summary.removedIndices} orphaned ${summary.removedIndices === 1 ? 'index' : 'indices'}`;
+  const lance =
+    summary.sweptLanceDirs > 0 ? ` + ${summary.sweptLanceDirs} legacy lance dir(s)` : '';
+  const freedMb = (summary.freedBytes / (1024 * 1024)).toFixed(1);
+  log?.(`[Lien] auto-GC: removed ${indices}${lance}, freed ${freedMb} MB`);
+}
+
+/**
+ * Run orphan GC + legacy lance sweep in the background on serve start — never
+ * stale GC (that stays opt-in via the CLI). Safe to fire-and-forget:
+ *
+ *  - Machine-wide throttle: at most once per ~24h across ALL serves, via a
+ *    stamp file plus an atomic exclusive-create lock in the lien home. Serves
+ *    demonstrably pile up (multiple per root), so they must not stampede or
+ *    double-delete — a peer already holding the lock simply no-ops here.
+ *  - Opt-out: `LIEN_AUTO_GC=off` (env only, KISS).
+ *  - Never throws — any failure resolves to `{ ran: false }`.
+ *
+ * Logs a single line only when something was collected; silent otherwise.
+ */
+export async function runAutoGc(options: AutoGcOptions = {}): Promise<AutoGcResult> {
+  if (process.env.LIEN_AUTO_GC === 'off') {
+    return { ran: false, reason: 'disabled' };
+  }
+
+  const lienDir = path.join(getLienHome(), '.lien');
+  const stampPath = path.join(lienDir, GC_STAMP_FILE);
+  const lockPath = path.join(lienDir, GC_LOCK_FILE);
+
+  try {
+    await fs.mkdir(lienDir, { recursive: true });
+
+    // Throttle check (cheap, lock-free) before contending for the lock.
+    if (await isThrottled(stampPath)) return { ran: false, reason: 'throttled' };
+
+    const lock = await acquireLock(lockPath);
+    if (!lock) return { ran: false, reason: 'locked' };
+
+    try {
+      // Re-check under the lock: a peer may have just finished.
+      if (await isThrottled(stampPath)) return { ran: false, reason: 'throttled' };
+
+      // Orphan + lance only. NEVER stale automatically.
+      const { summary } = await runGc({ protectedDirs: options.protectedDirs, dryRun: false });
+      await fs.writeFile(stampPath, Date.now().toString(), 'utf-8');
+      logCollected(summary, options.log);
+      return { ran: true, summary };
+    } finally {
+      await releaseLock(lock, lockPath);
+    }
+  } catch {
+    // Auto-GC is best-effort and must never disrupt serve.
+    return { ran: false, reason: 'locked' };
+  }
+}

--- a/packages/core/src/gc/dir-size.test.ts
+++ b/packages/core/src/gc/dir-size.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { computeDirSize, formatBytes } from './dir-size.js';
+
+describe('formatBytes', () => {
+  it('formats across units', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB');
+  });
+});
+
+describe('computeDirSize', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-dirsize-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('sums file sizes recursively', async () => {
+    await fs.writeFile(path.join(dir, 'a.txt'), 'x'.repeat(100));
+    await fs.mkdir(path.join(dir, 'sub'));
+    await fs.writeFile(path.join(dir, 'sub', 'b.txt'), 'y'.repeat(50));
+
+    expect(await computeDirSize(dir)).toBe(150);
+  });
+
+  it('returns 0 for a missing directory', async () => {
+    expect(await computeDirSize(path.join(dir, 'nope'))).toBe(0);
+  });
+});

--- a/packages/core/src/gc/dir-size.test.ts
+++ b/packages/core/src/gc/dir-size.test.ts
@@ -12,6 +12,12 @@ describe('formatBytes', () => {
     expect(formatBytes(1536)).toBe('1.5 KB');
     expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
     expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB');
+    expect(formatBytes(1024 * 1024 * 1024 * 1024)).toBe('1.0 TB');
+  });
+
+  it('rolls TB over into PB instead of rendering an out-of-range value', () => {
+    expect(formatBytes(1024 * 1024 * 1024 * 1024 * 1024)).toBe('1.0 PB');
+    expect(formatBytes(1536 * 1024 * 1024 * 1024 * 1024)).toBe('1.5 PB');
   });
 });
 

--- a/packages/core/src/gc/dir-size.ts
+++ b/packages/core/src/gc/dir-size.ts
@@ -40,14 +40,16 @@ export async function computeDirSize(dir: string): Promise<number> {
 
 /**
  * Format a byte count as a short human-readable string (e.g. "0 B", "512 B",
- * "1.5 KB", "136.4 MB", "2.0 GB").
+ * "1.5 KB", "136.4 MB", "2.0 GB"). Tops out at PB — index dirs never
+ * realistically get there, but the unit list still rolls over correctly
+ * instead of rendering an out-of-range value like "1024.0 TB".
  *
  * @param bytes - Byte count
  * @returns Formatted string
  */
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
-  const units = ['KB', 'MB', 'GB', 'TB'];
+  const units = ['KB', 'MB', 'GB', 'TB', 'PB'];
   let value = bytes / 1024;
   let unitIndex = 0;
   while (value >= 1024 && unitIndex < units.length - 1) {

--- a/packages/core/src/gc/dir-size.ts
+++ b/packages/core/src/gc/dir-size.ts
@@ -1,0 +1,58 @@
+import fs from 'fs/promises';
+import type { Dirent } from 'fs';
+import path from 'path';
+
+/**
+ * Recursively sum the byte size of every regular file under `dir`. Metadata
+ * only (no content reads), so it is cheap even for multi-GB index dirs. Missing
+ * or unreadable entries contribute 0 rather than throwing — size is reported
+ * for information, never a correctness input.
+ *
+ * @param dir - Directory to measure
+ * @returns Total size in bytes
+ */
+export async function computeDirSize(dir: string): Promise<number> {
+  let total = 0;
+
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) {
+        total += await computeDirSize(full);
+      } else if (entry.isFile()) {
+        const stat = await fs.stat(full);
+        total += stat.size;
+      }
+    } catch {
+      // Skip entries that vanish or can't be stat'd mid-walk.
+    }
+  }
+
+  return total;
+}
+
+/**
+ * Format a byte count as a short human-readable string (e.g. "0 B", "512 B",
+ * "1.5 KB", "136.4 MB", "2.0 GB").
+ *
+ * @param bytes - Byte count
+ * @returns Formatted string
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}

--- a/packages/core/src/gc/gc.test.ts
+++ b/packages/core/src/gc/gc.test.ts
@@ -7,7 +7,7 @@ import Database from 'better-sqlite3';
 import { openDatabase, STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
 import { planGc, executeGc, runGc, getIndicesRoot, LEGACY_LANCE_DIRNAME } from './gc.js';
 import { writeAccessStamp, readAccessStamp } from './access-stamp.js';
-import { isIndexLocked } from './live-handle.js';
+import { probeIndexLock } from './live-handle.js';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -186,7 +186,7 @@ describe('planGc — safety rails', () => {
     holder.pragma('busy_timeout = 0');
     holder.exec('BEGIN IMMEDIATE');
     try {
-      expect(isIndexLocked(dir)).toBe(true);
+      expect(probeIndexLock(dir)).toBe('locked');
 
       const plan = await planGc();
       expect(plan.removals.find(r => r.repoId === 'orphan-live')).toBeUndefined();
@@ -197,7 +197,7 @@ describe('planGc — safety rails', () => {
     }
 
     // Lock released → probe reports free again.
-    expect(isIndexLocked(dir)).toBe(false);
+    expect(probeIndexLock(dir)).toBe('unlocked');
   });
 
   it('never removes a protected (current-project) index', async () => {
@@ -219,5 +219,125 @@ describe('planGc — safety rails', () => {
 
     expect(plan.removals).toHaveLength(0);
     expect(plan.skipped.find(s => s.repoId === 'vol-1')?.reason).toBe('volume-offline');
+  });
+
+  it('recognizes Linux mount roots (/media, /mnt) split as POSIX paths regardless of host', async () => {
+    await makeIndex('media-1', {
+      sourceRoot: '/media/NonexistentDrive12345/project',
+      withDb: true,
+    });
+    await makeIndex('mnt-1', {
+      sourceRoot: '/mnt/NonexistentDrive12345/project',
+      withDb: true,
+    });
+
+    const plan = await planGc();
+
+    expect(plan.removals).toHaveLength(0);
+    expect(plan.skipped.find(s => s.repoId === 'media-1')?.reason).toBe('volume-offline');
+    expect(plan.skipped.find(s => s.repoId === 'mnt-1')?.reason).toBe('volume-offline');
+  });
+
+  it('does not misclassify an unrelated top-level dir as a mount root', async () => {
+    await makeIndex('unrelated-1', {
+      sourceRoot: goneRoot('unrelated/deep/nested'),
+      withDb: true,
+    });
+
+    const plan = await planGc();
+
+    // Not under /Volumes, /media, or /mnt — falls through to the ancestor-dir
+    // guard and, since `home` (the nearest existing ancestor) is a real dir,
+    // resolves as a genuine orphan rather than volume-offline.
+    expect(plan.removals.map(r => r.repoId)).toContain('unrelated-1');
+  });
+
+  it('skips an index whose structural store cannot be probed (fails closed)', async () => {
+    const dir = await makeIndex('unprobeable-1', {
+      sourceRoot: goneRoot('unprobeable'),
+      withDb: true,
+    });
+    const dbPath = path.join(dir, STRUCTURAL_DB_FILENAME);
+
+    if (process.getuid && process.getuid() === 0) {
+      // Running as root bypasses file permissions — chmod 000 is ineffective.
+      return;
+    }
+
+    await fs.chmod(dbPath, 0o000);
+    try {
+      expect(probeIndexLock(dir)).toBe('unprobeable');
+
+      const plan = await planGc();
+      expect(plan.removals.find(r => r.repoId === 'unprobeable-1')).toBeUndefined();
+      expect(plan.skipped.find(s => s.repoId === 'unprobeable-1')?.reason).toBe('unprobeable');
+    } finally {
+      await fs.chmod(dbPath, 0o600);
+    }
+  });
+});
+
+describe('classifyIndex — precedence', () => {
+  it('volume-offline outranks a locked structural store', async () => {
+    const dir = await makeIndex('vol-locked', {
+      sourceRoot: '/Volumes/NonexistentDrive99999/project',
+      withDb: true,
+    });
+    const holder = new Database(path.join(dir, STRUCTURAL_DB_FILENAME));
+    holder.pragma('busy_timeout = 0');
+    holder.exec('BEGIN IMMEDIATE');
+    try {
+      const plan = await planGc();
+      // volume-offline is decided before the lock is ever probed.
+      expect(plan.skipped.find(s => s.repoId === 'vol-locked')?.reason).toBe('volume-offline');
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
+    }
+  });
+
+  it('a live lock outranks an orphaned source root — never removed while locked', async () => {
+    const dir = await makeIndex('orphan-locked', {
+      sourceRoot: goneRoot('orphan-locked'),
+      withDb: true,
+    });
+    const holder = new Database(path.join(dir, STRUCTURAL_DB_FILENAME));
+    holder.pragma('busy_timeout = 0');
+    holder.exec('BEGIN IMMEDIATE');
+    try {
+      const plan = await planGc();
+      expect(plan.removals.find(r => r.repoId === 'orphan-locked')).toBeUndefined();
+      expect(plan.skipped.find(s => s.repoId === 'orphan-locked')?.reason).toBe('in-use');
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
+    }
+  });
+
+  it('--stale reclaims an unknown-provenance index once old enough, not before', async () => {
+    await makeIndex('legacy-not-old', { withDb: true, accessMs: Date.now() - 5 * DAY });
+    await makeIndex('legacy-old-enough', { withDb: true, accessMs: Date.now() - 90 * DAY });
+
+    const plan = await planGc({ staleDays: 60 });
+
+    expect(plan.skipped.find(s => s.repoId === 'legacy-not-old')?.reason).toBe(
+      'unknown-provenance',
+    );
+    const removal = plan.removals.find(r => r.repoId === 'legacy-old-enough');
+    expect(removal?.kind).toBe('stale');
+  });
+
+  it('a present-root index that is not old enough is labeled "present", never "stale"', async () => {
+    const root = await presentRoot('not-old-enough');
+    await makeIndex('present-not-old', {
+      sourceRoot: root,
+      withDb: true,
+      accessMs: Date.now() - 5 * DAY,
+    });
+
+    const plan = await planGc({ staleDays: 60 });
+
+    expect(plan.removals.find(r => r.repoId === 'present-not-old')).toBeUndefined();
+    expect(plan.skipped.find(s => s.repoId === 'present-not-old')?.reason).toBe('present');
   });
 });

--- a/packages/core/src/gc/gc.test.ts
+++ b/packages/core/src/gc/gc.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { openDatabase, STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
+import { planGc, executeGc, runGc, getIndicesRoot, LEGACY_LANCE_DIRNAME } from './gc.js';
+import { writeAccessStamp, readAccessStamp } from './access-stamp.js';
+import { isIndexLocked } from './live-handle.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+let originalHome: string | undefined;
+let home: string;
+
+interface FixtureOpts {
+  /** Absolute source root to record in the manifest (undefined = legacy manifest with no sourceRoot). */
+  sourceRoot?: string;
+  lastIndexed?: number;
+  withDb?: boolean;
+  lance?: boolean;
+  /** Access-stamp timestamp (epoch ms). */
+  accessMs?: number;
+}
+
+/** Create a fixture index directory under the sandbox indices root. */
+async function makeIndex(name: string, opts: FixtureOpts = {}): Promise<string> {
+  const dir = path.join(getIndicesRoot(), name);
+  await fs.mkdir(dir, { recursive: true });
+
+  const manifest: Record<string, unknown> = {
+    formatVersion: 5,
+    lienVersion: 'test',
+    lastIndexed: opts.lastIndexed ?? Date.now(),
+    files: {},
+  };
+  if (opts.sourceRoot) manifest.sourceRoot = opts.sourceRoot;
+  await fs.writeFile(path.join(dir, 'manifest.json'), JSON.stringify(manifest), 'utf-8');
+
+  if (opts.withDb) {
+    const db = openDatabase(path.join(dir, STRUCTURAL_DB_FILENAME));
+    db.close();
+  }
+  if (opts.lance) await fs.mkdir(path.join(dir, LEGACY_LANCE_DIRNAME), { recursive: true });
+  if (opts.accessMs !== undefined) {
+    await fs.writeFile(path.join(dir, '.lien-accessed'), String(opts.accessMs), 'utf-8');
+  }
+  return dir;
+}
+
+/** A present (existing) source root inside the sandbox home. */
+async function presentRoot(name: string): Promise<string> {
+  const root = path.join(home, 'roots', name);
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+/** A gone (non-existent) source root inside the sandbox home. */
+function goneRoot(name: string): string {
+  return path.join(home, 'gone', name);
+}
+
+beforeEach(async () => {
+  originalHome = process.env.LIEN_HOME;
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-gc-test-'));
+  process.env.LIEN_HOME = home;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.LIEN_HOME;
+  else process.env.LIEN_HOME = originalHome;
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+describe('planGc — orphan detection', () => {
+  it('flags an index whose source root is gone as orphan, keeps one whose root exists', async () => {
+    await makeIndex('orphan-1', { sourceRoot: goneRoot('deleted-repo'), withDb: true });
+    await makeIndex('present-1', { sourceRoot: await presentRoot('live-repo'), withDb: true });
+
+    const plan = await planGc();
+
+    expect(plan.removals.map(r => r.repoId)).toEqual(['orphan-1']);
+    expect(plan.removals[0].kind).toBe('orphan');
+    expect(plan.skipped.find(s => s.repoId === 'present-1')?.reason).toBe('present');
+  });
+
+  it('runGc deletes orphan dirs and reports freed space', async () => {
+    const dir = await makeIndex('orphan-real', { sourceRoot: goneRoot('gone-real'), withDb: true });
+
+    const { summary } = await runGc();
+
+    expect(summary.removedIndices).toBe(1);
+    expect(summary.dryRun).toBe(false);
+    expect(fsSync.existsSync(dir)).toBe(false);
+  });
+});
+
+describe('planGc — unknown provenance (legacy indices)', () => {
+  it('skips a legacy index with no recorded source root', async () => {
+    await makeIndex('legacy-1', { withDb: true });
+
+    const plan = await planGc();
+
+    expect(plan.removals).toHaveLength(0);
+    expect(plan.skipped.find(s => s.repoId === 'legacy-1')?.reason).toBe('unknown-provenance');
+  });
+
+  it('removes an unknown-provenance index only when --stale and old enough', async () => {
+    await makeIndex('legacy-old', { withDb: true, accessMs: Date.now() - 90 * DAY });
+
+    const plan = await planGc({ staleDays: 60 });
+
+    const removal = plan.removals.find(r => r.repoId === 'legacy-old');
+    expect(removal?.kind).toBe('stale');
+  });
+});
+
+describe('planGc — stale threshold + access stamp', () => {
+  it('honors the stale threshold using the access stamp', async () => {
+    const root = await presentRoot('shared');
+    await makeIndex('stale-1', { sourceRoot: root, withDb: true, accessMs: Date.now() - 90 * DAY });
+    await makeIndex('fresh-1', { sourceRoot: root, withDb: true, accessMs: Date.now() - 5 * DAY });
+
+    const plan = await planGc({ staleDays: 60 });
+
+    const removed = plan.removals.map(r => r.repoId);
+    expect(removed).toContain('stale-1');
+    expect(removed).not.toContain('fresh-1');
+    expect(plan.skipped.find(s => s.repoId === 'fresh-1')?.reason).toBe('present');
+  });
+
+  it('does not treat a present index as stale without the --stale opt-in', async () => {
+    const root = await presentRoot('old-but-no-optin');
+    await makeIndex('old-1', { sourceRoot: root, withDb: true, accessMs: Date.now() - 400 * DAY });
+
+    const plan = await planGc(); // no staleDays
+
+    expect(plan.removals).toHaveLength(0);
+  });
+
+  it('refreshes the access stamp on write', async () => {
+    const dir = await makeIndex('acc-1', { accessMs: 1000 });
+
+    await writeAccessStamp(dir);
+
+    const stamp = await readAccessStamp(dir);
+    expect(stamp).toBeGreaterThan(1000);
+  });
+});
+
+describe('planGc — legacy lance sweep', () => {
+  it('sweeps code_chunks.lance from a surviving index, keeping the index dir', async () => {
+    const root = await presentRoot('keep');
+    const dir = await makeIndex('keep-1', { sourceRoot: root, withDb: true, lance: true });
+
+    const plan = await planGc();
+    expect(plan.lanceSweeps.map(s => s.repoId)).toEqual(['keep-1']);
+
+    await executeGc(plan);
+
+    expect(fsSync.existsSync(path.join(dir, LEGACY_LANCE_DIRNAME))).toBe(false);
+    expect(fsSync.existsSync(dir)).toBe(true);
+  });
+});
+
+describe('executeGc — dry run', () => {
+  it('reports candidates but deletes nothing', async () => {
+    const dir = await makeIndex('orphan-dry', { sourceRoot: goneRoot('dry'), withDb: true });
+
+    const plan = await planGc({ dryRun: true });
+    const summary = await executeGc(plan, { dryRun: true });
+
+    expect(summary.dryRun).toBe(true);
+    expect(summary.removedIndices).toBe(1);
+    expect(fsSync.existsSync(dir)).toBe(true); // untouched
+  });
+});
+
+describe('planGc — safety rails', () => {
+  it('skips an index a live process holds open (BEGIN IMMEDIATE busy)', async () => {
+    const dir = await makeIndex('orphan-live', { sourceRoot: goneRoot('live'), withDb: true });
+
+    // Second connection holds the write lock, simulating a live serve/index.
+    const holder = new Database(path.join(dir, STRUCTURAL_DB_FILENAME));
+    holder.pragma('busy_timeout = 0');
+    holder.exec('BEGIN IMMEDIATE');
+    try {
+      expect(isIndexLocked(dir)).toBe(true);
+
+      const plan = await planGc();
+      expect(plan.removals.find(r => r.repoId === 'orphan-live')).toBeUndefined();
+      expect(plan.skipped.find(s => s.repoId === 'orphan-live')?.reason).toBe('in-use');
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
+    }
+
+    // Lock released → probe reports free again.
+    expect(isIndexLocked(dir)).toBe(false);
+  });
+
+  it('never removes a protected (current-project) index', async () => {
+    const dir = await makeIndex('orphan-prot', { sourceRoot: goneRoot('prot'), withDb: true });
+
+    const plan = await planGc({ protectedDirs: [dir] });
+
+    expect(plan.removals).toHaveLength(0);
+    expect(plan.skipped.find(s => s.repoId === 'orphan-prot')?.reason).toBe('current-project');
+  });
+
+  it('skips (does not orphan) an index whose source root is on an offline /Volumes mount', async () => {
+    await makeIndex('vol-1', {
+      sourceRoot: '/Volumes/NonexistentDrive12345/project',
+      withDb: true,
+    });
+
+    const plan = await planGc();
+
+    expect(plan.removals).toHaveLength(0);
+    expect(plan.skipped.find(s => s.repoId === 'vol-1')?.reason).toBe('volume-offline');
+  });
+});

--- a/packages/core/src/gc/gc.test.ts
+++ b/packages/core/src/gc/gc.test.ts
@@ -114,6 +114,26 @@ describe('planGc — unknown provenance (legacy indices)', () => {
     const removal = plan.removals.find(r => r.repoId === 'legacy-old');
     expect(removal?.kind).toBe('stale');
   });
+
+  it('treats a malformed (non-string) sourceRoot as unknown provenance instead of crashing', async () => {
+    // Regression test: readManifest used to cast JSON.parse() straight to
+    // Partial<IndexManifest> with no validation. A non-string sourceRoot would
+    // reach isSourceRootUnavailable's sourceRoot.split('/') and throw, aborting
+    // the entire GC run rather than just skipping this one index.
+    const dir = path.join(getIndicesRoot(), 'malformed-1');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'manifest.json'),
+      JSON.stringify({ formatVersion: 5, lienVersion: 'test', files: {}, sourceRoot: 12345 }),
+      'utf-8',
+    );
+    await makeIndex('present-2', { sourceRoot: await presentRoot('live-repo-2'), withDb: true });
+
+    const plan = await planGc();
+
+    expect(plan.skipped.find(s => s.repoId === 'malformed-1')?.reason).toBe('unknown-provenance');
+    expect(plan.skipped.find(s => s.repoId === 'present-2')?.reason).toBe('present');
+  });
 });
 
 describe('planGc — stale threshold + access stamp', () => {

--- a/packages/core/src/gc/gc.ts
+++ b/packages/core/src/gc/gc.ts
@@ -122,7 +122,13 @@ export async function enumerateIndexDirs(): Promise<string[]> {
 async function readManifest(indexDir: string): Promise<Partial<IndexManifest> | null> {
   try {
     const raw = await fs.readFile(path.join(indexDir, MANIFEST_FILE), 'utf-8');
-    return JSON.parse(raw) as Partial<IndexManifest>;
+    const parsed = JSON.parse(raw) as Partial<IndexManifest>;
+    // A malformed sourceRoot (wrong type) must not crash the whole GC run in
+    // analyzeProvenance — treat it as unrecorded (unknown provenance) instead.
+    if (parsed.sourceRoot !== undefined && typeof parsed.sourceRoot !== 'string') {
+      return { ...parsed, sourceRoot: undefined };
+    }
+    return parsed;
   } catch {
     return null;
   }

--- a/packages/core/src/gc/gc.ts
+++ b/packages/core/src/gc/gc.ts
@@ -5,7 +5,7 @@ import { readVersionFile } from '../vectordb/version.js';
 import type { IndexManifest } from '../indexer/manifest.js';
 import { readAccessStamp } from './access-stamp.js';
 import { computeDirSize } from './dir-size.js';
-import { isIndexLocked } from './live-handle.js';
+import { probeIndexLock } from './live-handle.js';
 
 const MANIFEST_FILE = 'manifest.json';
 
@@ -26,6 +26,7 @@ export type GcRemovalKind = 'orphan' | 'stale';
 export type GcSkipReason =
   | 'current-project' // the cwd's own project — never deleted
   | 'in-use' // a live process holds its structural store open
+  | 'unprobeable' // couldn't verify the store is free — fail closed, skip
   | 'volume-offline' // source root's backing volume is unavailable (not orphan)
   | 'unknown-provenance' // legacy index with no recorded source root
   | 'present'; // source root still exists on disk
@@ -144,23 +145,34 @@ async function isDirectory(p: string): Promise<boolean> {
   }
 }
 
+/** Well-known removable-media mount-root prefixes, checked as POSIX ('/'-
+ *  separated) paths regardless of the host OS's `path.sep` — a manifest's
+ *  `sourceRoot` is a recorded string that may have been captured on a
+ *  different OS than the one GC is currently running on (e.g. a macOS
+ *  `/Volumes/...` path inspected from a Linux CI runner). */
+const MOUNT_ROOT_PREFIXES = ['Volumes', 'media', 'mnt'] as const;
+
 /**
  * Whether a missing source root sits on a currently-unavailable volume rather
  * than having been deleted — the pragmatic mitigation against the
  * unmounted-drive false positive.
  *
  * Two guards (documented design choice):
- *  1. macOS external drives mount at `/Volumes/<name>`; if the source root is
- *     under one and that mount point is absent, the drive is unplugged.
+ *  1. Removable-media mount roots (macOS `/Volumes/<name>`, Linux
+ *     `/media/<name>`, `/mnt/<name>`); if the source root is under one and
+ *     that mount point is absent, the drive is unplugged.
  *  2. General: we only trust a "gone" verdict when the nearest EXISTING
  *     ancestor is a real directory. If the nearest existing ancestor is the
  *     filesystem root (an entire network/volume mount vanished), we decline.
  */
 async function isSourceRootUnavailable(sourceRoot: string): Promise<boolean> {
-  // Guard 1: macOS /Volumes mount check.
-  const segments = sourceRoot.split(path.sep);
-  if (segments[1] === 'Volumes' && segments[2]) {
-    const mountPoint = path.join(path.sep, 'Volumes', segments[2]);
+  // Guard 1: removable-media mount-root check. Always split on '/' — the
+  // recorded path's separator reflects where it was captured, not the host
+  // GC is running on.
+  const segments = sourceRoot.split('/');
+  const mountRoot = segments[1];
+  if (mountRoot && (MOUNT_ROOT_PREFIXES as readonly string[]).includes(mountRoot) && segments[2]) {
+    const mountPoint = `/${mountRoot}/${segments[2]}`;
     if (!(await pathExists(mountPoint))) return true;
   }
 
@@ -222,13 +234,25 @@ interface ClassifyContext {
   protectedSet: Set<string>;
 }
 
-/** Decide the fate of a single index dir. Never deletes — pure decision. */
+/**
+ * Decide the fate of a single index dir. Never deletes — pure decision.
+ *
+ * Precedence is deliberate and deletion-safety-first:
+ *   current-project > volume-offline > live-handle-locked/unprobeable >
+ *   orphan > stale (age-eligible, regardless of provenance) > skip-with-reason.
+ *
+ * volume-offline is checked before the lock probe because it is itself a skip
+ * (never a removal), so nothing unsafe happens by not probing the lock first.
+ * The lock probe then runs before orphan/stale so a live process always wins
+ * over any removal reason, even an orphaned source root. Stale eligibility is
+ * evaluated identically for 'present' and 'unknown' provenance — --stale must
+ * be able to reclaim a legacy (unknown-provenance) index once it is actually
+ * old enough, not just a present-root one; provenance only decides the *label*
+ * when an index is left in place because it isn't old enough yet.
+ */
 async function classifyIndex(indexDir: string, ctx: ClassifyContext): Promise<Classification> {
   if (ctx.protectedSet.has(path.resolve(indexDir))) {
     return { type: 'skip', reason: 'current-project', detail: 'current project' };
-  }
-  if (isIndexLocked(indexDir)) {
-    return { type: 'skip', reason: 'in-use', detail: 'held open by a live process' };
   }
 
   const manifest = await readManifest(indexDir);
@@ -242,6 +266,19 @@ async function classifyIndex(indexDir: string, ctx: ClassifyContext): Promise<Cl
       detail: `source root on an unavailable volume: ${sourceRoot}`,
     };
   }
+
+  const lockProbe = probeIndexLock(indexDir);
+  if (lockProbe === 'locked') {
+    return { type: 'skip', reason: 'in-use', detail: 'held open by a live process' };
+  }
+  if (lockProbe === 'unprobeable') {
+    return {
+      type: 'skip',
+      reason: 'unprobeable',
+      detail: 'could not verify the structural store is free — skipping to be safe',
+    };
+  }
+
   if (provenance === 'orphan') {
     return {
       type: 'remove',
@@ -250,7 +287,7 @@ async function classifyIndex(indexDir: string, ctx: ClassifyContext): Promise<Cl
     };
   }
 
-  // 'present' or 'unknown' → removable only via --stale.
+  // 'present' or 'unknown' → age-eligible removal only via --stale.
   if (ctx.staleDays !== undefined) {
     const lastAccess = await resolveLastAccess(indexDir, manifest);
     const ageDays = Math.floor((ctx.now - lastAccess) / DAY_MS);

--- a/packages/core/src/gc/gc.ts
+++ b/packages/core/src/gc/gc.ts
@@ -1,0 +1,376 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getLienHome } from '@liendev/parser';
+import { readVersionFile } from '../vectordb/version.js';
+import type { IndexManifest } from '../indexer/manifest.js';
+import { readAccessStamp } from './access-stamp.js';
+import { computeDirSize } from './dir-size.js';
+import { isIndexLocked } from './live-handle.js';
+
+const MANIFEST_FILE = 'manifest.json';
+
+/** Legacy LanceDB chunk store, dead weight since the embeddings/LanceDB removal
+ *  (#661). No code writes or reads it anymore — safe to sweep from surviving
+ *  index dirs to reclaim disk. */
+export const LEGACY_LANCE_DIRNAME = 'code_chunks.lance';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Default staleness window for `lien gc --stale` when no value is given. */
+export const DEFAULT_STALE_DAYS = 60;
+
+/** Why an index dir is scheduled for removal. */
+export type GcRemovalKind = 'orphan' | 'stale';
+
+/** Why a surviving index dir was left in place. */
+export type GcSkipReason =
+  | 'current-project' // the cwd's own project — never deleted
+  | 'in-use' // a live process holds its structural store open
+  | 'volume-offline' // source root's backing volume is unavailable (not orphan)
+  | 'unknown-provenance' // legacy index with no recorded source root
+  | 'present'; // source root still exists on disk
+
+/** An index directory scheduled for whole-directory removal. */
+export interface GcRemoval {
+  /** Absolute path of the index directory. */
+  dir: string;
+  /** repoId (directory basename under `indices/`). */
+  repoId: string;
+  kind: GcRemovalKind;
+  /** Human-readable explanation for the report. */
+  detail: string;
+  /** Bytes that will be freed by removing this directory. */
+  sizeBytes: number;
+}
+
+/** A legacy `code_chunks.lance` directory to sweep from a surviving index dir. */
+export interface GcLanceSweep {
+  /** Absolute path of the `code_chunks.lance` directory. */
+  dir: string;
+  /** repoId of the parent index directory. */
+  repoId: string;
+  sizeBytes: number;
+}
+
+/** A surviving index directory and why it was skipped. */
+export interface GcSkip {
+  dir: string;
+  repoId: string;
+  reason: GcSkipReason;
+  detail: string;
+}
+
+/** The set of actions GC would take. Pure data — computed without deleting. */
+export interface GcPlan {
+  indicesRoot: string;
+  removals: GcRemoval[];
+  lanceSweeps: GcLanceSweep[];
+  skipped: GcSkip[];
+}
+
+/** Outcome of executing (or previewing) a GC plan. */
+export interface GcSummary {
+  removedIndices: number;
+  sweptLanceDirs: number;
+  freedBytes: number;
+  skipped: number;
+  dryRun: boolean;
+}
+
+/** Plan + execution outcome. */
+export interface GcResult {
+  plan: GcPlan;
+  summary: GcSummary;
+}
+
+export interface GcOptions {
+  /**
+   * Also remove indices not accessed within this many days. Opt-in — when
+   * undefined, only orphaned indices are removed. Legacy "unknown provenance"
+   * and present-root indices are removable ONLY via this option.
+   */
+  staleDays?: number;
+  /** Index directories to never touch (absolute paths; e.g. the cwd's own). */
+  protectedDirs?: string[];
+  /** Preview only — executeGc deletes nothing when true. */
+  dryRun?: boolean;
+  /** Clock injection for deterministic tests. */
+  now?: number;
+}
+
+/** The indices root Lien enumerates for GC: `<LIEN_HOME>/.lien/indices`. */
+export function getIndicesRoot(): string {
+  return path.join(getLienHome(), '.lien', 'indices');
+}
+
+/** List repoId directory names directly under the indices root. */
+export async function enumerateIndexDirs(): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(getIndicesRoot(), { withFileTypes: true });
+    return entries.filter(e => e.isDirectory()).map(e => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read an index dir's manifest.json directly (NOT via ManifestManager, whose
+ * load() deletes the manifest on a format-version mismatch — GC must never
+ * mutate the indices it inspects).
+ */
+async function readManifest(indexDir: string): Promise<Partial<IndexManifest> | null> {
+  try {
+    const raw = await fs.readFile(path.join(indexDir, MANIFEST_FILE), 'utf-8');
+    return JSON.parse(raw) as Partial<IndexManifest>;
+  } catch {
+    return null;
+  }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(p: string): Promise<boolean> {
+  try {
+    return (await fs.stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether a missing source root sits on a currently-unavailable volume rather
+ * than having been deleted — the pragmatic mitigation against the
+ * unmounted-drive false positive.
+ *
+ * Two guards (documented design choice):
+ *  1. macOS external drives mount at `/Volumes/<name>`; if the source root is
+ *     under one and that mount point is absent, the drive is unplugged.
+ *  2. General: we only trust a "gone" verdict when the nearest EXISTING
+ *     ancestor is a real directory. If the nearest existing ancestor is the
+ *     filesystem root (an entire network/volume mount vanished), we decline.
+ */
+async function isSourceRootUnavailable(sourceRoot: string): Promise<boolean> {
+  // Guard 1: macOS /Volumes mount check.
+  const segments = sourceRoot.split(path.sep);
+  if (segments[1] === 'Volumes' && segments[2]) {
+    const mountPoint = path.join(path.sep, 'Volumes', segments[2]);
+    if (!(await pathExists(mountPoint))) return true;
+  }
+
+  // Guard 2: nearest existing ancestor must be a real directory.
+  const root = path.parse(sourceRoot).root;
+  let dir = path.dirname(sourceRoot);
+  while (dir !== root) {
+    if (await pathExists(dir)) {
+      return !(await isDirectory(dir)); // ancestor exists but isn't a dir → unsafe
+    }
+    dir = path.dirname(dir);
+  }
+  // Nearest existing ancestor is the filesystem root only → an entire mount is
+  // missing; decline to treat as a confident orphan.
+  return true;
+}
+
+type Provenance = 'orphan' | 'offline' | 'present' | 'unknown';
+
+async function analyzeProvenance(sourceRoot: string | undefined): Promise<Provenance> {
+  if (!sourceRoot) return 'unknown';
+  if (await pathExists(sourceRoot)) return 'present';
+  if (await isSourceRootUnavailable(sourceRoot)) return 'offline';
+  return 'orphan';
+}
+
+/**
+ * Resolve when an index was last used. Prefers the access stamp (written on
+ * serve start); falls back to the newest of manifest.lastIndexed, the version
+ * file, and the directory mtime so legacy indices without a stamp still have a
+ * sensible staleness signal.
+ */
+async function resolveLastAccess(
+  indexDir: string,
+  manifest: Partial<IndexManifest> | null,
+): Promise<number> {
+  const stamp = await readAccessStamp(indexDir);
+  if (stamp !== null) return stamp;
+
+  const candidates: number[] = [];
+  if (typeof manifest?.lastIndexed === 'number') candidates.push(manifest.lastIndexed);
+  const version = await readVersionFile(indexDir);
+  if (version > 0) candidates.push(version);
+  try {
+    candidates.push((await fs.stat(indexDir)).mtimeMs);
+  } catch {
+    // ignore
+  }
+  return candidates.length > 0 ? Math.max(...candidates) : 0;
+}
+
+type Classification =
+  | { type: 'remove'; kind: GcRemovalKind; detail: string }
+  | { type: 'skip'; reason: GcSkipReason; detail: string };
+
+interface ClassifyContext {
+  now: number;
+  staleDays?: number;
+  protectedSet: Set<string>;
+}
+
+/** Decide the fate of a single index dir. Never deletes — pure decision. */
+async function classifyIndex(indexDir: string, ctx: ClassifyContext): Promise<Classification> {
+  if (ctx.protectedSet.has(path.resolve(indexDir))) {
+    return { type: 'skip', reason: 'current-project', detail: 'current project' };
+  }
+  if (isIndexLocked(indexDir)) {
+    return { type: 'skip', reason: 'in-use', detail: 'held open by a live process' };
+  }
+
+  const manifest = await readManifest(indexDir);
+  const sourceRoot = manifest?.sourceRoot;
+  const provenance = await analyzeProvenance(sourceRoot);
+
+  if (provenance === 'offline') {
+    return {
+      type: 'skip',
+      reason: 'volume-offline',
+      detail: `source root on an unavailable volume: ${sourceRoot}`,
+    };
+  }
+  if (provenance === 'orphan') {
+    return {
+      type: 'remove',
+      kind: 'orphan',
+      detail: `source root no longer exists: ${sourceRoot}`,
+    };
+  }
+
+  // 'present' or 'unknown' → removable only via --stale.
+  if (ctx.staleDays !== undefined) {
+    const lastAccess = await resolveLastAccess(indexDir, manifest);
+    const ageDays = Math.floor((ctx.now - lastAccess) / DAY_MS);
+    if (ageDays > ctx.staleDays) {
+      return { type: 'remove', kind: 'stale', detail: `not accessed in ${ageDays}d` };
+    }
+  }
+
+  if (provenance === 'unknown') {
+    return {
+      type: 'skip',
+      reason: 'unknown-provenance',
+      detail: 'no recorded source root (legacy index)',
+    };
+  }
+  return { type: 'skip', reason: 'present', detail: `source root exists: ${sourceRoot}` };
+}
+
+/**
+ * Build the GC plan: classify every index dir into a removal or a skip, and
+ * queue legacy lance sweeps on surviving dirs. Computes sizes only for the
+ * things that free space (removals + lance dirs), keeping the scan cheap.
+ */
+export async function planGc(options: GcOptions = {}): Promise<GcPlan> {
+  const now = options.now ?? Date.now();
+  const protectedSet = new Set((options.protectedDirs ?? []).map(d => path.resolve(d)));
+  const indicesRoot = getIndicesRoot();
+  const names = await enumerateIndexDirs();
+
+  const removals: GcRemoval[] = [];
+  const lanceSweeps: GcLanceSweep[] = [];
+  const skipped: GcSkip[] = [];
+
+  for (const repoId of names) {
+    const dir = path.join(indicesRoot, repoId);
+    const decision = await classifyIndex(dir, { now, staleDays: options.staleDays, protectedSet });
+
+    if (decision.type === 'remove') {
+      removals.push({
+        dir,
+        repoId,
+        kind: decision.kind,
+        detail: decision.detail,
+        sizeBytes: await computeDirSize(dir),
+      });
+      continue;
+    }
+
+    skipped.push({ dir, repoId, reason: decision.reason, detail: decision.detail });
+
+    // Surviving dir: sweep a leftover legacy lance store if present.
+    const lanceDir = path.join(dir, LEGACY_LANCE_DIRNAME);
+    if (await isDirectory(lanceDir)) {
+      lanceSweeps.push({ dir: lanceDir, repoId, sizeBytes: await computeDirSize(lanceDir) });
+    }
+  }
+
+  return { indicesRoot, removals, lanceSweeps, skipped };
+}
+
+/**
+ * Execute a plan (or preview it under dryRun). Deletions happen one directory
+ * at a time with explicit absolute paths — never a glob — and a failed delete
+ * is counted as not-freed rather than aborting the run.
+ */
+export async function executeGc(plan: GcPlan, options: GcOptions = {}): Promise<GcSummary> {
+  const dryRun = options.dryRun ?? false;
+
+  if (dryRun) {
+    const freedBytes =
+      sumSizes(plan.removals) + plan.lanceSweeps.reduce((n, s) => n + s.sizeBytes, 0);
+    return {
+      removedIndices: plan.removals.length,
+      sweptLanceDirs: plan.lanceSweeps.length,
+      freedBytes,
+      skipped: plan.skipped.length,
+      dryRun: true,
+    };
+  }
+
+  let removedIndices = 0;
+  let sweptLanceDirs = 0;
+  let freedBytes = 0;
+
+  for (const removal of plan.removals) {
+    try {
+      await fs.rm(removal.dir, { recursive: true, force: true });
+      removedIndices++;
+      freedBytes += removal.sizeBytes;
+    } catch {
+      // Leave it for the next run rather than aborting the whole GC.
+    }
+  }
+
+  for (const sweep of plan.lanceSweeps) {
+    try {
+      await fs.rm(sweep.dir, { recursive: true, force: true });
+      sweptLanceDirs++;
+      freedBytes += sweep.sizeBytes;
+    } catch {
+      // best-effort
+    }
+  }
+
+  return {
+    removedIndices,
+    sweptLanceDirs,
+    freedBytes,
+    skipped: plan.skipped.length,
+    dryRun: false,
+  };
+}
+
+function sumSizes(removals: GcRemoval[]): number {
+  return removals.reduce((n, r) => n + r.sizeBytes, 0);
+}
+
+/** Convenience: plan then execute (respecting dryRun). */
+export async function runGc(options: GcOptions = {}): Promise<GcResult> {
+  const plan = await planGc(options);
+  const summary = await executeGc(plan, options);
+  return { plan, summary };
+}

--- a/packages/core/src/gc/index.ts
+++ b/packages/core/src/gc/index.ts
@@ -38,5 +38,6 @@ export { runAutoGc, AUTO_GC_INTERVAL_MS, GC_STAMP_FILE, GC_LOCK_FILE } from './a
 export type { AutoGcOptions, AutoGcResult } from './auto-gc.js';
 
 export { writeAccessStamp, readAccessStamp, ACCESS_STAMP_FILE } from './access-stamp.js';
-export { isIndexLocked } from './live-handle.js';
+export { probeIndexLock } from './live-handle.js';
+export type { LockProbeResult } from './live-handle.js';
 export { computeDirSize, formatBytes } from './dir-size.js';

--- a/packages/core/src/gc/index.ts
+++ b/packages/core/src/gc/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Index garbage collection.
+ *
+ * `~/.lien/indices` accumulates one directory per project root ever opened and
+ * nothing removes them. This module reclaims that space:
+ *  - orphan GC: an index whose recorded source root no longer exists on disk,
+ *  - legacy lance sweep: dead `code_chunks.lance` dirs left by the removed
+ *    LanceDB backend (#661),
+ *  - stale GC (opt-in): indices not accessed within N days.
+ *
+ * The `lien gc` CLI command and the throttled serve-start auto-GC both build on
+ * the engine here. Post-embeddings a full reindex is seconds with zero
+ * downloads, so reclaiming is nearly free — GC can be aggressive by design.
+ */
+
+export {
+  planGc,
+  executeGc,
+  runGc,
+  getIndicesRoot,
+  enumerateIndexDirs,
+  LEGACY_LANCE_DIRNAME,
+  DEFAULT_STALE_DAYS,
+} from './gc.js';
+export type {
+  GcOptions,
+  GcPlan,
+  GcResult,
+  GcSummary,
+  GcRemoval,
+  GcRemovalKind,
+  GcLanceSweep,
+  GcSkip,
+  GcSkipReason,
+} from './gc.js';
+
+export { runAutoGc, AUTO_GC_INTERVAL_MS, GC_STAMP_FILE, GC_LOCK_FILE } from './auto-gc.js';
+export type { AutoGcOptions, AutoGcResult } from './auto-gc.js';
+
+export { writeAccessStamp, readAccessStamp, ACCESS_STAMP_FILE } from './access-stamp.js';
+export { isIndexLocked } from './live-handle.js';
+export { computeDirSize, formatBytes } from './dir-size.js';

--- a/packages/core/src/gc/live-handle.ts
+++ b/packages/core/src/gc/live-handle.ts
@@ -16,6 +16,12 @@ function isSqliteBusy(error: unknown): boolean {
  *  peer's in-flight write. */
 const PROBE_BUSY_TIMEOUT_MS = 200;
 
+/** Outcome of probing an index's structural store for a live writer. */
+export type LockProbeResult =
+  | 'unlocked' // BEGIN IMMEDIATE + ROLLBACK succeeded — safe to reclaim
+  | 'locked' // SQLITE_BUSY — a live process holds the write lock
+  | 'unprobeable'; // any other error — can't tell, so don't risk it
+
 /**
  * Detect whether a live process (a `lien serve`, watcher, or concurrent index)
  * currently holds the index's structural store open for writing, so GC can skip
@@ -23,18 +29,19 @@ const PROBE_BUSY_TIMEOUT_MS = 200;
  *
  * Follows the #682 busy-skip philosophy: open a *writable* connection with a
  * short busy timeout and attempt `BEGIN IMMEDIATE` (the write-lock acquisition).
- * A `SQLITE_BUSY` means a peer holds the lock → treat as in use. Any other
- * outcome (lock acquired, no db file, or an unrelated/corrupt-db error) is
- * treated as NOT locked so a genuinely orphaned index can still be reclaimed.
+ * A `SQLITE_BUSY` means a peer holds the lock. Deletion safety fails CLOSED:
+ * any OTHER error (permission denied, read-only filesystem, corrupt db) is
+ * 'unprobeable' rather than 'unlocked' — GC must not delete a store it
+ * couldn't actually verify is free.
  *
  * @param indexDir - Path to the index directory
- * @returns true if a live process holds the write lock (skip GC)
+ * @returns the probe outcome; only 'unlocked' clears the index for GC
  */
-export function isIndexLocked(indexDir: string): boolean {
+export function probeIndexLock(indexDir: string): LockProbeResult {
   const dbFilePath = path.join(indexDir, STRUCTURAL_DB_FILENAME);
 
   // No structural store (e.g. a legacy lance-only dir) → nothing holds it.
-  if (!fs.existsSync(dbFilePath)) return false;
+  if (!fs.existsSync(dbFilePath)) return 'unlocked';
 
   let db: Database.Database | undefined;
   try {
@@ -44,11 +51,10 @@ export function isIndexLocked(indexDir: string): boolean {
     // busy timeout throws SQLITE_BUSY.
     db.exec('BEGIN IMMEDIATE');
     db.exec('ROLLBACK');
-    return false;
+    return 'unlocked';
   } catch (error) {
-    if (isSqliteBusy(error)) return true; // a live process is writing — skip
-    // Can't tell / not a usable db — don't let that block reclaiming an orphan.
-    return false;
+    if (isSqliteBusy(error)) return 'locked'; // a live process is writing — skip
+    return 'unprobeable'; // couldn't open/query it — fail closed, skip
   } finally {
     try {
       db?.close();

--- a/packages/core/src/gc/live-handle.ts
+++ b/packages/core/src/gc/live-handle.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
+
+/** Lock-contention error codes `BEGIN IMMEDIATE` raises when another process
+ *  holds the structural store's write lock past the busy timeout. Mirrors the
+ *  busy-skip classifier the overlay rebuild path uses (see #682). */
+function isSqliteBusy(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  const code = (error as { code: unknown }).code;
+  return code === 'SQLITE_BUSY' || code === 'SQLITE_BUSY_SNAPSHOT';
+}
+
+/** Short busy timeout for the probe — fail fast rather than block GC on a
+ *  peer's in-flight write. */
+const PROBE_BUSY_TIMEOUT_MS = 200;
+
+/**
+ * Detect whether a live process (a `lien serve`, watcher, or concurrent index)
+ * currently holds the index's structural store open for writing, so GC can skip
+ * it and never delete a store out from under an active process.
+ *
+ * Follows the #682 busy-skip philosophy: open a *writable* connection with a
+ * short busy timeout and attempt `BEGIN IMMEDIATE` (the write-lock acquisition).
+ * A `SQLITE_BUSY` means a peer holds the lock → treat as in use. Any other
+ * outcome (lock acquired, no db file, or an unrelated/corrupt-db error) is
+ * treated as NOT locked so a genuinely orphaned index can still be reclaimed.
+ *
+ * @param indexDir - Path to the index directory
+ * @returns true if a live process holds the write lock (skip GC)
+ */
+export function isIndexLocked(indexDir: string): boolean {
+  const dbFilePath = path.join(indexDir, STRUCTURAL_DB_FILENAME);
+
+  // No structural store (e.g. a legacy lance-only dir) → nothing holds it.
+  if (!fs.existsSync(dbFilePath)) return false;
+
+  let db: Database.Database | undefined;
+  try {
+    db = new Database(dbFilePath);
+    db.pragma(`busy_timeout = ${PROBE_BUSY_TIMEOUT_MS}`);
+    // BEGIN IMMEDIATE takes the write lock up front; a peer holding it past the
+    // busy timeout throws SQLITE_BUSY.
+    db.exec('BEGIN IMMEDIATE');
+    db.exec('ROLLBACK');
+    return false;
+  } catch (error) {
+    if (isSqliteBusy(error)) return true; // a live process is writing — skip
+    // Can't tell / not a usable db — don't let that block reclaiming an orphan.
+    return false;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore close failures
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,43 @@ export type { RelevanceCategory } from './vectordb/relevance.js';
 export { readVersionFile, writeVersionFile } from './vectordb/version.js';
 
 // =============================================================================
+// INDEX GARBAGE COLLECTION
+// =============================================================================
+
+export {
+  planGc,
+  executeGc,
+  runGc,
+  runAutoGc,
+  getIndicesRoot,
+  enumerateIndexDirs,
+  writeAccessStamp,
+  readAccessStamp,
+  isIndexLocked,
+  computeDirSize,
+  formatBytes,
+  LEGACY_LANCE_DIRNAME,
+  DEFAULT_STALE_DAYS,
+  AUTO_GC_INTERVAL_MS,
+  GC_STAMP_FILE,
+  GC_LOCK_FILE,
+  ACCESS_STAMP_FILE,
+} from './gc/index.js';
+export type {
+  GcOptions,
+  GcPlan,
+  GcResult,
+  GcSummary,
+  GcRemoval,
+  GcRemovalKind,
+  GcLanceSweep,
+  GcSkip,
+  GcSkipReason,
+  AutoGcOptions,
+  AutoGcResult,
+} from './gc/index.js';
+
+// =============================================================================
 // COMPLEXITY ANALYSIS
 // =============================================================================
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,7 +87,7 @@ export {
   enumerateIndexDirs,
   writeAccessStamp,
   readAccessStamp,
-  isIndexLocked,
+  probeIndexLock,
   computeDirSize,
   formatBytes,
   LEGACY_LANCE_DIRNAME,
@@ -109,6 +109,7 @@ export type {
   GcSkipReason,
   AutoGcOptions,
   AutoGcResult,
+  LockProbeResult,
 } from './gc/index.js';
 
 // =============================================================================

--- a/packages/core/src/indexer/index.test.ts
+++ b/packages/core/src/indexer/index.test.ts
@@ -37,6 +37,16 @@ describe('indexCodebase (lexical FTS5 structural index)', () => {
     expect(result.chunksCreated).toBeGreaterThan(0);
   });
 
+  it('records the source root in the manifest (GC provenance)', async () => {
+    await indexCodebase({ rootDir: testDir, force: true });
+
+    const db = await createVectorDB(testDir);
+    const manifestPath = path.join(db.dbPath, 'manifest.json');
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8'));
+
+    expect(manifest.sourceRoot).toBe(path.resolve(testDir));
+  });
+
   it('persists chunks with real structural metadata (imports/exports/symbolName)', async () => {
     const result = await indexCodebase({ rootDir: testDir, force: true });
     expect(result.success).toBe(true);

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -122,13 +122,19 @@ export async function scanFilesToIndex(rootDir: string): Promise<string[]> {
 }
 
 /**
- * Update git state after indexing (if in a git repo).
+ * Finalize the manifest after indexing: record provenance (the absolute source
+ * root, so `lien gc` can detect orphaned indices) and, when in a git repo, the
+ * current git state.
  */
-async function updateGitState(
+async function finalizeManifest(
   rootDir: string,
   vectorDB: VectorDBInterface,
   manifest: ManifestManager,
 ): Promise<void> {
+  // Provenance: always record the absolute root this index was built from,
+  // regardless of git — orphan GC depends on it.
+  await manifest.recordSourceRoot(path.resolve(rootDir));
+
   const gitAvailable = await isGitAvailable();
   const isRepo = await isGitRepo(rootDir);
 
@@ -268,7 +274,7 @@ async function tryIncrementalIndex(
   // Fast path: deletions-only — no need to initialize embeddings
   if (totalChanges === 0 && totalDeleted > 0) {
     await handleDeletions(changes.deleted, vectorDB, manifest);
-    await updateGitState(rootDir, vectorDB, manifest);
+    await finalizeManifest(rootDir, vectorDB, manifest);
 
     options.onProgress?.({
       phase: 'complete',
@@ -300,7 +306,7 @@ async function tryIncrementalIndex(
     rootDir,
   );
 
-  await updateGitState(rootDir, vectorDB, manifest);
+  await finalizeManifest(rootDir, vectorDB, manifest);
 
   options.onProgress?.({
     phase: 'complete',
@@ -420,7 +426,7 @@ async function saveIndexResults(
   );
 
   // Save git state if in a git repo
-  await updateGitState(rootDir, vectorDB, manifest);
+  await finalizeManifest(rootDir, vectorDB, manifest);
 
   // Write version file to mark successful completion
   await writeVersionFile(vectorDB.dbPath);

--- a/packages/core/src/indexer/manifest.test.ts
+++ b/packages/core/src/indexer/manifest.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
 import { ManifestManager } from './manifest.js';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
 
@@ -72,6 +74,29 @@ describe('ManifestManager', () => {
       const manifest = await manifestManager.load();
       expect(manifest?.sourceRoot).toBe('/abs/project/root');
       expect(manifest?.files['test.ts']).toBeTruthy();
+    });
+
+    it('no-ops on a format-version mismatch instead of wiping the files map', async () => {
+      // Regression test: recordSourceRoot used to fall back to load() || createEmpty(),
+      // and load() clears an incompatible-format manifest and returns null — so
+      // recordSourceRoot would write back a fresh, empty files map on top of an
+      // otherwise-valid legacy index.
+      const manifestPath = path.join(testDir, 'manifest.json');
+      const legacyManifest = {
+        formatVersion: 1, // stale relative to current INDEX_FORMAT_VERSION
+        lienVersion: 'old',
+        lastIndexed: Date.now(),
+        files: { 'kept.ts': { filepath: 'kept.ts', lastModified: Date.now(), chunkCount: 7 } },
+      };
+      await fs.writeFile(manifestPath, JSON.stringify(legacyManifest), 'utf-8');
+
+      await manifestManager.recordSourceRoot('/abs/project/root');
+
+      // No-op: the incompatible manifest is left exactly as-is on disk — not
+      // cleared, not overwritten with an empty files map.
+      const onDisk = JSON.parse(await fs.readFile(manifestPath, 'utf-8'));
+      expect(onDisk.files['kept.ts']).toBeTruthy();
+      expect(onDisk.sourceRoot).toBeUndefined();
     });
   });
 

--- a/packages/core/src/indexer/manifest.test.ts
+++ b/packages/core/src/indexer/manifest.test.ts
@@ -55,6 +55,26 @@ describe('ManifestManager', () => {
     });
   });
 
+  describe('recordSourceRoot', () => {
+    it('records the source root on a fresh manifest (GC provenance)', async () => {
+      await manifestManager.recordSourceRoot('/abs/project/root');
+
+      const manifest = await manifestManager.load();
+      expect(manifest?.sourceRoot).toBe('/abs/project/root');
+    });
+
+    it('preserves the source root across later manifest writes', async () => {
+      await manifestManager.recordSourceRoot('/abs/project/root');
+      await manifestManager.updateFiles([
+        { filepath: 'test.ts', lastModified: Date.now(), chunkCount: 3 },
+      ]);
+
+      const manifest = await manifestManager.load();
+      expect(manifest?.sourceRoot).toBe('/abs/project/root');
+      expect(manifest?.files['test.ts']).toBeTruthy();
+    });
+  });
+
   describe('updateFile', () => {
     it('should create manifest if it does not exist', async () => {
       const entry = {

--- a/packages/core/src/indexer/manifest.ts
+++ b/packages/core/src/indexer/manifest.ts
@@ -28,6 +28,12 @@ export interface IndexManifest {
   gitState?: GitState; // Last known git state
   files: Record<string, FileEntry>; // Map of filepath -> FileEntry (stored as object for JSON)
   hashAlgorithm?: 'sha256-16' | 'sha256-16-large'; // Content hash algorithm (for future migrations)
+  // Absolute source root this index was built from. Written at index time so
+  // `lien gc` can detect orphaned indices whose project directory was deleted.
+  // Optional: legacy indices written before provenance tracking lack it and are
+  // treated as "unknown provenance" (not orphan-checkable, removable only via
+  // `lien gc --stale`). Additive/optional — no INDEX_FORMAT_VERSION bump needed.
+  sourceRoot?: string;
 }
 
 /**
@@ -223,6 +229,34 @@ export class ManifestManager {
       })
       .catch(error => {
         console.error(`[Lien] Failed to update manifest for ${entries.length} files: ${error}`);
+        // Return to reset lock - don't let errors block future operations
+        return undefined;
+      });
+
+    // Wait for this operation to complete
+    await this.updateLock;
+  }
+
+  /**
+   * Records the absolute source root this index was built from (provenance for
+   * `lien gc` orphan detection). Best-effort, under the same lock as other
+   * mutations. No-op when the recorded value is already current.
+   *
+   * @param sourceRoot - Absolute path of the indexed project root
+   */
+  async recordSourceRoot(sourceRoot: string): Promise<void> {
+    // Chain this operation to the lock to ensure atomicity
+    this.updateLock = this.updateLock
+      .then(async () => {
+        const manifest = (await this.load()) || this.createEmpty();
+        if (manifest.sourceRoot === sourceRoot) {
+          return; // already current — skip the write
+        }
+        manifest.sourceRoot = sourceRoot;
+        await this.save(manifest);
+      })
+      .catch(error => {
+        console.error(`[Lien] Failed to record source root: ${error}`);
         // Return to reset lock - don't let errors block future operations
         return undefined;
       });

--- a/packages/core/src/indexer/manifest.ts
+++ b/packages/core/src/indexer/manifest.ts
@@ -248,7 +248,28 @@ export class ManifestManager {
     // Chain this operation to the lock to ensure atomicity
     this.updateLock = this.updateLock
       .then(async () => {
-        const manifest = (await this.load()) || this.createEmpty();
+        let existing: IndexManifest | null;
+        try {
+          const content = await fs.readFile(this.manifestPath, 'utf-8');
+          const parsed = JSON.parse(content) as IndexManifest;
+          if (parsed.formatVersion !== INDEX_FORMAT_VERSION) {
+            // Incompatible format: load() would clear the manifest and return
+            // null here, and we'd write back a fresh-but-empty manifest with
+            // just sourceRoot set — silently losing the files map. No-op and
+            // let the normal full-reindex path (which owns the clear+rebuild)
+            // repopulate it instead.
+            return;
+          }
+          existing = parsed;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            existing = null; // genuinely no manifest yet — safe to start fresh
+          } else {
+            throw error;
+          }
+        }
+
+        const manifest = existing || this.createEmpty();
         if (manifest.sourceRoot === sourceRoot) {
           return; // already current — skip the write
         }

--- a/packages/core/src/indexer/overlay-index.ts
+++ b/packages/core/src/indexer/overlay-index.ts
@@ -212,9 +212,13 @@ export async function buildOverlay(
   });
 
   if (changed) {
+    const overlayManifest = new ManifestManager(overlay.dbPath);
     if (manifestEntries.length > 0) {
-      await new ManifestManager(overlay.dbPath).updateFiles(manifestEntries);
+      await overlayManifest.updateFiles(manifestEntries);
     }
+    // Provenance for `lien gc`: the overlay's source root is the worktree, so a
+    // deleted worktree leaves an orphan-detectable overlay index.
+    await overlayManifest.recordSourceRoot(path.resolve(overlay.worktreeRoot));
     await overlay.bumpVersion();
   }
 


### PR DESCRIPTION
## Summary

`~/.lien/indices` accumulates one directory per project root ever opened — repos, worktrees, clones, scratch dirs — and nothing ever removed them (this machine peaked at ~230 dirs / 30 GB). This adds index garbage collection: a `lien gc` command and a throttled auto-GC on serve start. Post-embeddings a full reindex is seconds with zero downloads, so reclaiming is nearly free — GC is aggressive by design.

## Deliverable 1 — `lien gc`

- **Orphan GC (default):** removes an index whose recorded source root no longer exists on disk.
- **Legacy lance sweep (default):** removes dead `code_chunks.lance/` dirs left inside surviving index dirs after the LanceDB removal (#661 flagged this as future work).
- **`--stale [days]` (opt-in, default 60):** removes indices not accessed within N days.
- **`--dry-run`:** lists every candidate with size + reason, deletes nothing. A summary (removed / freed / skipped) always prints. `--format json` for scripting.
- **Safety rails:** never deletes the cwd's own project index; skips any index a live process holds open; deletes one directory at a time with explicit absolute paths (never a glob).

## Deliverable 2 — auto-GC on serve start

After the MCP server is up, a background (never-blocking) pass runs **orphan GC + lance sweep only** (never stale). Throttled machine-wide to once/24h. One log line when something was collected, silent otherwise. Opt out with `LIEN_AUTO_GC=off`.

## Design decisions

### Provenance recording
The index dir name is `<basename>-<md5(absPath)[0:8]>` — a one-way hash, so the source root can't be recovered from it. The manifest had no back-reference. Added an **optional** `sourceRoot` field to `IndexManifest`, written at index time by the core indexer (both the standalone finalize path and the worktree-overlay build). It's **additive/optional — no `INDEX_FORMAT_VERSION` bump** (a bump would force-invalidate every existing index on upgrade). Legacy manifests lacking it are treated as **"unknown provenance"**: not orphan-checkable, removable only via `--stale`.

### Unmounted-volume mitigation
A missing source root isn't always a deletion — an external drive may be unplugged. Two guards before flagging an orphan (`isSourceRootUnavailable`): (1) macOS external drives mount at `/Volumes/<name>`; if the root is under one and that mount point is absent, skip it as `volume-offline`; (2) general — only trust a "gone" verdict when the nearest **existing** ancestor is a real directory (if an entire network/volume mount vanished so the nearest existing ancestor is the filesystem root, decline). `volume-offline` wins over `--stale` too, so an unplugged-drive index isn't nuked for being "old".

### Live-handle skip (per #682)
Deleting a store a live `lien serve`/watcher/index is writing would be unsafe. `isIndexLocked` opens a **writable** second connection to `structural.db` with a short (200 ms) busy timeout and attempts `BEGIN IMMEDIATE`; a `SQLITE_BUSY`/`SQLITE_BUSY_SNAPSHOT` means a peer holds the write lock → skip. Mirrors the busy-skip philosophy of the overlay rebuild fix (#682). GC reads manifests directly (not via `ManifestManager.load()`, which deletes on a format-version mismatch) so inspecting an index never mutates it.

### Throttle mechanics (auto-GC)
Serves demonstrably pile up on this machine (multiple concurrent serves per root), so they must not stampede or double-delete. A stamp file `~/.lien/gc-last-run` (epoch ms) gates the 24h window; an **exclusive-create** lock `~/.lien/gc.lock` (`open(..., 'wx')`) serializes concurrent serves — a peer already holding it simply no-ops. The stamp is re-checked *under* the lock. A lock left by a crashed serve is reclaimed once older than 1h. Any failure resolves to a no-op; auto-GC never disrupts serve. Access stamp is touched on serve start only (cheap write, not on every query).

## Access stamp
New `.lien-accessed` file per index dir (epoch ms), touched on serve start. `--stale` prefers it and falls back to the newest of `manifest.lastIndexed` / the version file / dir mtime so legacy indices still have a sensible staleness signal.

## Tests
33 new/extended tests, all sandboxed via `LIEN_HOME` (per #653): orphan-vs-present detection, unknown-provenance skip, stale threshold + access-stamp refresh, lance sweep on a surviving index, dry-run deletes nothing, live-handle skip (real second connection holding `BEGIN IMMEDIATE`), throttle (second back-to-back run no-ops), and that auto-GC doesn't delay serve readiness (`startMCPServer` resolves even when auto-GC never settles). No test touches the real `~/.lien`.

## Verification (end-to-end, sandboxed `LIEN_HOME`)

Sandbox with four real indexed projects, then: `alpha` → orphan (source deleted), `beta` → live+orphan (source deleted + `structural.db` held open), `gamma` → present + a legacy `code_chunks.lance/`, `delta` → unknown-provenance (sourceRoot stripped).

**`lien gc --dry-run`:**
```
Lien index GC  (dry run)

Indices root: /tmp/lien-gc-e2e.../.lien/indices

Candidates:
  ✗ alpha-3adcd2f8  28.4 KB  orphan — source root no longer exists: /private/tmp/lien-gc-e2e.../projects/alpha
  🧹 gamma-3c0ec858/code_chunks.lance  1.0 MB  legacy lance sweep

Skipped 3: 1 in use by a live process, 1 unknown provenance (legacy), 1 source root present
Tip: add --stale [days] to also remove indices not accessed recently (default 60d).

Would remove 1 index + 1 lance dir(s), would free 1.0 MB, skipped 3  (dry run — nothing deleted)
```
(Indices dir unchanged after dry-run.)

**`lien gc` (real):**
```
Removed 1 index + 1 lance dir(s), freed 1.0 MB, skipped 3
```
After: `alpha` removed; `gamma`'s `code_chunks.lance` swept (dir kept with `manifest.json` + `structural.db`); `beta` preserved (in-use); `delta` preserved (unknown-provenance).

**Serve auto-GC (with a fresh orphan present, no prior stamp):**
```
{"level":"info","logger":"lien","data":"MCP server started and listening on stdio"}
{"level":"info","logger":"lien","data":"[Lien] auto-GC: removed 2 orphaned indices, freed 0.1 MB"}
```
`~/.lien/gc-last-run` written. **Second serve (throttled):** comes up with the readiness line, **no** auto-GC line, the fresh orphan survives, and the stamp is unchanged.

## Gate
`format:check` ✓ · `lint` ✓ (0 errors) · `typecheck` ✓ · `build` ✓ · `npm test` ✓ (parser 983, core 349, review 565, cli 766, action 28 — all green)

## Notes
Changeset: minor `@liendev/core` + `@liendev/lien` (parser untouched). No `~/.lien` on this machine was touched — all verification used a `/tmp` sandbox `LIEN_HOME`. `packages/review` untouched.

## Review findings triage

All six Lien Review findings addressed in a follow-up commit:

1. 🔴 `auto-gc.ts` `acquireLock` TOCTOU — reclaiming a stale lock now renames it aside atomically before recreating it, instead of an unconditional rm that could delete a peer's fresh lock and cause double GC.
2. 🟡 `live-handle.ts` `isIndexLocked` failed open — replaced with `probeIndexLock`, which fails closed: only a clean `BEGIN IMMEDIATE`/`ROLLBACK` counts as unlocked; any other error is `unprobeable` and skipped.
3. 🟡 `gc.ts` `classifyIndex` precedence — made explicit and tested: volume-offline > live-handle-locked/unprobeable > orphan > stale (age-eligible, regardless of provenance) > skip-with-reason.
4. 🟡 `cli/gc.ts` `parseStaleDays` accepted 0 — now requires an integer >= 1, otherwise exits 2 with a clear message.
5. 🟡 `gc.ts` `/Volumes` guard split by native `path.sep` — now splits on `'/'` explicitly and covers Linux mount roots (`/media`, `/mnt`) via a named constant.
6. 🟡 `dir-size.ts` `formatBytes` rendered >= 1024 TB as "1024.0 TB" — added PB to the unit list.


---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 13 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 3 | +8 |


> [!NOTE]
> **Low Risk**
>
> This PR adds index garbage collection via a `lien gc` command and a throttled, non-blocking auto-GC on serve start. The implementation includes sensible safety rails: live-handle probing via SQLite BEGIN IMMEDIATE, protection of the current project's index, offline-volume detection for unmounted drives, and a machine-wide lock/stamp throttle to prevent serve stampedes. The prior review findings appear addressed: `recordSourceRoot` no-ops on format-version mismatch instead of overwriting with an empty manifest, malformed `sourceRoot` is coerced to unknown provenance rather than crashing, the auto-GC lock uses atomic rename-aside with inode verification, live-handle probing fails closed, `--stale 0` is rejected, and `formatBytes` rolls over to PB. No new breaking changes or silent wrong-output bugs were identified in the reviewed code paths.
>
> - Added `lien gc` command with orphan, stale, and legacy-lance cleanup modes plus dry-run/JSON output
> - Added auto-GC on serve start (orphan + lance only, throttled to once per 24h, opt-out via LIEN_AUTO_GC=off)
> - Added `sourceRoot` provenance to IndexManifest and per-index `.lien-accessed` stamp

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a46d42d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `lien gc` command to clean up unused index storage.
  * Added automatic background cleanup when the server starts, with an option to disable it.
  * Added a dry-run mode and JSON output for easier review and scripting.

* **Bug Fixes**
  * Improved safety so active or current project indexes are not removed.
  * Added better handling for missing, offline, or legacy index data.
  * Indexes now keep track of their source location for more reliable cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
