### PR TITLE
test(gc): repeat the lock-race test to make a reintroduced race fail reliably

### DIFF
--- a/packages/core/src/gc/auto-gc.test.ts
+++ b/packages/core/src/gc/auto-gc.test.ts
@@ -125,22 +125,35 @@ describe('runAutoGc', () => {
 });
 
 describe('acquireLock — concurrent stale reclaim', () => {
-  it('exactly one of two racing acquires wins a stale lock', async () => {
+  it('exactly one of two racing acquires wins a stale lock, repeated to catch the race reliably', async () => {
+    // A single race is a weak regression guard: the double-acquire bug this
+    // test guards against (a slow reclaimer renaming a peer's brand-new live
+    // lock out from under it — fixed by the inode check in acquireLock's
+    // verifyReclaimedLock) reproduced in roughly half of individual runs
+    // before that fix. Looping within one test body, rather than spawning a
+    // process per iteration, keeps the added cost under 1ms/iteration (~90ms
+    // for 200 iterations, measured), so a reintroduced race fails reliably
+    // instead of flaking occasionally.
     const lienDir = path.join(home, '.lien');
     await fs.mkdir(lienDir, { recursive: true });
-    const lockPath = path.join(lienDir, GC_LOCK_FILE);
-    await fs.writeFile(lockPath, 'stale', 'utf-8');
-    const staleTime = new Date(Date.now() - STALE_LOCK_AGE_MS);
-    await fs.utimes(lockPath, staleTime, staleTime);
+    const ITERATIONS = 100;
 
-    const [a, b] = await Promise.all([acquireLock(lockPath), acquireLock(lockPath)]);
-    const winners = [a, b].filter((handle): handle is fs.FileHandle => handle !== null);
+    for (let i = 0; i < ITERATIONS; i++) {
+      const lockPath = path.join(lienDir, `${GC_LOCK_FILE}-${i}`);
+      await fs.writeFile(lockPath, 'stale', 'utf-8');
+      const staleTime = new Date(Date.now() - STALE_LOCK_AGE_MS);
+      await fs.utimes(lockPath, staleTime, staleTime);
 
-    expect(winners).toHaveLength(1);
-    await winners[0].close();
-    // No leftover reclaim artifact from either racer.
+      const [a, b] = await Promise.all([acquireLock(lockPath), acquireLock(lockPath)]);
+      const winners = [a, b].filter((handle): handle is fs.FileHandle => handle !== null);
+
+      expect(winners).toHaveLength(1);
+      await winners[0].close();
+    }
+
+    // No leftover reclaim artifact from any racer, across all iterations.
     const entries = await fs.readdir(lienDir);
-    expect(entries.filter(name => name.startsWith(`${GC_LOCK_FILE}.reclaim-`))).toHaveLength(0);
+    expect(entries.filter(name => name.includes('.reclaim-'))).toHaveLength(0);
   });
 
   it('reclaims a stale lock and lets a fresh acquire proceed afterward', async () => {


### PR DESCRIPTION
## Summary

- `acquireLock`'s stale-lock reclaim race (a slow reclaimer could rename a peer's brand-new live lock out from under it — fixed via the inode check in `verifyReclaimedLock`, landed in #684) reproduced in roughly half of individual test runs before that fix. A single race per test run is too weak a regression guard for this kind of concurrency bug.
- This loops the same race scenario 100x within one test body (not one process per iteration, which would add real startup overhead) so a reintroduced race fails the suite reliably instead of flaking occasionally.
- Measured cost: ~90ms for 200 iterations of the actual race logic (~0.44ms/iteration) — negligible against the suite's multi-second runtime.

## Test plan

- [x] `packages/core/src/gc/auto-gc.test.ts` passes, run 5x in a row with no flakes
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in touched file)
- [x] `npm run format:check` — clean
- [x] `npm test` — 772 core/cli/parser/review tests + 28 action tests, all green

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a test-only change that strengthens the regression guard for the stale-lock reclaim race in acquireLock by repeating the race scenario 100 times within a single test body. No production code is modified. The loop uses per-iteration lock paths to avoid cross-iteration interference, and the leftover-artifact assertion is correctly broadened to match reclaim files for the new `${GC_LOCK_FILE}-${i}` lock paths.
>
> - Wrapped the concurrent stale-reclaim race test in a 100-iteration loop using unique lock paths per iteration
> - Broadened the reclaim-artifact cleanup assertion from `startsWith(GC_LOCK_FILE)` to `includes('.reclaim-')` so it still catches artifacts across all iterations

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 94b17e1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened regression coverage for stale lock acquisition by repeating the concurrent reclaim scenario multiple times.
  * Added checks to ensure only one lock acquisition succeeds per attempt.
  * Verified no leftover stale reclaim artifacts remain after the test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->