### PR TITLE
test(cli): enforce CLAUDE.md and SERVER_INSTRUCTIONS MCP-policy sync

### DIFF
--- a/packages/cli/src/mcp/instructions.claude-md-sync.test.ts
+++ b/packages/cli/src/mcp/instructions.claude-md-sync.test.ts
@@ -66,12 +66,22 @@ function containsFragment(text: string, fragment: string): boolean {
 }
 
 /** True if both terms appear within `window` chars of each other, in either order. */
+function allIndexesOf(haystack: string, needle: string): number[] {
+  const indexes: number[] = [];
+  for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + 1)) {
+    indexes.push(i);
+  }
+  return indexes;
+}
+
+// Any occurrence pair within the window counts — first-occurrence-only would
+// false-fail when a term also appears earlier in an unrelated context (e.g. a
+// tool-selection table above the mandate that actually satisfies the check).
 function mentionsNear(text: string, termA: string, termB: string, window = 150): boolean {
   const lower = text.toLowerCase();
-  const a = lower.indexOf(termA.toLowerCase());
-  const b = lower.indexOf(termB.toLowerCase());
-  if (a === -1 || b === -1) return false;
-  return Math.abs(a - b) <= window;
+  const as = allIndexesOf(lower, termA.toLowerCase());
+  const bs = allIndexesOf(lower, termB.toLowerCase());
+  return as.some(a => bs.some(b => Math.abs(a - b) <= window));
 }
 
 const claudeMdPath = findClaudeMd(dirname(fileURLToPath(import.meta.url)));

--- a/packages/cli/src/mcp/instructions.claude-md-sync.test.ts
+++ b/packages/cli/src/mcp/instructions.claude-md-sync.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SERVER_INSTRUCTIONS } from './instructions.js';
+
+/**
+ * Guards the hand-sync between CLAUDE.md's "Lien MCP Tools — MANDATORY Usage"
+ * section and SERVER_INSTRUCTIONS (the string sent to every connecting MCP
+ * client on `initialize`). Today that sync is enforced by nothing but an
+ * expectation that whoever edits one remembers the other — this test makes
+ * drift fail CI instead.
+ *
+ * The two texts are DELIBERATELY not verbatim copies: CLAUDE.md is long-form
+ * guidance for a coding agent reading the repo, SERVER_INSTRUCTIONS is a
+ * token-budget-conscious prompt sent on every connection. So assertions here
+ * check for SUBSTANCE — tool names mentioned, mandates present, stable anchor
+ * phrases/fragments — never exact sentences. Keyword-brittle assertions rot
+ * (see packages/review/test/harness/README.md's Tier-2 note for the same
+ * lesson learned the hard way in the review harness).
+ */
+
+const SNAKE_CASE_TOKEN = /\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g;
+
+/** Walk up from `startDir` looking for a repo-root CLAUDE.md. */
+function findClaudeMd(startDir: string): string | null {
+  let dir = startDir;
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, 'CLAUDE.md');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Slice out just the "## Lien MCP Tools" section (up to the next top-level
+ * heading) so unrelated CLAUDE.md content can't accidentally satisfy an
+ * assertion. Matches on `\n## ` rather than `---` because the section
+ * contains a markdown table whose `|---|---|` separator row would otherwise
+ * be mistaken for the section's trailing horizontal rule.
+ */
+function extractMcpSection(claudeMdText: string): string {
+  const headingIdx = claudeMdText.indexOf('## Lien MCP Tools');
+  if (headingIdx === -1) {
+    throw new Error(
+      'CLAUDE.md no longer has a "## Lien MCP Tools" section — if it was renamed, update the anchor heading in this test.',
+    );
+  }
+  const rest = claudeMdText.slice(headingIdx + 3);
+  const nextHeadingRel = rest.indexOf('\n## ');
+  const end = nextHeadingRel === -1 ? claudeMdText.length : headingIdx + 3 + nextHeadingRel;
+  return claudeMdText.slice(headingIdx, end);
+}
+
+function extractToolNames(text: string): Set<string> {
+  return new Set(text.match(SNAKE_CASE_TOKEN) ?? []);
+}
+
+/** Case-insensitive, whitespace-collapsing substring check (tolerant of reflow/line-wrap). */
+function containsFragment(text: string, fragment: string): boolean {
+  const normalize = (s: string) => s.toLowerCase().replace(/\s+/g, ' ');
+  return normalize(text).includes(normalize(fragment));
+}
+
+/** True if both terms appear within `window` chars of each other, in either order. */
+function mentionsNear(text: string, termA: string, termB: string, window = 150): boolean {
+  const lower = text.toLowerCase();
+  const a = lower.indexOf(termA.toLowerCase());
+  const b = lower.indexOf(termB.toLowerCase());
+  if (a === -1 || b === -1) return false;
+  return Math.abs(a - b) <= window;
+}
+
+const claudeMdPath = findClaudeMd(dirname(fileURLToPath(import.meta.url)));
+
+describe('CLAUDE.md <-> SERVER_INSTRUCTIONS MCP policy sync', () => {
+  if (!claudeMdPath) {
+    it.skip('SKIPPED: CLAUDE.md not found by walking up from this file — not running inside a lien repo checkout', () => {});
+    return;
+  }
+
+  const mcpSection = extractMcpSection(readFileSync(claudeMdPath, 'utf8'));
+  const sides = [
+    ['CLAUDE.md', mcpSection],
+    ['SERVER_INSTRUCTIONS', SERVER_INSTRUCTIONS],
+  ] as const;
+
+  it('mentions the same set of Lien tool names as SERVER_INSTRUCTIONS', () => {
+    const claudeTools = extractToolNames(mcpSection);
+    const instructionTools = extractToolNames(SERVER_INSTRUCTIONS);
+    const onlyInClaudeMd = [...claudeTools].filter(t => !instructionTools.has(t)).sort();
+    const onlyInInstructions = [...instructionTools].filter(t => !claudeTools.has(t)).sort();
+
+    expect(
+      onlyInClaudeMd,
+      `Tools mentioned in CLAUDE.md but missing from SERVER_INSTRUCTIONS: ${onlyInClaudeMd.join(', ') || 'none'}`,
+    ).toEqual([]);
+    expect(
+      onlyInInstructions,
+      `Tools mentioned in SERVER_INSTRUCTIONS but missing from CLAUDE.md: ${onlyInInstructions.join(', ') || 'none'}`,
+    ).toEqual([]);
+    // Guard against both sides drifting to zero mentions and vacuously passing.
+    expect(claudeTools.size).toBeGreaterThan(0);
+  });
+
+  it('requires get_files_context before editing, in both texts', () => {
+    for (const [label, text] of sides) {
+      expect(
+        mentionsNear(text, 'get_files_context', 'edit'),
+        `${label} is missing the get_files_context-before-editing mandate`,
+      ).toBe(true);
+    }
+  });
+
+  it('requires get_dependents before renaming/removing/signature changes, in both texts', () => {
+    const fragment = 'renaming, removing, or changing the signature';
+    for (const [label, text] of sides) {
+      expect(
+        text.includes('get_dependents') && containsFragment(text, fragment),
+        `${label} is missing the get_dependents-before-signature-change mandate`,
+      ).toBe(true);
+    }
+  });
+
+  it('requires search_code before grep/glob for discovery, in both texts', () => {
+    for (const [label, text] of sides) {
+      expect(text.includes('search_code'), `${label} does not mention search_code`).toBe(true);
+      expect(/grep/i.test(text), `${label} does not mention grep as the discovery fallback`).toBe(
+        true,
+      );
+      expect(
+        containsFragment(text, 'discovery') || containsFragment(text, 'TODO'),
+        `${label} is missing discovery-vs-grep framing (expected "discovery" or "TODO(s)" context)`,
+      ).toBe(true);
+    }
+  });
+
+  it('states the no-embeddings / BM25 / camelCase-split keyword-search caveat, in both texts', () => {
+    for (const [label, text] of sides) {
+      expect(/BM25/.test(text), `${label} is missing the BM25 caveat`).toBe(true);
+      expect(/camelCase/.test(text), `${label} is missing the camelCase-split caveat`).toBe(true);
+      expect(/no embeddings/i.test(text), `${label} is missing the no-embeddings caveat`).toBe(
+        true,
+      );
+    }
+  });
+
+  it('escalates on high/critical riskLevel before proceeding, in both texts', () => {
+    for (const [label, text] of sides) {
+      expect(/riskLevel/.test(text), `${label} is missing riskLevel guidance`).toBe(true);
+      expect(
+        containsFragment(text, 'high') && containsFragment(text, 'critical'),
+        `${label} is missing the high/critical escalation levels`,
+      ).toBe(true);
+      expect(
+        containsFragment(text, 'list affected dependents'),
+        `${label} is missing the "list affected dependents" escalation action`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Why

CLAUDE.md's "Lien MCP Tools — MANDATORY Usage" section and `SERVER_INSTRUCTIONS`
in `packages/cli/src/mcp/instructions.ts` (the string sent to every connecting
MCP client on `initialize`) describe the same tool-usage policy but are
hand-synced by convention only — nothing enforces it, so the two can drift
silently.

## What

Added `packages/cli/src/mcp/instructions.claude-md-sync.test.ts`, a unit test
that fails when the two texts drift apart on substance. It checks:

- **Tool-name set equality** — extracts all `snake_case` tool identifiers from
  each text via regex and asserts the sets match, reporting exactly which
  tool is missing from which side.
- **Core mandates present in both**, keyed on stable anchor
  fragments/proximity rather than full sentences:
  - `get_files_context` mentioned near "edit" (before-edit mandate)
  - `get_dependents` + the "renaming, removing, or changing the signature"
    fragment (before-signature-change mandate)
  - `search_code` + "grep" + "discovery"/"TODO" framing (search-before-grep
    for discovery)
  - `BM25` + `camelCase` + "no embeddings" (the keyword-search caveat)
  - `riskLevel` + "high"/"critical" + "list affected dependents" (risk
    escalation)

## How the invariants were chosen (avoiding phrasing-brittleness)

CLAUDE.md and `SERVER_INSTRUCTIONS` are deliberately **not** verbatim copies —
one is long-form guidance for a coding agent, the other a
token-budget-conscious prompt sent on every MCP connection. Asserting exact
sentences would rot the first time either side's wording is tightened (a
lesson already learned the hard way with the review harness's Tier-2 keyword
checks — see `packages/review/test/harness/README.md`). So each check either:

- compares a *set* (tool names) rather than string equality, or
- checks for a short, structurally-necessary fragment (e.g. the exact list of
  triggering actions "renaming, removing, or changing the signature") or a
  proximity relationship between two terms (e.g. `get_files_context` appearing
  near "edit"), rather than a whole sentence.

If a mandate exists on only one side, the failing assertion names which file
is missing it.

## No corrections needed

Ran the test against the current CLAUDE.md and `SERVER_INSTRUCTIONS` (as of
this branch's base) — no genuine substance mismatch was found, so this PR is
test-only; neither file's content was changed. Sanity-checked the test isn't
vacuous by temporarily mutating CLAUDE.md (dropping a tool mention, dropping
the risk-escalation sentence) and confirming the corresponding assertion
fails with a clear message, then reverting.

## How verified

- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all pass (lint: 0 errors, pre-existing warnings only)
- `node packages/cli/dist/index.js delta` — exit 0
- New test passes standalone and as part of the full `packages/cli` suite
- Manual drift injection (see above) confirms the test actually catches sync breaks

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a single test-only file that enforces substance-level synchronization between CLAUDE.md's MCP policy section and the SERVER_INSTRUCTIONS string sent to MCP clients. It does not modify production code, exports, or runtime behavior. The assertions compare snake_case tool-name sets and check for key mandate fragments using case-insensitive, whitespace-tolerant substring and proximity checks. No breaking changes, logic errors, or silent failure modes were identified in the new test code.
>
> - Added packages/cli/src/mcp/instructions.claude-md-sync.test.ts to guard against drift between CLAUDE.md and SERVER_INSTRUCTIONS
> - Test compares snake_case tool-name sets and checks presence of core mandates in both texts

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a856c4d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->