### PR TITLE
ci: post-publish registry smoke test for @liendev packages

### DIFF
--- a/.github/scripts/mcp-initialize-probe.mjs
+++ b/.github/scripts/mcp-initialize-probe.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Boot-probes a Lien MCP server over stdio: spawns the given command, sends
+// a JSON-RPC `initialize` request on stdin, and asserts a response arrives
+// within a timeout.
+//
+// On failure it prints the child's raw stderr. This matters specifically
+// because a real MCP client (e.g. Claude Code) wraps a dead/crashed server
+// connection in a generic "-32000 Internal error" and swallows the actual
+// cause -- that masking is exactly what hid the 0.55.0/0.56.0
+// sibling-version-skew incident (a missing-export SyntaxError at import
+// time) until a human ran the server by hand. Surfacing stderr here is the
+// whole point of this probe.
+//
+// Usage: node mcp-initialize-probe.mjs <command> [args...]
+// Env:   MCP_PROBE_TIMEOUT_MS (default 90000)
+
+import { spawn } from 'node:child_process';
+
+const [, , command, ...args] = process.argv;
+if (!command) {
+  console.error('Usage: mcp-initialize-probe.mjs <command> [args...]');
+  process.exit(1);
+}
+
+const TIMEOUT_MS = Number(process.env.MCP_PROBE_TIMEOUT_MS ?? 90_000);
+
+const request = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'lien-registry-smoke', version: '1.0.0' },
+  },
+};
+
+const child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+let stdoutBuf = Buffer.alloc(0);
+let stderrBuf = '';
+let settled = false;
+
+function printStderr() {
+  if (stderrBuf.trim()) {
+    console.error('\n--- child stderr (the real error a client would mask as -32000) ---');
+    console.error(stderrBuf.trim());
+    console.error('--- end child stderr ---\n');
+  } else {
+    console.error('(child produced no stderr output)');
+  }
+}
+
+function fail(message) {
+  if (settled) return;
+  settled = true;
+  clearTimeout(timer);
+  console.error(`FAIL: ${message}`);
+  printStderr();
+  child.kill('SIGKILL');
+  process.exitCode = 1;
+}
+
+function succeed(serverInfo) {
+  if (settled) return;
+  settled = true;
+  clearTimeout(timer);
+  console.log(`OK: received initialize response from ${JSON.stringify(serverInfo)}`);
+  child.kill('SIGKILL');
+  process.exitCode = 0;
+}
+
+const timer = setTimeout(() => {
+  fail(`no initialize response within ${TIMEOUT_MS}ms`);
+}, TIMEOUT_MS);
+
+child.on('error', error => {
+  fail(`failed to spawn '${command}': ${error.message}`);
+});
+
+child.on('exit', (code, signal) => {
+  if (!settled) {
+    fail(`child exited early (code=${code}, signal=${signal}) before responding`);
+  }
+});
+
+child.stderr.on('data', chunk => {
+  stderrBuf += chunk.toString('utf8');
+});
+
+child.stdout.on('data', chunk => {
+  stdoutBuf = Buffer.concat([stdoutBuf, chunk]);
+
+  let index;
+  while ((index = stdoutBuf.indexOf('\n')) !== -1) {
+    const line = stdoutBuf.subarray(0, index).toString('utf8').replace(/\r$/, '');
+    stdoutBuf = stdoutBuf.subarray(index + 1);
+    if (!line.trim()) continue;
+
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      // Not a JSON-RPC frame (Lien logs go to stderr, but be lenient about
+      // any stray stdout noise from dependencies).
+      continue;
+    }
+
+    if (message.id !== request.id) continue;
+
+    if (message.error) {
+      fail(`server returned a JSON-RPC error: ${JSON.stringify(message.error)}`);
+      return;
+    }
+
+    succeed(message.result?.serverInfo ?? message.result ?? message);
+    return;
+  }
+});
+
+child.stdin.write(JSON.stringify(request) + '\n');

--- a/.github/scripts/mcp-initialize-probe.mjs
+++ b/.github/scripts/mcp-initialize-probe.mjs
@@ -22,7 +22,10 @@ if (!command) {
   process.exit(1);
 }
 
-const TIMEOUT_MS = Number(process.env.MCP_PROBE_TIMEOUT_MS ?? 90_000);
+// A malformed override (empty, non-numeric) must not collapse the timeout to
+// 0ms/NaN and fail a healthy server instantly — fall back to the default.
+const rawTimeout = Number(process.env.MCP_PROBE_TIMEOUT_MS ?? '');
+const TIMEOUT_MS = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 90_000;
 
 const request = {
   jsonrpc: '2.0',

--- a/.github/scripts/registry-smoke.sh
+++ b/.github/scripts/registry-smoke.sh
@@ -67,7 +67,13 @@ if [ -n "${LIEN_VERSION:-}" ]; then
 elif [ -n "${PUBLISHED_PACKAGES:-}" ]; then
   REQUESTED="$(node -e "
     const pkgs = JSON.parse(process.env.PUBLISHED_PACKAGES);
-    const lien = pkgs.find(p => p.name === '@liendev/lien');
+    if (!Array.isArray(pkgs)) {
+      throw new Error('PUBLISHED_PACKAGES is not a JSON array: ' + process.env.PUBLISHED_PACKAGES);
+    }
+    const lien = pkgs.find(p => p && p.name === '@liendev/lien');
+    if (lien && typeof lien.version !== 'string') {
+      throw new Error('publishedPackages entry for @liendev/lien has no version: ' + JSON.stringify(lien));
+    }
     console.log(lien ? lien.version : 'latest');
   ")"
   if [ "$REQUESTED" = "latest" ]; then

--- a/.github/scripts/registry-smoke.sh
+++ b/.github/scripts/registry-smoke.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Post-publish registry smoke test for @liendev packages.
+#
+# WHY THIS EXISTS: the CI `release-smoke-test` job (.github/workflows/ci.yml)
+# installs packed LOCAL tarballs into a scratch project, which proves the
+# packages install together as a *matched set* -- but it can never catch
+# resolution skew against whatever is already live on the npm registry. That
+# blind spot is exactly what shipped @liendev/core 0.55.0/0.56.0: they
+# imported `getIndexDir` from @liendev/parser, but parser had not been
+# republished with that export, so every fresh `npx @liendev/lien@latest
+# serve` crashed at startup with a missing-export SyntaxError. This script
+# installs the just-published version(s) FROM THE REGISTRY, in a directory
+# with no workspace/lockfile to fall back on, and boot-probes the result --
+# the same path a real first-time `npx @liendev/lien` user takes.
+#
+# Usage:
+#   PUBLISHED_PACKAGES='[{"name":"@liendev/lien","version":"1.2.3"}]' \
+#     .github/scripts/registry-smoke.sh
+#
+#   LIEN_VERSION=1.2.3 .github/scripts/registry-smoke.sh   # manual/local override,
+#                                                           # skips PUBLISHED_PACKAGES parsing
+#
+# A non-zero exit here means the just-published release is broken for fresh
+# installs. It cannot be rolled back (npm publishes are immutable) -- see the
+# remediation banner below.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGISTRY="https://registry.npmjs.org/"
+PROBE_TIMEOUT_MS="${MCP_PROBE_TIMEOUT_MS:-90000}"
+CONSUMER_DIR=""
+
+remediation() {
+  cat >&2 <<'EOF'
+
+================================================================================
+POST-PUBLISH REGISTRY SMOKE TEST FAILED.
+
+The just-published @liendev package(s) are broken for a fresh registry
+install. This CANNOT be rolled back -- npm publishes are immutable. The
+manual remediation is to deprecate the broken version(s) so npm/npx warns
+consumers away from them, e.g.:
+
+  npm deprecate @liendev/lien@<version>   "broken release, use <next-version> instead"
+  npm deprecate @liendev/core@<version>   "broken release, use <next-version> instead"
+  npm deprecate @liendev/parser@<version> "broken release, use <next-version> instead"
+
+then ship a fixed patch release through the normal changesets flow.
+================================================================================
+EOF
+}
+
+cleanup() {
+  [ -n "$CONSUMER_DIR" ] && rm -rf "$CONSUMER_DIR"
+}
+
+trap cleanup EXIT
+trap remediation ERR
+
+echo "== Resolving target @liendev/lien version to smoke-test =="
+
+if [ -n "${LIEN_VERSION:-}" ]; then
+  REQUESTED="$LIEN_VERSION"
+  echo "Using explicit override LIEN_VERSION=$REQUESTED"
+elif [ -n "${PUBLISHED_PACKAGES:-}" ]; then
+  REQUESTED="$(node -e "
+    const pkgs = JSON.parse(process.env.PUBLISHED_PACKAGES);
+    const lien = pkgs.find(p => p.name === '@liendev/lien');
+    console.log(lien ? lien.version : 'latest');
+  ")"
+  if [ "$REQUESTED" = "latest" ]; then
+    echo "@liendev/lien was not among the published packages -- falling back to the" \
+      "'latest' dist-tag to verify it pulls in the newly published sibling(s) via" \
+      "its semver ranges."
+  else
+    echo "@liendev/lien@$REQUESTED was published -- smoke-testing that exact version."
+  fi
+else
+  echo "Neither LIEN_VERSION nor PUBLISHED_PACKAGES was provided." >&2
+  exit 1
+fi
+
+echo "== Waiting for registry propagation =="
+V=""
+for attempt in $(seq 1 10); do
+  if RESOLVED="$(npm view --registry "$REGISTRY" "@liendev/lien@${REQUESTED}" version 2>/dev/null)" \
+    && [ -n "$RESOLVED" ]; then
+    V="$RESOLVED"
+    echo "Resolved @liendev/lien@${REQUESTED} -> $V (attempt $attempt/10)"
+    break
+  fi
+  echo "  attempt $attempt/10: @liendev/lien@${REQUESTED} not visible on the registry yet, retrying in 30s..."
+  sleep 30
+done
+
+if [ -z "$V" ]; then
+  echo "FAIL: @liendev/lien@${REQUESTED} never became visible on the registry after 10 attempts (5 minutes)." >&2
+  exit 1
+fi
+
+echo "== Installing @liendev/lien@$V into a fresh, workspace-free consumer directory =="
+CONSUMER_DIR="$(mktemp -d)"
+(
+  cd "$CONSUMER_DIR"
+  npm init -y >/dev/null
+  npm install --registry "$REGISTRY" --no-audit --no-fund "@liendev/lien@$V"
+)
+
+echo "== Probe 1: import integrity (the exact failure mode from the 0.55/0.56 incident) =="
+cat >"$CONSUMER_DIR/probe-imports.mjs" <<'EOF'
+const [core, parser] = await Promise.all([import('@liendev/core'), import('@liendev/parser')]);
+if (typeof core !== 'object' || typeof parser !== 'object') {
+  throw new Error('unexpected module shape from @liendev/core or @liendev/parser');
+}
+console.log('import probe OK');
+EOF
+(cd "$CONSUMER_DIR" && node probe-imports.mjs)
+
+ACTUAL_VERSION="$("$CONSUMER_DIR/node_modules/.bin/lien" --version)"
+if [ "$ACTUAL_VERSION" != "$V" ]; then
+  echo "FAIL: expected 'lien --version' to print $V, got '$ACTUAL_VERSION'" >&2
+  exit 1
+fi
+echo "lien --version OK ($ACTUAL_VERSION)"
+
+echo "== Probe 2: MCP stdio boot (initialize handshake) =="
+MCP_PROBE_TIMEOUT_MS="$PROBE_TIMEOUT_MS" node "$SCRIPT_DIR/mcp-initialize-probe.mjs" \
+  "$CONSUMER_DIR/node_modules/.bin/lien" serve --root "$CONSUMER_DIR"
+
+echo "== Registry smoke test passed for @liendev/lien@$V =="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       contents: write # Create releases
       pull-requests: write # Create "Version Packages" PR
       id-token: write # OIDC for npm provenance
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      published-packages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,6 +43,7 @@ jobs:
       - run: npm run build
 
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: npm run release
@@ -54,3 +58,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No NPM_TOKEN needed - uses OIDC provenance
+
+  registry-smoke:
+    name: Post-publish registry smoke test
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # `release`, above, only ever installs @liendev/* from the local npm
+    # workspace (via `npm ci`) and the CI `release-smoke-test` job
+    # (.github/workflows/ci.yml) only ever installs packed LOCAL tarballs —
+    # neither can detect resolution skew against what's actually live on the
+    # registry. That blind spot is exactly what shipped @liendev/core
+    # 0.55.0/0.56.0: they imported `getIndexDir` from @liendev/parser, but
+    # parser had not been republished with that export, so every fresh
+    # `npx @liendev/lien@latest serve` crashed at startup with a
+    # missing-export SyntaxError. This job installs the version(s) that were
+    # JUST published FROM THE REGISTRY, in a directory with no workspace or
+    # lockfile to fall back on, and boot-probes the result — the same path a
+    # real first-time `npx @liendev/lien` user takes. A red job here is a
+    # post-publish alarm: the release cannot be rolled back (npm publishes
+    # are immutable), so the manual remediation is `npm deprecate` on the
+    # broken version(s) (see the script's failure banner) followed by a
+    # fixed patch release.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run registry smoke test
+        env:
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.published-packages }}
+        run: .github/scripts/registry-smoke.sh


### PR DESCRIPTION
## What

Adds a `registry-smoke` job to `release.yml` that runs only when
`changesets/action` reports a publish (`needs.release.outputs.published ==
'true'`). It:

1. Resolves the just-published `@liendev/lien` version from the action's
   `publishedPackages` output (falling back to the `latest` dist-tag if only
   `core`/`parser` published, to still exercise the semver pull-through).
2. Retries `npm view` up to 10x/30s for registry propagation.
3. Installs that exact version **from the real npm registry** into a fresh,
   workspace-free scratch directory (no monorepo lockfile to fall back on).
4. Probe 1: imports `@liendev/core` and `@liendev/parser` (whatever versions
   the published `lien` actually pulls in) and checks `lien --version`.
5. Probe 2: boots `lien serve` and sends a real MCP `initialize` handshake
   over stdio, asserting a response within a timeout. On any failure it
   prints the child's raw stderr, so a masked `-32000 Internal error` (what a
   real MCP client shows) doesn't hide the actual crash.

A failing job fails the workflow run visibly — it's a post-publish alarm,
since npm publishes can't be rolled back. The failure output and the job
comment both point at the manual remediation (`npm deprecate` the broken
version, then ship a fixed patch release).

The smoke logic lives in `.github/scripts/registry-smoke.sh` (workflow just
calls it) so it's runnable locally against whatever is currently published.

## Why

The existing `release-smoke-test` job in `ci.yml` installs **packed local
tarballs**, which proves the packages install together as a matched set but
is structurally blind to registry-resolution skew. That blind spot is
exactly what shipped `@liendev/core` 0.55.0/0.56.0: they imported
`getIndexDir` from `@liendev/parser`, but `parser` hadn't been republished
with that export, so every fresh `npx @liendev/lien@latest serve` crashed at
startup with a missing-export `SyntaxError`. Nothing in CI caught it because
nothing installed from the registry post-publish. This job closes that gap.

## How verified

All six repo gates pass (`format:check`, `lint`, `typecheck`, `build`,
`test`, `lien delta`).

Ran the extracted script locally against the version currently live on npm
(`@liendev/lien@0.60.0`), both via the `LIEN_VERSION` override and via a
`PUBLISHED_PACKAGES` JSON payload (matching the real `changesets/action`
output shape):

```
== Resolving target @liendev/lien version to smoke-test ==
Using explicit override LIEN_VERSION=0.60.0
== Waiting for registry propagation ==
Resolved @liendev/lien@0.60.0 -> 0.60.0 (attempt 1/10)
== Installing @liendev/lien@0.60.0 into a fresh, workspace-free consumer directory ==
== Probe 1: import integrity (the exact failure mode from the 0.55/0.56 incident) ==
import probe OK
lien --version OK (0.60.0)
== Probe 2: MCP stdio boot (initialize handshake) ==
OK: received initialize response from {"name":"lien","version":"0.60.0"}
== Registry smoke test passed for @liendev/lien@0.60.0 ==
```

Also exercised the MCP probe's failure paths directly (bad command/ENOENT,
child exits early with a simulated stderr crash, hang/timeout, and a
`-32000`-style JSON-RPC error) — all four correctly fail and print the
child's real stderr. Note: local native compile needed
`CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++
CXXFLAGS="-std=c++17"` to prime the toolchain (known macOS SDK issue); the
GitHub Actions runner (ubuntu) doesn't need this.

Validated the workflow YAML with `actionlint` (clean) and a plain YAML
parse; the shell script passes `shellcheck` with no warnings.

No changeset — CI-only change.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **3 issues found** · Low Risk
>
> This PR adds a post-publish registry smoke-test job and two supporting scripts. The workflow and shell script are sound: they gate on the changesets publish output, retry `npm view` for registry propagation, install from the real registry into a fresh directory, and run import/version/MCP probes. The new Node probe, however, has two failure-path issues: it can throw an unhandled `ESRCH` when killing a child that has already exited (in both `fail` and `succeed`), and it parses arbitrary child stdout without validating that the parsed value is an object, so a `null` JSON line crashes the probe. These only affect diagnostic output on failure, not the success path, so overall risk remains low.
>
> - Added `.github/scripts/mcp-initialize-probe.mjs` to perform an MCP initialize handshake over stdio and surface child stderr on failure.
> - Added `.github/scripts/registry-smoke.sh` to resolve, install, and probe a published `@liendev/lien` version from the real npm registry.
> - Added `registry-smoke` job to `.github/workflows/release.yml`, gated on `needs.release.outputs.published == 'true'`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3a8bbb8. Updates automatically on new commits.</sup>
<!-- /lien-stats -->