### PR TITLE
feat(delta): --base ref comparison + CI gate for new complexity crossings

### DIFF
--- a/.changeset/delta-base-ci.md
+++ b/.changeset/delta-base-ci.md
@@ -1,0 +1,9 @@
+---
+'@liendev/lien': minor
+---
+
+`lien delta --base <ref>` — compare against any ref, not just `HEAD`, and give the sixth commit gate a CI backstop.
+
+Until now `lien delta` only ever compared the working tree to `HEAD`, so a crossing introduced by an earlier commit in a PR (already sitting at `HEAD`, with a clean working tree) was invisible to the gate — the other five commit gates are enforced in CI, but this one ran purely on an agent's honor system. `--base <ref>` compares the current state against any ref instead: `git diff --name-status` scoped to that ref, `before` content read via `git show <ref>:path`, same file filtering and edge-case handling (added/deleted/renamed/unborn) as the default mode. Composes with `--file`, `--format json`, `--soft`, and `--threshold`; omitting `--base` is byte-for-byte unchanged.
+
+CI now runs `lien delta --base "origin/$GITHUB_BASE_REF"` on every pull request, so a complexity crossing introduced anywhere in a PR's commits — not just its latest one — fails the build instead of merging silently.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,44 @@ jobs:
       - name: Build Action image (Dockerfile smoke test)
         run: docker build -f packages/action/Dockerfile -t lien-review:ci .
 
+  delta:
+    name: Complexity delta vs base branch (lien delta --base)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 10
+
+    # `lien delta` is the sixth pre-commit gate (see CLAUDE.md), but until now
+    # it only ran on an agent's honor system -- nothing stopped a PR whose
+    # commits raised a function's complexity over threshold from merging, as
+    # long as no individual commit happened to run the gate locally. This job
+    # gives the gate a CI backstop: it compares the checked-out PR state
+    # against the PR's target branch (not just the PR's own last commit, which
+    # a crossing introduced earlier in the same PR could hide from) and fails
+    # the build on any NEW threshold crossing.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Need the target branch's history locally (as `origin/<base>`) to
+          # diff against -- a shallow, single-ref checkout would not have it.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Parser, Core & CLI (required by lien delta)
+        run: npm run build:core && npm run build -w packages/cli
+
+      - name: lien delta --base origin/<target-branch>
+        run: node packages/cli/dist/index.js delta --base "origin/$GITHUB_BASE_REF"
+
   release-smoke-test:
     name: Release smoke test (npm pack -> external install)
     runs-on: ubuntu-latest

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -276,6 +276,35 @@ The asymmetry is the whole point: you are punished only for **making things
 worse than HEAD**, never for pre-existing debt you happened to touch. This keeps
 the gate honest and prevents it from blocking unrelated work in a hot file.
 
+### `--base <ref>` — comparing against something other than HEAD
+
+Everything above compares the working tree to `HEAD`. That is the right
+default for an agent running the gate locally mid-edit, but it has a blind
+spot for CI: by the time a PR's branch is checked out, its commits are already
+`HEAD` and the working tree is clean, so a crossing introduced by an *earlier*
+commit in the same PR produces **no diff at all** against `HEAD` — plain
+`lien delta` sees nothing to flag.
+
+`--base <ref>` compares the current state against any ref instead of `HEAD`:
+
+```bash
+lien delta --base origin/main
+lien delta --base origin/main --format json
+lien delta --base HEAD~3 --file src/foo.ts
+```
+
+Mechanically this is the same pipeline with one substitution: file discovery
+becomes `git diff --name-status --find-renames <ref>` (instead of `... HEAD`),
+and "before" content is read via `git show <ref>:path` (instead of `git show
+HEAD:path`). Untracked files are still additions regardless of the baseline.
+Composes with every other flag — `--file` (single-file fast path vs `<ref>`),
+`--format json`, `--soft`, `--threshold` — and omitting `--base` is
+byte-for-byte identical to the original HEAD-vs-working-tree behaviour.
+
+A `--base` ref that does not resolve to a commit is an operational error
+(clear message, exit 2) — the same convention as an unreadable file or a
+missing git binary, not a silent no-op.
+
 ### Optional MCP variant — deferred
 
 `get_complexity({ diff: true })` is attractive but does **not** fall out of A+B
@@ -533,3 +562,79 @@ the distinction the hook relies on to stay silent on non-regressions.
 - [x] 3. Mechanism 2: `lien delta --file` flag + `delta-write.sh` hook + hooks.json + unit tests
 - [x] 4. Mechanism 3: `complexityHeadroom` in `get_files_context` + description/instructions + unit tests
 - [x] 5. Verification: drive hook (3 transcripts) + MCP headroom response + latency; full gate green; changeset
+
+---
+
+# `--base <ref>` + the CI gate
+
+Phases 1–2 made `lien delta` available and, later, proactive at edit time — but
+it remained, end to end, an **honor-system** gate: nothing outside the agent's
+own discipline stopped a PR from merging with a new complexity crossing
+buried in one of its earlier commits. Every one of the *other* five commit
+gates (`format:check`, `lint`, `typecheck`, `build`, `test`) already runs in CI
+on every PR; `lien delta` was the one gate an agent could simply forget to run
+and nobody would know.
+
+## G. The CI backstop
+
+`.github/workflows/ci.yml` gains a `delta` job that runs only on
+`pull_request` events:
+
+```yaml
+delta:
+  if: github.event_name == 'pull_request'
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # need origin/<base> locally to diff against
+    - uses: actions/setup-node@v4
+    - run: npm ci
+    - run: npm run build:core && npm run build -w packages/cli
+    - run: node packages/cli/dist/index.js delta --base "origin/$GITHUB_BASE_REF"
+```
+
+`fetch-depth: 0` is required: a normal PR checkout is shallow and only fetches
+the merge-commit ref, so `origin/<base-branch>` would not exist locally to diff
+against. `$GITHUB_BASE_REF` is the PR's target branch name, populated
+automatically by Actions on `pull_request` events (e.g. `main`); the job
+compares the checked-out PR state against `origin/main`, catching a crossing
+introduced by **any** commit in the PR, not just its latest one — exactly the
+gap `--base` exists to close. A non-zero exit (a new crossing) fails the job.
+
+## H. `--base <ref>` implementation notes
+
+The mode reuses the Phase-1 pipeline (`packages/cli/src/cli/delta-git.ts`)
+with the ref that supplies "before" content generalized from a hardcoded
+`HEAD` to a parameter:
+
+- `collectFileChanges(rootDir, baseRef?)` and `collectFileChange(rootDir, filePath, baseRef?)`
+  both accept an optional ref. Omitted, behavior is byte-for-byte the original
+  (including the unborn-HEAD fallback, which only applies to the no-`--base`
+  default — an explicit `--base` ref is validated to exist, so there is no
+  "unborn base" case to handle).
+- File discovery: `git diff --name-status --find-renames -z <baseRef>`
+  (replaces `... HEAD`) plus the same untracked-file union as before.
+- Content: `git show <baseRef>:path` (replaces `git show HEAD:path`) for the
+  "before" side; the working tree is still read directly for "after" — `--base`
+  only moves the baseline, never the target.
+- A `baseRef` that doesn't resolve to a commit (`git rev-parse --verify --quiet
+  <ref>^{commit}`) throws a clear `base ref "<ref>" not found` error, which
+  `deltaCommand` reports and turns into exit 2 — the same operational-failure
+  convention as an unreadable file or a missing git binary.
+- The CLI report header reflects the comparison point (`lien delta —
+  complexity vs origin/main` instead of `... vs HEAD`) so `--format text`
+  output is honest about what it compared; `--format json` is unaffected
+  (the ref isn't part of `ComplexityDeltaResult`, only the CLI's own report
+  header).
+
+See "`--base <ref>` — comparing against something other than HEAD" above for
+the usage-level writeup.
+
+## Deferred
+
+`CLAUDE.md`'s "Before EVERY Commit (MANDATORY)" section is left untouched here
+even though it now undersells the gate — `lien delta` previously ran purely on
+an agent's honor system, and this PR gives it a CI backstop, which is context
+worth adding there. A parallel in-flight change already owns edits to that
+section's `lien delta` wording; folding this update into it there avoids two
+PRs racing on the same lines.

--- a/packages/cli/src/cli/delta-cmd.test.ts
+++ b/packages/cli/src/cli/delta-cmd.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import {
   computeComplexityDelta,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
@@ -12,7 +17,10 @@ import {
   formatDeltaText,
   fmtValue,
   deltaCommand,
+  type DeltaOptions,
 } from './delta-cmd.js';
+
+const execFileAsync = promisify(execFile);
 
 const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*m/g, '');
 
@@ -141,6 +149,16 @@ describe('formatDeltaText', () => {
     expect(text).toContain('5 ms');
   });
 
+  it('renders the header against a custom baseLabel (--base <ref>)', () => {
+    const result = computeComplexityDelta(
+      [{ filepath: 'src/foo.ts', before: BODY.twoNest, after: BODY.threeNest }],
+      COG_ONLY,
+    );
+    const text = stripAnsi(formatDeltaText(result, 7, 'origin/main'));
+    expect(text).toContain('lien delta — complexity vs origin/main');
+    expect(text).not.toContain('vs HEAD');
+  });
+
   it('labels renamed files', () => {
     const result = computeComplexityDelta(
       [{ filepath: 'new.ts', oldPath: 'old.ts', before: BODY.twoNest, after: BODY.threeNest }],
@@ -211,6 +229,11 @@ describe('deltaCommand — operational failures exit 2 (Phase-1 findings #2, #3)
     await expect(deltaCommand({ format: 'text', file: '   ' })).rejects.toThrow('__exit__:2');
   });
 
+  it('exits 2 on an empty --base (usage error, not "use HEAD")', async () => {
+    await expect(deltaCommand({ format: 'text', base: '' })).rejects.toThrow('__exit__:2');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('non-empty ref'));
+  });
+
   it('exits 2 when config fails to load (malformed .lien.config.json)', async () => {
     vi.spyOn(core.configService, 'load').mockRejectedValue(
       new SyntaxError('Unexpected token } in JSON'),
@@ -219,5 +242,127 @@ describe('deltaCommand — operational failures exit 2 (Phase-1 findings #2, #3)
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('failed to load config'));
     // No report is printed on the error path.
     expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('deltaCommand — --base <ref> integration (real git fixtures)', () => {
+  let dir: string;
+  let originalCwd: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  async function git(...args: string[]): Promise<void> {
+    await execFileAsync('git', args, { cwd: dir });
+  }
+
+  async function write(rel: string, content: string): Promise<void> {
+    const full = path.join(dir, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, 'utf-8');
+  }
+
+  async function initRepo(): Promise<void> {
+    await git('init', '-q');
+    await git('config', 'user.email', 'test@example.com');
+    await git('config', 'user.name', 'Test');
+    await git('config', 'commit.gpgsign', 'false');
+  }
+
+  async function commitAll(msg: string): Promise<void> {
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', msg);
+  }
+
+  async function revParse(ref: string): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['rev-parse', ref], { cwd: dir });
+    return stdout.trim();
+  }
+
+  /** Run deltaCommand and resolve to the exit code, instead of throwing the sentinel. */
+  async function runDelta(options: DeltaOptions): Promise<number> {
+    try {
+      await deltaCommand(options);
+    } catch (error) {
+      const match = /__exit__:(\d+)/.exec(error instanceof Error ? error.message : String(error));
+      if (match) return Number(match[1]);
+      throw error;
+    }
+    return 0;
+  }
+
+  /** Parses the last console.log call as JSON, stripping the timing-noise field. */
+  function lastJsonLog(): Record<string, unknown> {
+    const call = logSpy.mock.calls.at(-1);
+    const { elapsedMs: _elapsedMs, ...rest } = JSON.parse(String(call?.[0]));
+    return rest;
+  }
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-delta-cmd-'));
+    dir = await fs.realpath(dir); // resolve macOS /var -> /private/var
+    originalCwd = process.cwd();
+    process.chdir(dir);
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('--base <HEAD sha> is equivalent to the default (no --base)', async () => {
+    await initRepo();
+    await write('a.ts', BODY.oneIf);
+    await commitAll('init');
+    await write('a.ts', BODY.twoNest); // uncommitted crossing (against threshold 2)
+
+    const head = await revParse('HEAD');
+    const exitDefault = await runDelta({ format: 'json', threshold: '2' });
+    const resultDefault = lastJsonLog();
+    const exitWithBase = await runDelta({ format: 'json', threshold: '2', base: head });
+    const resultWithBase = lastJsonLog();
+
+    expect(exitDefault).toBe(1);
+    expect(exitWithBase).toBe(1);
+    expect(resultWithBase).toEqual(resultDefault);
+  });
+
+  it('catches a crossing introduced relative to base but invisible vs HEAD (the CI case)', async () => {
+    await initRepo();
+    await write('a.ts', BODY.oneIf);
+    await commitAll('init'); // this is the PR's base (e.g. origin/main)
+    const base = await revParse('HEAD');
+
+    await write('a.ts', BODY.twoNest);
+    await commitAll('introduce crossing'); // committed: HEAD === working tree now
+
+    // Plain `lien delta` (vs HEAD) sees no diff at all — nothing to flag.
+    const exitVsHead = await runDelta({ format: 'json', threshold: '2' });
+    expect(exitVsHead).toBe(0);
+    expect((lastJsonLog() as { summary: { regressions: number } }).summary.regressions).toBe(0);
+
+    // `lien delta --base <base>` sees the committed crossing.
+    const exitVsBase = await runDelta({ format: 'json', threshold: '2', base });
+    expect(exitVsBase).toBe(1);
+    const result = lastJsonLog() as { summary: { regressions: number } };
+    expect(result.summary.regressions).toBe(1);
+  });
+
+  it('exits 2 with a clear message when --base does not resolve to a commit', async () => {
+    await initRepo();
+    await write('a.ts', BODY.oneIf);
+    await commitAll('init');
+
+    const exitCode = await runDelta({ format: 'text', base: 'totally-not-a-ref' });
+    expect(exitCode).toBe(2);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('base ref "totally-not-a-ref" not found'),
+    );
   });
 });

--- a/packages/cli/src/cli/delta-cmd.ts
+++ b/packages/cli/src/cli/delta-cmd.ts
@@ -23,11 +23,18 @@ export interface DeltaOptions {
   format: 'text' | 'json';
   threshold?: string;
   /**
-   * Restrict analysis to a single file (working tree vs HEAD). The fast path
-   * the PostToolUse edit hook uses — bounds the work to the one edited file
-   * instead of scanning the whole working tree on every keystroke.
+   * Restrict analysis to a single file (working tree vs HEAD, or vs `base`
+   * when given). The fast path the PostToolUse edit hook uses — bounds the
+   * work to the one edited file instead of scanning the whole working tree on
+   * every keystroke.
    */
   file?: string;
+  /**
+   * Compare the working tree against this ref instead of `HEAD` (e.g.
+   * `origin/main` in CI, to catch a crossing introduced anywhere in the PR
+   * rather than only in its most recent commit). Composes with `--file`.
+   */
+  base?: string;
 }
 
 const VALID_FORMATS = ['text', 'json'];
@@ -156,8 +163,16 @@ function fmtFunction(fn: FunctionComplexityDelta): string {
   return `${head} ${chalk.dim(METRIC_LABEL[m.metricType])} ${fmtValue(m.before, m.metricType)} → ${fmtValue(m.after, m.metricType)}${limit}`;
 }
 
-/** Render the human-readable report. Pure — no I/O, no process state. */
-export function formatDeltaText(result: ComplexityDeltaResult, elapsedMs: number): string {
+/**
+ * Render the human-readable report. Pure — no I/O, no process state.
+ * `baseLabel` names the comparison point in the header (default `HEAD`;
+ * `--base <ref>` passes `ref` so the report is honest about what it compared).
+ */
+export function formatDeltaText(
+  result: ComplexityDeltaResult,
+  elapsedMs: number,
+  baseLabel = 'HEAD',
+): string {
   const { summary, files } = result;
   const filesWithFindings = files.filter(f => f.functions.length > 0);
 
@@ -166,10 +181,10 @@ export function formatDeltaText(result: ComplexityDeltaResult, elapsedMs: number
       summary.filesChanged === 0
         ? 'no complexity-affecting changes'
         : `no complexity changes across ${summary.filesChanged} file(s)`;
-    return chalk.dim(`lien delta — ${what} vs HEAD (${elapsedMs} ms)`);
+    return chalk.dim(`lien delta — ${what} vs ${baseLabel} (${elapsedMs} ms)`);
   }
 
-  const lines: string[] = [chalk.bold('lien delta — complexity vs HEAD'), ''];
+  const lines: string[] = [chalk.bold(`lien delta — complexity vs ${baseLabel}`), ''];
   for (const file of filesWithFindings) {
     const tag =
       file.status === 'renamed' && file.oldPath ? chalk.dim(` (renamed from ${file.oldPath})`) : '';
@@ -198,20 +213,33 @@ export function formatDeltaText(result: ComplexityDeltaResult, elapsedMs: number
   return lines.join('\n');
 }
 
-/** Analyze the working tree's complexity delta vs HEAD. */
+/**
+ * Validate the simple usage flags before any work: a malformed --format, or an
+ * empty --file / --base, is a usage error (exit 2), not a silent no-op —
+ * silence is reserved for genuinely out-of-scope inputs (a non-code file, a
+ * path outside the repo), never malformed flags. Returns the message to print,
+ * or undefined when every flag is valid.
+ */
+function usageFlagError(options: DeltaOptions): string | undefined {
+  if (!VALID_FORMATS.includes(options.format)) {
+    return `Invalid --format "${options.format}". Must be text or json.`;
+  }
+  if (options.file !== undefined && options.file.trim() === '') {
+    return '--file requires a non-empty path.';
+  }
+  if (options.base !== undefined && options.base.trim() === '') {
+    return '--base requires a non-empty ref.';
+  }
+  return undefined;
+}
+
+/** Analyze the working tree's complexity delta vs HEAD (or `--base <ref>`). */
 export async function deltaCommand(options: DeltaOptions): Promise<void> {
   const start = Date.now();
 
-  if (!VALID_FORMATS.includes(options.format)) {
-    console.error(chalk.red(`Error: Invalid --format "${options.format}". Must be text or json.`));
-    process.exit(2);
-  }
-
-  // Validate --file before doing any work: an empty value is a usage error
-  // (exit 2), not a silent no-op — silence is reserved for genuinely
-  // out-of-scope files (non-code, outside the repo), never malformed input.
-  if (options.file !== undefined && options.file.trim() === '') {
-    console.error(chalk.red('lien delta: --file requires a non-empty path.'));
+  const usageError = usageFlagError(options);
+  if (usageError) {
+    console.error(chalk.red(`lien delta: ${usageError}`));
     process.exit(2);
   }
 
@@ -252,10 +280,10 @@ export async function deltaCommand(options: DeltaOptions): Promise<void> {
     if (options.file !== undefined) {
       // Single-file fast path (the edit hook). An out-of-repo / unsupported /
       // absent file yields no change → empty result → clean exit 0.
-      const single = await collectFileChange(rootDir, options.file);
+      const single = await collectFileChange(rootDir, options.file, options.base);
       changes = single ? [single] : [];
     } else {
-      changes = await collectFileChanges(rootDir);
+      changes = await collectFileChanges(rootDir, options.base);
     }
   } catch (error) {
     console.error(
@@ -272,7 +300,7 @@ export async function deltaCommand(options: DeltaOptions): Promise<void> {
   if (options.format === 'json') {
     console.log(JSON.stringify({ ...result, elapsedMs }, null, 2));
   } else {
-    console.log(formatDeltaText(result, elapsedMs));
+    console.log(formatDeltaText(result, elapsedMs, options.base ?? 'HEAD'));
   }
 
   process.exit(deltaExitCode(result, options.soft));

--- a/packages/cli/src/cli/delta-git.test.ts
+++ b/packages/cli/src/cli/delta-git.test.ts
@@ -163,6 +163,86 @@ describe('delta-git', () => {
     expect(await collectFileChanges(dir)).toEqual([]);
   });
 
+  describe('collectFileChanges — --base <ref>', () => {
+    async function revParse(ref: string): Promise<string> {
+      const { stdout } = await execFileAsync('git', ['rev-parse', ref], { cwd: dir });
+      return stdout.trim();
+    }
+
+    it('baseRef === HEAD produces the same result as the default (no --base)', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      await write('a.ts', COMPLEX);
+
+      const head = await revParse('HEAD');
+      const withoutBase = await collectFileChanges(dir);
+      const withBase = await collectFileChanges(dir, head);
+      expect(withBase).toEqual(withoutBase);
+      const c = byPath(withBase, 'a.ts')!;
+      expect(c.before).toBe(SIMPLE);
+      expect(c.after).toBe(COMPLEX);
+    });
+
+    it('sees a change committed after the base ref, not just working-tree edits', async () => {
+      // The CI-relevant case: a crossing introduced in an earlier commit of the
+      // PR (already sitting in the working tree at HEAD, no uncommitted diff)
+      // must still show up when compared against origin/main.
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      const base = await revParse('HEAD');
+
+      await write('a.ts', COMPLEX);
+      await commitAll('introduce complexity'); // committed, HEAD now == working tree
+
+      // Against HEAD there is no diff at all (working tree matches HEAD).
+      expect(await collectFileChanges(dir)).toEqual([]);
+
+      // Against the earlier base, the committed change is visible.
+      const c = byPath(await collectFileChanges(dir, base), 'a.ts')!;
+      expect(c.before).toBe(SIMPLE);
+      expect(c.after).toBe(COMPLEX);
+    });
+
+    it('layers uncommitted working-tree edits on top of the committed base diff', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      const base = await revParse('HEAD');
+
+      await write('a.ts', COMPLEX);
+      await commitAll('commit 2');
+      await write('a.ts', COMPLEX + '// further uncommitted edit\n');
+
+      const c = byPath(await collectFileChanges(dir, base), 'a.ts')!;
+      expect(c.before).toBe(SIMPLE);
+      expect(c.after).toContain('further uncommitted edit');
+    });
+
+    it('still reports untracked new files as added, regardless of base', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+      const base = await revParse('HEAD');
+      await write('b.ts', COMPLEX); // untracked
+
+      const c = byPath(await collectFileChanges(dir, base), 'b.ts')!;
+      expect(c.before).toBeNull();
+      expect(c.after).toBe(COMPLEX);
+    });
+
+    it('throws a clear error when the base ref does not resolve to a commit', async () => {
+      await initRepo();
+      await write('a.ts', SIMPLE);
+      await commitAll('init');
+
+      await expect(collectFileChanges(dir, 'does-not-exist-ref')).rejects.toThrow(
+        /base ref "does-not-exist-ref" not found/,
+      );
+    });
+  });
+
   describe('collectFileChange — single-file fast path (edit hook)', () => {
     it('builds before/after for a modified file (relative path)', async () => {
       await initRepo();
@@ -273,6 +353,48 @@ describe('delta-git', () => {
       } finally {
         await fs.rm(linkParent, { recursive: true, force: true });
       }
+    });
+
+    describe('with baseRef', () => {
+      async function revParse(ref: string): Promise<string> {
+        const { stdout } = await execFileAsync('git', ['rev-parse', ref], { cwd: dir });
+        return stdout.trim();
+      }
+
+      it('baseRef === HEAD matches the default (no baseRef)', async () => {
+        await initRepo();
+        await write('a.ts', SIMPLE);
+        await commitAll('init');
+        await write('a.ts', COMPLEX);
+
+        const head = await revParse('HEAD');
+        expect(await collectFileChange(dir, 'a.ts', head)).toEqual(
+          await collectFileChange(dir, 'a.ts'),
+        );
+      });
+
+      it('reads "before" from an earlier ref, seeing a since-committed change', async () => {
+        await initRepo();
+        await write('a.ts', SIMPLE);
+        await commitAll('init');
+        const base = await revParse('HEAD');
+        await write('a.ts', COMPLEX);
+        await commitAll('commit 2');
+
+        const c = await collectFileChange(dir, 'a.ts', base);
+        expect(c!.before).toBe(SIMPLE);
+        expect(c!.after).toBe(COMPLEX);
+      });
+
+      it('throws a clear error when baseRef does not resolve to a commit', async () => {
+        await initRepo();
+        await write('a.ts', SIMPLE);
+        await commitAll('init');
+
+        await expect(collectFileChange(dir, 'a.ts', 'nope-not-a-ref')).rejects.toThrow(
+          /base ref "nope-not-a-ref" not found/,
+        );
+      });
     });
   });
 

--- a/packages/cli/src/cli/delta-git.ts
+++ b/packages/cli/src/cli/delta-git.ts
@@ -42,6 +42,16 @@ async function hasCommits(rootDir: string): Promise<boolean> {
   }
 }
 
+/** Whether `ref` resolves to a commit in this repository. */
+async function refExists(rootDir: string, ref: string): Promise<boolean> {
+  try {
+    await git(rootDir, ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 interface RawChange {
   status: 'A' | 'M' | 'D' | 'R';
   path: string;
@@ -84,14 +94,15 @@ function isSupported(filepath: string, supported: ReadonlySet<string>): boolean 
   return supported.has(filepath.slice(dot));
 }
 
-async function showHead(rootDir: string, gitPath: string): Promise<string | null> {
+async function showAtRef(rootDir: string, ref: string, gitPath: string): Promise<string | null> {
   try {
-    return await git(rootDir, ['show', `HEAD:${gitPath}`]);
+    return await git(rootDir, ['show', `${ref}:${gitPath}`]);
   } catch {
-    // `null` here means "no version of this path in HEAD" — i.e. the file is
-    // added/untracked. That is the intended, correct meaning of a `git show`
-    // failure for this path (unlike readWorktree below, where null must be
-    // reserved for genuine absence), so all errors legitimately map to null.
+    // `null` here means "no version of this path in `ref`" — i.e. the file is
+    // added/untracked (relative to that ref). That is the intended, correct
+    // meaning of a `git show` failure for this path (unlike readWorktree
+    // below, where null must be reserved for genuine absence), so all errors
+    // legitimately map to null.
     return null;
   }
 }
@@ -110,62 +121,99 @@ export async function readWorktree(rootDir: string, gitPath: string): Promise<st
   }
 }
 
-/** Turn a raw git change into a before/after content pair. */
+/**
+ * Turn a raw git change into a before/after content pair.
+ *
+ * `showRef` is the ref "before" content is read from (`git show
+ * ${showRef}:path`); `null` means there is no baseline at all (unborn HEAD,
+ * default mode only) — every change is then treated as an addition.
+ */
 async function toContentChange(
   rootDir: string,
   raw: RawChange,
-  unborn: boolean,
+  showRef: string | null,
 ): Promise<FileContentChange> {
-  if (unborn || raw.status === 'A') {
+  if (showRef === null || raw.status === 'A') {
     return { filepath: raw.path, before: null, after: await readWorktree(rootDir, raw.path) };
   }
   if (raw.status === 'D') {
-    return { filepath: raw.path, before: await showHead(rootDir, raw.path), after: null };
+    return { filepath: raw.path, before: await showAtRef(rootDir, showRef, raw.path), after: null };
   }
   if (raw.status === 'R') {
     const oldPath = raw.oldPath ?? raw.path;
     return {
       filepath: raw.path,
       oldPath,
-      before: await showHead(rootDir, oldPath),
+      before: await showAtRef(rootDir, showRef, oldPath),
       after: await readWorktree(rootDir, raw.path),
     };
   }
   // Modified
   return {
     filepath: raw.path,
-    before: await showHead(rootDir, raw.path),
+    before: await showAtRef(rootDir, showRef, raw.path),
     after: await readWorktree(rootDir, raw.path),
   };
 }
 
-/**
- * Collect before/after content pairs for every changed, parser-supported file
- * (working tree vs HEAD). Returns an empty array when there are no changes.
- */
-export async function collectFileChanges(rootDir: string): Promise<FileContentChange[]> {
-  const supported = new Set(getSupportedExtensions().map(ext => `.${ext}`));
-  const born = await hasCommits(rootDir);
+interface Baseline {
+  raw: RawChange[];
+  /** Ref "before" content is read from; null => no baseline (unborn HEAD). */
+  showRef: string | null;
+}
 
-  let raw: RawChange[];
-  if (born) {
-    raw = parseNameStatusZ(
-      await git(rootDir, ['diff', '--name-status', '--find-renames', '-z', 'HEAD']),
-    );
-  } else {
-    // Unborn HEAD: everything staged is "added"; nothing has a HEAD baseline.
-    const staged = splitZ(await git(rootDir, ['diff', '--cached', '--name-only', '-z']));
-    raw = staged.map(p => ({ status: 'A' as const, path: p }));
+/** Explicit `--base <ref>` baseline: diff working tree against that ref. */
+async function explicitBaseline(rootDir: string, baseRef: string): Promise<Baseline> {
+  if (!(await refExists(rootDir, baseRef))) {
+    throw new Error(`base ref "${baseRef}" not found`);
   }
+  const raw = parseNameStatusZ(
+    await git(rootDir, ['diff', '--name-status', '--find-renames', '-z', baseRef]),
+  );
+  return { raw, showRef: baseRef };
+}
 
-  // Untracked files are additions regardless of HEAD state.
+/** Default baseline: working tree vs `HEAD`, with the unborn-HEAD fallback. */
+async function headBaseline(rootDir: string): Promise<Baseline> {
+  if (!(await hasCommits(rootDir))) {
+    // Unborn HEAD: everything staged is "added"; nothing has a baseline.
+    const staged = splitZ(await git(rootDir, ['diff', '--cached', '--name-only', '-z']));
+    return { raw: staged.map(p => ({ status: 'A' as const, path: p })), showRef: null };
+  }
+  const raw = parseNameStatusZ(
+    await git(rootDir, ['diff', '--name-status', '--find-renames', '-z', 'HEAD']),
+  );
+  return { raw, showRef: 'HEAD' };
+}
+
+/**
+ * Collect before/after content pairs for every changed, parser-supported file.
+ *
+ * Default (`baseRef` omitted): working tree vs `HEAD` — byte-for-byte the
+ * original behaviour, including the unborn-HEAD fallback (no commits yet).
+ *
+ * `baseRef` set: working tree vs the given ref (`git show <ref>:path`), the
+ * mode `lien delta --base <ref>` uses to compare against e.g. `origin/main`
+ * in CI. Throws if `baseRef` does not resolve to a commit.
+ *
+ * Returns an empty array when there are no changes.
+ */
+export async function collectFileChanges(
+  rootDir: string,
+  baseRef?: string,
+): Promise<FileContentChange[]> {
+  const supported = new Set(getSupportedExtensions().map(ext => `.${ext}`));
+  const { raw, showRef } =
+    baseRef !== undefined ? await explicitBaseline(rootDir, baseRef) : await headBaseline(rootDir);
+
+  // Untracked files are additions regardless of baseline state.
   const untracked = splitZ(
     await git(rootDir, ['ls-files', '--others', '--exclude-standard', '-z']),
   );
   for (const p of untracked) raw.push({ status: 'A', path: p });
 
   const filtered = raw.filter(r => isSupported(r.path, supported));
-  return Promise.all(filtered.map(r => toContentChange(rootDir, r, !born)));
+  return Promise.all(filtered.map(r => toContentChange(rootDir, r, showRef)));
 }
 
 /**
@@ -187,19 +235,22 @@ async function canonicalize(p: string): Promise<string> {
 }
 
 /**
- * Build the before/after content pair for a SINGLE file (working tree vs HEAD).
- * This is the fast path for the per-edit hook: it avoids the full `git diff`
- * scan and touches only the one file that was just edited.
+ * Build the before/after content pair for a SINGLE file (working tree vs a
+ * ref — `HEAD` by default, or `baseRef` when given). This is the fast path
+ * for the per-edit hook: it avoids the full `git diff` scan and touches only
+ * the one file that was just edited.
  *
  * `filePath` may be absolute or relative to `rootDir`. Returns `null` — meaning
  * "nothing to analyze, stay silent" — when the path is outside the repo, its
  * extension is not parser-supported, or it exists on neither side (before and
  * after both absent). Read errors other than ENOENT propagate (operational
- * failure), matching `readWorktree`'s contract.
+ * failure), matching `readWorktree`'s contract. Throws if `baseRef` is given
+ * and does not resolve to a commit.
  */
 export async function collectFileChange(
   rootDir: string,
   filePath: string,
+  baseRef?: string,
 ): Promise<FileContentChange | null> {
   // Resolve to a repo-relative POSIX path; reject anything outside the repo.
   // Canonicalize symlinked path segments on BOTH sides first — otherwise a
@@ -224,7 +275,11 @@ export async function collectFileChange(
   const supported = new Set(getSupportedExtensions().map(ext => `.${ext}`));
   if (!isSupported(relPosix, supported)) return null;
 
-  const before = await showHead(rootDir, relPosix); // null => not in HEAD (added/new)
+  if (baseRef !== undefined && !(await refExists(rootDir, baseRef))) {
+    throw new Error(`base ref "${baseRef}" not found`);
+  }
+  const ref = baseRef ?? 'HEAD';
+  const before = await showAtRef(rootDir, ref, relPosix); // null => not in ref (added/new)
   const after = await readWorktree(rootDir, relPosix); // null => deleted (ENOENT only)
   if (before === null && after === null) return null;
 

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -97,6 +97,10 @@ program
   .option('--threshold <n>', 'Override cyclomatic + cognitive thresholds (default: from config)')
   .option('--soft', 'Advisory mode: always exit 0 (still prints the report)')
   .option('--file <path>', 'Analyze only this file vs HEAD (fast path for edit hooks)')
+  .option(
+    '--base <ref>',
+    'Compare the working tree against this ref instead of HEAD (e.g. origin/main in CI)',
+  )
   .action(deltaCommand);
 
 const configCmd = program


### PR DESCRIPTION
## What

Adds `lien delta --base <ref>` and wires a CI job that runs it on every pull request, so the sixth commit gate (`lien delta`) finally has a CI backstop — the other five gates (format, lint, typecheck, build, test) already run in CI.

## Why

`lien delta` only ever compared the working tree to `HEAD`. That's the right default for an agent running the gate mid-edit, but it has a blind spot in CI: by the time a PR is checked out, its own commits are already `HEAD` and the working tree is clean, so a crossing introduced by an *earlier* commit in the same PR produces no diff at all against `HEAD` — the gate sees nothing to flag, even though the crossing is sitting right there in the PR's history. Until this PR, `lien delta` ran purely on an agent's honor system with no automated enforcement.

## How

- `--base <ref>`: compares the current state against any ref instead of `HEAD`. File discovery becomes `git diff --name-status --find-renames <ref>` (was `... HEAD`), and "before" content is read via `git show <ref>:path` (was `git show HEAD:path`). Untracked files are still additions regardless of baseline. Omitting `--base` is byte-for-byte identical to the original HEAD-vs-working-tree behavior.
- Composes with every existing flag: `--file` (single-file fast path vs `<ref>`), `--format json`, `--soft`, `--threshold`.
- A `--base` ref that doesn't resolve to a commit is a clear operational error, exit 2 (same convention as an unreadable file or missing git binary).
- CI: new `delta` job on `pull_request` events only, `fetch-depth: 0` checkout (needed so `origin/<base-branch>` resolves locally), builds parser+core+cli, then runs `node packages/cli/dist/index.js delta --base "origin/$GITHUB_BASE_REF"`. Fails the job on exit 1 (a new crossing).
- Docs: added a `--base <ref>` usage section plus a CI-wiring section to `docs/architecture/lien-delta.md`.
- Changeset: minor bump for `@liendev/lien` (parser was untouched — the delta-computation primitive already took ref-agnostic before/after content strings, so no parser changes were needed).

Note: `CLAUDE.md`'s "Before EVERY Commit" section still describes `lien delta` as having no CI backstop — that wording is owned by a parallel in-flight PR (worktree-agent-setup-overhaul) touching the same section, so it's left alone here to avoid a merge conflict. It becomes stale once both land.

## Verified

Local repro (also covered by the new integration tests in `delta-cmd.test.ts`):

```
$ node packages/cli/dist/index.js delta            # vs HEAD: working tree == HEAD, nothing to see
lien delta — no complexity-affecting changes vs HEAD (22 ms)
exit: 0

$ node packages/cli/dist/index.js delta --base <base-sha>   # same repo, vs the PR's base
lien delta — complexity vs c2097333ba51...

  a.ts
    ✗ crossed   target    cognitive 1 → 15 (limit 15)

  ✗ 1 new crossing · 1 file · 40 ms
exit: 1
```

This is exactly the CI-relevant gap `--base` closes: a crossing already committed into a PR's history is invisible to plain `lien delta` but caught against the PR's base branch.

All six gates green locally: `format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`, `build`, `test` (all packages, 1740+ tests), `lien delta` (exit 0, no new crossings introduced by this change itself).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 28. 2 pre-existing issues remain in touched files.
🔗 **Impact**: 1 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | -13 |


> [!NOTE]
> **Low Risk**
>
> This PR adds `lien delta --base <ref>` and a CI backstop job with careful validation and preserved default behavior. Empty/whitespace `--base` is rejected as a usage error, non-existent refs produce a clear exit-2 message, and the HEAD-vs-working-tree default path is unchanged. The git plumbing correctly reads before-content from the supplied ref while keeping the working tree as the after side, untracked files remain additions, and the single-file fast path composes with `--base`. New integration tests cover the CI-relevant case where a crossing is invisible against HEAD but caught against the PR base.
>
> - Added optional `baseRef` parameter to `collectFileChanges` and `collectFileChange` with explicit ref validation
> - Added `--base <ref>` CLI option and empty-ref validation in `usageFlagError`
> - Updated text report header to name the actual comparison ref
> - Added CI `delta` job running `lien delta --base origin/$GITHUB_BASE_REF` on pull requests with `fetch-depth: 0`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit af5d0b8. Updates automatically on new commits.</sup>
<!-- /lien-stats -->