### PR TITLE
chore: SessionStart hook injects .claude/lessons.md into agent context

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -s .claude/lessons.md ] && cat .claude/lessons.md || true"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## What

Adds a `SessionStart` hook to the checked-in `.claude/settings.json` that emits `.claude/lessons.md` into agent context on `startup` and `clear`.

## Why

CLAUDE.md's Self-Improvement Loop instructs every agent to *read `.claude/lessons.md` at the start of each session* — but that was honor-based; nothing executed it. #687 made lessons.md git-tracked; this closes the loop by making the read automatic. Completes the drift-prevention set alongside #688/#689/#690/#691.

## Design

- **Matcher `startup|clear`**: fresh-context sessions are the ones missing the lessons. `resume` continues a context that already saw them at its original startup, so it's excluded to avoid duplicate injection.
- **`[ -s ... ]` guard**: silently no-ops when the file is absent (pre-#687 clones) or empty — sessions never break on a missing file.
- Existing PostToolUse prettier/eslint hooks untouched.

## Verified

- `jq -e` schema check: event/matcher/command nesting extracts cleanly; PostToolUse hooks preserved.
- Command pipe-tested standalone: file-present emits the lessons content; file-absent exits 0 silently.
- All six pre-commit gates green (format, lint 0 errors, typecheck, build, full test chain, `lien delta` exit 0).
- Note: SessionStart fires outside any in-session turn, so live-fire proof isn't possible from the authoring session — schema + pipe-test is the full available validation. Hook channel semantics per `docs/architecture/claude-code-hook-channels.md` (SessionStart stdout is injected as context).

This change was explicitly reviewed and approved by the maintainer before authoring (auto-mode classifier required direct review for agent-loaded config).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 95 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 500 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 38 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e5ef32e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->