### PR TITLE
feat: native parser becomes the default backend (ADR-013 Phase 4-A)

### DIFF
--- a/.changeset/parser-native-default.md
+++ b/.changeset/parser-native-default.md
@@ -1,0 +1,5 @@
+---
+'@liendev/parser': minor
+---
+
+The native backend (`@liendev/parser-native`) is now the default parser -- prebuilt binaries, 1.8-2.2x faster end-to-end than the previous `node-tree-sitter` path. `LIEN_PARSER=legacy` remains available as a transitional opt-out (scheduled for removal in a future release). If no prebuilt native binary can be loaded for your platform, lien automatically falls back to the legacy backend for the session and prints a one-time warning explaining why and how to build one -- see ADR-013 (docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md).

--- a/.github/scripts/plan-e2e-matrix.mjs
+++ b/.github/scripts/plan-e2e-matrix.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 // Computes the e2e-tests-parallel matrix for e2e.yml.
 //
-// Every normal (changeset- or `e2e`-label-triggered) PR run exercises all 12
-// project/language e2e scripts once under the default LIEN_PARSER=legacy
-// backend, PLUS a LIEN_PARSER=native rerun for exactly two representative
-// jobs -- TypeScript (the most heavily used grammar) and Kotlin (the one
-// vendored, non-npm-prebuilt grammar -- see ADR-013's Phase 0 crate audit)
-// -- so every release-bound PR proves native e2e coverage without doubling
-// all 12 jobs on every run.
+// ADR-013 Phase 4-A flipped the default LIEN_PARSER backend to native.
+// Every normal (changeset- or `e2e`-label-triggered) PR run now exercises
+// all 12 project/language e2e scripts once under native, PLUS a
+// LIEN_PARSER=legacy rerun for exactly two representative jobs --
+// TypeScript (the most heavily used grammar) and Kotlin (the one vendored,
+// non-npm-prebuilt grammar -- see ADR-013's Phase 0 crate audit) -- so
+// every release-bound PR proves the transitional legacy opt-out still
+// works without doubling all 12 jobs on every run.
 //
 // A workflow_dispatch run instead honors the `parser-mode` input, running
 // the full 12-project suite under 'legacy', 'native', or both ('both' = the
@@ -37,24 +38,24 @@ const PROJECTS = [
   { project: 'MCP Round Trip', language: 'Protocol', script: 'test:e2e:mcp' },
 ];
 
-// The two representative jobs that get a native rerun on every normal
+// The two representative jobs that get a legacy rerun on every normal
 // (non-dispatch) trigger -- see header comment above.
-const REPRESENTATIVE_NATIVE_LANGUAGES = ['TypeScript', 'Kotlin'];
+const REPRESENTATIVE_LEGACY_LANGUAGES = ['TypeScript', 'Kotlin'];
 
 function withMode(entry, mode) {
   return Object.assign({}, entry, { mode: mode });
 }
 
 function planNormalRun() {
-  const legacy = PROJECTS.map(function (p) {
-    return withMode(p, 'legacy');
-  });
-  const native = PROJECTS.filter(function (p) {
-    return REPRESENTATIVE_NATIVE_LANGUAGES.indexOf(p.language) !== -1;
-  }).map(function (p) {
+  const native = PROJECTS.map(function (p) {
     return withMode(p, 'native');
   });
-  return legacy.concat(native);
+  const legacy = PROJECTS.filter(function (p) {
+    return REPRESENTATIVE_LEGACY_LANGUAGES.indexOf(p.language) !== -1;
+  }).map(function (p) {
+    return withMode(p, 'legacy');
+  });
+  return native.concat(legacy);
 }
 
 function planDispatchRun(parserMode) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,25 +92,29 @@ jobs:
       - name: Build Action image (Dockerfile smoke test)
         run: docker build -f packages/action/Dockerfile -t lien-review:ci .
 
-  test-native:
-    name: Run tests (LIEN_PARSER=native)
+  test-legacy:
+    name: Run tests (LIEN_PARSER=legacy)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    # ADR-013 Phase 3 ("flagged swap -- CI runs both modes"): build-and-test
-    # above runs the full suite under the default LIEN_PARSER=legacy backend.
-    # This job is the native-backend counterpart, required (no
-    # continue-on-error) exactly like build-and-test. It's a dedicated job
-    # rather than a `parser-mode` matrix axis on build-and-test because most
-    # of that job's steps -- format/lint/typecheck, the full `npm run build`,
-    # the CLI smoke test, the Action Docker build -- are parser-backend
-    # independent; matrixing the whole job would double all of that on every
-    # push/PR for zero extra coverage. This job instead reuses only the setup
-    # `npm test` actually needs: the compiled native binary (loaded via
-    # index.js's local-dev fallback path) and a built parser/core/review
-    # (CLI and Action resolve those via `dist/`, same as build-and-test's
-    # "Build Parser, Core & Review" step) -- then runs the whole workspace
-    # test suite once under LIEN_PARSER=native.
+    # ADR-013 Phase 4-A ("flip + transitional fallback"): build-and-test
+    # above now runs the full suite under the default (unset) LIEN_PARSER,
+    # i.e. native. This job is the legacy-backend counterpart -- proving the
+    # transitional opt-out still works end to end -- required (no
+    # continue-on-error) exactly like build-and-test, for as long as legacy
+    # remains installed (one release; Phase 4-B removes it). It's a
+    # dedicated job rather than a `parser-mode` matrix axis on build-and-test
+    # because most of that job's steps -- format/lint/typecheck, the full
+    # `npm run build`, the CLI smoke test, the Action Docker build -- are
+    # parser-backend independent; matrixing the whole job would double all
+    # of that on every push/PR for zero extra coverage. This job instead
+    # reuses only the setup `npm test` actually needs: a built
+    # parser/core/review (CLI and Action resolve those via `dist/`, same as
+    # build-and-test's "Build Parser, Core & Review" step) -- then runs the
+    # whole workspace test suite once under LIEN_PARSER=legacy. The native
+    # binary is still built here (not skippable): legacy-mode tests still
+    # exercise ast/native/compat.test.ts's dual-backend equivalence checks,
+    # which drive the native path directly regardless of the job-wide env.
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -138,10 +142,10 @@ jobs:
       - name: Build Parser, Core & Review (required by CLI & Action)
         run: npm run build -w @liendev/parser && npm run build -w @liendev/core && npm run build -w @liendev/review
 
-      - name: Run tests (LIEN_PARSER=native)
+      - name: Run tests (LIEN_PARSER=legacy)
         run: npm test
         env:
-          LIEN_PARSER: native
+          LIEN_PARSER: legacy
 
   delta:
     name: Complexity delta vs base branch (lien delta --base)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       parser-mode:
-        description: 'LIEN_PARSER backend to run the full 12-project suite under (dispatch only -- the normal trigger always runs legacy for all projects plus a native rerun for TypeScript + Kotlin)'
+        description: 'LIEN_PARSER backend to run the full 12-project suite under (dispatch only -- the normal trigger always runs native for all projects plus a legacy rerun for TypeScript + Kotlin)'
         required: false
         default: legacy
         type: choice
@@ -68,10 +68,10 @@ jobs:
 
       # Computes the project/language/mode matrix from
       # .github/scripts/plan-e2e-matrix.mjs: every normal trigger runs all 12
-      # projects under LIEN_PARSER=legacy plus a native rerun for TypeScript +
+      # projects under LIEN_PARSER=native plus a legacy rerun for TypeScript +
       # Kotlin; a workflow_dispatch run instead honors `parser-mode` (legacy |
       # native | both) across the full 12-project suite -- see that script's
-      # header for the full rationale (ADR-013 Phase 3).
+      # header for the full rationale (ADR-013 Phase 4-A).
       - id: plan
         run: node .github/scripts/plan-e2e-matrix.mjs
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,20 +106,30 @@ npm test
 full list) and in CI only when a PR carries a changeset or the `e2e` label.
 
 **Native parser binary:** `packages/parser`'s `ast/native/compat.test.ts`
-drives the native backend (`LIEN_PARSER=native`) against the compiled
-`parser-native.node`. Run `npm run build:native -w @liendev/parser-native`
-first (compiles the Rust crate via `cargo build --release`) — without it,
-`npm test` fails loudly in that suite rather than skipping it. CI always
+drives the native backend (`LIEN_PARSER=native`, set explicitly inside that
+suite) against the compiled `parser-native.node`. Run
+`npm run build:native -w @liendev/parser-native` first (compiles the Rust
+crate via `cargo build --release`) — without it, that suite's
+explicit-native assertions fail loudly rather than skipping. CI always
 builds the native binary before running any test job.
 
-**`LIEN_PARSER=native|legacy`:** selects the AST parser backend; unset or
-`legacy` uses the existing `node-tree-sitter` path. CI runs the whole test
-suite under both — `build-and-test` (legacy, the default) and a dedicated
-`test-native` job — and `e2e.yml` reruns the TypeScript and Kotlin e2e
-projects under native on every changeset-triggered PR (the full 12-project
-suite in both modes is available via that workflow's manual
-`workflow_dispatch`). To reproduce a native-mode failure locally, build the
-binary as above, then run `LIEN_PARSER=native npm test`. See
+**`LIEN_PARSER=native|legacy`:** selects the AST parser backend. Unset or
+`native` uses `@liendev/parser-native`, the default since ADR-013 Phase 4-A.
+`legacy` opts out to the previous `node-tree-sitter` path — it is
+**transitional and scheduled for removal in a future release**; don't build
+new work against it. **Fallback:** on the default (unset) path only, if the
+native binding fails to *load* (e.g. an exotic platform with no prebuilt
+package and no local build), lien automatically falls back to legacy for
+the rest of the process and prints one `console.warn` naming the platform
+and the remedy — a per-file parse error from an already-loaded binding is
+unaffected and never triggers this. An **explicit** `LIEN_PARSER=native`
+does not fall back — it fails loud, which is what CI's dedicated
+native-mode coverage relies on. CI runs the whole test suite under both —
+`build-and-test` (native, the default) and a dedicated `test-legacy` job —
+and `e2e.yml` reruns the TypeScript and Kotlin e2e projects under legacy on
+every changeset-triggered PR (the full 12-project suite in both modes is
+available via that workflow's manual `workflow_dispatch`). To reproduce a
+legacy-mode failure locally, run `LIEN_PARSER=legacy npm test`. See
 [ADR-013](docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md)
 for the staged rollout this flag is part of.
 

--- a/docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md
+++ b/docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md
@@ -21,13 +21,14 @@ Build **`@liendev/parser-native`**: a napi-rs Rust crate that statically links `
 
 Distribution follows the esbuild pattern: prebuilt per-platform npm packages wired in via `optionalDependencies`, with **no runtime or build-time dependency on `@napi-rs/cli`** — a hand-rolled loader and build pipeline, per the spike's precedent, keeps the dependency tree in this package as small as the problem it replaces.
 
-Rollout is staged behind an environment flag, `LIEN_PARSER=native|legacy`, defaulting to `legacy` until the parity gate passes:
+Rollout is staged behind an environment flag, `LIEN_PARSER=native|legacy`, which defaulted to `legacy` through Phase 3 and now defaults to `native` as of Phase 4-A:
 
 1. **Audit** (Phase 0, this ADR) — prove every grammar resolves against one core and the wire/compat shape can represent everything lien's AST layer needs.
 2. **Foundation** (Phase 1) — build the crate, the compat deserializer, and the CI prebuild matrix.
 3. **Parity gate** (Phase 2) — diff lien-level output (chunks, symbols, complexity scores) between the legacy and native backends across all 11 languages.
 4. **Flagged swap** (Phase 3) — ship `LIEN_PARSER=native` as an opt-in flag, default still `legacy`, CI running both modes.
-5. **Flip + retire** (Phase 4) — flip the default to `native` and delete `node-tree-sitter` plus all 11 grammar npm packages, which collapses `docs/development/worktree-development.md` to nothing and retires the dual-core-lockfile and Kotlin-no-prebuilds landmines outright.
+5. **Flip** (Phase 4-A, executed 2026-07-09) — flip the default to `native`; `legacy` remains installed and reachable as a transitional, explicit opt-out with an automatic fallback-with-warning if the native binding can't load. CI's second mode job and `e2e.yml`'s representative rerun invert to cover `legacy` instead of `native`.
+6. **Retire** (Phase 4-B, one release later) — delete `legacy`, `node-tree-sitter`, and all 11 grammar npm packages, which collapses `docs/development/worktree-development.md` to nothing and retires the dual-core-lockfile and Kotlin-no-prebuilds landmines outright.
 
 A release/validation pass (changesets, the existing post-publish registry smoke test, and a fresh install on a stock Apple toolchain) follows the flip before general availability. Implementation work lands on `feat/parser-native` starting at Phase 1.
 
@@ -74,7 +75,7 @@ All 11 crates were independently resolved against `tree-sitter` core 0.25.x, com
 ### Positive
 
 - 1.82–2.21x faster end-to-end, and the *reason* is structural (traversal moves from per-node FFI calls to native array/object access on a plain JS tree), not a one-time tuning win.
-- No native compilation at install time once Phase 4 ships — prebuilt per-platform packages fix the exact failure `docs/development/worktree-development.md` documents, and retire the dual-tree-sitter-core lockfile hazard and the Kotlin-no-prebuilds gap outright, rather than working around either.
+- No native compilation at install time once Phase 4-B ships — prebuilt per-platform packages fix the exact failure `docs/development/worktree-development.md` documents, and retire the dual-tree-sitter-core lockfile hazard and the Kotlin-no-prebuilds gap outright, rather than working around either. (Phase 4-A already makes native the default; `node-tree-sitter` itself isn't removed, and its install-time compile risk isn't retired, until 4-B.)
 - Parity was proven empirically (100% TS/Python, 96.7% Kotlin with all divergences explained) *before* committing to the design, not assumed.
 - `SyntaxNode`-typed values already never cross the `@liendev/parser` package boundary (verified by grep across `core`/`cli`/`review`/`action`) — this migration changes an internal implementation detail, not any package's public API.
 
@@ -93,7 +94,7 @@ Six non-blocking issues surfaced by adversarial verification, all of which must 
 
 - Kotlin needs a vendored, patched crate — the only one of the 11 — which is a permanent, if small, maintenance surface (one `Cargo.toml` line, diffable against the unmodified upstream tarball) rather than a one-time cost.
 - No `@napi-rs/cli` dependency: the build and platform-package loader are hand-rolled, consistent with the project's dependency-minimalism, but that logic is now lien's own code to maintain rather than a library's.
-- `LIEN_PARSER` defaults to `legacy` through Phase 3 — no user-visible behavior change until Phase 4 flips the default, and `node-tree-sitter` isn't removed until then either.
+- `LIEN_PARSER` defaulted to `legacy` through Phase 3 — no user-visible behavior change until Phase 4-A flipped the default (2026-07-09). `node-tree-sitter` isn't removed until Phase 4-B; until then, `legacy` stays installed as an explicit, transitional opt-out, and a native binding that fails to load on the default path falls back to it automatically with a warning rather than failing.
 
 ## References
 

--- a/packages/parser/src/ast/backend.test.ts
+++ b/packages/parser/src/ast/backend.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveParserBackend, isBackendUnset } from './backend.js';
+
+/**
+ * LIEN_PARSER is read at call time (see backend.ts), so these tests flip it
+ * per-assertion and always restore it afterward rather than relying on test
+ * ordering.
+ */
+describe('resolveParserBackend', () => {
+  const original = process.env.LIEN_PARSER;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.LIEN_PARSER;
+    } else {
+      process.env.LIEN_PARSER = original;
+    }
+  });
+
+  it('defaults to native when LIEN_PARSER is unset (ADR-013 Phase 4-A)', () => {
+    delete process.env.LIEN_PARSER;
+    expect(resolveParserBackend()).toBe('native');
+  });
+
+  it('returns native when LIEN_PARSER=native is set explicitly', () => {
+    process.env.LIEN_PARSER = 'native';
+    expect(resolveParserBackend()).toBe('native');
+  });
+
+  it('returns legacy when LIEN_PARSER=legacy is set explicitly (the transitional opt-out)', () => {
+    process.env.LIEN_PARSER = 'legacy';
+    expect(resolveParserBackend()).toBe('legacy');
+  });
+
+  it('throws listing valid options for an unknown value', () => {
+    process.env.LIEN_PARSER = 'bogus';
+    expect(() => resolveParserBackend()).toThrow(/Invalid LIEN_PARSER/);
+    expect(() => resolveParserBackend()).toThrow(/'native', 'legacy'/);
+  });
+});
+
+describe('isBackendUnset', () => {
+  const original = process.env.LIEN_PARSER;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.LIEN_PARSER;
+    } else {
+      process.env.LIEN_PARSER = original;
+    }
+  });
+
+  it('is true when LIEN_PARSER is unset', () => {
+    delete process.env.LIEN_PARSER;
+    expect(isBackendUnset()).toBe(true);
+  });
+
+  it('is false when LIEN_PARSER is set explicitly, even to the default value', () => {
+    process.env.LIEN_PARSER = 'native';
+    expect(isBackendUnset()).toBe(false);
+  });
+
+  it('is false when LIEN_PARSER is set to legacy', () => {
+    process.env.LIEN_PARSER = 'legacy';
+    expect(isBackendUnset()).toBe(false);
+  });
+});

--- a/packages/parser/src/ast/backend.ts
+++ b/packages/parser/src/ast/backend.ts
@@ -11,7 +11,9 @@ export type ParserBackend = 'native' | 'legacy';
 
 const VALID_BACKENDS: ReadonlySet<string> = new Set(['native', 'legacy']);
 
-const DEFAULT_BACKEND: ParserBackend = 'legacy';
+// ADR-013 Phase 4-A: native is now the default. 'legacy' remains a valid
+// explicit opt-out for exactly one release (Phase 4-B removes it).
+const DEFAULT_BACKEND: ParserBackend = 'native';
 
 /**
  * Resolve which parser backend to use from LIEN_PARSER, read at call time
@@ -29,4 +31,17 @@ export function resolveParserBackend(): ParserBackend {
     );
   }
   return raw as ParserBackend;
+}
+
+/**
+ * True when LIEN_PARSER was left unset, i.e. the caller landed on 'native'
+ * by default rather than opting into it explicitly. ast/parser.ts uses this
+ * to decide whether a native binding load failure should transparently fall
+ * back to legacy (default path only -- see its transitional-fallback
+ * comment) or fail loud (an explicit LIEN_PARSER=native, e.g. CI's
+ * test-legacy/test-native jobs or an intentional user, must see real
+ * failures, not a silently masked one).
+ */
+export function isBackendUnset(): boolean {
+  return !process.env.LIEN_PARSER;
 }

--- a/packages/parser/src/ast/native/compat.test.ts
+++ b/packages/parser/src/ast/native/compat.test.ts
@@ -9,7 +9,6 @@ import Swift from 'tree-sitter-swift';
 import { parseAST } from '../parser.js';
 import { chunkByAST } from '../chunker.js';
 import { extractExports, extractImports, extractCallSites } from '../symbols.js';
-import { resolveParserBackend } from '../backend.js';
 import type { SupportedLanguage } from '../languages/registry.js';
 
 /**
@@ -314,38 +313,4 @@ describe('native compat deserializer: real extractor parity', () => {
   });
 });
 
-describe('resolveParserBackend', () => {
-  afterEach(() => {
-    delete process.env.LIEN_PARSER;
-  });
-
-  it('defaults to legacy when LIEN_PARSER is unset', () => {
-    delete process.env.LIEN_PARSER;
-    expect(resolveParserBackend()).toBe('legacy');
-  });
-
-  it('accepts an explicit legacy value', () => {
-    process.env.LIEN_PARSER = 'legacy';
-    expect(resolveParserBackend()).toBe('legacy');
-  });
-
-  it('accepts native', () => {
-    process.env.LIEN_PARSER = 'native';
-    expect(resolveParserBackend()).toBe('native');
-  });
-
-  it('throws a clear error for an unknown value', () => {
-    process.env.LIEN_PARSER = 'garbage';
-    expect(() => resolveParserBackend()).toThrowError(/Invalid LIEN_PARSER/);
-
-    try {
-      resolveParserBackend();
-      expect.unreachable('resolveParserBackend should have thrown');
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain('garbage');
-      expect(message).toContain('native');
-      expect(message).toContain('legacy');
-    }
-  });
-});
+// resolveParserBackend()/isBackendUnset() unit tests live in ../backend.test.ts.

--- a/packages/parser/src/ast/parser.test.ts
+++ b/packages/parser/src/ast/parser.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import Parser from 'tree-sitter';
+import { parseAST, clearParserCache } from './parser.js';
+
+const VALID_TS = 'const x = 1;';
+const INVALID_TS = 'const x = ;';
+
+/**
+ * ADR-013 Phase 4-A transitional fallback (see parser.ts's shouldFallBackToLegacy).
+ *
+ * `fs.existsSync` is mocked to simulate the native binding failing to *load*
+ * (findPackageDir can't resolve @liendev/parser-native, e.g. an exotic
+ * platform with no prebuilt package and no local build) -- following the
+ * same real-fs-spy pattern chunk-only-index.test.ts uses for `fs.readFile`,
+ * rather than vi.mock'ing the module.
+ *
+ * A real Parser.Tree instance (node-tree-sitter) vs. the native compat
+ * backend's plain-object CompatTree is used throughout as the discriminator
+ * for "which backend actually produced this result" -- see
+ * ast/native/compat-node.ts's `export interface CompatTree`.
+ *
+ * Order matters within this file: loadNativeBinding() memoizes a
+ * *successful* load in a module-level variable that clearParserCache() does
+ * not (and must not, per its own doc comment) reset. The load-failure tests
+ * must run before anything triggers a real successful native load, or the
+ * memoized handle would short-circuit the fs.existsSync mock. Each test
+ * file gets its own fresh module graph, so this only matters relative to
+ * other tests in this file.
+ */
+describe('parseAST native-load fallback (ADR-013 Phase 4-A)', () => {
+  const originalEnv = process.env.LIEN_PARSER;
+
+  beforeEach(() => {
+    clearParserCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearParserCache();
+    if (originalEnv === undefined) {
+      delete process.env.LIEN_PARSER;
+    } else {
+      process.env.LIEN_PARSER = originalEnv;
+    }
+  });
+
+  it('explicit LIEN_PARSER=native + load failure: fails loud, does not fall back, does not warn', () => {
+    process.env.LIEN_PARSER = 'native';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = parseAST(VALID_TS, 'typescript');
+
+    expect(result.tree).toBeNull();
+    expect(result.error).toBeTruthy();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('default (LIEN_PARSER unset) + load failure: falls back to legacy, warns exactly once', () => {
+    delete process.env.LIEN_PARSER;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const first = parseAST(VALID_TS, 'typescript');
+    const second = parseAST(VALID_TS, 'typescript');
+
+    // A real Parser.Tree means the legacy (node-tree-sitter) path ran.
+    expect(first.tree instanceof Parser.Tree).toBe(true);
+    expect(second.tree instanceof Parser.Tree).toBe(true);
+    expect(first.error).toBeUndefined();
+
+    // Cached decision -- the failing load is only attempted once per process.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0] as [string];
+    expect(message).toContain(process.platform);
+    expect(message).toContain('legacy');
+    expect(message).toContain('LIEN_PARSER=legacy');
+  });
+
+  it('default (LIEN_PARSER unset) + native loads successfully: uses native, no warning', () => {
+    delete process.env.LIEN_PARSER;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = parseAST(VALID_TS, 'typescript');
+
+    expect(result.tree).not.toBeNull();
+    // Native compat trees are plain objects, never real Parser.Tree instances.
+    expect(result.tree instanceof Parser.Tree).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('a per-file parse error from an already-loaded native binding does not trigger fallback', () => {
+    delete process.env.LIEN_PARSER;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = parseAST(INVALID_TS, 'typescript');
+
+    // Still native (a CompatTree), just with the normal hasError signal --
+    // not a load failure, so no fallback and no warning.
+    expect(result.tree).not.toBeNull();
+    expect(result.tree instanceof Parser.Tree).toBe(false);
+    expect(result.error).toBe('Parse completed with errors');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/parser/src/ast/parser.ts
+++ b/packages/parser/src/ast/parser.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { getLanguage, detectLanguage as registryDetectLanguage } from './languages/registry.js';
 import type { SupportedLanguage } from './languages/registry.js';
 import type { ASTParseResult } from './types.js';
-import { resolveParserBackend } from './backend.js';
+import { resolveParserBackend, isBackendUnset } from './backend.js';
 import { buildCompatTree } from './native/index.js';
 import type { WireNode } from '@liendev/parser-native';
 
@@ -157,13 +157,67 @@ function parseNative(content: string, language: SupportedLanguage): ASTParseResu
 }
 
 /**
+ * Cached decision for the default (LIEN_PARSER unset) path: whether the
+ * native binding failed to *load* and every subsequent call this process
+ * must run legacy instead. `null` = not yet decided. Populated once by
+ * shouldFallBackToLegacy() so a missing prebuilt/local build only pays the
+ * (failing) load attempt once per process, not once per file.
+ */
+let fellBackToLegacy: boolean | null = null;
+
+/**
+ * Transitional fallback (ADR-013 Phase 4-A): on the default path only
+ * (LIEN_PARSER unset), attempt to load the native binding and, on failure,
+ * permanently switch this process to legacy while emitting exactly one
+ * console.warn naming the platform, the fallback, and the remedy.
+ *
+ * This only covers *load* failure -- the binding cannot be obtained at all
+ * (e.g. no prebuilt package for this platform/arch and no local build
+ * present). A per-file parse error from an already-loaded binding (a real
+ * syntax error, `hasError`, etc.) must never reach here -- that is normal
+ * chunker-fallback territory handled entirely inside parseNative's own
+ * try/catch, which still runs afterwards for every file.
+ *
+ * An explicit `LIEN_PARSER=native` never calls this -- see parseAST -- so
+ * CI's dedicated native job and any user who opted in on purpose keep
+ * today's fail-into-`{tree:null,error}` semantics instead of a silent
+ * downgrade.
+ */
+function shouldFallBackToLegacy(): boolean {
+  if (fellBackToLegacy !== null) return fellBackToLegacy;
+
+  try {
+    loadNativeBinding();
+    fellBackToLegacy = false;
+  } catch (error) {
+    fellBackToLegacy = true;
+    const reason = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[lien] Native parser binding failed to load on ${process.platform}-${process.arch}: ${reason}\n` +
+        `Falling back to the legacy (node-tree-sitter) parser backend for the rest of this run. ` +
+        `This usually means no prebuilt @liendev/parser-native package exists for your platform ` +
+        `and no local build was found. To build one, see ` +
+        `docs/architecture/native-parser.md; to silence this warning, set LIEN_PARSER=legacy ` +
+        `explicitly. (Legacy is scheduled for removal in a future release -- see ADR-013.)`,
+    );
+  }
+
+  return fellBackToLegacy;
+}
+
+/**
  * Parse source code into an AST.
  *
  * Backend selected by LIEN_PARSER (see ./backend.ts), defaulting to
- * 'legacy' (node-tree-sitter). 'native' uses @liendev/parser-native plus
- * the compat deserializer in ./native/ -- see
- * docs/architecture/native-parser.md for the wire format and compat
- * contract. Both paths return the same {tree, error} shape.
+ * 'native' (@liendev/parser-native plus the compat deserializer in
+ * ./native/ -- see docs/architecture/native-parser.md for the wire format
+ * and compat contract). 'legacy' (node-tree-sitter) remains a transitional,
+ * explicit opt-out. Both paths return the same {tree, error} shape.
+ *
+ * On the default (unset) path, a native binding that fails to *load*
+ * transparently falls back to legacy for the rest of the process -- see
+ * shouldFallBackToLegacy above. An explicit LIEN_PARSER=native does not
+ * fall back.
  *
  * **Known Limitation (legacy only):** Tree-sitter may throw "Invalid argument" errors on very
  * large files (1000+ lines). This is a limitation of Tree-sitter's internal buffer handling. When
@@ -176,16 +230,24 @@ function parseNative(content: string, language: SupportedLanguage): ASTParseResu
  * @returns Parse result with tree or error
  */
 export function parseAST(content: string, language: SupportedLanguage): ASTParseResult {
-  return resolveParserBackend() === 'native'
-    ? parseNative(content, language)
-    : parseLegacy(content, language);
+  const backend = resolveParserBackend();
+  if (backend === 'legacy') {
+    return parseLegacy(content, language);
+  }
+  if (isBackendUnset() && shouldFallBackToLegacy()) {
+    return parseLegacy(content, language);
+  }
+  return parseNative(content, language);
 }
 
 /**
- * Clear parser cache (useful for testing). Only affects the legacy
- * backend's parser-instance cache -- the native backend keeps no
- * corresponding cache (see parseNative above).
+ * Clear parser cache (useful for testing). Resets the legacy backend's
+ * parser-instance cache and the default-path native-load-fallback decision
+ * (see shouldFallBackToLegacy) -- the native binding handle itself
+ * (nativeBinding) is intentionally left cached, since a successful load is
+ * always safe to reuse.
  */
 export function clearParserCache(): void {
   parserCache.clear();
+  fellBackToLegacy = null;
 }


### PR DESCRIPTION
## Summary

Phase 4-A of [ADR-013](docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md): `LIEN_PARSER` now defaults to **native**. Legacy (node-tree-sitter) remains installed and reachable via `LIEN_PARSER=legacy` for exactly one release — Phase 4-B (separate PR, held until this ships in a release) deletes it.

### Behavior
- Unset flag → native backend (prebuilt binaries; 1.82–2.21× faster end-to-end; parity proven over 18,523 real files in Phase 2).
- **Transitional fallback**: if the flag is unset and the native binding cannot load (exotic platform, no prebuilt, no local build), lien falls back to legacy for the process with a single clear warning naming the platform and remedies. Cached — no per-file retry.
- `LIEN_PARSER=native` set explicitly → fails loud (no fallback), preserving CI honesty.
- `LIEN_PARSER=legacy` → byte-identical pre-flip behavior; the native binding is never loaded (verified by parse-with-binary-renamed probe).
- Per-file parse errors on a working binding never trigger backend fallback (normal hasError → line-chunking semantics unchanged).

### CI
- `build-and-test` now implicitly exercises native; the extra blocking job is `test-legacy` (was `test-native`).
- e2e normal trigger: all 12 projects native + legacy reruns for TypeScript and Kotlin; `workflow_dispatch` parser-mode input unchanged (`legacy|native|both`).

### Docs / release
- CONTRIBUTING documents the new default, the fallback, and legacy's scheduled removal next release. ADR-013 rollout list updated (4-A executed, 4-B pending).
- Changeset: minor `@liendev/parser` (linked group carries core/cli).

## Verification
- Adversarial review (FIX_THEN_APPROVE → all findings fixed): proved all five fallback semantics paths incl. warn-once caching and legacy-mode laziness; dry-ran the e2e matrix planner in all four modes (14/12/12/24 entries).
- Gates green on the final tree (three independent full runs): format ✓, lint 0 errors ✓, typecheck ✓, build ✓, 2,792 tests across 6 workspaces under native default ✓, parser+core suites under `LIEN_PARSER=legacy` ✓, `lien delta` exit 0 ✓, docs-truth 65 files ✓, actionlint ✓.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR flips the default parser backend from legacy (node-tree-sitter) to native (@liendev/parser-native) with a well-designed transitional fallback. The implementation correctly distinguishes the three env states: explicit legacy runs legacy directly, explicit native fails loud without fallback, and unset/native-by-default attempts native once and falls back to legacy with a single warning if the binding cannot load. The fallback is cached per-process, per-file parse errors stay inside parseNative's existing error path, and clearParserCache resets only the decision (not the successful binding handle) as documented. Tests cover all four fallback semantics paths. No code paths produce wrong output or break callers.
>
> - Default LIEN_PARSER backend changed from 'legacy' to 'native' in resolveParserBackend
> - Added isBackendUnset() and shouldFallBackToLegacy() so unset-env runs attempt native once, then fall back to legacy with one warning
> - parseAST now branches: explicit legacy → legacy; explicit native → native (no fallback); unset → native with fallback on load failure
> - CI matrix inverted: default test job runs native, dedicated job runs legacy; e2e normal trigger runs native plus legacy rerun for TypeScript/Kotlin

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 24c9aee. Updates automatically on new commits.</sup>
<!-- /lien-stats -->