### PR TITLE
fix(ci): build-native must not node-gyp-compile node-tree-sitter (breaks win32 runner)

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -75,7 +75,13 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        # --ignore-scripts: this job only needs the workspace symlinks so
+        # `npm run build:native -w @liendev/parser-native` resolves — that
+        # script (fetch-vendor/copy-binary) is zero-dep and cargo does the
+        # real build. Skipping install scripts avoids node-gyp compiling
+        # node-tree-sitter, which fails outright on the windows runner (and
+        # is deleted entirely by ADR-013 Phase 4-B anyway).
+        run: npm ci --ignore-scripts
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The first real `build-native.yml` dispatch on main failed its **win32-x64-msvc job** (a required release platform) inside plain `npm ci`: node-gyp compiling `node-tree-sitter` breaks on the Windows runner. The job never needed the compile — it only needs workspace symlinks so `npm run build:native -w @liendev/parser-native` resolves; that script chain (fetch-vendor → cargo → copy-binary) is zero-npm-dep and cargo does the real build.

Fix: `npm ci --ignore-scripts` with a comment. Evidence: the identical workflow dispatched on the Phase 4-B branch (where node-tree-sitter is deleted) builds fine — and this whole dependency is gone at the next-but-one release anyway (#699).

**Release-critical**: `release.yml` calls this workflow on main at publish time — without this fix the transitional release (#693) would abort on the missing required win32 artifact.

## Verification
- actionlint clean; full local gate chain green (format, lint 0 errors, typecheck, build, all tests, delta).
- Failing run for reference: https://github.com/getlien/lien/actions/runs/28998645888 (win32 job, `npm error path ...packages\parser\node_modules\tree-sitter`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the native build workflow to avoid failing dependency installation on Windows, making builds more reliable.
  * Native build steps now skip unnecessary install scripts during setup, reducing build interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 503 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 58e5a7a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->