### PR TITLE
fix(ci): musl targets need -crt-static to produce a cdylib

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -108,6 +108,12 @@ jobs:
       - name: cargo build --release --target ${{ matrix.target }}
         run: cargo build --release --target ${{ matrix.target }}
         working-directory: packages/parser-native
+        env:
+          # musl targets default to +crt-static, which cannot produce a
+          # cdylib ("target does not support these crate types"). Disable
+          # static CRT linking there so the .node dynamic library builds —
+          # the standard napi-on-musl arrangement. Empty for other targets.
+          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=-crt-static' || '' }}
 
       - name: Copy binary to fixed name
         run: node scripts/copy-binary.mjs


### PR DESCRIPTION
First real musl run of build-native.yml failed with `cannot produce cdylib ... x86_64-unknown-linux-musl does not support these crate types` — Rust's musl targets default to +crt-static, which can't emit dynamic libraries. Standard napi-on-musl fix: `RUSTFLAGS=-C target-feature=-crt-static` scoped to musl matrix entries only (empty for all other targets). actionlint clean; full local gate chain green. Failing run: https://github.com/getlien/lien/actions/runs/28999422835

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 503 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e327114. Updates automatically on new commits.</sup>
<!-- /lien-stats -->