### PR TITLE
fix(ci): darwin-x64 runner label macos-13 is retired — use macos-15-intel

### DIFF
--- a/packages/parser-native/scripts/platforms.json
+++ b/packages/parser-native/scripts/platforms.json
@@ -17,7 +17,7 @@
       "nodePlatform": "darwin",
       "nodeArch": "x64",
       "libc": null,
-      "githubRunner": "macos-13"
+      "githubRunner": "macos-15-intel"
     },
     {
       "platform": "linux-x64-gnu",


### PR DESCRIPTION
The darwin-x64 build-native job queues forever: GitHub retired the macos-13 image (Dec 2025), so jobs targeting that label never get a runner (observed on runs 28998645888 and 28999023958 — the job sat queued while every other platform built). Switch platforms.json's githubRunner for darwin-x64 to macos-15-intel, the current Intel macOS image. platforms.json is the single source of truth for the matrix (planner dry-run verified). Full local gate chain green.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 503 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit eca2838. Updates automatically on new commits.</sup>
<!-- /lien-stats -->