### PR TITLE
docs: lessons from shipping the native parser (release mechanics, CI, monorepo)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -36,8 +36,10 @@ Durable, git-tracked record of corrections. Read this at the start of every sess
   list. When adding a package, grep `.github/` + Dockerfiles + root
   scripts for explicit `packages/...` enumerations before pushing.
 - **Every CI job whose code path reaches `parseAST`/`chunkFile` must build
-  the native binary first** (`npm run build:native -w
-  @liendev/parser-native` after `npm ci`). There is no legacy fallback:
+  the native binary first**, via
+  `npm run build:native -w @liendev/parser-native` after `npm ci`
+  (keep that command on one line in docs — the docs-truth linter cannot
+  resolve a wrapped `-w` workspace). There is no legacy fallback:
   a missing binding throws `NativeBindingLoadError` loudly by design.
   Audit new workflows for this — `npm test`, `lien delta`, review runs,
   and anything importing `@liendev/parser` all parse.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -1,3 +1,47 @@
 # Lessons
 
 Durable, git-tracked record of corrections. Read this at the start of every session. After any user correction, append a lesson here capturing the pattern (not just the fix) so it doesn't recur. Once a lesson proves durable, promote it to `CLAUDE.md` (or `docs/` for anything architectural) and remove it from here — this file is a staging area, not a permanent archive.
+
+## Releasing (learned shipping 0.61.0/0.62.0, ADR-013 campaign)
+
+- **Changesets "Version Packages" PRs have zero CI checks.** The bot pushes
+  `changeset-release/main` with `GITHUB_TOKEN`, and GitHub never triggers
+  workflows for such pushes — branch protection then blocks the merge and
+  `gh` suggests `--admin` (don't). Fix: push an empty commit to
+  `changeset-release/main` with your own credentials to fire the
+  `pull_request` events, then merge normally once green.
+- **npm/GitHub flake mid-release, and how to tell it from real failure.**
+  npm can return E401 *after* a publish PUT already succeeded — check
+  `npm view <pkg> time` for the version's timestamp before re-publishing,
+  and reconcile the git tag + GitHub release by hand if changesets aborted
+  between publish and tagging. A GitHub 502 during `gh pr merge` leaves a
+  stale "Merge already in progress" lock for ~15 minutes — wait for
+  `mergeStateStatus: CLEAN` and retry. An `npm install` seconds after a
+  publish can see the package but miss its fresh `optionalDependencies`
+  (registry propagation) — wait a minute and retry before diagnosing.
+- **First publish of a new package cannot use OIDC.** npm's
+  trusted-publishing UI only accepts packages that already exist, so a new
+  package's first publish is local: a granular token with **"Bypass 2FA"
+  explicitly enabled** (a plain granular token still gets EOTP), publish
+  with `--provenance=false`, then configure the trusted publisher
+  (workflow `release.yml`, environment field **empty** — no workflow here
+  declares a GitHub environment) and revoke the token.
+
+## CI / monorepo
+
+- **Adding a workspace means hunting hardcoded package lists.** The new
+  `packages/parser-native` broke three of them in separate CI rounds:
+  `packages/action/Dockerfile` COPY lines, root `package.json`
+  lint/format/test globs and scripts, and `ci.yml`'s release-smoke pack
+  list. When adding a package, grep `.github/` + Dockerfiles + root
+  scripts for explicit `packages/...` enumerations before pushing.
+- **Every CI job whose code path reaches `parseAST`/`chunkFile` must build
+  the native binary first** (`npm run build:native -w
+  @liendev/parser-native` after `npm ci`). There is no legacy fallback:
+  a missing binding throws `NativeBindingLoadError` loudly by design.
+  Audit new workflows for this — `npm test`, `lien delta`, review runs,
+  and anything importing `@liendev/parser` all parse.
+- **GitHub runner labels rot silently.** `macos-13` was retired; jobs
+  targeting it sit "queued" forever with no error while sibling matrix
+  jobs run. If one matrix job never starts, suspect the label before the
+  workload. Current Intel macOS label: `macos-15-intel`.


### PR DESCRIPTION
Captures the operational patterns learned shipping ADR-013 end-to-end (0.61.0 + 0.62.0) into `.claude/lessons.md`, per the self-improvement loop:

**Releasing**: changesets Version-Packages PRs carry zero CI checks (bot pushes don't trigger workflows) and how to unblock them without `--admin`; distinguishing transient npm E401/GitHub 502 from real failures (`npm view time` as the arbiter, stale merge locks, registry propagation lag); the OIDC first-publish bootstrap (Bypass-2FA granular token, empty environment field).

**CI/monorepo**: the hardcoded-package-list hunt when adding a workspace (bit us 3× in one night: Dockerfile COPY, root globs, smoke pack list); every parse-reaching CI job needs the native binary built (fail-fast `NativeBindingLoadError`, no fallback); retired runner labels queue forever silently (`macos-13` → `macos-15-intel`).

Docs-only; full gate chain green locally. Candidates for promotion to CLAUDE.md/docs once they prove durable across a few releases.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 503 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9266397. Updates automatically on new commits.</sup>
<!-- /lien-stats -->