### PR TITLE
fix(ci): registry smoke silently skipped when build-native skips (needs-cascade)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,13 @@ jobs:
   registry-smoke:
     name: Post-publish registry smoke test
     needs: release
-    if: needs.release.outputs.published == 'true'
+    # !cancelled() is load-bearing: build-native (a transitive dependency
+    # via `release`) is skipped on releases with no pending parser-native
+    # publish, and GitHub skips downstream jobs with any skipped transitive
+    # need unless the job's `if` opts out — without this, the smoke test
+    # silently skipped on exactly the releases it exists to validate
+    # (observed on 0.61.0 and 0.62.0).
+    if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.published == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
The post-publish registry smoke test skipped on both 0.61.0 and 0.62.0 — exactly the releases it exists to validate. Root cause: it `needs: release`, and `release` transitively needs `build-native`, which is (correctly) skipped when no parser-native publish is pending; GitHub skips any downstream job with a skipped transitive dependency unless its `if:` contains `!cancelled()`/`always()`. Fix: `if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.published == 'true' }}` with a comment explaining why !cancelled() is load-bearing. actionlint clean; full local gate chain green. Closes the follow-up noted on the 0.62.0 release.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 503 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e06f8b7. Updates automatically on new commits.</sup>
<!-- /lien-stats -->