### PR TITLE
fix(action): review image needs the native binary; image publishes silently stopped

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,10 @@
 packages/parser-native/target
 packages/parser-native/vendor
 **/*.node
+
+# ...except the one prebuilt linux-x64-gnu binary the action image actually
+# ships: it's built on the runner (npm run build:native -w
+# @liendev/parser-native) BEFORE the docker build step, landing at this fixed
+# path (see packages/parser-native/scripts/copy-binary.mjs), then COPYed into
+# the image -- see packages/action/Dockerfile.
+!packages/parser-native/parser-native.node

--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -6,64 +6,144 @@ name: Publish Action
 # getlien/lien-review dist repo and moves the floating v1 tag so
 # `uses: getlien/lien-review@v1` resolves to the new release.
 #
-# Trigger note: this repo releases via changesets (see .github/workflows/
-# release.yml), which tags pushes as `<pkg>@<version>` (e.g.
-# `@liendev/lien@0.51.0`), never a bare `v*` tag — so a `v*` trigger would
-# never fire. `@liendev/parser`, `@liendev/core`, and `@liendev/lien` are
-# version-linked (.changeset/config.json), so every monorepo release bumps
-# `@liendev/lien` and creates that tag exactly once. We piggyback on it rather
-# than adding a dedicated `@liendev/action` tag, because `packages/action` and
-# `packages/review` are private/unpublished and changesets' default
-# `privatePackages.tag: false` means changesets never tags them (see
-# https://github.com/changesets/changesets/blob/main/docs/config-file-options.md) —
-# wiring a dedicated tag would mean changing shared `.changeset/config.json`
-# behavior for every private package, out of scope here.
+# Trigger note: this used to fire on `push: tags: '@liendev/lien@*'` (the tag
+# changesets creates on every release that bumps the CLI). That never
+# actually fired: release.yml's changesets/action step pushes with
+# `commitMode: github-api`, using the default GITHUB_TOKEN, and GitHub does
+# not run workflows off of GITHUB_TOKEN-authored pushes (its documented
+# anti-recursion rule) -- so no image published from 0.61.0 or 0.62.0. No
+# human pushes these tags by hand as part of the documented release process
+# either, so there's no live path left that trigger ever serves; it's
+# replaced outright below rather than kept as a dead fallback.
 #
-# Caveat: an action-only change that doesn't also bump the CLI's version won't
-# trigger this automatically. workflow_dispatch does NOT fill that gap — on
-# dispatch, "Resolve tags" below emits only the sha tag, and the dist-repo
-# sync step is gated to `push` only, so dispatch never syncs the dist repo or
-# moves :v1/:latest. It's useful only as an image-only smoke test. To ship an
-# action-only fix, include a changeset that bumps `@liendev/lien` so the next
-# release tag carries it (see the README runbook).
-
+# Fix: trigger on `workflow_run` of the Release workflow instead -- that
+# event fires regardless of which token/actor made the push. The catch:
+# a workflow_run event can't see the triggering run's job outputs (those
+# belong to a different workflow run), so "did this Release run actually
+# publish @liendev/lien, and at what version" has to be derived independently
+# rather than read off release.yml. The most boring, reliable derivation:
+# check out the exact commit that triggered Release
+# (github.event.workflow_run.head_sha), read @liendev/lien's version straight
+# from packages/cli/package.json, and ask GHCR whether an image already
+# exists at that version tag. If it does, this Release run either didn't bump
+# the CLI or already got an image (re-run) -- skip. If it doesn't, this is a
+# new version -- publish it. This also means a Release run that only opens/
+# updates the "Version Packages" PR (no publish) is a correct no-op here: the
+# version on main hasn't moved, so the image for it already exists.
 on:
-  push:
-    tags:
-      - '@liendev/lien@*'
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
 
+# Guards against a workflow_dispatch smoke test racing a real workflow_run
+# publish and pushing the same tags out of order.
+concurrency:
+  group: publish-action
+  cancel-in-progress: false
+
 jobs:
+  resolve:
+    name: Resolve version and decide whether to publish
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      should-publish: ${{ steps.decide.outputs.should-publish }}
+      version: ${{ steps.decide.outputs.version }}
+      sha: ${{ steps.decide.outputs.sha }}
+    steps:
+      # For workflow_run, check out the exact commit that triggered Release
+      # -- NOT whatever main happens to be by the time this job runs -- so
+      # the version we read below matches the run being reacted to.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Decide whether a new image needs publishing
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SHA="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual/ad-hoc smoke test: always publish, same as before -- the
+            # sha tag only (see the "Resolve tags" step in publish-image).
+            echo "version=$SHA" >> "$GITHUB_OUTPUT"
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="$(node -p "require('./packages/cli/package.json').version")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          echo "${GH_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          export DOCKER_CLI_EXPERIMENTAL=enabled
+          if docker manifest inspect "ghcr.io/getlien/lien-review:${VERSION}" >/dev/null 2>&1; then
+            echo "ghcr.io/getlien/lien-review:${VERSION} already exists -- this Release run didn't bump @liendev/lien (or already published). Nothing to do."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ghcr.io/getlien/lien-review:${VERSION} not found -- new version to publish."
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-image:
+    needs: resolve
+    if: needs.resolve.outputs.should-publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      # Actions pinned to commit SHAs (supply-chain hardening for a job that
-      # publishes artifacts). persist-credentials:false — this job never needs
-      # the checkout token for a push, so don't leave it in local git config.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ needs.resolve.outputs.sha }}
           persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The action image bundles a linux-x64-gnu parser-native.node (see
+      # packages/action/Dockerfile) -- @liendev/parser hard-requires a
+      # loadable native binding at runtime since ADR-013 Phase 4-B deleted
+      # the legacy backend, so it must be built on the runner, in this
+      # workflow, before the docker build step below. Mirrors ci.yml's
+      # "Build native parser" step.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: packages/parser-native
+          shared-key: parser-native
+
+      - name: Build native parser
+        run: npm run build:native -w @liendev/parser-native
 
       - name: Resolve tags
         id: tags
         run: |
           IMAGE=ghcr.io/getlien/lien-review
           SHA_TAG="${IMAGE}:sha-${GITHUB_SHA::7}"
-          if [ "${{ github.event_name }}" = "push" ]; then
-            # Tagged release: publish the version, the floating major (:v1) and
-            # :latest, and the sha tag. The tag is `@liendev/lien@<version>` —
-            # strip everything up to the last '@' to get the bare semver
-            # (Docker tags can't contain '@' or '/').
-            VERSION="${GITHUB_REF##*@}"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Release publish: tag the version, the floating major (:v1), and
+            # :latest, plus the sha tag.
+            VERSION="${{ needs.resolve.outputs.version }}"
             {
               echo "tags<<EOF"
               echo "${IMAGE}:${VERSION}"
               # :v1 is the Action's own public-interface major version (its
-              # inputs/outputs contract), not derived from the CLI's semver —
+              # inputs/outputs contract), not derived from the CLI's semver --
               # bump it manually (v2, ...) only on a breaking action.yml
               # change, the same convention as actions/checkout@v4 et al.
               echo "${IMAGE}:v1"
@@ -74,7 +154,6 @@ jobs:
           else
             # Manual dispatch: publish ONLY the immutable sha tag, so a non-release
             # run can never overwrite :latest, :v1, or a version with an arbitrary commit.
-            echo "version=${{ github.sha }}" >> "$GITHUB_OUTPUT"
             {
               echo "tags<<EOF"
               echo "${SHA_TAG}"
@@ -117,15 +196,15 @@ jobs:
       # of failing the build, so the image publish above still succeeds and this
       # workflow is mergeable before that setup happens.
       - name: Sync action.yml + README to dist repo and move v1 tag
-        if: github.event_name == 'push'
+        if: github.event_name == 'workflow_run'
         env:
           GH_DIST_TOKEN: ${{ secrets.GH_DIST_TOKEN }}
-          VERSION: ${{ steps.tags.outputs.version }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
 
           if [ -z "${GH_DIST_TOKEN:-}" ]; then
-            echo "::notice::GH_DIST_TOKEN is not set — skipping the getlien/lien-review dist-repo sync. The GHCR image was published above, but 'uses: getlien/lien-review@v1' will not resolve to it yet. See packages/action/README.md 'Publishing the Action' for the one-time human setup (create the dist repo + add the secret). Once that's done, this step runs automatically on the next @liendev/lien@* release tag push — not on workflow_dispatch, which skips this step entirely."
+            echo "::notice::GH_DIST_TOKEN is not set — skipping the getlien/lien-review dist-repo sync. The GHCR image was published above, but 'uses: getlien/lien-review@v1' will not resolve to it yet. See packages/action/README.md 'Publishing the Action' for the one-time human setup (create the dist repo + add the secret). Once that's done, this step runs automatically on the next Release run that publishes a new @liendev/lien version — not on workflow_dispatch, which skips this step entirely."
             exit 0
           fi
 

--- a/packages/action/Dockerfile
+++ b/packages/action/Dockerfile
@@ -24,16 +24,32 @@ RUN npm ci
 
 # Copy source code
 #
-# parser-native is napi-rs (Rust) and isn't built in this image -- @liendev/parser
-# only needs its published JS surface (types + loader) to typecheck and link the
-# workspace symlink; see docs/architecture/native-parser.md. Copying it
-# selectively (not the whole dir) keeps Cargo.toml/target/vendor/*.node out.
+# parser-native is napi-rs (Rust): the crate itself is NOT built in this
+# image (no Rust toolchain here). ADR-013 Phase 4-B deleted the legacy
+# node-tree-sitter backend entirely, so @liendev/parser now hard-requires a
+# loadable native binding at runtime -- it can no longer fall back. The
+# workflow that docker-builds this image runs `npm run build:native -w
+# @liendev/parser-native` on the RUNNER first (see .github/workflows/ci.yml's
+# "Build native parser" step), which drops a linux-x64-gnu
+# parser-native.node at the fixed path below; we COPY that prebuilt binary
+# in alongside the package's JS surface (types + loader), same as we do for
+# index.js/index.d.ts/scripts/ -- see docs/architecture/native-parser.md.
+# Everything else under parser-native/ (Cargo.toml, target/, vendor/) stays
+# out via .dockerignore.
 COPY packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/
 COPY packages/parser-native/scripts/ packages/parser-native/scripts/
+COPY packages/parser-native/parser-native.node packages/parser-native/
 COPY packages/parser/ packages/parser/
 COPY packages/core/ packages/core/
 COPY packages/review/ packages/review/
 COPY packages/action/ packages/action/
+
+# Fail loudly and immediately if the runner didn't produce the binary above
+# (e.g. someone docker-builds this image directly, skipping the "Build
+# native parser" step) -- much cheaper than discovering it via a
+# NativeBindingLoadError several minutes into `npm run build`/test below.
+RUN test -f packages/parser-native/parser-native.node || \
+    (echo "Missing packages/parser-native/parser-native.node -- run 'npm run build:native -w @liendev/parser-native' before docker build" >&2 && exit 1)
 
 # Build packages in dependency order
 RUN npm run build -w packages/parser && \
@@ -72,6 +88,7 @@ COPY --from=builder /app/packages/parser-native/package.json packages/parser-nat
 COPY --from=builder /app/packages/parser-native/index.js packages/parser-native/
 COPY --from=builder /app/packages/parser-native/index.d.ts packages/parser-native/
 COPY --from=builder /app/packages/parser-native/scripts/ packages/parser-native/scripts/
+COPY --from=builder /app/packages/parser-native/parser-native.node packages/parser-native/
 COPY --from=builder /app/packages/parser/package.json packages/parser/
 COPY --from=builder /app/packages/parser/dist/ packages/parser/dist/
 COPY --from=builder /app/packages/core/package.json packages/core/
@@ -82,5 +99,18 @@ COPY --from=builder /app/packages/action/package.json packages/action/
 COPY --from=builder /app/packages/action/dist/ packages/action/dist/
 
 ENV GIT_TERMINAL_PROMPT=0
+
+# Runtime gate: actually load the native binding and parse one real snippet
+# through it, in the exact final-stage layout that ships (index.js's local-
+# dev fallback resolves ./parser-native.node next to itself -- see
+# packages/parser-native/index.js's "Resolution order" comment). A present-
+# but-wrong-platform, corrupted, or otherwise unloadable binary fails the
+# docker build here instead of surfacing as a NativeBindingLoadError the
+# first time the shipped Action tries to review a PR.
+RUN node -e "import('./packages/parser-native/index.js').then(({ parseTree }) => { \
+    const wire = parseTree('javascript', 'const x = 1;'); \
+    if (!wire || !JSON.parse(wire).type) throw new Error('parseTree returned an empty/invalid result'); \
+    console.log('native parser binding OK'); \
+  }).catch((err) => { console.error(err); process.exit(1); })"
 
 ENTRYPOINT ["node", "packages/action/dist/index.js"]


### PR DESCRIPTION
## Summary

Two production gaps in the self-hostable review action, found while auditing native-parser adoption:

### 1. The image can no longer parse
The Dockerfile shipped `@liendev/parser-native`'s JS loader but no compiled binary — fine while the legacy backend existed as default/fallback, fatal since #699 deleted it (`NativeBindingLoadError` on every review). Fix: COPY the linux binary (built by the same job two steps earlier — CI ordering verified) into both stages, `.dockerignore` negation scoped to exactly that file, and **two build-time guards**: a fast `test -f` in the builder, and a functional probe in the final stage that imports the loader in the shipped layout and parses a snippet — so CI's existing docker-build smoke step now fails on a missing/corrupt/wrong-platform binary instead of the first self-hosted review doing so.

### 2. No image has published since July 3
`publish-action.yml` triggered on `@liendev/lien@*` tag pushes — but changesets pushes tags with `GITHUB_TOKEN` (github-api commit mode), which never triggers workflows. The 0.61.0/0.62.0 releases fired nothing. Fix: `workflow_run` on Release (completed, main) + a cheap `resolve` job that checks out the triggering `head_sha`, reads the CLI version from `package.json`, and asks GHCR whether that image tag already exists — publish only when it doesn't (correctly no-ops on Version-PR-refresh runs and re-runs). The dead tag trigger is removed rather than left as a second path readers must rule out; `workflow_dispatch` semantics unchanged. The publish job now builds the native binary (rust-cache mirrored from ci.yml) before the docker build; new actions SHA-pinned matching the workflow's existing supply-chain policy; concurrency group added.

## Verification
- actionlint (with shellcheck) 0 issues; Dockerfile stages + both guards + the exact final-stage probe **simulated end-to-end in an isolated tree** (positive and negative cases) — Docker daemon unavailable locally, so the PR's own "Build Action image" CI step is the first real docker build, by design.
- Full gate chain green in the worktree: format ✓, lint 0 errors ✓, typecheck ✓, build ✓, all-workspace tests ✓, `lien delta` exit 0 ✓.

## Known follow-up (deliberate scope cut)
The `resolve` job's GHCR manifest check has no retry — a GHCR blip fails the run visibly rather than skipping silently. Acceptable for now; noted here for the record.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 94 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 503 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 37 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit deef255. Updates automatically on new commits.</sup>
<!-- /lien-stats -->