### PR TITLE
chore(core): remove dead chunkSize/chunkOverlap config keys (retired-key table)

### DIFF
--- a/.changeset/remove-dead-chunk-config.md
+++ b/.changeset/remove-dead-chunk-config.md
@@ -1,0 +1,19 @@
+---
+'@liendev/core': patch
+---
+
+Removed the dead `core.chunkSize`/`core.chunkOverlap` (and legacy
+`indexing.chunkSize`/`indexing.chunkOverlap`) config keys.
+
+These keys were validated in `ConfigService` — including range warnings for
+very small/large values — but never read by any indexing pipeline.
+`getIndexingConfig()` and every chunking call site in the full-index,
+incremental, overlay, and review chunk-only-index pipelines were hardcoded to
+`DEFAULT_CHUNK_SIZE`/`DEFAULT_CHUNK_OVERLAP` regardless of what a user
+configured. Chunking is AST-based (function/class-level) for all supported
+languages; these knobs only ever shaped the line-based fallback used for
+unsupported or unparseable files, where tuning has negligible value under
+BM25 lexical search — and `chunkOverlap` specifically was an embeddings-era
+relic (embeddings were removed in ADR-011). An existing `.lien.config.json`
+that still carries either key now warns once and ignores it instead of
+failing validation.

--- a/.lien.config.json
+++ b/.lien.config.json
@@ -1,9 +1,6 @@
 {
   "version": "0.1.0",
-  "core": {
-    "chunkSize": 75,
-    "chunkOverlap": 10
-  },
+  "core": {},
   "chunking": {
     "useAST": true,
     "astFallback": "line-based"

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -122,7 +122,6 @@ flowchart TD
     end
     
     subgraph "Field Validation"
-        CHUNK_SIZE{chunkSize > 0?}
         PORT{1024 ≤ port ≤ 65535?}
         TRANSPORT{stdio or socket?}
         PATH{Path relative?}
@@ -155,7 +154,6 @@ flowchart TD
     VAL_MCP_LEG --> WARN_LEGACY
     WARN_LEGACY --> COLLECT_ERRORS
     
-    VAL_CORE -.-> CHUNK_SIZE
     VAL_MCP -.-> PORT
     VAL_MCP -.-> TRANSPORT
     VAL_FRAMEWORKS -.-> PATH
@@ -276,15 +274,15 @@ const config = await service.load('/path/to/project');
 
 ```typescript
 const userInput = {
-  core: {
-    chunkSize: -10
+  mcp: {
+    port: 500
   }
 };
 
 const result = service.validatePartial(userInput);
 if (!result.valid) {
   console.error('Invalid config:', result.errors);
-  // ["core.chunkSize must be a positive number"]
+  // ["mcp.port must be between 1024 and 65535"]
 }
 
 if (result.warnings.length > 0) {
@@ -297,9 +295,9 @@ if (result.warnings.length > 0) {
 ```typescript
 const config: LienConfig = {
   ...defaultConfig,
-  core: {
-    ...defaultConfig.core,
-    chunkSize: 100
+  mcp: {
+    ...defaultConfig.mcp,
+    port: 8080
   }
 };
 
@@ -310,13 +308,6 @@ await service.save('/path/to/project', config);
 ```
 
 ## Validation Rules
-
-### Core Settings
-
-| Field | Type | Constraint | Warning |
-|-------|------|------------|---------|
-| chunkSize | number | > 0 | < 50: too small<br/>> 500: too large |
-| chunkOverlap | number | ≥ 0 | - |
 
 ### MCP Settings
 

--- a/packages/cli/.lien.config.json
+++ b/packages/cli/.lien.config.json
@@ -1,8 +1,6 @@
 {
   "version": "0.1.0",
   "core": {
-    "chunkSize": 75,
-    "chunkOverlap": 10,
     "embeddingBatchSize": 50
   },
   "chunking": {

--- a/packages/core/src/config/merge.test.ts
+++ b/packages/core/src/config/merge.test.ts
@@ -4,20 +4,6 @@ import type { LienConfig } from './schema.js';
 import { defaultConfig } from './schema.js';
 
 describe('deepMergeConfig', () => {
-  it('should merge core config while preserving defaults', () => {
-    const userConfig: Partial<LienConfig> = {
-      core: {
-        chunkSize: 100,
-        chunkOverlap: 20,
-      },
-    };
-
-    const result = deepMergeConfig(defaultConfig, userConfig);
-
-    expect(result.core.chunkSize).toBe(100);
-    expect(result.core.chunkOverlap).toBe(20);
-  });
-
   it('should merge mcp config while preserving defaults', () => {
     const userConfig: Partial<LienConfig> = {
       mcp: {
@@ -36,17 +22,17 @@ describe('deepMergeConfig', () => {
 
   it('should preserve default values for unspecified fields', () => {
     const userConfig: Partial<LienConfig> = {
-      core: {
-        ...defaultConfig.core,
-        chunkSize: 100,
+      mcp: {
+        ...defaultConfig.mcp,
+        port: 8080,
       },
     };
 
     const result = deepMergeConfig(defaultConfig, userConfig);
 
-    expect(result.core.chunkSize).toBe(100);
-    expect(result.core.chunkOverlap).toBe(defaultConfig.core.chunkOverlap);
-    expect(result.mcp).toEqual(defaultConfig.mcp);
+    expect(result.mcp.port).toBe(8080);
+    expect(result.mcp.transport).toBe(defaultConfig.mcp.transport);
+    expect(result.core).toEqual(defaultConfig.core);
     expect(result.gitDetection).toEqual(defaultConfig.gitDetection);
   });
 
@@ -88,10 +74,6 @@ describe('deepMergeConfig', () => {
 
   it('should work with actual Lien config', () => {
     const userConfig: Partial<LienConfig> = {
-      core: {
-        chunkSize: 100,
-        chunkOverlap: 20,
-      },
       frameworks: [
         {
           name: 'nodejs',
@@ -107,7 +89,6 @@ describe('deepMergeConfig', () => {
 
     const result = deepMergeConfig(defaultConfig, userConfig);
 
-    expect(result.core.chunkSize).toBe(100);
     expect(result.mcp.port).toBe(defaultConfig.mcp.port); // Default preserved
     expect(result.frameworks).toHaveLength(1);
   });
@@ -153,9 +134,9 @@ describe('detectNewFields', () => {
   it('should not report fields that exist with different values', () => {
     const existing: Partial<LienConfig> = {
       ...defaultConfig,
-      core: {
-        ...defaultConfig.core,
-        chunkSize: 100, // Different value
+      mcp: {
+        ...defaultConfig.mcp,
+        port: 9999, // Different value
       },
     };
 
@@ -166,10 +147,7 @@ describe('detectNewFields', () => {
 
   it('should work with actual Lien config upgrades', () => {
     const oldConfig: Partial<LienConfig> = {
-      core: {
-        chunkSize: 75,
-        chunkOverlap: 10,
-      },
+      core: defaultConfig.core,
       mcp: {
         port: 7133,
         transport: 'stdio' as const,

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,10 +1,4 @@
-import {
-  DEFAULT_CHUNK_SIZE,
-  DEFAULT_CHUNK_OVERLAP,
-  DEFAULT_PORT,
-  DEFAULT_GIT_POLL_INTERVAL_MS,
-  DEFAULT_DEBOUNCE_MS,
-} from '../constants.js';
+import { DEFAULT_PORT, DEFAULT_GIT_POLL_INTERVAL_MS, DEFAULT_DEBOUNCE_MS } from '../constants.js';
 
 /**
  * Framework-specific configuration
@@ -28,10 +22,16 @@ export interface FrameworkInstance {
  * Main Lien configuration supporting monorepo setups
  */
 export interface LienConfig {
-  core: {
-    chunkSize: number;
-    chunkOverlap: number;
-  };
+  /**
+   * Reserved for future project-wide core settings. `chunkSize`/`chunkOverlap`
+   * and `concurrency` used to live here but were removed as dead config —
+   * they were validated but never read by any indexing pipeline (chunking is
+   * AST-based for all supported languages; the line-based fallback and
+   * parse-stage concurrency are governed internally). Presence of this key
+   * still distinguishes the modern config shape from `LegacyLienConfig`, so
+   * it stays even though it's currently empty.
+   */
+  core: Record<string, never>;
   chunking: {
     useAST: boolean; // Enable AST-based chunking (v0.13.0)
     astFallback: 'line-based' | 'error'; // Fallback strategy on AST errors
@@ -75,8 +75,6 @@ export interface LegacyLienConfig {
   indexing: {
     exclude: string[];
     include: string[];
-    chunkSize: number;
-    chunkOverlap: number;
   };
   mcp: {
     port: number;
@@ -116,10 +114,7 @@ export function isModernConfig(config: LienConfig | LegacyLienConfig): config is
  * Frameworks should be detected and added via lien init
  */
 export const defaultConfig: LienConfig = {
-  core: {
-    chunkSize: DEFAULT_CHUNK_SIZE,
-    chunkOverlap: DEFAULT_CHUNK_OVERLAP,
-  },
+  core: {},
   chunking: {
     useAST: true, // AST-based chunking enabled by default (v0.13.0)
     astFallback: 'line-based', // Fallback to line-based on errors

--- a/packages/core/src/config/service.test.ts
+++ b/packages/core/src/config/service.test.ts
@@ -51,9 +51,9 @@ describe('ConfigService', () => {
     it('should load and merge user config with defaults', async () => {
       const userConfig: Partial<LienConfig> = {
         version: '0.3.0',
-        core: {
-          chunkSize: 100,
-          chunkOverlap: 20,
+        mcp: {
+          ...defaultConfig.mcp,
+          port: 8080,
         },
         frameworks: [],
       };
@@ -63,9 +63,8 @@ describe('ConfigService', () => {
 
       const config = await service.load(testDir);
 
-      expect(config.core.chunkSize).toBe(100);
-      expect(config.core.chunkOverlap).toBe(20);
-      expect(config.mcp).toEqual(defaultConfig.mcp); // Should merge with defaults
+      expect(config.mcp.port).toBe(8080);
+      expect(config.core).toEqual(defaultConfig.core); // Should merge with defaults
     });
 
     it('should throw ConfigError for invalid JSON', async () => {
@@ -82,8 +81,6 @@ describe('ConfigService', () => {
         indexing: {
           include: ['**/*.ts'],
           exclude: ['**/node_modules/**'],
-          chunkSize: 100,
-          chunkOverlap: 15,
         },
         mcp: {
           port: 7133,
@@ -107,12 +104,12 @@ describe('ConfigService', () => {
 
       // Migration removed - just merges with defaults
       // Old indexing field is ignored, uses defaults
-      expect(config.core.chunkSize).toBe(defaultConfig.core.chunkSize);
+      expect(config.core).toEqual(defaultConfig.core);
     });
   });
 
-  describe('retired concurrency key (graceful degradation)', () => {
-    // Import a fresh module instance so the warn-once flag is reset per test
+  describe('retired config keys (graceful degradation)', () => {
+    // Import a fresh module instance so the warn-once flags are reset per test
     async function freshConfigService() {
       vi.resetModules();
       const { ConfigService: FreshConfigService } = await import('./service.js');
@@ -125,59 +122,101 @@ describe('ConfigService', () => {
       vi.restoreAllMocks();
     });
 
-    it('should ignore core.concurrency and warn once instead of throwing', async () => {
-      const freshService = await freshConfigService();
-      const configPath = path.join(testDir, '.lien.config.json');
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ core: { chunkSize: 100, chunkOverlap: 20, concurrency: 8 } }, null, 2),
-      );
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    describe('concurrency', () => {
+      it('should ignore core.concurrency and warn once instead of throwing', async () => {
+        const freshService = await freshConfigService();
+        const configPath = path.join(testDir, '.lien.config.json');
+        await fs.writeFile(configPath, JSON.stringify({ core: { concurrency: 8 } }, null, 2));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      const config = await freshService.load(testDir);
+        const config = await freshService.load(testDir);
 
-      expect(config.core.chunkSize).toBe(100);
-      expect((config.core as Record<string, unknown>).concurrency).toBeUndefined();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"concurrency"'));
+        expect(config.core).toEqual(defaultConfig.core);
+        expect((config.core as Record<string, unknown>).concurrency).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"concurrency"'));
+      });
+
+      it('should ignore legacy indexing.concurrency and warn once instead of throwing', async () => {
+        const freshService = await freshConfigService();
+        const configPath = path.join(testDir, '.lien.config.json');
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({ indexing: { include: [], exclude: [], concurrency: 12 } }, null, 2),
+        );
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const config = await freshService.load(testDir);
+
+        // Legacy `indexing` is dropped entirely on merge (pre-existing behavior);
+        // what matters here is that the retired key didn't throw, and was warned about.
+        expect(config.core).toEqual(defaultConfig.core);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"concurrency"'));
+      });
+
+      it('should warn only once per process for repeated loads', async () => {
+        const freshService = await freshConfigService();
+        const configPath = path.join(testDir, '.lien.config.json');
+        await fs.writeFile(configPath, JSON.stringify({ core: { concurrency: 16 } }, null, 2));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await freshService.load(testDir);
+        await freshService.load(testDir);
+        await freshService.load(testDir);
+
+        expect(warnSpy).toHaveBeenCalledOnce();
+      });
     });
 
-    it('should ignore legacy indexing.concurrency and warn once instead of throwing', async () => {
-      const freshService = await freshConfigService();
-      const configPath = path.join(testDir, '.lien.config.json');
-      await fs.writeFile(
-        configPath,
-        JSON.stringify(
-          {
-            indexing: { include: [], exclude: [], chunkSize: 90, chunkOverlap: 5, concurrency: 12 },
-          },
-          null,
-          2,
-        ),
-      );
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    describe('chunkSize/chunkOverlap', () => {
+      it('should ignore core.chunkSize/core.chunkOverlap and warn once instead of throwing', async () => {
+        const freshService = await freshConfigService();
+        const configPath = path.join(testDir, '.lien.config.json');
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({ core: { chunkSize: 100, chunkOverlap: 20 } }, null, 2),
+        );
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      const config = await freshService.load(testDir);
+        const config = await freshService.load(testDir);
 
-      // Legacy `indexing` is dropped entirely on merge (pre-existing behavior);
-      // what matters here is that the retired key didn't throw, and was warned about.
-      expect(config.core.chunkSize).toBe(defaultConfig.core.chunkSize);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"concurrency"'));
-    });
+        expect(config.core).toEqual(defaultConfig.core);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"chunkSize"'));
+      });
 
-    it('should warn only once per process for repeated loads', async () => {
-      const freshService = await freshConfigService();
-      const configPath = path.join(testDir, '.lien.config.json');
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ core: { chunkSize: 75, chunkOverlap: 10, concurrency: 16 } }, null, 2),
-      );
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      it('should ignore legacy indexing.chunkSize/indexing.chunkOverlap and warn once instead of throwing', async () => {
+        const freshService = await freshConfigService();
+        const configPath = path.join(testDir, '.lien.config.json');
+        await fs.writeFile(
+          configPath,
+          JSON.stringify(
+            { indexing: { include: [], exclude: [], chunkSize: 90, chunkOverlap: 5 } },
+            null,
+            2,
+          ),
+        );
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      await freshService.load(testDir);
-      await freshService.load(testDir);
-      await freshService.load(testDir);
+        const config = await freshService.load(testDir);
 
-      expect(warnSpy).toHaveBeenCalledOnce();
+        expect(config.core).toEqual(defaultConfig.core);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"chunkSize"'));
+      });
+
+      it('should warn only once per process for repeated loads', async () => {
+        const freshService = await freshConfigService();
+        const configPath = path.join(testDir, '.lien.config.json');
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({ core: { chunkSize: 75, chunkOverlap: 10 } }, null, 2),
+        );
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await freshService.load(testDir);
+        await freshService.load(testDir);
+        await freshService.load(testDir);
+
+        expect(warnSpy).toHaveBeenCalledOnce();
+      });
     });
   });
 
@@ -185,9 +224,9 @@ describe('ConfigService', () => {
     it('should save valid config to file', async () => {
       const config: LienConfig = {
         ...defaultConfig,
-        core: {
-          ...defaultConfig.core,
-          chunkSize: 120,
+        mcp: {
+          ...defaultConfig.mcp,
+          port: 8080,
         },
       };
 
@@ -197,15 +236,15 @@ describe('ConfigService', () => {
       const savedContent = await fs.readFile(configPath, 'utf-8');
       const savedConfig = JSON.parse(savedContent);
 
-      expect(savedConfig.core.chunkSize).toBe(120);
+      expect(savedConfig.mcp.port).toBe(8080);
     });
 
     it('should throw ConfigError when trying to save invalid config', async () => {
       const invalidConfig = {
         ...defaultConfig,
-        core: {
-          ...defaultConfig.core,
-          chunkSize: -10, // Invalid: must be positive
+        mcp: {
+          ...defaultConfig.mcp,
+          port: 500, // Invalid: below 1024
         },
       };
 
@@ -254,21 +293,6 @@ describe('ConfigService', () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should reject invalid chunk size', () => {
-      const invalidConfig: LienConfig = {
-        ...defaultConfig,
-        core: {
-          ...defaultConfig.core,
-          chunkSize: -5,
-        },
-      };
-
-      const result = service.validate(invalidConfig);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('chunkSize'))).toBe(true);
-    });
-
     it('should reject invalid MCP port', () => {
       const invalidConfig: LienConfig = {
         ...defaultConfig,
@@ -299,44 +323,12 @@ describe('ConfigService', () => {
       expect(result.errors.some(e => e.includes('transport'))).toBe(true);
     });
 
-    it('should warn about very small chunk size', () => {
-      const config: LienConfig = {
-        ...defaultConfig,
-        core: {
-          ...defaultConfig.core,
-          chunkSize: 30, // Valid but small
-        },
-      };
-
-      const result = service.validate(config);
-
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some(w => w.includes('very small'))).toBe(true);
-    });
-
-    it('should warn about very large chunk size', () => {
-      const config: LienConfig = {
-        ...defaultConfig,
-        core: {
-          ...defaultConfig.core,
-          chunkSize: 600, // Valid but large
-        },
-      };
-
-      const result = service.validate(config);
-
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some(w => w.includes('very large'))).toBe(true);
-    });
-
     it('should warn about legacy config format', () => {
       const legacyConfig: LegacyLienConfig = {
         version: '0.2.0',
         indexing: {
           include: ['**/*.ts'],
           exclude: [],
-          chunkSize: 75,
-          chunkOverlap: 10,
         },
         mcp: {
           port: 7133,
@@ -361,32 +353,18 @@ describe('ConfigService', () => {
   });
 
   describe('validatePartial', () => {
-    it('should validate partial config with only core settings', () => {
-      const partialConfig: Partial<LienConfig> = {
-        core: {
-          chunkSize: 100,
-          chunkOverlap: 15,
-        },
-      };
-
-      const result = service.validatePartial(partialConfig);
-
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
     it('should reject invalid values in partial config', () => {
       const partialConfig: Partial<LienConfig> = {
-        core: {
-          chunkSize: -10, // Invalid
-          chunkOverlap: 10,
+        gitDetection: {
+          enabled: true,
+          pollIntervalMs: 50, // Invalid: must be at least 100ms
         },
       };
 
       const result = service.validatePartial(partialConfig);
 
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('chunkSize'))).toBe(true);
+      expect(result.errors.some(e => e.includes('pollIntervalMs'))).toBe(true);
     });
 
     it('should allow missing fields in partial config', () => {
@@ -408,10 +386,6 @@ describe('ConfigService', () => {
     it('should handle full lifecycle: save, load, validate', async () => {
       const customConfig: LienConfig = {
         ...defaultConfig,
-        core: {
-          ...defaultConfig.core,
-          chunkSize: 100,
-        },
         mcp: {
           ...defaultConfig.mcp,
           port: 8000,
@@ -428,7 +402,6 @@ describe('ConfigService', () => {
       const validation = service.validate(loadedConfig);
 
       expect(validation.valid).toBe(true);
-      expect(loadedConfig.core.chunkSize).toBe(100);
       expect(loadedConfig.mcp.port).toBe(8000);
     });
 
@@ -439,8 +412,6 @@ describe('ConfigService', () => {
         indexing: {
           include: ['**/*.ts', '**/*.js'],
           exclude: ['**/node_modules/**'],
-          chunkSize: 90,
-          chunkOverlap: 12,
         },
         mcp: {
           port: 7200,
@@ -464,7 +435,7 @@ describe('ConfigService', () => {
       const config = await service.load(testDir);
 
       // Migration removed - old indexing field ignored, uses defaults for core settings
-      expect(config.core.chunkSize).toBe(defaultConfig.core.chunkSize);
+      expect(config.core).toEqual(defaultConfig.core);
       expect(config.mcp.port).toBe(7200);
       expect(config.gitDetection.enabled).toBe(false);
       expect(config.fileWatching.enabled).toBe(true);

--- a/packages/core/src/config/service.test.ts
+++ b/packages/core/src/config/service.test.ts
@@ -263,6 +263,18 @@ describe('ConfigService', () => {
       expect(content).toContain('"core"');
       expect(content.endsWith('\n')).toBe(true);
     });
+
+    it('should not throw when saving a config with a stale core key (warn, never break)', async () => {
+      // A direct save() caller bypasses load()'s stripRetiredKeys() entirely,
+      // so this exercises the same "never hard-fail on stale config" guarantee
+      // via a different entry point.
+      const configWithRetiredKey = {
+        ...defaultConfig,
+        core: { chunkSize: 100 },
+      } as unknown as LienConfig;
+
+      await expect(service.save(testDir, configWithRetiredKey)).resolves.not.toThrow();
+    });
   });
 
   // Migration tests removed - migration no longer exists
@@ -273,6 +285,39 @@ describe('ConfigService', () => {
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
+    });
+
+    it('should warn (not error) about a retired key left in core on direct validate()', () => {
+      // load() strips retired keys before validate() ever sees them; direct
+      // validate() callers skip that strip, so this is the path where a
+      // stray retired key can actually reach validation.
+      const rawConfig = {
+        ...defaultConfig,
+        core: { chunkSize: 100 },
+      };
+
+      const result = service.validate(rawConfig);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings.some(w => w.includes('chunkSize'))).toBe(true);
+    });
+
+    it('should warn (not error) about a truly unexpected key in core, distinct from a retired one', () => {
+      const rawConfig = {
+        ...defaultConfig,
+        core: { notARealSetting: 'x' },
+      };
+
+      const result = service.validate(rawConfig);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(
+        result.warnings.some(w => w.includes('unexpected') && w.includes('notARealSetting')),
+      ).toBe(true);
+      // Distinct wording from the retired-key warning — not conflated
+      expect(result.warnings.some(w => w.includes('retired'))).toBe(false);
     });
 
     it('should reject non-object config', () => {
@@ -353,6 +398,20 @@ describe('ConfigService', () => {
   });
 
   describe('validatePartial', () => {
+    it('should warn (not error) about a retired key left in a partial core object', () => {
+      // core is typed Record<string, never>, so a stray key can only reach
+      // this path via raw/untyped input (e.g. JSON.parse output cast at the
+      // boundary) rather than a type-checked literal — hence the cast here.
+      const partialConfig = {
+        core: { chunkSize: 100 },
+      } as unknown as Partial<LienConfig>;
+
+      const result = service.validatePartial(partialConfig);
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.includes('chunkSize'))).toBe(true);
+    });
+
     it('should reject invalid values in partial config', () => {
       const partialConfig: Partial<LienConfig> = {
         gitDetection: {

--- a/packages/core/src/config/service.ts
+++ b/packages/core/src/config/service.ts
@@ -254,6 +254,11 @@ export class ConfigService {
     const errors: string[] = [];
     const warnings: string[] = [];
 
+    // Validate core settings if present
+    if (config.core) {
+      this.validateCoreConfig(config.core, warnings);
+    }
+
     // Validate MCP settings if present
     if (config.mcp) {
       this.validateMCPConfig(config.mcp, errors, warnings);
@@ -289,12 +294,13 @@ export class ConfigService {
   private validateModernConfig(config: LienConfig, errors: string[], warnings: string[]): void {
     // `core` currently holds no configurable settings (chunkSize/chunkOverlap
     // and concurrency were both removed as dead config) — its presence is
-    // only the modern/legacy discriminator, so there's nothing to validate
-    // beyond requiring the key to exist.
+    // only the modern/legacy discriminator. It's still required to exist,
+    // and validateCoreConfig below checks it's actually empty.
     if (!config.core) {
       errors.push('Missing required field: core');
       return;
     }
+    this.validateCoreConfig(config.core, warnings);
 
     // Validate MCP settings
     if (!config.mcp) {
@@ -344,6 +350,39 @@ export class ConfigService {
     // Validate MCP settings (same for both)
     if (config.mcp) {
       this.validateMCPConfig(config.mcp, errors, warnings);
+    }
+  }
+
+  /**
+   * Validate that `core` — which currently holds no configurable settings —
+   * hasn't been given any keys. This only fires for callers that hand
+   * validate()/validatePartial()/save() a raw config directly: the load()
+   * path already runs stripRetiredKeys() before validating, so a config
+   * file that still carries a retired key never reaches here with it.
+   * Never an error, even for recognized retired keys: this file's
+   * philosophy is to warn and ignore stale config, not break on it (see
+   * RETIRED_KEY_GROUPS), and validate()/save() must extend that same
+   * guarantee to direct callers, not just the load() path.
+   */
+  private validateCoreConfig(core: Record<string, unknown>, warnings: string[]): void {
+    const keys = Object.keys(core);
+    if (keys.length === 0) return;
+
+    const retiredKeyNames = new Set(RETIRED_KEY_GROUPS.flatMap(group => group.keys));
+    const retired = keys.filter(key => retiredKeyNames.has(key));
+    const unknown = keys.filter(key => !retiredKeyNames.has(key));
+
+    if (retired.length > 0) {
+      warnings.push(
+        `core has retired key(s) with no effect: ${retired.join(', ')}. These are silently ` +
+          'dropped by load() — remove them from your .lien.config.json.',
+      );
+    }
+    if (unknown.length > 0) {
+      warnings.push(
+        `core has unexpected key(s): ${unknown.join(', ')}. core currently holds no ` +
+          'configurable settings.',
+      );
     }
   }
 

--- a/packages/core/src/config/service.ts
+++ b/packages/core/src/config/service.ts
@@ -14,48 +14,82 @@ export interface ValidationResult {
   warnings: string[];
 }
 
-const CONCURRENCY_RETIRED_WARNING =
-  'Warning: the "concurrency" setting (core.concurrency / legacy indexing.concurrency) has been ' +
-  'removed — it was validated but never read by the indexing pipeline. Ignoring it; you can ' +
-  'delete it from your .lien.config.json. Parse-stage concurrency is now governed internally ' +
-  '(PARSE_STAGE_MAX_CONCURRENCY in @liendev/parser).';
-
-let concurrencyWarningShown = false;
-
 /**
- * Warn (once per process) that a retired `concurrency` key was found in a
- * loaded config.
+ * One entry per group of config keys retired together (validated in the
+ * past but never actually read by any pipeline). Each group is stripped
+ * from both the modern `core` section and the legacy `indexing` section
+ * before merge/validation, warning once per group per process instead of
+ * throwing — mirrors global-config.ts's stripRetiredBackends, generalized
+ * so a future retirement is a new array entry rather than a copy-pasted
+ * strip function.
  */
-function warnConcurrencyRetired(): void {
-  if (concurrencyWarningShown) return;
-  concurrencyWarningShown = true;
-  console.warn(CONCURRENCY_RETIRED_WARNING);
+interface RetiredKeyGroup {
+  keys: readonly string[];
+  message: string;
+  warned: boolean;
+}
+
+const RETIRED_KEY_GROUPS: RetiredKeyGroup[] = [
+  {
+    keys: ['concurrency'],
+    message:
+      'Warning: the "concurrency" setting (core.concurrency / legacy indexing.concurrency) has been ' +
+      'removed — it was validated but never read by the indexing pipeline. Ignoring it; you can ' +
+      'delete it from your .lien.config.json. Parse-stage concurrency is now governed internally ' +
+      '(PARSE_STAGE_MAX_CONCURRENCY in @liendev/parser).',
+    warned: false,
+  },
+  {
+    keys: ['chunkSize', 'chunkOverlap'],
+    message:
+      'Warning: the "chunkSize"/"chunkOverlap" settings (core.* / legacy indexing.*) have been ' +
+      'removed — they were validated but never read by any indexing pipeline. Chunking is ' +
+      'AST-based for all supported languages; these only ever shaped the line-based fallback ' +
+      'chunker, which now always uses its built-in defaults. Ignoring them; you can delete them ' +
+      'from your .lien.config.json.',
+    warned: false,
+  },
+];
+
+function warnRetiredOnce(group: RetiredKeyGroup): void {
+  if (group.warned) return;
+  group.warned = true;
+  console.warn(group.message);
 }
 
 /**
- * Strip the retired `concurrency` key from a raw parsed config before it is
- * merged/validated. Mirrors global-config.ts's stripRetiredBackends: warn
- * once and drop the key so an existing config that still has it never
+ * Strip one retired key group from a single config section (`core` or
+ * `indexing`), warning once if any of the group's keys were present.
+ */
+function stripGroupFromSection(
+  raw: Record<string, unknown>,
+  sectionName: 'core' | 'indexing',
+  group: RetiredKeyGroup,
+): Record<string, unknown> {
+  const section = raw[sectionName];
+  if (!section || typeof section !== 'object') return raw;
+
+  const sectionObj = section as Record<string, unknown>;
+  if (!group.keys.some(key => key in sectionObj)) return raw;
+
+  warnRetiredOnce(group);
+  const restSection = Object.fromEntries(
+    Object.entries(sectionObj).filter(([key]) => !group.keys.includes(key)),
+  );
+  return { ...raw, [sectionName]: restSection };
+}
+
+/**
+ * Strip all retired config key groups from a raw parsed config before it is
+ * merged/validated, so an existing config that still carries one never
  * throws.
  */
-function stripRetiredConcurrencyKey(raw: Record<string, unknown>): Record<string, unknown> {
-  let result = raw;
-
-  const core = result.core;
-  if (core && typeof core === 'object' && 'concurrency' in core) {
-    warnConcurrencyRetired();
-    const { concurrency: _concurrency, ...restCore } = core as Record<string, unknown>;
-    result = { ...result, core: restCore };
-  }
-
-  const indexing = result.indexing;
-  if (indexing && typeof indexing === 'object' && 'concurrency' in indexing) {
-    warnConcurrencyRetired();
-    const { concurrency: _concurrency, ...restIndexing } = indexing as Record<string, unknown>;
-    result = { ...result, indexing: restIndexing };
-  }
-
-  return result;
+function stripRetiredKeys(raw: Record<string, unknown>): Record<string, unknown> {
+  return RETIRED_KEY_GROUPS.reduce(
+    (result, group) =>
+      stripGroupFromSection(stripGroupFromSection(result, 'core', group), 'indexing', group),
+    raw,
+  );
 }
 
 /**
@@ -82,7 +116,7 @@ export class ConfigService {
 
     try {
       const configContent = await fs.readFile(configPath, 'utf-8');
-      const userConfig = stripRetiredConcurrencyKey(JSON.parse(configContent));
+      const userConfig = stripRetiredKeys(JSON.parse(configContent));
 
       // Merge with defaults - no migration needed
       const mergedConfig = deepMergeConfig(defaultConfig, userConfig as Partial<LienConfig>);
@@ -220,11 +254,6 @@ export class ConfigService {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    // Validate core settings if present
-    if (config.core) {
-      this.validateCoreConfig(config.core, errors, warnings);
-    }
-
     // Validate MCP settings if present
     if (config.mcp) {
       this.validateMCPConfig(config.mcp, errors, warnings);
@@ -258,12 +287,14 @@ export class ConfigService {
    * Validate modern (v0.3.0+) configuration
    */
   private validateModernConfig(config: LienConfig, errors: string[], warnings: string[]): void {
-    // Validate core settings
+    // `core` currently holds no configurable settings (chunkSize/chunkOverlap
+    // and concurrency were both removed as dead config) — its presence is
+    // only the modern/legacy discriminator, so there's nothing to validate
+    // beyond requiring the key to exist.
     if (!config.core) {
       errors.push('Missing required field: core');
       return;
     }
-    this.validateCoreConfig(config.core, errors, warnings);
 
     // Validate MCP settings
     if (!config.mcp) {
@@ -305,46 +336,14 @@ export class ConfigService {
       return;
     }
 
-    const { indexing } = config;
-
-    if (typeof indexing.chunkSize !== 'number' || indexing.chunkSize <= 0) {
-      errors.push('indexing.chunkSize must be a positive number');
-    }
-
-    if (typeof indexing.chunkOverlap !== 'number' || indexing.chunkOverlap < 0) {
-      errors.push('indexing.chunkOverlap must be a non-negative number');
-    }
+    // `indexing` currently has nothing left to numerically validate
+    // (chunkSize/chunkOverlap were removed as dead config); include/exclude
+    // are plain arrays with no constraints. Existence was already checked
+    // above.
 
     // Validate MCP settings (same for both)
     if (config.mcp) {
       this.validateMCPConfig(config.mcp, errors, warnings);
-    }
-  }
-
-  /**
-   * Validate core configuration settings
-   */
-  private validateCoreConfig(
-    core: Partial<LienConfig['core']>,
-    errors: string[],
-    warnings: string[],
-  ): void {
-    if (core.chunkSize !== undefined) {
-      if (typeof core.chunkSize !== 'number' || core.chunkSize <= 0) {
-        errors.push('core.chunkSize must be a positive number');
-      } else if (core.chunkSize < 50) {
-        warnings.push(
-          'core.chunkSize is very small (<50 lines). This may result in poor search quality',
-        );
-      } else if (core.chunkSize > 500) {
-        warnings.push('core.chunkSize is very large (>500 lines). This may impact performance');
-      }
-    }
-
-    if (core.chunkOverlap !== undefined) {
-      if (typeof core.chunkOverlap !== 'number' || core.chunkOverlap < 0) {
-        errors.push('core.chunkOverlap must be a non-negative number');
-      }
     }
   }
 

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -12,7 +12,6 @@ import { getTraverser } from './traversers/index.js';
 import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
 
 export interface ASTChunkOptions {
-  maxChunkSize?: number; // Reserved for future use (smart splitting of large functions)
   minChunkSize?: number;
   // Multi-tenant fields (optional for backward compatibility)
   repoId?: string; // Repository identifier for multi-tenant scenarios


### PR DESCRIPTION
## Summary

Second entry in the dead-config series (after #706). `core.chunkSize`/`core.chunkOverlap` (and legacy `indexing.*` shapes) were validated and merged but structurally unreachable from any indexing call site — full-index, incremental, overlay all hardcode `DEFAULT_CHUNK_SIZE`/`DEFAULT_CHUNK_OVERLAP`; the review engine's `ChunkOnlyOptions` accepts the values in principle but **zero callers ever pass them** (all four call sites traced); the watcher never touches chunk config. Chunking behavior is unchanged: the AST chunker is function/class-based and never consulted these; the parser's internal `ChunkOptions` params (75/10 fallback defaults) stay.

- **Generalized migration**: `stripRetiredConcurrencyKey` (from #706) refactored into a `RETIRED_KEY_GROUPS` table + one generic warn-once-and-strip pass over both modern and legacy sections — the third retirement becomes a one-entry addition. Existing configs with the keys warn once and continue.
- `validateCoreConfig` became empty after both retirements and was deleted (it was a pre-existing complexity violation at cognitive 17); `LienConfig.core` typed `Record<string, never>` to preserve the modern/legacy structural discriminator.
- Also deleted: `ASTChunkOptions.maxChunkSize` — "Reserved for future use", never set, never read.
- Dogfood configs cleaned; docs checked (site guide has no chunk-key guidance — verified; architecture docs' remaining mentions are accurate internal-default snapshots or "(Legacy)"-labeled history, with the one live diagram node updated per the #706 precedent).
- Changeset: patch `@liendev/core`.

## Verification
All gates green: format ✓, lint 0 errors ✓, typecheck ✓, build ✓, 152/152 test files across 6 workspaces ✓, `lien delta` exit 0 (3 improved, `validateCoreConfig` removed, no crossings) ✓, docs-truth 64 files ✓.

## Noted for the config follow-up
`packages/cli/.lien.config.json` still carries an orphaned embeddings-era `core.embeddingBatchSize` — one table entry away whenever the broader config cleanup lands.

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** This PR reduces complexity by 17.

> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it hit the token budget limit while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8eb0381. Updates automatically on new commits.</sup>
<!-- /lien-stats -->