### PR TITLE
test(core): fix flaky auto-gc heartbeat stop assertion (quiescence, not exact mtime)

### DIFF
--- a/packages/core/src/gc/auto-gc.test.ts
+++ b/packages/core/src/gc/auto-gc.test.ts
@@ -192,9 +192,18 @@ describe('startLockHeartbeat', () => {
     expect(refreshedMtime).toBeGreaterThan(past.getTime());
 
     clearInterval(timer);
-    const mtimeAfterStop = (await fs.stat(lockPath)).mtimeMs;
-    await new Promise(resolve => setTimeout(resolve, 80));
 
-    expect((await fs.stat(lockPath)).mtimeMs).toBe(mtimeAfterStop);
+    // clearInterval only stops FUTURE ticks — a tick that already fired just
+    // before this call fires its mtime refresh via an un-awaited fs.utimes,
+    // so that write can still land microseconds later. Comparing a pre-stop
+    // snapshot to a single post-stop stat (as this test used to) is racy
+    // against that straggler. Instead assert quiescence: let any in-flight
+    // write settle, then confirm two samples a full interval apart, both
+    // taken after stop, are identical — i.e. nothing refreshes it again.
+    await new Promise(resolve => setTimeout(resolve, 60));
+    const settled = (await fs.stat(lockPath)).mtimeMs;
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect((await fs.stat(lockPath)).mtimeMs).toBe(settled);
   });
 });


### PR DESCRIPTION
## Summary

The `startLockHeartbeat` stop test flaked twice today on unrelated PRs (#711, #713 — drift in both directions). Root cause: the heartbeat's tick fires `fs.utimes(...)` **fire-and-forget** (by design — best-effort, unref'd), so `clearInterval` only cancels future ticks; an already-fired tick's write can land after stop. The old assertion compared a pre-stop mtime snapshot to a single post-stop sample with exact float equality — precisely the boundary a straggler write crosses.

Fix (test-only; the implementation's trailing-write behavior is harmless and untouched): after stop, wait 3× the tick interval for stragglers to settle, then assert **two successive samples a full interval apart are equal** — proving no heartbeat activity survives stop, which is the property the test actually guards. Fake timers considered and rejected: the un-awaited real-fs write desyncs from virtual time (would swap one race for a less honest one).

## Verification
- 30/30 fresh-process runs of the test file — zero failures (vitest 4.0.8 has no `--repeat`; the loop is stronger anyway).
- Full core suite 369/369; format ✓, lint 0 errors ✓, typecheck ✓, build ✓, `lien delta` exit 0.
- One-file diff with a comment explaining why `clearInterval` can't guarantee no trailing write.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This is a test-only change that stabilizes a flaky assertion in `packages/core/src/gc/auto-gc.test.ts`. The production `startLockHeartbeat` implementation is intentionally left untouched: it fires `fs.utimes` fire-and-forget, so `clearInterval` cancels future ticks but cannot recall an already-issued async write. The new assertion waits for in-flight writes to settle and then checks that two post-stop samples a full interval apart are identical, which is the correct property to verify. No callers, exports, or runtime behavior are affected.
>
> - Replaced exact pre-stop vs. post-stop mtime equality check with a quiescence assertion: two post-stop samples taken one interval apart must be equal.
> - Added a comment explaining why `clearInterval` cannot prevent a trailing `fs.utimes` write from landing after stop.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8f40b5e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->