### PR TITLE
docs(site): post-migration sweep — install story, native parser, stale claims

### DIFF
--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -7,7 +7,7 @@ export default withMermaid(
     // Use /lien/ for GitHub Pages subdomain, / for custom domain
     base: process.env.VITE_BASE_PATH || '/',
     title: 'Lien',
-    description: 'Local-first semantic code search for AI assistants',
+    description: 'Local-first structural code search and dependency analysis for AI coding assistants',
     
     head: [
       ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],

--- a/packages/site/docs/guide/cli-commands.md
+++ b/packages/site/docs/guide/cli-commands.md
@@ -217,7 +217,7 @@ lien status [options]
 
 | Option | Description |
 |--------|-------------|
-| `-v, --verbose` | Also show indexing settings (concurrency, batch size, chunk size/overlap defaults) |
+| `-v, --verbose` | Also show indexing settings (concurrency, chunk size/overlap defaults) |
 | `--format <type>` | Output format: `text` (default) or `json` |
 
 ### Output
@@ -242,7 +242,7 @@ File watching: ✓ Enabled (default)
   Disable with: lien serve --no-watch
 ```
 
-With `--verbose`, an additional "Indexing Settings (defaults)" block prints the concurrency, batch size, and chunk size/overlap defaults. With `--format json`, the same data is emitted as a single JSON object (`version`, `indexPath`, `indexStatus`, `indexFiles`, `git`, `features`, `settings`) for scripting.
+With `--verbose`, an additional "Indexing Settings (defaults)" block prints the concurrency and chunk size/overlap defaults. With `--format json`, the same data is emitted as a single JSON object (`version`, `indexPath`, `indexStatus`, `indexFiles`, `git`, `features`, `settings`) for scripting.
 
 ## lien config
 

--- a/packages/site/docs/guide/installation.md
+++ b/packages/site/docs/guide/installation.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - **Node.js 22.21.0 or higher** (check with `node --version`)
-- At least 200MB free disk space (for ML model)
+- No compiler or build toolchain required — Lien's parser ships as prebuilt native binaries (macOS arm64/x64, Linux x64/arm64 for both glibc and musl, Windows x64), so there's no `node-gyp`, no Python/make/g++, no Xcode Command Line Tools step
 - 8GB+ RAM recommended for large codebases
 
 ## Claude Code Plugin (Recommended)

--- a/packages/site/docs/guide/installation.md
+++ b/packages/site/docs/guide/installation.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - **Node.js 22.21.0 or higher** (check with `node --version`)
-- No compiler or build toolchain required — Lien's parser ships as prebuilt native binaries (macOS arm64/x64, Linux x64/arm64 for both glibc and musl, Windows x64), so there's no `node-gyp`, no Python/make/g++, no Xcode Command Line Tools step
+- No compiler or build toolchain required on supported platforms — Lien's parser ships as prebuilt native binaries for macOS (arm64/x64), Linux (x64/arm64, glibc or musl, including Alpine), and Windows (x64), so there's no `node-gyp`, no Python/make/g++, no Xcode Command Line Tools step. Any other platform needs a one-time local build of the parser crate with the Rust toolchain
 - 8GB+ RAM recommended for large codebases
 
 ## Claude Code Plugin (Recommended)

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -79,8 +79,8 @@ Everything runs locally:
 ## Architecture
 
 Lien is built with modern, performant tools:
+- **Rust** (`@liendev/parser-native`) for parsing — a small native crate that statically links Tree-sitter and all supported language grammars, and returns one serialized tree per file instead of a live object graph, which avoids the per-node call overhead of a JS-to-native binding. It ships as prebuilt binaries for every supported platform, so installing Lien never compiles anything
 - **TypeScript** for type-safe development
-- **Tree-sitter** for AST-based semantic chunking and complexity analysis
 - **SQLite** (`better-sqlite3`) for the structural store, with **FTS5/BM25** for lexical search
 - **Model Context Protocol (MCP)** for AI assistant integration (Cursor, Claude Code, etc.)
 
@@ -185,7 +185,8 @@ worktree.
 - **File context lookup:** sub-millisecond (indexed lookup by file)
 - **Small projects** (1k files): minutes to index
 - **Medium projects** (10k files): ~15-20 minutes to index
-- **Native install:** ~1.8MB (SQLite binding) — no model download
+- **Parsing:** 1.82–2.21x faster end-to-end than Lien's previous `node-tree-sitter`-based parser, measured across benchmarked languages (see [ADR-013](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md))
+- **Native install:** ~1.8MB (SQLite binding) plus a small prebuilt parser binary — no model download, no compiler toolchain
 - **Disk usage:** roughly comparable to the source it indexes for a standalone
   index; a linked git worktree instead pays only for its overlay (see
   [Git Worktree Support](#git-worktree-support) above)


### PR DESCRIPTION
## Summary

Page-by-page sweep of the public site against what actually shipped (0.61.0/0.62.0 native parser + config collapse). Four files fixed; seven pages verified accurate and left alone.

### Fixed
- **guide/installation.md** — removed "at least 200MB free disk space (for ML model)" (embeddings died in ADR-011; there is no model). New install story: prebuilt native binaries per platform, **no compiler toolchain required** (no node-gyp/Python/Xcode CLT) — the former #1 install pain, now the selling point.
- **how-it-works.md** — architecture list now names the Rust parser (@liendev/parser-native, statically-linked tree-sitter grammars, serialized-tree design) and adds the measured "1.82–2.21× faster end-to-end" bullet sourced verbatim from ADR-013's evidence.
- **guide/cli-commands.md** — removed a false claim (pre-existing, caught in the sweep): `lien status --verbose` never printed a "batch size" field (verified against status.ts).
- **.vitepress/config.ts** — site-wide meta description still said "semantic code search" (embeddings-era); now "structural code search and dependency analysis."

### Verified accurate, unchanged
configuration.md (already truthful post-#713), getting-started, mcp-tools, lien-review, homepage, guide index (its brief "Tree-sitter" mention is literally true; the deep explanation lives in how-it-works by design), nav/theme.

## Verification
docs-truth 64 files ✓, `npm run docs:build` clean ✓, prettier ✓, plus the full repo gate chain green (lint 0 errors, typecheck, build, all tests, delta exit 0).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it ended without emitting a parseable JSON verdict while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4c805ea. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product descriptions to reflect structural code search and dependency analysis.
  * Clarified CLI `status --verbose` output details, including concurrency and chunk-size/overlap defaults.
  * Revised installation guidance to note prebuilt native binaries and remove the build-toolchain and disk-space requirement.
  * Refreshed the architecture and performance documentation with updated implementation details and improved speed claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->