### PR TITLE
feat(parser): markdown doc chunking + shared BFS primitive + ADR-009 note

### DIFF
--- a/.changeset/markdown-doc-chunking.md
+++ b/.changeset/markdown-doc-chunking.md
@@ -1,0 +1,8 @@
+---
+"@liendev/parser": minor
+"@liendev/core": minor
+---
+
+feat(parser): chunk markdown by heading section as a 'doc' chunk kind
+
+Markdown files (`.md`/`.mdx`/`.markdown`) now chunk by heading section — the heading breadcrumb becomes the chunk's symbol name — instead of fixed 75-line windows. Chunking is fenced-code- and YAML-front-matter-aware and splits oversized sections, and chunks are tagged with a new `type: 'doc'`. This improves `search_code` / `get_files_context` retrieval of README, CLAUDE.md, and `docs/` content. Internally, a shared bounded-BFS graph primitive (`walkBounded`) is extracted into `@liendev/parser` and reused by the review engine.

--- a/docs/architecture/decisions/0009-extract-parser-package.md
+++ b/docs/architecture/decisions/0009-extract-parser-package.md
@@ -5,6 +5,11 @@
 **Deciders**: Core Team
 **Related**: [Issue #207](https://github.com/getlien/lien/issues/207), PR #278
 
+> **Update (2026-07-09):** ADR-009's deploy-size / install-speed drivers are
+> now largely obsolete — the ~100MB embedding/vector-DB stack this ADR cited
+> was removed in [ADR-011](0011-sqlite-structural-store-fts5-lexical-search.md).
+> The parser/core split now stands on its clean-boundaries rationale alone.
+
 ## Context and Problem Statement
 
 `@liendev/core` bundles two distinct responsibilities: AST parsing/analysis (~5-10MB) and vector DB/embeddings integration (~100MB with native dependencies). `@liendev/review` only needs AST parsing and complexity analysis to generate PR review comments, yet it depends on `@liendev/core` and transitively pulls in LanceDB, Qdrant, and transformers.js — none of which it uses.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -5,6 +5,7 @@ import {
   matchesFile,
   getCanonicalPath,
   isTestFile,
+  COMPLEXITY_THRESHOLDS,
 } from '@liendev/parser';
 
 /**
@@ -33,18 +34,9 @@ export interface ComplexityMetrics {
   complexityRiskBoost: 'low' | 'medium' | 'high' | 'critical';
 }
 
-/**
- * Complexity thresholds for risk assessment.
- */
-const COMPLEXITY_THRESHOLDS = {
-  HIGH_COMPLEXITY_DEPENDENT: 10, // Individual file is complex
-  CRITICAL_AVG: 15, // Average complexity indicates systemic complexity
-  CRITICAL_MAX: 25, // Peak complexity indicates hotspot
-  HIGH_AVG: 10, // Moderately complex on average
-  HIGH_MAX: 20, // Some complex functions exist
-  MEDIUM_AVG: 6, // Slightly above simple code
-  MEDIUM_MAX: 15, // Occasional branching
-} as const;
+// Complexity thresholds for risk assessment live in @liendev/parser
+// (packages/parser/src/dependency-analyzer.ts) — imported above, not
+// re-declared here.
 
 type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
 

--- a/packages/core/src/vectordb/filters.ts
+++ b/packages/core/src/vectordb/filters.ts
@@ -10,6 +10,8 @@ export interface FilterableRecord {
   content?: string;
   file?: string;
   language?: string;
+  /** Chunk kind ('function' | 'class' | 'block' | 'template' | 'doc'). */
+  type?: string;
   symbolName?: string;
   symbolType?: string;
   functionNames?: unknown;
@@ -134,6 +136,14 @@ export function matchesSymbolFilter(
   r: FilterableRecord,
   { language, pattern, symbolType }: SymbolQueryOptions,
 ): boolean {
+  // Markdown 'doc' chunks carry a heading-breadcrumb symbolName but are prose,
+  // not code symbols -- never surface them via the symbol-lookup path
+  // (list_functions / querySymbols). They remain fully searchable via
+  // search_code / scanAll / scanWithFilter, which don't route through here.
+  if (r.type === 'doc') {
+    return false;
+  }
+
   // Language filter
   if (language && (!r.language || r.language.toLowerCase() !== language.toLowerCase())) {
     return false;

--- a/packages/core/src/vectordb/sqlite/row-mapping.ts
+++ b/packages/core/src/vectordb/sqlite/row-mapping.ts
@@ -191,7 +191,7 @@ function buildMetadata(r: SqliteChunkRecord): SearchResult['metadata'] {
     file: r.file,
     startLine: r.startLine,
     endLine: r.endLine,
-    type: r.type as 'function' | 'class' | 'block',
+    type: r.type as ChunkMetadata['type'],
     language: r.language,
     symbolName: r.symbolName || undefined,
     symbolType: r.symbolType as 'function' | 'method' | 'class' | 'interface' | undefined,

--- a/packages/parser/src/chunker.ts
+++ b/packages/parser/src/chunker.ts
@@ -5,6 +5,7 @@ import { shouldUseAST, chunkByAST } from './ast/chunker.js';
 import { NativeBindingLoadError } from './ast/parser.js';
 import { chunkLiquidFile } from './liquid-chunker.js';
 import { chunkJSONTemplate } from './json-template-chunker.js';
+import { chunkMarkdownFile } from './markdown-chunker.js';
 
 export interface ChunkOptions {
   chunkSize?: number;
@@ -25,6 +26,41 @@ export interface ChunkOptions {
   workspaceRoot?: string;
 }
 
+/**
+ * Route to a format-specific chunker for special-cased file types (Liquid,
+ * Shopify JSON templates, Markdown/MDX). Returns undefined when none apply,
+ * so the caller falls through to AST/line-based chunking.
+ */
+function chunkSpecialCase(
+  filepath: string,
+  content: string,
+  chunkSize: number,
+  chunkOverlap: number,
+  tenantContext: { repoId?: string; orgId?: string },
+): CodeChunk[] | undefined {
+  // Liquid files
+  if (filepath.endsWith('.liquid')) {
+    return chunkLiquidFile(filepath, content, chunkSize, chunkOverlap, tenantContext);
+  }
+
+  // Shopify JSON template files (templates/**/*.json). Regex ensures
+  // 'templates/' is a path segment, not part of another name.
+  // Matches: templates/product.json OR some-path/templates/customers/account.json
+  // Rejects: my-templates/config.json OR node_modules/pkg/templates/file.json (filtered by scanner)
+  if (filepath.endsWith('.json') && /(?:^|\/)templates\//.test(filepath)) {
+    return chunkJSONTemplate(filepath, content, tenantContext);
+  }
+
+  // Markdown/MDX — chunk by heading section instead of a fixed-size line
+  // window, so search_code retrieves a coherent section (e.g. README
+  // "Install") rather than an arbitrary slice.
+  if (/\.(md|mdx|markdown)$/i.test(filepath)) {
+    return chunkMarkdownFile(filepath, content, chunkSize, chunkOverlap, tenantContext);
+  }
+
+  return undefined;
+}
+
 export function chunkFile(
   filepath: string,
   content: string,
@@ -40,18 +76,11 @@ export function chunkFile(
     workspaceRoot,
   } = options;
 
-  // Special handling for Liquid files
-  if (filepath.endsWith('.liquid')) {
-    return chunkLiquidFile(filepath, content, chunkSize, chunkOverlap, { repoId, orgId });
-  }
-
-  // Special handling for Shopify JSON template files (templates/**/*.json)
-  // Use regex to ensure 'templates/' is a path segment, not part of another name
-  // Matches: templates/product.json OR some-path/templates/customers/account.json
-  // Rejects: my-templates/config.json OR node_modules/pkg/templates/file.json (filtered by scanner)
-  if (filepath.endsWith('.json') && /(?:^|\/)templates\//.test(filepath)) {
-    return chunkJSONTemplate(filepath, content, { repoId, orgId });
-  }
+  const specialCaseChunks = chunkSpecialCase(filepath, content, chunkSize, chunkOverlap, {
+    repoId,
+    orgId,
+  });
+  if (specialCaseChunks) return specialCaseChunks;
 
   // Try AST-based chunking for supported languages
   if (useAST && shouldUseAST(filepath)) {

--- a/packages/parser/src/graph/bounded-bfs.test.ts
+++ b/packages/parser/src/graph/bounded-bfs.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { walkBounded } from './bounded-bfs.js';
+
+interface TestEdge {
+  to: string;
+}
+
+/** Build a `getNeighbors` function from a plain adjacency list. */
+function makeGraph(adjacency: Record<string, string[]>): (node: string) => TestEdge[] {
+  return (node: string) => (adjacency[node] ?? []).map(to => ({ to }));
+}
+
+const getNextNode = (edge: TestEdge): string => edge.to;
+const getEdgeKey = (edge: TestEdge): string => edge.to;
+const getNodeKey = (node: string): string => node;
+
+describe('walkBounded', () => {
+  it('expands level by level, labeling each edge with its shortest hop', () => {
+    const getNeighbors = makeGraph({
+      seed: ['a'],
+      a: ['b'],
+    });
+
+    const result = walkBounded<string, TestEdge>(
+      'seed',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 2, maxNodes: 10 },
+    );
+
+    expect(result.results.map(r => r.edge.to)).toEqual(['a', 'b']);
+    expect(result.results.map(r => r.hops)).toEqual([1, 2]);
+    expect(result.results.map(r => r.fromNode)).toEqual(['seed', 'a']);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('does not walk past the requested depth', () => {
+    const getNeighbors = makeGraph({
+      seed: ['a'],
+      a: ['b'],
+      b: ['c'],
+    });
+
+    const result = walkBounded<string, TestEdge>(
+      'seed',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 2, maxNodes: 10 },
+    );
+
+    expect(result.results.map(r => r.edge.to)).toEqual(['a', 'b']);
+  });
+
+  it('terminates cleanly on a cycle without re-emitting the seed', () => {
+    const getNeighbors = makeGraph({
+      a: ['b'],
+      b: ['a'],
+    });
+
+    const result = walkBounded<string, TestEdge>(
+      'a',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 5, maxNodes: 10 },
+    );
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].edge.to).toBe('b');
+    expect(result.results[0].hops).toBe(1);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('dedups a node reached via multiple paths, keeping the shortest hop', () => {
+    // Diamond: seed -> a -> c, seed -> b -> c. "c" is reachable at hop 2 via
+    // either path but must be emitted exactly once.
+    const getNeighbors = makeGraph({
+      seed: ['a', 'b'],
+      a: ['c'],
+      b: ['c'],
+    });
+
+    const result = walkBounded<string, TestEdge>(
+      'seed',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 3, maxNodes: 10 },
+    );
+
+    const cEdges = result.results.filter(r => r.edge.to === 'c');
+    expect(cEdges).toHaveLength(1);
+    expect(cEdges[0].hops).toBe(2);
+    expect(result.results).toHaveLength(3); // a, b, c
+  });
+
+  it('truncates when maxNodes is exceeded, stopping the walk immediately', () => {
+    const getNeighbors = makeGraph({
+      seed: ['a', 'b', 'c', 'd', 'e'],
+    });
+
+    const result = walkBounded<string, TestEdge>(
+      'seed',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 2, maxNodes: 2 },
+    );
+
+    expect(result.results).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('returns an empty result for depth < 1 or maxNodes < 1', () => {
+    const getNeighbors = makeGraph({ seed: ['a'] });
+
+    const zeroDepth = walkBounded<string, TestEdge>(
+      'seed',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 0, maxNodes: 10 },
+    );
+    expect(zeroDepth.results).toEqual([]);
+    expect(zeroDepth.truncated).toBe(false);
+    expect(zeroDepth.visitedCount).toBe(0);
+
+    const zeroMaxNodes = walkBounded<string, TestEdge>(
+      'seed',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 2, maxNodes: 0 },
+    );
+    expect(zeroMaxNodes.results).toEqual([]);
+    expect(zeroMaxNodes.visitedCount).toBe(0);
+  });
+
+  it('returns an empty result for a seed with no neighbors', () => {
+    const getNeighbors = makeGraph({});
+
+    const result = walkBounded<string, TestEdge>(
+      'unknown',
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      getNodeKey,
+      { depth: 2, maxNodes: 10 },
+    );
+
+    expect(result.results).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+});

--- a/packages/parser/src/graph/bounded-bfs.ts
+++ b/packages/parser/src/graph/bounded-bfs.ts
@@ -1,0 +1,142 @@
+/**
+ * Generic bounded level-BFS over an arbitrary graph.
+ *
+ * Extracted from the caller-graph BFS in `@liendev/review`'s
+ * `dependency-graph.ts` (`bfsTransitiveCallers` / `expandFrontier`). This file
+ * keeps the traversal *shape* — frontier expansion, dedup, depth cap, maxNodes
+ * truncation — generic and domain-agnostic. Callers supply the domain (what a
+ * "node" and an "edge" are, and how to get from one to the other); this module
+ * does not know anything about symbols, callers, or files.
+ */
+
+export interface BoundedBfsOptions {
+  /** Max hop distance from the seed. Unbounded if omitted. */
+  depth?: number;
+  /** Max edges to emit before stopping. Unbounded if omitted. */
+  maxNodes?: number;
+}
+
+export interface BoundedBfsEdgeResult<TNode, TEdge> {
+  /** The edge as returned by `getNeighbors`. */
+  edge: TEdge;
+  /** The node whose neighbors produced this edge (the BFS predecessor). */
+  fromNode: TNode;
+  /** Hop distance from the seed. Direct neighbors of the seed are 1. */
+  hops: number;
+}
+
+export interface BoundedBfsResult<TNode, TEdge> {
+  results: Array<BoundedBfsEdgeResult<TNode, TEdge>>;
+  /** True if the walk stopped because it hit maxNodes before exploring the full graph. */
+  truncated: boolean;
+  /** Count of distinct nodes whose neighbors were expanded (for diagnostics). */
+  visitedCount: number;
+}
+
+interface QueueItem<TNode> {
+  node: TNode;
+  hops: number;
+}
+
+/**
+ * BFS-walk outward from `seed` up to `opts.depth` hops. Each reachable node is
+ * emitted exactly once (via its edge), at its shortest hop distance from the
+ * seed. Stops once `opts.maxNodes` edges have been emitted (sets
+ * `truncated: true`).
+ *
+ * @param seed - The starting node.
+ * @param getNeighbors - Returns the outgoing edges of a node.
+ * @param getNextNode - Extracts the node an edge leads to.
+ * @param getEdgeKey - Dedup key for the node an edge leads to (equivalent to
+ *   `getNodeKey(getNextNode(edge))`, but callers may compute it more directly).
+ * @param getNodeKey - Dedup key for a node — must produce the same key format
+ *   as `getEdgeKey` for equivalent nodes.
+ */
+export function walkBounded<TNode, TEdge>(
+  seed: TNode,
+  getNeighbors: (node: TNode) => TEdge[],
+  getNextNode: (edge: TEdge) => TNode,
+  getEdgeKey: (edge: TEdge) => string,
+  getNodeKey: (node: TNode) => string,
+  opts: BoundedBfsOptions = {},
+): BoundedBfsResult<TNode, TEdge> {
+  const depth = opts.depth ?? Number.POSITIVE_INFINITY;
+  const maxNodes = opts.maxNodes ?? Number.POSITIVE_INFINITY;
+
+  if (depth < 1 || maxNodes < 1) {
+    return { results: [], truncated: false, visitedCount: 0 };
+  }
+
+  // Seed in `visited` ensures cycles can never re-emit the seed.
+  const visited = new Set<string>([getNodeKey(seed)]);
+  const expanded = new Set<string>();
+  const results: Array<BoundedBfsEdgeResult<TNode, TEdge>> = [];
+  const queue: Array<QueueItem<TNode>> = [{ node: seed, hops: 0 }];
+  const state = { truncated: false };
+
+  while (queue.length > 0 && !state.truncated) {
+    const current = queue.shift();
+    if (!current) break;
+    const currentKey = getNodeKey(current.node);
+    if (expanded.has(currentKey)) continue;
+    expanded.add(currentKey);
+    expandFrontier(
+      current,
+      getNeighbors,
+      getNextNode,
+      getEdgeKey,
+      { depth, maxNodes },
+      visited,
+      results,
+      queue,
+      state,
+    );
+  }
+
+  return { results, truncated: state.truncated, visitedCount: expanded.size };
+}
+
+interface ExpandLimits {
+  depth: number;
+  maxNodes: number;
+}
+
+/**
+ * Process the direct neighbors of a single frontier node.
+ *
+ * Truncation is deterministic but ordering-dependent: when maxNodes is hit
+ * mid-expansion, the remaining neighbors of the current node (and any deeper
+ * nodes still in the queue) are dropped silently. Which edges survive
+ * therefore depends on the iteration order of `getNeighbors` — consumers
+ * should not rely on any particular subset appearing in a truncated result.
+ */
+function expandFrontier<TNode, TEdge>(
+  current: QueueItem<TNode>,
+  getNeighbors: (node: TNode) => TEdge[],
+  getNextNode: (edge: TEdge) => TNode,
+  getEdgeKey: (edge: TEdge) => string,
+  limits: ExpandLimits,
+  visited: Set<string>,
+  results: Array<BoundedBfsEdgeResult<TNode, TEdge>>,
+  queue: Array<QueueItem<TNode>>,
+  state: { truncated: boolean },
+): void {
+  const edges = getNeighbors(current.node);
+  for (const edge of edges) {
+    const key = getEdgeKey(edge);
+    if (visited.has(key)) continue;
+
+    if (results.length >= limits.maxNodes) {
+      state.truncated = true;
+      return;
+    }
+
+    visited.add(key);
+    const hops = current.hops + 1;
+    results.push({ edge, fromNode: current.node, hops });
+
+    if (hops < limits.depth) {
+      queue.push({ node: getNextNode(edge), hops });
+    }
+  }
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -125,6 +125,17 @@ export { computeContentHash, isHashAlgorithmCompatible } from './content-hash.js
 export { findTestAssociationsFromChunks } from './test-associations.js';
 
 // =============================================================================
+// GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)
+// =============================================================================
+
+export { walkBounded } from './graph/bounded-bfs.js';
+export type {
+  BoundedBfsOptions,
+  BoundedBfsEdgeResult,
+  BoundedBfsResult,
+} from './graph/bounded-bfs.js';
+
+// =============================================================================
 // DEPENDENCY ANALYSIS
 // =============================================================================
 

--- a/packages/parser/src/markdown-chunker.test.ts
+++ b/packages/parser/src/markdown-chunker.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { chunkMarkdownFile } from './markdown-chunker.js';
+
+describe('chunkMarkdownFile', () => {
+  it('splits into one chunk per heading section with a breadcrumb per chunk', () => {
+    const content = ['# Title', 'intro text', '', '## Section A', 'content A'].join('\n');
+
+    const chunks = chunkMarkdownFile('README.md', content);
+
+    expect(chunks).toHaveLength(2);
+
+    expect(chunks[0].metadata.symbolName).toBe('Title');
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(3);
+    expect(chunks[0].content).toBe('# Title\nintro text\n');
+    expect(chunks[0].metadata.type).toBe('doc');
+    expect(chunks[0].metadata.language).toBe('markdown');
+
+    expect(chunks[1].metadata.symbolName).toBe('Title > Section A');
+    expect(chunks[1].metadata.startLine).toBe(4);
+    expect(chunks[1].metadata.endLine).toBe(5);
+    expect(chunks[1].content).toBe('## Section A\ncontent A');
+  });
+
+  it('builds a full ancestor breadcrumb across three heading levels', () => {
+    const content = ['# Docs', '', '## Install', '', '### Requirements', 'content'].join('\n');
+
+    const chunks = chunkMarkdownFile('docs/install.md', content);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0].metadata.symbolName).toBe('Docs');
+    expect(chunks[1].metadata.symbolName).toBe('Docs > Install');
+    expect(chunks[2].metadata.symbolName).toBe('Docs > Install > Requirements');
+    expect(chunks[2].metadata.startLine).toBe(5);
+    expect(chunks[2].metadata.endLine).toBe(6);
+  });
+
+  it('does not pop ancestors past a sibling heading of the same level', () => {
+    const content = ['# Docs', '## A', 'a content', '## B', 'b content'].join('\n');
+
+    const chunks = chunkMarkdownFile('docs/sib.md', content);
+
+    expect(chunks.map(c => c.metadata.symbolName)).toEqual(['Docs', 'Docs > A', 'Docs > B']);
+  });
+
+  it('does not treat a "#" line inside a fenced code block as a heading', () => {
+    const content = ['# Title', '', '```js', '# not a heading', '```', '', 'more text'].join('\n');
+
+    const chunks = chunkMarkdownFile('README.md', content);
+
+    // Whole file stays one section under "Title" -- the fenced "#" never
+    // starts a new section.
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('Title');
+    expect(chunks[0].content).toContain('# not a heading');
+    expect(chunks[0].metadata.endLine).toBe(7);
+  });
+
+  it('treats tilde fences the same as backtick fences', () => {
+    const content = ['# Title', '~~~', '# not a heading', '~~~', 'tail'].join('\n');
+
+    const chunks = chunkMarkdownFile('README.md', content);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('Title');
+  });
+
+  it('skips YAML front-matter, folding it into the preamble with no breadcrumb', () => {
+    const content = [
+      '---',
+      'title: Test',
+      '# not a heading',
+      '---',
+      '# Heading',
+      'content here',
+    ].join('\n');
+
+    const chunks = chunkMarkdownFile('post.md', content);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].metadata.symbolName).toBeUndefined();
+    expect(chunks[0].content).toContain('# not a heading');
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(4);
+
+    expect(chunks[1].metadata.symbolName).toBe('Heading');
+    expect(chunks[1].content).toBe('# Heading\ncontent here');
+  });
+
+  it('creates a preamble chunk for content before the first heading', () => {
+    const content = ['Some intro paragraph.', '', '# First Heading', 'body'].join('\n');
+
+    const chunks = chunkMarkdownFile('README.md', content);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].metadata.symbolName).toBeUndefined();
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(2);
+    expect(chunks[0].content).toBe('Some intro paragraph.\n');
+  });
+
+  it('splits an oversized section into overlapping line-window sub-chunks', () => {
+    const bodyLines = Array.from({ length: 40 }, (_, i) => `line ${i + 1}`);
+    const content = ['# Section', ...bodyLines].join('\n');
+
+    const chunks = chunkMarkdownFile('big.md', content, 10, 2);
+
+    // 41 total lines > chunkSize*3 (30) -> must be split.
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach(c => expect(c.metadata.symbolName).toBe('Section'));
+
+    expect(chunks[0].metadata.startLine).toBe(1);
+    // Overlap: second chunk starts before the first chunk ends.
+    expect(chunks[1].metadata.startLine).toBeLessThan(chunks[0].metadata.endLine);
+    // Last chunk reaches the end of the file (41 lines total).
+    expect(chunks[chunks.length - 1].metadata.endLine).toBe(41);
+  });
+
+  it('returns a single chunk for a file with no headings', () => {
+    const content = ['Hello', 'World', 'no headings here'].join('\n');
+
+    const chunks = chunkMarkdownFile('plain.md', content);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBeUndefined();
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(3);
+    expect(chunks[0].content).toBe(content);
+  });
+
+  it('returns an empty array for an empty file', () => {
+    expect(chunkMarkdownFile('empty.md', '')).toEqual([]);
+  });
+
+  it('passes through repoId/orgId tenant context', () => {
+    const chunks = chunkMarkdownFile('README.md', '# Title\ncontent', 75, 10, {
+      repoId: 'repo-1',
+      orgId: 'org-1',
+    });
+
+    expect(chunks[0].metadata.repoId).toBe('repo-1');
+    expect(chunks[0].metadata.orgId).toBe('org-1');
+  });
+});

--- a/packages/parser/src/markdown-chunker.ts
+++ b/packages/parser/src/markdown-chunker.ts
@@ -1,0 +1,283 @@
+import type { CodeChunk } from './types.js';
+
+/**
+ * Markdown-specific chunking
+ *
+ * Splits Markdown/MDX files by ATX heading section (`#`..`######`) instead of
+ * the generic fixed-size line window, so `search_code` can retrieve a
+ * coherent section (e.g. a README's "Install" instructions) rather than an
+ * arbitrary 75-line slice.
+ *
+ * Rules:
+ * - Each ATX heading starts a new section that runs until the next heading of
+ *   ANY level (or EOF).
+ * - Lines inside fenced code blocks (``` or ~~~) are never treated as
+ *   headings, even if they start with `#`.
+ * - A leading YAML front-matter block (`---` ... `---`) is skipped for
+ *   heading detection and folded into the preamble.
+ * - Content before the first heading (including front-matter) becomes its
+ *   own "preamble" chunk with no breadcrumb.
+ * - `metadata.symbolName` carries the heading breadcrumb built from the full
+ *   ancestor chain, e.g. "Docs > Install > Requirements".
+ * - Sections larger than `chunkSize * 3` lines are split into overlapping
+ *   line-window sub-chunks (mirrors liquid-chunker's splitLargeBlock),
+ *   preserving the breadcrumb on every piece.
+ */
+
+interface HeadingMatch {
+  level: number;
+  text: string;
+}
+
+/** A contiguous line range (0-based, `endLine` exclusive) with its heading breadcrumb. */
+interface Section {
+  startLine: number;
+  endLine: number;
+  breadcrumb: string | undefined;
+}
+
+// Fence delimiter: up to 3 leading spaces, then 3+ backticks or 3+ tildes.
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+// ATX heading: up to 3 leading spaces, 1-6 '#', then whitespace + text (or end of line).
+const ATX_HEADING_RE = /^ {0,3}(#{1,6})(?:\s+(.*))?$/;
+
+/** Parse a single line as an ATX heading, or return null if it isn't one. */
+function parseHeading(line: string): HeadingMatch | null {
+  const match = ATX_HEADING_RE.exec(line);
+  if (!match) return null;
+
+  const level = match[1].length;
+  // Strip an optional closing hash sequence, e.g. "## Title ##" -> "Title".
+  const text = (match[2] ?? '').trim().replace(/\s+#+\s*$/, '');
+  return { level, text };
+}
+
+/**
+ * Compute, for each line, whether it falls inside a fenced code block
+ * (including the fence delimiter lines themselves).
+ */
+function computeFenceMask(lines: string[]): boolean[] {
+  const mask: boolean[] = new Array(lines.length).fill(false);
+  let fenceChar: string | null = null;
+  let fenceLen = 0;
+
+  lines.forEach((line, i) => {
+    const match = FENCE_RE.exec(line);
+
+    if (fenceChar) {
+      mask[i] = true;
+      if (match && match[1][0] === fenceChar && match[1].length >= fenceLen) {
+        fenceChar = null;
+        fenceLen = 0;
+      }
+      return;
+    }
+
+    if (match) {
+      fenceChar = match[1][0];
+      fenceLen = match[1].length;
+      mask[i] = true;
+    }
+  });
+
+  return mask;
+}
+
+/**
+ * Find the end (0-based, exclusive) of a leading YAML front-matter block, or
+ * 0 if the file has none (or the block is unterminated).
+ */
+function frontMatterEnd(lines: string[]): number {
+  if (lines.length === 0 || lines[0].trim() !== '---') return 0;
+
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return i + 1;
+  }
+
+  return 0;
+}
+
+/** A heading found outside front-matter and fenced code, with its line number. */
+interface HeadingLine {
+  line: number;
+  heading: HeadingMatch;
+}
+
+/**
+ * Find every real ATX heading in the file: skips lines inside the leading
+ * front-matter block and lines inside fenced code blocks.
+ */
+function extractHeadingLines(lines: string[], fenceMask: boolean[], fmEnd: number): HeadingLine[] {
+  const headingLines: HeadingLine[] = [];
+  lines.forEach((line, i) => {
+    if (i < fmEnd || fenceMask[i]) return;
+    const heading = parseHeading(line);
+    if (heading) headingLines.push({ line: i, heading });
+  });
+  return headingLines;
+}
+
+/**
+ * Turn the flat list of headings into sections, tracking an ancestor stack
+ * so each section's breadcrumb includes every enclosing heading level.
+ */
+function buildHeadingSections(lines: string[], headingLines: HeadingLine[]): Section[] {
+  const stack: HeadingMatch[] = [];
+
+  return headingLines.map(({ line, heading }, idx) => {
+    while (stack.length > 0 && stack[stack.length - 1].level >= heading.level) {
+      stack.pop();
+    }
+    stack.push(heading);
+
+    const nextLine = idx + 1 < headingLines.length ? headingLines[idx + 1].line : lines.length;
+    const breadcrumb = stack
+      .map(h => h.text)
+      .filter(Boolean)
+      .join(' > ');
+
+    return {
+      startLine: line,
+      endLine: nextLine,
+      breadcrumb: breadcrumb.length > 0 ? breadcrumb : undefined,
+    };
+  });
+}
+
+/**
+ * Build the section boundaries for a markdown file: a preamble (if any
+ * content precedes the first heading) plus one section per heading, each
+ * running until the next heading of any level.
+ */
+function findSections(lines: string[]): Section[] {
+  const fenceMask = computeFenceMask(lines);
+  const fmEnd = frontMatterEnd(lines);
+  const headingLines = extractHeadingLines(lines, fenceMask, fmEnd);
+
+  const sections: Section[] = [];
+
+  // Preamble: everything before the first heading (front-matter included).
+  const firstHeadingLine = headingLines.length > 0 ? headingLines[0].line : lines.length;
+  if (firstHeadingLine > 0) {
+    sections.push({ startLine: 0, endLine: firstHeadingLine, breadcrumb: undefined });
+  }
+
+  sections.push(...buildHeadingSections(lines, headingLines));
+
+  return sections;
+}
+
+/**
+ * Create a markdown 'doc' chunk with consistent metadata.
+ */
+function createDocChunk(
+  content: string,
+  startLine: number,
+  endLine: number,
+  filepath: string,
+  symbolName: string | undefined,
+  tenantContext?: { repoId?: string; orgId?: string },
+): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file: filepath,
+      startLine,
+      endLine,
+      language: 'markdown',
+      type: 'doc',
+      symbolName,
+      ...(tenantContext?.repoId && { repoId: tenantContext.repoId }),
+      ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
+    },
+  };
+}
+
+/**
+ * Split an oversized section into overlapping line-window sub-chunks so no
+ * single chunk is unbounded. Mirrors liquid-chunker's splitLargeBlock, and
+ * preserves the section's breadcrumb across every piece.
+ */
+function splitLargeSection(
+  lines: string[],
+  section: Section,
+  filepath: string,
+  chunkSize: number,
+  chunkOverlap: number,
+  tenantContext?: { repoId?: string; orgId?: string },
+): CodeChunk[] {
+  const chunks: CodeChunk[] = [];
+  const sectionLines = lines.slice(section.startLine, section.endLine);
+  const step = Math.max(1, chunkSize - chunkOverlap);
+
+  for (let offset = 0; offset < sectionLines.length; offset += step) {
+    const endOffset = Math.min(offset + chunkSize, sectionLines.length);
+    const chunkContent = sectionLines.slice(offset, endOffset).join('\n');
+
+    if (chunkContent.trim().length > 0) {
+      chunks.push(
+        createDocChunk(
+          chunkContent,
+          section.startLine + offset + 1,
+          section.startLine + endOffset,
+          filepath,
+          section.breadcrumb,
+          tenantContext,
+        ),
+      );
+    }
+
+    if (endOffset >= sectionLines.length) break;
+  }
+
+  return chunks;
+}
+
+/**
+ * Chunk a Markdown/MDX file by heading section.
+ *
+ * @param filepath - File path, used as chunk metadata and for symbol context.
+ * @param content - Raw file content.
+ * @param chunkSize - Max lines per chunk before an oversized section is split
+ *   into windows; also the window size used when splitting (default 75).
+ * @param chunkOverlap - Line overlap between windows when splitting an
+ *   oversized section (default 10).
+ * @param tenantContext - Optional repoId/orgId passthrough for multi-tenant indexes.
+ */
+export function chunkMarkdownFile(
+  filepath: string,
+  content: string,
+  chunkSize: number = 75,
+  chunkOverlap: number = 10,
+  tenantContext?: { repoId?: string; orgId?: string },
+): CodeChunk[] {
+  const lines = content.split('\n');
+  if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {
+    return [];
+  }
+
+  const sections = findSections(lines);
+  const maxSectionSize = chunkSize * 3;
+
+  return sections.flatMap(section => {
+    const sectionLineCount = section.endLine - section.startLine;
+    const sectionContent = lines.slice(section.startLine, section.endLine).join('\n');
+
+    if (sectionContent.trim().length === 0) return [];
+
+    if (sectionLineCount <= maxSectionSize) {
+      return [
+        createDocChunk(
+          sectionContent,
+          section.startLine + 1,
+          section.endLine,
+          filepath,
+          section.breadcrumb,
+          tenantContext,
+        ),
+      ];
+    }
+
+    return splitLargeSection(lines, section, filepath, chunkSize, chunkOverlap, tenantContext);
+  });
+}

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -7,7 +7,7 @@ export interface ChunkMetadata {
   file: string;
   startLine: number;
   endLine: number;
-  type: 'function' | 'class' | 'block' | 'template';
+  type: 'function' | 'class' | 'block' | 'template' | 'doc';
   language: string;
   // Extracted symbols for direct querying
   symbols?: {

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -8,6 +8,7 @@
 
 import path from 'node:path/posix';
 import type { CodeChunk } from '@liendev/parser';
+import { walkBounded } from '@liendev/parser';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -139,16 +140,30 @@ export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
 }
 
 // ---------------------------------------------------------------------------
-// Transitive BFS — extracted so buildDependencyGraph stays a thin wire-up.
+// Transitive BFS — thin domain wrapper around @liendev/parser's walkBounded.
+//
+// The generic primitive owns the frontier-expansion loop: dedup, the depth
+// cap, and maxNodes truncation. This wrapper supplies the caller-graph domain
+// (an exported symbol at a filepath as the node identity) and decorates the
+// raw walk results with the hop/viaSymbol fields callers of this module
+// expect — that decoration happens here, not inside walkBounded.
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TRANSITIVE_DEPTH = 2;
 const DEFAULT_TRANSITIVE_MAX_NODES = 30;
 
-interface BfsQueueItem {
+/** Node identity for the caller-graph BFS: an exported symbol at a filepath. */
+interface CallerGraphNode {
   filepath: string;
   symbolName: string;
-  hops: number;
+}
+
+function callerGraphNodeKey(node: CallerGraphNode): string {
+  return `${node.filepath}::${node.symbolName}`;
+}
+
+function callerEdgeKey(edge: CallerEdge): string {
+  return `${edge.caller.filepath}::${edge.caller.symbolName}`;
 }
 
 function bfsTransitiveCallers(
@@ -160,79 +175,23 @@ function bfsTransitiveCallers(
   const depth = opts.depth ?? DEFAULT_TRANSITIVE_DEPTH;
   const maxNodes = opts.maxNodes ?? DEFAULT_TRANSITIVE_MAX_NODES;
 
-  if (depth < 1 || maxNodes < 1) {
-    return { callers: [], truncated: false, visitedSymbols: 0 };
-  }
+  const { results, truncated, visitedCount } = walkBounded<CallerGraphNode, CallerEdge>(
+    { filepath, symbolName },
+    node => getCallers(node.filepath, node.symbolName),
+    edge => ({ filepath: edge.caller.filepath, symbolName: edge.caller.symbolName }),
+    callerEdgeKey,
+    callerGraphNodeKey,
+    { depth, maxNodes },
+  );
 
-  // Seed in emittedCallers ensures cycles can never re-emit the seed.
-  const emittedCallers = new Set<string>([`${filepath}::${symbolName}`]);
-  const expandedSymbols = new Set<string>();
-  const result: TransitiveCallerEdge[] = [];
-  const queue: BfsQueueItem[] = [{ filepath, symbolName, hops: 0 }];
-  const state = { truncated: false };
+  const callers: TransitiveCallerEdge[] = results.map(({ edge, fromNode, hops }) => ({
+    caller: edge.caller,
+    callSiteLine: edge.callSiteLine,
+    hops,
+    viaSymbol: fromNode.symbolName,
+  }));
 
-  while (queue.length > 0 && !state.truncated) {
-    const current = queue.shift();
-    if (!current) break;
-    const currentKey = `${current.filepath}::${current.symbolName}`;
-    if (expandedSymbols.has(currentKey)) continue;
-    expandedSymbols.add(currentKey);
-    expandFrontier(current, getCallers, { depth, maxNodes }, emittedCallers, result, queue, state);
-  }
-
-  return { callers: result, truncated: state.truncated, visitedSymbols: expandedSymbols.size };
-}
-
-interface ExpandLimits {
-  depth: number;
-  maxNodes: number;
-}
-
-/**
- * Process the direct callers of a single frontier symbol.
- *
- * Truncation is deterministic but ordering-dependent: when maxNodes is hit
- * mid-expansion, the remaining callers of the current symbol (and any deeper
- * symbols still in the queue) are dropped silently. Which callers survive
- * therefore depends on the iteration order of getCallers — consumers should
- * not rely on any particular subset appearing in a truncated result.
- */
-function expandFrontier(
-  current: BfsQueueItem,
-  getCallers: (filepath: string, symbolName: string) => CallerEdge[],
-  limits: ExpandLimits,
-  emittedCallers: Set<string>,
-  result: TransitiveCallerEdge[],
-  queue: BfsQueueItem[],
-  state: { truncated: boolean },
-): void {
-  const directCallers = getCallers(current.filepath, current.symbolName);
-  for (const edge of directCallers) {
-    const callerKey = `${edge.caller.filepath}::${edge.caller.symbolName}`;
-    if (emittedCallers.has(callerKey)) continue;
-
-    if (result.length >= limits.maxNodes) {
-      state.truncated = true;
-      return;
-    }
-
-    emittedCallers.add(callerKey);
-    const hops = current.hops + 1;
-    result.push({
-      caller: edge.caller,
-      callSiteLine: edge.callSiteLine,
-      hops,
-      viaSymbol: current.symbolName,
-    });
-
-    if (hops < limits.depth) {
-      queue.push({
-        filepath: edge.caller.filepath,
-        symbolName: edge.caller.symbolName,
-        hops,
-      });
-    }
-  }
+  return { callers, truncated, visitedSymbols: visitedCount };
 }
 
 type ExportEntry = { filepath: string; chunk: CodeChunk };


### PR DESCRIPTION
## Summary

Three pieces from the docs-index design (`.wip/design-docs-index-and-review-consolidation.md`), built by an orchestrated subagent team:

### 1. `feat(parser)` — markdown chunked by heading section (Phase 1 / A1)
Markdown (`.md`/`.mdx`/`.markdown`) previously fell through to fixed 75-line window chunking with no structure. New `chunkMarkdownFile()`:
- splits by **heading section**, heading breadcrumb (e.g. `Install > Requirements`) as `symbolName`
- tracks fenced code blocks (so `#` inside a fence isn't a heading) and skips YAML front-matter
- splits oversized sections (mirrors `liquid-chunker`'s large-block handling)
- tags chunks with a new `type: 'doc'`

Downstream: widened `ChunkMetadata.type`; fixed the `row-mapping` cast to derive from `ChunkMetadata['type']` (**also restores the previously-missing `'template'`** — a latent bug); excluded doc chunks from symbol-filter listings so headings don't pollute `list_functions`. Improves `search_code`/`get_files_context` retrieval of README/CLAUDE.md/docs.

### 2. `refactor(parser,review)` — shared bounded-BFS graph primitive (D-Option 0)
The design doc claimed review reimplements graph-walking that parser has. **A read-only investigation debunked most of that**: review's `dependency-graph.ts` (symbol-level call resolution over `callSites`) and parser's `dependency-analyzer.ts` (file-level import matching over `imports`) solve *different* problems on *different* data; the risk primitive is already shared. The **one** genuine overlap — a ~40-line frontier-BFS loop — is extracted into a generic `walkBounded()` in `@liendev/parser` and review's `getCallersTransitive` refactored onto it. Review-specific decorations (`hops`, `viaSymbol`) stay in review as post-processing; **observable review output is unchanged** (all dependency-graph/blast-radius/agent tests pass with zero test-file edits). Also deduped the CLI's re-declared `COMPLEXITY_THRESHOLDS` to import from parser.

### 3. `docs(adr)` — ADR-009 forward-note
**ADR-011 already exists** on `main` (the design doc's "missing ADR-011" premise was stale) and is accurate, so it was left untouched. Added a dated forward-note to ADR-009 recording that its deploy-size/install-speed rationale is now obsolete (ADR-011 removed the embedding stack) — the parser/core split stands on clean boundaries alone.

## What was deliberately NOT done
- No full review↔core consolidation (D-Option 2/3) — the docs feature doesn't need it and it's YAGNI.
- CLI's own file-level BFS left on its own path (MCP-facing; separate follow-up).
- No new `docComment` DB column (no migration mechanism exists; deferred per design doc).

## Verification (in-worktree, full gate)
- `format:check` ✓ · `lint` ✓ (0 errors) · `typecheck` ✓ · `build` ✓
- **All test suites green**: parser-native 27, parser 1045, core 356, review 565, cli 792, action 28
- `lien delta` exit 0 (3 complexity *improvements*, 1 within-budget worsen: `matchesSymbolFilter` 9→10)
- Rust `parser-native` built locally to run the AST-dependent suites

## Notes for reviewer
- Review behavior is calibration-sensitive; the BFS extraction is a verbatim-logic move proven identical by the existing (unedited) `getCallersTransitive` test contract. No harness re-calibration needed (no rule prompt / `system-prompt.ts` change).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it hit the token budget limit while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ea5d9a4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown and MDX document chunking by headings, including breadcrumbs, front matter, fenced-code handling, and large-section splitting.
  * Added bounded graph traversal with depth and result limits.
  * Documentation chunks are now supported throughout parsing and search workflows.

* **Bug Fixes**
  * Prevented documentation chunks from being processed as symbol matches.
  * Centralized complexity thresholds for consistent risk analysis.

* **Documentation**
  * Updated architecture guidance to reflect the current parser and core package boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->