### PR TITLE
fix(review): exclude markdown 'doc' chunks from list_functions

### DIFF
--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -163,7 +163,10 @@ export function listFunctions(input: Record<string, unknown>, ctx: AgentToolCont
       MAX_FUNCTIONS_LIMIT,
     );
 
-    let results = ctx.repoChunks.filter(c => !!c.metadata.symbolName);
+    // Exclude markdown 'doc' chunks: they carry a heading-breadcrumb symbolName
+    // but are prose sections, not real code symbols (mirrors core's
+    // matchesSymbolFilter, which review can't import across the package boundary).
+    let results = ctx.repoChunks.filter(c => !!c.metadata.symbolName && c.metadata.type !== 'doc');
 
     if (symbolType) {
       results = results.filter(c => c.metadata.symbolType === symbolType);

--- a/packages/review/test/plugins-agent-listfunctions.test.ts
+++ b/packages/review/test/plugins-agent-listfunctions.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+
+import { listFunctions } from '../src/plugins/agent/agent-tools.js';
+import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { createTestChunk, silentLogger } from '../src/test-helpers.js';
+import type { AgentToolContext } from '../src/plugins/agent/types.js';
+
+/** Parsed shape of listFunctions' JSON return. */
+interface ListFnResult {
+  results?: Array<{ symbolName: string; symbolType: string | null; filepath: string }>;
+  count?: number;
+  error?: string;
+}
+
+function ctxWith(repoChunks: CodeChunk[]): AgentToolContext {
+  return {
+    repoChunks,
+    repoRootDir: '/tmp/does-not-matter',
+    graph: buildDependencyGraph([]),
+    logger: silentLogger,
+  };
+}
+
+function run(repoChunks: CodeChunk[], input: Record<string, unknown> = {}): ListFnResult {
+  return JSON.parse(listFunctions(input, ctxWith(repoChunks))) as ListFnResult;
+}
+
+const codeChunk = createTestChunk({
+  metadata: {
+    file: 'src/foo.ts',
+    startLine: 1,
+    endLine: 5,
+    type: 'function',
+    symbolName: 'doThing',
+    symbolType: 'function',
+    language: 'typescript',
+  },
+});
+
+// A markdown 'doc' chunk carries a heading-breadcrumb symbolName (0.64.0+) but is
+// prose, not a code symbol. It must not appear in list_functions results.
+const docChunk = createTestChunk({
+  content: '## Install\n\nRun the installer.\n',
+  metadata: {
+    file: 'README.md',
+    startLine: 1,
+    endLine: 10,
+    type: 'doc',
+    symbolName: 'Guide > Install',
+    language: 'markdown',
+  },
+});
+
+describe('listFunctions — markdown doc chunks are not treated as symbols', () => {
+  it('lists real code symbols but excludes doc-heading breadcrumbs', () => {
+    const res = run([codeChunk, docChunk]);
+    const names = (res.results ?? []).map(r => r.symbolName);
+
+    expect(res.error).toBeUndefined();
+    expect(names).toContain('doThing');
+    expect(names).not.toContain('Guide > Install');
+    expect(res.count).toBe(1);
+  });
+
+  it('returns no results when the repo has only doc chunks', () => {
+    const res = run([docChunk]);
+    expect(res.count).toBe(0);
+    expect(res.results).toEqual([]);
+  });
+
+  it('excludes doc chunks even when a pattern would otherwise match their breadcrumb', () => {
+    const res = run([codeChunk, docChunk], { pattern: 'Install' });
+    const names = (res.results ?? []).map(r => r.symbolName);
+    expect(names).not.toContain('Guide > Install');
+    expect(res.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #718. That PR made markdown chunk as `type:'doc'` with a heading-breadcrumb `symbolName`. Core's symbol filter (`matchesSymbolFilter`) was updated to exclude `doc` chunks, but **review's own `list_functions` agent tool was not** — it filtered only on `!!symbolName`, so every markdown heading (~1,488 of them on this repo) leaked in as a fake "symbol," able to crowd out real code symbols in a `list_functions` result.

This mirrors core's guard in review's tool (review depends on `parser` only, so it can't import core's filter across the package boundary):

```ts
ctx.repoChunks.filter(c => !!c.metadata.symbolName && c.metadata.type !== 'doc')
```

## Why it matters (and its bounds)
Surfaced by investigating whether #718 degraded the review action. It did **not** blow the token budget (the tool is hard-capped at `limit`, and `list_functions` wasn't even called in #718's run) — but returning prose headings as "symbols" is incorrect and could pollute a single tool response. This closes the one real gap the feature introduced.

## Verification
- `format:check` ✓ · `lint` ✓ (0 errors) · `typecheck` ✓ · `build` ✓
- Review suite: **568 tests pass** (added 3: real symbol listed, doc breadcrumb excluded; only-docs → empty; pattern match still excludes docs)
- `lien delta` exit 0

No changeset — `@liendev/review` is unpublished.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 4 | +8 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it ended without emitting a parseable JSON verdict while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1693e1b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function listings by excluding documentation headings from code symbol results.
  * Search patterns no longer return markdown breadcrumbs as functions.

* **Tests**
  * Added coverage for repositories containing code symbols, documentation-only content, and matching documentation headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->