### PR TITLE
test(review): reconcile known-red Kimi canaries; fail loudly on partial-index captures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,10 @@ exists specifically to make that cycle ~30 minutes instead of hours.
   the repo root.
 - Workflow + failure modes: see `packages/review/test/harness/README.md`.
   Includes the end-to-end recipe for capturing a real-PR fixture, authoring
-  Tier 1/2 assertions, iterating, and calibrating. A couple of existing
-  canaries were calibrated on Gemini and are currently known-red on Kimi —
-  see the README's "Known-red reconciliation" note; that's tracked
-  separately, not a blocker for new rule work.
+  Tier 1/2 assertions, iterating, and calibrating. The formerly known-red
+  Kimi canaries were reconciled 2026-07-10 (see the README's "Known-red
+  reconciliation" note); before trusting any red fixture, confirm it's a
+  healthy capture — the native parser must be built or capture fails loudly.
 
 A rule is not shippable until its calibration meets the bar. CC mode is
 necessary but not sufficient.

--- a/packages/review/test/harness-runner.test.ts
+++ b/packages/review/test/harness-runner.test.ts
@@ -20,7 +20,12 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 import { runFixture, toolCallsFromTrace, turnCountFromTrace } from './harness/runner.js';
-import { expectRuleFired, expectToolCalled } from './harness/assertions.js';
+import {
+  expectAnyToolCalled,
+  expectRuleFired,
+  expectToolCalled,
+  HarnessAssertionError,
+} from './harness/assertions.js';
 import type { AgentTrace, TurnTrace } from '../src/plugins/agent/types.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -40,6 +45,25 @@ function turn(turnNumber: number, toolNames: string[], responseText = ''): TurnT
 function traceOf(turns: TurnTrace[]): AgentTrace {
   return { systemPrompt: 'sys', initialMessage: 'init', model: 'test-model', turns };
 }
+
+describe('expectAnyToolCalled', () => {
+  const result = { findings: [], toolCalls: ['tool=read_file'], turns: 1 };
+
+  it('passes when any of the accepted tools was called', () => {
+    expect(() => expectAnyToolCalled(['get_files_context', 'read_file'], result)).not.toThrow();
+  });
+
+  it('throws Tier 1 when none of the accepted tools was called', () => {
+    expect(() => expectAnyToolCalled(['get_files_context', 'grep_codebase'], result)).toThrow(
+      HarnessAssertionError,
+    );
+  });
+
+  it('does not false-match a tool name substring', () => {
+    const subst = { findings: [], toolCalls: ['tool=file_reader_x'], turns: 1 };
+    expect(() => expectAnyToolCalled(['read_file'], subst)).toThrow(HarnessAssertionError);
+  });
+});
 
 describe('toolCallsFromTrace / turnCountFromTrace (pure trace helpers)', () => {
   it('flattens tool calls across turns, in order', () => {

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -135,6 +135,13 @@ so the fixture is reproducible. A leftover git worktree at
 `/tmp/lien-capture-<sha>` is reused on re-runs (clean up with
 `git worktree remove --force <path>` when done).
 
+**Prerequisite: the native parser must be built** in the checkout you capture
+from (`npm run build:native -w @liendev/parser-native` — the binding is
+gitignored and per-worktree). Without it, every AST-language file silently
+chunks to zero and the fixture's corpus ends up markdown/Vue-only (~800
+chunks instead of ~5300). `capture-pr.ts` now fails loudly on that signature
+(`assertIndexComplete`) instead of writing a partial fixture.
+
 Hand-authored placeholder fixtures (small, committed) live alongside.
 
 ## Layout
@@ -269,31 +276,41 @@ This bar is what gates the harness from "shipped" to "trusted for the
 parked prompt-tweak issues" (#284, #286, #287, #288, #289, #302, #339, and
 the §4.3 "test pair" tweak in `.wip/retro-blast-radius.md`).
 
-### Known-red reconciliation: Gemini-calibrated canaries vs the Kimi default
+### Known-red reconciliation: resolved 2026-07-10
 
-The canary corpus predates the Kimi cutover (#592/#591) and some fixtures
-were calibrated (and last hit ≥ 9/10) against `google/gemini-3-flash-preview`,
-not the current prod default. Running `--calibrate 10` with no `--model`
-now exercises Kimi, and two canaries are **known-red** there:
-`stale-duplicate/model-partial-update` and
-`untrusted-input-validation/harness-initial` (2/9 rules — the corpus grew to
-9 with the `doc-truth` canary added 2026-07-04, itself calibrated fresh
-against Kimi at 10/10, so it isn't part of this known-red set). This is
-expected, already-understood drift from the Kimi cutover (#592) — not a
-regression introduced by this doc change, and not something this change
-attempts to fix. See `packages/review/src/defaults.ts` for the current
-default model.
+The corpus previously carried two canaries flagged "known-red on Kimi"
+(`stale-duplicate/model-partial-update` and
+`untrusted-input-validation/harness-initial`), attributed to drift from the
+Kimi cutover (#592). A dedicated reconciliation found neither was a model
+capability gap:
 
-Because of this, the bar for **touching an existing rule's prompt** is not
-"single-rule calibrate ≥ 9/10 on every canary in the repo" — it's ≥ 9/10 on
-the rule(s) you actually changed. The bar for **the full corpus** (e.g.
-before a model swap, or a change that touches shared prompt scaffolding used
-by multiple rules) is **no regression vs main's pass/fail pattern**, checked
-by re-running the full canary sweep (`sweep.sh`, or `--calibrate 10` with no
-`--rule` filter) on both branches and diffing which fixtures flip — not
-"every fixture is green." Do not spend calibration budget trying to push the
-two known-red fixtures above 9/10 as a side effect of unrelated work; that's
-tracked as its own fix separately.
+- **untrusted-input-validation** — the assertion demanded
+  `get_files_context` while the rule prompt offers "get_files_context (or
+  read_file)"; correct Kimi runs failed Tier 1 purely on tool choice
+  (7/10, all misses `read_file`-only with Tier-2-passing findings). Fixed by
+  `expectAnyToolCalled(['get_files_context', 'read_file'])`. **10/10 on Kimi**
+  (2026-07-10, healthy fixture).
+- **stale-duplicate** — red only when replayed against a *broken capture*: a
+  fixture whose corpus was markdown/Vue-only because the native parser wasn't
+  built at capture time, so `<stale_literal_candidates>` rendered "None" and
+  suppressed the finding. With a healthy capture the deterministic scan finds
+  the candidate and the rule is **10/10 on Kimi** (2026-07-10). `capture-pr.ts`
+  now fails loudly on partial-index captures (`assertIndexComplete`).
+
+Also reconciled the same day: `error-swallowing/scanall-null-guard-fp`'s
+header claimed it "will fail on the current prompt" — that was true on
+Gemini (2026-05-16) but the gap is closed on Kimi: **10/10 empty**, no prompt
+change needed. `payment-error-swallowed` **10/10**,
+`harness-gitignore-convention-fp` **9/10** (single miss was a stray
+`incomplete-handling`-labeled finding).
+
+The calibration bars are unchanged: **touching an existing rule's prompt**
+requires ≥ 9/10 on the rule(s) you actually changed. **Full-corpus changes**
+(model swap, shared prompt scaffolding) require **no regression vs main's
+pass/fail pattern**, checked by running the sweep (`sweep.sh`, or
+`--calibrate 10` with no `--rule` filter) on both branches and diffing which
+fixtures flip. Before trusting any red, verify the fixture is a healthy
+capture (the capture guard now enforces this at capture time).
 
 ## Runbook: §4.3 boundary-change "test pair" tweak
 

--- a/packages/review/test/harness/assertions.ts
+++ b/packages/review/test/harness/assertions.ts
@@ -101,6 +101,22 @@ export function expectToolCalled(tool: string, result: HarnessResult): void {
   }
 }
 
+/**
+ * Pass if ANY of the named tools was called. Use when the rule prompt offers
+ * the model a choice of tools for the same step (e.g. "get_files_context or
+ * read_file") — asserting on a single one fails correct runs on tool choice.
+ */
+export function expectAnyToolCalled(tools: string[], result: HarnessResult): void {
+  const called = result.toolCalls.some(entry => tools.some(tool => isToolCall(entry, tool)));
+  if (!called) {
+    throw new HarnessAssertionError(
+      `Tier 1: expected any of [${tools.join(', ')}] to be called. Calls observed: ` +
+        (result.toolCalls.length === 0 ? '(none)' : result.toolCalls.slice(0, 8).join('; ')),
+      1,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tier 2
 // ---------------------------------------------------------------------------
@@ -144,6 +160,7 @@ export const harness = {
   expectEmpty,
   expectFindingsCount,
   expectToolCalled,
+  expectAnyToolCalled,
   expectFindingMentions,
 };
 

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -273,6 +273,68 @@ function selectDiffSource(
   };
 }
 
+/**
+ * Extensions whose chunking goes through the native AST parser
+ * (@liendev/parser-native). Markdown (heading-chunked) and Vue (line-based)
+ * do NOT — they survive even when the native binding fails, which is exactly
+ * why a broken index looks like a markdown/Vue-only corpus. `.liquid` is
+ * omitted deliberately: it's uncertain whether it needs the binding, and a
+ * false positive here would abort a legitimate capture.
+ */
+const NATIVE_SOURCE_EXT =
+  /\.(ts|tsx|js|jsx|mjs|cjs|py|php|go|rs|java|kt|swift|rb|cs|scala|c|cpp|cc|cxx|h|hpp)$/;
+
+const NATIVE_BUILD_HINT =
+  '@liendev/parser-native is almost certainly not built in this worktree, so ' +
+  'every AST-language file was silently dropped (performChunkOnlyIndex still ' +
+  'reports success). Build it with `npm run build:native -w @liendev/parser-native` ' +
+  'and re-run.';
+
+/**
+ * Guard against a silent partial index. When the native parser can't load, the
+ * scan still finds every file but `chunkFile` throws per-file; those errors are
+ * swallowed and only markdown/Vue chunks survive, yet the overall result is
+ * `success: true`. Persisting that produces a fixture whose corpus is missing
+ * all source code — the agent then "reviews" a diff it has no context for.
+ * Fail loudly instead, on two independent signatures:
+ *   1. A changed source file that exists on disk and is non-empty but produced
+ *      zero chunks (the PR's own files are absent from the corpus).
+ *   2. Zero source-code chunks anywhere in the corpus, even when the PR only
+ *      touched docs — the repoChunks corpus is the agent's whole search space.
+ */
+async function assertIndexComplete(
+  repoChunks: Array<{ metadata: { file: string } }>,
+  changedFiles: string[],
+  worktree: string,
+): Promise<void> {
+  const indexed = new Set(repoChunks.map(c => toRepoRelative(c.metadata.file, worktree)));
+  const missing: string[] = [];
+  for (const f of changedFiles) {
+    const rel = toRepoRelative(f, worktree);
+    if (!NATIVE_SOURCE_EXT.test(rel) || indexed.has(rel)) continue;
+    let size = 0;
+    try {
+      size = (await fs.stat(join(worktree, rel))).size;
+    } catch {
+      continue; // deleted at this SHA: legitimately absent, skip
+    }
+    if (size > 0) missing.push(rel);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `partial index: ${missing.length} changed source file(s) produced zero chunks ` +
+        `(e.g. ${missing.slice(0, 3).join(', ')}). ${NATIVE_BUILD_HINT}`,
+    );
+  }
+  const sourceChunks = repoChunks.filter(c => NATIVE_SOURCE_EXT.test(c.metadata.file)).length;
+  if (sourceChunks === 0) {
+    throw new Error(
+      `partial index: ${repoChunks.length} chunks captured but zero from AST source ` +
+        `files. ${NATIVE_BUILD_HINT}`,
+    );
+  }
+}
+
 /** Index the worktree and return both repo-wide chunks and the
  * subset belonging to the PR's changed files. */
 async function indexCapturedWorktree(worktree: string, changedFiles: string[]) {
@@ -283,6 +345,7 @@ async function indexCapturedWorktree(worktree: string, changedFiles: string[]) {
   }
   const repoChunks = indexResult.chunks;
   console.error(`[capture] indexed ${repoChunks.length} chunks`);
+  await assertIndexComplete(repoChunks, changedFiles, worktree);
 
   // Path-shape between the parser's chunk metadata and `gh pr view`'s file
   // list isn't guaranteed to match byte-for-byte (Windows backslashes,

--- a/packages/review/test/harness/fixtures/error-swallowing/harness-gitignore-convention-fp.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/harness-gitignore-convention-fp.assertions.ts
@@ -26,6 +26,10 @@
  * different `error-swallowing` FP shape (early null-guard before try/catch
  * read as unguarded deref). Both rules-iteration targets should be checked
  * before any `error-swallowing` prompt change ships.
+ *
+ * Calibration status: 9/10 empty on `moonshotai/kimi-k2.7-code`
+ * (2026-07-10, --calibrate 10, healthy capture; the single miss was a stray
+ * `incomplete-handling`-labeled finding, not the captured FP shape).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
@@ -3,6 +3,9 @@
  * false; }. Throws are silently converted to a `false` result. Textbook
  * error-swallowing: the caller cannot distinguish "charge declined" from
  * "charge crashed".
+ *
+ * Calibration status: 10/10 on `moonshotai/kimi-k2.7-code` (2026-07-10,
+ * --calibrate 10, healthy capture).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/harness/fixtures/error-swallowing/scanall-null-guard-fp.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/scanall-null-guard-fp.assertions.ts
@@ -12,9 +12,11 @@
  * `table: LanceDBTable | null` does this guard), so silencing this FP
  * shape is a high-leverage prompt fix.
  *
- * Calibration status (recorded 2026-05-16, against the unmodified prompt):
- *   pending — fixture authored, calibration run not yet executed. Will
- *   fail on the current prompt; that's the documented gap.
+ * Calibration status: 10/10 empty on `moonshotai/kimi-k2.7-code`
+ * (2026-07-10, --calibrate 10, healthy capture). The 2026-05-16 note that
+ * this fixture "will fail on the current prompt" described Gemini-era
+ * behavior; the FP shape does not reproduce on the Kimi prod default, so
+ * no prompt change was needed.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
+++ b/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
@@ -19,6 +19,12 @@
  * Tier 2: the finding cites adapterContext / line 300 / claude-sonnet-4-6
  * or proposes a hoist to a shared const. Keyword set is deliberately wide
  * to cover the phrasings any correct rendering will use.
+ *
+ * Calibration status: 10/10 on `moonshotai/kimi-k2.7-code` (2026-07-10,
+ * --calibrate 10). The earlier "known-red on Kimi" label was stale: red
+ * runs traced to a broken capture (native parser unbuilt → markdown-only
+ * corpus → <stale_literal_candidates> rendered "None" and suppressed the
+ * finding). capture-pr.ts now rejects such partial captures loudly.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
+++ b/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
@@ -13,9 +13,11 @@
  *     packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.fixture.json \
  *     --sha 7cb0149
  *
- * Tier 1: rule fires + get_files_context is called (the rule still mandates
- * inspecting consumers of the parsed value — get_files_context reads in-memory
- * repoChunks, so unlike grep/read it is NOT blind in replay). The *discovery*
+ * Tier 1: rule fires + a consumer-inspection tool is called. The rule prompt
+ * mandates tracing the parsed value's consumers via "get_files_context (or
+ * read_file)", so the gate accepts either — asserting get_files_context alone
+ * failed correct Kimi runs purely on tool choice (7/10 on 2026-07-10; all 3
+ * misses called read_file 8x with Tier-2-passing findings). The *discovery*
  * half is now deterministic: a pre-computed <untrusted_input_sites> worklist is
  * injected (see packages/review/src/untrusted-input-signals.ts), which hands the
  * agent the parse sites and counters the silence-bias 0-findings failure mode.
@@ -33,7 +35,7 @@ const assertions: FixtureAssertions = {
   rule: 'untrusted-input-validation',
   expect: (result, h) => {
     h.expectRuleFired('untrusted-input-validation', result);
-    h.expectToolCalled('get_files_context', result);
+    h.expectAnyToolCalled(['get_files_context', 'read_file'], result);
     h.expectFindingMentions(
       [
         // Function/symbol names from the buggy code

--- a/packages/review/test/harness/sweep.sh
+++ b/packages/review/test/harness/sweep.sh
@@ -8,9 +8,10 @@
 # Default models: moonshotai/kimi-k2.7-code google/gemini-3-flash-preview
 #   (Kimi is the prod default; Gemini 3 Flash is kept as the original
 #   calibration baseline some canaries were tuned against, for regression
-#   comparison. A couple of canaries are known-red on Kimi — see the
-#   README's "Known-red reconciliation" note — so this sweep's bar is "no
-#   regression vs main," not literal 9/10 on every fixture/model pair.)
+#   comparison. The former "known-red on Kimi" canaries were reconciled
+#   2026-07-10 — see the README's "Known-red reconciliation" note. The
+#   sweep's bar remains "no regression vs main," not literal 9/10 on every
+#   fixture/model pair.)
 #
 # A calibration that misses the 9/10 bar exits non-zero — that's expected
 # data, not a script error. So we deliberately do NOT use `set -e` here.


### PR DESCRIPTION
## Summary

A dedicated reconciliation of the harness's two "known-red on Kimi" canaries (tracked separately per the README note from #642). Neither was a model capability gap; the whole canary corpus is now at/above the 9/10 bar on the prod default model (`moonshotai/kimi-k2.7-code`), on verified-healthy captures.

### untrusted-input-validation/harness-initial — assertion stricter than prompt
The rule prompt says consumers must be traced via "`get_files_context` (or `read_file`)", but the Tier-1 gate accepted only `get_files_context`. Live calibrate-10: 7/10, all three misses were correct runs (Tier-2-passing findings) that happened to use `read_file`. Fix: new `expectAnyToolCalled` helper (+ unit tests) and the fixture gate now accepts either tool. **10/10** on Kimi afterwards.

### stale-duplicate/model-partial-update — broken captures, not model drift
When `@liendev/parser-native` isn't built in the capturing checkout, `chunkFile` throws for every AST-language file, the per-file catch swallows it, and `performChunkOnlyIndex` returns `success: true` with a markdown/Vue-only corpus (~800 chunks instead of ~5300, zero source code). The fixture then renders `<stale_literal_candidates>` as "None", suppressing the very finding the canary asserts. Fix: `assertIndexComplete` in `capture-pr.ts` fails the capture loudly (naming the `build:native` remedy) on either signature: a changed source file with zero chunks, or zero source chunks corpus-wide. On a healthy capture the rule is **10/10** on Kimi.

### Stale fixture-header claims reconciled
`error-swallowing/scanall-null-guard-fp` (the PR #574 early-null-guard FP) claimed it "will fail on the current prompt" — Gemini-era. On Kimi it's **10/10 empty**; the FP gap closed with no prompt change. Canary `payment-error-swallowed` **10/10**, `harness-gitignore-convention-fp` **9/10**.

### Full corpus Kimi status (2026-07-10, healthy fixtures)
| Fixture | Result |
|---|---|
| stale-duplicate/model-partial-update | 10/10 (calibrate-10) |
| untrusted-input-validation/harness-initial | 10/10 (calibrate-10) |
| error-swallowing/payment-error-swallowed | 10/10 (calibrate-10) |
| error-swallowing/scanall-null-guard-fp | 10/10 empty (calibrate-10) |
| error-swallowing/harness-gitignore-convention-fp | 9/10 (calibrate-10) |
| edge-case-sweep/percent-change-sign-flip | 10/10 (calibrate-10) |
| structural-analysis/removed-export | 3/3 |
| concurrency-race/credit-service-toctou | 3/3 |
| incomplete-handling/enum-variant-removed | 3/3 |
| boundary-change / doc-truth | green (prior records, 2026-06-27 / 2026-07-04) |

README ("Known-red reconciliation" section + capture prerequisites), `sweep.sh`, `CLAUDE.md`, and the four fixture headers record the new status.

## Follow-up (not in this PR)
Parser-level hardening: make a native-binding **load** failure fatal in `performChunkOnlyIndex` instead of the per-file swallow, distinguishing "binding missing" from "one file failed to parse" — closes the latent risk for all callers, but has 7 dependents and deserves its own PR.

## Verification
- `format:check`, `lint` (0 errors), `typecheck`, `build`, `npm test`, `lien delta` (exit 0) all pass.
- Capture guard proven: with the native binary moved aside, capture exits 1 naming the missing build and writes no fixture; determinism verified (identical fileset hash across two captures).
- Total OpenRouter calibration spend for the reconciliation: ~$6.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR reconciles two known-red Kimi canaries through narrow test-harness changes: a new `expectAnyToolCalled` assertion that accepts either `get_files_context` or `read_file`, and an `assertIndexComplete` guard in `capture-pr.ts` that fails loudly when the native parser is unbuilt and produces a partial index. Both changes are confined to test infrastructure, include unit tests, and do not affect production callers. The guard correctly handles deleted files, empty files, and renames, and the new assertion correctly avoids substring false-positives via the existing `isToolCall` word-boundary logic.
>
> - Added `expectAnyToolCalled` helper and switched `harness-initial` Tier-1 gate to accept `get_files_context` or `read_file`
> - Added `assertIndexComplete` to `capture-pr.ts` to abort partial native-parser index captures with a clear build-remedy message
> - Updated README/CLAUDE.md and fixture headers to reflect reconciled calibration status

<sup>Reviewed by [Lien Review](https://lien.dev) for commit be1d1a4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an assertion that verifies whether any tool from an accepted set was called.
  - Added validation to prevent incomplete fixture captures when native parsing is unavailable.

- **Tests**
  - Added coverage for accepted-tool matching, failure handling, and substring safety.
  - Broadened tool expectations for input-validation fixtures.

- **Documentation**
  - Updated harness guidance with capture prerequisites and refreshed calibration results.
  - Clarified canary status, sweep expectations, and fixture metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->