### PR TITLE
fix(review): recover findings emitted under a corrupted JSON key

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -157,10 +157,33 @@ export function extractFindingsWithReasoningFallback(
 /** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
 export function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
   const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
-  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  let rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  if (!Array.isArray(rawFindings) && typeof parsed === 'object' && parsed !== null) {
+    rawFindings = findingsUnderCorruptedKey(parsed as Record<string, unknown>);
+  }
   const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
   const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
   return { findings, summary };
+}
+
+/**
+ * Recover a findings array whose key got mangled. Kimi has been observed
+ * emitting an otherwise-valid verdict as `{":  ": [...], "summary": {...}}` —
+ * the findings intact but the key corrupted — which previously read as a
+ * clean zero-finding review: the valid summary satisfied the summary-retry
+ * and incomplete checks, so real findings were silently discarded. When no
+ * `findings` array is present, accept another property only if it holds a
+ * non-empty array in which EVERY element is a valid finding; anything less
+ * stays unrecovered rather than guessed at.
+ */
+function findingsUnderCorruptedKey(obj: Record<string, unknown>): AgentFinding[] | undefined {
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'findings' || key === 'summary') continue;
+    if (Array.isArray(value) && value.length > 0 && value.every(isValidFinding)) {
+      return value as AgentFinding[];
+    }
+  }
+  return undefined;
 }
 
 /** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -188,6 +188,30 @@ describe('readVerdict', () => {
     expect(findings).toHaveLength(1);
     expect(s).toBeUndefined();
   });
+
+  // Kimi emitted `{":  ": [...], "summary": {...}}` on a real calibration run
+  // (untrusted-input-validation vote-5, 2026-07-10): findings intact, key
+  // mangled. The valid summary made the run look complete, so the findings
+  // were silently discarded.
+  it('recovers findings under a corrupted key when no findings array exists', () => {
+    const { findings, summary: s } = readVerdict({ ':  ': [finding, finding], summary });
+    expect(findings).toHaveLength(2);
+    expect(s).toEqual(summary);
+  });
+
+  it('does not recover from a corrupted key holding anything but pure findings', () => {
+    const { findings } = readVerdict({ ':  ': [finding, { bogus: true }], summary });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('does not second-guess a present findings array (empty means clean review)', () => {
+    const { findings } = readVerdict({ findings: [], ':  ': [finding], summary });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('ignores non-array and empty-array corrupted candidates', () => {
+    expect(readVerdict({ oops: 'text', other: [], summary }).findings).toHaveLength(0);
+  });
 });
 
 describe('extractFindingsFromText (fence-priority verdict recovery)', () => {


### PR DESCRIPTION
## Summary

Trace-mining the calibration votes from #722 found that the corpus's one "silence" miss was never silence: the model investigated for 4 turns and emitted a complete, valid verdict — **5 findings + summary** — but the top-level key came back mangled as `":  "` instead of `"findings"`:

```json
{":  ": [ ...5 valid findings... ], "summary": {"riskLevel": "low", ...}}
```

`readVerdict` only reads `obj.findings`, so the findings vanished. Worse, the **valid summary** made the run look complete: the summary-retry guard (`openai-client.ts`) never fired and `incomplete` stayed false, so the review was reported as a clean zero-finding pass while real findings were silently discarded. None of the existing recovery paths (fence-priority parsing, reasoning-channel fallback from #669, summary-retry from #612) cover this shape — they all key on the envelope or the channel, not the key itself.

## Fix

When no `findings` array is present, `readVerdict` now accepts the first other property holding a **non-empty array in which every element is a valid finding**. Deliberately strict:
- a present `findings` array — including `[]`, meaning a clean review — is never second-guessed;
- a candidate array with even one invalid element is left unrecovered rather than guessed at;
- `summary` is skipped (it's an object, but explicitly excluded for clarity).

## Verification

- 4 new unit tests in `plugins-agent-client-shared.test.ts` (38/38 pass), including the exact observed corruption.
- Replayed the actual failing vote's raw turn output through the fixed pipeline: **all 5 findings recovered** (3 correctly labeled `untrusted-input-validation` — that vote would now pass its canary).
- `format:check` / `lint` (0 errors) / `typecheck` / `build` / full `npm test` (575+792+28) / `lien delta` (exit 0) all pass.

## Context

Frequency: 1 of 43 saved calibration votes — rare, but the failure mode is the worst kind (real findings dropped from a prod-shaped run that reports success). This is a parse-robustness code change, not a prompt change, so no calibration run is required; it can only add recovered findings, never remove any.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a narrow, defensive recovery path in readVerdict for a rare model-output corruption where the findings array is emitted under a mangled key while a valid summary is present. The new helper only runs when no canonical findings array exists, skips the summary key, and requires every element of a candidate array to pass isValidFinding, so it cannot invent findings or override a legitimate empty verdict. Callers keep the same contract and no breaking changes were introduced. Existing and new unit tests cover the behavior.
>
> - readVerdict now recovers a findings array stored under a non-findings/non-summary key when the canonical findings key is absent
> - New private helper findingsUnderCorruptedKey validates every candidate element before accepting it
> - Four unit tests pin recovery, rejection of impure arrays, and non-override of a present findings: []

<sup>Reviewed by [Lien Review](https://lien.dev) for commit c2d5c13. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

## Harness evidence
End-to-end no-regression run with the fix in place, prod model (`moonshotai/kimi-k2.7-code`):
`npm run test:harness -w @liendev/review -- --rule untrusted-input-validation` → **3/3 passed** ($0.19). A full `--calibrate 10` is not warranted for this change: it is parse-time recovery of a 1-in-43 malformed-output shape, strictly additive (can only recover findings, never drop or alter any), and the exact observed corruption is replay-verified plus pinned by 4 unit tests.