### PR TITLE
fix(parser): fail fast when the native binding cannot load

### DIFF
--- a/packages/parser/src/ast/parser.ts
+++ b/packages/parser/src/ast/parser.ts
@@ -126,9 +126,10 @@ function loadNativeBinding(): typeof import('@liendev/parser-native') {
       `[lien] Failed to load the native parser binding (@liendev/parser-native) on ` +
         `${process.platform}-${process.arch}: ${reason}\n` +
         `This usually means no prebuilt @liendev/parser-native package exists for your ` +
-        `platform/arch and no local build was found. See docs/architecture/native-parser.md ` +
-        `for how to build one. (The legacy node-tree-sitter backend has been removed ` +
-        `(see ADR-013), so there is no fallback.)`,
+        `platform/arch and no local build was found. Build it with ` +
+        `\`npm run build:native -w @liendev/parser-native\` (see ` +
+        `docs/architecture/native-parser.md). (The legacy node-tree-sitter backend has ` +
+        `been removed (see ADR-013), so there is no fallback.)`,
     );
     throw nativeLoadError;
   }

--- a/packages/parser/src/chunk-only-index-native-load.test.ts
+++ b/packages/parser/src/chunk-only-index-native-load.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import nodeFs from 'node:fs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { performChunkOnlyIndex } from './chunk-only-index.js';
+import { clearParserCache } from './ast/parser.js';
+
+/**
+ * Companion to chunker-native-load.test.ts, one level up the call stack.
+ *
+ * chunker.ts already re-throws a NativeBindingLoadError past its `astFallback`
+ * catch, but `performChunkOnlyIndex` wraps every file in
+ * `chunkFileForCollection`'s own try/catch, which historically returned
+ * `false` for ANY thrown error. A missing native binding throws that error
+ * for EVERY AST-language file, so the per-file catch would swallow all of
+ * them and `performChunkOnlyIndex` would still report `success: true` on a
+ * corpus containing only the format-specific chunkers' output
+ * (markdown/Liquid/Vue) -- a silently partial index. This is the exact
+ * failure mode the harness's `assertIndexComplete` guard (PR #722) had to
+ * paper over from the outside.
+ *
+ * The fix makes `chunkFileForCollection` re-throw a NativeBindingLoadError
+ * (mirroring chunker.ts) so it propagates to `performChunkOnlyIndex`'s outer
+ * handler, which surfaces it as `{ success: false, error }`. Per-file parse
+ * or read errors (anything that is NOT a NativeBindingLoadError) still skip
+ * the file and keep the run going -- see the sibling test in
+ * chunk-only-index.test.ts.
+ *
+ * Lives in its own file (not alongside chunk-only-index.test.ts) so the
+ * fs.existsSync mock below runs before any successful native load memoizes a
+ * binding handle in ast/parser.ts's module-level cache -- a memoized success
+ * would short-circuit the mock (clearParserCache only resets the failure
+ * cache, not the success handle). Same ordering note as
+ * chunker-native-load.test.ts / ast/parser.test.ts.
+ */
+describe('performChunkOnlyIndex native-load failure (fail fast, no silent partial index)', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    clearParserCache();
+    testDir = path.join(
+      os.tmpdir(),
+      `lien-native-load-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    );
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    clearParserCache();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('reports success:false with an actionable error instead of a partial success', async () => {
+    const file = path.join(testDir, 'sample.ts');
+    await fs.writeFile(file, 'export function sample() { return 42; }');
+
+    // Force the native binding lookup (findPackageDir) to fail, simulating a
+    // platform/worktree where @liendev/parser-native was never built.
+    vi.spyOn(nodeFs, 'existsSync').mockReturnValue(false);
+
+    // Must resolve (never reject) -- performChunkOnlyIndex's contract is a
+    // ChunkOnlyResult, and every caller branches on `.success`.
+    const result = await performChunkOnlyIndex(testDir, { filesToIndex: [file] });
+
+    expect(result.success).toBe(false);
+    expect(result.chunksCreated).toBe(0);
+    expect(result.chunks).toHaveLength(0);
+    // The actionable remedy is threaded all the way up from ast/parser.ts.
+    expect(result.error).toContain('@liendev/parser-native');
+    expect(result.error).toContain('npm run build:native');
+  });
+});

--- a/packages/parser/src/chunk-only-index.test.ts
+++ b/packages/parser/src/chunk-only-index.test.ts
@@ -118,3 +118,34 @@ describe('performChunkOnlyIndex parse-stage concurrency cap', () => {
     }
   });
 });
+
+describe('performChunkOnlyIndex per-file error handling', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  it('skips an unreadable file (ENOENT) without failing the whole run', async () => {
+    // Only a native-binding LOAD failure is fatal (see
+    // chunk-only-index-native-load.test.ts). An ordinary per-file error --
+    // here a missing file whose read throws ENOENT -- is swallowed per-file
+    // so one bad file never aborts the index.
+    const [validFile] = await writeTestFiles(testDir, 1);
+    const missingFile = path.join(testDir, 'does-not-exist.ts');
+
+    const result = await performChunkOnlyIndex(testDir, {
+      filesToIndex: [validFile, missingFile],
+    });
+
+    expect(result.success).toBe(true);
+    // Both files were attempted; the missing one contributed no chunks but
+    // did not abort the run.
+    expect(result.filesIndexed).toBe(2);
+    expect(result.chunksCreated).toBeGreaterThan(0);
+  });
+});

--- a/packages/parser/src/chunk-only-index.ts
+++ b/packages/parser/src/chunk-only-index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import pLimit from 'p-limit';
 import type { CodeChunk } from './types.js';
 import { chunkFile } from './chunker.js';
+import { NativeBindingLoadError } from './ast/parser.js';
 import { scanCodebase } from './scanner.js';
 import { detectEcosystems, getEcosystemExcludePatterns } from './ecosystem-presets.js';
 import { extractRepoId } from './utils/repo-id.js';
@@ -88,6 +89,17 @@ async function chunkFileForCollection(
     }
     return false;
   } catch (error) {
+    // A native-binding load failure is systemic, not per-file: the binding
+    // can't load for ANY file, so every AST-language file throws the same
+    // error here. Swallowing it per-file would let performChunkOnlyIndex
+    // report success on a corpus containing only the format-specific chunkers'
+    // output (markdown/Liquid/Vue) -- a silently partial index. Re-throw so
+    // the run fails loudly; performChunkOnlyIndex's outer handler catches it
+    // once and surfaces the actionable message. Mirrors the same re-throw in
+    // chunker.ts; see NativeBindingLoadError in ast/parser.ts.
+    if (error instanceof NativeBindingLoadError) {
+      throw error;
+    }
     console.error(
       `[parser] Failed to process ${file}: ${error instanceof Error ? error.message : String(error)}`,
     );


### PR DESCRIPTION
## Problem: silent partial index when `@liendev/parser-native` can't load

`performChunkOnlyIndex` wraps every file in `chunkFileForCollection`'s own `try/catch`, which returned `false` for **any** thrown error. When the gitignored native binding (`@liendev/parser-native`) isn't built for the current platform/worktree, `chunkFile(..., useAST:true)` throws a `NativeBindingLoadError` for **every** AST-language file. The per-file catch swallowed all of them, and `performChunkOnlyIndex` still returned `success: true` on a corpus containing only the format-specific chunkers' output (markdown / Liquid / Vue).

That's a **silently partial index**: every caller — the review engine (`engine.ts`), complexity analysis (`analysis.ts`), and the harness capture (`capture-pr.ts`) — then operates on a repo it has almost no chunks for. The harness gained an external guard for this in #722 (`assertIndexComplete`), but the parser itself still degraded silently, leaving the risk latent for all other callers (CLI/review) if a platform prebuilt is ever missing.

`chunkFile` / `parseAST` already handle this correctly (ADR-013 Phase 4-B, #699): `chunker.ts` re-throws a `NativeBindingLoadError` past its `astFallback` catch. The gap was purely at the `performChunkOnlyIndex` layer.

## Fix

- **`chunk-only-index.ts`** — `chunkFileForCollection` now re-throws a `NativeBindingLoadError` (a systemic, process-wide condition, not a per-file parse problem), mirroring the existing re-throw in `chunker.ts`. It propagates to `performChunkOnlyIndex`'s existing outer handler, which surfaces it as `{ success: false, error }`.
- **`ast/parser.ts`** — the `NativeBindingLoadError` message now names the exact remedy, `npm run build:native -w @liendev/parser-native`, so the fatal error is directly actionable for every caller (it previously only pointed at a doc).

### Semantics
| Failure | Before | After |
|---|---|---|
| Native binding cannot load | swallowed per-file → `success: true`, partial corpus | **fatal** → `success: false` with actionable error |
| Per-file parse / read error (e.g. ENOENT, syntax) | skipped, run continues | **unchanged** — still skipped, run continues |

The never-reject contract is preserved: `performChunkOnlyIndex` still always resolves to a `ChunkOnlyResult` (never throws), so no caller needs a new `try/catch`.

## Dependents audited

All real callers of `performChunkOnlyIndex` already branch on `.success` and treat `false` as skip/fail — **none** relied on the silent `success: true` degrade:
- `review/src/engine.ts:277` — `if (indexResult.success && ...)` else logs a warning
- `review/src/analysis.ts:89` and `:160` — `if (!result.success || ...)` → warn + return
- `review/src/review-pr.ts:474`
- `review/test/harness/capture-pr.ts:343` — throws on `!success`, then `assertIndexComplete` (unchanged; still valid as a second line of defense)

The CLI indexer does **not** use `performChunkOnlyIndex`; it goes through `chunkFile` directly, which already propagated `NativeBindingLoadError` — so it was never affected. No binding-less caller exists (markdown-only/site builds don't call this API), so no opt-in escape hatch was needed (YAGNI).

## Tests

- `chunk-only-index-native-load.test.ts` (new, in its own file for the memoization-ordering reason documented in `chunker-native-load.test.ts`): mocks the binding lookup to fail and asserts `performChunkOnlyIndex` returns `success: false` with `chunksCreated: 0` and an error naming `@liendev/parser-native` + `npm run build:native` — and that it resolves rather than rejects.
- `chunk-only-index.test.ts`: added a per-file-error test proving an ENOENT (non-native) error still skips just that file while the run succeeds.

## Gates
`format:check` ✅ · `lint` ✅ (0 errors) · `typecheck` ✅ · `build` ✅ · `npm test` ✅ (parser 1047, review 571, cli 792, action 28) · `lien delta` ✅ exit 0

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a silently partial index by making `performChunkOnlyIndex` fail fast when the native parser binding cannot load, while preserving per-file error skipping for ordinary parse/read failures. The change mirrors the existing behavior in `chunker.ts`, and all known callers already branch on `result.success`. No callers are broken, and no silent error swallowing or logic regressions were introduced.
>
> - `chunkFileForCollection` now re-throws `NativeBindingLoadError` so the run surfaces `success: false` instead of degrading to a partial corpus.
> - The native-binding error message now names the build command `npm run build:native -w @liendev/parser-native`.
> - Tests verify both fail-fast on missing native binding and continued per-file skipping for ENOENT-style errors.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 352f604. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when the native parser binding is unavailable, including a command to build it.
  * Native parser loading failures are now reported clearly instead of appearing as partially successful indexing.
  * File-specific indexing errors remain isolated, allowing valid files to be processed when another file is missing.

* **Tests**
  * Added coverage for native binding failures and missing input files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->