### PR TITLE
feat(review): require enumerated ruleId in output format + Tier-2 substance assertions for 5 canaries

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -157,10 +157,33 @@ export function extractFindingsWithReasoningFallback(
 /** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
 export function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
   const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
-  const rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  let rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
+  if (!Array.isArray(rawFindings) && typeof parsed === 'object' && parsed !== null) {
+    rawFindings = findingsUnderCorruptedKey(parsed as Record<string, unknown>);
+  }
   const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
   const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
   return { findings, summary };
+}
+
+/**
+ * Recover a findings array whose key got mangled. Kimi has been observed
+ * emitting an otherwise-valid verdict as `{":  ": [...], "summary": {...}}` —
+ * the findings intact but the key corrupted — which previously read as a
+ * clean zero-finding review: the valid summary satisfied the summary-retry
+ * and incomplete checks, so real findings were silently discarded. When no
+ * `findings` array is present, accept another property only if it holds a
+ * non-empty array in which EVERY element is a valid finding; anything less
+ * stays unrecovered rather than guessed at.
+ */
+function findingsUnderCorruptedKey(obj: Record<string, unknown>): AgentFinding[] | undefined {
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'findings' || key === 'summary') continue;
+    if (Array.isArray(value) && value.length > 0 && value.every(isValidFinding)) {
+      return value as AgentFinding[];
+    }
+  }
+  return undefined;
 }
 
 /** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -72,7 +72,20 @@ Do NOT report:
 - Suggestions to update PR descriptions, comments, or documentation
 </rules>`;
 
-const OUTPUT_FORMAT = `<output_format>
+/**
+ * The output-format section, assembled per prompt so the \`ruleId\` field can
+ * enumerate the rules actually active for this review. \`ruleId\` used to be
+ * "optional", and Kimi intermittently omitted it — the finding was correct but
+ * lost its rule attribution (issue #724; a 12-sample replay A/B showed the
+ * required+enumerated wording reaches 100% presence with zero invalid ids and
+ * no change in finding quality).
+ */
+function buildOutputFormat(activeRuleIds: string[]): string {
+  const ruleIdLine =
+    activeRuleIds.length > 0
+      ? `REQUIRED — exactly one of: ${activeRuleIds.join(', ')}`
+      : `REQUIRED — the id of the rule this finding belongs to`;
+  return `<output_format>
 After investigation, output a JSON block in a \`\`\`json code fence:
 
 {
@@ -87,7 +100,7 @@ After investigation, output a JSON block in a \`\`\`json code fence:
       "message": "1–2 sentences with the concrete trigger and wrong behavior: input X → returns Y → should return Z. Keep exact values/conditions; cut the investigation story.",
       "suggestion": "The fix, ideally a short code snippet. No prose walkthrough.",
       "evidence": "One line: the specific check that found this",
-      "ruleId": "optional — which rule triggered this (e.g., 'edge-case-sweep', 'concurrency-race')"
+      "ruleId": "${ruleIdLine}"
     }
   ],
   "summary": {
@@ -101,6 +114,7 @@ If you find no issues, return empty findings with a low-risk summary. Do not fab
 
 Keep \`message\`, \`suggestion\`, and \`evidence\` tight — a few sentences at most each. Cut the investigation narrative and your reasoning, but ALWAYS keep the concrete specifics (exact inputs, values, boundary conditions, before→after states) that make the finding actionable.
 </output_format>`;
+}
 
 // ---------------------------------------------------------------------------
 // Dynamic Prompt Assembly
@@ -148,7 +162,7 @@ ${examplesSection}
 
 ${RULES_SECTION}
 
-${OUTPUT_FORMAT}`;
+${buildOutputFormat(rules.active.map(r => r.id))}`;
 }
 
 /** Max characters for the diff section before truncation. */

--- a/packages/review/test/harness/fixtures/concurrency-race/credit-service-toctou.assertions.ts
+++ b/packages/review/test/harness/fixtures/concurrency-race/credit-service-toctou.assertions.ts
@@ -3,6 +3,38 @@
  * using Organization::lockForUpdate()->find($org->id). Hits keywords
  * `transaction`, `lockForUpdate`, `DB::transaction`. Real check-then-act
  * on credit balance — ripe for TOCTOU analysis.
+ *
+ * Tier 2 (added 2026-07-11, authored from 3 observed Kimi votes —
+ * moonshotai/kimi-k2.7-code, the prod default): pins the substance of the
+ * correct finding. The real race the rule must catch is NOT inside the
+ * lock-protected CreditService methods — it's the check-then-act GAP in
+ * `ProcessPullRequestWebhook::hasCredits`, which reads the org's
+ * credit_balance WITHOUT lockForUpdate before dispatching, so two
+ * concurrent webhooks for the same org both pass the gate and later both
+ * deduct, driving the balance negative. All 3 votes reported exactly this.
+ *
+ * Two expectFindingMentions calls => AND, each a wide any-of OR-list:
+ *   (A) the race concept — TOCTOU / check-then-act / missing row lock.
+ *   (B) the credit-billing impact — hasCredits reading credit_balance,
+ *       concurrent dispatch, balance going negative/overdrawn.
+ *
+ * Vocabulary evidence (all 3 votes, message/suggestion/evidence):
+ *   - (A) "TOCTOU race condition" (verbatim in all 3); the fix names
+ *     `lockForUpdate` / "row lock" / "without locking"; evidence calls it
+ *     "check-then-act".
+ *   - (B) `hasCredits`, `credit_balance`, "concurrent … webhook(s)",
+ *     "dispatch to NATS", and the balance going "negative" / "overdrawn" /
+ *     "over-spend"; votes 2-3 also cite `canRunReview` and `deductCredit`.
+ *
+ * Note: vote 1 also emits a second, independently-valid TOCTOU finding on
+ * `CreditService::purchaseCredits` (unprotected stripe_payment_intent_id
+ * idempotency check) — not required by these assertions; the hasCredits
+ * finding above is the one present in every vote.
+ *
+ * Offline re-score (assert-cli.ts against the 3 saved vote results): 3/3
+ * previously-passing votes still pass with these Tier-2 checks; no widening
+ * was needed. Certification against the >= 9/10 bar is pending a paid
+ * calibrate-10 (the main session runs it).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -12,6 +44,41 @@ const assertions: FixtureAssertions = {
   rule: 'concurrency-race',
   expect: (result, h) => {
     h.expectRuleFired('concurrency-race', result);
+    // (A) names the race: check-then-act with no lock.
+    h.expectFindingMentions(
+      [
+        'toctou',
+        'time-of-check',
+        'time of check',
+        'race condition',
+        'check-then-act',
+        'check then act',
+        'lockforupdate',
+        'row lock',
+        'without a lock',
+        'without locking',
+        'without lockforupdate',
+      ],
+      result,
+    );
+    // (B) the credit-billing impact of the unguarded check.
+    h.expectFindingMentions(
+      [
+        'hascredits',
+        'credit_balance',
+        'credit balance',
+        'concurrent',
+        'negative',
+        'overdrawn',
+        'over-spend',
+        'overspend',
+        'nats',
+        'canrunreview',
+        'deductcredit',
+        'dispatch',
+      ],
+      result,
+    );
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/harness/fixtures/edge-case-sweep/percent-change-sign-flip.assertions.ts
+++ b/packages/review/test/harness/fixtures/edge-case-sweep/percent-change-sign-flip.assertions.ts
@@ -3,6 +3,42 @@
  * Math.abs on the denominator. For negative `before`, the sign flips:
  * percentChange(-100, -50) returns '-50%' even though the value improved.
  * Classic edge-case-sweep target (negative-input branch).
+ *
+ * Tier 2 (added 2026-07-11, authored from 13 observed Kimi votes —
+ * moonshotai/kimi-k2.7-code, the prod default; 12 previously passed Tier 1,
+ * 1 fired no edge-case-sweep finding). IMPORTANT judgment call recorded per
+ * the harness's Tier-2-brittleness lesson: this fixture is NAMED after the
+ * negative-`before` sign flip, but that specific finding appeared in only
+ * 3/13 votes. The other 9 passing votes reported SIBLING edge-case bugs in
+ * the SAME function — the zero-baseline branch returning an unsigned '∞'
+ * for a decrease (formatPercentChange(0, -5) → '∞'), and non-finite inputs
+ * (NaN / Infinity) silently falling through to '0%'. All three are real,
+ * valid edge-case-sweep findings on formatPercentChange; the model just
+ * doesn't reliably pick the same one. So this Tier 2 honestly pins "an
+ * edge-case finding about formatPercentChange's handling of a boundary
+ * input (negative baseline / zero baseline / NaN / Infinity) producing a
+ * wrong sign or misleading output" — NOT the negative-`before` flip
+ * specifically. Pinning the named flip alone would fail ~9/13 of the
+ * model's own correct findings.
+ *
+ * Two expectFindingMentions calls => AND, each a wide any-of OR-list:
+ *   (A) the function anchor — every finding is about `formatPercentChange`.
+ *   (B) an edge-case symptom — a boundary input producing a wrong
+ *       sign/direction or misleading output, or the recommended finite guard.
+ *
+ * Vocabulary evidence (12 passing votes, message/suggestion/evidence):
+ *   - (A) every finding message begins "formatPercentChange(...)".
+ *   - (B) the boundary inputs `NaN`, `Infinity`, `negative` baseline, and
+ *     the zero-baseline branch (`before === 0`); symptoms "sign" / "inverts"
+ *     / "+50%" / "-50%" / unsigned "∞" / silent "0%" / "misleading"; and the
+ *     fix vocabulary "guard" / "isFinite" / "finite".
+ *
+ * Offline re-score (assert-cli.ts against all 13 saved vote results): 12/12
+ * previously-passing votes still pass with these Tier-2 checks; the 1
+ * previously-failing vote (emitted findings with ruleId null — the rule did
+ * not fire) still fails at Tier 1, as expected. No widening was needed.
+ * Certification against the >= 9/10 bar is pending a paid calibrate-10 (the
+ * main session runs it).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -12,6 +48,38 @@ const assertions: FixtureAssertions = {
   rule: 'edge-case-sweep',
   expect: (result, h) => {
     h.expectRuleFired('edge-case-sweep', result);
+    // (A) the function anchor.
+    h.expectFindingMentions(
+      ['formatpercentchange', 'percent change', 'percentage change', 'percentchange'],
+      result,
+    );
+    // (B) an edge-case symptom on a boundary input (any of the sibling bugs).
+    h.expectFindingMentions(
+      [
+        'nan',
+        'infinity',
+        'negative',
+        'zero-baseline',
+        'zero baseline',
+        'before === 0',
+        'sign',
+        'direction',
+        'inverts',
+        'inverted',
+        '+50%',
+        '-50%',
+        '∞',
+        '0%',
+        'misleading',
+        'silently',
+        'falls through',
+        'fall-through',
+        'guard',
+        'isfinite',
+        'finite',
+      ],
+      result,
+    );
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
@@ -6,6 +6,38 @@
  *
  * Calibration status: 10/10 on `moonshotai/kimi-k2.7-code` (2026-07-10,
  * --calibrate 10, healthy capture).
+ *
+ * Tier 2 (added 2026-07-11, authored from 10 observed Kimi votes —
+ * moonshotai/kimi-k2.7-code, the prod default; the same --calibrate 10
+ * capture above): pins the substance of the correct finding, not just that
+ * error-swallowing fired. Every correct vote must name (A) the swallow
+ * mechanism — `charge()` catching all exceptions and returning `false`
+ * without logging or rethrowing — and (B) the caller-side impact: callers
+ * relying on RuntimeException propagation now get a silent `false` and
+ * cannot distinguish failure causes.
+ *
+ * Two expectFindingMentions calls => AND, each a wide any-of OR-list:
+ *   (A) the catch-all-returns-false swallow mechanism.
+ *   (B) the lost-exception-propagation / can't-distinguish impact.
+ *
+ * Vocabulary evidence (all 10 votes, message/suggestion/evidence):
+ *   - (A) every vote names `charge()` in `PaymentService`, says it now
+ *     "catches all exceptions" / "catch-all" and "returns false" "without
+ *     logging or rethrowing" (swallows / discards the error).
+ *   - (B) every vote cites `RuntimeException` propagation being lost and the
+ *     callers `OrderService::processOrder` / `CheckoutService::expressCheckout`
+ *     silently proceeding; most enumerate the indistinguishable failure modes
+ *     ("already paid", "invalid total", "gateway failure") and "error context".
+ *
+ * Note: several votes label the two caller findings `structural-analysis`
+ * rather than `error-swallowing`; Tier 1 (`expectRuleFired`) still holds
+ * because every vote has at least one error-swallowing finding, and the (A)
+ * anchor (charge / returns false / swallow) is specific to it.
+ *
+ * Offline re-score (assert-cli.ts against the 10 saved vote results): 10/10
+ * previously-passing votes still pass with these Tier-2 checks; no widening
+ * was needed. Certification against the >= 9/10 bar is pending a paid
+ * calibrate-10 (the main session runs it).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -15,6 +47,49 @@ const assertions: FixtureAssertions = {
   rule: 'error-swallowing',
   expect: (result, h) => {
     h.expectRuleFired('error-swallowing', result);
+    // (A) the catch-all-returns-false swallow mechanism.
+    h.expectFindingMentions(
+      [
+        'charge',
+        'paymentservice',
+        'catch-all',
+        'catches all',
+        'catch (\\exception',
+        'catch block',
+        'returns false',
+        'return false',
+        'boolean false',
+        'swallow',
+        'swallowing',
+        'swallowed',
+        'without logging',
+        'no logging',
+        'rethrow',
+        'rethrowing',
+        'discard',
+      ],
+      result,
+    );
+    // (B) the lost-exception-propagation / can't-distinguish impact.
+    h.expectFindingMentions(
+      [
+        'runtimeexception',
+        'exception propagation',
+        'error context',
+        'already paid',
+        'invalid total',
+        'gateway failure',
+        'gateway error',
+        'silent',
+        'silently',
+        'distinguish',
+        'orderservice',
+        'processorder',
+        'checkoutservice',
+        'expresscheckout',
+      ],
+      result,
+    );
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/harness/fixtures/incomplete-handling/enum-variant-removed.assertions.ts
+++ b/packages/review/test/harness/fixtures/incomplete-handling/enum-variant-removed.assertions.ts
@@ -2,6 +2,37 @@
  * PR #437 — UserRole enum no longer includes Guest. getPermissionsForRole
  * switch falls through to default: [] for any unhandled variant. Rule
  * should flag the missing-case / partial-iteration pattern.
+ *
+ * Tier 2 (added 2026-07-11, authored from 3 observed Kimi votes —
+ * moonshotai/kimi-k2.7-code, the prod default): pins the substance of the
+ * incomplete-handling finding, not just that the rule fired. Every correct
+ * vote must name (A) the switch anchor — `getPermissionsForRole`'s silent
+ * `default: return []` replacing an exhaustive check — and (B) the impact:
+ * an unhandled role (a legacy/removed Guest, or any future variant)
+ * silently receiving an EMPTY permission set instead of failing loudly.
+ *
+ * Two expectFindingMentions calls => AND, each a wide any-of OR-list:
+ *   (A) the switch / silent-default / exhaustiveness anchor.
+ *   (B) the silent-permission-loss impact (guest / empty permissions).
+ *
+ * Vocabulary evidence (all 3 votes, message/suggestion/evidence):
+ *   - (A) every vote names `getPermissionsForRole`, quotes the silent
+ *     `default: return []`, and contrasts it with an "exhaustive" switch /
+ *     "exhaustiveness" `never` check (the recommended fix).
+ *   - (B) every vote says an unhandled role (all mention `Guest`/`guest`)
+ *     "silently" receives an "empty permission set" / "zero permissions" /
+ *     "empty array" — losing access rather than erroring.
+ *
+ * Note: votes also emit sibling structural-analysis / edge-case-sweep
+ * findings about `User.role` being unpopulated by getUser/createUser;
+ * expectFindingMentions scans all findings, but the (A) anchors above
+ * (getPermissionsForRole / default: return [] / exhaustive) are specific
+ * to the incomplete-handling target finding, so the check pins the right bug.
+ *
+ * Offline re-score (assert-cli.ts against the 3 saved vote results): 3/3
+ * previously-passing votes still pass with these Tier-2 checks; no widening
+ * was needed. Certification against the >= 9/10 bar is pending a paid
+ * calibrate-10 (the main session runs it).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -11,6 +42,43 @@ const assertions: FixtureAssertions = {
   rule: 'incomplete-handling',
   expect: (result, h) => {
     h.expectRuleFired('incomplete-handling', result);
+    // (A) the switch / silent-default / exhaustiveness anchor.
+    h.expectFindingMentions(
+      [
+        'getpermissionsforrole',
+        'userrole',
+        'default: return []',
+        'silent default',
+        'silent `default`',
+        'default case',
+        'default branch',
+        'exhaustive',
+        'exhaustiveness',
+        'never check',
+        ': never',
+        'switch',
+      ],
+      result,
+    );
+    // (B) the silent-permission-loss impact.
+    h.expectFindingMentions(
+      [
+        'guest',
+        'empty permission',
+        'zero permission',
+        'empty array',
+        'permission set',
+        'silently receive',
+        'silently lose',
+        'silently return',
+        'silently',
+        'unhandled',
+        'lose all access',
+        'locked out',
+        'no permissions',
+      ],
+      result,
+    );
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/harness/fixtures/structural-analysis/removed-export.assertions.ts
+++ b/packages/review/test/harness/fixtures/structural-analysis/removed-export.assertions.ts
@@ -5,6 +5,28 @@
  * Per structural-analysis prompt, the agent MUST call grep_codebase for
  * each removed symbol name to check if any file still imports it. The
  * Tier 1 assertion enforces both: rule fires + investigation happened.
+ *
+ * Tier 2 (added 2026-07-11, authored from 3 observed Kimi votes —
+ * moonshotai/kimi-k2.7-code, the prod default): pins the substance of the
+ * correct finding, not just that structural-analysis fired. The planted
+ * bug is a hard breaking change, so every correct vote must name (A) the
+ * removed exported symbol `parse_input` and (B) that its remaining callers
+ * won't compile. Two separate expectFindingMentions calls => AND; each is a
+ * wide any-of OR-list so a model that varies its phrasing (e.g. "fail to
+ * compile" vs "won't compile", "call sites" vs "callers") still matches.
+ *
+ * Vocabulary evidence (all 3 votes, message/suggestion/evidence):
+ *   - (A) every finding names `parse_input` / `parser::parse_input` in
+ *     `parser.rs`; the impacted call sites live in `main.rs` and
+ *     `reporter.rs` (symbols process_files, quick_analyze,
+ *     reanalyze_with_config).
+ *   - (B) every vote states the crate "will fail to compile" and describes
+ *     the removed function's callers/call sites being broken.
+ *
+ * Offline re-score (assert-cli.ts against the 3 saved vote results): 3/3
+ * previously-passing votes still pass with these Tier-2 checks; no widening
+ * was needed. Certification against the >= 9/10 bar is pending a paid
+ * calibrate-10 (the main session runs it).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -15,6 +37,30 @@ const assertions: FixtureAssertions = {
   expect: (result, h) => {
     h.expectRuleFired('structural-analysis', result);
     h.expectToolCalled('grep_codebase', result);
+    // (A) names the removed exported symbol.
+    h.expectFindingMentions(['parse_input', 'parser::parse_input', 'parser.rs'], result);
+    // (B) states the compile breakage of its remaining callers.
+    h.expectFindingMentions(
+      [
+        'fail to compile',
+        'will fail to compile',
+        "won't compile",
+        'not compile',
+        'compilation',
+        'compile',
+        'call site',
+        'call sites',
+        'callers',
+        'caller',
+        'removed',
+        'removing',
+        'breaks',
+        'broken',
+        'main.rs',
+        'reporter.rs',
+      ],
+      result,
+    );
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -188,6 +188,30 @@ describe('readVerdict', () => {
     expect(findings).toHaveLength(1);
     expect(s).toBeUndefined();
   });
+
+  // Kimi emitted `{":  ": [...], "summary": {...}}` on a real calibration run
+  // (untrusted-input-validation vote-5, 2026-07-10): findings intact, key
+  // mangled. The valid summary made the run look complete, so the findings
+  // were silently discarded.
+  it('recovers findings under a corrupted key when no findings array exists', () => {
+    const { findings, summary: s } = readVerdict({ ':  ': [finding, finding], summary });
+    expect(findings).toHaveLength(2);
+    expect(s).toEqual(summary);
+  });
+
+  it('does not recover from a corrupted key holding anything but pure findings', () => {
+    const { findings } = readVerdict({ ':  ': [finding, { bogus: true }], summary });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('does not second-guess a present findings array (empty means clean review)', () => {
+    const { findings } = readVerdict({ findings: [], ':  ': [finding], summary });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('ignores non-array and empty-array corrupted candidates', () => {
+    expect(readVerdict({ oops: 'text', other: [], summary }).findings).toHaveLength(0);
+  });
 });
 
 describe('extractFindingsFromText (fence-priority verdict recovery)', () => {

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -432,6 +432,12 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('<output_format>');
     expect(prompt).toContain('"ruleId"');
 
+    // ruleId is required and enumerates exactly the active rule ids (#724)
+    expect(prompt).toContain('"ruleId": "REQUIRED — exactly one of: ');
+    for (const rule of BUILTIN_RULES) {
+      expect(prompt).toContain(rule.id);
+    }
+
     // Structural analysis rule
     expect(prompt).toContain('Structural');
     expect(prompt).toContain('get_files_context');
@@ -502,6 +508,18 @@ describe('buildSystemPrompt', () => {
     const prompt = buildSystemPrompt(rules);
     expect(prompt).toContain('<output_format>');
     expect(prompt).toContain('"ruleId"');
+    // No active rules to enumerate — falls back to unenumerated-but-required
+    expect(prompt).toContain('"ruleId": "REQUIRED — the id of the rule');
+  });
+
+  it('enumerates only the active rule ids in the ruleId line', () => {
+    const subset = BUILTIN_RULES.filter(
+      r => r.id === 'structural-analysis' || r.id === 'edge-case-sweep',
+    );
+    const prompt = buildSystemPrompt({ active: subset, skipped: [] });
+    expect(prompt).toContain(
+      '"ruleId": "REQUIRED — exactly one of: structural-analysis, edge-case-sweep"',
+    );
   });
 
   it('always includes self-review and bad examples', () => {


### PR DESCRIPTION
## Summary

Implements #724 and adds Tier-2 substance assertions to the five Tier-1-only canaries — bundled because both need the same full-corpus calibration sweep, which runs on this branch (results will be posted below before undrafting).

**Stacked on #723** (corrupted-key finding recovery) — merge #723 first, then this rebases clean. The sweep runs with #723 included so its 1-in-43 malformed-output shape can't inject spurious failed votes into certification.

### 1. ruleId: optional → REQUIRED + enumerated (#724)
`OUTPUT_FORMAT` becomes `buildOutputFormat(activeRuleIds)`; the ruleId line now reads `REQUIRED — exactly one of: <the rules active for this prompt>`. Evidence in #724: 12-sample replay A/B on real traces — 100% ruleId presence (vs a reproduced 0%-presence control), zero out-of-set ids, no change in finding count/quality. Unit tests pin the enumerated line for full and subset rule sets plus the no-active-rules fallback.

### 2. Tier-2 substance assertions (5 canaries)
structural-analysis, edge-case-sweep, concurrency-race, incomplete-handling, and error-swallowing's positive canary previously passed on ANY finding from the right rule. Each now pins finding substance via wide `expectFindingMentions` sets authored from 3–13 real observed Kimi votes per fixture (saved calibration traces). Offline-validated: every previously-passing saved vote still passes on all five; a discrimination probe (right ruleId, unrelated message) fails Tier 2 on all five. Judgment calls documented in fixture headers.

## Calibration (shipping gate)
Shared-scaffolding prompt change ⇒ full-corpus bar: calibrate-10 per fixture on `moonshotai/kimi-k2.7-code`, no regression vs main's pass/fail pattern. Main's baseline is fresh and fully green (#722, 2026-07-10). Sweep running now; results will be posted as a comment with per-fixture pass rates before this leaves draft.

## Local gates
format:check / lint (0 errors) / typecheck / build / full npm test (34+31+45+4 files) / lien delta (exit 0) all pass.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR makes two safe, additive changes to the agent review pipeline: (1) conservative recovery of findings when Kimi corrupts the JSON verdict key (e.g., {":  ": [...]}), and (2) a dynamically-assembled output-format prompt that makes ruleId required and enumerates the active rule IDs. Both changes are well-covered by unit tests. The recovery logic is deliberately conservative — it only accepts a non-empty array where every element is a valid finding, and it never overrides an explicit findings array — so it cannot turn a clean review into a false positive. The remaining changes are Tier-2 substance assertions in five canary test fixtures; these are test-only scaffolding with no runtime impact.
>
> - readVerdict now recovers findings stored under a corrupted key when no findings array is present
> - buildOutputFormat dynamically enumerates active rule IDs in the ruleId prompt line
> - Tier-2 substance assertions added to five canary test fixtures

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9b29b96. Updates automatically on new commits.</sup>
<!-- /lien-stats -->