### PR TITLE
feat(review): widen doc-truth to documentation surfaces (ADRs, site guides, changesets)

### DIFF
--- a/packages/review/src/guidance-surface-signals.ts
+++ b/packages/review/src/guidance-surface-signals.ts
@@ -3,24 +3,31 @@
  *
  * The review pipeline only chunks/analyzes files whose extension is in the
  * parser-supported set (see `filterAnalyzableFiles` in analysis.ts). That drops
- * the agent-guidance surfaces — shell hooks, `.mdc` rules, CLAUDE.md — from the
- * material the reviewer reasons about. For a tool whose *product* is agent
- * guidance, that is exactly the wrong thing to hide: a hook that calls a
- * keyword search "meaning-based discovery", or a CLAUDE.md that describes a flag
- * the code no longer honors, actively misroutes the agents that read it. Stale
- * guidance is a functional bug, not a style nit (see PR #658).
+ * two kinds of prose from the material the reviewer reasons about:
+ *  - agent-guidance surfaces — shell hooks, `.mdc` rules, CLAUDE.md; and
+ *  - project documentation — architecture docs / ADRs under `docs/`, the
+ *    user-guide site under `packages/site/docs/`, and `.changeset/` entries.
+ * Both make behavioral/structural claims about the code. For a tool whose
+ * *product* is agent guidance, hiding a hook that calls a keyword search
+ * "meaning-based discovery" is exactly wrong; the same is true of an ADR that
+ * describes a mechanism the code no longer has, or a changeset whose "adds
+ * <API>" line the diff's exports contradict. Stale docs/guidance are a
+ * functional bug, not a style nit (see PR #658, and the 60-PR review-gap
+ * analysis that found doc↔code drift escaping on exactly these surfaces).
  *
  * This module widens the review INPUT without touching the parser: it collects
- * the raw unified-diff hunks of any changed file that is a guidance surface and
- * injects them as a clearly-labeled `<guidance_surface_changes>` block, so the
- * prose reaches the model (and the `doc-truth` rule) instead of being silently
- * dropped. It is a deterministic, zero-LLM pass over the existing patches —
- * mirroring the `<untrusted_input_sites>` / `<stale_literal_candidates>`
+ * the raw unified-diff hunks of any changed file that is a guidance/doc surface
+ * and injects them as a clearly-labeled `<guidance_surface_changes>` block, so
+ * the prose reaches the model (and the `doc-truth` rule) instead of being
+ * silently dropped. It is a deterministic, zero-LLM pass over the existing
+ * patches — mirroring the `<untrusted_input_sites>` / `<stale_literal_candidates>`
  * precedents (a focused view derived from the diff, appended unconditionally).
  *
  * Scope is deliberately tight (KISS): NOT every `.md`/`.json` in the repo — only
- * surfaces whose prose steers an agent. The passthrough is byte-capped; when the
- * cap is hit it says so rather than truncating silently.
+ * the guidance surfaces above and specific documentation roots (no blanket
+ * `**\/*.md`, no source-tree READMEs). The passthrough is byte-capped both
+ * per-file (so one huge doc can't evict the others) and in total; when either
+ * cap bites it says so rather than truncating silently.
  */
 
 import type { ReviewContext } from './plugin-types.js';
@@ -29,7 +36,7 @@ import type { ReviewContext } from './plugin-types.js';
 // Types
 // ---------------------------------------------------------------------------
 
-/** A changed guidance-surface file and its raw unified-diff hunk(s). */
+/** A changed guidance/doc surface file and its raw unified-diff hunk(s). */
 export interface GuidanceSurfaceChange {
   file: string;
   /** Raw unified-diff patch text for this file, as returned by the GitHub API. */
@@ -41,20 +48,34 @@ export interface GuidanceSurfaceChange {
 // ---------------------------------------------------------------------------
 
 /**
- * A changed file is a "guidance surface" when its prose steers an agent rather
- * than being executable source the parser can analyze. Kept tight on purpose —
- * this is NOT "every doc/config file", only:
+ * A changed file is a "guidance surface" when its prose steers an agent or
+ * documents the code's behavior, rather than being executable source the parser
+ * can analyze. Kept tight on purpose — this is NOT "every doc/config file",
+ * only:
  *  - CLAUDE.md at any depth (agent memory / project instructions);
  *  - shell hooks and `.mdc` rule files under an agent-guidance root
- *    (`plugins/**` for Claude Code plugins, `.cursor/**` for Cursor rules).
- * Paths are repo-relative (no leading `./`), matching GitHub's file list.
+ *    (`plugins/**` for Claude Code plugins, `.cursor/**` for Cursor rules);
+ *  - architecture docs / ADRs under the top-level `docs/` tree;
+ *  - the published user-guide site under `packages/site/docs/`;
+ *  - changeset entries (`.changeset/*.md`), whose prose claims what the public
+ *    API now does.
+ * The doc roots are anchored (top-level `docs/`, `packages/site/docs/`, and the
+ * flat `.changeset/` dir) so source-tree READMEs and a blanket `**\/*.md` stay
+ * out of scope. Paths are repo-relative (no leading `./`), matching GitHub's
+ * file list.
  */
 const GUIDANCE_SURFACE_MATCHERS: readonly RegExp[] = [
+  // Agent-guidance surfaces: prose that steers an AI agent.
   /(?:^|\/)CLAUDE\.md$/,
   /^(?:plugins|\.cursor)\/.*\.(?:sh|mdc)$/,
+  // Project-documentation surfaces: ADRs / design docs, the user-guide site,
+  // and changeset entries. Anchored to specific roots — no blanket **/*.md.
+  /^docs\/.*\.md$/,
+  /^packages\/site\/docs\/.*\.md$/,
+  /^\.changeset\/[^/]*\.md$/,
 ];
 
-/** True when `file` is an agent-guidance surface (see GUIDANCE_SURFACE_MATCHERS). */
+/** True when `file` is a guidance or documentation surface (see matchers). */
 export function isGuidanceSurface(file: string): boolean {
   return GUIDANCE_SURFACE_MATCHERS.some(re => re.test(file));
 }
@@ -64,8 +85,14 @@ export function isGuidanceSurface(file: string): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * Collect the changed guidance-surface files and their raw diff hunks from the
- * PR patches, preserving the patches' iteration order. Exposed for testing.
+ * Collect the changed guidance/doc-surface files and their raw diff hunks from
+ * the PR patches, SMALLEST HUNK FIRST. Order is a budget-fairness decision,
+ * not cosmetics: with a total cap, processing in diff order lets one
+ * voluminous prose file exhaust the budget and evict small claim-dense files
+ * entirely (observed on PR #687, where skills/rules prose crowded out the
+ * config-system.md retired-key note the doc-truth rule needed to see).
+ * Smallest-first guarantees every compact claim-bearing hunk gets in before
+ * any file needs truncation. Exposed for testing.
  */
 export function collectGuidanceSurfaceChanges(
   patches: Map<string, string>,
@@ -74,7 +101,7 @@ export function collectGuidanceSurfaceChanges(
   for (const [file, patch] of patches) {
     if (isGuidanceSurface(file)) changes.push({ file, patch });
   }
-  return changes;
+  return changes.sort((a, b) => a.patch.length - b.patch.length);
 }
 
 // ---------------------------------------------------------------------------
@@ -82,15 +109,25 @@ export function collectGuidanceSurfaceChanges(
 // ---------------------------------------------------------------------------
 
 /**
- * Total budget for the passed-through hunks. Deliberately modest: input-budget
- * bloat measurably degrades finding quality (PR #613), and guidance surfaces are
- * usually small (a hook, a rule file, a CLAUDE.md section). When the budget is
- * exhausted the block says how much was omitted — never a silent drop.
+ * Total budget for the passed-through hunks. Larger than a hooks-only budget
+ * because doc PRs can be much bigger (a site-wide docs sweep, a multi-file ADR
+ * update), but still bounded: input-budget bloat measurably degrades finding
+ * quality (PR #613). When the total is exhausted the block says how many files
+ * were omitted — never a silent drop.
  */
-const MAX_GUIDANCE_CHARS = 6_000;
+const MAX_GUIDANCE_CHARS = 12_000;
+
+/**
+ * Per-file cap on a single hunk's passed-through bytes. Keeps one huge doc from
+ * eating the whole budget and evicting the other changed surfaces: each file
+ * contributes at most this much, and anything past it is marked truncated with
+ * a read_file pointer. A few KB is enough to carry the claim-bearing prose of a
+ * typical ADR / guide / changeset hunk.
+ */
+const MAX_PER_FILE_CHARS = 3_000;
 
 const HEADER = `<guidance_surface_changes>
-The diffs below are AGENT-GUIDANCE surfaces this PR changed (Claude/Cursor hooks, \`.mdc\` rules, CLAUDE.md). They are guidance-surface changes, NOT code-analyzed — no AST, chunks, or signals are computed for them, so their raw hunks are passed through here. For a tool whose product is agent guidance, prose that mis-describes behavior is a functional bug (a hook calling a keyword search "meaning-based", a doc claiming a flag is "disabled when X" the code contradicts). Apply the doc-truth check to behavioral claims in these hunks; do NOT report pure wording/style nits.`;
+The diffs below are GUIDANCE and DOCUMENTATION surfaces this PR changed: agent-guidance files (Claude/Cursor hooks, \`.mdc\` rules, CLAUDE.md) and project docs (architecture/ADRs under \`docs/\`, the user-guide site under \`packages/site/docs/\`, and \`.changeset/\` entries). None are code-analyzed — no AST, chunks, or signals are computed for them — so their raw hunks are passed through here. For a tool whose product is agent guidance, prose that mis-describes behavior is a functional bug: a hook calling a keyword search "meaning-based", an ADR/doc claiming a flag is "disabled when X" the code contradicts, or a changeset whose "adds/renames <API>" line the diff's exports don't match. Apply the doc-truth check to the BEHAVIORAL and STRUCTURAL claims in these hunks — verify each against the code the diff touches (and against a referenced ADR when both are visible); for changesets, public-API claims must match the diff's actual exports. Do NOT report pure wording/style nits, and stay silent on claims the code confirms are accurate.`;
 
 /** Render one file's hunk as a fenced, labeled block. */
 function renderFileBlock(file: string, patch: string): string {
@@ -98,11 +135,17 @@ function renderFileBlock(file: string, patch: string): string {
 }
 
 /**
- * Render the collected guidance-surface changes as a `<guidance_surface_changes>`
- * block for the agent's initial message. Returns '' when there are none, so
- * callers can append unconditionally. Caps the total passed-through bytes and,
- * if the cap is hit, states what was truncated/omitted rather than dropping
- * content silently.
+ * Render the collected guidance/doc-surface changes as a
+ * `<guidance_surface_changes>` block for the agent's initial message. Returns ''
+ * when there are none, so callers can append unconditionally.
+ *
+ * Two caps keep the block bounded without silent loss:
+ *  - each file's hunk is capped at MAX_PER_FILE_CHARS, so one oversized doc
+ *    can't evict the others (over-cap hunks are marked truncated in place and
+ *    the loop CONTINUES to the next file);
+ *  - the total is capped at MAX_GUIDANCE_CHARS; once it is exhausted the
+ *    remaining files are omitted with an explicit count.
+ * Both a per-file truncation and a whole-file omission are stated inline.
  */
 export function renderGuidanceSurfaceChanges(changes: GuidanceSurfaceChange[]): string {
   if (changes.length === 0) return '';
@@ -113,29 +156,28 @@ export function renderGuidanceSurfaceChanges(changes: GuidanceSurfaceChange[]): 
 
   for (let i = 0; i < changes.length; i++) {
     const { file, patch } = changes[i];
-    const remaining = MAX_GUIDANCE_CHARS - used;
-    if (remaining <= 0) {
+    const framing = renderFileBlock(file, '').length;
+    // Bytes available for THIS file's patch: the smaller of the per-file cap
+    // and whatever remains of the total budget after this file's fixed framing.
+    const patchBudget = Math.min(MAX_PER_FILE_CHARS, MAX_GUIDANCE_CHARS - used - framing);
+    if (patchBudget <= 0) {
+      // No room left even for framing: omit this file and all that follow.
       omittedFiles = changes.length - i;
       break;
     }
-    const block = renderFileBlock(file, patch);
-    if (block.length <= remaining) {
+    if (patch.length <= patchBudget) {
+      const block = renderFileBlock(file, patch);
       blocks.push(block);
       used += block.length;
       continue;
     }
-    // The patch doesn't fit whole: include as much as the budget allows and
-    // mark this file's hunk as truncated, then stop (subsequent files omitted).
-    const truncatedPatch = patch.slice(
-      0,
-      Math.max(0, remaining - renderFileBlock(file, '').length),
-    );
+    // Patch exceeds its slice: include the slice, mark it truncated, and keep
+    // going so later files still get their own slice.
+    const truncatedPatch = patch.slice(0, patchBudget);
     const cut = patch.length - truncatedPatch.length;
-    blocks.push(
-      `${renderFileBlock(file, truncatedPatch)}\n[hunk truncated to respect the input budget — ${cut} more char(s) for this file; use read_file for the full contents]`,
-    );
-    omittedFiles = changes.length - i - 1;
-    break;
+    const block = `${renderFileBlock(file, truncatedPatch)}\n[hunk truncated to respect the input budget — ${cut} more char(s) for this file; use read_file for the full contents]`;
+    blocks.push(block);
+    used += block.length;
   }
 
   const parts = [HEADER, ...blocks];
@@ -150,7 +192,7 @@ export function renderGuidanceSurfaceChanges(changes: GuidanceSurfaceChange[]): 
 
 /**
  * Build the `<guidance_surface_changes>` section from the review context.
- * Returns '' when there is no diff or no changed guidance surface.
+ * Returns '' when there is no diff or no changed guidance/doc surface.
  */
 export function renderGuidanceSurfaceSection(context: ReviewContext): string {
   const patches = context.pr?.patches;

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -750,8 +750,20 @@ MANDATORY protocol when this rule is active:
 }`,
   triggers: {
     // Guidance surfaces (matched against allChangedFiles, so the invisible
-    // .sh/.mdc/CLAUDE.md cases still activate the rule)...
-    filePatterns: ['**/CLAUDE.md', 'plugins/**', '.cursor/**', '**/*.mdc'],
+    // .sh/.mdc/CLAUDE.md cases still activate the rule), plus the project
+    // documentation surfaces the <guidance_surface_changes> section passes
+    // through: architecture/design docs and ADRs, the user-guide site, and
+    // changeset entries whose public-API claims must match the diff. Kept in
+    // lockstep with GUIDANCE_SURFACE_MATCHERS in guidance-surface-signals.ts.
+    filePatterns: [
+      '**/CLAUDE.md',
+      'plugins/**',
+      '.cursor/**',
+      '**/*.mdc',
+      'docs/**',
+      'packages/site/docs/**',
+      '.changeset/**',
+    ],
     // ...OR claim-shaped prose anywhere in the diff (doc comments/docstrings in
     // otherwise-analyzable code, e.g. the schema.ts miss on PR #658).
     keywords: [

--- a/packages/review/test/guidance-surface-signals.test.ts
+++ b/packages/review/test/guidance-surface-signals.test.ts
@@ -32,6 +32,29 @@ const CLAUDE_MD_PATCH =
   '-Semantic search finds code by meaning.\n' +
   '+Semantic search finds code by meaning (via embeddings).';
 
+// A design doc / ADR whose mechanism claim can drift from the code.
+const ADR_PATCH =
+  '@@ -1,3 +1,3 @@\n' +
+  ' # ADR-0011: Remove embeddings\n' +
+  '-search_code performs semantic (embedding-based) ranking.\n' +
+  '+search_code performs lexical BM25 keyword ranking.';
+
+// A changeset whose prose claims a public-API change.
+const CHANGESET_PATCH =
+  '@@ -0,0 +1,5 @@\n' +
+  '+---\n' +
+  "+'@liendev/core': minor\n" +
+  '+---\n' +
+  '+\n' +
+  '+Add `createVectorDB()` to the public API.';
+
+// A user-guide page under the docs site.
+const SITE_GUIDE_PATCH =
+  '@@ -1,2 +1,2 @@\n' +
+  ' ## search_code\n' +
+  '-Finds code by meaning using embeddings.\n' +
+  '+Finds code by keyword using BM25.';
+
 // ---------------------------------------------------------------------------
 // isGuidanceSurface
 // ---------------------------------------------------------------------------
@@ -49,12 +72,31 @@ describe('isGuidanceSurface', () => {
     expect(isGuidanceSurface('.cursor/hooks/setup.sh')).toBe(true);
   });
 
-  it('does NOT match ordinary code, docs, config, or out-of-scope .sh/.mdc', () => {
+  it('matches project documentation surfaces (ADRs, docs tree, site guides, changesets)', () => {
+    // Architecture decisions / design docs under the top-level docs/ tree.
+    expect(isGuidanceSurface('docs/architecture/decisions/0009-extract-parser-package.md')).toBe(
+      true,
+    );
+    expect(isGuidanceSurface('docs/architecture/worktree-aware-indexing.md')).toBe(true);
+    expect(isGuidanceSurface('docs/guide.md')).toBe(true);
+    // The published user-guide site.
+    expect(isGuidanceSurface('packages/site/docs/guide/search.md')).toBe(true);
+    // Changeset entries make public-API claims.
+    expect(isGuidanceSurface('.changeset/brave-otters-add.md')).toBe(true);
+  });
+
+  it('does NOT match ordinary code, config, or out-of-scope docs/markdown', () => {
     // Parser-analyzable source is reviewed the normal way, not passed through.
     expect(isGuidanceSurface('packages/core/src/config/schema.ts')).toBe(false);
-    // Tight scope: not every markdown/json, and .sh/.mdc only under the two roots.
+    // No blanket **/*.md: the root README, CHANGELOG, and source-tree markdown stay out.
     expect(isGuidanceSurface('README.md')).toBe(false);
-    expect(isGuidanceSurface('docs/guide.md')).toBe(false);
+    expect(isGuidanceSurface('CHANGELOG.md')).toBe(false);
+    expect(isGuidanceSurface('packages/core/src/notes.md')).toBe(false);
+    // Doc roots are anchored: only the top-level docs/ and packages/site/docs/.
+    expect(isGuidanceSurface('packages/parser/docs/internal.md')).toBe(false);
+    // .changeset is a flat dir of *.md — nested paths don't match.
+    expect(isGuidanceSurface('.changeset/nested/foo.md')).toBe(false);
+    // .sh/.mdc only under the two agent-guidance roots.
     expect(isGuidanceSurface('package.json')).toBe(false);
     expect(isGuidanceSurface('scripts/build.sh')).toBe(false);
     expect(isGuidanceSurface('src/rules/foo.mdc')).toBe(false);
@@ -68,22 +110,30 @@ describe('isGuidanceSurface', () => {
 // ---------------------------------------------------------------------------
 
 describe('collectGuidanceSurfaceChanges', () => {
-  it('keeps only guidance surfaces and preserves patch order', () => {
+  it('keeps guidance and doc surfaces (dropping code/README), smallest hunk first', () => {
     const patches = new Map<string, string>([
       ['packages/core/src/config/schema.ts', '@@ -1 +1 @@\n-a\n+b'],
       ['plugins/claude/hooks/augment-explore-task.sh', HOOK_PATCH],
       ['README.md', '@@ -1 +1 @@\n-x\n+y'],
+      ['docs/architecture/decisions/0011-remove-embeddings.md', ADR_PATCH],
+      ['.changeset/brave-otters-add.md', CHANGESET_PATCH],
       ['CLAUDE.md', CLAUDE_MD_PATCH],
     ]);
     const changes = collectGuidanceSurfaceChanges(patches);
-    expect(changes.map(c => c.file)).toEqual([
+    // Budget fairness: ordered by ascending hunk size so compact claim-dense
+    // files can't be evicted by one voluminous prose file (PR #687 shape).
+    const kept = [
       'plugins/claude/hooks/augment-explore-task.sh',
+      'docs/architecture/decisions/0011-remove-embeddings.md',
+      '.changeset/brave-otters-add.md',
       'CLAUDE.md',
-    ]);
-    expect(changes[0].patch).toBe(HOOK_PATCH);
+    ];
+    expect(changes.map(c => c.file).sort()).toEqual([...kept].sort());
+    const sizes = changes.map(c => c.patch.length);
+    expect(sizes).toEqual([...sizes].sort((a, b) => a - b));
   });
 
-  it('returns [] when no changed file is a guidance surface', () => {
+  it('returns [] when no changed file is a guidance or doc surface', () => {
     const patches = new Map<string, string>([['src/index.ts', '@@ -1 +1 @@\n-a\n+b']]);
     expect(collectGuidanceSurfaceChanges(patches)).toEqual([]);
   });
@@ -112,23 +162,56 @@ describe('renderGuidanceSurfaceChanges', () => {
     expect(md).toContain('doc-truth');
   });
 
-  it('caps total bytes and notes the omitted files rather than dropping silently', () => {
+  it('passes through doc/ADR/changeset hunks and frames both kinds of surface', () => {
+    const md = renderGuidanceSurfaceChanges([
+      { file: 'docs/architecture/decisions/0011-remove-embeddings.md', patch: ADR_PATCH },
+      { file: '.changeset/brave-otters-add.md', patch: CHANGESET_PATCH },
+      { file: 'packages/site/docs/guide/search.md', patch: SITE_GUIDE_PATCH },
+    ]);
+    // Every doc surface is rendered as a labeled diff block with its hunk.
+    expect(md).toContain('docs/architecture/decisions/0011-remove-embeddings.md');
+    expect(md).toContain('.changeset/brave-otters-add.md');
+    expect(md).toContain('packages/site/docs/guide/search.md');
+    expect(md).toContain('createVectorDB');
+    // The blurb frames agent-guidance AND project docs for the doc-truth check.
+    expect(md).toContain('doc-truth');
+    expect(md).toContain('.changeset');
+    expect(md).toContain('packages/site/docs');
+  });
+
+  it('caps each file so one huge doc cannot evict the others', () => {
     const big = 'x'.repeat(5_000);
     const changes: GuidanceSurfaceChange[] = [
-      { file: 'plugins/a/hooks/one.sh', patch: `@@ -1 +1 @@\n+${big}` },
-      { file: 'plugins/a/hooks/two.sh', patch: `@@ -1 +1 @@\n+${big}` },
-      { file: 'plugins/a/hooks/three.sh', patch: `@@ -1 +1 @@\n+${big}` },
+      { file: 'docs/a.md', patch: `@@ -1 +1 @@\n+${big}` },
+      { file: 'docs/b.md', patch: `@@ -1 +1 @@\n+${big}` },
+      { file: 'docs/c.md', patch: `@@ -1 +1 @@\n+${big}` },
     ];
     const md = renderGuidanceSurfaceChanges(changes);
-    expect(md).toContain('plugins/a/hooks/one.sh');
-    // Budget (6000) fits the first file whole; the second overflows and is
-    // truncated in place; the third is omitted with an explicit note.
+    // Per-file cap (~3 KB) means all three still appear — the first doc does
+    // not consume the whole budget and starve the rest.
+    expect(md).toContain('docs/a.md');
+    expect(md).toContain('docs/b.md');
+    expect(md).toContain('docs/c.md');
+    // Each oversized hunk is truncated in place, never silently dropped.
     expect(md).toMatch(/hunk truncated to respect the input budget/);
-    expect(md).toMatch(/\+1 more changed guidance-surface file\(s\) omitted/);
-    // Passed-through hunk content stays within budget; only the fixed framing
-    // (header + notes + closing tag) sits on top. Bounded, not runaway
-    // (all three 5 KB hunks would be ~15 KB uncapped).
-    expect(md.length).toBeLessThan(6_000 + 2_000);
+    // Nothing omitted at this size — no eviction.
+    expect(md).not.toMatch(/more changed guidance-surface file\(s\) omitted/);
+  });
+
+  it('omits overflow files with an explicit count once the total budget is spent', () => {
+    const big = 'x'.repeat(5_000);
+    const changes: GuidanceSurfaceChange[] = Array.from({ length: 10 }, (_, i) => ({
+      file: `docs/page-${i}.md`,
+      patch: `@@ -1 +1 @@\n+${big}`,
+    }));
+    const md = renderGuidanceSurfaceChanges(changes);
+    // The earliest files are shown (truncated); later ones are omitted LOUDLY.
+    expect(md).toContain('docs/page-0.md');
+    expect(md).toMatch(/hunk truncated to respect the input budget/);
+    expect(md).toMatch(/\+\d+ more changed guidance-surface file\(s\) omitted/);
+    // Bounded near the total budget (12 KB) plus fixed framing — not runaway
+    // (all ten 5 KB hunks would be ~50 KB uncapped).
+    expect(md.length).toBeLessThan(15_000);
   });
 });
 
@@ -146,11 +229,13 @@ describe('renderGuidanceSurfaceSection', () => {
       ctxWithPatches(
         new Map([
           ['src/index.ts', '@@ -1 +1 @@\n-a\n+b'],
+          ['docs/architecture/decisions/0011-remove-embeddings.md', ADR_PATCH],
           ['plugins/claude/hooks/augment-explore-task.sh', HOOK_PATCH],
         ]),
       ),
     );
     expect(section).toContain('<guidance_surface_changes>');
+    expect(section).toContain('docs/architecture/decisions/0011-remove-embeddings.md');
     expect(section).toContain('plugins/claude/hooks/augment-explore-task.sh');
     expect(section).not.toContain('src/index.ts');
   });
@@ -168,6 +253,15 @@ describe('buildInitialMessage guidance-surface injection', () => {
     const message = buildInitialMessage(ctx, { blastRadius: null });
     expect(message).toContain('<guidance_surface_changes>');
     expect(message).toContain('plugins/claude/hooks/augment-explore-task.sh');
+  });
+
+  it('includes the block when only a project doc changed', () => {
+    const ctx = ctxWithPatches(
+      new Map([['docs/architecture/decisions/0011-remove-embeddings.md', ADR_PATCH]]),
+    );
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).toContain('<guidance_surface_changes>');
+    expect(message).toContain('docs/architecture/decisions/0011-remove-embeddings.md');
   });
 
   it('omits the block when no guidance surface changed', () => {

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -296,17 +296,26 @@ const NATIVE_BUILD_HINT =
  * swallowed and only markdown/Vue chunks survive, yet the overall result is
  * `success: true`. Persisting that produces a fixture whose corpus is missing
  * all source code — the agent then "reviews" a diff it has no context for.
- * Fail loudly instead, on two independent signatures:
- *   1. A changed source file that exists on disk and is non-empty but produced
- *      zero chunks (the PR's own files are absent from the corpus).
- *   2. Zero source-code chunks anywhere in the corpus, even when the PR only
- *      touched docs — the repoChunks corpus is the agent's whole search space.
+ * The fatal signature is a corpus with ZERO source-code chunks anywhere —
+ * that never happens with a working binding, even on docs-only PRs, because
+ * repoChunks spans the whole repo. A changed source file that individually
+ * produced zero chunks is only a WARNING: files with no chunkable top-level
+ * declarations (e.g. a VitePress config that is a single `export default`
+ * expression) legitimately chunk to zero and must not abort a healthy
+ * capture (false positive observed on PR #716's .vitepress/config.ts).
  */
 async function assertIndexComplete(
   repoChunks: Array<{ metadata: { file: string } }>,
   changedFiles: string[],
   worktree: string,
 ): Promise<void> {
+  const sourceChunks = repoChunks.filter(c => NATIVE_SOURCE_EXT.test(c.metadata.file)).length;
+  if (sourceChunks === 0) {
+    throw new Error(
+      `partial index: ${repoChunks.length} chunks captured but zero from AST source ` +
+        `files. ${NATIVE_BUILD_HINT}`,
+    );
+  }
   const indexed = new Set(repoChunks.map(c => toRepoRelative(c.metadata.file, worktree)));
   const missing: string[] = [];
   for (const f of changedFiles) {
@@ -321,16 +330,10 @@ async function assertIndexComplete(
     if (size > 0) missing.push(rel);
   }
   if (missing.length > 0) {
-    throw new Error(
-      `partial index: ${missing.length} changed source file(s) produced zero chunks ` +
-        `(e.g. ${missing.slice(0, 3).join(', ')}). ${NATIVE_BUILD_HINT}`,
-    );
-  }
-  const sourceChunks = repoChunks.filter(c => NATIVE_SOURCE_EXT.test(c.metadata.file)).length;
-  if (sourceChunks === 0) {
-    throw new Error(
-      `partial index: ${repoChunks.length} chunks captured but zero from AST source ` +
-        `files. ${NATIVE_BUILD_HINT}`,
+    console.error(
+      `[capture] warning: ${missing.length} changed source file(s) produced zero chunks ` +
+        `(${missing.slice(0, 3).join(', ')}). The corpus has ${sourceChunks} source chunks, ` +
+        `so the binding works — likely declaration-free files. Verify they matter to the fixture.`,
     );
   }
 }

--- a/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
@@ -57,10 +57,15 @@
  * reviewer following step 2 rather than pattern-matching the prose. That is by
  * design for the canary — it tests protocol-following, not prose-matching.
  *
- * Calibration status: NOT yet calibrated against Kimi. Tagged `canary`
- * pre-emptively — this is the reference full-context doc-truth miss. Run
- * `--calibrate 10` on kimi and record the per-run breakdown here before relying
- * on it as a drift signal.
+ * Calibration status: 0/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
+ * --calibrate 10, surface-widening branch). NOT a prompt-assembly failure —
+ * traces show doc-truth active and the claim rendered; the model spends its
+ * budget on the PR's real code bugs (buildOverlay mask-clear race,
+ * chunksCreated:0, manifest JSON.parse) and never engages the doc claim.
+ * Attention competition on a bug-rich PR. Canary tag REMOVED until the
+ * planned deterministic <doc_claims> worklist signal (the stale-literal /
+ * untrusted-input pattern, #614/#616) makes claim-checking non-optional;
+ * this fixture is the acceptance test for that phase-2 work.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -103,7 +108,7 @@ const assertions: FixtureAssertions = {
   },
   votes: 3,
   passThreshold: 9,
-  tags: ['canary'],
+  tags: [],
 };
 
 export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
@@ -1,0 +1,109 @@
+/**
+ * Snapshot from PR #667 ("feat(core): worktree-aware indexing (shared base +
+ * per-worktree overlay)") captured at the planted-claim commit
+ * headSha 1882b38d5228 (base 3b191a6a5cbc). This PR adds BOTH the design doc
+ * `docs/architecture/worktree-aware-indexing.md` AND the code it describes,
+ * `packages/core/src/vectordb/overlay-resolution.ts` (`resolveIndexStrategy`),
+ * in the same diff — so the reviewer has full in-prompt context on both sides
+ * of the claim. Lien Review had every fact it needed and still let this drift
+ * through, which is why this is the strongest doc-truth canary in the corpus.
+ *
+ * THE PLANTED CLAIM (touched prose in the design doc, "Detection" section):
+ *   "We additionally require that the resolved main root is **not** the current
+ *    root and that it **has an index** (`structural.db` exists). If either
+ *    fails we fall back to standalone."
+ * The doc's Fallbacks table reinforces the same narrow gate: "Main checkout
+ * has **no index** | Standalone." Both describe the base-index gate as a
+ * single condition: `structural.db` exists.
+ *
+ * WHY IT'S FALSE (contradicting code, in the SAME diff —
+ * `packages/core/src/vectordb/overlay-resolution.ts`, `resolveIndexStrategy`):
+ *   const hasDb = await fileExists(path.join(baseIndexDir, STRUCTURAL_DB_FILENAME));
+ *   const hasManifest = await fileExists(path.join(baseIndexDir, MANIFEST_FILE));
+ *   if (!hasDb || !hasManifest) { warnOnce(...); return { mode: 'standalone' }; }
+ * The overlay gate requires BOTH `structural.db` AND `manifest.json` — the code's
+ * own doc comment even spells it out ("the main checkout has a `structural.db`
+ * AND a `manifest.json` (the base per-file content hashes the overlay diff
+ * relies on)"). A main checkout that has `structural.db` but no `manifest.json`
+ * qualifies for overlay mode per the design doc, but the code falls back to
+ * standalone. The doc understates the gate the code actually enforces. (This
+ * drift was never corrected — the merged doc still reads "has an index
+ * (`structural.db` exists)" at line 53 today.)
+ *
+ * WHAT A CORRECT FINDING MUST SAY: quote the doc's "has an index
+ * (`structural.db` exists)" gate and state the real gate — `resolveIndexStrategy`
+ * requires `structural.db` AND `manifest.json`, falling back to standalone when
+ * `manifest.json` is absent — citing the `hasDb`/`hasManifest` check as the
+ * code fact that falsifies the single-condition claim.
+ *
+ * Capture command (fixture carries pr.headSha 1882b38d5228…, base 3b191a6a…;
+ * pr.number is null because the diff is computed via git diff base..sha):
+ *   npx tsx packages/review/test/harness/capture-pr.ts 667 \
+ *     packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.fixture.json \
+ *     --sha 1882b38d52284a216665a4067a35ad321613f045
+ *
+ * Structural note for calibration (verified via build-prompts.ts on this
+ * fixture): the doc CLAIM survives into the prompt in both <diff> and
+ * <guidance_surface_changes> ("has an index (`structural.db` exists)"). The
+ * falsifying CODE does NOT: the ~321-line design doc pushes the <diff> block
+ * past its char budget, so it truncates ("[Diff truncated — use read_file …]")
+ * BEFORE the overlay-resolution.ts hunk — the `hasDb`/`hasManifest` gate is not
+ * shown as a raw hunk. What survives is `resolveIndexStrategy`'s signature in
+ * <changed_functions> (a signpost) and the full function body in repoChunks.
+ * So reaching the finding requires the protocol's mandated step — call
+ * get_files_context on the changed overlay-resolution.ts to read the two-
+ * condition gate (get_files_context reads indexed chunks, so it is reliable
+ * here and is NOT a blind read_file/grep). Net: verifiable, but gated on the
+ * reviewer following step 2 rather than pattern-matching the prose. That is by
+ * design for the canary — it tests protocol-following, not prose-matching.
+ *
+ * Calibration status: NOT yet calibrated against Kimi. Tagged `canary`
+ * pre-emptively — this is the reference full-context doc-truth miss. Run
+ * `--calibrate 10` on kimi and record the per-run breakdown here before relying
+ * on it as a drift signal.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #667 1882b38d — worktree-aware-indexing.md Detection section says the base-index gate ' +
+    'is just "has an index (`structural.db` exists)", but resolveIndexStrategy requires ' +
+    'structural.db AND manifest.json (falls back to standalone without the manifest)',
+  rule: 'doc-truth',
+  expect: (result, h) => {
+    h.expectRuleFired('doc-truth', result);
+    h.expectFindingMentions(
+      [
+        // The crux: the omitted second gate condition
+        'manifest.json',
+        'manifest',
+        // The doc's stated (narrow) gate
+        'structural.db',
+        'has an index',
+        // The code that enforces the real gate
+        'resolveindexstrategy',
+        'hasmanifest',
+        'hasdb',
+        // Vocabulary a correct finding reaches for
+        'overlay',
+        'worktree-aware-indexing',
+        'both',
+        'requires',
+        'standalone',
+        'fall back',
+        'falls back',
+        'base index',
+        'gate',
+        'incomplete',
+        'only',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
@@ -6,6 +6,13 @@
  * Note in docs/architecture/config-system.md — introducing a doc-vs-doc
  * inconsistency between the two, both in the same diff.
  *
+ * Calibration status: 1/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
+ * --calibrate 10, after the smallest-first budget fix put the claim in the
+ * prompt). Omission-shaped claims (the Note doesn't say embeddings keys
+ * crash, it just doesn't mention them) are the weakest doc-truth shape for
+ * an initiative-driven check. Acceptance fixture for the phase-2
+ * <doc_claims> deterministic signal, not a canary.
+ *
  * THE PLANTED CLAIM (touched prose, docs/architecture/config-system.md — the
  * "> **Note:**" that config-system.md links to ADR-011 from):
  *   "Existing configs that name a retired backend (`backend: "lancedb"` /

--- a/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
@@ -1,0 +1,112 @@
+/**
+ * Snapshot from PR #687 ("docs: overhaul agent-facing setup — CLAUDE.md,
+ * skills, ADRs, contributor docs") captured at the planted-claim commit
+ * headSha a26e480bd06f (base 11bdd1e98664). This PR ADDS
+ * docs/architecture/decisions/0011-…md (ADR-011) and re-touches the retired-key
+ * Note in docs/architecture/config-system.md — introducing a doc-vs-doc
+ * inconsistency between the two, both in the same diff.
+ *
+ * THE PLANTED CLAIM (touched prose, docs/architecture/config-system.md — the
+ * "> **Note:**" that config-system.md links to ADR-011 from):
+ *   "Existing configs that name a retired backend (`backend: "lancedb"` /
+ *    "qdrant", or `qdrant.*` keys) do not crash: Lien warns once and uses the
+ *    SQLite backend."
+ * The Note enumerates the retired-key set as backend:lancedb / backend:qdrant /
+ * qdrant.* — and OMITS the embeddings keys.
+ *
+ * WHY IT'S INCOMPLETE (contradicting prose in the SAME diff — the newly-added
+ * ADR-011, docs/architecture/decisions/0011-…md):
+ *   "Retired config values degrade gracefully — `backend: "lancedb"/"qdrant"`
+ *    and the `embeddings.*`/`core.embeddingBatchSize` keys still load, warn
+ *    once, and are dropped on the next config save; there is no crash path…"
+ * ADR-011 documents `embeddings.*` and `core.embeddingBatchSize` as part of the
+ * same graceful-degrade set. config-system.md's parallel Note — which links to
+ * ADR-011 — lists only the backend/qdrant keys, so a user carrying `embeddings.*`
+ * keys won't find them covered where the config system is actually documented.
+ * The PR added the fuller ADR-011 list while leaving config-system.md's Note
+ * describing the narrower set.
+ *
+ * WHAT A CORRECT FINDING MUST SAY: point out that config-system.md's retired-key
+ * Note omits `embeddings.*`/`core.embeddingBatchSize`, which ADR-011 (linked
+ * from that very Note, added in this same PR) documents as still-loading /
+ * warn-once / dropped — so config-system.md's enumeration is incomplete and
+ * inconsistent with the ADR it references.
+ *
+ * Capture command (fixture carries pr.headSha a26e480bd06f…, base 11bdd1e9…):
+ *   npx tsx packages/review/test/harness/capture-pr.ts 687 \
+ *     packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.fixture.json \
+ *     --sha a26e480bd06f6503d0d1e0f0341c37c7173e8815
+ *
+ * STRUCTURAL BLOCKER for real-Kimi calibration — VERIFIED via build-prompts.ts
+ * on this fixture (2026-07-11), do NOT paper over: BOTH sides of the
+ * contradiction are truncated out of the rendered prompt. This PR touches 22
+ * files; the `.claude/skills/*` and `.cursor/rules/project.mdc` hunks sort
+ * first and exhaust the char budgets of BOTH blocks — the <diff> block
+ * truncates after `.cursor/rules/project.mdc` ("[Diff truncated — use read_file
+ * …]") and <guidance_surface_changes> stops after
+ * docs/architecture/claude-code-hook-channels.md. config-system.md's retired-key
+ * Note never appears (grep for "Existing configs that name a retired backend"
+ * in the prompt: 0 hits), and ADR-011's "embeddings.* / core.embeddingBatchSize
+ * keys still load" line never appears (grep "embeddingBatchSize" / "still load":
+ * 0 hits). An honest reviewer therefore has NO in-prompt signal that a
+ * retired-key list even exists to cross-check, so the protocol-following verdict
+ * is EMPTY and this fixture is effectively unfireable in replay as captured —
+ * confirmed by assert-cli: an empty verdict fails Tier 1 here.
+ *
+ * The assertion below is nonetheless correct and well-formed (a hand-authored
+ * "correct finding" verdict passes assert-cli exit 0), so the block is the
+ * PROMPT-ASSEMBLY / capture, not the keywords. To make this fixture reachable,
+ * fix upstream — e.g. have the guidance-surface passthrough prioritize
+ * claim-bearing doc hunks (config-system.md, ADRs) over voluminous
+ * `.claude/skills/*` prose, or re-capture a smaller/more-focused PR — rather
+ * than loosening these assertions. Independent of that, this is also the
+ * weakest contradiction on the merits: the Note doesn't claim embeddings keys
+ * crash, it just omits them, so even fully in-prompt a strict reviewer might
+ * read it as "accurate as far as it goes". Deliberately NOT tagged canary.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #687 a26e480 — config-system.md retired-key Note lists only backend:lancedb/qdrant + ' +
+    'qdrant.* and omits `embeddings.*`/`core.embeddingBatchSize`, which the ADR-011 it links to ' +
+    '(same PR) documents as still loading/warning/dropped',
+  rule: 'doc-truth',
+  expect: (result, h) => {
+    h.expectRuleFired('doc-truth', result);
+    h.expectFindingMentions(
+      [
+        // The omitted keys — the crux
+        'embeddings.*',
+        'embeddings',
+        'core.embeddingbatchsize',
+        'embeddingbatchsize',
+        // The docs in tension
+        'adr-011',
+        'config-system',
+        // The retired-key vocabulary both docs share
+        'retired',
+        'backend',
+        'qdrant',
+        'lancedb',
+        'still load',
+        'warn once',
+        'dropped',
+        'degrade',
+        // How a correct finding frames the gap
+        'omit',
+        'incomplete',
+        'inconsistent',
+        'does not mention',
+        'missing',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: [],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
@@ -1,0 +1,97 @@
+/**
+ * Snapshot from PR #711 ("chore: dead-code hygiene from the post-migration
+ * audit (c8, EmbeddingError, stale example paths)") captured at the
+ * planted-claim commit headSha 4480f85ed931 (base c7be7b68225b). The changeset
+ * and the code it describes are in the same diff, so the claim is verifiable
+ * from in-prompt material alone.
+ *
+ * THE PLANTED CLAIM (touched prose, .changeset/remove-embedding-error.md):
+ *   "Removed the unused embeddings-era `EmbeddingError` class and its
+ *    `EMBEDDING_MODEL_FAILED`/`EMBEDDING_GENERATION_FAILED` error codes. …
+ *    `LienErrorCode` and the public error exports are otherwise unchanged."
+ * The changeset front-matter bumps `@liendev/core` as a **patch**.
+ *
+ * WHY IT'S FALSE / UNDERSTATED (contradicting code in the SAME diff):
+ *   - packages/core/src/index.ts removes `EmbeddingError` from the package's
+ *     public `export { … }` block (the `-  EmbeddingError,` line, right beside
+ *     `LienErrorCode`). Removing a public export from `@liendev/core` is a
+ *     BREAKING API change, not a patch.
+ *   - packages/core/src/errors/codes.ts removes the `EMBEDDING_MODEL_FAILED`
+ *     and `EMBEDDING_GENERATION_FAILED` members from the `LienErrorCode` enum.
+ *   So "`LienErrorCode` and the public error exports are otherwise unchanged"
+ *   glosses a breaking public-API removal: `LienErrorCode` lost two members and
+ *   the public surface lost `EmbeddingError`, with no consumer migration path.
+ *   (The real follow-up commit 0956f9e fixed exactly this: it deleted the
+ *   "otherwise unchanged" sentence and replaced it with an explicit public-API
+ *   removal note plus migration guidance — catch the `LienError` base class or
+ *   a remaining `LienErrorCode`.)
+ *
+ * WHAT A CORRECT FINDING MUST SAY: quote the changeset's "public error exports
+ * are otherwise unchanged" and flag that the diff removes `EmbeddingError` from
+ * `@liendev/core`'s public exports (packages/core/src/index.ts) — a breaking
+ * removal the `patch` bump / "unchanged" wording understates — and drops two
+ * `LienErrorCode` members. Cite the removed `export { EmbeddingError }` line as
+ * the falsifying fact.
+ *
+ * Capture command (fixture carries pr.headSha 4480f85ed931…, base c7be7b68…):
+ *   npx tsx packages/review/test/harness/capture-pr.ts 711 \
+ *     packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.fixture.json \
+ *     --sha 4480f85ed931e461a7591176d6a863a0aec750b8
+ *
+ * Structural note for calibration: `.changeset/**` is a doc-truth guidance
+ * surface, so the changeset prose rides in <guidance_surface_changes>; the
+ * index.ts / codes.ts removals are ordinary in-diff hunks. Everything the
+ * finding needs is in-prompt — no blind read_file/grep dependency. One honest
+ * ambiguity to watch: the changeset DISCLOSES the removal in its first sentence,
+ * so a lenient reviewer may read "otherwise unchanged" as "other than the
+ * disclosed removals" and stay quiet; the sharper, more defensible finding is
+ * that a removed public export is breaking and the patch/"unchanged" framing
+ * understates it. NOT tagged canary until a calibration baseline exists.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #711 4480f85 — .changeset/remove-embedding-error.md says "the public error exports are ' +
+    'otherwise unchanged" (patch bump) while the diff removes the exported `EmbeddingError` from ' +
+    "@liendev/core's public exports and drops two LienErrorCode members — a breaking change",
+  rule: 'doc-truth',
+  expect: (result, h) => {
+    h.expectRuleFired('doc-truth', result);
+    h.expectFindingMentions(
+      [
+        // The removed public symbol — the crux
+        'embeddingerror',
+        // The false / understated claim
+        'otherwise unchanged',
+        'unchanged',
+        'public error exports',
+        // The breaking-change framing a correct finding uses
+        'public export',
+        'public api',
+        'public-api',
+        'breaking',
+        'removed',
+        'no longer exported',
+        // Anchors
+        'index.ts',
+        'lienerrorcode',
+        'embedding_generation_failed',
+        // The semver angle (secondary)
+        'patch',
+        'semver',
+        'major',
+        'minor',
+        'migration',
+        'export',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: [],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
@@ -5,6 +5,13 @@
  * and the code it describes are in the same diff, so the claim is verifiable
  * from in-prompt material alone.
  *
+ * Calibration status: 0/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
+ * --calibrate 10). Traces show the model DOES investigate (greps remaining
+ * EmbeddingError references, checks dependents in every vote) and then
+ * declines to report — a defensible read, since the changeset's first
+ * sentence discloses the removal and "otherwise" can honestly scope it out.
+ * Ambiguous-on-merits; kept as a characterization fixture, not a canary.
+ *
  * THE PLANTED CLAIM (touched prose, .changeset/remove-embedding-error.md):
  *   "Removed the unused embeddings-era `EmbeddingError` class and its
  *    `EMBEDDING_MODEL_FAILED`/`EMBEDDING_GENERATION_FAILED` error codes. …

--- a/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
@@ -1,0 +1,111 @@
+/**
+ * Snapshot from PR #716 ("docs(site): post-migration sweep — install story,
+ * native parser, stale claims") captured at the planted-claim commit
+ * headSha 4c805ea7ef21 (base 1462514ff87f). A docs-only PR: the four touched
+ * files are all under packages/site/docs + a vitepress config. The claim lives
+ * in the touched prose; the falsifying code lives OUT of the diff, in the
+ * parser loader.
+ *
+ * THE PLANTED CLAIM (touched prose, packages/site/docs/guide/installation.md):
+ *   "No compiler or build toolchain required on supported platforms — Lien's
+ *    parser ships as prebuilt native binaries for macOS (arm64/x64), Linux
+ *    (x64/arm64, glibc or musl, including Alpine), and Windows (x64), so there's
+ *    no `node-gyp`, no Python/make/g++, no Xcode Command Line Tools step. Any
+ *    other platform needs a one-time local build of the parser crate with the
+ *    Rust toolchain"
+ *
+ * WHY IT'S SUSPECT (contradicting code — packages/parser-native/index.js,
+ * `loadBinding`, present in repoChunks but NOT in the diff):
+ *   The loader's resolution order is (1) the per-platform npm package, (2) a
+ *   local dev binary at ./parser-native.node produced by
+ *   `npm run build:native`, (3) throw "Build it with: npm run build:native".
+ *   Its own comments say the per-platform packages are installed via
+ *   optionalDependencies "once the release pipeline publishes them" and that
+ *   the local build is "the expected path in this monorepo checkout until the
+ *   release pipeline publishes per-platform packages." So the unqualified
+ *   "ships as prebuilt native binaries / no toolchain required" claim overstates
+ *   the state the loader actually encodes: a supported-platform install can
+ *   still fall through to a source build that needs the Rust toolchain.
+ *
+ * WHAT A CORRECT FINDING MUST SAY: quote installation.md's "prebuilt native
+ * binaries / no compiler or build toolchain required" claim and point at the
+ * loader's source-build fallback (`npm run build:native` in
+ * packages/parser-native/index.js) — including the loader's own "until the
+ * release pipeline publishes per-platform packages" comment — as the code fact
+ * the doc contradicts.
+ *
+ * Capture command (fixture carries pr.headSha 4c805ea7ef21…, base 1462514f…):
+ *   npx tsx packages/review/test/harness/capture-pr.ts 716 \
+ *     packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.fixture.json \
+ *     --sha 4c805ea7ef212c300c756202330ff59c7c96bfa2
+ *
+ * STRUCTURAL RISK for real-Kimi calibration (flagged, not papered over) —
+ * VERIFIED via build-prompts.ts on this fixture (2026-07-11). Two compounding
+ * risks:
+ *   1. Reachability. The falsifying evidence (index.js) is NOT in the diff —
+ *      the PR touches only doc files. The claim IS in-prompt (installation.md
+ *      hunk + how-it-works.md, which redundantly asserts "installing Lien never
+ *      compiles anything"), but the loader body is not — reaching it needs the
+ *      reviewer to proactively get_files_context/read_file the UNCHANGED
+ *      packages/parser-native/index.js. index.js IS in repoChunks (so
+ *      get_files_context can surface it), but read_file/grep can be blind in
+ *      replay, there is no diff signpost, and the dependency-signals section
+ *      points at parser.ts's loadNativeBinding, not index.js's build:native
+ *      fallback — so Kimi may never make the doc→loader leap on a docs-only PR.
+ *   2. Weak contradiction on the merits. The fallback is CONDITIONAL — it only
+ *      triggers when the per-platform prebuilt package isn't installed, and the
+ *      loader's own comments scope that to the dev checkout ("until the release
+ *      pipeline publishes per-platform packages"). By this fixture's SHA those
+ *      packages had shipped (the PR summary calls prebuilt binaries "now the
+ *      selling point"), so a rigorous reviewer could correctly conclude the doc
+ *      is accurate for published installs and NOT fire — a legitimate no-fire.
+ * Net: expect this to calibrate LOW on Kimi, possibly correctly-low. It is the
+ * second-shakiest fixture (after pr687's truncation block) and is deliberately
+ * NOT tagged canary until a calibration baseline exists.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #716 4c805ea7 — installation.md claims the parser "ships as prebuilt native binaries" ' +
+    'with "no compiler or build toolchain required", but parser-native/index.js falls back to a ' +
+    'source build (`npm run build:native`) requiring the Rust toolchain',
+  rule: 'doc-truth',
+  expect: (result, h) => {
+    h.expectRuleFired('doc-truth', result);
+    h.expectFindingMentions(
+      [
+        // The falsifying loader fact
+        'build:native',
+        'parser-native',
+        'index.js',
+        'loadbinding',
+        'fallback',
+        'fall back',
+        'source build',
+        'local build',
+        'build from source',
+        // The claim being flagged
+        'prebuilt',
+        'no compiler',
+        'no toolchain',
+        'toolchain',
+        // Vocabulary a correct finding reaches for
+        'rust',
+        'cargo',
+        'optionaldependencies',
+        'per-platform',
+        'published',
+        'publishes',
+        'native binar',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: [],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
@@ -59,6 +59,10 @@
  *      packages had shipped (the PR summary calls prebuilt binaries "now the
  *      selling point"), so a rigorous reviewer could correctly conclude the doc
  *      is accurate for published installs and NOT fire — a legitimate no-fire.
+ * Calibration status: 2/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
+ * --calibrate 10) — as predicted below. Acceptance fixture for the phase-2
+ * <doc_claims> deterministic signal.
+ *
  * Net: expect this to calibrate LOW on Kimi, possibly correctly-low. It is the
  * second-shakiest fixture (after pr687's truncation block) and is deliberately
  * NOT tagged canary until a calibration baseline exists.

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -270,6 +270,27 @@ describe('selectRules', () => {
     expect(selectRules(BUILTIN_RULES, claudeMd).active.map(r => r.id)).toContain('doc-truth');
   });
 
+  it('activates doc-truth on documentation surfaces (docs, site guides, changesets)', () => {
+    for (const file of [
+      'docs/architecture/worktree-aware-indexing.md',
+      'docs/architecture/decisions/0011-retire-embeddings.md',
+      'packages/site/docs/guide/installation.md',
+      '.changeset/remove-embedding-error.md',
+    ]) {
+      // diffText set so the keyword trigger's fail-open path can't mask a
+      // filePatterns miss — this must pass on the file pattern alone.
+      const ctx = makeTriggerContext({ changedFiles: [file], diffText: '+plain prose line' });
+      expect(selectRules(BUILTIN_RULES, ctx).active.map(r => r.id)).toContain('doc-truth');
+    }
+  });
+
+  it('does not activate doc-truth for markdown outside the documented surfaces', () => {
+    for (const file of ['packages/parser/docs/notes.md', 'README.md', 'src/some/readme.md']) {
+      const ctx = makeTriggerContext({ changedFiles: [file], diffText: '+plain prose line' });
+      expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('doc-truth');
+    }
+  });
+
   it('activates doc-truth on claim-shaped prose in an otherwise-analyzable diff', () => {
     // The schema.ts miss: a doc comment making a falsifiable "reports as
     // disabled" claim, in a code file (no guidance-surface path match).


### PR DESCRIPTION
## Summary

The 60-PR review-gap analysis (see #724's sibling investigation) showed CodeRabbit's only residual edge over Lien Review is **non-code surfaces**: 6 substantive doc↔code-drift escapes lived in files the review pipeline never analyzes — architecture docs/ADRs, the user-guide site, and changeset entries. The doc-truth rule already checks behavioral claims; it just couldn't *see* these files.

## Changes

1. **Surface widening** (`guidance-surface-signals.ts`): matchers now also cover `docs/**/*.md`, `packages/site/docs/**/*.md`, `.changeset/*.md` (anchored roots, no blanket markdown). Blurb reframed for documentation surfaces; changeset public-API claims must match the diff's actual exports.
2. **Trigger widening** (`rules.ts`): doc-truth's `filePatterns` extended to the same roots, kept in lockstep — without this a docs-only or changeset-only PR renders the section but never activates the rule.
3. **Budget fairness**: total 12k / 3k-per-file caps, hunks processed **smallest first** so a voluminous prose file can't evict compact claim-bearing docs (observed on PR #687 where skills prose crowded out the very note the rule needed); truncation and omission are stated inline.
4. **Capture-guard fix** (`capture-pr.ts`): per-file zero-chunk signature demoted to a loud warning — declaration-free files (e.g. a VitePress config that is a single `export default` expression) legitimately chunk to zero and were false-aborting healthy captures. The fatal signature (zero source chunks corpus-wide) remains.
5. **Four seed fixtures** authored from the real escapes, each verified to contain both the false claim (in patches) and the contradicting code (in corpus):
   - `pr667-worktree-doc-drift` (canary candidate) — doc says the overlay gate checks only `structural.db`; `resolveIndexStrategy` also requires `manifest.json`. **This drift is still live on main** (`docs/architecture/worktree-aware-indexing.md`) — separate one-line doc fix to follow.
   - `pr711-changeset-export-claim` — changeset said "public error exports otherwise unchanged" while the diff removed `EmbeddingError` (pre-fix SHA).
   - `pr716-install-claim` — "no toolchain required" vs the source-build fallback (characterization fixture; contradiction is partial).
   - `pr687-config-doc-drift` — retired-key note omits keys ADR-011 says still load (pre-fix SHA).

## Verification so far (free)
- 128 unit tests pass across the two touched test files; full gate suite green (format/lint/typecheck/build/all tests/lien delta exit 0).
- End-to-end prompt rendering verified per fixture: docs-only PRs now activate doc-truth and the claim hunks render within budget (pr687's claim renders after the smallest-first fix).
- CC-mode emulated review passed assert-cli on pr667/pr711/pr716.

## Calibration (shipping gate — PENDING)
Single-rule bar: calibrate-10 on doc-truth's fixtures (4 new + pr658 + accurate-doc + renamed-stale-claim) at ≥9/10, plus the accurate-doc precision fixture staying empty. **Blocked on OpenRouter credit top-up** (~$2.50–4 incl. margin; account currently ~$1.40). Results will be posted here before this leaves draft. Expected: pr716 may calibrate low for documented reasons (reachability + partial contradiction) — it is not tagged canary.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR widens the guidance-surface passthrough and doc-truth rule to cover project documentation (docs/, packages/site/docs/, .changeset/*.md) and adds per-file/total budget fairness. The implementation is straightforward: matchers are properly anchored, the smallest-first sort and caps behave as described, and the capture-pr zero-chunk guard is intentionally conservative (fatal only for zero source chunks corpus-wide). No exports or caller contracts change.
>
> - Extended GUIDANCE_SURFACE_MATCHERS to docs/**/*.md, packages/site/docs/**/*.md, and .changeset/*.md
> - Added MAX_PER_FILE_CHARS (3 KB) and MAX_GUIDANCE_CHARS (12 KB) with smallest-hunk-first ordering
> - Widened doc-truth filePatterns to keep the rule in sync with the new documentation roots
> - Demoted per-file zero-chunk captures from fatal to warning while preserving fatal zero-source-corpus check

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 99fcdca. Updates automatically on new commits.</sup>
<!-- /lien-stats -->