### PR TITLE
docs(architecture): overlay gate requires manifest.json, not just structural.db

### DIFF
--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -50,8 +50,9 @@ The **main checkout root** is taken from the first `worktree <path>` line of
 `git worktree list --porcelain` — this is authoritative and also correct for
 bare-repo topologies (where deriving `dirname(commonDir)` would be wrong). We
 additionally require that the resolved main root is **not** the current root and
-that it **has an index** (`structural.db` exists). If either fails we fall back
-to standalone.
+that it **has a complete index** (both `structural.db` and `manifest.json`
+exist — see `resolveIndexStrategy` in `overlay-resolution.ts`). If either fails
+we fall back to standalone.
 
 ### Escape hatch
 

--- a/docs/architecture/worktree-aware-indexing.md
+++ b/docs/architecture/worktree-aware-indexing.md
@@ -27,6 +27,7 @@ as a **read-only base** and store only a small per-worktree **overlay**:
 
 ```
 ~/.lien/indices/<main-repoId>/structural.db      ← BASE  (read-only, owned by main)
+~/.lien/indices/<main-repoId>/manifest.json      ← BASE manifest (also required for overlay eligibility)
 ~/.lien/indices/<worktree-repoId>/structural.db  ← OVERLAY (rows for diverged files)
 ~/.lien/indices/<worktree-repoId>/overlay.db     ← (see "One overlay DB" below)
 ```


### PR DESCRIPTION
One-line doc-drift fix surfaced by the doc-truth surface-widening work (#727): `docs/architecture/worktree-aware-indexing.md` describes the overlay eligibility gate as "`structural.db` exists", but `resolveIndexStrategy` (`packages/core/src/vectordb/overlay-resolution.ts`) requires **both** `structural.db` and `manifest.json` before choosing overlay mode. Stale since #667 — it's the exact claim pinned by the new `pr667-worktree-doc-drift` fixture, still live on main until now.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 93 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 11 high-risk file(s) with 455 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 36 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ea2d12c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified linked worktree indexing behavior when the main checkout has an incomplete index.
  * Documented that both required index files must be present to use the shared index; otherwise, standalone indexing is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->