### PR TITLE
feat(review): deterministic <doc_claims> worklist signal for doc-truth

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -1,0 +1,298 @@
+/**
+ * Deterministic discovery signal for the doc-truth rule.
+ *
+ * doc-truth's MANDATORY protocol tells the agent to "list every claim-bearing
+ * line the diff touched" and verify each against the code — but nothing makes
+ * that inventory non-optional, and calibration of the four seed fixtures
+ * (pr667 0/10, pr711 0/10, pr716 2/10, pr687 1/10 on kimi-k2.7-code) showed the
+ * model, under budget pressure on a bug-rich PR, doesn't reliably *chase* the
+ * doc claim on its own initiative (issue #729). The claim was in-prompt and the
+ * rule was active; what was missing was a handed-to-it worklist.
+ *
+ * This module pre-computes that worklist, mirroring the
+ * `<stale_literal_candidates>` / `<untrusted_input_sites>` precedents: a
+ * zero-LLM regex pass over the ADDED lines of the touched guidance/doc surfaces
+ * (the exact surfaces `guidance-surface-signals` passes through), extracting
+ * claim-shaped prose and injecting it as a `<doc_claims>` block — "the
+ * discovery step is done for you; verify EACH against the code". It hands the
+ * agent concrete claims to check, countering the initiative-driven miss.
+ *
+ * It is a DISCOVERY aid, not a verdict: extraction is intentionally recall-
+ * biased on claim shapes but skips code (fenced blocks) and tabular data, and
+ * the render layer reminds the agent that a worklist entry may be descriptive
+ * prose rather than a falsifiable behavioral claim — those need no finding, so
+ * the block never manufactures a contradiction the code doesn't support.
+ */
+
+import type { ReviewContext } from './plugin-types.js';
+import { collectGuidanceSurfaceChanges } from './guidance-surface-signals.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The claim shapes doc-truth enumerates, plus the two scope shapes the seed
+ * fixtures need. Used as a hint label internally (extraction order) — the
+ * rendered worklist lists the prose, not the shape.
+ */
+export type DocClaimShape =
+  | 'mechanism'
+  | 'state'
+  | 'default'
+  | 'scope-gate'
+  | 'scope-unchanged'
+  | 'requirement'
+  | 'negation';
+
+/** A claim-shaped line the diff added to a guidance/doc surface. */
+export interface DocClaim {
+  /** Repo-relative path of the guidance/doc surface the claim was added to. */
+  file: string;
+  /** The added line, trimmed and capped (see MAX_CLAIM_CHARS). */
+  claimText: string;
+  /** Which claim shape matched — most-specific-first (see CLAIM_SHAPES). */
+  shape: DocClaimShape;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cap the worklist so the prompt stays compact (protects the input budget). */
+const MAX_CLAIMS = 20;
+/** Per-claim character cap — a claim line is a pointer, not the whole hunk. */
+const MAX_CLAIM_CHARS = 200;
+
+const HUNK_META_RE = /^(?:\+\+\+|---)/;
+/** A fenced code block opener/closer — claims are prose, not code samples. */
+const FENCE_RE = /^(?:```|~~~)/;
+
+/**
+ * Claim-shaped prose matchers, most-specific first (first match wins the
+ * shape label; one claim per line). Deliberately tight to keep the worklist
+ * high-signal on doc-heavy PRs:
+ *  - `mechanism`   — the classic doc-truth case: a search/discovery mechanism
+ *    named as meaning-based/semantic/lexical/keyword/embedding/BM25/full-text.
+ *    Requires a nearby search-domain word so "lexical scope" prose elsewhere
+ *    doesn't match.
+ *  - `state`       — "reports as disabled", "X disabled/enabled/required when Y"
+ *    (doc-truth's own state-claim keywords).
+ *  - `default`     — "defaults to N", "by default", "default: true".
+ *  - `scope-gate`  — an existence/index-presence gate paired with a
+ *    fallback/otherwise/standalone consequence (pr667's "has an index
+ *    (`structural.db` exists) … we fall back to standalone").
+ *  - `scope-unchanged` — "X are/is/remain(s) … unchanged" or "otherwise
+ *    unchanged" (pr711's "public error exports are otherwise unchanged"). The
+ *    linking verb keeps it off bare status-word fragments.
+ *  - `requirement` — "requires"/"required" (pr716's "no compiler or build
+ *    toolchain required").
+ *  - `negation`    — a software-subject behavioral negation "(does|do|is|are|
+ *    it|they|which|that) not <verb>" (pr687's "do not crash"). Bare modal
+ *    "never/must/cannot" is intentionally NOT a trigger — in these docs it is
+ *    almost always a developer imperative ("never run npm install", "must echo
+ *    back"), not a falsifiable claim about the code the diff touches.
+ */
+const CLAIM_SHAPES: ReadonlyArray<{ shape: DocClaimShape; re: RegExp; near?: RegExp }> = [
+  {
+    shape: 'mechanism',
+    re: /\b(?:meaning-based|semantic(?:ally)?|lexical|keyword-based|embedding-based|bm25|full-text|substring)\b/i,
+    near: /\b(?:search|match(?:ing)?|similar|discover|rank(?:ing|ed)?|index|quer|token)/i,
+  },
+  { shape: 'state', re: /\breports?\s+as\s+(?:disabled|enabled|inactive|active|unavailable)\b/i },
+  {
+    shape: 'state',
+    re: /\b(?:disabled|enabled|inactive|inert|no-?op|ignored|unavailable|read-only|optional|required|active)\s+(?:when|unless|if|without)\b/i,
+  },
+  { shape: 'default', re: /\bdefaults?\s+(?:to|:)|\bby default\b|default:\s*(?:true|false|\d)/i },
+  {
+    shape: 'scope-gate',
+    re: /\b(?:exists?|has (?:an?|no) index|is present|is absent|is missing|no longer exists?)\b/i,
+    near: /\b(?:fall(?:s)? back|fallback|otherwise|unless|only if|standalone|if (?:either|the|it|not))\b/i,
+  },
+  {
+    shape: 'scope-unchanged',
+    re: /\b(?:are|is|remains?|stays?)\s+(?:\w+\s+){0,3}unchanged\b|\botherwise\s+unchanged\b/i,
+  },
+  { shape: 'requirement', re: /\brequires?\b|\brequired\b/i },
+  { shape: 'negation', re: /\b(?:does|do|is|are|it|they|which|that)\s+not\s+\w+/i },
+];
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/** Return the first matching claim shape for a prose line, or null. */
+function classifyClaim(text: string): { shape: DocClaimShape; matchIndex: number } | null {
+  for (const { shape, re, near } of CLAIM_SHAPES) {
+    const m = re.exec(text);
+    if (m && (!near || near.test(text))) return { shape, matchIndex: m.index };
+  }
+  return null;
+}
+
+/**
+ * Trim and cap a claim line. When the line exceeds the cap, the excerpt is
+ * CENTERED on the matched claim phrase rather than taken from the line's head —
+ * a long markdown line (e.g. a one-line blockquote Note) can carry its
+ * falsifiable phrase hundreds of chars in, and a head-truncated pointer would
+ * cut off exactly the words the reviewer must verify.
+ */
+function toClaimText(line: string, matchIndex: number): string {
+  const t = line.trim();
+  if (t.length <= MAX_CLAIM_CHARS) return t;
+  const offset = Math.max(0, matchIndex - (line.length - line.trimStart().length));
+  const start = Math.min(
+    Math.max(0, offset - Math.floor(MAX_CLAIM_CHARS / 2)),
+    t.length - MAX_CLAIM_CHARS,
+  );
+  const excerpt = t.slice(start, start + MAX_CLAIM_CHARS);
+  return `${start > 0 ? '…' : ''}${excerpt}${start + MAX_CLAIM_CHARS < t.length ? '…' : ''}`;
+}
+
+/** One line of a patch's NEW-file view (context + added), stripped of prefix. */
+interface NewFileLine {
+  text: string;
+  isAdded: boolean;
+}
+
+/**
+ * The NEW-file view of a patch: context and added lines in order, prefix
+ * stripped and tagged with `isAdded`. Removed (`-`) lines don't exist in the
+ * new file, so they're dropped — which is also why fence state (tracked by the
+ * caller over this view) stays correct.
+ */
+function newFileLines(patch: string): NewFileLine[] {
+  const out: NewFileLine[] = [];
+  for (const raw of patch.split('\n')) {
+    if (HUNK_META_RE.test(raw)) continue;
+    if (raw.startsWith('+')) out.push({ text: raw.slice(1), isAdded: true });
+    else if (raw.startsWith(' ') || raw === '')
+      out.push({ text: raw === '' ? '' : raw.slice(1), isAdded: false });
+  }
+  return out;
+}
+
+/**
+ * The candidate-claim prose lines of one file's patch: ADDED lines that are
+ * outside fenced code blocks, non-blank, and not Markdown table rows. A
+ * ` ```sql ` block's contents are skipped — a doc's code SAMPLES are not
+ * claims; blank lines and table rows (`|`) are tabular layout, not prose.
+ */
+function addedProseLines(patch: string): string[] {
+  const out: string[] = [];
+  let inFence = false;
+
+  for (const { text, isAdded } of newFileLines(patch)) {
+    if (FENCE_RE.test(text.trim())) {
+      inFence = !inFence;
+      continue;
+    }
+    if (!isAdded || inFence) continue;
+
+    const t = text.trim();
+    if (t && !t.startsWith('|')) out.push(t);
+  }
+
+  return out;
+}
+
+/**
+ * Reduce a markdown link to its display text. Link TARGETS are not prose: a
+ * slug like `0011-…-fts5-lexical-search.md` contains claim-shaped words
+ * ("lexical", "search") that false-classify the line and steal the excerpt
+ * center from the real claim later in the sentence (observed on PR #687's
+ * one-line Note, where the ADR-011 link out-matched "do not crash").
+ */
+function stripLinkTargets(text: string): string {
+  return text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+}
+
+/** Extract classified claim lines from one file's patch. */
+function extractClaimsFromPatch(file: string, patch: string): DocClaim[] {
+  const claims: DocClaim[] = [];
+  for (const raw of addedProseLines(patch)) {
+    const text = stripLinkTargets(raw);
+    const match = classifyClaim(text);
+    if (match)
+      claims.push({ file, claimText: toClaimText(text, match.matchIndex), shape: match.shape });
+  }
+  return claims;
+}
+
+/**
+ * Collect claim-shaped lines from every changed guidance/doc surface, smallest
+ * hunk first (reusing `collectGuidanceSurfaceChanges`' ordering so a voluminous
+ * doc can't crowd a small changeset's claims out of the cap downstream).
+ * Identical claim lines are deduped. Returns ALL claims (uncapped); the render
+ * layer caps and notes any overflow. Exposed for testing.
+ */
+export function extractDocClaims(patches: Map<string, string>): DocClaim[] {
+  const claims: DocClaim[] = [];
+  const seen = new Set<string>();
+
+  for (const { file, patch } of collectGuidanceSurfaceChanges(patches)) {
+    for (const claim of extractClaimsFromPatch(file, patch)) {
+      if (seen.has(claim.claimText)) continue;
+      seen.add(claim.claimText);
+      claims.push(claim);
+    }
+  }
+
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const DOC_CLAIMS_HEADER =
+  'Pre-computed: behavioral/structural claims this PR added to its touched ' +
+  'guidance/doc surfaces (ADRs, site guides, changesets, CLAUDE.md, hooks). ' +
+  'This is the doc-truth discovery step done for you — do NOT skip it; it is ' +
+  'your primary claim inventory. The scan can miss claims and can list prose ' +
+  'that is merely descriptive, so also skim the touched hunks for any not here. ' +
+  'For EACH entry: locate the code it describes using material already in your ' +
+  'prompt (the diff hunks, <changed_functions>, and get_files_context on the ' +
+  'described symbols — it reads indexed chunks, so it works even when ' +
+  'grep_codebase/read_file are blind). Then: if the code CONFIRMS the claim, ' +
+  'stay silent on it; if the code CONTRADICTS it — or the diff changed the ' +
+  'behavior and left the prose describing the OLD behavior — emit a doc-truth ' +
+  'finding that QUOTES the claim and cites the falsifying code fact; if the ' +
+  'entry is a genuine behavioral claim you cannot locate the code for, report ' +
+  'it as a warning "unverifiable behavioral claim in touched prose". An entry ' +
+  'that is plainly descriptive prose (not a falsifiable claim about this code) ' +
+  'needs no finding — do NOT report wording/style nits or manufacture a ' +
+  'contradiction the code does not support.';
+
+/**
+ * Render the doc-claims worklist as a `<doc_claims>` block for the agent's
+ * initial message. Returns '' when there are no claims so callers can append
+ * unconditionally. Caps at MAX_CLAIMS with an explicit omission note (never a
+ * silent drop).
+ */
+export function renderDocClaims(claims: DocClaim[]): string {
+  if (claims.length === 0) return '';
+
+  const lines: string[] = ['<doc_claims>', DOC_CLAIMS_HEADER];
+  for (const c of claims.slice(0, MAX_CLAIMS)) {
+    lines.push(`- ${c.file}: "${c.claimText}"`);
+  }
+  if (claims.length > MAX_CLAIMS) {
+    lines.push(
+      `- [+${claims.length - MAX_CLAIMS} more claim(s) omitted to respect the input budget — skim the touched doc hunks for any not listed]`,
+    );
+  }
+  lines.push('</doc_claims>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<doc_claims>` section from the review context. Returns '' when
+ * there is no diff or no changed guidance/doc surface with a claim-shaped line.
+ */
+export function renderDocClaimsSection(context: ReviewContext): string {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return '';
+  return renderDocClaims(extractDocClaims(patches));
+}

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -704,8 +704,14 @@ prose describing the OLD behavior):
 
 MANDATORY protocol when this rule is active:
 
-1. List every claim-bearing line the diff touched (from \`<diff>\` and from
-   \`<guidance_surface_changes>\`). If there are none, the rule has nothing
+1. **Check for a \`<doc_claims>\` block in your initial message FIRST.** Lien
+   pre-computes it by deterministically scanning the ADDED lines of the
+   touched guidance/doc surfaces for claim-shaped prose — the inventory step
+   is done for you, so treat every entry as a MANDATORY worklist item, not an
+   optional one. The scan can miss claims and can list merely-descriptive
+   prose, so also skim the touched \`<diff>\` and \`<guidance_surface_changes>\`
+   hunks for any claim-bearing line not listed. If there is no \`<doc_claims>\`
+   block AND no claim-bearing line in the touched prose, the rule has nothing
    to do — that is the only clean way to finish with zero findings.
 2. For EACH claim, locate the code it describes using material ALREADY in
    your prompt: the diff hunks, \`<changed_functions>\`, and — for symbols in

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -19,6 +19,7 @@ import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
+import { renderDocClaimsSection } from '../../doc-claims-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -196,6 +197,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderUntrustedInputSection(context));
   appendIfPresent(sections, renderRenameSweepSection(context));
   appendIfPresent(sections, renderGuidanceSurfaceSection(context));
+  appendIfPresent(sections, renderDocClaimsSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  extractDocClaims,
+  renderDocClaims,
+  renderDocClaimsSection,
+  type DocClaim,
+} from '../src/doc-claims-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+function ctxWithPatches(patches?: Map<string, string>): ReviewContext {
+  return {
+    pr: patches ? { patches } : undefined,
+    changedFiles: patches ? [...patches.keys()] : [],
+    chunks: [],
+  } as unknown as ReviewContext;
+}
+
+/** Build a one-hunk patch adding the given lines to a file. */
+function added(...lines: string[]): string {
+  const body = lines.map(l => `+${l}`).join('\n');
+  return `@@ -1,1 +1,${lines.length + 1} @@\n # context\n${body}`;
+}
+
+// A guidance/doc surface (matches isGuidanceSurface) for each shape.
+const DOC = 'docs/architecture/thing.md';
+
+// ---------------------------------------------------------------------------
+// extractDocClaims — per shape
+// ---------------------------------------------------------------------------
+
+describe('extractDocClaims — claim shapes', () => {
+  function shapeOf(line: string, file = DOC): DocClaim | undefined {
+    return extractDocClaims(new Map([[file, added(line)]]))[0];
+  }
+
+  it('mechanism: a search mechanism named lexical/semantic', () => {
+    const c = shapeOf(
+      '`search_code` is now lexical BM25 keyword search, not meaning-based matching.',
+    );
+    expect(c).toMatchObject({ file: DOC, shape: 'mechanism' });
+  });
+
+  it('mechanism requires a nearby search-domain word (no bare "lexical")', () => {
+    // "lexical scope" is a language concept, not a search-mechanism claim.
+    expect(shapeOf('Variables follow lexical scope inside the closure.')).toBeUndefined();
+  });
+
+  it('state: "reports as disabled"', () => {
+    expect(shapeOf('When the index is empty, search reports as disabled.')?.shape).toBe('state');
+  });
+
+  it('state: "disabled when …"', () => {
+    expect(shapeOf('The feature is disabled when embeddings are absent.')?.shape).toBe('state');
+  });
+
+  it('default: "defaults to N"', () => {
+    expect(shapeOf('The chunk batch size defaults to 32.')?.shape).toBe('default');
+  });
+
+  it('scope-gate: existence gate paired with a fallback consequence (pr667 shape)', () => {
+    const c = shapeOf(
+      'It has an index (`structural.db` exists). If either fails we fall back to standalone.',
+    );
+    expect(c?.shape).toBe('scope-gate');
+  });
+
+  it('scope-unchanged: "are otherwise unchanged" (pr711 shape)', () => {
+    expect(
+      shapeOf('LienErrorCode and the public error exports are otherwise unchanged.')?.shape,
+    ).toBe('scope-unchanged');
+  });
+
+  it('scope-unchanged does NOT match a bare status-word fragment', () => {
+    // "unchanged" as a lone descriptor (no linking verb) is not a scope claim.
+    expect(shapeOf('An unchanged file resolves from the base.')).toBeUndefined();
+  });
+
+  it('requirement: "… required" (pr716 shape)', () => {
+    expect(shapeOf('No compiler or build toolchain required on supported platforms.')?.shape).toBe(
+      'requirement',
+    );
+  });
+
+  it('negation: a software-subject "do not <verb>" (pr687 shape)', () => {
+    expect(
+      shapeOf('Configs that name a retired backend do not crash: Lien warns once.')?.shape,
+    ).toBe('negation');
+  });
+
+  it('does NOT trigger on a bare developer imperative ("never run …")', () => {
+    // Bare modal imperatives are guidance to humans, not falsifiable code claims.
+    expect(shapeOf('Never run a plain `npm install` in the worktree.')).toBeUndefined();
+  });
+
+  it('does NOT trigger on plain descriptive prose', () => {
+    expect(shapeOf('This section explains the overall design of the overlay.')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDocClaims — surface scoping, fences, tables, removed lines
+// ---------------------------------------------------------------------------
+
+describe('extractDocClaims — scoping and filtering', () => {
+  it('only scans guidance/doc surfaces, not analyzable source', () => {
+    const patch = added('The parser is disabled when the flag is off.');
+    // Same claim line in a .ts source file must NOT be extracted here.
+    expect(extractDocClaims(new Map([['packages/core/src/thing.ts', patch]]))).toHaveLength(0);
+    // But in a doc surface it is.
+    expect(extractDocClaims(new Map([[DOC, patch]]))).toHaveLength(1);
+  });
+
+  it('skips claim-shaped lines inside fenced code blocks', () => {
+    const patch =
+      '@@ -1,1 +1,4 @@\n' +
+      ' # Doc\n' +
+      '+```ts\n' +
+      '+const cfg = load(); // defaults to 32, required, disabled when empty\n' +
+      '+```';
+    expect(extractDocClaims(new Map([[DOC, patch]]))).toHaveLength(0);
+  });
+
+  it('skips Markdown table rows', () => {
+    const patch = added('| disabled when empty | yes |');
+    expect(extractDocClaims(new Map([[DOC, patch]]))).toHaveLength(0);
+  });
+
+  it('ignores claim-shaped removed ("-") lines — only added prose counts', () => {
+    const patch =
+      '@@ -1,2 +1,1 @@\n' +
+      '-The feature is disabled when embeddings are absent.\n' +
+      '+The feature runs.';
+    expect(extractDocClaims(new Map([[DOC, patch]]))).toHaveLength(0);
+  });
+
+  it('dedupes identical claim lines across files', () => {
+    const line = 'The batch size defaults to 32.';
+    const claims = extractDocClaims(
+      new Map([
+        [DOC, added(line)],
+        ['.changeset/x.md', added(line)],
+      ]),
+    );
+    expect(claims).toHaveLength(1);
+  });
+
+  it('caps a claim line at ~200 chars with an ellipsis', () => {
+    const long = `The batch size defaults to 32 ${'x'.repeat(400)}`;
+    const c = extractDocClaims(new Map([[DOC, added(long)]]))[0];
+    expect(c.claimText.length).toBeLessThanOrEqual(202);
+    expect(c.claimText.endsWith('…')).toBe(true);
+  });
+
+  it('ignores claim-shaped words inside markdown link targets', () => {
+    // PR #687's Note: the ADR link slug contains "lexical-search", which
+    // false-classified the line as `mechanism` and stole the excerpt center
+    // from the real claim ("do not crash") later in the sentence.
+    const note = `> **Note:** backend removed (see [ADR-011](decisions/0011-sqlite-structural-store-fts5-lexical-search.md)). ${'y'.repeat(200)} configs that name a retired backend do not crash: Lien warns once.`;
+    const c = extractDocClaims(new Map([[DOC, added(note)]]))[0];
+    expect(c.shape).toBe('negation');
+    expect(c.claimText).toContain('do not crash');
+  });
+
+  it('centers a capped excerpt on the matched phrase, not the line head', () => {
+    // The PR #687 shape: a one-line blockquote Note whose falsifiable phrase
+    // ("do not crash") sits hundreds of chars in. Head-truncation would cut
+    // exactly the words the reviewer must verify.
+    const long = `> **Note:** ${'y'.repeat(300)} existing configs that name a retired backend do not crash: Lien warns once ${'z'.repeat(100)}`;
+    const c = extractDocClaims(new Map([[DOC, added(long)]]))[0];
+    expect(c.claimText).toContain('do not crash');
+    expect(c.claimText.startsWith('…')).toBe(true);
+    expect(c.claimText.length).toBeLessThanOrEqual(202);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderDocClaims
+// ---------------------------------------------------------------------------
+
+describe('renderDocClaims', () => {
+  it('returns "" for no claims', () => {
+    expect(renderDocClaims([])).toBe('');
+  });
+
+  it('renders a <doc_claims> block naming doc-truth and listing file: "claim"', () => {
+    const md = renderDocClaims([
+      { file: DOC, claimText: 'search reports as disabled', shape: 'state' },
+    ]);
+    expect(md).toContain('<doc_claims>');
+    expect(md).toContain('</doc_claims>');
+    expect(md).toContain('doc-truth');
+    expect(md).toContain(`- ${DOC}: "search reports as disabled"`);
+  });
+
+  it('caps at 20 entries and notes the overflow rather than dropping silently', () => {
+    const many: DocClaim[] = Array.from({ length: 25 }, (_, i) => ({
+      file: DOC,
+      claimText: `claim number ${i}`,
+      shape: 'requirement' as const,
+    }));
+    const md = renderDocClaims(many);
+    expect(md).toContain('[+5 more claim(s) omitted');
+    // 20 rendered claim lines + the overflow note
+    expect(md.match(/^- docs\//gm)).toHaveLength(20);
+  });
+});
+
+describe('renderDocClaimsSection', () => {
+  it('returns "" when there is no diff', () => {
+    expect(renderDocClaimsSection(ctxWithPatches())).toBe('');
+  });
+
+  it('renders the block from context patches', () => {
+    const section = renderDocClaimsSection(
+      ctxWithPatches(new Map([[DOC, added('The batch size defaults to 32.')]])),
+    );
+    expect(section).toContain('<doc_claims>');
+    expect(section).toContain('The batch size defaults to 32.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage doc-claims injection', () => {
+  it('includes the <doc_claims> block when a guidance surface has a claim', () => {
+    const ctx = ctxWithPatches(new Map([[DOC, added('The batch size defaults to 32.')]]));
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).toContain('<doc_claims>');
+    expect(message).toContain('The batch size defaults to 32.');
+  });
+
+  it('omits the block when no guidance surface carries a claim', () => {
+    const ctx = ctxWithPatches(
+      new Map([['packages/core/src/thing.ts', added('const y = x + 1;')]]),
+    );
+    const message = buildInitialMessage(ctx, { blastRadius: null });
+    expect(message).not.toContain('<doc_claims>');
+  });
+});

--- a/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
@@ -57,15 +57,18 @@
  * reviewer following step 2 rather than pattern-matching the prose. That is by
  * design for the canary — it tests protocol-following, not prose-matching.
  *
- * Calibration status: 0/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
- * --calibrate 10, surface-widening branch). NOT a prompt-assembly failure —
- * traces show doc-truth active and the claim rendered; the model spends its
- * budget on the PR's real code bugs (buildOverlay mask-clear race,
- * chunksCreated:0, manifest JSON.parse) and never engages the doc claim.
- * Attention competition on a bug-rich PR. Canary tag REMOVED until the
- * planned deterministic <doc_claims> worklist signal (the stale-literal /
- * untrusted-input pattern, #614/#616) makes claim-checking non-optional;
- * this fixture is the acceptance test for that phase-2 work.
+ * Calibration status (2026-07-11, kimi-k2.7-code, --calibrate 10):
+ * - 0/10 pre-signal (surface-widening branch). Not prompt assembly — traces
+ *   showed doc-truth active and the claim rendered; the model spent its
+ *   budget on the PR's real code bugs (buildOverlay mask-clear race,
+ *   chunksCreated:0, manifest JSON.parse) and never engaged the doc claim.
+ * - 2/10 with the <doc_claims> worklist. The signal verifiably engages:
+ *   passing votes emit doc-truth findings verifying OTHER worklist entries
+ *   (a JSDoc logger claim, a version-stamp claim) — but with 11 entries on a
+ *   bug-rich PR the model samples a few claims and rarely reaches this one.
+ *   Remaining gap is per-claim verification COST, not discovery: fixing it
+ *   needs claim->code evidence pre-fetch (#729 stays open for that design).
+ * No canary tag until this fixture clears the bar.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
@@ -6,12 +6,13 @@
  * Note in docs/architecture/config-system.md — introducing a doc-vs-doc
  * inconsistency between the two, both in the same diff.
  *
- * Calibration status: 1/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
- * --calibrate 10, after the smallest-first budget fix put the claim in the
- * prompt). Omission-shaped claims (the Note doesn't say embeddings keys
- * crash, it just doesn't mention them) are the weakest doc-truth shape for
- * an initiative-driven check. Acceptance fixture for the phase-2
- * <doc_claims> deterministic signal, not a canary.
+ * Calibration status (2026-07-11, kimi-k2.7-code, --calibrate 10): 1/10
+ * pre-signal, 1/10 with the <doc_claims> worklist. Omission-shaped claims
+ * (the Note doesn't FALSELY state anything — it omits keys ADR-011 covers)
+ * are the weakest doc-truth shape: verifying an omission means comparing
+ * the claim against a DIFFERENT doc's enumeration, which the worklist
+ * doesn't link. Needs claim->code/claim->doc evidence pre-fetch (#729).
+ * Characterization fixture, not a canary.
  *
  * THE PLANTED CLAIM (touched prose, docs/architecture/config-system.md — the
  * "> **Note:**" that config-system.md links to ADR-011 from):
@@ -44,32 +45,19 @@
  *     packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.fixture.json \
  *     --sha a26e480bd06f6503d0d1e0f0341c37c7173e8815
  *
- * STRUCTURAL BLOCKER for real-Kimi calibration — VERIFIED via build-prompts.ts
- * on this fixture (2026-07-11), do NOT paper over: BOTH sides of the
- * contradiction are truncated out of the rendered prompt. This PR touches 22
- * files; the `.claude/skills/*` and `.cursor/rules/project.mdc` hunks sort
- * first and exhaust the char budgets of BOTH blocks — the <diff> block
- * truncates after `.cursor/rules/project.mdc` ("[Diff truncated — use read_file
- * …]") and <guidance_surface_changes> stops after
- * docs/architecture/claude-code-hook-channels.md. config-system.md's retired-key
- * Note never appears (grep for "Existing configs that name a retired backend"
- * in the prompt: 0 hits), and ADR-011's "embeddings.* / core.embeddingBatchSize
- * keys still load" line never appears (grep "embeddingBatchSize" / "still load":
- * 0 hits). An honest reviewer therefore has NO in-prompt signal that a
- * retired-key list even exists to cross-check, so the protocol-following verdict
- * is EMPTY and this fixture is effectively unfireable in replay as captured —
- * confirmed by assert-cli: an empty verdict fails Tier 1 here.
- *
- * The assertion below is nonetheless correct and well-formed (a hand-authored
- * "correct finding" verdict passes assert-cli exit 0), so the block is the
- * PROMPT-ASSEMBLY / capture, not the keywords. To make this fixture reachable,
- * fix upstream — e.g. have the guidance-surface passthrough prioritize
- * claim-bearing doc hunks (config-system.md, ADRs) over voluminous
- * `.claude/skills/*` prose, or re-capture a smaller/more-focused PR — rather
- * than loosening these assertions. Independent of that, this is also the
- * weakest contradiction on the merits: the Note doesn't claim embeddings keys
- * crash, it just omits them, so even fully in-prompt a strict reviewer might
- * read it as "accurate as far as it goes". Deliberately NOT tagged canary.
+ * Structural history: as first captured, BOTH sides of the contradiction were
+ * truncated out of the rendered prompt (22-file PR; `.claude/skills/*` prose
+ * exhausted the block budgets first). The smallest-hunk-first budget reorder
+ * (#727) fixed that — the retired-key Note now renders in
+ * <guidance_surface_changes> and its claim line appears in <doc_claims>
+ * (verified via build-prompts.ts post-fix). What remains unreachable is
+ * ADR-011's fuller enumeration (large hunk, still truncated), which is one
+ * half of the omission comparison — hence the evidence-pre-fetch need above.
+ * The assertion itself is well-formed (a hand-authored correct-finding verdict
+ * passes assert-cli exit 0). Also the weakest contradiction on the merits: the
+ * Note doesn't claim embeddings keys crash, it just omits them, so even fully
+ * in-prompt a strict reviewer might read it as "accurate as far as it goes".
+ * Deliberately NOT tagged canary.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
@@ -5,12 +5,14 @@
  * and the code it describes are in the same diff, so the claim is verifiable
  * from in-prompt material alone.
  *
- * Calibration status: 0/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
- * --calibrate 10). Traces show the model DOES investigate (greps remaining
- * EmbeddingError references, checks dependents in every vote) and then
- * declines to report — a defensible read, since the changeset's first
- * sentence discloses the removal and "otherwise" can honestly scope it out.
- * Ambiguous-on-merits; kept as a characterization fixture, not a canary.
+ * Calibration status (2026-07-11, kimi-k2.7-code, --calibrate 10): 0/10
+ * pre-signal AND 0/10 with the <doc_claims> worklist. In both runs traces
+ * show the model engages the claim in EVERY vote (investigates remaining
+ * EmbeddingError references, checks dependents, discusses "otherwise
+ * unchanged") and then deliberately declines — the changeset's first
+ * sentence discloses the removal, so "otherwise" has an honest lenient
+ * reading. A consistent judgment call, not a discovery failure; no signal
+ * fixes judgment. Characterization fixture, not a canary.
  *
  * THE PLANTED CLAIM (touched prose, .changeset/remove-embedding-error.md):
  *   "Removed the unused embeddings-era `EmbeddingError` class and its

--- a/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
@@ -59,9 +59,10 @@
  *      packages had shipped (the PR summary calls prebuilt binaries "now the
  *      selling point"), so a rigorous reviewer could correctly conclude the doc
  *      is accurate for published installs and NOT fire — a legitimate no-fire.
- * Calibration status: 2/10 on `moonshotai/kimi-k2.7-code` (2026-07-11,
- * --calibrate 10) — as predicted below. Acceptance fixture for the phase-2
- * <doc_claims> deterministic signal.
+ * Calibration status (2026-07-11, kimi-k2.7-code, --calibrate 10): 2/10
+ * pre-signal, 0/10 with the <doc_claims> worklist (within noise of each
+ * other) — as predicted below: the contradiction is partial and possibly
+ * correctly-declined at this SHA. Characterization fixture.
  *
  * Net: expect this to calibrate LOW on Kimi, possibly correctly-low. It is the
  * second-shakiest fixture (after pr687's truncation block) and is deliberately


### PR DESCRIPTION
## Summary

Implements the worklist half of #729 (**partial — do not auto-close**; the first commit's message says "Closes #729", strip that line when squash-merging): a zero-LLM regex pass over the ADDED lines of touched guidance/doc surfaces extracts claim-shaped prose (mechanism, state, default, scope-gate, scope-unchanged, requirement, software-subject negation) and injects it as a `<doc_claims>` block — the stale-literal/untrusted-input pattern applied to doc-truth's discovery step. doc-truth's protocol step 1 now names the block as the primary claim inventory.

Extraction details that mattered: fenced code blocks, table rows, and **markdown link targets** are skipped (an ADR slug like `fts5-lexical-search.md` false-classified PR #687's Note and stole the excerpt from its real claim); long lines excerpt **centered on the matched phrase** so the falsifiable words survive the 200-char cap; capped at 20 entries with an explicit omission note. 27 unit tests.

## Calibration (single-rule bar, kimi-k2.7-code, calibrate-10 each — PASSED)

| Certified fixture | pre-signal | with signal |
|---|---|---|
| pr658-search-code-rename | 9/10 | **10/10** ⬆ |
| accurate-doc (precision) | 10/10 | **10/10** — the worklist adds zero FP pressure |
| renamed-stale-claim | 10/10 | **10/10** |

## Honest negative result: the worklist alone doesn't fix the seed fixtures

| Seed fixture | pre-signal | with signal | trace-verified mechanics |
|---|---|---|---|
| pr667-worktree-doc-drift | 0/10 | 2/10 | worklist **engages** — passing votes emit doc-truth findings verifying *other* entries — but 11 entries on a bug-rich PR = partial coverage; the planted claim is rarely reached |
| pr711-changeset-export-claim | 0/10 | 0/10 | model engages the claim in **every** vote, then deliberately declines (disclosed removal, honest lenient reading) — judgment, not discovery |
| pr716-install-claim | 2/10 | 0/10 | partial contradiction, possibly correctly declined at this SHA |
| pr687-config-doc-drift | 1/10 | 1/10 | omission shape needs a claim→doc comparison the worklist doesn't provide |

**Why the precedent didn't transfer:** `<stale_literal_candidates>` pre-computes the *answer* (changed literal + surviving line — the model just confirms). `<doc_claims>` pre-computes only the *question*; per-claim verification is still O(n) tool investigations, which doesn't fit the budget on doc-heavy PRs. The remaining design (tracked in #729) is **claim→code evidence pre-fetch**: link each claim to the chunks it describes and inject the evidence, collapsing verification to a comparison.

## Why ship it anyway
Strictly additive on certified behavior (table 1 — one fixture improved, precision intact), and the trace evidence shows real doc-truth findings emerging from worklist entries that would previously never be checked. Seed fixtures remain characterization fixtures with documented per-fixture rates and mechanics in their headers.

## Gates
format / lint (0 errors) / typecheck / build / full npm test (156 files) / lien delta exit 0. Calibration spend ~$3.10 reported this branch.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic `<doc_claims>` worklist signal for the doc-truth rule: a new zero-LLM regex pass over added lines in guidance/doc surfaces extracts claim-shaped prose and injects it into the agent's initial message, mirroring the existing stale-literal and untrusted-input signal patterns. The change is strictly additive — it widens the review input without altering existing analysis behavior — and is well-covered by 27 new unit tests. The wiring into `buildInitialMessage` is conditional (returns empty when no claims exist), so prompts only grow when there is actual doc-surface content to surface.
>
> - New `doc-claims-signals.ts` module extracts claim-shaped prose (mechanism, state, default, scope-gate, scope-unchanged, requirement, negation) from added lines of guidance/doc surfaces, skipping fences, tables, removed lines, and markdown link targets.
> - `<doc_claims>` block is appended to the agent initial message via `buildInitialMessage`, capped at 20 entries with an explicit overflow note.
> - doc-truth rule protocol updated to treat `<doc_claims>` as the primary claim inventory.
> - Fixture assertion comments updated with honest pre/post calibration rates.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit f6092e0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic extraction of factual claims from documentation changes.
  * Added claim classification, duplicate removal, and concise excerpts for easier review.
  * Added a `<doc_claims>` worklist to review prompts, including overflow notices for large lists.
  * The review workflow now prioritizes this worklist when checking documentation accuracy.

* **Tests**
  * Added coverage for claim detection, filtering, formatting, deduplication, and prompt integration.
  * Updated documentation-truth calibration fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->