### PR TITLE
feat(review): claim->code evidence pre-fetch for <doc_claims> (flat on acceptance targets — hold)

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -380,9 +380,10 @@ const TEST_FILE_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/)/;
  * Evidence-source ranking. A claim describes code the PR touched, so a changed
  * code file is the strongest locate; a changed sibling DOC is next (the
  * omission-claim case, e.g. an ADR's fuller enumeration); then any code, then
- * any doc; tests are last (a fixture rarely IS the described behavior). An
- * exact symbolName match beats every content match — that chunk is literally
- * the named symbol.
+ * any doc. Among NON-TEST files, an exact symbolName match beats every content
+ * match — that chunk is literally the named symbol. Test files always rank
+ * last, even on a symbolName match: a same-named helper in a test fixture is a
+ * collision, not the described behavior (see tierOf's early return).
  */
 const enum EvidenceTier {
   Test = 0,

--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -24,6 +24,7 @@
  * the block never manufactures a contradiction the code doesn't support.
  */
 
+import type { CodeChunk } from '@liendev/parser';
 import type { ReviewContext } from './plugin-types.js';
 import { collectGuidanceSurfaceChanges } from './guidance-surface-signals.js';
 
@@ -45,6 +46,30 @@ export type DocClaimShape =
   | 'requirement'
   | 'negation';
 
+/**
+ * A code (or sibling-doc) excerpt located deterministically for a claim: the
+ * material the reviewer must COMPARE the claim against. Turns verification from
+ * an O(n) tool investigation into a single comparison, mirroring how
+ * `<stale_literal_candidates>` pre-computes the surviving line.
+ */
+export interface DocClaimEvidence {
+  /** Repo-relative path of the chunk the evidence was taken from. */
+  file: string;
+  /** New-file line number of the first excerpt line. */
+  startLine: number;
+  /** The relevant lines of the located chunk (windowed + capped). */
+  excerpt: string;
+  /** The anchor token that located this evidence (used to center the excerpt). */
+  anchor: string;
+  /**
+   * True when the evidence is a sibling DOC/guidance file rather than code —
+   * the acceptable evidence shape for omission claims (e.g. a claim's
+   * enumeration compared against an ADR's fuller list), flagged so the agent
+   * weighs it as prose-vs-prose, not prose-vs-code.
+   */
+  fromDoc: boolean;
+}
+
 /** A claim-shaped line the diff added to a guidance/doc surface. */
 export interface DocClaim {
   /** Repo-relative path of the guidance/doc surface the claim was added to. */
@@ -53,6 +78,13 @@ export interface DocClaim {
   claimText: string;
   /** Which claim shape matched — most-specific-first (see CLAIM_SHAPES). */
   shape: DocClaimShape;
+  /**
+   * The code/sibling-doc the claim describes, located deterministically over
+   * the indexed repo. Absent when no anchor in the claim resolves to a chunk
+   * (or when there is no repo index to search) — the render layer then falls
+   * back to the investigate-it-yourself instruction.
+   */
+  evidence?: DocClaimEvidence;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +95,17 @@ export interface DocClaim {
 const MAX_CLAIMS = 20;
 /** Per-claim character cap — a claim line is a pointer, not the whole hunk. */
 const MAX_CLAIM_CHARS = 200;
+/** Per-claim evidence excerpt cap — enough to carry the described code, not a hunk. */
+const MAX_EVIDENCE_CHARS = 400;
+/** Lines of context above / below the anchor line in an evidence excerpt (~6-line window). */
+const EVIDENCE_LINES_BEFORE = 2;
+const EVIDENCE_LINES_AFTER = 3;
+/**
+ * Total budget for the whole `<doc_claims>` block. Evidence excerpts are
+ * dropped (with an inline note) before any claim is dropped, so the worklist
+ * itself always survives even on a doc-heavy PR.
+ */
+const MAX_DOC_CLAIMS_CHARS = 8_000;
 
 const HUNK_META_RE = /^(?:\+\+\+|---)/;
 /** A fenced code block opener/closer — claims are prose, not code samples. */
@@ -243,6 +286,309 @@ export function extractDocClaims(patches: Map<string, string>): DocClaim[] {
 }
 
 // ---------------------------------------------------------------------------
+// Anchor extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * A dotted / starred config-or-file key: `structural.db`, `embeddings.*`,
+ * `core.embeddingBatchSize`, `qdrant.*`. The most specific anchor shape —
+ * these tokens are rare enough that a content match is almost always the
+ * described key.
+ */
+const DOTTED_KEY_RE = /\b[A-Za-z_$][\w$-]*(?:\.[\w$*-]+)+/g;
+/** A camelCase / PascalCase identifier: `resolveIndexStrategy`, `OverlayBackend`, `LienErrorCode`. */
+const CAMEL_ID_RE = /\b[A-Za-z][a-z0-9]*(?:[A-Z][a-z0-9]*)+\b/g;
+/** A snake / SCREAMING_SNAKE identifier: `search_code`, `LIEN_WORKTREE_STANDALONE`. */
+const SNAKE_ID_RE = /\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b/g;
+/** Backtick-quoted spans — high-confidence code tokens even when a bare word. */
+const BACKTICK_SPAN_RE = /`([^`]+)`/g;
+/** Plain word tokens (letters/digits), used only to mine backtick spans. */
+const PLAIN_WORD_RE = /[A-Za-z][A-Za-z0-9]*/g;
+
+/** Minimum anchor length — shorter tokens are too common to locate anything. */
+const MIN_ANCHOR_CHARS = 4;
+
+/**
+ * Plain backtick words that are code-ish but too generic to anchor on their
+ * own (they'd match half the repo). Dotted/camel/snake identifiers bypass this
+ * — their shape already makes them distinctive.
+ */
+const ANCHOR_STOP_WORDS = new Set([
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'string',
+  'number',
+  'object',
+  'return',
+  'import',
+  'export',
+  'const',
+  'type',
+  'when',
+  'then',
+  'with',
+  'from',
+  'that',
+  'this',
+  'null',
+  'note',
+]);
+
+/** Push a candidate anchor if it clears the length / noise filters and is new. */
+function pushAnchor(out: string[], seen: Set<string>, token: string, isPlainWord: boolean): void {
+  const t = token.trim();
+  if (t.length < MIN_ANCHOR_CHARS) return;
+  if (/^\d+$/.test(t)) return; // pure number
+  if (isPlainWord && ANCHOR_STOP_WORDS.has(t.toLowerCase())) return;
+  if (seen.has(t)) return;
+  seen.add(t);
+  out.push(t);
+}
+
+/**
+ * Extract locate-able anchors from a claim line, most-distinctive first:
+ * dotted/starred config keys, then camelCase/PascalCase and snake identifiers,
+ * then the plain words inside backtick spans (e.g. `backend: "lancedb"` yields
+ * `backend`, `lancedb`). Free-prose plain words are deliberately NOT anchors —
+ * only backtick-quoted ones — to keep the lookup from matching generic vocab.
+ * Exposed for testing.
+ */
+export function extractAnchors(text: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const m of text.matchAll(DOTTED_KEY_RE)) pushAnchor(out, seen, m[0], false);
+  for (const m of text.matchAll(CAMEL_ID_RE)) pushAnchor(out, seen, m[0], false);
+  for (const m of text.matchAll(SNAKE_ID_RE)) pushAnchor(out, seen, m[0], false);
+  for (const span of text.matchAll(BACKTICK_SPAN_RE)) {
+    for (const w of span[1].matchAll(PLAIN_WORD_RE)) pushAnchor(out, seen, w[0], true);
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Evidence lookup
+// ---------------------------------------------------------------------------
+
+const DOC_FILE_RE = /\.mdc?$/;
+const TEST_FILE_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/)/;
+
+/**
+ * Evidence-source ranking. A claim describes code the PR touched, so a changed
+ * code file is the strongest locate; a changed sibling DOC is next (the
+ * omission-claim case, e.g. an ADR's fuller enumeration); then any code, then
+ * any doc; tests are last (a fixture rarely IS the described behavior). An
+ * exact symbolName match beats every content match — that chunk is literally
+ * the named symbol.
+ */
+const enum EvidenceTier {
+  Test = 0,
+  Doc = 1,
+  Code = 2,
+  ChangedDoc = 3,
+  ChangedCode = 4,
+  SymbolMatch = 5,
+}
+
+/** The union of every path this PR changed (analyzable + non-code + patched). */
+function collectChangedFiles(context: ReviewContext): Set<string> {
+  const files = new Set<string>(context.changedFiles ?? []);
+  for (const f of context.allChangedFiles ?? []) files.add(f);
+  for (const f of context.pr?.patches?.keys() ?? []) files.add(f);
+  return files;
+}
+
+interface ChunkMatch {
+  /** Distinct anchors present in the chunk, in the claim's anchor priority order. */
+  matched: string[];
+  /** True when the chunk's symbolName exactly equals one of the anchors. */
+  symbolMatched: boolean;
+}
+
+/**
+ * Which of `anchors` this chunk carries — by exact symbolName equality or by
+ * content substring. `compare` lowercases both sides on the case-insensitive
+ * fallback pass; on the (common) case-sensitive pass it is identity, so no
+ * per-chunk lowercasing cost is paid.
+ */
+function matchChunk(
+  chunk: CodeChunk,
+  anchors: string[],
+  compare: (s: string) => string,
+): ChunkMatch | null {
+  const content = compare(chunk.content);
+  const symbolName = chunk.metadata.symbolName ? compare(chunk.metadata.symbolName) : undefined;
+  const matched: string[] = [];
+  let symbolMatched = false;
+  for (const anchor of anchors) {
+    const needle = compare(anchor);
+    if (symbolName !== undefined && symbolName === needle) {
+      symbolMatched = true;
+      matched.push(anchor);
+    } else if (content.includes(needle)) {
+      matched.push(anchor);
+    }
+  }
+  return matched.length > 0 ? { matched, symbolMatched } : null;
+}
+
+/** Rank a matched chunk into an evidence tier (see EvidenceTier). */
+function tierOf(file: string, symbolMatched: boolean, changed: Set<string>): EvidenceTier {
+  if (TEST_FILE_RE.test(file)) return EvidenceTier.Test;
+  if (symbolMatched) return EvidenceTier.SymbolMatch;
+  const isDoc = DOC_FILE_RE.test(file);
+  const isChanged = changed.has(file);
+  if (isChanged) return isDoc ? EvidenceTier.ChangedDoc : EvidenceTier.ChangedCode;
+  return isDoc ? EvidenceTier.Doc : EvidenceTier.Code;
+}
+
+interface EvidenceCandidate {
+  chunk: CodeChunk;
+  /** All anchors the chunk carries, in the claim's anchor priority order. */
+  anchors: string[];
+  tier: EvidenceTier;
+  matchCount: number;
+}
+
+/**
+ * A single pass over `repoChunks` for the best evidence chunk: highest tier,
+ * then most distinct anchors matched, keeping the FIRST such chunk in traversal
+ * order (a stable, deterministic tiebreak). Chunks from `claimFile` are skipped
+ * so a doc never cites itself as its own evidence.
+ */
+function scanForEvidence(
+  anchors: string[],
+  claimFile: string,
+  repoChunks: CodeChunk[],
+  changed: Set<string>,
+  compare: (s: string) => string,
+): EvidenceCandidate | null {
+  let best: EvidenceCandidate | null = null;
+  for (const chunk of repoChunks) {
+    if (chunk.metadata.file === claimFile) continue;
+    const m = matchChunk(chunk, anchors, compare);
+    if (!m) continue;
+    const tier = tierOf(chunk.metadata.file, m.symbolMatched, changed);
+    const matchCount = m.matched.length;
+    if (best && (tier < best.tier || (tier === best.tier && matchCount <= best.matchCount))) {
+      continue; // strictly-better replaces only; ties keep the earlier chunk
+    }
+    best = { chunk, anchors: m.matched, tier, matchCount };
+  }
+  return best;
+}
+
+const IDENTITY = (s: string): string => s;
+const LOWER = (s: string): string => s.toLowerCase();
+
+/** Cap `text` to `max` chars, centered on `needleIndex` with ellipses when cut. */
+function capCentered(text: string, needleIndex: number, max: number): string {
+  if (text.length <= max) return text;
+  const start = Math.min(Math.max(0, needleIndex - Math.floor(max / 2)), text.length - max);
+  const excerpt = text.slice(start, start + max);
+  return `${start > 0 ? '…' : ''}${excerpt}${start + max < text.length ? '…' : ''}`;
+}
+
+/** How many of `anchors` appear on one line (compare-mode aware). */
+function anchorsOnLine(line: string, anchors: string[], compare: (s: string) => string): number {
+  const l = compare(line);
+  let n = 0;
+  for (const a of anchors) if (l.includes(compare(a))) n++;
+  return n;
+}
+
+/**
+ * Build the excerpt for a located chunk: a ~6-line window centered on the line
+ * that carries the MOST of the claim's anchors (not merely the first one). A
+ * chunk can mention a generic anchor near its top and the load-bearing cluster
+ * (e.g. the retired-key list the claim omits) lower down; centering on the
+ * densest line lands the excerpt on the region the claim is actually about.
+ * Capped at MAX_EVIDENCE_CHARS (re-centered on an anchor when the window itself
+ * is too long). Any ``` is defanged so it can't break the renderer's fence.
+ */
+function buildExcerpt(
+  chunk: CodeChunk,
+  anchors: string[],
+  compare: (s: string) => string,
+): { startLine: number; excerpt: string; anchor: string } {
+  const lines = chunk.content.split('\n');
+  let bestIdx = 0;
+  let bestCount = -1;
+  lines.forEach((line, i) => {
+    const count = anchorsOnLine(line, anchors, compare);
+    if (count > bestCount) {
+      bestCount = count;
+      bestIdx = i;
+    }
+  });
+
+  const from = Math.max(0, bestIdx - EVIDENCE_LINES_BEFORE);
+  const window = lines.slice(from, bestIdx + EVIDENCE_LINES_AFTER + 1).join('\n');
+  const cmpWindow = compare(window);
+  const anchor = anchors.find(a => cmpWindow.includes(compare(a))) ?? anchors[0];
+  const needleIndex = Math.max(0, cmpWindow.indexOf(compare(anchor)));
+  const capped = capCentered(window, needleIndex, MAX_EVIDENCE_CHARS);
+  return {
+    startLine: chunk.metadata.startLine + from,
+    excerpt: capped.replace(/```/g, "'''"),
+    anchor,
+  };
+}
+
+/**
+ * Locate the code (or sibling doc) a single claim describes. Tries a
+ * case-sensitive pass first (identifiers/keys are case-bearing), then a
+ * case-insensitive fallback. Returns undefined when no anchor resolves or
+ * there is no repo index to search.
+ */
+export function findClaimEvidence(
+  claim: DocClaim,
+  repoChunks: CodeChunk[] | undefined,
+  changed: Set<string>,
+): DocClaimEvidence | undefined {
+  if (!repoChunks || repoChunks.length === 0) return undefined;
+  const anchors = extractAnchors(claim.claimText);
+  if (anchors.length === 0) return undefined;
+
+  // Case-sensitive first (identifiers/keys are case-bearing); the whole
+  // selection then uses that one compare mode, so the excerpt re-finds the
+  // anchor consistently. Only fall back to case-insensitive when nothing
+  // matched verbatim anywhere.
+  const caseSensitive = scanForEvidence(anchors, claim.file, repoChunks, changed, IDENTITY);
+  const candidate =
+    caseSensitive ?? scanForEvidence(anchors, claim.file, repoChunks, changed, LOWER);
+  if (!candidate) return undefined;
+
+  const compare = caseSensitive ? IDENTITY : LOWER;
+  const built = buildExcerpt(candidate.chunk, candidate.anchors, compare);
+  return {
+    file: candidate.chunk.metadata.file,
+    startLine: built.startLine,
+    excerpt: built.excerpt,
+    anchor: built.anchor,
+    fromDoc: DOC_FILE_RE.test(candidate.chunk.metadata.file),
+  };
+}
+
+/**
+ * Attach located evidence to each claim (up to the render cap — evidence for
+ * claims that would be dropped is never computed). Returns a new array; input
+ * claims are not mutated. Exposed for testing.
+ */
+export function attachEvidence(claims: DocClaim[], context: ReviewContext): DocClaim[] {
+  const repoChunks = context.repoChunks;
+  const changed = collectChangedFiles(context);
+  return claims.map((claim, i) => {
+    if (i >= MAX_CLAIMS) return claim; // beyond the render cap — evidence would never show
+    const evidence = findClaimEvidence(claim, repoChunks, changed);
+    return evidence ? { ...claim, evidence } : claim;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
@@ -252,31 +598,65 @@ const DOC_CLAIMS_HEADER =
   'This is the doc-truth discovery step done for you — do NOT skip it; it is ' +
   'your primary claim inventory. The scan can miss claims and can list prose ' +
   'that is merely descriptive, so also skim the touched hunks for any not here. ' +
-  'For EACH entry: locate the code it describes using material already in your ' +
+  'Most entries carry an `evidence` excerpt: the code (or a sibling doc, for ' +
+  'omission claims) the claim describes, located deterministically for you — ' +
+  'COMPARE the claim against that excerpt. The locator can pick the wrong site, ' +
+  'so first confirm the excerpt IS the described code; then: if it CONFIRMS the ' +
+  'claim, stay silent; if it CONTRADICTS the claim — or the diff changed the ' +
+  'behavior and left the prose describing the OLD behavior — emit a doc-truth ' +
+  'finding that QUOTES the claim and cites the falsifying fact. For an entry ' +
+  'with NO evidence, locate the code yourself using material already in your ' +
   'prompt (the diff hunks, <changed_functions>, and get_files_context on the ' +
   'described symbols — it reads indexed chunks, so it works even when ' +
-  'grep_codebase/read_file are blind). Then: if the code CONFIRMS the claim, ' +
-  'stay silent on it; if the code CONTRADICTS it — or the diff changed the ' +
-  'behavior and left the prose describing the OLD behavior — emit a doc-truth ' +
-  'finding that QUOTES the claim and cites the falsifying code fact; if the ' +
-  'entry is a genuine behavioral claim you cannot locate the code for, report ' +
-  'it as a warning "unverifiable behavioral claim in touched prose". An entry ' +
-  'that is plainly descriptive prose (not a falsifiable claim about this code) ' +
-  'needs no finding — do NOT report wording/style nits or manufacture a ' +
-  'contradiction the code does not support.';
+  'grep_codebase/read_file are blind); if it is a genuine behavioral claim you ' +
+  'still cannot locate, report a warning "unverifiable behavioral claim in ' +
+  'touched prose". An entry that is plainly descriptive prose (not a ' +
+  'falsifiable claim about this code) needs no finding — do NOT report ' +
+  'wording/style nits or manufacture a contradiction the code does not support.';
+
+/** The no-evidence pointer appended to a claim the locator could not resolve. */
+const NO_EVIDENCE_HINT =
+  '  (evidence: none located — find the described code yourself via get_files_context on the named symbols/files)';
+
+/**
+ * Render one claim entry's lines: the `file: "claim"` header, then either its
+ * located evidence excerpt (as a fenced block) or the no-evidence hint. Evidence
+ * is suppressed with an inline note once `remaining` budget can't hold it, so
+ * the claim inventory itself never gets dropped for an excerpt.
+ */
+function renderClaimEntry(claim: DocClaim, remaining: number): string[] {
+  const header = `- ${claim.file}: "${claim.claimText}"`;
+  if (!claim.evidence) return [header, NO_EVIDENCE_HINT];
+
+  const { file, startLine, excerpt, fromDoc } = claim.evidence;
+  const label = fromDoc ? 'evidence (sibling doc)' : 'evidence';
+  const block = [`  ${label} — ${file}:${startLine}:`, '  ```', excerpt, '  ```'].join('\n');
+  if (block.length > remaining) {
+    return [
+      header,
+      '  (evidence located but omitted to respect the input budget — see the diff/index)',
+    ];
+  }
+  return [header, block];
+}
 
 /**
  * Render the doc-claims worklist as a `<doc_claims>` block for the agent's
  * initial message. Returns '' when there are no claims so callers can append
- * unconditionally. Caps at MAX_CLAIMS with an explicit omission note (never a
- * silent drop).
+ * unconditionally. Caps at MAX_CLAIMS with an explicit omission note; drops
+ * per-entry evidence (never a whole claim) once MAX_DOC_CLAIMS_CHARS is hit.
  */
 export function renderDocClaims(claims: DocClaim[]): string {
   if (claims.length === 0) return '';
 
   const lines: string[] = ['<doc_claims>', DOC_CLAIMS_HEADER];
+  let used = lines.join('\n').length;
   for (const c of claims.slice(0, MAX_CLAIMS)) {
-    lines.push(`- ${c.file}: "${c.claimText}"`);
+    const entry = renderClaimEntry(c, MAX_DOC_CLAIMS_CHARS - used);
+    for (const line of entry) {
+      lines.push(line);
+      used += line.length + 1;
+    }
   }
   if (claims.length > MAX_CLAIMS) {
     lines.push(
@@ -290,9 +670,11 @@ export function renderDocClaims(claims: DocClaim[]): string {
 /**
  * Build the `<doc_claims>` section from the review context. Returns '' when
  * there is no diff or no changed guidance/doc surface with a claim-shaped line.
+ * Each rendered claim carries a deterministically-located code/sibling-doc
+ * evidence excerpt when one is found in the repo index.
  */
 export function renderDocClaimsSection(context: ReviewContext): string {
   const patches = context.pr?.patches;
   if (!patches || patches.size === 0) return '';
-  return renderDocClaims(extractDocClaims(patches));
+  return renderDocClaims(attachEvidence(extractDocClaims(patches), context));
 }

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -373,6 +373,21 @@ describe('findClaimEvidence — ranking', () => {
     expect(ev?.file).toBe('docs/notes.md');
   });
 
+  it('ranks a test file last even on an exact symbolName match (deliberate)', () => {
+    // A same-named helper defined in a test fixture is a collision, not the
+    // described behavior — the test-file demotion wins over SymbolMatch.
+    const claim = claimOf('`resolveIndexStrategy` gates overlay mode');
+    const chunks = [
+      chunk('packages/core/test/strategy.test.ts', 5, 'function resolveIndexStrategy() {}', {
+        symbolName: 'resolveIndexStrategy',
+        type: 'function',
+      }),
+      chunk('packages/core/src/strategy.ts', 84, 'calls resolveIndexStrategy() at startup'),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set());
+    expect(ev?.file).toBe('packages/core/src/strategy.ts');
+  });
+
   it('never cites the claim’s own file as its evidence', () => {
     const claim = claimOf('`structural.db` exists', DOC);
     const chunks = [chunk(DOC, 2, 'the doc itself mentions structural.db here')];

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
 import type { ReviewContext } from '../src/plugin-types.js';
 import {
+  extractAnchors,
   extractDocClaims,
+  findClaimEvidence,
+  attachEvidence,
   renderDocClaims,
   renderDocClaimsSection,
   type DocClaim,
+  type DocClaimEvidence,
 } from '../src/doc-claims-signals.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
 
@@ -14,6 +19,31 @@ function ctxWithPatches(patches?: Map<string, string>): ReviewContext {
     changedFiles: patches ? [...patches.keys()] : [],
     chunks: [],
   } as unknown as ReviewContext;
+}
+
+/** Build a synthetic repo chunk for evidence-lookup tests. */
+function chunk(
+  file: string,
+  startLine: number,
+  content: string,
+  extra: Partial<CodeChunk['metadata']> = {},
+): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'block',
+      language: 'typescript',
+      ...extra,
+    },
+  } as CodeChunk;
+}
+
+/** A DocClaim with the given text (shape is irrelevant to evidence lookup). */
+function claimOf(claimText: string, file = DOC): DocClaim {
+  return { file, claimText, shape: 'mechanism' };
 }
 
 /** Build a one-hunk patch adding the given lines to a file. */
@@ -238,5 +268,243 @@ describe('buildInitialMessage doc-claims injection', () => {
     );
     const message = buildInitialMessage(ctx, { blastRadius: null });
     expect(message).not.toContain('<doc_claims>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAnchors
+// ---------------------------------------------------------------------------
+
+describe('extractAnchors', () => {
+  it('extracts a dotted/starred config key', () => {
+    expect(extractAnchors('the `embeddings.*` keys still load')).toContain('embeddings.*');
+    expect(extractAnchors('requires a `structural.db` file')).toContain('structural.db');
+    expect(extractAnchors('bump `core.embeddingBatchSize` to 64')).toContain(
+      'core.embeddingBatchSize',
+    );
+  });
+
+  it('extracts camelCase and PascalCase identifiers', () => {
+    const a = extractAnchors('resolveIndexStrategy returns an OverlayBackend when linked');
+    expect(a).toContain('resolveIndexStrategy');
+    expect(a).toContain('OverlayBackend');
+  });
+
+  it('extracts snake_case / SCREAMING_SNAKE identifiers', () => {
+    const a = extractAnchors('the `search_code` tool honors LIEN_WORKTREE_STANDALONE');
+    expect(a).toContain('search_code');
+    expect(a).toContain('LIEN_WORKTREE_STANDALONE');
+  });
+
+  it('mines plain words only from backtick spans, not free prose', () => {
+    // `lancedb`/`qdrant` inside backticks are anchors …
+    const a = extractAnchors('a retired backend (`backend: "lancedb"` / `"qdrant"`)');
+    expect(a).toContain('lancedb');
+    expect(a).toContain('qdrant');
+    // … but the same word bare in prose is NOT (kept off generic vocabulary).
+    expect(extractAnchors('the backend was retired and removed')).not.toContain('backend');
+  });
+
+  it('filters noise: sub-4-char tokens, pure numbers, stop words', () => {
+    // `db` is too short; `32` is a number; `true`/`when` are stop words.
+    const a = extractAnchors('set `db` to `32` when `true`');
+    expect(a).not.toContain('db');
+    expect(a).not.toContain('32');
+    expect(a).not.toContain('true');
+    expect(a).not.toContain('when');
+  });
+
+  it('returns [] for prose with no code-ish tokens', () => {
+    expect(extractAnchors('This section explains the overall design of the overlay.')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaimEvidence — ranking
+// ---------------------------------------------------------------------------
+
+describe('findClaimEvidence — ranking', () => {
+  const CODE = 'packages/core/src/overlay-resolution.ts';
+  const OTHER_DOC = 'docs/architecture/other.md';
+
+  it('prefers a changed code file over a changed doc for the same anchor', () => {
+    const claim = claimOf('the `structuralStore` is the only backend');
+    const chunks = [
+      chunk(OTHER_DOC, 10, 'mentions structuralStore in prose'),
+      chunk(CODE, 20, 'export const structuralStore = makeStore();'),
+    ];
+    const changed = new Set([CODE, OTHER_DOC]);
+    const ev = findClaimEvidence(claim, chunks, changed);
+    expect(ev?.file).toBe(CODE);
+  });
+
+  it('prefers a changed sibling doc over a NON-changed code file (omission shape)', () => {
+    const claim = claimOf('a retired backend (`backend: "lancedb"`) does not crash');
+    const chunks = [
+      chunk('packages/core/src/legacy.ts', 5, 'const lancedb = null; // non-changed code'),
+      chunk(OTHER_DOC, 40, 'ADR: lancedb and embeddings.* keys still load, warn once'),
+    ];
+    const changed = new Set([OTHER_DOC]); // only the sibling doc is part of this PR
+    const ev = findClaimEvidence(claim, chunks, changed);
+    expect(ev?.file).toBe(OTHER_DOC);
+    expect(ev?.fromDoc).toBe(true);
+  });
+
+  it('prefers an exact symbolName match over a plain content match', () => {
+    const claim = claimOf('`resolveIndexStrategy` gates overlay mode');
+    const chunks = [
+      chunk(CODE, 8, 'a comment mentioning resolveIndexStrategy in passing'),
+      chunk('packages/core/src/strategy.ts', 84, 'export function resolveIndexStrategy() {}', {
+        symbolName: 'resolveIndexStrategy',
+        type: 'function',
+      }),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set([CODE])); // symbol chunk file NOT changed
+    expect(ev?.file).toBe('packages/core/src/strategy.ts');
+  });
+
+  it('ranks a test-file match below a non-changed doc match', () => {
+    const claim = claimOf('the `overlayMask` suppresses base rows');
+    const chunks = [
+      chunk('packages/core/src/x.test.ts', 3, 'expect(overlayMask).toBe(true)'),
+      chunk('docs/notes.md', 12, 'overlayMask is the per-file suppression set'),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set());
+    expect(ev?.file).toBe('docs/notes.md');
+  });
+
+  it('never cites the claim’s own file as its evidence', () => {
+    const claim = claimOf('`structural.db` exists', DOC);
+    const chunks = [chunk(DOC, 2, 'the doc itself mentions structural.db here')];
+    expect(findClaimEvidence(claim, chunks, new Set([DOC]))).toBeUndefined();
+  });
+
+  it('falls back to a case-insensitive match when nothing matches verbatim', () => {
+    const claim = claimOf('the `OverlayBackend` merges rows');
+    const chunks = [chunk('packages/core/src/x.ts', 1, 'class overlaybackend {}')];
+    const ev = findClaimEvidence(claim, chunks, new Set());
+    expect(ev?.file).toBe('packages/core/src/x.ts');
+  });
+
+  it('returns undefined when the claim has no anchors or there is no index', () => {
+    expect(
+      findClaimEvidence(
+        claimOf('purely descriptive prose here'),
+        [chunk('a.ts', 1, 'x')],
+        new Set(),
+      ),
+    ).toBeUndefined();
+    expect(
+      findClaimEvidence(claimOf('`structural.db` exists'), undefined, new Set()),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaimEvidence — excerpt windowing
+// ---------------------------------------------------------------------------
+
+describe('findClaimEvidence — excerpt', () => {
+  it('centers the window on the line carrying the MOST anchors, not the first', () => {
+    // `SqliteBackend` appears alone up top; the load-bearing cluster
+    // (`lancedb` + `qdrant`) sits lower — the excerpt must land on the cluster.
+    const content = [
+      'line0: SqliteBackend is the store', // 1 anchor
+      'line1: filler',
+      'line2: filler',
+      'line3: filler',
+      'line4: retired `lancedb`/`qdrant` keys still load', // 2 anchors
+      'line5: filler',
+    ].join('\n');
+    const claim = claimOf('`SqliteBackend`, `lancedb`, and `qdrant` behavior');
+    const chunks = [chunk('docs/adr.md', 100, content)];
+    const ev = findClaimEvidence(claim, chunks, new Set(['docs/adr.md']))!;
+    expect(ev.excerpt).toContain('lancedb');
+    expect(ev.excerpt).toContain('qdrant');
+    expect(ev.excerpt).not.toContain('line0'); // not centered on the lone top anchor
+    expect(ev.startLine).toBe(102); // 100 + (line4 index 4 - 2 lines of lead-in)
+  });
+
+  it('caps the excerpt near MAX_EVIDENCE_CHARS with ellipses', () => {
+    const long = `prefix ${'x'.repeat(300)} structuralStore ${'y'.repeat(300)} suffix`;
+    const ev = findClaimEvidence(
+      claimOf('`structuralStore` here'),
+      [chunk('a.ts', 1, long)],
+      new Set(),
+    )!;
+    expect(ev.excerpt.length).toBeLessThanOrEqual(402);
+    expect(ev.excerpt).toContain('structuralStore');
+    expect(ev.excerpt.startsWith('…')).toBe(true);
+  });
+
+  it('defangs triple backticks so they cannot break the render fence', () => {
+    const ev = findClaimEvidence(
+      claimOf('`sampleFn` example'),
+      [chunk('a.ts', 1, 'before\n```ts\nsampleFn()\n```\nafter')],
+      new Set(),
+    )!;
+    expect(ev.excerpt).not.toContain('```');
+    expect(ev.excerpt).toContain("'''");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachEvidence + render integration
+// ---------------------------------------------------------------------------
+
+describe('attachEvidence and renderer', () => {
+  it('attaches located evidence and renders it as a fenced excerpt', () => {
+    const ctx = {
+      changedFiles: ['packages/core/src/store.ts'],
+      chunks: [],
+      repoChunks: [chunk('packages/core/src/store.ts', 42, 'export const structuralStore = 1;')],
+      pr: { patches: new Map() },
+    } as unknown as ReviewContext;
+    const claims = attachEvidence([claimOf('the `structuralStore` is the default')], ctx);
+    expect(claims[0].evidence?.file).toBe('packages/core/src/store.ts');
+
+    const md = renderDocClaims(claims);
+    expect(md).toContain('evidence — packages/core/src/store.ts:42:');
+    expect(md).toContain('structuralStore');
+  });
+
+  it('labels sibling-doc evidence and shows the no-evidence hint otherwise', () => {
+    const withDoc: DocClaim = {
+      file: DOC,
+      claimText: 'omission claim',
+      shape: 'negation',
+      evidence: {
+        file: 'docs/adr.md',
+        startLine: 5,
+        excerpt: 'the fuller enumeration',
+        anchor: 'x',
+        fromDoc: true,
+      } satisfies DocClaimEvidence,
+    };
+    const md = renderDocClaims([withDoc, claimOf('unlocatable claim')]);
+    expect(md).toContain('evidence (sibling doc) — docs/adr.md:5:');
+    expect(md).toContain('none located');
+  });
+
+  it('drops per-entry evidence (never a claim) once the block budget is hit', () => {
+    // 20 claims each carrying a ~400-char excerpt overflows the 8k block cap,
+    // so later entries must swap the excerpt for the omission note while every
+    // claim header still renders.
+    const big = 'Z'.repeat(400);
+    const claims: DocClaim[] = Array.from({ length: 20 }, (_, i) => ({
+      file: DOC,
+      claimText: `claim ${i}`,
+      shape: 'requirement' as const,
+      evidence: {
+        file: `code/f${i}.ts`,
+        startLine: i + 1,
+        excerpt: big,
+        anchor: 'a',
+        fromDoc: false,
+      },
+    }));
+    const md = renderDocClaims(claims);
+    expect(md.match(/^- docs\//gm)).toHaveLength(20); // all claims survive
+    expect(md).toContain('evidence located but omitted to respect the input budget');
   });
 });


### PR DESCRIPTION
## Summary

Implements the evidence-pre-fetch half of #729: each `<doc_claims>` entry now carries the code (or sibling-doc enumeration) it describes, located deterministically (anchor mining from backtick spans/identifiers, ranked lookup over repoChunks, densest-anchor-line windowing). 25 new unit tests; acceptance entries verified in rendered prompts — pr667's claim carries overlay-resolution.ts's own two-condition gate doc-comment, pr687's carries ADR-011's embeddings enumeration.

## Calibration verdict: non-regressive but FLAT on its purpose — recommend HOLD

| Fixture | worklist-only (#730) | + evidence | |
|---|---|---|---|
| pr658-search-code-rename (canary) | 10/10 | **10/10** | no regression |
| accurate-doc (precision) | 10/10 | **10/10** | zero FP pressure |
| pr667-worktree-doc-drift | 2/10 | **2/10** | flat |
| pr687-config-doc-drift | 1/10 | **2/10** | noise |

## The terminal diagnosis (trace-proven)

In pr667's 8 failing votes, the model emits **1–3 findings (median 1)** and stops; **zero** failing votes engage the planted claim even though the claim AND its contradicting evidence sit side-by-side in the prompt. After three phases of deterministic input work (surface #727, worklist #730, evidence here), the bottleneck is neither discovery, nor coverage, nor verification cost — it is **output economy**: the #613 anti-ramble tuning makes the model satisfied after one good finding on a multi-issue PR. Doc-truth findings lose that competition structurally.

The remaining levers are different in kind and out of this arc's scope:
1. touch the #613 conciseness tuning (high risk — it was calibrated deliberately),
2. a dedicated doc-truth-only second pass on doc-heavy PRs (new cost per review), or
3. accept that doc-truth catches drift reliably on doc-focused PRs (where it is now certified 10/10) and not on bug-rich ones.

## Recommendation
Hold this PR unless option 2 is pursued (the evidence machinery becomes the input to that dedicated pass). It certifies clean, so merging is safe — but per KISS it adds ~400 lines whose measured benefit today is nil. Decision deliberately left to the maintainer.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR adds deterministic evidence pre-fetch for doc-truth claims: anchor extraction, tiered repo-chunk ranking, windowed excerpts, and budget-aware rendering. The change is additive and backward-compatible. The only concrete bug found is an under-count in the per-entry budget check that can let the rendered `<doc_claims>` block exceed its declared character cap. No breaking changes for callers were identified.
>
> - Added anchor extraction and evidence lookup for doc claims
> - Added tiered ranking (changed code > changed doc > code > doc > test) and excerpt windowing
> - Added render-time budget enforcement with a minor under-count bug

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 95ac1c2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review documentation claims now include relevant repository evidence excerpts when available.
  * Evidence is prioritized using changed files, matching symbols, and related documentation.
  * Related documentation evidence is clearly labeled for easier comparison.
* **Bug Fixes**
  * Claims without matching evidence now display a clear “none located” indication.
  * Evidence excerpts are safely truncated when space is limited without removing claim entries.
  * Excerpts are formatted safely to prevent broken code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->