### PR TITLE
feat(review): dedicated doc-truth pass for doc-touching PRs (#732)

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -81,7 +81,13 @@ const DOC_PASS_INTRO =
   '"covers the main case", or "the extra condition is an implementation detail" ' +
   'are NOT confirmations — if the enumerations differ, report it and cite both ' +
   'sides. Descriptive prose without a checkable enumeration or behavior stays ' +
-  'held to the ordinary contradicts-or-confirms standard.';
+  'held to the ordinary contradicts-or-confirms standard.\n\n' +
+  'Budget discipline: an evidence excerpt attached to a claim IS the described ' +
+  'code — compare against it directly and do NOT re-read that file with tools; ' +
+  'spend tool calls ONLY on claims with no attached evidence. Your budget is ' +
+  'sized for comparisons, not re-investigation: emit your verdict JSON as soon ' +
+  'as the worklist is judged, and if you approach the budget, output the ' +
+  'verdict for the claims you have judged rather than reading more files.';
 
 // ---------------------------------------------------------------------------
 // Gate

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -72,7 +72,16 @@ const DOC_PASS_INTRO =
   'excerpt (or locate the described code via get_files_context when no excerpt ' +
   'is attached), and emit a doc-truth finding only when the code CONTRADICTS the ' +
   'claim — or when the diff changed the behavior and left the prose describing ' +
-  'the OLD behavior. A claim the code confirms needs no finding.';
+  'the OLD behavior. A claim the code confirms needs no finding.\n\n' +
+  'Compare claims STRICTLY, not charitably. When a claim enumerates conditions, ' +
+  'requirements, gates, or a key/file list, the enumeration must match the code ' +
+  'EXACTLY: a condition the code checks but the claim omits IS a contradiction ' +
+  '(the doc tells readers a weaker rule than the code enforces), and so is a ' +
+  'condition the claim states but the code does not check. "Close enough", ' +
+  '"covers the main case", or "the extra condition is an implementation detail" ' +
+  'are NOT confirmations — if the enumerations differ, report it and cite both ' +
+  'sides. Descriptive prose without a checkable enumeration or behavior stays ' +
+  'held to the ordinary contradicts-or-confirms standard.';
 
 // ---------------------------------------------------------------------------
 // Gate

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -1,0 +1,248 @@
+/**
+ * Dedicated doc-truth second pass (issue #732).
+ *
+ * A single review call gives all nine rules one findings list to compete for,
+ * under a prompt that rewards concision. On a doc-touching PR that also carries
+ * real code bugs, documentation drift rationally loses that competition — a
+ * failure verified to be architectural, not model-bound (Sonnet 5 fails pr667
+ * exactly like Kimi). This module removes the competition: for a PR that
+ * touched documentation/guidance surfaces, run a SECOND, claims-only review
+ * after the main pass, with the doc-truth rule as the only active rule and only
+ * the doc-claim signals in the prompt — no blast radius, no complexity, no code
+ * bugs to chase. Its findings fold back into the main review's output.
+ *
+ * The orchestration (running the client, merging usage/trace/findings) lives in
+ * `index.ts`'s `analyze()`; this module holds the deterministic, LLM-free pieces
+ * it composes: the gate, the prompt builder, and the merge helpers. The client
+ * runner is injected into `runDocTruthPass` so failure isolation and gating are
+ * unit-testable with zero LLM spend.
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
+import { extractDocClaims, renderDocClaimsSection } from '../../doc-claims-signals.js';
+import type { Logger } from '../../logger.js';
+
+import type { AgentConfig, AgentFinding, AgentResult, AgentTrace, ResolvedRules } from './types.js';
+import { DOC_TRUTH } from './rules.js';
+import { buildSystemPrompt } from './system-prompt.js';
+import { envDisabled } from './agent-client-shared.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn cap for the claims-only pass. The evidence is inline (the <doc_claims>
+ * worklist pre-computes each claim's code excerpt), so verification is a
+ * comparison, not an investigation — it rarely needs the tool loop. A small cap
+ * keeps a doc-heavy PR from spending main-pass-sized budget on the second call.
+ */
+export const DOC_PASS_MAX_TURNS = 6;
+
+/**
+ * The doc pass's token budget as a fraction of the main pass's base budget.
+ * ~40% is ample for a claims-only pass whose input is the (already compact)
+ * doc-claim signals rather than the full diff + all signals.
+ */
+export const DOC_PASS_BUDGET_FRACTION = 0.4;
+
+/** Env kill-switch (parity with the client's LIEN_REVIEW_LOG_AGENT style). */
+const DOC_PASS_ENV = 'LIEN_REVIEW_DOC_PASS';
+
+/**
+ * Two findings on the same file within this many lines are treated as the same
+ * location when deduping the doc pass against the main pass.
+ */
+const DEDUPE_LINE_PROXIMITY = 2;
+
+/**
+ * Only the doc-truth rule is active in the second pass. `skipped` is unused by
+ * `buildSystemPrompt` (it reads `active` only), so an empty list is honest here.
+ */
+const DOC_TRUTH_ONLY_RULES: ResolvedRules = { active: [DOC_TRUTH], skipped: [] };
+
+const DOC_PASS_INTRO =
+  'This is a DOCUMENTATION-TRUTHFULNESS review — a dedicated second pass over a ' +
+  'PR that touched documentation/guidance surfaces. Your ONLY job is to verify ' +
+  'the behavioral and structural CLAIMS those surfaces make against the code the ' +
+  'PR changed. Do NOT report code bugs, style, naming, or anything outside ' +
+  'documentation truthfulness — those are handled elsewhere. Work the ' +
+  '<doc_claims> worklist: for each claim, compare it against its evidence ' +
+  'excerpt (or locate the described code via get_files_context when no excerpt ' +
+  'is attached), and emit a doc-truth finding only when the code CONTRADICTS the ' +
+  'claim — or when the diff changed the behavior and left the prose describing ' +
+  'the OLD behavior. A claim the code confirms needs no finding.';
+
+// ---------------------------------------------------------------------------
+// Gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether to run the doc-truth second pass. True iff the PR added at least one
+ * claim-shaped line to a touched guidance/doc surface (which also implies a doc
+ * surface was touched), and neither the config nor the env kill-switch disables
+ * it. Extraction is the same deterministic pass the main prompt already runs,
+ * so a non-empty worklist here means the pass has something to verify.
+ */
+export function shouldRunDocTruthPass(context: ReviewContext, config?: AgentConfig): boolean {
+  if (config?.docTruthPass === false) return false;
+  if (envDisabled(process.env[DOC_PASS_ENV])) return false;
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return false;
+  return extractDocClaims(patches).length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+/** Push a section only when it is a non-empty string (signal renderers return ''). */
+function pushIfPresent(sections: string[], value: string | null | undefined): void {
+  if (value) sections.push(value);
+}
+
+/** The PR title/body header, mirroring the main pass's <pr_metadata> block. */
+function renderPrHeader(context: ReviewContext): string | null {
+  if (!context.pr) return null;
+  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
+  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
+}
+
+/**
+ * Build the claims-only initial message: the PR header, the intro that scopes
+ * the pass to doc-truth, the <doc_claims> worklist WITH its pre-fetched
+ * evidence, and the <guidance_surface_changes> hunks (the isGuidanceSurface-
+ * filtered, budget-capped diff of exactly the touched doc surfaces — the same
+ * block the doc-truth rule and the doc_claims header reference by name). No
+ * blast-radius, complexity, or other-rule signals: no competition, no
+ * distraction.
+ */
+export function buildDocTruthPassInitialMessage(context: ReviewContext): string {
+  const sections: string[] = [];
+  pushIfPresent(sections, renderPrHeader(context));
+  sections.push(DOC_PASS_INTRO);
+  pushIfPresent(sections, renderDocClaimsSection(context));
+  pushIfPresent(sections, renderGuidanceSurfaceSection(context));
+  sections.push(
+    'Verify each claim against the code, then output findings as JSON. If every ' +
+      'claim checks out, output an empty findings array with a low-risk summary.',
+  );
+  return sections.join('\n\n');
+}
+
+/**
+ * The system + initial prompts for the doc-truth pass. The system prompt is the
+ * standard agent prompt with ONLY the doc-truth rule active (so the output
+ * format enumerates just `doc-truth` and no competing investigation strategies
+ * appear).
+ */
+export function buildDocTruthPassPrompts(context: ReviewContext): {
+  systemPrompt: string;
+  initialMessage: string;
+} {
+  return {
+    systemPrompt: buildSystemPrompt(DOC_TRUTH_ONLY_RULES),
+    initialMessage: buildDocTruthPassInitialMessage(context),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+/** The doc pass's token budget: a fraction of the main pass's base budget. */
+export function docTruthPassBudget(baseBudget: number): number {
+  return Math.round(baseBudget * DOC_PASS_BUDGET_FRACTION);
+}
+
+// ---------------------------------------------------------------------------
+// Runner (client injected for zero-LLM testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the doc-truth client loop for the given prompts and budget. Injected
+ * into `runDocTruthPass` so the gate, prompt build, and failure isolation are
+ * unit-testable without a real client. `index.ts` supplies a closure over
+ * `runAgentClient` (with the shared tool executor) as the production impl.
+ */
+export type DocTruthClientRunner = (
+  systemPrompt: string,
+  initialMessage: string,
+  maxTokenBudget: number,
+  maxTurns: number,
+) => Promise<AgentResult>;
+
+/**
+ * Run the second, claims-only doc-truth pass when the PR warrants it. Returns
+ * the pass's AgentResult, or null when the pass is gated off OR when it fails —
+ * a pass-2 error must never fail the whole review, so it is caught, logged, and
+ * swallowed here (the caller keeps the main-pass findings).
+ */
+export async function runDocTruthPass(
+  context: ReviewContext,
+  config: AgentConfig,
+  logger: Logger,
+  runClient: DocTruthClientRunner,
+): Promise<AgentResult | null> {
+  if (!shouldRunDocTruthPass(context, config)) return null;
+  try {
+    const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(context);
+    const budget = docTruthPassBudget(config.maxTokenBudget);
+    const result = await runClient(systemPrompt, initialMessage, budget, DOC_PASS_MAX_TURNS);
+    logger.info(
+      `[agent] doc-truth pass: ${result.findings.length} finding(s) in ${result.turns} turn(s) ($${result.usage.cost.toFixed(4)})`,
+    );
+    return result;
+  } catch (err) {
+    logger.warning(
+      `[agent] doc-truth pass failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers
+// ---------------------------------------------------------------------------
+
+/** Same file and within DEDUPE_LINE_PROXIMITY lines — treat as one location. */
+function sameLocation(a: AgentFinding, b: AgentFinding): boolean {
+  return a.filepath === b.filepath && Math.abs(a.line - b.line) <= DEDUPE_LINE_PROXIMITY;
+}
+
+/**
+ * Fold the doc pass's findings into the main pass's. Every doc-pass finding gets
+ * `ruleId: 'doc-truth'` (the pass has a single rule, so attribution is
+ * unambiguous regardless of what the model emitted). A doc-pass finding is
+ * dropped when the main pass already reported one at the same file within
+ * DEDUPE_LINE_PROXIMITY lines — the main-pass version is kept. Returns a new
+ * array; inputs are not mutated.
+ */
+export function mergeDocTruthFindings(
+  mainFindings: AgentFinding[],
+  docFindings: AgentFinding[],
+): AgentFinding[] {
+  const forced = docFindings.map(f => ({ ...f, ruleId: 'doc-truth' }));
+  const kept = forced.filter(df => !mainFindings.some(mf => sameLocation(mf, df)));
+  return [...mainFindings, ...kept];
+}
+
+/**
+ * Append the doc pass's turns to the main trace so the single trace surfaced via
+ * `reportTrace` carries BOTH passes: the harness derives tool calls and turn
+ * count from `trace.turns`, so main-pass `expectToolCalled` assertions keep
+ * working while the doc pass's tool calls also become visible. Doc turns are
+ * renumbered to continue after the main pass and stamped `phase: 'doc-truth'`.
+ * No-op when either trace is absent (production runners don't capture traces).
+ */
+export function appendDocTruthTurns(
+  mainTrace: AgentTrace | undefined,
+  docTrace: AgentTrace | undefined,
+): void {
+  if (!mainTrace || !docTrace) return;
+  const offset = mainTrace.turns.length;
+  for (const turn of docTrace.turns) {
+    mainTrace.turns.push({ ...turn, turnNumber: offset + turn.turnNumber, phase: 'doc-truth' });
+  }
+}

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -185,6 +185,10 @@ export class AgentReviewPlugin implements ReviewPlugin {
     const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
     appendIncompleteNotice(findings, pluginId, result);
+    // The doc pass's summary is deliberately discarded (claims-only overview;
+    // the main pass owns the PR's risk profile) — but an INCOMPLETE doc pass
+    // must not read as "no doc issues": surface its own notice.
+    if (docResult?.incomplete) appendDocPassIncompleteNotice(findings, pluginId, docResult);
 
     return findings;
   }
@@ -410,6 +414,32 @@ function appendIncompleteNotice(
     category: 'summary',
     message,
     metadata: { incomplete: true, stopReason: result.stopReason, overview: message },
+  });
+}
+
+/**
+ * Surface an incomplete doc-truth SECOND pass. Kept separate from
+ * `appendIncompleteNotice` so the wording says which pass died: the main
+ * review completed normally, only the documentation check is partial —
+ * "re-run the review" guidance would be misleadingly broad here.
+ */
+function appendDocPassIncompleteNotice(
+  findings: ReviewFinding[],
+  pluginId: string,
+  docResult: AgentResult,
+): void {
+  const message =
+    'The dedicated documentation-truthfulness pass did not finish ' +
+    `(${docResult.stopReason ?? 'stopped unexpectedly'}) — doc-claim ` +
+    'verification is partial. Code findings above are unaffected.';
+  findings.push({
+    pluginId,
+    filepath: '',
+    line: 0,
+    severity: 'warning' as const,
+    category: 'summary',
+    message,
+    metadata: { incomplete: true, stopReason: docResult.stopReason, overview: message },
   });
 }
 

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -24,6 +24,7 @@ import { OpenAIAgentClient, toOpenAITools } from './openai-client.js';
 import { buildSystemPrompt, buildInitialMessage } from './system-prompt.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
+import { runDocTruthPass, mergeDocTruthFindings, appendDocTruthTurns } from './doc-truth-pass.js';
 import {
   DEFAULT_REVIEW_MODEL,
   DEFAULT_OPENROUTER_BASE_URL,
@@ -58,6 +59,11 @@ const configSchema = z.object({
       maxSeeds: z.number().int().min(1).max(20).default(8),
     })
     .optional(),
+  /**
+   * Run the dedicated claims-only doc-truth second pass on doc-touching PRs
+   * (issue #732). Default true; env LIEN_REVIEW_DOC_PASS=0 also disables it.
+   */
+  docTruthPass: z.boolean().default(true),
 });
 
 export interface AgentReviewPluginOptions {
@@ -154,14 +160,61 @@ export class AgentReviewPlugin implements ReviewPlugin {
       maxTokenBudget,
     );
 
+    // Second, claims-only doc-truth pass for doc-touching PRs (issue #732).
+    // A dedicated pass with no competing rules keeps documentation drift from
+    // being out-competed by the PR's real code bugs in a single findings list.
+    // Its trace/usage fold into the main run; a failure returns null and leaves
+    // the main-pass output untouched.
+    const docResult = await this.runSecondDocPass(
+      context,
+      config,
+      apiKey,
+      provider,
+      logger,
+      toolExecutor,
+    );
+    if (docResult) {
+      appendDocTruthTurns(result.trace, docResult.trace);
+      context.reportUsage?.(docResult.usage);
+    }
+
     reportAgentRun(this.id, context, logger, result);
 
     const pluginId = this.id;
-    const findings = result.findings.map(f => mapToReviewFinding(f, pluginId));
+    const agentFindings = mergeDocTruthFindings(result.findings, docResult?.findings ?? []);
+    const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
     appendIncompleteNotice(findings, pluginId, result);
 
     return findings;
+  }
+
+  /**
+   * Run the doc-truth second pass, wiring the shared tool executor into a client
+   * runner the pass can invoke with its own (smaller) turn/token budget. Returns
+   * null when the pass is gated off or fails — kept as a thin method so
+   * `analyze()` stays under its complexity budget.
+   */
+  private runSecondDocPass(
+    context: ReviewContext,
+    config: AgentConfig,
+    apiKey: string,
+    provider: string,
+    logger: Logger,
+    toolExecutor: ToolExecutor,
+  ): Promise<AgentResult | null> {
+    return runDocTruthPass(context, config, logger, (sys, init, budget, maxTurns) =>
+      runAgentClient(
+        provider,
+        { ...config, maxTurns },
+        apiKey,
+        logger,
+        sys,
+        init,
+        toolExecutor,
+        budget,
+      ),
+    );
   }
 
   async present(findings: ReviewFinding[], context: PresentContext): Promise<void> {

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -665,7 +665,12 @@ matches.`,
   source: 'builtin',
 };
 
-const DOC_TRUTH: ReviewRule = {
+/**
+ * The documentation-truthfulness rule. Exported so the dedicated doc-truth
+ * second pass (issue #732) can build a single-rule ResolvedRules set without
+ * re-deriving it from BUILTIN_RULES.
+ */
+export const DOC_TRUTH: ReviewRule = {
   id: 'doc-truth',
   name: 'Documentation / Guidance Truthfulness',
   description:

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -45,6 +45,12 @@ export interface AgentConfig {
   requestTimeoutMs?: number;
   /** Inject transitive blast radius into the agent's initial message. */
   blastRadius?: BlastRadiusConfig;
+  /**
+   * Run the dedicated claims-only doc-truth second pass on doc-touching PRs
+   * (issue #732). Default true; set false (or env LIEN_REVIEW_DOC_PASS=0) to
+   * skip it and run the single main pass only.
+   */
+  docTruthPass?: boolean;
 }
 
 /** A single finding produced by the agent during review. */
@@ -152,6 +158,13 @@ export interface ToolInvocation {
  */
 export interface TurnTrace {
   turnNumber: number;
+  /**
+   * Which review pass produced this turn. Absent means the main pass; the
+   * dedicated doc-truth second pass (issue #732) stamps its appended turns
+   * `'doc-truth'` so a merged trace stays interpretable. Optional/additive —
+   * existing consumers ignore it.
+   */
+  phase?: 'main' | 'doc-truth';
   /** Full assistant message content, captured before extractResponse. */
   responseText: string;
   /**

--- a/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
@@ -68,7 +68,17 @@
  *   bug-rich PR the model samples a few claims and rarely reaches this one.
  *   Remaining gap is per-claim verification COST, not discovery: fixing it
  *   needs claim->code evidence pre-fetch (#729 stays open for that design).
- * No canary tag until this fixture clears the bar.
+ * - 5/10 with the DEDICATED doc-truth pass (#732/#733): the pass runs every
+ *   vote, competition eliminated; residual = lenient equivalence ("has an
+ *   index" judged consistent with the two-file gate ~50%).
+ * - 7/10 after the strict-enumeration intro; 6/10 after adding budget
+ *   discipline (statistically flat — plateau). Residuals: ~1 lenient vote +
+ *   occasional evidence-ignoring read_file flood exhausting the pass budget.
+ *   Model-judgment frontier on Kimi; further prompt iteration showed
+ *   diminishing returns and was stopped per cost discipline.
+ * No canary tag: this fixture measures the frontier (~6-7/10), it does not
+ * gate. The feature itself is certified on the canary corpus (pr658 10/10,
+ * accurate-doc 10/10 precision with the strict language).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, afterEach } from 'vitest';
+
+import {
+  shouldRunDocTruthPass,
+  buildDocTruthPassPrompts,
+  buildDocTruthPassInitialMessage,
+  mergeDocTruthFindings,
+  appendDocTruthTurns,
+  docTruthPassBudget,
+  runDocTruthPass,
+  DOC_PASS_MAX_TURNS,
+} from '../src/plugins/agent/doc-truth-pass.js';
+import { createTestContext, silentLogger } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { Logger } from '../src/logger.js';
+import type {
+  AgentConfig,
+  AgentFinding,
+  AgentResult,
+  AgentTrace,
+  TurnTrace,
+} from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+/** A doc-surface hunk carrying a state claim ("disabled … when"). */
+const DOC_CLAIM_PATCH = `@@ -1,3 +1,4 @@
+ # Worktree indexing
++The overlay is disabled when the base checkout has no index.
+
+ Some prose.`;
+
+/** A doc-surface hunk with only plain descriptive prose (no claim shape). */
+const DOC_NO_CLAIM_PATCH = `@@ -1,2 +1,3 @@
+ # Title
++Just some ordinary descriptive prose about the project layout.`;
+
+/** A code-file hunk whose text happens to look claim-shaped — but it is not a
+ *  guidance surface, so the claim scanner must ignore it entirely. */
+const CODE_PATCH = `@@ -1,3 +1,4 @@
+ export function overlay() {
++  return UNIQUE_CODE_MARKER_XYZ; // disabled when true
+ }`;
+
+function contextWithPatches(entries: Array<[string, string]>): ReviewContext {
+  return createTestContext({
+    changedFiles: entries.map(([f]) => f),
+    allChangedFiles: entries.map(([f]) => f),
+    pr: {
+      title: 'docs: worktree indexing',
+      body: 'Clarify the overlay gate.',
+      patches: new Map(entries),
+    } as unknown as ReviewContext['pr'],
+  });
+}
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+function finding(overrides: Partial<AgentFinding> = {}): AgentFinding {
+  return {
+    filepath: 'a.md',
+    line: 1,
+    severity: 'warning',
+    category: 'bug',
+    message: 'msg',
+    ...overrides,
+  };
+}
+
+function fakeResult(findings: AgentFinding[] = [], trace?: AgentTrace): AgentResult {
+  return {
+    findings,
+    summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2, cost: 0.01 },
+    turns: 1,
+    stopReason: 'completed',
+    incomplete: false,
+    trace,
+  };
+}
+
+function turn(turnNumber: number, toolNames: string[] = []): TurnTrace {
+  return {
+    turnNumber,
+    responseText: '',
+    toolCalls: toolNames.map(name => ({ name, input: {}, output: 'ok' })),
+    finishReason: 'stop',
+  };
+}
+
+function trace(turns: TurnTrace[]): AgentTrace {
+  return { systemPrompt: 's', initialMessage: 'i', model: 'm', turns };
+}
+
+function capturingLogger(): { logger: Logger; lines: string[] } {
+  const lines: string[] = [];
+  const record = (m: string): void => {
+    lines.push(m);
+  };
+  return { logger: { info: record, warning: record, error: record, debug: record }, lines };
+}
+
+afterEach(() => {
+  delete process.env.LIEN_REVIEW_DOC_PASS;
+});
+
+// ---------------------------------------------------------------------------
+// shouldRunDocTruthPass
+// ---------------------------------------------------------------------------
+
+describe('shouldRunDocTruthPass', () => {
+  it('is true when a touched doc surface carries a claim-shaped line', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    expect(shouldRunDocTruthPass(ctx)).toBe(true);
+  });
+
+  it('is false when the touched doc surface has no claim-shaped prose', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_NO_CLAIM_PATCH]]);
+    expect(shouldRunDocTruthPass(ctx)).toBe(false);
+  });
+
+  it('is false when only non-guidance code files changed (claim scanner skips them)', () => {
+    const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]);
+    expect(shouldRunDocTruthPass(ctx)).toBe(false);
+  });
+
+  it('is false when there are no patches', () => {
+    expect(shouldRunDocTruthPass(createTestContext())).toBe(false);
+  });
+
+  it('is false when the config kill-switch is set, even with claims', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    expect(shouldRunDocTruthPass(ctx, cfg({ docTruthPass: false }))).toBe(false);
+  });
+
+  it('is false when the env kill-switch LIEN_REVIEW_DOC_PASS=0 is set', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    process.env.LIEN_REVIEW_DOC_PASS = '0';
+    expect(shouldRunDocTruthPass(ctx)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+describe('buildDocTruthPassPrompts', () => {
+  it('activates ONLY the doc-truth rule in the system prompt', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const { systemPrompt } = buildDocTruthPassPrompts(ctx);
+
+    // The doc-truth strategy and its enumerated (sole) ruleId are present…
+    expect(systemPrompt).toContain('Documentation / Guidance Truthfulness Check');
+    expect(systemPrompt).toContain('exactly one of: doc-truth');
+    // …and no competing rule's investigation strategy leaks in.
+    expect(systemPrompt).not.toContain('Edge Case Sweep');
+    expect(systemPrompt).not.toContain('Concurrency Check');
+    expect(systemPrompt).not.toContain('### Structural Analysis');
+  });
+
+  it('builds an initial message with doc_claims + guidance hunks and NO competing signals', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ['packages/core/src/overlay.ts', CODE_PATCH],
+    ]);
+    const message = buildDocTruthPassInitialMessage(ctx);
+
+    // PR header + the doc-truth signals are present.
+    expect(message).toContain('<pr_metadata>');
+    expect(message).toContain('docs: worktree indexing');
+    expect(message).toContain('<doc_claims>');
+    expect(message).toContain('<guidance_surface_changes>');
+    expect(message).toContain('disabled when the base checkout');
+
+    // The diff carries ONLY doc-surface hunks — the code file's content must not
+    // appear (it is neither a guidance surface nor a doc claim).
+    expect(message).not.toContain('UNIQUE_CODE_MARKER_XYZ');
+
+    // No blast-radius / complexity / other-rule signal blocks.
+    expect(message).not.toContain('<blast_radius>');
+    expect(message).not.toContain('<complexity_regressions>');
+    expect(message).not.toContain('<stale_literal_candidates>');
+    expect(message).not.toContain('<untrusted_input_sites>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+describe('docTruthPassBudget', () => {
+  it('is ~40% of the base budget, rounded to an integer', () => {
+    expect(docTruthPassBudget(100_000)).toBe(40_000);
+    expect(docTruthPassBudget(50_001)).toBe(20_000); // round(20000.4)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeDocTruthFindings
+// ---------------------------------------------------------------------------
+
+describe('mergeDocTruthFindings', () => {
+  it('keeps the main-pass finding and drops the doc-pass dup at the same line', () => {
+    const main = [
+      finding({ filepath: 'a.md', line: 10, ruleId: 'edge-case-sweep', message: 'main' }),
+    ];
+    const doc = [finding({ filepath: 'a.md', line: 10, message: 'dup' })];
+
+    const merged = mergeDocTruthFindings(main, doc);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('main');
+    expect(merged[0].ruleId).toBe('edge-case-sweep');
+  });
+
+  it('dedupes a nearby doc finding (within ±2 lines) but appends a distant one', () => {
+    const main = [finding({ filepath: 'a.md', line: 10, message: 'main' })];
+    const doc = [
+      finding({ filepath: 'a.md', line: 12, message: 'near' }), // distance 2 → deduped
+      finding({ filepath: 'a.md', line: 13, message: 'far' }), // distance 3 → appended
+    ];
+
+    const merged = mergeDocTruthFindings(main, doc);
+
+    expect(merged.map(f => f.message)).toEqual(['main', 'far']);
+  });
+
+  it('appends a finding on a distinct file and forces its ruleId to doc-truth', () => {
+    const main = [finding({ filepath: 'a.md', line: 10, ruleId: 'edge-case-sweep' })];
+    const doc = [
+      finding({ filepath: 'b.md', line: 1, ruleId: undefined, message: 'no-rule' }),
+      finding({ filepath: 'c.md', line: 5, ruleId: 'stale-duplicate', message: 'wrong-rule' }),
+    ];
+
+    const merged = mergeDocTruthFindings(main, doc);
+
+    expect(merged).toHaveLength(3);
+    const byMsg = Object.fromEntries(merged.map(f => [f.message, f.ruleId]));
+    expect(byMsg['no-rule']).toBe('doc-truth');
+    expect(byMsg['wrong-rule']).toBe('doc-truth'); // forced, overriding the emitted id
+  });
+
+  it('does not mutate the input arrays', () => {
+    const main = [finding({ filepath: 'a.md', line: 10 })];
+    const doc = [finding({ filepath: 'b.md', line: 1, ruleId: 'x' })];
+    mergeDocTruthFindings(main, doc);
+    expect(doc[0].ruleId).toBe('x'); // original untouched
+    expect(main).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendDocTruthTurns
+// ---------------------------------------------------------------------------
+
+describe('appendDocTruthTurns', () => {
+  it('appends renumbered, phase-labeled doc turns so both passes stay in one trace', () => {
+    const mainTrace = trace([turn(1, ['grep_codebase']), turn(2)]);
+    const docTrace = trace([turn(1, ['get_files_context']), turn(2)]);
+
+    appendDocTruthTurns(mainTrace, docTrace);
+
+    expect(mainTrace.turns).toHaveLength(4);
+    expect(mainTrace.turns[2].turnNumber).toBe(3);
+    expect(mainTrace.turns[2].phase).toBe('doc-truth');
+    expect(mainTrace.turns[3].turnNumber).toBe(4);
+    // Tool calls from BOTH passes are now flattenable (keeps expectToolCalled
+    // working for main-pass assertions AND surfaces the doc pass's tools).
+    const toolNames = mainTrace.turns.flatMap(t => t.toolCalls.map(c => c.name));
+    expect(toolNames).toContain('grep_codebase');
+    expect(toolNames).toContain('get_files_context');
+  });
+
+  it('is a no-op when either trace is absent', () => {
+    const mainTrace = trace([turn(1)]);
+    expect(() => appendDocTruthTurns(undefined, trace([turn(1)]))).not.toThrow();
+    appendDocTruthTurns(mainTrace, undefined);
+    expect(mainTrace.turns).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDocTruthPass (client injected — zero LLM)
+// ---------------------------------------------------------------------------
+
+describe('runDocTruthPass', () => {
+  it('does not invoke the client and returns null when the pass is gated off', async () => {
+    const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]); // no claims
+    let called = false;
+    const res = await runDocTruthPass(ctx, cfg(), silentLogger, async () => {
+      called = true;
+      return fakeResult();
+    });
+    expect(res).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it('runs the client with the doc-pass budget/turns and returns its result', async () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const captured: { sys?: string; init?: string; budget?: number; maxTurns?: number } = {};
+    const res = await runDocTruthPass(
+      ctx,
+      cfg({ maxTokenBudget: 100_000 }),
+      silentLogger,
+      async (sys, init, budget, maxTurns) => {
+        Object.assign(captured, { sys, init, budget, maxTurns });
+        return fakeResult([finding({ filepath: 'docs/architecture/worktree.md', line: 2 })]);
+      },
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.findings).toHaveLength(1);
+    expect(captured.budget).toBe(40_000);
+    expect(captured.maxTurns).toBe(DOC_PASS_MAX_TURNS);
+    expect(captured.sys).toContain('doc-truth');
+    expect(captured.init).toContain('<doc_claims>');
+  });
+
+  it('isolates a pass failure: a throwing client yields null and a logged warning', async () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const { logger, lines } = capturingLogger();
+    const res = await runDocTruthPass(ctx, cfg(), logger, async () => {
+      throw new Error('boom');
+    });
+    expect(res).toBeNull();
+    expect(lines.some(l => l.includes('doc-truth pass failed') && l.includes('boom'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #732: when a PR's touched doc surfaces carry claim-shaped prose, `analyze()` runs a second, claims-only review pass — doc-truth rule alone, `<doc_claims>` with pre-fetched evidence, doc-surface hunks, no competing rules or signals, maxTurns 6 at 40% token budget. Findings force ruleId `doc-truth`, dedupe against main-pass findings (±2 lines, main kept), and append; doc-pass turns merge into the main trace stamped `phase: 'doc-truth'`. Failure-isolated (a pass-2 error logs and keeps main findings); kill-switches via config `docTruthPass: false` or `LIEN_REVIEW_DOC_PASS=0`. 18 unit tests; full suite 647/647; all gates green.

## Calibration status — INTERRUPTED by credit exhaustion, partial results

| Fixture | Before | This run | Validity |
|---|---|---|---|
| pr667-worktree-doc-drift | 2/10 | **5/10** | ✅ valid — doc pass ran in all 10 votes (3–4 doc turns each) |
| pr658-search-code-rename | 10/10 | 4/10 | ❌ invalid — account ran dry mid-batch; failures are 1–2-turn 402-starved runs with empty responses; pass-2 was swallowed by failure isolation (working as designed) |
| pr687-config-doc-drift | 2/10 | 0/10 @ $0.00 | ❌ invalid — zero API calls (account empty) |

## What the valid data shows

The architecture delivers: on pr667 the doc pass executes every vote and **passing votes carry correct doc-truth findings** — competition eliminated, discovery + evidence delivered. The remaining 5 failures are a *judgment-strictness* call: the pass reads the claim ("has an index — `structural.db` exists") next to the evidence ("`structural.db` AND a `manifest.json`") and concludes "accurately described" ~50% of the time — a lenient equivalence reading of an under-enumerated condition list.

## Remaining work before undraft
1. Re-run pr658 + pr687 with a funded account (current numbers are starvation artifacts).
2. One prompt-sharpening iteration in the pass prompt: an enumerated condition/requirement list must match the code's enumeration exactly — a missing condition IS a contradiction. Then pr667 calibrate-10, bar ≥9/10.
3. Real per-doc-PR cost measurement (~$0.03–0.09/vote observed for the second pass).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +27 |


> [!WARNING]
> **3 issues found** · Medium Risk
>
> The PR implements a dedicated doc-truth second pass with sound gating, prompt construction, and failure isolation, but the merge/presentation layer has three output bugs: the doc-pass incomplete notice is hidden behind the main-pass summary, the top-level risk summary ignores doc-truth findings, and proximity-based deduplication can suppress distinct doc-truth findings that happen to be near main-pass findings. These were also flagged in the PR's own lien-stats self-review.
>
> - New doc-truth pass module with gate, prompt builder, 40% budget, and merge helpers
> - Main agent plugin orchestrates a second LLM call and merges doc-truth findings/trace/usage
> - Summary and incomplete-notice generation still only consider the main pass, causing output mismatches

<sup>Reviewed by [Lien Review](https://lien.dev) for commit df0ff8c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated documentation truth review pass for pull requests containing claim-like documentation changes.
  * Integrated documentation findings into the main review while removing nearby duplicates.
  * Added clear trace labels and partial-verification notices when the documentation pass cannot complete.
  * Added configuration and environment controls to disable the pass when needed.
* **Bug Fixes**
  * Documentation review failures are isolated so they no longer fail the overall review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->