### PR TITLE
fix(review): fold doc-pass state into the rendered summary; severity-aware dedupe

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -226,21 +226,68 @@ function sameLocation(a: AgentFinding, b: AgentFinding): boolean {
   return a.filepath === b.filepath && Math.abs(a.line - b.line) <= DEDUPE_LINE_PROXIMITY;
 }
 
+/** error outranks warning — used so dedupe never drops the sharper finding. */
+function severityRank(f: AgentFinding): number {
+  return f.severity === 'error' ? 1 : 0;
+}
+
 /**
  * Fold the doc pass's findings into the main pass's. Every doc-pass finding gets
  * `ruleId: 'doc-truth'` (the pass has a single rule, so attribution is
  * unambiguous regardless of what the model emitted). A doc-pass finding is
- * dropped when the main pass already reported one at the same file within
- * DEDUPE_LINE_PROXIMITY lines — the main-pass version is kept. Returns a new
- * array; inputs are not mutated.
+ * dropped only when the main pass already reported one at the same location
+ * (same file, within DEDUPE_LINE_PROXIMITY lines) AT LEAST AS SEVERE — a
+ * doc-truth `error` must not be silenced by a nearby main-pass `warning`.
+ * Returns a new array; inputs are not mutated.
  */
 export function mergeDocTruthFindings(
   mainFindings: AgentFinding[],
   docFindings: AgentFinding[],
 ): AgentFinding[] {
   const forced = docFindings.map(f => ({ ...f, ruleId: 'doc-truth' }));
-  const kept = forced.filter(df => !mainFindings.some(mf => sameLocation(mf, df)));
+  const kept = forced.filter(
+    df => !mainFindings.some(mf => sameLocation(mf, df) && severityRank(mf) >= severityRank(df)),
+  );
   return [...mainFindings, ...kept];
+}
+
+/**
+ * Merge the doc pass's RESULT-LEVEL state into the main pass's before the
+ * summary/incomplete notices are appended. The render path (`present()` /
+ * `formatCheckSummary()`) consumes a SINGLE summary-category finding — a
+ * second appended notice is never rendered — so doc-pass state must be folded
+ * into the one summary the main pass owns:
+ *  - incomplete: an unfinished doc pass marks the merged result incomplete
+ *    (with the doc pass's stopReason when the main pass finished cleanly);
+ *  - risk: doc-truth `error` findings lift a low/absent risk level to medium
+ *    and note the documentation contradictions in the overview, so the
+ *    headline can't read "Low Risk / no issues" above doc-truth errors.
+ * Mutates and returns `main` (the caller owns it).
+ */
+export function mergeDocPassIntoResult(
+  main: AgentResult,
+  docResult: AgentResult | null,
+  mergedFindings: AgentFinding[],
+): AgentResult {
+  if (!docResult) return main;
+
+  if (docResult.incomplete && !main.incomplete) {
+    main.incomplete = true;
+    main.stopReason = docResult.stopReason;
+    main.incompleteFromDocPass = true;
+  }
+
+  const docErrors = mergedFindings.filter(
+    f => f.ruleId === 'doc-truth' && f.severity === 'error',
+  ).length;
+  if (docErrors > 0 && main.summary) {
+    const level = main.summary.riskLevel?.toLowerCase();
+    if (level === undefined || level === 'low') main.summary.riskLevel = 'medium';
+    main.summary.overview =
+      `${main.summary.overview} The documentation-truthfulness pass found ` +
+      `${docErrors} contradiction(s) between touched docs and the code — see the doc-truth findings.`;
+  }
+  return main;
 }
 
 /**

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -24,7 +24,12 @@ import { OpenAIAgentClient, toOpenAITools } from './openai-client.js';
 import { buildSystemPrompt, buildInitialMessage } from './system-prompt.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
-import { runDocTruthPass, mergeDocTruthFindings, appendDocTruthTurns } from './doc-truth-pass.js';
+import {
+  runDocTruthPass,
+  mergeDocTruthFindings,
+  mergeDocPassIntoResult,
+  appendDocTruthTurns,
+} from './doc-truth-pass.js';
 import {
   DEFAULT_REVIEW_MODEL,
   DEFAULT_OPENROUTER_BASE_URL,
@@ -182,13 +187,14 @@ export class AgentReviewPlugin implements ReviewPlugin {
 
     const pluginId = this.id;
     const agentFindings = mergeDocTruthFindings(result.findings, docResult?.findings ?? []);
+    // The render path consumes ONE summary finding, so doc-pass state (an
+    // unfinished pass, error-severity doc findings) must be folded into the
+    // main result BEFORE the notices are appended — a second summary finding
+    // would never render.
+    mergeDocPassIntoResult(result, docResult, agentFindings);
     const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
     appendIncompleteNotice(findings, pluginId, result);
-    // The doc pass's summary is deliberately discarded (claims-only overview;
-    // the main pass owns the PR's risk profile) — but an INCOMPLETE doc pass
-    // must not read as "no doc issues": surface its own notice.
-    if (docResult?.incomplete) appendDocPassIncompleteNotice(findings, pluginId, docResult);
 
     return findings;
   }
@@ -403,9 +409,13 @@ function appendIncompleteNotice(
         : result.stopReason === 'completed'
           ? 'ended without emitting a parseable JSON verdict'
           : 'stopped unexpectedly';
-  const message =
-    `Lien Review did not finish — it ${reason} while investigating. ` +
-    `Any findings shown are partial; re-run the review to retry.`;
+  // An incomplete that came only from the doc-truth SECOND pass must not
+  // imply the whole review is partial — the main pass finished normally.
+  const message = result.incompleteFromDocPass
+    ? `The documentation-truthfulness pass did not finish — it ${reason}. ` +
+      `Doc-claim verification is partial; code findings are unaffected.`
+    : `Lien Review did not finish — it ${reason} while investigating. ` +
+      `Any findings shown are partial; re-run the review to retry.`;
   findings.push({
     pluginId,
     filepath: '',
@@ -414,32 +424,6 @@ function appendIncompleteNotice(
     category: 'summary',
     message,
     metadata: { incomplete: true, stopReason: result.stopReason, overview: message },
-  });
-}
-
-/**
- * Surface an incomplete doc-truth SECOND pass. Kept separate from
- * `appendIncompleteNotice` so the wording says which pass died: the main
- * review completed normally, only the documentation check is partial —
- * "re-run the review" guidance would be misleadingly broad here.
- */
-function appendDocPassIncompleteNotice(
-  findings: ReviewFinding[],
-  pluginId: string,
-  docResult: AgentResult,
-): void {
-  const message =
-    'The dedicated documentation-truthfulness pass did not finish ' +
-    `(${docResult.stopReason ?? 'stopped unexpectedly'}) — doc-claim ` +
-    'verification is partial. Code findings above are unaffected.';
-  findings.push({
-    pluginId,
-    filepath: '',
-    line: 0,
-    severity: 'warning' as const,
-    category: 'summary',
-    message,
-    metadata: { incomplete: true, stopReason: docResult.stopReason, overview: message },
   });
 }
 

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -216,6 +216,12 @@ export interface AgentResult {
    * result must NOT be presented as a clean/approving review.
    */
   incomplete: boolean;
+  /**
+   * True when `incomplete` was set by an unfinished doc-truth SECOND pass
+   * while the main pass finished cleanly — the incomplete notice then names
+   * the doc pass instead of implying the whole review is partial.
+   */
+  incompleteFromDocPass?: boolean;
   /** Per-turn trace data — only populated when the caller wires up trace capture. */
   trace?: AgentTrace;
 }

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -5,6 +5,7 @@ import {
   buildDocTruthPassPrompts,
   buildDocTruthPassInitialMessage,
   mergeDocTruthFindings,
+  mergeDocPassIntoResult,
   appendDocTruthTurns,
   docTruthPassBudget,
   runDocTruthPass,
@@ -250,6 +251,89 @@ describe('mergeDocTruthFindings', () => {
     mergeDocTruthFindings(main, doc);
     expect(doc[0].ruleId).toBe('x'); // original untouched
     expect(main).toHaveLength(1);
+  });
+
+  it('keeps a doc-pass ERROR that overlaps a main-pass WARNING (severity-aware dedupe)', () => {
+    const main = [finding({ filepath: 'a.md', line: 10, severity: 'warning', message: 'main' })];
+    const doc = [finding({ filepath: 'a.md', line: 10, severity: 'error', message: 'doc-error' })];
+
+    const merged = mergeDocTruthFindings(main, doc);
+
+    expect(merged.map(f => f.message)).toEqual(['main', 'doc-error']);
+  });
+
+  it('still drops a doc-pass warning that overlaps a main-pass error', () => {
+    const main = [finding({ filepath: 'a.md', line: 10, severity: 'error', message: 'main' })];
+    const doc = [finding({ filepath: 'a.md', line: 11, severity: 'warning', message: 'doc' })];
+
+    expect(mergeDocTruthFindings(main, doc)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeDocPassIntoResult
+// ---------------------------------------------------------------------------
+
+describe('mergeDocPassIntoResult', () => {
+  it('marks the merged result incomplete when only the doc pass died', () => {
+    const main = fakeResult();
+    main.incomplete = false;
+    main.stopReason = 'completed';
+    const doc = fakeResult();
+    doc.incomplete = true;
+    doc.stopReason = 'budget';
+
+    mergeDocPassIntoResult(main, doc, []);
+
+    expect(main.incomplete).toBe(true);
+    expect(main.stopReason).toBe('budget');
+    expect(main.incompleteFromDocPass).toBe(true);
+  });
+
+  it('leaves a main-pass incomplete untouched (no doc-pass attribution)', () => {
+    const main = fakeResult();
+    main.incomplete = true;
+    main.stopReason = 'max_turns';
+    const doc = fakeResult();
+    doc.incomplete = true;
+    doc.stopReason = 'budget';
+
+    mergeDocPassIntoResult(main, doc, []);
+
+    expect(main.stopReason).toBe('max_turns');
+    expect(main.incompleteFromDocPass).toBeUndefined();
+  });
+
+  it('lifts a low risk level to medium and notes contradictions when the doc pass found errors', () => {
+    const main = fakeResult();
+    main.summary = { riskLevel: 'low', overview: 'Fine.', keyChanges: [] };
+    const merged = [finding({ ruleId: 'doc-truth', severity: 'error' })];
+
+    mergeDocPassIntoResult(main, fakeResult(), merged);
+
+    expect(main.summary.riskLevel).toBe('medium');
+    expect(main.summary.overview).toContain('documentation-truthfulness pass found 1');
+  });
+
+  it('does not lower an already-elevated risk level', () => {
+    const main = fakeResult();
+    main.summary = { riskLevel: 'critical', overview: 'Bad.', keyChanges: [] };
+    const merged = [finding({ ruleId: 'doc-truth', severity: 'error' })];
+
+    mergeDocPassIntoResult(main, fakeResult(), merged);
+
+    expect(main.summary.riskLevel).toBe('critical');
+  });
+
+  it('is a no-op for doc-truth warnings only or a null doc result', () => {
+    const main = fakeResult();
+    main.summary = { riskLevel: 'low', overview: 'Fine.', keyChanges: [] };
+
+    mergeDocPassIntoResult(main, fakeResult(), [finding({ ruleId: 'doc-truth' })]);
+    expect(main.summary.riskLevel).toBe('low');
+
+    mergeDocPassIntoResult(main, null, [finding({ ruleId: 'doc-truth', severity: 'error' })]);
+    expect(main.summary.riskLevel).toBe('low');
   });
 });
 


### PR DESCRIPTION
Triage follow-up on #733 — Lien Review's own findings on the final push landed after the merge (my miss: I triaged inline comments but not the review body). All three confirmed real and fixed:

1. **Dead-code incomplete notice**: `present()`/`formatCheckSummary()` consume only the FIRST summary finding, so the separately-appended doc-pass notice never rendered — an unfinished doc pass still read as "no doc issues". Doc-pass state now folds into the main result before the notices (`mergeDocPassIntoResult`), with `incompleteFromDocPass` making the notice say the doc pass specifically ("code findings are unaffected") instead of implying the whole review is partial.
2. **Misleading risk headline**: doc-truth `error` findings now lift a low/absent risk level to medium and append the contradiction count to the overview.
3. **Severity-blind dedupe**: a doc-pass ERROR overlapping a main-pass WARNING within ±2 lines was silently dropped; dedupe now only drops the doc finding when the main finding is at least as severe.

7 new unit tests. No prompt changes — code-level rendering/merge logic only, zero-LLM-testable, no calibration required.

## Harness evidence
No rule prompt or signal text changed; the calibrate-gated surface is untouched (see #733's certified table — this PR only fixes how already-produced results render/merge).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 1. 3 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | -1 |


> [!WARNING]
> **1 issue found** · Low Risk
>
> The PR folds doc-pass incomplete state and doc-truth errors into the main result before rendering, fixing the previously unrendered doc-pass notice and misleading low-risk headline. It also makes dedupe severity-aware. The only real issue is that the severity ranking is binary, which can still drop a doc warning when a main info finding overlaps it.
>
> - mergeDocPassIntoResult folds doc-pass incomplete state and doc-truth errors into the main result before summary/incomplete notices are appended
> - mergeDocTruthFindings now uses severity-aware dedupe so a doc error is not dropped by a nearby main warning
> - severityRank is incomplete: it treats warning and info as equal, allowing a main info finding to suppress a doc warning

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d8794ea. Updates automatically on new commits.</sup>
<!-- /lien-stats -->