### PR TITLE
feat(review): <removed_exports> signal — deterministic removed-symbol + reference sweep

### DIFF
--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -425,7 +425,7 @@ const REPLAY_UNAVAILABLE_REASON =
   'The repository working tree is not available in this run (e.g. offline fixture ' +
   'replay), so disk-backed search is blind here — a zero/empty result does NOT mean ' +
   '"no match exists". Rely on the pre-computed signals in your initial message ' +
-  '(<stale_literal_candidates>, <blast_radius>, <deleted_exports>) and the ' +
+  '(<stale_literal_candidates>, <blast_radius>, <removed_exports>) and the ' +
   'chunk-backed tools (get_files_context, get_dependents, list_functions) instead.';
 
 /**

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -145,7 +145,7 @@ const STRUCTURAL_ANALYSIS: ReviewRule = {
 Use tools to understand impact:
 1. Use get_files_context on changed files to understand imports/exports
 2. Use get_dependents on every changed/exported symbol to find callers
-3. **CRITICAL**: If the diff removes exports from a barrel/index file, you MUST use grep_codebase for EACH removed symbol name to check if any file still imports it. This is the #1 source of breaking changes in deletion PRs. Do not skip this step.
+3. **CRITICAL — removed exports**: A \`<removed_exports>\` section may be in your initial message. When present it pre-computes the removed public symbols AND the surviving-reference sweep, so treat EVERY entry that lists surviving references as a mandatory breaking-change check — verify and report it — and do NOT re-grep those symbols. Only \`grep_codebase\` for removed symbols NOT covered there (the scan can miss exotic export shapes). Removed exports are the #1 source of breaking changes in deletion PRs; do not skip this.
 4. Check if callers handle new behavior correctly
 5. Use read_file to get the FULL body of every changed function (not just the diff)`,
   example: `### Good finding — structural, caller broken:
@@ -399,6 +399,13 @@ MANDATORY protocol when this rule is active:
    new boundary semantics cascade into that caller. This is
    additional evidence for the finding, not a replacement for the
    test-coverage check.
+5. If a \`<removed_exports>\` section is present, cross-check each
+   entry against the PR's changeset entries and description. An
+   export removal the changeset omits, or describes as unchanged /
+   patch-level / non-breaking, is a reportable contradiction: the
+   public surface shrank but the release notes claim it did not.
+   Quote the changeset's claim and name the removed symbol in the
+   finding.
 
 Do not finalize a response for this rule with zero findings unless
 step 2 found a qualifying test. "I could not find an obvious bug"

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -16,6 +16,7 @@ import type { ReviewContext } from '../../plugin-types.js';
 import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
+import { renderRemovedExportsSection } from '../../removed-export-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
@@ -192,7 +193,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderComplexityRegressions(context));
   appendIfPresent(sections, renderChangedFunctions(context));
   appendIfPresent(sections, renderBlastRadius(opts));
-  appendIfPresent(sections, renderDeletedExports(context));
+  appendIfPresent(sections, renderRemovedExportsSection(context));
   appendIfPresent(sections, renderStaleLiteralSection(context));
   appendIfPresent(sections, renderUntrustedInputSection(context));
   appendIfPresent(sections, renderRenameSweepSection(context));
@@ -263,46 +264,4 @@ function renderBlastRadius(opts: BuildInitialMessageOptions): string | null {
   if (!opts.blastRadius) return null;
   const rendered = renderBlastRadiusMarkdown(opts.blastRadius);
   return rendered.length > 0 ? rendered : null;
-}
-
-function renderDeletedExports(context: ReviewContext): string | null {
-  const patches = context.pr?.patches;
-  if (!patches) return null;
-  const deletedExports = extractDeletedExports(patches);
-  if (deletedExports.length === 0) return null;
-  const list = deletedExports.map(e => `- ${e}`).join('\n');
-  return `<deleted_exports>\nThese exports were REMOVED in this PR. Use grep_codebase to check if any file still imports them. After checking deleted exports, continue with the rest of your investigation (edge case sweep on new/changed functions, self-review).\n${list}\n</deleted_exports>`;
-}
-
-/**
- * Extract symbol names of deleted exports from diff patches.
- * Looks for lines like `-export { Foo } from ...` or `-export { Foo, Bar }`.
- */
-function extractDeletedExports(patches: Map<string, string>): string[] {
-  const symbols: string[] = [];
-
-  for (const [, patch] of patches) {
-    const lines = patch.split('\n');
-    for (const line of lines) {
-      // Match removed export lines: -export { X, Y } from ...
-      if (!line.startsWith('-')) continue;
-      const exportMatch = line.match(/^-\s*export\s*\{([^}]+)\}/);
-      if (exportMatch) {
-        const names = exportMatch[1].split(',').map(s =>
-          s
-            .trim()
-            .split(/\s+as\s+/)[0]
-            .trim(),
-        );
-        symbols.push(...names.filter(n => n && !n.startsWith('type ')));
-      }
-      // Match removed re-export: -export { default as X } from ...
-      const reexportMatch = line.match(/^-\s*export\s*\{\s*(\w+)\s*\}/);
-      if (reexportMatch && !exportMatch) {
-        symbols.push(reexportMatch[1]);
-      }
-    }
-  }
-
-  return [...new Set(symbols)];
 }

--- a/packages/review/src/removed-export-signals.ts
+++ b/packages/review/src/removed-export-signals.ts
@@ -1,0 +1,479 @@
+/**
+ * Deterministic "removed public export" signal for PR reviews.
+ *
+ * Two rules share this signal:
+ *  - structural-analysis, whose prompt used to tell the model to
+ *    "grep_codebase for EACH removed symbol" — the grep-and-reason
+ *    anti-pattern CLAUDE.md's design principle warns against; and
+ *  - boundary-change, which needs to cross-check a removed public export
+ *    against what the PR's changeset claims (a removal a changeset calls
+ *    "unchanged" is a contradiction — the real escape on PR #711).
+ *
+ * This module pre-computes the structural facts instead, mirroring the
+ * `<stale_literal_candidates>` / `<doc_claims>` precedents: parse each
+ * file's diff for exported symbols the PR REMOVES (minus any re-added
+ * anywhere — a moved/renamed-file export is not a removal), then scan the
+ * indexed head corpus for chunks that STILL reference each removed symbol
+ * outside its own file. A surviving reference is a near-certain breaking
+ * change; a removed export a changeset describes as unchanged is a
+ * documentation contradiction. Both facts are injected as a
+ * `<removed_exports>` block so the agent confirms a handed-to-it worklist
+ * rather than discovering it via blind grep.
+ *
+ * Scope is deliberately TS/JS (this repo's surface) plus a cheap Rust
+ * `pub` shape (the structural-analysis canary is a Rust testbed file).
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A symbol this PR removes from a module's exported surface. */
+export interface RemovedExport {
+  /** Public export name; a default export is recorded as `default (X)`. */
+  symbol: string;
+  /** First file the diff removed this symbol from. */
+  file: string;
+}
+
+/** A surviving occurrence of a removed export, outside its own file. */
+export interface ExportReference {
+  file: string;
+  line: number;
+}
+
+/** A removed export with its surviving references and any changeset mention. */
+export interface RemovedExportContext {
+  symbol: string;
+  file: string;
+  survivingReferences: ExportReference[];
+  /** The `.changeset/*.md` file that mentions this symbol, or null. */
+  changesetFile: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max removed exports listed — keeps the block compact. */
+const MAX_ENTRIES = 15;
+/** Max surviving references listed per symbol. */
+const MAX_REFS_PER_SYMBOL = 5;
+/** Total block character budget. */
+const MAX_BLOCK_CHARS = 4_000;
+
+/** Files whose diffs we parse for export declarations (this repo's code surface). */
+const CODE_FILE_RE = /\.(?:[cm]?[jt]sx?|rs)$/;
+/** A top-level changeset entry (public-API claims live here). */
+const CHANGESET_FILE_RE = /(?:^|\/)\.changeset\/[^/]+\.md$/;
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/;
+/** An `export {` / `export type {` list opener (the brace right after export). */
+const EXPORT_LIST_OPEN_RE = /\bexport\s+(?:type\s+)?\{/;
+const DEFAULT_PREFIX = 'default (';
+
+// ---------------------------------------------------------------------------
+// Declaration / member parsing
+// ---------------------------------------------------------------------------
+
+const IDENT_RE = /^[A-Za-z_$][\w$]*$/;
+
+/**
+ * Parse the members of an `export { ... }` body (the text between braces, or
+ * one bare member line). Each member's PUBLIC name is taken — the alias for
+ * `A as B` (and `default as B`), the bare name otherwise; a leading `type`
+ * modifier is stripped. Non-identifier fragments are dropped.
+ */
+function parseMemberList(body: string): string[] {
+  const out: string[] = [];
+  for (const raw of body.split(',')) {
+    const cleaned = raw.trim().replace(/^type\s+/, '');
+    if (!cleaned) continue;
+    const parts = cleaned.split(/\s+as\s+/);
+    const name = parts[parts.length - 1].trim();
+    if (IDENT_RE.test(name)) out.push(name);
+  }
+  return out;
+}
+
+/**
+ * The exported symbol(s) a single declaration line publishes, or [] when the
+ * line is not an export declaration. Handles the TS/JS shapes (function,
+ * class, const/let/var, interface, type alias, enum, inline `export { … }`
+ * list, `export * as X`, `export default function/class X`) plus a cheap Rust
+ * `pub` item shape. The leading `+`/`-` must already be stripped.
+ */
+function extractExportSymbolsFromDeclLine(code: string): string[] {
+  const t = code.trim();
+
+  const inlineList = t.match(/^export\s+(?:type\s+)?\{([^}]*)\}/);
+  if (inlineList) return parseMemberList(inlineList[1]);
+
+  const patterns: Array<[RegExp, (name: string) => string]> = [
+    [/^export\s+default\s+(?:async\s+)?(?:function\*?|class)\s+([A-Za-z_$][\w$]*)/, defaultName],
+    [/^export\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from/, identity],
+    [/^export\s+(?:declare\s+)?(?:async\s+)?function\*?\s+([A-Za-z_$][\w$]*)/, identity],
+    [/^export\s+(?:declare\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/, identity],
+    [/^export\s+(?:declare\s+)?(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)/, identity],
+    [/^export\s+(?:declare\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)/, identity],
+    [/^export\s+(?:declare\s+)?interface\s+([A-Za-z_$][\w$]*)/, identity],
+    [/^export\s+(?:declare\s+)?type\s+([A-Za-z_$][\w$]*)/, identity],
+    // Rust: module-level `pub` items are the crate's exported surface.
+    [/^pub\s+(?:async\s+|unsafe\s+|const\s+)*fn\s+([A-Za-z_][\w]*)/, identity],
+    [/^pub\s+(?:struct|enum|trait|type|const|static)\s+([A-Za-z_][\w]*)/, identity],
+  ];
+
+  for (const [re, format] of patterns) {
+    const m = t.match(re);
+    if (m) return [format(m[1])];
+  }
+  return [];
+}
+
+function identity(name: string): string {
+  return name;
+}
+function defaultName(name: string): string {
+  return `${DEFAULT_PREFIX}${name})`;
+}
+
+/**
+ * Update `inList` (are we inside a multi-line `export { … }` block?) for one
+ * code line. Only an `export {`-shaped opener starts a block (a function body's
+ * bare `{` must not), and any `}` closes it. Deliberately brace-count-free —
+ * export member bodies don't nest braces.
+ */
+function updateListState(inList: boolean, code: string): boolean {
+  if (inList) return !code.includes('}');
+  if (!EXPORT_LIST_OPEN_RE.test(code)) return false;
+  // Opener only counts if the list isn't also closed on the same line.
+  const braceIdx = code.indexOf('{', code.search(EXPORT_LIST_OPEN_RE));
+  return !code.includes('}', braceIdx);
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+interface PatchExportScan {
+  removed: RemovedExport[];
+  added: Set<string>;
+}
+
+/** A line's export symbols in the given block state, updating that state. */
+function symbolsForLine(code: string, inList: boolean): { symbols: string[]; inList: boolean } {
+  const decl = extractExportSymbolsFromDeclLine(code);
+  const symbols = decl.length > 0 ? decl : inList ? parseMemberList(stripCloser(code)) : [];
+  return { symbols, inList: updateListState(inList, code) };
+}
+
+/** Drop a trailing `}`/`} from '…'` so a closer line's members parse cleanly. */
+function stripCloser(code: string): string {
+  const brace = code.indexOf('}');
+  return brace === -1 ? code : code.slice(0, brace);
+}
+
+/**
+ * Walk one file's unified-diff patch, collecting exported symbols the diff
+ * removes (`-` lines) and adds (`+` lines). The old-file view (context + `-`)
+ * and new-file view (context + `+`) each track their own `export { … }` block
+ * state so a bare member line is only read as an export inside a list.
+ */
+interface ScanState {
+  removed: RemovedExport[];
+  added: Set<string>;
+  inListOld: boolean;
+  inListNew: boolean;
+}
+
+/** Apply a removed (`-`) line: collect its export symbols, advance old state. */
+function applyRemovedLine(state: ScanState, code: string, file: string): void {
+  const r = symbolsForLine(code, state.inListOld);
+  for (const s of r.symbols) state.removed.push({ symbol: s, file });
+  state.inListOld = r.inList;
+}
+
+/** Apply an added (`+`) line: collect its export symbols, advance new state. */
+function applyAddedLine(state: ScanState, code: string): void {
+  const r = symbolsForLine(code, state.inListNew);
+  for (const s of r.symbols) state.added.add(s);
+  state.inListNew = r.inList;
+}
+
+/** Apply a context line: advances both views' block state identically. */
+function applyContextLine(state: ScanState, code: string): void {
+  const next = updateListState(state.inListOld, code);
+  state.inListOld = next;
+  state.inListNew = next;
+}
+
+/** Route one raw diff line to the matching state transition. */
+function processDiffLine(state: ScanState, raw: string, file: string): void {
+  if (raw.startsWith('+++') || raw.startsWith('---')) return;
+
+  const hunk = raw.match(HUNK_HEADER_RE);
+  if (hunk) {
+    state.inListOld = state.inListNew = updateListState(false, hunk[1]);
+    return;
+  }
+
+  if (raw.startsWith('-')) applyRemovedLine(state, raw.slice(1), file);
+  else if (raw.startsWith('+')) applyAddedLine(state, raw.slice(1));
+  else applyContextLine(state, raw.startsWith(' ') ? raw.slice(1) : raw);
+}
+
+function scanPatchExports(file: string, patch: string): PatchExportScan {
+  const state: ScanState = { removed: [], added: new Set(), inListOld: false, inListNew: false };
+  for (const raw of patch.split('\n')) processDiffLine(state, raw, file);
+  return { removed: state.removed, added: state.added };
+}
+
+/**
+ * Collect every exported symbol this PR removes, minus any re-added on a `+`
+ * export line ANYWHERE in the PR (a moved/renamed-file export is not a
+ * removal). Deduped by symbol, keeping the first file it was removed from.
+ * Skips non-code files. Exposed for testing.
+ */
+export function extractRemovedExports(patches: Map<string, string>): RemovedExport[] {
+  const removedRaw: RemovedExport[] = [];
+  const added = new Set<string>();
+
+  for (const [file, patch] of patches) {
+    if (!CODE_FILE_RE.test(file)) continue;
+    const scan = scanPatchExports(file, patch);
+    removedRaw.push(...scan.removed);
+    for (const s of scan.added) added.add(s);
+  }
+
+  const out: RemovedExport[] = [];
+  const seen = new Set<string>();
+  for (const entry of removedRaw) {
+    if (added.has(entry.symbol) || seen.has(entry.symbol)) continue;
+    seen.add(entry.symbol);
+    out.push(entry);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Surviving-reference scan
+// ---------------------------------------------------------------------------
+
+/** The bare name to search for, or null for a default export (no stable name). */
+function searchableName(symbol: string): string | null {
+  return symbol.startsWith(DEFAULT_PREFIX) ? null : symbol;
+}
+
+function wordBoundaryRe(name: string): RegExp {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\b`);
+}
+
+interface SymbolSpec {
+  symbol: string;
+  file: string;
+  re: RegExp;
+}
+
+/** Record word-boundary matches of one symbol within one chunk (capped). */
+function addLineRefs(
+  chunk: CodeChunk,
+  spec: SymbolSpec,
+  refsBySymbol: Map<string, ExportReference[]>,
+  seen: Set<string>,
+): void {
+  const refs = refsBySymbol.get(spec.symbol) ?? [];
+  const lines = chunk.content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (refs.length >= MAX_REFS_PER_SYMBOL) break;
+    if (!spec.re.test(lines[i])) continue;
+    const line = chunk.metadata.startLine + i;
+    const key = `${chunk.metadata.file}:${line}:${spec.symbol}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    refs.push({ file: chunk.metadata.file, line });
+  }
+  refsBySymbol.set(spec.symbol, refs);
+}
+
+/** Scan one chunk for every not-yet-capped symbol not removed from this file. */
+function collectRefsFromChunk(
+  chunk: CodeChunk,
+  specs: SymbolSpec[],
+  refsBySymbol: Map<string, ExportReference[]>,
+  seen: Set<string>,
+): void {
+  const file = chunk.metadata.file;
+  let content: string | undefined;
+  for (const spec of specs) {
+    if (spec.file === file) continue; // its own removal site is not a survivor
+    const refs = refsBySymbol.get(spec.symbol);
+    if (refs && refs.length >= MAX_REFS_PER_SYMBOL) continue;
+    content ??= chunk.content;
+    if (!content.includes(spec.symbol)) continue; // fast reject before per-line regex
+    addLineRefs(chunk, spec, refsBySymbol, seen);
+  }
+}
+
+/**
+ * For each removed export, find chunks in the head corpus that STILL reference
+ * it (word-boundary) outside the file it was removed from — the breakage
+ * candidates. Default exports are skipped (no stable importable name). Exposed
+ * for testing.
+ */
+export function findSurvivingReferences(
+  removed: RemovedExport[],
+  repoChunks: CodeChunk[] | undefined,
+): Map<string, ExportReference[]> {
+  const refsBySymbol = new Map<string, ExportReference[]>();
+  if (!repoChunks || repoChunks.length === 0) return refsBySymbol;
+
+  const specs: SymbolSpec[] = [];
+  for (const r of removed) {
+    const name = searchableName(r.symbol);
+    if (name) specs.push({ symbol: r.symbol, file: r.file, re: wordBoundaryRe(name) });
+  }
+  if (specs.length === 0) return refsBySymbol;
+
+  const seen = new Set<string>();
+  for (const chunk of repoChunks) collectRefsFromChunk(chunk, specs, refsBySymbol, seen);
+  return refsBySymbol;
+}
+
+// ---------------------------------------------------------------------------
+// Changeset cross-check
+// ---------------------------------------------------------------------------
+
+/**
+ * For each removed export, the `.changeset/*.md` file (if any) whose ADDED
+ * lines mention the symbol — the claim-vs-reality angle for boundary-change.
+ * Exposed for testing.
+ */
+export function changesetMentions(
+  removed: RemovedExport[],
+  patches: Map<string, string>,
+): Map<string, string> {
+  const mentions = new Map<string, string>();
+  const changesets: Array<{ file: string; added: string[] }> = [];
+  for (const [file, patch] of patches) {
+    if (!CHANGESET_FILE_RE.test(file)) continue;
+    const added = patch.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'));
+    changesets.push({ file, added });
+  }
+  if (changesets.length === 0) return mentions;
+
+  for (const r of removed) {
+    const name = searchableName(r.symbol);
+    if (!name) continue;
+    const re = wordBoundaryRe(name);
+    const hit = changesets.find(cs => cs.added.some(l => re.test(l)));
+    if (hit) mentions.set(r.symbol, hit.file);
+  }
+  return mentions;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * The `<removed_exports>` worklist for a review: removed exports, each with its
+ * surviving references and any changeset mention. Sorted breakage-first
+ * (most surviving references first), then changeset-mentioned, then the rest;
+ * ties broken by symbol name for determinism. Returns [] when no diff.
+ */
+export function computeRemovedExportContexts(context: ReviewContext): RemovedExportContext[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+
+  const removed = extractRemovedExports(patches);
+  if (removed.length === 0) return [];
+
+  const refs = findSurvivingReferences(removed, context.repoChunks);
+  const mentions = changesetMentions(removed, patches);
+
+  const contexts = removed.map(r => ({
+    symbol: r.symbol,
+    file: r.file,
+    survivingReferences: refs.get(r.symbol) ?? [],
+    changesetFile: mentions.get(r.symbol) ?? null,
+  }));
+
+  contexts.sort((a, b) => {
+    const byRefs = b.survivingReferences.length - a.survivingReferences.length;
+    if (byRefs !== 0) return byRefs;
+    const byChangeset = Number(!!b.changesetFile) - Number(!!a.changesetFile);
+    if (byChangeset !== 0) return byChangeset;
+    return a.symbol.localeCompare(b.symbol);
+  });
+
+  return contexts;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const HEADER =
+  'Pre-computed by a deterministic diff scan — the removed-symbol discovery ' +
+  'AND the reference sweep are done for you; do NOT re-grep these. Each entry ' +
+  "is a symbol this PR removes from a module's exported surface, with any " +
+  'SURVIVING references found in the head corpus. A surviving reference is a ' +
+  'near-certain breaking change — verify and report it (structural-analysis). ' +
+  'A removed export that a changeset describes as unchanged/non-breaking is a ' +
+  'contradiction (boundary-change). No surviving references + accurate ' +
+  'changeset = likely intentional; stay silent.';
+
+/** Render one removed-export entry line. */
+function renderEntry(c: RemovedExportContext): string {
+  const refs = c.survivingReferences;
+  const refList =
+    refs.length > 0
+      ? refs.map(r => `${r.file}:${r.line}`).join(', ')
+      : 'none found in the head corpus';
+  const changeset = c.changesetFile ? `; described in changeset ${c.changesetFile}` : '';
+  return `- ${c.symbol} (removed from ${c.file}) — ${refs.length} surviving reference(s): ${refList}${changeset}`;
+}
+
+/**
+ * Render removed-export contexts as a `<removed_exports>` block for the agent's
+ * initial message. Returns '' when there are none so callers can append
+ * unconditionally. Caps at MAX_ENTRIES and MAX_BLOCK_CHARS with an explicit
+ * omission note. Exposed for testing.
+ */
+export function renderRemovedExports(contexts: RemovedExportContext[]): string {
+  if (contexts.length === 0) return '';
+
+  const lines: string[] = ['<removed_exports>', HEADER];
+  let used = lines.join('\n').length;
+  let rendered = 0;
+
+  for (const c of contexts.slice(0, MAX_ENTRIES)) {
+    const entry = renderEntry(c);
+    if (used + entry.length + 1 > MAX_BLOCK_CHARS) break;
+    lines.push(entry);
+    used += entry.length + 1;
+    rendered++;
+  }
+
+  const omitted = contexts.length - rendered;
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more removed export(s) omitted to respect the input budget — inspect the diff for the rest]`,
+    );
+  }
+
+  lines.push('</removed_exports>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<removed_exports>` section from the review context. Returns ''
+ * when the PR removes no exported symbols (or there is no diff).
+ */
+export function renderRemovedExportsSection(context: ReviewContext): string {
+  return renderRemovedExports(computeRemovedExportContexts(context));
+}

--- a/packages/review/src/removed-export-signals.ts
+++ b/packages/review/src/removed-export-signals.ts
@@ -74,6 +74,8 @@ const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$/;
 /** An `export {` / `export type {` list opener (the brace right after export). */
 const EXPORT_LIST_OPEN_RE = /\bexport\s+(?:type\s+)?\{/;
 const DEFAULT_PREFIX = 'default (';
+/** Bulk re-export removals (`export * from '…'`) — listed, never swept. */
+const BULK_PREFIX = "* (all re-exports of '";
 
 // ---------------------------------------------------------------------------
 // Declaration / member parsing
@@ -94,7 +96,12 @@ function parseMemberList(body: string): string[] {
     if (!cleaned) continue;
     const parts = cleaned.split(/\s+as\s+/);
     const name = parts[parts.length - 1].trim();
-    if (IDENT_RE.test(name)) out.push(name);
+    if (!IDENT_RE.test(name)) continue;
+    // `export { default }` / `A as default`: the public name is the module's
+    // default export. Record it in the default form so the reference sweep
+    // skips it — a bare `default` would word-boundary-match every `default`
+    // keyword in the repo.
+    out.push(name === 'default' ? `${DEFAULT_PREFIX}default)` : name);
   }
   return out;
 }
@@ -111,6 +118,12 @@ function extractExportSymbolsFromDeclLine(code: string): string[] {
 
   const inlineList = t.match(/^export\s+(?:type\s+)?\{([^}]*)\}/);
   if (inlineList) return parseMemberList(inlineList[1]);
+
+  // A removed bulk re-export (`export * from './m'`) removes EVERY symbol the
+  // source module re-published — no individual names to sweep, but the agent
+  // must know the surface shrank. Recorded as a bulk entry (no ref sweep).
+  const bulk = t.match(/^export\s+(?:type\s+)?\*\s+from\s+['"]([^'"]+)['"]/);
+  if (bulk) return [`${BULK_PREFIX}${bulk[1]}')`];
 
   const patterns: Array<[RegExp, (name: string) => string]> = [
     [/^export\s+default\s+(?:async\s+)?(?:function\*?|class)\s+([A-Za-z_$][\w$]*)/, defaultName],
@@ -140,18 +153,27 @@ function defaultName(name: string): string {
   return `${DEFAULT_PREFIX}${name})`;
 }
 
+/** The line with `//` comments stripped — a `}` in a comment must not end a list. */
+function withoutLineComment(code: string): string {
+  const idx = code.indexOf('//');
+  return idx === -1 ? code : code.slice(0, idx);
+}
+
 /**
  * Update `inList` (are we inside a multi-line `export { … }` block?) for one
  * code line. Only an `export {`-shaped opener starts a block (a function body's
- * bare `{` must not), and any `}` closes it. Deliberately brace-count-free —
- * export member bodies don't nest braces.
+ * bare `{` must not), and a STRUCTURAL `}` closes it — a `}` inside a trailing
+ * `//` comment doesn't count (a commented member line must not silently drop
+ * the rest of the list). Deliberately brace-count-free — export member bodies
+ * don't nest braces.
  */
 function updateListState(inList: boolean, code: string): boolean {
-  if (inList) return !code.includes('}');
-  if (!EXPORT_LIST_OPEN_RE.test(code)) return false;
+  const structural = withoutLineComment(code);
+  if (inList) return !structural.includes('}');
+  if (!EXPORT_LIST_OPEN_RE.test(structural)) return false;
   // Opener only counts if the list isn't also closed on the same line.
-  const braceIdx = code.indexOf('{', code.search(EXPORT_LIST_OPEN_RE));
-  return !code.includes('}', braceIdx);
+  const braceIdx = structural.indexOf('{', structural.search(EXPORT_LIST_OPEN_RE));
+  return !structural.includes('}', braceIdx);
 }
 
 // ---------------------------------------------------------------------------
@@ -264,7 +286,7 @@ export function extractRemovedExports(patches: Map<string, string>): RemovedExpo
 
 /** The bare name to search for, or null for a default export (no stable name). */
 function searchableName(symbol: string): string | null {
-  return symbol.startsWith(DEFAULT_PREFIX) ? null : symbol;
+  return symbol.startsWith(DEFAULT_PREFIX) || symbol.startsWith(BULK_PREFIX) ? null : symbol;
 }
 
 function wordBoundaryRe(name: string): RegExp {
@@ -309,7 +331,14 @@ function collectRefsFromChunk(
   const file = chunk.metadata.file;
   let content: string | undefined;
   for (const spec of specs) {
-    if (spec.file === file) continue; // its own removal site is not a survivor
+    // Deliberate precision tradeoff: the whole removal FILE is excluded, not
+    // just the removal site. An export removal is not always a definition
+    // removal (`export { foo }` dropped while `function foo` stays for
+    // internal use) — same-file references are then legitimate, and flagging
+    // them would manufacture breakage. Same-file dangling refs from a true
+    // definition removal are the compiler/CI's job; the review's signal is
+    // the CROSS-FILE importers that silently break.
+    if (spec.file === file) continue;
     const refs = refsBySymbol.get(spec.symbol);
     if (refs && refs.length >= MAX_REFS_PER_SYMBOL) continue;
     content ??= chunk.content;

--- a/packages/review/src/removed-export-signals.ts
+++ b/packages/review/src/removed-export-signals.ts
@@ -238,6 +238,14 @@ function processDiffLine(state: ScanState, raw: string, file: string): void {
 
   const hunk = raw.match(HUNK_HEADER_RE);
   if (hunk) {
+    // List state is deliberately RESET at every hunk header and re-derived
+    // from the header's section text only. Hunks are non-contiguous: the
+    // unseen gap between them can contain the list's closing `}`, so carrying
+    // `inList` across a boundary would misparse unrelated `-  Foo,` lines in
+    // later hunks as removed list members (precision loss). The cost is a
+    // rare recall miss — a single export list spanning multiple hunks whose
+    // later header carries no section text — which the rendered block's
+    // "the scan can miss exotic shapes" caveat already covers.
     state.inListOld = state.inListNew = updateListState(false, hunk[1]);
     return;
   }

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -8,7 +8,7 @@
  * exists), so the rule can never find the surviving copy.
  *
  * This module pre-computes the structural fact instead, mirroring the
- * `<blast_radius>` / `<deleted_exports>` precedents: collect every distinctive
+ * `<blast_radius>` / `<removed_exports>` precedents: collect every distinctive
  * literal the diff TOUCHES (on a `+` or `-` line — this covers both a literal
  * the PR removed and one it conditionalized in place), then scan the indexed
  * repo's post-image chunk content for the SAME literal surviving unchanged

--- a/packages/review/src/untrusted-input-signals.ts
+++ b/packages/review/src/untrusted-input-signals.ts
@@ -10,7 +10,7 @@
  *
  * This module pre-computes the parse sites the diff introduces/modifies and
  * injects them as an `<untrusted_input_sites>` worklist, mirroring the
- * `<deleted_exports>` / `<stale_literal_candidates>` precedents. It hands the
+ * `<removed_exports>` / `<stale_literal_candidates>` precedents. It hands the
  * agent a concrete list to trace, which counters the silence-bias failure mode
  * (the agent investigates but emits nothing). It injects only locations — never
  * a verdict; the agent still traces each site to its consumers and judges.

--- a/packages/review/test/harness/fixtures/structural-analysis/removed-export.assertions.ts
+++ b/packages/review/test/harness/fixtures/structural-analysis/removed-export.assertions.ts
@@ -2,9 +2,14 @@
  * PR #399 — `parse_input` (Rust exported function) entirely removed.
  * Classic structural breakage: any caller of `parse_input` is now broken.
  *
- * Per structural-analysis prompt, the agent MUST call grep_codebase for
- * each removed symbol name to check if any file still imports it. The
- * Tier 1 assertion enforces both: rule fires + investigation happened.
+ * The Tier 1 assertion enforces that the structural-analysis rule fires.
+ * It no longer requires a `grep_codebase` call: since the `<removed_exports>`
+ * signal (removed-export-signals.ts) pre-computes the removed symbol AND the
+ * surviving-reference sweep and hands it to the agent, the prompt now tells
+ * the model NOT to re-grep covered symbols. Requiring the grep would test the
+ * retired grep-and-reason path, not finding quality. The Tier 2 checks below
+ * pin the substance — that the agent names the removed symbol and the compile
+ * breakage of its remaining callers — which is what actually matters.
  *
  * Tier 2 (added 2026-07-11, authored from 3 observed Kimi votes —
  * moonshotai/kimi-k2.7-code, the prod default): pins the substance of the
@@ -36,7 +41,6 @@ const assertions: FixtureAssertions = {
   rule: 'structural-analysis',
   expect: (result, h) => {
     h.expectRuleFired('structural-analysis', result);
-    h.expectToolCalled('grep_codebase', result);
     // (A) names the removed exported symbol.
     h.expectFindingMentions(['parse_input', 'parser::parse_input', 'parser.rs'], result);
     // (B) states the compile breakage of its remaining callers.

--- a/packages/review/test/plugins-agent-blast-radius.test.ts
+++ b/packages/review/test/plugins-agent-blast-radius.test.ts
@@ -76,7 +76,7 @@ describe('buildInitialMessage with blast-radius injection', () => {
     expect(message).not.toContain('<blast_radius>');
   });
 
-  it('places <blast_radius> after <changed_files> and before <deleted_exports>', () => {
+  it('places <blast_radius> after <changed_files> and before <removed_exports>', () => {
     const context = createTestContext({
       changedFiles: ['src/auth/validate.ts'],
       pr: {
@@ -92,14 +92,14 @@ describe('buildInitialMessage with blast-radius injection', () => {
 
     const changedFilesIdx = message.indexOf('<changed_files>');
     const blastIdx = message.indexOf('<blast_radius>');
-    const deletedIdx = message.indexOf('<deleted_exports>');
+    const removedIdx = message.indexOf('<removed_exports>');
 
     // All three blocks must be present — otherwise the ordering assertion
     // silently no-ops and this test loses its point.
     expect(changedFilesIdx).toBeGreaterThan(-1);
     expect(blastIdx).toBeGreaterThan(-1);
-    expect(deletedIdx).toBeGreaterThan(-1);
+    expect(removedIdx).toBeGreaterThan(-1);
     expect(blastIdx).toBeGreaterThan(changedFilesIdx);
-    expect(blastIdx).toBeLessThan(deletedIdx);
+    expect(blastIdx).toBeLessThan(removedIdx);
   });
 });

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -462,7 +462,7 @@ describe('buildSystemPrompt', () => {
     // Structural analysis rule
     expect(prompt).toContain('Structural');
     expect(prompt).toContain('get_files_context');
-    expect(prompt).toContain('barrel/index file');
+    expect(prompt).toContain('<removed_exports>');
 
     // Edge case sweep rule
     expect(prompt).toContain('Edge Case Sweep');

--- a/packages/review/test/removed-export-signals.test.ts
+++ b/packages/review/test/removed-export-signals.test.ts
@@ -177,6 +177,49 @@ describe('extractRemovedExports', () => {
     expect(embedding).toHaveLength(1);
     expect(embedding[0].file).toBe('src/errors/index.ts'); // first occurrence
   });
+  it('a } inside a trailing comment does not end a multi-line export list', () => {
+    const patches = new Map([
+      [
+        'src/a.ts',
+        patch(
+          '@@ -1,5 +1,2 @@',
+          ' export {',
+          '-  Foo, // note: old }',
+          '-  Bar,',
+          ' } from "./m";',
+        ),
+      ],
+    ]);
+    const symbols = extractRemovedExports(patches).map(r => r.symbol);
+    expect(symbols).toEqual(expect.arrayContaining(['Foo', 'Bar']));
+  });
+
+  it('records a removed bulk re-export as a bulk entry (never swept)', () => {
+    const patches = new Map([
+      ['src/index.ts', patch('@@ -1,1 +1,0 @@', "-export * from './internal';")],
+    ]);
+    const removed = extractRemovedExports(patches);
+    expect(removed).toHaveLength(1);
+    expect(removed[0].symbol).toBe("* (all re-exports of './internal')");
+    // The bulk entry must not produce a reference sweep.
+    const refs = findSurvivingReferences(removed, [
+      makeChunk('src/other.ts', 1, "export * from './elsewhere';"),
+    ]);
+    expect(refs.get(removed[0].symbol)).toBeUndefined();
+  });
+
+  it('treats a bare default list member as a default export, not a sweepable name', () => {
+    const patches = new Map([
+      ['src/index.ts', patch('@@ -1,1 +1,0 @@', "-export { default } from './widget';")],
+    ]);
+    const removed = extractRemovedExports(patches);
+    expect(removed[0].symbol).toBe('default (default)');
+    const refs = findSurvivingReferences(removed, [
+      makeChunk('src/other.ts', 1, 'export default function x() {}'),
+    ]);
+    // No `\bdefault\b` sweep — every default keyword in the repo must NOT match.
+    expect(refs.get(removed[0].symbol)).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -184,6 +227,16 @@ describe('extractRemovedExports', () => {
 // ---------------------------------------------------------------------------
 
 describe('findSurvivingReferences', () => {
+  it('excludes same-file references by design (export removal ≠ definition removal)', () => {
+    // `export { helper }` dropped while `function helper` stays for internal
+    // use: same-file refs are legitimate; cross-file importers are the signal.
+    const removed = [{ symbol: 'helper', file: 'src/a.ts' }];
+    const refs = findSurvivingReferences(removed, [
+      makeChunk('src/a.ts', 10, 'function helper() {}\nconst x = helper();'),
+      makeChunk('src/b.ts', 3, "import { helper } from './a';"),
+    ]);
+    expect(refs.get('helper')?.map(r => r.file)).toEqual(['src/b.ts']);
+  });
   const removed: RemovedExport[] = [{ symbol: 'parse_input', file: 'src/parser.rs' }];
 
   it('finds references in the head corpus outside the symbol’s own file', () => {

--- a/packages/review/test/removed-export-signals.test.ts
+++ b/packages/review/test/removed-export-signals.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  extractRemovedExports,
+  findSurvivingReferences,
+  changesetMentions,
+  computeRemovedExportContexts,
+  renderRemovedExports,
+  renderRemovedExportsSection,
+  type RemovedExport,
+  type RemovedExportContext,
+} from '../src/removed-export-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+  };
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  repoChunks?: CodeChunk[];
+}): ReviewContext {
+  const pr = opts.patches ? { patches: opts.patches } : undefined;
+  return { pr, repoChunks: opts.repoChunks } as unknown as ReviewContext;
+}
+
+function patch(...lines: string[]): string {
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// extractRemovedExports — declaration shapes
+// ---------------------------------------------------------------------------
+
+describe('extractRemovedExports', () => {
+  it('extracts each removed export declaration shape', () => {
+    const patches = new Map([
+      [
+        'src/a.ts',
+        patch(
+          '@@ -1,8 +1,0 @@',
+          '-export function doThing() {}',
+          '-export class Widget {}',
+          '-export const CONFIG = 1;',
+          '-export interface Options {}',
+          '-export type Handler = () => void;',
+          '-export enum Color { Red }',
+        ),
+      ],
+    ]);
+    const symbols = extractRemovedExports(patches).map(r => r.symbol);
+    expect(symbols).toEqual(
+      expect.arrayContaining(['doThing', 'Widget', 'CONFIG', 'Options', 'Handler', 'Color']),
+    );
+  });
+
+  it('extracts a removed default export as `default (X)`', () => {
+    const patches = new Map([
+      ['src/a.ts', patch('@@ -1,1 +0,0 @@', '-export default function handler() {}')],
+    ]);
+    expect(extractRemovedExports(patches).map(r => r.symbol)).toContain('default (handler)');
+  });
+
+  it('extracts members of an inline `export { A, B } from` list', () => {
+    const patches = new Map([
+      ['src/index.ts', patch('@@ -1,1 +0,0 @@', "-export { Alpha, Beta } from './mod';")],
+    ]);
+    const symbols = extractRemovedExports(patches).map(r => r.symbol);
+    expect(symbols).toEqual(expect.arrayContaining(['Alpha', 'Beta']));
+  });
+
+  it('takes the public alias for `A as B` re-exports (incl. `default as X`)', () => {
+    const patches = new Map([
+      [
+        'src/index.ts',
+        patch(
+          '@@ -1,1 +0,0 @@',
+          "-export { internal as publicName, default as Thing } from './m';",
+        ),
+      ],
+    ]);
+    const symbols = extractRemovedExports(patches).map(r => r.symbol);
+    expect(symbols).toContain('publicName');
+    expect(symbols).toContain('Thing');
+    expect(symbols).not.toContain('internal');
+  });
+
+  it('detects a single member removed from a surviving multi-line export list', () => {
+    // The `export {` opener is only in the hunk-header section text; the sole
+    // change is a bare `-  EmbeddingError,` member line (the PR #711 shape).
+    const patches = new Map([
+      [
+        'packages/core/src/index.ts',
+        patch(
+          '@@ -182,7 +182,6 @@ export {',
+          '   LienError,',
+          '-  EmbeddingError,',
+          '   IndexingError,',
+        ),
+      ],
+    ]);
+    expect(extractRemovedExports(patches).map(r => r.symbol)).toEqual(['EmbeddingError']);
+  });
+
+  it('detects one member dropped when the whole inline list is rewritten (- list vs + list)', () => {
+    const patches = new Map([
+      [
+        'src/index.ts',
+        patch(
+          '@@ -1,1 +1,1 @@',
+          '-export { Keep, Drop } from "./m";',
+          '+export { Keep } from "./m";',
+        ),
+      ],
+    ]);
+    const symbols = extractRemovedExports(patches).map(r => r.symbol);
+    expect(symbols).toContain('Drop');
+    expect(symbols).not.toContain('Keep'); // survived on the `+` line
+  });
+
+  it('excludes a symbol re-added on a `+` export line anywhere (a moved export)', () => {
+    const patches = new Map([
+      ['src/old.ts', patch('@@ -1,1 +0,0 @@', "-export { Mover } from './impl';")],
+      ['src/new.ts', patch('@@ -0,0 +1,1 @@', "+export { Mover } from './impl';")],
+    ]);
+    expect(extractRemovedExports(patches).map(r => r.symbol)).not.toContain('Mover');
+  });
+
+  it('extracts a removed Rust `pub fn` (and other pub items)', () => {
+    const patches = new Map([
+      [
+        'src/parser.rs',
+        patch(
+          '@@ -1,3 +0,0 @@',
+          '-pub fn parse_input(path: &str) -> Result<Parsed, Error> {',
+          '-pub struct ParsedInput {}',
+          '-pub enum Kind { A }',
+        ),
+      ],
+    ]);
+    const symbols = extractRemovedExports(patches).map(r => r.symbol);
+    expect(symbols).toEqual(expect.arrayContaining(['parse_input', 'ParsedInput', 'Kind']));
+  });
+
+  it('skips non-code files', () => {
+    const patches = new Map([
+      ['README.md', patch('@@ -1,1 +0,0 @@', '-export function fromDocs() {}')],
+      ['package.json', patch('@@ -1,1 +0,0 @@', '-  "export": "value"')],
+    ]);
+    expect(extractRemovedExports(patches)).toEqual([]);
+  });
+
+  it('records the file a symbol was removed from and dedupes by symbol', () => {
+    const patches = new Map([
+      [
+        'src/errors/index.ts',
+        patch('@@ -1,1 +0,0 @@', '-export class EmbeddingError extends X {}'),
+      ],
+      ['src/index.ts', patch('@@ -1,3 +1,2 @@ export {', '   A,', '-  EmbeddingError,', '   B,')],
+    ]);
+    const removed = extractRemovedExports(patches);
+    const embedding = removed.filter(r => r.symbol === 'EmbeddingError');
+    expect(embedding).toHaveLength(1);
+    expect(embedding[0].file).toBe('src/errors/index.ts'); // first occurrence
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSurvivingReferences
+// ---------------------------------------------------------------------------
+
+describe('findSurvivingReferences', () => {
+  const removed: RemovedExport[] = [{ symbol: 'parse_input', file: 'src/parser.rs' }];
+
+  it('finds references in the head corpus outside the symbol’s own file', () => {
+    const repoChunks = [
+      makeChunk('src/main.rs', 200, 'let x = 1;\nlet input = parser::parse_input(path)?;'),
+      makeChunk('src/reporter.rs', 40, 'let input = parser::parse_input(p)?;'),
+    ];
+    const refs = findSurvivingReferences(removed, repoChunks).get('parse_input') ?? [];
+    expect(refs.map(r => `${r.file}:${r.line}`)).toEqual(['src/main.rs:201', 'src/reporter.rs:40']);
+  });
+
+  it('excludes the file the symbol was removed from', () => {
+    const repoChunks = [
+      makeChunk('src/parser.rs', 5, '// parse_input used to live here'),
+      makeChunk('src/main.rs', 10, 'parser::parse_input(p);'),
+    ];
+    const refs = findSurvivingReferences(removed, repoChunks).get('parse_input') ?? [];
+    expect(refs.every(r => r.file !== 'src/parser.rs')).toBe(true);
+    expect(refs.map(r => r.file)).toContain('src/main.rs');
+  });
+
+  it('matches on word boundaries — parse_input must not match parse_inputs', () => {
+    const repoChunks = [makeChunk('src/main.rs', 1, 'let y = parse_inputs(all);')];
+    const refs = findSurvivingReferences(removed, repoChunks).get('parse_input') ?? [];
+    expect(refs).toHaveLength(0);
+  });
+
+  it('caps references per symbol at 5, in traversal order', () => {
+    const many = Array.from({ length: 8 }, (_, i) =>
+      makeChunk(`src/c${i}.rs`, 1, 'parse_input(x);'),
+    );
+    const refs = findSurvivingReferences(removed, many).get('parse_input') ?? [];
+    expect(refs).toHaveLength(5);
+    expect(refs.map(r => r.file)).toEqual([
+      'src/c0.rs',
+      'src/c1.rs',
+      'src/c2.rs',
+      'src/c3.rs',
+      'src/c4.rs',
+    ]);
+  });
+
+  it('dedupes a physical line covered by overlapping chunks', () => {
+    const repoChunks = [
+      makeChunk('src/main.rs', 5, 'let a = 1;\nparse_input(x);'), // line 6
+      makeChunk('src/main.rs', 6, 'parse_input(x);\nlet b = 2;'), // line 6 again
+    ];
+    const refs = findSurvivingReferences(removed, repoChunks).get('parse_input') ?? [];
+    expect(refs.filter(r => r.line === 6)).toHaveLength(1);
+  });
+
+  it('skips default exports (no stable importable name)', () => {
+    const refs = findSurvivingReferences(
+      [{ symbol: 'default (handler)', file: 'src/a.ts' }],
+      [makeChunk('src/b.ts', 1, 'handler();')],
+    );
+    expect(refs.size).toBe(0);
+  });
+
+  it('returns an empty map when there is no repo index', () => {
+    expect(findSurvivingReferences(removed, undefined).size).toBe(0);
+    expect(findSurvivingReferences(removed, []).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// changesetMentions
+// ---------------------------------------------------------------------------
+
+describe('changesetMentions', () => {
+  it('detects a removed symbol mentioned on a `+` line of a changeset', () => {
+    const removed: RemovedExport[] = [{ symbol: 'EmbeddingError', file: 'src/errors/index.ts' }];
+    const patches = new Map([
+      [
+        '.changeset/remove-embedding-error.md',
+        patch('@@ -0,0 +1,2 @@', '+Removed the unused `EmbeddingError` class and its error codes.'),
+      ],
+    ]);
+    expect(changesetMentions(removed, patches).get('EmbeddingError')).toBe(
+      '.changeset/remove-embedding-error.md',
+    );
+  });
+
+  it('ignores mentions on non-added lines and outside .changeset', () => {
+    const removed: RemovedExport[] = [{ symbol: 'Widget', file: 'src/a.ts' }];
+    const patches = new Map([
+      ['.changeset/x.md', patch('@@ -1,1 +0,0 @@', '-Removed Widget in a prior release.')],
+      ['docs/notes.md', patch('@@ -0,0 +1,1 @@', '+Widget is documented here.')],
+    ]);
+    expect(changesetMentions(removed, patches).has('Widget')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rendering
+// ---------------------------------------------------------------------------
+
+describe('renderRemovedExports', () => {
+  it('returns "" for no contexts', () => {
+    expect(renderRemovedExports([])).toBe('');
+  });
+
+  it('renders a block naming the symbol, its removal file, and surviving refs', () => {
+    const contexts: RemovedExportContext[] = [
+      {
+        symbol: 'parse_input',
+        file: 'src/parser.rs',
+        survivingReferences: [
+          { file: 'src/main.rs', line: 210 },
+          { file: 'src/reporter.rs', line: 40 },
+        ],
+        changesetFile: null,
+      },
+    ];
+    const md = renderRemovedExports(contexts);
+    expect(md).toContain('<removed_exports>');
+    expect(md).toContain('</removed_exports>');
+    expect(md).toContain('parse_input (removed from src/parser.rs)');
+    expect(md).toContain('2 surviving reference(s): src/main.rs:210, src/reporter.rs:40');
+  });
+
+  it('notes a changeset mention on a clean (0-reference) removal', () => {
+    const md = renderRemovedExports([
+      {
+        symbol: 'EmbeddingError',
+        file: 'src/errors/index.ts',
+        survivingReferences: [],
+        changesetFile: '.changeset/remove-embedding-error.md',
+      },
+    ]);
+    expect(md).toContain('EmbeddingError');
+    expect(md).toContain('0 surviving reference(s)');
+    expect(md).toContain('described in changeset .changeset/remove-embedding-error.md');
+  });
+
+  it('names both rules’ verbs in the header (structural-analysis + boundary-change)', () => {
+    const md = renderRemovedExports([
+      { symbol: 'X', file: 'a.ts', survivingReferences: [], changesetFile: null },
+    ]);
+    expect(md).toContain('structural-analysis');
+    expect(md).toContain('boundary-change');
+  });
+
+  it('caps at 15 entries with an explicit omission note', () => {
+    const contexts: RemovedExportContext[] = Array.from({ length: 20 }, (_, i) => ({
+      symbol: `Sym${i}`,
+      file: 'src/a.ts',
+      survivingReferences: [],
+      changesetFile: null,
+    }));
+    const md = renderRemovedExports(contexts);
+    expect(md).toContain('more removed export(s) omitted');
+    // 5 omitted (20 - 15).
+    expect(md).toContain('+5 more');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRemovedExportContexts — sorting
+// ---------------------------------------------------------------------------
+
+describe('computeRemovedExportContexts', () => {
+  it('sorts surviving-reference entries first, then changeset-mentioned', () => {
+    const patches = new Map([
+      [
+        'src/index.ts',
+        patch(
+          '@@ -1,3 +0,0 @@',
+          '-export const Clean = 1;',
+          '-export const Breaks = 2;',
+          '-export const Documented = 3;',
+        ),
+      ],
+      ['.changeset/x.md', patch('@@ -0,0 +1,1 @@', '+Removed `Documented`.')],
+    ]);
+    const repoChunks = [makeChunk('src/consumer.ts', 1, 'use(Breaks);')];
+    const order = computeRemovedExportContexts(makeContext({ patches, repoChunks })).map(
+      c => c.symbol,
+    );
+    expect(order[0]).toBe('Breaks'); // has a surviving reference
+    expect(order[1]).toBe('Documented'); // changeset-mentioned
+    expect(order[2]).toBe('Clean'); // neither
+  });
+
+  it('returns [] when there is no diff', () => {
+    expect(computeRemovedExportContexts(makeContext({}))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderRemovedExportsSection + buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('renderRemovedExportsSection', () => {
+  it('returns "" when the PR removes no exports', () => {
+    const patches = new Map([
+      ['src/a.ts', patch('@@ -1,1 +1,1 @@', '-const x = 1;', '+const x = 2;')],
+    ]);
+    expect(renderRemovedExportsSection(makeContext({ patches }))).toBe('');
+  });
+});
+
+describe('buildInitialMessage injection', () => {
+  it('includes the <removed_exports> block with surviving references', () => {
+    const patches = new Map([
+      ['src/parser.rs', patch('@@ -1,1 +0,0 @@', '-pub fn parse_input(p: &str) {}')],
+    ]);
+    const repoChunks = [makeChunk('src/main.rs', 210, 'parser::parse_input(p);')];
+    const context = {
+      ...makeContext({ patches, repoChunks }),
+      changedFiles: ['src/parser.rs'],
+      chunks: [],
+    } as unknown as ReviewContext;
+
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).toContain('<removed_exports>');
+    expect(message).toContain('parse_input (removed from src/parser.rs)');
+    expect(message).toContain('src/main.rs:210');
+  });
+
+  it('omits the block entirely when no exports were removed', () => {
+    const patches = new Map([
+      ['src/a.ts', patch('@@ -1,1 +1,1 @@', '-const x = 1;', '+const x = 2;')],
+    ]);
+    const context = {
+      ...makeContext({ patches }),
+      changedFiles: ['src/a.ts'],
+      chunks: [],
+    } as unknown as ReviewContext;
+    expect(buildInitialMessage(context, { blastRadius: null })).not.toContain('<removed_exports>');
+  });
+});


### PR DESCRIPTION
## Summary

The last evidence-backed thread from the 60-PR gap analysis: a deterministic signal that replaces the grep-and-reason path for removed exports, serving **two rules**. `extractRemovedExports` parses removed export declarations from the diff (TS/JS incl. list members, re-exports, defaults; Rust pub items), subtracting re-added symbols (moves ≠ removals). `findSurvivingReferences` pre-sweeps the head corpus for code still referencing each removed symbol — structural-analysis no longer needs to "grep for EACH removed symbol". `changesetMentions` cross-checks changeset claims — boundary-change can now flag a removal described as unchanged (the PR #711 escape).

Replaces the older `<deleted_exports>` block (which instructed the agent to grep) — running both would hand the model contradictory worklists. The structural-analysis canary's `expectToolCalled('grep_codebase')` retires with the path it tested (the #614 stale-duplicate precedent). 29 unit tests; e2e-verified on the #399 canary (parse_input + 3 surviving refs) and pr711 (EmbeddingError + changeset mention).

## Calibration (kimi-k2.7-code)

| Fixture | Result | |
|---|---|---|
| structural-analysis/removed-export | **10/10** | measured with the STRICTER pre-relaxation assertion still in place — certified with margin |
| boundary-change/placeholder | **9/10** | = bar |
| boundary-change/ge-5-threshold-shift | 8/10 ⚠️ | both misses are Tier-2 phrasing: model reports the planted bug from the threshold-value angle ("changed from >5 to >4") vs the expected classification phrasing ("low to medium") — substance present |
| stale-duplicate / error-swallowing ×3 / untrusted (3-vote spot-checks) | **all green** | `<deleted_exports>` replacement is corpus-safe |

## Remaining before undraft
One clean ge-5 calibrate-10 (the verification re-run hit account exhaustion at $0.00 — no data): if ≥9/10 → noise, ship as-is; if 8/10 again → widen the fixture's Tier-2 accepted phrasings (substance is present in the failing votes' traces), validate the widening free by offline re-score, one confirming c10. Blocked on an OpenRouter top-up (~$2 covers it with margin).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 16. 7 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 2 | -16 |
| ⏱️ time to understand | 5 | +0 |


> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR replaces the old grep-and-reason `<deleted_exports>` block with a deterministic `<removed_exports>` signal computed by a new `removed-export-signals.ts` module. The change is well-scoped and extensively tested, but the reference-sweep regex mishandles `$`-prefixed identifiers because `\b` word boundaries treat `$` as a non-word character. That produces false negatives for a realistic class of exported symbols and, since the prompt now instructs the agent not to re-grep covered symbols, those misses are unlikely to be caught manually.
>
> - Added `removed-export-signals.ts` with deterministic removed-export extraction, surviving-reference sweep, changeset cross-check, and rendering.
> - Replaced `<deleted_exports>` with `<removed_exports>` in the system prompt and structural-analysis/boundary-change rules.
> - Updated tests and fixtures to stop requiring `grep_codebase` for covered removed-export symbols.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 18968ec. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated detection of removed public exports and surviving references.
  * Review context now includes a `<removed_exports>` section highlighting potential breaking changes and related changeset mentions.
  * Structural and boundary reviews now validate removed exports more thoroughly.

* **Bug Fixes**
  * Corrected unavailable-tool messaging in offline replay mode.

* **Tests**
  * Added comprehensive coverage for export detection, reference tracking, ordering, truncation, and prompt integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->