### PR TITLE
fix(review): a starved review fails loudly instead of passing as clean

### DIFF
--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -141,6 +141,13 @@ export class AnthropicAgentClient {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let turn = 0;
+    // Turns the model actually completed (a usable response came back), as
+    // opposed to `turn`, which counts attempts including one that throws. A run
+    // where the first request fails terminally reports 0 completed turns and is
+    // marked `neverRan`. See the OpenAI client for the same accounting.
+    let completedTurns = 0;
+    // The terminal error that ended the run, surfaced on the result.
+    let terminalError: string | undefined;
     let lastResponse: Anthropic.Messages.Message | null = null;
     const turnTraces: TurnTrace[] = [];
     // Defaults to 'max_turns': if the loop exits via its `while` condition
@@ -154,23 +161,37 @@ export class AnthropicAgentClient {
       turn++;
 
       const used = totalInputTokens + totalOutputTokens;
-      const response = await this.client.messages.create({
-        model: this.model,
-        max_tokens: requestMaxTokens(this.maxTokenBudget - used),
-        thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET_TOKENS },
-        system: [
-          {
-            type: 'text',
-            text: systemPrompt,
-            cache_control: { type: 'ephemeral' },
-          },
-        ],
-        messages,
-        tools,
-        // tool_choice:'none' forbids tool calls, forcing a findings response.
-        // Compatible with extended thinking (unlike 'any'/'tool').
-        ...(forceFinish ? { tool_choice: { type: 'none' as const } } : {}),
-      });
+      let response: Anthropic.Messages.Message;
+      try {
+        response = await this.client.messages.create({
+          model: this.model,
+          max_tokens: requestMaxTokens(this.maxTokenBudget - used),
+          thinking: { type: 'enabled', budget_tokens: THINKING_BUDGET_TOKENS },
+          system: [
+            {
+              type: 'text',
+              text: systemPrompt,
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+          messages,
+          tools,
+          // tool_choice:'none' forbids tool calls, forcing a findings response.
+          // Compatible with extended thinking (unlike 'any'/'tool').
+          ...(forceFinish ? { tool_choice: { type: 'none' as const } } : {}),
+        });
+      } catch (err) {
+        // The SDK already retries transient failures; a throw here means it gave
+        // up (e.g. credits exhausted). End gracefully as an error stop — a
+        // propagated throw would be silently dropped by the engine's
+        // Promise.allSettled, letting a starved review read as clean.
+        terminalError = err instanceof Error ? err.message : String(err);
+        this.logger.warning(`[agent] message request failed (${terminalError}); ending run`);
+        stopReason = 'error';
+        break;
+      }
+      // A usable response came back — this turn genuinely completed.
+      completedTurns++;
 
       lastResponse = response;
 
@@ -287,9 +308,12 @@ export class AnthropicAgentClient {
     // This also catches an `end_turn` that emitted prose instead of the findings
     // JSON: that must NOT be reported as a clean 0-findings review.
     const incomplete = !parsed.summary;
+    // Never-ran = a terminal error with zero completed turns (parity with the
+    // OpenAI client): every request failed, so nothing was investigated.
+    const neverRan = stopReason === 'error' && completedTurns === 0;
     if (incomplete) {
       this.logger.warning(
-        `[agent] Review incomplete (stopReason=${stopReason}, no verdict/summary after ${turn} turns)`,
+        `[agent] Review ${neverRan ? 'never ran' : 'incomplete'} (stopReason=${stopReason}, no verdict/summary after ${completedTurns} completed turn(s))`,
       );
       // Always surface what the agent was doing when it bailed.
       logTurn(this.logger, lastLoopTurn, 'last turn before bail');
@@ -304,9 +328,11 @@ export class AnthropicAgentClient {
         totalTokens: totalInputTokens + totalOutputTokens,
         cost,
       },
-      turns: turn,
+      turns: completedTurns,
       stopReason,
       incomplete,
+      neverRan,
+      errorMessage: terminalError,
       trace: {
         systemPrompt,
         initialMessage,

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -169,15 +169,12 @@ export class AgentReviewPlugin implements ReviewPlugin {
     // A dedicated pass with no competing rules keeps documentation drift from
     // being out-competed by the PR's real code bugs in a single findings list.
     // Its trace/usage fold into the main run; a failure returns null and leaves
-    // the main-pass output untouched.
-    const docResult = await this.runSecondDocPass(
-      context,
-      config,
-      apiKey,
-      provider,
-      logger,
-      toolExecutor,
-    );
+    // the main-pass output untouched. Skipped entirely when the main pass never
+    // ran (provider down) — a second pass would only fire more doomed requests,
+    // and its own incomplete state must not overwrite the never-ran marker.
+    const docResult = result.neverRan
+      ? null
+      : await this.runSecondDocPass(context, config, apiKey, provider, logger, toolExecutor);
     if (docResult) {
       appendDocTruthTurns(result.trace, docResult.trace);
       context.reportUsage?.(docResult.usage);
@@ -391,24 +388,27 @@ export function scaleBudgetForBlastRadius(baseBudget: number, riskLevel?: string
 }
 
 /**
- * When the agent bailed on a budget/turn limit before producing a verdict,
- * append a `summary` finding flagged `incomplete` so `present()` surfaces a
- * clear warning instead of a misleading "no issues found" / clean review.
+ * When the agent bailed before producing a verdict, append a `summary` finding
+ * so `present()` surfaces a clear notice instead of a misleading "no issues
+ * found" / clean review.
+ *
+ * A NEVER-RAN main pass (every provider request failed — infrastructure, not a
+ * partial review) escalates to an `error` finding so the check concludes
+ * `failure` rather than the passing `neutral` a `warning` maps to. A partial
+ * run, or an incomplete that came only from the failure-isolated doc-truth
+ * pass, stays a `warning` (fail-open) — but still never reads as clean.
  */
-function appendIncompleteNotice(
+export function appendIncompleteNotice(
   findings: ReviewFinding[],
   pluginId: string,
   result: AgentResult,
 ): void {
   if (!result.incomplete) return;
-  const reason =
-    result.stopReason === 'budget'
-      ? 'hit the token budget limit'
-      : result.stopReason === 'max_turns'
-        ? 'hit the turn limit'
-        : result.stopReason === 'completed'
-          ? 'ended without emitting a parseable JSON verdict'
-          : 'stopped unexpectedly';
+  if (result.neverRan && !result.incompleteFromDocPass) {
+    appendNeverRanNotice(findings, pluginId, result);
+    return;
+  }
+  const reason = describeIncompleteStop(result.stopReason);
   // An incomplete that came only from the doc-truth SECOND pass must not
   // imply the whole review is partial — the main pass finished normally.
   const message = result.incompleteFromDocPass
@@ -425,6 +425,62 @@ function appendIncompleteNotice(
     message,
     metadata: { incomplete: true, stopReason: result.stopReason, overview: message },
   });
+}
+
+/** Human-readable phrase for why an incomplete (but partial) run stopped. */
+function describeIncompleteStop(stopReason: AgentResult['stopReason']): string {
+  switch (stopReason) {
+    case 'budget':
+      return 'hit the token budget limit';
+    case 'max_turns':
+      return 'hit the turn limit';
+    case 'completed':
+      return 'ended without emitting a parseable JSON verdict';
+    default:
+      return 'stopped unexpectedly';
+  }
+}
+
+/**
+ * Append the never-ran notice: an `error`-severity summary finding naming the
+ * provider failure. The error severity is load-bearing — `determineConclusion`
+ * maps it to a `failure` check conclusion, so a fully starved review can't pass
+ * as clean. `metadata.neverRan` lets a conclusion-mapper key on it explicitly.
+ */
+function appendNeverRanNotice(
+  findings: ReviewFinding[],
+  pluginId: string,
+  result: AgentResult,
+): void {
+  const cause = summarizeProviderError(result.errorMessage);
+  const message =
+    `Lien Review did not run — every provider request failed${cause ? ` (${cause})` : ''}. ` +
+    `This is NOT a clean review; no code was analyzed. Re-run once the provider ` +
+    `issue is resolved.`;
+  findings.push({
+    pluginId,
+    filepath: '',
+    line: 0,
+    severity: 'error' as const,
+    category: 'summary',
+    message,
+    metadata: {
+      incomplete: true,
+      neverRan: true,
+      stopReason: result.stopReason,
+      overview: message,
+    },
+  });
+}
+
+/** Cap the provider error to a short, single-line cause for the notice. */
+const MAX_PROVIDER_ERROR_CHARS = 160;
+function summarizeProviderError(msg?: string): string {
+  if (!msg) return '';
+  const oneLine = msg.replace(/\s+/g, ' ').trim();
+  return oneLine.length <= MAX_PROVIDER_ERROR_CHARS
+    ? oneLine
+    : `${oneLine.slice(0, MAX_PROVIDER_ERROR_CHARS - 1).trimEnd()}…`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -291,6 +291,15 @@ export class OpenAIAgentClient {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let turn = 0;
+    // Turns the model actually completed (a usable response came back). `turn`
+    // increments at the top of the loop, BEFORE the API call — so a request that
+    // throws on its first attempt leaves turn=1 with nothing accomplished. This
+    // counts only real responses, so a fully starved run (every request 402s)
+    // reports 0 turns instead of a misleading 1, and marks the run `neverRan`.
+    let completedTurns = 0;
+    // The terminal error that ended the run, surfaced on the result so the
+    // never-ran notice can name the provider failure (e.g. a 402).
+    let terminalError: string | undefined;
     let lastContent: string | null = null;
     const turnTraces: TurnTrace[] = [];
     // Defaults to 'max_turns': if the loop exits via its `while` condition
@@ -311,12 +320,15 @@ export class OpenAIAgentClient {
         // Transient failures are already retried inside chatCompletion; a throw
         // here means it gave up. End the run gracefully (stopReason 'error' → no
         // summary → incomplete notice) rather than crashing the whole plugin.
+        terminalError = err instanceof Error ? err.message : String(err);
         this.logger.warning(
-          `[agent] chat request failed after retries (${err instanceof Error ? err.message : String(err)}); ending run`,
+          `[agent] chat request failed after retries (${terminalError}); ending run`,
         );
         stopReason = 'error';
         break;
       }
+      // A usable response came back — this turn genuinely completed.
+      completedTurns++;
 
       const turnInputTokens = response.usage?.prompt_tokens ?? 0;
       const turnOutputTokens = response.usage?.completion_tokens ?? 0;
@@ -401,7 +413,9 @@ export class OpenAIAgentClient {
     // field, not `content`). Result: silent-bail failures on rules
     // whose runs the model was actively investigating. Trace evidence
     // gathered after #553 — see PR description.
-    if (!parsed.summary && turn > 0) {
+    // Gated on a completed turn: a never-ran run (every request failed) has no
+    // conversation to summarize, so skip the doomed retry (and its 3s sleep).
+    if (!parsed.summary && completedTurns > 0) {
       const retry = await this.runSummaryRetry(messages, turn);
       if (retry) {
         totalInputTokens += retry.inputTokens;
@@ -423,9 +437,14 @@ export class OpenAIAgentClient {
     // prose instead of the findings JSON (the model "completed" but delivered no
     // verdict): that must NOT be reported as a clean 0-findings review.
     const incomplete = !parsed.summary;
+    // Never-ran = a terminal error with zero completed turns: every provider
+    // request failed (e.g. an overdrawn account 402ing on every call), so the
+    // agent investigated nothing. This is an infrastructure failure, not a
+    // partial review, and must not read as a clean/neutral result downstream.
+    const neverRan = stopReason === 'error' && completedTurns === 0;
     if (incomplete) {
       this.logger.warning(
-        `[agent] Review incomplete (stopReason=${stopReason}, no verdict/summary after ${turn} turns)`,
+        `[agent] Review ${neverRan ? 'never ran' : 'incomplete'} (stopReason=${stopReason}, no verdict/summary after ${completedTurns} completed turn(s))`,
       );
       // Always surface what the agent was doing when it bailed — the single
       // most useful datum for diagnosing an incomplete run in CI logs.
@@ -441,9 +460,11 @@ export class OpenAIAgentClient {
         totalTokens: totalInputTokens + totalOutputTokens,
         cost,
       },
-      turns: turn,
+      turns: completedTurns,
       stopReason,
       incomplete,
+      neverRan,
+      errorMessage: terminalError,
       trace: {
         systemPrompt,
         initialMessage,

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -217,6 +217,21 @@ export interface AgentResult {
    */
   incomplete: boolean;
   /**
+   * True when the agent pass NEVER completed a single model turn — every
+   * provider request failed terminally (e.g. a 402 on an overdrawn account, or a
+   * network outage that outlasted the retries). Distinct from a PARTIAL
+   * incomplete run (some turns completed, then it bailed): a never-ran review
+   * investigated nothing, so it must drive a FAILING check conclusion rather
+   * than the neutral one a partial run gets. Always implies `incomplete`. Set on
+   * the MAIN pass only — a failure-isolated doc-truth second pass never sets it.
+   */
+  neverRan?: boolean;
+  /**
+   * The terminal error message that ended the run (present when `stopReason` is
+   * 'error'), so the never-ran/incomplete notice can name the provider failure.
+   */
+  errorMessage?: string;
+  /**
    * True when `incomplete` was set by an unfinished doc-truth SECOND pass
    * while the main pass finished cleanly — the incomplete notice then names
    * the doc pass instead of implying the whole review is partial.

--- a/packages/review/test/engine-present.test.ts
+++ b/packages/review/test/engine-present.test.ts
@@ -304,6 +304,38 @@ describe('ReviewEngine.present()', () => {
     );
   });
 
+  it('concludes failure on a never-ran summary error finding (not neutral)', async () => {
+    // Guards the #737 contract at the conclusion layer: the never-ran notice is
+    // a category:'summary', line:0 ERROR finding. determineConclusion must map it
+    // to 'failure' — a starved review that investigated nothing cannot conclude
+    // with the passing 'neutral' a warning-severity incomplete notice gets.
+    const engine = new ReviewEngine();
+    const octokit = {
+      checks: {
+        create: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    const findings: ReviewFinding[] = [
+      {
+        pluginId: 'agent-review',
+        filepath: '',
+        line: 0,
+        severity: 'error',
+        category: 'summary',
+        message: 'Lien Review did not run — every provider request failed (402).',
+        metadata: { incomplete: true, neverRan: true, stopReason: 'error' },
+      },
+    ];
+
+    await engine.present(findings, createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(octokit.checks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ conclusion: 'failure' }),
+    );
+  });
+
   it('captures debug log in check run text field', async () => {
     const engine = new ReviewEngine();
     const octokit = {

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -168,3 +168,31 @@ describe('AnthropicAgentClient extended thinking + retry forcing', () => {
     expect(retryArgs.tools).toBeDefined();
   }, 15000);
 });
+
+describe('AnthropicAgentClient never-ran (terminal API failure)', () => {
+  it('returns a never-ran result instead of propagating the throw', async () => {
+    // An overdrawn account: the SDK exhausts its own retries and throws. A
+    // propagated throw would be silently dropped by the engine's
+    // Promise.allSettled — letting a starved review read as clean — so the
+    // client must catch it and return a neverRan result with zero completed
+    // turns and no summary.
+    createMock.mockRejectedValue(new Error('402 Insufficient credits'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(1_000_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.neverRan).toBe(true);
+    expect(result.incomplete).toBe(true);
+    expect(result.turns).toBe(0);
+    expect(result.summary).toBeUndefined();
+    expect(result.stopReason).toBe('error');
+    expect(result.errorMessage).toContain('402');
+    // No summary-retry: with no lastResponse there is nothing to summarize.
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { OpenAIAgentClient, envDisabled } from '../src/plugins/agent/openai-client.js';
 import {
   AgentReviewPlugin,
+  appendIncompleteNotice,
   scaleBudgetForBlastRadius,
   clampText,
 } from '../src/plugins/agent/index.js';
@@ -10,6 +11,7 @@ import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.j
 import { silentLogger } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
 import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
+import type { AgentResult } from '../src/plugins/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // fetch mock helpers (OpenAI-compatible chat/completions)
@@ -327,6 +329,126 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.incomplete).toBe(true);
     expect(result.summary).toBeUndefined();
   }, 20000); // retries + the summary-retry's own attempts/sleep
+
+  it('marks a credit-starved run never-ran (402 on every request), not a clean review', async () => {
+    // The exact #737 signature: an overdrawn account 402s on every request. A
+    // non-429/non-5xx 4xx is a fatal throw (no retry), so no turn ever completes.
+    // The run must report neverRan with ZERO completed turns and no summary — an
+    // infrastructure failure, not a misleading "0 findings in 1 turns".
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        return {
+          ok: false,
+          status: 402,
+          text: async () => '{"error":{"message":"Insufficient credits"}}',
+        };
+      }),
+    );
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.neverRan).toBe(true);
+    expect(result.incomplete).toBe(true);
+    expect(result.turns).toBe(0);
+    expect(result.summary).toBeUndefined();
+    expect(result.findings).toHaveLength(0);
+    expect(result.errorMessage).toContain('402');
+    // Zero completed turns ⇒ the doomed summary-retry is skipped (one call only).
+    expect(calls).toBe(1);
+  });
+
+  it('does NOT mark a partial run (a turn completed, then failures) never-ran', async () => {
+    // Turn 1 completes with tool_calls; the next request (and its retries) fail.
+    // A turn ran, so this is a PARTIAL incomplete — fail-open — not never-ran.
+    let calls = 0;
+    const ok = toolCallTurn(100);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) return { ok: true, status: 200, text: async () => JSON.stringify(ok) };
+        throw new TypeError('fetch failed');
+      }),
+    );
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(true);
+    expect(result.neverRan).toBe(false);
+    expect(result.turns).toBeGreaterThanOrEqual(1);
+  }, 20000);
+});
+
+describe('appendIncompleteNotice — severity by run outcome', () => {
+  function baseResult(overrides: Partial<AgentResult>): AgentResult {
+    return {
+      findings: [],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 },
+      turns: 0,
+      stopReason: 'error',
+      incomplete: true,
+      ...overrides,
+    };
+  }
+
+  it('escalates a never-ran main pass to an ERROR notice naming the cause', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: true, errorMessage: 'API error (402): Insufficient credits' }),
+    );
+
+    expect(findings).toHaveLength(1);
+    const notice = findings[0];
+    expect(notice.severity).toBe('error');
+    expect(notice.category).toBe('summary');
+    expect(notice.message).toContain('did not run');
+    expect(notice.message).toContain('402');
+    expect(notice.message).toContain('NOT a clean review');
+    expect(notice.metadata).toMatchObject({ neverRan: true, incomplete: true });
+  });
+
+  it('keeps a partial (budget) incomplete a WARNING, not clean', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: false, stopReason: 'budget' }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toContain('did not finish');
+    expect(findings[0].message).not.toContain('did not run');
+  });
+
+  it('keeps a doc-pass-only incomplete a WARNING even if that pass never ran', () => {
+    // A never-ran flag arriving alongside incompleteFromDocPass must NOT escalate
+    // — the doc-truth second pass is failure-isolated; the main pass ran fine.
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: true, incompleteFromDocPass: true, stopReason: 'error' }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toContain('documentation-truthfulness pass');
+    expect(findings[0].message).toContain('code findings are unaffected');
+  });
+
+  it('is a no-op for a complete run', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(findings, 'agent-review', baseResult({ incomplete: false }));
+    expect(findings).toHaveLength(0);
+  });
 });
 
 describe('envDisabled (LIEN_REVIEW_LOG_AGENT parsing — logging on by default)', () => {


### PR DESCRIPTION
Closes #737.

## The four links that made total starvation look clean
1. `turn++` before the API call → "1 turns" on zero successful responses
2. `incomplete` was correctly set (#735 machinery worked)
3. …but the notice was only `severity: 'warning'`
4. warning → `neutral` → **passing** GitHub conclusion, exit 0

## Fix
- **Clients** count `completedTurns` (usable responses only) and report them honestly; terminal error + 0 completed turns ⇒ `neverRan` with the provider error captured. **Second hole closed:** the Anthropic path had no try/catch around `messages.create` — total failure threw out of `analyze()` and `Promise.allSettled` silently dropped it. Doomed summary-retries are skipped when nothing ran.
- **Plugin**: a never-ran MAIN pass escalates to an **error-severity** notice naming the cause ("This is NOT a clean review; no code was analyzed"). Doc-pass-only starvation keeps its fail-open warning; the doc pass is skipped when the main pass never ran.
- **Conclusion**: no mapper change needed — error findings already drive `failure` + exit 1 + a cause-naming annotation.

| Run | notice | conclusion |
|---|---|---|
| never-ran (main) | error | **failure** + annotation |
| partial incomplete | warning | neutral (unchanged) |
| doc-pass-only incomplete | warning | neutral (fail-open by design) |
| clean | — | success |

## Evidence & scope
Repro was run 29160321548 (PR #736): the starved review posted zero findings and passed; the funded re-run of the same commit found 4 real findings. Zero prompt/signal text changed — off the calibration bar; fully unit-tested (695 review tests green, new coverage for both client paths, the notice mapping, and the conclusion drive).

Known residual (out of scope, noted in-code): `runActivePlugins`' `Promise.allSettled` still silently drops findings of any plugin that THROWS for non-starvation reasons — the starvation route is closed at the client layer; a defense-in-depth pass there is a possible follow-up.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 14 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 3 high-risk file(s) with 5 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +6 |
| 🧠 mental load | 3 | +7 |
| ⏱️ time to understand | 6 | +99 |
| 🐛 estimated bugs | 2 | +0.312 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it stopped unexpectedly while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit f950870. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

## Harness evidence
No-regression run with the fix in place, prod model: `npm run test:harness -w @liendev/review -- --rule structural-analysis` → **3/3 passed** ($0.02). No prompt/signal text changed; the error-path changes are pinned by unit tests (a full calibrate sweep is not warranted for terminal-error plumbing).