### PR TITLE
feat(review): harness UX — default trace persistence, characterization tier, --bail; render all summaries

### DIFF
--- a/docs/development/review-harness-judgment.md
+++ b/docs/development/review-harness-judgment.md
@@ -68,12 +68,15 @@ gitignored, regenerated per-machine via `capture-pr.ts <pr> <out> [--sha]`.
   is a drift signal. The bar for touching a rule's prompt is ≥9/10 on that
   rule's canaries; shared scaffolding (output format, injected sections all
   rules see) needs a full-corpus no-regression sweep.
-- **Characterization fixtures** (no tag): measure a known frontier and don't
-  gate. Their headers record the measured rate, the trace-verified failure
-  mode, and why iteration stopped. Never spend calibration budget pushing a
-  characterization fixture "green as a side effect" — read its header first;
-  some (e.g. disclosed-removal changeset claims) are *correctly* declined by
-  the model.
+- **Characterization fixtures** (`tags: ['characterization']`): measure a known
+  frontier and don't gate. The harness renders them as a neutral `~ … measured
+  N/M (non-gating, see fixture header)` line rather than a red `✗`, and their
+  result is excluded from the process exit code — so a run where only
+  characterization fixtures miss their historical rate still exits 0. Their
+  headers record the measured rate, the trace-verified failure mode, and why
+  iteration stopped. Never spend calibration budget pushing a characterization
+  fixture "green as a side effect" — read its header first; some (e.g.
+  disclosed-removal changeset claims) are *correctly* declined by the model.
 
 ## The deterministic-signal pattern — and its limit
 
@@ -128,6 +131,7 @@ competition is the bottleneck.
 - Deterministic signals: `packages/review/src/*-signals.ts`
 - The doc-truth second pass: `packages/review/src/plugins/agent/doc-truth-pass.ts`
 - Calibration driver: `packages/review/test/harness/run.ts` (`--calibrate`,
-  `--trace`, `--fixture`, `--rule`, `--model`)
+  `--trace`, `--fixture`, `--rule`, `--model`, `--bail`; traces persist to
+  `.wip/traces/` by default)
 - Offline re-scoring: `packages/review/test/harness/assert-cli.ts`
 - Prompt rendering without an LLM: `packages/review/test/harness/build-prompts.ts`

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -184,10 +184,13 @@ export class AgentReviewPlugin implements ReviewPlugin {
 
     const pluginId = this.id;
     const agentFindings = mergeDocTruthFindings(result.findings, docResult?.findings ?? []);
-    // The render path consumes ONE summary finding, so doc-pass state (an
-    // unfinished pass, error-severity doc findings) must be folded into the
-    // main result BEFORE the notices are appended — a second summary finding
-    // would never render.
+    // Fold doc-pass result state (an unfinished pass, error-severity doc
+    // findings) into the main result before the notices are appended: it lifts
+    // the PRIMARY summary's risk level for doc-truth errors, and marks the run
+    // incomplete so `appendIncompleteNotice` emits the doc-pass notice. The
+    // render path (`present`/`formatCheckSummary`) now renders every summary
+    // finding, so that appended notice is visible as its own section — this
+    // fold shapes the primary block, it no longer has to be the only summary.
     mergeDocPassIntoResult(result, docResult, agentFindings);
     const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
@@ -234,7 +237,10 @@ export class AgentReviewPlugin implements ReviewPlugin {
       f => f.line > 0 && f.category !== 'architectural' && f.category !== 'summary',
     );
     const archFindings = findings.filter(f => f.category === 'architectural');
-    const summaryFinding = findings.find(f => f.category === 'summary');
+    // Render EVERY summary finding, not just the first: the agent can append a
+    // second summary (e.g. the doc-truth-pass incomplete notice) that would
+    // otherwise silently never render (the trap behind #733).
+    const summaryFindings = findings.filter(f => f.category === 'summary');
 
     // 1. Post bug findings. GitHub only anchors inline review comments to lines
     //    inside the PR's diff hunks, so split findings by whether their line is
@@ -271,7 +277,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
     }
 
     // 2. Contribute to PR description — GitHub callout box style
-    const description = buildDescription(bugFindings, summaryFinding, archFindings, commitSha);
+    const description = buildDescription(bugFindings, summaryFindings, archFindings, commitSha);
     context.appendDescription(description, this.id);
 
     // 4. Append to check run summary
@@ -535,22 +541,27 @@ function formatCheckSummary(findings: ReviewFinding[], name: string): string {
     f => f.category !== 'architectural' && f.category !== 'summary' && f.line > 0,
   );
   const arch = findings.filter(f => f.category === 'architectural');
-  const summary = findings.find(f => f.category === 'summary');
+  const summaries = findings.filter(f => f.category === 'summary');
 
   const sections: string[] = [`### ${name}`];
 
-  if (summary) {
+  // First summary → the primary risk/overview (or incomplete) line, byte-for-byte
+  // as before. Any further summary → its own appended line so an appended notice
+  // (e.g. an incomplete doc-truth pass) is never silently dropped.
+  summaries.forEach((summary, i) => {
     const meta = summary.metadata as
       | { riskLevel?: string; overview?: string; incomplete?: boolean }
       | undefined;
     if (meta?.incomplete) {
       sections.push(`⚠️ **Review incomplete** — ${meta.overview ?? summary.message}`);
-    } else {
+    } else if (i === 0) {
       sections.push(
         `**${capitalize(meta?.riskLevel ?? 'unknown')} Risk** — ${meta?.overview ?? summary.message}`,
       );
+    } else {
+      sections.push(meta?.overview ?? summary.message);
     }
-  }
+  });
 
   if (bugs.length > 0) {
     const bugLines = bugs.map(f => {
@@ -565,28 +576,51 @@ function formatCheckSummary(findings: ReviewFinding[], name: string): string {
     sections.push(`**Architectural (${arch.length})**\n${archLines.join('\n')}`);
   }
 
-  if (bugs.length === 0 && arch.length === 0 && !summary) {
+  if (bugs.length === 0 && arch.length === 0 && summaries.length === 0) {
     sections.push('No issues found.');
   }
 
   return sections.join('\n\n');
 }
 
+interface SummaryMeta {
+  riskLevel?: string;
+  overview?: string;
+  keyChanges?: string[];
+  incomplete?: boolean;
+}
+
+function summaryMetaOf(finding: ReviewFinding | undefined): SummaryMeta | undefined {
+  return finding?.metadata as SummaryMeta | undefined;
+}
+
+/**
+ * Render a NON-primary summary finding (any beyond the first) as its own
+ * section: incomplete-flagged notices get a ⚠️ warning line; anything else a
+ * plain paragraph. Shared by the PR description and the check-run summary so a
+ * second summary the primary block can't absorb still surfaces.
+ */
+function formatExtraSummary(finding: ReviewFinding): string {
+  const meta = summaryMetaOf(finding);
+  const text = meta?.overview ?? finding.message;
+  return meta?.incomplete ? `⚠️ ${text}` : text;
+}
+
 /**
  * Build the PR description section using GitHub's callout blockquote syntax.
- * Uses > [!NOTE] for clean PRs, > [!WARNING] when issues are found.
+ * Uses > [!NOTE] for clean PRs, > [!WARNING] when issues are found. The first
+ * summary drives the callout; any further summaries render as appended
+ * sections so an appended notice (e.g. an incomplete doc-truth pass) is visible.
  */
 function buildDescription(
   bugFindings: ReviewFinding[],
-  summaryFinding: ReviewFinding | undefined,
+  summaryFindings: ReviewFinding[],
   archFindings: ReviewFinding[],
   commitSha?: string,
 ): string {
-  const meta = summaryFinding?.metadata as
-    | { riskLevel?: string; overview?: string; keyChanges?: string[]; incomplete?: boolean }
-    | undefined;
+  const meta = summaryMetaOf(summaryFindings[0]);
   const risk = meta?.riskLevel ?? 'low';
-  const overview = meta?.overview ?? summaryFinding?.message ?? '';
+  const overview = meta?.overview ?? summaryFindings[0]?.message ?? '';
   const incomplete = meta?.incomplete === true;
 
   // An incomplete review must never read as a clean/approving NOTE.
@@ -614,6 +648,10 @@ function buildDescription(
   }
 
   const parts: string[] = [lines.join('\n')];
+
+  for (const extra of summaryFindings.slice(1)) {
+    parts.push(formatExtraSummary(extra));
+  }
 
   if (archFindings.length > 0) {
     parts.push(formatArchDescription(archFindings));

--- a/packages/review/test/harness-runner.test.ts
+++ b/packages/review/test/harness-runner.test.ts
@@ -26,6 +26,8 @@ import {
   expectToolCalled,
   HarnessAssertionError,
 } from './harness/assertions.js';
+import { reportCalibrate, reportVote } from './harness/reporter.js';
+import type { AssertedRun, CalibrateResult, VoteResult } from './harness/voting.js';
 import type { AgentTrace, TurnTrace } from '../src/plugins/agent/types.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -202,5 +204,98 @@ describe('runFixture — HarnessResult.toolCalls/turns come from the trace', () 
     expect(result.trace?.turns).toHaveLength(2);
 
     expectRuleFired('boundary-change', result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reporter — characterization rendering, --bail aborted lines, byte-identical
+// default output. These are pure string formatters (no LLM).
+// ---------------------------------------------------------------------------
+
+function fakeRun(passed: boolean): AssertedRun {
+  return { result: { findings: [], toolCalls: [], turns: 0 }, cost: 0, passed };
+}
+
+function calResult(overrides: Partial<CalibrateResult> = {}): CalibrateResult {
+  const runs = Array.from({ length: 10 }, () => fakeRun(true));
+  return {
+    runs,
+    passes: 10,
+    passRate: 1,
+    totalCost: 0.5,
+    meetsReliabilityBar: true,
+    requested: 10,
+    aborted: false,
+    ...overrides,
+  };
+}
+
+describe('reportCalibrate', () => {
+  it('renders a passing bar exactly as before (byte-identical default)', () => {
+    const line = reportCalibrate('doc-truth/pr658', calResult());
+    expect(line).toBe('✓ doc-truth/pr658 — 10/10 passed (100%) · $0.5000');
+  });
+
+  it('renders a characterization fixture as a neutral non-gating ~ line', () => {
+    const runs = [
+      ...Array.from({ length: 6 }, () => fakeRun(true)),
+      ...Array.from({ length: 4 }, () => fakeRun(false)),
+    ];
+    const line = reportCalibrate(
+      'doc-truth/pr667-worktree-doc-drift',
+      calResult({ runs, passes: 6, passRate: 0.6, meetsReliabilityBar: false }),
+      { characterization: true },
+    );
+    expect(line).toBe(
+      '~ doc-truth/pr667-worktree-doc-drift — measured 6/10 (non-gating, see fixture header) · $0.5000',
+    );
+    // No red ✗, no "BAR NOT MET" scare line.
+    expect(line).not.toContain('✗');
+    expect(line).not.toContain('BAR NOT MET');
+  });
+
+  it('renders an aborted --bail run with the aborted headline', () => {
+    const runs = [fakeRun(true), fakeRun(false), fakeRun(false)];
+    const line = reportCalibrate(
+      'concurrency-race/toctou',
+      calResult({
+        runs,
+        passes: 1,
+        passRate: 1 / 3,
+        meetsReliabilityBar: false,
+        aborted: true,
+        bail: 2,
+      }),
+    );
+    expect(line).toContain('✗ concurrency-race/toctou — aborted after 3/10 votes (--bail 2)');
+    // The aborted headline replaces the "BAR NOT MET" advisory (it's redundant).
+    expect(line).not.toContain('BAR NOT MET');
+    expect(line).toContain('failures: 0 tier-1');
+  });
+});
+
+describe('reportVote', () => {
+  function voteResult(overrides: Partial<VoteResult> = {}): VoteResult {
+    const votes = Array.from({ length: 3 }, () => fakeRun(true));
+    return { votes, agree: true, passes: 3, totalCost: 0.18, ...overrides };
+  }
+
+  it('renders a passing vote exactly as before (byte-identical default)', () => {
+    expect(reportVote('boundary-change/ge5', voteResult())).toBe(
+      '✓ boundary-change/ge5 — 3/3 passed · $0.1800',
+    );
+  });
+
+  it('renders a characterization fixture as a neutral non-gating ~ line', () => {
+    const votes = [fakeRun(true), fakeRun(false), fakeRun(false)];
+    const line = reportVote(
+      'doc-truth/pr716-install-claim',
+      voteResult({ votes, agree: false, passes: 1 }),
+      { characterization: true },
+    );
+    expect(line).toBe(
+      '~ doc-truth/pr716-install-claim — measured 1/3 (non-gating, see fixture header) · $0.1800',
+    );
+    expect(line).not.toContain('FLAKY');
   });
 });

--- a/packages/review/test/harness-voting-bail.test.ts
+++ b/packages/review/test/harness-voting-bail.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the `--bail N` early-abort dispatch in the harness voting
+ * layer. `runVotesWithBail` takes a vote thunk, so the abort logic is testable
+ * with fake fast/slow/failing vote fns and zero LLM spend.
+ *
+ * The invariants under test:
+ *  - No `bail` → every vote dispatches (byte-identical to the prior Promise.all
+ *    path), aborted:false.
+ *  - `bail` → votes run in waves; once cumulative failures reach `bail`,
+ *    dispatch stops and `aborted` is true iff votes were left unrun.
+ *  - A wave in flight always finishes before the bail check — a slow failing
+ *    vote still counts toward the threshold.
+ */
+import { describe, it, expect } from 'vitest';
+import { runVotesWithBail, BAIL_WAVE_SIZE } from './harness/voting.js';
+import type { AssertedRun } from './harness/voting.js';
+
+function fakeRun(passed: boolean): AssertedRun {
+  return { result: { findings: [], toolCalls: [], turns: 0 }, cost: 0, passed };
+}
+
+/** A vote thunk that returns the next scripted outcome and counts invocations. */
+function sequencedVoteFn(outcomes: boolean[]): {
+  voteFn: () => Promise<AssertedRun>;
+  calls: () => number;
+} {
+  let i = 0;
+  return {
+    voteFn: () => Promise.resolve(fakeRun(outcomes[i++])),
+    calls: () => i,
+  };
+}
+
+describe('runVotesWithBail — default (no bail)', () => {
+  it('dispatches every vote and never aborts', async () => {
+    const { voteFn, calls } = sequencedVoteFn([true, false, true, false, true]);
+    const { runs, aborted } = await runVotesWithBail(voteFn, 5);
+    expect(runs).toHaveLength(5);
+    expect(calls()).toBe(5);
+    expect(aborted).toBe(false);
+  });
+
+  it('does not abort even when most votes fail', async () => {
+    const { voteFn } = sequencedVoteFn([false, false, false, false]);
+    const { runs, aborted } = await runVotesWithBail(voteFn, 4);
+    expect(runs).toHaveLength(4);
+    expect(aborted).toBe(false);
+  });
+});
+
+describe('runVotesWithBail — with bail', () => {
+  it('aborts after the wave in which the Nth failure lands', async () => {
+    // waveSize 3, bail 2: wave 1 = [fail, fail, pass] → 2 failures → abort with
+    // 7 of 10 votes never dispatched.
+    const { voteFn, calls } = sequencedVoteFn([
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    const { runs, aborted } = await runVotesWithBail(voteFn, 10, 2, 3);
+    expect(runs).toHaveLength(3);
+    expect(calls()).toBe(3); // remaining 7 never dispatched
+    expect(aborted).toBe(true);
+    expect(runs.filter(r => !r.passed)).toHaveLength(2);
+  });
+
+  it('does not abort when the Nth failure lands in the final wave (nothing left to skip)', async () => {
+    // count 3, waveSize 3, bail 2: one wave of [pass, fail, fail]. Failures hit
+    // the threshold but every requested vote already ran → not aborted.
+    const { voteFn } = sequencedVoteFn([true, false, false]);
+    const { runs, aborted } = await runVotesWithBail(voteFn, 3, 2, 3);
+    expect(runs).toHaveLength(3);
+    expect(aborted).toBe(false);
+  });
+
+  it('runs all votes when failures never reach the bail threshold', async () => {
+    const { voteFn, calls } = sequencedVoteFn([true, false, true, true, true, true]);
+    const { runs, aborted } = await runVotesWithBail(voteFn, 6, 3, 3);
+    expect(runs).toHaveLength(6);
+    expect(calls()).toBe(6);
+    expect(aborted).toBe(false);
+  });
+
+  it('waits for a slow failing vote within a wave before deciding to bail', async () => {
+    // The 2nd vote is slow AND failing. The bail check runs only after the wave's
+    // Promise.all settles, so the slow failure must count — proving waves await
+    // in full rather than racing the abort.
+    const delays = [1, 25, 1, 1, 1, 1];
+    const passed = [true, false, true, true, true, true];
+    let i = 0;
+    const voteFn = (): Promise<AssertedRun> => {
+      const idx = i++;
+      return new Promise(res => setTimeout(() => res(fakeRun(passed[idx])), delays[idx]));
+    };
+    const { runs, aborted } = await runVotesWithBail(voteFn, 6, 1, 3);
+    expect(runs).toHaveLength(3); // first wave of 3 contained the slow failure
+    expect(aborted).toBe(true);
+    expect(runs.filter(r => !r.passed)).toHaveLength(1);
+  });
+
+  it('exposes a small default wave size', () => {
+    expect(BAIL_WAVE_SIZE).toBe(3);
+  });
+});

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -256,9 +256,24 @@ const assertions: FixtureAssertions = {
 export default assertions;
 ```
 
-`tags: ['canary']` marks a fixture as a drift signal — when multiple
-canaries flip simultaneously after a model update, the harness should be
-re-baselined under human review, not silently re-pinned.
+### Fixture tags — canary vs characterization
+
+`tags` classify what a fixture's pass/fail *means*:
+
+- **`['canary']`** — a drift signal, certified ≥9/10 on the prod model. When
+  multiple canaries flip simultaneously after a model update, the harness
+  should be re-baselined under human review, not silently re-pinned. Canaries
+  gate: a red canary fails the run.
+- **`['characterization']`** — measures a known frontier (a shape the prod
+  model handles unreliably or declines defensibly) and does **not** gate. The
+  harness renders it as a neutral `~ <label> — measured N/M (non-gating, see
+  fixture header)` line instead of a red `✗`, and its result never contributes
+  to the process exit code. The fixture's header records the measured rate and
+  why iteration stopped; don't spend calibration budget pushing it green. The
+  four doc-truth frontier fixtures (`pr667-*`, `pr687-*`, `pr711-*`, `pr716-*`)
+  carry this tag.
+- **untagged** — an ordinary fixture; it gates like a canary but isn't a
+  drift-signal alarm.
 
 ## The 9/10 reliability bar (#538)
 
@@ -420,15 +435,21 @@ If you can't tell what's happening, `--json` is your friend — pipe through
 
 When the `failureMessage` alone doesn't tell you why a vote bailed —
 typically `Tier 1: ... (no findings)` where the model investigated but
-decided silence — capture per-vote traces and compare a passing vote to
+decided silence — read the per-vote traces and compare a passing vote to
 a failing one.
+
+**Traces persist by default.** Every run writes them, even without `--trace`,
+to `.wip/traces/<UTC-timestamp>-<rule-or-fixture>/` (repo-root-relative;
+`.wip/` is gitignored). The run prints the directory (`Traces: …`) on exit, so
+diagnosing the last run never needs a fresh paid call. Pass `--trace <dir>` to
+write somewhere explicit instead:
 
 ```bash
 npm run test:harness -w @liendev/review -- \
   --rule concurrency-race --calibrate 10 --trace /tmp/cal-trace
 ```
 
-Each vote produces `/tmp/cal-trace/<rule>/<scenario>/vote-<N>.json`
+Each vote produces `<trace-dir>/<rule>/<scenario>/vote-<N>.json`
 containing the rendered system prompt, the rendered initial message, the
 full per-turn assistant response (including reasoning prose outside the
 JSON fence — normally stripped), and tool-call inputs + outputs.
@@ -484,9 +505,11 @@ fixture writes ~100-500 KB to disk.
 real money, not a free inner loop (~$0.05-0.50/fixture, ~$5-8 for a full
 corpus sweep). Before spending another round:
 
-- **Diagnose from existing `--trace` dumps first** (free) — most "why did
-  this fail" questions are answerable from a trace already on disk without
-  another network call.
+- **Diagnose from existing traces first** (free) — every run now persists
+  per-vote traces (see "Debugging a failing vote" below), so a trace of the
+  last run is *always* on disk. Most "why did this fail" questions are
+  answerable from it without another network call; the run prints the exact
+  trace directory (`Traces: …`) so it's a copy-paste away.
 - **Stop after one non-converging iteration.** If a prompt/tool-fallback
   change doesn't move the pass rate, don't chain another calibration sweep on
   the same hypothesis — reassess and report the cost spent so far before the

--- a/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
@@ -76,9 +76,10 @@
  *   occasional evidence-ignoring read_file flood exhausting the pass budget.
  *   Model-judgment frontier on Kimi; further prompt iteration showed
  *   diminishing returns and was stopped per cost discipline.
- * No canary tag: this fixture measures the frontier (~6-7/10), it does not
- * gate. The feature itself is certified on the canary corpus (pr658 10/10,
- * accurate-doc 10/10 precision with the strict language).
+ * Tagged `characterization` (not canary): this fixture measures the frontier
+ * (~6-7/10), so the harness renders it as a non-gating `~` line and excludes it
+ * from the exit code. The feature itself is certified on the canary corpus
+ * (pr658 10/10, accurate-doc 10/10 precision with the strict language).
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -121,7 +122,7 @@ const assertions: FixtureAssertions = {
   },
   votes: 3,
   passThreshold: 9,
-  tags: [],
+  tags: ['characterization'],
 };
 
 export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
@@ -57,7 +57,8 @@
  * passes assert-cli exit 0). Also the weakest contradiction on the merits: the
  * Note doesn't claim embeddings keys crash, it just omits them, so even fully
  * in-prompt a strict reviewer might read it as "accurate as far as it goes".
- * Deliberately NOT tagged canary.
+ * Tagged `characterization` (not canary): the harness renders it as a
+ * non-gating `~` line and excludes it from the exit code.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -101,7 +102,7 @@ const assertions: FixtureAssertions = {
   },
   votes: 3,
   passThreshold: 9,
-  tags: [],
+  tags: ['characterization'],
 };
 
 export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
@@ -55,7 +55,9 @@
  * so a lenient reviewer may read "otherwise unchanged" as "other than the
  * disclosed removals" and stay quiet; the sharper, more defensible finding is
  * that a removed public export is breaking and the patch/"unchanged" framing
- * understates it. NOT tagged canary until a calibration baseline exists.
+ * understates it. Tagged `characterization` (not canary): the model declines it
+ * consistently and defensibly, so the harness renders it as a non-gating `~`
+ * line and excludes it from the exit code.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -100,7 +102,7 @@ const assertions: FixtureAssertions = {
   },
   votes: 3,
   passThreshold: 9,
-  tags: [],
+  tags: ['characterization'],
 };
 
 export default assertions;

--- a/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
@@ -65,8 +65,9 @@
  * correctly-declined at this SHA. Characterization fixture.
  *
  * Net: expect this to calibrate LOW on Kimi, possibly correctly-low. It is the
- * second-shakiest fixture (after pr687's truncation block) and is deliberately
- * NOT tagged canary until a calibration baseline exists.
+ * second-shakiest fixture (after pr687's truncation block). Tagged
+ * `characterization` (not canary): the harness renders it as a non-gating `~`
+ * line and excludes it from the exit code.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -110,7 +111,7 @@ const assertions: FixtureAssertions = {
   },
   votes: 3,
   passThreshold: 9,
-  tags: [],
+  tags: ['characterization'],
 };
 
 export default assertions;

--- a/packages/review/test/harness/reporter.ts
+++ b/packages/review/test/harness/reporter.ts
@@ -8,7 +8,20 @@ function previewMessage(msg: string, max = 220): string {
   return msg.length <= max ? msg : `${msg.slice(0, max)}…`;
 }
 
-export function reportVote(label: string, result: VoteResult): string {
+/**
+ * Render options common to both reporters. A `characterization` fixture
+ * measures a known frontier and does not gate: it renders as a neutral `~`
+ * line reporting the measured rate rather than a red `✗`, and its result never
+ * contributes to the process exit code (that gating is enforced in run.ts).
+ */
+export interface ReportOptions {
+  characterization?: boolean;
+}
+
+export function reportVote(label: string, result: VoteResult, opts?: ReportOptions): string {
+  if (opts?.characterization) {
+    return `~ ${label} — measured ${result.passes}/${result.votes.length} (non-gating, see fixture header) · $${result.totalCost.toFixed(4)}`;
+  }
   const lines: string[] = [];
   const status = result.agree ? (result.passes === result.votes.length ? '✓' : '✗') : '?';
   lines.push(
@@ -27,13 +40,27 @@ export function reportVote(label: string, result: VoteResult): string {
   return lines.join('\n');
 }
 
-export function reportCalibrate(label: string, result: CalibrateResult): string {
+/** The headline outcome line for a calibration run (aborted vs completed). */
+function calibrateStatusLine(label: string, result: CalibrateResult): string {
   const status = result.meetsReliabilityBar ? '✓' : '✗';
-  const lines: string[] = [];
-  lines.push(
-    `${status} ${label} — ${result.passes}/${result.runs.length} passed (${(result.passRate * 100).toFixed(0)}%) · $${result.totalCost.toFixed(4)}`,
-  );
-  if (!result.meetsReliabilityBar) {
+  const cost = `$${result.totalCost.toFixed(4)}`;
+  if (result.aborted) {
+    return `${status} ${label} — aborted after ${result.runs.length}/${result.requested} votes (--bail ${result.bail}) · ${cost}`;
+  }
+  const pct = (result.passRate * 100).toFixed(0);
+  return `${status} ${label} — ${result.passes}/${result.runs.length} passed (${pct}%) · ${cost}`;
+}
+
+export function reportCalibrate(
+  label: string,
+  result: CalibrateResult,
+  opts?: ReportOptions,
+): string {
+  if (opts?.characterization) {
+    return `~ ${label} — measured ${result.passes}/${result.runs.length} (non-gating, see fixture header) · $${result.totalCost.toFixed(4)}`;
+  }
+  const lines: string[] = [calibrateStatusLine(label, result)];
+  if (!result.meetsReliabilityBar && !result.aborted) {
     lines.push('    BAR NOT MET — assertions too tight or fixture too ambiguous (per #538)');
   }
   const failures = result.runs.filter(r => !r.passed);

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -13,8 +13,13 @@
  *   --fixture <path>     run only this fixture
  *   --votes <k>          K-of-M voting per fixture (default 3)
  *   --calibrate <n>      run each fixture N times, report pass rate (the 9/10 bar)
+ *   --bail <n>           abort a fixture's calibration once N votes have failed
  *   --json               emit machine-readable JSON instead of text
  *   --trace <dir>        write per-vote trace JSON to <dir>/<rule>/<scenario>/vote-<N>.json
+ *
+ * Traces are ALWAYS written: with no `--trace`, every run dumps per-vote traces
+ * to `.wip/traces/<UTC-timestamp>-<rule-or-fixture>/` (repo-root-relative,
+ * gitignored) so "diagnose from an existing trace first" is always possible.
  *
  * Env: OPENROUTER_API_KEY required.
  */
@@ -47,6 +52,7 @@ interface CliFlags {
   fixture?: string;
   votes: number;
   calibrate?: number;
+  bail?: number;
   json: boolean;
   model?: string;
   traceDir?: string;
@@ -90,6 +96,9 @@ const VALUE_FLAG_SETTERS: Record<string, (f: CliFlags, value: string | undefined
   '--calibrate': (f, v) => {
     f.calibrate = requirePositiveInt('--calibrate', v);
   },
+  '--bail': (f, v) => {
+    f.bail = requirePositiveInt('--bail', v);
+  },
   '--model': (f, v) => {
     f.model = requireString('--model', v);
   },
@@ -124,14 +133,34 @@ function parseFlags(argv: string[]): CliFlags {
 function printUsage(): void {
   console.error(
     [
-      'Usage: tsx run.ts [--rule <id>] [--fixture <path>] [--votes K] [--calibrate N] [--json] [--trace <dir>]',
+      'Usage: tsx run.ts [--rule <id>] [--fixture <path>] [--votes K] [--calibrate N] [--bail N] [--json] [--trace <dir>]',
       '',
       '  Default: K=3 voting on every fixture under test/harness/fixtures/',
       '  --calibrate 10: runs N times and checks the 9/10 reliability bar',
+      '  --bail N:       abort a fixture calibration once N votes have failed',
       '  --trace <dir>:  write per-vote trace JSON to <dir>/<rule>/<scenario>/vote-<N>.json',
+      '                  (defaults to .wip/traces/<timestamp>-<rule-or-fixture>/)',
       '  Env: OPENROUTER_API_KEY required',
     ].join('\n'),
   );
+}
+
+/**
+ * The trace directory for this run. An explicit `--trace` wins; otherwise
+ * traces persist under `.wip/traces/<UTC-timestamp>-<rule-or-fixture>/`
+ * (repo-root-relative, gitignored) so the next "diagnose from a trace" is a
+ * copy-paste away instead of requiring a fresh paid run. Computed once per run
+ * so every fixture in the run shares one timestamped directory.
+ */
+function resolveTraceDir(flags: CliFlags): string {
+  if (flags.traceDir) return flags.traceDir;
+  const repoRoot = resolve(HERE, '../../../../');
+  const stamp = new Date()
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z')
+    .replace(/:/g, '-');
+  const slug = flags.rule ?? (flags.fixture ? basename(flags.fixture, '.fixture.json') : 'all');
+  return join(repoRoot, '.wip', 'traces', `${stamp}-${slug}`);
 }
 
 interface FixturePair {
@@ -219,32 +248,40 @@ async function runOneFixture(
   f: FixturePair,
   opts: RunnerOptions,
   flags: CliFlags,
+  traceDir: string,
 ): Promise<FixtureOutcome> {
   const assertions = await loadAssertions(f.assertionsPath);
   const label = `${f.rule}/${f.name}`;
+  // A characterization fixture measures a known frontier — render it neutrally
+  // and never let its miss gate the run's exit code.
+  const characterization = assertions.tags?.includes('characterization') ?? false;
+  const reportOpts = { characterization };
 
   if (flags.calibrate !== undefined) {
-    const result = await calibrate(f.fixturePath, assertions, opts, flags.calibrate);
-    if (flags.traceDir) {
-      await writeTraces(flags.traceDir, label, f.rule, f.name, result.runs);
-    }
+    const result = await calibrate(
+      f.fixturePath,
+      assertions,
+      opts,
+      flags.calibrate,
+      undefined,
+      flags.bail,
+    );
+    await writeTraces(traceDir, label, f.rule, f.name, result.runs);
     return {
-      passed: result.meetsReliabilityBar,
+      passed: characterization || result.meetsReliabilityBar,
       cost: result.totalCost,
-      jsonEntry: { label, mode: 'calibrate', result },
-      text: reportCalibrate(label, result),
+      jsonEntry: { label, mode: 'calibrate', characterization, result },
+      text: reportCalibrate(label, result, reportOpts),
     };
   }
   const k = assertions.votes ?? flags.votes;
   const result = await vote(f.fixturePath, assertions, opts, k);
-  if (flags.traceDir) {
-    await writeTraces(flags.traceDir, label, f.rule, f.name, result.votes);
-  }
+  await writeTraces(traceDir, label, f.rule, f.name, result.votes);
   return {
-    passed: result.agree && result.passes === result.votes.length,
+    passed: characterization || (result.agree && result.passes === result.votes.length),
     cost: result.totalCost,
-    jsonEntry: { label, mode: 'vote', result },
-    text: reportVote(label, result),
+    jsonEntry: { label, mode: 'vote', characterization, result },
+    text: reportVote(label, result, reportOpts),
   };
 }
 
@@ -290,15 +327,17 @@ function printSummary(
   totalCost: number,
   jsonReport: unknown[],
   flags: CliFlags,
+  traceDir: string,
 ): void {
   if (flags.json) {
     process.stdout.write(
-      JSON.stringify({ allPassed, totalCost, fixtures: jsonReport }, null, 2) + '\n',
+      JSON.stringify({ allPassed, totalCost, traceDir, fixtures: jsonReport }, null, 2) + '\n',
     );
     return;
   }
   console.log('');
   console.log(`Total cost: $${totalCost.toFixed(4)}`);
+  console.log(`Traces: ${traceDir}`);
   if (!allPassed) {
     console.log(
       '\n⚠️  One or more fixtures failed. Iterate prompts via /test-harness (CC mode), then re-calibrate here.',
@@ -318,19 +357,26 @@ async function main(): Promise<void> {
   const opts: RunnerOptions = { apiKey, model: flags.model };
   if (flags.model) console.error(`[harness] model: ${flags.model}`);
 
+  // Resolve (and pre-create) the trace directory once so every fixture in this
+  // run shares one timestamped folder, and print it up front so a follow-up
+  // diagnose-from-trace is a copy-paste away.
+  const traceDir = resolveTraceDir(flags);
+  await fs.mkdir(traceDir, { recursive: true });
+  console.error(`[harness] traces: ${traceDir}`);
+
   let allPassed = true;
   let totalCost = 0;
   const jsonReport: unknown[] = [];
 
   for (const f of fixtures) {
-    const outcome = await runOneFixture(f, opts, flags);
+    const outcome = await runOneFixture(f, opts, flags, traceDir);
     if (!outcome.passed) allPassed = false;
     totalCost += outcome.cost;
     if (flags.json) jsonReport.push(outcome.jsonEntry);
     else console.log(outcome.text);
   }
 
-  printSummary(allPassed, totalCost, jsonReport, flags);
+  printSummary(allPassed, totalCost, jsonReport, flags, traceDir);
   process.exit(allPassed ? 0 : 1);
 }
 

--- a/packages/review/test/harness/voting.ts
+++ b/packages/review/test/harness/voting.ts
@@ -103,22 +103,64 @@ async function runOnce(
   }
 }
 
+/** Wave size for `--bail` chunked dispatch. Kept small so an early abort saves
+ * most of the batch while still overlapping a few calls per round-trip. */
+export const BAIL_WAVE_SIZE = 3;
+
 /**
- * Run K calls in parallel. Transient LLM errors are caught inside runOnce
- * and become passed=false results, so flaky network/5xx doesn't poison the
- * batch. Setup errors (fixture schema, programmer bugs) DO propagate and
- * reject the whole calibration — that's intentional, those should surface
- * loudly rather than masquerade as model flakiness across N votes.
- * OpenRouter handles 10 concurrent OpenAI-compat requests without rate-limit
- * issues at our volume.
+ * Dispatch `count` votes, optionally aborting early once `bail` failures land.
+ *
+ * `voteFn` is a thunk producing one AssertedRun — injected so the abort logic
+ * is unit-testable with fake fast/slow/failing vote fns and zero LLM spend.
+ *
+ * With no `bail`, all votes dispatch at once via `Promise.all` — byte-identical
+ * to the historical behavior (OpenRouter handles our concurrency fine). With
+ * `bail`, votes run in waves of `waveSize`; after each wave, if the cumulative
+ * failure count has reached `bail`, dispatch stops and `aborted` is true when
+ * votes were left unrun. A wave in flight always finishes (we don't cancel
+ * in-flight requests), so up to `waveSize - 1` extra votes may land past the
+ * bail threshold — an accepted tradeoff for a simple chunked implementation.
+ */
+export async function runVotesWithBail(
+  voteFn: () => Promise<AssertedRun>,
+  count: number,
+  bail?: number,
+  waveSize: number = BAIL_WAVE_SIZE,
+): Promise<{ runs: AssertedRun[]; aborted: boolean }> {
+  if (bail === undefined) {
+    const runs = await Promise.all(Array.from({ length: count }, () => voteFn()));
+    return { runs, aborted: false };
+  }
+  const runs: AssertedRun[] = [];
+  let failures = 0;
+  while (runs.length < count) {
+    const size = Math.min(waveSize, count - runs.length);
+    const wave = await Promise.all(Array.from({ length: size }, () => voteFn()));
+    runs.push(...wave);
+    failures += wave.filter(r => !r.passed).length;
+    if (failures >= bail) {
+      return { runs, aborted: runs.length < count };
+    }
+  }
+  return { runs, aborted: false };
+}
+
+/**
+ * Run K calls. Transient LLM errors are caught inside runOnce and become
+ * passed=false results, so flaky network/5xx doesn't poison the batch. Setup
+ * errors (fixture schema, programmer bugs) DO propagate and reject the whole
+ * calibration — that's intentional, those should surface loudly rather than
+ * masquerade as model flakiness across N votes. OpenRouter handles 10
+ * concurrent OpenAI-compat requests without rate-limit issues at our volume.
  */
 async function runMany(
   fixturePath: string,
   assertions: FixtureAssertions,
   opts: RunnerOptions,
   count: number,
-): Promise<AssertedRun[]> {
-  return Promise.all(Array.from({ length: count }, () => runOnce(fixturePath, assertions, opts)));
+  bail?: number,
+): Promise<{ runs: AssertedRun[]; aborted: boolean }> {
+  return runVotesWithBail(() => runOnce(fixturePath, assertions, opts), count, bail);
 }
 
 export async function vote(
@@ -127,7 +169,7 @@ export async function vote(
   opts: RunnerOptions,
   k: number = 3,
 ): Promise<VoteResult> {
-  const votes = await runMany(fixturePath, assertions, opts, k);
+  const { runs: votes } = await runMany(fixturePath, assertions, opts, k);
   const passes = votes.filter(v => v.passed).length;
   const agree = passes === 0 || passes === k;
   const totalCost = votes.reduce((sum, v) => sum + v.cost, 0);
@@ -141,6 +183,12 @@ export interface CalibrateResult {
   totalCost: number;
   /** Whether the 9/10 bar from #538 was met. Bar threshold scales with N. */
   meetsReliabilityBar: boolean;
+  /** The N runs requested (may exceed runs.length when `--bail` aborted early). */
+  requested: number;
+  /** True when `--bail` stopped dispatch before all N runs completed. */
+  aborted: boolean;
+  /** The `--bail` failure threshold that was in effect, if any. */
+  bail?: number;
 }
 
 export async function calibrate(
@@ -149,16 +197,22 @@ export async function calibrate(
   opts: RunnerOptions,
   n: number = 10,
   passThreshold?: number,
+  bail?: number,
 ): Promise<CalibrateResult> {
   const threshold = passThreshold ?? assertions.passThreshold ?? Math.max(1, Math.ceil(n * 0.9));
-  const runs = await runMany(fixturePath, assertions, opts, n);
+  const { runs, aborted } = await runMany(fixturePath, assertions, opts, n, bail);
   const passes = runs.filter(r => r.passed).length;
   const totalCost = runs.reduce((sum, r) => sum + r.cost, 0);
   return {
     runs,
     passes,
-    passRate: passes / n,
+    // Rate over the runs that actually happened; equals passes/n unless aborted.
+    passRate: passes / (runs.length || n),
     totalCost,
-    meetsReliabilityBar: passes >= threshold,
+    // An aborted run can never certify the bar — it stopped on failures.
+    meetsReliabilityBar: !aborted && passes >= threshold,
+    requested: n,
+    aborted,
+    bail,
   };
 }

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -569,6 +569,110 @@ describe('AgentReviewPlugin.present — incomplete review', () => {
   });
 });
 
+describe('AgentReviewPlugin.present — multiple summary findings', () => {
+  function primarySummary(overview: string): ReviewFinding {
+    return {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'info',
+      category: 'summary',
+      message: overview,
+      metadata: { riskLevel: 'low', overview, keyChanges: [] },
+    };
+  }
+
+  function appendedIncompleteSummary(overview: string): ReviewFinding {
+    return {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message: overview,
+      metadata: { incomplete: true, stopReason: 'budget', overview },
+    };
+  }
+
+  it('renders a single summary byte-identically (no appended sections)', async () => {
+    const plugin = new AgentReviewPlugin();
+    const appendDescription = vi.fn();
+    const appendSummary = vi.fn();
+    const ctx = {
+      addAnnotations: vi.fn(),
+      appendDescription,
+      appendSummary,
+    } as unknown as PresentContext;
+
+    await plugin.present([primarySummary('All good')], ctx);
+
+    expect(appendDescription.mock.calls[0][0]).toBe(
+      '> [!NOTE]\n> **Low Risk**\n>\n> All good\n\n' +
+        '<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>',
+    );
+    expect(appendSummary.mock.calls[0][0]).toBe('### Agent Review\n\n**Low Risk** — All good');
+  });
+
+  it('renders a second (appended) summary that the old first-only logic dropped', async () => {
+    const plugin = new AgentReviewPlugin();
+    const appendDescription = vi.fn();
+    const appendSummary = vi.fn();
+    const ctx = {
+      addAnnotations: vi.fn(),
+      appendDescription,
+      appendSummary,
+    } as unknown as PresentContext;
+
+    const docNotice = 'The documentation-truthfulness pass did not finish — it hit the budget.';
+    await plugin.present(
+      [primarySummary('Main overview'), appendedIncompleteSummary(docNotice)],
+      ctx,
+    );
+
+    // Primary block still drives the callout (low risk → NOTE), and the second
+    // summary surfaces as its own ⚠️ warning section — the #733 trap fixed.
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('> [!NOTE]');
+    expect(description).toContain('> **Low Risk**');
+    expect(description).toContain('> Main overview');
+    expect(description).toContain(`⚠️ ${docNotice}`);
+
+    const summary = appendSummary.mock.calls[0][0] as string;
+    expect(summary).toContain('**Low Risk** — Main overview');
+    expect(summary).toContain(`⚠️ **Review incomplete** — ${docNotice}`);
+  });
+
+  it('renders a second non-incomplete summary as a plain appended paragraph', async () => {
+    const plugin = new AgentReviewPlugin();
+    const appendDescription = vi.fn();
+    const appendSummary = vi.fn();
+    const ctx = {
+      addAnnotations: vi.fn(),
+      appendDescription,
+      appendSummary,
+    } as unknown as PresentContext;
+
+    const second: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'info',
+      category: 'summary',
+      message: 'A secondary note.',
+      metadata: { overview: 'A secondary note.' },
+    };
+    await plugin.present([primarySummary('Main overview'), second], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('A secondary note.');
+    expect(description).not.toContain('⚠️ A secondary note.');
+    const summary = appendSummary.mock.calls[0][0] as string;
+    // Plain paragraph, not a "Review incomplete" line, not a duplicated Risk line.
+    expect(summary).toContain('\n\nA secondary note.');
+    expect(summary).not.toContain('Review incomplete');
+  });
+});
+
 describe('clampText (finding free-text cap)', () => {
   it('leaves short text unchanged', () => {
     expect(clampText('short message')).toBe('short message');


### PR DESCRIPTION
Four quality-of-life debts surfaced by the 2026-07 campaign, all zero-LLM and off the calibration bar:

1. **Traces always persist**: calibration runs write per-vote traces to `.wip/traces/<UTC stamp>-<scope>/` when `--trace` isn't given (dir printed in output, included in `--json`). "Diagnose from existing traces first" is now always possible — previously every diagnosis started with a paid re-run just to obtain traces.
2. **Characterization tier**: fixtures tagged `characterization` render as `~ measured N/M (non-gating, see fixture header)` and never gate the exit code. The four documented-frontier doc-truth fixtures are tagged — they no longer masquerade as failures (the exact shape that bred the "known-red" folklore this campaign spent a day debunking). Canary behavior byte-identical.
3. **`--bail N`**: opt-in early abort once N failures land (waved dispatch ×3; no-flag path byte-identical; reported as `aborted after K/M votes`). A clearly-broken fixture no longer burns the full 10-vote cost.
4. **Render all summary findings**: `present()`/`formatCheckSummary()` switch find→filter — first summary renders byte-identically (pinned by test), subsequent ones append (⚠️ for incomplete-flagged). Removes the first-summary-wins trap that silently hid the #733 doc-pass incomplete notice; composes with #738's never-ran notice.

Rebased on post-#738 main (disjoint functions, clean). README + judgment guide updated. 18 new tests; full suite green; lien delta exit 0.

## Harness evidence
No rule prompt, system-prompt section, or signal render text changed — harness tooling + render-path only, pinned byte-identical for existing single-summary output and untagged fixtures. (Gate keyword: no calibrate run warranted.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional early-abort controls for review runs after a configurable number of failures.
  - Review traces are now automatically saved and their location is shown in results.
  - Characterization checks now display neutral measured results without affecting pass/fail status.

- **Bug Fixes**
  - Review summaries now include all relevant findings, including incomplete or additional summaries.
  - Aborted runs clearly report their status and avoid misleading completion guidance.

- **Documentation**
  - Clarified fixture categories, trace locations, stop reasons, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +9 |


> [!NOTE]
> **Low Risk**
>
> This PR is a harness UX improvement with no LLM-facing production changes. It adds default trace persistence to .wip/traces/, a characterization fixture tier that renders neutrally and does not gate exit codes, an opt-in --bail early-abort path for calibration, and switches the render path to display every summary finding instead of only the first. The implementation aligns with the documentation claims: traces persist by default under .wip/traces/, characterization fixtures are excluded from process exit via runOneFixture's passed logic, --bail chunked dispatch waits for in-flight waves, and present()/formatCheckSummary()/buildDescription() now render appended summary notices. No callers are broken; the blast radius is confined to harness tooling and the agent plugin's own present path.
>
> - Default trace persistence to .wip/traces/<timestamp>-<scope>/ with traceDir included in --json output
> - Characterization fixtures render as neutral ~ measured N/M lines and never gate process exit
> - Opt-in --bail N early abort for calibration with wave-in-flight completion
> - present()/formatCheckSummary()/buildDescription() render all summary findings, not just the first

⚠️ The documentation-truthfulness pass did not finish — it ended without emitting a parseable JSON verdict. Doc-claim verification is partial; code findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8160c5c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->