### PR TITLE
fix(review): generalize boundary-change triggers beyond TS numeric-threshold idioms

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -441,11 +441,16 @@ is not a qualifying test; an actual test file + line is.`,
       // bare 'severity' matches every ReviewFinding and logger call in this
       // codebase.
       '\\bthreshold\\b',
-      // `boundary=` is the multipart MIME delimiter (Content-Type:
-      // multipart/form-data; boundary=...) — an HTTP literal unrelated to
-      // threshold logic. It coincidentally activated this rule on
-      // httpx#2400 during the 2026-07 cross-repo pilot (#741).
-      '\\bboundary\\b(?!\\s*=)',
+      // `boundary=` (no space — RFC 2045 parameter syntax) is the
+      // multipart MIME delimiter (Content-Type: multipart/form-data;
+      // boundary=...), an HTTP literal unrelated to threshold logic that
+      // coincidentally activated this rule on httpx#2400 during the
+      // 2026-07 cross-repo pilot (#741). The lookahead deliberately
+      // rejects only the immediate `=` so spaced assignments to a
+      // threshold variable (`const boundary = maxSize`) still fire —
+      // per Lien Review + CodeRabbit on #743, `(?!\s*=)` also swallowed
+      // those real boundary definitions.
+      '\\bboundary\\b(?!=)',
       '\\bcutoff\\b',
       'severity\\s*[:=]',
       // Type-acceptance gates (#741): a diff that touches a type

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -441,9 +441,37 @@ is not a qualifying test; an actual test file + line is.`,
       // bare 'severity' matches every ReviewFinding and logger call in this
       // codebase.
       '\\bthreshold\\b',
-      '\\bboundary\\b',
+      // `boundary=` is the multipart MIME delimiter (Content-Type:
+      // multipart/form-data; boundary=...) — an HTTP literal unrelated to
+      // threshold logic. It coincidentally activated this rule on
+      // httpx#2400 during the 2026-07 cross-repo pilot (#741).
+      '\\bboundary\\b(?!\\s*=)',
       '\\bcutoff\\b',
       'severity\\s*[:=]',
+      // Type-acceptance gates (#741): a diff that touches a type
+      // allow-list or raises a type error is a validation-boundary shift
+      // even with no numeric comparison. Shape missed on httpx#2523
+      // (universal str(value) fallback → isinstance allow-list) and
+      // httpx#2400 (text-mode rejection via raised TypeError) in the
+      // cross-repo pilot. Cross-language analogues included (PHP is_*,
+      // Ruby is_a?/kind_of?, JS/Java/PHP instanceof).
+      'isinstance\\s*\\(',
+      '\\bTypeError\\b',
+      '\\binstanceof\\s',
+      '\\bis_(?:int|string|float|numeric|bool|array)\\s*\\(',
+      '\\bis_a\\?',
+      '\\bkind_of\\?',
+      // Integer-truncation idioms (#741): `| 0` / `~~` (JS) and
+      // fixed-width narrowing casts (Rust `as i32`, Go `int32(...)`)
+      // change a value's numeric range. Shape missed on hono#3605
+      // (Math.floor → `| 0`, Y2038 overflow in JWT verification).
+      // `| 0` is LHS-anchored like the bare comparison operators above so
+      // `||` alternation never fires it, and the lookahead excludes
+      // `0x`/`0b`/`0o`/decimal literals where `0` starts a wider number.
+      '[\\w)\\]]\\s*\\|\\s*0(?![\\dxXbBoO.])',
+      '~~[\\w(]',
+      '\\bas\\s+[iu](?:8|16|32)\\b',
+      '\\bu?int(?:8|16|32)\\s*\\(',
     ],
   },
   requiresBlastRadius: true,

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -457,7 +457,7 @@ is not a qualifying test; an actual test file + line is.`,
       // Ruby is_a?/kind_of?, JS/Java/PHP instanceof).
       'isinstance\\s*\\(',
       '\\bTypeError\\b',
-      '\\binstanceof\\s',
+      '\\binstanceof\\b',
       '\\bis_(?:int|string|float|numeric|bool|array)\\s*\\(',
       '\\bis_a\\?',
       '\\bkind_of\\?',

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -716,6 +716,14 @@ describe('boundary-change rule', () => {
     expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
   });
 
+  it('does activate on a spaced assignment to a variable named boundary', () => {
+    // Lien Review + CodeRabbit on #743: the MIME guard must not swallow
+    // real threshold definitions — only the unspaced RFC 2045 `boundary=`
+    // parameter form is excluded.
+    const ctx = makeTriggerContext({ diffText: '+  const boundary = maxSize;' });
+    expect(selectRules(BUILTIN_RULES, ctx).active.map(r => r.id)).toContain('boundary-change');
+  });
+
   it('does not activate on `|| 0` fallbacks or wider numeric literals after `| 0x`', () => {
     const orFallback = makeTriggerContext({ diffText: '+  const count = input.length || 0;' });
     const hexMask = makeTriggerContext({ diffText: '+  const flags = base | 0x40;' });

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -655,6 +655,68 @@ describe('boundary-change rule', () => {
     expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
   });
 
+  // #741 (cross-repo pilot): validation-boundary shifts with no numeric
+  // comparison in the diff. Each activation case below is an evidenced
+  // miss shape; the no-fire cases pin the false-positive guards.
+
+  it('activates on a type allow-list change (isinstance) — httpx#2523 shape', () => {
+    const ctx = makeTriggerContext({
+      diffText:
+        '-    return str(value)\n+    if isinstance(value, (str, float, int)):\n+        return str(value)',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).active.map(r => r.id)).toContain('boundary-change');
+  });
+
+  it('activates on a raised/thrown TypeError — httpx#2400 shape', () => {
+    const ctx = makeTriggerContext({
+      diffText: '+        raise TypeError(f"Unexpected type for file content: {value!r}")',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).active.map(r => r.id)).toContain('boundary-change');
+  });
+
+  it('activates on instanceof and language-specific type checks', () => {
+    const js = makeTriggerContext({ diffText: '+  if (err instanceof HttpError) rethrow(err);' });
+    const php = makeTriggerContext({ diffText: '+  if (!is_string($body)) { return; }' });
+    const rb = makeTriggerContext({ diffText: '+    return value if value.is_a?(String)' });
+    expect(selectRules(BUILTIN_RULES, js).active.map(r => r.id)).toContain('boundary-change');
+    expect(selectRules(BUILTIN_RULES, php).active.map(r => r.id)).toContain('boundary-change');
+    expect(selectRules(BUILTIN_RULES, rb).active.map(r => r.id)).toContain('boundary-change');
+  });
+
+  it('activates on integer-truncation idioms (`| 0`, `~~`, narrowing casts) — hono#3605 shape', () => {
+    const bitwiseOr = makeTriggerContext({
+      diffText:
+        '-  const now = Math.floor(Date.now() / 1000);\n+  const now = (Date.now() / 1000) | 0;',
+    });
+    const doubleNot = makeTriggerContext({ diffText: '+  const idx = ~~(offset / size);' });
+    const rustCast = makeTriggerContext({
+      diffText: '+        let secs = duration.as_secs() as i32;',
+    });
+    const goCast = makeTriggerContext({ diffText: '+\tsize := int32(len(payload))' });
+    expect(selectRules(BUILTIN_RULES, bitwiseOr).active.map(r => r.id)).toContain(
+      'boundary-change',
+    );
+    expect(selectRules(BUILTIN_RULES, doubleNot).active.map(r => r.id)).toContain(
+      'boundary-change',
+    );
+    expect(selectRules(BUILTIN_RULES, rustCast).active.map(r => r.id)).toContain('boundary-change');
+    expect(selectRules(BUILTIN_RULES, goCast).active.map(r => r.id)).toContain('boundary-change');
+  });
+
+  it('does not activate on the multipart MIME delimiter literal `boundary=`', () => {
+    const ctx = makeTriggerContext({
+      diffText: '+        content_type = "multipart/form-data; boundary=abc123"',
+    });
+    expect(selectRules(BUILTIN_RULES, ctx).skipped).toContain('boundary-change');
+  });
+
+  it('does not activate on `|| 0` fallbacks or wider numeric literals after `| 0x`', () => {
+    const orFallback = makeTriggerContext({ diffText: '+  const count = input.length || 0;' });
+    const hexMask = makeTriggerContext({ diffText: '+  const flags = base | 0x40;' });
+    expect(selectRules(BUILTIN_RULES, orFallback).skipped).toContain('boundary-change');
+    expect(selectRules(BUILTIN_RULES, hexMask).skipped).toContain('boundary-change');
+  });
+
   it('carries requiresBlastRadius=true so the agent gate can detect it', () => {
     const ctx = makeTriggerContext({
       diffText: '+  if (dependentCount >= 5) return "medium";',

--- a/packages/review/test/plugins-agent-rules.test.ts
+++ b/packages/review/test/plugins-agent-rules.test.ts
@@ -676,6 +676,12 @@ describe('boundary-change rule', () => {
 
   it('activates on instanceof and language-specific type checks', () => {
     const js = makeTriggerContext({ diffText: '+  if (err instanceof HttpError) rethrow(err);' });
+    // Parenthesized RHS form (`instanceof(Foo)`) — no whitespace after the
+    // keyword; per Lien Review on #743 the pattern must not require `\s`.
+    const jsParen = makeTriggerContext({
+      diffText: '+  if (err instanceof(HttpError)) rethrow(err);',
+    });
+    expect(selectRules(BUILTIN_RULES, jsParen).active.map(r => r.id)).toContain('boundary-change');
     const php = makeTriggerContext({ diffText: '+  if (!is_string($body)) { return; }' });
     const rb = makeTriggerContext({ diffText: '+    return value if value.is_a?(String)' });
     expect(selectRules(BUILTIN_RULES, js).active.map(r => r.id)).toContain('boundary-change');


### PR DESCRIPTION
Closes #741.

## Problem

The 2026-07 cross-repo validation pilot showed `boundary-change`'s trigger keywords only recognize TS-style numeric comparison shifts. On 3 of 6 externally-mined regression fixtures the semantically-right rule was trigger-blocked or fired by coincidence:

- **httpx#2523** — universal `str(value)` fallback → `isinstance` allow-list raising `TypeError` (an unannounced breaking change later reverted). The rule's own prompt describes this case almost verbatim, but no comparison operator appears in the diff → never triggered.
- **hono#3605** — `Math.floor` → `| 0` truncates JWT timestamps to 32-bit signed (Y2038). Arithmetic/bitwise boundary change → never triggered.
- **httpx#2400** — triggered only via the multipart MIME literal `boundary=...` in test files, unrelated to threshold logic.

## Fix (data-only)

Two evidenced keyword groups + one false-positive guard in `BOUNDARY_CHANGE.triggers.keywords` — `ruleMatchesTriggers` logic untouched (it sits at 12/15 cognitive headroom):

- **Type-acceptance gates:** `isinstance(`, `TypeError`, `instanceof `, PHP `is_int|string|float|numeric|bool|array(`, Ruby `is_a?`/`kind_of?`
- **Integer-truncation idioms:** LHS-anchored `| 0` (never matches `|| 0` or `| 0x..`), `~~`, Rust `as i8/i16/i32/u*`, Go `int8/16/32(`/`uint*(` narrowing conversions
- `\bboundary\b` gains `(?!\s*=)` so the MIME delimiter literal no longer activates the rule

## Evidence

**Deterministic (zero-LLM):** rendered active-rule sets via `build-prompts.ts` for **all 19 lien-corpus fixtures are byte-identical before/after** (trigger keywords are not part of any prompt). Existing calibration evidence therefore carries over unchanged — the change is provably behavior-neutral on the entire committed corpus, including the `boundary-change/ge-5` canary. The only rule-set changes are on the external pilot fixtures this fix targets (pr2523/pr3605 gain boundary-change; pr2400 keeps it for the right reason; pr1948 gains it via its `raise TypeError` hunk).

**Unit tests:** each activation shape and both no-fire guards pinned in `plugins-agent-rules.test.ts` (128 tests green); the keyword-sanity invariant verifies every new pattern compiles via `safeRegex`.

**Harness evidence.** The lien-corpus no-regression case rests on the byte-identical-prompts proof above (rule-set diff via build-prompts across all 19 fixtures — the existing `--calibrate 10` certifications, e.g. boundary-change/ge-5, remain valid because their inputs are provably unchanged). Paid post-fix validation on the prompt-changed external fixtures (kimi-k2.7-code; wave-1 baselines were `--calibrate 10` runs) (kimi-k2.7-code, harness `--votes 3`, traces in `.wip/traces/2026-07-11T22-2*`):
- hono pr3605 (Y2038): **3/3 passed** with boundary-change active (was 8/10 pre-fix under edge-case-sweep alone)
- httpx pr2523: 0/3 — rule now active, but traces show the model sees the exact change and judges it an intentional improvement (judgment-bounded, pr711 class; not a trigger problem)
- httpx pr1948: 0/3 — hardest fixture (inherited-`read()` dispatch subtlety); blind Sonnet missed it too

The residual misses are model-judgment frontiers documented in the pilot log — consistent with the house law that input engineering can't fix output/judgment economy. The trigger gap itself (this issue's scope) is closed: the right rule now activates on all evidenced shapes.

Full pilot evidence trail: `.wip/crossrepo-pilot/PILOT-LOG.md` + `REPORT.md` (local, gitignored). Total validation spend this PR: ~$0.36.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a data-only expansion of the `boundary-change` rule's trigger keywords in the agent rules engine. It adds type-acceptance gates (`isinstance`, `instanceof`, `TypeError`, PHP `is_*`, Ruby `is_a?`/`kind_of?`) and integer-truncation idioms (`| 0`, `~~`, Rust `as i32`, Go `int32(...)`) while guarding the `boundary` keyword against MIME delimiter false positives with `(?!=)`. The matching logic in `ruleMatchesTriggers` is unchanged, and every new keyword is covered by both functional tests and the `safeRegex` sanity invariant. The regex patterns compile correctly, the guard preserves spaced threshold assignments, and the no-fire cases for `|| 0`, hex masks, and `boundary=` are pinned.
>
> - Extended `boundary-change` trigger keywords with type-acceptance and integer-truncation patterns
> - Changed `\bboundary\b` guard to `(?!=)` so only unspaced `boundary=` (MIME parameter) is suppressed
> - Added unit tests covering activation and no-fire cases for all new patterns

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4f2de6c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of validation and threshold boundary changes across common type-checking and integer-narrowing patterns.
  * Reduced false positives for multipart form-data `boundary=` literals, logical fallbacks, and hexadecimal masks.

* **Tests**
  * Added coverage for additional language-specific type checks, truncation patterns, narrowing casts, and excluded false-positive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->