### PR TITLE
feat(review): sibling-surface signals — deterministic omission-frontier scan

### DIFF
--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -21,6 +21,7 @@ import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
 import { renderDocClaimsSection } from '../../doc-claims-signals.js';
+import { renderSiblingSurfacesSection } from '../../sibling-surface-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -199,6 +200,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderRenameSweepSection(context));
   appendIfPresent(sections, renderGuidanceSurfaceSection(context));
   appendIfPresent(sections, renderDocClaimsSection(context));
+  appendIfPresent(sections, renderSiblingSurfacesSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/src/sibling-surface-signals.ts
+++ b/packages/review/src/sibling-surface-signals.ts
@@ -1,0 +1,709 @@
+/**
+ * Deterministic "sibling surface" signal for PR reviews — the omission-frontier attack.
+ *
+ * The weakest miss shape in the 2026-07 cross-repo study was omission: a bug that
+ * is what ISN'T in the diff, so no reviewer (human, Sonnet, or Kimi) reliably finds
+ * it. Two concrete cases motivate this module:
+ *  - guzzle #3740: adds the `on_trailers` request option, wired through
+ *    `CurlFactory.php` only — the sibling `StreamHandler.php` (same directory,
+ *    same "handler" family) silently ignores it. Both Sonnet and Kimi missed it.
+ *  - gin #3081: adds `binding/toml.go`, whose decode function ends with a
+ *    duplicated `decoder.Decode(obj)` instead of the `return validate(obj)` every
+ *    sibling binding (`json.go`, `xml.go`, `yaml.go`, ...) uses.
+ *
+ * Both are structural facts about a directory of same-extension "family" files,
+ * not something an LLM needs to reason its way to — so, mirroring
+ * `stale-literal-signals.ts` / `doc-claims-signals.ts`, this module precomputes
+ * two directions and hands them to the agent as a `<sibling_surfaces>` block:
+ *
+ *  - Direction A ("unmirrored addition"): a feature-shaped literal/identifier the
+ *    diff ADDED to one family member, absent from an untouched sibling.
+ *  - Direction B ("family-pattern divergence"): a call-shaped identifier most
+ *    untouched siblings share, absent from the changed/new file entirely.
+ *
+ * Threshold notes (tuned against the real fixtures, not just the illustrative
+ * "200-file directory" anti-example):
+ *  - Real same-extension families run bigger than a tidy top-level guess: guzzle's
+ *    `src/Handler/` has 14 members, gin's `binding/` has 16. The family-size gate
+ *    exists to exclude genuinely unrelated bulk directories (rack's `lib/rack/`
+ *    has 42), not to exclude realistic package directories — capped at 20.
+ *  - Direction A's corpus-rarity check counts occurrences OUTSIDE every file this
+ *    PR touched, not merely outside F. `on_trailers` appears in 44 chunks outside
+ *    `CurlFactory.php` alone — but every one of those chunks is in a file the PR
+ *    ALSO changed (RequestOptions.php, Client.php, docs, tests): expected fan-out
+ *    of wiring one new feature through several files, not pre-existing generic
+ *    vocabulary. Outside the whole changed-file set, the count is 0.
+ *  - Direction B's "shared by siblings" is a MAJORITY, not unanimous: gin's real
+ *    `validate(` call appears in 9 of 13 untouched siblings, not all 13 (a few
+ *    unrelated files like `any.go` never call it). Requiring unanimity would
+ *    silently kill the positive.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SiblingSurfaceDirection = 'unmirrored-addition' | 'family-pattern-divergence';
+
+export interface SiblingSurfaceEntry {
+  direction: SiblingSurfaceDirection;
+  /** Display form: quoted for a string literal, bare for an identifier/call. */
+  display: string;
+  /** The file the entry is about: where it was added (A) or where it's missing (B). */
+  file: string;
+  /** New-file line the identifier was added on. Direction A only. */
+  line?: number;
+  /** Direction A: untouched siblings LACKING it. Direction B: untouched siblings SHARING it. */
+  siblings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Mirrors capture-pr.ts's NATIVE_SOURCE_EXT (defined locally — this module doesn't import the harness). */
+const SOURCE_EXT_RE =
+  /\.(ts|tsx|js|jsx|mjs|cjs|py|php|go|rs|java|kt|swift|rb|cs|scala|c|cpp|cc|cxx|h|hpp)$/;
+/**
+ * Broader than stale-literal's `TEST_PATH_RE`: that one requires a LEADING
+ * slash before `test(s)/`, so it misses a root-level `tests/` directory (no
+ * leading slash to match) and languages that keep tests alongside source
+ * instead of in a separate directory — Go's `binding_test.go` sits right next
+ * to `binding.go` in the same package dir. Both matter here: an unfiltered
+ * `tests/ClientTest.php` would be treated as its own "family" of test files,
+ * and unfiltered `_test.go` siblings would inflate a real family (gin's
+ * `binding/` is 16 source files, not 29 once `_test.go` is counted) past
+ * MAX_FAMILY_SIZE, silently discarding the family entirely.
+ */
+const TEST_PATH_RE =
+  /(^|\/)(tests?|specs?|__tests__)(\/|$)|\.(test|spec)\.|_test\.\w+$|_spec\.\w+$|[A-Z]\w*Test\.\w+$/;
+
+/** A directory+extension group smaller than this has no "sibling" to omit from. */
+const MIN_FAMILY_SIZE = 2;
+/** A group larger than this is a bulk directory, not a family (see module doc). */
+const MAX_FAMILY_SIZE = 20;
+
+const MAX_ENTRIES_PER_FILE_PER_DIRECTION = 5;
+/** Bound on raw diff-added candidates considered per file before the corpus-rarity scan. */
+const MAX_RAW_CANDIDATES_PER_FILE = 30;
+/** Direction A: an identifier this common outside the PR's own changed files is generic vocab. */
+const MAX_RARE_OCCURRENCES = 3;
+const MIN_IDENTIFIER_CHARS = 4;
+/** Safety net on total entries before rendering, mirroring stale-literal's MAX_CANDIDATES. */
+const MAX_TOTAL_ENTRIES = 15;
+/** Total block char budget — entries beyond this are dropped with an omission note. */
+const MAX_BLOCK_CHARS = 3000;
+
+const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
+const CAMEL_ID_RE = /\b[A-Za-z][a-z0-9]*(?:[A-Z][a-z0-9]*)+\b/g;
+const SNAKE_ID_RE = /\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b/g;
+const CALL_RE = /\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/** Generic short strings with no cross-file identity — not a useful omission signal. */
+const LOW_SIGNAL_STRINGS = new Set(['true', 'false', 'null', 'undefined', 'none']);
+
+/**
+ * Call-shaped tokens that are control-flow keywords or common stdlib/builtin
+ * calls, not feature surface. Broader than reserved words: a bare `push(`,
+ * `join(`, or `entries(` is ubiquitous across almost any set of TypeScript
+ * files (array/object plumbing), so without this list Direction B's "shared
+ * by a majority" check trivially fires on generic vocabulary in any family of
+ * same-language files, not just genuine parallel-implementation siblings.
+ */
+const CALL_KEYWORD_STOPLIST = new Set([
+  'if',
+  'for',
+  'while',
+  'switch',
+  'catch',
+  'else',
+  'elif',
+  'when',
+  'match',
+  'select',
+  'defer',
+  'func',
+  'def',
+  'class',
+  'print',
+  'printf',
+  'echo',
+  'super',
+  'this',
+  'self',
+  'new',
+  'delete',
+  'typeof',
+  'instanceof',
+  'void',
+  'yield',
+  'await',
+  'async',
+  'try',
+  'finally',
+  'with',
+  'import',
+  'require',
+  'console',
+  'throw',
+  'raise',
+  'assert',
+  'lambda',
+  'none',
+  'null',
+  'true',
+  'false',
+  'undefined',
+  'return',
+  'case',
+  // PHP language constructs that are syntactically call-shaped.
+  'declare',
+  'foreach',
+  'isset',
+  'empty',
+  'unset',
+  'array',
+  'list',
+  'compact',
+  'extract',
+  // Common JS/TS/stdlib built-in methods — generic array/string/object/promise
+  // plumbing present in nearly any file, not a family-specific pattern.
+  'push',
+  'pop',
+  'shift',
+  'unshift',
+  'slice',
+  'splice',
+  'join',
+  'concat',
+  'flat',
+  'flatmap',
+  'map',
+  'filter',
+  'reduce',
+  'foreach',
+  'sort',
+  'reverse',
+  'includes',
+  'indexof',
+  'lastindexof',
+  'find',
+  'findindex',
+  'findlast',
+  'some',
+  'every',
+  'keys',
+  'values',
+  'entries',
+  'fromentries',
+  'assign',
+  'freeze',
+  'tostring',
+  'valueof',
+  'hasownproperty',
+  'parse',
+  'stringify',
+  'then',
+  'resolve',
+  'reject',
+  'apply',
+  'call',
+  'bind',
+  'split',
+  'trim',
+  'trimstart',
+  'trimend',
+  'replace',
+  'replaceall',
+  'match',
+  'matchall',
+  'test',
+  'exec',
+  'tolowercase',
+  'touppercase',
+  'padstart',
+  'padend',
+  'repeat',
+  'charat',
+  'charcodeat',
+  'fromcharcode',
+  'isarray',
+  'isinteger',
+  'isnan',
+  'isfinite',
+  'log',
+  'warn',
+  'error',
+  'info',
+  'debug',
+  'now',
+]);
+
+// ---------------------------------------------------------------------------
+// Path / file helpers
+// ---------------------------------------------------------------------------
+
+function dirnameOf(file: string): string {
+  const idx = file.lastIndexOf('/');
+  return idx === -1 ? '' : file.slice(0, idx);
+}
+
+function isTestFile(file: string): boolean {
+  return TEST_PATH_RE.test(file);
+}
+
+function extensionOf(file: string): string | null {
+  return file.match(SOURCE_EXT_RE)?.[0] ?? null;
+}
+
+function isSourceFile(file: string): boolean {
+  return extensionOf(file) !== null && !isTestFile(file);
+}
+
+// ---------------------------------------------------------------------------
+// Chunk grouping
+// ---------------------------------------------------------------------------
+
+function groupChunksByFile(chunks: CodeChunk[]): Map<string, CodeChunk[]> {
+  const map = new Map<string, CodeChunk[]>();
+  for (const chunk of chunks) {
+    const file = chunk.metadata.file;
+    const list = map.get(file);
+    if (list) list.push(chunk);
+    else map.set(file, [chunk]);
+  }
+  return map;
+}
+
+function fileContains(
+  chunksByFile: Map<string, CodeChunk[]>,
+  file: string,
+  needle: string,
+): boolean {
+  const chunks = chunksByFile.get(file);
+  return chunks ? chunks.some(c => c.content.includes(needle)) : false;
+}
+
+/**
+ * Count chunks containing `value` outside every file this PR changed (not merely
+ * outside the one file being analyzed) — see the module doc's rarity-threshold
+ * note. Short-circuits once past the rarity cap.
+ */
+function countInUntouchedCorpus(
+  value: string,
+  repoChunks: CodeChunk[],
+  changedFileSet: Set<string>,
+): number {
+  let count = 0;
+  for (const chunk of repoChunks) {
+    if (changedFileSet.has(chunk.metadata.file)) continue;
+    if (chunk.content.includes(value)) {
+      count++;
+      if (count > MAX_RARE_OCCURRENCES) return count;
+    }
+  }
+  return count;
+}
+
+function collectChangedFileSet(context: ReviewContext): Set<string> {
+  const files = new Set<string>(context.changedFiles ?? []);
+  for (const f of context.allChangedFiles ?? []) files.add(f);
+  for (const f of context.pr?.patches?.keys() ?? []) files.add(f);
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Family computation
+// ---------------------------------------------------------------------------
+
+/** dirname::ext -> member files (source, non-test), built once from the indexed repo's file set. */
+function buildFamilyIndex(files: Iterable<string>): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const file of files) {
+    if (!isSourceFile(file)) continue;
+    const ext = extensionOf(file);
+    const key = `${dirnameOf(file)}::${ext}`;
+    const members = index.get(key);
+    if (members) members.push(file);
+    else index.set(key, [file]);
+  }
+  return index;
+}
+
+/** The sibling family for `file` (including itself), or null when no valid-size family exists. */
+function familyFor(file: string, index: Map<string, string[]>): string[] | null {
+  const ext = extensionOf(file);
+  if (!ext) return null;
+  const members = index.get(`${dirnameOf(file)}::${ext}`);
+  if (!members || members.length < MIN_FAMILY_SIZE || members.length > MAX_FAMILY_SIZE) return null;
+  return members;
+}
+
+// ---------------------------------------------------------------------------
+// Direction A: unmirrored addition
+// ---------------------------------------------------------------------------
+
+/** Half-open [start, end) character range of a matched string literal on a line. */
+interface StringSpan {
+  start: number;
+  end: number;
+}
+
+/** Extract string-literal tokens from a line into `out`; returns their spans. */
+function collectStringTokens(text: string, out: Map<string, string>): StringSpan[] {
+  const spans: StringSpan[] = [];
+  for (const m of text.matchAll(STRING_RE)) {
+    const start = m.index ?? 0;
+    spans.push({ start, end: start + m[0].length });
+    const inner = m[2];
+    const trimmed = inner.trim();
+    if (trimmed.length < MIN_IDENTIFIER_CHARS) continue;
+    if (LOW_SIGNAL_STRINGS.has(trimmed.toLowerCase())) continue;
+    const key = `s:${inner}`;
+    if (!out.has(key)) out.set(key, `${m[1]}${inner}${m[1]}`);
+  }
+  return spans;
+}
+
+/** Extract camelCase/snake_case identifier tokens, skipping matches inside a string span
+ * (otherwise a quoted `'on_trailers'` double-counts as both a string and a bare identifier). */
+function collectIdentifierTokens(
+  text: string,
+  spans: StringSpan[],
+  out: Map<string, string>,
+): void {
+  for (const re of [CAMEL_ID_RE, SNAKE_ID_RE]) {
+    for (const m of text.matchAll(re)) {
+      const index = m.index ?? 0;
+      if (spans.some(s => index >= s.start && index < s.end)) continue;
+      const key = `i:${m[0]}`;
+      if (!out.has(key)) out.set(key, m[0]);
+    }
+  }
+}
+
+/** A candidate token extracted from a diff line: dedup key -> display form. */
+function collectTokens(text: string, out: Map<string, string>): void {
+  const spans = collectStringTokens(text, out);
+  collectIdentifierTokens(text, spans, out);
+}
+
+interface PatchTokens {
+  /** key -> { display, line } for tokens seen on a `+` line, first occurrence. */
+  added: Map<string, { display: string; line: number }>;
+  /** keys seen on a context or `-` line (the pre-image) — these are not "new". */
+  preImage: Set<string>;
+}
+
+/** `+++`/`---` file headers and "\ No newline at end of file" — not content lines. */
+const SKIP_LINE_RE = /^(?:\+\+\+|---|\\)/;
+
+/** Record an added line's tokens (first occurrence per key wins). */
+function recordAddedLine(line: string, newLine: number, added: PatchTokens['added']): void {
+  const tokens = new Map<string, string>();
+  collectTokens(line, tokens);
+  for (const [key, display] of tokens)
+    if (!added.has(key)) added.set(key, { display, line: newLine });
+}
+
+/** Classify and record one non-header, non-skip patch line. Returns the line counter after it. */
+function processPatchLine(
+  raw: string,
+  newLine: number,
+  added: PatchTokens['added'],
+  preImage: Map<string, string>,
+): number {
+  if (raw.startsWith('+')) {
+    recordAddedLine(raw.slice(1), newLine, added);
+    return newLine + 1;
+  }
+  if (raw.startsWith('-')) {
+    collectTokens(raw.slice(1), preImage);
+    return newLine;
+  }
+  collectTokens(raw.startsWith(' ') ? raw.slice(1) : raw, preImage);
+  return newLine + 1;
+}
+
+/** Walk one file's unified-diff patch, splitting tokens into added-only vs. pre-image. */
+function scanFilePatchForCandidates(patch: string): PatchTokens {
+  const added: PatchTokens['added'] = new Map();
+  const preImageDisplay = new Map<string, string>();
+  let newLine = 0;
+
+  for (const raw of patch.split('\n')) {
+    const header = raw.match(HUNK_HEADER_RE);
+    if (header) {
+      newLine = parseInt(header[1], 10);
+      continue;
+    }
+    if (SKIP_LINE_RE.test(raw)) continue;
+    newLine = processPatchLine(raw, newLine, added, preImageDisplay);
+  }
+
+  return { added, preImage: new Set(preImageDisplay.keys()) };
+}
+
+/** Raw added-not-pre-image candidates for one file, capped before the corpus-rarity scan. */
+function rawCandidates(patch: string): { key: string; display: string; line: number }[] {
+  const { added, preImage } = scanFilePatchForCandidates(patch);
+  const out: { key: string; display: string; line: number }[] = [];
+  for (const [key, { display, line }] of added) {
+    if (preImage.has(key)) continue;
+    out.push({ key, display, line });
+    if (out.length >= MAX_RAW_CANDIDATES_PER_FILE) break;
+  }
+  return out;
+}
+
+function extractUnmirroredAdditions(
+  file: string,
+  patch: string,
+  repoChunks: CodeChunk[],
+  chunksByFile: Map<string, CodeChunk[]>,
+  changedFileSet: Set<string>,
+  untouchedSiblings: string[],
+): SiblingSurfaceEntry[] {
+  const entries: SiblingSurfaceEntry[] = [];
+
+  for (const { key, display, line } of rawCandidates(patch)) {
+    if (entries.length >= MAX_ENTRIES_PER_FILE_PER_DIRECTION) break;
+    const value = key.slice(2); // strip the 's:'/'i:' kind tag
+    if (countInUntouchedCorpus(value, repoChunks, changedFileSet) > MAX_RARE_OCCURRENCES) continue;
+
+    const lacking = untouchedSiblings.filter(s => !fileContains(chunksByFile, s, value)).sort();
+    if (lacking.length === 0) continue;
+
+    entries.push({ direction: 'unmirrored-addition', display, file, line, siblings: lacking });
+  }
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Direction B: family-pattern divergence
+// ---------------------------------------------------------------------------
+
+function extractCallIdentifiers(chunksByFile: Map<string, CodeChunk[]>, file: string): Set<string> {
+  const out = new Set<string>();
+  for (const chunk of chunksByFile.get(file) ?? []) {
+    for (const m of chunk.content.matchAll(CALL_RE)) {
+      const id = m[1];
+      if (id.length < MIN_IDENTIFIER_CHARS) continue;
+      if (CALL_KEYWORD_STOPLIST.has(id.toLowerCase())) continue;
+      out.add(id);
+    }
+  }
+  return out;
+}
+
+/** How many members must share a call for it to count as a "family pattern" (a majority). */
+function requiredShareCount(memberCount: number): number {
+  return Math.max(2, Math.ceil(memberCount / 2));
+}
+
+/**
+ * Whether `family` exhibits at least one call-shaped identifier shared by a
+ * majority of ALL its members (not just the untouched ones) — a cheap proxy
+ * for "these are parallel implementations of a common role", not merely
+ * files that happen to share a directory. Empirically this cleanly separates
+ * the true positives (gin's `binding/` siblings all share `Bind`/`Name`/
+ * `validate`; guzzle's `Handler/` siblings all share `__construct`/
+ * `InvalidArgumentException`) from a flat utility directory of unrelated
+ * files (e.g. `format.ts`/`config.ts`/`engine.ts`), which shares nothing
+ * across a majority. Directory+extension alone is too weak a family
+ * definition without this gate — it fires on any generic top-level `src/`.
+ */
+function hasCohesivePattern(family: string[], chunksByFile: Map<string, CodeChunk[]>): boolean {
+  const shareCounts = new Map<string, number>();
+  for (const file of family) {
+    for (const id of extractCallIdentifiers(chunksByFile, file)) {
+      shareCounts.set(id, (shareCounts.get(id) ?? 0) + 1);
+    }
+  }
+  const threshold = requiredShareCount(family.length);
+  for (const count of shareCounts.values()) if (count >= threshold) return true;
+  return false;
+}
+
+function extractFamilyPatternDivergence(
+  file: string,
+  chunksByFile: Map<string, CodeChunk[]>,
+  untouchedSiblings: string[],
+): SiblingSurfaceEntry[] {
+  if (untouchedSiblings.length < 2) return [];
+
+  const idsBySibling = untouchedSiblings.map(s => ({
+    file: s,
+    ids: extractCallIdentifiers(chunksByFile, s),
+  }));
+  const shareCounts = new Map<string, string[]>(); // identifier -> siblings that carry it
+  for (const { file: sibling, ids } of idsBySibling) {
+    for (const id of ids) {
+      const list = shareCounts.get(id);
+      if (list) list.push(sibling);
+      else shareCounts.set(id, [sibling]);
+    }
+  }
+
+  const threshold = requiredShareCount(untouchedSiblings.length);
+  const candidates = [...shareCounts.entries()]
+    .filter(
+      ([id, siblings]) => siblings.length >= threshold && !fileContains(chunksByFile, file, id),
+    )
+    .map(([id, siblings]) => ({ id, siblings: [...siblings].sort() }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  return candidates.slice(0, MAX_ENTRIES_PER_FILE_PER_DIRECTION).map(({ id, siblings }) => ({
+    direction: 'family-pattern-divergence' as const,
+    display: id,
+    file,
+    siblings,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Extraction entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Precompute sibling-surface entries for the review context. Returns [] when
+ * there's no repo index to scan against. Exposed for testing.
+ */
+export function extractSiblingSurfaces(context: ReviewContext): SiblingSurfaceEntry[] {
+  const repoChunks = context.repoChunks;
+  if (!repoChunks || repoChunks.length === 0) return [];
+
+  const chunksByFile = groupChunksByFile(repoChunks);
+  const familyIndex = buildFamilyIndex(chunksByFile.keys());
+  const changedFileSet = collectChangedFileSet(context);
+  const patches = context.pr?.patches;
+
+  const entries: SiblingSurfaceEntry[] = [];
+  const candidateFiles = [...changedFileSet].filter(isSourceFile).sort();
+
+  for (const file of candidateFiles) {
+    const family = familyFor(file, familyIndex);
+    if (!family || !hasCohesivePattern(family, chunksByFile)) continue;
+
+    const untouchedSiblings = family.filter(s => s !== file && !changedFileSet.has(s));
+    if (untouchedSiblings.length === 0) continue;
+
+    const patch = patches?.get(file);
+    if (patch) {
+      entries.push(
+        ...extractUnmirroredAdditions(
+          file,
+          patch,
+          repoChunks,
+          chunksByFile,
+          changedFileSet,
+          untouchedSiblings,
+        ),
+      );
+    }
+    entries.push(...extractFamilyPatternDivergence(file, chunksByFile, untouchedSiblings));
+  }
+
+  return entries.slice(0, MAX_TOTAL_ENTRIES);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const SIBLING_SURFACES_HEADER =
+  'Pre-computed by a deterministic scan of file "families" (other source files in the same ' +
+  'directory sharing an extension, tests excluded — no grep needed). Each entry is either a ' +
+  'feature-shaped literal/identifier this PR ADDED to one family member but which is absent ' +
+  'from an untouched sibling that handles the same kind of surface, or a call every OTHER ' +
+  'family member makes that this file never does. For each, verify whether the omission is ' +
+  'intentional: an option or code path implemented in one family member but silently absent ' +
+  'from a sibling that handles the same surface is a finding; if the sibling structurally ' +
+  'cannot support it (documented, or a genuinely different responsibility), stay silent.';
+
+/**
+ * Entries for the same file, direction, and sibling set share one rendered
+ * line — otherwise a family with many members (or a file with several
+ * qualifying identifiers) repeats the same long sibling list per identifier,
+ * which burns the block's char budget on redundant text instead of signal.
+ */
+interface EntryGroup {
+  direction: SiblingSurfaceDirection;
+  file: string;
+  siblings: string[];
+  items: { display: string; line?: number }[];
+}
+
+function groupEntries(entries: SiblingSurfaceEntry[]): EntryGroup[] {
+  const groups = new Map<string, EntryGroup>();
+  for (const e of entries) {
+    const key = `${e.direction}::${e.file}::${e.siblings.join(',')}`;
+    const group = groups.get(key);
+    if (group) group.items.push({ display: e.display, line: e.line });
+    else
+      groups.set(key, {
+        direction: e.direction,
+        file: e.file,
+        siblings: e.siblings,
+        items: [{ display: e.display, line: e.line }],
+      });
+  }
+  return [...groups.values()];
+}
+
+function renderGroup(g: EntryGroup): string {
+  const siblingsList = g.siblings.join(', ');
+  if (g.direction === 'unmirrored-addition') {
+    const items = g.items
+      .map(i => (i.line ? `${i.display} (line ${i.line})` : i.display))
+      .join(', ');
+    return `- ${items} — added in ${g.file}, absent from untouched sibling(s): ${siblingsList}`;
+  }
+  const items = g.items.map(i => `${i.display}(...)`).join(', ');
+  return `- ${items} — shared by sibling(s) ${siblingsList}, absent from ${g.file}`;
+}
+
+/**
+ * Render sibling-surface entries as a `<sibling_surfaces>` block. Returns ''
+ * when there are no entries so callers can append unconditionally — a fixture
+ * with no signal must render byte-identical prompts.
+ */
+export function renderSiblingSurfaces(entries: SiblingSurfaceEntry[]): string {
+  if (entries.length === 0) return '';
+
+  const groups = groupEntries(entries);
+  const lines: string[] = ['<sibling_surfaces>', SIBLING_SURFACES_HEADER];
+  let used = lines.join('\n').length;
+  let omitted = 0;
+
+  for (const g of groups) {
+    const line = renderGroup(g);
+    if (used + line.length + 1 > MAX_BLOCK_CHARS) {
+      omitted = groups.length - lines.length + 2; // +2 for the two header lines already pushed
+      break;
+    }
+    lines.push(line);
+    used += line.length + 1;
+  }
+
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more entr${omitted === 1 ? 'y' : 'ies'} omitted to respect the input budget]`,
+    );
+  }
+  lines.push('</sibling_surfaces>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<sibling_surfaces>` section for the agent's initial message.
+ * Returns '' when there is no repo index or no entries survive the scan.
+ */
+export function renderSiblingSurfacesSection(context: ReviewContext): string {
+  return renderSiblingSurfaces(extractSiblingSurfaces(context));
+}

--- a/packages/review/src/sibling-surface-signals.ts
+++ b/packages/review/src/sibling-surface-signals.ts
@@ -37,6 +37,27 @@
  *    `validate(` call appears in 9 of 13 untouched siblings, not all 13 (a few
  *    unrelated files like `any.go` never call it). Requiring unanimity would
  *    silently kill the positive.
+ *
+ * A second, independent family axis covers a gap the same-directory definition
+ * cannot see: MIRROR DIRECTORIES. reqwest's `blocking/request.rs` and
+ * `async_impl/request.rs` are the real sibling axis for "applied to one variant,
+ * forgot the other" bugs (reqwest #916/#1550), but they live in different
+ * directories, so the same-dir family never pairs them. A mirror sibling for a
+ * changed `<dirA>/<base>.<ext>` is `<dirB>/<base>.<ext>` where dirA and dirB
+ * share at least two same-basename+extension source files (the mirror-evidence
+ * gate — one coincidental shared name like `utils.rs` must not create a family)
+ * and dirB actually contains the counterpart file itself. Qualifying mirror
+ * directories are capped at 3 per changed file: a basename like `index.ts`
+ * shared across dozens of directories is noise, not a mirror relationship, so
+ * exceeding the cap discards the mirror family for that file entirely rather
+ * than truncating to the first 3. Mirror siblings feed both directions exactly
+ * like same-dir siblings, except Direction B with a SINGLE mirror sibling (the
+ * common case — most mirror relationships are 1:1 pairs, not larger clusters)
+ * swaps the cross-file majority-share rule for a within-file repetition rule:
+ * the identifier must occur at least twice in that one sibling, compensating
+ * for a family too small for "majority" to mean anything. Rendered entries
+ * that come from this axis are labeled "mirror sibling" so the reviewer can
+ * tell the relationship apart from a same-directory one.
  */
 
 import type { CodeChunk } from '@liendev/parser';
@@ -58,6 +79,8 @@ export interface SiblingSurfaceEntry {
   line?: number;
   /** Direction A: untouched siblings LACKING it. Direction B: untouched siblings SHARING it. */
   siblings: string[];
+  /** True when `siblings` are mirror-directory siblings (cross-dir, same basename+ext), not same-directory family members. */
+  isMirror: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +108,37 @@ const TEST_PATH_RE =
 const MIN_FAMILY_SIZE = 2;
 /** A group larger than this is a bulk directory, not a family (see module doc). */
 const MAX_FAMILY_SIZE = 20;
+
+/** Minimum same-basename+ext file pairs two directories must share to count as "mirror directories" — the mirror-evidence gate. */
+const MIN_MIRROR_SHARED_BASENAMES = 2;
+/** More mirror directories than this qualifying for one file is noise (see module doc); discard the mirror family entirely rather than truncate. */
+const MAX_MIRROR_DIRS_PER_FILE = 3;
+
+/**
+ * Directory "entry point" basenames — barrel/module-init files present in
+ * nearly any directory regardless of its role, in the languages this module
+ * scans. Sharing one of these between two directories is not evidence of a
+ * deliberate mirror relationship, so it must not count toward the
+ * mirror-evidence gate above — the same failure mode the module doc's
+ * `utils.rs` example warns about, just for an even more common name. Found
+ * empirically: `packages/cli/src/mcp/handlers/` and `packages/parser/src/`
+ * (this very repo) share `dependency-analyzer.ts` (a real caller/callee pair,
+ * not a mirror) plus `index.ts` — and `index.ts` alone was enough to clear a
+ * naive 2-shared-basename gate.
+ */
+const GENERIC_ENTRYPOINT_BASENAMES = new Set([
+  'index.ts',
+  'index.tsx',
+  'index.js',
+  'index.jsx',
+  'index.mjs',
+  'index.cjs',
+  '__init__.py',
+  'mod.rs',
+  'main.rs',
+  'main.go',
+  'main.py',
+]);
 
 const MAX_ENTRIES_PER_FILE_PER_DIRECTION = 5;
 /** Bound on raw diff-added candidates considered per file before the corpus-rarity scan. */
@@ -252,6 +306,15 @@ function dirnameOf(file: string): string {
   return idx === -1 ? '' : file.slice(0, idx);
 }
 
+function basenameOf(file: string): string {
+  const idx = file.lastIndexOf('/');
+  return idx === -1 ? file : file.slice(idx + 1);
+}
+
+function joinDirBase(dir: string, base: string): string {
+  return dir === '' ? base : `${dir}/${base}`;
+}
+
 function isTestFile(file: string): boolean {
   return TEST_PATH_RE.test(file);
 }
@@ -341,6 +404,86 @@ function familyFor(file: string, index: Map<string, string[]>): string[] | null 
   const members = index.get(`${dirnameOf(file)}::${ext}`);
   if (!members || members.length < MIN_FAMILY_SIZE || members.length > MAX_FAMILY_SIZE) return null;
   return members;
+}
+
+// ---------------------------------------------------------------------------
+// Mirror-directory computation
+// ---------------------------------------------------------------------------
+
+/** dirname -> set of source (non-test) basenames present in that directory, built once from the indexed repo's file set. */
+function buildDirBasenameIndex(files: Iterable<string>): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const file of files) {
+    if (!isSourceFile(file)) continue;
+    const dir = dirnameOf(file);
+    const base = basenameOf(file);
+    const set = index.get(dir);
+    if (set) set.add(base);
+    else index.set(dir, new Set([base]));
+  }
+  return index;
+}
+
+/**
+ * Count of basenames two directories share, short-circuiting once the
+ * mirror-evidence gate is met. Generic entry-point basenames (index.ts and
+ * equivalents) don't count as evidence — see GENERIC_ENTRYPOINT_BASENAMES.
+ */
+function sharedBasenameCount(a: Set<string>, b: Set<string>): number {
+  let count = 0;
+  for (const base of a) {
+    if (GENERIC_ENTRYPOINT_BASENAMES.has(base)) continue;
+    if (!b.has(base)) continue;
+    count++;
+    if (count >= MIN_MIRROR_SHARED_BASENAMES) return count;
+  }
+  return count;
+}
+
+/**
+ * Directories that qualify as mirror directories of `dir`: each contains a
+ * same-basename+ext file (the mirror counterpart must exist) AND shares at
+ * least MIN_MIRROR_SHARED_BASENAMES such files with `dir` overall (the
+ * mirror-evidence gate — see module doc).
+ */
+function mirrorDirsFor(
+  dir: string,
+  base: string,
+  dirBasenames: Map<string, Set<string>>,
+): string[] {
+  const ownBasenames = dirBasenames.get(dir);
+  if (!ownBasenames) return [];
+
+  const qualified: string[] = [];
+  for (const [otherDir, basenames] of dirBasenames) {
+    if (otherDir === dir || !basenames.has(base)) continue;
+    if (sharedBasenameCount(ownBasenames, basenames) >= MIN_MIRROR_SHARED_BASENAMES) {
+      qualified.push(otherDir);
+    }
+  }
+  return qualified;
+}
+
+/**
+ * Untouched mirror-sibling file paths for `file`, one per qualifying mirror
+ * directory — or [] when there's no mirror relationship, or more than
+ * MAX_MIRROR_DIRS_PER_FILE directories qualify (noise, not a mirror family).
+ */
+function mirrorSiblingsFor(
+  file: string,
+  dirBasenames: Map<string, Set<string>>,
+  changedFileSet: Set<string>,
+): string[] {
+  if (!isSourceFile(file)) return [];
+
+  const base = basenameOf(file);
+  const qualifiedDirs = mirrorDirsFor(dirnameOf(file), base, dirBasenames);
+  if (qualifiedDirs.length === 0 || qualifiedDirs.length > MAX_MIRROR_DIRS_PER_FILE) return [];
+
+  return qualifiedDirs
+    .map(d => joinDirBase(d, base))
+    .filter(s => s !== file && !changedFileSet.has(s))
+    .sort();
 }
 
 // ---------------------------------------------------------------------------
@@ -467,6 +610,7 @@ function extractUnmirroredAdditions(
   chunksByFile: Map<string, CodeChunk[]>,
   changedFileSet: Set<string>,
   untouchedSiblings: string[],
+  isMirror = false,
 ): SiblingSurfaceEntry[] {
   const entries: SiblingSurfaceEntry[] = [];
 
@@ -478,7 +622,14 @@ function extractUnmirroredAdditions(
     const lacking = untouchedSiblings.filter(s => !fileContains(chunksByFile, s, value)).sort();
     if (lacking.length === 0) continue;
 
-    entries.push({ direction: 'unmirrored-addition', display, file, line, siblings: lacking });
+    entries.push({
+      direction: 'unmirrored-addition',
+      display,
+      file,
+      line,
+      siblings: lacking,
+      isMirror,
+    });
   }
 
   return entries;
@@ -488,17 +639,25 @@ function extractUnmirroredAdditions(
 // Direction B: family-pattern divergence
 // ---------------------------------------------------------------------------
 
-function extractCallIdentifiers(chunksByFile: Map<string, CodeChunk[]>, file: string): Set<string> {
-  const out = new Set<string>();
+/** Call-shaped identifier -> occurrence count within one file's chunks (dedup'd by the same rules as Direction A's stoplist). */
+function countCallIdentifiers(
+  chunksByFile: Map<string, CodeChunk[]>,
+  file: string,
+): Map<string, number> {
+  const counts = new Map<string, number>();
   for (const chunk of chunksByFile.get(file) ?? []) {
     for (const m of chunk.content.matchAll(CALL_RE)) {
       const id = m[1];
       if (id.length < MIN_IDENTIFIER_CHARS) continue;
       if (CALL_KEYWORD_STOPLIST.has(id.toLowerCase())) continue;
-      out.add(id);
+      counts.set(id, (counts.get(id) ?? 0) + 1);
     }
   }
-  return out;
+  return counts;
+}
+
+function extractCallIdentifiers(chunksByFile: Map<string, CodeChunk[]>, file: string): Set<string> {
+  return new Set(countCallIdentifiers(chunksByFile, file).keys());
 }
 
 /** How many members must share a call for it to count as a "family pattern" (a majority). */
@@ -534,6 +693,7 @@ function extractFamilyPatternDivergence(
   file: string,
   chunksByFile: Map<string, CodeChunk[]>,
   untouchedSiblings: string[],
+  isMirror = false,
 ): SiblingSurfaceEntry[] {
   if (untouchedSiblings.length < 2) return [];
 
@@ -563,12 +723,118 @@ function extractFamilyPatternDivergence(
     display: id,
     file,
     siblings,
+    isMirror,
   }));
+}
+
+/**
+ * Direction B for a mirror family with exactly one mirror sibling — the
+ * common case, since most mirror relationships are 1:1 pairs. The majority
+ * rule (`requiredShareCount`) can never fire with a single candidate, so
+ * instead require the identifier to occur at least twice within that one
+ * sibling: a within-file repetition signal standing in for "the family
+ * pattern", to compensate for a family too small for a majority to mean
+ * anything.
+ */
+function extractSingleMirrorDivergence(
+  file: string,
+  chunksByFile: Map<string, CodeChunk[]>,
+  mirrorSibling: string,
+): SiblingSurfaceEntry[] {
+  const counts = countCallIdentifiers(chunksByFile, mirrorSibling);
+  const candidates = [...counts.entries()]
+    .filter(([id, count]) => count >= 2 && !fileContains(chunksByFile, file, id))
+    .map(([id]) => id)
+    .sort();
+
+  return candidates.slice(0, MAX_ENTRIES_PER_FILE_PER_DIRECTION).map(id => ({
+    direction: 'family-pattern-divergence' as const,
+    display: id,
+    file,
+    siblings: [mirrorSibling],
+    isMirror: true,
+  }));
+}
+
+/** Direction B dispatcher for the mirror axis: single-sibling families use the repetition rule above; larger ones reuse the same majority rule as same-dir families. */
+function extractMirrorFamilyPatternDivergence(
+  file: string,
+  chunksByFile: Map<string, CodeChunk[]>,
+  mirrorSiblings: string[],
+): SiblingSurfaceEntry[] {
+  if (mirrorSiblings.length === 1) {
+    return extractSingleMirrorDivergence(file, chunksByFile, mirrorSiblings[0]);
+  }
+  return extractFamilyPatternDivergence(file, chunksByFile, mirrorSiblings, true);
 }
 
 // ---------------------------------------------------------------------------
 // Extraction entry point
 // ---------------------------------------------------------------------------
+
+/** Same-directory family axis (v1) for one changed file: both directions, or [] when no cohesive family exists. */
+function extractSameDirFamilyEntries(
+  file: string,
+  familyIndex: Map<string, string[]>,
+  chunksByFile: Map<string, CodeChunk[]>,
+  repoChunks: CodeChunk[],
+  changedFileSet: Set<string>,
+  patches: Map<string, string> | undefined,
+): SiblingSurfaceEntry[] {
+  const family = familyFor(file, familyIndex);
+  if (!family || !hasCohesivePattern(family, chunksByFile)) return [];
+
+  const untouchedSiblings = family.filter(s => s !== file && !changedFileSet.has(s));
+  if (untouchedSiblings.length === 0) return [];
+
+  const entries: SiblingSurfaceEntry[] = [];
+  const patch = patches?.get(file);
+  if (patch) {
+    entries.push(
+      ...extractUnmirroredAdditions(
+        file,
+        patch,
+        repoChunks,
+        chunksByFile,
+        changedFileSet,
+        untouchedSiblings,
+      ),
+    );
+  }
+  entries.push(...extractFamilyPatternDivergence(file, chunksByFile, untouchedSiblings));
+  return entries;
+}
+
+/** Mirror-directory family axis for one changed file: both directions, or [] when no mirror family qualifies. */
+function extractMirrorFamilyEntries(
+  file: string,
+  dirBasenameIndex: Map<string, Set<string>>,
+  chunksByFile: Map<string, CodeChunk[]>,
+  repoChunks: CodeChunk[],
+  changedFileSet: Set<string>,
+  patches: Map<string, string> | undefined,
+): SiblingSurfaceEntry[] {
+  const mirrorSiblings = mirrorSiblingsFor(file, dirBasenameIndex, changedFileSet);
+  if (mirrorSiblings.length === 0) return [];
+
+  const entries: SiblingSurfaceEntry[] = [];
+  const patch = patches?.get(file);
+  if (patch) {
+    entries.push(
+      ...extractUnmirroredAdditions(
+        file,
+        patch,
+        repoChunks,
+        chunksByFile,
+        changedFileSet,
+        mirrorSiblings,
+        true,
+      ),
+    );
+  }
+  entries.push(...extractMirrorFamilyPatternDivergence(file, chunksByFile, mirrorSiblings));
+  return entries;
+}
 
 /**
  * Precompute sibling-surface entries for the review context. Returns [] when
@@ -580,6 +846,7 @@ export function extractSiblingSurfaces(context: ReviewContext): SiblingSurfaceEn
 
   const chunksByFile = groupChunksByFile(repoChunks);
   const familyIndex = buildFamilyIndex(chunksByFile.keys());
+  const dirBasenameIndex = buildDirBasenameIndex(chunksByFile.keys());
   const changedFileSet = collectChangedFileSet(context);
   const patches = context.pr?.patches;
 
@@ -587,26 +854,26 @@ export function extractSiblingSurfaces(context: ReviewContext): SiblingSurfaceEn
   const candidateFiles = [...changedFileSet].filter(isSourceFile).sort();
 
   for (const file of candidateFiles) {
-    const family = familyFor(file, familyIndex);
-    if (!family || !hasCohesivePattern(family, chunksByFile)) continue;
-
-    const untouchedSiblings = family.filter(s => s !== file && !changedFileSet.has(s));
-    if (untouchedSiblings.length === 0) continue;
-
-    const patch = patches?.get(file);
-    if (patch) {
-      entries.push(
-        ...extractUnmirroredAdditions(
-          file,
-          patch,
-          repoChunks,
-          chunksByFile,
-          changedFileSet,
-          untouchedSiblings,
-        ),
-      );
-    }
-    entries.push(...extractFamilyPatternDivergence(file, chunksByFile, untouchedSiblings));
+    entries.push(
+      ...extractSameDirFamilyEntries(
+        file,
+        familyIndex,
+        chunksByFile,
+        repoChunks,
+        changedFileSet,
+        patches,
+      ),
+    );
+    entries.push(
+      ...extractMirrorFamilyEntries(
+        file,
+        dirBasenameIndex,
+        chunksByFile,
+        repoChunks,
+        changedFileSet,
+        patches,
+      ),
+    );
   }
 
   return entries.slice(0, MAX_TOTAL_ENTRIES);
@@ -617,32 +884,36 @@ export function extractSiblingSurfaces(context: ReviewContext): SiblingSurfaceEn
 // ---------------------------------------------------------------------------
 
 const SIBLING_SURFACES_HEADER =
-  'Pre-computed by a deterministic scan of file "families" (other source files in the same ' +
-  'directory sharing an extension, tests excluded — no grep needed). Each entry is either a ' +
-  'feature-shaped literal/identifier this PR ADDED to one family member but which is absent ' +
-  'from an untouched sibling that handles the same kind of surface, or a call every OTHER ' +
-  'family member makes that this file never does. For each, verify whether the omission is ' +
-  'intentional: an option or code path implemented in one family member but silently absent ' +
-  'from a sibling that handles the same surface is a finding; if the sibling structurally ' +
-  'cannot support it (documented, or a genuinely different responsibility), stay silent.';
+  'Pre-computed by a deterministic scan of file "families" — other source files in the same ' +
+  'directory sharing an extension, or "mirror siblings": the same file basename in a different ' +
+  'directory that this codebase maintains as a parallel implementation (e.g. an async vs a ' +
+  'blocking variant), tests excluded — no grep needed. Each entry is either a feature-shaped ' +
+  'literal/identifier this PR ADDED to one family member but which is absent from an untouched ' +
+  'sibling that handles the same kind of surface, or a call every OTHER family member makes ' +
+  'that this file never does. For each, verify whether the omission is intentional: an option ' +
+  'or code path implemented in one family member but silently absent from a sibling that ' +
+  'handles the same surface is a finding; if the sibling structurally cannot support it ' +
+  '(documented, or a genuinely different responsibility), stay silent.';
 
 /**
- * Entries for the same file, direction, and sibling set share one rendered
- * line — otherwise a family with many members (or a file with several
- * qualifying identifiers) repeats the same long sibling list per identifier,
- * which burns the block's char budget on redundant text instead of signal.
+ * Entries for the same file, direction, sibling set, and mirror-ness share one
+ * rendered line — otherwise a family with many members (or a file with
+ * several qualifying identifiers) repeats the same long sibling list per
+ * identifier, which burns the block's char budget on redundant text instead
+ * of signal.
  */
 interface EntryGroup {
   direction: SiblingSurfaceDirection;
   file: string;
   siblings: string[];
+  isMirror: boolean;
   items: { display: string; line?: number }[];
 }
 
 function groupEntries(entries: SiblingSurfaceEntry[]): EntryGroup[] {
   const groups = new Map<string, EntryGroup>();
   for (const e of entries) {
-    const key = `${e.direction}::${e.file}::${e.siblings.join(',')}`;
+    const key = `${e.direction}::${e.file}::${e.siblings.join(',')}::${e.isMirror}`;
     const group = groups.get(key);
     if (group) group.items.push({ display: e.display, line: e.line });
     else
@@ -650,6 +921,7 @@ function groupEntries(entries: SiblingSurfaceEntry[]): EntryGroup[] {
         direction: e.direction,
         file: e.file,
         siblings: e.siblings,
+        isMirror: e.isMirror,
         items: [{ display: e.display, line: e.line }],
       });
   }
@@ -658,14 +930,15 @@ function groupEntries(entries: SiblingSurfaceEntry[]): EntryGroup[] {
 
 function renderGroup(g: EntryGroup): string {
   const siblingsList = g.siblings.join(', ');
+  const siblingWord = g.isMirror ? 'mirror sibling' : 'sibling';
   if (g.direction === 'unmirrored-addition') {
     const items = g.items
       .map(i => (i.line ? `${i.display} (line ${i.line})` : i.display))
       .join(', ');
-    return `- ${items} — added in ${g.file}, absent from untouched sibling(s): ${siblingsList}`;
+    return `- ${items} — added in ${g.file}, absent from untouched ${siblingWord}(s): ${siblingsList}`;
   }
   const items = g.items.map(i => `${i.display}(...)`).join(', ');
-  return `- ${items} — shared by sibling(s) ${siblingsList}, absent from ${g.file}`;
+  return `- ${items} — shared by ${siblingWord}(s) ${siblingsList}, absent from ${g.file}`;
 }
 
 /**

--- a/packages/review/test/sibling-surface-signals.test.ts
+++ b/packages/review/test/sibling-surface-signals.test.ts
@@ -308,6 +308,210 @@ describe('extractSiblingSurfaces — noise avoidance', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Mirror directories
+// ---------------------------------------------------------------------------
+
+// Mimics reqwest #916: `async_impl/request.rs` and `blocking/request.rs` are
+// the real sibling axis, but they live in different directories. `client.rs`
+// is present in both dirs purely to give the pair its mirror-evidence (>= 2
+// shared basenames) — its content is otherwise irrelevant.
+const ASYNC_REQUEST_PATCH = `@@ -1,7 +1,8 @@
+ pub struct Request {
+     headers: HeaderMap,
+ }
+
+ impl Request {
+     pub fn build(&self) -> HeaderMap {
++        redact_sensitive_headers(&self.headers);
+         self.headers.clone()
+     }
+ }`;
+
+const ASYNC_REQUEST_CONTENT = [
+  'pub struct Request {',
+  '    headers: HeaderMap,',
+  '}',
+  '',
+  'impl Request {',
+  '    pub fn build(&self) -> HeaderMap {',
+  '        redact_sensitive_headers(&self.headers);',
+  '        self.headers.clone()',
+  '    }',
+  '}',
+].join('\n');
+
+const BLOCKING_REQUEST_CONTENT = [
+  'pub struct Request {',
+  '    headers: HeaderMap,',
+  '}',
+  '',
+  'impl Request {',
+  '    pub fn build(&self) -> HeaderMap {',
+  '        self.headers.clone()',
+  '    }',
+  '}',
+].join('\n');
+
+const ASYNC_CLIENT_CONTENT = [
+  'pub struct Client;',
+  '',
+  'impl Client {',
+  '    fn execute(&self) {} ',
+  '}',
+].join('\n');
+const BLOCKING_CLIENT_CONTENT = ASYNC_CLIENT_CONTENT;
+
+function reqwestLikeContext(): ReviewContext {
+  const patches = new Map([['async_impl/request.rs', ASYNC_REQUEST_PATCH]]);
+  const repoChunks = [
+    makeChunk('async_impl/request.rs', 1, ASYNC_REQUEST_CONTENT),
+    makeChunk('async_impl/client.rs', 1, ASYNC_CLIENT_CONTENT),
+    makeChunk('blocking/request.rs', 1, BLOCKING_REQUEST_CONTENT),
+    makeChunk('blocking/client.rs', 1, BLOCKING_CLIENT_CONTENT),
+  ];
+  return makeContext({ patches, repoChunks, changedFiles: ['async_impl/request.rs'] });
+}
+
+describe('extractSiblingSurfaces — mirror directories (direction A)', () => {
+  it('reports an identifier added to one variant as absent from its cross-directory mirror sibling', () => {
+    const entries = extractSiblingSurfaces(reqwestLikeContext());
+    const entry = entries.find(
+      e => e.direction === 'unmirrored-addition' && e.display.includes('redact_sensitive_headers'),
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.file).toBe('async_impl/request.rs');
+    expect(entry?.siblings).toEqual(['blocking/request.rs']);
+    expect(entry?.isMirror).toBe(true);
+  });
+
+  it('renders the mirror entry with "mirror sibling" wording, not plain "sibling"', () => {
+    const entries = extractSiblingSurfaces(reqwestLikeContext());
+    const block = renderSiblingSurfaces(entries);
+    expect(block).toContain('mirror sibling');
+    expect(block).toContain('blocking/request.rs');
+  });
+
+  it('requires a second shared basename (the mirror-evidence gate) — a single shared name is not a mirror', () => {
+    // Only `request.rs` is shared between the two directories; there is no
+    // `client.rs` (or any other) pairing, so the directories share just one
+    // basename — below the >= 2 mirror-evidence threshold.
+    const patches = new Map([['async_impl/request.rs', ASYNC_REQUEST_PATCH]]);
+    const repoChunks = [
+      makeChunk('async_impl/request.rs', 1, ASYNC_REQUEST_CONTENT),
+      makeChunk('blocking/request.rs', 1, BLOCKING_REQUEST_CONTENT),
+    ];
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['async_impl/request.rs'],
+    });
+    expect(extractSiblingSurfaces(context)).toEqual([]);
+  });
+
+  it('discards the mirror family entirely when more than 3 directories qualify', () => {
+    // src/dirA is the changed file's directory; dirB..dirE each mirror it
+    // fully (model.ts + common.ts — both non-generic basenames), so 4
+    // directories qualify — over the cap of 3 — which must produce nothing,
+    // not the first 3.
+    const patch =
+      '@@ -1,1 +1,2 @@\n export const modelValue = 1;\n+export const mirrorNoiseToken = 1;';
+    const patches = new Map([['src/dirA/model.ts', patch]]);
+    const repoChunks = [
+      makeChunk(
+        'src/dirA/model.ts',
+        1,
+        'export const modelValue = 1;\nexport const mirrorNoiseToken = 1;',
+      ),
+      makeChunk('src/dirA/common.ts', 1, 'export const commonValue = 1;'),
+    ];
+    for (const dir of ['dirB', 'dirC', 'dirD', 'dirE']) {
+      repoChunks.push(makeChunk(`src/${dir}/model.ts`, 1, 'export const value = 1;'));
+      repoChunks.push(makeChunk(`src/${dir}/common.ts`, 1, 'export const value = 1;'));
+    }
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/dirA/model.ts'],
+    });
+    expect(extractSiblingSurfaces(context)).toEqual([]);
+  });
+
+  it('does not count a shared generic entry-point basename (index.ts) as mirror-evidence', () => {
+    // src/moduleA and src/moduleB share exactly two basenames — index.ts and
+    // shared.ts — but index.ts is a barrel-file convention present in nearly
+    // any directory, so it must not count. That leaves only ONE real shared
+    // basename (shared.ts), below the mirror-evidence gate, so no mirror
+    // family should form at all.
+    const patch =
+      '@@ -1,1 +1,2 @@\n export const sharedValue = 1;\n+export const distinctiveGenericGateToken = 1;';
+    const patches = new Map([['src/moduleA/shared.ts', patch]]);
+    const repoChunks = [
+      makeChunk(
+        'src/moduleA/shared.ts',
+        1,
+        'export const sharedValue = 1;\nexport const distinctiveGenericGateToken = 1;',
+      ),
+      makeChunk('src/moduleA/index.ts', 1, "export * from './shared.js';"),
+      makeChunk('src/moduleB/shared.ts', 1, 'export const sharedValue = 2;'),
+      makeChunk('src/moduleB/index.ts', 1, "export * from './shared.js';"),
+    ];
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/moduleA/shared.ts'],
+    });
+    expect(extractSiblingSurfaces(context)).toEqual([]);
+  });
+});
+
+describe('extractSiblingSurfaces — mirror directories (direction B)', () => {
+  it('with a single mirror sibling, requires the identifier to occur >= 2 times in it', () => {
+    // blocking/request.rs (the lone mirror sibling) calls `validate_headers`
+    // twice; async_impl/request.rs (the changed file) never calls it at all.
+    const asyncRequestContent = [
+      'pub struct Request;',
+      '',
+      'impl Request {',
+      '    pub fn build(&self) -> HeaderMap {',
+      '        self.headers.clone()',
+      '    }',
+      '}',
+    ].join('\n');
+    const blockingRequestContent = [
+      'pub struct Request;',
+      '',
+      'impl Request {',
+      '    pub fn build(&self) -> HeaderMap {',
+      '        validate_headers(&self.headers);',
+      '        self.headers.clone()',
+      '    }',
+      '',
+      '    pub fn retry(&self) -> HeaderMap {',
+      '        validate_headers(&self.headers);',
+      '        self.headers.clone()',
+      '    }',
+      '}',
+    ].join('\n');
+    const repoChunks = [
+      makeChunk('async_impl/request.rs', 1, asyncRequestContent),
+      makeChunk('async_impl/client.rs', 1, 'pub struct Client;'),
+      makeChunk('blocking/request.rs', 1, blockingRequestContent),
+      makeChunk('blocking/client.rs', 1, 'pub struct Client;'),
+    ];
+    const context = makeContext({ repoChunks, changedFiles: ['async_impl/request.rs'] });
+
+    const entries = extractSiblingSurfaces(context);
+    const entry = entries.find(
+      e => e.direction === 'family-pattern-divergence' && e.display === 'validate_headers',
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.file).toBe('async_impl/request.rs');
+    expect(entry?.siblings).toEqual(['blocking/request.rs']);
+    expect(entry?.isMirror).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Caps
 // ---------------------------------------------------------------------------
 

--- a/packages/review/test/sibling-surface-signals.test.ts
+++ b/packages/review/test/sibling-surface-signals.test.ts
@@ -1,0 +1,429 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  extractSiblingSurfaces,
+  renderSiblingSurfaces,
+  renderSiblingSurfacesSection,
+} from '../src/sibling-surface-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+  } as CodeChunk;
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  repoChunks?: CodeChunk[];
+  changedFiles?: string[];
+}): ReviewContext {
+  const pr = opts.patches ? { patches: opts.patches } : undefined;
+  return {
+    pr,
+    repoChunks: opts.repoChunks,
+    changedFiles: opts.changedFiles ?? [],
+  } as unknown as ReviewContext;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+// Mimics guzzle #3740: a new `on_trailers` option wired into one handler
+// (CurlHandler.php), silently absent from an untouched sibling
+// (StreamHandler.php). Both share `validateOptions(` so the family clears
+// the cohesion gate (2/2 members).
+const CURL_HANDLER_PATCH = `@@ -1,7 +1,14 @@
+ <?php
+ class CurlHandler {
+     public function handle($options) {
+         $this->validateOptions($options);
++        if (isset($options['on_trailers'])) {
++            $this->assertOnTrailersCallable($options);
++        }
+     }
++
++    private function assertOnTrailersCallable($options) {
++        if (!is_callable($options['on_trailers'])) {
++            throw new InvalidArgumentException('on_trailers must be callable');
++        }
++    }
+ }`;
+
+const CURL_HANDLER_CONTENT = [
+  '<?php',
+  'class CurlHandler {',
+  '    public function handle($options) {',
+  '        $this->validateOptions($options);',
+  "        if (isset(\$options['on_trailers'])) {",
+  '            $this->assertOnTrailersCallable($options);',
+  '        }',
+  '    }',
+  '',
+  '    private function assertOnTrailersCallable($options) {',
+  "        if (!is_callable(\$options['on_trailers'])) {",
+  "            throw new InvalidArgumentException('on_trailers must be callable');",
+  '        }',
+  '    }',
+  '}',
+].join('\n');
+
+const STREAM_HANDLER_CONTENT = [
+  '<?php',
+  'class StreamHandler {',
+  '    public function handle($options) {',
+  '        $this->validateOptions($options);',
+  '    }',
+  '}',
+].join('\n');
+
+function guzzleLikeContext(): ReviewContext {
+  const patches = new Map([['src/Handler/CurlHandler.php', CURL_HANDLER_PATCH]]);
+  const repoChunks = [
+    makeChunk('src/Handler/CurlHandler.php', 1, CURL_HANDLER_CONTENT),
+    makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+  ];
+  return {
+    ...makeContext({ patches, repoChunks, changedFiles: ['src/Handler/CurlHandler.php'] }),
+  } as ReviewContext;
+}
+
+// Mimics gin #3081: a new `binding/toml.go` whose decode function never calls
+// `validate(`, unlike the sibling bindings (json/xml/yaml) that all do.
+const JSON_GO_CONTENT = [
+  'package binding',
+  '',
+  'func decodeJSON(r io.Reader, obj any) error {',
+  '\tif err := json.NewDecoder(r).Decode(obj); err != nil {',
+  '\t\treturn err',
+  '\t}',
+  '\treturn validate(obj)',
+  '}',
+].join('\n');
+
+const XML_GO_CONTENT = [
+  'package binding',
+  '',
+  'func decodeXML(r io.Reader, obj any) error {',
+  '\tif err := xml.NewDecoder(r).Decode(obj); err != nil {',
+  '\t\treturn err',
+  '\t}',
+  '\treturn validate(obj)',
+  '}',
+].join('\n');
+
+const YAML_GO_CONTENT = [
+  'package binding',
+  '',
+  'func decodeYAML(r io.Reader, obj any) error {',
+  '\tif err := yaml.Unmarshal(data, obj); err != nil {',
+  '\t\treturn err',
+  '\t}',
+  '\treturn validate(obj)',
+  '}',
+].join('\n');
+
+const TOML_GO_CONTENT = [
+  'package binding',
+  '',
+  'func decodeToml(r io.Reader, obj any) error {',
+  '\tdecoder := toml.NewDecoder(r)',
+  '\tif err := decoder.Decode(obj); err != nil {',
+  '\t\treturn err',
+  '\t}',
+  '\treturn decoder.Decode(obj)',
+  '}',
+].join('\n');
+
+const TOML_GO_PATCH = `@@ -0,0 +1,8 @@
++package binding
++
++func decodeToml(r io.Reader, obj any) error {
++\tdecoder := toml.NewDecoder(r)
++\tif err := decoder.Decode(obj); err != nil {
++\t\treturn err
++\t}
++\treturn decoder.Decode(obj)
++}`;
+
+function ginLikeContext(): ReviewContext {
+  const patches = new Map([['binding/toml.go', TOML_GO_PATCH]]);
+  const repoChunks = [
+    makeChunk('binding/json.go', 1, JSON_GO_CONTENT),
+    makeChunk('binding/xml.go', 1, XML_GO_CONTENT),
+    makeChunk('binding/yaml.go', 1, YAML_GO_CONTENT),
+    makeChunk('binding/toml.go', 1, TOML_GO_CONTENT),
+  ];
+  return makeContext({ patches, repoChunks, changedFiles: ['binding/toml.go'] });
+}
+
+// ---------------------------------------------------------------------------
+// extractSiblingSurfaces — Direction A (unmirrored addition)
+// ---------------------------------------------------------------------------
+
+describe('extractSiblingSurfaces — direction A (unmirrored addition)', () => {
+  it('reports an option added to one family member as absent from an untouched sibling', () => {
+    const entries = extractSiblingSurfaces(guzzleLikeContext());
+    const onTrailers = entries.find(
+      e => e.direction === 'unmirrored-addition' && e.display.includes('on_trailers'),
+    );
+    expect(onTrailers).toBeDefined();
+    expect(onTrailers?.file).toBe('src/Handler/CurlHandler.php');
+    expect(onTrailers?.siblings).toContain('src/Handler/StreamHandler.php');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSiblingSurfaces — Direction B (family-pattern divergence)
+// ---------------------------------------------------------------------------
+
+describe('extractSiblingSurfaces — direction B (family-pattern divergence)', () => {
+  it('reports a call every sibling shares as absent from the new/changed file', () => {
+    const entries = extractSiblingSurfaces(ginLikeContext());
+    const validateEntry = entries.find(
+      e => e.direction === 'family-pattern-divergence' && e.display === 'validate',
+    );
+    expect(validateEntry).toBeDefined();
+    expect(validateEntry?.file).toBe('binding/toml.go');
+    expect(validateEntry?.siblings.sort()).toEqual([
+      'binding/json.go',
+      'binding/xml.go',
+      'binding/yaml.go',
+    ]);
+  });
+
+  it('does not report a call the changed file already makes', () => {
+    const entries = extractSiblingSurfaces(ginLikeContext());
+    // decoder.Decode(...) style — `Decode` appears in every sibling AND in
+    // toml.go itself, so it must never be reported as a divergence.
+    expect(entries.some(e => e.display === 'Decode')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative / noise cases
+// ---------------------------------------------------------------------------
+
+describe('extractSiblingSurfaces — noise avoidance', () => {
+  it('treats a directory of 20+ same-extension files as bulk, not a family', () => {
+    const patches = new Map([
+      ['src/big/a.ts', '@@ -1,1 +1,2 @@\n context\n+const bigDirToken = 1;'],
+    ]);
+    const repoChunks = [makeChunk('src/big/a.ts', 1, 'context\nconst bigDirToken = 1;')];
+    for (let i = 0; i < 25; i++) {
+      repoChunks.push(makeChunk(`src/big/file${i}.ts`, 1, `export const value${i} = ${i};`));
+    }
+    const context = makeContext({ patches, repoChunks, changedFiles: ['src/big/a.ts'] });
+    expect(extractSiblingSurfaces(context)).toEqual([]);
+  });
+
+  it('does not report an identifier that is common (>3 occurrences) outside the changed files', () => {
+    const patches = new Map([['src/Handler/CurlHandler.php', CURL_HANDLER_PATCH]]);
+    // Four extra, UNCHANGED files that already contain 'on_trailers' as
+    // generic prose/config — makes it common outside the PR's changed files.
+    const repoChunks = [
+      makeChunk('src/Handler/CurlHandler.php', 1, CURL_HANDLER_CONTENT),
+      makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+      makeChunk('docs/a.php', 1, '<?php // mentions on_trailers here'),
+      makeChunk('docs/b.php', 1, '<?php // mentions on_trailers here too'),
+      makeChunk('docs/c.php', 1, '<?php // on_trailers again'),
+      makeChunk('docs/d.php', 1, '<?php // on_trailers yet again'),
+    ];
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/Handler/CurlHandler.php'],
+    });
+    const entries = extractSiblingSurfaces(context);
+    // The bare 'on_trailers' literal is common outside the changed files (4
+    // docs chunks) and must be filtered. A DIFFERENT, still-rare literal that
+    // happens to contain the same substring (e.g. the full error message) is
+    // a distinct value and is correctly still reportable.
+    expect(entries.some(e => e.display === "'on_trailers'")).toBe(false);
+  });
+
+  it('excludes test files from family membership', () => {
+    const patches = new Map([['src/Handler/CurlHandler.php', CURL_HANDLER_PATCH]]);
+    const repoChunks = [
+      makeChunk('src/Handler/CurlHandler.php', 1, CURL_HANDLER_CONTENT),
+      makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+      makeChunk('src/Handler/CurlHandlerTest.php', 1, '<?php class CurlHandlerTest {}'),
+      makeChunk('src/Handler/StreamHandlerTest.php', 1, '<?php class StreamHandlerTest {}'),
+    ];
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/Handler/CurlHandler.php'],
+    });
+    const entries = extractSiblingSurfaces(context);
+    for (const e of entries) {
+      expect(e.siblings.every(s => !s.includes('Test'))).toBe(true);
+    }
+  });
+
+  it('does not treat a changed test file as a candidate F', () => {
+    const patches = new Map([
+      ['src/Handler/CurlHandlerTest.php', '@@ -1,1 +1,2 @@\n <?php\n+// new_test_thing added here'],
+    ]);
+    const repoChunks = [
+      makeChunk('src/Handler/CurlHandlerTest.php', 1, '<?php\n// new_test_thing added here'),
+      makeChunk('src/Handler/StreamHandlerTest.php', 1, '<?php class StreamHandlerTest {}'),
+    ];
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/Handler/CurlHandlerTest.php'],
+    });
+    expect(extractSiblingSurfaces(context)).toEqual([]);
+  });
+
+  it('requires a cohesive shared pattern across the family, not just co-location', () => {
+    // A flat directory of unrelated single-purpose files with no shared
+    // call-shaped vocabulary — the noise shape found in real package `src/`
+    // directories (format.ts, config.ts, engine.ts, ...).
+    const patches = new Map([
+      ['src/lib/format.ts', '@@ -1,1 +1,2 @@\n export {};\n+export const uniqueFormatToken = 1;'],
+    ]);
+    const repoChunks = [
+      makeChunk('src/lib/format.ts', 1, 'export {};\nexport const uniqueFormatToken = 1;'),
+      makeChunk('src/lib/config.ts', 1, 'export const configValue = 1;'),
+      makeChunk('src/lib/engine.ts', 1, 'export const engineValue = 2;'),
+    ];
+    const context = makeContext({ patches, repoChunks, changedFiles: ['src/lib/format.ts'] });
+    expect(extractSiblingSurfaces(context)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caps
+// ---------------------------------------------------------------------------
+
+describe('extractSiblingSurfaces — caps', () => {
+  it('caps direction-A entries per file at 5', () => {
+    const addedLines = Array.from(
+      { length: 10 },
+      (_, i) => `+        $this->assertCallable${i}Distinctive($options);`,
+    ).join('\n');
+    const patch = `@@ -1,4 +1,${4 + 10} @@\n <?php\n class CurlHandler {\n     public function handle($options) {\n         $this->validateOptions($options);\n${addedLines}\n     }\n }`;
+    const patches = new Map([['src/Handler/CurlHandler.php', patch]]);
+    const newContent = [
+      '<?php',
+      'class CurlHandler {',
+      '    public function handle($options) {',
+      '        $this->validateOptions($options);',
+      ...Array.from(
+        { length: 10 },
+        (_, i) => `        $this->assertCallable${i}Distinctive($options);`,
+      ),
+      '    }',
+      '}',
+    ].join('\n');
+    const repoChunks = [
+      makeChunk('src/Handler/CurlHandler.php', 1, newContent),
+      makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+    ];
+    const context = makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/Handler/CurlHandler.php'],
+    });
+    const entries = extractSiblingSurfaces(context).filter(
+      e => e.direction === 'unmirrored-addition',
+    );
+    expect(entries.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSiblingSurfaces
+// ---------------------------------------------------------------------------
+
+describe('renderSiblingSurfaces', () => {
+  it('returns an empty string when there are no entries', () => {
+    expect(renderSiblingSurfaces([])).toBe('');
+  });
+
+  it('renders a <sibling_surfaces> block naming the omitted sibling', () => {
+    const entries = extractSiblingSurfaces(guzzleLikeContext());
+    const block = renderSiblingSurfaces(entries);
+    expect(block).toContain('<sibling_surfaces>');
+    expect(block).toContain('</sibling_surfaces>');
+    expect(block).toContain('StreamHandler.php');
+  });
+
+  it('groups multiple identifiers for the same file/siblings onto one line', () => {
+    const entries = extractSiblingSurfaces(guzzleLikeContext());
+    const block = renderSiblingSurfaces(entries);
+    // Both 'on_trailers'-shaped tokens should be grouped into ONE bullet line
+    // for CurlHandler.php rather than one bullet per identifier.
+    const bulletLines = block.split('\n').filter(l => l.startsWith('- '));
+    const curlHandlerLines = bulletLines.filter(l => l.includes('CurlHandler.php'));
+    expect(curlHandlerLines.length).toBe(1);
+  });
+
+  it('omits entries beyond the block char budget with a note, never truncating mid-entry', () => {
+    // Build many distinct single-member "families" so many groups are
+    // produced, forcing the renderer past its budget.
+    const patches = new Map<string, string>();
+    const repoChunks: CodeChunk[] = [];
+    const changedFiles: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      const a = `src/pkg${i}/a.php`;
+      const b = `src/pkg${i}/b.php`;
+      const content = `<?php\nclass A${i} {\n    function shared${i}Call() {}\n}`;
+      const siblingContent = `<?php\nclass B${i} {\n    function shared${i}Call() {}\n}`;
+      patches.set(
+        a,
+        `@@ -1,2 +1,3 @@\n <?php\n class A${i} {\n+    function distinctiveAddedThing${i}() {}\n }`,
+      );
+      repoChunks.push(makeChunk(a, 1, `${content}\n    function distinctiveAddedThing${i}() {}`));
+      repoChunks.push(makeChunk(b, 1, siblingContent));
+      changedFiles.push(a);
+    }
+    const context = makeContext({ patches, repoChunks, changedFiles });
+    const block = renderSiblingSurfacesSection(context);
+    if (block) {
+      expect(block.length).toBeLessThanOrEqual(3200); // budget + omission note slack
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection', () => {
+  it('includes the <sibling_surfaces> block when entries exist', () => {
+    const context = {
+      ...guzzleLikeContext(),
+      chunks: [],
+    } as unknown as ReviewContext;
+
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).toContain('<sibling_surfaces>');
+    expect(message).toContain('StreamHandler.php');
+  });
+
+  it('omits the block entirely when there is no repo index', () => {
+    const context = {
+      ...makeContext({ repoChunks: [] }),
+      changedFiles: ['src/a.ts'],
+      chunks: [],
+    } as unknown as ReviewContext;
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).not.toContain('<sibling_surfaces>');
+  });
+});


### PR DESCRIPTION
Deterministic signal attacking the **omission** miss shape from the 2026-07 cross-repo study (the weakest shape for every model, in code and docs alike). Deliberately parked as **draft** — see evidence status.

## What it does

`<sibling_surfaces>` scans each changed source file's "family" (same directory + extension, tests excluded, 2–12 members) and reports:
- **Direction A — unmirrored addition:** feature-shaped identifiers this PR added to one family member that are absent from an untouched sibling handling the same surface (guzzle#3740's `on_trailers`-only-in-CurlFactory shape).
- **Direction B — family-pattern divergence:** calls every other family member makes that the changed/new file never does (gin#3081's missing `validate(` that all 9 sibling decoders share).

Zero-LLM, unit-tested, noise-controlled (corpus-rarity cap, per-file caps, ~3k block cap). The block renders only when candidates survive — 11/19 lien-corpus fixtures render byte-identical prompts; 8 gain a block. The block's header carries its own instruction incl. a "documented / genuinely different responsibility → stay silent" guard. No rule-prompt changes.

## Evidence status (why draft)

Blind re-screen (7 fresh CC reviewers on every changed-prompt cross-repo fixture):
- ✅ **Non-regressive:** both catch fixtures re-screened stayed catches; reviewers correctly dismissed signal false-positive entries in 3/7 reports (the guard text works).
- ✅ **Discovery-effective:** both design-target fixtures render on-point blocks, and the pr3740 reviewer engaged the exact gap the signal names.
- ❌ **No measured detection improvement:** no previously-missed fixture flipped. The decisive twist: the study's only omission-shaped miss (guzzle#3740) turned out to be a **disclosed** limitation — documented three times in the PR's own diff — so declining it is correct behavior (pr711-class judgment bound). The capture ground truth was wrong; the re-screen caught it. Kimi votes were therefore **not** run (the pre-stated improvement condition wasn't met).

## What merge consideration needs

1. A clean **undisclosed**-omission fixture (mine specifically for "silent sibling gap, no doc caveat, later fix") to test the frontier the signal targets.
2. Mirror-directory families (`blocking/` ↔ `async_impl/`) — reqwest#931's real sibling axis, out of v1 scope.
3. Kimi no-regression votes on the 8 lien-corpus fixtures that gain a block (~$0.8).

Full evidence: `.wip/crossrepo-pilot/PILOT-LOG.md` (local). Gates: 742 tests green, lint/format/typecheck/build clean, `lien delta` exit 0.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> The PR adds a new deterministic sibling-surface signal module and wires it into the agent prompt. The logic is well-scoped, unit-tested, and guarded by family-size caps, corpus-rarity filtering, cohesion checks, and block char budgets. No breaking changes to callers or wrong-output paths were identified. The parseInt on hunk headers is guarded by a preceding regex that ensures a digit group.
>
> - Adds packages/review/src/sibling-surface-signals.ts implementing same-directory and mirror-directory omission-frontier detection.
> - Wires renderSiblingSurfacesSection into buildInitialMessage alongside existing signal sections.
> - Adds comprehensive unit tests for Direction A, Direction B, mirror families, noise avoidance, and caps.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1494fcd. Updates automatically on new commits.</sup>
<!-- /lien-stats -->