### PR TITLE
docs(review): add distractor smoke-test workflow for fixture assertions

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -256,6 +256,40 @@ const assertions: FixtureAssertions = {
 export default assertions;
 ```
 
+### Smoke-test new assertions with THREE verdicts — including a distractor
+
+Before a new `.assertions.ts` is trusted, run it through `assert-cli.ts`
+against three hand-written verdict JSONs (zero LLM spend):
+
+1. **Perfect** — a finding stating the ground truth (right rule, right
+   file, the bug's mechanism in its message) → must **exit 0**.
+2. **Empty** — `{"findings":[],"toolCalls":[],"turns":1}` → must exit
+   non-zero.
+3. **Distractor** — a *plausible but wrong* finding about the same
+   file/function: a different real-looking issue, a test-quality nit, or
+   an adjacent hazard that is NOT the fixture's bug → must **exit
+   non-zero**.
+
+The distractor is the step that earns its keep. Keyword lists built from
+bare domain nouns (`'etag'`, `'netloc'`, the changed function's name)
+false-pass any finding that merely *talks about* the changed code — in
+the 2026-07 cross-repo Python round, **all three first-draft keyword
+lists false-passed their distractors** and had to be rewritten around
+compound phrases naming the bug's specific shape (`'weak etag'` +
+`'w/ prefix'`, `'empty netloc'` + `'no authority'`) before shipping. The
+same failure class previously let a test-bug finding score as a "catch"
+on a fixture whose real bug went unmentioned, silently corrupting a
+calibration result. A distractor that passes means your assertions
+measure "mentioned the neighborhood", not "found the bug".
+
+Keep the discrimination without going brittle: the keyword list should
+still accept sibling manifestations of the same root cause (a correct
+finding about the same defect in a second file must pass — use synonyms
+and the sibling's name), while the distractor pins that *different*
+defects in the same neighborhood fail. Delete the three scratch verdict
+JSONs afterwards; they must never live where blind-review verdicts are
+collected.
+
 ### Fixture tags — canary vs characterization
 
 `tags` classify what a fixture's pass/fail *means*:
@@ -382,7 +416,10 @@ harness lets you do it autonomously once `OPENROUTER_API_KEY` is in `.env`.
    `expectToolCalled` for whatever tool the rule's prompt mandates.
    Don't add Tier 2 keyword checks until after baseline calibration is
    green — they're what proves the prompt produces the *right* finding,
-   and you need a reliable Tier 1 first.
+   and you need a reliable Tier 1 first. When you do add Tier 2, run the
+   three-verdict smoke test (perfect / empty / **distractor** — see
+   "Smoke-test new assertions" above) before spending any calibration
+   money against them.
 
 4. **Add the rule to `BUILTIN_RULES`** in
    `packages/review/src/plugins/agent/rules.ts`. Mirror the existing


### PR DESCRIPTION
Documents the three-verdict smoke protocol for new `.assertions.ts` files: **perfect** (must exit 0), **empty** (must exit non-zero), and **distractor** — a plausible-but-wrong finding about the same file/function that must also exit non-zero.

The distractor step comes straight from the 2026-07 cross-repo Python round: all three first-draft keyword lists false-passed hand-written distractor verdicts (bare domain nouns like `'etag'`/`'netloc'` accept any finding that merely mentions the changed code) and were rewritten around compound bug-shape phrases before shipping. The same failure class earlier let a test-quality finding score as a "catch" on a fixture whose actual bug went unmentioned — silently corrupting a calibration result. The guidance also pins the balance: keep accepting sibling manifestations of the same root cause, while different defects in the same neighborhood must fail.

Docs-only; zero LLM spend involved in the workflow itself (all three verdicts are hand-written and scored offline via `assert-cli.ts`).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 452 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 989b295. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a three-verdict smoke test procedure for validating new assertion modules.
  * Documented expected results for perfect, empty, and distractor findings.
  * Updated the workflow to require smoke testing before calibration runs.
  * Reinforced establishing reliable baseline behavior before advancing to higher-tier validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->