### PR TITLE
test(review): cross-repo fixture corpus from the Python validation round

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -76,6 +76,38 @@ npx tsx packages/review/test/harness/capture-pr.ts 541 "$ROOT/untrusted-input-va
 npx tsx packages/review/test/harness/capture-pr.ts 658 "$ROOT/doc-truth/pr658-search-code-rename.fixture.json"
 ```
 
+## Cross-repo corpus (`fixtures/crossrepo/`)
+
+Fixtures mined from real regression history of EXTERNAL open-source repos
+during the 2026-07 cross-repo validation study — real bugs that shipped
+past those projects' own maintainers, with a later fix commit as ground
+truth. They exercise the whole pipeline on codebases and languages the
+rules were never tuned on, so they're the drift signal for "still works
+beyond our own repo". Fixture JSONs are gitignored like the rest of the
+corpus, but regeneration needs the external clone first — each
+`.assertions.ts` header carries its exact recipe, e.g.:
+
+```bash
+git clone https://github.com/encode/starlette /tmp/starlette && cd /tmp/starlette
+git fetch origin pull/2334/head:pr-2334-head   # squash-merged heads aren't in default refs
+npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2334 \
+  <lien>/packages/review/test/harness/fixtures/crossrepo/pr2334-etag-weak-indicator-strip.fixture.json
+```
+
+(`capture-pr.ts` retargets to whatever repo the cwd is in — no flags needed.)
+
+| Source | PR | Fixture | Bug shape | Status |
+| --- | :---: | --- | --- | --- |
+| encode/starlette | #2334 | `crossrepo/pr2334-etag-weak-indicator-strip` | `.strip(" W/")` char-set gotcha | characterization (measured 5/10 — borderline-judgment, see header) |
+| encode/starlette | #2191 | `crossrepo/pr2191-templateresponse-offbyone` | positional-args index collision | **canary** (certified 10/10, 2026-07-12) |
+| pallets/werkzeug | #2678 | `crossrepo/pr2678-multipart-index-offset` | slice-relative index used as absolute | characterization (cert deferred) |
+| pallets/werkzeug | #2017 | `crossrepo/pr2017-multipart-boundary-regex` | unescaped client boundary in regex | characterization (cert deferred) |
+
+The two `characterization`-tagged entries have 3/3 Kimi vote evidence but
+not yet a `--calibrate 10` certification — promote by running the
+calibration, recording the result in the header, and flipping the tag to
+`canary` (the bar is the same ≥9/10 as everywhere else).
+
 ## Negative-regression fixtures
 
 These capture real-world false positives the rule produced on a non-bug

--- a/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.assertions.ts
@@ -1,0 +1,125 @@
+/**
+ * Cross-repo pilot fixture — mined from pallets/werkzeug (Python), not the lien
+ * monorepo. Captures the OFFENDING PR (the one that introduced the bug);
+ * ground truth below comes from the later FIX PR.
+ *
+ * OFFENDING PR: pallets/werkzeug #2017 "Refactor the Multipart parsing into a
+ * Sans-IO layer" — merged 2021-01-26, head
+ * 76bb39a32f4be455feef765ea05d7acc9b6b25ad, released in werkzeug 2.0.0.
+ * Extracts multipart body parsing into a new sans-IO `MultipartDecoder`
+ * class (~1050 lines across ~10 files).
+ *
+ * FIX: pallets/werkzeug #2126 "Multipart fix" — merged 2021-05-14 (~4 months
+ * later), head 3f8a95fb275dcad27d541f00026b229636e1a485, released in
+ * werkzeug 2.0.1. CHANGES.rst (2.0.1): "Fix multipart parsing bug when
+ * boundary contains special regex characters. :issue:`2125`". Issue #2125's
+ * own title and body name the regression explicitly: "[BUG] Multipart data
+ * parse regression" — "Seems that there is a regression in the new
+ * MultiPartPaser implementation... does not work in Werkzeug==2.0.0; but,
+ * works in Werkzeug<2.0.0", with a repro using boundary
+ * `----------a_BoUnDaRy9009049739267083$` (trailing `$`, a regex
+ * end-of-string anchor).
+ *
+ * THE BUG: `MultipartDecoder.__init__` (werkzeug/sansio/multipart.py)
+ * compiles two regexes, `preamble_re` and `boundary_re`, by interpolating
+ * the caller-supplied multipart `boundary` bytes directly into a
+ * `%`-formatted pattern:
+ *   br"%s?--%s(--[^\S\n\r]*%s?|[^\S\n\r]*%s)" % (LINE_BREAK, boundary, LINE_BREAK, LINE_BREAK)
+ * The multipart boundary value is chosen by the CLIENT — RFC 2046's `bchars`
+ * charset for boundaries legally includes characters that are regex
+ * metacharacters (`.`, `+`, `-`, `(`, `)`, `?`, `$`, etc.) — and is never
+ * passed through `re.escape()` before being spliced into the pattern. Any
+ * boundary containing such a character is silently reinterpreted as regex
+ * syntax instead of matched literally, so the compiled pattern no longer
+ * matches the real boundary bytes in the request body, breaking multipart
+ * parsing for that request. Both `preamble_re` and `boundary_re` have the
+ * identical bug (same missing escape, same call pattern).
+ *
+ * WHAT A CORRECT FINDING MUST SAY: flag that `boundary` is spliced into the
+ * `preamble_re`/`boundary_re` patterns via `%`-formatting without
+ * `re.escape(boundary)` first, so any client-supplied multipart boundary
+ * containing a regex metacharacter (`.`, `+`, `*`, `(`, `)`, `$`, `[`, `\`,
+ * etc. — all legal per RFC 2046) is misinterpreted as regex syntax rather
+ * than matched literally, breaking parsing of that request's body. File:
+ * werkzeug/sansio/multipart.py, `MultipartDecoder.__init__`.
+ *
+ * Capture command (run from inside the werkzeug clone):
+ *   tsx packages/review/test/harness/capture-pr.ts 2017 \
+ *     .wip/crossrepo-pilot/fixtures/werkzeug/pr2017-multipart-boundary-regex.fixture.json
+ *
+ * Rule-trigger note: build-prompts.ts activates ['structural-analysis',
+ * 'edge-case-sweep', 'error-swallowing', 'boundary-change', 'stale-duplicate',
+ * 'doc-truth'] for this fixture (11 changed files; the buggy hunk in
+ * sansio/multipart.py renders well before the initial message's end — no
+ * truncation). 'edge-case-sweep' is the semantically ideal rule: its prompt
+ * directs mentally executing changed functions with unusual/boundary inputs,
+ * and a boundary value containing regex metacharacters is exactly such an
+ * adversarial edge-case input.
+ */
+
+/*
+ * PROMOTED TO CROSS-REPO CANARY (2026-07-12): external fixture from
+ * pallets/werkzeug PR #2017, mined in the cross-repo validation study's Python
+ * round. Blind-screen + Kimi 3-vote evidence in the pilot log; canary
+ * certification: --calibrate 10 run recorded below.
+ *
+ * REGENERATE (fixture JSON is gitignored):
+ *   git clone https://github.com/pallets/werkzeug /tmp/werkzeug && cd /tmp/werkzeug
+ *   git fetch origin pull/2017/head:pr-2017-head
+ *   npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2017 \
+ *     <lien>/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.fixture.json
+ * (capture-pr.ts retargets to whatever repo the cwd is in.)
+ *
+ * CALIBRATION (kimi-k2.7-code): NOT YET CERTIFIED — canary requires a
+ * --calibrate 10 run at >=9/10; deferred 2026-07-12 for session-budget
+ * reasons. Evidence so far: 3/3 Kimi votes + blind-CC content catch
+ * (2026-07-12 Python round). Tagged characterization (non-gating) until
+ * certified; to promote, run --calibrate 10, record the result here,
+ * and flip tags to canary.
+ */
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'werkzeug PR #2017 (fixed by #2126) — MultipartDecoder.__init__ (werkzeug/sansio/multipart.py) ' +
+    'splices the client-supplied multipart boundary directly into preamble_re/boundary_re via ' +
+    '%-formatting without re.escape(), so a boundary containing a regex metacharacter (e.g. trailing ' +
+    '$, or ., +, (, )) is misinterpreted as regex syntax and breaks parsing of that request',
+  rule: 'edge-case-sweep',
+  expect: (result, h) => {
+    const ruleCandidates = ['edge-case-sweep', 'structural-analysis'];
+    if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {
+      h.expectRuleFired(ruleCandidates[0], result);
+    }
+    h.expectFindingMentions(
+      [
+        // The mechanism
+        're.escape',
+        'escape(boundary)',
+        'regex metacharacter',
+        'special regex character',
+        'special character',
+        'unescaped',
+        'not escaped',
+        'without escaping',
+        'metacharacter',
+        'regex injection',
+        'interpolat',
+        'literal',
+        // The identifiers
+        'preamble_re',
+        'boundary_re',
+        'multipartdecoder',
+        // The domain
+        'boundary',
+        'multipart',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['characterization', 'crossrepo', 'python'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.assertions.ts
@@ -1,0 +1,145 @@
+/**
+ * Cross-repo pilot fixture — mined from encode/starlette (Python), not the
+ * lien monorepo. Captures the OFFENDING PR (the one that introduced the
+ * bug); ground truth below comes from the later FIX PR.
+ *
+ * OFFENDING PR: encode/starlette #2191 "Add `request` argument to
+ * `TemplateResponse`" — merged 2023-07-13, head
+ * 030868188328165c78010e7dc4e22b2afa32882c, released in starlette 0.28.0.
+ * Rewrote `Jinja2Templates.TemplateResponse()` to accept both the old
+ * positional signature `(name, context, status_code, headers, media_type,
+ * background)` and the new one prefixed with `request`, dispatching on
+ * `args[0]`'s type. Both branches unpack trailing positional args by index:
+ *
+ *   old-style (7 total params incl. name, so headers should be args[3]):
+ *     status_code = args[2] if len(args) > 2 else kwargs.get("status_code", 200)
+ *     headers     = args[2] if len(args) > 2 else kwargs.get("headers")
+ *     media_type  = args[3] if len(args) > 3 else kwargs.get("media_type")
+ *     background  = args[4] if len(args) > 4 else kwargs.get("background")
+ *
+ * THE BUG: `headers`, `media_type`, and `background` reuse the SAME index
+ * as `status_code`/`headers`/`media_type` respectively instead of the next
+ * one — `headers` is read from `args[2]` (the `status_code` slot) instead
+ * of `args[3]`, `media_type` from `args[3]` (the `headers` slot) instead of
+ * `args[4]`, and `background` from `args[4]` (the `media_type` slot)
+ * instead of `args[5]`. Calling the old-style
+ * `TemplateResponse(name, context, status_code, headers, media_type,
+ * background)` with 4+ positional args therefore assigns the WRONG value
+ * to each of `headers`/`media_type`/`background` — e.g. passing a real
+ * `headers` dict positionally makes `headers` actually receive the
+ * `status_code` int, and the true headers dict silently lands in
+ * `media_type` instead. (The new-style branch, one index further right
+ * because of the added `request` slot, has the same off-by-one shape:
+ * `headers = args[4]` reads the `status_code` slot, `media_type =
+ * args[5]` reads the `headers` slot, etc.) With 4+ positional args this
+ * silently scrambles which value ends up in which parameter; with exactly
+ * 3 or fewer positional args plus keyword args it instead raises
+ * `IndexError` for the keyword path, matching the closed issue title.
+ *
+ * FIX: encode/starlette #2909 "fix IndexError in TemplateResponse" —
+ * merged 2025-03-16, head bcdf0ad017168408060b6faab156636ced4c94f7, fixes
+ * issue #2906. Shifts each old-style index up by one:
+ *   headers = args[2] -> args[3]; media_type = args[3] -> args[4];
+ *   background = args[4] -> args[5]. Gap between offending PR and fix:
+ *   ~1.7 years.
+ *
+ * WHAT A CORRECT FINDING MUST SAY: in the old-style branch of
+ * `TemplateResponse()` (starlette/templating.py, ~line 168-171), `headers`,
+ * `media_type`, and `background` each read the wrong positional index —
+ * `headers = args[2]` collides with the `status_code` slot instead of
+ * using `args[3]`, and `media_type`/`background` are each off by one in
+ * the same way — so calling the old (deprecated but still-supported)
+ * positional signature with more than 3 positional arguments assigns each
+ * of those parameters the value meant for the PRECEDING one, silently
+ * scrambling `status_code`/`headers`/`media_type`/`background`.
+ *
+ * Capture command (run from inside the starlette clone):
+ *   tsx packages/review/test/harness/capture-pr.ts 2191 \
+ *     .wip/crossrepo-pilot/fixtures/starlette/pr2191-templateresponse-offbyone.fixture.json
+ *
+ * Rule-trigger note: build-prompts.ts activates ['structural-analysis',
+ * 'edge-case-sweep', 'boundary-change', 'stale-duplicate', 'doc-truth'] for
+ * this fixture; 'concurrency-race', 'incomplete-handling',
+ * 'error-swallowing', and 'untrusted-input-validation' are skipped.
+ * Unlike the other two starlette fixtures in this batch, 'boundary-change'
+ * IS active here (not trigger-blocked) — the diff is literally adjacent
+ * integer-index arithmetic (`args[2]`/`args[3]`/`args[4]`), which trips its
+ * numeric-threshold-shift trigger keywords even though the bug is an
+ * off-by-one index collision rather than a comparison operator. This is
+ * the best rule-fit of the three starlette fixtures in this batch.
+ */
+
+/*
+ * PROMOTED TO CROSS-REPO CANARY (2026-07-12): external fixture from
+ * encode/starlette PR #2191, mined in the cross-repo validation study's Python
+ * round. Blind-screen + Kimi 3-vote evidence in the pilot log; canary
+ * certification: --calibrate 10 run recorded below.
+ *
+ * REGENERATE (fixture JSON is gitignored):
+ *   git clone https://github.com/encode/starlette /tmp/starlette && cd /tmp/starlette
+ *   git fetch origin pull/2191/head:pr-2191-head
+ *   npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2191 \
+ *     <lien>/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.fixture.json
+ * (capture-pr.ts retargets to whatever repo the cwd is in.)
+ *
+ * CALIBRATION (kimi-k2.7-code): CERTIFIED 2026-07-12 — --calibrate 10
+ * scored 10/10 ($0.39). Prior evidence: 3/3 Kimi screen + blind-CC
+ * catch (2026-07 Python round).
+ */
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    "starlette PR #2191 (fixed 1.7 years later by #2909) — TemplateResponse's old-style " +
+    'positional-arg branch reads headers/media_type/background from args[2]/args[3]/args[4] ' +
+    "(each one index too low, colliding with the preceding parameter's slot) instead of " +
+    'args[3]/args[4]/args[5], silently scrambling which value lands in which parameter',
+  rule: 'boundary-change',
+  expect: (result, h) => {
+    const ruleCandidates = ['boundary-change', 'edge-case-sweep', 'structural-analysis'];
+    if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {
+      h.expectRuleFired(ruleCandidates[0], result);
+    }
+    h.expectFindingMentions(
+      [
+        // The mechanism
+        'args[2]',
+        'args[3]',
+        'args[4]',
+        'off-by-one',
+        'off by one',
+        'wrong index',
+        'incorrect index',
+        'index shift',
+        'shifted by one',
+        'wrong slot',
+        'same index',
+        'collide',
+        'collision',
+        // The domain — combined with index/positional-arg language so a
+        // finding must be about the ARGUMENT PLUMBING, not just anything
+        // touching this function (e.g. a test-cleanup nit that happens to
+        // say "TemplateResponse" would not match any of these)
+        'positional argument',
+        'positional arg',
+        'headers slot',
+        'status_code slot',
+        'args tuple',
+        // How a correct finding frames the gap
+        'scramble',
+        'scrambled',
+        'wrong value',
+        'wrong parameter',
+        'silently assign',
+        'misassign',
+        'misassigned',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary', 'crossrepo', 'python'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/crossrepo/pr2334-etag-weak-indicator-strip.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2334-etag-weak-indicator-strip.assertions.ts
@@ -1,0 +1,145 @@
+/**
+ * Cross-repo pilot fixture — mined from encode/starlette (Python), not the
+ * lien monorepo. Captures the OFFENDING PR (the one that introduced the
+ * bug); ground truth below comes from the later FIX PR.
+ *
+ * OFFENDING PR: encode/starlette #2334 "Take weak ETags in consideration on
+ * `StaticFiles`" — merged 2023-12-16, head 3c8ab8e74a8c773624d6149d8c04cf5a09d4f1c4,
+ * released in starlette 0.34.0. `starlette/staticfiles.py`'s `is_not_modified()`
+ * changed:
+ *   - if if_none_match == etag:
+ *   + if etag in [tag.strip(" W/") for tag in if_none_match.split(",")]:
+ * intending to make If-None-Match matching tolerant of the weak-ETag `W/`
+ * prefix (and multiple comma-separated tags) per RFC 7232.
+ *
+ * THE BUG: `str.strip(chars)` treats its argument as a *character set*, not
+ * a literal prefix/suffix. `tag.strip(" W/")` strips any combination of the
+ * three characters `' '`, `'W'`, `'/'` from BOTH ends of the string — it
+ * does not remove "the substring `W/`". For the common case (a quoted hex
+ * ETag like `W/"abcd1234"`) this happens to look right, because stripping
+ * halts at the closing `"`, which isn't in the set — but the moment an ETag
+ * or client-sent If-None-Match value ends or begins with a bare `W`, `/`, or
+ * space *outside* the quotes (or is passed unquoted), `.strip(" W/")`
+ * over-trims it, producing a comparison against a mangled tag: legitimate
+ * matches can be missed (no 304 when one is due) or, in principle, two
+ * different tags can collapse to the same stripped value (an incorrect
+ * 304). The code's own intent — "strip the leading `W/` weak indicator" —
+ * is not what `.strip()` does; the fix (starlette #3193, ~2.5 years later)
+ * replaces it with `tag.strip().removeprefix("W/")`, which strips
+ * whitespace first and then removes the literal `W/` prefix only.
+ *
+ * FIX: encode/starlette #3193 "Use `removeprefix` to strip weak ETag
+ * indicator in `is_not_modified`" — merged 2026-06-10, head
+ * 37309255b4c1b9c381a2d24a1eaf83100984a16a, released in starlette 1.3.1.
+ * PR body: "`strip()` works on a character set — it strips any combination
+ * of `' '`, `'W'`, and `'/'` from both ends of the string. This means an
+ * ETag value ending in `W` or `/` would get incorrectly trimmed... the fix
+ * makes the code do what it actually intends to do."
+ *
+ * WHAT A CORRECT FINDING MUST SAY: `tag.strip(" W/")` in
+ * `is_not_modified()` (starlette/staticfiles.py, ~line 228) uses `str.strip`
+ * with a character-set argument to remove the weak-ETag `W/` prefix, but
+ * `strip()` removes characters from a set, not a literal prefix — any tag
+ * value ending (or beginning) with `'W'`, `'/'`, or a space gets
+ * over-trimmed, so the intended "ignore the weak indicator" comparison can
+ * silently mismatch/mismatch-collide instead of comparing the real tag
+ * value.
+ *
+ * Capture command (run from inside the starlette clone):
+ *   tsx packages/review/test/harness/capture-pr.ts 2334 \
+ *     .wip/crossrepo-pilot/fixtures/starlette/pr2334-etag-weak-indicator-strip.fixture.json
+ *
+ * Rule-trigger note: build-prompts.ts activates ['structural-analysis',
+ * 'edge-case-sweep', 'error-swallowing', 'boundary-change', 'stale-duplicate']
+ * for this fixture; 'concurrency-race', 'incomplete-handling',
+ * 'untrusted-input-validation', and 'doc-truth' are skipped. Unlike most
+ * string-method fixtures, 'boundary-change' is ACTIVE here (not
+ * trigger-blocked) — the diff visibly changes an equality comparison
+ * (`if_none_match == etag`) into a different comparison shape, which is
+ * enough to trip its trigger keywords even though the actual bug is a
+ * string-method misuse, not a numeric threshold. 'edge-case-sweep' is the
+ * best semantic fit (mentally executing the strip against a tag ending in
+ * `W`/`/` is exactly this bug).
+ */
+
+/*
+ * PROMOTED TO CROSS-REPO CANARY (2026-07-12): external fixture from
+ * encode/starlette PR #2334, mined in the cross-repo validation study's Python
+ * round. Blind-screen + Kimi 3-vote evidence in the pilot log; canary
+ * certification: --calibrate 10 run recorded below.
+ *
+ * REGENERATE (fixture JSON is gitignored):
+ *   git clone https://github.com/encode/starlette /tmp/starlette && cd /tmp/starlette
+ *   git fetch origin pull/2334/head:pr-2334-head
+ *   npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2334 \
+ *     <lien>/packages/review/test/harness/fixtures/crossrepo/pr2334-etag-weak-indicator-strip.fixture.json
+ * (capture-pr.ts retargets to whatever repo the cwd is in.)
+ *
+ * CALIBRATION (kimi-k2.7-code): --calibrate 10 on 2026-07-12 measured
+ * 5/10 (5 tier-1 no-finding misses, 0 tier-2) — BAR NOT MET, tagged
+ * characterization (non-gating). The earlier 3/3 screen was sampling
+ * luck. Failure mode matches the "engaged-and-rationalized" shape:
+ * whether .strip(" W/") can over-strip here requires arguing about the
+ * ETag alphabet (self-generated MD5 hex never contains W/space, quotes
+ * bound the tag), so ~half of votes judge it safe-in-context — the
+ * same call the blind Sonnet reviewer made. A borderline-judgment
+ * fixture, not a prompt-iteration target; do not spend calibration
+ * budget pushing it green (see the judgment guide).
+ */
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'starlette PR #2334 (fixed 2.5 years later by #3193) — is_not_modified() uses ' +
+    'tag.strip(" W/") to remove the weak-ETag prefix, but str.strip treats its argument ' +
+    'as a character set, not a literal prefix, so tags ending in W, /, or space get ' +
+    'over-trimmed instead of just having the W/ prefix removed',
+  rule: 'edge-case-sweep',
+  expect: (result, h) => {
+    const ruleCandidates = ['edge-case-sweep', 'boundary-change', 'structural-analysis'];
+    if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {
+      h.expectRuleFired(ruleCandidates[0], result);
+    }
+    h.expectFindingMentions(
+      [
+        // The mechanism
+        'strip(" w/")',
+        "strip(' w/')",
+        'str.strip',
+        '.strip(',
+        'character set',
+        'character class',
+        'charset',
+        'not a prefix',
+        'not a literal',
+        'literal prefix',
+        'removeprefix',
+        // The domain — kept to compound phrases naming the WEAK-INDICATOR
+        // mechanism specifically, not bare 'etag'/'if-none-match'/
+        // 'is_not_modified', which a distractor finding about a *different*
+        // bug in the same function (stale mtime-based etag, swallowed
+        // KeyError, etc.) could also legitimately use
+        'weak etag',
+        'weak indicator',
+        'w/ prefix',
+        'w/" prefix',
+        // How a correct finding frames the gap
+        'over-trim',
+        'over trim',
+        'overtrim',
+        'strips too much',
+        'unintended characters',
+        'trailing w',
+        'trailing slash',
+        'ends in w',
+        'ends with w',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['characterization', 'crossrepo', 'python'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.assertions.ts
@@ -1,0 +1,123 @@
+/**
+ * Cross-repo pilot fixture — mined from pallets/werkzeug (Python), not the lien
+ * monorepo. Captures the OFFENDING PR (the one that introduced the bug);
+ * ground truth below comes from the later FIX PR.
+ *
+ * OFFENDING PR: pallets/werkzeug #2678 "Fix the parsing of large multipart
+ * bodies" — merged 2023-05-01, head f0a1733f52a7241f51cc519593233e8be6aeaa0e,
+ * released in werkzeug 2.3.3.
+ *
+ * FIX: pallets/werkzeug #2763 "Fix multipart parsing when additional newlines
+ * are present" — merged 2023-08-12 (~3 months later), head
+ * db32625cf7498267a918a356021fb228f7ce2588, released in werkzeug 2.3.7.
+ * CHANGES.rst (2.3.7): "Fix parsing of multipart bodies. Adjust index of
+ * last newline in data start. :issue:`2761`". Issue #2761 "Extra Newline
+ * Added to Binary File Upload" reports a spurious leading newline appearing
+ * in uploaded binary files larger than 64KB (i.e. spanning multiple socket
+ * reads).
+ *
+ * THE BUG: werkzeug/sansio/multipart.py's `MultipartDecoder._parse_data`
+ * computes where a body part's data ends by calling
+ * `self.last_newline(data[data_start:])`. That method returns an index
+ * RELATIVE to the sliced buffer `data[data_start:]` — but PR #2678 assigns
+ * the return value directly to `data_end`/`del_index`, which are then used
+ * as ABSOLUTE indices into the UNSLICED `data` buffer
+ * (`data[data_start:data_end]`), at BOTH call sites in `_parse_data`.
+ * Whenever `data_start > 0` (the part's data begins with a leading CR/LF
+ * that was stripped first — exactly what happens when a part's payload is
+ * split across multiple `receive_data` calls, as with large uploads), the
+ * returned index is `data_start` positions too small, so `data_end`
+ * under-shoots. Slicing with the under-shot `data_end` truncates the
+ * returned data short; the skipped bytes (which include a real newline)
+ * are left to be re-parsed and reappear as the START of the NEXT emitted
+ * chunk — manifesting as an extra newline prepended to the file content.
+ *
+ * WHAT A CORRECT FINDING MUST SAY: flag that `self.last_newline(data[data_start:])`
+ * returns an index relative to the slice `data[data_start:]`, but is used
+ * directly as `data_end`/`del_index` — an absolute index into the full
+ * (unsliced) `data` buffer — without adding back `data_start`. Both
+ * occurrences in `_parse_data` (werkzeug/sansio/multipart.py) share the bug.
+ * Concretely: when `data_start > 0`, the computed `data_end` is too small by
+ * `data_start`, so returned data is truncated short and the skipped bytes
+ * resurface at the start of subsequently parsed data.
+ *
+ * Capture command (run from inside the werkzeug clone):
+ *   tsx packages/review/test/harness/capture-pr.ts 2678 \
+ *     .wip/crossrepo-pilot/fixtures/werkzeug/pr2678-multipart-index-offset.fixture.json
+ *
+ * Rule-trigger note: build-prompts.ts activates ['structural-analysis',
+ * 'edge-case-sweep', 'error-swallowing', 'boundary-change', 'stale-duplicate']
+ * for this fixture (2 changed files: CHANGES.rst, multipart.py — diff renders
+ * in full, no truncation). 'edge-case-sweep' is the semantically ideal rule:
+ * its prompt directs mentally executing changed functions with "zero" and
+ * "boundary" inputs, and `data_start == 0` vs `data_start > 0` is exactly the
+ * boundary case this diff mishandles.
+ */
+
+/*
+ * PROMOTED TO CROSS-REPO CANARY (2026-07-12): external fixture from
+ * pallets/werkzeug PR #2678, mined in the cross-repo validation study's Python
+ * round. Blind-screen + Kimi 3-vote evidence in the pilot log; canary
+ * certification: --calibrate 10 run recorded below.
+ *
+ * REGENERATE (fixture JSON is gitignored):
+ *   git clone https://github.com/pallets/werkzeug /tmp/werkzeug && cd /tmp/werkzeug
+ *   git fetch origin pull/2678/head:pr-2678-head
+ *   npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2678 \
+ *     <lien>/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.fixture.json
+ * (capture-pr.ts retargets to whatever repo the cwd is in.)
+ *
+ * CALIBRATION (kimi-k2.7-code): NOT YET CERTIFIED — canary requires a
+ * --calibrate 10 run at >=9/10; deferred 2026-07-12 for session-budget
+ * reasons. Evidence so far: 3/3 Kimi votes + blind-CC content catch
+ * (2026-07-12 Python round). Tagged characterization (non-gating) until
+ * certified; to promote, run --calibrate 10, record the result here,
+ * and flip tags to canary.
+ */
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'werkzeug PR #2678 (fixed by #2763) — MultipartDecoder._parse_data (werkzeug/sansio/multipart.py) ' +
+    'uses self.last_newline(data[data_start:]), an index relative to the sliced buffer, directly as an ' +
+    'absolute index (data_end/del_index) into the unsliced data buffer, truncating parsed data short ' +
+    'whenever data_start > 0 and leaking a spurious newline into the next chunk',
+  rule: 'edge-case-sweep',
+  expect: (result, h) => {
+    const ruleCandidates = ['edge-case-sweep', 'structural-analysis', 'boundary-change'];
+    if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {
+      h.expectRuleFired(ruleCandidates[0], result);
+    }
+    h.expectFindingMentions(
+      [
+        // The mechanism
+        'data_start',
+        'last_newline',
+        'data_end',
+        'del_index',
+        'relative index',
+        'relative to',
+        'absolute index',
+        'off-by',
+        'offset',
+        'slice',
+        'sliced',
+        '+ data_start',
+        // The symptom
+        'extra newline',
+        'spurious newline',
+        'truncat',
+        'newline',
+        // The domain
+        'multipart',
+        'boundary',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['characterization', 'crossrepo', 'python'],
+};
+
+export default assertions;


### PR DESCRIPTION
Promotes the Python-round fixtures from the 2026-07 cross-repo validation study into the committed corpus, under a new `fixtures/crossrepo/` directory. These are real regressions that shipped past starlette's and werkzeug's own maintainers (fix commits as ground truth) — the drift signal for "detection still works beyond our own repo".

## Status per fixture (all evidence from kimi-k2.7-code)

| Fixture | Source | Certification |
|---|---|---|
| `pr2191-templateresponse-offbyone` | starlette#2191 | **canary** — `--calibrate 10` = **10/10** ($0.39) |
| `pr2334-etag-weak-indicator-strip` | starlette#2334 | characterization — measured **5/10**; borderline-judgment fixture (over-strip requires arguing the ETag alphabet; half the votes judge it safe-in-context, as did the blind Sonnet screen). Header documents why iteration stopped. |
| `pr2678-multipart-index-offset` | werkzeug#2678 | characterization — 3/3 Kimi screen; calibrate-10 deferred (session budget), upgrade path in header |
| `pr2017-multipart-boundary-regex` | werkzeug#2017 | characterization — 3/3 Kimi screen; calibrate-10 deferred (session budget), upgrade path in header |

Honest-scoring note: pr2334 was originally slated for canary on its 3/3 screen; the calibrate-10 run (5/10) demoted it — screens are screens. The two werkzeug fixtures are strong candidates but stay non-gating until someone runs their certification (~$1.5-2 real, one command each, recipe in the headers).

Fixture JSONs are gitignored per corpus convention; each `.assertions.ts` header carries the exact external-clone regeneration recipe (`capture-pr.ts` retargets to whatever repo the cwd is in). README gains a "Cross-repo corpus" section with the recipe and this table.

Characterization tags are non-gating by design (render as `~ measured N/M`, excluded from exit code), so this PR adds one gating canary and three documented frontier measurements — no risk to existing runs.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds four cross-repo test fixture assertion files under `fixtures/crossrepo/` and updates the harness README. The fixtures are pure test metadata describing historical regressions from starlette and werkzeug; no production code is changed. The assertion metadata (rule, tags, passThreshold, votes) is internally consistent with the PR description: one gating canary (pr2191, certified 10/10) and three non-gating characterization fixtures (pr2017, pr2334, pr2678). The stale-literal candidates are existing rule IDs referenced in the rules registry and other tests; they are intentional cross-references, not untracked duplicates.
>
> - Added four `.assertions.ts` cross-repo fixtures for external Python-repo regressions.
> - Updated README with cross-repo corpus section, regeneration recipes, and certification table.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 443138a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->