### PR TITLE
docs(action,site): audited setup guide, evidence page, and stale-claim sweep

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -7,9 +7,11 @@ name: Lien Review
 # diff), inline PR comments, and a step summary.
 #
 # The public, external-consumer path is `uses: getlien/lien-review@v1` (a Docker
-# action backed by a prebuilt GHCR image — see packages/action/README.md). That
-# image + the public dist repo aren't published yet, so here we build the action
-# from source and run its entrypoint directly. Same code path, no publish needed.
+# action backed by a prebuilt GHCR image — see packages/action/README.md). Both
+# the image and the public dist repo are published; this monorepo still builds
+# the action from source and runs its entrypoint directly on purpose, so CI
+# dogfoods the current commit instead of the last released tag. Same code
+# path either way, so this isn't a stand-in for the real thing.
 #
 # The review is advisory by default (fail-on defaults to 'never'), so the check
 # stays green whenever the action *runs*; findings show as annotations + comments.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Lien connects AI coding assistants like Cursor and Claude Code to your codebase 
 - 📦 **No Model Download** - No embeddings, no ~100MB model — tiny install, instant offline indexing
 - 🎯 **MCP Integration** - Works seamlessly with Cursor, Claude Code, and other MCP-compatible tools
 - ⚡ **Fast** - Sub-millisecond file context; minutes to index large codebases
-- 🆓 **Free Forever** - No API costs, no subscriptions, no usage limits
+- 🆓 **Free Forever** - No API costs, no subscriptions, no usage limits (applies to the local MCP/search tooling — [Lien Review](#lien-review)'s agent pass uses your own LLM key and has its own token cost)
 - 🏗️ **Framework-Aware & Monorepo** - Auto-detects 12+ ecosystems; supports 15+ languages
 
 ## Quick Start

--- a/docs/architecture/decisions/0012-self-hostable-review-action.md
+++ b/docs/architecture/decisions/0012-self-hostable-review-action.md
@@ -34,6 +34,7 @@ Decouple Lien Review from the hosted platform entirely: ship it as a self-contai
 
 - No cross-repo aggregation or dashboard — each repo runs review independently inside its own Actions minutes, with no shared queue, retry infrastructure, or cross-repo view.
 - Publishing still requires one-time human setup (the `getlien/lien-review` dist repo plus a `GH_DIST_TOKEN` secret) that hasn't happened yet — until it does, the documented `uses: getlien/lien-review@v1` quick start doesn't resolve to a real release, and this repo's own CI builds the action from source instead.
+  **Update (2026-07-12):** that setup is done — `getlien/lien-review` is a real, published dist repo (tags `v1`, `0.62.0`–`0.64.0`, resolving to `docker://ghcr.io/getlien/lien-review:v1`), so the quick start now resolves for consumers. This monorepo's own CI still builds from source rather than pulling the image, unchanged and deliberate: it dogfoods the current commit, not the last released tag.
 - `platform/` and `packages/runner` are retired in git but not guaranteed gone from every working checkout — a checkout that predates PR #593, or a local restore of `platform/`, leaves an untracked, undocumented pile of dead Laravel code. Both are remnants scheduled for deletion, not live parts of the monorepo.
 
 ### Neutral

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -57,8 +57,9 @@ explicit block is what re-grants the write scopes this action needs.
 
 The agent (bug) review needs an LLM key, provided as a workflow **secret**:
 
-1. Get an [OpenRouter](https://openrouter.ai/) API key (preferred — cheaper
-   Gemini path) or an Anthropic API key.
+1. Get an [OpenRouter](https://openrouter.ai/) API key (preferred — runs
+   OpenRouter's calibrated default model, cheaper than Anthropic) or an
+   Anthropic API key.
 2. Add it to your repo under **Settings → Secrets and variables → Actions →
    New repository secret** as `OPENROUTER_API_KEY` (or `ANTHROPIC_API_KEY`).
 3. Pass it through the action's `with:` block:
@@ -74,6 +75,13 @@ If **both** keys are omitted the review still runs, but **complexity-only** —
 the agent bug/summary/architectural passes are skipped. When both are present
 OpenRouter wins.
 
+**Cost:** a typical PR review costs roughly **$0.02–$0.15** in OpenRouter
+tokens on the default model (measured across the 2026-07 cross-repo study;
+~$0.03/vote median, with complex multi-pass reviews at the high end —
+OpenRouter's own billing can run ~1.5–2× the harness-reported figure). The
+exact cost of every run is printed in the job's step summary (the
+`**Tokens:** ... · **Cost:** $...` line).
+
 > Never hard-code an API key in the workflow YAML. Always reference it from
 > `secrets`.
 
@@ -82,7 +90,7 @@ OpenRouter wins.
 | Input                 | Required | Default                         | Description                                                                                                                                |
 | --------------------- | -------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `github-token`        | no       | `${{ github.token }}`           | Token used to clone the PR and post inline comments. Needs `contents:read` and `pull-requests:write`.                                    |
-| `openrouter-api-key`  | no       | `''`                            | OpenRouter API key for agent review (preferred provider — runs Gemini). If omitted, falls back to `anthropic-api-key`, then complexity-only. |
+| `openrouter-api-key`  | no       | `''`                            | OpenRouter API key for agent review (preferred provider — runs OpenRouter's calibrated default model, currently `moonshotai/kimi-k2.7-code`; see `packages/review/src/defaults.ts` for the source of truth). If omitted, falls back to `anthropic-api-key`, then complexity-only. |
 | `anthropic-api-key`   | no       | `''`                            | Anthropic API key for agent review (fallback when `openrouter-api-key` is not set). If both are omitted, review is complexity-only.       |
 | `threshold`           | no       | `15`                            | Complexity threshold above which violations are reported.                                                                                 |
 | `review-types`        | no       | `complexity,bugs,summary`       | Comma-separated review types to enable. `complexity` toggles the complexity check. `bugs`, `architectural`, and `summary` all come from the single agent reviewer, so they switch it on/off as a group (and only when an API key is set) — they can't be toggled independently. |
@@ -112,6 +120,29 @@ Reference them from a later step via the step `id`:
 - run: echo "Lien found ${{ steps.lien.outputs.error-count }} errors"
 ```
 
+## Advanced configuration
+
+Beyond the inputs above, one behavior is tunable only via an environment
+variable on the action step, not a formal input:
+
+```yaml
+- uses: getlien/lien-review@v1
+  env:
+    LIEN_REVIEW_DOC_PASS: '0' # disable the doc-truth second pass
+  with:
+    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+- **`LIEN_REVIEW_DOC_PASS=0`** (or `false`) — disables the dedicated
+  doc-truth second pass, a claims-only re-review that runs only on PRs
+  touching documentation/guidance surfaces and checks their prose against the
+  code. On by default.
+
+There is currently no `model` input — the OpenRouter path pins the calibrated
+default deliberately, since the calibration evidence backing this review
+(see the [test harness](https://github.com/getlien/lien/tree/main/packages/review/test/harness))
+only covers that one model.
+
 ## Blocking a PR on the review
 
 By default the review is **advisory** (`fail-on: never`) — it never fails CI, so
@@ -121,6 +152,18 @@ in your branch protection rules. With `fail-on: error` the action exits non-zero
 only when the review's overall conclusion is a failure (driven by
 `block-on-new-errors`); `fail-on: any` is stricter (any error- or warning-level
 finding fails the check).
+
+## Fail-loudly guarantee
+
+If the agent review's main pass never runs at all — every request to the LLM
+provider failed (exhausted key, a terminal provider error, etc.) — Lien marks
+the result with an **error-severity finding** and a **`failure`** conclusion
+naming the cause, instead of a clean-looking review. That finding is what
+`fail-on: error`/`any` act on, so a starved review fails the check under
+either gating mode. Under the default `fail-on: never` the job itself still
+exits `0` (advisory stays advisory), but the step summary, PR description, and
+`conclusion` output make the failure impossible to mistake for "no issues
+found."
 
 ## Fork PRs
 
@@ -194,15 +237,30 @@ The action ships as a Docker container action pulling a prebuilt image from
 JavaScript/composite action), so each run pulls the image rather than building
 it.
 
+## License note (AGPL-3.0)
+
+Lien Review is licensed AGPL-3.0. Running the unmodified, published
+`getlien/lien-review` action/image in your own CI against your own repos
+(including private ones) does not trigger AGPL §13's network-copyleft
+obligations toward *your* codebase — the license governs Lien's own source,
+not the code Lien reviews. §13 obligations attach to modifications of Lien
+itself that you convey or offer as a network service to others. This is a
+factual summary, not legal advice — consult counsel for your specific
+situation.
+
 ## Publishing the Action (maintainer runbook)
 
 This section is for Lien maintainers cutting a release, not action consumers.
 
-Until the one-time human setup below is done, `.github/workflows/publish-action.yml`
-publishes the GHCR image but **cannot** yet update the public
-`getlien/lien-review` dist repo that `uses: getlien/lien-review@v1` resolves
-to — the sync step detects the missing secret and no-ops with a
-`::notice::` log line instead of failing the build.
+**Update (2026-07-12):** the one-time human setup below is done — the
+`getlien/lien-review` dist repo exists and syncs automatically on release, so
+`uses: getlien/lien-review@v1` resolves to a real, published release (tags
+`v1`, `0.62.0`–`0.64.0`, backed by `docker://ghcr.io/getlien/lien-review:v1`).
+The steps below are kept for reference (re-provisioning after a token
+rotation, or setting up a fork of this repo). If `GH_DIST_TOKEN` is ever
+unset or revoked, `.github/workflows/publish-action.yml` still publishes the
+GHCR image but the dist-repo sync step no-ops with a `::notice::` log line
+instead of failing the build.
 
 ### One-time human setup
 

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -18,8 +18,9 @@ inputs:
     default: ${{ github.token }}
   openrouter-api-key:
     description: >-
-      OpenRouter API key for agent review (preferred provider — runs Gemini).
-      If omitted, falls back to anthropic-api-key, then to complexity-only.
+      OpenRouter API key for agent review (preferred provider — runs
+      OpenRouter's calibrated default model). If omitted, falls back to
+      anthropic-api-key, then to complexity-only.
     required: false
     default: ''
   anthropic-api-key:

--- a/packages/action/examples/lien-review.yml
+++ b/packages/action/examples/lien-review.yml
@@ -21,8 +21,9 @@ jobs:
     steps:
       - uses: getlien/lien-review@v1
         with:
-          # Preferred LLM provider — cheaper Gemini path. Add OPENROUTER_API_KEY
-          # under Settings → Secrets and variables → Actions.
+          # Preferred LLM provider — runs OpenRouter's calibrated default
+          # model. Add OPENROUTER_API_KEY under Settings → Secrets and
+          # variables → Actions.
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Or use Anthropic instead (omit openrouter-api-key above):
           # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/packages/action/src/inputs.ts
+++ b/packages/action/src/inputs.ts
@@ -119,8 +119,8 @@ function parseReviewTypes(raw: string): ReviewTypes {
 
 /**
  * Resolve the LLM provider from the supplied keys. OpenRouter takes precedence
- * (cheaper Gemini path); Anthropic is the fallback; absent both, `null` means
- * complexity-only review with no agent.
+ * (runs DEFAULT_REVIEW_MODEL, the calibrated default); Anthropic is the
+ * fallback; absent both, `null` means complexity-only review with no agent.
  */
 function resolveLLM(openrouterKey: string, anthropicKey: string): ReviewLLMConfig {
   if (openrouterKey) {

--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -50,6 +50,7 @@ export default withMermaid(
             text: 'Usage',
             items: [
               { text: 'MCP Tools', link: '/guide/mcp-tools' },
+              { text: 'Claude Code Plugin', link: '/guide/claude-code-plugin' },
               { text: 'CLI Commands', link: '/guide/cli-commands' },
               { text: 'Lien Review', link: '/guide/lien-review' },
               { text: 'Review Evidence', link: '/guide/review-evidence' },

--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -52,6 +52,7 @@ export default withMermaid(
               { text: 'MCP Tools', link: '/guide/mcp-tools' },
               { text: 'CLI Commands', link: '/guide/cli-commands' },
               { text: 'Lien Review', link: '/guide/lien-review' },
+              { text: 'Review Evidence', link: '/guide/review-evidence' },
             ]
           },
         ]

--- a/packages/site/docs/guide/claude-code-plugin.md
+++ b/packages/site/docs/guide/claude-code-plugin.md
@@ -1,0 +1,126 @@
+# Claude Code Plugin
+
+Installing Lien as a Claude Code plugin gets you more than an MCP config. Two
+`PostToolUse` hooks push structural context and complexity accounting into the
+agent's next turn automatically — after a read, before a commit — without the
+agent having to ask, and without depending on it remembering to. This page
+covers what ships and what each hook actually does.
+
+## Install
+
+```text
+/plugin marketplace add getlien/lien
+/plugin install lien
+```
+
+That's it — no `npm install`, no `lien init`, no per-project `.mcp.json`. The
+plugin's MCP server launches on demand via `npx -y @liendev/lien@latest serve`,
+which always resolves against the npm registry, so it runs the latest
+published release even if you have a local `npm link` or workspace copy of
+`@liendev/lien` on the machine. First use in a new git repo triggers a
+one-time index automatically.
+
+::: tip Working on Lien itself?
+Don't install this plugin in Lien's own dev environment — it points the MCP
+server at the published npm binary, bypassing your local build. See
+[CONTRIBUTING.md](https://github.com/getlien/lien/blob/main/CONTRIBUTING.md#dogfooding-lien-while-working-on-lien)
+for the dogfooding setup that points at your local build instead.
+:::
+
+This is Claude Code-specific. For other MCP-compatible editors (Cursor,
+Windsurf, OpenCode, Kilo Code, Antigravity), see the
+[installation guide](/guide/installation).
+
+## What you get
+
+### MCP tools
+
+`search_code`, `get_files_context`, `get_dependents`, `list_functions`,
+`get_complexity`, and `find_similar` all become available with no server to
+configure. See the [MCP Tools reference](/guide/mcp-tools) for parameters and
+response shapes.
+
+### The read hook — structural context before you edit
+
+`annotate-read.sh` fires on `PostToolUse:Read`. When the file you just read has
+non-trivial blast radius, it injects a short impact summary as
+`additionalContext` — the one hook output channel verified to actually reach
+the model on its next turn (a bare `systemMessage` does not). A real example,
+captured live in this session:
+
+```
+Lien impact for packages/cli/src/cli/annotate-cmd.ts:
+  • 2 files import this — packages/cli/src/cli/index.ts, packages/cli/src/cli/annotate-cmd.test.ts; risk: medium (2 callers, 1 untested).
+  • Test coverage: packages/cli/src/cli/annotate-cmd.test.ts.
+```
+
+It reports dependent count and blast-radius risk (with reasoning), test
+coverage, and — when present — a complexity warning (max cyclomatic complexity
+and how many functions in the file are over the warn threshold). It stays
+silent when impact is trivial (0-1 dependents, no complexity warnings,
+existing test coverage), and it won't repeat for the same file within a
+session for a TTL (default 5 minutes, `LIEN_ANNOTATE_TTL_MIN`). The effect is
+that you see who depends on a file and how well it's tested *before* you touch
+it, without having to call `get_files_context` yourself.
+
+### The write gate — `lien delta` on every edit
+
+`delta-write.sh` fires on `PostToolUse:Edit|Write|MultiEdit`. It runs
+`lien delta --file <path> --format json` and warns only when *that specific
+edit* pushed a function to a new complexity-threshold crossing — a function
+that was under a cyclomatic/cognitive/Halstead threshold before and is now
+over it, or a brand-new function that starts out over. It's silent for
+everything else: improvements, pre-existing violations, or worsened-but-still-
+under movement. The underlying delta computation is a ~50ms deterministic
+check (no LLM call); the hook's own end-to-end latency, including CLI process
+startup, measures ~215ms warm / ~410ms cold — well under its 5s timeout.
+
+```
+⚠ lien delta: extractSymbols cognitive 12→29 (threshold 15) — consider simplifying before you commit.
+```
+
+This drives the exact same primitive that backs the `lien delta` CLI gate, so
+the hook's verdict and the command's verdict can never disagree. Because the
+warning lands via `additionalContext`, it reaches the agent on its very next
+turn — while the change is still in hand, not after a PR review catches it
+later. Disable with `LIEN_DELTA_HOOK=off`.
+
+### Explore-agent nudge
+
+A third hook (`PreToolUse:Agent|Task`) appends a short Lien-tool mandate to the
+prompt whenever Claude Code launches its built-in `Explore` subagent —
+subagents start with a fresh prompt and don't inherit the parent session's
+instructions, so this is the only channel available to reach them. It's a
+no-op if the repo has no index yet, or if the prompt already names a Lien MCP
+tool. The plugin doesn't ship its own Explore agent definition — this targets
+Claude Code's built-in `Explore` subagent (or one installed the legacy way via
+`lien init --legacy`).
+
+## Why hooks, not CLAUDE.md rules
+
+A rule written into `CLAUDE.md` only helps if the agent remembers to follow
+it, and that gets less reliable as a session's context fills up. A
+`PostToolUse` hook fires deterministically on every matching tool call,
+regardless of what's still in context. Lien's own `CLAUDE.md` notes that this
+hook pair automates two of its own MANDATORY policies — checking file context
+before an edit, and running `lien delta` before a commit — which is also why
+the plugin runs on Lien's own development, not just its users' repos.
+
+## Configuration
+
+Every hook is best-effort: a missing `lien`/`jq`, an unindexed repo, or any
+internal error exits silently rather than blocking your tool call.
+
+| Env var | Effect |
+|---|---|
+| `LIEN_ANNOTATE_TTL_MIN` | Read-hook suppression window in minutes (default 5) |
+| `LIEN_DELTA_HOOK=off` | Disables the write-time complexity gate |
+| `LIEN_EXPLORE_INJECT=off` | Disables the Explore-agent prompt nudge |
+
+## Updating
+
+Installed plugins are commit-pinned snapshots
+(`~/.claude/plugins/cache/lien/lien/<commit>/`) — merging a change into this
+repo does not update a session that already installed the plugin. Run
+`/plugin update lien`, or if that errors, `/plugin uninstall lien@lien` then
+`/plugin install lien@lien` to force a fresh snapshot.

--- a/packages/site/docs/guide/lien-review.md
+++ b/packages/site/docs/guide/lien-review.md
@@ -43,11 +43,13 @@ permissions:
 
 The agent (bug) review needs an LLM key, provided as a workflow **secret**:
 
-1. Get an [OpenRouter](https://openrouter.ai/) API key (preferred — cheaper Gemini path) or an Anthropic API key.
+1. Get an [OpenRouter](https://openrouter.ai/) API key (preferred — runs OpenRouter's calibrated default model, currently `moonshotai/kimi-k2.7-code`; see [`packages/review/src/defaults.ts`](https://github.com/getlien/lien/blob/main/packages/review/src/defaults.ts) for the source of truth) or an Anthropic API key.
 2. Add it under **Settings → Secrets and variables → Actions → New repository secret** as `OPENROUTER_API_KEY` (or `ANTHROPIC_API_KEY`).
 3. Pass it through the action's `with:` block, as shown above.
 
 If both keys are omitted, the review still runs but **complexity-only** — the agent bug/summary/architectural passes are skipped.
+
+**Cost:** a typical PR review costs roughly $0.02–$0.15 in OpenRouter tokens on the default model (measured across the 2026-07 cross-repo study; ~$0.03/vote median, with complex multi-pass reviews at the high end — OpenRouter's own billing can run ~1.5–2× the harness-reported figure). The exact cost of every run is printed in the job's step summary.
 
 ## What it checks
 
@@ -58,9 +60,15 @@ If both keys are omitted, the review still runs but **complexity-only** — the 
 | PR summary | A concise summary of the change, posted as a step summary |
 | Advisory by default | `fail-on: never` — the check never blocks a PR unless you opt in |
 
+## Advanced configuration
+
+One behavior is tunable only via an environment variable on the action step, not a formal input: set `LIEN_REVIEW_DOC_PASS=0` to disable the dedicated doc-truth second pass that checks documentation/guidance prose against the code it describes (on by default, and only runs on PRs touching doc surfaces). There is currently no `model` input — the OpenRouter path pins the calibrated default deliberately, since the calibration evidence backing this review only covers that one model. See [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md#advanced-configuration) for details.
+
 ## Blocking a PR on the review
 
 By default the review is **advisory** — it never fails CI. To gate merges on it, set `fail-on: error` (or `any`) and mark the workflow's job as a **Required status check** in your branch protection rules. See the [inputs table](https://github.com/getlien/lien/blob/main/packages/action/README.md#inputs) for the full set of options (`threshold`, `review-types`, `block-on-new-errors`, `fail-on`).
+
+If the agent review's main pass never runs at all (every LLM provider request failed), Lien marks the result with an error-severity finding and a `failure` conclusion instead of a clean-looking review, so a starved run is never mistaken for "no issues found." See [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md#fail-loudly-guarantee) for the full behavior, including how it interacts with `fail-on`.
 
 ## Fork PRs
 

--- a/packages/site/docs/guide/review-evidence.md
+++ b/packages/site/docs/guide/review-evidence.md
@@ -1,0 +1,92 @@
+# How Good Is Lien Review?
+
+Lien Review's agent-driven bug review is validated the same way any rule in it
+ships: fixtures scored against committed assertions, not a demo reel. This page
+summarizes a 2026-07 study that ran the production pipeline against real,
+historical bugs in codebases Lien has never been tuned on, to check whether the
+quality holds up outside the lien repo itself.
+
+## Method
+
+Every fixture is mined from the real regression history of an external
+open-source repo: find a merged PR that shipped a bug, capture the codebase at
+the commit right before the fix, and use the actual later fix commit as ground
+truth. There are no hand-labeled opinions — a fixture either reproduces a bug
+the project's own maintainers later had to patch, or it doesn't exist. Each
+fixture is replayed through the production review pipeline against the
+production default model (`moonshotai/kimi-k2.7-code`) and scored by the same
+committed Tier-1/2 assertions used to gate every in-repo rule change (see
+`packages/review/test/harness/`).
+
+To keep this affordable, a free blind screen (Claude Code on a Claude
+subscription, no OpenRouter spend) triages fixtures before paying for
+confirmation: a 3-vote Kimi screen confirms the screen's catches, and a
+`--calibrate 10` run (≥9/10 required) certifies the ones promoted to permanent
+canaries. The full study — 24 fixtures across 8 external repos in 6 languages,
+mined 2026-07-11/12 — cost **$13.11 of a $15 authorized OpenRouter budget**.
+
+The screen isn't infallible: across all 24 fixtures it produced one
+false negative (`starlette` #2334 below) — a blind miss that Kimi caught
+3/3 anyway. That's the only counter-example found to date.
+
+## Results
+
+| Language | Repo(s) | Regressions tested | Result |
+|---|---|---|---|
+| TypeScript | hono | 3 | Kimi 10-vote calibration: **10/10, 10/10, 8/10** |
+| Ruby | rack | 3 (2 blind-catches, 1 miss) | Kimi 3-vote screen on the 2 catches: **3/3, 3/3** |
+| Go | gin | 3 (2 blind-catches, 1 miss) | Kimi 3-vote screen on the 2 catches: **2/3, 3/3** |
+| Python | starlette + werkzeug | 6 | Kimi 3-vote screen: **16/18 votes, 6/6 fixtures at majority**. One promoted to a canary via 10-vote calibration: starlette #2191 (positional-args off-by-one) = **10/10** |
+| Rust | reqwest | 3 (1 blind-catch, 2 misses) | Kimi 3-vote screen on the 1 catch: **0/3** — judgment-shaped miss (spec-knowledge-bounded) |
+| PHP | guzzle | 3 (1 blind-catch, 2 misses) | Kimi 3-vote screen on the 1 catch: **0/3** — judgment-shaped miss (adversarial-depth) |
+
+"Blind-catch" means Claude Code, reviewing with no knowledge of the fixture's
+intended finding, flagged the bug unaided — that's the free filter before any
+paid confirmation. Fixtures the blind screen missed weren't automatically
+wrong calls: every one is trace-attributed to a specific frontier below, not
+to a broken pipeline. Rust and PHP each had three fixtures total; only one per
+language cleared the blind screen, and that one came back a paid-confirmation
+miss in both cases — the taxonomy below explains why.
+
+## What It Misses — The Honest Part
+
+Four miss shapes showed up across the whole study, stable across both models
+that were tried (Claude Code and Kimi):
+
+**Deep-traced, wrong conclusion.** The reviewer engages the exact question and
+reasons its way to the wrong answer, rather than not noticing the question at
+all. Example: `reqwest` #1645 — a redirect-limit off-by-one. Both models
+traced the limit-check logic directly and still concluded it was correct.
+
+**Omission.** The bug is what *isn't* there — a silently-skipped code path
+with no local diff to point at. Example: `guzzle` #3740 — an `on_trailers`
+callback that silently no-ops. This is the weakest shape the study found, in
+both docs and code review.
+
+**External-usage blindness.** Every in-repo caller is fine; the break only
+shows up in downstream consumers the reviewer can't see. Example: `guzzle`
+#3714 — a validation-before-middleware ordering change that's safe for every
+caller inside the repo but breaks consumers' own middleware.
+
+**Judgment/framing acceptance.** The reviewer sees the change and accepts the
+PR's own framing of it — including a spec-knowledge-bounded variant, where
+catching the bug requires knowledge the PR body actively contradicts. Example:
+`reqwest` #1927 — a deflate-decoder change that violates RFC 9110 (deflate is
+zlib-wrapped), which the reviewer would need to know independently of what
+the PR says it's doing.
+
+## Reproducing This
+
+- The corpus lives in the repo: `packages/review/test/harness/fixtures/crossrepo/`
+  plus per-rule canaries promoted from it.
+- Fixture JSONs are gitignored and regenerate from the public PRs — each
+  fixture's `.assertions.ts` header carries the exact `capture-pr.ts` recipe
+  (clone the public repo, fetch the PR ref, run the capture script).
+- The calibration bar is the same everywhere: **≥9/10** on a 10-vote
+  `--calibrate 10` run against the production default model.
+- Fixtures tagged `characterization` (e.g. `werkzeug` #2678, #2017) document
+  known frontiers without gating anything — they're allowed to sit below the
+  bar until someone iterates on the rule that should catch them.
+
+See `packages/review/test/harness/README.md` for the full corpus table and
+the harness workflow.

--- a/packages/site/docs/guide/review-evidence.md
+++ b/packages/site/docs/guide/review-evidence.md
@@ -75,10 +75,17 @@ catching the bug requires knowledge the PR body actively contradicts. Example:
 zlib-wrapped), which the reviewer would need to know independently of what
 the PR says it's doing.
 
+All four miss examples cite public PRs from the study record, so each is
+independently checkable against the linked project's history — but note that
+only a subset of the study's 24 fixtures is committed in the repo's corpus
+(the miss examples above are documented in the study log, not all carried as
+replayable fixtures).
+
 ## Reproducing This
 
-- The corpus lives in the repo: `packages/review/test/harness/fixtures/crossrepo/`
-  plus per-rule canaries promoted from it.
+- The committed corpus lives in the repo:
+  `packages/review/test/harness/fixtures/crossrepo/` plus the per-rule
+  canaries.
 - Fixture JSONs are gitignored and regenerate from the public PRs — each
   fixture's `.assertions.ts` header carries the exact `capture-pr.ts` recipe
   (clone the public repo, fetch the PR ref, run the capture script).

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -183,10 +183,24 @@ worktree.
 ## Performance
 
 - **File context lookup:** sub-millisecond (indexed lookup by file)
-- **Small projects** (1k files): minutes to index
-- **Medium projects** (10k files): ~15-20 minutes to index
+- **Indexing:** measured full reindexes (`lien index -f`, not incremental) on
+  an Apple Silicon laptop (M3 Pro), 2026-07:
+
+  | Corpus | Files indexed | Wall time |
+  |---|---|---|
+  | reqwest (Rust) | 79 | 0.7s |
+  | gin (Go) | 107 | 1.1s |
+  | hono (TypeScript) | 370 | 1.7s |
+  | Lien monorepo itself (6 languages) | 517 | 1.8s |
+
+  The largest corpus measured here is 517 files, so anything past that is a
+  linear extrapolation, not a direct measurement — but scaling these numbers
+  out lands a 1k-file project around 3s and a 10k-file project around
+  25-30s. There's no embedding step to slow this down: indexing is
+  Tree-sitter AST parsing plus a SQLite write, so it's CPU-bound and roughly
+  linear in file count.
 - **Parsing:** 1.82–2.21x faster end-to-end than Lien's previous `node-tree-sitter`-based parser, measured across benchmarked languages (see [ADR-013](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0013-prebuilt-native-parser-napi-rs.md))
-- **Native install:** ~1.8MB (SQLite binding) plus a small prebuilt parser binary — no model download, no compiler toolchain
+- **Native install:** ~22MB of native binaries for your platform (~1.8MB SQLite binding + ~20MB prebuilt parser binary; only the one matching platform variant is downloaded) — no model download, no compiler toolchain
 - **Disk usage:** roughly comparable to the source it indexes for a standalone
   index; a linked git worktree instead pays only for its overlay (see
   [Git Worktree Support](#git-worktree-support) above)

--- a/packages/site/docs/index.md
+++ b/packages/site/docs/index.md
@@ -48,7 +48,7 @@ features:
 /plugin install lien
 ```
 
-That's it. Lien's MCP tools and the Explore agent are available in every Claude Code session, in every repo — no per-project setup. First use in a new git repo triggers a one-time index automatically.
+That's it. Lien's MCP tools and the Explore agent are available in every Claude Code session, in every repo — no per-project setup. First use in a new git repo triggers a one-time index automatically. See the [Claude Code plugin guide](/guide/claude-code-plugin) for what its hooks do beyond the MCP config.
 
 ### Other editors (Cursor, Windsurf, OpenCode, Kilo Code, Antigravity)
 


### PR DESCRIPTION
Product of a fresh-stranger audit of the review action's adoption path ("can someone who found the repo get PR reviews running today?") followed by a write pass. Everything below was verified against source before writing — the audit's charter was killing doc drift, not adding more.

## Fixed
- **"runs Gemini" (5 public spots + 1 source comment)** — stale since #592 switched the default to `moonshotai/kimi-k2.7-code`. Now: "OpenRouter's calibrated default model", named concretely once per doc with `packages/review/src/defaults.ts` cited as source of truth so the docs can't silently drift again.
- **"dist repo / GHCR image not published yet"** (ADR-012, workflow header) — stale; `getlien/lien-review` exists with `v1`/`0.62.0`–`0.64.0` tags. ADR gets a dated update note; the workflow comment now explains the monorepo builds from source deliberately (dogfooding the current commit).
- **how-it-works.md Performance section** — embeddings-era fossils ("10k files: ~15–20 minutes to index") replaced with **measured** post-ADR-011/013 numbers: 79/107/370/517-file corpora (reqwest, gin, hono, the lien monorepo) fresh-index in 0.7–1.8s on an M3 Pro; ~25–30s at 10k files, explicitly labeled as linear extrapolation. Native-binary footprint corrected to ~22MB (measured from the published `parser-native` tarball, not assumed).

## Added
- **`guide/review-evidence.md`** — public distillation of the 2026-07 cross-repo validation study: method (regression-pair mining, prod pipeline, prod model), per-language results with 3-vote screens distinguished from 10-vote calibrations, the four trace-verified miss categories with concrete cited examples (the honest section is the pitch), and reproduction instructions. In the sidebar next to the Lien Review guide.
- **Stranger-gap docs**: per-review cost ballpark (~\$0.02–0.15, measured; exact figure prints in each run's step summary), `LIEN_REVIEW_DOC_PASS=0` advanced switch, the #738 fail-loudly guarantee, AGPL-for-CI-consumers note, and a "Free Forever applies to local tooling" disclaimer next to the root README bullet it was being misread from.

## Unblocked (not in this diff)
The audit found `ghcr.io/getlien/lien-review` was **private** (org-level packages setting) — every external `uses: getlien/lien-review@v1` would have failed at image pull, making the whole quick start fiction. Alf flipped the org + package settings; anonymous pull now verified (token endpoint 200, tags list publicly readable). The documented path works mechanically end-to-end.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **3 issues found** · Low Risk
>
> This PR is almost entirely documentation and guidance-surface updates: it corrects stale claims about the default review model, publishing status, performance figures, and cost; adds a new review-evidence guide and a Claude Code plugin guide; and updates the site sidebar. The only code file touched is `packages/action/src/inputs.ts`, and the change there is purely a comment update in `resolveLLM` — no executable logic changed. All behavioral claims in the touched docs (default model pinning, no `model` input, `LIEN_REVIEW_DOC_PASS=0` kill-switch, fail-loudly behavior) were verified against the implementation and are accurate. No callers are affected and no wrong outputs are introduced.
>
> - Comment-only update in `packages/action/src/inputs.ts` referencing `DEFAULT_REVIEW_MODEL` instead of the stale 'Gemini' description.
> - Documentation sweep correcting model name, publishing status, performance figures, cost estimates, and adding the review-evidence guide plus sidebar link.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1ba669a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->