### PR TITLE
fix(review): treat cited file paths as top-tier doc-claims evidence anchors

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -298,7 +298,11 @@ function extractClaimsFromPatch(file: string, patch: string): DocClaim[] {
     const match = classifyClaim(text);
     if (!match) continue;
     const claimText = toClaimText(text, match.matchIndex);
-    const citedPath = extractCitedPath(claimText);
+    // Extract the citation from the FULL line, not the windowed claimText:
+    // match-centered capping routinely cuts a trailing "see path/to/file.ts"
+    // out of the excerpt, which is exactly where citations live (found by
+    // replaying the fix against PR #748, the issue's motivating case).
+    const citedPath = extractCitedPath(text);
     claims.push({ file, claimText, shape: match.shape, ...(citedPath && { citedPath }) });
   }
   return claims;

--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -22,6 +22,18 @@
  * the render layer reminds the agent that a worklist entry may be descriptive
  * prose rather than a falsifiable behavioral claim — those need no finding, so
  * the block never manufactures a contradiction the code doesn't support.
+ *
+ * `citedPath` (issue #749) handles the doc-that-cites-its-own-source shape: on
+ * PR #748, 3 of 4 doc-truth findings were the model flagging "the code proving
+ * this could not be located" against prose that named its own evidence file
+ * (e.g. "see `packages/review/src/defaults.ts` for the source of truth") — the
+ * evidence pre-fetch never treated the citation as an anchor, so the model
+ * never saw the file and flagged absence-of-verification as if it were
+ * falsehood. When a claim's own excerpt names a repo file, that citation
+ * outranks every other evidence tier (a claim that ships its own pointer
+ * should arrive pre-verified), and a citation that does NOT resolve gets a
+ * one-line "not found" note instead — a stale citation is itself doc-truth
+ * signal, not something to search around.
  */
 
 import type { CodeChunk } from '@liendev/parser';
@@ -68,6 +80,27 @@ export interface DocClaimEvidence {
    * weighs it as prose-vs-prose, not prose-vs-code.
    */
   fromDoc: boolean;
+  /**
+   * True when this entry is a one-line "cited file not found in the index"
+   * note rather than a located excerpt — the claim named its own evidence
+   * file (see `DocClaim.citedPath`) but that file doesn't resolve against
+   * `repoChunks`. `file` carries the cited (unresolved) path; `excerpt` is
+   * unused. A stale citation is itself doc-truth signal (issue #749).
+   */
+  citedPathMissing?: boolean;
+}
+
+/**
+ * An explicit repo-file citation found in a claim's own excerpt — "see
+ * `packages/review/src/defaults.ts`" — plus, when present, an adjacent
+ * backticked identifier in the same excerpt that narrows which chunk of that
+ * file is the described one (issue #749). See `extractCitedPath`.
+ */
+export interface DocClaimCitedPath {
+  /** The path token as it appeared in the claim excerpt (repo-relative). */
+  path: string;
+  /** An adjacent backticked identifier in the same excerpt, if any. */
+  symbol?: string;
 }
 
 /** A claim-shaped line the diff added to a guidance/doc surface. */
@@ -78,6 +111,12 @@ export interface DocClaim {
   claimText: string;
   /** Which claim shape matched — most-specific-first (see CLAIM_SHAPES). */
   shape: DocClaimShape;
+  /**
+   * An explicit file citation the claim's own excerpt names, if any. When
+   * present it takes priority over every other evidence tier — see
+   * `findClaimEvidence`.
+   */
+  citedPath?: DocClaimCitedPath;
   /**
    * The code/sibling-doc the claim describes, located deterministically over
    * the indexed repo. Absent when no anchor in the claim resolves to a chunk
@@ -257,8 +296,10 @@ function extractClaimsFromPatch(file: string, patch: string): DocClaim[] {
   for (const raw of addedProseLines(patch)) {
     const text = stripLinkTargets(raw);
     const match = classifyClaim(text);
-    if (match)
-      claims.push({ file, claimText: toClaimText(text, match.matchIndex), shape: match.shape });
+    if (!match) continue;
+    const claimText = toClaimText(text, match.matchIndex);
+    const citedPath = extractCitedPath(claimText);
+    claims.push({ file, claimText, shape: match.shape, ...(citedPath && { citedPath }) });
   }
   return claims;
 }
@@ -367,6 +408,45 @@ export function extractAnchors(text: string): string[] {
   }
 
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Cited-path extraction (issue #749)
+// ---------------------------------------------------------------------------
+
+/**
+ * A repo-file-shaped token: a path/filename ending in a recognized source or
+ * doc extension. Not anchored to `/` on purpose — a bare cited filename
+ * (`defaults.ts`) is still a citation, just a less specific one; resolution
+ * against the corpus (see `findCitedPathEvidence`) is the real precision gate,
+ * not the shape regex.
+ */
+const CITED_PATH_RE = /[\w./-]+\.(?:ts|tsx|js|jsx|py|go|rs|rb|php|md|yml|yaml|json)\b/;
+/** A backtick span that reads as a plain identifier, not a path — used to tell
+ *  an adjacent symbol citation apart from the cited path itself. */
+const SYMBOL_SPAN_RE = /^[A-Za-z_$][\w$]*$/;
+
+/**
+ * Extract an explicit repo-file citation from a claim's own excerpt, plus an
+ * adjacent backticked identifier in the same excerpt (if any) to narrow which
+ * chunk of that file is the described one. Both the backtick form
+ * ("see `packages/review/src/defaults.ts`") and the markdown-link form whose
+ * display text is the path itself ("[packages/review/src/defaults.ts](../..)")
+ * parse identically here, since both leave a bare path token in `text` once
+ * `stripLinkTargets` and backtick delimiters are out of the way. A bare word
+ * with no extension/path shape (e.g. "defaults") never matches. Exposed for
+ * testing.
+ */
+export function extractCitedPath(text: string): DocClaimCitedPath | undefined {
+  const m = CITED_PATH_RE.exec(text);
+  if (!m) return undefined;
+  const path = m[0].replace(/^\/+/, '');
+
+  for (const span of text.matchAll(BACKTICK_SPAN_RE)) {
+    const candidate = span[1].trim();
+    if (candidate !== path && SYMBOL_SPAN_RE.test(candidate)) return { path, symbol: candidate };
+  }
+  return { path };
 }
 
 // ---------------------------------------------------------------------------
@@ -540,10 +620,88 @@ function buildExcerpt(
 }
 
 /**
- * Locate the code (or sibling doc) a single claim describes. Tries a
- * case-sensitive pass first (identifiers/keys are case-bearing), then a
- * case-insensitive fallback. Returns undefined when no anchor resolves or
- * there is no repo index to search.
+ * Which chunk of a cited file is the described one: the chunk containing the
+ * adjacent symbol (by exact symbolName or content match) when one was
+ * captured, else the file's best keyword-overlap chunk against the claim's
+ * own anchors (ties keep the first chunk in traversal order). `centerOn` is
+ * always non-empty so `buildExcerpt` always has something to center on.
+ */
+function pickCitedChunk(
+  fileChunks: CodeChunk[],
+  symbol: string | undefined,
+  keywordAnchors: string[],
+): { chunk: CodeChunk; centerOn: string[] } {
+  if (symbol) {
+    const bySymbol = fileChunks.find(
+      c => c.metadata.symbolName === symbol || c.content.includes(symbol),
+    );
+    if (bySymbol) return { chunk: bySymbol, centerOn: [symbol] };
+  }
+
+  let best = fileChunks[0];
+  let bestCount = -1;
+  for (const c of fileChunks) {
+    const count = keywordAnchors.filter(a => c.content.includes(a)).length;
+    if (count > bestCount) {
+      bestCount = count;
+      best = c;
+    }
+  }
+  return {
+    chunk: best,
+    centerOn: keywordAnchors.length > 0 ? keywordAnchors : [best.metadata.file],
+  };
+}
+
+/**
+ * Resolve a claim's own file citation (see `DocClaim.citedPath`) against the
+ * repo index. A citation is authoritative — a claim that ships its own
+ * pointer should arrive pre-verified — so a resolved hit is returned directly,
+ * bypassing the generic anchor/tier scan entirely (it outranks every tier).
+ * When the cited path does NOT resolve to any indexed chunk, returns a
+ * one-line `citedPathMissing` note instead: a stale citation is itself
+ * doc-truth signal, not something to search around (issue #749).
+ */
+function findCitedPathEvidence(
+  cited: DocClaimCitedPath,
+  claimText: string,
+  repoChunks: CodeChunk[],
+): DocClaimEvidence {
+  const resolvedFile = repoChunks.find(
+    c => c.metadata.file === cited.path || c.metadata.file.endsWith(`/${cited.path}`),
+  )?.metadata.file;
+
+  if (!resolvedFile) {
+    return {
+      file: cited.path,
+      startLine: 0,
+      excerpt: '',
+      anchor: cited.path,
+      fromDoc: DOC_FILE_RE.test(cited.path),
+      citedPathMissing: true,
+    };
+  }
+
+  const fileChunks = repoChunks.filter(c => c.metadata.file === resolvedFile);
+  const keywordAnchors = extractAnchors(claimText).filter(a => a !== cited.symbol);
+  const { chunk, centerOn } = pickCitedChunk(fileChunks, cited.symbol, keywordAnchors);
+  const built = buildExcerpt(chunk, centerOn, IDENTITY);
+  return {
+    file: resolvedFile,
+    startLine: built.startLine,
+    excerpt: built.excerpt,
+    anchor: built.anchor,
+    fromDoc: DOC_FILE_RE.test(resolvedFile),
+  };
+}
+
+/**
+ * Locate the code (or sibling doc) a single claim describes. An explicit
+ * self-citation (`claim.citedPath`) is resolved first and, when present,
+ * short-circuits the rest of this function — see `findCitedPathEvidence`.
+ * Otherwise tries a case-sensitive anchor pass (identifiers/keys are
+ * case-bearing), then a case-insensitive fallback. Returns undefined when no
+ * anchor resolves or there is no repo index to search.
  */
 export function findClaimEvidence(
   claim: DocClaim,
@@ -551,6 +709,7 @@ export function findClaimEvidence(
   changed: Set<string>,
 ): DocClaimEvidence | undefined {
   if (!repoChunks || repoChunks.length === 0) return undefined;
+  if (claim.citedPath) return findCitedPathEvidence(claim.citedPath, claim.claimText, repoChunks);
   const anchors = extractAnchors(claim.claimText);
   if (anchors.length === 0) return undefined;
 
@@ -621,13 +780,21 @@ const NO_EVIDENCE_HINT =
 
 /**
  * Render one claim entry's lines: the `file: "claim"` header, then either its
- * located evidence excerpt (as a fenced block) or the no-evidence hint. Evidence
- * is suppressed with an inline note once `remaining` budget can't hold it, so
- * the claim inventory itself never gets dropped for an excerpt.
+ * located evidence excerpt (as a fenced block), the one-line "cited file not
+ * found" note (see `DocClaimEvidence.citedPathMissing`), or the no-evidence
+ * hint. Evidence is suppressed with an inline note once `remaining` budget
+ * can't hold it, so the claim inventory itself never gets dropped for an
+ * excerpt.
  */
 function renderClaimEntry(claim: DocClaim, remaining: number): string[] {
   const header = `- ${claim.file}: "${claim.claimText}"`;
   if (!claim.evidence) return [header, NO_EVIDENCE_HINT];
+  if (claim.evidence.citedPathMissing) {
+    return [
+      header,
+      `  (evidence: the cited file "${claim.evidence.file}" was not found in the index — the citation itself may be stale)`,
+    ];
+  }
 
   const { file, startLine, excerpt, fromDoc } = claim.evidence;
   const label = fromDoc ? 'evidence (sibling doc)' : 'evidence';

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -387,6 +387,21 @@ describe('extractDocClaims — citedPath wiring', () => {
     const c = extractDocClaims(new Map([[DOC, added('The batch size defaults to 32.')]]))[0];
     expect(c.citedPath).toBeUndefined();
   });
+
+  it('extracts a citation that the claim-excerpt window truncates away', () => {
+    // Regression pin from replaying against PR #748: the claim phrase sits
+    // early in a long line, the citation sits past MAX_CLAIM_CHARS, so the
+    // match-centered excerpt excludes it — extraction must run on the FULL
+    // line, not the windowed claimText.
+    const filler = 'and the surrounding prose keeps going with more descriptive detail '.repeat(4);
+    const line = `The pass defaults to on ${filler}— see \`packages/review/src/defaults.ts\` for \`DEFAULT_REVIEW_MODEL\`, the source of truth.`;
+    const c = extractDocClaims(new Map([[DOC, added(line)]]))[0];
+    expect(c.claimText).not.toContain('defaults.ts'); // window really cut it
+    expect(c.citedPath).toEqual({
+      path: 'packages/review/src/defaults.ts',
+      symbol: 'DEFAULT_REVIEW_MODEL',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -3,12 +3,14 @@ import type { CodeChunk } from '@liendev/parser';
 import type { ReviewContext } from '../src/plugin-types.js';
 import {
   extractAnchors,
+  extractCitedPath,
   extractDocClaims,
   findClaimEvidence,
   attachEvidence,
   renderDocClaims,
   renderDocClaimsSection,
   type DocClaim,
+  type DocClaimCitedPath,
   type DocClaimEvidence,
 } from '../src/doc-claims-signals.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
@@ -44,6 +46,11 @@ function chunk(
 /** A DocClaim with the given text (shape is irrelevant to evidence lookup). */
 function claimOf(claimText: string, file = DOC): DocClaim {
   return { file, claimText, shape: 'mechanism' };
+}
+
+/** A DocClaim carrying an explicit citedPath (see extractCitedPath), for evidence tests. */
+function claimWithCitedPath(claimText: string, citedPath: DocClaimCitedPath, file = DOC): DocClaim {
+  return { file, claimText, shape: 'mechanism', citedPath };
 }
 
 /** Build a one-hunk patch adding the given lines to a file. */
@@ -320,6 +327,69 @@ describe('extractAnchors', () => {
 });
 
 // ---------------------------------------------------------------------------
+// extractCitedPath (#749)
+// ---------------------------------------------------------------------------
+
+describe('extractCitedPath', () => {
+  it('extracts a backtick-quoted path plus an adjacent backtick symbol', () => {
+    const cp = extractCitedPath(
+      'currently `moonshotai/kimi-k2.7-code`; see `packages/review/src/defaults.ts` for `DEFAULT_REVIEW_MODEL`, the source of truth.',
+    );
+    expect(cp?.path).toBe('packages/review/src/defaults.ts');
+    expect(cp?.symbol).toBe('DEFAULT_REVIEW_MODEL');
+  });
+
+  it('parses a markdown-link citation whose display text is the path', () => {
+    const cp = extractCitedPath(
+      'see [packages/review/src/defaults.ts](../../packages/review/src/defaults.ts) for the source of truth',
+    );
+    expect(cp?.path).toBe('packages/review/src/defaults.ts');
+  });
+
+  it('does not treat a bare word without an extension/path shape as a citedPath', () => {
+    expect(extractCitedPath('see defaults for the source of truth')).toBeUndefined();
+  });
+
+  it('returns the path with no symbol when no adjacent backticked identifier is present', () => {
+    const cp = extractCitedPath('the default lives in packages/review/src/defaults.ts today');
+    expect(cp).toEqual({ path: 'packages/review/src/defaults.ts' });
+  });
+
+  it('does not mistake the backtick-quoted path token itself for the adjacent symbol', () => {
+    const cp = extractCitedPath('see `packages/review/src/defaults.ts` for details');
+    expect(cp?.symbol).toBeUndefined();
+  });
+
+  it('skips a non-identifier-shaped backtick span (e.g. a model name) when looking for the adjacent symbol', () => {
+    const cp = extractCitedPath(
+      'model is `moonshotai/kimi-k2.7-code`; source: `packages/review/src/defaults.ts`',
+    );
+    expect(cp?.symbol).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDocClaims — citedPath wiring (#749)
+// ---------------------------------------------------------------------------
+
+describe('extractDocClaims — citedPath wiring', () => {
+  it('records the citedPath (and adjacent symbol) extracted from a real claim line', () => {
+    const line =
+      'The review model defaults to `moonshotai/kimi-k2.7-code`; see `packages/review/src/defaults.ts` for `DEFAULT_REVIEW_MODEL`, the source of truth.';
+    const c = extractDocClaims(new Map([[DOC, added(line)]]))[0];
+    expect(c.citedPath).toEqual({
+      path: 'packages/review/src/defaults.ts',
+      symbol: 'DEFAULT_REVIEW_MODEL',
+    });
+  });
+
+  it('leaves citedPath unset for a claim with no file citation', () => {
+    const c = extractDocClaims(new Map([[DOC, added('The batch size defaults to 32.')]]))[0];
+    expect(c.citedPath).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // findClaimEvidence — ranking
 // ---------------------------------------------------------------------------
 
@@ -460,6 +530,84 @@ describe('findClaimEvidence — excerpt', () => {
     )!;
     expect(ev.excerpt).not.toContain('```');
     expect(ev.excerpt).toContain("'''");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaimEvidence — citedPath (#749)
+// ---------------------------------------------------------------------------
+
+describe('findClaimEvidence — citedPath', () => {
+  const CODE = 'packages/review/src/defaults.ts';
+
+  it("ranks the cited file's symbol chunk first, bypassing decoys in other files entirely", () => {
+    const claim = claimWithCitedPath(
+      'currently `moonshotai/kimi-k2.7-code`; see `packages/review/src/defaults.ts` for `DEFAULT_REVIEW_MODEL`, the source of truth.',
+      { path: CODE, symbol: 'DEFAULT_REVIEW_MODEL' },
+    );
+    const chunks = [
+      // A decoy in a different file mentioning the same symbol/keywords.
+      chunk(
+        'packages/review/src/other.ts',
+        1,
+        'DEFAULT_REVIEW_MODEL mentioned here too, moonshotai/kimi-k2.7-code',
+      ),
+      chunk(CODE, 1, 'export const OTHER_CONST = 1;'),
+      chunk(CODE, 12, 'export const DEFAULT_REVIEW_MODEL = "moonshotai/kimi-k2.7-code";', {
+        symbolName: 'DEFAULT_REVIEW_MODEL',
+        type: 'const',
+      }),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set())!;
+    expect(ev.file).toBe(CODE);
+    expect(ev.startLine).toBe(12);
+    expect(ev.excerpt).toContain('DEFAULT_REVIEW_MODEL');
+  });
+
+  it("falls back to the cited file's best keyword-overlap chunk when no symbol was captured", () => {
+    const claim = claimWithCitedPath(
+      'the `packages/review/src/defaults.ts` module exports `modelList` among other config',
+      { path: CODE },
+    );
+    const chunks = [
+      chunk(CODE, 1, 'export const UNRELATED = 1;'),
+      chunk(CODE, 20, 'export const modelList = ["a", "b"];'),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set())!;
+    expect(ev.file).toBe(CODE);
+    expect(ev.startLine).toBe(20);
+  });
+
+  it('attaches a one-line "not found" note — not a fenced excerpt — when the cited path does not resolve', () => {
+    const claim = claimWithCitedPath('see `packages/review/src/ghost.ts` for details', {
+      path: 'packages/review/src/ghost.ts',
+    });
+    const chunks = [chunk(CODE, 1, 'export const DEFAULT_REVIEW_MODEL = 1;')];
+    const ev = findClaimEvidence(claim, chunks, new Set())!;
+    expect(ev.citedPathMissing).toBe(true);
+    expect(ev.file).toBe('packages/review/src/ghost.ts');
+
+    const md = renderDocClaims([{ ...claim, evidence: ev }]);
+    expect(md).toContain('was not found in the index');
+    expect(md).not.toContain('```'); // a one-line note, not a fenced block
+  });
+
+  it('takes priority over the generic anchor/tier scan even when a changed file would otherwise win', () => {
+    const claim = claimWithCitedPath(
+      'the `structuralStore` lives in `packages/core/src/store.ts`',
+      {
+        path: 'packages/core/src/store.ts',
+      },
+    );
+    const chunks = [
+      chunk('packages/core/src/changed.ts', 1, 'export const structuralStore = 1;'),
+      chunk('packages/core/src/store.ts', 5, 'export const structuralStore = makeStore();'),
+    ];
+    // changed.ts is CHANGED and would win the generic tier scan — the citation
+    // must still resolve to the cited file, not the changed decoy.
+    const changed = new Set(['packages/core/src/changed.ts']);
+    const ev = findClaimEvidence(claim, chunks, changed)!;
+    expect(ev.file).toBe('packages/core/src/store.ts');
   });
 });
 


### PR DESCRIPTION
Closes #749.

## Problem

Doc prose that cites its own source ("currently `moonshotai/kimi-k2.7-code`; see `packages/review/src/defaults.ts`") was getting flagged by the doc-truth pass as *"the code proving this could not be located"* — 5 of 6 findings on PR #748 had this shape. The evidence pre-fetch didn't treat explicit file citations as anchors, so the generic keyword tiers attached the wrong file (e.g. `inputs.ts` for a claim citing `defaults.ts`) and the reviewer, correctly, refused to accept it as proof.

## Fix (two layers, both zero-LLM)

1. **Cited-path anchors** (`extractCitedPath`): a claim whose line names a resolvable repo file gets that citation recorded (`{path, symbol}` — an adjacent backticked identifier narrows chunk selection). `findClaimEvidence` short-circuits on it before the tier scan even runs, so cited evidence outranks everything. A citation that does NOT resolve against the index renders a one-line "cited file was not found — the citation itself may be stale" note (a stale citation is itself doc-truth signal).
2. **Full-line extraction**: found by replaying the fix against PR #748 itself — the claim excerpt is match-centered and capped at 200 chars, which routinely cuts a trailing "see path/to/file" out of the window. Extraction runs on the full added line before windowing.

## Evidence

- **Unit tests**: 19 new (60 total in the file, 740 in the package, all green), including the citation-outside-window regression pin and the exact `defaults.ts`/`DEFAULT_REVIEW_MODEL` shape from #748.
- **Deterministic no-regression**: all 32 locally-present fixtures (19 corpus + 13 cross-repo study) render **byte-identical** `<doc_claims>` blocks before/after — no existing fixture's claims carry resolvable citations, so behavior is provably unchanged everywhere except the shape this fixes. No paid re-validation needed.
- **Real-world positive**: captured the merged #748 as a fixture and replayed. Before: the self-citing claim carried `evidence — packages/action/src/inputs.ts:128` (the wrong layer — the exact false-positive anatomy). After: `evidence (sibling doc) — packages/action/README.md:59` (the cited file). The PR that motivated the issue now renders correctly.

Gates: format/lint/typecheck/build green, full review suite green, `lien delta` exit 0.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR adds a zero-LLM cited-path anchor layer so doc prose that names its own source file is resolved directly before the generic keyword tier scan. The change is localized to `doc-claims-signals.ts`, thoroughly unit-tested, and the fixture replay shows the intended fix works for the motivating case. However, the new `extractCitedPath` symbol-selection logic can pick an unrelated backtick identifier (including generic literals like `true`) instead of the identifier adjacent to the cited path, which may center evidence excerpts on the wrong chunk.
>
> - Added `extractCitedPath`/`findCitedPathEvidence` to resolve explicit file citations before the tier scan, with a stale-citation note when the path does not resolve.
> - Moved citation extraction to run on the full added line before `toClaimText` windowing, fixing truncation of trailing citations.
> - Added 19 unit tests covering extraction, evidence ranking, and stale-citation rendering.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a39631a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting file and symbol citations in documentation claims.
  * Evidence lookup now prioritizes explicitly cited files and symbols for more relevant results.
  * Added clear messaging when a cited file cannot be found.

* **Bug Fixes**
  * Improved evidence selection by avoiding unrelated files and supporting keyword-based fallback within cited files.
  * Preserved citation details even when claim excerpts are truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->