### PR TITLE
chore: remove vestigial onnxruntime .npmrc config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-# Skip CUDA GPU binary download for onnxruntime-node.
-# Lien uses CPU-only embeddings via transformers.js — no GPU needed.
-# Without this, onnxruntime-node's postinstall script tries to download
-# GPU binaries from GitHub releases, which fails on CI runners.
-onnxruntime_node_install_cuda=skip


### PR DESCRIPTION
## What

Removes the `.npmrc` file entirely. It contained only one setting:

```
onnxruntime_node_install_cuda=skip
```

along with its explanatory comment block.

## Why

`onnxruntime-node` (via `transformers.js`) was the CPU-only embeddings dependency this setting worked around. Embeddings were removed entirely per ADR-011 (sqlite structural store + FTS5 lexical search), so the config has been vestigial since then. Newer npm versions emit an "Unknown project config" warning for it, and a future npm major is expected to hard-fail on unrecognized `.npmrc` keys.

Verified before removal:
- `onnxruntime` has zero hits in any `package.json` or in `package-lock.json` — no real dependency depends on this setting.
- No other references to `onnxruntime_node_install_cuda` exist in `.github/`, `docs/`, or `CONTRIBUTING.md`.
- Remaining repo-wide references to `onnxruntime` are historical only: three ADR docs (0008, 0009, 0011) and per-package `CHANGELOG.md` entries — left untouched.

Closes #537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored automatic downloading of CUDA GPU binaries during installation, enabling GPU acceleration where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 452 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d48a794. Updates automatically on new commits.</sup>
<!-- /lien-stats -->