### PR TITLE
fix(review): stop silently dropping inline comments when batch review fails

### DIFF
--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -540,8 +540,8 @@ function buildPresentContext(
         : undefined,
     postReviewComment:
       octokit && pr
-        ? async (body, comments) => {
-            await postPRReview(octokit, pr, comments ?? [], body, logger, 'COMMENT');
+        ? async body => {
+            await postPRReview(octokit, pr, [], body, logger, 'COMMENT');
           }
         : undefined,
     minimizeOutdatedComments:

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -540,7 +540,9 @@ function buildPresentContext(
         : undefined,
     postReviewComment:
       octokit && pr
-        ? (body, comments) => postPRReview(octokit, pr, comments ?? [], body, logger, 'COMMENT')
+        ? async (body, comments) => {
+            await postPRReview(octokit, pr, comments ?? [], body, logger, 'COMMENT');
+          }
         : undefined,
     minimizeOutdatedComments:
       octokit && pr ? marker => minimizeOutdatedComments(octokit, pr, marker, logger) : undefined,
@@ -607,8 +609,15 @@ async function postPluginInlineComments(
   );
   if (toPost.length === 0) return { posted: 0, skipped };
 
-  await postPRReview(octokit, pr, toPost, summaryBody, logger, 'COMMENT');
-  return { posted: toPost.length, skipped };
+  const { posted, dropped } = await postPRReview(
+    octokit,
+    pr,
+    toPost,
+    summaryBody,
+    logger,
+    'COMMENT',
+  );
+  return { posted, skipped: skipped + dropped.length };
 }
 
 /** Fetch diff lines and filter findings to those within the diff. Returns null on API failure. */

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -213,18 +213,32 @@ export async function getFileContent(
 }
 
 /**
- * Result of {@link postPRReview}: how many line comments actually landed, and
- * which ones were dropped (with why) so callers can surface the degradation
- * instead of losing it silently.
+ * Result of {@link postPRReview}: how many line comments actually landed,
+ * which ones were dropped (with why), and whether the summary body itself
+ * made it through — so callers can surface the degradation instead of
+ * losing it silently.
  */
 export interface PostReviewResult {
   posted: number;
   dropped: Array<{ path: string; line: number; error: string }>;
+  /**
+   * Whether the summary body was posted — either as part of the successful
+   * batch, or via the body-only fallback after a batch validation failure.
+   * `false` means the body-only post itself failed (best-effort; salvaging
+   * the inline comments still proceeds regardless).
+   */
+  bodyPosted: boolean;
 }
 
 /** Shape a LineComment into the params octokit expects for a review comment. */
-function toReviewCommentParams(c: LineComment) {
+function toReviewCommentParams(c: LineComment, logger: Logger) {
   const hasValidStartLine = typeof c.start_line === 'number' && c.start_line > 0;
+  if (c.start_line !== undefined && !hasValidStartLine) {
+    logger.warning(
+      `Stripping invalid start_line (${c.start_line}) for comment at ${c.path}:${c.line}; ` +
+        'posting as a single-line comment instead',
+    );
+  }
   return {
     path: c.path,
     line: c.line,
@@ -234,16 +248,28 @@ function toReviewCommentParams(c: LineComment) {
   };
 }
 
+/** Does this error look like a GitHub API rejection we can retry per-comment (a 422 on the batch)? */
+function isBatchValidationError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    (error as { status: unknown }).status === 422
+  );
+}
+
 /**
  * Post a review with line-specific comments.
  *
  * `octokit.pulls.createReview` is all-or-nothing: if ANY comment anchors to a
- * line outside the diff, GitHub rejects the entire batch — including every
- * valid comment in it. On that failure we post the summary body on its own
- * first (it must survive), then retry each comment individually via
- * `createReviewComment` so one bad anchor can't take the rest down with it.
- * Comments that still fail are logged and returned in `dropped`, never
- * silently discarded.
+ * line outside the diff, GitHub rejects the whole batch with a 422 —
+ * including every valid comment in it. Only that validation failure triggers
+ * the per-comment salvage path below: we post the summary body on its own,
+ * then retry each comment individually via `createReviewComment` so one bad
+ * anchor can't take the rest down with it. Comments that still fail are
+ * logged and returned in `dropped`, never silently discarded. Any other
+ * failure (auth, rate-limit, 5xx, network) is rethrown as-is — those aren't
+ * anchor problems and salvaging would just mask the real error.
  */
 export async function postPRReview(
   octokit: Octokit,
@@ -262,16 +288,19 @@ export async function postPRReview(
     commit_id: prContext.headSha,
     event,
     body: summaryBody,
-    ...(comments.length > 0 ? { comments: comments.map(toReviewCommentParams) } : {}),
+    ...(comments.length > 0
+      ? { comments: comments.map(c => toReviewCommentParams(c, logger)) }
+      : {}),
   };
 
   try {
     await octokit.pulls.createReview(reviewParams);
     logger.info('Review posted successfully');
-    return { posted: comments.length, dropped: [] };
+    return { posted: comments.length, dropped: [], bodyPosted: true };
   } catch (error) {
-    if (comments.length === 0) {
-      // Nothing to salvage individually — surface the failure as before.
+    if (comments.length === 0 || !isBatchValidationError(error)) {
+      // Nothing to salvage individually, or this isn't a bad-anchor
+      // rejection we know how to retry around — surface it as before.
       throw error;
     }
 
@@ -288,14 +317,14 @@ export async function postPRReview(
 }
 
 /**
- * Batch fallback: post the summary alone first (it must survive the batch
- * failure), then retry each comment individually via `createReviewComment` so
- * one bad anchor can't take the rest of the batch down with it.
+ * Batch-validation fallback: attempt the summary body alone first, then
+ * retry each comment individually via `createReviewComment` so one bad
+ * anchor can't take the rest of the batch down with it.
  *
- * The body-only post can itself fail (e.g. a transient network error right
- * after the batch failure) — that's caught and logged rather than thrown, so
- * the per-comment salvage loop below still runs. Individual comments are the
- * real salvage path; the body is a bonus, not a precondition for it.
+ * The body-only post is best-effort — if it fails (e.g. a transient network
+ * error right after the batch failure), that's caught, logged, and reported
+ * back via `bodyPosted: false` rather than thrown, so the per-comment
+ * salvage loop below still runs regardless.
  */
 async function postBodyThenRetryCommentsIndividually(
   octokit: Octokit,
@@ -307,6 +336,7 @@ async function postBodyThenRetryCommentsIndividually(
 ): Promise<PostReviewResult> {
   logger.info('Posting body-only review, then retrying comments individually');
 
+  let bodyPosted = true;
   try {
     await octokit.pulls.createReview({
       owner: prContext.owner,
@@ -318,6 +348,7 @@ async function postBodyThenRetryCommentsIndividually(
     });
   } catch (error) {
     logger.warning(`Failed to post body-only review after batch failure: ${error}`);
+    bodyPosted = false;
   }
 
   const dropped: PostReviewResult['dropped'] = [];
@@ -330,7 +361,7 @@ async function postBodyThenRetryCommentsIndividually(
         repo: prContext.repo,
         pull_number: prContext.pullNumber,
         commit_id: prContext.headSha,
-        ...toReviewCommentParams(comment),
+        ...toReviewCommentParams(comment, logger),
       });
       posted++;
     } catch (commentError) {
@@ -345,7 +376,7 @@ async function postBodyThenRetryCommentsIndividually(
       `${dropped.length} dropped`,
   );
 
-  return { posted, dropped };
+  return { posted, dropped, bodyPosted };
 }
 
 /**

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -213,7 +213,36 @@ export async function getFileContent(
 }
 
 /**
- * Post a review with line-specific comments
+ * Result of {@link postPRReview}: how many line comments actually landed, and
+ * which ones were dropped (with why) so callers can surface the degradation
+ * instead of losing it silently.
+ */
+export interface PostReviewResult {
+  posted: number;
+  dropped: Array<{ path: string; line: number; error: string }>;
+}
+
+/** Shape a LineComment into the params octokit expects for a review comment. */
+function toReviewCommentParams(c: LineComment) {
+  return {
+    path: c.path,
+    line: c.line,
+    ...(c.start_line ? { start_line: c.start_line, start_side: 'RIGHT' as const } : {}),
+    side: 'RIGHT' as const,
+    body: c.body,
+  };
+}
+
+/**
+ * Post a review with line-specific comments.
+ *
+ * `octokit.pulls.createReview` is all-or-nothing: if ANY comment anchors to a
+ * line outside the diff, GitHub rejects the entire batch — including every
+ * valid comment in it. On that failure we post the summary body on its own
+ * first (it must survive), then retry each comment individually via
+ * `createReviewComment` so one bad anchor can't take the rest down with it.
+ * Comments that still fail are logged and returned in `dropped`, never
+ * silently discarded.
  */
 export async function postPRReview(
   octokit: Octokit,
@@ -222,7 +251,7 @@ export async function postPRReview(
   summaryBody: string,
   logger: Logger,
   event: 'COMMENT' | 'REQUEST_CHANGES' = 'COMMENT',
-): Promise<void> {
+): Promise<PostReviewResult> {
   logger.info(`Creating review with ${comments.length} line comments (event: ${event})`);
 
   const reviewParams = {
@@ -232,39 +261,81 @@ export async function postPRReview(
     commit_id: prContext.headSha,
     event,
     body: summaryBody,
-    ...(comments.length > 0
-      ? {
-          comments: comments.map(c => ({
-            path: c.path,
-            line: c.line,
-            ...(c.start_line ? { start_line: c.start_line, start_side: 'RIGHT' } : {}),
-            side: 'RIGHT' as const,
-            body: c.body,
-          })),
-        }
-      : {}),
+    ...(comments.length > 0 ? { comments: comments.map(toReviewCommentParams) } : {}),
   };
 
   try {
     await octokit.pulls.createReview(reviewParams);
     logger.info('Review posted successfully');
+    return { posted: comments.length, dropped: [] };
   } catch (error) {
-    if (comments.length > 0) {
-      // Line comments failed (e.g., lines not in diff) — retry as body-only review
-      logger.warning(`Failed to post line comments: ${error}`);
-      logger.info('Retrying as body-only review');
-      await octokit.pulls.createReview({
+    if (comments.length === 0) {
+      // Nothing to salvage individually — surface the failure as before.
+      throw error;
+    }
+
+    logger.warning(`Failed to post line comments as a batch: ${error}`);
+    return postBodyThenRetryCommentsIndividually(
+      octokit,
+      prContext,
+      comments,
+      summaryBody,
+      logger,
+      event,
+    );
+  }
+}
+
+/**
+ * Batch fallback: post the summary alone first (it must survive the batch
+ * failure), then retry each comment individually via `createReviewComment` so
+ * one bad anchor can't take the rest of the batch down with it.
+ */
+async function postBodyThenRetryCommentsIndividually(
+  octokit: Octokit,
+  prContext: PRContext,
+  comments: LineComment[],
+  summaryBody: string,
+  logger: Logger,
+  event: 'COMMENT' | 'REQUEST_CHANGES',
+): Promise<PostReviewResult> {
+  logger.info('Posting body-only review, then retrying comments individually');
+
+  await octokit.pulls.createReview({
+    owner: prContext.owner,
+    repo: prContext.repo,
+    pull_number: prContext.pullNumber,
+    commit_id: prContext.headSha,
+    event,
+    body: summaryBody,
+  });
+
+  const dropped: PostReviewResult['dropped'] = [];
+  let posted = 0;
+
+  for (const comment of comments) {
+    try {
+      await octokit.pulls.createReviewComment({
         owner: prContext.owner,
         repo: prContext.repo,
         pull_number: prContext.pullNumber,
         commit_id: prContext.headSha,
-        event,
-        body: summaryBody,
+        ...toReviewCommentParams(comment),
       });
-    } else {
-      throw error;
+      posted++;
+    } catch (commentError) {
+      const message = commentError instanceof Error ? commentError.message : String(commentError);
+      logger.warning(`Dropped inline comment at ${comment.path}:${comment.line}: ${message}`);
+      dropped.push({ path: comment.path, line: comment.line, error: message });
     }
   }
+
+  logger.info(
+    `Posted ${posted} of ${comments.length} line comments individually after batch failure; ` +
+      `${dropped.length} dropped`,
+  );
+
+  return { posted, dropped };
 }
 
 /**

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -264,12 +264,13 @@ function isBatchValidationError(error: unknown): boolean {
  * `octokit.pulls.createReview` is all-or-nothing: if ANY comment anchors to a
  * line outside the diff, GitHub rejects the whole batch with a 422 —
  * including every valid comment in it. Only that validation failure triggers
- * the per-comment salvage path below: we post the summary body on its own,
- * then retry each comment individually via `createReviewComment` so one bad
- * anchor can't take the rest down with it. Comments that still fail are
- * logged and returned in `dropped`, never silently discarded. Any other
- * failure (auth, rate-limit, 5xx, network) is rethrown as-is — those aren't
- * anchor problems and salvaging would just mask the real error.
+ * the per-comment salvage path below: we attempt the summary body on its own
+ * (best-effort — see `bodyPosted` on the result), then retry each comment
+ * individually via `createReviewComment` so one bad anchor can't take the
+ * rest down with it. Comments that still fail are logged and returned in
+ * `dropped`, never silently discarded. Any other failure (auth, rate-limit,
+ * 5xx, network) is rethrown as-is — those aren't anchor problems and
+ * salvaging would just mask the real error.
  */
 export async function postPRReview(
   octokit: Octokit,

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -224,10 +224,11 @@ export interface PostReviewResult {
 
 /** Shape a LineComment into the params octokit expects for a review comment. */
 function toReviewCommentParams(c: LineComment) {
+  const hasValidStartLine = typeof c.start_line === 'number' && c.start_line > 0;
   return {
     path: c.path,
     line: c.line,
-    ...(c.start_line ? { start_line: c.start_line, start_side: 'RIGHT' as const } : {}),
+    ...(hasValidStartLine ? { start_line: c.start_line, start_side: 'RIGHT' as const } : {}),
     side: 'RIGHT' as const,
     body: c.body,
   };
@@ -290,6 +291,11 @@ export async function postPRReview(
  * Batch fallback: post the summary alone first (it must survive the batch
  * failure), then retry each comment individually via `createReviewComment` so
  * one bad anchor can't take the rest of the batch down with it.
+ *
+ * The body-only post can itself fail (e.g. a transient network error right
+ * after the batch failure) — that's caught and logged rather than thrown, so
+ * the per-comment salvage loop below still runs. Individual comments are the
+ * real salvage path; the body is a bonus, not a precondition for it.
  */
 async function postBodyThenRetryCommentsIndividually(
   octokit: Octokit,
@@ -301,14 +307,18 @@ async function postBodyThenRetryCommentsIndividually(
 ): Promise<PostReviewResult> {
   logger.info('Posting body-only review, then retrying comments individually');
 
-  await octokit.pulls.createReview({
-    owner: prContext.owner,
-    repo: prContext.repo,
-    pull_number: prContext.pullNumber,
-    commit_id: prContext.headSha,
-    event,
-    body: summaryBody,
-  });
+  try {
+    await octokit.pulls.createReview({
+      owner: prContext.owner,
+      repo: prContext.repo,
+      pull_number: prContext.pullNumber,
+      commit_id: prContext.headSha,
+      event,
+      body: summaryBody,
+    });
+  } catch (error) {
+    logger.warning(`Failed to post body-only review after batch failure: ${error}`);
+  }
 
   const dropped: PostReviewResult['dropped'] = [];
   let posted = 0;

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -11,7 +11,7 @@
 
 import type { z } from 'zod';
 import type { CodeChunk, ComplexityReport } from '@liendev/parser';
-import type { PRContext, LineComment, ReviewConfig } from './types.js';
+import type { PRContext, ReviewConfig } from './types.js';
 import type { Logger } from './logger.js';
 import type { ComplexityDelta, DeltaSummary } from './delta.js';
 
@@ -265,10 +265,11 @@ export interface PresentContext {
   ): Promise<{ posted: number; skipped: number }>;
 
   /**
-   * Post a PR review with optional inline comments.
+   * Post a PR review with a summary body only (no inline comments — use
+   * postInlineComments for those, which surfaces per-comment drops).
    * Only available when pr + octokit are present.
    */
-  postReviewComment?(body: string, lineComments?: LineComment[]): Promise<void>;
+  postReviewComment?(body: string): Promise<void>;
 
   /**
    * Minimize (hide as "outdated") existing PR comments matching a marker string.

--- a/packages/review/test/github-api.test.ts
+++ b/packages/review/test/github-api.test.ts
@@ -76,6 +76,20 @@ describe('postPRReview', () => {
     expect(result).toEqual({ posted: 2, dropped: [] });
   });
 
+  it('drops an invalid (negative) start_line instead of passing it through', async () => {
+    const createReview = vi.fn().mockResolvedValue({});
+    const octokit = createMockOctokit({ createReview });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [{ path: 'a.ts', line: 10, start_line: -1, body: 'nit a' }];
+
+    await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
+
+    const postedComment = createReview.mock.calls[0][0].comments[0];
+    expect(postedComment).not.toHaveProperty('start_line');
+    expect(postedComment).not.toHaveProperty('start_side');
+  });
+
   it('posts the body alone, then every comment individually, when the batch is rejected', async () => {
     const createReview = vi
       .fn()
@@ -130,6 +144,32 @@ describe('postPRReview', () => {
     ]);
     expect(logger.warning).toHaveBeenCalledWith(
       expect.stringContaining('Dropped inline comment at b.ts:20'),
+    );
+  });
+
+  it('still retries comments individually when the body-only post also fails', async () => {
+    const createReview = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('batch rejected'))
+      .mockRejectedValueOnce(new Error('body-only post also failed'));
+    const createReviewComment = vi.fn().mockResolvedValue({});
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [
+      { path: 'a.ts', line: 10, body: 'nit a' },
+      { path: 'b.ts', line: 20, body: 'nit b' },
+    ];
+
+    const result = await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
+
+    // Both createReview attempts happened, but neither throws out of the function.
+    expect(createReview).toHaveBeenCalledTimes(2);
+    // The salvage path still ran for every comment.
+    expect(createReviewComment).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ posted: 2, dropped: [] });
+    expect(logger.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to post body-only review after batch failure'),
     );
   });
 

--- a/packages/review/test/github-api.test.ts
+++ b/packages/review/test/github-api.test.ts
@@ -26,6 +26,11 @@ function createMockLogger(): Logger {
   };
 }
 
+/** Octokit RequestError-shaped rejection: a batch validation failure (invalid comment anchor). */
+function validationError(message: string): Error & { status: number } {
+  return Object.assign(new Error(message), { status: 422 });
+}
+
 /** Minimal Octokit stand-in — only the two REST methods postPRReview touches. */
 function createMockOctokit(overrides?: {
   createReview?: ReturnType<typeof vi.fn>;
@@ -73,10 +78,10 @@ describe('postPRReview', () => {
     );
     // Batch succeeded — no per-comment fallback calls.
     expect(createReviewComment).not.toHaveBeenCalled();
-    expect(result).toEqual({ posted: 2, dropped: [] });
+    expect(result).toEqual({ posted: 2, dropped: [], bodyPosted: true });
   });
 
-  it('drops an invalid (negative) start_line instead of passing it through', async () => {
+  it('drops an invalid (negative) start_line instead of passing it through, and warns', async () => {
     const createReview = vi.fn().mockResolvedValue({});
     const octokit = createMockOctokit({ createReview });
     const logger = createMockLogger();
@@ -88,12 +93,31 @@ describe('postPRReview', () => {
     const postedComment = createReview.mock.calls[0][0].comments[0];
     expect(postedComment).not.toHaveProperty('start_line');
     expect(postedComment).not.toHaveProperty('start_side');
+    expect(logger.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Stripping invalid start_line (-1) for comment at a.ts:10'),
+    );
   });
 
-  it('posts the body alone, then every comment individually, when the batch is rejected', async () => {
+  it('drops a zero start_line instead of passing it through, and warns', async () => {
+    const createReview = vi.fn().mockResolvedValue({});
+    const octokit = createMockOctokit({ createReview });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [{ path: 'a.ts', line: 10, start_line: 0, body: 'nit a' }];
+
+    await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
+
+    const postedComment = createReview.mock.calls[0][0].comments[0];
+    expect(postedComment).not.toHaveProperty('start_line');
+    expect(logger.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Stripping invalid start_line (0) for comment at a.ts:10'),
+    );
+  });
+
+  it('posts the body alone, then every comment individually, when the batch is rejected as invalid (422)', async () => {
     const createReview = vi
       .fn()
-      .mockRejectedValueOnce(new Error('Line 999 is not part of the diff'))
+      .mockRejectedValueOnce(validationError('Line 999 is not part of the diff'))
       .mockResolvedValueOnce({});
     const createReviewComment = vi.fn().mockResolvedValue({});
     const octokit = createMockOctokit({ createReview, createReviewComment });
@@ -113,7 +137,7 @@ describe('postPRReview', () => {
 
     // Every comment retried individually — none silently dropped.
     expect(createReviewComment).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({ posted: 2, dropped: [] });
+    expect(result).toEqual({ posted: 2, dropped: [], bodyPosted: true });
     expect(logger.warning).toHaveBeenCalledWith(
       expect.stringContaining('Failed to post line comments as a batch'),
     );
@@ -122,7 +146,7 @@ describe('postPRReview', () => {
   it('drops only the comment that still fails individually, and never throws', async () => {
     const createReview = vi
       .fn()
-      .mockRejectedValueOnce(new Error('batch rejected'))
+      .mockRejectedValueOnce(validationError('batch rejected'))
       .mockResolvedValueOnce({});
     const createReviewComment = vi
       .fn()
@@ -139,6 +163,7 @@ describe('postPRReview', () => {
     const result = await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
 
     expect(result.posted).toBe(1);
+    expect(result.bodyPosted).toBe(true);
     expect(result.dropped).toEqual([
       { path: 'b.ts', line: 20, error: 'Line 20 is not part of the diff' },
     ]);
@@ -147,10 +172,10 @@ describe('postPRReview', () => {
     );
   });
 
-  it('still retries comments individually when the body-only post also fails', async () => {
+  it('still retries comments individually, and reports bodyPosted: false, when the body-only post also fails', async () => {
     const createReview = vi
       .fn()
-      .mockRejectedValueOnce(new Error('batch rejected'))
+      .mockRejectedValueOnce(validationError('batch rejected'))
       .mockRejectedValueOnce(new Error('body-only post also failed'));
     const createReviewComment = vi.fn().mockResolvedValue({});
     const octokit = createMockOctokit({ createReview, createReviewComment });
@@ -167,7 +192,7 @@ describe('postPRReview', () => {
     expect(createReview).toHaveBeenCalledTimes(2);
     // The salvage path still ran for every comment.
     expect(createReviewComment).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({ posted: 2, dropped: [] });
+    expect(result).toEqual({ posted: 2, dropped: [], bodyPosted: false });
     expect(logger.warning).toHaveBeenCalledWith(
       expect.stringContaining('Failed to post body-only review after batch failure'),
     );
@@ -182,6 +207,40 @@ describe('postPRReview', () => {
     await expect(postPRReview(octokit, pr, [], 'summary body', logger, 'COMMENT')).rejects.toThrow(
       'network error',
     );
+    expect(createReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-validation batch failure (e.g. 500) instead of salvaging, even with comments present', async () => {
+    const serverError = Object.assign(new Error('Internal Server Error'), { status: 500 });
+    const createReview = vi.fn().mockRejectedValue(serverError);
+    const createReviewComment = vi.fn();
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [{ path: 'a.ts', line: 10, body: 'nit a' }];
+
+    await expect(
+      postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT'),
+    ).rejects.toThrow('Internal Server Error');
+
+    // Only the initial batch attempt — no body-only fallback, no per-comment salvage.
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect(createReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a batch failure with no status (e.g. a plain network error) instead of salvaging', async () => {
+    const createReview = vi.fn().mockRejectedValue(new Error('socket hang up'));
+    const createReviewComment = vi.fn();
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [{ path: 'a.ts', line: 10, body: 'nit a' }];
+
+    await expect(
+      postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT'),
+    ).rejects.toThrow('socket hang up');
+
+    expect(createReview).toHaveBeenCalledTimes(1);
     expect(createReviewComment).not.toHaveBeenCalled();
   });
 });

--- a/packages/review/test/github-api.test.ts
+++ b/packages/review/test/github-api.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import { postPRReview, parsePatchLines } from '../src/github-api.js';
+import type { Octokit } from '../src/github-api.js';
+import type { LineComment, PRContext } from '../src/types.js';
+import type { Logger } from '../src/logger.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const pr: PRContext = {
+  owner: 'test-owner',
+  repo: 'test-repo',
+  pullNumber: 42,
+  title: 'Test PR',
+  baseSha: 'base-sha',
+  headSha: 'head-sha',
+};
+
+function createMockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+/** Minimal Octokit stand-in — only the two REST methods postPRReview touches. */
+function createMockOctokit(overrides?: {
+  createReview?: ReturnType<typeof vi.fn>;
+  createReviewComment?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    pulls: {
+      createReview: overrides?.createReview ?? vi.fn().mockResolvedValue({}),
+      createReviewComment: overrides?.createReviewComment ?? vi.fn().mockResolvedValue({}),
+    },
+  } as unknown as Octokit;
+}
+
+// ---------------------------------------------------------------------------
+// postPRReview
+// ---------------------------------------------------------------------------
+
+describe('postPRReview', () => {
+  it('posts the whole batch in one call when it succeeds', async () => {
+    const createReview = vi.fn().mockResolvedValue({});
+    const createReviewComment = vi.fn();
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [
+      { path: 'a.ts', line: 10, body: 'nit a' },
+      { path: 'b.ts', line: 20, body: 'nit b' },
+    ];
+
+    const result = await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
+
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect(createReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        pull_number: 42,
+        commit_id: 'head-sha',
+        body: 'summary body',
+        comments: [
+          expect.objectContaining({ path: 'a.ts', line: 10, body: 'nit a' }),
+          expect.objectContaining({ path: 'b.ts', line: 20, body: 'nit b' }),
+        ],
+      }),
+    );
+    // Batch succeeded — no per-comment fallback calls.
+    expect(createReviewComment).not.toHaveBeenCalled();
+    expect(result).toEqual({ posted: 2, dropped: [] });
+  });
+
+  it('posts the body alone, then every comment individually, when the batch is rejected', async () => {
+    const createReview = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Line 999 is not part of the diff'))
+      .mockResolvedValueOnce({});
+    const createReviewComment = vi.fn().mockResolvedValue({});
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [
+      { path: 'a.ts', line: 10, body: 'nit a' },
+      { path: 'b.ts', line: 20, body: 'nit b' },
+    ];
+
+    const result = await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
+
+    // First call attempted the batch; second posted the summary body only.
+    expect(createReview).toHaveBeenCalledTimes(2);
+    expect(createReview.mock.calls[1][0]).not.toHaveProperty('comments');
+    expect(createReview.mock.calls[1][0]).toMatchObject({ body: 'summary body' });
+
+    // Every comment retried individually — none silently dropped.
+    expect(createReviewComment).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ posted: 2, dropped: [] });
+    expect(logger.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to post line comments as a batch'),
+    );
+  });
+
+  it('drops only the comment that still fails individually, and never throws', async () => {
+    const createReview = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('batch rejected'))
+      .mockResolvedValueOnce({});
+    const createReviewComment = vi
+      .fn()
+      .mockResolvedValueOnce({}) // a.ts posts fine
+      .mockRejectedValueOnce(new Error('Line 20 is not part of the diff')); // b.ts still fails
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    const comments: LineComment[] = [
+      { path: 'a.ts', line: 10, body: 'nit a' },
+      { path: 'b.ts', line: 20, body: 'nit b' },
+    ];
+
+    const result = await postPRReview(octokit, pr, comments, 'summary body', logger, 'COMMENT');
+
+    expect(result.posted).toBe(1);
+    expect(result.dropped).toEqual([
+      { path: 'b.ts', line: 20, error: 'Line 20 is not part of the diff' },
+    ]);
+    expect(logger.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped inline comment at b.ts:20'),
+    );
+  });
+
+  it('rethrows on batch failure when there are no comments to salvage', async () => {
+    const createReview = vi.fn().mockRejectedValue(new Error('network error'));
+    const createReviewComment = vi.fn();
+    const octokit = createMockOctokit({ createReview, createReviewComment });
+    const logger = createMockLogger();
+
+    await expect(postPRReview(octokit, pr, [], 'summary body', logger, 'COMMENT')).rejects.toThrow(
+      'network error',
+    );
+    expect(createReviewComment).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePatchLines
+// ---------------------------------------------------------------------------
+
+describe('parsePatchLines', () => {
+  it('collects context and added lines, skipping deleted lines', () => {
+    const patch = [
+      '@@ -10,3 +10,4 @@ function foo() {',
+      ' context1',
+      '+added1',
+      ' context2',
+      '-removed1',
+      ' context3',
+    ].join('\n');
+
+    expect(parsePatchLines(patch)).toEqual(new Set([10, 11, 12, 13]));
+  });
+
+  it('resets the line counter at each hunk header', () => {
+    const patch = ['@@ -1,2 +1,2 @@', '+line1', ' line2', '@@ -20,1 +21,1 @@', '+line3'].join('\n');
+
+    expect(parsePatchLines(patch)).toEqual(new Set([1, 2, 21]));
+  });
+
+  it('ignores the "+++ b/file" header line instead of counting it as line 0', () => {
+    const patch = ['--- a/file.ts', '+++ b/file.ts', '@@ -1,1 +1,2 @@', ' context', '+added'].join(
+      '\n',
+    );
+
+    expect(parsePatchLines(patch)).toEqual(new Set([1, 2]));
+  });
+});


### PR DESCRIPTION
## Root cause

`octokit.pulls.createReview` (used by `postPRReview` in `packages/review/src/github-api.ts`) posts the summary body and all line comments in a single atomic call. GitHub rejects the *entire* call if even one comment anchors to a line outside the diff. The old catch block retried as a body-only review on any failure — which silently discarded every inline comment in the batch, including the valid ones. This is exactly what happened on PR #557: findings rendered in the check-run summary, but zero inline comments landed.

Callers already filter findings to diff lines before reaching `postPRReview` (via `getPRDiffLines`/`filterToDiffLines`), so the all-or-nothing batch failure should be rare in practice — but it's catastrophic when it does happen, since one bad anchor takes every valid comment down with it.

## Fix

- On batch failure, `postPRReview` now posts the summary body alone first (it must survive), then retries each comment individually via `octokit.pulls.createReviewComment` so one bad anchor can't sink the rest.
- Every comment that still fails gets a `logger.warning` with its `path:line` and the error message, plus a final info-level tally (`Posted N of M line comments individually after batch failure; K dropped`) — nothing is silently dropped anymore.
- The zero-comments case is unchanged: a batch failure with no comments to salvage still rethrows.
- `postPRReview`'s return type changed from `void` to `{ posted: number; dropped: Array<{ path, line, error }> }` so callers can observe the degradation. Both call sites in `engine.ts` were updated:
  - `postPluginInlineComments` now returns the *actual* posted/dropped counts (previously it optimistically assumed the whole batch landed).
  - The `postReviewComment` `PresentContext` callback (used for out-of-diff findings promoted to the review body) keeps its `Promise<void>` contract — it just awaits the result without restructuring the plugin-facing interface.

## Test coverage

`packages/review/src/github-api.ts` had zero test coverage. Added `packages/review/test/github-api.test.ts`:
- happy path: batch succeeds, no individual fallback calls
- batch fails → body posted alone + every comment retried individually, tallies correct
- batch fails **and** one individual comment still fails → that one lands in `dropped` with path/line, the other posts, no throw
- zero comments + batch failure → rethrows (preserves prior behavior)
- a few small `parsePatchLines` tests (exported for testing, previously untested)

## Verification

- `npm run test -w @liendev/review -- test/github-api.test.ts` — 7/7 passing
- Full gate chain from repo root: `format:check`, `lint` (0 errors), `typecheck`, `build`, `test` (all packages, 747/747 in review) all green
- `lien delta` — exit 0, no new complexity crossings (splitting the batch-failure retry loop into its own function kept `postPRReview` under threshold)
- No changeset added: `@liendev/review` is private/unpublished and has never carried a changeset in this repo's history

Closes #558

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +1 |


> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR fixes the silent inline-comment drop bug by salvaging individual comments after a 422 batch failure and reporting drops. The new fallback logic is well-scoped: only 422 validation errors trigger per-comment retries, other errors still propagate, and the zero-comments rethrow path is preserved. The main observable issue is a reporting blur in `postPluginInlineComments`, which adds API-dropped comments to the `skipped` tally instead of surfacing them separately. No callers are broken and no comments are silently discarded anymore.
>
> - postPRReview now posts the summary body alone then retries each comment individually on 422 batch failures, returning posted/dropped/bodyPosted
> - Non-422 failures and empty-comment failures still rethrow, avoiding masking auth/rate-limit/network errors
> - Invalid start_line values are stripped before posting with a warning
> - parsePatchLines is now exported and tested

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 22c1025. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request review comment delivery when batch posting fails.
  - Individual inline comments are now retried automatically, allowing successful comments to be posted even when others fail.
  - Review results now accurately report comments that could not be posted.
  - Invalid inline comment locations are excluded from submitted review payloads.
  - Improved handling of patch line parsing, including deleted lines and file headers.

- **Tests**
  - Added coverage for successful posting, fallback behavior, partial failures, and patch parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->