### PR TITLE
feat(review): harness preflight rejects assertions expecting inactive rules

### DIFF
--- a/packages/review/test/harness-rule-coverage.test.ts
+++ b/packages/review/test/harness-rule-coverage.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the harness's rule-coverage preflight (#742).
+ *
+ * Since #724, the agent's output format enumerates `ruleId` to the fixture's
+ * ACTIVE rule set only, so an `.assertions.ts` whose `rule` (and every
+ * `ruleCandidates` entry) is trigger-skipped is unpassable by construction —
+ * every paid vote against it is wasted OpenRouter spend. `checkRuleCoverage`
+ * is the pure decision logic; these tests cover it with zero network/LLM
+ * spend by hand-building `{ rule, ruleCandidates }` inputs and an active-rule
+ * id list, rather than replaying a real fixture through `selectRules`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { checkRuleCoverage } from './harness/rule-coverage.js';
+
+describe('checkRuleCoverage', () => {
+  it('passes when `rule` is in the active set', () => {
+    const result = checkRuleCoverage({ rule: 'boundary-change' }, [
+      'structural-analysis',
+      'boundary-change',
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('flags when `rule` is inactive and there are no ruleCandidates', () => {
+    const result = checkRuleCoverage({ rule: 'concurrency-race' }, ['structural-analysis']);
+    expect(result).not.toBeNull();
+  });
+
+  it('passes when `rule` is inactive but a ruleCandidates entry is active', () => {
+    const result = checkRuleCoverage(
+      { rule: 'boundary-change', ruleCandidates: ['boundary-change', 'edge-case-sweep'] },
+      ['structural-analysis', 'edge-case-sweep'],
+    );
+    expect(result).toBeNull();
+  });
+
+  it('flags when `rule` and every ruleCandidates entry are inactive', () => {
+    const result = checkRuleCoverage(
+      { rule: 'boundary-change', ruleCandidates: ['boundary-change', 'edge-case-sweep'] },
+      ['structural-analysis'],
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it('violation message names the expected rule, the active set, and is fixture-actionable', () => {
+    const result = checkRuleCoverage(
+      { rule: 'concurrency-race', ruleCandidates: ['error-swallowing'] },
+      ['structural-analysis', 'doc-truth'],
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain("rule 'concurrency-race'");
+    expect(result).toContain('ruleCandidates: [error-swallowing]');
+    expect(result).toContain('structural-analysis, doc-truth');
+    expect(result).toContain('#724');
+    expect(result).toMatch(/fix the assertion|fixture's trigger conditions/);
+  });
+
+  it('reports "(none)" for the active set when no rules are active at all', () => {
+    const result = checkRuleCoverage({ rule: 'doc-truth' }, []);
+    expect(result).toContain('(none)');
+  });
+});

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -43,6 +43,26 @@ npm run test:harness -w @liendev/review -- \
 An inline `OPENROUTER_API_KEY=…` still wins over the `.env` value if you want
 to override per-invocation (e.g., to test against a different account's quota).
 
+## Rule-coverage preflight (#742)
+
+Since #724, the agent's output format enumerates `ruleId` to the fixture's
+ACTIVE rule set only (see `buildOutputFormat` in `system-prompt.ts`) — a
+fixture whose assertion targets a trigger-skipped rule is unpassable by
+construction, and every paid vote against it is wasted money. Before `run.ts`
+casts any vote, it preflights the WHOLE discovered batch: for each fixture it
+computes the active rule set (the same `selectRules`/`buildTriggerContext`
+call `build-prompts.ts` uses) and checks it against the `.assertions.ts`'s
+`rule`. Any violation aborts the run with `exit 2` and prints every offending
+fixture — before fixture 1 has spent a cent.
+
+If a fixture's bug could plausibly be surfaced by more than one rule (e.g. an
+off-by-one caught by either `edge-case-sweep` or `boundary-change`, depending
+on trigger context), declare the extra rule ids in `ruleCandidates` alongside
+`rule` — the preflight passes if `rule` OR any `ruleCandidates` entry is
+active. See the `crossrepo/` fixtures for the pattern; pair with
+`expectAnyRuleFired` in a new `expect` closure rather than hand-rolling the
+OR check.
+
 ## Canary corpus
 
 One captured fixture per `BUILTIN_RULES` rule, all from closed planted-regression

--- a/packages/review/test/harness/assertions.ts
+++ b/packages/review/test/harness/assertions.ts
@@ -71,6 +71,26 @@ export function expectRuleFired(ruleId: string, result: HarnessResult): void {
   }
 }
 
+/**
+ * Pass if ANY of the named rules fired. Use when a bug could plausibly be
+ * surfaced by more than one rule (e.g. an off-by-one index caught by either
+ * `edge-case-sweep` or `boundary-change` depending on which one is active
+ * for a given fixture's trigger context) — asserting on a single rule id
+ * fails correct runs where a sibling rule reasonably fires instead. Pair
+ * with `FixtureAssertions.ruleCandidates` so the harness's rule-coverage
+ * preflight (`rule-coverage.ts`) recognizes the OR-across-rules intent.
+ */
+export function expectAnyRuleFired(ruleIds: string[], result: HarnessResult): void {
+  const fired = result.findings.some(f => f.ruleId && ruleIds.includes(f.ruleId));
+  if (!fired) {
+    const observed = result.findings.map(f => f.ruleId ?? '(none)').join(', ') || '(no findings)';
+    throw new HarnessAssertionError(
+      `Tier 1: expected any of [${ruleIds.join(', ')}] to fire. Got: ${observed}`,
+      1,
+    );
+  }
+}
+
 export function expectEmpty(result: HarnessResult): void {
   if (result.findings.length > 0) {
     throw new HarnessAssertionError(
@@ -157,6 +177,7 @@ export function expectFindingMentions(keywords: string[], result: HarnessResult)
 
 export const harness = {
   expectRuleFired,
+  expectAnyRuleFired,
   expectEmpty,
   expectFindingsCount,
   expectToolCalled,
@@ -173,4 +194,14 @@ export interface FixtureAssertions {
   votes?: number;
   passThreshold?: number;
   tags?: string[];
+  /**
+   * Additional rule ids under which a correct finding is also accepted —
+   * for fixtures whose `expect` closure checks `rule` OR one of these
+   * (e.g. a bug that several rules could plausibly surface). Declaring the
+   * candidates here lets the harness's rule-coverage preflight
+   * (`rule-coverage.ts`) recognize the closure's OR-across-rules logic
+   * instead of false-flagging `rule` as unpassable whenever it isn't the
+   * active rule that happens to fire.
+   */
+  ruleCandidates?: string[];
 }

--- a/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.assertions.ts
@@ -86,6 +86,7 @@ const assertions: FixtureAssertions = {
     '%-formatting without re.escape(), so a boundary containing a regex metacharacter (e.g. trailing ' +
     '$, or ., +, (, )) is misinterpreted as regex syntax and breaks parsing of that request',
   rule: 'edge-case-sweep',
+  ruleCandidates: ['edge-case-sweep', 'structural-analysis'],
   expect: (result, h) => {
     const ruleCandidates = ['edge-case-sweep', 'structural-analysis'];
     if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {

--- a/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.assertions.ts
@@ -95,6 +95,7 @@ const assertions: FixtureAssertions = {
     "(each one index too low, colliding with the preceding parameter's slot) instead of " +
     'args[3]/args[4]/args[5], silently scrambling which value lands in which parameter',
   rule: 'boundary-change',
+  ruleCandidates: ['boundary-change', 'edge-case-sweep', 'structural-analysis'],
   expect: (result, h) => {
     const ruleCandidates = ['boundary-change', 'edge-case-sweep', 'structural-analysis'];
     if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {

--- a/packages/review/test/harness/fixtures/crossrepo/pr2334-etag-weak-indicator-strip.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2334-etag-weak-indicator-strip.assertions.ts
@@ -95,6 +95,7 @@ const assertions: FixtureAssertions = {
     'as a character set, not a literal prefix, so tags ending in W, /, or space get ' +
     'over-trimmed instead of just having the W/ prefix removed',
   rule: 'edge-case-sweep',
+  ruleCandidates: ['edge-case-sweep', 'boundary-change', 'structural-analysis'],
   expect: (result, h) => {
     const ruleCandidates = ['edge-case-sweep', 'boundary-change', 'structural-analysis'];
     if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {

--- a/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.assertions.ts
@@ -83,6 +83,7 @@ const assertions: FixtureAssertions = {
     'absolute index (data_end/del_index) into the unsliced data buffer, truncating parsed data short ' +
     'whenever data_start > 0 and leaking a spurious newline into the next chunk',
   rule: 'edge-case-sweep',
+  ruleCandidates: ['edge-case-sweep', 'structural-analysis', 'boundary-change'],
   expect: (result, h) => {
     const ruleCandidates = ['edge-case-sweep', 'structural-analysis', 'boundary-change'];
     if (!result.findings.some(f => f.ruleId && ruleCandidates.includes(f.ruleId))) {

--- a/packages/review/test/harness/rule-coverage.ts
+++ b/packages/review/test/harness/rule-coverage.ts
@@ -1,0 +1,40 @@
+/**
+ * Preflight check: does a fixture's assertion target a rule that is even
+ * active for that fixture's trigger context?
+ *
+ * Since #724, the agent's output format enumerates `ruleId` to the fixture's
+ * ACTIVE rule set only (see `buildOutputFormat` in
+ * `../../src/plugins/agent/system-prompt.ts`) — the model cannot emit a
+ * finding tagged with a skipped rule's id even if it correctly spots the bug.
+ * An `.assertions.ts` whose `rule` (and every `ruleCandidates` entry) is
+ * trigger-skipped is therefore unpassable by construction: every paid vote
+ * against it is wasted OpenRouter spend. This module is the pure decision
+ * logic; `run.ts` wires it into a preflight that runs before any API call.
+ */
+
+import type { FixtureAssertions } from './assertions.js';
+
+/**
+ * Returns a human-actionable message when neither `assertions.rule` nor any
+ * of `assertions.ruleCandidates` is in `activeRuleIds`, or `null` when the
+ * fixture's assertion is passable.
+ */
+export function checkRuleCoverage(
+  assertions: Pick<FixtureAssertions, 'rule' | 'ruleCandidates'>,
+  activeRuleIds: string[],
+): string | null {
+  const candidates = [assertions.rule, ...(assertions.ruleCandidates ?? [])];
+  if (candidates.some(id => activeRuleIds.includes(id))) return null;
+
+  const active = activeRuleIds.length > 0 ? activeRuleIds.join(', ') : '(none)';
+  const candidateList =
+    assertions.ruleCandidates && assertions.ruleCandidates.length > 0
+      ? ` (also checked ruleCandidates: [${assertions.ruleCandidates.join(', ')}])`
+      : '';
+  return (
+    `fixture expects rule '${assertions.rule}'${candidateList} but the active rule set for ` +
+    `this fixture's trigger context is [${active}]; unpassable since #724 (agent output is ` +
+    `enumerated to active rules only) — fix the assertion's rule/ruleCandidates or the ` +
+    `fixture's trigger conditions`
+  );
+}

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -28,11 +28,15 @@ import { promises as fs } from 'node:fs';
 import { dirname, basename, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../../src/plugins/agent/rules.js';
+
 import type { FixtureAssertions } from './assertions.js';
 import { vote, calibrate } from './voting.js';
 import type { AssertedRun } from './voting.js';
 import type { RunnerOptions } from './runner.js';
 import { reportVote, reportCalibrate } from './reporter.js';
+import { loadFixture } from './fixture-loader.js';
+import { checkRuleCoverage } from './rule-coverage.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_ROOT = resolve(HERE, 'fixtures');
@@ -227,6 +231,38 @@ async function loadAssertions(path: string): Promise<FixtureAssertions> {
   return mod.default;
 }
 
+/**
+ * Preflight the WHOLE discovered batch before any fixture runs, so a bad
+ * assertion in fixture N is caught before fixtures 1..N-1 have already spent
+ * OpenRouter money. Returns one human-readable violation per offending
+ * fixture (a load failure counts as a violation of its own); an empty array
+ * means every fixture's assertion targets a rule that's actually active for
+ * its trigger context. See `rule-coverage.ts` for the #724 background.
+ */
+async function validateFixtureRuleCoverage(fixtures: FixturePair[]): Promise<string[]> {
+  const violations: string[] = [];
+  for (const f of fixtures) {
+    const label = `${f.rule}/${f.name}`;
+    try {
+      const [assertions, ctx] = await Promise.all([
+        loadAssertions(f.assertionsPath),
+        loadFixture(f.fixturePath),
+      ]);
+      const activeRuleIds = selectRules(BUILTIN_RULES, buildTriggerContext(ctx)).active.map(
+        r => r.id,
+      );
+      const violation = checkRuleCoverage(assertions, activeRuleIds);
+      if (violation) violations.push(`${label}: ${violation}`);
+    } catch (err) {
+      violations.push(
+        `${label}: failed to load for rule-coverage preflight — ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+  }
+  return violations;
+}
+
 function requireApiKey(): string {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) {
@@ -345,6 +381,17 @@ function printSummary(
   }
 }
 
+/** Exits the process (code 2) if any discovered fixture fails the rule-coverage preflight. */
+async function abortOnRuleCoverageViolations(fixtures: FixturePair[]): Promise<void> {
+  const violations = await validateFixtureRuleCoverage(fixtures);
+  if (violations.length === 0) return;
+  console.error(
+    `Rule-coverage preflight failed for ${violations.length} fixture(s) — aborting before any paid votes:`,
+  );
+  for (const v of violations) console.error(`  - ${v}`);
+  process.exit(2);
+}
+
 async function main(): Promise<void> {
   const flags = parseFlags(process.argv.slice(2));
   const apiKey = requireApiKey();
@@ -353,6 +400,7 @@ async function main(): Promise<void> {
     console.error('No fixtures found.');
     process.exit(2);
   }
+  await abortOnRuleCoverageViolations(fixtures);
 
   const opts: RunnerOptions = { apiKey, model: flags.model };
   if (flags.model) console.error(`[harness] model: ${flags.model}`);


### PR DESCRIPTION
## Problem

Since #724, the agent-review plugin's output format enumerates `ruleId` to a fixture's *active* rule set only (`buildOutputFormat` in `packages/review/src/plugins/agent/system-prompt.ts`). Consequently an `.assertions.ts` whose `rule` (or every entry in `ruleCandidates`) is trigger-skipped for that fixture is unpassable by construction — the model literally cannot emit a finding tagged with a rule id that isn't active. Every `--votes`/`--calibrate` run against such a fixture burns real OpenRouter spend before failing, and the failure looks like a flaky prompt rather than a structurally-impossible assertion.

## Fix

`run.ts` now preflights the *whole* discovered fixture batch before casting a single vote:

- For each fixture, compute the active rule set the same way `build-prompts.ts` does today (`selectRules(BUILTIN_RULES, buildTriggerContext(ctx))`).
- `checkRuleCoverage` (new, pure, in `packages/review/test/harness/rule-coverage.ts`) checks whether the assertion's `rule` — or any of its new optional `ruleCandidates` — is in that active set.
- Any violation across the batch aborts with `exit 2`, printing every offending fixture, before the first API call (mirrors the existing zero-fixtures `exit 2`).
- A fixture that fails to load surfaces as its own clear violation message instead of crashing the whole preflight.

### `ruleCandidates`

The four `crossrepo/` fixtures hand-roll OR-across-rules logic inside their `expect` closures (a bug that several rules could plausibly surface, e.g. `edge-case-sweep` *or* `boundary-change` depending on trigger context). A naive rule-coverage check would false-positive on all four, since `assertions.rule` only names one. Added the optional `ruleCandidates?: string[]` field to `FixtureAssertions` and set it on each of the four fixtures to match their existing in-closure candidate list **byte-for-byte** — field addition only, no change to any `expect` closure or other logic. `pr2191` is a certified canary (10/10 `--calibrate`); its assertion behavior is unchanged.

Also added `expectAnyRuleFired` next to `expectRuleFired` (mirroring `expectAnyToolCalled`) so future fixtures can declare this OR-across-rules pattern instead of hand-rolling it — not retrofitted into the existing four.

## Tests

- `packages/review/test/harness-rule-coverage.test.ts` — zero-LLM unit tests for `checkRuleCoverage`: rule active → pass, rule inactive with no candidates → violation, rule inactive but a candidate active → pass, rule and all candidates inactive → violation, plus assertions on the violation message's actionable phrasing and the "(none)" active-set case.
- Sanity-checked the preflight's actual composition (`loadFixture` → `buildTriggerContext` → `selectRules` → `checkRuleCoverage`) offline against two real `crossrepo/` fixtures (no network/LLM calls) — both pass as expected, and a synthetic bad-rule-name input correctly produces a violation.
- Full gate chain green: `format:check`, `lint` (0 errors), `typecheck` (incl. `typecheck:harness`), `build`, `npm test` (all workspaces, 2996 tests), `lien delta` (exit 0 — new functions well under complexity thresholds).

Closes #742

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a focused test-harness preflight that rejects fixtures whose assertions target rules that are inactive for the fixture's trigger context, preventing wasted OpenRouter votes on unpassable assertions. The core logic is a small pure helper (`checkRuleCoverage`) with dedicated unit tests, and it is wired into `run.ts` before any API calls. The optional `ruleCandidates` field and `expectAnyRuleFired` helper correctly model OR-across-rules assertions without changing existing fixture behavior. No production review code is affected.
>
> - New `checkRuleCoverage` pure helper in `packages/review/test/harness/rule-coverage.ts` with unit tests
> - Preflight in `run.ts` aborts with exit 2 before any paid votes when fixtures target inactive rules
> - Optional `ruleCandidates` field on `FixtureAssertions` and `expectAnyRuleFired` helper for OR-across-rules assertions

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ae109d5. Updates automatically on new commits.</sup>
<!-- /lien-stats -->