### PR TITLE
fix(review): stop surfacing whole-repo complexity findings on PRs with no analyzable files

### DIFF
--- a/packages/review/src/plugins/complexity.ts
+++ b/packages/review/src/plugins/complexity.ts
@@ -44,7 +44,14 @@ export class ComplexityPlugin implements ReviewPlugin {
   async analyze(context: ReviewContext): Promise<ReviewFinding[]> {
     const { complexityReport, deltas, logger } = context;
 
-    const allViolations = Object.values(complexityReport.files).flatMap(f => f.violations);
+    // On the normal path, complexityReport.files is already scoped to the PR's
+    // analyzable files. On the full-repo fallback path (PR touches zero
+    // analyzable files), complexityReport covers the whole repo — scope here
+    // so pre-existing violations elsewhere don't surface as PR findings.
+    const scopedFiles = new Set(context.allChangedFiles ?? context.changedFiles);
+    const allViolations = Object.values(complexityReport.files)
+      .flatMap(f => f.violations)
+      .filter(v => scopedFiles.has(v.filepath));
     const violations = prioritizeViolations(allViolations, complexityReport);
     logger.info(`Complexity plugin: ${violations.length} violations to review`);
 

--- a/packages/review/src/plugins/complexity.ts
+++ b/packages/review/src/plugins/complexity.ts
@@ -62,8 +62,19 @@ export class ComplexityPlugin implements ReviewPlugin {
   async present(findings: ReviewFinding[], context: PresentContext): Promise<void> {
     context.appendSummary(buildComplexitySummary(findings, context));
 
+    // `findings` is this plugin's own analyze() output, already scoped to the
+    // PR's changed files (see analyze() above). If the underlying report has
+    // more violations than made it into findings, analyze() must have filtered
+    // out-of-scope ones — i.e. this is the full-repo fallback report (#572),
+    // and the badge shouldn't claim those counts are "in touched files".
+    const isRepoWide = findings.length < (context.complexityReport?.summary.totalViolations ?? 0);
     context.appendDescription(
-      buildComplexityStatus(context.complexityReport, context.deltaSummary, context.deltas),
+      buildComplexityStatus(
+        context.complexityReport,
+        context.deltaSummary,
+        context.deltas,
+        isRepoWide,
+      ),
       'complexity',
     );
 

--- a/packages/review/src/prompt.ts
+++ b/packages/review/src/prompt.ts
@@ -337,12 +337,27 @@ export function getViolationKey(violation: ComplexityViolation): string {
 }
 
 /**
+ * Where the pre-existing-violation count in the status message applies:
+ * scoped to the files this PR touched, or the whole repo (the full-repo
+ * fallback report used when a PR has zero analyzable files — see #572).
+ */
+function scopeLabel(isRepoWide: boolean): string {
+  return isRepoWide ? 'repo-wide' : 'in touched files';
+}
+
+/**
  * Determine human-friendly status message based on violations and delta.
  * Prioritizes positive messaging when PR improves complexity.
+ *
+ * @param isRepoWide - True when `report` is the full-repo fallback scan (PR
+ *   touched zero analyzable files) rather than one scoped to the PR's changed
+ *   files. Changes the wording from "in touched files" to "repo-wide" so the
+ *   badge doesn't misattribute repo-wide violations to this PR.
  */
 function determineStatus(
   report: ComplexityReport | null,
   deltaSummary: DeltaSummary | null,
+  isRepoWide = false,
 ): { emoji: string; message: string } {
   const violations = report?.summary.totalViolations ?? 0;
   const errors = report?.summary.bySeverity.error ?? 0;
@@ -355,7 +370,7 @@ function determineStatus(
     if (preExisting > 0) {
       return {
         emoji: '✅',
-        message: `**Improved!** Complexity reduced by ${Math.abs(delta)}. ${preExisting} pre-existing issue${preExisting === 1 ? '' : 's'} remain${preExisting === 1 ? 's' : ''} in touched files.`,
+        message: `**Improved!** Complexity reduced by ${Math.abs(delta)}. ${preExisting} pre-existing issue${preExisting === 1 ? '' : 's'} remain${preExisting === 1 ? 's' : ''} ${scopeLabel(isRepoWide)}.`,
       };
     }
     return {
@@ -383,7 +398,7 @@ function determineStatus(
   if (violations > 0) {
     return {
       emoji: '➡️',
-      message: `**Stable** - ${preExisting} pre-existing issue${preExisting === 1 ? '' : 's'} in touched files (none introduced).`,
+      message: `**Stable** - ${preExisting} pre-existing issue${preExisting === 1 ? '' : 's'} ${scopeLabel(isRepoWide)} (none introduced).`,
     };
   }
 
@@ -485,13 +500,17 @@ function buildImpactSummary(report: ComplexityReport | null): string {
 /**
  * Build complexity status content (no heading, no footer).
  * Used as a content fragment for the unified PR description section.
+ *
+ * @param isRepoWide - See `determineStatus`. Defaults to false (the normal,
+ *   PR-scoped path) so existing callers are unaffected.
  */
 export function buildComplexityStatus(
   report: ComplexityReport | null,
   deltaSummary: DeltaSummary | null,
   deltas: ComplexityDelta[] | null,
+  isRepoWide = false,
 ): string {
-  const status = determineStatus(report, deltaSummary);
+  const status = determineStatus(report, deltaSummary, isRepoWide);
   const metricTable = buildMetricTable(report, deltas);
   const impactSummary = buildImpactSummary(report);
 

--- a/packages/review/test/plugins-complexity.test.ts
+++ b/packages/review/test/plugins-complexity.test.ts
@@ -31,11 +31,47 @@ describe('ComplexityPlugin', () => {
       { filepath: 'b.ts', symbolName: 'fnB', complexity: 25, threshold: 15, severity: 'error' },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts', 'b.ts'] }),
+    );
     expect(findings).toHaveLength(2);
     expect(findings[0].pluginId).toBe('complexity');
     const severities = findings.map(f => f.severity).sort();
     expect(severities).toEqual(['error', 'warning']);
+  });
+
+  it('scopes findings to PR files on the full-repo fallback path (#572)', async () => {
+    // Simulates the fallback: a PR that touched zero analyzable files (e.g. docs-only)
+    // still gets a full-repo complexity report for the stats badge, but none of those
+    // pre-existing violations belong to this PR.
+    const report = createTestReport([
+      { filepath: 'unrelated/a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },
+      { filepath: 'unrelated/b.ts', symbolName: 'fnB', complexity: 25, threshold: 15 },
+    ]);
+
+    const findings = await plugin.analyze(
+      createTestContext({
+        complexityReport: report,
+        changedFiles: [],
+        allChangedFiles: ['README.md'],
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('normal-path equivalence: report scoped to changedFiles produces identical findings', async () => {
+    const report = createTestReport([
+      { filepath: 'a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },
+      { filepath: 'b.ts', symbolName: 'fnB', complexity: 25, threshold: 15, severity: 'error' },
+    ]);
+
+    const scoped = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts', 'b.ts'] }),
+    );
+    const unscoped = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts', 'b.ts', 'c.ts'] }),
+    );
+    expect(scoped).toEqual(unscoped);
   });
 
   it('uses per-metric messages for cyclomatic violations', async () => {
@@ -49,7 +85,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     expect(findings[0].message).toContain('branches');
     expect(findings[0].message).toContain('20 tests');
   });
@@ -65,7 +103,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     expect(findings[0].message).toContain('cognitive complexity 20');
     expect(findings[0].message).toContain('early returns');
   });
@@ -81,7 +121,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     expect(findings[0].message).toContain('to understand');
     expect(findings[0].message).toContain('readability');
   });
@@ -97,7 +139,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     expect(findings[0].message).toContain('bug density');
     expect(findings[0].message).toContain('error likelihood');
   });
@@ -113,7 +157,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     expect(findings[0].metadata).toEqual({
       pluginType: 'complexity',
       metricType: 'cognitive',
@@ -130,7 +176,9 @@ describe('ComplexityPlugin', () => {
       { filepath: 'b.ts', symbolName: 'fnB', complexity: 30, threshold: 15, severity: 'error' },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts', 'b.ts'] }),
+    );
 
     const addAnnotations = vi.fn();
     const ctx = {
@@ -179,7 +227,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     expect(findings).toHaveLength(2);
 
     const addAnnotations = vi.fn();
@@ -217,7 +267,9 @@ describe('ComplexityPlugin', () => {
       },
     ]);
 
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     const addAnnotations = vi.fn();
     const ctx = {
       addAnnotations,
@@ -242,7 +294,9 @@ describe('ComplexityPlugin', () => {
         severity: 'warning',
       },
     ]);
-    const findings = await plugin.analyze(createTestContext({ complexityReport: report }));
+    const findings = await plugin.analyze(
+      createTestContext({ complexityReport: report, changedFiles: ['a.ts'] }),
+    );
     const appendSummary = vi.fn();
     await plugin.present(findings, {
       addAnnotations: vi.fn(),

--- a/packages/review/test/plugins-complexity.test.ts
+++ b/packages/review/test/plugins-complexity.test.ts
@@ -59,6 +59,40 @@ describe('ComplexityPlugin', () => {
     expect(findings).toHaveLength(0);
   });
 
+  it('present() reports the stats badge as repo-wide, not "in touched files", on the full-repo fallback path (#572)', async () => {
+    // Same fallback scenario as above, but this time asserting the PR-description
+    // badge itself doesn't claim the pre-existing violations are "in touched files"
+    // when the PR touched none of them.
+    const report = createTestReport([
+      { filepath: 'unrelated/a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },
+      { filepath: 'unrelated/b.ts', symbolName: 'fnB', complexity: 25, threshold: 15 },
+    ]);
+
+    const findings = await plugin.analyze(
+      createTestContext({
+        complexityReport: report,
+        changedFiles: [],
+        allChangedFiles: ['README.md'],
+      }),
+    );
+
+    const appendDescription = vi.fn();
+    const ctx = {
+      complexityReport: report,
+      deltaSummary: null,
+      deltas: null,
+      addAnnotations: vi.fn(),
+      appendSummary: vi.fn(),
+      appendDescription,
+    } as unknown as PresentContext;
+    await plugin.present(findings, ctx);
+
+    expect(appendDescription).toHaveBeenCalledTimes(1);
+    const badge: string = appendDescription.mock.calls[0][0];
+    expect(badge).toContain('repo-wide');
+    expect(badge).not.toContain('in touched files');
+  });
+
   it('normal-path equivalence: report scoped to changedFiles produces identical findings', async () => {
     const report = createTestReport([
       { filepath: 'a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },

--- a/packages/review/test/prompt.test.ts
+++ b/packages/review/test/prompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildComplexityStatus } from '../src/prompt.js';
+import { createTestReport } from '../src/test-helpers.js';
+
+describe('buildComplexityStatus', () => {
+  it('says "in touched files" for a normal, PR-scoped report', () => {
+    const report = createTestReport([
+      { filepath: 'a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },
+      { filepath: 'b.ts', symbolName: 'fnB', complexity: 25, threshold: 15 },
+    ]);
+
+    const status = buildComplexityStatus(report, null, null);
+    expect(status).toContain('2 pre-existing issues in touched files');
+    expect(status).not.toContain('repo-wide');
+  });
+
+  it('says "repo-wide" instead of "in touched files" when the report covers files beyond the PR (#572 fallback)', () => {
+    const report = createTestReport([
+      { filepath: 'unrelated/a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },
+      { filepath: 'unrelated/b.ts', symbolName: 'fnB', complexity: 25, threshold: 15 },
+    ]);
+
+    const status = buildComplexityStatus(report, null, null, true);
+    expect(status).toContain('2 pre-existing issues repo-wide');
+    expect(status).not.toContain('in touched files');
+  });
+
+  it('defaults to the "in touched files" wording when isRepoWide is omitted', () => {
+    const report = createTestReport([
+      { filepath: 'a.ts', symbolName: 'fnA', complexity: 20, threshold: 15 },
+    ]);
+
+    const status = buildComplexityStatus(report, null, null);
+    expect(status).toContain('in touched files');
+  });
+});


### PR DESCRIPTION
## Repro (from #572)

A docs-only PR (or any PR touching zero complexity-analyzable files) with summary enabled surfaced 77 complexity findings/annotations — none belonging to files the PR touched. The issue cites #568, #570, and #571 as prior examples.

Live repro on this repo tonight: #751 deletes only the root `.npmrc` (zero analyzable files), yet its `lien-stats` block reported "➡️ Stable - 92 pre-existing issues in touched files (none introduced). Impact: 12 high-risk file(s) with 452 total dependents" (commit `3b853a0`) — the full-repo fallback scan leaking whole-repo violations into a config-only PR's stats, same root cause as the findings/annotations noise this PR fixes.

## Root cause

When a PR touches zero complexity-analyzable files and summary is enabled, `runAnalysisPhase` (`packages/review/src/review-pr.ts`, ~line 431) falls back to a full-repo complexity scan and returns it as `currentReport` (with `chunks: []`). `ComplexityPlugin.analyze` (`packages/review/src/plugins/complexity.ts:47`) then did `Object.values(complexityReport.files).flatMap(f => f.violations)` — every pre-existing violation in the repo became a finding/annotation on a PR that touched none of those files.

The full-repo report exists only to feed the repo-wide stats badge (`buildComplexityStatus`, called from `present()`) — that part is by design and is untouched by the findings/annotations fix below. Its *wording* was still wrong, though — see "Follow-up" below.

## Fix

Scope `ComplexityPlugin.analyze` to `context.allChangedFiles ?? context.changedFiles` before flattening violations — the same fallback idiom already used in `plugins/agent/rules.ts:66`.

- **Normal path**: `complexityReport.files` keys are already a subset of `changedFiles` (verified: `runComplexityAnalysis` filters to `filesToAnalyze`, and `analyzeComplexityFromChunks` filters chunks to those files), so this scoping is a provable no-op — added a dedicated equivalence test proving identical findings before/after.
- **Fallback path**: `changedFiles` is empty and `allChangedFiles` contains only non-analyzable files (e.g. `README.md`), so none of the full-repo violations match — findings correctly drop to zero.
- `present()` / `buildComplexityStatus` is untouched — the repo-wide stats badge stays repo-wide, as intended.
- `shouldActivate` still keys off `complexityReport.summary.totalViolations`, so on an all-out-of-scope fallback report the plugin still activates and `present()` now correctly writes "✅ No complexity violations found." — accurate for a PR that introduced no analyzable code.

## Tests

Added to `packages/review/test/plugins-complexity.test.ts`:
- A failing-first test (`scopes findings to PR files on the full-repo fallback path (#572)`) reproducing the issue — confirmed it failed against pre-fix code (2 findings instead of 0), now passes.
- A normal-path equivalence test proving the scoping is a no-op when the report is already scoped to `changedFiles`.
- Updated all pre-existing `analyze()`-calling tests to pass a matching `changedFiles`, since they previously relied on no scoping being applied.

## Follow-up: honest badge wording (#751 live repro)

The findings/annotations fix above deliberately left `buildComplexityStatus` untouched — its repo-wide numbers are correct by design. But its copy wasn't: on the same full-repo-fallback path, the badge said "N pre-existing issues **in touched files**", which is false when the PR touched none of them. #751 on this repo is a live example: it deletes only the root `.npmrc` (zero analyzable files) yet its badge read "➡️ Stable - 92 pre-existing issues in touched files (none introduced)."

Fix: `determineStatus`/`buildComplexityStatus` (`packages/review/src/prompt.ts`) now take an `isRepoWide` flag (default `false`, so existing callers are unaffected) and say "repo-wide" instead of "in touched files" in both branches that used the phrase. `ComplexityPlugin.present()` derives `isRepoWide` locally with no new plumbing: `findings.length` (this plugin's own already-scoped `analyze()` output) versus `context.complexityReport.summary.totalViolations` (the full report's count) — if `analyze()` had to filter anything out of scope, the two diverge, which is the same fallback signal. This avoids widening `PresentContext`/`AdapterContext` (which would have rippled into the terminal and SARIF adapters too).

New `packages/review/test/prompt.test.ts` pins `buildComplexityStatus`'s wording on both paths (confirmed failing pre-fix); a new `ComplexityPlugin` test in `plugins-complexity.test.ts` pins the same behavior through `present()`'s `appendDescription` call, reproducing #751's exact scenario.

## Verification

- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green (0 lint errors, all packages passing, no regressions) after both commits.
- `lien delta` — exit 0 after both commits (only "worsened" notes on touched functions' Halstead time estimates from the added logic, plus one new trivial helper; no threshold crossings).

Part of #572 — the other half of that issue (agent summary never firing on docs-only PRs) is intentionally out of scope here; see the tracking comment on the issue for that root cause.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a bug where docs-only or config-only PRs surfaced whole-repo complexity findings by scoping `ComplexityPlugin.analyze` to the PR's changed files (`allChangedFiles ?? changedFiles`) and updating the status wording to 'repo-wide' when the underlying report is repo-wide. The change is well-contained: the normal path remains a no-op because the report is already scoped to changed files, the fallback path correctly drops unrelated violations, and the repo-wide stats badge path is preserved. Tests cover both the fallback zero-finding case and normal-path equivalence.
>
> - ComplexityPlugin.analyze now filters violations by context.allChangedFiles ?? context.changedFiles before prioritization
> - present() detects repo-wide reports via a findings-count heuristic and passes isRepoWide to buildComplexityStatus
> - buildComplexityStatus/determineStatus switch wording from 'in touched files' to 'repo-wide' when isRepoWide is true

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6ec59d6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

