### PR TITLE
fix(cli): expose repoId in metadata for find_similar, get_files_context, list_functions (#103)

### DIFF
--- a/packages/cli/src/mcp/utils/metadata-shaper.test.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.test.ts
@@ -22,6 +22,7 @@ function createFullResult(): SearchResult {
       importedSymbols: { './utils': ['helper'] },
       callSites: [{ symbol: 'helper', line: 5 }],
       symbols: { functions: ['example'], classes: [], interfaces: [] },
+      repoId: 'repo-a',
       complexity: 3,
       cognitiveComplexity: 2,
       halsteadVolume: 100,
@@ -51,6 +52,7 @@ describe('shapeResultMetadata', () => {
     expect(m.parentClass).toBe('ExampleClass');
     expect(m.parameters).toEqual(['a', 'b']);
     expect(m.exports).toEqual(['example']);
+    expect(m.repoId).toBe('repo-a');
 
     // Stripped — only allowed keys should be present
     const keys = Object.keys(m);
@@ -67,6 +69,7 @@ describe('shapeResultMetadata', () => {
     const m = result.metadata;
 
     expect(m.exports).toEqual(['example']);
+    expect(m.repoId).toBe('repo-a');
     const keys = Object.keys(m);
     expect(keys).not.toContain('imports');
     expect(keys).not.toContain('callSites');
@@ -84,6 +87,7 @@ describe('shapeResultMetadata', () => {
     expect(m.callSites).toEqual([{ symbol: 'helper', line: 5 }]);
     expect(m.exports).toEqual(['example']);
     expect(m.symbols).toEqual({ functions: ['example'], classes: [], interfaces: [] });
+    expect(m.repoId).toBe('repo-a');
 
     // Stripped
     const keys = Object.keys(m);
@@ -98,6 +102,7 @@ describe('shapeResultMetadata', () => {
     // Kept
     expect(m.symbols).toEqual({ functions: ['example'], classes: [], interfaces: [] });
     expect(m.exports).toEqual(['example']);
+    expect(m.repoId).toBe('repo-a');
 
     // Stripped
     const keys = Object.keys(m);
@@ -105,6 +110,20 @@ describe('shapeResultMetadata', () => {
     expect(keys).not.toContain('callSites');
     expect(keys).not.toContain('complexity');
     expect(keys).not.toContain('halsteadEffort');
+  });
+
+  it.each<[import('./metadata-shaper.js').ToolName]>([
+    ['search_code'],
+    ['find_similar'],
+    ['get_files_context'],
+    ['list_functions'],
+  ])('%s: omits repoId key entirely in single-repo mode (not present at all)', tool => {
+    const result = createFullResult();
+    delete (result.metadata as { repoId?: string }).repoId;
+
+    const shaped = shapeResultMetadata(result, tool);
+    expect(Object.keys(shaped.metadata)).not.toContain('repoId');
+    expect(shaped.metadata.repoId).toBeUndefined();
   });
 
   it('preserves content, score, and relevance', () => {

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -80,6 +80,7 @@ const FIELD_ALLOWLISTS: Record<ToolName, ReadonlySet<AllowlistKey>> = {
     'parentClass',
     'parameters',
     'exports',
+    'repoId',
   ]),
   get_files_context: new Set<AllowlistKey>([
     'language',
@@ -94,6 +95,7 @@ const FIELD_ALLOWLISTS: Record<ToolName, ReadonlySet<AllowlistKey>> = {
     'importedSymbols',
     'callSites',
     'symbols',
+    'repoId',
   ]),
   list_functions: new Set<AllowlistKey>([
     'language',
@@ -105,6 +107,7 @@ const FIELD_ALLOWLISTS: Record<ToolName, ReadonlySet<AllowlistKey>> = {
     'parameters',
     'exports',
     'symbols',
+    'repoId',
   ]),
 };
 


### PR DESCRIPTION
## Summary
- In cross-repo MCP mode, `search_code` results include `repoId` in chunk metadata, but `find_similar`, `get_files_context`, and `list_functions` strip it via their per-tool allowlist in `metadata-shaper.ts`, so consumers can't tell which repo a result came from.
- Adds `repoId` to those three tools' allowlists (`search_code` already had it). Purely additive: `repoId` is only present in raw metadata in cross-repo mode, so single-repo consumers see no change.

## Why
Without this, an LLM using these tools in a multi-repo setup may suggest edits to the wrong file when identical relative paths exist across repos.

Closes #103

## Test plan
- [x] Added failing tests first (`find_similar`, `get_files_context`, `list_functions` each asserting `repoId` passes through) — confirmed all 3 failed pre-fix.
- [x] Added a parameterized test asserting `repoId` is omitted entirely (not present as an `undefined`-valued key) for all four tools in single-repo mode.
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` all green.
- [x] `node packages/cli/dist/index.js delta` — exit 0 (only an advisory "worsened" note on a test fixture, no new threshold crossing).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds `repoId` to the metadata allowlists for `find_similar`, `get_files_context`, and `list_functions` so cross-repo MCP results preserve repository provenance. The change is purely additive: `repoId` already existed on the output interface and is omitted entirely when undefined (single-repo mode) because `cleanMetadataValue` strips undefined values. The existing `deduplicateResults` function already incorporated `repoId` in its key. Tests cover both the pass-through and omission behaviors for all four tools.
>
> - Added `repoId` to `FIELD_ALLOWLISTS` for `find_similar`, `get_files_context`, and `list_functions`
> - Added tests verifying `repoId` passes through in cross-repo mode and is omitted entirely in single-repo mode for all four tools

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b18d2e2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->