### PR TITLE
refactor(parser,cli): single source of truth for re-export intersection logic

### DIFF
--- a/.changeset/dedupe-reexport-intersection.md
+++ b/.changeset/dedupe-reexport-intersection.md
@@ -1,0 +1,6 @@
+---
+'@liendev/parser': patch
+'@liendev/lien': patch
+---
+
+refactor: single source of truth for re-export intersection logic

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -1,6 +1,7 @@
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 import {
   findTransitiveDependents,
+  findReExportedSymbolsForFile,
   normalizePath,
   matchesFile,
   getCanonicalPath,
@@ -114,87 +115,15 @@ interface ReExporter {
 }
 
 /**
- * Collect named symbols from a chunk's importedSymbols that match the target path.
- */
-function collectNamedSymbolsFromChunk(
-  chunk: SearchResult,
-  normalizedTarget: string,
-  normalizePathCached: (path: string) => string,
-  symbols: Set<string>,
-): void {
-  const importedSymbols = chunk.metadata.importedSymbols;
-  if (!importedSymbols || typeof importedSymbols !== 'object') return;
-  for (const [importPath, syms] of Object.entries(importedSymbols)) {
-    if (matchesFile(normalizePathCached(importPath), normalizedTarget)) {
-      for (const sym of syms) symbols.add(sym);
-    }
-  }
-}
-
-/**
- * Collect symbols imported from a target path across all chunks of a file,
- * sourced exclusively from `importedSymbols`.
- *
- * We deliberately do NOT fall back to the raw `imports` array to synthesize a
- * `'*'` sentinel. Doing so flagged any file that raw-imports the target AND
- * exports anything as a re-exporter of *all* the target's exports — even when
- * the file had precise named imports (e.g. `import { x } from './a'`
- * populates both `imports` and `importedSymbols['./a'] = ['x']`, so the
- * sentinel would always fire). See #526.
- *
- * Legitimate wildcard cases (`import * as x` in JS, `use foo::*` in Rust)
- * are already represented in `importedSymbols` as `'* as x'` or `'*'`, so
- * `findReExportedSymbols` still handles them correctly.
- */
-function collectImportedSymbolsFromTarget(
-  chunks: SearchResult[],
-  normalizedTarget: string,
-  normalizePathCached: (path: string) => string,
-): Set<string> {
-  const symbols = new Set<string>();
-  for (const chunk of chunks) {
-    collectNamedSymbolsFromChunk(chunk, normalizedTarget, normalizePathCached, symbols);
-  }
-  return symbols;
-}
-
-/**
- * Collect all exported symbols across all chunks of a file.
- */
-function collectExportsFromChunks(chunks: SearchResult[]): Set<string> {
-  const allExports = new Set<string>();
-  for (const chunk of chunks) {
-    for (const exp of chunk.metadata.exports || []) allExports.add(exp);
-  }
-  return allExports;
-}
-
-/**
- * Find which symbols are re-exported (imported from target AND exported).
- * Handles wildcard/namespace imports by treating all exports as re-exported.
- */
-function findReExportedSymbols(importsFromTarget: Set<string>, allExports: Set<string>): string[] {
-  if (importsFromTarget.has('*')) return [...allExports];
-
-  for (const sym of importsFromTarget) {
-    if (sym.startsWith('* as ')) return [...allExports];
-  }
-
-  const reExported: string[] = [];
-  for (const sym of importsFromTarget) {
-    if (allExports.has(sym)) reExported.push(sym);
-  }
-  return reExported;
-}
-
-/**
  * Build a graph of re-exporter files for a given target.
  *
  * A re-exporter is a file where a symbol appears in both
  * `importedSymbols[targetPath]` AND `exports`. This identifies barrel files
  * that re-export from the target.
  *
- * No new DB queries needed; uses the already-scanned chunks.
+ * No new DB queries needed; uses the already-scanned chunks. The intersection
+ * algorithm itself lives in `@liendev/parser` (`findReExportedSymbolsForFile`)
+ * — shared with the parser's own `fileIsReExporter` (#532).
  */
 function buildReExportGraph(
   allChunksByFile: Map<string, SearchResult[]>,
@@ -206,15 +135,11 @@ function buildReExportGraph(
   for (const [filepath, chunks] of allChunksByFile.entries()) {
     if (matchesFile(filepath, normalizedTarget)) continue;
 
-    const importsFromTarget = collectImportedSymbolsFromTarget(
+    const reExportedSymbols = findReExportedSymbolsForFile(
       chunks,
       normalizedTarget,
       normalizePathCached,
     );
-    const allExports = collectExportsFromChunks(chunks);
-    if (importsFromTarget.size === 0 || allExports.size === 0) continue;
-
-    const reExportedSymbols = findReExportedSymbols(importsFromTarget, allExports);
     if (reExportedSymbols.length > 0) {
       reExporters.push({ filepath, reExportedSymbols });
     }

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { analyzeDependencies, COMPLEXITY_THRESHOLDS } from './dependency-analyzer.js';
+import {
+  analyzeDependencies,
+  findReExportedSymbolsForFile,
+  COMPLEXITY_THRESHOLDS,
+} from './dependency-analyzer.js';
 import type { CodeChunk, ChunkMetadata } from './types.js';
 
 describe('analyzeDependencies', () => {
@@ -488,5 +492,80 @@ describe('analyzeDependencies', () => {
       expect(result.dependentCount).toBe(1);
       expect(result.dependents[0].filepath).toBe('src/app.ts');
     });
+  });
+});
+
+// Direct unit coverage for the shared re-export intersection algorithm,
+// consumed by both `fileIsReExporter` here and the CLI's `get_dependents`
+// handler (#532).
+describe('findReExportedSymbolsForFile', () => {
+  const identity = (path: string): string => path;
+
+  function chunk(
+    file: string,
+    options?: { exports?: string[]; importedSymbols?: Record<string, string[]> },
+  ): CodeChunk {
+    return {
+      content: 'test content',
+      metadata: {
+        file,
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        language: 'typescript',
+        ...(options?.exports && { exports: options.exports }),
+        ...(options?.importedSymbols && { importedSymbols: options.importedSymbols }),
+      } as ChunkMetadata,
+    };
+  }
+
+  it('returns empty when the file imports nothing from the source', () => {
+    const chunks = [chunk('src/b.ts', { exports: ['fnB'] })];
+    expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual([]);
+  });
+
+  it('returns empty when the file exports nothing of its own', () => {
+    const chunks = [chunk('src/b.ts', { importedSymbols: { 'src/a.ts': ['fnA'] } })];
+    expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual([]);
+  });
+
+  it('returns empty when imported symbols and exports do not intersect (#526)', () => {
+    const chunks = [
+      chunk('src/b.ts', {
+        importedSymbols: { 'src/a.ts': ['fnA'] },
+        exports: ['fnB'],
+      }),
+    ];
+    expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual([]);
+  });
+
+  it('returns the intersecting symbols for a genuine re-export', () => {
+    const chunks = [
+      chunk('src/b.ts', {
+        importedSymbols: { 'src/a.ts': ['fnA', 'fnB'] },
+        exports: ['fnA', 'fnC'],
+      }),
+    ];
+    expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual(['fnA']);
+  });
+
+  it('treats a "*" wildcard import as re-exporting all of the file\'s exports', () => {
+    const chunks = [
+      chunk('src/b.ts', {
+        importedSymbols: { 'src/a.ts': ['*'] },
+        exports: ['fnA', 'fnB'],
+      }),
+    ];
+    expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual(['fnA', 'fnB']);
+  });
+
+  it('treats a "* as ns" namespace import as re-exporting all of the file\'s exports', () => {
+    const chunks = [
+      chunk('src/b.ts', {
+        importedSymbols: { 'src/a.ts': ['* as ns'] },
+        exports: ['ns'],
+      }),
+    ];
+    expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual(['ns']);
   });
 });

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -343,8 +343,7 @@ export function groupChunksByNormalizedPath(
 
 /**
  * Collect the symbols a file imports from a given source path, sourced
- * exclusively from `importedSymbols`. Mirrors the CLI-side approach in
- * `packages/cli/src/mcp/handlers/dependency-analyzer.ts`.
+ * exclusively from `importedSymbols`.
  *
  * Deliberately ignores the raw `imports` array — a raw-only match means the
  * file imports for side effect or does `export * from`, neither of which
@@ -380,7 +379,7 @@ function collectExportsFromChunks(chunks: CodeChunk[]): Set<string> {
 }
 
 /**
- * Check if a file (given its chunks) genuinely re-exports symbols from a
+ * Find which symbols a file (given its chunks) genuinely re-exports from a
  * source path.
  *
  * Requires a non-empty intersection between (a) symbols the file imports from
@@ -390,31 +389,49 @@ function collectExportsFromChunks(chunks: CodeChunk[]): Set<string> {
  *
  * Wildcard markers (`'*'` from Rust `use foo::*`, `'* as x'` from JS
  * namespace imports) still trigger re-export detection: both mean "we pulled
- * in everything the source exports," so intersection against the file's own
- * export list is the right signal.
+ * in everything the source exports," so every own export counts as
+ * re-exported.
+ *
+ * Single source of truth for this algorithm: both `fileIsReExporter` below
+ * and the CLI's `get_dependents` handler
+ * (`packages/cli/src/mcp/handlers/dependency-analyzer.ts`) consume this (#532).
+ *
+ * @returns The re-exported symbols; empty means the file is not a re-exporter.
+ */
+export function findReExportedSymbolsForFile(
+  chunks: CodeChunk[],
+  sourcePath: string,
+  normalizePathCached: (path: string) => string,
+): string[] {
+  const importsFromSource = collectImportedSymbolsFromSource(
+    chunks,
+    sourcePath,
+    normalizePathCached,
+  );
+  if (importsFromSource.size === 0) return [];
+
+  const allExports = collectExportsFromChunks(chunks);
+  if (allExports.size === 0) return [];
+
+  // Wildcards mean "imported everything"; every own export counts as re-exported.
+  if (importsFromSource.has('*')) return [...allExports];
+  for (const sym of importsFromSource) {
+    if (sym.startsWith('* as ')) return [...allExports];
+  }
+
+  return [...importsFromSource].filter(sym => allExports.has(sym));
+}
+
+/**
+ * Check if a file (given its chunks) genuinely re-exports anything from a
+ * source path. Thin boolean wrapper over `findReExportedSymbolsForFile`.
  */
 export function fileIsReExporter(
   chunks: CodeChunk[],
   sourcePath: string,
   normalizePathCached: (path: string) => string,
 ): boolean {
-  const importsFromSource = collectImportedSymbolsFromSource(
-    chunks,
-    sourcePath,
-    normalizePathCached,
-  );
-  if (importsFromSource.size === 0) return false;
-
-  const allExports = collectExportsFromChunks(chunks);
-  if (allExports.size === 0) return false;
-
-  // Wildcards mean "imported everything"; any own export then counts.
-  if (importsFromSource.has('*')) return true;
-  for (const sym of importsFromSource) {
-    if (sym.startsWith('* as ')) return true;
-    if (allExports.has(sym)) return true;
-  }
-  return false;
+  return findReExportedSymbolsForFile(chunks, sourcePath, normalizePathCached).length > 0;
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -145,6 +145,7 @@ export {
   groupChunksByNormalizedPath,
   chunkImportsFrom,
   fileIsReExporter,
+  findReExportedSymbolsForFile,
   DEPENDENT_COUNT_THRESHOLDS,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';


### PR DESCRIPTION
## Background

`packages/cli/src/mcp/handlers/dependency-analyzer.ts` and `packages/parser/src/dependency-analyzer.ts` implemented the same re-export-detection algorithm after #526, just with different return shapes:

| CLI (removed) | Parser |
|---|---|
| `collectNamedSymbolsFromChunk` + `collectImportedSymbolsFromTarget` | `collectImportedSymbolsFromSource` |
| `collectExportsFromChunks` | `collectExportsFromChunks` |
| `findReExportedSymbols` (returns `string[]`) | `fileIsReExporter` (returned `boolean`) |

Byte-for-byte comparison confirmed both `collectExportsFromChunks` implementations were already identical, and the two "collect imports from target" helpers did the same `importedSymbols` walk — just split across an extra one-chunk helper on the CLI side. The only real difference was the return shape at the top of the stack.

## Unification

- `packages/parser/src/dependency-analyzer.ts`: extracted `findReExportedSymbolsForFile(chunks, sourcePath, normalizePathCached): string[]` — returns the actual re-exported symbols (empty = not a re-exporter), lifting the exact list-building logic that used to live only in the CLI's `findReExportedSymbols`. `fileIsReExporter` is now a one-line boolean wrapper (`.length > 0`) over it.
- Exported `findReExportedSymbolsForFile` from the parser's public `index.ts`.
- `packages/cli/src/mcp/handlers/dependency-analyzer.ts`: deleted its four local helpers (`collectNamedSymbolsFromChunk`, `collectImportedSymbolsFromTarget`, `collectExportsFromChunks`, `findReExportedSymbols` — all private, no external callers) and `buildReExportGraph` now calls the shared `findReExportedSymbolsForFile` directly.
- `SearchResult` (CLI/core) is structurally assignable to `CodeChunk` (parser) — same `content`/`metadata: ChunkMetadata` shape, `SearchResult` just adds `score`/`relevance` — so no cast is needed at the call site. The CLI already relied on this same structural compatibility for `findTransitiveDependents`.

## No-behavior-change proof

- Both packages' existing test suites pass **unchanged**: parser's 23 pre-existing `dependency-analyzer.test.ts` cases (barrel/wildcard/namespace/cyclic-import scenarios) and the CLI's 41 `dependency-analyzer.test.ts` + 38 `get-dependents.test.ts` cases, none of which were touched.
- Added 6 new direct unit tests for `findReExportedSymbolsForFile` in `packages/parser/src/dependency-analyzer.test.ts` covering: no imports from source, no own exports, non-intersecting imports/exports (#526 case), a genuine intersection, `'*'` wildcard, and `'* as ns'` namespace wildcard.
- Full monorepo test run: parser 1053/1053, core 356/356, review 740/740, cli 792/792, action 28/28 — all green.

## Dependents / risk

- `fileIsReExporter` is exported from `@liendev/parser` with 1 dependent (`packages/parser/src/index.ts` re-export only) — `riskLevel: low`.
- The four removed CLI helpers were all private (no `export` keyword) — zero external dependents, confirmed via grep.
- New export `findReExportedSymbolsForFile` has no prior callers by definition.

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `test` (all packages green) / `lien delta` — exit 0, complexity **improved**: `buildReExportGraph` cognitive 8→5, `fileIsReExporter` cognitive 8→0, four CLI helpers removed entirely, new `findReExportedSymbolsForFile` at cognitive 6 (well under threshold).

Changeset added: `@liendev/parser` + `@liendev/lien` patch.

Closes #532

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This is a clean refactor that extracts the re-export intersection algorithm into a single shared helper in `@liendev/parser` and removes the duplicated private helpers from the CLI. The new `findReExportedSymbolsForFile` is behaviorally equivalent to the old CLI `findReExportedSymbols` (same wildcard/namespace handling and intersection logic), and `fileIsReExporter` is now a thin boolean wrapper over it. `SearchResult` is structurally assignable to `CodeChunk` for the metadata reads the helper performs, so the CLI call site is type-safe without a cast. All existing test suites reportedly pass, and six new direct unit tests cover the key scenarios (no imports, no exports, non-intersecting symbols, genuine intersection, `*`, and `* as ns`).
>
> - Extracted `findReExportedSymbolsForFile` in `@liendev/parser` as the single source of truth for re-export intersection logic.
> - Deleted four private CLI helpers and switched `buildReExportGraph` to call the shared parser function.
> - Exported the new helper from `packages/parser/src/index.ts` and added direct unit tests.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 951d231. Updates automatically on new commits.</sup>
<!-- /lien-stats -->