### PR TITLE
feat(review): test-coverage-gap signal block in review prompt

### DIFF
--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -21,6 +21,7 @@ import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
 import { renderDocClaimsSection } from '../../doc-claims-signals.js';
+import { renderTestCoverageSection } from '../../test-coverage-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -199,6 +200,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderRenameSweepSection(context));
   appendIfPresent(sections, renderGuidanceSurfaceSection(context));
   appendIfPresent(sections, renderDocClaimsSection(context));
+  appendIfPresent(sections, renderTestCoverageSection(context));
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',
   );

--- a/packages/review/src/test-coverage-signals.ts
+++ b/packages/review/src/test-coverage-signals.ts
@@ -1,0 +1,104 @@
+/**
+ * Deterministic "no test coverage" signal for PR reviews (issue #288).
+ *
+ * `ComplexityReport.files[path].testAssociations` already carries which test
+ * files map to each changed source file, but nothing surfaces it in the
+ * architectural prompt — the agent can't say "you added 3 files with no
+ * tests" without seeing this data. This module serializes it as a
+ * `<test_coverage>` block, mirroring the `<removed_exports>` /
+ * `<stale_literal_candidates>` precedents: pre-compute the deterministic fact,
+ * inject it, and let the agent decide whether it matters for this PR.
+ *
+ * `testAssociations` is a required `string[]` that defaults to `[]` in TWO
+ * situations the type can't distinguish: enrichment ran and genuinely found
+ * no test file, OR enrichment never ran (it's wrapped in try/catch in
+ * review-pr.ts and silently no-ops when the repo has no test files at all —
+ * see `enrichWithTestAssociations` in analysis.ts). There is no separate flag
+ * for "did enrichment run." To avoid manufacturing gaps out of missing data,
+ * this module keys off PER-FILE entry presence in `complexityReport.files`
+ * rather than trusting every empty array: a changed file with NO entry at all
+ * has no complexity data one way or the other and is skipped, not flagged. An
+ * empty `testAssociations` is only treated as a real gap on a file that DOES
+ * have a report entry. Practically, this also covers "enrichment never ran
+ * for any file" — every lookup misses, so the gap list ends up empty and the
+ * block renders nothing, matching the "absence of data is not evidence of a
+ * gap" principle.
+ */
+
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max changed files listed — keeps the block within the ~100-200 token target. */
+const MAX_FILES = 10;
+
+const HEADER =
+  'Pre-computed from the complexity report’s test-association data — ' +
+  'deterministic, not a tool call; do not re-derive it. Each listed file ' +
+  'changed in this PR and has NO associated test file. This is a factual ' +
+  'observation, not an instruction to report each one as a finding (missing ' +
+  'tests are out of scope for individual findings — see Rules); use it only ' +
+  'as context, e.g. for the summary/overview when substantial new logic ' +
+  'ships with no test coverage at all.';
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Changed files that have a complexity-report entry but no associated test
+ * file. Files with no entry in `complexityReport.files` (not analyzed, or
+ * enrichment never ran) are skipped — absence of data is not evidence of a
+ * gap. Exposed for testing.
+ */
+export function computeTestCoverageGaps(context: ReviewContext): string[] {
+  const files = context.complexityReport?.files;
+  if (!files) return [];
+
+  const gaps: string[] = [];
+  for (const file of context.changedFiles) {
+    const data = files[file];
+    if (!data || !Array.isArray(data.testAssociations)) continue;
+    if (data.testAssociations.length === 0) gaps.push(file);
+  }
+  return gaps;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the gap list as a `<test_coverage>` block for the agent's initial
+ * message. Returns '' when there are no gaps, so callers can append
+ * unconditionally. Caps at MAX_FILES with an explicit omission note — no
+ * silent truncation. Exposed for testing.
+ */
+export function renderTestCoverageGaps(gaps: string[]): string {
+  if (gaps.length === 0) return '';
+
+  const lines: string[] = ['<test_coverage>', HEADER];
+  const shown = gaps.slice(0, MAX_FILES);
+  for (const file of shown) lines.push(`- ${file}`);
+
+  const omitted = gaps.length - shown.length;
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more changed file(s) with no associated tests omitted — see the complexity report for the rest]`,
+    );
+  }
+
+  lines.push('</test_coverage>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<test_coverage>` section from the review context. Returns ''
+ * when every changed file with complexity data has test associations, or when
+ * no changed file has complexity data at all.
+ */
+export function renderTestCoverageSection(context: ReviewContext): string {
+  return renderTestCoverageGaps(computeTestCoverageGaps(context));
+}

--- a/packages/review/test/test-coverage-signals.test.ts
+++ b/packages/review/test/test-coverage-signals.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import type { ComplexityReport } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import { createTestContext } from '../src/test-helpers.js';
+import {
+  computeTestCoverageGaps,
+  renderTestCoverageGaps,
+  renderTestCoverageSection,
+} from '../src/test-coverage-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** One `complexityReport.files[path]` entry with the given test associations. */
+function fileEntry(testAssociations: string[]): ComplexityReport['files'][string] {
+  return {
+    violations: [],
+    dependents: [],
+    testAssociations,
+    riskLevel: 'low',
+  };
+}
+
+function makeReport(files: Record<string, string[]>): ComplexityReport {
+  const entries: ComplexityReport['files'] = {};
+  for (const [file, associations] of Object.entries(files)) {
+    entries[file] = fileEntry(associations);
+  }
+  return {
+    files: entries,
+    summary: {
+      filesAnalyzed: Object.keys(entries).length,
+      totalViolations: 0,
+      bySeverity: { error: 0, warning: 0 },
+      avgComplexity: 0,
+      maxComplexity: 0,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeTestCoverageGaps
+// ---------------------------------------------------------------------------
+
+describe('computeTestCoverageGaps', () => {
+  it('flags a changed file with a report entry but no test associations', () => {
+    const context = createTestContext({
+      changedFiles: ['src/new-module.ts'],
+      complexityReport: makeReport({ 'src/new-module.ts': [] }),
+    });
+    expect(computeTestCoverageGaps(context)).toEqual(['src/new-module.ts']);
+  });
+
+  it('does not flag a file with at least one test association', () => {
+    const context = createTestContext({
+      changedFiles: ['src/auth.ts'],
+      complexityReport: makeReport({ 'src/auth.ts': ['test/auth.test.ts'] }),
+    });
+    expect(computeTestCoverageGaps(context)).toEqual([]);
+  });
+
+  it('skips a changed file with no complexity-report entry at all (no data, not a gap)', () => {
+    const context = createTestContext({
+      changedFiles: ['src/not-analyzed.ts'],
+      complexityReport: makeReport({}),
+    });
+    expect(computeTestCoverageGaps(context)).toEqual([]);
+  });
+
+  it('mixes tested, gap, and no-data files correctly', () => {
+    const context = createTestContext({
+      changedFiles: ['src/auth.ts', 'src/new-module.ts', 'src/not-analyzed.ts'],
+      complexityReport: makeReport({
+        'src/auth.ts': ['test/auth.test.ts'],
+        'src/new-module.ts': [],
+      }),
+    });
+    expect(computeTestCoverageGaps(context)).toEqual(['src/new-module.ts']);
+  });
+
+  it('returns [] when complexityReport.files is empty (enrichment never ran)', () => {
+    const context = createTestContext({
+      changedFiles: ['src/a.ts', 'src/b.ts'],
+      complexityReport: makeReport({}),
+    });
+    expect(computeTestCoverageGaps(context)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderTestCoverageGaps
+// ---------------------------------------------------------------------------
+
+describe('renderTestCoverageGaps', () => {
+  it('returns "" for no gaps', () => {
+    expect(renderTestCoverageGaps([])).toBe('');
+  });
+
+  it('renders a block listing every gap file', () => {
+    const md = renderTestCoverageGaps(['src/new-module.ts', 'src/utils/helper.ts']);
+    expect(md).toContain('<test_coverage>');
+    expect(md).toContain('</test_coverage>');
+    expect(md).toContain('- src/new-module.ts');
+    expect(md).toContain('- src/utils/helper.ts');
+  });
+
+  it('caps at 10 files with an explicit omission note', () => {
+    const gaps = Array.from({ length: 13 }, (_, i) => `src/file${i}.ts`);
+    const md = renderTestCoverageGaps(gaps);
+    for (let i = 0; i < 10; i++) expect(md).toContain(`src/file${i}.ts`);
+    expect(md).not.toContain('src/file10.ts');
+    expect(md).toContain('+3 more changed file(s) with no associated tests omitted');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderTestCoverageSection
+// ---------------------------------------------------------------------------
+
+describe('renderTestCoverageSection', () => {
+  it('returns "" when every changed file has test associations', () => {
+    const context = createTestContext({
+      changedFiles: ['src/auth.ts'],
+      complexityReport: makeReport({ 'src/auth.ts': ['test/auth.test.ts'] }),
+    });
+    expect(renderTestCoverageSection(context)).toBe('');
+  });
+
+  it('returns "" when no changed file has complexity data', () => {
+    const context = createTestContext({
+      changedFiles: ['src/a.ts'],
+      complexityReport: makeReport({}),
+    });
+    expect(renderTestCoverageSection(context)).toBe('');
+  });
+
+  it('renders the gap block otherwise', () => {
+    const context = createTestContext({
+      changedFiles: ['src/new-module.ts'],
+      complexityReport: makeReport({ 'src/new-module.ts': [] }),
+    });
+    expect(renderTestCoverageSection(context)).toContain('<test_coverage>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection', () => {
+  it('includes the <test_coverage> block when a changed file has no tests', () => {
+    const context = {
+      ...createTestContext({
+        changedFiles: ['src/new-module.ts'],
+        complexityReport: makeReport({ 'src/new-module.ts': [] }),
+      }),
+      chunks: [],
+    } as unknown as ReviewContext;
+
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).toContain('<test_coverage>');
+    expect(message).toContain('src/new-module.ts');
+  });
+
+  it('omits the block when every changed file has test associations', () => {
+    const context = {
+      ...createTestContext({
+        changedFiles: ['src/auth.ts'],
+        complexityReport: makeReport({ 'src/auth.ts': ['test/auth.test.ts'] }),
+      }),
+      chunks: [],
+    } as unknown as ReviewContext;
+
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).not.toContain('<test_coverage>');
+  });
+
+  it('omits the block when there is no test-association data at all', () => {
+    const context = {
+      ...createTestContext({
+        changedFiles: ['src/a.ts'],
+        complexityReport: makeReport({}),
+      }),
+      chunks: [],
+    } as unknown as ReviewContext;
+
+    const message = buildInitialMessage(context, { blastRadius: null });
+    expect(message).not.toContain('<test_coverage>');
+  });
+});


### PR DESCRIPTION
## ⚠️ CANARY PROMPT CHANGED — needs paid recalibration before merge (~$0.5), deferred to owner

All **10/10 certified canary fixtures** in the harness corpus gain a new `<test_coverage>` block in `buildInitialMessage`'s output (see byte-diff evidence below). This is expected — most real captured PRs have at least one changed file with no test association — but it means the production agent-review prompt's shape changes for the majority of real reviews. Per this repo's evidence bar for prompt-affecting changes, that needs a `--calibrate 10` run against `moonshotai/kimi-k2.7-code` (the prod default) before merge to confirm finding quality doesn't regress from the added input. I have not run that calibration (real OpenRouter spend, ~$0.5) — deferring to the owner's go-ahead.

## Problem (#288)

The architectural review prompt didn't surface which changed files have test coverage and which don't. `ComplexityReport.files[path].testAssociations` already carries this data (populated by test-to-code mapping enrichment) — it just wasn't serialized into the prompt.

## Design

New module `packages/review/src/test-coverage-signals.ts`, following the repo's established "precompute a deterministic signal, inject as a block" pattern (`removed-export-signals.ts`, `stale-literal-signals.ts`, etc.) — wired into `buildInitialMessage` in `packages/review/src/plugins/agent/system-prompt.ts`.

**Key design decision — per-file entry presence, not raw array emptiness:** `FileComplexityData.testAssociations` is a required `string[]` that defaults to `[]` in TWO situations the type can't distinguish: enrichment ran and genuinely found no test file, OR enrichment never ran/failed (it's wrapped in try/catch and no-ops early when the checkout has no test files at all — see `enrichWithTestAssociations` in `analysis.ts`). There's no separate flag for "did enrichment run."

To avoid manufacturing gaps out of missing data, the gap computation keys off **per-file entry presence** in `complexityReport.files`:
- A changed file with **no entry at all** in `complexityReport.files` → skipped (no data one way or the other, not evidence of a gap).
- A changed file **with** a report entry but an empty `testAssociations` → real gap.

This also naturally covers "no coverage data at all" (every changed file misses → gap list ends up empty → block renders nothing), without needing a separate global-level check.

The block only lists **untested** files (not the issue mockup's full tested+untested list) — caps at 10 with an explicit omission note, no silent truncation. Wording is deliberately factual ("these changed files have no associated test file") rather than an instruction to always flag it, since the existing `RULES_SECTION` already excludes "Missing tests" from individual findings — this signal is meant as context for the summary/overview, not a per-file finding generator.

## Tests

`packages/review/test/test-coverage-signals.test.ts` — 14 tests mirroring the `removed-export-signals.test.ts` style:
- gap present (report entry + empty `testAssociations`) → file listed
- file with associations → not flagged
- file with no report entry at all → skipped, not flagged
- mixed tested/gap/no-data changed files → only the real gap listed
- no test-association data anywhere → block renders nothing
- >10 gaps → truncation note, no silent cap
- `buildInitialMessage` wiring: block included/omitted correctly

## Full gate chain (all pass)

```
npm run format:check   ✓
npm run lint           ✓ (0 errors; pre-existing warnings only, unrelated to this change)
npm run typecheck      ✓
npm run build          ✓
npm test               ✓ (all 5 packages green: parser 27, core 1047, review 356, cli 792, action 28)
node packages/cli/dist/index.js delta   ✓ exit 0 (no new-over-threshold or crossed functions;
  one below-threshold "worsened" note on buildInitialMessage's Halstead `time` metric, 17m→18m,
  from the one-line append — not a crossing)
```

## Byte-diff evidence (zero LLM spend)

Rendered every `.fixture.json` present on disk (22 total — only committed fixtures exist; the rest are gitignored per-harness convention) through `packages/review/test/harness/build-prompts.ts`, once against this branch and once against `origin/main`'s `packages/review/src`, then diffed each rendered `{systemPrompt, initialMessage}` JSON byte-for-byte.

Commands used:
```bash
# 1. Render at HEAD (this branch)
git rev-parse HEAD  # commit under test
find packages/review/test/harness/fixtures -name '*.fixture.json' | while read f; do
  npx tsx packages/review/test/harness/build-prompts.ts "$f" > after/<name>.json
done

# 2. Swap packages/review/src to origin/main, render again
git checkout origin/main -- packages/review/src
find packages/review/test/harness/fixtures -name '*.fixture.json' | while read f; do
  npx tsx packages/review/test/harness/build-prompts.ts "$f" > before/<name>.json
done

# 3. Restore this branch exactly
git checkout HEAD -- packages/review/src
git status   # confirmed clean, byte-identical to HEAD

# 4. Diff every before/after pair (Python: JSON-parse, diff each top-level key,
#    and for initialMessage confirm any change is a PURE INSERTION whose inserted
#    text is exactly one well-formed <test_coverage>...</test_coverage> block)
```

**Result: 3 identical, 19 gained-block-only, 0 other-diff.**

| Outcome | Count | Fixtures |
|---|---:|---|
| Byte-identical | 3 | `boundary-change/placeholder` (hand-authored), `doc-truth/accurate-doc`, `doc-truth/renamed-stale-claim` |
| Gained `<test_coverage>` only, nothing else changed | 19 | see breakdown below |
| Any other diff (would indicate a regression) | 0 | — |

Breakdown of the 19 gained-block fixtures:
- **All 10 certified canaries** (100% of the canary corpus): `boundary-change/ge-5-threshold-shift`, `structural-analysis/removed-export`, `edge-case-sweep/percent-change-sign-flip`, `concurrency-race/credit-service-toctou`, `incomplete-handling/enum-variant-removed`, `error-swallowing/payment-error-swallowed`, `stale-duplicate/model-partial-update`, `untrusted-input-validation/harness-initial`, `doc-truth/pr658-search-code-rename`, `crossrepo/pr2191-templateresponse-offbyone`
- 2 untagged negative-regression fixtures (bundled with the canary corpus per the harness README, not individually canary-tagged): `error-swallowing/scanall-null-guard-fp`, `error-swallowing/harness-gitignore-convention-fp`
- 3 `characterization`-tagged crossrepo fixtures (cert deferred, not canary): `crossrepo/pr2334-etag-weak-indicator-strip`, `crossrepo/pr2678-multipart-index-offset`, `crossrepo/pr2017-multipart-boundary-regex`
- 4 doc-truth seed/dev fixtures (not in the canary table): `doc-truth/pr667-worktree-doc-drift`, `doc-truth/pr687-config-doc-drift`, `doc-truth/pr711-changeset-export-claim`, `doc-truth/pr716-install-claim`

Zero fixtures showed any diff beyond the clean inserted block — no removed text, no reordering, no truncation-budget interaction with other signal sections.

Closes #288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test coverage insights to review agent messages.
  * Highlights changed files that lack associated tests.
  * Limits displayed file listings and indicates when additional gaps exist.
  * Omits the section when coverage data is unavailable or no gaps are detected.

* **Tests**
  * Added coverage for gap detection, rendering, and message inclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic `<test_coverage>` signal block to the agent review prompt, surfacing changed files that have complexity-report entries but no associated test files. The implementation follows the established signal-module pattern, keys off per-file entry presence to avoid manufacturing gaps from missing enrichment data, caps the list at 10 with an explicit omission note, and is wired into `buildInitialMessage` via the existing `appendIfPresent` helper. The change is localized, well-tested, and introduces no breaking API changes.
>
> - New `packages/review/src/test-coverage-signals.ts` computes and renders test-coverage gaps
> - `buildInitialMessage` appends the `<test_coverage>` block alongside other deterministic signal sections
> - 14 unit tests cover gap detection, omission logic, truncation, and prompt wiring

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d7aa36e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->