### PR TITLE
test(review): drop redundant chunks override and unsafe cast in test-coverage contexts

### DIFF
--- a/packages/review/test/test-coverage-signals.test.ts
+++ b/packages/review/test/test-coverage-signals.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import type { ComplexityReport } from '@liendev/parser';
-import type { ReviewContext } from '../src/plugin-types.js';
 import { createTestContext } from '../src/test-helpers.js';
 import {
   computeTestCoverageGaps,
@@ -151,13 +150,10 @@ describe('renderTestCoverageSection', () => {
 
 describe('buildInitialMessage injection', () => {
   it('includes the <test_coverage> block when a changed file has no tests', () => {
-    const context = {
-      ...createTestContext({
-        changedFiles: ['src/new-module.ts'],
-        complexityReport: makeReport({ 'src/new-module.ts': [] }),
-      }),
-      chunks: [],
-    } as unknown as ReviewContext;
+    const context = createTestContext({
+      changedFiles: ['src/new-module.ts'],
+      complexityReport: makeReport({ 'src/new-module.ts': [] }),
+    });
 
     const message = buildInitialMessage(context, { blastRadius: null });
     expect(message).toContain('<test_coverage>');
@@ -165,26 +161,20 @@ describe('buildInitialMessage injection', () => {
   });
 
   it('omits the block when every changed file has test associations', () => {
-    const context = {
-      ...createTestContext({
-        changedFiles: ['src/auth.ts'],
-        complexityReport: makeReport({ 'src/auth.ts': ['test/auth.test.ts'] }),
-      }),
-      chunks: [],
-    } as unknown as ReviewContext;
+    const context = createTestContext({
+      changedFiles: ['src/auth.ts'],
+      complexityReport: makeReport({ 'src/auth.ts': ['test/auth.test.ts'] }),
+    });
 
     const message = buildInitialMessage(context, { blastRadius: null });
     expect(message).not.toContain('<test_coverage>');
   });
 
   it('omits the block when there is no test-association data at all', () => {
-    const context = {
-      ...createTestContext({
-        changedFiles: ['src/a.ts'],
-        complexityReport: makeReport({}),
-      }),
-      chunks: [],
-    } as unknown as ReviewContext;
+    const context = createTestContext({
+      changedFiles: ['src/a.ts'],
+      complexityReport: makeReport({}),
+    });
 
     const message = buildInitialMessage(context, { blastRadius: null });
     expect(message).not.toContain('<test_coverage>');


### PR DESCRIPTION
## What

In `packages/review/test/test-coverage-signals.test.ts`, the three tests in the `buildInitialMessage injection` describe block built contexts as:

```ts
const context = {
  ...createTestContext({...}),
  chunks: [],
} as unknown as ReviewContext;
```

`createTestContext` (`packages/review/src/test-helpers.ts`) already returns a fully-typed `ReviewContext` with `chunks: []` defaulted, so this simplifies to a plain `createTestContext({...})` call — dropping the spread, the redundant `chunks: []` override, and the `as unknown as ReviewContext` cast.

## Why

Addresses a [CodeRabbit nitpick](https://github.com/getlien/lien/pull/757#pullrequestreview-4680890942) on #757: the `as unknown as ReviewContext` cast suppresses future type errors if `ReviewContext` gains required fields, and removing it surfaced no real type issues (confirmed via `tsc --noEmit`).

## Test plan

- [x] `npm run test -w @liendev/review -- test/test-coverage-signals.test.ts` (14/14 pass)
- [x] `npm run format:check`
- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck` (0 errors)
- [x] `npm run build`
- [x] `npm test` (full suite green)
- [x] `lien delta` (exit 0, no complexity changes)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a test-only refactor that removes redundant `chunks: []` overrides and an unnecessary `as unknown as ReviewContext` cast in three tests within `test-coverage-signals.test.ts`. The `createTestContext` helper already returns a fully-typed `ReviewContext` with `chunks: []` as a default, so the simplified calls are equivalent and improve type safety. No production code or runtime behavior is affected.
>
> - Replaced spread + override + unsafe cast with direct `createTestContext(...)` calls in three tests
> - Removed the now-unused `ReviewContext` type import from the test file

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8f5d2ac. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup for coverage-related review messages.
  * Preserved validation that coverage details are included or omitted under the expected conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->