### PR TITLE
refactor: purge never-functional cross-repo scaffolding

### DIFF
--- a/.changeset/purge-dead-crossrepo-scaffolding.md
+++ b/.changeset/purge-dead-crossrepo-scaffolding.md
@@ -1,0 +1,18 @@
+---
+'@liendev/parser': patch
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+refactor: remove never-functional cross-repo scaffolding
+
+Cross-repo MCP mode was never implemented in the SQLite era: `repoId` was
+computed in-memory but never persisted to the structural store, both
+backends hardcoded `supportsCrossRepo = false` with `scanCrossRepo()`
+stubbed to `[]`, and `lien serve` is one-repo-per-process — making every
+`crossRepo`/`repoIds` code path unreachable. Removes the always-false
+`supportsCrossRepo` flag and `scanCrossRepo()` stub from both backends and
+`VectorDBInterface`, the `crossRepo`/`repoIds` MCP tool parameters and their
+`groupedByRepo` response fields, the `repoId` field on `ChunkMetadata` and
+its plumbing through the chunkers, and the corresponding doc claims. No
+behavior change for the single-repo path.

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -344,7 +344,7 @@ chunks_fts  -- FTS5 external-content virtual table (content='chunks')
   kept in sync by AFTER INSERT/UPDATE/DELETE triggers on chunks
 ```
 
-`startLine`/`endLine` are `INTEGER` (the structural-store spike stored them as REAL; fixed in production). Multi-tenant fields (`repoId`, `orgId`, `branch`, `commitSha`) exist in `ChunkMetadata` for a future cross-repo backend but are not stored as columns today.
+`startLine`/`endLine` are `INTEGER` (the structural-store spike stored them as REAL; fixed in production). Multi-tenant fields (`orgId`, `branch`, `commitSha`) exist in `ChunkMetadata` for a possible future multi-tenant backend but are not stored as columns today. Cross-repo MCP mode itself (the `crossRepo`/`repoIds` tool parameters, `supportsCrossRepo`, `scanCrossRepo`, and the `repoId` metadata field) was removed — it was never implemented in the SQLite era.
 
 ### Version File
 

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -135,7 +135,6 @@ async function run(file: string): Promise<void> {
     const result = await findDependents(
       vectorDB,
       filepath,
-      false,
       log,
       undefined,
       undefined,

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SearchResult } from '@liendev/core';
-import {
-  findDependents,
-  groupDependentsByRepo,
-  clearDependencyCache,
-} from './dependency-analyzer.js';
+import { findDependents, clearDependencyCache } from './dependency-analyzer.js';
 
 /**
  * Helper to create a mock SearchResult chunk with sensible defaults.
@@ -18,7 +14,6 @@ function createChunk(
     complexity: number;
     callSites: Array<{ symbol: string; line: number }>;
     symbolName: string;
-    repoId: string;
     startLine: number;
     endLine: number;
   }> = {},
@@ -43,7 +38,6 @@ function createChunk(
 describe('findDependents', () => {
   let mockDB: {
     scanAll: ReturnType<typeof vi.fn>;
-    scanCrossRepo: ReturnType<typeof vi.fn>;
   };
   let mockLog: ReturnType<typeof vi.fn<(message: string, level?: 'warning') => void>>;
 
@@ -52,7 +46,6 @@ describe('findDependents', () => {
     clearDependencyCache();
     mockDB = {
       scanAll: vi.fn().mockResolvedValue([]),
-      scanCrossRepo: vi.fn().mockResolvedValue([]),
     };
     mockLog = vi.fn<(message: string, level?: 'warning') => void>();
   });
@@ -64,7 +57,7 @@ describe('findDependents', () => {
         createChunk('src/target.ts', { exports: ['doStuff'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/consumer.ts');
@@ -79,7 +72,7 @@ describe('findDependents', () => {
         createChunk('src/consumer.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       const filepaths = result.dependents.map(d => d.filepath);
       expect(filepaths).not.toContain('src/target.ts');
@@ -96,7 +89,7 @@ describe('findDependents', () => {
         createChunk('src/target.ts', { exports: ['Foo', 'Bar'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/consumer.ts');
@@ -110,7 +103,7 @@ describe('findDependents', () => {
         createChunk('src/utils.ts', { exports: ['helper'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/utils.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/utils.ts', mockLog);
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/consumer.ts');
@@ -135,7 +128,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       const filepaths = result.dependents.map(d => d.filepath);
       expect(filepaths).toContain('src/index.ts');
@@ -165,7 +158,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'Foo');
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'Foo');
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/uses-foo.ts');
@@ -190,7 +183,7 @@ describe('findDependents', () => {
         chunk,
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'doWork');
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'doWork');
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].usages).toHaveLength(1);
@@ -212,7 +205,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'Bar');
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'Bar');
 
       // Should log a warning, not throw
       expect(mockLog).toHaveBeenCalledWith(
@@ -244,7 +237,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       // File complexities
       expect(result.fileComplexities).toHaveLength(2);
@@ -266,7 +259,7 @@ describe('findDependents', () => {
         createChunk('src/consumer.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.complexityMetrics.averageComplexity).toBe(0);
       expect(result.complexityMetrics.maxComplexity).toBe(0);
@@ -291,7 +284,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'Foo');
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'Foo');
 
       expect(result.dependents).toHaveLength(0);
       expect(result.fileComplexities).toHaveLength(0);
@@ -322,7 +315,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog, 'Foo');
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'Foo');
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/uses-foo.ts');
@@ -345,7 +338,7 @@ describe('findDependents', () => {
         createChunk('test/integration.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.productionDependentCount).toBe(1);
       expect(result.testDependentCount).toBe(2);
@@ -362,7 +355,7 @@ describe('findDependents', () => {
         createChunk('test/b.spec.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       // Production files come first
       const firstTestIndex = result.dependents.findIndex(d => d.isTestFile);
@@ -381,7 +374,7 @@ describe('findDependents', () => {
         createChunk('src/consumer.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.hitLimit).toBe(false);
     });
@@ -394,7 +387,7 @@ describe('findDependents', () => {
         createChunk('src/unrelated.ts', { imports: ['src/other.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.dependents).toHaveLength(0);
       expect(result.productionDependentCount).toBe(0);
@@ -416,7 +409,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/a.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/a.ts', mockLog);
 
       // B imports A, so B is a dependent of A
       expect(result.dependents).toHaveLength(1);
@@ -441,7 +434,6 @@ describe('findDependents', () => {
       const result = await findDependents(
         mockDB as any,
         'src/a.ts',
-        false,
         mockLog,
         undefined,
         undefined,
@@ -480,7 +472,6 @@ describe('findDependents', () => {
       const result = await findDependents(
         mockDB as any,
         'packages/cli/src/mcp/handlers/dependency-analyzer.ts',
-        false,
         mockLog,
       );
 
@@ -512,7 +503,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/a.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/a.ts', mockLog);
 
       const filepaths = result.dependents.map(d => d.filepath);
       // b is a direct dependent of a — correct.
@@ -538,7 +529,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/a.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/a.ts', mockLog);
 
       expect(result.dependents.map(d => d.filepath)).toEqual(['src/b.ts']);
       expect(result.dependents[0].hops).toBe(1);
@@ -560,7 +551,6 @@ describe('findDependents', () => {
       const result = await findDependents(
         mockDB as any,
         'src/a.ts',
-        false,
         mockLog,
         undefined,
         undefined,
@@ -592,7 +582,6 @@ describe('findDependents', () => {
       const result = await findDependents(
         mockDB as any,
         'src/a.ts',
-        false,
         mockLog,
         undefined,
         undefined,
@@ -625,7 +614,6 @@ describe('findDependents', () => {
       const result = await findDependents(
         mockDB as any,
         'src/a.ts',
-        false,
         mockLog,
         undefined,
         undefined,
@@ -655,7 +643,6 @@ describe('findDependents', () => {
       const result = await findDependents(
         mockDB as any,
         'src/a.ts',
-        false,
         mockLog,
         undefined,
         undefined,
@@ -679,15 +666,7 @@ describe('findDependents', () => {
         }),
       ]);
 
-      const result = await findDependents(
-        mockDB as any,
-        'src/a.ts',
-        false,
-        mockLog,
-        'fnA',
-        undefined,
-        3,
-      );
+      const result = await findDependents(mockDB as any, 'src/a.ts', mockLog, 'fnA', undefined, 3);
 
       // At depth 1 for symbol fnA, only src/b.ts imports the symbol directly.
       expect(result.dependents.map(d => d.filepath)).toEqual(['src/b.ts']);
@@ -707,7 +686,7 @@ describe('findDependents', () => {
         createChunk('src/uncovered.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.productionDependentCount).toBe(2);
       expect(result.uncoveredProductionDependents).toBe(1);
@@ -720,7 +699,7 @@ describe('findDependents', () => {
         createChunk('src/a.test.ts', { imports: ['src/a.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.productionDependentCount).toBe(1);
       expect(result.uncoveredProductionDependents).toBe(0);
@@ -735,40 +714,10 @@ describe('findDependents', () => {
         createChunk('src/consumer.ts', { imports: ['src/target.ts'] }),
       ]);
 
-      const result = await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
 
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('src/consumer.ts');
-    });
-  });
-
-  describe('cross-repo with a cross-repo-capable backend', () => {
-    it('should call scanCrossRepo when vectorDB supports cross-repo and crossRepo=true', async () => {
-      const mockCrossRepoDB: any = {
-        scanAll: vi.fn().mockResolvedValue([]),
-        scanCrossRepo: vi.fn().mockResolvedValue([]),
-        supportsCrossRepo: true,
-      };
-
-      await findDependents(mockCrossRepoDB, 'src/target.ts', true, mockLog);
-
-      expect(mockCrossRepoDB.scanCrossRepo).toHaveBeenCalledWith(
-        expect.objectContaining({ limit: 100000 }),
-      );
-      expect(mockCrossRepoDB.scanAll).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('cross-repo fallback for unsupported backends', () => {
-    it('should log warning and use scanAll when vectorDB lacks cross-repo support', async () => {
-      await findDependents(mockDB as any, 'src/target.ts', true, mockLog);
-
-      expect(mockLog).toHaveBeenCalledWith(
-        expect.stringContaining('crossRepo=true requires a cross-repo-capable backend'),
-        'warning',
-      );
-      expect(mockDB.scanAll).toHaveBeenCalled();
-      expect(mockDB.scanCrossRepo).not.toHaveBeenCalled();
     });
   });
 
@@ -781,27 +730,13 @@ describe('findDependents', () => {
       mockDB.scanAll.mockResolvedValue(chunks);
 
       // First call: should scan
-      const result1 = await findDependents(
-        mockDB as any,
-        'src/target.ts',
-        false,
-        mockLog,
-        undefined,
-        100,
-      );
+      const result1 = await findDependents(mockDB as any, 'src/target.ts', mockLog, undefined, 100);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(1);
       expect(result1.dependents).toHaveLength(1);
 
       // Second call with same indexVersion: should use cache
       mockDB.scanAll.mockResolvedValue([]);
-      const result2 = await findDependents(
-        mockDB as any,
-        'src/target.ts',
-        false,
-        mockLog,
-        undefined,
-        100,
-      );
+      const result2 = await findDependents(mockDB as any, 'src/target.ts', mockLog, undefined, 100);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(1); // not called again
       expect(result2.dependents).toHaveLength(1); // same results from cache
     });
@@ -814,19 +749,12 @@ describe('findDependents', () => {
       mockDB.scanAll.mockResolvedValue(chunks);
 
       // First call with version 100
-      await findDependents(mockDB as any, 'src/target.ts', false, mockLog, undefined, 100);
+      await findDependents(mockDB as any, 'src/target.ts', mockLog, undefined, 100);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(1);
 
       // Second call with version 200: should re-scan
       mockDB.scanAll.mockResolvedValue([createChunk('src/target.ts', { exports: ['foo'] })]);
-      const result2 = await findDependents(
-        mockDB as any,
-        'src/target.ts',
-        false,
-        mockLog,
-        undefined,
-        200,
-      );
+      const result2 = await findDependents(mockDB as any, 'src/target.ts', mockLog, undefined, 200);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(2);
       expect(result2.dependents).toHaveLength(0); // no consumers in new scan
     });
@@ -839,7 +767,7 @@ describe('findDependents', () => {
       mockDB.scanAll.mockResolvedValue(chunks);
 
       // First call: populates cache
-      await findDependents(mockDB as any, 'src/target.ts', false, mockLog, undefined, 100);
+      await findDependents(mockDB as any, 'src/target.ts', mockLog, undefined, 100);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(1);
 
       // Clear cache
@@ -847,25 +775,8 @@ describe('findDependents', () => {
 
       // Same version but cache cleared: should re-scan
       mockDB.scanAll.mockResolvedValue(chunks);
-      await findDependents(mockDB as any, 'src/target.ts', false, mockLog, undefined, 100);
+      await findDependents(mockDB as any, 'src/target.ts', mockLog, undefined, 100);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(2);
-    });
-
-    it('should invalidate cache when crossRepo mode changes', async () => {
-      const chunks = [
-        createChunk('src/target.ts', { exports: ['foo'] }),
-        createChunk('src/consumer.ts', { imports: ['src/target.ts'] }),
-      ];
-      mockDB.scanAll.mockResolvedValue(chunks);
-
-      // First call with crossRepo=false
-      await findDependents(mockDB as any, 'src/target.ts', false, mockLog, undefined, 100);
-      expect(mockDB.scanAll).toHaveBeenCalledTimes(1);
-
-      // Second call with crossRepo=true, same indexVersion: should re-scan
-      mockDB.scanCrossRepo.mockResolvedValue(chunks);
-      await findDependents(mockDB as any, 'src/target.ts', true, mockLog, undefined, 100);
-      expect(mockDB.scanAll.mock.calls.length + mockDB.scanCrossRepo.mock.calls.length).toBe(2);
     });
 
     it('should not cache when indexVersion is not provided', async () => {
@@ -876,90 +787,13 @@ describe('findDependents', () => {
       mockDB.scanAll.mockResolvedValue(chunks);
 
       // First call without indexVersion
-      await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      await findDependents(mockDB as any, 'src/target.ts', mockLog);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(1);
 
       // Second call without indexVersion: should scan again
       mockDB.scanAll.mockResolvedValue(chunks);
-      await findDependents(mockDB as any, 'src/target.ts', false, mockLog);
+      await findDependents(mockDB as any, 'src/target.ts', mockLog);
       expect(mockDB.scanAll).toHaveBeenCalledTimes(2);
     });
-  });
-});
-
-describe('groupDependentsByRepo', () => {
-  it('should group dependents by repoId from chunk metadata', () => {
-    const dependents = [
-      { filepath: 'repo-a/src/a.ts', isTestFile: false },
-      { filepath: 'repo-b/src/b.ts', isTestFile: false },
-      { filepath: 'repo-a/src/c.ts', isTestFile: true },
-    ];
-
-    const chunks: SearchResult[] = [
-      createChunk('repo-a/src/a.ts', { repoId: 'repo-a' }),
-      createChunk('repo-b/src/b.ts', { repoId: 'repo-b' }),
-      createChunk('repo-a/src/c.ts', { repoId: 'repo-a' }),
-    ];
-
-    const result = groupDependentsByRepo(dependents, chunks);
-
-    expect(Object.keys(result)).toHaveLength(2);
-    expect(result['repo-a']).toHaveLength(2);
-    expect(result['repo-b']).toHaveLength(1);
-    expect(result['repo-a'].map(d => d.filepath)).toEqual(['repo-a/src/a.ts', 'repo-a/src/c.ts']);
-  });
-
-  it('should fall back to "unknown" when chunk has no repoId', () => {
-    const dependents = [{ filepath: 'src/a.ts', isTestFile: false }];
-
-    const chunks: SearchResult[] = [
-      createChunk('src/a.ts'), // no repoId
-    ];
-
-    const result = groupDependentsByRepo(dependents, chunks);
-
-    expect(result['unknown']).toHaveLength(1);
-    expect(result['unknown'][0].filepath).toBe('src/a.ts');
-  });
-
-  it('should return empty object when no dependents are provided', () => {
-    const result = groupDependentsByRepo([], []);
-    expect(result).toEqual({});
-  });
-
-  it('should handle multiple repos with mixed dependents', () => {
-    const dependents = [
-      { filepath: 'a/src/x.ts', isTestFile: false },
-      { filepath: 'b/src/y.ts', isTestFile: false },
-      { filepath: 'c/src/z.ts', isTestFile: true },
-      { filepath: 'a/src/w.ts', isTestFile: false },
-    ];
-
-    const chunks: SearchResult[] = [
-      createChunk('a/src/x.ts', { repoId: 'alpha' }),
-      createChunk('b/src/y.ts', { repoId: 'beta' }),
-      createChunk('c/src/z.ts', { repoId: 'gamma' }),
-      createChunk('a/src/w.ts', { repoId: 'alpha' }),
-    ];
-
-    const result = groupDependentsByRepo(dependents, chunks);
-
-    expect(Object.keys(result).sort()).toEqual(['alpha', 'beta', 'gamma']);
-    expect(result['alpha']).toHaveLength(2);
-    expect(result['beta']).toHaveLength(1);
-    expect(result['gamma']).toHaveLength(1);
-    expect(result['gamma'][0].isTestFile).toBe(true);
-  });
-
-  it('should assign "unknown" when dependent filepath has no matching chunk', () => {
-    const dependents = [{ filepath: 'src/orphan.ts', isTestFile: false }];
-
-    // Chunks do not include orphan.ts
-    const chunks: SearchResult[] = [createChunk('src/other.ts', { repoId: 'repo-a' })];
-
-    const result = groupDependentsByRepo(dependents, chunks);
-
-    expect(result['unknown']).toHaveLength(1);
-    expect(result['unknown'][0].filepath).toBe('src/orphan.ts');
   });
 });

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -48,7 +48,6 @@ type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
  */
 let scanCache: {
   indexVersion: number;
-  crossRepo: boolean;
   importIndex: Map<string, SearchResult[]>;
   allChunksByFile: Map<string, SearchResult[]>;
   totalChunks: number;
@@ -235,8 +234,6 @@ function addChunkToFileMap(
  */
 async function scanAllChunks(
   vectorDB: VectorDBInterface,
-  crossRepo: boolean,
-  log: (message: string, level?: 'warning') => void,
   normalizePathCached: (path: string) => string,
 ): Promise<{
   importIndex: Map<string, SearchResult[]>;
@@ -247,32 +244,6 @@ async function scanAllChunks(
   const importIndex = new Map<string, SearchResult[]>();
   const allChunksByFile = new Map<string, SearchResult[]>();
   const seenRanges = new Map<string, Set<string>>();
-
-  if (crossRepo && vectorDB.supportsCrossRepo) {
-    const CROSS_REPO_LIMIT = 100000;
-    const allChunks = await vectorDB.scanCrossRepo({
-      limit: CROSS_REPO_LIMIT,
-    });
-    const hitLimit = allChunks.length >= CROSS_REPO_LIMIT;
-    if (hitLimit) {
-      log(
-        `Warning: cross-repo scan hit ${CROSS_REPO_LIMIT} chunk limit. Results may be incomplete.`,
-        'warning',
-      );
-    }
-    for (const chunk of allChunks) {
-      addChunkToImportIndex(chunk, normalizePathCached, importIndex);
-      addChunkToFileMap(chunk, normalizePathCached, allChunksByFile, seenRanges);
-    }
-    return { importIndex, allChunksByFile, totalChunks: allChunks.length, hitLimit };
-  }
-
-  if (crossRepo) {
-    log(
-      'Warning: crossRepo=true requires a cross-repo-capable backend. Falling back to single-repo scan.',
-      'warning',
-    );
-  }
 
   const allChunks = await vectorDB.scanAll();
   for (const chunk of allChunks) {
@@ -428,7 +399,6 @@ function mergeTransitiveDependents(
  */
 async function getOrScanChunks(
   vectorDB: VectorDBInterface,
-  crossRepo: boolean,
   log: (message: string, level?: 'warning') => void,
   normalizePathCached: (path: string) => string,
   indexVersion?: number,
@@ -438,20 +408,15 @@ async function getOrScanChunks(
   totalChunks: number;
   hitLimit: boolean;
 }> {
-  if (
-    indexVersion !== undefined &&
-    scanCache !== null &&
-    scanCache.indexVersion === indexVersion &&
-    scanCache.crossRepo === crossRepo
-  ) {
+  if (indexVersion !== undefined && scanCache !== null && scanCache.indexVersion === indexVersion) {
     log(`Using cached import index (${scanCache.totalChunks} chunks, version ${indexVersion})`);
     return scanCache;
   }
 
-  const scanResult = await scanAllChunks(vectorDB, crossRepo, log, normalizePathCached);
+  const scanResult = await scanAllChunks(vectorDB, normalizePathCached);
 
   if (indexVersion !== undefined) {
-    scanCache = { indexVersion, crossRepo, ...scanResult };
+    scanCache = { indexVersion, ...scanResult };
   }
   log(`Scanned ${scanResult.totalChunks} chunks for imports...`);
   return scanResult;
@@ -509,7 +474,6 @@ interface ScanContext {
 export async function findDependents(
   vectorDB: VectorDBInterface,
   filepath: string,
-  crossRepo: boolean,
   log: (message: string, level?: 'warning') => void,
   symbol?: string,
   indexVersion?: number,
@@ -517,8 +481,7 @@ export async function findDependents(
   maxNodes: number = 500,
   /**
    * Surface the full normalized chunk set on the result.
-   * Cross-repo callers always get it (used by groupDependentsByRepo);
-   * other callers opt in by passing `true` only if they need the chunks
+   * Callers opt in by passing `true` only if they need the chunks
    * (e.g., the annotator for test-association + complexity lookups).
    * Default `false` keeps memory cost down for the common MCP path.
    */
@@ -529,7 +492,6 @@ export async function findDependents(
 
   const { importIndex, allChunksByFile, hitLimit } = await getOrScanChunks(
     vectorDB,
-    crossRepo,
     log,
     normalizePathCached,
     indexVersion,
@@ -580,13 +542,11 @@ export async function findDependents(
   const productionDependentCount = dependents.length - testDependentCount;
   const uncoveredProductionDependents = countUncoveredProductionDependents(dependents, ctx);
 
-  // Surface the full normalized chunk set only when the caller asks for it.
-  // Cross-repo paths always need it (groupDependentsByRepo); single-repo
-  // callers opt in via the `includeAllChunks` flag. Leaving it `[]` for
-  // the common case avoids allocating a flat array of every indexed chunk
-  // on each MCP get_dependents call.
-  const allChunks =
-    crossRepo || includeAllChunks ? Array.from(allChunksByFile.values()).flat() : [];
+  // Surface the full normalized chunk set only when the caller asks for it via
+  // the `includeAllChunks` flag. Leaving it `[]` for the common case avoids
+  // allocating a flat array of every indexed chunk on each MCP get_dependents
+  // call.
+  const allChunks = includeAllChunks ? Array.from(allChunksByFile.values()).flat() : [];
 
   return {
     dependents,
@@ -978,46 +938,6 @@ function calculateComplexityRiskBoost(avgComplexity: number, maxComplexity: numb
     return 'medium';
   }
   return 'low';
-}
-
-/**
- * Group dependents by repository ID.
- */
-export function groupDependentsByRepo(
-  dependents: DependentInfo[],
-  chunks: SearchResult[],
-): Record<string, DependentInfo[]> {
-  const repoMap = new Map<string, Set<string>>();
-
-  // Build map of filepath -> repoId
-  for (const chunk of chunks) {
-    const repoId = chunk.metadata.repoId || 'unknown';
-    const filepath = chunk.metadata.file;
-    if (!repoMap.has(repoId)) {
-      repoMap.set(repoId, new Set());
-    }
-    repoMap.get(repoId)!.add(filepath);
-  }
-
-  // Group dependents by repo
-  const grouped: Record<string, DependentInfo[]> = {};
-  for (const dependent of dependents) {
-    // Find which repo this file belongs to
-    let foundRepo = 'unknown';
-    for (const [repoId, files] of repoMap.entries()) {
-      if (files.has(dependent.filepath)) {
-        foundRepo = repoId;
-        break;
-      }
-    }
-
-    if (!grouped[foundRepo]) {
-      grouped[foundRepo] = [];
-    }
-    grouped[foundRepo].push(dependent);
-  }
-
-  return grouped;
 }
 
 /**

--- a/packages/cli/src/mcp/handlers/get-complexity.test.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.test.ts
@@ -30,8 +30,6 @@ vi.mock('@liendev/core', async () => {
 describe('handleGetComplexity', () => {
   const mockVectorDB = {
     scanWithFilter: vi.fn(),
-    scanCrossRepo: vi.fn(),
-    supportsCrossRepo: false,
     getCurrentVersion: vi.fn(() => 1234567890),
     getVersionDate: vi.fn(() => '2025-12-19'),
   };

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -3,21 +3,14 @@ import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetComplexitySchema } from '../schemas/index.js';
 import type { GetComplexityInput } from '../schemas/index.js';
 import { ComplexityAnalyzer } from '@liendev/core';
-import type { VectorDBInterface } from '@liendev/core';
 import type { ComplexityViolation, FileComplexityData, ComplexityReport } from '@liendev/parser';
-import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
+import type { ToolContext, MCPToolResult } from '../types.js';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-type ChunkWithRepo = { metadata: { file: string; repoId?: string } };
 type TransformedViolation = ReturnType<typeof transformViolation>;
-
-interface CrossRepoResult {
-  chunks: ChunkWithRepo[];
-  fallback: boolean;
-}
 
 interface ProcessedViolations {
   violations: TransformedViolation[];
@@ -49,62 +42,6 @@ function transformViolation(v: ComplexityViolation, fileData: FileComplexityData
     riskLevel: fileData.riskLevel,
     ...(v.halsteadDetails && { halsteadDetails: v.halsteadDetails }),
   };
-}
-
-/**
- * Group complexity violations by repository ID.
- */
-function groupViolationsByRepo(
-  violations: TransformedViolation[],
-  allChunks: ChunkWithRepo[],
-): Record<string, TransformedViolation[]> {
-  const fileToRepo = new Map<string, string>();
-
-  for (const chunk of allChunks) {
-    const repoId = chunk.metadata.repoId || 'unknown';
-    fileToRepo.set(chunk.metadata.file, repoId);
-  }
-
-  const grouped: Record<string, TransformedViolation[]> = {};
-  for (const violation of violations) {
-    const repoId = fileToRepo.get(violation.filepath) || 'unknown';
-    if (!grouped[repoId]) {
-      grouped[repoId] = [];
-    }
-    grouped[repoId].push(violation);
-  }
-
-  return grouped;
-}
-
-/**
- * Fetch chunks for cross-repo analysis.
- * Returns fallback=true if cross-repo was requested but the backend does not support it.
- */
-async function fetchCrossRepoChunks(
-  vectorDB: VectorDBInterface,
-  crossRepo: boolean | undefined,
-  repoIds: string[] | undefined,
-  log: LogFn,
-): Promise<CrossRepoResult> {
-  if (!crossRepo) {
-    return { chunks: [], fallback: false };
-  }
-
-  if (vectorDB.supportsCrossRepo) {
-    // Chunks here feed only `groupViolationsByRepo` (file → repoId mapping).
-    // The actual analyzer scan that reads complexity/halstead/imports
-    // happens inside ComplexityAnalyzer.analyze. `repoId` is required for
-    // grouping on cross-repo backends — not applicable to the single-repo backend.
-    const chunks = await vectorDB.scanCrossRepo({
-      limit: 100000,
-      repoIds,
-    });
-    log(`Scanned ${chunks.length} chunks across repos`);
-    return { chunks, fallback: false };
-  }
-
-  return { chunks: [], fallback: true };
 }
 
 /**
@@ -144,15 +81,6 @@ function processViolations(
   };
 }
 
-/**
- * Build warning note for cross-repo fallback.
- */
-function buildCrossRepoFallbackNote(fallback: boolean): string | undefined {
-  return fallback
-    ? 'Cross-repo analysis requires a cross-repo-capable backend. Fell back to single-repo analysis.'
-    : undefined;
-}
-
 // ============================================================================
 // Main Handler
 // ============================================================================
@@ -165,39 +93,22 @@ export async function handleGetComplexity(args: unknown, ctx: ToolContext): Prom
   const { vectorDB, log, checkAndReconnect, getIndexMetadata } = ctx;
 
   return await wrapToolHandler(GetComplexitySchema, async validatedArgs => {
-    const { crossRepo, repoIds, files, top, threshold, metricType } = validatedArgs;
-    log(`Analyzing complexity${crossRepo ? ' (cross-repo)' : ''}...`);
+    const { files, top, threshold, metricType } = validatedArgs;
+    log('Analyzing complexity...');
     await checkAndReconnect();
 
-    // Step 1: Fetch cross-repo chunks if needed
-    const { chunks: allChunks, fallback } = await fetchCrossRepoChunks(
-      vectorDB,
-      crossRepo,
-      repoIds,
-      log,
-    );
-
-    // Step 2: Run complexity analysis
+    // Step 1: Run complexity analysis
     const analyzer = new ComplexityAnalyzer(vectorDB);
-    const report = await analyzer.analyze(files, crossRepo && !fallback, repoIds);
+    const report = await analyzer.analyze(files);
     log(`Analyzed ${report.summary.filesAnalyzed} files`);
 
-    // Step 3: Process violations
+    // Step 2: Process violations
     const { violations, topViolations, bySeverity } = processViolations(
       report,
       threshold,
       top ?? 10,
       metricType,
     );
-
-    // Step 4: Build response
-    const note = buildCrossRepoFallbackNote(fallback);
-    if (note) {
-      log(
-        'Warning: crossRepo=true requires a cross-repo-capable backend. Falling back to single-repo analysis.',
-        'warning',
-      );
-    }
 
     return {
       indexInfo: getIndexMetadata(),
@@ -209,12 +120,6 @@ export async function handleGetComplexity(args: unknown, ctx: ToolContext): Prom
         bySeverity,
       },
       violations: topViolations,
-      ...(crossRepo &&
-        !fallback &&
-        allChunks.length > 0 && {
-          groupedByRepo: groupViolationsByRepo(topViolations, allChunks),
-        }),
-      ...(note && { note }),
     };
   })(args);
 }

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -24,8 +24,6 @@ describe('handleGetDependents', () => {
 
   let mockVectorDB: {
     scanWithFilter: ReturnType<typeof vi.fn>;
-    scanCrossRepo: ReturnType<typeof vi.fn>;
-    supportsCrossRepo: boolean;
   };
 
   let mockCtx: ToolContext;
@@ -86,8 +84,6 @@ describe('handleGetDependents', () => {
 
     mockVectorDB = {
       scanWithFilter: vi.fn(),
-      scanCrossRepo: vi.fn(),
-      supportsCrossRepo: false,
     };
 
     mockCtx = {
@@ -136,7 +132,6 @@ describe('handleGetDependents', () => {
       expect(findDependents).toHaveBeenCalledWith(
         mockVectorDB,
         'src/utils/helpers.ts',
-        false, // crossRepo default
         mockLog,
         undefined, // symbol default
         1234567890, // indexVersion from mock
@@ -273,165 +268,6 @@ describe('handleGetDependents', () => {
     });
   });
 
-  describe('hitLimit behavior', () => {
-    it('should include warning note when scan limit is reached', async () => {
-      vi.mocked(findDependents).mockResolvedValue(
-        createMockAnalysis({
-          hitLimit: true,
-          dependents: Array(50)
-            .fill(null)
-            .map((_, i) => ({
-              filepath: `src/file${i}.ts`,
-              isTestFile: false,
-            })),
-        }),
-      );
-
-      const result = await handleGetDependents({ filepath: 'src/widely-used.ts' }, mockCtx);
-
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.note).toContain('100,000');
-      expect(parsed.note).toContain('Cross-repo');
-      expect(parsed.note).toContain('incomplete');
-    });
-
-    it('should not include note when scan limit is not reached', async () => {
-      vi.mocked(findDependents).mockResolvedValue(
-        createMockAnalysis({
-          hitLimit: false,
-        }),
-      );
-
-      const result = await handleGetDependents({ filepath: 'src/normal.ts' }, mockCtx);
-
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.note).toBeUndefined();
-    });
-  });
-
-  describe('cross-repo search with a cross-repo-capable backend', () => {
-    let mockCrossRepoDB: any;
-
-    beforeEach(() => {
-      mockCrossRepoDB = {
-        scanWithFilter: vi.fn(),
-        scanCrossRepo: vi.fn(),
-        supportsCrossRepo: true,
-      };
-
-      mockCtx = {
-        vectorDB: mockCrossRepoDB,
-        log: mockLog,
-        checkAndReconnect: mockCheckAndReconnect,
-        getIndexMetadata: mockGetIndexMetadata,
-        getReindexState: vi.fn(() => ({
-          inProgress: false,
-          pendingFiles: [],
-          lastReindexTimestamp: null,
-          lastReindexDurationMs: null,
-        })),
-        rootDir: '/fake/workspace',
-      };
-    });
-
-    it('should pass crossRepo=true to findDependents when enabled', async () => {
-      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
-
-      await handleGetDependents({ filepath: 'src/shared/utils.ts', crossRepo: true }, mockCtx);
-
-      expect(findDependents).toHaveBeenCalledWith(
-        mockCrossRepoDB,
-        'src/shared/utils.ts',
-        true,
-        mockLog,
-        undefined,
-        1234567890,
-        1,
-        500,
-      );
-    });
-
-    it('should include groupedByRepo when crossRepo=true with a cross-repo-capable backend', async () => {
-      const mockChunks: SearchResult[] = [
-        {
-          content: 'import { util } from "./utils"',
-          metadata: {
-            file: 'repo-a/src/consumer.ts',
-            repoId: 'repo-a',
-            startLine: 1,
-            endLine: 5,
-            type: 'block',
-            language: 'typescript',
-          },
-          score: 0,
-          relevance: 'highly_relevant',
-        },
-        {
-          content: 'import { util } from "./utils"',
-          metadata: {
-            file: 'repo-b/src/other.ts',
-            repoId: 'repo-b',
-            startLine: 1,
-            endLine: 5,
-            type: 'block',
-            language: 'typescript',
-          },
-          score: 0,
-          relevance: 'highly_relevant',
-        },
-      ];
-
-      vi.mocked(findDependents).mockResolvedValue({
-        ...createMockAnalysis({
-          dependents: [
-            { filepath: 'repo-a/src/consumer.ts', isTestFile: false },
-            { filepath: 'repo-b/src/other.ts', isTestFile: false },
-          ],
-        }),
-        allChunks: mockChunks,
-      });
-
-      const result = await handleGetDependents(
-        { filepath: 'shared/utils.ts', crossRepo: true },
-        mockCtx,
-      );
-
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.groupedByRepo).toBeDefined();
-    });
-  });
-
-  describe('cross-repo fallback (unsupported backend)', () => {
-    it('should not include groupedByRepo when the backend lacks cross-repo support', async () => {
-      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
-
-      const result = await handleGetDependents(
-        { filepath: 'src/utils.ts', crossRepo: true },
-        mockCtx,
-      );
-
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.groupedByRepo).toBeUndefined();
-    });
-
-    it('should still pass crossRepo to findDependents (which handles warning)', async () => {
-      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
-
-      await handleGetDependents({ filepath: 'src/utils.ts', crossRepo: true }, mockCtx);
-
-      expect(findDependents).toHaveBeenCalledWith(
-        mockVectorDB,
-        'src/utils.ts',
-        true,
-        mockLog,
-        undefined,
-        1234567890,
-        1,
-        500,
-      );
-    });
-  });
-
   describe('validation', () => {
     it('should reject empty filepath', async () => {
       const result = await handleGetDependents({ filepath: '' }, mockCtx);
@@ -472,14 +308,6 @@ describe('handleGetDependents', () => {
       await handleGetDependents({ filepath: 'src/important.ts' }, mockCtx);
 
       expect(mockLog).toHaveBeenCalledWith('Finding dependents of: src/important.ts');
-    });
-
-    it('should indicate cross-repo in log when enabled', async () => {
-      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
-
-      await handleGetDependents({ filepath: 'src/shared.ts', crossRepo: true }, mockCtx);
-
-      expect(mockLog).toHaveBeenCalledWith('Finding dependents of: src/shared.ts (cross-repo)');
     });
 
     it('should log dependent count with prod/test breakdown', async () => {
@@ -629,7 +457,6 @@ describe('handleGetDependents', () => {
       expect(findDependents).toHaveBeenCalledWith(
         mockVectorDB,
         'src/utils/validate.ts',
-        false,
         mockLog,
         'validateEmail',
         1234567890,
@@ -764,7 +591,6 @@ describe('handleGetDependents', () => {
       expect(findDependents).toHaveBeenCalledWith(
         mockVectorDB,
         'src/target.ts',
-        false,
         mockLog,
         undefined,
         1234567890,

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -2,11 +2,9 @@ import type { z } from 'zod';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetDependentsSchema } from '../schemas/index.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
-import type { VectorDBInterface } from '@liendev/core';
 import { computeBlastRadiusRisk, type BlastRadiusRisk } from '@liendev/parser';
 import {
   findDependents,
-  groupDependentsByRepo,
   type DependencyAnalysisResult,
   type DependentInfo,
   type ComplexityMetrics,
@@ -46,35 +44,6 @@ interface DependentsResponse {
   riskReasoning: string[];
   dependents: DependentInfo[];
   complexityMetrics: ComplexityMetrics;
-  note?: string;
-  groupedByRepo?: Record<string, DependentInfo[]>;
-}
-
-/**
- * Check if cross-repo search is requested but not supported.
- */
-function checkCrossRepoFallback(
-  crossRepo: boolean | undefined,
-  vectorDB: VectorDBInterface,
-): boolean {
-  return Boolean(crossRepo && !vectorDB.supportsCrossRepo);
-}
-
-/**
- * Build warning notes for the response.
- */
-function buildNotes(crossRepoFallback: boolean, hitLimit: boolean): string[] {
-  const notes: string[] = [];
-  if (crossRepoFallback) {
-    notes.push(
-      'Cross-repo search requires a cross-repo-capable backend. Fell back to single-repo search.',
-    );
-  }
-  if (hitLimit) {
-    // Only set by the cross-repo scan path (single-repo pagination is unbounded).
-    notes.push('Cross-repo scan reached its 100,000-chunk limit. Results may be incomplete.');
-  }
-  return notes;
 }
 
 /**
@@ -139,9 +108,6 @@ function buildDependentsResponse(
   args: ValidatedArgs,
   risk: BlastRadiusRisk,
   indexInfo: IndexInfo,
-  notes: string[],
-  crossRepo: boolean | undefined,
-  vectorDB: VectorDBInterface,
 ): DependentsResponse {
   const { symbol, filepath, depth } = args;
 
@@ -167,14 +133,6 @@ function buildDependentsResponse(
   if (analysis.totalUsageCount !== undefined) {
     response.totalUsageCount = analysis.totalUsageCount;
   }
-  if (notes.length > 0) {
-    response.note = notes.join(' ');
-  }
-
-  // Group by repo if cross-repo search on a cross-repo-capable backend
-  if (crossRepo && vectorDB.supportsCrossRepo) {
-    response.groupedByRepo = groupDependentsByRepo(analysis.dependents, analysis.allChunks);
-  }
 
   return response;
 }
@@ -197,13 +155,12 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
     // defaults aren't reflected in `raw`'s type. At runtime Zod has already
     // applied them, so the cast is sound.
     const validatedArgs = raw as ValidatedArgs;
-    const { crossRepo, filepath, symbol, depth, maxNodes } = validatedArgs;
+    const { filepath, symbol, depth, maxNodes } = validatedArgs;
 
     // Log initial request
     const symbolSuffix = symbol ? ` (symbol: ${symbol})` : '';
-    const crossRepoSuffix = crossRepo ? ' (cross-repo)' : '';
     const depthSuffix = depth > 1 ? ` (depth: ${depth})` : '';
-    log(`Finding dependents of: ${filepath}${symbolSuffix}${crossRepoSuffix}${depthSuffix}`);
+    log(`Finding dependents of: ${filepath}${symbolSuffix}${depthSuffix}`);
 
     await checkAndReconnect();
 
@@ -214,7 +171,6 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
     const analysis = await findDependents(
       vectorDB,
       filepath,
-      crossRepo ?? false,
       log,
       symbol,
       indexInfo.indexVersion,
@@ -229,17 +185,6 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
     logRiskAssessment(analysis, risk.level, symbol, log);
 
     // Build and return response
-    const crossRepoFallback = checkCrossRepoFallback(crossRepo, vectorDB);
-    const notes = buildNotes(crossRepoFallback, analysis.hitLimit);
-
-    return buildDependentsResponse(
-      analysis,
-      validatedArgs,
-      risk,
-      indexInfo,
-      notes,
-      crossRepo,
-      vectorDB,
-    );
+    return buildDependentsResponse(analysis, validatedArgs, risk, indexInfo);
   })(args);
 }

--- a/packages/cli/src/mcp/handlers/search-code.test.ts
+++ b/packages/cli/src/mcp/handlers/search-code.test.ts
@@ -26,7 +26,7 @@ describe('handleSearchCode', () => {
   function createMockResult(
     overrides: {
       content?: string;
-      metadata?: Partial<typeof defaultMetadata & { repoId?: string }>;
+      metadata?: Partial<typeof defaultMetadata>;
       score?: number;
       relevance?: 'highly_relevant' | 'relevant' | 'loosely_related' | 'not_relevant';
     } = {},
@@ -44,7 +44,6 @@ describe('handleSearchCode', () => {
 
   let mockVectorDB: {
     search: ReturnType<typeof vi.fn>;
-    supportsCrossRepo: boolean;
   };
 
   let mockCtx: ToolContext;
@@ -54,7 +53,6 @@ describe('handleSearchCode', () => {
 
     mockVectorDB = {
       search: vi.fn(),
-      supportsCrossRepo: false,
     };
 
     mockCtx = {
@@ -159,48 +157,6 @@ describe('handleSearchCode', () => {
     });
   });
 
-  describe('cross-repo fallback (unsupported by the bundled backend)', () => {
-    it('should fall back to single-repo search when crossRepo=true', async () => {
-      const mockResults = [createMockResult()];
-      mockVectorDB.search.mockResolvedValue(mockResults);
-
-      const result = await handleSearchCode(
-        { query: 'test fallback query', crossRepo: true },
-        mockCtx,
-      );
-
-      // Should log a warning
-      expect(mockLog).toHaveBeenCalledWith(
-        'Warning: crossRepo=true requires a cross-repo-capable backend. Falling back to single-repo search.',
-        'warning',
-      );
-
-      // Should use regular lexical search
-      expect(mockVectorDB.search).toHaveBeenCalled();
-
-      // Should not include groupedByRepo in response (single-repo backend)
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.groupedByRepo).toBeUndefined();
-    });
-
-    it('should still return results when falling back', async () => {
-      const mockResults = [
-        createMockResult({ content: 'fallback result 1', metadata: { file: 'src/fb1.ts' } }),
-        createMockResult({ content: 'fallback result 2', metadata: { file: 'src/fb2.ts' } }),
-      ];
-      mockVectorDB.search.mockResolvedValue(mockResults);
-
-      const result = await handleSearchCode(
-        { query: 'test fallback results', crossRepo: true },
-        mockCtx,
-      );
-
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.results).toHaveLength(2);
-      expect(parsed.indexInfo).toBeDefined();
-    });
-  });
-
   describe('validation', () => {
     it('should reject queries shorter than 3 characters', async () => {
       const result = await handleSearchCode({ query: 'ab' }, mockCtx);
@@ -280,23 +236,6 @@ describe('handleSearchCode', () => {
       expect(parsed.indexInfo).toBeDefined();
     });
 
-    it('should merge crossRepo fallback note with not_relevant note', async () => {
-      const mockResults = [
-        createMockResult({ relevance: 'not_relevant', metadata: { file: 'src/a.ts' } }),
-      ];
-      mockVectorDB.search.mockResolvedValue(mockResults);
-
-      const result = await handleSearchCode(
-        { query: 'something irrelevant', crossRepo: true },
-        mockCtx,
-      );
-
-      const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.results).toHaveLength(0);
-      expect(parsed.note).toContain('Cross-repo search requires a cross-repo-capable backend');
-      expect(parsed.note).toContain('No relevant matches found.');
-    });
-
     it('should keep results when at least one is relevant', async () => {
       const mockResults = [
         createMockResult({ relevance: 'not_relevant', metadata: { file: 'src/a.ts' } }),
@@ -318,14 +257,6 @@ describe('handleSearchCode', () => {
       await handleSearchCode({ query: 'authentication handler' }, mockCtx);
 
       expect(mockLog).toHaveBeenCalledWith('Searching for: "authentication handler"');
-    });
-
-    it('should indicate cross-repo in log when enabled', async () => {
-      mockVectorDB.search.mockResolvedValue([]);
-
-      await handleSearchCode({ query: 'cross repo test', crossRepo: true }, mockCtx);
-
-      expect(mockLog).toHaveBeenCalledWith('Searching for: "cross repo test" (cross-repo)');
     });
 
     it('should log result count', async () => {

--- a/packages/cli/src/mcp/handlers/search-code.ts
+++ b/packages/cli/src/mcp/handlers/search-code.ts
@@ -4,49 +4,23 @@ import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import type { VectorDBInterface, SearchResult } from '@liendev/core';
 
-/**
- * Group search results by repository ID.
- */
-function groupResultsByRepo(results: Array<{ metadata: { repoId?: string } }>) {
-  const grouped: Record<string, typeof results> = {};
-
-  for (const result of results) {
-    const repoId = result.metadata.repoId || 'unknown';
-    if (!grouped[repoId]) {
-      grouped[repoId] = [];
-    }
-    grouped[repoId].push(result);
-  }
-
-  return grouped;
-}
-
 interface SearchParams {
   query: string;
   limit: number;
-  crossRepo?: boolean;
 }
 
 /**
- * Execute the lexical search. Cross-repo search is unsupported by the bundled
- * SQLite backend, so a crossRepo request falls back to a single-repo search.
+ * Execute the lexical search.
  */
 async function executeSearch(
   vectorDB: VectorDBInterface,
   params: SearchParams,
   log: LogFn,
-): Promise<{ results: SearchResult[]; crossRepoFallback: boolean }> {
-  const { query, limit, crossRepo } = params;
-
-  if (crossRepo) {
-    log(
-      'Warning: crossRepo=true requires a cross-repo-capable backend. Falling back to single-repo search.',
-      'warning',
-    );
-  }
+): Promise<SearchResult[]> {
+  const { query, limit } = params;
   const results = await vectorDB.search(query, limit);
   log(`Found ${results.length} results`);
-  return { results, crossRepoFallback: !!crossRepo };
+  return results;
 }
 
 /**
@@ -54,16 +28,9 @@ async function executeSearch(
  */
 function processResults(
   rawResults: SearchResult[],
-  crossRepoFallback: boolean,
   log: LogFn,
 ): { results: SearchResult[]; notes: string[] } {
   const notes: string[] = [];
-  if (crossRepoFallback) {
-    notes.push(
-      'Cross-repo search requires a cross-repo-capable backend. Fell back to single-repo search.',
-    );
-  }
-
   const results = deduplicateResults(rawResults);
 
   if (results.length > 0 && results.every(r => r.relevance === 'not_relevant')) {
@@ -79,25 +46,20 @@ function processResults(
  * Handle search_code tool calls.
  *
  * Runs lexical full-text (FTS5/BM25) search over code, docstrings, and
- * camelCase-split identifiers via `vectorDB.search`. Cross-repo search is
- * unsupported by the bundled single-repo SQLite backend.
+ * camelCase-split identifiers via `vectorDB.search`.
  */
 export async function handleSearchCode(args: unknown, ctx: ToolContext): Promise<MCPToolResult> {
   const { vectorDB, log, checkAndReconnect, getIndexMetadata } = ctx;
 
   return await wrapToolHandler(SearchCodeSchema, async validatedArgs => {
-    const { crossRepo, query, limit } = validatedArgs;
+    const { query, limit } = validatedArgs;
 
-    log(`Searching for: "${query}"${crossRepo ? ' (cross-repo)' : ''}`);
+    log(`Searching for: "${query}"`);
     await checkAndReconnect();
 
-    const { results: rawResults, crossRepoFallback } = await executeSearch(
-      vectorDB,
-      { query, limit: limit ?? 5, crossRepo },
-      log,
-    );
+    const rawResults = await executeSearch(vectorDB, { query, limit: limit ?? 5 }, log);
 
-    const { results, notes } = processResults(rawResults, crossRepoFallback, log);
+    const { results, notes } = processResults(rawResults, log);
 
     log(`Returning ${results.length} results`);
 
@@ -112,7 +74,6 @@ export async function handleSearchCode(args: unknown, ctx: ToolContext): Promise
     return {
       indexInfo: getIndexMetadata(),
       results: shaped,
-      ...(crossRepo && vectorDB.supportsCrossRepo && { groupedByRepo: groupResultsByRepo(shaped) }),
       ...(notes.length > 0 && { note: notes.join(' ') }),
     };
   })(args);

--- a/packages/cli/src/mcp/schemas/complexity.schema.ts
+++ b/packages/cli/src/mcp/schemas/complexity.schema.ts
@@ -52,24 +52,6 @@ export const GetComplexitySchema = z.object({
     .enum(['cyclomatic', 'cognitive', 'halstead_effort', 'halstead_bugs'])
     .optional()
     .describe('Filter violations to a specific metric type. If omitted, returns all types.'),
-
-  crossRepo: z
-    .boolean()
-    .default(false)
-    .describe(
-      'If true, analyze complexity across all repos in the organization (requires a cross-repo-capable backend; the bundled SQLite backend is single-repo).\n\n' +
-        'Default: false (single-repo analysis)\n' +
-        'When enabled, results are aggregated by repository.',
-    ),
-
-  repoIds: z
-    .array(z.string().max(255))
-    .optional()
-    .describe(
-      'Optional: Filter to specific repos when crossRepo=true.\n\n' +
-        'If provided, only analyzes the specified repositories.\n' +
-        'If omitted and crossRepo=true, analyzes all repos in the organization.',
-    ),
 });
 
 /**

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -11,9 +11,7 @@ import path from 'path';
  * for that exported symbol instead of just file-level dependencies.
  *
  * Limitations:
- * - Single-repo scans iterate every indexed chunk with no chunk-count cap.
- * - Cross-repo scans (`crossRepo: true`) cap at 100,000 chunks; if that cap is
- *   reached, a warning is returned in the response `note`.
+ * - Scans iterate every indexed chunk with no chunk-count cap.
  */
 export const GetDependentsSchema = z.object({
   filepath: z
@@ -27,10 +25,7 @@ export const GetDependentsSchema = z.object({
     .describe(
       'Path to file to find dependents for (relative to workspace root).\n\n' +
         "Example: 'src/utils/validate.ts'\n\n" +
-        'Returns all files that import or depend on this file.\n\n' +
-        'Single-repo scans are unbounded. Cross-repo scans cap at 100,000\n' +
-        'chunks — a warning is included in the response `note` if the cap\n' +
-        'is reached.',
+        'Returns all files that import or depend on this file. The scan is unbounded.',
     ),
 
   symbol: z
@@ -75,15 +70,6 @@ export const GetDependentsSchema = z.object({
         'is the scan-level `hitLimit`). A `depth=1` response can therefore\n' +
         'exceed `maxNodes` with `truncated: false`. When the BFS walk itself\n' +
         'hits the cap mid-expansion, `truncated: true` is set.',
-    ),
-
-  crossRepo: z
-    .boolean()
-    .default(false)
-    .describe(
-      'If true, find dependents across all repos in the organization (requires a cross-repo-capable backend; the bundled SQLite backend is single-repo).\n\n' +
-        'Default: false (single-repo search)\n' +
-        'When enabled, results are grouped by repository.',
     ),
 });
 

--- a/packages/cli/src/mcp/schemas/schemas.test.ts
+++ b/packages/cli/src/mcp/schemas/schemas.test.ts
@@ -68,11 +68,6 @@ describe('SearchCodeSchema', () => {
     const result = SearchCodeSchema.parse({ query: 'test', limit: 50 });
     expect(result.limit).toBe(50);
   });
-
-  it('should reject too-long repoIds element', () => {
-    const longRepoId = 'a'.repeat(256);
-    expect(() => SearchCodeSchema.parse({ query: 'test', repoIds: [longRepoId] })).toThrow();
-  });
 });
 
 describe('FindSimilarSchema', () => {
@@ -499,10 +494,5 @@ describe('GetComplexitySchema', () => {
   it('should reject too-long files element', () => {
     const longPath = 'a'.repeat(1001);
     expect(() => GetComplexitySchema.parse({ files: [longPath] })).toThrow();
-  });
-
-  it('should reject too-long repoIds element', () => {
-    const longRepoId = 'a'.repeat(256);
-    expect(() => GetComplexitySchema.parse({ repoIds: [longRepoId] })).toThrow();
   });
 });

--- a/packages/cli/src/mcp/schemas/search.schema.ts
+++ b/packages/cli/src/mcp/schemas/search.schema.ts
@@ -35,24 +35,6 @@ export const SearchCodeSchema = z.object({
         'Default: 5\n' +
         'Increase to 10-15 for broad exploration.',
     ),
-
-  crossRepo: z
-    .boolean()
-    .default(false)
-    .describe(
-      'If true, search across all repos in the organization (requires a cross-repo-capable backend; the bundled backend is single-repo).\n\n' +
-        'Default: false (single-repo search)\n' +
-        'When enabled, results are grouped by repository.',
-    ),
-
-  repoIds: z
-    .array(z.string().max(255))
-    .optional()
-    .describe(
-      'Optional: Filter to specific repos when crossRepo=true.\n\n' +
-        'If provided, only searches within the specified repositories.\n' +
-        'If omitted and crossRepo=true, searches all repos in the organization.',
-    ),
 });
 
 /**

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -29,8 +29,7 @@ IMPORTANT: Query with concrete KEYWORDS, identifiers, and domain terms that actu
 Returns:
 - results[]: { content, score, relevance, metadata: { file, startLine, endLine, language?, symbolName?, symbolType?, signature?, enclosingSymbol? } }
 - enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
-- relevance: "highly_relevant" | "relevant" | "loosely_related" (not_relevant auto-filtered)
-- groupedByRepo?: Record<repoId, results[]> (when crossRepo=true)`,
+- relevance: "highly_relevant" | "relevant" | "loosely_related" (not_relevant auto-filtered)`,
   ),
   toMCPToolSchema(
     FindSimilarSchema,
@@ -139,8 +138,7 @@ Returns:
 - riskLevel: "low" | "medium" | "high" | "critical"
 - dependents[]: { filepath, isTestFile, usages[]? }
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
-- totalUsageCount?: number (when symbol parameter provided)
-- groupedByRepo?: Record<repoId, dependents[]> (when crossRepo=true)`,
+- totalUsageCount?: number (when symbol parameter provided)`,
   ),
   toMCPToolSchema(
     GetComplexitySchema,
@@ -167,7 +165,6 @@ Returns:
 - summary: { filesAnalyzed, avgComplexity, maxComplexity, violationCount, bySeverity: { error, warning } }
 - violations[]: { filepath, symbolName, symbolType, complexity, metricType, threshold, severity, riskLevel, dependentCount }
 - metricType: "cyclomatic" | "cognitive" | "halstead_effort" | "halstead_bugs"
-- severity: "error" | "warning"
-- groupedByRepo?: Record<repoId, violations[]> (when crossRepo=true)`,
+- severity: "error" | "warning"`,
   ),
 ];

--- a/packages/cli/src/mcp/types.ts
+++ b/packages/cli/src/mcp/types.ts
@@ -68,9 +68,7 @@ export interface IndexMetadata {
 export interface SearchResultResponse {
   indexInfo: IndexMetadata;
   results: ToolResult[];
-  /** Results grouped by repository when cross-repo search is used */
-  groupedByRepo?: Record<string, ToolResult[]>;
-  /** Warning note when cross-repo fallback occurs or other issues */
+  /** Diagnostic note, e.g. when no relevant results are found */
   note?: string;
 }
 

--- a/packages/cli/src/mcp/utils/metadata-shaper.test.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.test.ts
@@ -257,33 +257,4 @@ describe('deduplicateResults', () => {
   it('handles empty array', () => {
     expect(deduplicateResults([])).toEqual([]);
   });
-
-  it('keeps results from different repos with same file path and line range', () => {
-    const r1 = {
-      ...createFullResult(),
-      metadata: { ...createFullResult().metadata, repoId: 'repo-a' },
-    };
-    const r2 = {
-      ...createFullResult(),
-      metadata: { ...createFullResult().metadata, repoId: 'repo-b' },
-    };
-
-    const results = deduplicateResults([r1, r2]);
-    expect(results).toHaveLength(2);
-  });
-
-  it('deduplicates results within the same repo', () => {
-    const r1 = {
-      ...createFullResult(),
-      metadata: { ...createFullResult().metadata, repoId: 'repo-a' },
-    };
-    const r2 = {
-      ...createFullResult(),
-      metadata: { ...createFullResult().metadata, repoId: 'repo-a' },
-      content: 'duplicate',
-    };
-
-    const results = deduplicateResults([r1, r2]);
-    expect(results).toHaveLength(1);
-  });
 });

--- a/packages/cli/src/mcp/utils/metadata-shaper.ts
+++ b/packages/cli/src/mcp/utils/metadata-shaper.ts
@@ -30,7 +30,6 @@ export interface ToolResultMetadata {
   importedSymbols?: Record<string, string[]>;
   callSites?: Array<{ symbol: string; line: number }>;
   symbols?: { functions: string[]; classes: string[]; interfaces: string[] };
-  repoId?: string;
   enclosingSymbol?: string;
 }
 
@@ -69,7 +68,6 @@ const FIELD_ALLOWLISTS: Record<ToolName, ReadonlySet<AllowlistKey>> = {
     'parentClass',
     'parameters',
     'exports',
-    'repoId',
   ]),
   find_similar: new Set<AllowlistKey>([
     'language',
@@ -109,16 +107,13 @@ const FIELD_ALLOWLISTS: Record<ToolName, ReadonlySet<AllowlistKey>> = {
 };
 
 /**
- * Deduplicate results by repoId + file + startLine + endLine.
+ * Deduplicate results by file + startLine + endLine.
  * Keeps the first occurrence (highest ranked) of each unique chunk.
- * Includes repoId so cross-repo searches don't collapse results from
- * different repos that share the same relative path and line range.
  */
 export function deduplicateResults(results: SearchResult[]): SearchResult[] {
   const seen = new Set<string>();
   return results.filter(r => {
     const key = JSON.stringify([
-      r.metadata.repoId ?? '',
       r.metadata.file ? normalizeToRelativePath(r.metadata.file) : '',
       r.metadata.startLine,
       r.metadata.endLine,

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -11,7 +11,7 @@ import {
 import { ManifestManager } from './manifest.js';
 import type { Result } from '../utils/result.js';
 import { Ok, Err, isOk } from '../utils/result.js';
-import { chunkFile, computeContentHash, extractRepoId } from '@liendev/parser';
+import { chunkFile, computeContentHash } from '@liendev/parser';
 import type { CodeChunk } from '@liendev/parser';
 
 /**
@@ -46,7 +46,7 @@ export function normalizeToRelativePath(filepath: string, rootDir?: string): str
 
 export interface IncrementalIndexOptions {
   verbose?: boolean;
-  rootDir?: string; // Root directory for extracting repoId
+  rootDir?: string; // Workspace root, enables cross-package import resolution
 }
 
 /**
@@ -91,9 +91,7 @@ async function processFileContent(
   const useAST = true; // Always use AST-based chunking
   const astFallback = 'line-based' as const;
 
-  // Extract tenant context for multi-tenant scenarios
   // orgId is now handled in createVectorDB() via global config and git remote detection
-  const repoId = rootDir ? extractRepoId(rootDir) : undefined;
   const orgId = undefined; // Not needed here - handled in VectorDB factory
 
   // Chunk the file
@@ -102,7 +100,6 @@ async function processFileContent(
     chunkOverlap,
     useAST,
     astFallback,
-    repoId,
     orgId,
     workspaceRoot: rootDir,
   });

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -31,7 +31,6 @@ import { buildOverlay } from './overlay-index.js';
 import type { VectorDBInterface } from '../vectordb/types.js';
 import type { OverlayBackend } from '../vectordb/overlay-backend.js';
 import {
-  extractRepoId,
   scanCodebase,
   detectEcosystems,
   getEcosystemExcludePatterns,
@@ -82,15 +81,12 @@ interface IndexingConfig {
   chunkOverlap: number;
   useAST: boolean;
   astFallback: 'line-based' | 'error';
-  repoId?: string;
   orgId?: string;
 }
 
 /** Extract indexing config values using defaults */
-function getIndexingConfig(rootDir: string): IndexingConfig {
+function getIndexingConfig(_rootDir: string): IndexingConfig {
   // Use defaults for all settings - no config needed!
-  const repoId = extractRepoId(rootDir);
-
   // orgId is now handled in createVectorDB() via global config and git remote detection
   // No need to extract it here anymore
 
@@ -99,7 +95,6 @@ function getIndexingConfig(rootDir: string): IndexingConfig {
     chunkOverlap: DEFAULT_CHUNK_OVERLAP,
     useAST: true, // Always use AST-based chunking
     astFallback: 'line-based' as const,
-    repoId,
     orgId: undefined, // Not needed here - handled in VectorDB factory
   };
 }
@@ -352,7 +347,6 @@ async function processFileForIndexing(
       chunkOverlap: indexConfig.chunkOverlap,
       useAST: indexConfig.useAST,
       astFallback: indexConfig.astFallback,
-      repoId: indexConfig.repoId,
       orgId: indexConfig.orgId,
       workspaceRoot: rootDir,
     });

--- a/packages/core/src/indexer/overlay-index.ts
+++ b/packages/core/src/indexer/overlay-index.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { createHash } from 'crypto';
 import pLimit from 'p-limit';
-import { chunkFile, computeContentHash, extractRepoId } from '@liendev/parser';
+import { chunkFile, computeContentHash } from '@liendev/parser';
 import type { ChunkMetadata } from '@liendev/parser';
 import {
   DEFAULT_CONCURRENCY,
@@ -169,7 +169,6 @@ export async function buildOverlay(
   }
 
   // ── Chunk the diverged files into in-memory batches (async I/O) ─────────
-  const repoId = extractRepoId(rootDir);
   const chunkBatches: Array<{ metadatas: ChunkMetadata[]; contents: string[] }> = [];
   const manifestEntries: FileEntry[] = [];
   // Separate limiter for this CPU-bound parse/chunk phase (chunkFile below) —
@@ -185,7 +184,6 @@ export async function buildOverlay(
           chunkOverlap: DEFAULT_CHUNK_OVERLAP,
           useAST: true,
           astFallback: 'line-based',
-          repoId,
         });
         const stats = await fs.stat(d.abs);
         if (chunks.length > 0) {

--- a/packages/core/src/insights/complexity-analyzer.ts
+++ b/packages/core/src/insights/complexity-analyzer.ts
@@ -36,25 +36,12 @@ export class ComplexityAnalyzer {
   /**
    * Analyze complexity of codebase or specific files
    * @param files - Optional list of specific files to analyze
-   * @param crossRepo - If true, analyze across all repos (requires a cross-repo-capable backend)
-   * @param repoIds - Optional list of repo IDs to filter to (when crossRepo=true)
    * @returns Complexity report with violations and summary
    */
-  async analyze(
-    files?: string[],
-    crossRepo?: boolean,
-    repoIds?: string[],
-  ): Promise<ComplexityReport> {
-    // 1. Get all chunks from index
-    // For cross-repo, use scanCrossRepo
+  async analyze(files?: string[]): Promise<ComplexityReport> {
     // Note: We fetch all chunks even with --files filter because dependency analysis
     // needs the complete dataset to find dependents accurately.
-    let allChunks: SearchResult[];
-    if (crossRepo && this.vectorDB.supportsCrossRepo) {
-      allChunks = await this.vectorDB.scanCrossRepo({ limit: 100000, repoIds });
-    } else {
-      allChunks = await this.vectorDB.scanAll();
-    }
+    const allChunks: SearchResult[] = await this.vectorDB.scanAll();
 
     // 2. Filter to specified files if provided
     const chunks = files
@@ -174,7 +161,7 @@ export class ComplexityAnalyzer {
     for (const { metadata } of chunks) {
       if (metadata.symbolType !== 'function' && metadata.symbolType !== 'method') continue;
 
-      const key = `${metadata.repoId ?? ''}:${this.normalizeFilePath(metadata.file)}:${metadata.startLine}-${metadata.endLine}`;
+      const key = `${this.normalizeFilePath(metadata.file)}:${metadata.startLine}-${metadata.endLine}`;
       if (seen.has(key)) continue;
 
       seen.add(key);

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -66,7 +66,6 @@ function isSqliteBusy(error: unknown): boolean {
  */
 export class OverlayBackend implements VectorDBInterface {
   public readonly dbPath: string;
-  public readonly supportsCrossRepo = false;
   public readonly isOverlay = true;
   public readonly worktreeRoot: string;
   public readonly baseIndexDir: string;
@@ -520,15 +519,5 @@ export class OverlayBackend implements VectorDBInterface {
   getVersionDate(): string {
     if (this.currentVersion === 0) return 'Unknown';
     return new Date(this.currentVersion).toLocaleString();
-  }
-
-  async scanCrossRepo(_options: {
-    language?: string;
-    pattern?: string;
-    limit?: number;
-    repoIds?: string[];
-    branch?: string;
-  }): Promise<SearchResult[]> {
-    return [];
   }
 }

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
@@ -316,13 +316,6 @@ describe('SqliteBackend', () => {
     });
   });
 
-  describe('cross-repo stubs', () => {
-    it('reports no cross-repo support and returns [] from cross-repo methods', async () => {
-      expect(db.supportsCrossRepo).toBe(false);
-      expect(await db.scanCrossRepo({})).toEqual([]);
-    });
-  });
-
   describe('version accessors', () => {
     it('returns Unknown before any version and a date after', async () => {
       expect(db.getVersionDate()).toBe('Unknown');

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.ts
@@ -41,7 +41,6 @@ export class SqliteBackend implements VectorDBInterface {
   private db: DatabaseType.Database | null = null;
   public readonly dbPath: string;
   private readonly dbFilePath: string;
-  public readonly supportsCrossRepo = false;
   public readonly isOverlay = false;
   private lastVersionCheck = 0;
   private currentVersion = 0;
@@ -257,16 +256,6 @@ export class SqliteBackend implements VectorDBInterface {
       return 'Unknown';
     }
     return new Date(this.currentVersion).toLocaleString();
-  }
-
-  async scanCrossRepo(_options: {
-    language?: string;
-    pattern?: string;
-    limit?: number;
-    repoIds?: string[];
-    branch?: string;
-  }): Promise<SearchResult[]> {
-    return [];
   }
 
   static async load(projectRoot: string): Promise<SqliteBackend> {

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -57,18 +57,8 @@ export interface VectorDBInterface {
   reconnect(): Promise<void>;
   getCurrentVersion(): number;
   getVersionDate(): string;
-  /** Whether this backend supports cross-repo operations. */
-  readonly supportsCrossRepo: boolean;
   /** True for the worktree overlay backend (shared read-only base + writable
    *  overlay). Lets the indexer route to the overlay build instead of a full
    *  reindex of the worktree. */
   readonly isOverlay: boolean;
-  /** Scan across all repos in the organization. Returns [] if unsupported. */
-  scanCrossRepo(options: {
-    language?: string;
-    pattern?: string;
-    limit?: number;
-    repoIds?: string[];
-    branch?: string;
-  }): Promise<SearchResult[]>;
 }

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -14,7 +14,6 @@ import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
 export interface ASTChunkOptions {
   minChunkSize?: number;
   // Multi-tenant fields (optional for backward compatibility)
-  repoId?: string; // Repository identifier for multi-tenant scenarios
   orgId?: string; // Organization identifier for multi-tenant scenarios
   /**
    * Absolute path to the workspace/monorepo root. When provided (and the
@@ -120,7 +119,7 @@ function processTopLevelNode(
   content: string,
   context: ASTContext,
   language: SupportedLanguage,
-  tenantContext: { repoId?: string; orgId?: string },
+  tenantContext: { orgId?: string },
 ): ASTChunk {
   const { lines, fileImports, fileExports, importedSymbols, traverser } = context;
 
@@ -160,7 +159,7 @@ function processTopLevelNodes(
   content: string,
   context: ASTContext,
   language: SupportedLanguage,
-  tenantContext: { repoId?: string; orgId?: string },
+  tenantContext: { orgId?: string },
 ): ASTChunk[] {
   return topLevelNodes.map(node =>
     processTopLevelNode(node, filepath, content, context, language, tenantContext),
@@ -189,8 +188,8 @@ export function chunkByAST(
   content: string,
   options: ASTChunkOptions = {},
 ): ASTChunk[] {
-  const { minChunkSize = 5, repoId, orgId, workspaceRoot } = options;
-  const tenantContext = { repoId, orgId };
+  const { minChunkSize = 5, orgId, workspaceRoot } = options;
+  const tenantContext = { orgId };
 
   // Parse and validate
   const { language, rootNode } = parseAndValidate(filepath, content);
@@ -357,7 +356,7 @@ function createChunk(
   symbolInfo: ReturnType<typeof extractSymbolInfo>,
   imports: string[],
   language: SupportedLanguage,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk {
@@ -406,7 +405,6 @@ function createChunk(
       halsteadEffort: halstead?.effort,
       halsteadBugs: halstead?.bugs,
       // Multi-tenant fields
-      ...(tenantContext?.repoId && { repoId: tenantContext.repoId }),
       ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
@@ -461,7 +459,7 @@ function createChunkFromRange(
   filepath: string,
   language: SupportedLanguage,
   imports: string[],
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk {
@@ -483,7 +481,6 @@ function createChunkFromRange(
       ...(fileExports && fileExports.length > 0 && { exports: fileExports }),
       ...(importedSymbols && Object.keys(importedSymbols).length > 0 && { importedSymbols }),
       // Multi-tenant fields
-      ...(tenantContext?.repoId && { repoId: tenantContext.repoId }),
       ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
@@ -508,7 +505,7 @@ function extractUncoveredCode(
   minChunkSize: number,
   imports: string[],
   language: SupportedLanguage,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk[] {

--- a/packages/parser/src/chunk-only-index.ts
+++ b/packages/parser/src/chunk-only-index.ts
@@ -6,7 +6,6 @@ import { chunkFile } from './chunker.js';
 import { NativeBindingLoadError } from './ast/parser.js';
 import { scanCodebase } from './scanner.js';
 import { detectEcosystems, getEcosystemExcludePatterns } from './ecosystem-presets.js';
-import { extractRepoId } from './utils/repo-id.js';
 import {
   DEFAULT_CHUNK_SIZE,
   DEFAULT_CHUNK_OVERLAP,
@@ -66,7 +65,7 @@ function normalizeToRelativePath(file: string, rootDir: string): string {
 async function chunkFileForCollection(
   file: string,
   rootDir: string,
-  config: { chunkSize: number; chunkOverlap: number; repoId?: string },
+  config: { chunkSize: number; chunkOverlap: number },
   output: CodeChunk[],
 ): Promise<boolean> {
   try {
@@ -79,7 +78,6 @@ async function chunkFileForCollection(
       chunkOverlap: config.chunkOverlap,
       useAST: true,
       astFallback: 'line-based',
-      repoId: config.repoId,
       workspaceRoot: rootDir,
     });
 
@@ -134,7 +132,6 @@ export async function performChunkOnlyIndex(
     const config = {
       chunkSize: options.chunkSize ?? DEFAULT_CHUNK_SIZE,
       chunkOverlap: options.chunkOverlap ?? DEFAULT_CHUNK_OVERLAP,
-      repoId: extractRepoId(rootDir),
     };
 
     const allChunks: CodeChunk[] = [];

--- a/packages/parser/src/chunker.ts
+++ b/packages/parser/src/chunker.ts
@@ -16,7 +16,6 @@ export interface ChunkOptions {
   // parser binding) -- that is a systemic, process-wide failure and always
   // propagates regardless of this setting; see ast/parser.ts.
   // Multi-tenant fields (optional for backward compatibility)
-  repoId?: string; // Repository identifier for multi-tenant scenarios
   orgId?: string; // Organization identifier for multi-tenant scenarios
   /**
    * Absolute path to the workspace/monorepo root. Enables cross-package
@@ -36,7 +35,7 @@ function chunkSpecialCase(
   content: string,
   chunkSize: number,
   chunkOverlap: number,
-  tenantContext: { repoId?: string; orgId?: string },
+  tenantContext: { orgId?: string },
 ): CodeChunk[] | undefined {
   // Liquid files
   if (filepath.endsWith('.liquid')) {
@@ -71,13 +70,11 @@ export function chunkFile(
     chunkOverlap = 10,
     useAST = true,
     astFallback = 'line-based',
-    repoId,
     orgId,
     workspaceRoot,
   } = options;
 
   const specialCaseChunks = chunkSpecialCase(filepath, content, chunkSize, chunkOverlap, {
-    repoId,
     orgId,
   });
   if (specialCaseChunks) return specialCaseChunks;
@@ -87,7 +84,6 @@ export function chunkFile(
     try {
       return chunkByAST(filepath, content, {
         minChunkSize: Math.floor(chunkSize / 10),
-        repoId,
         orgId,
         workspaceRoot,
       });
@@ -115,7 +111,7 @@ export function chunkFile(
   }
 
   // Line-based chunking (original implementation)
-  return chunkByLines(filepath, content, chunkSize, chunkOverlap, { repoId, orgId });
+  return chunkByLines(filepath, content, chunkSize, chunkOverlap, { orgId });
 }
 
 /**
@@ -127,7 +123,7 @@ function buildLineChunk(
   startLine: number,
   endLine: number,
   fileType: string,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk {
   return {
     content: chunkContent,
@@ -138,7 +134,6 @@ function buildLineChunk(
       type: 'block',
       language: fileType,
       symbols: extractSymbols(chunkContent, fileType),
-      ...(tenantContext?.repoId && { repoId: tenantContext.repoId }),
       ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
@@ -152,7 +147,7 @@ function chunkByLines(
   content: string,
   chunkSize: number,
   chunkOverlap: number,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const lines = content.split('\n');
   if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {

--- a/packages/parser/src/insights/chunk-complexity.ts
+++ b/packages/parser/src/insights/chunk-complexity.ts
@@ -247,7 +247,7 @@ export function getUniqueFunctionChunks(
   for (const { metadata } of chunks) {
     if (metadata.symbolType !== 'function' && metadata.symbolType !== 'method') continue;
 
-    const key = `${metadata.repoId ?? ''}:${normalizeFilePath(metadata.file)}:${metadata.startLine}-${metadata.endLine}`;
+    const key = `${normalizeFilePath(metadata.file)}:${metadata.startLine}-${metadata.endLine}`;
     if (seen.has(key)) continue;
 
     seen.add(key);

--- a/packages/parser/src/json-template-chunker.ts
+++ b/packages/parser/src/json-template-chunker.ts
@@ -71,7 +71,7 @@ function extractTemplateName(filepath: string): string | undefined {
 export function chunkJSONTemplate(
   filepath: string,
   content: string,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   // Skip empty files
   if (content.trim().length === 0) {
@@ -94,7 +94,6 @@ export function chunkJSONTemplate(
         symbolName: templateName,
         symbolType: 'template',
         imports: sectionReferences.length > 0 ? sectionReferences : undefined,
-        ...(tenantContext?.repoId && { repoId: tenantContext.repoId }),
         ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
       },
     },

--- a/packages/parser/src/liquid-chunker.ts
+++ b/packages/parser/src/liquid-chunker.ts
@@ -198,7 +198,6 @@ function createCodeChunk(
     symbolName?: string;
     symbolType?: LiquidBlock['type'];
     imports?: string[];
-    repoId?: string;
     orgId?: string;
   } = {},
 ): CodeChunk {
@@ -213,7 +212,6 @@ function createCodeChunk(
       symbolName: options.symbolName,
       symbolType: options.symbolType,
       imports: options.imports?.length ? options.imports : undefined,
-      ...(options.repoId && { repoId: options.repoId }),
       ...(options.orgId && { orgId: options.orgId }),
     },
   };
@@ -227,7 +225,7 @@ function splitLargeBlock(
   ctx: ChunkContext,
   symbolName: string | undefined,
   imports: string[],
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const chunks: CodeChunk[] = [];
   const blockLines = block.content.split('\n');
@@ -264,7 +262,7 @@ function processSpecialBlock(
   block: LiquidBlock,
   ctx: ChunkContext,
   coveredLines: Set<number>,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   // Mark lines as covered
   for (let i = block.startLine; i <= block.endLine; i++) {
@@ -308,7 +306,7 @@ function flushTemplateChunk(
   chunkStartLine: number,
   endLine: number,
   ctx: ChunkContext,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk | null {
   if (currentChunk.length === 0) return null;
 
@@ -334,7 +332,7 @@ function flushTemplateChunk(
 function processTemplateContent(
   ctx: ChunkContext,
   coveredLines: Set<number>,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const chunks: CodeChunk[] = [];
   const { lines, params } = ctx;
@@ -387,7 +385,7 @@ export function chunkLiquidFile(
   content: string,
   chunkSize: number = 75,
   chunkOverlap: number = 10,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   // Build context once for reuse across helpers
   const contentWithoutComments = removeComments(content);

--- a/packages/parser/src/markdown-chunker.test.ts
+++ b/packages/parser/src/markdown-chunker.test.ts
@@ -132,13 +132,11 @@ describe('chunkMarkdownFile', () => {
     expect(chunkMarkdownFile('empty.md', '')).toEqual([]);
   });
 
-  it('passes through repoId/orgId tenant context', () => {
+  it('passes through orgId tenant context', () => {
     const chunks = chunkMarkdownFile('README.md', '# Title\ncontent', 75, 10, {
-      repoId: 'repo-1',
       orgId: 'org-1',
     });
 
-    expect(chunks[0].metadata.repoId).toBe('repo-1');
     expect(chunks[0].metadata.orgId).toBe('org-1');
   });
 });

--- a/packages/parser/src/markdown-chunker.ts
+++ b/packages/parser/src/markdown-chunker.ts
@@ -176,7 +176,7 @@ function createDocChunk(
   endLine: number,
   filepath: string,
   symbolName: string | undefined,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk {
   return {
     content,
@@ -187,7 +187,6 @@ function createDocChunk(
       language: 'markdown',
       type: 'doc',
       symbolName,
-      ...(tenantContext?.repoId && { repoId: tenantContext.repoId }),
       ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
@@ -204,7 +203,7 @@ function splitLargeSection(
   filepath: string,
   chunkSize: number,
   chunkOverlap: number,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const chunks: CodeChunk[] = [];
   const sectionLines = lines.slice(section.startLine, section.endLine);
@@ -242,14 +241,14 @@ function splitLargeSection(
  *   into windows; also the window size used when splitting (default 75).
  * @param chunkOverlap - Line overlap between windows when splitting an
  *   oversized section (default 10).
- * @param tenantContext - Optional repoId/orgId passthrough for multi-tenant indexes.
+ * @param tenantContext - Optional orgId passthrough for multi-tenant indexes.
  */
 export function chunkMarkdownFile(
   filepath: string,
   content: string,
   chunkSize: number = 75,
   chunkOverlap: number = 10,
-  tenantContext?: { repoId?: string; orgId?: string },
+  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const lines = content.split('\n');
   if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -66,13 +66,6 @@ export interface ChunkMetadata {
 
   // Multi-tenant fields (optional for backward compatibility)
   /**
-   * Unique repository identifier for multi-tenant scenarios.
-   * Used for cross-repo search and tenant isolation in cross-repo-capable backends.
-   * Typically derived from project root path or GitHub repository identifier.
-   */
-  repoId?: string;
-
-  /**
    * Organization identifier for multi-tenant scenarios.
    * Used for tenant isolation in cross-repo-capable backends.
    */

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -25,8 +25,6 @@ name for backward compatibility.
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | Keyword search query (identifiers and domain terms that appear in the code) |
 | `limit` | number | No | 5 | Maximum number of results to return |
-| `crossRepo` | boolean | No | false | Search across all repos in the organization. Requires a cross-repo-capable backend (the bundled SQLite backend is single-repo); unsupported backends fall back to single-repo search |
-| `repoIds` | string[] | No | - | Restrict cross-repo search to these repo IDs. Only applied when `crossRepo=true` with a supporting backend; ignored otherwise |
 
 ### Usage
 
@@ -54,8 +52,6 @@ Find code with terms: jwt token validation verify
   ]
 }
 ```
-
-When `crossRepo=true` with a cross-repo-capable backend, the response also includes a `groupedByRepo` field that organizes results by repository.
 
 ### Best Practices
 
@@ -299,7 +295,6 @@ Find all files that depend on a given file (reverse dependency lookup). Essentia
 | `filepath` | string | Yes | - | Path to file (relative to project root) |
 | `depth` | number | No | 1 | Dependency depth (currently only 1 supported) |
 | `symbol` | string | No | - | Specific exported symbol to find usages of (returns call sites instead of just importing files) |
-| `crossRepo` | boolean | No | false | Find dependents across all repos. Requires a cross-repo-capable backend (the bundled SQLite backend is single-repo) |
 
 ### Usage
 
@@ -340,8 +335,6 @@ Is it safe to change this file?
 
 When `symbol` is provided, the response also includes `totalUsageCount` (number of tracked call sites across all files) and each dependent may include a `usages` array with `callerSymbol`, `line`, and `snippet` fields.
 
-When `crossRepo=true` with a cross-repo-capable backend, the response includes a `groupedByRepo` field.
-
 ### Risk Levels
 
 | Level | Dependent Count | Meaning |
@@ -378,8 +371,6 @@ Analyze code complexity for tech debt identification and refactoring prioritizat
 | `files` | string[] | No | - | Specific files to analyze (analyzes all if omitted) |
 | `top` | number | No | 10 | Return top N most complex functions |
 | `threshold` | number | No | config | Only return functions above this complexity |
-| `crossRepo` | boolean | No | false | Analyze across all repos in the organization. Requires a cross-repo-capable backend (the bundled SQLite backend is single-repo) |
-| `repoIds` | string[] | No | - | Filter to specific repos when `crossRepo=true` |
 
 ### Usage
 


### PR DESCRIPTION
Closes #103

## Audit summary

A liveness audit found that cross-repo MCP mode was never wired up in the SQLite era (it dates back to the retired LanceDB/Qdrant multi-tenant exploration, see ADR-0010/0011):

- `repoId` is computed in-memory during chunking but never persisted — `chunkToRow()`/`buildMetadata()` in `packages/core/src/vectordb/sqlite/row-mapping.ts` never read or write it, so it's gone by the time a chunk reaches the structural store.
- Both backends hardcode `supportsCrossRepo = false` and stub `scanCrossRepo()` to `[]`.
- `lien serve` is one-repo-per-process, so there's no cross-repo runtime to serve anyway.
- `git log -S` archaeology found zero commits that ever wired `repoId` into SQLite persistence — every `crossRepo`/`repoIds` branch in the MCP handlers has been dead code since the SQLite migration.

This is a pure deletion/simplification PR: no behavior change for the single-repo path.

## Purge inventory, by category

**Interface fields removed:**
- `VectorDBInterface.supportsCrossRepo` and `.scanCrossRepo()` (`packages/core/src/vectordb/types.ts`).
- `ChunkMetadata.repoId` (`packages/parser/src/types.ts`).
- The `crossRepo`/`repoIds` input-schema fields on `search_code`, `get_dependents`, `get_complexity` (`packages/cli/src/mcp/schemas/*.schema.ts`), and the `groupedByRepo` field on `SearchResultResponse` (`packages/cli/src/mcp/types.ts`).

**Backend flags/stubs removed:**
- `SqliteBackend` and `OverlayBackend`'s concrete `supportsCrossRepo = false` and `scanCrossRepo()` (always-`[]`) implementations.
- `sqlite-backend.test.ts`'s "reports no cross-repo support" assertion of the same (see Deleted tests).

**Parser threading removed** (the part that grew past the original 4-line estimate — `repoId` assignment happens in core's indexer, but the actual metadata construction, and therefore the type dependency, lives one layer down in every parser chunker):
- `ChunkOptions.repoId` / `tenantContext.repoId` plumbing through `chunker.ts`, `markdown-chunker.ts`, `json-template-chunker.ts`, `liquid-chunker.ts`, `ast/chunker.ts`, and `chunk-only-index.ts` — `orgId` (the sibling field) is left in place throughout.
- The corresponding `repoId` assignment sites in core's indexer: `index.ts`, `incremental.ts`, `overlay-index.ts`.
- `extractRepoId()` itself is untouched — still live, still used to name the per-repo index directory under `~/.lien/indices/<repoId>` (`sqlite-backend.ts`).

**Handler branches removed:**
- `search-code.ts`, `get-dependents.ts`, `get-complexity.ts`: every branch gated on `crossRepo`/`vectorDB.supportsCrossRepo`, including the `groupResultsByRepo`/`groupDependentsByRepo`/`groupViolationsByRepo` helpers and the cross-repo fallback warning notes.
- `dependency-analyzer.ts`: `CROSS_REPO_LIMIT`, the `scanCrossRepo` scan path, `crossRepo`-keyed scan-cache invalidation, and the exported `groupDependentsByRepo` (deleted — no longer has any caller).
- `ComplexityAnalyzer.analyze`'s `crossRepo`/`repoIds` parameters and its `scanCrossRepo` call (core).
- The `repoId`-keyed dedup logic in `complexity-analyzer.ts` (core) and its sibling `chunk-complexity.ts` (parser) — both built a key as `` `${repoId}:${file}:${startLine}-${endLine}` ``; simplified to drop the repoId component in both.
- `metadata-shaper.ts`: removed `repoId` from the `search_code` allowlist (the only one of the four tools that had it — see PR history note below) and simplified `deduplicateResults`'s key.

**Docs corrected:**
- `packages/site/docs/guide/mcp-tools.md`: removed `crossRepo`/`repoIds` param rows + `groupedByRepo` response prose across all three affected tool sections.
- `docs/architecture/data-flow.md`: `repoId` dropped from the "multi-tenant fields" list.
- Left untouched: ADR-0010/0011/0012 (historical decision records, correctly describe what was true when written) and the unrelated "cross-repo pilot/study" terminology in `packages/review/**`, `packages/action/README.md`, and the site's review-evidence/lien-review pages — that's Lien Review's cross-repo *validation corpus*, an unrelated concept.

## Notes for the reviewer

- **PR history**: PR #755 (adds `repoId` to three more MCP allowlists, closes #103) was closed unmerged with the audit rationale — it was never on `main`, so this PR only had to remove `repoId` from `search_code`'s pre-existing allowlist, not revert anything from the other three tools.
- `orgId`, `branch`, and `commitSha` (repoId's sibling "multi-tenant fields" on `ChunkMetadata`) are left untouched — they're also always-undefined today, but weren't in the audit's scope, so I didn't expand into them. (`orgId` has been flagged separately to the owner as a possible follow-up.)
- `DependencyAnalysisResult.hitLimit` is now always `false` (it was only ever set by the cross-repo scan path) but I left the field itself in place rather than threading its removal through `scanAllChunks`/`getOrScanChunks`/`findDependents` — it's harmless internal plumbing, not part of the named cross-repo surface, and removing it would have widened the diff further for no behavior change.

## Deleted tests (asserted the purged surface directly)

- `packages/core/src/vectordb/sqlite/sqlite-backend.test.ts`: "reports no cross-repo support" describe block.
- `packages/cli/src/mcp/utils/metadata-shaper.test.ts`: two repoId-dedup tests.
- `packages/cli/src/mcp/schemas/schemas.test.ts`: two `repoIds`-too-long validation tests.
- `packages/cli/src/mcp/handlers/search-code.test.ts`: "cross-repo fallback" describe block + 2 crossRepo-specific tests elsewhere.
- `packages/cli/src/mcp/handlers/get-complexity.test.ts`: crossRepo/scanCrossRepo mock fields (no dedicated tests, just mock plumbing).
- `packages/cli/src/mcp/handlers/get-dependents.test.ts`: "hitLimit behavior", "cross-repo search with a cross-repo-capable backend", and "cross-repo fallback (unsupported backend)" describe blocks + 2 crossRepo-specific tests elsewhere.
- `packages/cli/src/mcp/handlers/dependency-analyzer.test.ts`: "cross-repo with a cross-repo-capable backend" and "cross-repo fallback for unsupported backends" describe blocks, the crossRepo cache-invalidation test, and the entire `groupDependentsByRepo` describe block (5 tests) — that exported function no longer exists.
- `packages/parser/src/markdown-chunker.test.ts`: narrowed the repoId+orgId passthrough test to orgId only.

All remaining tests are unchanged in intent — call sites that merely passed a now-removed `crossRepo` positional arg were mechanically updated to match the new signature.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `npm run typecheck` — clean across parser/core/cli/review/action
- [x] `npm run build` — clean
- [x] `npm test` — all green: parser 1053/1053, core 355/355, review 754/754, cli 769/769, action 28/28
- [x] `node packages/cli/dist/index.js delta` — exit 0 (38 improved, 2 pre-existing advisory "worsened" notes, zero new threshold crossings)
- [x] `npm run docs:build` — clean

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 3. 5 pre-existing issues remain in touched files.
🔗 **Impact**: 1 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 4 | -3 |


> [!NOTE]
> **Low Risk**
>
> This PR is a large but mechanical deletion of never-functional cross-repo scaffolding. It removes dead `repoId`/`crossRepo`/`repoIds`/`supportsCrossRepo`/`scanCrossRepo` plumbing from the parser, core, and CLI layers, and updates the MCP tool schemas, handlers, and docs to match. No single-repo behavior changes. All removed exports were verified to have zero surviving references, and the changeset accurately describes the public-surface shrinkage.
>
> - Removed `repoId` from `ChunkMetadata` and all chunker plumbing
> - Removed `supportsCrossRepo`/`scanCrossRepo()` from `VectorDBInterface` and both backends
> - Removed `crossRepo`/`repoIds` parameters and `groupedByRepo` response fields from MCP tool schemas and handlers
> - Simplified deduplication keys in complexity analyzers to drop the never-persisted `repoId` component
> - Updated docs and changeset to reflect the removed surface

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 47aa389. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
