### PR TITLE
refactor: remove dead orgId multi-tenant plumbing

### DIFF
--- a/.changeset/purge-dead-orgid.md
+++ b/.changeset/purge-dead-orgid.md
@@ -1,0 +1,7 @@
+---
+'@liendev/parser': patch
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+refactor: remove dead orgId multi-tenant plumbing

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -47,7 +47,7 @@ async function initializeDatabase(
 ): Promise<{
   vectorDB: VectorDBInterface;
 }> {
-  // Create the structural store using global config (auto-detects backend and orgId)
+  // Create the structural store using global config (auto-detects backend)
   log('Creating structural store...');
   const vectorDB = await createVectorDB(rootDir, { warn: message => log(message, 'warning') });
 

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -91,16 +91,12 @@ async function processFileContent(
   const useAST = true; // Always use AST-based chunking
   const astFallback = 'line-based' as const;
 
-  // orgId is now handled in createVectorDB() via global config and git remote detection
-  const orgId = undefined; // Not needed here - handled in VectorDB factory
-
   // Chunk the file
   const chunks = chunkFile(filepath, content, {
     chunkSize,
     chunkOverlap,
     useAST,
     astFallback,
-    orgId,
     workspaceRoot: rootDir,
   });
 

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -81,21 +81,16 @@ interface IndexingConfig {
   chunkOverlap: number;
   useAST: boolean;
   astFallback: 'line-based' | 'error';
-  orgId?: string;
 }
 
 /** Extract indexing config values using defaults */
 function getIndexingConfig(_rootDir: string): IndexingConfig {
   // Use defaults for all settings - no config needed!
-  // orgId is now handled in createVectorDB() via global config and git remote detection
-  // No need to extract it here anymore
-
   return {
     chunkSize: DEFAULT_CHUNK_SIZE,
     chunkOverlap: DEFAULT_CHUNK_OVERLAP,
     useAST: true, // Always use AST-based chunking
     astFallback: 'line-based' as const,
-    orgId: undefined, // Not needed here - handled in VectorDB factory
   };
 }
 
@@ -347,7 +342,6 @@ async function processFileForIndexing(
       chunkOverlap: indexConfig.chunkOverlap,
       useAST: indexConfig.useAST,
       astFallback: indexConfig.astFallback,
-      orgId: indexConfig.orgId,
       workspaceRoot: rootDir,
     });
 

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -13,8 +13,6 @@ import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
 
 export interface ASTChunkOptions {
   minChunkSize?: number;
-  // Multi-tenant fields (optional for backward compatibility)
-  orgId?: string; // Organization identifier for multi-tenant scenarios
   /**
    * Absolute path to the workspace/monorepo root. When provided (and the
    * root has an npm `workspaces` field), bare package specifiers that name a
@@ -119,7 +117,6 @@ function processTopLevelNode(
   content: string,
   context: ASTContext,
   language: SupportedLanguage,
-  tenantContext: { orgId?: string },
 ): ASTChunk {
   const { lines, fileImports, fileExports, importedSymbols, traverser } = context;
 
@@ -144,7 +141,6 @@ function processTopLevelNode(
     symbolInfo,
     fileImports,
     language,
-    tenantContext,
     fileExports,
     importedSymbols,
   );
@@ -159,11 +155,8 @@ function processTopLevelNodes(
   content: string,
   context: ASTContext,
   language: SupportedLanguage,
-  tenantContext: { orgId?: string },
 ): ASTChunk[] {
-  return topLevelNodes.map(node =>
-    processTopLevelNode(node, filepath, content, context, language, tenantContext),
-  );
+  return topLevelNodes.map(node => processTopLevelNode(node, filepath, content, context, language));
 }
 
 /**
@@ -188,8 +181,7 @@ export function chunkByAST(
   content: string,
   options: ASTChunkOptions = {},
 ): ASTChunk[] {
-  const { minChunkSize = 5, orgId, workspaceRoot } = options;
-  const tenantContext = { orgId };
+  const { minChunkSize = 5, workspaceRoot } = options;
 
   // Parse and validate
   const { language, rootNode } = parseAndValidate(filepath, content);
@@ -199,14 +191,7 @@ export function chunkByAST(
 
   // Find and process top-level nodes
   const topLevelNodes = findTopLevelNodes(rootNode, context.traverser);
-  const topLevelChunks = processTopLevelNodes(
-    topLevelNodes,
-    filepath,
-    content,
-    context,
-    language,
-    tenantContext,
-  );
+  const topLevelChunks = processTopLevelNodes(topLevelNodes, filepath, content, context, language);
 
   // Extract uncovered code (imports, exports, top-level statements)
   const coveredRanges = topLevelNodes.map(n => ({
@@ -220,7 +205,6 @@ export function chunkByAST(
     minChunkSize,
     context.fileImports,
     language,
-    tenantContext,
     context.fileExports,
     context.importedSymbols,
   );
@@ -356,7 +340,6 @@ function createChunk(
   symbolInfo: ReturnType<typeof extractSymbolInfo>,
   imports: string[],
   language: SupportedLanguage,
-  tenantContext?: { orgId?: string },
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk {
@@ -404,8 +387,6 @@ function createChunk(
       halsteadDifficulty: halstead?.difficulty,
       halsteadEffort: halstead?.effort,
       halsteadBugs: halstead?.bugs,
-      // Multi-tenant fields
-      ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
 }
@@ -459,7 +440,6 @@ function createChunkFromRange(
   filepath: string,
   language: SupportedLanguage,
   imports: string[],
-  tenantContext?: { orgId?: string },
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk {
@@ -480,8 +460,6 @@ function createChunkFromRange(
       // Symbol-level dependency tracking
       ...(fileExports && fileExports.length > 0 && { exports: fileExports }),
       ...(importedSymbols && Object.keys(importedSymbols).length > 0 && { importedSymbols }),
-      // Multi-tenant fields
-      ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
 }
@@ -505,7 +483,6 @@ function extractUncoveredCode(
   minChunkSize: number,
   imports: string[],
   language: SupportedLanguage,
-  tenantContext?: { orgId?: string },
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk[] {
@@ -515,16 +492,7 @@ function extractUncoveredCode(
 
   return uncoveredRanges
     .map(range =>
-      createChunkFromRange(
-        range,
-        lines,
-        filepath,
-        language,
-        imports,
-        tenantContext,
-        fileExports,
-        importedSymbols,
-      ),
+      createChunkFromRange(range, lines, filepath, language, imports, fileExports, importedSymbols),
     )
     .filter(chunk => (hasExports ? chunk.content.length > 0 : isValidChunk(chunk, minChunkSize)));
 }

--- a/packages/parser/src/chunker.ts
+++ b/packages/parser/src/chunker.ts
@@ -15,8 +15,6 @@ export interface ChunkOptions {
   // Does NOT govern a NativeBindingLoadError (missing/unloadable native
   // parser binding) -- that is a systemic, process-wide failure and always
   // propagates regardless of this setting; see ast/parser.ts.
-  // Multi-tenant fields (optional for backward compatibility)
-  orgId?: string; // Organization identifier for multi-tenant scenarios
   /**
    * Absolute path to the workspace/monorepo root. Enables cross-package
    * import resolution for JS/TS monorepos — see `ASTChunkOptions.workspaceRoot`.
@@ -35,11 +33,10 @@ function chunkSpecialCase(
   content: string,
   chunkSize: number,
   chunkOverlap: number,
-  tenantContext: { orgId?: string },
 ): CodeChunk[] | undefined {
   // Liquid files
   if (filepath.endsWith('.liquid')) {
-    return chunkLiquidFile(filepath, content, chunkSize, chunkOverlap, tenantContext);
+    return chunkLiquidFile(filepath, content, chunkSize, chunkOverlap);
   }
 
   // Shopify JSON template files (templates/**/*.json). Regex ensures
@@ -47,14 +44,14 @@ function chunkSpecialCase(
   // Matches: templates/product.json OR some-path/templates/customers/account.json
   // Rejects: my-templates/config.json OR node_modules/pkg/templates/file.json (filtered by scanner)
   if (filepath.endsWith('.json') && /(?:^|\/)templates\//.test(filepath)) {
-    return chunkJSONTemplate(filepath, content, tenantContext);
+    return chunkJSONTemplate(filepath, content);
   }
 
   // Markdown/MDX — chunk by heading section instead of a fixed-size line
   // window, so search_code retrieves a coherent section (e.g. README
   // "Install") rather than an arbitrary slice.
   if (/\.(md|mdx|markdown)$/i.test(filepath)) {
-    return chunkMarkdownFile(filepath, content, chunkSize, chunkOverlap, tenantContext);
+    return chunkMarkdownFile(filepath, content, chunkSize, chunkOverlap);
   }
 
   return undefined;
@@ -70,13 +67,10 @@ export function chunkFile(
     chunkOverlap = 10,
     useAST = true,
     astFallback = 'line-based',
-    orgId,
     workspaceRoot,
   } = options;
 
-  const specialCaseChunks = chunkSpecialCase(filepath, content, chunkSize, chunkOverlap, {
-    orgId,
-  });
+  const specialCaseChunks = chunkSpecialCase(filepath, content, chunkSize, chunkOverlap);
   if (specialCaseChunks) return specialCaseChunks;
 
   // Try AST-based chunking for supported languages
@@ -84,7 +78,6 @@ export function chunkFile(
     try {
       return chunkByAST(filepath, content, {
         minChunkSize: Math.floor(chunkSize / 10),
-        orgId,
         workspaceRoot,
       });
     } catch (error) {
@@ -111,7 +104,7 @@ export function chunkFile(
   }
 
   // Line-based chunking (original implementation)
-  return chunkByLines(filepath, content, chunkSize, chunkOverlap, { orgId });
+  return chunkByLines(filepath, content, chunkSize, chunkOverlap);
 }
 
 /**
@@ -123,7 +116,6 @@ function buildLineChunk(
   startLine: number,
   endLine: number,
   fileType: string,
-  tenantContext?: { orgId?: string },
 ): CodeChunk {
   return {
     content: chunkContent,
@@ -134,7 +126,6 @@ function buildLineChunk(
       type: 'block',
       language: fileType,
       symbols: extractSymbols(chunkContent, fileType),
-      ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
 }
@@ -147,7 +138,6 @@ function chunkByLines(
   content: string,
   chunkSize: number,
   chunkOverlap: number,
-  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const lines = content.split('\n');
   if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {
@@ -163,7 +153,7 @@ function chunkByLines(
     const chunkContent = lines.slice(i, endLine).join('\n');
 
     if (chunkContent.trim().length > 0) {
-      chunks.push(buildLineChunk(chunkContent, filepath, i + 1, endLine, fileType, tenantContext));
+      chunks.push(buildLineChunk(chunkContent, filepath, i + 1, endLine, fileType));
     }
 
     if (endLine >= lines.length) break;

--- a/packages/parser/src/json-template-chunker.ts
+++ b/packages/parser/src/json-template-chunker.ts
@@ -68,11 +68,7 @@ function extractTemplateName(filepath: string): string | undefined {
  * JSON templates are typically small (define section layout),
  * so we keep them as a single chunk and extract section references.
  */
-export function chunkJSONTemplate(
-  filepath: string,
-  content: string,
-  tenantContext?: { orgId?: string },
-): CodeChunk[] {
+export function chunkJSONTemplate(filepath: string, content: string): CodeChunk[] {
   // Skip empty files
   if (content.trim().length === 0) {
     return [];
@@ -94,7 +90,6 @@ export function chunkJSONTemplate(
         symbolName: templateName,
         symbolType: 'template',
         imports: sectionReferences.length > 0 ? sectionReferences : undefined,
-        ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
       },
     },
   ];

--- a/packages/parser/src/liquid-chunker.ts
+++ b/packages/parser/src/liquid-chunker.ts
@@ -198,7 +198,6 @@ function createCodeChunk(
     symbolName?: string;
     symbolType?: LiquidBlock['type'];
     imports?: string[];
-    orgId?: string;
   } = {},
 ): CodeChunk {
   return {
@@ -212,7 +211,6 @@ function createCodeChunk(
       symbolName: options.symbolName,
       symbolType: options.symbolType,
       imports: options.imports?.length ? options.imports : undefined,
-      ...(options.orgId && { orgId: options.orgId }),
     },
   };
 }
@@ -225,7 +223,6 @@ function splitLargeBlock(
   ctx: ChunkContext,
   symbolName: string | undefined,
   imports: string[],
-  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const chunks: CodeChunk[] = [];
   const blockLines = block.content.split('\n');
@@ -243,7 +240,7 @@ function splitLargeBlock(
           block.startLine + endOffset,
           filepath,
           'block',
-          { symbolName, symbolType: block.type, imports, ...tenantContext },
+          { symbolName, symbolType: block.type, imports },
         ),
       );
     }
@@ -262,7 +259,6 @@ function processSpecialBlock(
   block: LiquidBlock,
   ctx: ChunkContext,
   coveredLines: Set<number>,
-  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   // Mark lines as covered
   for (let i = block.startLine; i <= block.endLine; i++) {
@@ -290,12 +286,12 @@ function processSpecialBlock(
         block.endLine + 1,
         ctx.params.filepath,
         'block',
-        { symbolName, symbolType: block.type, imports, ...tenantContext },
+        { symbolName, symbolType: block.type, imports },
       ),
     ];
   }
 
-  return splitLargeBlock(block, ctx, symbolName, imports, tenantContext);
+  return splitLargeBlock(block, ctx, symbolName, imports);
 }
 
 /**
@@ -306,7 +302,6 @@ function flushTemplateChunk(
   chunkStartLine: number,
   endLine: number,
   ctx: ChunkContext,
-  tenantContext?: { orgId?: string },
 ): CodeChunk | null {
   if (currentChunk.length === 0) return null;
 
@@ -322,18 +317,16 @@ function flushTemplateChunk(
     endLine,
     ctx.params.filepath,
     'template',
-    { imports, ...tenantContext },
+    {
+      imports,
+    },
   );
 }
 
 /**
  * Process uncovered template content into chunks
  */
-function processTemplateContent(
-  ctx: ChunkContext,
-  coveredLines: Set<number>,
-  tenantContext?: { orgId?: string },
-): CodeChunk[] {
+function processTemplateContent(ctx: ChunkContext, coveredLines: Set<number>): CodeChunk[] {
   const chunks: CodeChunk[] = [];
   const { lines, params } = ctx;
   const { chunkSize, chunkOverlap } = params;
@@ -342,7 +335,7 @@ function processTemplateContent(
   let chunkStartLine = 0;
 
   const flush = (endLine: number) => {
-    const chunk = flushTemplateChunk(currentChunk, chunkStartLine, endLine, ctx, tenantContext);
+    const chunk = flushTemplateChunk(currentChunk, chunkStartLine, endLine, ctx);
     if (chunk) chunks.push(chunk);
   };
 
@@ -385,7 +378,6 @@ export function chunkLiquidFile(
   content: string,
   chunkSize: number = 75,
   chunkOverlap: number = 10,
-  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   // Build context once for reuse across helpers
   const contentWithoutComments = removeComments(content);
@@ -400,12 +392,10 @@ export function chunkLiquidFile(
   const coveredLines = new Set<number>();
 
   // Process special blocks
-  const blockChunks = blocks.flatMap(block =>
-    processSpecialBlock(block, ctx, coveredLines, tenantContext),
-  );
+  const blockChunks = blocks.flatMap(block => processSpecialBlock(block, ctx, coveredLines));
 
   // Process uncovered template content
-  const templateChunks = processTemplateContent(ctx, coveredLines, tenantContext);
+  const templateChunks = processTemplateContent(ctx, coveredLines);
 
   // Combine and sort by line number
   return [...blockChunks, ...templateChunks].sort(

--- a/packages/parser/src/markdown-chunker.test.ts
+++ b/packages/parser/src/markdown-chunker.test.ts
@@ -131,12 +131,4 @@ describe('chunkMarkdownFile', () => {
   it('returns an empty array for an empty file', () => {
     expect(chunkMarkdownFile('empty.md', '')).toEqual([]);
   });
-
-  it('passes through orgId tenant context', () => {
-    const chunks = chunkMarkdownFile('README.md', '# Title\ncontent', 75, 10, {
-      orgId: 'org-1',
-    });
-
-    expect(chunks[0].metadata.orgId).toBe('org-1');
-  });
 });

--- a/packages/parser/src/markdown-chunker.ts
+++ b/packages/parser/src/markdown-chunker.ts
@@ -176,7 +176,6 @@ function createDocChunk(
   endLine: number,
   filepath: string,
   symbolName: string | undefined,
-  tenantContext?: { orgId?: string },
 ): CodeChunk {
   return {
     content,
@@ -187,7 +186,6 @@ function createDocChunk(
       language: 'markdown',
       type: 'doc',
       symbolName,
-      ...(tenantContext?.orgId && { orgId: tenantContext.orgId }),
     },
   };
 }
@@ -203,7 +201,6 @@ function splitLargeSection(
   filepath: string,
   chunkSize: number,
   chunkOverlap: number,
-  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const chunks: CodeChunk[] = [];
   const sectionLines = lines.slice(section.startLine, section.endLine);
@@ -221,7 +218,6 @@ function splitLargeSection(
           section.startLine + endOffset,
           filepath,
           section.breadcrumb,
-          tenantContext,
         ),
       );
     }
@@ -241,14 +237,12 @@ function splitLargeSection(
  *   into windows; also the window size used when splitting (default 75).
  * @param chunkOverlap - Line overlap between windows when splitting an
  *   oversized section (default 10).
- * @param tenantContext - Optional orgId passthrough for multi-tenant indexes.
  */
 export function chunkMarkdownFile(
   filepath: string,
   content: string,
   chunkSize: number = 75,
   chunkOverlap: number = 10,
-  tenantContext?: { orgId?: string },
 ): CodeChunk[] {
   const lines = content.split('\n');
   if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {
@@ -272,11 +266,10 @@ export function chunkMarkdownFile(
           section.endLine,
           filepath,
           section.breadcrumb,
-          tenantContext,
         ),
       ];
     }
 
-    return splitLargeSection(lines, section, filepath, chunkSize, chunkOverlap, tenantContext);
+    return splitLargeSection(lines, section, filepath, chunkSize, chunkOverlap);
   });
 }

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -64,13 +64,7 @@ export interface ChunkMetadata {
   halsteadEffort?: number; // E = D × V - mental effort required
   halsteadBugs?: number; // B = E^(2/3) / 3000 - estimated delivered bugs
 
-  // Multi-tenant fields (optional for backward compatibility)
-  /**
-   * Organization identifier for multi-tenant scenarios.
-   * Used for tenant isolation in cross-repo-capable backends.
-   */
-  orgId?: string;
-
+  // Cross-repo-capable backend fields (optional for backward compatibility)
   /**
    * Git branch name for branch/commit tracking in cross-repo-capable backends.
    * Used to isolate indexes by branch (e.g., main vs PR branches).


### PR DESCRIPTION
## Summary

Follow-up to #760 (the crossRepo/repoId purge), same treatment for `orgId`. Owner-approved scope: `orgId` rode the same tenantContext/ChunkOptions threading that `repoId` rode, and core explicitly set `const orgId = undefined` with a comment noting it was unused — handled instead by `createVectorDB()`'s global-config/git-remote detection, which never actually threaded a value back through.

## Scope

Removed `orgId` from:
- `ChunkMetadata` (`packages/parser/src/types.ts`)
- Every chunker/tenantContext/ChunkOptions thread in `packages/parser/src`: `chunker.ts`, `ast/chunker.ts`, `markdown-chunker.ts`, `json-template-chunker.ts`, `liquid-chunker.ts`
- Core's indexer: the two dead `const orgId = undefined` / `orgId: undefined` assignment sites in `packages/core/src/indexer/incremental.ts` and `packages/core/src/indexer/index.ts` (including the now-unused `IndexingConfig.orgId` field)
- A stray comment reference in `packages/cli/src/mcp/server.ts`

Per the "delete the whole thread if it exists only to carry orgId" instruction, the `tenantContext: { orgId?: string }` parameter itself is gone from every function that only used it for that — not just the field inside it (`chunkSpecialCase`, `buildLineChunk`, `chunkByLines`, `processTopLevelNode(s)`, `createChunk`, `createChunkFromRange`, `extractUncoveredCode`, `createDocChunk`, `splitLargeSection`, `chunkMarkdownFile`, `chunkJSONTemplate`, `createCodeChunk`, `splitLargeBlock`, `processSpecialBlock`, `flushTemplateChunk`, `processTemplateContent`, `chunkLiquidFile`).

Verified via full-repo `grep -rn "orgId\|tenantContext" packages/ --include='*.ts'` (excluding node_modules/dist) both before (to build the inventory) and after (zero remaining hits) the change. `get_dependents` on `chunkFile` and `chunkByAST` confirmed the complete external caller set matched the grep inventory (core's `incremental.ts`/`index.ts` only).

## branch / commitSha liveness verdict

Per instructions, `branch` and `commitSha` on `ChunkMetadata` are **not** removed here — but they're just as dead as `orgId` was. Neither field is ever assigned by any chunker (only `orgId` had actual write sites before this PR), neither appears as a column in the SQLite schema (`packages/core/src/vectordb/sqlite/schema.ts`'s `CREATE TABLE chunks` has no `orgId`/`branch`/`commitSha` columns), and neither is referenced anywhere in `write-ops.ts`'s row mapping or the overlay/worktree-indexing path. The only `branch`/`commit` and `commitSha` hits elsewhere in the codebase are unrelated concepts (git state tracking in `git/tracker.ts`/`change-detector.ts`, and a PR head SHA in the review plugin) — not this metadata field. They're declared-but-unused exactly like `orgId` was, and are a same-shape follow-up candidate whenever that's wanted.

## Tests

- Deleted the one test that asserted orgId passthrough: `packages/parser/src/markdown-chunker.test.ts` ("passes through orgId tenant context").
- No other tests referenced `orgId`.
- Everything else passes unchanged.

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — pass (0 errors, pre-existing warnings only)
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm test` — pass (parser 1052/1052, core 355/355, cli 769/769 excl. e2e, review 760/760, action 28/28)
- [x] `node packages/cli/dist/index.js delta` — exit 0, 23 functions improved, 0 new crossings

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This is a pure dead-code refactor: `orgId` and the `tenantContext` carrier parameter are removed from `ChunkMetadata`, all chunkers, and core's indexing pipeline. The full-repo sweep confirms zero surviving `orgId`/`tenantContext` references in source code, and all internal call sites were updated to match the new signatures. No runtime behavior changes — the field was always `undefined` in practice — and no active callers are affected. Tests, lint, typecheck, and build all pass per the test plan.
>
> - Removed `orgId` from `ChunkMetadata` and all chunker option interfaces
> - Deleted the `tenantContext` parameter thread through AST, line-based, markdown, liquid, and JSON-template chunkers
> - Removed dead `orgId` assignments in core's `index.ts`/`incremental.ts`
> - Deleted the one test that asserted `orgId` passthrough

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6ca0143. Updates automatically on new commits.</sup>
<!-- /lien-stats -->