### PR TITLE
refactor: remove dead branch/commitSha chunk-metadata fields

### DIFF
--- a/.changeset/purge-dead-branch-commitsha.md
+++ b/.changeset/purge-dead-branch-commitsha.md
@@ -1,0 +1,5 @@
+---
+'@liendev/parser': patch
+---
+
+remove dead branch/commitSha chunk-metadata fields

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -344,7 +344,7 @@ chunks_fts  -- FTS5 external-content virtual table (content='chunks')
   kept in sync by AFTER INSERT/UPDATE/DELETE triggers on chunks
 ```
 
-`startLine`/`endLine` are `INTEGER` (the structural-store spike stored them as REAL; fixed in production). Multi-tenant fields (`orgId`, `branch`, `commitSha`) exist in `ChunkMetadata` for a possible future multi-tenant backend but are not stored as columns today. Cross-repo MCP mode itself (the `crossRepo`/`repoIds` tool parameters, `supportsCrossRepo`, `scanCrossRepo`, and the `repoId` metadata field) was removed — it was never implemented in the SQLite era.
+`startLine`/`endLine` are `INTEGER` (the structural-store spike stored them as REAL; fixed in production). The multi-tenant `ChunkMetadata` fields (`repoId`, `orgId`, `branch`, `commitSha`) were never stored as columns and have since been removed entirely — none were ever wired to a write site. Cross-repo MCP mode itself (the `crossRepo`/`repoIds` tool parameters, `supportsCrossRepo`, `scanCrossRepo`) was removed — it was never implemented in the SQLite era.
 
 ### Version File
 

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -63,19 +63,6 @@ export interface ChunkMetadata {
   halsteadDifficulty?: number; // D = (n1/2) × (N2/n2) - error-proneness
   halsteadEffort?: number; // E = D × V - mental effort required
   halsteadBugs?: number; // B = E^(2/3) / 3000 - estimated delivered bugs
-
-  // Cross-repo-capable backend fields (optional for backward compatibility)
-  /**
-   * Git branch name for branch/commit tracking in cross-repo-capable backends.
-   * Used to isolate indexes by branch (e.g., main vs PR branches).
-   */
-  branch?: string;
-
-  /**
-   * Git commit SHA for branch/commit tracking in cross-repo-capable backends.
-   * Used to isolate indexes by commit (e.g., for PR analysis).
-   */
-  commitSha?: string;
 }
 
 export interface ScanOptions {


### PR DESCRIPTION
## Summary

Third purge in the multi-tenant fossil family, following #760 (repoId) and #762 (orgId): removes the dead `branch` and `commitSha` fields from `ChunkMetadata` (`packages/parser/src/types.ts`).

## Inventory

Grepped `commitSha` and `\bbranch\b` across `packages/**/*.ts` (excluding node_modules/dist).

**Removed (dead ChunkMetadata scaffolding):**
- `packages/parser/src/types.ts` — `branch?: string` and `commitSha?: string` on `ChunkMetadata`, plus their doc comments. Zero write sites (no chunker ever assigned them), zero persistence (no column in `packages/core/src/vectordb/sqlite/schema.ts`, absent from write-ops/row-mapping, unread by overlay/worktree indexing). `get_dependents` on `ChunkMetadata` confirms zero symbol-level usages across the file's 6 dependents.

**Kept (unrelated, live concepts with the same names — verified by reading each hit):**
- `packages/core/src/git/utils.ts`, `packages/core/src/git/tracker.ts`, `packages/core/src/indexer/change-detector.ts` — git-state tracking (`GitState.branch`/`commit`) for incremental indexing. Live, actively read/written.
- `packages/cli/src/cli/status.ts`, `packages/cli/src/mcp/server.ts`, `packages/cli/src/mcp/types.ts` — same `GitState` shape surfaced via `lien status`/MCP `indexedBranch`.
- `packages/review/src/plugins/agent/index.ts` — `commitSha` param is the PR head SHA (`context.pr?.headSha`), used to build the review description. Unrelated to ChunkMetadata.
- `packages/review/src/clone.ts` — `branch` param for cloning a repo by branch name (baseline clones). Unrelated.
- All `branch: 'main'`/`'feature'` test fixture literals in `manifest.test.ts`, `change-detector.test.ts`, `real-projects.test.ts`, `server.test.ts` — these construct the `GitState` shape, not `ChunkMetadata`. Confirmed by reading each file; none reference `ChunkMetadata`.

## Deleted tests

None — no test directly asserted `ChunkMetadata.branch`/`commitSha` (grepped every test file that imports `ChunkMetadata`: `complexity-analyzer.test.ts`, `fts-search.test.ts`, `sqlite-backend.test.ts`, `complexity.test.ts`, `dependency-analyzer.test.ts` — zero hits).

## Docs

`docs/architecture/data-flow.md` described `orgId`/`branch`/`commitSha` as scaffolding kept for "a possible future multi-tenant backend." Since all three are now removed (repoId via #760, orgId via #762, these two here), updated the sentence to say so. Left the historical ADRs (0010, 0011) untouched — they're decision records frozen at the time, consistent with how #762 left them.

## Gates

`format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`, `build`, and `test` (2997 tests across parser/core/review/cli/action, all green) all pass. `node packages/cli/dist/index.js delta` exits 0 (no complexity changes).

Only `packages/parser` files changed, so the changeset bumps `@liendev/parser` only (patch).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR removes two optional and entirely unused `ChunkMetadata` fields (`branch`, `commitSha`) from the parser package. There are zero symbol-level dependents, no persistence columns, and no write sites for these fields, so the change is a safe cleanup with no runtime impact.
>
> - Removed `branch?` and `commitSha?` from `ChunkMetadata` in `packages/parser/src/types.ts`
> - Updated `docs/architecture/data-flow.md` to reflect that all multi-tenant scaffolding fields are now removed

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e1a8eef. Updates automatically on new commits.</sup>
<!-- /lien-stats -->