### PR TITLE
fix(review,action): fail the check when the review provider fails every request

### DIFF
--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -95,7 +95,7 @@ exact cost of every run is printed in the job's step summary (the
 | `threshold`           | no       | `15`                            | Complexity threshold above which violations are reported.                                                                                 |
 | `review-types`        | no       | `complexity,bugs,summary`       | Comma-separated review types to enable. `complexity` toggles the complexity check. `bugs`, `architectural`, and `summary` all come from the single agent reviewer, so they switch it on/off as a group (and only when an API key is set) — they can't be toggled independently. |
 | `block-on-new-errors` | no       | `false`                         | Post `REQUEST_CHANGES` (instead of `COMMENT`) when the PR introduces new error-level complexity violations.                               |
-| `fail-on`             | no       | `never`                         | Whether the review fails the check (so a Required check can block the PR). Default `never` — **advisory**, never fails CI. Opt into gating with `error` (a failure conclusion / new error-level findings) or `any` (any error or warning finding). |
+| `fail-on`             | no       | `never`                         | Whether the review fails the check (so a Required check can block the PR). Default `never` — **advisory** for review findings. Opt into gating with `error` (a failure conclusion / new error-level findings) or `any` (any error or warning finding). Exception: a total LLM-provider failure always fails the check regardless of this setting — see [Fail-loudly guarantee](#fail-loudly-guarantee). |
 
 > The action posts **no check run of its own** — the workflow job is the single
 > status check. Findings surface as workflow annotations (inline on the diff),
@@ -145,13 +145,15 @@ only covers that one model.
 
 ## Blocking a PR on the review
 
-By default the review is **advisory** (`fail-on: never`) — it never fails CI, so
-adding the action can't break anyone's pipeline. To gate merges on it, opt in by
-setting `fail-on` and marking the workflow's job as a **Required status check**
-in your branch protection rules. With `fail-on: error` the action exits non-zero
-only when the review's overall conclusion is a failure (driven by
-`block-on-new-errors`); `fail-on: any` is stricter (any error- or warning-level
-finding fails the check).
+By default the review is **advisory** (`fail-on: never`) for its own findings —
+it never fails CI on those, so adding the action can't break anyone's
+pipeline. To gate merges on findings, opt in by setting `fail-on` and marking
+the workflow's job as a **Required status check** in your branch protection
+rules. With `fail-on: error` the action exits non-zero only when the review's
+overall conclusion is a failure (driven by `block-on-new-errors`); `fail-on:
+any` is stricter (any error- or warning-level finding fails the check). A
+total LLM-provider failure is a separate case that always fails the check,
+even under `fail-on: never` — see below.
 
 ## Fail-loudly guarantee
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -156,14 +156,19 @@ finding fails the check).
 ## Fail-loudly guarantee
 
 If the agent review's main pass never runs at all — every request to the LLM
-provider failed (exhausted key, a terminal provider error, etc.) — Lien marks
-the result with an **error-severity finding** and a **`failure`** conclusion
-naming the cause, instead of a clean-looking review. That finding is what
-`fail-on: error`/`any` act on, so a starved review fails the check under
-either gating mode. Under the default `fail-on: never` the job itself still
-exits `0` (advisory stays advisory), but the step summary, PR description, and
-`conclusion` output make the failure impossible to mistake for "no issues
-found."
+provider failed terminally (insufficient credits, an invalid/expired key, a
+provider outage, etc.) — Lien marks the result with an **error-severity
+finding** and a **`failure`** conclusion naming the cause, instead of a
+clean-looking review.
+
+This is treated as an **operational failure, not an advisory finding**: a
+review that never ran isn't something `fail-on` gates on, because there's
+nothing to be advisory *about* — no code was analyzed. **The check fails
+regardless of `fail-on`, including the advisory default `never`.** A partial
+run (some turns completed before it bailed on a budget/turn limit) is
+different — that's a genuine advisory finding and still obeys `fail-on` as
+before. Either way, the step summary, PR description, and `conclusion` output
+make the failure impossible to mistake for "no issues found."
 
 ## Fork PRs
 

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -23,7 +23,7 @@ import {
 
 import { readInputs, type FailOn } from './inputs.js';
 import { loadContext } from './context.js';
-import { writeStepSummary, writeOutputs, countErrors, hasProviderFailure } from './summary.js';
+import { writeStepSummary, writeOutputs, countErrors } from './summary.js';
 import { actionLogger, group, endGroup, annotate } from './logger.js';
 
 /**
@@ -75,9 +75,11 @@ function exitCodeFor(
 
 /**
  * Log a clear, actionable message naming why the review couldn't run at all.
- * The finding's own message already carries the raw provider error (e.g. "API
- * error (402): ..."); this adds the common-cause remediation so a maintainer
- * doesn't have to guess.
+ * Only called once `result.providerFailure` (the authoritative signal from
+ * `@liendev/review`) is already known true — this just locates the specific
+ * never-ran notice among `findings` to quote its message (which already
+ * carries the raw provider error, e.g. "API error (402): ..."), then adds the
+ * common-cause remediation so a maintainer doesn't have to guess.
  */
 function logProviderFailure(findings: ReviewFinding[]): void {
   const notice = findings.find(f => (f.metadata as { neverRan?: boolean } | undefined)?.neverRan);
@@ -103,7 +105,7 @@ export async function finishRun(
   failOn: FailOn,
 ): Promise<number> {
   const errorCount = countErrors(result.findings);
-  const providerFailure = hasProviderFailure(result.findings);
+  const providerFailure = result.providerFailure;
 
   await writeStepSummary(result);
   await writeOutputs({

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -23,7 +23,7 @@ import {
 
 import { readInputs, type FailOn } from './inputs.js';
 import { loadContext } from './context.js';
-import { writeStepSummary, writeOutputs, countErrors } from './summary.js';
+import { writeStepSummary, writeOutputs, countErrors, hasProviderFailure } from './summary.js';
 import { actionLogger, group, endGroup, annotate } from './logger.js';
 
 /**
@@ -57,13 +57,38 @@ function exitCodeFor(
   conclusion: 'success' | 'failure' | 'neutral',
   errorCount: number,
   warningCount: number,
+  providerFailure: boolean,
 ): number {
+  // A total provider failure means the agent review never ran at all — an
+  // operational failure, not an advisory finding. A user who enabled (and is
+  // paying for) the review deserves a red check when it didn't happen, so
+  // this fails regardless of `fail-on`, including the advisory default
+  // `never`. See the "Fail-loudly guarantee" section of the action README.
+  if (providerFailure) return 1;
   if (failOn === 'never') return 0;
   // 'any' is strictly stricter than 'error': fail on a failure conclusion (e.g.
   // analysis failed with no findings) OR on any error/warning finding.
   if (failOn === 'any') return conclusion === 'failure' || errorCount + warningCount > 0 ? 1 : 0;
   // failOn === 'error'
   return conclusion === 'failure' ? 1 : 0;
+}
+
+/**
+ * Log a clear, actionable message naming why the review couldn't run at all.
+ * The finding's own message already carries the raw provider error (e.g. "API
+ * error (402): ..."); this adds the common-cause remediation so a maintainer
+ * doesn't have to guess.
+ */
+function logProviderFailure(findings: ReviewFinding[]): void {
+  const notice = findings.find(f => (f.metadata as { neverRan?: boolean } | undefined)?.neverRan);
+  const cause = notice?.message ?? 'every LLM provider request failed.';
+  actionLogger.error(
+    `Lien Review could not run: ${cause} This fails the check even with fail-on: never — a ` +
+      'review that never ran is an operational failure, not an advisory finding. Common causes: ' +
+      'insufficient provider credits (402, add credits), an invalid/expired API key (401/403, ' +
+      'check the openrouter-api-key/anthropic-api-key secret), or a provider outage (5xx, re-run ' +
+      'once it recovers).',
+  );
 }
 
 /**
@@ -78,6 +103,7 @@ export async function finishRun(
   failOn: FailOn,
 ): Promise<number> {
   const errorCount = countErrors(result.findings);
+  const providerFailure = hasProviderFailure(result.findings);
 
   await writeStepSummary(result);
   await writeOutputs({
@@ -90,13 +116,14 @@ export async function finishRun(
   // post (annotations + the step summary still do). Note it once. Skipped under
   // pull_request_target, which grants forks a writable token.
   if (forkReadOnly) emitForkWarning();
+  if (providerFailure) logProviderFailure(result.findings);
 
   const warningCount = result.findings.filter(f => f.severity === 'warning').length;
   actionLogger.info(
     `Review complete: ${result.findings.length} findings (${errorCount} errors), ` +
       `conclusion=${result.conclusion}, files=${result.filesAnalyzed}`,
   );
-  return exitCodeFor(failOn, result.conclusion, errorCount, warningCount);
+  return exitCodeFor(failOn, result.conclusion, errorCount, warningCount, providerFailure);
 }
 
 async function main(): Promise<void> {

--- a/packages/action/src/summary.ts
+++ b/packages/action/src/summary.ts
@@ -26,6 +26,22 @@ export function countErrors(findings: ReviewFinding[]): number {
 }
 
 /**
+ * True when a finding signals that the agent-review MAIN pass never ran at
+ * all — every LLM provider request failed terminally (a 402 on an overdrawn
+ * account, an invalid key, a provider outage). Set via `AgentResult.neverRan`
+ * and surfaced as `metadata.neverRan` by `appendNeverRanNotice` in
+ * `packages/review/src/plugins/agent/index.ts`.
+ *
+ * This is an operational failure, not an advisory finding: a user who
+ * configured and paid for a review deserves to know it didn't run, so the
+ * action fails the check for this even under `fail-on: never` (see
+ * `finishRun`) — unlike ordinary error/warning findings, which stay advisory.
+ */
+export function hasProviderFailure(findings: ReviewFinding[]): boolean {
+  return findings.some(f => (f.metadata as { neverRan?: boolean } | undefined)?.neverRan === true);
+}
+
+/**
  * Append the review summary to `$GITHUB_STEP_SUMMARY`. No-op when the env var is
  * unset (e.g. running outside Actions) so local invocations don't crash.
  */

--- a/packages/action/src/summary.ts
+++ b/packages/action/src/summary.ts
@@ -26,22 +26,6 @@ export function countErrors(findings: ReviewFinding[]): number {
 }
 
 /**
- * True when a finding signals that the agent-review MAIN pass never ran at
- * all — every LLM provider request failed terminally (a 402 on an overdrawn
- * account, an invalid key, a provider outage). Set via `AgentResult.neverRan`
- * and surfaced as `metadata.neverRan` by `appendNeverRanNotice` in
- * `packages/review/src/plugins/agent/index.ts`.
- *
- * This is an operational failure, not an advisory finding: a user who
- * configured and paid for a review deserves to know it didn't run, so the
- * action fails the check for this even under `fail-on: never` (see
- * `finishRun`) — unlike ordinary error/warning findings, which stay advisory.
- */
-export function hasProviderFailure(findings: ReviewFinding[]): boolean {
-  return findings.some(f => (f.metadata as { neverRan?: boolean } | undefined)?.neverRan === true);
-}
-
-/**
  * Append the review summary to `$GITHUB_STEP_SUMMARY`. No-op when the env var is
  * unset (e.g. running outside Actions) so local invocations don't crash.
  */

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -12,6 +12,7 @@ function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
     summaryMarkdown: 'All good.',
     filesAnalyzed: 3,
     usage: { totalTokens: 0, cost: 0 },
+    providerFailure: false,
     ...overrides,
   };
 }
@@ -103,7 +104,15 @@ describe('finishRun', () => {
   it('fails the check on a total provider failure even under fail-on=never (#764)', async () => {
     vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
     const error = vi.spyOn(actionLogger, 'error').mockImplementation(() => {});
-    const result = makeResult({ conclusion: 'failure', findings: [neverRanFinding()] });
+    // `providerFailure` is the authoritative signal computed by `@liendev/review`
+    // (see review-pr.ts's `hasProviderFailure`) — `conclusion`/`findings` mirror
+    // what it would actually produce alongside it, but `finishRun` gates on
+    // `providerFailure` directly, not on re-deriving it from findings/strings.
+    const result = makeResult({
+      conclusion: 'failure',
+      findings: [neverRanFinding()],
+      providerFailure: true,
+    });
 
     const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
 
@@ -118,10 +127,30 @@ describe('finishRun', () => {
   it('still fails a total provider failure under fail-on=error and fail-on=any', async () => {
     vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
     vi.spyOn(actionLogger, 'error').mockImplementation(() => {});
-    const result = makeResult({ conclusion: 'failure', findings: [neverRanFinding()] });
+    const result = makeResult({
+      conclusion: 'failure',
+      findings: [neverRanFinding()],
+      providerFailure: true,
+    });
 
     expect(await finishRun(result, false, 'error')).toBe(1);
     expect(await finishRun(result, false, 'any')).toBe(1);
+  });
+
+  it('a findings-based failure conclusion (providerFailure=false) still obeys fail-on=never', async () => {
+    // Distinguishes the two ways `conclusion` can be 'failure': ordinary error
+    // findings (e.g. a new complexity violation) must stay advisory under the
+    // default, unlike an operational provider failure (the test above).
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    const result = makeResult({
+      conclusion: 'failure',
+      findings: [{ severity: 'error' } as ReviewCoreResult['findings'][number]],
+      providerFailure: false,
+    });
+
+    const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
+
+    expect(exitCode).toBe(0);
   });
 
   it('a PARTIAL incomplete run (budget/turn limit, not neverRan) stays advisory under fail-on=never', async () => {

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -81,4 +81,72 @@ describe('finishRun', () => {
 
     expect(exitCode).toBe(1);
   });
+
+  // Regression coverage for #764: a total provider failure (every OpenRouter
+  // request 402'd) reached a green check because `fail-on: never` forced exit 0
+  // unconditionally, with no distinction between an advisory finding and an
+  // operational "the review never ran" failure.
+  function neverRanFinding(): ReviewCoreResult['findings'][number] {
+    return {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'error',
+      category: 'summary',
+      message:
+        'Lien Review did not run — every provider request failed (API error (402): Insufficient credits). ' +
+        'This is NOT a clean review; no code was analyzed. Re-run once the provider issue is resolved.',
+      metadata: { incomplete: true, neverRan: true, stopReason: 'error' },
+    };
+  }
+
+  it('fails the check on a total provider failure even under fail-on=never (#764)', async () => {
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    const error = vi.spyOn(actionLogger, 'error').mockImplementation(() => {});
+    const result = makeResult({ conclusion: 'failure', findings: [neverRanFinding()] });
+
+    const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
+
+    expect(exitCode).toBe(1);
+    // A clear, actionable message names the cause — not just the raw finding.
+    expect(error).toHaveBeenCalled();
+    const logged = error.mock.calls.map(c => c[0]).join('\n');
+    expect(logged).toContain('402');
+    expect(logged).toContain('fail-on: never');
+  });
+
+  it('still fails a total provider failure under fail-on=error and fail-on=any', async () => {
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    vi.spyOn(actionLogger, 'error').mockImplementation(() => {});
+    const result = makeResult({ conclusion: 'failure', findings: [neverRanFinding()] });
+
+    expect(await finishRun(result, false, 'error')).toBe(1);
+    expect(await finishRun(result, false, 'any')).toBe(1);
+  });
+
+  it('a PARTIAL incomplete run (budget/turn limit, not neverRan) stays advisory under fail-on=never', async () => {
+    // Some turns completed before the run bailed — this is a warning-severity
+    // notice (see appendIncompleteNotice), not the never-ran operational failure,
+    // so it must not force a failing exit code by itself.
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    const result = makeResult({
+      conclusion: 'neutral',
+      findings: [
+        {
+          pluginId: 'agent-review',
+          filepath: '',
+          line: 0,
+          severity: 'warning',
+          category: 'summary',
+          message:
+            'Lien Review did not finish — it hit the token budget limit while investigating.',
+          metadata: { incomplete: true, stopReason: 'budget' },
+        } as ReviewCoreResult['findings'][number],
+      ],
+    });
+
+    const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
+
+    expect(exitCode).toBe(0);
+  });
 });

--- a/packages/action/test/summary.test.ts
+++ b/packages/action/test/summary.test.ts
@@ -2,19 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import type { ReviewFinding } from '@liendev/review';
 
-import { countErrors, hasProviderFailure } from '../src/summary.js';
-
-function summaryFinding(metadata?: Record<string, unknown>): ReviewFinding {
-  return {
-    pluginId: 'agent-review',
-    filepath: '',
-    line: 0,
-    severity: 'error',
-    category: 'summary',
-    message: 'Lien Review did not run — every provider request failed (API error (402): ...).',
-    metadata,
-  };
-}
+import { countErrors } from '../src/summary.js';
 
 describe('countErrors', () => {
   it('counts only error-severity findings', () => {
@@ -24,28 +12,5 @@ describe('countErrors', () => {
       { severity: 'error' } as ReviewFinding,
     ];
     expect(countErrors(findings)).toBe(2);
-  });
-});
-
-describe('hasProviderFailure', () => {
-  it('is true when a finding carries metadata.neverRan', () => {
-    expect(hasProviderFailure([summaryFinding({ neverRan: true, incomplete: true })])).toBe(true);
-  });
-
-  it('is false for an ordinary error finding with no neverRan metadata', () => {
-    expect(hasProviderFailure([summaryFinding(undefined)])).toBe(false);
-  });
-
-  it('is false for a partial-incomplete finding (neverRan absent, not just falsy)', () => {
-    // The doc-truth-only / budget-exhausted incomplete notices set `incomplete`
-    // but never `neverRan` — these must stay advisory, not escalate to a
-    // provider-failure exit code.
-    expect(hasProviderFailure([summaryFinding({ incomplete: true, stopReason: 'budget' })])).toBe(
-      false,
-    );
-  });
-
-  it('is false for an empty findings list', () => {
-    expect(hasProviderFailure([])).toBe(false);
   });
 });

--- a/packages/action/test/summary.test.ts
+++ b/packages/action/test/summary.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+
+import type { ReviewFinding } from '@liendev/review';
+
+import { countErrors, hasProviderFailure } from '../src/summary.js';
+
+function summaryFinding(metadata?: Record<string, unknown>): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'error',
+    category: 'summary',
+    message: 'Lien Review did not run — every provider request failed (API error (402): ...).',
+    metadata,
+  };
+}
+
+describe('countErrors', () => {
+  it('counts only error-severity findings', () => {
+    const findings = [
+      { severity: 'error' } as ReviewFinding,
+      { severity: 'warning' } as ReviewFinding,
+      { severity: 'error' } as ReviewFinding,
+    ];
+    expect(countErrors(findings)).toBe(2);
+  });
+});
+
+describe('hasProviderFailure', () => {
+  it('is true when a finding carries metadata.neverRan', () => {
+    expect(hasProviderFailure([summaryFinding({ neverRan: true, incomplete: true })])).toBe(true);
+  });
+
+  it('is false for an ordinary error finding with no neverRan metadata', () => {
+    expect(hasProviderFailure([summaryFinding(undefined)])).toBe(false);
+  });
+
+  it('is false for a partial-incomplete finding (neverRan absent, not just falsy)', () => {
+    // The doc-truth-only / budget-exhausted incomplete notices set `incomplete`
+    // but never `neverRan` — these must stay advisory, not escalate to a
+    // provider-failure exit code.
+    expect(hasProviderFailure([summaryFinding({ incomplete: true, stopReason: 'budget' })])).toBe(
+      false,
+    );
+  });
+
+  it('is false for an empty findings list', () => {
+    expect(hasProviderFailure([])).toBe(false);
+  });
+});

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -31,7 +31,7 @@ export { ReviewEngine, createDefaultEngine, type EngineOptions } from './engine.
 
 // Built-in plugins
 export { ComplexityPlugin } from './plugins/complexity.js';
-export { AgentReviewPlugin } from './plugins/agent/index.js';
+export { AgentReviewPlugin, hasProviderFailure } from './plugins/agent/index.js';
 
 // Dependency graph
 export {

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -479,6 +479,20 @@ function appendNeverRanNotice(
   });
 }
 
+/**
+ * True when `findings` contains the never-ran notice from `appendNeverRanNotice`
+ * — the agent-review MAIN pass never completed a single turn because every LLM
+ * provider request failed terminally (a 402 on an overdrawn account, an
+ * invalid key, a provider outage). This is the single source of truth for that
+ * signal: callers outside this module (the transport-agnostic review core, the
+ * GitHub Action) key off this instead of re-deriving it from `metadata` shape
+ * or from `conclusion`/summary text, so the contract only needs to change here
+ * if the notice's shape ever does.
+ */
+export function hasProviderFailure(findings: ReviewFinding[]): boolean {
+  return findings.some(f => (f.metadata as { neverRan?: boolean } | undefined)?.neverRan === true);
+}
+
 /** Cap the provider error to a short, single-line cause for the notice. */
 const MAX_PROVIDER_ERROR_CHARS = 160;
 function summarizeProviderError(msg?: string): string {

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -35,6 +35,7 @@ import {
   ReviewEngine,
   ComplexityPlugin,
   AgentReviewPlugin,
+  hasProviderFailure,
 } from './index.js';
 import type { CodeChunk } from '@liendev/parser';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
@@ -94,6 +95,16 @@ export interface ReviewCoreResult {
   summaryMarkdown: string;
   filesAnalyzed: number;
   usage: { totalTokens: number; cost: number };
+  /**
+   * True when the agent-review MAIN pass never ran at all — every LLM provider
+   * request failed terminally (see `hasProviderFailure` / `AgentResult.neverRan`).
+   * This is an OPERATIONAL failure, not an advisory finding: a caller (e.g. the
+   * GitHub Action) should treat it as failing regardless of its own advisory/gating
+   * policy, since a review that never ran isn't something to be advisory *about*.
+   * Always `false` when the agent review didn't run for an unrelated reason (not
+   * enabled, or the pipeline failed before reaching the engine).
+   */
+  providerFailure: boolean;
 }
 
 export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewCoreResult> {
@@ -157,7 +168,12 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
 // ---------------------------------------------------------------------------
 // Helpers
 
-/** Build a no-findings result for the no-files / analysis-failed early returns. */
+/**
+ * Build a no-findings result for the no-files / analysis-failed early returns.
+ * Both are unrelated to the LLM provider (no files to review; the pipeline
+ * failed before the engine ever ran), so `providerFailure` is always false —
+ * only `hasProviderFailure` on the engine's actual findings sets it.
+ */
 function emptyResult(
   conclusion: 'success' | 'failure',
   summaryMarkdown: string,
@@ -169,6 +185,7 @@ function emptyResult(
     summaryMarkdown,
     filesAnalyzed,
     usage: { totalTokens: 0, cost: 0 },
+    providerFailure: false,
   };
 }
 
@@ -212,6 +229,7 @@ interface PresentedReview {
   conclusion: 'success' | 'failure' | 'neutral';
   summaryMarkdown: string;
   usage: { totalTokens: number; cost: number };
+  providerFailure: boolean;
 }
 
 /** Run the review engine over an analyzed PR and present the findings to GitHub. */
@@ -270,6 +288,7 @@ async function analyzeAndPresent(
     conclusion: presentation.conclusion,
     summaryMarkdown: presentation.summary,
     usage: { totalTokens: agentUsage.totalTokens, cost: agentUsage.cost },
+    providerFailure: hasProviderFailure(findings),
   };
 }
 

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -5,6 +5,7 @@ import {
   appendIncompleteNotice,
   scaleBudgetForBlastRadius,
   clampText,
+  hasProviderFailure,
 } from '../src/plugins/agent/index.js';
 import { scaleAgentBudget } from '../src/review-pr.js';
 import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
@@ -384,18 +385,19 @@ describe('OpenAIAgentClient budget handling', () => {
   }, 20000);
 });
 
-describe('appendIncompleteNotice — severity by run outcome', () => {
-  function baseResult(overrides: Partial<AgentResult>): AgentResult {
-    return {
-      findings: [],
-      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 },
-      turns: 0,
-      stopReason: 'error',
-      incomplete: true,
-      ...overrides,
-    };
-  }
+/** Shared by both the `appendIncompleteNotice` and `hasProviderFailure` suites below. */
+function baseResult(overrides: Partial<AgentResult>): AgentResult {
+  return {
+    findings: [],
+    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 },
+    turns: 0,
+    stopReason: 'error',
+    incomplete: true,
+    ...overrides,
+  };
+}
 
+describe('appendIncompleteNotice — severity by run outcome', () => {
   it('escalates a never-ran main pass to an ERROR notice naming the cause', () => {
     const findings: ReviewFinding[] = [];
     appendIncompleteNotice(
@@ -448,6 +450,53 @@ describe('appendIncompleteNotice — severity by run outcome', () => {
     const findings: ReviewFinding[] = [];
     appendIncompleteNotice(findings, 'agent-review', baseResult({ incomplete: false }));
     expect(findings).toHaveLength(0);
+  });
+});
+
+describe('hasProviderFailure — the single source of truth for #764-class detection', () => {
+  // Regression coverage for #764/#765: the action layer (and review-pr.ts's
+  // `ReviewCoreResult.providerFailure`) both key off this function rather than
+  // re-deriving the signal from `metadata` shape or conclusion/summary text.
+  function neverRanNotice(): ReviewFinding[] {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: true, errorMessage: 'API error (402): Insufficient credits' }),
+    );
+    return findings;
+  }
+
+  it('is true when findings carry the never-ran notice', () => {
+    expect(hasProviderFailure(neverRanNotice())).toBe(true);
+  });
+
+  it('is false for a partial (budget) incomplete notice — no neverRan metadata', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: false, stopReason: 'budget' }),
+    );
+    expect(hasProviderFailure(findings)).toBe(false);
+  });
+
+  it('is false for a doc-pass-only incomplete notice (main pass ran fine)', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: true, incompleteFromDocPass: true, stopReason: 'error' }),
+    );
+    expect(hasProviderFailure(findings)).toBe(false);
+  });
+
+  it('is false for an ordinary error finding with no metadata at all', () => {
+    expect(hasProviderFailure([{ severity: 'error' } as ReviewFinding])).toBe(false);
+  });
+
+  it('is false for an empty findings list', () => {
+    expect(hasProviderFailure([])).toBe(false);
   });
 });
 

--- a/packages/site/docs/guide/lien-review.md
+++ b/packages/site/docs/guide/lien-review.md
@@ -68,7 +68,7 @@ One behavior is tunable only via an environment variable on the action step, not
 
 By default the review is **advisory** — it never fails CI. To gate merges on it, set `fail-on: error` (or `any`) and mark the workflow's job as a **Required status check** in your branch protection rules. See the [inputs table](https://github.com/getlien/lien/blob/main/packages/action/README.md#inputs) for the full set of options (`threshold`, `review-types`, `block-on-new-errors`, `fail-on`).
 
-If the agent review's main pass never runs at all (every LLM provider request failed), Lien marks the result with an error-severity finding and a `failure` conclusion instead of a clean-looking review, so a starved run is never mistaken for "no issues found." See [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md#fail-loudly-guarantee) for the full behavior, including how it interacts with `fail-on`.
+If the agent review's main pass never runs at all (every LLM provider request failed — insufficient credits, an invalid key, a provider outage), Lien marks the result with an error-severity finding and a `failure` conclusion instead of a clean-looking review — and **fails the check regardless of `fail-on`**, including the advisory default `never`. A review that never ran isn't an advisory finding to gate on; a partial run (some turns completed before it bailed) still obeys `fail-on` as before. See [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md#fail-loudly-guarantee) for the full behavior.
 
 ## Fork PRs
 

--- a/packages/site/docs/guide/lien-review.md
+++ b/packages/site/docs/guide/lien-review.md
@@ -58,7 +58,7 @@ If both keys are omitted, the review still runs but **complexity-only** — the 
 | Complexity analysis | Flags new/worsened cyclomatic, cognitive, and Halstead complexity violations |
 | Agent bug review | LLM-driven review for correctness bugs (OpenRouter or Anthropic) |
 | PR summary | A concise summary of the change, posted as a step summary |
-| Advisory by default | `fail-on: never` — the check never blocks a PR unless you opt in |
+| Advisory by default | `fail-on: never` — review findings never block a PR unless you opt in (a total LLM-provider failure still fails the check regardless) |
 
 ## Advanced configuration
 
@@ -66,7 +66,7 @@ One behavior is tunable only via an environment variable on the action step, not
 
 ## Blocking a PR on the review
 
-By default the review is **advisory** — it never fails CI. To gate merges on it, set `fail-on: error` (or `any`) and mark the workflow's job as a **Required status check** in your branch protection rules. See the [inputs table](https://github.com/getlien/lien/blob/main/packages/action/README.md#inputs) for the full set of options (`threshold`, `review-types`, `block-on-new-errors`, `fail-on`).
+By default the review is **advisory** for its own findings — it never fails CI on those. To gate merges on findings, set `fail-on: error` (or `any`) and mark the workflow's job as a **Required status check** in your branch protection rules. See the [inputs table](https://github.com/getlien/lien/blob/main/packages/action/README.md#inputs) for the full set of options (`threshold`, `review-types`, `block-on-new-errors`, `fail-on`). A total LLM-provider failure is a separate case that always fails the check, even under `fail-on: never` — see the paragraph below.
 
 If the agent review's main pass never runs at all (every LLM provider request failed — insufficient credits, an invalid key, a provider outage), Lien marks the result with an error-severity finding and a `failure` conclusion instead of a clean-looking review — and **fails the check regardless of `fail-on`**, including the advisory default `never`. A review that never ran isn't an advisory finding to gate on; a partial run (some turns completed before it bailed) still obeys `fail-on` as before. See [`packages/action/README.md`](https://github.com/getlien/lien/blob/main/packages/action/README.md#fail-loudly-guarantee) for the full behavior.
 


### PR DESCRIPTION
## The bug (live repro)

PR #764 (2026-07-15, before OpenRouter credits were topped up): OpenRouter returned `402 insufficient credits` on **every** provider request. The agent-review plugin analyzed zero code, and the `lien-stats` badge said so plainly — yet the action's own check concluded **green**. An enabled, paid-for review that couldn't run at all silently passed.

## Root cause

Not where it first looked. PR #738/#739 ("a starved review fails loudly instead of passing as clean") already made the **review-core layer** correctly classify a total provider outage:

- `OpenAIAgentClient.run()` (`packages/review/src/plugins/agent/openai-client.ts`): a 402 is a non-retryable 4xx, throws immediately with `completedTurns === 0` → `neverRan: true`.
- `appendNeverRanNotice` (`packages/review/src/plugins/agent/index.ts`) escalates that into an **error-severity** `summary` finding (`metadata.neverRan: true`).
- `determineConclusion` (`packages/review/src/engine.ts`) maps any error-severity finding to conclusion `'failure'`.

All of that is already covered by existing tests (`plugins-agent-budget.test.ts`) and was working correctly on `main` before this PR.

The actual remaining gap is one layer further down, in `packages/action/src/index.ts`:

```ts
function exitCodeFor(failOn, conclusion, errorCount, warningCount): number {
  if (failOn === 'never') return 0;   // <-- unconditional, no matter what caused `failure`
  ...
}
```

`fail-on` defaults to `'never'` (advisory-by-default is deliberate, documented policy — see `packages/action/README.md`). But `exitCodeFor` never distinguished "an ordinary advisory finding" from "the review never ran at all" — under the default, **both** collapsed to exit 0. The action's job is the *only* status check (no separate Checks-API run), so exit code 0 == green PR check, full stop. That's why the 402 still passed as green four days after #738/#739 merged: those PRs fixed the `conclusion` computation, not the exit-code decision that actually gates the check.

## Design decision

`packages/action/README.md`'s "Fail-loudly guarantee" section documented the *old* behavior as intentional: "Under the default `fail-on: never` the job itself still exits `0`." I'm overriding that for this one case, and updating the docs to match:

**A total provider failure is an operational failure, not an advisory finding — it now fails the check regardless of `fail-on`, including the default `never`.** The general "advisory by default" philosophy is right for opinionated code-quality findings (you shouldn't be forced to gate CI on an LLM's opinion), but it doesn't hold when the tool did nothing at all. A user who enabled and is paying for a review deserves a red check when it silently didn't happen — otherwise the greenness is a lie.

A **partial** failure (some turns completed before hitting a budget/turn limit) is unaffected — that's a genuine advisory `warning`-severity finding and still obeys `fail-on` exactly as before (verified via existing + new tests). And when the agent isn't enabled at all (no API key), behavior is unchanged — complexity-only review, no never-ran signal is ever produced.

## The matrix

| Case | `ReviewCoreResult.providerFailure` | conclusion | exit code under `fail-on: never` |
|---|---|---|---|
| Total provider failure (every request 402/401/5xx) | `true` | `failure` | **1** (new — was 0) |
| Partial failure (some turns ran, then bailed) | `false` | `neutral` | 0 (unchanged) |
| Agent not enabled (no key) | `false` — no plugin runs | `success` | 0 (unchanged) |
| Ordinary bug/summary findings | `false` | varies | 0 (unchanged — still advisory) |

## Changes

Two commits. First lands the fix at the layer that actually gates the check; second is a follow-up refactor (from a parallel design-review pass) that elevates the signal to a typed field instead of the action package re-deriving it from finding metadata shape:

- `packages/review/src/plugins/agent/index.ts`: new exported `hasProviderFailure(findings)`, colocated with `appendNeverRanNotice` — the single source of truth for the never-ran contract.
- `packages/review/src/review-pr.ts`: `ReviewCoreResult` gains `providerFailure: boolean`, computed once in `analyzeAndPresent()` via `hasProviderFailure`. The two early-return paths (`emptyResult` — no analyzable files, or the complexity pipeline failing before the engine runs) always set it `false` — those failure modes are unrelated to the LLM provider.
- `packages/action/src/index.ts`: `exitCodeFor` takes `providerFailure` and forces exit 1 before consulting `fail-on`; `finishRun` reads `result.providerFailure` directly and logs a clear, actionable message (names the provider error class from the finding's own message, plus generic remediation: 402→add credits, 401/403→check the API key secret, 5xx→re-run).
- `packages/action/test/finish-run.test.ts`: covers total-failure-forces-exit-1 under every `fail-on` mode, a findings-based `failure` conclusion (no provider failure) staying advisory under `never`, and partial-failure staying advisory.
- `packages/review/test/plugins-agent-budget.test.ts`: new `hasProviderFailure` suite (true/false/partial/doc-pass-only/empty cases) next to the existing `appendIncompleteNotice` tests.
- `packages/action/README.md` + `packages/site/docs/guide/lien-review.md`: updated the "Fail-loudly guarantee" section and the `fail-on` table row / "Blocking a PR" paragraph (previously unqualified "never fails CI" claims) to describe the new behavior.

## Changeset

None — both touched packages (`@liendev/action`, `@liendev/review`) are `private: true` (unpublished); nothing here touches a published package (`parser`/`core`/`cli`).

## Harness evidence

This PR touches `packages/review/src/plugins/agent/index.ts`, which trips the harness-attestation gate. The only change there is `hasProviderFailure(findings)` — a pure function reading a boolean off finding metadata. It touches zero prompt/rule/trigger content (`system-prompt.ts`, `rules.ts`) and cannot affect what the agent does or finds, so a fresh `--calibrate 10` run would be pointless spend re-verifying output quality that literally cannot have changed. Evidence instead follows the deterministic zero-LLM proof pattern from #743/#750:

**Method:** for all 23 fixtures on disk under `packages/review/test/harness/fixtures/`, render `system prompt + initial message` via `build-prompts.ts` twice — once with `packages/review/src` checked out from `origin/main`, once from this branch's `HEAD` — and diff byte-for-byte.

```bash
git checkout origin/main -- packages/review/src
# render all 23 fixtures to A/ via: npx tsx test/harness/build-prompts.ts <fixture> > A/<name>.json
git checkout HEAD -- packages/review/src   # confirms `git status` clean before AND after
# render all 23 fixtures to B/ the same way
cmp -s A/<name>.json B/<name>.json   # for every fixture
```

**Result: 23/23 byte-identical.** Zero diffs. Every existing `--calibrate 10` certification for every rule (including the canaries) remains valid unchanged, because the exact bytes an agent run would see are provably unmodified by this PR.

## Gates

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green across every package (parser, core, review, cli, action — 2000+ tests, zero failures; lint 0 errors, only pre-existing warnings elsewhere). `lien delta` exits 0 (informational "worsened" time-to-understand/cognitive notes on `exitCodeFor`/`finishRun`/`analyzeAndPresent`, all still far under threshold — not a crossing). Re-verified after the README wording fixes below.

## Test plan

- [x] Unit test: total provider-failure finding forces exit 1 under `fail-on: never/error/any`
- [x] Unit test: a findings-based `failure` conclusion (no provider failure) stays exit 0 under `fail-on: never` (unchanged advisory semantics)
- [x] Unit test: `hasProviderFailure` pure classifier (true/false/partial/doc-pass-only/empty cases)
- [x] Deterministic byte-diff harness evidence: 23/23 fixtures byte-identical (see above)
- [x] CI green (build-and-test, review, CodeRabbit, docs build, release smoke test, complexity delta)
- [x] Lien Review triage: two rounds of findings, all fixed - stale PR-description claim about hasProviderFailure's location (2nd commit), then four remaining unqualified "never fails CI/blocks a PR" spots across README.md and the site guide (2 caught per round, 3rd & 4th commits). Final pass on commit fbb106c: clean, 0 findings.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 11 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 4 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes the silent-green-check bug for total LLM-provider failures by adding a typed `providerFailure` signal in `@liendev/review` and forcing the GitHub Action to exit 1 regardless of `fail-on`. The change is narrow, well-scoped, and covered by new unit tests. The logic correctly distinguishes total provider failures (every request failed, `neverRan: true`) from partial runs, ordinary findings, and unrelated pipeline failures, and the documentation accurately reflects the new behavior.
>
> - Added `hasProviderFailure()` classifier and `ReviewCoreResult.providerFailure` field to surface total provider failures as an operational signal.
> - Updated `exitCodeFor()` in `packages/action/src/index.ts` to return 1 before consulting `fail-on` when `providerFailure` is true.
> - Added regression tests for total-failure, partial-failure, and advisory-boundary cases; updated README/site docs to describe the new fail-loudly guarantee.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fbb106c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->