### PR TITLE
docs: remove stale platform/runner reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@ Local-first structural code search tool (lexical FTS5 search + dependency analys
 - Dependency chain: `parser` ← `core` ← `cli`; `review` depends on `parser` only (not `core`); `action` wraps `review` as a self-hostable GitHub Action ([ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)).
 - `plugins/claude/` — the dogfooded Claude Code plugin (MCP server config + hooks). Hooks auto-annotate reads and run the `lien delta` gate on writes, i.e. they automate two of this file's own MANDATORY policies — see `plugins/claude/README.md`.
 - `lien-review-testbed/` — tracked, multi-language fixture app used by the review-agent test harness. Not a demo to clean up.
-- `platform/` and `packages/runner` — retired hosted-platform remnants (see [ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)); safe to ignore.
 
 **Package Structure:**
 ```


### PR DESCRIPTION
## Summary

Original task was to delete `platform/` and `packages/runner` from the
repo (retired hosted-platform remnants per ADR-012). Scope check found
those directories were **already deleted** — by commit `06cf2b6`
("chore: retire packages/runner and the platform/ Laravel app", PR
#593, merged 2026-06-27). That PR also cleaned up the workspace,
lockfile, and CI wiring at the time, and updated CLAUDE.md.

However, a later PR (#687, "agent setup overhaul") reintroduced a line
into CLAUDE.md's monorepo structure list:

```
- `platform/` and `packages/runner` — retired hosted-platform remnants (see ADR-012); safe to ignore.
```

This describes them as if they still exist in the tree as remnants to
ignore, which is misleading — they don't exist. This PR removes that
one stale line.

No code changes; nothing to delete. Confirmed no other live references
to these paths remain:
- `.github/workflows/*` matches are all about OS/arch "platform"
  packages or GitHub Actions "runner" labels — unrelated false
  positives.
- `docs/architecture/README.md` and
  `docs/architecture/system-overview.md` already describe the
  retirement correctly in past tense — left untouched.
- `CONTRIBUTING.md`'s one "platform" hit is about OS platforms,
  unrelated.
- `package-lock.json` has no `packages/runner` / `@liendev/runner`
  entries (already pruned in #593).
- ADR-012 itself is historical record — untouched.

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — 0 errors (pre-existing warnings only, unrelated)
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm test` — 45 test files / 769 tests (cli+core+parser+review) + 4 files / 28 tests (action) all pass
- [x] `node packages/cli/dist/index.js delta` — exit 0, no complexity-affecting changes

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 453 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b3dce7d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->