### PR TITLE
feat(review,action): delivery attestation — machine-readable receipt for every review run

### DIFF
--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -65,6 +65,14 @@ outputs:
     description: 'Total number of findings produced.'
   error-count:
     description: 'Number of error-severity findings.'
+  attestation:
+    description: >-
+      JSON-encoded delivery attestation (v1): provider health, token budget,
+      what was actually delivered (inline comments posted/dropped,
+      annotations, PR description badge), review scope, and an overall
+      verdict (delivered / degraded:<reason> / failed:<reason>). Observational
+      only in v1 — it does not change the exit code beyond the existing
+      provider-never-ran behavior.
 
 runs:
   using: 'docker'

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   createOctokit,
+  emptyAttestation,
   type ReviewCoreContext,
   type ReviewCoreResult,
   type ReviewFinding,
@@ -94,6 +95,27 @@ function logProviderFailure(findings: ReviewFinding[]): void {
 }
 
 /**
+ * Build the ReviewCoreResult for when `reviewPullRequest()` itself throws
+ * before returning one — e.g. a clone or GitHub API failure outside the
+ * analysis-phase null-return path `emptyResult`/`pipelineFailed` already
+ * covers inside `@liendev/review`. Without this, main()'s outer catch (below)
+ * would set exit code 1 with no step summary, no outputs, and no attestation
+ * ever written — the receipt this feature exists to guarantee would be the
+ * one thing missing on the run that most needs it.
+ */
+export function buildCrashResult(message: string): ReviewCoreResult {
+  return {
+    findings: [],
+    conclusion: 'failure',
+    summaryMarkdown: `Lien Review crashed before producing a result: ${message}`,
+    filesAnalyzed: 0,
+    usage: { totalTokens: 0, cost: 0 },
+    providerFailure: false,
+    attestation: emptyAttestation('failure', 0, 'normal', true),
+  };
+}
+
+/**
  * Finalize a completed review: write the step summary + outputs, note the fork
  * read-only-token limitation if applicable, and return the process exit code
  * (per `fail-on`) so the entrypoint and tests can assert it without reading
@@ -156,9 +178,17 @@ async function main(): Promise<void> {
   };
 
   group('Lien Review');
-  let result;
+  let result: ReviewCoreResult;
+  let crashed = false;
   try {
-    result = await reviewPullRequest(ctx);
+    try {
+      result = await reviewPullRequest(ctx);
+    } catch (error) {
+      crashed = true;
+      const message = error instanceof Error ? error.message : String(error);
+      actionLogger.error(`Lien Review crashed before producing a result: ${message}`);
+      result = buildCrashResult(message);
+    }
     // Full attestation JSON for scripted consumption (e.g. `gh run view --log`
     // grep); the step summary/PR-description renderings stay short by design.
     actionLogger.info(`Attestation: ${JSON.stringify(result.attestation)}`);
@@ -172,7 +202,14 @@ async function main(): Promise<void> {
   // A fork's GITHUB_TOKEN is read-only on `pull_request` (inline comments can't
   // post), but pull_request_target grants a writable token — only warn in the former.
   const forkReadOnly = context.isFork && process.env.GITHUB_EVENT_NAME !== 'pull_request_target';
-  process.exitCode = await finishRun(result, forkReadOnly, inputs.failOn);
+  const exitCode = await finishRun(result, forkReadOnly, inputs.failOn);
+  // A pipeline crash is an operational failure — no review happened at all —
+  // so it must fail the check unconditionally, the same guarantee
+  // `providerFailure` already gets inside `finishRun`/`exitCodeFor` (#764).
+  // Forced here rather than threaded through `exitCodeFor` since this is a
+  // distinct signal (the call threw) that never becomes part of a real
+  // ReviewCoreResult on its own.
+  process.exitCode = crashed ? 1 : exitCode;
 }
 
 /** True when this module is the process entrypoint (not imported by a test). */

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -112,6 +112,7 @@ export async function finishRun(
     conclusion: result.conclusion,
     findingsCount: result.findings.length,
     errorCount,
+    attestation: result.attestation,
   });
 
   // Read-only fork token (a `pull_request` from a fork): inline comments can't
@@ -158,6 +159,9 @@ async function main(): Promise<void> {
   let result;
   try {
     result = await reviewPullRequest(ctx);
+    // Full attestation JSON for scripted consumption (e.g. `gh run view --log`
+    // grep); the step summary/PR-description renderings stay short by design.
+    actionLogger.info(`Attestation: ${JSON.stringify(result.attestation)}`);
   } finally {
     endGroup();
   }

--- a/packages/action/src/summary.ts
+++ b/packages/action/src/summary.ts
@@ -18,6 +18,7 @@ export interface ActionOutputs {
   conclusion: ReviewCoreResult['conclusion'];
   findingsCount: number;
   errorCount: number;
+  attestation: ReviewCoreResult['attestation'];
 }
 
 /** Count findings whose severity marks them as errors. */
@@ -43,9 +44,29 @@ export async function writeStepSummary(result: ReviewCoreResult): Promise<void> 
     `**Findings:** ${result.findings.length} (${errorCount} error${errorCount === 1 ? '' : 's'})`,
     `**Tokens:** ${tokens} · **Cost:** $${cost}`,
     '',
+    formatAttestationDetails(result.attestation),
+    '',
   ].join('\n');
 
   await appendFile(summaryPath, body, 'utf8');
+}
+
+/**
+ * A collapsed `<details>` block with the full attestation JSON. Collapsed by
+ * default so it costs nothing in the visible summary; the JSON inside is the
+ * complete record — see `@liendev/review`'s `attestation.ts` for the schema.
+ */
+function formatAttestationDetails(attestation: ReviewCoreResult['attestation']): string {
+  return [
+    '<details>',
+    '<summary>Delivery attestation</summary>',
+    '',
+    '```json',
+    JSON.stringify(attestation, null, 2),
+    '```',
+    '',
+    '</details>',
+  ].join('\n');
 }
 
 /** Format one `$GITHUB_OUTPUT` entry using the heredoc form (safe for any value). */
@@ -65,6 +86,7 @@ export async function writeOutputs(outputs: ActionOutputs): Promise<void> {
     formatOutput('conclusion', outputs.conclusion),
     formatOutput('findings-count', String(outputs.findingsCount)),
     formatOutput('error-count', String(outputs.errorCount)),
+    formatOutput('attestation', JSON.stringify(outputs.attestation)),
   ].join('');
 
   await appendFile(outputPath, body, 'utf8');

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import type { ReviewCoreResult } from '@liendev/review';
+import { emptyAttestation, type ReviewCoreResult } from '@liendev/review';
 
 import { finishRun } from '../src/index.js';
 import { actionLogger } from '../src/logger.js';
@@ -13,6 +13,7 @@ function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
     filesAnalyzed: 3,
     usage: { totalTokens: 0, cost: 0 },
     providerFailure: false,
+    attestation: emptyAttestation('success', 3, 'normal'),
     ...overrides,
   };
 }
@@ -177,5 +178,47 @@ describe('finishRun', () => {
     const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
 
     expect(exitCode).toBe(0);
+  });
+
+  describe('attestation output + summary rendering', () => {
+    let summaryPath: string;
+    let outputPath: string;
+
+    beforeEach(async () => {
+      const { mkdtemp, mkdir } = await import('node:fs/promises');
+      const { join } = await import('node:path');
+      const { tmpdir } = await import('node:os');
+      const dir = await mkdtemp(join(tmpdir(), 'lien-action-test-'));
+      await mkdir(dir, { recursive: true });
+      summaryPath = join(dir, 'summary.md');
+      outputPath = join(dir, 'output.txt');
+      process.env.GITHUB_STEP_SUMMARY = summaryPath;
+      process.env.GITHUB_OUTPUT = outputPath;
+    });
+
+    it('writes the attestation JSON into the step summary as a collapsed details block', async () => {
+      vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+      const result = makeResult({ attestation: emptyAttestation('success', 5, 'normal') });
+
+      await finishRun(result, false, 'never');
+
+      const { readFile } = await import('node:fs/promises');
+      const summary = await readFile(summaryPath, 'utf8');
+      expect(summary).toContain('<summary>Delivery attestation</summary>');
+      expect(summary).toContain('"attestationVersion": 1');
+      expect(summary).toContain('"verdict": "delivered"');
+    });
+
+    it('writes the attestation as a JSON action output', async () => {
+      vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+      const result = makeResult({ attestation: emptyAttestation('success', 5, 'normal') });
+
+      await finishRun(result, false, 'never');
+
+      const { readFile } = await import('node:fs/promises');
+      const output = await readFile(outputPath, 'utf8');
+      expect(output).toContain('attestation<<');
+      expect(output).toContain('"verdict":"delivered"');
+    });
   });
 });

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { emptyAttestation, type ReviewCoreResult } from '@liendev/review';
 
-import { finishRun } from '../src/index.js';
+import { finishRun, buildCrashResult } from '../src/index.js';
 import { actionLogger } from '../src/logger.js';
 
 function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
@@ -178,6 +178,34 @@ describe('finishRun', () => {
     const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
 
     expect(exitCode).toBe(0);
+  });
+
+  // Regression coverage for the CodeRabbit #768 finding: `reviewPullRequest()`
+  // throwing (e.g. a clone failure) used to escape with no result at all — no
+  // attestation, no step summary, no outputs — reaching only main()'s top-level
+  // catch. `buildCrashResult` is what main() now falls back to so the receipt
+  // still gets written before the check fails.
+  describe('buildCrashResult', () => {
+    it('produces a failed:analysis_error attestation carrying the crash message', () => {
+      const result = buildCrashResult('clone failed: ENOTFOUND');
+
+      expect(result.conclusion).toBe('failure');
+      expect(result.providerFailure).toBe(false);
+      expect(result.attestation.verdict).toBe('failed:analysis_error');
+      expect(result.summaryMarkdown).toContain('clone failed: ENOTFOUND');
+    });
+
+    it('still writes the attestation/summary/outputs via finishRun', async () => {
+      vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+      const result = buildCrashResult('boom');
+
+      const exitCode = await finishRun(result, false, 'never');
+
+      // finishRun alone doesn't force this to fail (that's main()'s job, since
+      // `crashed` isn't part of ReviewCoreResult) — this just proves the crash
+      // result flows through the normal write path without throwing.
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe('attestation output + summary rendering', () => {

--- a/packages/action/test/summary.test.ts
+++ b/packages/action/test/summary.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { emptyAttestation, type ReviewFinding, type ReviewCoreResult } from '@liendev/review';
 

--- a/packages/action/test/summary.test.ts
+++ b/packages/action/test/summary.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import type { ReviewFinding } from '@liendev/review';
+import { emptyAttestation, type ReviewFinding, type ReviewCoreResult } from '@liendev/review';
 
-import { countErrors } from '../src/summary.js';
+import { countErrors, writeStepSummary, writeOutputs } from '../src/summary.js';
 
 describe('countErrors', () => {
   it('counts only error-severity findings', () => {
@@ -12,5 +15,65 @@ describe('countErrors', () => {
       { severity: 'error' } as ReviewFinding,
     ];
     expect(countErrors(findings)).toBe(2);
+  });
+});
+
+function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
+  return {
+    findings: [],
+    conclusion: 'success',
+    summaryMarkdown: 'All good.',
+    filesAnalyzed: 3,
+    usage: { totalTokens: 0, cost: 0 },
+    providerFailure: false,
+    attestation: emptyAttestation('success', 3, 'normal'),
+    ...overrides,
+  };
+}
+
+describe('attestation rendering', () => {
+  let summaryPath: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'lien-summary-test-'));
+    summaryPath = join(dir, 'summary.md');
+    outputPath = join(dir, 'output.txt');
+    process.env.GITHUB_STEP_SUMMARY = summaryPath;
+    process.env.GITHUB_OUTPUT = outputPath;
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_STEP_SUMMARY;
+    delete process.env.GITHUB_OUTPUT;
+  });
+
+  it('writeStepSummary appends a collapsed <details> block with the full attestation JSON', async () => {
+    const result = makeResult({
+      attestation: emptyAttestation('failure', 0, 'zero_files_early_exit'),
+    });
+
+    await writeStepSummary(result);
+
+    const summary = await readFile(summaryPath, 'utf8');
+    expect(summary).toContain('<details>');
+    expect(summary).toContain('<summary>Delivery attestation</summary>');
+    expect(summary).toContain('</details>');
+    expect(summary).toContain('"eligibilityPath": "zero_files_early_exit"');
+  });
+
+  it('writeOutputs writes the attestation as a JSON-string output', async () => {
+    const attestation = emptyAttestation('success', 3, 'normal');
+
+    await writeOutputs({
+      conclusion: 'success',
+      findingsCount: 0,
+      errorCount: 0,
+      attestation,
+    });
+
+    const output = await readFile(outputPath, 'utf8');
+    expect(output).toContain('attestation<<');
+    expect(output).toContain(JSON.stringify(attestation));
   });
 });

--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -1,0 +1,274 @@
+/**
+ * Delivery attestation — a machine-readable receipt for a single Lien Review
+ * run, answering "did the review actually happen and reach the PR" as a
+ * structured, versioned record rather than prose scattered across findings,
+ * logs, and a swallowed `.catch()`.
+ *
+ * Every value plumbed in here is already computed somewhere in the pipeline
+ * (agent-review's `AgentResult`, `postPRReview`'s `PostReviewResult`, the
+ * engine's skip/annotation bookkeeping) — this module only assembles and
+ * classifies it. No new detection logic, no LLM calls: the same
+ * precompute-a-signal-block pattern as `blast-radius.ts` and
+ * `stale-literal-signals.ts`, applied to operational state instead of code
+ * findings.
+ *
+ * See `.wip/attestation-design.md` for the full design (schema rationale,
+ * the two discard-point bugs this closes, and the open questions this file's
+ * behavior resolves).
+ */
+
+import type { ReviewFinding } from './plugin-types.js';
+import type { AgentStopReason } from './plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Schema (v1)
+// ---------------------------------------------------------------------------
+
+export const ATTESTATION_VERSION = 1 as const;
+
+/** `AgentStopReason` plus `'not_run'` for a pass that was never attempted. */
+export type ProviderStopReason = AgentStopReason | 'not_run';
+
+export interface ProviderPassAttestation {
+  name: 'main';
+  ran: boolean;
+  stopReason: ProviderStopReason;
+  /** Every provider request failed terminally — zero completed turns. */
+  neverRan: boolean;
+}
+
+/** A plugin (or a plugin's internal sub-pass) that didn't run this turn, and why. */
+export interface SkippedPass {
+  plugin: string;
+  reason: string;
+}
+
+export interface BudgetAttestation {
+  allocatedTokens: number;
+  spentTokens: number;
+  /** Ran out of budget before finishing — the main pass's `stopReason` was `'budget'`. */
+  starved: boolean;
+}
+
+export interface InlineCommentsAttestation {
+  /** Candidate inline comments the plugin wanted to post. */
+  attempted: number;
+  /** Actually landed on the PR, per `PostReviewResult` — not the attempted count. */
+  posted: number;
+  /** Failed to land: outside the diff, or dropped by GitHub on anchor validation. */
+  dropped: number;
+  /** Skipped because an equivalent comment already existed from a prior run. */
+  deduped: number;
+}
+
+export interface DeliveryAttestation {
+  annotationsEmitted: number;
+  inlineComments: InlineCommentsAttestation;
+  descriptionBadge: { updated: boolean };
+  /** null when no plugin attempted an out-of-diff review comment this run. */
+  outOfDiffReviewPosted: boolean | null;
+}
+
+export type EligibilityPath = 'normal' | 'zero_files_early_exit' | 'full_repo_fallback';
+
+export interface ScopeAttestation {
+  eligibilityPath: EligibilityPath;
+  filesAnalyzed: number;
+}
+
+/**
+ * `degraded:provider_partial` covers any non-`neverRan` incomplete stop
+ * (`max_turns`, or `completed` without a parseable verdict) that budget
+ * exhaustion doesn't already explain more specifically.
+ * `failed:analysis_error` covers a pre-engine pipeline failure (the
+ * complexity report itself couldn't be built) — distinct from a provider
+ * failure, but still not a "delivered" run.
+ */
+export type AttestationVerdict =
+  | 'delivered'
+  | 'degraded:provider_partial'
+  | 'degraded:budget_starved'
+  | 'degraded:comments_dropped'
+  | 'failed:provider_never_ran'
+  | 'failed:analysis_error';
+
+export interface Attestation {
+  attestationVersion: typeof ATTESTATION_VERSION;
+  run: { conclusion: 'success' | 'failure' | 'neutral'; filesAnalyzed: number };
+  provider: { passes: ProviderPassAttestation[] };
+  budget: BudgetAttestation;
+  passesSkipped: SkippedPass[];
+  delivery: DeliveryAttestation;
+  scope: ScopeAttestation;
+  verdict: AttestationVerdict;
+}
+
+// ---------------------------------------------------------------------------
+// Derivation
+// ---------------------------------------------------------------------------
+
+/** Narrow shape of the metadata `appendIncompleteNotice`/`appendNeverRanNotice` attach. */
+interface AgentSummaryMetadata {
+  incomplete?: boolean;
+  neverRan?: boolean;
+  stopReason?: AgentStopReason;
+}
+
+/**
+ * Derive the main agent-review pass's outcome from its findings. Reliable
+ * because the notice-appending helpers in `plugins/agent/index.ts` are
+ * exhaustive: a neverRan or incomplete run always leaves a marked summary
+ * finding, and a run that completed cleanly leaves neither — so their
+ * absence IS the "completed" signal, not just a default.
+ */
+export function deriveMainPassAttestation(
+  findings: ReviewFinding[],
+  agentAttempted: boolean,
+  providerFailure: boolean,
+): ProviderPassAttestation {
+  if (!agentAttempted) {
+    return { name: 'main', ran: false, stopReason: 'not_run', neverRan: false };
+  }
+  if (providerFailure) {
+    return { name: 'main', ran: true, stopReason: 'error', neverRan: true };
+  }
+  const incompleteFinding = findings.find(
+    f => (f.metadata as AgentSummaryMetadata | undefined)?.incomplete === true,
+  );
+  if (incompleteFinding) {
+    const stopReason = (incompleteFinding.metadata as AgentSummaryMetadata).stopReason ?? 'error';
+    return { name: 'main', ran: true, stopReason, neverRan: false };
+  }
+  return { name: 'main', ran: true, stopReason: 'completed', neverRan: false };
+}
+
+/**
+ * Verdict precedence (most to least severe): a provider that never ran at all
+ * outranks everything — nothing was analyzed. Budget starvation is a more
+ * specific, more actionable diagnosis than the generic "partial" bucket, so
+ * it's checked first among incomplete-stop reasons. Dropped inline comments
+ * only matter once the review itself came back clean.
+ */
+export function computeVerdict(input: {
+  pipelineFailed: boolean;
+  providerFailure: boolean;
+  mainPass: ProviderPassAttestation;
+  budget: BudgetAttestation;
+  inlineComments: InlineCommentsAttestation;
+}): AttestationVerdict {
+  if (input.pipelineFailed) return 'failed:analysis_error';
+  if (input.providerFailure) return 'failed:provider_never_ran';
+  if (input.mainPass.ran && input.mainPass.stopReason !== 'completed') {
+    return input.budget.starved ? 'degraded:budget_starved' : 'degraded:provider_partial';
+  }
+  if (input.inlineComments.dropped > 0) return 'degraded:comments_dropped';
+  return 'delivered';
+}
+
+export interface AttestationInput {
+  conclusion: 'success' | 'failure' | 'neutral';
+  filesAnalyzed: number;
+  eligibilityPath: EligibilityPath;
+  findings: ReviewFinding[];
+  /** Was the agent-review plugin registered AND not skipped by shouldActivate? */
+  agentAttempted: boolean;
+  /** `hasProviderFailure(findings)` — the existing SSOT (see plugins/agent/index.ts). */
+  providerFailure: boolean;
+  allocatedTokens: number;
+  spentTokens: number;
+  passesSkipped: SkippedPass[];
+  annotationsEmitted: number;
+  inlineComments: InlineCommentsAttestation;
+  descriptionBadgeUpdated: boolean;
+  outOfDiffReviewPosted: boolean | null;
+  /** True for the pre-engine "couldn't build a complexity report" failure path. */
+  pipelineFailed?: boolean;
+}
+
+export function assembleAttestation(input: AttestationInput): Attestation {
+  const mainPass = deriveMainPassAttestation(
+    input.findings,
+    input.agentAttempted,
+    input.providerFailure,
+  );
+  const budget: BudgetAttestation = {
+    allocatedTokens: input.allocatedTokens,
+    spentTokens: input.spentTokens,
+    starved: mainPass.stopReason === 'budget',
+  };
+  const verdict = computeVerdict({
+    pipelineFailed: input.pipelineFailed ?? false,
+    providerFailure: input.providerFailure,
+    mainPass,
+    budget,
+    inlineComments: input.inlineComments,
+  });
+
+  return {
+    attestationVersion: ATTESTATION_VERSION,
+    run: { conclusion: input.conclusion, filesAnalyzed: input.filesAnalyzed },
+    provider: { passes: input.agentAttempted ? [mainPass] : [] },
+    budget,
+    passesSkipped: input.passesSkipped,
+    delivery: {
+      annotationsEmitted: input.annotationsEmitted,
+      inlineComments: input.inlineComments,
+      descriptionBadge: { updated: input.descriptionBadgeUpdated },
+      outOfDiffReviewPosted: input.outOfDiffReviewPosted,
+    },
+    scope: { eligibilityPath: input.eligibilityPath, filesAnalyzed: input.filesAnalyzed },
+    verdict,
+  };
+}
+
+/** Zero-value attestation for the early-return paths where the engine never ran. */
+export function emptyAttestation(
+  conclusion: 'success' | 'failure',
+  filesAnalyzed: number,
+  eligibilityPath: EligibilityPath,
+  pipelineFailed = false,
+): Attestation {
+  return assembleAttestation({
+    conclusion,
+    filesAnalyzed,
+    eligibilityPath,
+    findings: [],
+    agentAttempted: false,
+    providerFailure: false,
+    allocatedTokens: 0,
+    spentTokens: 0,
+    passesSkipped: [],
+    annotationsEmitted: 0,
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    descriptionBadgeUpdated: false,
+    outOfDiffReviewPosted: null,
+    pipelineFailed,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * One compact line for the PR description — only meant to be shown when
+ * `verdict !== 'delivered'` (a clean run doesn't need the line; see the
+ * budget-discipline precedent in `guidance-surface-signals.ts`).
+ */
+export function formatAttestationBadgeLine(attestation: Attestation): string {
+  const { inlineComments } = attestation.delivery;
+  const parts = [`Attested: ${attestation.verdict}`];
+  if (inlineComments.attempted > 0) {
+    parts.push(`${inlineComments.posted}/${inlineComments.attempted} comments posted`);
+  }
+  if (attestation.budget.allocatedTokens > 0) {
+    parts.push(
+      `${formatKTokens(attestation.budget.spentTokens)}/${formatKTokens(attestation.budget.allocatedTokens)} tokens`,
+    );
+  }
+  return parts.join(' · ');
+}
+
+function formatKTokens(tokens: number): string {
+  return `${Math.round(tokens / 1000)}K`;
+}

--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -64,7 +64,8 @@ export interface InlineCommentsAttestation {
 export interface DeliveryAttestation {
   annotationsEmitted: number;
   inlineComments: InlineCommentsAttestation;
-  descriptionBadge: { updated: boolean };
+  /** null when no plugin contributed a description section this run (nothing to update). */
+  descriptionBadge: { updated: boolean | null };
   /** null when no plugin attempted an out-of-diff review comment this run. */
   outOfDiffReviewPosted: boolean | null;
 }
@@ -80,6 +81,9 @@ export interface ScopeAttestation {
  * `degraded:provider_partial` covers any non-`neverRan` incomplete stop
  * (`max_turns`, or `completed` without a parseable verdict) that budget
  * exhaustion doesn't already explain more specifically.
+ * `degraded:delivery_incomplete` covers a description-badge update or an
+ * out-of-diff review comment that was attempted and failed to land — distinct
+ * from `comments_dropped` (which is about the per-finding inline comments).
  * `failed:analysis_error` covers a pre-engine pipeline failure (the
  * complexity report itself couldn't be built) — distinct from a provider
  * failure, but still not a "delivered" run.
@@ -89,6 +93,7 @@ export type AttestationVerdict =
   | 'degraded:provider_partial'
   | 'degraded:budget_starved'
   | 'degraded:comments_dropped'
+  | 'degraded:delivery_incomplete'
   | 'failed:provider_never_ran'
   | 'failed:analysis_error';
 
@@ -147,7 +152,10 @@ export function deriveMainPassAttestation(
  * outranks everything — nothing was analyzed. Budget starvation is a more
  * specific, more actionable diagnosis than the generic "partial" bucket, so
  * it's checked first among incomplete-stop reasons. Dropped inline comments
- * only matter once the review itself came back clean.
+ * and other delivery failures only matter once the review itself came back
+ * clean. `descriptionBadgeUpdated`/`outOfDiffReviewPosted` are checked against
+ * `=== false` specifically (not falsy) — `null`/`undefined` means "nothing was
+ * attempted this run", which is not a failure.
  */
 export function computeVerdict(input: {
   pipelineFailed: boolean;
@@ -155,6 +163,8 @@ export function computeVerdict(input: {
   mainPass: ProviderPassAttestation;
   budget: BudgetAttestation;
   inlineComments: InlineCommentsAttestation;
+  descriptionBadgeUpdated?: boolean | null;
+  outOfDiffReviewPosted?: boolean | null;
 }): AttestationVerdict {
   if (input.pipelineFailed) return 'failed:analysis_error';
   if (input.providerFailure) return 'failed:provider_never_ran';
@@ -162,6 +172,9 @@ export function computeVerdict(input: {
     return input.budget.starved ? 'degraded:budget_starved' : 'degraded:provider_partial';
   }
   if (input.inlineComments.dropped > 0) return 'degraded:comments_dropped';
+  if (input.descriptionBadgeUpdated === false || input.outOfDiffReviewPosted === false) {
+    return 'degraded:delivery_incomplete';
+  }
   return 'delivered';
 }
 
@@ -179,7 +192,8 @@ export interface AttestationInput {
   passesSkipped: SkippedPass[];
   annotationsEmitted: number;
   inlineComments: InlineCommentsAttestation;
-  descriptionBadgeUpdated: boolean;
+  /** null when no plugin contributed a description section this run (nothing to update). */
+  descriptionBadgeUpdated: boolean | null;
   outOfDiffReviewPosted: boolean | null;
   /** True for the pre-engine "couldn't build a complexity report" failure path. */
   pipelineFailed?: boolean;
@@ -202,6 +216,8 @@ export function assembleAttestation(input: AttestationInput): Attestation {
     mainPass,
     budget,
     inlineComments: input.inlineComments,
+    descriptionBadgeUpdated: input.descriptionBadgeUpdated,
+    outOfDiffReviewPosted: input.outOfDiffReviewPosted,
   });
 
   return {
@@ -240,7 +256,7 @@ export function emptyAttestation(
     passesSkipped: [],
     annotationsEmitted: 0,
     inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
-    descriptionBadgeUpdated: false,
+    descriptionBadgeUpdated: null,
     outOfDiffReviewPosted: null,
     pipelineFailed,
   });

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -57,12 +57,19 @@ export interface PresentDelivery {
   outOfDiffReviewPosted: boolean | null;
 }
 
-/** Zero-value delivery, for paths where `present()` never ran (e.g. it threw). */
+/**
+ * Delivery for the sole path that uses this: `presentFindings` in
+ * review-pr.ts, when `engine.present()` itself throws. This is a delivery
+ * ATTEMPT that crashed, not one that never happened — `descriptionBadgeUpdated`
+ * and `outOfDiffReviewPosted` are `false` (attempted-and-failed), not `null`
+ * (never attempted): `computeVerdict` treats `null` as nothing-to-report, so
+ * `null` here would let a catastrophic present() failure attest 'delivered'.
+ */
 export const EMPTY_DELIVERY: PresentDelivery = {
   annotationsEmitted: 0,
   inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
-  descriptionBadgeUpdated: null,
-  outOfDiffReviewPosted: null,
+  descriptionBadgeUpdated: false,
+  outOfDiffReviewPosted: false,
 };
 
 /** Mutable accumulator threaded through a single `present()` call. */

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -42,6 +42,41 @@ export interface EngineOptions {
   verbose?: boolean;
 }
 
+/**
+ * What `present()` actually delivered, as ground truth rather than "attempted"
+ * counts — feeds the delivery attestation. Populated from the SAME
+ * `PostReviewResult` the GitHub API call returns, not from the size of the
+ * batch a plugin asked to post.
+ */
+export interface PresentDelivery {
+  annotationsEmitted: number;
+  inlineComments: { attempted: number; posted: number; dropped: number; deduped: number };
+  descriptionBadgeUpdated: boolean;
+  /** null when no plugin attempted an out-of-diff review comment this run. */
+  outOfDiffReviewPosted: boolean | null;
+}
+
+/** Zero-value delivery, for paths where `present()` never ran (e.g. it threw). */
+export const EMPTY_DELIVERY: PresentDelivery = {
+  annotationsEmitted: 0,
+  inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+  descriptionBadgeUpdated: false,
+  outOfDiffReviewPosted: null,
+};
+
+/** Mutable accumulator threaded through a single `present()` call. */
+interface DeliveryTracker {
+  inlineComments: { attempted: number; posted: number; dropped: number; deduped: number };
+  outOfDiffReviewPosted: boolean | null;
+}
+
+function createDeliveryTracker(): DeliveryTracker {
+  return {
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    outOfDiffReviewPosted: null,
+  };
+}
+
 export class ReviewEngine {
   private plugins: ReviewPlugin[] = [];
   private readonly verbose: boolean;
@@ -142,6 +177,7 @@ export class ReviewEngine {
 
       if (skipReason) {
         if (this.verbose) context.logger.debug(`[engine] Skipping "${plugin.id}" — ${skipReason}`);
+        context.reportSkip?.({ plugin: plugin.id, reason: skipReason });
         continue;
       }
 
@@ -166,13 +202,18 @@ export class ReviewEngine {
     findings: ReviewFinding[],
     adapterContext: AdapterContext,
     opts?: { pluginFilter?: string; checkRunId?: number; skipCheckRun?: boolean },
-  ): Promise<{ conclusion: 'success' | 'failure' | 'neutral'; summary: string }> {
+  ): Promise<{
+    conclusion: 'success' | 'failure' | 'neutral';
+    summary: string;
+    delivery: PresentDelivery;
+  }> {
     const octokit = adapterContext.octokit as Octokit | undefined;
     const pr = adapterContext.pr;
     const pendingAnnotations: CheckAnnotation[] = [];
     const debugLog: string[] = [];
     const summarySections: TaggedSection[] = [];
     const descriptionParts = new Map<string, string>();
+    const deliveryTracker = createDeliveryTracker();
 
     const checkRunId = opts?.skipCheckRun
       ? undefined
@@ -185,6 +226,7 @@ export class ReviewEngine {
       summarySections,
       descriptionParts,
       debugLog,
+      deliveryTracker,
     );
     await dispatchPresent(
       this.plugins,
@@ -196,10 +238,21 @@ export class ReviewEngine {
     );
 
     // Compose unified PR description from all plugin fragments
-    await finalizeDescription(descriptionParts, octokit, pr, adapterContext.logger);
+    const descriptionBadgeUpdated = await finalizeDescription(
+      descriptionParts,
+      octokit,
+      pr,
+      adapterContext.logger,
+    );
+    const delivery: PresentDelivery = {
+      annotationsEmitted: pendingAnnotations.length,
+      inlineComments: deliveryTracker.inlineComments,
+      descriptionBadgeUpdated,
+      outOfDiffReviewPosted: deliveryTracker.outOfDiffReviewPosted,
+    };
 
     if (octokit && pr && checkRunId != null) {
-      return await finalizePresentation(
+      const presented = await finalizePresentation(
         octokit,
         pr,
         checkRunId,
@@ -209,6 +262,7 @@ export class ReviewEngine {
         debugLog,
         adapterContext.logger,
       );
+      return { ...presented, delivery };
     }
 
     // No check run was finalized (no octokit/pr/checkRunId), but callers still
@@ -217,6 +271,7 @@ export class ReviewEngine {
     return {
       conclusion: determineConclusion(findings),
       summary: ordered.length > 0 ? ordered.join('\n\n') : buildCheckSummary(findings),
+      delivery,
     };
   }
 }
@@ -396,8 +451,8 @@ async function finalizeDescription(
   octokit: Octokit | undefined,
   pr: PRContext | undefined,
   logger: Logger,
-): Promise<void> {
-  if (!octokit || !pr || descriptionParts.size === 0) return;
+): Promise<boolean> {
+  if (!octokit || !pr || descriptionParts.size === 0) return false;
 
   const ordered: string[] = [];
   for (const id of PLUGIN_ORDER) {
@@ -411,9 +466,13 @@ async function finalizeDescription(
   const body = ordered.join('\n\n');
   const markdown = `### Lien Review\n\n${body}`;
 
-  await updatePRDescription(octokit, pr, markdown, logger).catch(err =>
-    logger.warning(`Failed to update PR description: ${err instanceof Error ? err.message : err}`),
-  );
+  try {
+    await updatePRDescription(octokit, pr, markdown, logger);
+    return true;
+  } catch (err) {
+    logger.warning(`Failed to update PR description: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
 }
 
 async function ensureCheckRun(
@@ -504,6 +563,44 @@ async function finalizePresentation(
 // PresentContext Builder
 // ---------------------------------------------------------------------------
 
+/** Wrap `postPluginInlineComments` to also accumulate its outcome into the delivery tracker. */
+function createPostInlineComments(
+  octokit: Octokit,
+  pr: PRContext,
+  logger: Logger,
+  deliveryTracker: DeliveryTracker,
+): NonNullable<PresentContext['postInlineComments']> {
+  return async (findings, summaryBody) => {
+    const result = await postPluginInlineComments(octokit, pr, findings, summaryBody, logger);
+    deliveryTracker.inlineComments.attempted += result.attempted;
+    deliveryTracker.inlineComments.posted += result.posted;
+    deliveryTracker.inlineComments.dropped += result.dropped;
+    deliveryTracker.inlineComments.deduped += result.deduped;
+    return result;
+  };
+}
+
+/** Wrap the out-of-diff review-comment post so its success/failure reaches the delivery tracker. */
+function createPostReviewComment(
+  octokit: Octokit,
+  pr: PRContext,
+  logger: Logger,
+  deliveryTracker: DeliveryTracker,
+): NonNullable<PresentContext['postReviewComment']> {
+  return async body => {
+    try {
+      await postPRReview(octokit, pr, [], body, logger, 'COMMENT');
+      deliveryTracker.outOfDiffReviewPosted = true;
+      return { posted: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warning(`Failed to post out-of-diff review comment: ${message}`);
+      deliveryTracker.outOfDiffReviewPosted = false;
+      return { posted: false, error: message };
+    }
+  };
+}
+
 function buildPresentContext(
   adapterContext: AdapterContext,
   octokit: Octokit | undefined,
@@ -512,6 +609,7 @@ function buildPresentContext(
   summarySections: TaggedSection[],
   descriptionParts: Map<string, string>,
   debugLog: string[],
+  deliveryTracker: DeliveryTracker,
 ): PresentContext {
   const logger = adapterContext.logger;
   const debugLogger = createDebugCapturingLogger(logger, debugLog);
@@ -534,16 +632,9 @@ function buildPresentContext(
             updatePRDescription(octokit, pr, markdown, logger, sectionId)
         : undefined,
     postInlineComments:
-      octokit && pr
-        ? (findings, summaryBody) =>
-            postPluginInlineComments(octokit, pr, findings, summaryBody, logger)
-        : undefined,
+      octokit && pr ? createPostInlineComments(octokit, pr, logger, deliveryTracker) : undefined,
     postReviewComment:
-      octokit && pr
-        ? async body => {
-            await postPRReview(octokit, pr, [], body, logger, 'COMMENT');
-          }
-        : undefined,
+      octokit && pr ? createPostReviewComment(octokit, pr, logger, deliveryTracker) : undefined,
     minimizeOutdatedComments:
       octokit && pr ? marker => minimizeOutdatedComments(octokit, pr, marker, logger) : undefined,
   };
@@ -553,21 +644,35 @@ function buildPresentContext(
 // Inline Comment Posting
 // ---------------------------------------------------------------------------
 
+/**
+ * Ground truth for one `postInlineComments` call, feeding both the
+ * plugin-facing `{posted, skipped}` contract and the delivery attestation.
+ * Invariant: `attempted === posted + dropped + deduped`.
+ */
+interface InlinePostOutcome {
+  posted: number;
+  skipped: number;
+  attempted: number;
+  dropped: number;
+  deduped: number;
+}
+
 async function postPluginInlineComments(
   octokit: Octokit,
   pr: PRContext,
   findings: ReviewFinding[],
   summaryBody: string,
   logger: Logger,
-): Promise<{ posted: number; skipped: number }> {
-  if (findings.length === 0) return { posted: 0, skipped: 0 };
+): Promise<InlinePostOutcome> {
+  const attempted = findings.length;
+  if (attempted === 0) return { posted: 0, skipped: 0, attempted: 0, dropped: 0, deduped: 0 };
 
   const pluginId = findings[0].pluginId;
   if (findings.some(f => f.pluginId !== pluginId)) {
     logger.warning(
       `postInlineComments: mixed pluginIds in findings, skipping to avoid mis-attribution`,
     );
-    return { posted: 0, skipped: findings.length };
+    return { posted: 0, skipped: attempted, attempted, dropped: attempted, deduped: 0 };
   }
 
   const markerPrefix = `${PLUGIN_MARKER_PREFIX}${pluginId}:`;
@@ -575,10 +680,10 @@ async function postPluginInlineComments(
   const diffResult = await filterToDiffLines(octokit, pr, findings, logger);
   if (!diffResult) {
     logger.info(
-      `postInlineComments(${pluginId}): posting 0 of ${findings.length} finding(s) ` +
+      `postInlineComments(${pluginId}): posting 0 of ${attempted} finding(s) ` +
         `(diff fetch failed — see warning above)`,
     );
-    return { posted: 0, skipped: findings.length };
+    return { posted: 0, skipped: attempted, attempted, dropped: attempted, deduped: 0 };
   }
 
   const { inDiff, outOfDiffCount } = diffResult;
@@ -604,10 +709,12 @@ async function postPluginInlineComments(
 
   const skipped = outOfDiffCount + dedupSkipped;
   logger.info(
-    `postInlineComments(${pluginId}): posting ${toPost.length} of ${findings.length} finding(s) ` +
+    `postInlineComments(${pluginId}): posting ${toPost.length} of ${attempted} finding(s) ` +
       `(${outOfDiffCount} outside diff, ${dedupSkipped} already commented)`,
   );
-  if (toPost.length === 0) return { posted: 0, skipped };
+  if (toPost.length === 0) {
+    return { posted: 0, skipped, attempted, dropped: outOfDiffCount, deduped: dedupSkipped };
+  }
 
   const { posted, dropped } = await postPRReview(
     octokit,
@@ -617,7 +724,13 @@ async function postPluginInlineComments(
     logger,
     'COMMENT',
   );
-  return { posted, skipped: skipped + dropped.length };
+  return {
+    posted,
+    skipped: skipped + dropped.length,
+    attempted,
+    dropped: outOfDiffCount + dropped.length,
+    deduped: dedupSkipped,
+  };
 }
 
 /** Fetch diff lines and filter findings to those within the diff. Returns null on API failure. */

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -51,7 +51,8 @@ export interface EngineOptions {
 export interface PresentDelivery {
   annotationsEmitted: number;
   inlineComments: { attempted: number; posted: number; dropped: number; deduped: number };
-  descriptionBadgeUpdated: boolean;
+  /** null when no plugin contributed a description section this run (nothing to update). */
+  descriptionBadgeUpdated: boolean | null;
   /** null when no plugin attempted an out-of-diff review comment this run. */
   outOfDiffReviewPosted: boolean | null;
 }
@@ -60,7 +61,7 @@ export interface PresentDelivery {
 export const EMPTY_DELIVERY: PresentDelivery = {
   annotationsEmitted: 0,
   inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
-  descriptionBadgeUpdated: false,
+  descriptionBadgeUpdated: null,
   outOfDiffReviewPosted: null,
 };
 
@@ -245,35 +246,74 @@ export class ReviewEngine {
       adapterContext.logger,
     );
     const delivery: PresentDelivery = {
-      annotationsEmitted: pendingAnnotations.length,
+      annotationsEmitted: 0,
       inlineComments: deliveryTracker.inlineComments,
       descriptionBadgeUpdated,
       outOfDiffReviewPosted: deliveryTracker.outOfDiffReviewPosted,
     };
 
-    if (octokit && pr && checkRunId != null) {
-      const presented = await finalizePresentation(
-        octokit,
-        pr,
-        checkRunId,
-        findings,
-        summarySections,
-        pendingAnnotations,
-        debugLog,
-        adapterContext.logger,
-      );
-      return { ...presented, delivery };
-    }
-
-    // No check run was finalized (no octokit/pr/checkRunId), but callers still
-    // want the conclusion + summary for step summaries and exit codes.
-    const ordered = reorderSections(summarySections);
-    return {
-      conclusion: determineConclusion(findings),
-      summary: ordered.length > 0 ? ordered.join('\n\n') : buildCheckSummary(findings),
+    return finalizePresentResult(
+      octokit,
+      pr,
+      checkRunId,
+      findings,
+      summarySections,
+      pendingAnnotations,
+      debugLog,
       delivery,
+      adapterContext.logger,
+    );
+  }
+}
+
+/**
+ * `present()`'s two return paths, split out so annotationsEmitted is stamped
+ * correctly on each: only the check-run path (Checks API) actually sends
+ * annotations to GitHub. The no-check-run path — the Action's primary flow,
+ * since `presentFindings` always calls `present()` with `skipCheckRun: true`
+ * — never emits any, so `delivery.annotationsEmitted` stays the 0 it's
+ * initialized with.
+ */
+async function finalizePresentResult(
+  octokit: Octokit | undefined,
+  pr: PRContext | undefined,
+  checkRunId: number | undefined,
+  findings: ReviewFinding[],
+  summarySections: TaggedSection[],
+  pendingAnnotations: CheckAnnotation[],
+  debugLog: string[],
+  delivery: PresentDelivery,
+  logger: Logger,
+): Promise<{
+  conclusion: 'success' | 'failure' | 'neutral';
+  summary: string;
+  delivery: PresentDelivery;
+}> {
+  if (octokit && pr && checkRunId != null) {
+    const presented = await finalizePresentation(
+      octokit,
+      pr,
+      checkRunId,
+      findings,
+      summarySections,
+      pendingAnnotations,
+      debugLog,
+      logger,
+    );
+    return {
+      ...presented,
+      delivery: { ...delivery, annotationsEmitted: pendingAnnotations.length },
     };
   }
+
+  // No check run was finalized (no octokit/pr/checkRunId), but callers still
+  // want the conclusion + summary for step summaries and exit codes.
+  const ordered = reorderSections(summarySections);
+  return {
+    conclusion: determineConclusion(findings),
+    summary: ordered.length > 0 ? ordered.join('\n\n') : buildCheckSummary(findings),
+    delivery,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -444,15 +484,18 @@ function reorderSections(sections: TaggedSection[]): string[] {
 
 /**
  * Compose all plugin description fragments into a single "Lien Review" section
- * and update the PR description once.
+ * and update the PR description once. Returns null when there was nothing to
+ * describe (no octokit/pr, or no plugin contributed a section) — distinct
+ * from `false`, which means an update was actually attempted and failed (see
+ * `updatePRDescription`'s own success/failure return).
  */
 async function finalizeDescription(
   descriptionParts: Map<string, string>,
   octokit: Octokit | undefined,
   pr: PRContext | undefined,
   logger: Logger,
-): Promise<boolean> {
-  if (!octokit || !pr || descriptionParts.size === 0) return false;
+): Promise<boolean | null> {
+  if (!octokit || !pr || descriptionParts.size === 0) return null;
 
   const ordered: string[] = [];
   for (const id of PLUGIN_ORDER) {
@@ -466,13 +509,7 @@ async function finalizeDescription(
   const body = ordered.join('\n\n');
   const markdown = `### Lien Review\n\n${body}`;
 
-  try {
-    await updatePRDescription(octokit, pr, markdown, logger);
-    return true;
-  } catch (err) {
-    logger.warning(`Failed to update PR description: ${err instanceof Error ? err.message : err}`);
-    return false;
-  }
+  return updatePRDescription(octokit, pr, markdown, logger);
 }
 
 async function ensureCheckRun(
@@ -628,8 +665,9 @@ function buildPresentContext(
       descriptionParts.set(pluginId, markdown),
     updateDescription:
       octokit && pr
-        ? (markdown: string, sectionId?: string) =>
-            updatePRDescription(octokit, pr, markdown, logger, sectionId)
+        ? async (markdown: string, sectionId?: string) => {
+            await updatePRDescription(octokit, pr, markdown, logger, sectionId);
+          }
         : undefined,
     postInlineComments:
       octokit && pr ? createPostInlineComments(octokit, pr, logger, deliveryTracker) : undefined,

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -532,6 +532,10 @@ function stripSection(text: string, startMarker: string, endMarker: string): str
  * @param sectionId - Optional section identifier for per-plugin markers.
  *   When provided, uses `<!-- lien:{sectionId} -->` / `<!-- /lien:{sectionId} -->`.
  *   When omitted, uses the default `<!-- lien-stats -->` markers (backward compat).
+ * @returns true on a successful update, false on failure — never rejects (an
+ *   action shouldn't fail just because the description couldn't be updated),
+ *   but callers that need to know whether the write actually landed (e.g. the
+ *   delivery attestation) can check the return value instead of assuming success.
  */
 export async function updatePRDescription(
   octokit: Octokit,
@@ -539,7 +543,7 @@ export async function updatePRDescription(
   badgeMarkdown: string,
   logger: Logger,
   sectionId?: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
     // Get current PR
     const { data: pr } = await octokit.pulls.get({
@@ -584,9 +588,50 @@ export async function updatePRDescription(
     });
 
     logger.info(`PR description updated with ${sectionId ?? 'complexity stats'}`);
+    return true;
   } catch (error) {
     // Don't fail the action if we can't update the description
     logger.warning(`Failed to update PR description: ${error}`);
+    return false;
+  }
+}
+
+/**
+ * Remove a marker-delimited section from the PR description, if present.
+ * Used to clear a stale badge (e.g. the degraded-attestation notice) once a
+ * rerun no longer needs it — see `postAttestationBadgeIfDegraded`'s
+ * delivered-verdict path in review-pr.ts. A no-op (no API call) when the
+ * section isn't in the current body, so a normal run that never posted the
+ * badge doesn't touch the description at all.
+ */
+export async function removePRDescriptionSection(
+  octokit: Octokit,
+  prContext: PRContext,
+  sectionId: string,
+  logger: Logger,
+): Promise<boolean> {
+  try {
+    const { data: pr } = await octokit.pulls.get({
+      owner: prContext.owner,
+      repo: prContext.repo,
+      pull_number: prContext.pullNumber,
+    });
+    const currentBody = pr.body || '';
+    const { start: startMarker, end: endMarker } = sectionMarkers(sectionId);
+    if (!currentBody.includes(startMarker)) return true;
+
+    const newBody = stripSection(currentBody, startMarker, endMarker);
+    await octokit.pulls.update({
+      owner: prContext.owner,
+      repo: prContext.repo,
+      pull_number: prContext.pullNumber,
+      body: newBody,
+    });
+    logger.info(`Removed stale ${sectionId} section from PR description`);
+    return true;
+  } catch (error) {
+    logger.warning(`Failed to remove ${sectionId} section from PR description: ${error}`);
+    return false;
   }
 }
 

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -27,7 +27,34 @@ export type {
 } from './plugin-types.js';
 
 // Engine
-export { ReviewEngine, createDefaultEngine, type EngineOptions } from './engine.js';
+export {
+  ReviewEngine,
+  createDefaultEngine,
+  type EngineOptions,
+  type PresentDelivery,
+  EMPTY_DELIVERY,
+} from './engine.js';
+
+// Delivery attestation
+export {
+  assembleAttestation,
+  emptyAttestation,
+  computeVerdict,
+  deriveMainPassAttestation,
+  formatAttestationBadgeLine,
+  ATTESTATION_VERSION,
+  type Attestation,
+  type AttestationVerdict,
+  type AttestationInput,
+  type ProviderPassAttestation,
+  type ProviderStopReason,
+  type SkippedPass,
+  type BudgetAttestation,
+  type InlineCommentsAttestation,
+  type DeliveryAttestation,
+  type ScopeAttestation,
+  type EligibilityPath,
+} from './attestation.js';
 
 // Built-in plugins
 export { ComplexityPlugin } from './plugins/complexity.js';

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -114,6 +114,7 @@ export {
   getFileContent,
   postPRReview,
   updatePRDescription,
+  removePRDescriptionSection,
   parsePatchLines,
   getPRDiffLines,
   getPRPatchData,

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -109,6 +109,23 @@ export interface ReviewContext {
    * runners leave this unset and the client skips trace accumulation.
    */
   reportTrace?: (trace: import('./plugins/agent/types.js').AgentTrace) => void;
+  /**
+   * Callback invoked by the engine whenever a registered plugin is skipped
+   * during activation (see `getSkipReason` in engine.ts), and by a plugin
+   * itself for an internal sub-pass it decides not to run (e.g. the
+   * agent-review plugin's doc-truth second pass). Feeds the delivery
+   * attestation's `passesSkipped` list so a silent skip (misconfigured API
+   * key, a gate that didn't fire) stays inspectable instead of vanishing
+   * outside verbose logs.
+   */
+  reportSkip?: (skip: { plugin: string; reason: string }) => void;
+  /**
+   * Callback for an agent-style plugin to report the final token budget it
+   * allocated for a pass (after any scaling, e.g. blast-radius-based
+   * upscaling), independent of `reportUsage`'s spent-tokens report. Feeds
+   * the delivery attestation's `budget.allocatedTokens`.
+   */
+  reportBudget?: (allocatedTokens: number) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -267,9 +284,12 @@ export interface PresentContext {
   /**
    * Post a PR review with a summary body only (no inline comments — use
    * postInlineComments for those, which surfaces per-comment drops).
-   * Only available when pr + octokit are present.
+   * Only available when pr + octokit are present. Returns whether the post
+   * actually succeeded — previously `Promise<void>`, which made the
+   * out-of-diff review-comment path structurally unable to observe its own
+   * delivery outcome (see the delivery attestation's `outOfDiffReviewPosted`).
    */
-  postReviewComment?(body: string): Promise<void>;
+  postReviewComment?(body: string): Promise<{ posted: boolean; error?: string }>;
 
   /**
    * Minimize (hide as "outdated") existing PR comments matching a marker string.

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -94,6 +94,23 @@ const DOC_PASS_INTRO =
 // ---------------------------------------------------------------------------
 
 /**
+ * Precisely why the doc-truth pass would not run right now, or null if it
+ * should run. Kept separate from `shouldRunDocTruthPass`'s boolean so a
+ * caller reporting the skip to the delivery attestation (see `runDocTruthPass`
+ * below) can name the REAL reason — config-disabled, env-disabled, or no
+ * doc claims are three different operational states that a bare boolean
+ * collapses into one.
+ */
+function docTruthSkipReason(context: ReviewContext, config?: AgentConfig): string | null {
+  if (config?.docTruthPass === false) return 'disabled via config (docTruthPass: false)';
+  if (envDisabled(process.env[DOC_PASS_ENV])) return `disabled via ${DOC_PASS_ENV} env var`;
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return 'no PR patch data available';
+  if (extractDocClaims(patches).length === 0) return 'not a doc-touching PR (no doc claims)';
+  return null;
+}
+
+/**
  * Whether to run the doc-truth second pass. True iff the PR added at least one
  * claim-shaped line to a touched guidance/doc surface (which also implies a doc
  * surface was touched), and neither the config nor the env kill-switch disables
@@ -101,11 +118,7 @@ const DOC_PASS_INTRO =
  * so a non-empty worklist here means the pass has something to verify.
  */
 export function shouldRunDocTruthPass(context: ReviewContext, config?: AgentConfig): boolean {
-  if (config?.docTruthPass === false) return false;
-  if (envDisabled(process.env[DOC_PASS_ENV])) return false;
-  const patches = context.pr?.patches;
-  if (!patches || patches.size === 0) return false;
-  return extractDocClaims(patches).length > 0;
+  return docTruthSkipReason(context, config) === null;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,11 +201,21 @@ export type DocTruthClientRunner = (
   maxTurns: number,
 ) => Promise<AgentResult>;
 
+/** Plugin name the doc-truth pass reports itself under in the delivery attestation. */
+const DOC_TRUTH_SKIP_PLUGIN = 'agent-review:doc-truth';
+
 /**
  * Run the second, claims-only doc-truth pass when the PR warrants it. Returns
  * the pass's AgentResult, or null when the pass is gated off OR when it fails —
  * a pass-2 error must never fail the whole review, so it is caught, logged, and
  * swallowed here (the caller keeps the main-pass findings).
+ *
+ * Reports its own outcome to `context.reportSkip` in both the gated-off and
+ * failed cases — this is the one place that knows the REAL reason (the exact
+ * gate that fired, or the caught error), so a caller doesn't need to duplicate
+ * `shouldRunDocTruthPass`'s check just to guess why nothing came back. A run
+ * that never reaches this function at all (the main pass never ran) is
+ * reported by the caller instead — this pass is never invoked in that case.
  */
 export async function runDocTruthPass(
   context: ReviewContext,
@@ -200,7 +223,11 @@ export async function runDocTruthPass(
   logger: Logger,
   runClient: DocTruthClientRunner,
 ): Promise<AgentResult | null> {
-  if (!shouldRunDocTruthPass(context, config)) return null;
+  const skipReason = docTruthSkipReason(context, config);
+  if (skipReason) {
+    context.reportSkip?.({ plugin: DOC_TRUTH_SKIP_PLUGIN, reason: skipReason });
+    return null;
+  }
   try {
     const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(context);
     const budget = docTruthPassBudget(config.maxTokenBudget);
@@ -210,9 +237,9 @@ export async function runDocTruthPass(
     );
     return result;
   } catch (err) {
-    logger.warning(
-      `[agent] doc-truth pass failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warning(`[agent] doc-truth pass failed: ${message}`);
+    context.reportSkip?.({ plugin: DOC_TRUTH_SKIP_PLUGIN, reason: `failed: ${message}` });
     return null;
   }
 }

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -26,7 +26,6 @@ import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
 import {
   runDocTruthPass,
-  shouldRunDocTruthPass,
   mergeDocTruthFindings,
   mergeDocPassIntoResult,
   appendDocTruthTurns,
@@ -178,7 +177,15 @@ export class AgentReviewPlugin implements ReviewPlugin {
     // the main-pass output untouched. Skipped entirely when the main pass never
     // ran (provider down) — a second pass would only fire more doomed requests,
     // and its own incomplete state must not overwrite the never-ran marker.
-    this.reportDocTruthPassSkip(context, config, result);
+    // `runDocTruthPass` reports its own gated-off/failed outcome to the
+    // attestation; this is the one case it never even gets called for, so it's
+    // reported here instead.
+    if (result.neverRan) {
+      context.reportSkip?.({
+        plugin: 'agent-review:doc-truth',
+        reason: 'main pass never ran (provider failure)',
+      });
+    }
     const docResult = result.neverRan
       ? null
       : await this.runSecondDocPass(context, config, apiKey, provider, logger, toolExecutor);
@@ -204,31 +211,6 @@ export class AgentReviewPlugin implements ReviewPlugin {
     appendIncompleteNotice(findings, pluginId, result);
 
     return findings;
-  }
-
-  /**
-   * Report why the doc-truth second pass won't run this turn, if applicable —
-   * feeds the delivery attestation's `passesSkipped`. A no-op when the pass
-   * will actually run. Duplicates `shouldRunDocTruthPass`'s gate check (already
-   * evaluated inside `runDocTruthPass`) purely to distinguish "gated off" from
-   * "ran" for reporting; the check itself is a cheap, pure function.
-   */
-  private reportDocTruthPassSkip(
-    context: ReviewContext,
-    config: AgentConfig,
-    result: AgentResult,
-  ): void {
-    if (result.neverRan) {
-      context.reportSkip?.({
-        plugin: 'agent-review:doc-truth',
-        reason: 'main pass never ran (provider failure)',
-      });
-    } else if (!shouldRunDocTruthPass(context, config)) {
-      context.reportSkip?.({
-        plugin: 'agent-review:doc-truth',
-        reason: 'not a doc-touching PR (no doc claims)',
-      });
-    }
   }
 
   /**

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -26,6 +26,7 @@ import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
 import {
   runDocTruthPass,
+  shouldRunDocTruthPass,
   mergeDocTruthFindings,
   mergeDocPassIntoResult,
   appendDocTruthTurns,
@@ -151,6 +152,11 @@ export class AgentReviewPlugin implements ReviewPlugin {
         `[${this.id}] Token budget scaled ${config.maxTokenBudget} → ${maxTokenBudget} for ${blastRadius?.globalRisk.level} blast radius`,
       );
     }
+    // Report the FINAL allocated ceiling (post blast-radius scaling) for the
+    // delivery attestation's budget.allocatedTokens — the pre-scaling value
+    // computed upstream in review-pr.ts's scaleAgentBudget() isn't the real
+    // ceiling this run was held to.
+    context.reportBudget?.(maxTokenBudget);
 
     const systemPrompt = buildSystemPrompt(rules);
     const initialMessage = buildInitialMessage(context, { blastRadius });
@@ -172,6 +178,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
     // the main-pass output untouched. Skipped entirely when the main pass never
     // ran (provider down) — a second pass would only fire more doomed requests,
     // and its own incomplete state must not overwrite the never-ran marker.
+    this.reportDocTruthPassSkip(context, config, result);
     const docResult = result.neverRan
       ? null
       : await this.runSecondDocPass(context, config, apiKey, provider, logger, toolExecutor);
@@ -197,6 +204,31 @@ export class AgentReviewPlugin implements ReviewPlugin {
     appendIncompleteNotice(findings, pluginId, result);
 
     return findings;
+  }
+
+  /**
+   * Report why the doc-truth second pass won't run this turn, if applicable —
+   * feeds the delivery attestation's `passesSkipped`. A no-op when the pass
+   * will actually run. Duplicates `shouldRunDocTruthPass`'s gate check (already
+   * evaluated inside `runDocTruthPass`) purely to distinguish "gated off" from
+   * "ran" for reporting; the check itself is a cheap, pure function.
+   */
+  private reportDocTruthPassSkip(
+    context: ReviewContext,
+    config: AgentConfig,
+    result: AgentResult,
+  ): void {
+    if (result.neverRan) {
+      context.reportSkip?.({
+        plugin: 'agent-review:doc-truth',
+        reason: 'main pass never ran (provider failure)',
+      });
+    } else if (!shouldRunDocTruthPass(context, config)) {
+      context.reportSkip?.({
+        plugin: 'agent-review:doc-truth',
+        reason: 'not a doc-touching PR (no doc claims)',
+      });
+    }
   }
 
   /**

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -23,6 +23,7 @@ import type {
   ComplexityReport,
   ComplexityDelta,
   AdapterContext,
+  PresentDelivery,
 } from './index.js';
 import {
   runComplexityAnalysis,
@@ -36,10 +37,20 @@ import {
   ComplexityPlugin,
   AgentReviewPlugin,
   hasProviderFailure,
+  updatePRDescription,
+  EMPTY_DELIVERY,
 } from './index.js';
 import type { CodeChunk } from '@liendev/parser';
 import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
 import { reviewTokenBudgetMultiplier, MAX_REVIEW_TOKEN_BUDGET } from './defaults.js';
+import {
+  assembleAttestation,
+  emptyAttestation,
+  formatAttestationBadgeLine,
+  type Attestation,
+  type EligibilityPath,
+  type SkippedPass,
+} from './attestation.js';
 
 import { cloneBySha, type CloneResult } from './clone.js';
 
@@ -105,6 +116,8 @@ export interface ReviewCoreResult {
    * enabled, or the pipeline failed before reaching the engine).
    */
   providerFailure: boolean;
+  /** Machine-readable receipt of this run — provider health, budget, delivery, verdict (v1). */
+  attestation: Attestation;
 }
 
 export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewCoreResult> {
@@ -130,7 +143,12 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
 
     if (filesToAnalyze.length === 0 && !summaryEnabled) {
       logger.info('No analyzable files changed — skipping complexity/agent review');
-      return emptyResult('success', 'No files eligible for complexity analysis.', filesAnalyzed);
+      return emptyResult(
+        'success',
+        'No files eligible for complexity analysis.',
+        filesAnalyzed,
+        'zero_files_early_exit',
+      );
     }
 
     const analysis = await runAnalysisPhase(
@@ -147,6 +165,8 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
         'failure',
         'Review failed — could not produce a complexity report.',
         filesAnalyzed,
+        'normal',
+        true,
       );
     }
     baseClone = analysis.baseClone;
@@ -178,6 +198,8 @@ function emptyResult(
   conclusion: 'success' | 'failure',
   summaryMarkdown: string,
   filesAnalyzed: number,
+  eligibilityPath: EligibilityPath,
+  pipelineFailed = false,
 ): ReviewCoreResult {
   return {
     findings: [],
@@ -186,6 +208,7 @@ function emptyResult(
     filesAnalyzed,
     usage: { totalTokens: 0, cost: 0 },
     providerFailure: false,
+    attestation: emptyAttestation(conclusion, filesAnalyzed, eligibilityPath, pipelineFailed),
   };
 }
 
@@ -230,27 +253,45 @@ interface PresentedReview {
   summaryMarkdown: string;
   usage: { totalTokens: number; cost: number };
   providerFailure: boolean;
+  attestation: Attestation;
 }
 
-/** Run the review engine over an analyzed PR and present the findings to GitHub. */
-async function analyzeAndPresent(
+/** Telemetry the engine reports out-of-band during `run()`, via callbacks. */
+interface RunTelemetry {
+  findings: ReviewFinding[];
+  agentUsage: { promptTokens: number; completionTokens: number; totalTokens: number; cost: number };
+  allocatedTokens: number;
+  passesSkipped: SkippedPass[];
+}
+
+/**
+ * Register plugins and run the engine, collecting findings plus the
+ * out-of-band telemetry (usage/budget/skips) it reports via callback —
+ * agent-review bypasses the LLMClient meter and `run()`'s return value only
+ * carries findings, so this is the one place that wiring lives.
+ */
+async function runEngineForReview(
   ctx: ReviewCoreContext,
   analysis: AnalysisPhaseResult,
   filesToAnalyze: string[],
   allChangedFiles: string[],
   headCloneDir: string,
-): Promise<PresentedReview> {
-  const { octokit, pr, logger } = ctx;
+  engine: ReviewEngine,
+  agentAttempted: boolean,
+): Promise<RunTelemetry> {
+  const { pr, logger } = ctx;
   const { currentReport, chunks, baselineReport, deltas } = analysis;
-
-  const engine = new ReviewEngine();
   if (ctx.config.reviewTypes.complexity) engine.register(new ComplexityPlugin());
-  if (isAgentEnabled(ctx)) engine.register(new AgentReviewPlugin());
+  if (agentAttempted) engine.register(new AgentReviewPlugin());
 
-  // Agent usage is reported via callback since it bypasses the LLMClient meter.
-  let agentUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 };
+  const telemetry: RunTelemetry = {
+    findings: [],
+    agentUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 },
+    allocatedTokens: 0,
+    passesSkipped: [],
+  };
 
-  const findings = await engine.run({
+  telemetry.findings = await engine.run({
     chunks,
     changedFiles: filesToAnalyze,
     allChangedFiles,
@@ -263,16 +304,71 @@ async function analyzeAndPresent(
     logger,
     repoRootDir: headCloneDir,
     reportUsage: usage => {
-      agentUsage = usage;
+      telemetry.agentUsage = usage;
     },
+    reportBudget: tokens => {
+      telemetry.allocatedTokens = tokens;
+    },
+    reportSkip: skip => telemetry.passesSkipped.push(skip),
   });
-  logger.info(`Engine produced ${findings.length} total findings`);
+  logger.info(`Engine produced ${telemetry.findings.length} total findings`);
+  return telemetry;
+}
+
+/** Assemble the attestation from the run's telemetry + the present() delivery outcome. */
+function buildRunAttestation(
+  analysis: AnalysisPhaseResult,
+  filesToAnalyze: string[],
+  telemetry: RunTelemetry,
+  agentAttempted: boolean,
+  providerFailure: boolean,
+  presentation: { conclusion: 'success' | 'failure' | 'neutral'; delivery: PresentDelivery },
+): Attestation {
+  return assembleAttestation({
+    conclusion: presentation.conclusion,
+    filesAnalyzed: filesToAnalyze.length,
+    eligibilityPath: analysis.eligibilityPath,
+    findings: telemetry.findings,
+    agentAttempted,
+    providerFailure,
+    allocatedTokens: telemetry.allocatedTokens,
+    spentTokens: telemetry.agentUsage.totalTokens,
+    passesSkipped: telemetry.passesSkipped,
+    annotationsEmitted: presentation.delivery.annotationsEmitted,
+    inlineComments: presentation.delivery.inlineComments,
+    descriptionBadgeUpdated: presentation.delivery.descriptionBadgeUpdated,
+    outOfDiffReviewPosted: presentation.delivery.outOfDiffReviewPosted,
+  });
+}
+
+/** Run the review engine over an analyzed PR and present the findings to GitHub. */
+async function analyzeAndPresent(
+  ctx: ReviewCoreContext,
+  analysis: AnalysisPhaseResult,
+  filesToAnalyze: string[],
+  allChangedFiles: string[],
+  headCloneDir: string,
+): Promise<PresentedReview> {
+  const { octokit, pr, logger } = ctx;
+  const agentAttempted = isAgentEnabled(ctx);
+  const engine = new ReviewEngine();
+
+  const telemetry = await runEngineForReview(
+    ctx,
+    analysis,
+    filesToAnalyze,
+    allChangedFiles,
+    headCloneDir,
+    engine,
+    agentAttempted,
+  );
+  const { findings, agentUsage } = telemetry;
 
   const adapterContext: AdapterContext = {
-    complexityReport: currentReport,
-    baselineReport,
-    deltas,
-    deltaSummary: deltas ? calculateDeltaSummary(deltas) : null,
+    complexityReport: analysis.currentReport,
+    baselineReport: analysis.baselineReport,
+    deltas: analysis.deltas,
+    deltaSummary: analysis.deltas ? calculateDeltaSummary(analysis.deltas) : null,
     pr,
     octokit,
     logger,
@@ -282,14 +378,53 @@ async function analyzeAndPresent(
   };
 
   const presentation = await presentFindings(engine, findings, adapterContext, logger);
+  const providerFailure = hasProviderFailure(findings);
+  const attestation = buildRunAttestation(
+    analysis,
+    filesToAnalyze,
+    telemetry,
+    agentAttempted,
+    providerFailure,
+    presentation,
+  );
+
+  await postAttestationBadgeIfDegraded(octokit, pr, attestation, logger);
 
   return {
     findings,
     conclusion: presentation.conclusion,
     summaryMarkdown: presentation.summary,
     usage: { totalTokens: agentUsage.totalTokens, cost: agentUsage.cost },
-    providerFailure: hasProviderFailure(findings),
+    providerFailure,
+    attestation,
   };
+}
+
+/**
+ * Post the attestation's compact status line as its own PR-description
+ * section — only when the run is NOT a clean `delivered` (a healthy run
+ * doesn't need the extra line; see `formatAttestationBadgeLine`). Runs after
+ * `engine.present()` has already posted the main "Lien Review" section, so
+ * this is a separate `<!-- attestation -->`-marked section rather than a
+ * fragment folded into that one (the attestation isn't known until delivery
+ * — inline comments posted/dropped — has already happened).
+ */
+async function postAttestationBadgeIfDegraded(
+  octokit: Octokit,
+  pr: PRContext,
+  attestation: Attestation,
+  logger: Logger,
+): Promise<void> {
+  if (attestation.verdict === 'delivered') return;
+  await updatePRDescription(
+    octokit,
+    pr,
+    formatAttestationBadgeLine(attestation),
+    logger,
+    'attestation',
+  ).catch(err =>
+    logger.warning(`Failed to post attestation badge: ${err instanceof Error ? err.message : err}`),
+  );
 }
 
 /**
@@ -302,13 +437,21 @@ async function presentFindings(
   findings: ReviewFinding[],
   adapterContext: AdapterContext,
   logger: Logger,
-): Promise<{ conclusion: 'success' | 'failure' | 'neutral'; summary: string }> {
+): Promise<{
+  conclusion: 'success' | 'failure' | 'neutral';
+  summary: string;
+  delivery: PresentDelivery;
+}> {
   try {
     return await engine.present(findings, adapterContext, { skipCheckRun: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`engine.present() failed: ${message}`);
-    return { conclusion: 'neutral', summary: `An error occurred: ${message}` };
+    return {
+      conclusion: 'neutral',
+      summary: `An error occurred: ${message}`,
+      delivery: EMPTY_DELIVERY,
+    };
   }
 }
 
@@ -391,6 +534,8 @@ interface AnalysisPhaseResult {
   baselineReport: ComplexityReport | null;
   deltas: ComplexityDelta[] | null;
   baseClone: CloneResult | null;
+  /** 'normal' when the PR had analyzable files; 'full_repo_fallback' otherwise (#572/#754). */
+  eligibilityPath: EligibilityPath;
 }
 
 async function runAnalysisPhase(
@@ -444,6 +589,7 @@ async function runAnalysisPhase(
       baselineReport,
       deltas,
       baseClone,
+      eligibilityPath: 'normal',
     };
   }
 
@@ -459,6 +605,7 @@ async function runAnalysisPhase(
       baselineReport: null,
       deltas: null,
       baseClone: null,
+      eligibilityPath: 'full_repo_fallback',
     };
   }
   return {
@@ -478,6 +625,7 @@ async function runAnalysisPhase(
     baselineReport: null,
     deltas: null,
     baseClone: null,
+    eligibilityPath: 'full_repo_fallback',
   };
 }
 

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -15,6 +15,9 @@
  * Flow: clone head → analyze → clone base → deltas → engine.run → engine.present.
  */
 
+import type { CodeChunk } from '@liendev/parser';
+import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
+
 import type {
   Octokit,
   PRContext,
@@ -38,10 +41,9 @@ import {
   AgentReviewPlugin,
   hasProviderFailure,
   updatePRDescription,
+  removePRDescriptionSection,
   EMPTY_DELIVERY,
 } from './index.js';
-import type { CodeChunk } from '@liendev/parser';
-import { performChunkOnlyIndex, analyzeComplexityFromChunks } from '@liendev/parser';
 import { reviewTokenBudgetMultiplier, MAX_REVIEW_TOKEN_BUDGET } from './defaults.js';
 import {
   assembleAttestation,
@@ -51,7 +53,6 @@ import {
   type EligibilityPath,
   type SkippedPass,
 } from './attestation.js';
-
 import { cloneBySha, type CloneResult } from './clone.js';
 
 /**
@@ -256,12 +257,35 @@ interface PresentedReview {
   attestation: Attestation;
 }
 
+/** Prompt/completion token + cost usage, as reported by a single agent-client run. */
+export interface AgentUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cost: number;
+}
+
 /** Telemetry the engine reports out-of-band during `run()`, via callbacks. */
 interface RunTelemetry {
   findings: ReviewFinding[];
-  agentUsage: { promptTokens: number; completionTokens: number; totalTokens: number; cost: number };
+  agentUsage: AgentUsage;
   allocatedTokens: number;
   passesSkipped: SkippedPass[];
+}
+
+/**
+ * Sum two usage snapshots. `reportUsage` fires once per agent-client pass —
+ * the main review and (on doc-touching PRs) the doc-truth second pass — and
+ * both must contribute to the run's total spend. Assigning the latest call's
+ * value instead of accumulating silently drops whichever pass reported first.
+ */
+export function accumulateUsage(a: AgentUsage, b: AgentUsage): AgentUsage {
+  return {
+    promptTokens: a.promptTokens + b.promptTokens,
+    completionTokens: a.completionTokens + b.completionTokens,
+    totalTokens: a.totalTokens + b.totalTokens,
+    cost: a.cost + b.cost,
+  };
 }
 
 /**
@@ -304,7 +328,7 @@ async function runEngineForReview(
     logger,
     repoRootDir: headCloneDir,
     reportUsage: usage => {
-      telemetry.agentUsage = usage;
+      telemetry.agentUsage = accumulateUsage(telemetry.agentUsage, usage);
     },
     reportBudget: tokens => {
       telemetry.allocatedTokens = tokens;
@@ -388,7 +412,7 @@ async function analyzeAndPresent(
     presentation,
   );
 
-  await postAttestationBadgeIfDegraded(octokit, pr, attestation, logger);
+  await syncAttestationBadge(octokit, pr, attestation, logger);
 
   return {
     findings,
@@ -401,30 +425,34 @@ async function analyzeAndPresent(
 }
 
 /**
- * Post the attestation's compact status line as its own PR-description
- * section — only when the run is NOT a clean `delivered` (a healthy run
- * doesn't need the extra line; see `formatAttestationBadgeLine`). Runs after
+ * Sync the attestation's compact status line as its own PR-description
+ * section — posted only when the run is NOT a clean `delivered` (a healthy
+ * run doesn't need the extra line; see `formatAttestationBadgeLine`), and
+ * REMOVED when it is (a PR that recovers from degraded to delivered must not
+ * keep showing the old degraded badge from a prior run). Runs after
  * `engine.present()` has already posted the main "Lien Review" section, so
  * this is a separate `<!-- attestation -->`-marked section rather than a
  * fragment folded into that one (the attestation isn't known until delivery
  * — inline comments posted/dropped — has already happened).
  */
-async function postAttestationBadgeIfDegraded(
+async function syncAttestationBadge(
   octokit: Octokit,
   pr: PRContext,
   attestation: Attestation,
   logger: Logger,
 ): Promise<void> {
-  if (attestation.verdict === 'delivered') return;
-  await updatePRDescription(
+  if (attestation.verdict === 'delivered') {
+    await removePRDescriptionSection(octokit, pr, 'attestation', logger);
+    return;
+  }
+  const posted = await updatePRDescription(
     octokit,
     pr,
     formatAttestationBadgeLine(attestation),
     logger,
     'attestation',
-  ).catch(err =>
-    logger.warning(`Failed to post attestation badge: ${err instanceof Error ? err.message : err}`),
   );
+  if (!posted) logger.warning('Failed to post attestation badge');
 }
 
 /**

--- a/packages/review/test/attestation.test.ts
+++ b/packages/review/test/attestation.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  assembleAttestation,
+  emptyAttestation,
+  computeVerdict,
+  deriveMainPassAttestation,
+  formatAttestationBadgeLine,
+  ATTESTATION_VERSION,
+  type AttestationInput,
+  type ReviewFinding,
+} from '../src/index.js';
+
+/** A baseline set of inputs representing a clean, fully-delivered run. */
+function baseInput(overrides?: Partial<AttestationInput>): AttestationInput {
+  return {
+    conclusion: 'success',
+    filesAnalyzed: 3,
+    eligibilityPath: 'normal',
+    findings: [],
+    agentAttempted: true,
+    providerFailure: false,
+    allocatedTokens: 100_000,
+    spentTokens: 12_000,
+    passesSkipped: [],
+    annotationsEmitted: 0,
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    descriptionBadgeUpdated: true,
+    outOfDiffReviewPosted: null,
+    ...overrides,
+  };
+}
+
+function neverRanFinding(): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'error',
+    category: 'summary',
+    message: 'Lien Review did not run — every provider request failed.',
+    metadata: { incomplete: true, neverRan: true, stopReason: 'error' },
+  };
+}
+
+function incompleteFinding(stopReason: 'budget' | 'max_turns'): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'warning',
+    category: 'summary',
+    message: 'Lien Review did not finish.',
+    metadata: { incomplete: true, stopReason },
+  };
+}
+
+describe('assembleAttestation', () => {
+  it('is versioned as v1', () => {
+    expect(assembleAttestation(baseInput()).attestationVersion).toBe(ATTESTATION_VERSION);
+    expect(ATTESTATION_VERSION).toBe(1);
+  });
+
+  it('produces verdict "delivered" for a clean, fully-delivered run', () => {
+    const attestation = assembleAttestation(baseInput());
+    expect(attestation.verdict).toBe('delivered');
+    expect(attestation.provider.passes).toEqual([
+      { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
+    ]);
+    expect(attestation.budget).toEqual({
+      allocatedTokens: 100_000,
+      spentTokens: 12_000,
+      starved: false,
+    });
+  });
+
+  it('produces verdict "failed:provider_never_ran" when the main pass never ran', () => {
+    const attestation = assembleAttestation(
+      baseInput({ conclusion: 'failure', findings: [neverRanFinding()], providerFailure: true }),
+    );
+    expect(attestation.verdict).toBe('failed:provider_never_ran');
+    expect(attestation.provider.passes[0]).toEqual({
+      name: 'main',
+      ran: true,
+      stopReason: 'error',
+      neverRan: true,
+    });
+  });
+
+  it('produces verdict "degraded:budget_starved" when the main pass stopped on budget', () => {
+    const attestation = assembleAttestation(
+      baseInput({
+        conclusion: 'neutral',
+        findings: [incompleteFinding('budget')],
+        allocatedTokens: 100_000,
+        spentTokens: 99_500,
+      }),
+    );
+    expect(attestation.verdict).toBe('degraded:budget_starved');
+    expect(attestation.budget.starved).toBe(true);
+  });
+
+  it('produces verdict "degraded:provider_partial" for a non-budget incomplete stop', () => {
+    const attestation = assembleAttestation(
+      baseInput({ conclusion: 'neutral', findings: [incompleteFinding('max_turns')] }),
+    );
+    expect(attestation.verdict).toBe('degraded:provider_partial');
+    expect(attestation.budget.starved).toBe(false);
+  });
+
+  it('produces verdict "degraded:comments_dropped" when comments were dropped on an otherwise clean run', () => {
+    const attestation = assembleAttestation(
+      baseInput({
+        inlineComments: { attempted: 4, posted: 2, dropped: 2, deduped: 0 },
+      }),
+    );
+    expect(attestation.verdict).toBe('degraded:comments_dropped');
+  });
+
+  it('produces verdict "failed:analysis_error" when the pipeline failed before the engine ran', () => {
+    const attestation = assembleAttestation(
+      baseInput({ conclusion: 'failure', agentAttempted: false, pipelineFailed: true }),
+    );
+    expect(attestation.verdict).toBe('failed:analysis_error');
+    expect(attestation.provider.passes).toEqual([]);
+  });
+
+  it('never_ran outranks a starved budget or dropped comments (precedence)', () => {
+    const attestation = assembleAttestation(
+      baseInput({
+        conclusion: 'failure',
+        findings: [neverRanFinding()],
+        providerFailure: true,
+        inlineComments: { attempted: 4, posted: 0, dropped: 4, deduped: 0 },
+      }),
+    );
+    expect(attestation.verdict).toBe('failed:provider_never_ran');
+  });
+
+  it('reports an empty passes array when the agent-review plugin never ran', () => {
+    const attestation = assembleAttestation(
+      baseInput({
+        agentAttempted: false,
+        passesSkipped: [{ plugin: 'agent-review', reason: 'requires LLM but none configured' }],
+      }),
+    );
+    expect(attestation.provider.passes).toEqual([]);
+    expect(attestation.passesSkipped).toEqual([
+      { plugin: 'agent-review', reason: 'requires LLM but none configured' },
+    ]);
+    expect(attestation.verdict).toBe('delivered');
+  });
+});
+
+describe('emptyAttestation', () => {
+  it('builds a "delivered" v1 attestation for the zero-files early-exit path', () => {
+    const attestation = emptyAttestation('success', 0, 'zero_files_early_exit');
+    expect(attestation.verdict).toBe('delivered');
+    expect(attestation.scope).toEqual({
+      eligibilityPath: 'zero_files_early_exit',
+      filesAnalyzed: 0,
+    });
+    expect(attestation.provider.passes).toEqual([]);
+  });
+
+  it('builds a "failed:analysis_error" attestation for the pre-engine pipeline failure path', () => {
+    const attestation = emptyAttestation('failure', 5, 'normal', true);
+    expect(attestation.verdict).toBe('failed:analysis_error');
+  });
+});
+
+describe('deriveMainPassAttestation', () => {
+  it('returns ran:false, stopReason:not_run when the agent-review plugin was never attempted', () => {
+    expect(deriveMainPassAttestation([], false, false)).toEqual({
+      name: 'main',
+      ran: false,
+      stopReason: 'not_run',
+      neverRan: false,
+    });
+  });
+
+  it('defaults an unlabeled incomplete finding to stopReason "error" rather than throwing', () => {
+    const malformed: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message: 'incomplete, no stopReason',
+      metadata: { incomplete: true },
+    };
+    expect(deriveMainPassAttestation([malformed], true, false)).toEqual({
+      name: 'main',
+      ran: true,
+      stopReason: 'error',
+      neverRan: false,
+    });
+  });
+});
+
+describe('computeVerdict', () => {
+  it('pipelineFailed takes precedence over everything else', () => {
+    const verdict = computeVerdict({
+      pipelineFailed: true,
+      providerFailure: true,
+      mainPass: { name: 'main', ran: true, stopReason: 'budget', neverRan: false },
+      budget: { allocatedTokens: 1, spentTokens: 1, starved: true },
+      inlineComments: { attempted: 1, posted: 0, dropped: 1, deduped: 0 },
+    });
+    expect(verdict).toBe('failed:analysis_error');
+  });
+});
+
+describe('formatAttestationBadgeLine', () => {
+  it('renders verdict, comment counts, and token usage in one compact line', () => {
+    const attestation = assembleAttestation(
+      baseInput({
+        inlineComments: { attempted: 6, posted: 4, dropped: 2, deduped: 0 },
+        allocatedTokens: 250_000,
+        spentTokens: 238_000,
+      }),
+    );
+    const line = formatAttestationBadgeLine(attestation);
+    expect(line).toContain(`Attested: ${attestation.verdict}`);
+    expect(line).toContain('4/6 comments posted');
+    expect(line).toContain('238K/250K tokens');
+  });
+});

--- a/packages/review/test/attestation.test.ts
+++ b/packages/review/test/attestation.test.ts
@@ -117,6 +117,30 @@ describe('assembleAttestation', () => {
     expect(attestation.verdict).toBe('degraded:comments_dropped');
   });
 
+  // Regression coverage for the CodeRabbit #768 finding: computeVerdict used
+  // to ignore descriptionBadgeUpdated/outOfDiffReviewPosted entirely, so a run
+  // where the PR-description update failed (or the out-of-diff summary
+  // comment failed to post) was still attested "delivered".
+  it('produces verdict "degraded:delivery_incomplete" when the description badge update failed', () => {
+    const attestation = assembleAttestation(baseInput({ descriptionBadgeUpdated: false }));
+    expect(attestation.verdict).toBe('degraded:delivery_incomplete');
+  });
+
+  it('produces verdict "degraded:delivery_incomplete" when the out-of-diff review comment failed', () => {
+    const attestation = assembleAttestation(baseInput({ outOfDiffReviewPosted: false }));
+    expect(attestation.verdict).toBe('degraded:delivery_incomplete');
+  });
+
+  it('stays "delivered" when nothing was attempted (null), not just when it succeeded', () => {
+    // null means "no plugin contributed a description this run" / "no plugin
+    // attempted an out-of-diff comment" — distinct from false ("attempted and
+    // failed"). Only false should degrade the verdict.
+    const attestation = assembleAttestation(
+      baseInput({ descriptionBadgeUpdated: null, outOfDiffReviewPosted: null }),
+    );
+    expect(attestation.verdict).toBe('delivered');
+  });
+
   it('produces verdict "failed:analysis_error" when the pipeline failed before the engine ran', () => {
     const attestation = assembleAttestation(
       baseInput({ conclusion: 'failure', agentAttempted: false, pipelineFailed: true }),
@@ -161,6 +185,9 @@ describe('emptyAttestation', () => {
       filesAnalyzed: 0,
     });
     expect(attestation.provider.passes).toEqual([]);
+    // Nothing was attempted on this early-exit path — null ("not attempted"),
+    // not false ("attempted and failed"), so it must not read as degraded.
+    expect(attestation.delivery.descriptionBadge.updated).toBeNull();
   });
 
   it('builds a "failed:analysis_error" attestation for the pre-engine pipeline failure path', () => {

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -6,7 +6,8 @@
  * attestation design identified (see `.wip/attestation-design.md` §1).
  */
 import { describe, it, expect, vi } from 'vitest';
-import { ReviewEngine } from '../src/engine.js';
+import { ReviewEngine, EMPTY_DELIVERY } from '../src/engine.js';
+import { computeVerdict } from '../src/attestation.js';
 import { createTestReport, silentLogger } from '../src/test-helpers.js';
 import type {
   ReviewPlugin,
@@ -259,5 +260,32 @@ describe('ReviewEngine.present() delivery truth', () => {
 
       expect(result.delivery.descriptionBadgeUpdated).toBe(false);
     });
+  });
+});
+
+// Regression coverage for a finding Lien Review's own dogfooded check caught
+// on this PR: `presentFindings` (review-pr.ts) falls back to EMPTY_DELIVERY
+// when `engine.present()` itself throws — a delivery ATTEMPT that crashed,
+// not one that never happened. Its two nullable fields must be `false`
+// (attempted-and-failed), not `null` (never attempted), or a catastrophic
+// present() failure would attest 'delivered' via computeVerdict's null
+// carve-out.
+describe('EMPTY_DELIVERY', () => {
+  it('reports description/out-of-diff delivery as failed, not "not attempted"', () => {
+    expect(EMPTY_DELIVERY.descriptionBadgeUpdated).toBe(false);
+    expect(EMPTY_DELIVERY.outOfDiffReviewPosted).toBe(false);
+  });
+
+  it('computes a degraded verdict, not "delivered", from its own shape', () => {
+    const verdict = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      mainPass: { name: 'main', ran: false, stopReason: 'not_run', neverRan: false },
+      budget: { allocatedTokens: 0, spentTokens: 0, starved: false },
+      inlineComments: EMPTY_DELIVERY.inlineComments,
+      descriptionBadgeUpdated: EMPTY_DELIVERY.descriptionBadgeUpdated,
+      outOfDiffReviewPosted: EMPTY_DELIVERY.outOfDiffReviewPosted,
+    });
+    expect(verdict).toBe('degraded:delivery_incomplete');
   });
 });

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -162,4 +162,102 @@ describe('ReviewEngine.present() delivery truth', () => {
     const result = await engine.present([], createAdapterContext());
     expect(result.delivery.outOfDiffReviewPosted).toBeNull();
   });
+
+  // Regression coverage for the CodeRabbit #768 finding: annotationsEmitted
+  // used to report the QUEUED count on every path, even the one where no
+  // check run exists to send them to — the real Action flow, since
+  // `presentFindings` always calls `present()` with `skipCheckRun: true`.
+  describe('annotationsEmitted', () => {
+    it('stays 0 when no check run is finalized (skipCheckRun), even if a plugin queued annotations', async () => {
+      const engine = new ReviewEngine();
+      engine.register(
+        createTestPlugin({
+          present: async (_findings, ctx: PresentContext) => {
+            ctx.addAnnotations([{ path: 'a.ts', line: 1, level: 'warning', message: 'nit' }]);
+          },
+        }),
+      );
+
+      const result = await engine.present([], createAdapterContext(), { skipCheckRun: true });
+
+      expect(result.delivery.annotationsEmitted).toBe(0);
+    });
+
+    it('reflects the actual sent count when a check run is created and finalized', async () => {
+      const octokit = {
+        checks: {
+          create: vi.fn().mockResolvedValue({ data: { id: 99 } }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+      };
+      const engine = new ReviewEngine();
+      engine.register(
+        createTestPlugin({
+          present: async (_findings, ctx: PresentContext) => {
+            ctx.addAnnotations([{ path: 'a.ts', line: 1, level: 'warning', message: 'nit' }]);
+          },
+        }),
+      );
+
+      const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+      expect(result.delivery.annotationsEmitted).toBe(1);
+      expect(octokit.checks.update).toHaveBeenCalled();
+    });
+  });
+
+  // Regression coverage for the CodeRabbit #768 finding: updatePRDescription
+  // used to swallow every error internally and never reject, so
+  // descriptionBadgeUpdated was always true whenever an update was attempted
+  // — it could never reflect a real failure.
+  describe('descriptionBadgeUpdated', () => {
+    it('is null when no plugin contributes a description section', async () => {
+      const engine = new ReviewEngine();
+      engine.register(createTestPlugin());
+      const result = await engine.present([], createAdapterContext({ octokit: {}, pr: mockPR }));
+      expect(result.delivery.descriptionBadgeUpdated).toBeNull();
+    });
+
+    it('is true when a plugin contributes a description and the update succeeds', async () => {
+      const octokit = {
+        pulls: {
+          get: vi.fn().mockResolvedValue({ data: { body: '' } }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+      };
+      const engine = new ReviewEngine();
+      engine.register(
+        createTestPlugin({
+          present: async (_findings, ctx: PresentContext) => {
+            ctx.appendDescription('Some findings.', 'test');
+          },
+        }),
+      );
+
+      const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+      expect(result.delivery.descriptionBadgeUpdated).toBe(true);
+    });
+
+    it('is false (not thrown) when the underlying PR update actually fails', async () => {
+      const octokit = {
+        pulls: {
+          get: vi.fn().mockResolvedValue({ data: { body: '' } }),
+          update: vi.fn().mockRejectedValue(new Error('403 Forbidden')),
+        },
+      };
+      const engine = new ReviewEngine();
+      engine.register(
+        createTestPlugin({
+          present: async (_findings, ctx: PresentContext) => {
+            ctx.appendDescription('Some findings.', 'test');
+          },
+        }),
+      );
+
+      const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+      expect(result.delivery.descriptionBadgeUpdated).toBe(false);
+    });
+  });
 });

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Delivery-truth tests: `present()`'s returned `delivery` counts (and the
+ * `postReviewComment` outcome) must reflect what `postPRReview` ACTUALLY did
+ * — the real `PostReviewResult` — not the size of the batch a plugin asked
+ * to post. Regression coverage for the discard-point bug the delivery
+ * attestation design identified (see `.wip/attestation-design.md` §1).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ReviewEngine } from '../src/engine.js';
+import { createTestReport, silentLogger } from '../src/test-helpers.js';
+import type {
+  ReviewPlugin,
+  ReviewFinding,
+  AdapterContext,
+  PresentContext,
+} from '../src/plugin-types.js';
+
+function createTestPlugin(overrides?: Partial<ReviewPlugin>): ReviewPlugin {
+  return {
+    id: 'test',
+    name: 'Test Plugin',
+    description: 'A test plugin',
+    shouldActivate: () => true,
+    analyze: () => [],
+    ...overrides,
+  };
+}
+
+function createAdapterContext(overrides?: Partial<AdapterContext>): AdapterContext {
+  return {
+    complexityReport: createTestReport(),
+    baselineReport: null,
+    deltas: null,
+    deltaSummary: null,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+const mockPR = {
+  owner: 'test-owner',
+  repo: 'test-repo',
+  pullNumber: 1,
+  title: 'Test PR',
+  baseSha: 'abc',
+  headSha: 'def',
+};
+
+function finding(overrides?: Partial<ReviewFinding>): ReviewFinding {
+  return {
+    pluginId: 'test',
+    filepath: 'src/a.ts',
+    line: 5,
+    severity: 'warning',
+    category: 'logic_error',
+    message: 'Something is off.',
+    ...overrides,
+  };
+}
+
+/** Async iterator over a single page — enough to satisfy `octokit.paginate.iterator`. */
+function onePage(data: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { data };
+    },
+  };
+}
+
+describe('ReviewEngine.present() delivery truth', () => {
+  it('inlineComments.{posted,dropped} reflect PostReviewResult, not the attempted count', async () => {
+    // Two findings, both anchorable (lines 5 and 6 are in the diff). The batch
+    // createReview 422s (a bad-anchor rejection), so the engine falls back to
+    // posting the body alone (succeeds) then each comment individually: the
+    // first succeeds, the second fails — 1 posted, 1 dropped, of 2 attempted.
+    const patch = '@@ -1,2 +5,3 @@\n+line5\n+line6\n+line7';
+    const octokit = {
+      paginate: {
+        iterator: vi.fn((fn: unknown, _params: unknown) => {
+          if (fn === octokit.pulls.listFiles) {
+            return onePage([{ filename: 'src/a.ts', patch }]);
+          }
+          return onePage([]); // listReviewComments — no existing comments
+        }),
+      },
+      pulls: {
+        listFiles: vi.fn(),
+        listReviewComments: vi.fn(),
+        createReview: vi
+          .fn()
+          .mockRejectedValueOnce({ status: 422 }) // batch attempt: bad anchor
+          .mockResolvedValueOnce({}), // body-only retry: succeeds
+        createReviewComment: vi
+          .fn()
+          .mockResolvedValueOnce({}) // comment 1: posted
+          .mockRejectedValueOnce(new Error('422 Unprocessable')), // comment 2: dropped
+      },
+    };
+
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!(
+            [finding({ line: 5 }), finding({ line: 6 })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(result.delivery.inlineComments).toEqual({
+      attempted: 2,
+      posted: 1,
+      dropped: 1,
+      deduped: 0,
+    });
+  });
+
+  it('outOfDiffReviewPosted is true on a successful out-of-diff review comment', async () => {
+    const octokit = {
+      pulls: { createReview: vi.fn().mockResolvedValue({}) },
+    };
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          const outcome = await ctx.postReviewComment!('out of diff notice');
+          expect(outcome).toEqual({ posted: true });
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+    expect(result.delivery.outOfDiffReviewPosted).toBe(true);
+  });
+
+  it('outOfDiffReviewPosted is false (not thrown) when the post fails', async () => {
+    const octokit = {
+      pulls: { createReview: vi.fn().mockRejectedValue(new Error('network error')) },
+    };
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          const outcome = await ctx.postReviewComment!('out of diff notice');
+          expect(outcome.posted).toBe(false);
+          expect(outcome.error).toContain('network error');
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+    expect(result.delivery.outOfDiffReviewPosted).toBe(false);
+  });
+
+  it('outOfDiffReviewPosted stays null when no plugin attempts it', async () => {
+    const engine = new ReviewEngine();
+    engine.register(createTestPlugin());
+    const result = await engine.present([], createAdapterContext());
+    expect(result.delivery.outOfDiffReviewPosted).toBeNull();
+  });
+});

--- a/packages/review/test/github-api.test.ts
+++ b/packages/review/test/github-api.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { postPRReview, parsePatchLines } from '../src/github-api.js';
+import {
+  postPRReview,
+  parsePatchLines,
+  updatePRDescription,
+  removePRDescriptionSection,
+} from '../src/github-api.js';
 import type { Octokit } from '../src/github-api.js';
 import type { LineComment, PRContext } from '../src/types.js';
 import type { Logger } from '../src/logger.js';
@@ -242,6 +247,91 @@ describe('postPRReview', () => {
 
     expect(createReview).toHaveBeenCalledTimes(1);
     expect(createReviewComment).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePRDescription / removePRDescriptionSection
+// ---------------------------------------------------------------------------
+
+/** Minimal Octokit stand-in for the PR-description read/write pair. */
+function createDescriptionOctokit(overrides?: {
+  body?: string;
+  get?: ReturnType<typeof vi.fn>;
+  update?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    pulls: {
+      get: overrides?.get ?? vi.fn().mockResolvedValue({ data: { body: overrides?.body ?? '' } }),
+      update: overrides?.update ?? vi.fn().mockResolvedValue({}),
+    },
+  } as unknown as Octokit;
+}
+
+describe('updatePRDescription', () => {
+  // Regression coverage for the CodeRabbit #768 finding: this used to swallow
+  // every error and always resolve void, so a caller tracking delivery (the
+  // attestation's descriptionBadgeUpdated) could never see a real failure.
+  it('returns true on a successful update', async () => {
+    const octokit = createDescriptionOctokit();
+    const logger = createMockLogger();
+
+    await expect(updatePRDescription(octokit, pr, 'badge', logger, 'attestation')).resolves.toBe(
+      true,
+    );
+  });
+
+  it('returns false (does not throw) when octokit.pulls.update rejects', async () => {
+    const octokit = createDescriptionOctokit({
+      update: vi.fn().mockRejectedValue(new Error('403 Forbidden')),
+    });
+    const logger = createMockLogger();
+
+    await expect(updatePRDescription(octokit, pr, 'badge', logger, 'attestation')).resolves.toBe(
+      false,
+    );
+    expect(logger.warning).toHaveBeenCalled();
+  });
+});
+
+describe('removePRDescriptionSection', () => {
+  it('strips an existing marker-delimited section and updates the PR', async () => {
+    const body =
+      'Intro.\n\n<!-- lien:attestation -->\nAttested: degraded\n<!-- /lien:attestation -->';
+    const update = vi.fn().mockResolvedValue({});
+    const octokit = createDescriptionOctokit({ body, update });
+    const logger = createMockLogger();
+
+    const ok = await removePRDescriptionSection(octokit, pr, 'attestation', logger);
+
+    expect(ok).toBe(true);
+    expect(update).toHaveBeenCalledTimes(1);
+    const newBody = update.mock.calls[0][0].body as string;
+    expect(newBody).not.toContain('lien:attestation');
+    expect(newBody).toContain('Intro.');
+  });
+
+  it('is a no-op (no update call) when the section is not present', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const octokit = createDescriptionOctokit({ body: 'Just a plain PR description.', update });
+    const logger = createMockLogger();
+
+    const ok = await removePRDescriptionSection(octokit, pr, 'attestation', logger);
+
+    expect(ok).toBe(true);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('returns false (does not throw) when the API call fails', async () => {
+    const octokit = createDescriptionOctokit({
+      get: vi.fn().mockRejectedValue(new Error('network error')),
+    });
+    const logger = createMockLogger();
+
+    const ok = await removePRDescriptionSection(octokit, pr, 'attestation', logger);
+
+    expect(ok).toBe(false);
+    expect(logger.warning).toHaveBeenCalled();
   });
 });
 

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
 import {
   shouldRunDocTruthPass,
@@ -45,7 +45,10 @@ const CODE_PATCH = `@@ -1,3 +1,4 @@
 +  return UNIQUE_CODE_MARKER_XYZ; // disabled when true
  }`;
 
-function contextWithPatches(entries: Array<[string, string]>): ReviewContext {
+function contextWithPatches(
+  entries: Array<[string, string]>,
+  extra?: Partial<ReviewContext>,
+): ReviewContext {
   return createTestContext({
     changedFiles: entries.map(([f]) => f),
     allChangedFiles: entries.map(([f]) => f),
@@ -54,6 +57,7 @@ function contextWithPatches(entries: Array<[string, string]>): ReviewContext {
       body: 'Clarify the overlay gate.',
       patches: new Map(entries),
     } as unknown as ReviewContext['pr'],
+    ...extra,
   });
 }
 
@@ -412,5 +416,65 @@ describe('runDocTruthPass', () => {
     });
     expect(res).toBeNull();
     expect(lines.some(l => l.includes('doc-truth pass failed') && l.includes('boom'))).toBe(true);
+  });
+
+  // Regression coverage for the CodeRabbit #768 finding: reportDocTruthPassSkip
+  // used to report a generic "no doc claims" reason for every gated-off case,
+  // and a thrown pass-2 error vanished from the attestation entirely (neither
+  // "ran" nor "skipped"). `runDocTruthPass` now reports its own precise reason
+  // for both the gate and the failure, straight from the one place that knows it.
+  it('reports the CONFIG-disabled reason, not the generic "no doc claims" one', async () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const reportSkip = vi.fn();
+    await runDocTruthPass(
+      { ...ctx, reportSkip },
+      cfg({ docTruthPass: false }),
+      silentLogger,
+      async () => fakeResult(),
+    );
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:doc-truth',
+      reason: expect.stringContaining('config'),
+    });
+  });
+
+  it('reports the ENV-disabled reason', async () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    process.env.LIEN_REVIEW_DOC_PASS = '0';
+    const reportSkip = vi.fn();
+    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => fakeResult());
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:doc-truth',
+      reason: expect.stringContaining('LIEN_REVIEW_DOC_PASS'),
+    });
+  });
+
+  it('reports "no doc claims" only when that is the actual reason', async () => {
+    const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]); // no claims
+    const reportSkip = vi.fn();
+    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => fakeResult());
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:doc-truth',
+      reason: expect.stringContaining('no doc claims'),
+    });
+  });
+
+  it('reports a FAILED outcome (not silence) when the client throws', async () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const reportSkip = vi.fn();
+    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => {
+      throw new Error('boom');
+    });
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:doc-truth',
+      reason: expect.stringContaining('failed: boom'),
+    });
+  });
+
+  it('does not report anything when the pass runs to completion', async () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const reportSkip = vi.fn();
+    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => fakeResult());
+    expect(reportSkip).not.toHaveBeenCalled();
   });
 });

--- a/packages/review/test/review-pr-scope.test.ts
+++ b/packages/review/test/review-pr-scope.test.ts
@@ -1,0 +1,118 @@
+/**
+ * End-to-end `reviewPullRequest` coverage for the attestation's `scope`
+ * field — the exact ambiguity that let #572/#754 through (a full-repo
+ * complexity scan misattributed as PR-scoped). Only the clone and GitHub API
+ * boundary are mocked; complexity analysis runs for real against a temp
+ * checkout so the eligibility-path branching is exercised, not re-described.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { silentLogger } from '../src/test-helpers.js';
+import type { ReviewCoreContext } from '../src/review-pr.js';
+
+const { cloneBySha } = vi.hoisted(() => ({ cloneBySha: vi.fn() }));
+vi.mock('../src/clone.js', () => ({ cloneBySha }));
+
+const githubApi = vi.hoisted(() => ({
+  getPRChangedFiles: vi.fn(),
+  getPRPatchData: vi.fn(async () => ({ patches: new Map(), diffLines: new Map() })),
+  updatePRDescription: vi.fn(async () => {}),
+}));
+vi.mock('../src/github-api.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/github-api.js')>();
+  return { ...actual, ...githubApi };
+});
+
+const { reviewPullRequest } = await import('../src/review-pr.js');
+
+async function makeCheckout(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'lien-review-pr-test-'));
+  await writeFile(
+    join(dir, 'foo.ts'),
+    'export function add(a: number, b: number): number {\n  return a + b;\n}\n',
+    'utf8',
+  );
+  return { dir, cleanup: async () => rm(dir, { recursive: true, force: true }) };
+}
+
+function baseCtx(overrides?: Partial<ReviewCoreContext>): ReviewCoreContext {
+  return {
+    octokit: {} as ReviewCoreContext['octokit'],
+    pr: {
+      owner: 'o',
+      repo: 'r',
+      pullNumber: 1,
+      title: 'Test PR',
+      baseSha: 'base-sha',
+      headSha: 'head-sha',
+    },
+    headRepoFullName: 'o/r',
+    baseRepoFullName: 'o/r',
+    token: 'tok',
+    config: {
+      threshold: '15',
+      blockOnNewErrors: false,
+      reviewTypes: { complexity: true, summary: false, architectural: false, bugs: false },
+    },
+    llm: null,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+describe('reviewPullRequest — scope.eligibilityPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    githubApi.getPRPatchData.mockResolvedValue({ patches: new Map(), diffLines: new Map() });
+    githubApi.updatePRDescription.mockResolvedValue(undefined);
+  });
+
+  it('is "zero_files_early_exit" when the PR touches no analyzable files and summary is off', async () => {
+    githubApi.getPRChangedFiles.mockResolvedValue(['README.md']);
+    const checkout = await makeCheckout();
+    cloneBySha.mockResolvedValueOnce(checkout);
+
+    const result = await reviewPullRequest(baseCtx());
+
+    expect(result.attestation.scope.eligibilityPath).toBe('zero_files_early_exit');
+    expect(result.attestation.verdict).toBe('delivered');
+    expect(cloneBySha).toHaveBeenCalledTimes(1); // only the head clone — base is never attempted
+    await checkout.cleanup();
+  });
+
+  it('is "full_repo_fallback" when the PR touches no analyzable files but summary is on', async () => {
+    githubApi.getPRChangedFiles.mockResolvedValue(['README.md']);
+    const checkout = await makeCheckout();
+    cloneBySha.mockResolvedValueOnce(checkout);
+
+    const result = await reviewPullRequest(
+      baseCtx({
+        config: {
+          threshold: '15',
+          blockOnNewErrors: false,
+          reviewTypes: { complexity: true, summary: true, architectural: false, bugs: false },
+        },
+      }),
+    );
+
+    expect(result.attestation.scope.eligibilityPath).toBe('full_repo_fallback');
+    await checkout.cleanup();
+  });
+
+  it('is "normal" when the PR touches analyzable files', async () => {
+    githubApi.getPRChangedFiles.mockResolvedValue(['foo.ts']);
+    const headCheckout = await makeCheckout();
+    cloneBySha.mockResolvedValueOnce(headCheckout);
+    // Base clone: reject — runAnalysisPhase swallows this into baselineReport:null.
+    cloneBySha.mockRejectedValueOnce(new Error('base clone skipped in test'));
+
+    const result = await reviewPullRequest(baseCtx());
+
+    expect(result.attestation.scope.eligibilityPath).toBe('normal');
+    expect(result.attestation.scope.filesAnalyzed).toBe(1);
+    await headCheckout.cleanup();
+  });
+});

--- a/packages/review/test/review-pr-scope.test.ts
+++ b/packages/review/test/review-pr-scope.test.ts
@@ -5,10 +5,11 @@
  * boundary are mocked; complexity analysis runs for real against a temp
  * checkout so the eligibility-path branching is exercised, not re-described.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { silentLogger } from '../src/test-helpers.js';
 import type { ReviewCoreContext } from '../src/review-pr.js';
@@ -19,7 +20,8 @@ vi.mock('../src/clone.js', () => ({ cloneBySha }));
 const githubApi = vi.hoisted(() => ({
   getPRChangedFiles: vi.fn(),
   getPRPatchData: vi.fn(async () => ({ patches: new Map(), diffLines: new Map() })),
-  updatePRDescription: vi.fn(async () => {}),
+  updatePRDescription: vi.fn(async () => true),
+  removePRDescriptionSection: vi.fn(async () => true),
 }));
 vi.mock('../src/github-api.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/github-api.js')>();
@@ -67,7 +69,8 @@ describe('reviewPullRequest — scope.eligibilityPath', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     githubApi.getPRPatchData.mockResolvedValue({ patches: new Map(), diffLines: new Map() });
-    githubApi.updatePRDescription.mockResolvedValue(undefined);
+    githubApi.updatePRDescription.mockResolvedValue(true);
+    githubApi.removePRDescriptionSection.mockResolvedValue(true);
   });
 
   it('is "zero_files_early_exit" when the PR touches no analyzable files and summary is off', async () => {

--- a/packages/review/test/review-pr-usage.test.ts
+++ b/packages/review/test/review-pr-usage.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression coverage for the CodeRabbit #768 finding: `reportUsage` fires
+ * once per agent-client pass (the main review, and on doc-touching PRs the
+ * doc-truth second pass), and `review-pr.ts` used to ASSIGN the latest call's
+ * usage instead of accumulating it — so the run's reported spend silently
+ * reflected only whichever pass reported last, dropping the other entirely.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { accumulateUsage, type AgentUsage } from '../src/review-pr.js';
+
+describe('accumulateUsage', () => {
+  it('sums every field across two usage snapshots', () => {
+    const main: AgentUsage = {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      cost: 0.01,
+    };
+    const docTruth: AgentUsage = {
+      promptTokens: 20,
+      completionTokens: 10,
+      totalTokens: 30,
+      cost: 0.002,
+    };
+
+    expect(accumulateUsage(main, docTruth)).toEqual({
+      promptTokens: 120,
+      completionTokens: 60,
+      totalTokens: 180,
+      cost: 0.012,
+    });
+  });
+
+  it('is a no-op when accumulating onto a zero baseline (the single-pass case)', () => {
+    const zero: AgentUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 };
+    const only: AgentUsage = { promptTokens: 5, completionTokens: 5, totalTokens: 10, cost: 0.001 };
+
+    expect(accumulateUsage(zero, only)).toEqual(only);
+  });
+});


### PR DESCRIPTION
## Why

PR #764 showed the exact trust gap this closes: a total OpenRouter provider
failure (every request 402'd) produced a correct-looking failure badge, but
`fail-on: never`'s default advisory policy still collapsed the check to
green, because "the review never ran" (an operational failure) and "the
review ran and found nothing" (an advisory clean pass) were indistinguishable
downstream of `findings`. #765 already fixed the conclusion-flip for that one
state (`providerFailure` → hard fail regardless of `fail-on`) — this PR does
NOT touch that. It builds the general-purpose receipt the fix should have
had from the start: a versioned JSON attestation answering "did this review
actually happen and reach the PR" for every run, not just the 402 case.

The design's inventory (`.wip/attestation-design.md`) found the same "did it
happen" ambiguity in five more places already computed somewhere in the
pipeline but never surfaced structurally: token budget allocated vs. spent
(no consumer could tell "spent 240K of 250K, starved" from "finished early"),
whether a plugin or the doc-truth pass silently didn't run, findings produced
vs. actually posted, and — the two real bugs below — inline comments
attempted vs. delivered, and the out-of-diff review-comment path's inability
to observe its own success.

## What changed

**Two discard-point fixes** (the design's §1 inventory):
1. `engine.ts`'s `postPluginInlineComments` — already used `PostReviewResult`'s
   real `posted`/`dropped` on `main` (the design's line numbers were stale by
   the time I read the code), but didn't expose `attempted`/`deduped`
   separately. Widened its return shape and added an engine-level
   `present()` delivery tracker that aggregates the ground truth across all
   plugin calls.
2. `PresentContext.postReviewComment` was `Promise<void>` — the out-of-diff
   review-comment path (agent/index.ts) could structurally never know if its
   post succeeded. Now returns `{ posted: boolean; error?: string }`; the one
   call site and its engine-side implementation (try/catch instead of an
   uncaught throw) are updated. Its outcome feeds
   `delivery.outOfDiffReviewPosted`.

**New `packages/review/src/attestation.ts`** — pure, zero-I/O assembly:
```jsonc
{
  "attestationVersion": 1,
  "run": { "conclusion": "success|failure|neutral", "filesAnalyzed": 12 },
  "provider": { "passes": [{ "name": "main", "ran": true, "stopReason": "completed|budget|max_turns|error|not_run", "neverRan": false }] },
  "budget": { "allocatedTokens": 250000, "spentTokens": 238412, "starved": false },
  "passesSkipped": [{ "plugin": "agent-review", "reason": "requires LLM but none configured" }],
  "delivery": {
    "annotationsEmitted": 4,
    "inlineComments": { "attempted": 6, "posted": 4, "dropped": 2, "deduped": 0 },
    "descriptionBadge": { "updated": true },
    "outOfDiffReviewPosted": null
  },
  "scope": { "eligibilityPath": "normal|zero_files_early_exit|full_repo_fallback", "filesAnalyzed": 12 },
  "verdict": "delivered|degraded:provider_partial|degraded:budget_starved|degraded:comments_dropped|failed:provider_never_ran|failed:analysis_error"
}
```
`provider.passes[]`'s single `main` entry is derived from the SAME
`hasProviderFailure`/`incomplete`/`stopReason` metadata `#738` already
attaches to findings — no new detection logic. `budget.allocatedTokens` is
threaded via a new optional `context.reportBudget` callback from
`agent/index.ts` (the FINAL post-blast-radius-scaled ceiling, not the
pre-scaling estimate `review-pr.ts` computes) — same out-of-band-reporting
pattern as the existing `reportUsage`/`reportTrace`. `passesSkipped` is fed
by a new `context.reportSkip` callback, called from the engine's activation
loop (plugin-level skips) and from the agent plugin (the doc-truth pass's own
gate, `shouldRunDocTruthPass`).

**Emission** (4 places, per the design's §3):
- `action/src/summary.ts`: a collapsed `<details><summary>Delivery
  attestation</summary>` block in the step summary — pretty-printed JSON,
  zero cost when collapsed.
- `review-pr.ts`: when `verdict !== 'delivered'`, a compact line
  (`Attested: <verdict> · 4/6 comments posted · 238K/250K tokens`) posted as
  its own `<!-- attestation -->`-marked PR-description section (see open
  question 1 below for why it's a separate section, not folded into the
  existing lien-stats block).
- `action/src/index.ts`: the full JSON logged inside the existing `group('Lien
  Review')` (open question 3 — reused rather than a dedicated group).
- `action.yml` / `writeOutputs`: a new `attestation` JSON-string output.

**Conclusion policy unchanged.** This PR does not touch `exitCodeFor` or any
exit-code logic — v1 attestation only observes and reports. The sole
check-flipping state remains `providerFailure` (#765); a `failed:*` or
`degraded:*` verdict renders loudly (step summary, PR description, log,
output) but stays advisory under `fail-on`.

## Open-question calls (from `.wip/attestation-design.md` §5)

1. **`degraded:comments_dropped` is its own verdict bucket** (not folded into
   `delivered`), per the design's leaning — dropped comments are the exact
   #558/#752 failure class, so they get visibility rather than fail-open
   silence. I also added a 5th bucket the design didn't anticipate,
   `failed:analysis_error`, for the pre-engine "couldn't build a complexity
   report" pipeline failure — without it that path would have misleadingly
   attested `delivered`.
2. **`attestationVersion` compatibility**: went with the design's second
   option (the action's own version pin, `ghcr.io/getlien/lien-review:v1`,
   is the compatibility boundary) — no shim added. A breaking schema change
   bumps `attestationVersion` and is a new action major.
3. **Action log emission reuses the existing `group('Lien Review')`** rather
   than a dedicated group, per the design's leaning.

One call the design didn't pose as a question: `budget.starved` is simply
`stopReason === 'budget'` rather than the design's proposed
"spent within N% of allocated AND stopReason==budget" — the discrete stop
reason already means the same thing, so the percentage threshold would have
added a knob with no added signal.

## Harness evidence

`packages/review/src/plugins/agent/index.ts` is touched (two `reportBudget`/
`reportSkip` calls + one new import), so the harness-evidence gate applies.
No prompt-affecting file (`rules.ts`, `system-prompt.ts`, `tools.ts`, etc.)
was changed, so existing `--calibrate 10` certifications remain valid:
rendered prompts are byte-identical across all 23 fixtures, so calibration
inputs are provably unchanged and there is nothing new to re-certify.
Byte-diff proof: rendered `build-prompts.ts` output (system prompt + initial
message + rule selection) for all 23 fixtures on disk, `origin/main` vs this
branch's `HEAD`, via a second git worktree checked out at `origin/main`
(sequential-checkout method, no destructive checkout in the working
worktree) with the same fixture corpus copied over for a fair comparison.
**23/23 byte-identical** after normalizing the (legitimately
absolute-path-dependent) `fixturePath` field. Temporary worktree removed;
`git status` confirmed clean afterward.

**Addendum (CodeRabbit review-findings pass):** the doc-truth pass's
skip/failure reporting was reworked (`doc-truth-pass.ts` / `plugins/agent/
index.ts`) to fix a CodeRabbit finding (the pre-run gate check misreported
config/env-disabled as "no doc claims", and a thrown pass-2 error vanished
from the attestation instead of being reported) — reporting/telemetry only,
no change to prompt-building code. Re-ran the byte-diff proof, this time
against the *actual merge-base* (`0088f0e`) rather than `origin/main`'s
current tip: `origin/main` has since advanced with an unrelated PR (#770,
a new error-swallowing signal) that changes rendered prompts for 2 of the 23
fixtures on its own, which would have been a false positive for this PR's
diff specifically. Against the correct base, **23/23 byte-identical** (same
method: second detached worktree, same fixture corpus by absolute path, no
destructive checkout in the working worktree; both comparison worktrees
removed afterward, `git status` clean).

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `test` all green
across `parser`, `core`, `review`, `cli`, `action`. `lien delta` exits 0 (no
new-over-threshold or crossed functions — `buildPresentContext` and
`analyzeAndPresent` actually improved after extracting helpers to stay under
budget). No changeset: `@liendev/review` and `@liendev/action` are both
`"private": true`.

## Tests

- `attestation.test.ts` — pure unit coverage of every verdict state
  (delivered, degraded:budget_starved, degraded:provider_partial,
  degraded:comments_dropped, failed:provider_never_ran,
  failed:analysis_error) plus precedence and the empty/pipeline-failed
  factories.
- `engine-delivery.test.ts` — proves `present()`'s delivery counts reflect
  `PostReviewResult` truth (a batch-validation 422 → per-comment salvage
  scenario: 2 attempted, 1 posted, 1 dropped) and that
  `postReviewComment`'s new return value/tracker are correct on both success
  and failure.
- `review-pr-scope.test.ts` — first integration coverage of
  `reviewPullRequest` itself (previously zero): all three `eligibilityPath`
  branches end-to-end, with only the clone/GitHub-API boundary mocked (real
  complexity analysis runs against a temp checkout).
- `action/test/finish-run.test.ts` + `summary.test.ts` — attestation reaches
  the step summary and the JSON output.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 6 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 23 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 6 | +24 |


> [!WARNING]
> **2 issues found** · Medium Risk
>
> This PR introduces a versioned delivery-attestation JSON receipt that surfaces provider health, token budget, inline-comment delivery, PR-description updates, and an overall verdict. The new attestation.ts is pure assembly over existing pipeline signals; engine.ts widens postPluginInlineComments to expose attempted/dropped/deduped counts and makes postReviewComment observable; review-pr.ts and the action wire the receipt into the step summary, PR description, action output, and logs. Two real bugs remain in the delivery-tracking paths: a failed check-run finalization is still reported as having emitted annotations, and a plugin analyze() crash is invisible to the attestation so the main pass is misreported as completed.
>
> - New packages/review/src/attestation.ts assembles a v1 JSON receipt from existing engine/agent/post metadata.
> - engine.ts tracks real delivery counts via PresentDelivery and makes postReviewComment return its delivery outcome.
> - review-pr.ts builds the attestation from run telemetry and posts a compact badge only when verdict is not delivered.
> - Action emits the full attestation in a collapsed step-summary block and as a new attestation output.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit f9dded3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a machine-readable delivery attestation for every review run, including provider status, token budget, review scope, comment delivery, and overall verdict.
  * GitHub Actions now expose the attestation as an output and display it in the step summary and logs.
  * Reviews can display a compact delivery-status badge when results are incomplete or degraded.
  * Delivery tracking now distinguishes posted, dropped, skipped, and deduplicated comments, including out-of-diff review comments.

* **Bug Fixes**
  * Delivery results now reflect actual posting outcomes rather than attempted comment counts.
  * Added clearer reporting when review passes are skipped or providers fail to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
