### PR TITLE
feat(review): deterministic undiscriminated-catch signal for error-swallowing

### DIFF
--- a/packages/review/src/catch-discrimination-signals.ts
+++ b/packages/review/src/catch-discrimination-signals.ts
@@ -1,0 +1,571 @@
+/**
+ * Deterministic "undiscriminated catch" signal for PR reviews.
+ *
+ * Provenance: PR #752 (this repo) — `postPRReview`'s catch block salvaged
+ * EVERY `createReview` error (auth, rate-limit, 5xx, network) the same way
+ * it salvaged the one 422 anchor-validation failure the fallback was
+ * designed for, silently degrading an infra outage into a success-shaped
+ * `{posted: 0, dropped: <all>}` result instead of rethrowing. CodeRabbit
+ * caught it same-SHA; Lien Review's `error-swallowing` rule did not (3-vote
+ * baseline: 0/3 — see
+ * `test/harness/fixtures/error-swallowing/pr752-undiscriminated-catch-salvage`).
+ *
+ * The rule asks the agent to notice, for each catch block, whether it
+ * actually discriminates between error classes before choosing to degrade
+ * instead of rethrow — a judgment call that's easy to skip when a catch's
+ * *shape* (try/catch, some logging, a fallback call) reads as "handled" at
+ * a glance. This module pre-computes the STRUCTURAL fact instead, mirroring
+ * the `<stale_literal_candidates>` / `<removed_exports>` precedents: find
+ * every catch clause the diff ADDS or MODIFIES, and flag it when:
+ *   (a) its body never inspects the caught error's type/class/status (no
+ *       `instanceof`, no `.status`/`.code`/`.name`/etc. on the caught
+ *       binding);
+ *   (b) it does not unconditionally rethrow — the last statement not
+ *       nested inside a conditional block is not a `throw` (so at least one
+ *       path degrades instead of propagating); and
+ *   (c) it does something beyond pure logging — a call or a value-returning
+ *       `return` (an actual fallback/degrade path, not just "log and let it
+ *       fall through").
+ * A catch clause with NO binding (`catch { ... }`) is never flagged: it
+ * cannot discriminate by construction (there is no reference to check), and
+ * it is also an extremely common, usually-correct idiom for a best-effort
+ * probe ("any failure here means use the safe default") — the byte-diff
+ * census run while building this module caught it over-firing on exactly
+ * that shape in this repo's own `worktree.ts`/`overlay-backend.ts` before
+ * this exclusion was added.
+ *
+ * The result is injected as an `<undiscriminated_catch_candidates>` block
+ * so the agent confirms a handed-to-it candidate instead of re-reading
+ * every catch body itself.
+ *
+ * v1 scope: TS/JS only, operating on the changed-file chunks the engine
+ * already parses (`context.chunks`) — text/light-parsing (brace-depth
+ * tracking to isolate a catch body, no full AST), consistent with this
+ * file's siblings. Known limitations, kept honest rather than papered over:
+ *  - Bindingless catches are never flagged (see above) — a true positive
+ *    that happens to omit the binding (rare; nothing to check against
+ *    anyway) is invisible to this scan by design.
+ *  - "discrimination" is a shallow textual check on the bound identifier.
+ *    A check performed via a helper function (`if (isRetryable(err))`) is
+ *    invisible to this scan — it will still flag such a catch.
+ *  - "rethrows" is approximated as "the last statement not nested in a
+ *    block is a throw", not full control-flow/exhaustiveness analysis. A
+ *    body that rethrows inside a non-trailing branch (rather than as a
+ *    trailing statement) can still be flagged as a false positive.
+ *  - Catches with no textual overlap with the diff's added/changed lines
+ *    (i.e. untouched by this PR) are never considered, regardless of shape.
+ *  - Catch-shaped text inside a comment or string literal is excluded via a
+ *    masking pre-pass (see `maskNonCode`) — found over-firing on this
+ *    repo's own `.assertions.ts` fixtures, whose docstrings quote code
+ *    snippets like `catch { return false; }` as narrative prose.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A catch clause this PR added or modified that appears to degrade indiscriminately. */
+export interface UndiscriminatedCatchCandidate {
+  file: string;
+  /** Line of the `catch` keyword. */
+  line: number;
+  /** Line of the catch block's closing brace. */
+  endLine: number;
+  /** The caught binding's identifier, or null for a bindingless `catch { }`. */
+  binding: string | null;
+  /** One-line explanation of why this catch was flagged. */
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max candidates reported — keeps the prompt compact. */
+const MAX_CANDIDATES = 10;
+
+/** Files whose diffs we parse (this repo's TS/JS surface — v1 scope). */
+const TS_JS_FILE_RE = /\.(?:[cm]?[jt]sx?)$/;
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/** Matches a `catch`, with an optional (possibly typed) binding, up to its opening `{`. */
+const CATCH_RE = /\bcatch\s*(?:\(\s*([A-Za-z_$][\w$]*)\s*(?::\s*[^)]+)?\s*\))?\s*\{/g;
+
+const GENERIC_DISCRIMINATION_RE = /\binstanceof\b/;
+const BINDING_PROPERTY_SUFFIX = 'status|code|name|statusCode|errno|type';
+
+/** A trailing, unconditional (not nested in any block) throw statement. */
+const TRAILING_THROW_RE = /\bthrow\b[^;{}]*;\s*$/;
+
+/** A `return` with a non-empty expression — "returns a value" per the design. */
+const RETURN_WITH_VALUE_RE = /\breturn\s+[^\s;][^;]*;/;
+
+const LOGGING_CALL_STATEMENT_RE =
+  /\b(?:console|logger|log)\s*\.\s*(?:debug|info|warn|warning|error|trace|log)\s*\([^)]*\)\s*;?/gi;
+
+/** JS/TS keywords that can precede `(` without being a function call. */
+const CONTROL_KEYWORDS = new Set([
+  'if',
+  'for',
+  'while',
+  'switch',
+  'catch',
+  'return',
+  'throw',
+  'function',
+  'typeof',
+  'instanceof',
+  'new',
+  'do',
+  'try',
+  'yield',
+  'await',
+  'void',
+  'delete',
+  'in',
+  'of',
+]);
+
+// ---------------------------------------------------------------------------
+// Diff scanning — which new-file lines did this PR add/change?
+// ---------------------------------------------------------------------------
+
+/** Mutable new-file line cursor threaded through {@link applyPatchLine}. */
+interface LineCursor {
+  newLine: number;
+}
+
+/**
+ * Apply one raw unified-diff line to the cursor/line-set: advance past hunk
+ * headers and `+++`/`---`/no-newline markers, record `+` lines as touched,
+ * and advance the new-file counter for `+` and context lines (`-` lines
+ * don't advance it and are never "touched" in the new file). Split out of
+ * {@link computeTouchedLines} so the per-file loop stays flat.
+ */
+function applyPatchLine(raw: string, cursor: LineCursor, lines: Set<number>): void {
+  const header = raw.match(HUNK_HEADER_RE);
+  if (header) {
+    cursor.newLine = parseInt(header[1], 10);
+    return;
+  }
+  if (raw.startsWith('+++') || raw.startsWith('---')) return;
+  if (raw.startsWith('\\')) return; // "\ No newline at end of file"
+
+  if (raw.startsWith('+')) {
+    lines.add(cursor.newLine);
+    cursor.newLine++;
+  } else if (!raw.startsWith('-')) {
+    cursor.newLine++; // context line
+  }
+}
+
+/**
+ * Walk each file's unified-diff patch and collect the new-file line numbers
+ * it adds or changes (the `+` lines). Mirrors the equivalent step in
+ * stale-literal-signals.ts.
+ */
+function computeTouchedLines(patches: Map<string, string>): Map<string, Set<number>> {
+  const touched = new Map<string, Set<number>>();
+
+  for (const [file, patch] of patches) {
+    const lines = new Set<number>();
+    const cursor: LineCursor = { newLine: 0 };
+    for (const raw of patch.split('\n')) applyPatchLine(raw, cursor, lines);
+    touched.set(file, lines);
+  }
+
+  return touched;
+}
+
+/** Union patch-derived touched lines with any caller-provided diffLines. */
+function mergeTouchedLines(
+  patchLines: Map<string, Set<number>>,
+  provided: Map<string, Set<number>> | undefined,
+): Map<string, Set<number>> {
+  const merged = new Map<string, Set<number>>();
+  for (const [file, set] of patchLines) merged.set(file, new Set(set));
+  if (provided) {
+    for (const [file, set] of provided) {
+      const existing = merged.get(file) ?? new Set<number>();
+      for (const n of set) existing.add(n);
+      merged.set(file, existing);
+    }
+  }
+  return merged;
+}
+
+function rangeOverlaps(start: number, end: number, touched: Set<number>): boolean {
+  for (let line = start; line <= end; line++) {
+    if (touched.has(line)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Light parsing — isolate a catch clause's body from chunk text
+// ---------------------------------------------------------------------------
+
+/** Skip a quoted string/template literal (any of `'`, `"`, `` ` ``), returning the index after it. */
+function skipStringLike(text: string, i: number): number {
+  const quote = text[i];
+  i++;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * If `i` sits at the start of a string/template literal or a `//`/`/* *‍/`
+ * comment, return the index just past it; otherwise null (nothing to skip).
+ * Shared by {@link findMatchingBrace} and {@link extractTopLevelText} so
+ * neither duplicates string/comment-skipping in its own depth-tracking loop.
+ */
+function skipNonStructural(text: string, i: number): number | null {
+  const ch = text[i];
+  if (ch === '"' || ch === "'" || ch === '`') return skipStringLike(text, i);
+  if (ch === '/' && text[i + 1] === '/') {
+    const j = text.indexOf('\n', i);
+    return j === -1 ? text.length : j;
+  }
+  if (ch === '/' && text[i + 1] === '*') {
+    const j = text.indexOf('*/', i + 2);
+    return j === -1 ? text.length : j + 2;
+  }
+  return null;
+}
+
+/**
+ * Given the index of an opening `{`, find the index of its matching `}`,
+ * skipping over string/template literals and comments so stray brace-like
+ * characters inside them don't confuse the depth count. Returns -1 if the
+ * braces never balance (malformed/truncated source — bail rather than guess).
+ */
+function findMatchingBrace(text: string, openIdx: number): number {
+  let depth = 0;
+  let i = openIdx;
+  while (i < text.length) {
+    const skipped = skipNonStructural(text, i);
+    if (skipped !== null) {
+      i = skipped;
+      continue;
+    }
+    const ch = text[i];
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      i++;
+      if (depth === 0) return i - 1;
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Extract only the depth-0 text of a block body — i.e. everything NOT
+ * nested inside a further `{...}` (an `if`/`for`/`try`/etc. block). This is
+ * what lets us ask "is the code that ALWAYS runs, regardless of any
+ * conditional inside this catch, a trailing throw?" without full
+ * control-flow analysis: a nested block's content is opaque to this scan,
+ * but its header (e.g. `if (comments.length === 0)`) stays, since only `{`
+ * and `}` affect depth.
+ */
+function extractTopLevelText(body: string): string {
+  let depth = 0;
+  let i = 0;
+  let out = '';
+  while (i < body.length) {
+    const skipped = skipNonStructural(body, i);
+    if (skipped !== null) {
+      if (depth === 0) out += body.slice(i, skipped);
+      i = skipped;
+      continue;
+    }
+    const ch = body[i];
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth = Math.max(0, depth - 1);
+      i++;
+      continue;
+    }
+    if (depth === 0) out += ch;
+    i++;
+  }
+  return out;
+}
+
+function countNewlines(text: string, upTo: number): number {
+  let n = 0;
+  for (let i = 0; i < upTo; i++) {
+    if (text[i] === '\n') n++;
+  }
+  return n;
+}
+
+/**
+ * Replace every string/template literal and comment span in `text` with
+ * same-length whitespace (preserving newlines, so absolute line numbers
+ * computed from the result still match the original). Used so the literal
+ * word "catch" inside a docstring or a quoted code example — real content in
+ * this repo's own `.assertions.ts` fixtures — never matches {@link CATCH_RE}.
+ * Indices into the masked string line up 1:1 with the original, so callers
+ * can find-match on the masked text but slice the ORIGINAL for real content.
+ */
+function maskNonCode(text: string): string {
+  let i = 0;
+  let out = '';
+  while (i < text.length) {
+    const skipped = skipNonStructural(text, i);
+    if (skipped === null) {
+      out += text[i];
+      i++;
+      continue;
+    }
+    for (let j = i; j < skipped; j++) out += text[j] === '\n' ? '\n' : ' ';
+    i = skipped;
+  }
+  return out;
+}
+
+interface RawCatchMatch {
+  binding: string | null;
+  startLine: number;
+  endLine: number;
+  body: string;
+}
+
+/** Find every REAL (non-comment, non-string) catch clause in one chunk's content. */
+function findCatchClauses(chunk: CodeChunk): RawCatchMatch[] {
+  const { content, metadata } = chunk;
+  const masked = maskNonCode(content);
+  const results: RawCatchMatch[] = [];
+
+  for (const m of masked.matchAll(CATCH_RE)) {
+    const openIdx = m.index + m[0].length - 1; // index of the matched '{'
+    const closeIdx = findMatchingBrace(content, openIdx);
+    if (closeIdx === -1) continue; // unbalanced — skip rather than guess
+
+    results.push({
+      binding: m[1] ?? null,
+      startLine: metadata.startLine + countNewlines(content, m.index),
+      endLine: metadata.startLine + countNewlines(content, closeIdx),
+      body: content.slice(openIdx + 1, closeIdx),
+    });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic — does this catch body degrade indiscriminately?
+// ---------------------------------------------------------------------------
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** (a) Does the body ever inspect the caught error's type/class/status? */
+function hasDiscrimination(body: string, binding: string | null): boolean {
+  if (GENERIC_DISCRIMINATION_RE.test(body)) return true;
+  if (!binding) return false;
+  const re = new RegExp(`\\b${escapeRegExp(binding)}\\s*\\.\\s*(?:${BINDING_PROPERTY_SUFFIX})\\b`);
+  return re.test(body);
+}
+
+/** (b) Is the last statement NOT nested in a conditional block an unconditional throw? */
+function endsWithUnconditionalThrow(topLevelText: string): boolean {
+  return TRAILING_THROW_RE.test(topLevelText.trim());
+}
+
+/** Remove logging-call statements so what's left only reflects "real" actions. */
+function stripLoggingCalls(text: string): string {
+  return text.replace(LOGGING_CALL_STATEMENT_RE, '');
+}
+
+/** Does `text` contain a call to something other than a JS/TS keyword? */
+function hasNonKeywordCall(text: string): boolean {
+  for (const m of text.matchAll(/\b([A-Za-z_$][\w$]*)\s*\(/g)) {
+    if (!CONTROL_KEYWORDS.has(m[1])) return true;
+  }
+  return false;
+}
+
+/** (c) Does the body do something beyond pure logging (a call, or a value-returning return)? */
+function hasDegradeAction(strippedTopLevelText: string): boolean {
+  return RETURN_WITH_VALUE_RE.test(strippedTopLevelText) || hasNonKeywordCall(strippedTopLevelText);
+}
+
+/**
+ * Classify one catch body. Returns a one-line reason when it should be
+ * flagged as an undiscriminated-degrade candidate, or null when it's exempt
+ * (no binding to discriminate on, discriminates by error type, unconditionally
+ * rethrows, or only logs). Exposed for direct unit testing of the heuristic,
+ * independent of diff/chunk plumbing.
+ */
+export function classifyCatchBody(binding: string | null, body: string): string | null {
+  // A bindingless `catch { ... }` cannot discriminate by construction — there
+  // is no reference to check `.status`/`.code`/instanceof against. This is
+  // also an extremely common, usually-correct idiom in this repo (a
+  // best-effort probe that treats every failure as "use the safe default":
+  // `catch { return standalone; }`, `catch { return []; }`) — measured via
+  // this module's own byte-diff census on real fixtures. v1 stays silent on
+  // it rather than mislabel that pattern as a bug the agent should "fix" by
+  // adding a check that would never make sense here.
+  if (!binding) return null;
+
+  if (hasDiscrimination(body, binding)) return null;
+
+  const topLevel = extractTopLevelText(body);
+  if (endsWithUnconditionalThrow(topLevel)) return null;
+
+  const stripped = stripLoggingCalls(topLevel);
+  if (!hasDegradeAction(stripped)) return null; // pure logging (or no-op) — not a degrade path
+
+  return (
+    `treats every error class alike (no instanceof/.status/.code/.name check on the caught \`${binding}\`) ` +
+    'and degrades via a fallback instead of rethrowing'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate every catch clause found in one chunk against `fileTouched`,
+ * pushing a candidate for each one that overlaps the diff and classifies as
+ * a degrade. `seen` dedupes by `file:line` across chunks whose ranges
+ * overlap (e.g. an enclosing chunk and a nested one), split out of
+ * {@link computeUndiscriminatedCatches} so its own loop stays flat.
+ */
+function collectCandidatesFromChunk(
+  chunk: CodeChunk,
+  fileTouched: Set<number>,
+  seen: Set<string>,
+  candidates: UndiscriminatedCatchCandidate[],
+): void {
+  const file = chunk.metadata.file;
+  for (const found of findCatchClauses(chunk)) {
+    if (!rangeOverlaps(found.startLine, found.endLine, fileTouched)) continue;
+
+    const key = `${file}:${found.startLine}`;
+    if (seen.has(key)) continue; // overlapping chunks (e.g. nested) can revisit the same catch
+
+    const reason = classifyCatchBody(found.binding, found.body);
+    if (!reason) continue;
+
+    seen.add(key);
+    candidates.push({
+      file,
+      line: found.startLine,
+      endLine: found.endLine,
+      binding: found.binding,
+      reason,
+    });
+  }
+}
+
+/**
+ * Find every catch clause this PR adds or modifies that appears to degrade
+ * indiscriminately. Returns [] when there is no diff or no changed-file
+ * chunks to scan. Exposed for testing.
+ */
+export function computeUndiscriminatedCatches(
+  context: ReviewContext,
+): UndiscriminatedCatchCandidate[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+  const chunks = context.chunks;
+  if (!chunks || chunks.length === 0) return [];
+
+  const touchedLines = mergeTouchedLines(computeTouchedLines(patches), context.pr?.diffLines);
+
+  const seen = new Set<string>();
+  const candidates: UndiscriminatedCatchCandidate[] = [];
+
+  for (const chunk of chunks) {
+    if (!TS_JS_FILE_RE.test(chunk.metadata.file)) continue;
+    const fileTouched = touchedLines.get(chunk.metadata.file);
+    if (!fileTouched || fileTouched.size === 0) continue;
+    collectCandidatesFromChunk(chunk, fileTouched, seen, candidates);
+  }
+
+  candidates.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const HEADER =
+  'Pre-computed by a deterministic diff scan — the catch-clause discovery is ' +
+  'done for you; do not re-read every catch block from scratch looking for this. ' +
+  'Each entry is a catch clause this PR added or modified that appears to treat ' +
+  'every error class alike (no instanceof/.status/.code/.name check on the ' +
+  'caught binding) and does not unconditionally rethrow — it falls through to a ' +
+  'fallback/degrade path instead. Confirm before reporting: if the degrade path ' +
+  'is only correct for ONE error class (e.g. one specific HTTP status) while ' +
+  'other classes (auth, rate-limit, 5xx, network) take the identical path, ' +
+  'that is error-swallowing — report it. If the catch genuinely handles every ' +
+  'error the same way correctly, stay silent.';
+
+function renderEntry(c: UndiscriminatedCatchCandidate): string {
+  const bindingLabel = c.binding ? `\`${c.binding}\`` : '(no binding)';
+  return `- ${c.file}:${c.line}-${c.endLine} — caught as ${bindingLabel}: ${c.reason}`;
+}
+
+/**
+ * Render undiscriminated-catch candidates as an
+ * `<undiscriminated_catch_candidates>` block for the agent's initial
+ * message. Returns '' when there are no candidates so callers can append
+ * unconditionally. Caps at MAX_CANDIDATES with an explicit omission note —
+ * never truncates silently. Exposed for testing.
+ */
+export function renderUndiscriminatedCatchCandidates(
+  candidates: UndiscriminatedCatchCandidate[],
+): string {
+  if (candidates.length === 0) return '';
+
+  const lines: string[] = ['<undiscriminated_catch_candidates>', HEADER];
+  const shown = candidates.slice(0, MAX_CANDIDATES);
+  for (const c of shown) lines.push(renderEntry(c));
+
+  const omitted = candidates.length - shown.length;
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more candidate(s) omitted to respect the input budget — inspect the diff for the rest]`,
+    );
+  }
+
+  lines.push('</undiscriminated_catch_candidates>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<undiscriminated_catch_candidates>` section from the review
+ * context. Returns '' when the PR adds/modifies no catch clause that fits
+ * the shape, or there's no diff/changed-file chunks to scan.
+ */
+export function renderUndiscriminatedCatchSection(context: ReviewContext): string {
+  return renderUndiscriminatedCatchCandidates(computeUndiscriminatedCatches(context));
+}

--- a/packages/review/src/catch-discrimination-signals.ts
+++ b/packages/review/src/catch-discrimination-signals.ts
@@ -58,6 +58,15 @@
  *    masking pre-pass (see `maskNonCode`) — found over-firing on this
  *    repo's own `.assertions.ts` fixtures, whose docstrings quote code
  *    snippets like `catch { return false; }` as narrative prose.
+ *  - Masking treats a whole template literal (backtick string) as opaque,
+ *    including any `${...}` interpolation slots — real, executing code that
+ *    can itself contain a discrimination check (e.g. `` `LLM error:
+ *    ${err instanceof Error ? err.message : String(err)}` ``, used only to
+ *    format a log message, found via this module's own census against
+ *    `voting.ts`). Such a check is invisible to criterion (a), so a catch
+ *    that only inspects the error inside an interpolation slot is still
+ *    flagged as a candidate — the agent's own read of the actual code is
+ *    the backstop, per this block's "confirm before reporting" framing.
  */
 
 import type { CodeChunk } from '@liendev/parser';
@@ -98,11 +107,30 @@ const CATCH_RE = /\bcatch\s*(?:\(\s*([A-Za-z_$][\w$]*)\s*(?::\s*[^)]+)?\s*\))?\s
 const GENERIC_DISCRIMINATION_RE = /\binstanceof\b/;
 const BINDING_PROPERTY_SUFFIX = 'status|code|name|statusCode|errno|type';
 
-/** A trailing, unconditional (not nested in any block) throw statement. */
-const TRAILING_THROW_RE = /\bthrow\b[^;{}]*;\s*$/;
+// Both patterns make the trailing `;` optional so an ASI-style statement —
+// legal JS, common outside this repo's own Prettier `semi: true` style — is
+// still recognized instead of silently falling through as "no match".
 
-/** A `return` with a non-empty expression — "returns a value" per the design. */
-const RETURN_WITH_VALUE_RE = /\breturn\s+[^\s;][^;]*;/;
+/**
+ * A trailing, unconditional (not nested in any block) throw statement. Not
+ * multiline — `$` must anchor to the true end of the (already-trimmed)
+ * input, not merely the end of some earlier line, since this specifically
+ * asks "is the LAST statement a throw", not "does a throw exist somewhere".
+ * No `{}` exclusion: by the time text reaches this check it has already
+ * been through {@link extractTopLevelText}, which elides hidden control-block
+ * content entirely — any brace still present here belongs to a transparent
+ * value literal (e.g. `throw wrapError(err, 'msg', { dbPath });`) and must
+ * not stop the match.
+ */
+const TRAILING_THROW_RE = /\bthrow\b[^;]*;?\s*$/;
+
+/**
+ * A `return` with a non-empty expression — "returns a value" per the
+ * design. Multiline: this is an existence check (does a value-return appear
+ * ANYWHERE in the top-level text), so `$` matching each line's end lets an
+ * ASI-style return be found regardless of where it sits in the body.
+ */
+const RETURN_WITH_VALUE_RE = /\breturn\s+[^\s;][^;\n]*(?:;|$)/m;
 
 const LOGGING_CALL_STATEMENT_RE =
   /\b(?:console|logger|log)\s*\.\s*(?:debug|info|warn|warning|error|trace|log)\s*\([^)]*\)\s*;?/gi;
@@ -277,40 +305,76 @@ function findMatchingBrace(text: string, openIdx: number): number {
 }
 
 /**
- * Extract only the depth-0 text of a block body — i.e. everything NOT
- * nested inside a further `{...}` (an `if`/`for`/`try`/etc. block). This is
- * what lets us ask "is the code that ALWAYS runs, regardless of any
- * conditional inside this catch, a trailing throw?" without full
- * control-flow analysis: a nested block's content is opaque to this scan,
- * but its header (e.g. `if (comments.length === 0)`) stays, since only `{`
- * and `}` affect depth.
+ * Trailing context after which a `{` opens an object-literal VALUE (e.g.
+ * `return { posted: 0 }`, `fn({ a: 1 })`, `x = { ... }`) rather than a
+ * control-flow block. Anchored to the end of the text emitted so far.
  */
+const VALUE_BRACE_CONTEXT_RE = /(?:\breturn|[=,([:])\s*$/;
+
+/** Whether a `{` right after `emittedSoFar` opens a value literal, not a control block. */
+function opensValueLiteral(emittedSoFar: string): boolean {
+  return emittedSoFar.trim() === '' || VALUE_BRACE_CONTEXT_RE.test(emittedSoFar);
+}
+
+/**
+ * Extract only the visible text of a block body — i.e. everything NOT
+ * nested inside a control-flow block (`if`/`for`/`try`/`else`/a function
+ * body/etc.). This is what lets us ask "is the code that ALWAYS runs,
+ * regardless of any conditional inside this catch, a trailing throw?"
+ * without full control-flow analysis: a nested block's content is opaque to
+ * this scan, but its header (e.g. `if (comments.length === 0)`) stays.
+ *
+ * An object-literal VALUE brace (`return { posted: 0, dropped: [] };`) is
+ * NOT a control block — hiding it would make a degrade-via-object-return
+ * invisible to {@link hasDegradeAction}. `opensValueLiteral` distinguishes
+ * the two by what precedes the `{`; only braces nested inside an ALREADY
+ * hidden control block are exempt from this check (their content is opaque
+ * either way, so the distinction stops mattering once hidden).
+ */
+/** Running state for {@link extractTopLevelText}'s single pass. */
+interface ExtractCursor {
+  /** Count of enclosing CONTROL blocks currently open (content hidden while > 0). */
+  hiddenDepth: number;
+  out: string;
+}
+
+/**
+ * Apply one `{`/`}` structural character to the cursor: a `{` either opens a
+ * transparent value literal (appended, {@link hiddenDepth} unchanged) or
+ * enters/deepens a hidden control block; a `}` closes whichever is
+ * currently open. Split out of {@link extractTopLevelText} so its own loop
+ * stays flat.
+ */
+function applyBraceChar(ch: '{' | '}', cursor: ExtractCursor): void {
+  if (ch === '{') {
+    if (cursor.hiddenDepth > 0) cursor.hiddenDepth++;
+    else if (opensValueLiteral(cursor.out)) cursor.out += ch;
+    else cursor.hiddenDepth = 1;
+    return;
+  }
+  if (cursor.hiddenDepth > 0) cursor.hiddenDepth--;
+  else cursor.out += ch; // closing a transparent value literal
+}
+
 function extractTopLevelText(body: string): string {
-  let depth = 0;
+  const cursor: ExtractCursor = { hiddenDepth: 0, out: '' };
   let i = 0;
-  let out = '';
   while (i < body.length) {
     const skipped = skipNonStructural(body, i);
     if (skipped !== null) {
-      if (depth === 0) out += body.slice(i, skipped);
+      if (cursor.hiddenDepth === 0) cursor.out += body.slice(i, skipped);
       i = skipped;
       continue;
     }
     const ch = body[i];
-    if (ch === '{') {
-      depth++;
-      i++;
-      continue;
+    if (ch === '{' || ch === '}') {
+      applyBraceChar(ch, cursor);
+    } else if (cursor.hiddenDepth === 0) {
+      cursor.out += ch;
     }
-    if (ch === '}') {
-      depth = Math.max(0, depth - 1);
-      i++;
-      continue;
-    }
-    if (depth === 0) out += ch;
     i++;
   }
-  return out;
+  return cursor.out;
 }
 
 function countNewlines(text: string, upTo: number): number {
@@ -432,9 +496,14 @@ export function classifyCatchBody(binding: string | null, body: string): string 
   // adding a check that would never make sense here.
   if (!binding) return null;
 
-  if (hasDiscrimination(body, binding)) return null;
+  // Mask comments/strings ONCE up front so every check below only sees real
+  // code: a comment like `// check err.status before degrading` must not
+  // exempt a catch that never actually inspects the error at runtime.
+  const masked = maskNonCode(body);
 
-  const topLevel = extractTopLevelText(body);
+  if (hasDiscrimination(masked, binding)) return null;
+
+  const topLevel = extractTopLevelText(masked);
   if (endsWithUnconditionalThrow(topLevel)) return null;
 
   const stripped = stripLoggingCalls(topLevel);

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -153,7 +153,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
     }
 
     const systemPrompt = buildSystemPrompt(rules);
-    const initialMessage = buildInitialMessage(context, { blastRadius });
+    const initialMessage = buildInitialMessage(context, { blastRadius, rules });
     const result = await runAgentClient(
       provider,
       config,

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -16,6 +16,7 @@ import type { ReviewContext } from '../../plugin-types.js';
 import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
+import { renderUndiscriminatedCatchSection } from '../../catch-discrimination-signals.js';
 import { renderRemovedExportsSection } from '../../removed-export-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
@@ -175,6 +176,13 @@ const MAX_DIFF_CHARS = 50_000;
 export interface BuildInitialMessageOptions {
   /** Pre-computed blast-radius report to inject as a `<blast_radius>` block. */
   blastRadius?: BlastRadiusReport | null;
+  /**
+   * Rules active for this run. Used to gate rule-scoped signal injection —
+   * e.g. `<undiscriminated_catch_candidates>` only makes sense to compute
+   * and render when `error-swallowing` is actually active for this PR.
+   * Omit (CLI callers that don't resolve rules) to skip that gating.
+   */
+  rules?: ResolvedRules;
 }
 
 /**
@@ -196,6 +204,9 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderBlastRadius(opts));
   appendIfPresent(sections, renderRemovedExportsSection(context));
   appendIfPresent(sections, renderStaleLiteralSection(context));
+  if (isRuleActive(opts.rules, 'error-swallowing')) {
+    appendIfPresent(sections, renderUndiscriminatedCatchSection(context));
+  }
   appendIfPresent(sections, renderUntrustedInputSection(context));
   appendIfPresent(sections, renderRenameSweepSection(context));
   appendIfPresent(sections, renderGuidanceSurfaceSection(context));
@@ -209,6 +220,17 @@ export function buildInitialMessage(
 
 function appendIfPresent(sections: string[], value: string | null): void {
   if (value) sections.push(value);
+}
+
+/**
+ * Whether `ruleId` is among this run's active rules. Used to gate a
+ * rule-scoped signal (computing and rendering it is only worth the cost
+ * when the rule it feeds is actually going to see the result). `rules`
+ * is optional — callers that don't resolve rules (none currently) would
+ * skip the gated signal entirely rather than risk rendering it unchecked.
+ */
+function isRuleActive(rules: ResolvedRules | undefined, ruleId: string): boolean {
+  return rules?.active.some(r => r.id === ruleId) ?? false;
 }
 
 function renderPrMetadata(context: ReviewContext): string | null {

--- a/packages/review/test/catch-discrimination-signals.test.ts
+++ b/packages/review/test/catch-discrimination-signals.test.ts
@@ -158,6 +158,51 @@ describe('classifyCatchBody', () => {
     const body = '    return fallbackResult();';
     expect(classifyCatchBody(null, body)).toBeNull();
   });
+
+  it('flags a catch that degrades via an object-literal return value (real #752 return shape)', () => {
+    // Found missed by an earlier version: the brace-depth tracker treated
+    // the object literal's own `{}` as a hidden nested block, stripping its
+    // content and defeating the value-returning-return check regardless of
+    // the trailing semicolon. Caught by Lien Review's own CI pass on this PR.
+    const body = [
+      '    logger.warning(`batch failed: ${error}`);',
+      '    return { posted: 0, dropped: comments };',
+    ].join('\n');
+    expect(classifyCatchBody('error', body)).not.toBeNull();
+  });
+
+  it('flags a degrading return with no trailing semicolon (ASI)', () => {
+    const body = '    return fallbackResult()';
+    expect(classifyCatchBody('error', body)).not.toBeNull();
+  });
+
+  it('does not flag a catch that rethrows with no trailing semicolon (ASI)', () => {
+    const body = ['    logger.error(err)', '    throw err'].join('\n');
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
+
+  it('does not let a comment fake a discrimination check', () => {
+    // Found missed by an earlier version: hasDiscrimination scanned the raw
+    // (unmasked) body, so a comment merely mentioning `err.status` or
+    // `instanceof` exempted a catch that never actually inspects the error
+    // at runtime. Caught by Lien Review's own CI pass on this PR.
+    const body = [
+      '    // check err.status / instanceof before degrading, but we never do',
+      '    return fallback();',
+    ].join('\n');
+    expect(classifyCatchBody('err', body)).not.toBeNull();
+  });
+
+  it('does not flag a rethrow whose call argument is an object literal', () => {
+    // Regression: fixing the object-literal-return visibility (see above)
+    // made `{}` characters appear in topLevelText for value literals, which
+    // broke TRAILING_THROW_RE's original `[^;{}]*` exclusion — a real
+    // rethrow like `throw wrapError(err, 'msg', { dbPath });` (found via
+    // this module's own byte-diff census against overlay-backend.ts) was
+    // no longer recognized as ending in a throw once braces became visible.
+    const body = "    throw wrapError(err, 'Failed to initialize', { dbPath: this.dbPath });";
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/catch-discrimination-signals.test.ts
+++ b/packages/review/test/catch-discrimination-signals.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { ReviewRule, ResolvedRules } from '../src/plugins/agent/types.js';
+import {
+  classifyCatchBody,
+  computeUndiscriminatedCatches,
+  renderUndiscriminatedCatchCandidates,
+  renderUndiscriminatedCatchSection,
+} from '../src/catch-discrimination-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+  };
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  chunks?: CodeChunk[];
+  diffLines?: Map<string, Set<number>>;
+}): ReviewContext {
+  const pr =
+    opts.patches || opts.diffLines
+      ? { patches: opts.patches, diffLines: opts.diffLines }
+      : undefined;
+  return { pr, chunks: opts.chunks ?? [], changedFiles: [] } as unknown as ReviewContext;
+}
+
+function errorSwallowingRule(): ReviewRule {
+  return {
+    id: 'error-swallowing',
+    name: 'Silent Error Swallowing',
+    description: 'test rule',
+    prompt: 'test prompt',
+    triggers: { always: true },
+    severity: 'error',
+    category: 'error_handling',
+    enabled: true,
+    source: 'builtin',
+  };
+}
+
+function resolvedRulesWith(...ids: string[]): ResolvedRules {
+  return {
+    active: ids.map(id => ({ ...errorSwallowingRule(), id })),
+    skipped: [],
+  };
+}
+
+/** All-added unified diff hunk header for a brand-new N-line file. */
+function addedHunk(lineCount: number): string {
+  return `@@ -0,0 +1,${lineCount} @@`;
+}
+
+function asAddedPatch(content: string): string {
+  const lines = content.split('\n').map(l => `+${l}`);
+  return [addedHunk(lines.length), ...lines].join('\n');
+}
+
+// The canonical PR #752 shape: a batch catch that only rethrows when
+// comments.length === 0, and otherwise unconditionally falls back to
+// postBodyThenRetryCommentsIndividually — regardless of WHY createReview
+// failed (auth, rate-limit, 5xx, network all take the same path as a 422).
+const PR752_FUNCTION = [
+  'export async function postPRReview(octokit, prContext, comments, summaryBody, logger, event) {',
+  '  try {',
+  '    await octokit.pulls.createReview(reviewParams);',
+  '    return { posted: comments.length, dropped: [] };',
+  '  } catch (error) {',
+  '    if (comments.length === 0) {',
+  '      throw error;',
+  '    }',
+  '    logger.warning(`Failed to post line comments as a batch: ${error}`);',
+  '    return postBodyThenRetryCommentsIndividually(',
+  '      octokit,',
+  '      prContext,',
+  '      comments,',
+  '      summaryBody,',
+  '      logger,',
+  '      event,',
+  '    );',
+  '  }',
+  '}',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// classifyCatchBody — the pure heuristic
+// ---------------------------------------------------------------------------
+
+describe('classifyCatchBody', () => {
+  it('flags the PR #752 shape: guard-rethrow on an unrelated condition, degrade otherwise', () => {
+    const body = [
+      '    if (comments.length === 0) {',
+      '      throw error;',
+      '    }',
+      '    logger.warning(`batch failed: ${error}`);',
+      '    return postBodyThenRetryCommentsIndividually(octokit, prContext, comments);',
+    ].join('\n');
+    const reason = classifyCatchBody('error', body);
+    expect(reason).not.toBeNull();
+    expect(reason).toMatch(/every error class alike/);
+  });
+
+  it('does not flag a catch that discriminates via instanceof, even with no rethrow', () => {
+    const body = [
+      '    if (err instanceof ValidationError) {',
+      '      return degrade();',
+      '    }',
+      '    return fallback();',
+    ].join('\n');
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
+
+  it('does not flag a catch that discriminates via a status check on the caught binding', () => {
+    const body = [
+      '    if (err.status === 422) {',
+      '      return degrade();',
+      '    }',
+      '    return fallback();',
+    ].join('\n');
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
+
+  it('does not flag a catch that unconditionally rethrows at the end', () => {
+    const body = ['    logger.error(err);', '    throw err;'].join('\n');
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
+
+  it('does not flag a catch that only logs (no degrade action)', () => {
+    const body = "    logger.error('failed', err);";
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
+
+  it('does not flag a catch that logs and returns nothing (bare return)', () => {
+    const body = ['    logger.error(err);', '    return;'].join('\n');
+    expect(classifyCatchBody('err', body)).toBeNull();
+  });
+
+  it('does not flag a bindingless catch, even one that degrades — no reference to discriminate on', () => {
+    // The common "best-effort probe, safe default on ANY failure" idiom
+    // (e.g. worktree.ts's `catch { return standalone; }`) — legitimately
+    // correct, and there is no binding to check .status/.code/instanceof
+    // against even in principle. Found over-firing on this exact shape via
+    // the byte-diff census against this repo's own fixtures.
+    const body = '    return fallbackResult();';
+    expect(classifyCatchBody(null, body)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeUndiscriminatedCatches — diff + chunk wiring
+// ---------------------------------------------------------------------------
+
+describe('computeUndiscriminatedCatches', () => {
+  it('returns [] when there is no diff', () => {
+    const context = makeContext({ chunks: [makeChunk('src/a.ts', 1, PR752_FUNCTION)] });
+    expect(computeUndiscriminatedCatches(context)).toEqual([]);
+  });
+
+  it('returns [] when there are no chunks', () => {
+    const patches = new Map([['src/a.ts', asAddedPatch(PR752_FUNCTION)]]);
+    expect(computeUndiscriminatedCatches(makeContext({ patches }))).toEqual([]);
+  });
+
+  it('flags the PR #752 shape when the whole function is added by the diff', () => {
+    const patches = new Map([['src/github-api.ts', asAddedPatch(PR752_FUNCTION)]]);
+    const chunks = [makeChunk('src/github-api.ts', 1, PR752_FUNCTION)];
+    const candidates = computeUndiscriminatedCatches(makeContext({ patches, chunks }));
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].file).toBe('src/github-api.ts');
+    expect(candidates[0].binding).toBe('error');
+    expect(candidates[0].line).toBe(5); // the `} catch (error) {` line
+  });
+
+  it('does not flag a catch whose lines the diff never touches', () => {
+    // Diff only touches the function signature line (line 1); the catch
+    // block (lines 5-18) is pre-existing, unchanged code.
+    const patch = [
+      '@@ -1,1 +1,1 @@',
+      '-export async function postPRReview(octokit, prContext, comments, summaryBody, logger) {',
+      '+export async function postPRReview(octokit, prContext, comments, summaryBody, logger, event) {',
+    ].join('\n');
+    const patches = new Map([['src/github-api.ts', patch]]);
+    const chunks = [makeChunk('src/github-api.ts', 1, PR752_FUNCTION)];
+    expect(computeUndiscriminatedCatches(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('ignores non-TS/JS files (v1 scope)', () => {
+    const patches = new Map([['src/lib.rs', asAddedPatch(PR752_FUNCTION)]]);
+    const chunks = [makeChunk('src/lib.rs', 1, PR752_FUNCTION)];
+    expect(computeUndiscriminatedCatches(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('does not flag catch-shaped text inside a comment/docstring (not real code)', () => {
+    // This exact shape was found over-firing against this repo's own
+    // .assertions.ts fixtures, whose docstrings narrate a PR's bug by
+    // quoting its code, e.g. "wrapped in try { ... } catch { return false; }".
+    const source = [
+      '/**',
+      ' * PR #411 — PaymentService::charge wrapped in try { ... } catch { return',
+      ' * false; }. Throws are silently converted to a `false` result.',
+      ' */',
+      'export function real() {',
+      '  try {',
+      '    doThing();',
+      '  } catch (err) {',
+      '    if (err instanceof ValidationError) return null;',
+      '    throw err;',
+      '  }',
+      '}',
+    ].join('\n');
+    const patches = new Map([['src/annotated.ts', asAddedPatch(source)]]);
+    const chunks = [makeChunk('src/annotated.ts', 1, source)];
+    // The only REAL catch clause discriminates + rethrows -> no candidates,
+    // and specifically none anchored inside the docstring's line range.
+    expect(computeUndiscriminatedCatches(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('handles multiple catch clauses independently: one flagged, one exempt', () => {
+    const source = [
+      'export function a() {',
+      '  try {',
+      '    doA();',
+      '  } catch (err) {',
+      '    if (err instanceof ValidationError) {',
+      '      return null;',
+      '    }',
+      '    throw err;',
+      '  }',
+      '}',
+      '',
+      'export function b() {',
+      '  try {',
+      '    doB();',
+      '  } catch (err) {',
+      '    return fallback();',
+      '  }',
+      '}',
+    ].join('\n');
+    const patches = new Map([['src/two.ts', asAddedPatch(source)]]);
+    const chunks = [makeChunk('src/two.ts', 1, source)];
+    const candidates = computeUndiscriminatedCatches(makeContext({ patches, chunks }));
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].line).toBe(15); // the second function's catch
+  });
+
+  it('dedupes when overlapping chunks cover the same catch clause', () => {
+    const patches = new Map([['src/github-api.ts', asAddedPatch(PR752_FUNCTION)]]);
+    // Two chunks both containing the full function (e.g. an enclosing +
+    // nested chunk) must not produce two candidates for the same catch.
+    const chunks = [
+      makeChunk('src/github-api.ts', 1, PR752_FUNCTION),
+      makeChunk('src/github-api.ts', 1, PR752_FUNCTION),
+    ];
+    const candidates = computeUndiscriminatedCatches(makeContext({ patches, chunks }));
+    expect(candidates).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderUndiscriminatedCatchCandidates — rendering + explicit truncation
+// ---------------------------------------------------------------------------
+
+describe('renderUndiscriminatedCatchCandidates', () => {
+  it('returns empty string for no candidates', () => {
+    expect(renderUndiscriminatedCatchCandidates([])).toBe('');
+  });
+
+  it('renders the block naming file:line and the caught binding', () => {
+    const rendered = renderUndiscriminatedCatchCandidates([
+      {
+        file: 'src/github-api.ts',
+        line: 5,
+        endLine: 18,
+        binding: 'error',
+        reason: 'treats every error class alike and degrades via a fallback instead of rethrowing',
+      },
+    ]);
+    expect(rendered).toContain('<undiscriminated_catch_candidates>');
+    expect(rendered).toContain('src/github-api.ts:5-18');
+    expect(rendered).toContain('`error`');
+    expect(rendered).toContain('</undiscriminated_catch_candidates>');
+  });
+
+  it('caps at MAX_CANDIDATES with an explicit omission note — never truncates silently', () => {
+    const many = Array.from({ length: 14 }, (_, i) => ({
+      file: `src/f${i}.ts`,
+      line: 10,
+      endLine: 20,
+      binding: 'err',
+      reason: 'treats every error class alike and degrades via a fallback instead of rethrowing',
+    }));
+    const rendered = renderUndiscriminatedCatchCandidates(many);
+
+    const shownCount = many.slice(0, 10).length;
+    for (let i = 0; i < shownCount; i++) expect(rendered).toContain(`src/f${i}.ts`);
+    expect(rendered).toContain('+4 more candidate(s) omitted');
+    expect(rendered).not.toContain('src/f13.ts');
+  });
+
+  it('omits the truncation note entirely when under the cap', () => {
+    const rendered = renderUndiscriminatedCatchCandidates([
+      { file: 'src/a.ts', line: 1, endLine: 5, binding: 'err', reason: 'x' },
+    ]);
+    expect(rendered).not.toContain('omitted');
+  });
+});
+
+describe('renderUndiscriminatedCatchSection', () => {
+  it("returns '' when there is no diff or no chunks", () => {
+    expect(renderUndiscriminatedCatchSection(makeContext({}))).toBe('');
+  });
+
+  it('renders candidates found from context', () => {
+    const patches = new Map([['src/github-api.ts', asAddedPatch(PR752_FUNCTION)]]);
+    const chunks = [makeChunk('src/github-api.ts', 1, PR752_FUNCTION)];
+    const rendered = renderUndiscriminatedCatchSection(makeContext({ patches, chunks }));
+    expect(rendered).toContain('<undiscriminated_catch_candidates>');
+    expect(rendered).toContain('src/github-api.ts:5-18');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring — gated on the error-swallowing rule
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection (rule-gated)', () => {
+  const patches = new Map([['src/github-api.ts', asAddedPatch(PR752_FUNCTION)]]);
+  const chunks = [makeChunk('src/github-api.ts', 1, PR752_FUNCTION)];
+
+  it('includes the block when error-swallowing is active and candidates exist', () => {
+    const context = makeContext({ patches, chunks });
+    const message = buildInitialMessage(context, { rules: resolvedRulesWith('error-swallowing') });
+    expect(message).toContain('<undiscriminated_catch_candidates>');
+  });
+
+  it('omits the block when rules are not provided at all', () => {
+    const context = makeContext({ patches, chunks });
+    const message = buildInitialMessage(context);
+    expect(message).not.toContain('<undiscriminated_catch_candidates>');
+  });
+
+  it('omits the block when error-swallowing is not among the active rules', () => {
+    const context = makeContext({ patches, chunks });
+    const message = buildInitialMessage(context, {
+      rules: resolvedRulesWith('boundary-change', 'edge-case-sweep'),
+    });
+    expect(message).not.toContain('<undiscriminated_catch_candidates>');
+  });
+
+  it('omits the block when the rule is active but no candidates are found', () => {
+    const context = makeContext({ chunks: [] });
+    const message = buildInitialMessage(context, { rules: resolvedRulesWith('error-swallowing') });
+    expect(message).not.toContain('<undiscriminated_catch_candidates>');
+  });
+});

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -30,7 +30,7 @@ async function main(): Promise<void> {
   const rules = selectRules(BUILTIN_RULES, triggerCtx);
 
   const systemPrompt = buildSystemPrompt(rules);
-  const initialMessage = buildInitialMessage(ctx, { blastRadius: null });
+  const initialMessage = buildInitialMessage(ctx, { blastRadius: null, rules });
 
   const output = {
     fixturePath,


### PR DESCRIPTION
## Provenance

On PR #752 (this repo, `fix(review): stop silently dropping inline comments when batch review fails`), `postPRReview`'s catch block in `packages/review/src/github-api.ts` salvaged **every** `octokit.pulls.createReview` error — auth/401, rate-limit/429, 5xx, plain network errors — the same way it salvaged the one 422 anchor-validation failure the fallback (`postBodyThenRetryCommentsIndividually`) was actually designed for. An infrastructure outage got silently repackaged as a success-shaped `{ posted: 0, dropped: <all> }` result instead of rethrowing.

CodeRabbit caught this same-SHA (2026-07-15). Lien Review's live run on the identical commit produced 4 unrelated findings and missed it. The captured, sanitized fixture (`packages/review/test/harness/fixtures/error-swallowing/pr752-undiscriminated-catch-salvage`) measured a **0/3 baseline** on the prod default model (`moonshotai/kimi-k2.7-code`) — see the fixture's own header for the full miss analysis and the capture-bug (stale `lien-stats` badge leak) found and fixed while building it.

This PR is the first conversion of that miss-frontier into a deterministic, zero-LLM signal — the same design pattern as `stale-literal-signals.ts` / `removed-export-signals.ts`.

## Detection heuristic (`packages/review/src/catch-discrimination-signals.ts`)

Pure, deterministic, zero-LLM. Scans the PR's diff patches + the changed-file chunks the engine already parses (`context.chunks`). For each catch clause the diff **adds or modifies** (any line in its span overlaps a `+` line), flags it when:

- **(a)** the body never inspects the caught error's type/class/status — no `instanceof`, no `.status`/`.code`/`.name`/`.statusCode`/`.errno`/`.type` on the caught binding;
- **(b)** it does not unconditionally rethrow — the last statement not nested inside a conditional block is not a `throw` (approximated via a brace-depth "top-level text" extraction, not full control-flow analysis); and
- **(c)** it does something beyond pure logging — a call or a value-returning `return` (an actual fallback/degrade path).

Emitted as an `<undiscriminated_catch_candidates>` block (capped at 10 entries with an explicit "+N more omitted" note — never silently truncated), gated on the `error-swallowing` rule being active for the run (threaded through `buildInitialMessage`'s new `rules` option, mirroring how `requiresBlastRadius` gates blast-radius computation).

**v1 scope and stated limits (kept honest in the module's own doc comment):**
- TS/JS only, text/light-parsing (brace-depth tracking), no full AST.
- **Bindingless catches (`catch { ... }`) are never flagged** — they cannot discriminate by construction (no reference to check), and are also an extremely common, usually-*correct* idiom in this repo (`catch { return standalone; }` in `worktree.ts`, `catch { return []; }` in `overlay-backend.ts` — "any failure here means use the safe default"). The byte-diff census below caught this signal over-firing on exactly that shape before the exclusion was added.
- Catch-shaped text inside a comment/string is excluded via a masking pre-pass — the census also caught this repo's own `.assertions.ts` fixtures (whose docstrings narrate a bug by quoting code, e.g. `catch { return false; }`) being misdetected as real catch clauses.
- "Discrimination via a helper function" (`if (isRetryable(err))`) is invisible to this scan — it will still flag such a catch.
- "Rethrows" is a last-statement heuristic, not exhaustive control-flow analysis — a body that rethrows inside a non-trailing branch can still be a false positive.

## Byte-diff census (gate 4)

Rendered `build-prompts.ts` for all 22 fixtures present on disk (of 23 total; `doc-truth/pr711-changeset-export-claim` couldn't be regenerated — its recorded `--sha` is no longer within the PR's commit range, a pre-existing stale-header issue unrelated to this change), origin/main vs this branch.

**First pass** surfaced exactly the over-firing described above: 3 fixtures gained the block (`pr752-undiscriminated-catch-salvage` — the intended target — plus `doc-truth/pr667-worktree-doc-drift` and `untrusted-input-validation/harness-initial`, both via bindingless-catch and comment-text false positives). Both exclusions above were added in response, and the census was re-run.

**Final result: exactly 1 of 22 fixtures gains the block** — `error-swallowing/pr752-undiscriminated-catch-salvage`, pointing precisely at `packages/review/src/github-api.ts:272-287` (the real bug site). All other 21 fixtures render byte-identical prompts pre/post-change.

## Calibration (gate 5)

Since the census proves only `pr752-undiscriminated-catch-salvage`'s rendered prompt changes at all, calibration was scoped to that one fixture (the other 3 `error-swallowing` fixtures are byte-identical pre/post-change, so re-spending on them can only reconfirm already-documented, unaffected numbers — `payment-error-swallowed` is a separately-documented 10/10 canary, and the two negative-regression fixtures are unrelated to catch-discrimination). This keeps spend inside the task's $2 hard cap while still measuring the one fixture that could actually move.

`npm run test:harness -w @liendev/review -- --fixture .../pr752-undiscriminated-catch-salvage.fixture.json --calibrate 10` (prod default model, no `--model` override):

**5/10** — up from an effective 0/10 baseline. This fixture is tagged `characterization` (non-gating per the harness's own convention — a known frontier, not yet required to hit the 9/10 bar) and stays that way; 5/10 is real, substantial lift, not full reliability.

## Lift measurement (gate 6)

`npm run test:harness -w @liendev/review -- --fixture .../pr752-undiscriminated-catch-salvage.fixture.json --votes 3`:

**0/3** on this specific 3-vote sample. Reported honestly per instruction — with a true rate near 50% (per the 5/10 calibration above), a 3-vote sample landing at 0/3 has ~12.5% probability under the binomial and isn't inconsistent with real, substantial lift; it just isn't guaranteed to be visible in every small sample. Ship-or-not is the owner's call — the calibration number (5/10, real improvement from 0/10) and this 3-vote sample (0/3) are both reported without spin.

## Spend

$0.4361 (calibrate 10) + $0.1260 (votes 3) = **$0.5621 total**, against the $2.00 cap. Fixture regeneration (16 lien-repo PRs + 4 cross-repo PRs from werkzeug/starlette) used `capture-pr.ts`, which hits GitHub/git only — no LLM spend.

## Gates

- `npm run format:check` / `npm run lint` (0 errors) / `npm run typecheck` / `npm run build` / `npm test` — all green across `parser`, `core`, `review`, `cli`, `action`.
- `node packages/cli/dist/index.js delta` — exit 0, no complexity crossings (all new functions kept under threshold via extraction; see commit history in this branch if useful).
- 25 new zero-LLM unit tests in `packages/review/test/catch-discrimination-signals.test.ts`: the PR #752 shape, instanceof/status discrimination, unconditional rethrow, pure-logging-only, bindingless exemption, comment-masking, multi-catch, dedup on overlapping chunks, truncation-with-explicit-note, and the rule-gated `buildInitialMessage` wiring.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +1 |


> [!NOTE]
> **Low Risk**
>
> The PR introduces a deterministic, zero-LLM catch-discrimination signal gated on the `error-swallowing` rule, with comprehensive unit tests and proper caller updates. No breaking changes or caller regressions were found: the new `rules` option on `buildInitialMessage` is optional, preserving backward compatibility for any caller that does not resolve rules. The only parse site (`parseInt` on a diff hunk header) is guarded by a regex that captures only digits, so malformed input cannot produce NaN line numbers. The heuristic has documented limitations, but they are acknowledged in the module docstring and do not create wrong output for realistic inputs.
>
> - Adds deterministic catch-discrimination scanner in catch-discrimination-signals.ts
> - Wires renderUndiscriminatedCatchSection into buildInitialMessage gated by the error-swallowing rule
> - Updates production (plugins/agent/index.ts) and harness (build-prompts.ts) callers to pass resolved rules
> - Adds 25 zero-LLM unit tests covering heuristic behavior, diff wiring, rendering, truncation, and rule gating

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 86f866a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

## Findings triage (Lien Review's own CI pass on this PR)

Lien Review flagged 2 issues on the initial commit (both `logic_error`, medium risk overall) — both confirmed real and fixed in a follow-up commit, with regression tests added:

1. **`RETURN_WITH_VALUE_RE` missed object-literal return values.** The brace-depth tracker treated a `return`'s own object-literal value (`return { posted: 0, dropped: comments };` — the actual return shape used by the real `postPRReview` degrade path) the same as a hidden control block, stripping its content regardless of the trailing semicolon. Fixed: `extractTopLevelText` now distinguishes value-literal braces (kept visible) from control-block braces (hidden) via what precedes the `{` (`return`/`=`/`,`/`(`/`[`/`:` → value; everything else → control). Also made both `RETURN_WITH_VALUE_RE` and `TRAILING_THROW_RE` tolerant of ASI (semicolon-omitted) statements, since the reviewer's own suggested fix named the semicolon angle.
2. **`hasDiscrimination` scanned the raw (unmasked) body.** A comment like `// check err.status before degrading` with no real check would incorrectly exempt a catch. Fixed: the body is now masked (comments/strings blanked) once, up front, before all checks.

Fixing (1) surfaced a related regression: making value-literal braces visible broke `TRAILING_THROW_RE`'s own `{}`-exclusion (originally there to avoid crossing into hidden content, now stale) — a real rethrow with an object-literal call argument (`throw wrapError(err, 'msg', { dbPath });`, from `overlay-backend.ts`) stopped being recognized as ending in a throw. Fixed by dropping that exclusion (safe: any brace reaching this check is now, by construction, a visible value literal, never hidden content).

**Updated byte-diff census after both fixes:** re-ran across all 22 fixtures. Still exactly the intended target (`error-swallowing/pr752-undiscriminated-catch-salvage`) plus one additional, judgment-requiring candidate: `untrusted-input-validation/harness-initial` now flags `packages/review/test/harness/voting.ts:41-51`, a catch that uses `err instanceof Error` only inside a template-literal interpolation slot (for message formatting, not control flow) — a documented v1 limitation (masking treats a whole template literal, including its `${...}` code slots, as opaque). This is a legitimate, intentional "treat every LLM/network failure alike" harness pattern, not a bug; the block's own header instructs the agent to stay silent when the catch genuinely handles every error the same way correctly. All other 20 fixtures remain byte-identical.

25 new tests became 30, covering both fixes plus their own regression coverage. Full gate chain (`format:check`/`lint`/`typecheck`/`build`/`test`/`lien delta`) re-run clean after the fixes.
