### PR TITLE
feat(cli,plugin): plan-time complexity nudge before edits

### DIFF
--- a/.changeset/plan-time-nudge.md
+++ b/.changeset/plan-time-nudge.md
@@ -1,0 +1,9 @@
+---
+'@liendev/lien': minor
+---
+
+Add the plan-time complexity nudge — surfacing near/over-budget functions as an imperative warning *before* an agent edits, not just after (`lien delta`) or as inert data (`get_files_context`'s `complexityHeadroom`).
+
+- `get_files_context` gains an optional `complexityHeadroomWarning` string field, spread ahead of `complexityHeadroom` in the response so it's the first thing an agent reads when a function in the file is at/near its complexity budget. Purely additive — `complexityHeadroom` itself is unchanged.
+- `lien annotate` (and therefore the plugin's `annotate-read.sh` read-hook) now computes the same headroom for the file it annotates and, when non-empty, leads the printed annotation with the same shared warning line — reusing `get_files_context`'s exact computation so the two can never disagree. The annotation now also fires (instead of staying silent) when a file has a near-budget function even if it would otherwise look trivial (no dependents, existing test coverage).
+- No new hook: a `PreToolUse:Edit|Write` hook was considered and rejected — per `docs/architecture/claude-code-hook-channels.md`, `PreToolUse` has no channel that delivers model-visible content for `Edit`/`Write` without either doing nothing or blocking the edit outright (`exit 2`). The existing `PostToolUse:Read` annotation hook already fires right before the mandatory `get_files_context` → `Edit` sequence, so it carries the nudge instead — inheriting the existing per-file TTL suppression for free.

--- a/docs/architecture/lien-delta.md
+++ b/docs/architecture/lien-delta.md
@@ -767,3 +767,78 @@ tool's own output, not only in this doc.
   structural index itself is already scoped per `repoId`. A user with several
   worktrees of the same repo gets one independent log per worktree (same
   isolation the index already has), not a merged view.
+
+---
+
+# The plan-time nudge — moving the headroom signal before the write
+
+Everything above (Phase 1, Phase 2, `--base`, the event log) still leaves one
+gap: `lien delta` and `delta-write.sh` both fire **after** code is written.
+Mechanism 3 (`complexityHeadroom` in `get_files_context`, section E above)
+moved the *data* earlier — to the mandatory pre-edit `get_files_context` call —
+but it was still data, not a nudge an agent could miss. This section covers
+turning that data into an unmissable imperative warning, and doing so for the
+*other* mandatory pre-edit moment: reading the file.
+
+## Why not a new `PreToolUse:Edit|Write` hook
+
+The obvious design is a third plugin hook, `PreToolUse` on
+`Edit|Write|MultiEdit`, mirroring `delta-write.sh`'s `PostToolUse` counterpart.
+It doesn't work, per
+[claude-code-hook-channels.md](claude-code-hook-channels.md): `PreToolUse`'s
+only channel that delivers content the model reads is
+`hookSpecificOutput.updatedInput.prompt`, and that's specific to the
+subagent-launch tool (`augment-explore-task.sh` rewrites a launched
+subagent's own prompt) — `Edit`/`Write`'s `tool_input` has `file_path`,
+`old_string`/`new_string` or `content`, never a `prompt` field to rewrite.
+`PreToolUse`'s other channel, `exit 2` + stderr, reaches the model too — but
+by *blocking* the tool call. Using it for an advisory nudge would silently
+convert "steer away from this function" into a hard stop, and would violate
+every existing hook's fail-open discipline (a warning must never block the
+edit).
+
+**Decision:** fall back to the channel that already works. `annotate-read.sh`
+(`PostToolUse:Read`, `additionalContext`) already fires right before the
+mandatory `get_files_context` → `Edit` sequence in the normal agent workflow.
+Enriching its existing annotation reaches the same moment — "before you write"
+— through infrastructure that's already proven to reach the model, with TTL
+suppression inherited for free instead of rebuilt.
+
+## What changed
+
+- **`get-files-context.ts`**: `computeComplexityHeadroom`'s parameter type
+  widened from `SearchResult[]` to a minimal `{ metadata: ChunkMetadata }`
+  shape (`HeadroomInputChunk`) — no behavior change, but now callable with
+  `@liendev/parser`'s `CodeChunk[]` too, which is what `annotate-cmd.ts` has in
+  hand. A new `formatComplexityHeadroomWarning(entries, overflow)` renders the
+  headroom array as one imperative line (`⚠ Lien: <fn> <metric> <value>/<threshold>
+  [(over)], … — avoid adding complexity here; prefer extraction.`), shared by
+  both callers below so the wording can never drift between them.
+- **`get_files_context` response**: gains an optional `complexityHeadroomWarning`
+  string field, spread into the response object *before* `complexityHeadroom`
+  so it's the first thing the agent reads in the serialized JSON. Purely
+  additive — `complexityHeadroom` itself is unchanged, so nothing that already
+  parses it breaks.
+- **`lien annotate` / `annotate-read.sh`**: `annotate-cmd.ts` now computes the
+  same headroom for the file it's annotating (scoped to that file's own
+  chunks — `allChunks` from `findDependents` spans dependents too, so it's
+  filtered down first) and, when non-empty, prepends the shared warning line
+  ahead of the "Lien impact for …" header — literally the first line the
+  agent sees. `isTrivial` gained a fourth `headroomCount` parameter (defaulted
+  to `0` so existing 3-arg callers are unaffected): a near/over-budget function
+  now forces the annotation to print even when dependents/tests/complexity
+  would otherwise call it trivial.
+
+## What was deliberately deferred
+
+A `delta-events.jsonl` entry for "nudge shown" (to let `lien stats` eventually
+correlate warnings-shown against later crossings-flagged) was scoped out of
+this change. `DeltaEvent`'s shape (`mode`, `exitCode`, `counts.crossings`) is
+built around a *delta run*, not a *read-time annotation* — there's no exit
+code or crossings count for "the agent read a file and saw a warning." Fitting
+a nudge event into that shape would mean either overloading `DeltaEvent`'s
+existing fields with meanings they don't have, or introducing a second
+event/log format alongside it — real design work, not a natural extension of
+the current schema. Left as a follow-up once there's a clearer answer for what
+"correlate nudge-shown with later-resolved" should even mean when the nudge
+fires on Read, potentially many turns before any edit happens.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -1,13 +1,27 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
 import os from 'os';
+import * as coreModule from '@liendev/core';
 import {
   annotateCommand,
   isTrivial,
   formatDependents,
   formatTests,
   formatComplexity,
+  withHeadroomWarning,
 } from './annotate-cmd.js';
+
+// Only `createVectorDB` is mocked (and only used by the plan-time-nudge
+// integration block below) — every other integration test in this file
+// exercises the real factory against an empty tmp home. `...actual` keeps
+// `ComplexityAnalyzer` (also imported by annotate-cmd.ts) real throughout.
+vi.mock('@liendev/core', async () => {
+  const actual = await vi.importActual<typeof import('@liendev/core')>('@liendev/core');
+  return {
+    ...actual,
+    createVectorDB: vi.fn(actual.createVectorDB),
+  };
+});
 
 describe('isTrivial', () => {
   it('is trivial when no deps, no complexity, and tests present', () => {
@@ -25,6 +39,38 @@ describe('isTrivial', () => {
 
   it('is non-trivial above the dependent threshold', () => {
     expect(isTrivial(2, 0, 1)).toBe(false);
+  });
+
+  it('defaults headroomCount to 0 — pre-existing 3-arg callers are unaffected', () => {
+    expect(isTrivial(0, 0, 1)).toBe(true);
+  });
+
+  it('is non-trivial when a function is near/over its complexity budget, even otherwise-trivial', () => {
+    expect(isTrivial(0, 0, 1, 1)).toBe(false);
+    expect(isTrivial(1, 0, 1, 2)).toBe(false);
+  });
+
+  it('is trivial when headroomCount is explicitly 0', () => {
+    expect(isTrivial(0, 0, 1, 0)).toBe(true);
+  });
+});
+
+describe('withHeadroomWarning', () => {
+  const lines = ['Lien impact for src/a.ts:', '  • No test coverage.'];
+
+  it('passes lines through unchanged when there are no headroom entries', () => {
+    expect(withHeadroomWarning(lines, { entries: [], overflow: 0 })).toBe(lines);
+  });
+
+  it('prepends the shared nudge line ahead of the existing lines', () => {
+    const result = withHeadroomWarning(lines, {
+      entries: [{ symbol: 'scanPatches', metric: 'cognitive', value: 18, threshold: 15 }],
+      overflow: 0,
+    });
+    expect(result[0]).toBe(
+      '⚠ Lien: scanPatches cognitive 18/15 (over) — avoid adding complexity here; prefer extraction.',
+    );
+    expect(result.slice(1)).toEqual(lines);
   });
 });
 
@@ -151,5 +197,92 @@ describe('annotateCommand (integration)', () => {
     // VectorDB init against an empty tmp home should fail or return empty;
     // either way, the command must not throw or print errors.
     expect(errSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('annotateCommand — plan-time nudge (integration)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  // A real, stable file so `resolvePaths`' existsSync check passes — same
+  // one the "missing index" test above already relies on resolving cleanly.
+  const target = 'packages/cli/src/cli/index.ts';
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    vi.mocked(coreModule.createVectorDB).mockClear();
+  });
+
+  it('leads the printed annotation with the shared headroom nudge line', async () => {
+    const overBudgetChunk = {
+      content: '',
+      metadata: {
+        file: target,
+        startLine: 1,
+        endLine: 20,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'overBudgetFn',
+        symbolType: 'function',
+        cognitiveComplexity: 20,
+        imports: [],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      scanAll: vi.fn().mockResolvedValue([overBudgetChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCommand(target);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const printed = logSpy.mock.calls[0][0] as string;
+    const printedLines = printed.split('\n');
+    expect(printedLines[0]).toBe(
+      '⚠ Lien: overBudgetFn cognitive 20/15 (over) — avoid adding complexity here; prefer extraction.',
+    );
+    expect(printed).toContain(`Lien impact for ${target}:`);
+  });
+
+  it('stays on the non-nudge path (no leading warning line) when nothing is near budget', async () => {
+    const quietChunk = {
+      content: '',
+      metadata: {
+        file: target,
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'tidyFn',
+        symbolType: 'function',
+        cognitiveComplexity: 2,
+        imports: [],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      scanAll: vi.fn().mockResolvedValue([quietChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCommand(target);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    // Still non-trivial (no test coverage), so it prints — but the first line
+    // must be the impact header, not a nudge, since nothing is near budget.
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const printed = logSpy.mock.calls[0][0] as string;
+    expect(printed.split('\n')[0]).toBe(`Lien impact for ${target}:`);
+    expect(printed).not.toContain('avoid adding complexity');
   });
 });

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -7,6 +7,10 @@ import {
   type CodeChunk,
 } from '@liendev/parser';
 import { findDependents, type DependentInfo } from '../mcp/handlers/dependency-analyzer.js';
+import {
+  computeComplexityHeadroom,
+  formatComplexityHeadroomWarning,
+} from '../mcp/handlers/get-files-context.js';
 import { resolveProjectRoot } from './project-root.js';
 import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/paths.js';
 
@@ -21,7 +25,11 @@ const MAX_DEPS_LISTED = 4;
 /**
  * Produce a short impact summary for a single file. Output is empty when
  * impact is trivial (no dependents, no complexity warnings, test coverage
- * present) — that's the signal to the PostToolUse hook to stay silent.
+ * present, no near-budget functions) — that's the signal to the PostToolUse
+ * hook to stay silent. When a function in the file is at/near its complexity
+ * budget, the output leads with an imperative nudge line (shared with
+ * `get_files_context`'s `complexityHeadroomWarning`) — the plan-time nudge:
+ * surfacing it on Read, before the agent edits, not after via `lien delta`.
  *
  * All errors result in empty stdout and exit 0, so a missing index or
  * unknown file never breaks the hook pipeline.
@@ -147,6 +155,14 @@ async function run(file: string): Promise<void> {
     const tests =
       findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
     const complexity = computeComplexitySummary(allChunks, filepath);
+    // Plan-time nudge (mirrors get_files_context's complexityHeadroom): reuses
+    // the exact same computation the MCP tool uses, so a "near budget" verdict
+    // can never disagree between the read-hook annotation and get_files_context.
+    // `allChunks` spans the target file plus its dependents/dependencies, so
+    // filter down to the target file's own chunks first — other files' near-
+    // budget functions must not leak into this file's nudge (mirrors
+    // computeComplexitySummary's own `[filepath]` scoping below).
+    const headroom = computeComplexityHeadroom(allChunks.filter(c => c.metadata.file === filepath));
     const dependentCount = result.dependents.length;
     const uncovered = result.uncoveredProductionDependents;
     // Dependents' max complexity feeds the blast-radius risk score. The
@@ -164,7 +180,9 @@ async function run(file: string): Promise<void> {
       rootDir,
     );
 
-    if (isTrivial(dependentCount, complexity.warningCount, tests.length)) return;
+    if (isTrivial(dependentCount, complexity.warningCount, tests.length, headroom.entries.length)) {
+      return;
+    }
 
     emitAnnotation(
       filepath,
@@ -175,10 +193,25 @@ async function run(file: string): Promise<void> {
       uncovered,
       maxDependentComplexity,
       hasHighComplexityUncovered,
+      headroom,
     );
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
+}
+
+/** Return type of `computeComplexityHeadroom` — the plan-time nudge data. */
+type ComplexityHeadroom = ReturnType<typeof computeComplexityHeadroom>;
+
+/**
+ * Prepend the shared headroom nudge (if any) to the annotation's other lines,
+ * so a near/over-budget function is the first thing the agent reads — not
+ * buried after dependents/test-coverage bullets. Pure and exported so the
+ * wiring is unit-testable without indexing a real project.
+ */
+export function withHeadroomWarning(lines: string[], headroom: ComplexityHeadroom): string[] {
+  const warning = formatComplexityHeadroomWarning(headroom.entries, headroom.overflow);
+  return warning ? [warning, ...lines] : lines;
 }
 
 function emitAnnotation(
@@ -190,6 +223,7 @@ function emitAnnotation(
   uncovered: number,
   maxDependentComplexity: number,
   hasHighComplexityUncovered: boolean,
+  headroom: ComplexityHeadroom,
 ): void {
   const risk = computeBlastRadiusRisk({
     dependentCount,
@@ -207,15 +241,16 @@ function emitAnnotation(
     lines.push(`  • ${formatComplexity(complexity)}`);
   }
 
-  console.log(lines.join('\n'));
+  console.log(withHeadroomWarning(lines, headroom).join('\n'));
 }
 
 export function isTrivial(
   dependentCount: number,
   complexityWarnings: number,
   testCount: number,
+  headroomCount = 0,
 ): boolean {
-  return dependentCount <= 1 && complexityWarnings === 0 && testCount > 0;
+  return dependentCount <= 1 && complexityWarnings === 0 && testCount > 0 && headroomCount === 0;
 }
 
 interface ComplexitySummary {

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -5,6 +5,7 @@ import {
   handleGetFilesContext,
   clearTestAssociationScanCache,
   computeComplexityHeadroom,
+  formatComplexityHeadroomWarning,
 } from './get-files-context.js';
 import type { ToolContext } from '../types.js';
 import type { SearchResult } from '@liendev/core';
@@ -406,6 +407,50 @@ describe('computeComplexityHeadroom (Mechanism 3)', () => {
     expect(entries.map(e => e.symbol)).toEqual(['f7', 'f6', 'f5', 'f4', 'f3']); // worst-first
     expect(overflow).toBe(2);
   });
+
+  it('accepts a minimal { metadata } chunk shape (not just full SearchResult)', () => {
+    // annotate-cmd.ts passes @liendev/parser's CodeChunk (content + metadata,
+    // no score/relevance) — this is what makes that reuse possible.
+    const { entries } = computeComplexityHeadroom([
+      { metadata: makeFnChunk('bareChunk', { cognitive: 18 }).metadata },
+    ]);
+    expect(entries).toEqual([
+      { symbol: 'bareChunk', metric: 'cognitive', value: 18, threshold: 15 },
+    ]);
+  });
+});
+
+describe('formatComplexityHeadroomWarning', () => {
+  it('returns undefined when there are no entries', () => {
+    expect(formatComplexityHeadroomWarning([])).toBeUndefined();
+  });
+
+  it('renders a single near-budget entry as an imperative one-liner', () => {
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'scanPatches', metric: 'cognitive', value: 14, threshold: 15 },
+    ]);
+    expect(warning).toBe(
+      '⚠ Lien: scanPatches cognitive 14/15 — avoid adding complexity here; prefer extraction.',
+    );
+  });
+
+  it('tags an over-threshold entry with "(over)" and joins multiple entries', () => {
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'extractSymbols', metric: 'cognitive', value: 18, threshold: 15 },
+      { symbol: 'helper', metric: 'cyclomatic', value: 13, threshold: 15 },
+    ]);
+    expect(warning).toBe(
+      '⚠ Lien: extractSymbols cognitive 18/15 (over), helper cyclomatic 13/15 — avoid adding complexity here; prefer extraction.',
+    );
+  });
+
+  it('appends an overflow count when more functions are near/over budget than shown', () => {
+    const warning = formatComplexityHeadroomWarning(
+      [{ symbol: 'a', metric: 'cognitive', value: 18, threshold: 15 }],
+      2,
+    );
+    expect(warning).toContain('(+2 more near/over budget)');
+  });
 });
 
 describe('handleGetFilesContext — complexityHeadroom in the response', () => {
@@ -458,5 +503,43 @@ describe('handleGetFilesContext — complexityHeadroom in the response', () => {
     const parsed = JSON.parse(result.content![0].text);
     expect(parsed).not.toHaveProperty('complexityHeadroom');
     expect(parsed).not.toHaveProperty('complexityHeadroomMore');
+  });
+
+  it('leads with complexityHeadroomWarning — the plan-time nudge — before the data field', async () => {
+    const ctx = ctxReturning([makeFnChunk('extractSymbols', { cognitive: 18, file: 'src/a.ts' })]);
+    const result = await handleGetFilesContext(
+      { filepaths: 'src/a.ts', includeRelated: false },
+      ctx,
+    );
+    const text = result.content![0].text as string;
+    const parsed = JSON.parse(text);
+    expect(parsed.complexityHeadroomWarning).toBe(
+      '⚠ Lien: extractSymbols cognitive 18/15 (over) — avoid adding complexity here; prefer extraction.',
+    );
+    // Not just present — it must appear before complexityHeadroom in the
+    // serialized JSON, so it's the first thing the agent reads.
+    expect(text.indexOf('complexityHeadroomWarning')).toBeLessThan(
+      text.indexOf('"complexityHeadroom"'),
+    );
+  });
+
+  it('omits complexityHeadroomWarning entirely when nothing is near budget', async () => {
+    const ctx = ctxReturning([makeFnChunk('tidy', { cognitive: 4, file: 'src/a.ts' })]);
+    const result = await handleGetFilesContext(
+      { filepaths: 'src/a.ts', includeRelated: false },
+      ctx,
+    );
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed).not.toHaveProperty('complexityHeadroomWarning');
+  });
+
+  it('includes complexityHeadroomWarning in the batch (multi-file) response shape too', async () => {
+    const ctx = ctxReturning([makeFnChunk('extractSymbols', { cognitive: 18, file: 'src/a.ts' })]);
+    const result = await handleGetFilesContext(
+      { filepaths: ['src/a.ts'], includeRelated: false },
+      ctx,
+    );
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed.files['src/a.ts'].complexityHeadroomWarning).toContain('extractSymbols');
   });
 });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -304,15 +304,24 @@ const HEADROOM_METRICS: ReadonlyArray<{
 ];
 
 /**
+ * Minimal chunk shape the headroom computation needs: just the metadata,
+ * not the full `SearchResult` (score/relevance are irrelevant here). Accepts
+ * `SearchResult[]` (the MCP path, via the index) and `@liendev/parser`'s
+ * `CodeChunk[]` (the CLI `annotate` path, via `findDependents`) alike, so both
+ * callers share this one computation — see `annotate-cmd.ts`.
+ */
+export type HeadroomInputChunk = { metadata: SearchResult['metadata'] };
+
+/**
  * Compute the complexity headroom for a file from its already-fetched chunks.
  *
  * No re-parse: cyclomatic/cognitive metrics are stored per chunk in the index
- * and are carried on `SearchResult.metadata`. For each function/method at
- * >= 80% of a threshold, emit its single worst metric (highest value/threshold
- * ratio) — one entry per function, never two. Sorted worst-first and capped at
+ * and are carried on chunk metadata. For each function/method at >= 80% of a
+ * threshold, emit its single worst metric (highest value/threshold ratio) —
+ * one entry per function, never two. Sorted worst-first and capped at
  * MAX_HEADROOM_PER_FILE, with an overflow count for the remainder.
  */
-export function computeComplexityHeadroom(chunks: SearchResult[]): {
+export function computeComplexityHeadroom(chunks: readonly HeadroomInputChunk[]): {
   entries: ComplexityHeadroomEntry[];
   overflow: number;
 } {
@@ -353,6 +362,29 @@ export function computeComplexityHeadroom(chunks: SearchResult[]): {
   const overflow = Math.max(0, sorted.length - MAX_HEADROOM_PER_FILE);
 
   return { entries, overflow };
+}
+
+/**
+ * Render headroom entries as one imperative, agent-actionable warning line —
+ * the plan-time nudge. `computeComplexityHeadroom` only produces data; this is
+ * the "make it unmissable" step, shared by the `get_files_context` response
+ * (`complexityHeadroomWarning`) and the CLI `annotate` command (which leads
+ * its printed annotation with this same line — see `annotate-cmd.ts`).
+ *
+ * Returns `undefined` when there's nothing to warn about, so callers can
+ * `if (warning)` rather than checking `entries.length` themselves.
+ */
+export function formatComplexityHeadroomWarning(
+  entries: ComplexityHeadroomEntry[],
+  overflow = 0,
+): string | undefined {
+  if (entries.length === 0) return undefined;
+  const parts = entries.map(
+    e =>
+      `${e.symbol} ${e.metric} ${e.value}/${e.threshold}${e.value >= e.threshold ? ' (over)' : ''}`,
+  );
+  const more = overflow > 0 ? ` (+${overflow} more near/over budget)` : '';
+  return `⚠ Lien: ${parts.join(', ')}${more} — avoid adding complexity here; prefer extraction.`;
 }
 
 /**
@@ -433,6 +465,14 @@ function buildSingleFileResponse(
     chunks: shapeResults(data.chunks, 'get_files_context'),
     testAssociations: data.testAssociations,
     // Omit entirely when nothing is near budget (the common case → zero bytes).
+    // The warning field is spread first so it's the first thing the agent
+    // reads in the serialized JSON — the imperative nudge, not just data.
+    ...(data.headroom.length > 0 && {
+      complexityHeadroomWarning: formatComplexityHeadroomWarning(
+        data.headroom,
+        data.headroomOverflow,
+      ),
+    }),
     ...(data.headroom.length > 0 && { complexityHeadroom: data.headroom }),
     ...(data.headroomOverflow > 0 && { complexityHeadroomMore: data.headroomOverflow }),
     ...(note && { note }),
@@ -452,6 +492,7 @@ function buildMultiFileResponse(
     {
       chunks: ReturnType<typeof shapeResults>;
       testAssociations: string[];
+      complexityHeadroomWarning?: string;
       complexityHeadroom?: ComplexityHeadroomEntry[];
       complexityHeadroomMore?: number;
     }
@@ -460,6 +501,12 @@ function buildMultiFileResponse(
     shaped[filepath] = {
       chunks: shapeResults(data.chunks, 'get_files_context'),
       testAssociations: data.testAssociations,
+      ...(data.headroom.length > 0 && {
+        complexityHeadroomWarning: formatComplexityHeadroomWarning(
+          data.headroom,
+          data.headroomOverflow,
+        ),
+      }),
       ...(data.headroom.length > 0 && { complexityHeadroom: data.headroom }),
       ...(data.headroomOverflow > 0 && { complexityHeadroomMore: data.headroomOverflow }),
     };

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -14,7 +14,8 @@ REQUIRED before Edit/Write on any file:
   associations. Batch form: { filepaths: [...] } for multi-file edits.
   Always check testAssociations and run those tests after changes.
   If it returns complexityHeadroom, those functions are at/near their
-  complexity budget — avoid adding complexity to them.
+  complexity budget — avoid adding complexity to them. complexityHeadroomWarning
+  (when present) is the same signal as one imperative line — read it first.
 
 REQUIRED before renaming, removing, or changing the signature of any exported
 symbol:

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -95,7 +95,7 @@ Returns for each file:
 ALWAYS check testAssociations before modifying source code.
 After changes, remind the user to run the associated tests.
 
-May include complexityHeadroom: functions already at/near their complexity budget (cyclomatic/cognitive) — steer clear of adding to them.
+May include complexityHeadroom: functions already at/near their complexity budget (cyclomatic/cognitive) — steer clear of adding to them. When present, complexityHeadroomWarning is a one-line imperative summary of the same data — read it first.
 
 Batch calls are more efficient than multiple single-file calls.`,
   ),

--- a/packages/site/docs/guide/claude-code-plugin.md
+++ b/packages/site/docs/guide/claude-code-plugin.md
@@ -58,10 +58,34 @@ It reports dependent count and blast-radius risk (with reasoning), test
 coverage, and — when present — a complexity warning (max cyclomatic complexity
 and how many functions in the file are over the warn threshold). It stays
 silent when impact is trivial (0-1 dependents, no complexity warnings,
-existing test coverage), and it won't repeat for the same file within a
-session for a TTL (default 5 minutes, `LIEN_ANNOTATE_TTL_MIN`). The effect is
-that you see who depends on a file and how well it's tested *before* you touch
-it, without having to call `get_files_context` yourself.
+existing test coverage, no near-budget functions), and it won't repeat for the
+same file within a session for a TTL (default 5 minutes,
+`LIEN_ANNOTATE_TTL_MIN`). The effect is that you see who depends on a file and
+how well it's tested *before* you touch it, without having to call
+`get_files_context` yourself.
+
+#### The plan-time nudge — before you write, not after
+
+When a function in the file is already at or near its complexity budget
+(cyclomatic/cognitive ≥ 80% of threshold — the same computation
+`get_files_context`'s `complexityHeadroom` uses), the annotation *leads* with
+an imperative warning line instead of burying it as data:
+
+```
+⚠ Lien: extractSymbols cognitive 18/15 (over) — avoid adding complexity here; prefer extraction.
+Lien impact for packages/cli/src/cli/annotate-cmd.ts:
+  • 2 files import this — packages/cli/src/cli/index.ts, packages/cli/src/cli/annotate-cmd.test.ts; risk: medium (2 callers, 1 untested).
+  • Test coverage: packages/cli/src/cli/annotate-cmd.test.ts.
+```
+
+This is the moment `lien delta` can't reach: the write-gate hook below only
+fires *after* an edit, once the complexity is already in the file. Reading a
+file is the step that happens right before editing it in the mandatory
+workflow, so surfacing the same "near budget" signal here — via the one
+verified `PostToolUse` channel — gets it in front of the agent while there's
+still a chance to steer around the hot function or extract instead of adding
+to it. `get_files_context`'s response carries the identical signal as a
+`complexityHeadroomWarning` field for the same reason.
 
 ### The write gate — `lien delta` on every edit
 

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -18,7 +18,7 @@ for which hook output channels actually reach the model.
 
 | Hook | Event | What it does | Kill switch |
 | --- | --- | --- | --- |
-| `annotate-read.sh` | PostToolUse: `Read` | Surfaces dependents/coverage/complexity for the file just read, as an `additionalContext` annotation. Suppressed per file per session within a TTL. | `LIEN_ANNOTATE_TTL_MIN=<minutes>` (default 5) |
+| `annotate-read.sh` | PostToolUse: `Read` | Surfaces dependents/coverage/complexity for the file just read, as an `additionalContext` annotation. When a function in the file is at/near its complexity budget, the annotation *leads* with an imperative nudge line ("avoid adding complexity here; prefer extraction") — the plan-time nudge, surfaced before the agent edits rather than after via `delta-write.sh`. Suppressed per file per session within a TTL. | `LIEN_ANNOTATE_TTL_MIN=<minutes>` (default 5) |
 | `delta-write.sh` | PostToolUse: `Edit\|Write\|MultiEdit` | Runs `lien delta --file <path> --format json`; warns only when the edit pushed a function to a new complexity-threshold crossing. Silent on everything else (improvements, pre-existing violations, advisory movement). | `LIEN_DELTA_HOOK=off` |
 | `augment-explore-task.sh` | PreToolUse: `Agent\|Task` | When the subagent being launched is `Explore` (or `lien:Explore`/`project:Explore`), appends a Lien-tool-usage mandate to its prompt. Skips if the repo has no `structural.db` index yet, or the prompt already names a Lien MCP tool. | `LIEN_EXPLORE_INJECT=off` |
 | `annotate-clean.sh` | SessionStart | GCs `annotated-sessions/` dirs untouched for >24h; pre-warms the npx fallback in the background so the first real hook call of the session doesn't pay a cold `npx` install. | none |
@@ -34,6 +34,21 @@ or CI) is recorded locally as one JSONL line in `delta-events.jsonl` next to
 the project's index; nothing leaves the machine. Run `lien stats` for 7/30-day
 counts. Kill switch: `LIEN_DELTA_EVENTS=off`. See
 [docs/architecture/lien-delta.md](../../docs/architecture/lien-delta.md#measuring-the-nudge-loop--delta-eventsjsonl--lien-stats).
+
+### Why the nudge rides `annotate-read.sh`, not a new `PreToolUse:Edit` hook
+
+The obvious design for a "before you edit" complexity nudge is a `PreToolUse`
+hook on `Edit|Write|MultiEdit`. It doesn't work: per
+[docs/architecture/claude-code-hook-channels.md](../../docs/architecture/claude-code-hook-channels.md),
+`PreToolUse`'s only channel that reaches the model is `updatedInput.prompt`,
+and that's specific to the subagent-launch tool (`augment-explore-task.sh`) —
+`Edit`/`Write`'s `tool_input` has no `prompt` field to rewrite. The other
+`PreToolUse` channel, `exit 2` + stderr, *blocks* the tool call — turning an
+advisory nudge into a hard stop and breaking every hook's fail-open contract.
+So the nudge instead enriches `annotate-read.sh`'s existing `PostToolUse:Read`
+annotation, which already fires before the mandatory `get_files_context` /
+`Edit` step in the normal workflow, reaches the model via the verified
+`additionalContext` channel, and inherits the same TTL suppression for free.
 
 ### The Explore agent
 


### PR DESCRIPTION
## Why (the wedge, step 2)

Lien already computes `complexityHeadroom` (functions at/near their complexity budget) and returns it from `get_files_context`, and `lien delta` flags crossings **after** code is written (the write-time hook, `delta-write.sh`). The missing moment is **before** the agent writes: when it reads or is about to edit a file, near-budget functions should be unmissable so the agent steers around them or extracts instead of piling on. A prior behavioral A/B in this repo proved a well-placed warning changes agent output (#672/#682 line) — this extends that to pre-write.

## Channel decision (read first: `docs/architecture/claude-code-hook-channels.md`)

The obvious design is a new `PreToolUse:Edit|Write` hook mirroring `delta-write.sh`. **Rejected** — per the repo's own hook-channels doc, `PreToolUse`'s only channel that delivers model-visible content is `hookSpecificOutput.updatedInput.prompt`, and that's specific to the subagent-launch tool (`augment-explore-task.sh` rewrites a launched subagent's own prompt). `Edit`/`Write`'s `tool_input` has no `prompt` field to rewrite. The other `PreToolUse` channel, `exit 2` + stderr, does reach the model — but by *blocking* the tool call, which would turn an advisory nudge into a hard stop and break every existing hook's fail-open contract.

**Fallback (shipped):** enrich the existing `annotate-read.sh` (`PostToolUse:Read`, `additionalContext` — the channel proven to reach the model). It already fires right before the mandatory `get_files_context` → `Edit` sequence in the normal agent workflow, so it lands at the same "before you write" moment through infrastructure already proven to work. TTL suppression (per file per session) is inherited for free — no new dedup logic needed. Fail-open is unaffected: I didn't touch hook error-handling, only the CLI output it wraps.

## What shipped

- **`get_files_context`**: new optional `complexityHeadroomWarning` string field, spread into the response *before* `complexityHeadroom` so it's the first thing the agent reads in the serialized JSON — an imperative line instead of just data. `complexityHeadroom` itself is unchanged (no schema break).
- **`computeComplexityHeadroom`** (in `get-files-context.ts`): parameter type widened from `SearchResult[]` to a minimal `{ metadata: ChunkMetadata }` shape, so the exact same computation is reusable by the CLI (no re-implementation, no drift risk between the MCP tool and the CLI).
- **`lien annotate`**: now computes the same headroom for the file it's annotating (scoped to that file's own chunks) and, when non-empty, leads the printed annotation with the shared warning line — literally the first line the agent sees, ahead of "Lien impact for …". `isTrivial` gained a 4th `headroomCount` param (defaulted to 0, so old 3-arg callers are unaffected): a near/over-budget function now forces the annotation to print even when it would otherwise look trivial.
- Docs: `plugins/claude/README.md` hook table + a new "why not a new hook" section, `packages/site/docs/guide/claude-code-plugin.md` guide page, and a design addendum in `docs/architecture/lien-delta.md`.

## Deferred (noted, not built)

Metrics tie-in (a `delta-events.jsonl` "nudge shown" event) was scoped out. `DeltaEvent`'s shape (`mode`, `exitCode`, `counts.crossings`) is built around a *delta run*; there's no natural exit code or crossings count for "the agent read a file and saw a warning." Shoehorning it in would be real design work (what does "resolved after a Read-time nudge, not a delta run" even mean?), not a clean extension — left as a follow-up once that's answered. v1 is the nudge itself.

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `npm test` (all 6 packages, 3110 tests) / `node packages/cli/dist/index.js delta --base origin/main` (exit 0 — only advisory "worsened" movement, e.g. `annotate-cmd.ts`'s `run` 33m→41m against a 60m threshold; no new crossings) / `npm run docs:build` (site) all green locally.

## Test plan

- [x] `formatComplexityHeadroomWarning` unit tests (rendering, over/near tagging, overflow suffix)
- [x] `computeComplexityHeadroom` accepts the minimal chunk shape (not just full `SearchResult`)
- [x] `get_files_context` response tests: `complexityHeadroomWarning` present/absent, ordered ahead of `complexityHeadroom`, present in both single- and multi-file response shapes
- [x] `isTrivial` 4-arg behavior (headroom alone forces non-trivial; default `0` preserves old callers)
- [x] `withHeadroomWarning` pure wiring test
- [x] `annotateCommand` integration tests: leads with the nudge line when a function is near/over budget; no nudge line when nothing is near budget

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it ended without emitting a parseable JSON verdict while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 71d30b6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear warnings when functions are near or over their complexity budgets.
  * Warnings appear before code changes in file context and read annotations.
  * Warnings identify affected functions and indicate when complexity limits are exceeded.
  * The same guidance is now consistently surfaced across single-file and multi-file context results.

* **Documentation**
  * Updated usage guides to explain complexity warnings, timing, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->