### PR TITLE
docs: mandate dogfooding before shipping in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,18 @@ spend; see `packages/review/src/stale-literal-signals.ts` for the template.
 - Explain changes at each step with a high-level summary
 - Run tests, check logs, demonstrate correctness
 
+**Dogfood before shipping (MANDATORY).** CI-green + unit tests are not
+shipping criteria on their own. Before a PR is declared merge-ready,
+exercise the change the way its real consumer experiences it and put the
+verbatim evidence in the PR body:
+- CLI/MCP changes → run the actual command/tool against this repo and read the output.
+- Hook/plugin changes → invoke the hook with the real stdin shape Claude Code sends; verify what surfaces (and TTL/fail-open behavior).
+- Review-engine changes → replay through the harness (build-prompts/fixtures) or a captured real run.
+- Site/docs → `npm run docs:build` AND read the rendered result.
+If pre-merge dogfooding is genuinely impossible (needs production traffic),
+the PR must say so explicitly and the dogfood happens immediately
+post-merge — silence is not an option.
+
 ### 5. Demand Elegance (Balanced)
 - For non-trivial changes: pause and ask "is there a more elegant way?"
 - If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"


### PR DESCRIPTION
## Summary

Owner-dictated standing rule: **we must always dogfood our changes before shipping.** CI-green plus passing unit tests is not sufficient evidence that a change works the way its real consumer will experience it.

Motivating incident: **#772** shipped CI-green (build, lint, typecheck, tests all passed) but nobody had actually looked at the real warning line the change was supposed to produce — the gap only surfaced after merge.

This PR extends `### 4. Verification Before Done` (under Workflow Orchestration) with a MANDATORY dogfooding block:
- CLI/MCP changes → run the actual command/tool against this repo and read the output.
- Hook/plugin changes → invoke the hook with the real stdin shape Claude Code sends; verify what surfaces (and TTL/fail-open behavior).
- Review-engine changes → replay through the harness (build-prompts/fixtures) or a captured real run.
- Site/docs → `npm run docs:build` AND read the rendered result.
- If pre-merge dogfooding is genuinely impossible (needs production traffic), the PR must say so explicitly and the dogfood happens immediately post-merge — silence is not an option.

## Dogfood

This PR's own change is documentation, so its "dogfood" is the rendered CLAUDE.md diff itself — reviewed above via `git diff` and included verbatim in this description.

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — pass (pre-existing warnings only, 0 errors)
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm test` — pass (all suites green, incl. `instructions.claude-md-sync.test.ts` confirming no MCP-instructions sync was needed since this edit is outside the synced section)
- [x] `node packages/cli/dist/index.js delta` — exit 0, no complexity-affecting changes

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 476 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 72b5af1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->