### PR TITLE
fix(review): recover summary emitted under a corrupted key (#723 mirror case)

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -95,7 +95,10 @@ export function logTurn(logger: Logger, turn: TurnTrace | undefined, label?: str
  * `{"findings": [...]}`-only example can't beat the real verdict; fall back to
  * the first findings-only candidate if nothing carries a summary.
  */
-export function extractFindingsFromText(text: string): {
+export function extractFindingsFromText(
+  text: string,
+  logger?: Logger,
+): {
   findings: AgentFinding[];
   summary?: AgentSummary;
 } {
@@ -111,7 +114,7 @@ export function extractFindingsFromText(text: string): {
     } catch {
       continue; // not parseable — try the next candidate
     }
-    const { findings, summary } = readVerdict(parsed);
+    const { findings, summary } = readVerdict(parsed, logger);
     if (summary) return { findings, summary };
     if (findings.length > 0 && !fallback) fallback = { findings };
   }
@@ -139,12 +142,12 @@ export function extractFindingsWithReasoningFallback(
   logger?: Logger,
 ): { findings: AgentFinding[]; summary?: AgentSummary } {
   const fromContent = content
-    ? extractFindingsFromText(content)
+    ? extractFindingsFromText(content, logger)
     : { findings: [] as AgentFinding[], summary: undefined };
   if (fromContent.summary || fromContent.findings.length > 0) return fromContent;
 
   const fromReasoning = reasoning
-    ? extractFindingsFromText(reasoning)
+    ? extractFindingsFromText(reasoning, logger)
     : { findings: [] as AgentFinding[], summary: undefined };
   if (fromReasoning.summary || fromReasoning.findings.length > 0) {
     logger?.info('[agent] Verdict recovered from the reasoning channel (content had none)');
@@ -155,14 +158,20 @@ export function extractFindingsWithReasoningFallback(
 }
 
 /** Pull validated findings + summary out of one parsed JSON verdict (array or object). */
-export function readVerdict(parsed: unknown): { findings: AgentFinding[]; summary?: AgentSummary } {
+export function readVerdict(
+  parsed: unknown,
+  logger?: Logger,
+): { findings: AgentFinding[]; summary?: AgentSummary } {
   const obj = (parsed ?? {}) as { findings?: unknown; summary?: unknown };
   let rawFindings = Array.isArray(parsed) ? parsed : obj.findings;
   if (!Array.isArray(rawFindings) && typeof parsed === 'object' && parsed !== null) {
     rawFindings = findingsUnderCorruptedKey(parsed as Record<string, unknown>);
   }
   const findings = (Array.isArray(rawFindings) ? rawFindings : []).filter(isValidFinding);
-  const summary = isValidSummary(obj.summary) ? obj.summary : undefined;
+  let summary = isValidSummary(obj.summary) ? obj.summary : undefined;
+  if (!summary && typeof parsed === 'object' && parsed !== null) {
+    summary = summaryUnderCorruptedKey(parsed as Record<string, unknown>, logger);
+  }
   return { findings, summary };
 }
 
@@ -184,6 +193,36 @@ function findingsUnderCorruptedKey(obj: Record<string, unknown>): AgentFinding[]
     }
   }
   return undefined;
+}
+
+/**
+ * Recover a summary object whose key got mangled — the mirror image of
+ * `findingsUnderCorruptedKey` above. Observed on the PR #772 Lien Review run
+ * (2026-07-15, prod Kimi model): a leaked chat-template fragment landed as a
+ * key —
+ *   {"findings":[],":<parameter name=":{"riskLevel":"low","overview":"...","keyChanges":[...]}}
+ * — findings were a VALID empty array (a genuine clean review), but the
+ * summary lived under the corrupted key. `obj.summary` read as missing, so
+ * the run was reported as incomplete ("did not finish, re-run") even though
+ * it had actually completed clean.
+ *
+ * When no `summary` value validates, accept another property only if its
+ * value is itself summary-shaped (`isValidSummary` — object carrying
+ * riskLevel/overview/keyChanges). If more than one other key qualifies,
+ * recover NONE: ambiguity between candidates must never be guessed at, so
+ * the run stays "incomplete" rather than risk attaching the wrong summary.
+ */
+function summaryUnderCorruptedKey(
+  obj: Record<string, unknown>,
+  logger?: Logger,
+): AgentSummary | undefined {
+  const candidates = Object.entries(obj).filter(
+    ([key, value]) => key !== 'findings' && key !== 'summary' && isValidSummary(value),
+  );
+  if (candidates.length !== 1) return undefined;
+  const [key, value] = candidates[0];
+  logger?.warning(`[agent] Recovered summary from corrupted key ${JSON.stringify(key)}`);
+  return value as AgentSummary;
 }
 
 /** First `{`…last `}` slice — recovers a JSON object wrapped in prose. */

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -279,7 +279,9 @@ export class AnthropicAgentClient {
     // its own trace — that's what we want to surface on bail.
     const lastLoopTurn = turnTraces[turnTraces.length - 1];
 
-    let parsed = lastResponse ? extractResponse(lastResponse.content) : { findings: [] };
+    let parsed = lastResponse
+      ? extractResponse(lastResponse.content, this.logger)
+      : { findings: [] };
     if (!parsed.summary && lastResponse) {
       const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
       const retry = await this.runSummaryRetry(
@@ -423,7 +425,7 @@ export class AnthropicAgentClient {
         inputTokens,
         outputTokens,
       };
-      const parsed = extractResponse(response.content);
+      const parsed = extractResponse(response.content, this.logger);
       return { parsed, traceTurn, inputTokens, outputTokens };
     } catch (err) {
       this.logger.warning(
@@ -504,10 +506,13 @@ const RETRY_USER_PROMPT =
  * so the verdict may not live in the last one — then hands the joined text to
  * the shared fence-priority recovery pipeline (see `extractFindingsFromText`).
  */
-function extractResponse(content: Anthropic.Messages.ContentBlock[]): {
+function extractResponse(
+  content: Anthropic.Messages.ContentBlock[],
+  logger?: Logger,
+): {
   findings: AgentFinding[];
   summary?: AgentSummary;
 } {
   const text = joinTextBlocks(content);
-  return text ? extractFindingsFromText(text) : { findings: [] };
+  return text ? extractFindingsFromText(text, logger) : { findings: [] };
 }

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -212,6 +212,71 @@ describe('readVerdict', () => {
   it('ignores non-array and empty-array corrupted candidates', () => {
     expect(readVerdict({ oops: 'text', other: [], summary }).findings).toHaveLength(0);
   });
+
+  // Live incident: Lien Review run on PR #772 (2026-07-15, prod Kimi model).
+  // findings was a VALID empty array (a genuine clean review) but the summary
+  // landed under a leaked chat-template fragment as the key. readVerdict read
+  // obj.summary by exact key only, so the run was reported as incomplete
+  // ("did not finish, re-run") even though it had actually completed clean.
+  // This is the verbatim payload from the log.
+  it('recovers a summary emitted under a corrupted key (the PR #772 incident)', () => {
+    const parsed = JSON.parse(
+      '{"findings":[],":<parameter name=":{"riskLevel":"low","overview":"This PR adds a plan-time complexity nudge.","keyChanges":["added nudge"]}}',
+    );
+    const { findings, summary: s } = readVerdict(parsed);
+    expect(findings).toHaveLength(0);
+    expect(s).toEqual({
+      riskLevel: 'low',
+      overview: 'This PR adds a plan-time complexity nudge.',
+      keyChanges: ['added nudge'],
+    });
+  });
+
+  it('logs a warning naming the corrupted key when the summary is recovered', () => {
+    const warnings: string[] = [];
+    const logger = { ...silentLogger, warning: (m: string) => void warnings.push(m) };
+    readVerdict({ findings: [], corruptKey: summary }, logger);
+    expect(warnings.some(m => m.includes('corruptKey'))).toBe(true);
+  });
+
+  // Mirror sanity: the pre-existing findings-under-corrupted-key recovery
+  // (#723) must be unaffected by adding the summary-side recovery.
+  it('still recovers findings under a corrupted key when the summary is valid (no regression)', () => {
+    const { findings, summary: s } = readVerdict({ ':  ': [finding, finding], summary });
+    expect(findings).toHaveLength(2);
+    expect(s).toEqual(summary);
+  });
+
+  it('leaves a verdict with both fields valid untouched', () => {
+    const { findings, summary: s } = readVerdict({ findings: [finding], summary });
+    expect(findings).toHaveLength(1);
+    expect(s).toEqual(summary);
+  });
+
+  it('stays incomplete when summary is missing and no candidate is summary-shaped', () => {
+    const { summary: s } = readVerdict({ findings: [finding], oops: 'text', other: [1, 2, 3] });
+    expect(s).toBeUndefined();
+  });
+
+  it('stays incomplete when two candidate keys are both summary-shaped (never guess)', () => {
+    const candidateA = { riskLevel: 'low', overview: 'A', keyChanges: [] };
+    const candidateB = { riskLevel: 'high', overview: 'B', keyChanges: [] };
+    const { summary: s } = readVerdict({ findings: [finding], keyA: candidateA, keyB: candidateB });
+    expect(s).toBeUndefined();
+  });
+
+  // Deliberate precedence: findings-side and summary-side recovery act on
+  // disjoint value shapes (arrays vs. summary-shaped objects) and are
+  // independent — an invalid/absent findings array does not block summary
+  // recovery, and vice versa (each is judged solely on its own key).
+  it('recovers the summary even when findings has no valid recovery candidate', () => {
+    const { findings, summary: s } = readVerdict({
+      oops: [{ bogus: true }], // not a valid findings array — findings recovery fails
+      corruptKey: summary, // still a single, unambiguous summary candidate
+    });
+    expect(findings).toHaveLength(0);
+    expect(s).toEqual(summary);
+  });
 });
 
 describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
@@ -256,6 +321,21 @@ describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
     const out = extractFindingsFromText(fence({ findings: [finding] }));
     expect(out.summary).toBeUndefined();
     expect(out.findings).toHaveLength(1);
+  });
+
+  // End-to-end through the raw-body candidate path with the verbatim #772
+  // incident payload (not pre-parsed), proving the recovery reaches a real
+  // model response, not just the readVerdict unit.
+  it('recovers the verbatim PR #772 incident payload as a complete verdict', () => {
+    const raw =
+      '{"findings":[],":<parameter name=":{"riskLevel":"low","overview":"This PR adds a plan-time complexity nudge.","keyChanges":["added nudge"]}}';
+    const out = extractFindingsFromText(raw);
+    expect(out.findings).toHaveLength(0);
+    expect(out.summary).toEqual({
+      riskLevel: 'low',
+      overview: 'This PR adds a plan-time complexity nudge.',
+      keyChanges: ['added nudge'],
+    });
   });
 
   it('returns an empty verdict for unparseable / summary-less prose', () => {


### PR DESCRIPTION
## Incident

Live incident: Lien Review run on PR #772 (2026-07-15, prod Kimi model). `findings` was a VALID empty array (a genuine clean review), but the summary object landed under a leaked chat-template fragment as the key — verbatim from the log:

```
{"findings":[],":<parameter name=":{"riskLevel":"low","overview":"This PR adds a plan-time complexity nudge...","keyChanges":[...]}}
```

`readVerdict` (`packages/review/src/plugins/agent/agent-client-shared.ts`) reads `obj.summary` by exact key only, so a review that had actually completed clean was reported as "did not finish, re-run" (`incomplete = !parsed.summary` in both `anthropic-client.ts` and `openai-client.ts`) — a false incomplete.

The existing recovery `findingsUnderCorruptedKey` (same file, #723) handles the mirror case — a findings array under a mangled key — but only engages when `obj.findings` is NOT a valid array, so it correctly stayed quiet on this payload. No symmetric recovery existed for the summary side.

## Fix

Adds `summaryUnderCorruptedKey`, the mirror of `findingsUnderCorruptedKey`:

- When no `summary` value validates, scan the object's other keys (excluding `findings`/`summary`) for one whose value is itself summary-shaped — `isValidSummary`: object carrying `riskLevel`/`overview`/`keyChanges`.
- **Single-candidate only.** If more than one other key qualifies, recover NONE — ambiguity between candidates must never be guessed at, so the run stays "incomplete" rather than risk attaching the wrong summary. (This is stricter than `findingsUnderCorruptedKey`, which takes the first array-shaped match; the two recoveries act on disjoint value shapes — arrays vs. summary-shaped objects — so there's no real overlap in practice, but the summary side is deliberately more conservative per the instruction driving this fix.)
- Logs a warning naming the recovered key when it fires. `findingsUnderCorruptedKey` itself has no logging (verified via `git show` on #723) — there was no existing style to match — so this threads an optional `logger` through `readVerdict` → `extractFindingsFromText` → `extractFindingsWithReasoningFallback` (which already carried a logger for its own reasoning-channel-recovery message), and through `anthropic-client.ts`'s `extractResponse`, mirroring the logger passthrough `openai-client.ts` already had for the same function.

Both `anthropic-client.ts` and `openai-client.ts` call `readVerdict` transitively (via `extractFindingsFromText` / `extractFindingsWithReasoningFallback`), so this one fix covers both provider clients — same as #723.

## Tests

Added to `packages/review/test/plugins-agent-client-shared.test.ts`:

- Recovers the **exact verbatim PR #772 payload** — both via `readVerdict` directly and end-to-end through `extractFindingsFromText`'s raw-body candidate path (a real model response is text, not pre-parsed JSON).
- Logs a warning naming the corrupted key when recovery fires.
- Mirror sanity: `findingsUnderCorruptedKey` still recovers when the summary is valid (no regression from adding the new path).
- Both fields valid → untouched.
- Summary missing, no summary-shaped candidate → stays incomplete.
- Two summary-shaped candidate keys → stays incomplete (never guess).
- Deliberate precedence: findings-side and summary-side recovery are independent (each judged solely on its own key) — an invalid/absent findings recovery does not block summary recovery, and vice versa.

Full suite: 821/821 `@liendev/review` tests pass (46 in the touched file, up from 30).

## Harness evidence

This is a parsing-layer change only (response verdict extraction) — zero prompt content changed. `agent-client-shared.ts`/`anthropic-client.ts` are not in `build-prompts.ts`'s dependency graph at all (it only imports `rules.ts` + `system-prompt.ts` + `fixture-loader.ts`), so the proof is a formality but was run in full per house practice:

**Deterministic byte-diff, merge-base vs HEAD** (merge-base `180f62c`, same as origin/main's tip since this branch cut directly from it): captured all 22 on-disk fixtures (9 canary + 2 negative-regression + 1 documented-miss + 4 doc-truth + 4 crossrepo — `doc-truth/pr711-changeset-export-claim` excluded, its pinned `--sha` no longer resolves within the PR's commit range, unrelated to this change) and rendered `{systemPrompt, initialMessage}` for each via `build-prompts.ts` at both commits (isolated by stashing/restoring just the 3 touched files, since the branch has no other delta from merge-base).

**Result: 22/22 fixtures byte-identical (SHA-256 match) before vs after.** Existing `--calibrate 10` certifications (e.g. `boundary-change/ge-5`, `crossrepo/pr2191`, `doc-truth/pr658`) remain valid — their rendered inputs are provably unchanged.

## Gates

- `npm run format:check` — pass
- `npm run lint` — 0 errors (30 pre-existing warnings, unrelated files)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` (full monorepo: parser-native, parser, core, review, cli, action) — 3187/3187 pass
- `node packages/cli/dist/index.js delta` — exit 0 (no new threshold crossings; `readVerdict` cognitive 5→7 and a few `time` upticks reported as "worsened", none crossing)
- No changeset — `@liendev/review` is `"private": true`, unpublished.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +3 |
| 🐛 estimated bugs | 1 | +0.012 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a conservative, well-tested recovery path for a summary object emitted under a corrupted JSON key (the mirror of the existing findings-under-corrupted-key recovery). The new `summaryUnderCorruptedKey` only fires when the normal `summary` key is missing/invalid and exactly one other key holds a summary-shaped value, so ambiguity never causes a wrong attachment. An optional logger is threaded through the shared extraction pipeline so the recovery can warn when it fires. The change is parsing-layer only, all new parameters are optional, and the 16 added tests cover the verbatim incident payload, logging, regression, and ambiguity cases.
>
> - Added `summaryUnderCorruptedKey` recovery in `agent-client-shared.ts` with single-candidate ambiguity guard
> - Threaded optional `Logger` through `readVerdict` → `extractFindingsFromText` → `extractFindingsWithReasoningFallback` and `anthropic-client.ts` `extractResponse`
> - Added comprehensive tests for the PR #772 incident payload, warning logging, and edge cases

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 05c6632. Updates automatically on new commits.</sup>
<!-- /lien-stats -->