### PR TITLE
test(review): certify werkzeug crossrepo fixtures

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -120,13 +120,18 @@ npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2334 \
 | --- | :---: | --- | --- | --- |
 | encode/starlette | #2334 | `crossrepo/pr2334-etag-weak-indicator-strip` | `.strip(" W/")` char-set gotcha | characterization (measured 5/10 — borderline-judgment, see header) |
 | encode/starlette | #2191 | `crossrepo/pr2191-templateresponse-offbyone` | positional-args index collision | **canary** (certified 10/10, 2026-07-12) |
-| pallets/werkzeug | #2678 | `crossrepo/pr2678-multipart-index-offset` | slice-relative index used as absolute | characterization (cert deferred) |
-| pallets/werkzeug | #2017 | `crossrepo/pr2017-multipart-boundary-regex` | unescaped client boundary in regex | characterization (cert deferred) |
+| pallets/werkzeug | #2678 | `crossrepo/pr2678-multipart-index-offset` | slice-relative index used as absolute | **canary** (certified 10/10, 2026-07-16) |
+| pallets/werkzeug | #2017 | `crossrepo/pr2017-multipart-boundary-regex` | unescaped client boundary in regex | characterization (measured 8/10 — below bar, see header) |
 
-The two `characterization`-tagged entries have 3/3 Kimi vote evidence but
-not yet a `--calibrate 10` certification — promote by running the
-calibration, recording the result in the header, and flipping the tag to
-`canary` (the bar is the same ≥9/10 as everywhere else).
+The two remaining `characterization`-tagged entries are both below the ≥9/10
+bar, for different reasons: `pr2334-etag-weak-indicator-strip` has 3/3 Kimi
+vote evidence but scores 5/10 on `--calibrate 10` (borderline judgment, not a
+budget deferral). `pr2017-multipart-boundary-regex` raw-scored 10/10 on
+`--calibrate 10` (2026-07-16), but a post-cert dogfood assert-cli smoke test
+(perfect/empty/distractor, see below) found its keyword list's bare
+identifiers/domain nouns let 2 of the 10 votes false-pass on unrelated
+findings; re-scored against the corrected keyword list its true rate is
+8/10. See each header before spending more calibration budget or re-promoting.
 
 ## Negative-regression fixtures
 

--- a/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.assertions.ts
@@ -58,10 +58,9 @@
  */
 
 /*
- * PROMOTED TO CROSS-REPO CANARY (2026-07-12): external fixture from
+ * CROSS-REPO CHARACTERIZATION (updated 2026-07-16): external fixture from
  * pallets/werkzeug PR #2017, mined in the cross-repo validation study's Python
- * round. Blind-screen + Kimi 3-vote evidence in the pilot log; canary
- * certification: --calibrate 10 run recorded below.
+ * round. Blind-screen + Kimi 3-vote evidence in the pilot log.
  *
  * REGENERATE (fixture JSON is gitignored):
  *   git clone https://github.com/pallets/werkzeug /tmp/werkzeug && cd /tmp/werkzeug
@@ -70,12 +69,37 @@
  *     <lien>/packages/review/test/harness/fixtures/crossrepo/pr2017-multipart-boundary-regex.fixture.json
  * (capture-pr.ts retargets to whatever repo the cwd is in.)
  *
- * CALIBRATION (kimi-k2.7-code): NOT YET CERTIFIED — canary requires a
- * --calibrate 10 run at >=9/10; deferred 2026-07-12 for session-budget
- * reasons. Evidence so far: 3/3 Kimi votes + blind-CC content catch
- * (2026-07-12 Python round). Tagged characterization (non-gating) until
- * certified; to promote, run --calibrate 10, record the result here,
- * and flip tags to canary.
+ * CALIBRATION (kimi-k2.7-code): measured 8/10, BELOW the >=9/10 canary bar —
+ * NOT promoted. `--calibrate 10` run 2026-07-16 against `--fixture` in
+ * isolation, prod default model moonshotai/kimi-k2.7-code (no --model
+ * override), cost $0.8681. NOTE: this measurement reflects the prompt as of
+ * 2026-07-16 (post #757 test-coverage block, post #770 catch signal) — later
+ * than the 2026-07-12 cross-repo validation study that mined this fixture.
+ *
+ * RAW vs CORRECTED: the raw --calibrate 10 run scored 10/10 against the
+ * keyword list as it stood before this pass (which included the identifiers
+ * 'preamble_re'/'boundary_re'/'multipartdecoder' and the bare domain nouns
+ * 'boundary'/'multipart'). A dogfood assert-cli smoke test (perfect / empty
+ * / distractor verdicts, see harness README) caught that a plausible
+ * off-topic distractor about this same file/class — a finding about
+ * recompiling preamble_re/boundary_re on every request being wasteful, NOT
+ * about the missing re.escape() — still passed Tier 2, because 'boundary_re'
+ * and 'boundary'/'multipart' are near-unavoidable vocabulary for ANY finding
+ * about this file. Re-scoring the 10 stored vote traces from this run
+ * against a keyword list restricted to the escaping-specific mechanism
+ * phrases (re.escape, unescaped, regex metacharacter, etc.) drops the score
+ * to 8/10: votes 5 and 9 (see
+ * .wip/traces/2026-07-15T23-07-44Z-pr2017-multipart-boundary-regex/crossrepo/pr2017-multipart-boundary-regex/vote-5.json
+ * and .../vote-9.json) each reported OTHER genuine werkzeug 2.0.0 issues
+ * (an empty-part/boundary_re edge case, and a max_form_memory_size /
+ * _fix_ie_filename regression) but never mentioned the escaping bug at all —
+ * they were false Tier-2 passes, not real catches. The keyword list below is
+ * the corrected one (identifiers/domain nouns removed); this fixture's
+ * measured rate is the corrected 8/10, not the raw 10/10. Per the harness's
+ * own reliability-bar standard, an unexpected miss pattern uncovered while
+ * certifying is data for the owner, not something to paper over — do not
+ * re-inflate this back to canary without a fresh >=9/10 run against THIS
+ * keyword list.
  */
 import type { FixtureAssertions } from '../../assertions.js';
 
@@ -107,13 +131,6 @@ const assertions: FixtureAssertions = {
         'regex injection',
         'interpolat',
         'literal',
-        // The identifiers
-        'preamble_re',
-        'boundary_re',
-        'multipartdecoder',
-        // The domain
-        'boundary',
-        'multipart',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.assertions.ts
@@ -55,10 +55,10 @@
  */
 
 /*
- * PROMOTED TO CROSS-REPO CANARY (2026-07-12): external fixture from
+ * PROMOTED TO CROSS-REPO CANARY (2026-07-16): external fixture from
  * pallets/werkzeug PR #2678, mined in the cross-repo validation study's Python
- * round. Blind-screen + Kimi 3-vote evidence in the pilot log; canary
- * certification: --calibrate 10 run recorded below.
+ * round (2026-07-12). Blind-screen + Kimi 3-vote evidence in the pilot log;
+ * canary certification: --calibrate 10 run recorded below.
  *
  * REGENERATE (fixture JSON is gitignored):
  *   git clone https://github.com/pallets/werkzeug /tmp/werkzeug && cd /tmp/werkzeug
@@ -67,12 +67,27 @@
  *     <lien>/packages/review/test/harness/fixtures/crossrepo/pr2678-multipart-index-offset.fixture.json
  * (capture-pr.ts retargets to whatever repo the cwd is in.)
  *
- * CALIBRATION (kimi-k2.7-code): NOT YET CERTIFIED — canary requires a
- * --calibrate 10 run at >=9/10; deferred 2026-07-12 for session-budget
- * reasons. Evidence so far: 3/3 Kimi votes + blind-CC content catch
- * (2026-07-12 Python round). Tagged characterization (non-gating) until
- * certified; to promote, run --calibrate 10, record the result here,
- * and flip tags to canary.
+ * CALIBRATION (kimi-k2.7-code): CERTIFIED 10/10 (2026-07-16, prod default
+ * model moonshotai/kimi-k2.7-code, no --model override, cost $0.6662) —
+ * `--calibrate 10` run against `--fixture` in isolation. Prior evidence: 3/3
+ * Kimi votes + blind-CC content catch (2026-07-12 Python round). NOTE: this
+ * cert reflects the prompt as of 2026-07-16 (post #757 test-coverage block,
+ * post #770 catch signal) — later than the 2026-07-12 cross-repo validation
+ * study that mined this fixture.
+ *
+ * DOGFOOD (2026-07-16): a post-cert assert-cli smoke test (perfect / empty /
+ * distractor verdicts, see harness README) found the original keyword list's
+ * '// The domain' entries ('multipart', 'boundary') were bare nouns that a
+ * plausible off-topic distractor about this same file (a max_form_memory_size
+ * accounting gap, not the data_start slice-offset bug) also satisfied —
+ * false Tier-2 pass. Sibling fixture pr2017 (same file) had the same class
+ * of bug and its raw calibration score DID move (10/10 -> 8/10 corrected).
+ * For pr2678, re-scoring all 10 stored vote traces from the run above
+ * against a keyword list with the domain nouns removed (mechanism + symptom
+ * phrases only, below) still holds 10/10 — every real vote independently
+ * named data_start/last_newline/data_end/del_index, so the cert stands, but
+ * the keyword list below is the corrected/tightened one, not the raw one the
+ * --calibrate 10 run above technically scored against.
  */
 import type { FixtureAssertions } from '../../assertions.js';
 
@@ -109,16 +124,13 @@ const assertions: FixtureAssertions = {
         'spurious newline',
         'truncat',
         'newline',
-        // The domain
-        'multipart',
-        'boundary',
       ],
       result,
     );
   },
   votes: 3,
   passThreshold: 9,
-  tags: ['characterization', 'crossrepo', 'python'],
+  tags: ['canary', 'crossrepo', 'python'],
 };
 
 export default assertions;


### PR DESCRIPTION
## Summary

Certifies the two deferred werkzeug cross-repo fixtures (deferred 2026-07-12 for session budget) via `--calibrate 10` on the prod default model (`moonshotai/kimi-k2.7-code`, no `--model` override). Timing: run now, after this week's prompt changes (#757 test-coverage block, #770 catch signal), so the cert reflects current-prompt reality.

## Per-fixture results

**`crossrepo/pr2678-multipart-index-offset`** (werkzeug #2678, slice-relative index used as absolute)
- `--calibrate 10`: **10/10**, cost $0.6662
- Tag: `characterization` → **`canary`**

**`crossrepo/pr2017-multipart-boundary-regex`** (werkzeug #2017, unescaped client boundary spliced into regex)
- `--calibrate 10`: **10/10** raw, cost $0.8681
- Tag: **stays `characterization`** — see "Dogfood finding" below; corrected measured rate is **8/10**, below the ≥9/10 canary bar.

Total harness spend: **$1.5343** (cap was $2.00).

## Dogfood finding (house law: verify assertions still discriminate)

Per the harness README's three-verdict smoke test protocol (perfect / empty / distractor, zero LLM), I ran `assert-cli.ts` against a stored passing vote, an empty verdict, and a hand-written plausible-but-wrong distractor finding for both fixtures.

Both fixtures' distractors **false-passed** the original assertions: the keyword lists included bare identifiers/domain nouns (`multipart`, `boundary`, `boundary_re`, `preamble_re`, `multipartdecoder`) that are near-unavoidable vocabulary for *any* finding about `werkzeug/sansio/multipart.py` — not specific to the ground-truth bug. This is exactly the failure mode the README warns about ("keyword lists built from bare domain nouns false-pass any finding that merely talks about the changed code").

I tightened both keyword lists down to mechanism-specific phrases only, then re-scored all 10 stored vote traces from each `--calibrate 10` run against the corrected lists:

- **pr2678**: still 10/10 — every real vote independently named `data_start`/`last_newline`/`data_end`/`del_index`. Cert holds.
- **pr2017**: drops to **8/10** — `vote-5` and `vote-9` (see trace refs below) each reported *other* genuine werkzeug 2.0.0 issues (an empty-part/`boundary_re` edge case; a `max_form_memory_size`/`_fix_ie_filename` regression) but never mentioned the escaping bug. They were false Tier-2 passes, not real catches. This fixture is **not promoted**; its header records the corrected 8/10 and cites the standing caveat that canary certs predate this week's prompt changes, so this miss pattern is data for the owner, not noise.

Trace refs for the two pr2017 misses:
- `.wip/traces/2026-07-15T23-07-44Z-pr2017-multipart-boundary-regex/crossrepo/pr2017-multipart-boundary-regex/vote-5.json`
- `.wip/traces/2026-07-15T23-07-44Z-pr2017-multipart-boundary-regex/crossrepo/pr2017-multipart-boundary-regex/vote-9.json`

(Traces are gitignored/local; paths given for the owner's own harness run.)

After tightening, re-ran the perfect/empty/distractor smoke test again for both fixtures — perfect still passes, empty still fails, and the distractor now correctly fails (Tier 2, no keyword match) for both.

## Verification

- Regenerated both fixture JSONs from fresh clones (`pallets/werkzeug` #2678, #2017), native parser built first; captures healthy (2375 / 2368 repoChunks, non-zero AST chunks, `assertIndexComplete` passed).
- Verified no `lien-stats`/`coderabbit` spoiler leakage in either captured PR body (the `422` hits are werkzeug's own `UnprocessableEntity` HTTP-exception code, unrelated).
- Preflight: `build-prompts.ts` confirms each fixture's `ruleCandidates` are in its active rule set (`edge-case-sweep` central to both).
- Full gate chain green: format:check, lint (0 errors), typecheck, build, full test suite (857+817+39 tests), `lien delta` (exit 0, no crossings).

## Test plan

- [x] Both fixtures regenerated from live werkzeug PRs and verified healthy
- [x] `--calibrate 10` run for each on prod default model
- [x] Rule-coverage preflight confirmed via `build-prompts.ts`
- [x] Three-verdict dogfood smoke test (perfect/empty/distractor) re-run after tightening keyword lists
- [x] Full gate chain (format/lint/typecheck/build/test/delta) green
- [ ] Owner review of the pr2017 characterization downgrade decision

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR certifies two werkzeug cross-repo test fixtures. It updates fixture metadata (tags, calibration notes, keyword lists) and the harness README to reflect fresh `--calibrate 10` results: pr2678 is promoted to canary (10/10), while pr2017 remains characterization after a post-cert dogfood smoke test corrected its score from 10/10 to 8/10 by removing bare domain nouns from the keyword list. No production code is changed; the edits are limited to test-fixture assertions and documentation. The changes are internally consistent and the tightened keyword lists are justified by the stored vote-trace re-scoring described in the headers.
>
> - Promoted pr2678-multipart-index-offset to canary with 10/10 certification and tightened keyword list
> - Kept pr2017-multipart-boundary-regex as characterization after corrected 8/10 score and tightened keyword list
> - Updated README cross-repo fixture status table and explanation

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b27c7b6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->