### PR TITLE
feat(review): diff-based summary for PRs with no analyzable files (#572)

### DIFF
--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -70,7 +70,17 @@ export interface DeliveryAttestation {
   outOfDiffReviewPosted: boolean | null;
 }
 
-export type EligibilityPath = 'normal' | 'zero_files_early_exit' | 'full_repo_fallback';
+/**
+ * `summary_only_diff` (#572): zero analyzable files, but the diff-only
+ * summary-only agent mode ran (summary review type on, non-empty PR diff) —
+ * distinct from `full_repo_fallback`, where the agent didn't run at all
+ * (summary off, or no diff data available).
+ */
+export type EligibilityPath =
+  | 'normal'
+  | 'zero_files_early_exit'
+  | 'full_repo_fallback'
+  | 'summary_only_diff';
 
 export interface ScopeAttestation {
   eligibilityPath: EligibilityPath;

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -31,6 +31,11 @@ import {
   appendDocTruthTurns,
 } from './doc-truth-pass.js';
 import {
+  isSummaryOnlyMode,
+  buildSummaryOnlyPrompts,
+  SUMMARY_ONLY_MAX_TURNS,
+} from './summary-only-pass.js';
+import {
   DEFAULT_REVIEW_MODEL,
   DEFAULT_OPENROUTER_BASE_URL,
   MAX_REVIEW_TOKEN_BUDGET,
@@ -69,6 +74,11 @@ const configSchema = z.object({
    * (issue #732). Default true; env LIEN_REVIEW_DOC_PASS=0 also disables it.
    */
   docTruthPass: z.boolean().default(true),
+  /**
+   * Whether the `summary` review type is enabled (issue #572). Gates the
+   * diff-only summary-only mode — see `summary-only-pass.ts`.
+   */
+  summaryEnabled: z.boolean().default(false),
 });
 
 export interface AgentReviewPluginOptions {
@@ -92,7 +102,14 @@ export class AgentReviewPlugin implements ReviewPlugin {
   shouldActivate(context: ReviewContext): boolean {
     const apiKey =
       (context.config.apiKey as string) ?? (context.config.anthropicApiKey as string) ?? '';
-    return apiKey.length > 0 && context.chunks.length > 0;
+    if (apiKey.length === 0) return false;
+    if (context.chunks.length > 0) return true;
+    // No analyzable chunks — only activate for the diff-only summary-only
+    // mode (issue #572): summary review type enabled AND the PR's raw diff
+    // is available. Every other condition (apiKey, chunks>0) is unchanged
+    // from before this mode existed.
+    const config = context.config as unknown as AgentConfig;
+    return isSummaryOnlyMode(context, !!config.summaryEnabled);
   }
 
   async analyze(context: ReviewContext): Promise<ReviewFinding[]> {
@@ -100,6 +117,14 @@ export class AgentReviewPlugin implements ReviewPlugin {
     const logger = context.logger;
     const apiKey = config.apiKey ?? config.anthropicApiKey ?? '';
     const provider = config.provider ?? (config.anthropicApiKey ? 'anthropic' : 'openai');
+
+    // Diff-only summary-only mode (issue #572) — strictly gated, see
+    // `shouldActivate` above. Kept as an early-return to a dedicated method
+    // rather than branching inline so the normal (chunks-driven) path below
+    // is untouched by this mode's existence.
+    if (isSummaryOnlyMode(context, !!config.summaryEnabled)) {
+      return this.analyzeSummaryOnly(context, config, apiKey, provider, logger);
+    }
 
     // Build dependency graph from in-memory chunks (no embeddings needed)
     const graph = buildDependencyGraph(context.repoChunks!);
@@ -205,6 +230,80 @@ export class AgentReviewPlugin implements ReviewPlugin {
     // render path (`present`/`formatCheckSummary`) now renders every summary
     // finding, so that appended notice is visible as its own section — this
     // fold shapes the primary block, it no longer has to be the only summary.
+    mergeDocPassIntoResult(result, docResult, agentFindings);
+    const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
+    appendSummaryFinding(findings, pluginId, result.summary);
+    appendIncompleteNotice(findings, pluginId, result);
+
+    return findings;
+  }
+
+  /**
+   * Diff-only summary-only mode (issue #572). Kept as its OWN method — not a
+   * branch spliced into `analyze()`'s body — so the normal (chunks-driven)
+   * path above is provably unaffected by this mode's existence: every line of
+   * `analyze()` after the early-return guard runs exactly as it did before
+   * this mode was added. Deliberately mirrors that tail (doc-truth pass, then
+   * merge/map/append) rather than sharing it, for the same reason.
+   *
+   * The doc-truth SECOND pass still runs here (unlike the summary-only main
+   * pass, its gate — `docTruthSkipReason` — reads `context.pr.patches`
+   * directly, not chunks) — a docs-only PR is exactly the case doc-truth
+   * verification is for, so it is not disabled in this mode.
+   */
+  private async analyzeSummaryOnly(
+    context: ReviewContext,
+    config: AgentConfig,
+    apiKey: string,
+    provider: string,
+    logger: Logger,
+  ): Promise<ReviewFinding[]> {
+    const graph = buildDependencyGraph(context.repoChunks ?? []);
+    const toolExecutor = (name: string, input: Record<string, unknown>) =>
+      dispatchTool(name, input, {
+        repoChunks: context.repoChunks ?? [],
+        repoRootDir: context.repoRootDir!,
+        graph,
+        logger,
+      });
+
+    const { systemPrompt, initialMessage } = buildSummaryOnlyPrompts(context);
+    // The final budget was already scaled diff-proportionally by
+    // `scaleSummaryOnlyBudget` upstream (review-pr.ts's buildPluginConfigs) —
+    // unlike the normal path, there's no blast-radius upscale to layer on top
+    // (no chunks means no blast radius is computed).
+    const maxTokenBudget = config.maxTokenBudget;
+    context.reportBudget?.(maxTokenBudget);
+
+    const result = await runAgentClient(
+      provider,
+      { ...config, maxTurns: SUMMARY_ONLY_MAX_TURNS },
+      apiKey,
+      logger,
+      systemPrompt,
+      initialMessage,
+      toolExecutor,
+      maxTokenBudget,
+    );
+
+    if (result.neverRan) {
+      context.reportSkip?.({
+        plugin: 'agent-review:doc-truth',
+        reason: 'main pass never ran (provider failure)',
+      });
+    }
+    const docResult = result.neverRan
+      ? null
+      : await this.runSecondDocPass(context, config, apiKey, provider, logger, toolExecutor);
+    if (docResult) {
+      appendDocTruthTurns(result.trace, docResult.trace);
+      context.reportUsage?.(docResult.usage);
+    }
+
+    reportAgentRun(this.id, context, logger, result);
+
+    const pluginId = this.id;
+    const agentFindings = mergeDocTruthFindings(result.findings, docResult?.findings ?? []);
     mergeDocPassIntoResult(result, docResult, agentFindings);
     const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);

--- a/packages/review/src/plugins/agent/summary-only-pass.ts
+++ b/packages/review/src/plugins/agent/summary-only-pass.ts
@@ -1,0 +1,220 @@
+/**
+ * Diff-only summary pass (issue #572, remaining half).
+ *
+ * `AgentReviewPlugin.shouldActivate` has always required `context.chunks.length
+ * > 0` — no analyzable code chunks, no review. That's correct for bug-hunting
+ * (there's nothing to investigate), but it also silences the plugin's SUMMARY
+ * output on a PR that touches only non-indexed files (docs, config, shell
+ * scripts): `runAnalysisPhase`'s zero-analyzable-files fallback in
+ * `review-pr.ts` already fetches the PR's patches when `summary` is enabled
+ * (`tryFetchPRPatches`), but hardcodes `chunks: []` — so the plugin never even
+ * activates, and the PR description ends up with an empty "Low Risk" shell and
+ * no overview (see PR #766 as a live repro).
+ *
+ * This module is the fix's payload: a STRICTLY GATED alternate mode that runs
+ * only when there are zero analyzable chunks AND summary review is enabled AND
+ * the PR's raw diff is available. It builds its initial message from
+ * `pr.patches` instead of chunks, uses a single dedicated "summary-only" rule
+ * (no bug-hunting investigation strategy competes for the findings list), and
+ * scales the token budget down to a diff-proportional, low-capped amount —
+ * this is a summary, not an investigation.
+ *
+ * Mirrors the `doc-truth-pass.ts` shape: the gate, prompt builder, and budget
+ * function live here as pure/deterministic pieces; `index.ts`'s `analyze()`
+ * composes them with the shared agent-client runner.
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+import { reviewTokenBudgetMultiplier } from '../../defaults.js';
+
+import type { ReviewRule, ResolvedRules } from './types.js';
+import { buildSystemPrompt } from './system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Gate
+// ---------------------------------------------------------------------------
+
+/**
+ * The pure triple condition this whole mode is gated on, expressed over
+ * primitives so every layer that needs it (the plugin's `shouldActivate`,
+ * `review-pr.ts`'s budget selection, and its `eligibilityPath` tagging) can
+ * evaluate it from whatever shape of context it has on hand, without each
+ * layer re-deriving the boolean logic independently.
+ */
+export function isSummaryOnlyEligible(
+  noAnalyzableChunks: boolean,
+  summaryEnabled: boolean,
+  hasPatches: boolean,
+): boolean {
+  return noAnalyzableChunks && summaryEnabled && hasPatches;
+}
+
+/** `isSummaryOnlyEligible`, evaluated against a `ReviewContext`. */
+export function isSummaryOnlyMode(context: ReviewContext, summaryEnabled: boolean): boolean {
+  return isSummaryOnlyEligible(
+    context.chunks.length === 0,
+    summaryEnabled,
+    (context.pr?.patches?.size ?? 0) > 0,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule (single, dedicated — never added to BUILTIN_RULES/selectRules)
+// ---------------------------------------------------------------------------
+
+export const SUMMARY_ONLY_RULE: ReviewRule = {
+  id: 'summary-only',
+  name: 'Diff-Only Summary',
+  description:
+    'Produce a risk overview from the raw diff alone, for PRs with no analyzable code chunks',
+  prompt: `### Diff-Only Summary
+This PR touches no files eligible for structural code analysis (e.g. docs,
+config, or shell scripts) — there are no indexed code chunks to investigate,
+so tools like get_dependents/get_files_context/get_complexity will find
+nothing useful here. Base your summary ONLY on the <diff> and
+<changed_files> sections below.
+
+Your job is limited to the "summary" field: a concise overview of what
+changed and why it matters, a realistic riskLevel, and 2-4 keyChanges
+bullets. Do NOT fabricate a code investigation you did not perform, and do
+NOT report code "bugs" — there is no analyzable code in this PR to find bugs
+in. Leave "findings" empty unless the diff itself reveals an unambiguous,
+self-contained problem visible directly in the patch text (e.g. a broken
+link, invalid config syntax, a contradiction between two edited docs)
+without further investigation.
+
+Budget discipline: this pass has a small, diff-proportional token budget.
+Read the diff once, then answer — avoid unnecessary tool calls.`,
+  example: `### Good output — docs-only PR, no findings, plain summary:
+{
+  "findings": [],
+  "summary": {
+    "riskLevel": "low",
+    "overview": "Removes one stale sentence from CLAUDE.md that described packages/runner and platform/ as retired remnants still present in the tree — they were already deleted in an earlier PR. No code or behavior changes.",
+    "keyChanges": ["Deleted one outdated line from the monorepo structure list in CLAUDE.md"]
+  }
+}`,
+  triggers: { always: false },
+  severity: 'warning',
+  category: 'summary',
+  enabled: true,
+  source: 'builtin',
+};
+
+/**
+ * Only the summary-only rule is active. `skipped` is unused by
+ * `buildSystemPrompt` (it reads `active` only), so an empty list is honest.
+ */
+export const SUMMARY_ONLY_RULES: ResolvedRules = { active: [SUMMARY_ONLY_RULE], skipped: [] };
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+/** Max diff characters before truncation — small relative to the main pass's
+ * 50K (`MAX_DIFF_CHARS` in system-prompt.ts): this mode's whole token budget
+ * is capped low (see `scaleSummaryOnlyBudget`), so the diff itself must not
+ * consume it all. */
+export const MAX_SUMMARY_DIFF_CHARS = 12_000;
+
+function renderSummaryOnlyDiff(context: ReviewContext): string {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return '<diff>\n(no diff available)\n</diff>';
+  let diffText = '';
+  for (const [file, patch] of patches) {
+    diffText += `### ${file}\n\`\`\`diff\n${patch}\n\`\`\`\n\n`;
+  }
+  if (diffText.length > MAX_SUMMARY_DIFF_CHARS) {
+    diffText =
+      diffText.slice(0, MAX_SUMMARY_DIFF_CHARS) +
+      '\n\n[Diff truncated for this summary-only pass — base your summary on what is shown above.]';
+  }
+  return `<diff>\n${diffText}</diff>`;
+}
+
+function renderSummaryOnlyChangedFiles(context: ReviewContext): string {
+  const files = context.allChangedFiles ?? context.changedFiles;
+  const list = files.map(f => `- ${f}`).join('\n');
+  return `<changed_files>\n${list}\n</changed_files>`;
+}
+
+function renderSummaryOnlyPrMetadata(context: ReviewContext): string | null {
+  if (!context.pr) return null;
+  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
+  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
+}
+
+/**
+ * Build the diff-only initial message: PR header, the changed-files list
+ * (from `allChangedFiles` since there are no analyzable chunks to derive it
+ * from), and the raw diff — no blast radius, no complexity, no per-rule
+ * signal sections (those all key off `context.chunks`, which is empty here).
+ */
+export function buildSummaryOnlyInitialMessage(context: ReviewContext): string {
+  const sections: string[] = [];
+  const prMeta = renderSummaryOnlyPrMetadata(context);
+  if (prMeta) sections.push(prMeta);
+  sections.push(renderSummaryOnlyChangedFiles(context));
+  sections.push(renderSummaryOnlyDiff(context));
+  sections.push(
+    'This PR has no analyzable code chunks. Write a summary per the Diff-Only ' +
+      'Summary strategy above, based on the diff, then output it as JSON.',
+  );
+  return sections.join('\n\n');
+}
+
+/**
+ * The system + initial prompts for the summary-only pass. The system prompt
+ * reuses the standard `buildSystemPrompt` pipeline with ONLY the
+ * `summary-only` rule active, so the output format enumerates just that rule
+ * id and no bug-hunting investigation strategy appears.
+ */
+export function buildSummaryOnlyPrompts(context: ReviewContext): {
+  systemPrompt: string;
+  initialMessage: string;
+} {
+  return {
+    systemPrompt: buildSystemPrompt(SUMMARY_ONLY_RULES),
+    initialMessage: buildSummaryOnlyInitialMessage(context),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+/** Turn cap for the summary-only pass. No chunks to investigate and the
+ * evidence (the diff) is inline — this is a read-once-then-answer pass, not
+ * a tool-calling investigation. Small but non-zero: the model may still use
+ * a tool (e.g. read_file) to double-check something the diff alone doesn't
+ * make clear. */
+export const SUMMARY_ONLY_MAX_TURNS = 4;
+
+const SUMMARY_ONLY_MIN_BUDGET = 6_000;
+/** Low cap — this is a summary, not a review. Well below the normal path's
+ * 60K floor (`scaleAgentBudget`'s clamp). */
+const SUMMARY_ONLY_MAX_BUDGET = 20_000;
+const SUMMARY_ONLY_CHARS_PER_TOKEN = 4;
+/** Fixed overhead: system prompt + PR metadata + JSON verdict output,
+ * independent of diff size. */
+const SUMMARY_ONLY_BASE_OVERHEAD_TOKENS = 2_500;
+
+/**
+ * Scale the summary-only pass's token budget proportionally to the diff's
+ * size, clamped to a low ceiling. Unlike `scaleAgentBudget` (sized for a
+ * multi-phase investigation over indexed chunks), this mode has no chunks and
+ * no investigation phases — the diff IS the input, so the budget only needs
+ * to cover reading it once plus a compact JSON verdict.
+ */
+export function scaleSummaryOnlyBudget(
+  patches: Map<string, string> | undefined,
+  model: string,
+): number {
+  const diffChars = patches
+    ? [...patches.values()].reduce((sum, patch) => sum + patch.length, 0)
+    : 0;
+  const estimatedDiffTokens = Math.ceil(diffChars / SUMMARY_ONLY_CHARS_PER_TOKEN);
+  const base = SUMMARY_ONLY_BASE_OVERHEAD_TOKENS + estimatedDiffTokens;
+  const scaled = Math.round(base * reviewTokenBudgetMultiplier(model));
+  return Math.min(Math.max(scaled, SUMMARY_ONLY_MIN_BUDGET), SUMMARY_ONLY_MAX_BUDGET);
+}

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -51,6 +51,13 @@ export interface AgentConfig {
    * skip it and run the single main pass only.
    */
   docTruthPass?: boolean;
+  /**
+   * Whether the `summary` review type is enabled for this run (issue #572).
+   * Gates the diff-only summary-only mode: with zero analyzable chunks, the
+   * plugin only activates when this is true AND the PR's patches are
+   * available — see `summary-only-pass.ts`'s `isSummaryOnlyMode`.
+   */
+  summaryEnabled?: boolean;
 }
 
 /** A single finding produced by the agent during review. */

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -54,6 +54,11 @@ import {
   type SkippedPass,
 } from './attestation.js';
 import { cloneBySha, type CloneResult } from './clone.js';
+import {
+  isSummaryOnlyEligible,
+  scaleSummaryOnlyBudget,
+  SUMMARY_ONLY_MAX_TURNS,
+} from './plugins/agent/summary-only-pass.js';
 
 /**
  * LLM provider selection for the agent-review plugin. Either an OpenAI-compatible
@@ -152,6 +157,12 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
       );
     }
 
+    // Whether the diff-only summary-only mode (issue #572) is in play for
+    // this run. Threaded into `runAnalysisPhase` purely to tag
+    // `eligibilityPath` correctly; `buildPluginConfigs` below re-derives the
+    // same condition to pick the agent's budget (see `summaryOnlyEligibleFor`).
+    const summaryOnlyEligible = summaryOnlyEligibleFor(filesToAnalyze, summaryEnabled, pr);
+
     const analysis = await runAnalysisPhase(
       filesToAnalyze,
       ctx.config.threshold,
@@ -160,6 +171,7 @@ export async function reviewPullRequest(ctx: ReviewCoreContext): Promise<ReviewC
       pr.baseSha,
       token,
       logger,
+      summaryOnlyEligible,
     );
     if (!analysis) {
       return emptyResult(
@@ -223,12 +235,55 @@ function isAgentEnabled(ctx: ReviewCoreContext): boolean {
   );
 }
 
+/**
+ * Whether the diff-only summary-only mode (issue #572) applies: zero
+ * analyzable files, the `summary` review type on, and a non-empty PR diff.
+ * Shared by `reviewPullRequest` (to tag `eligibilityPath`) and
+ * `resolveAgentBudget` (to pick the agent's budget) so both layers agree on
+ * the exact same triple condition — see `isSummaryOnlyEligible`'s doc
+ * comment for why each layer re-evaluates it instead of passing one shared
+ * boolean around.
+ */
+export function summaryOnlyEligibleFor(
+  filesToAnalyze: string[],
+  summaryEnabled: boolean,
+  pr: PRContext,
+): boolean {
+  return isSummaryOnlyEligible(
+    filesToAnalyze.length === 0,
+    summaryEnabled,
+    (pr.patches?.size ?? 0) > 0,
+  );
+}
+
+/**
+ * Pick the agent's turn/token budget: the diff-proportional, low-capped
+ * summary-only budget when the summary-only mode (issue #572) applies,
+ * otherwise the normal chunks-driven `scaleAgentBudget`.
+ */
+export function resolveAgentBudget(
+  ctx: ReviewCoreContext,
+  filesToAnalyze: string[],
+  chunks: CodeChunk[],
+  summaryEnabled: boolean,
+): { maxTurns: number; maxTokenBudget: number } {
+  const model = ctx.llm?.model ?? '';
+  if (summaryOnlyEligibleFor(filesToAnalyze, summaryEnabled, ctx.pr)) {
+    return {
+      maxTurns: SUMMARY_ONLY_MAX_TURNS,
+      maxTokenBudget: scaleSummaryOnlyBudget(ctx.pr.patches, model),
+    };
+  }
+  return scaleAgentBudget(filesToAnalyze.length, chunks, model);
+}
+
 /** Assemble the per-plugin engine config (complexity threshold + agent LLM settings). */
 function buildPluginConfigs(
   ctx: ReviewCoreContext,
   filesToAnalyze: string[],
   chunks: CodeChunk[],
 ): Record<string, Record<string, unknown>> {
+  const summaryEnabled = !!ctx.config.reviewTypes.summary;
   return {
     complexity: {
       threshold: parseInt(ctx.config.threshold, 10),
@@ -242,7 +297,8 @@ function buildPluginConfigs(
           baseUrl: ctx.llm.provider === 'openai' ? ctx.llm.baseUrl : undefined,
           inputCostPerMTok: ctx.llm.inputCostPerMTok,
           outputCostPerMTok: ctx.llm.outputCostPerMTok,
-          ...scaleAgentBudget(filesToAnalyze.length, chunks, ctx.llm.model),
+          summaryEnabled,
+          ...resolveAgentBudget(ctx, filesToAnalyze, chunks, summaryEnabled),
         }
       : {},
   };
@@ -562,8 +618,17 @@ interface AnalysisPhaseResult {
   baselineReport: ComplexityReport | null;
   deltas: ComplexityDelta[] | null;
   baseClone: CloneResult | null;
-  /** 'normal' when the PR had analyzable files; 'full_repo_fallback' otherwise (#572/#754). */
+  /**
+   * 'normal' when the PR had analyzable files; 'summary_only_diff' when it
+   * didn't but the diff-only summary-only mode applies (#572); otherwise
+   * 'full_repo_fallback' (#572/#754).
+   */
   eligibilityPath: EligibilityPath;
+}
+
+/** The fallback branch's `eligibilityPath` — see `AnalysisPhaseResult.eligibilityPath`. */
+function fallbackEligibilityPath(summaryOnlyEligible: boolean): EligibilityPath {
+  return summaryOnlyEligible ? 'summary_only_diff' : 'full_repo_fallback';
 }
 
 async function runAnalysisPhase(
@@ -574,6 +639,7 @@ async function runAnalysisPhase(
   baseSha: string,
   token: string,
   logger: Logger,
+  summaryOnlyEligible: boolean,
 ): Promise<AnalysisPhaseResult | null> {
   if (filesToAnalyze.length > 0) {
     const headResult = await runComplexityAnalysis(filesToAnalyze, threshold, headCloneDir, logger);
@@ -633,7 +699,7 @@ async function runAnalysisPhase(
       baselineReport: null,
       deltas: null,
       baseClone: null,
-      eligibilityPath: 'full_repo_fallback',
+      eligibilityPath: fallbackEligibilityPath(summaryOnlyEligible),
     };
   }
   return {
@@ -653,7 +719,7 @@ async function runAnalysisPhase(
     baselineReport: null,
     deltas: null,
     baseClone: null,
-    eligibilityPath: 'full_repo_fallback',
+    eligibilityPath: fallbackEligibilityPath(summaryOnlyEligible),
   };
 }
 

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -7,12 +7,14 @@ import {
   clampText,
   hasProviderFailure,
 } from '../src/plugins/agent/index.js';
-import { scaleAgentBudget } from '../src/review-pr.js';
+import { scaleAgentBudget, resolveAgentBudget, summaryOnlyEligibleFor } from '../src/review-pr.js';
+import type { ReviewCoreContext } from '../src/review-pr.js';
 import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
 import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
 import type { AgentResult } from '../src/plugins/agent/types.js';
+import type { PRContext } from '../src/types.js';
 
 // ---------------------------------------------------------------------------
 // fetch mock helpers (OpenAI-compatible chat/completions)
@@ -575,6 +577,54 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
       ...scaleAgentBudget(5, [{ content: 'x'.repeat(40_002) }], DEFAULT_REVIEW_MODEL),
     };
     expect(() => plugin.configSchema.parse(cfg)).not.toThrow();
+  });
+});
+
+describe('summaryOnlyEligibleFor / resolveAgentBudget — issue #572 budget selection', () => {
+  function pr(patches?: Map<string, string>): PRContext {
+    return {
+      owner: 'o',
+      repo: 'r',
+      pullNumber: 1,
+      title: 't',
+      baseSha: 'base',
+      headSha: 'head',
+      patches,
+    };
+  }
+
+  function llmCtx(patches?: Map<string, string>): ReviewCoreContext {
+    return {
+      pr: pr(patches),
+      llm: { provider: 'openai', apiKey: 'k', model: DEFAULT_REVIEW_MODEL } as never,
+    } as unknown as ReviewCoreContext;
+  }
+
+  it('summaryOnlyEligibleFor is true only for the exact triple', () => {
+    expect(summaryOnlyEligibleFor([], true, pr(new Map([['a.md', 'd']])))).toBe(true);
+    expect(summaryOnlyEligibleFor(['x.ts'], true, pr(new Map([['a.md', 'd']])))).toBe(false);
+    expect(summaryOnlyEligibleFor([], false, pr(new Map([['a.md', 'd']])))).toBe(false);
+    expect(summaryOnlyEligibleFor([], true, pr())).toBe(false);
+  });
+
+  it('resolveAgentBudget picks the low-capped summary-only budget under the gate', () => {
+    const patches = new Map([['CLAUDE.md', 'x'.repeat(4_000)]]);
+    const { maxTurns, maxTokenBudget } = resolveAgentBudget(llmCtx(patches), [], [], true);
+    expect(maxTurns).toBeLessThanOrEqual(8);
+    expect(maxTokenBudget).toBeLessThan(60_000); // well under scaleAgentBudget's floor
+  });
+
+  it('resolveAgentBudget falls back to scaleAgentBudget outside the gate', () => {
+    const chunks = [{ content: 'x'.repeat(40_000) }];
+    const withFiles = resolveAgentBudget(llmCtx(new Map()), ['a.ts', 'b.ts'], chunks, true);
+    const expected = scaleAgentBudget(2, chunks, DEFAULT_REVIEW_MODEL);
+    expect(withFiles).toEqual(expected);
+  });
+
+  it('resolveAgentBudget uses the normal budget when summary is disabled, even with patches', () => {
+    const patches = new Map([['CLAUDE.md', 'x'.repeat(4_000)]]);
+    const result = resolveAgentBudget(llmCtx(patches), [], [], false);
+    expect(result).toEqual(scaleAgentBudget(0, [], DEFAULT_REVIEW_MODEL));
   });
 });
 

--- a/packages/review/test/plugins-agent-summary-only.test.ts
+++ b/packages/review/test/plugins-agent-summary-only.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Tests for the diff-only summary-only mode (issue #572, remaining half).
+ *
+ * Covers:
+ *  - `isSummaryOnlyEligible`/`isSummaryOnlyMode` — the exact triple gate
+ *  - `buildSummaryOnlyInitialMessage` — renders patches, truncation for huge diffs
+ *  - `scaleSummaryOnlyBudget` — proportional to diff size, low-capped
+ *  - `AgentReviewPlugin.shouldActivate` — activates ONLY under the exact
+ *    triple condition (chunks empty + patches present + summary enabled)
+ *  - `AgentReviewPlugin.analyze` — the summary-only branch renders the
+ *    dedicated diff-only prompt (not the normal bug-hunting rules), and the
+ *    normal (chunks-driven) path is unaffected — it never takes this branch.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import {
+  isSummaryOnlyEligible,
+  isSummaryOnlyMode,
+  buildSummaryOnlyInitialMessage,
+  buildSummaryOnlyPrompts,
+  scaleSummaryOnlyBudget,
+  MAX_SUMMARY_DIFF_CHARS,
+  SUMMARY_ONLY_MAX_TURNS,
+} from '../src/plugins/agent/summary-only-pass.js';
+import { AgentReviewPlugin } from '../src/plugins/agent/index.js';
+import { createTestContext } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import { DEFAULT_REVIEW_MODEL } from '../src/defaults.js';
+
+// ---------------------------------------------------------------------------
+// isSummaryOnlyEligible / isSummaryOnlyMode
+// ---------------------------------------------------------------------------
+
+describe('isSummaryOnlyEligible — the exact triple gate', () => {
+  it('is true only when all three conditions hold', () => {
+    expect(isSummaryOnlyEligible(true, true, true)).toBe(true);
+  });
+
+  it('is false when chunks ARE analyzable, regardless of the other two', () => {
+    expect(isSummaryOnlyEligible(false, true, true)).toBe(false);
+    expect(isSummaryOnlyEligible(false, false, false)).toBe(false);
+  });
+
+  it('is false when summary is not enabled', () => {
+    expect(isSummaryOnlyEligible(true, false, true)).toBe(false);
+  });
+
+  it('is false when there are no patches', () => {
+    expect(isSummaryOnlyEligible(true, true, false)).toBe(false);
+  });
+
+  it('is false when nothing holds', () => {
+    expect(isSummaryOnlyEligible(false, false, false)).toBe(false);
+  });
+});
+
+describe('isSummaryOnlyMode — ReviewContext-shaped wrapper', () => {
+  function ctx(overrides?: Partial<ReviewContext>): ReviewContext {
+    return createTestContext({ chunks: [], ...overrides });
+  }
+
+  it('is true with empty chunks, summary enabled, and non-empty patches', () => {
+    const context = ctx({ pr: { patches: new Map([['a.md', 'diff']]) } as ReviewContext['pr'] });
+    expect(isSummaryOnlyMode(context, true)).toBe(true);
+  });
+
+  it('is false when chunks are present', () => {
+    const context = ctx({
+      chunks: [{ content: 'x' } as never],
+      pr: { patches: new Map([['a.ts', 'diff']]) } as ReviewContext['pr'],
+    });
+    expect(isSummaryOnlyMode(context, true)).toBe(false);
+  });
+
+  it('is false when summaryEnabled is false', () => {
+    const context = ctx({ pr: { patches: new Map([['a.md', 'diff']]) } as ReviewContext['pr'] });
+    expect(isSummaryOnlyMode(context, false)).toBe(false);
+  });
+
+  it('is false when pr.patches is undefined or empty', () => {
+    expect(isSummaryOnlyMode(ctx({ pr: undefined }), true)).toBe(false);
+    expect(
+      isSummaryOnlyMode(ctx({ pr: { patches: new Map() } as ReviewContext['pr'] }), true),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSummaryOnlyInitialMessage
+// ---------------------------------------------------------------------------
+
+describe('buildSummaryOnlyInitialMessage', () => {
+  function ctx(overrides?: Partial<ReviewContext>): ReviewContext {
+    return createTestContext({ chunks: [], ...overrides });
+  }
+
+  it('renders the PR metadata, changed files, and diff patches', () => {
+    const context = ctx({
+      allChangedFiles: ['CLAUDE.md'],
+      pr: {
+        title: 'docs: fix stale line',
+        body: 'Removes a stale sentence.',
+        patches: new Map([['CLAUDE.md', '@@ -1,2 +1,1 @@\n-stale line\n context']]),
+      } as ReviewContext['pr'],
+    });
+
+    const message = buildSummaryOnlyInitialMessage(context);
+
+    expect(message).toContain('<pr_metadata>');
+    expect(message).toContain('docs: fix stale line');
+    expect(message).toContain('Removes a stale sentence.');
+    expect(message).toContain('<changed_files>');
+    expect(message).toContain('- CLAUDE.md');
+    expect(message).toContain('<diff>');
+    expect(message).toContain('stale line');
+    expect(message).toContain('This PR has no analyzable code chunks.');
+  });
+
+  it('falls back to changedFiles when allChangedFiles is absent', () => {
+    const context = ctx({ changedFiles: ['README.md'], allChangedFiles: undefined });
+    expect(buildSummaryOnlyInitialMessage(context)).toContain('- README.md');
+  });
+
+  it('says no diff is available when patches are absent', () => {
+    const context = ctx({ pr: undefined });
+    expect(buildSummaryOnlyInitialMessage(context)).toContain('(no diff available)');
+  });
+
+  it('truncates a huge diff and appends a truncation note', () => {
+    const hugePatch = 'x'.repeat(MAX_SUMMARY_DIFF_CHARS + 5_000);
+    const context = ctx({
+      pr: { patches: new Map([['big.md', hugePatch]]) } as ReviewContext['pr'],
+    });
+
+    const message = buildSummaryOnlyInitialMessage(context);
+
+    expect(message).toContain('[Diff truncated for this summary-only pass');
+    // The raw diff section itself must not carry the full huge patch through.
+    const diffSection = message.slice(message.indexOf('<diff>'), message.indexOf('</diff>'));
+    expect(diffSection.length).toBeLessThan(hugePatch.length);
+  });
+
+  it('does not truncate a diff at or under the cap', () => {
+    const patch = 'y'.repeat(1_000);
+    const context = ctx({ pr: { patches: new Map([['small.md', patch]]) } as ReviewContext['pr'] });
+    expect(buildSummaryOnlyInitialMessage(context)).not.toContain('truncated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSummaryOnlyPrompts — reduced rule set, no bug-hunting rules
+// ---------------------------------------------------------------------------
+
+describe('buildSummaryOnlyPrompts', () => {
+  it('enumerates ONLY the summary-only rule id in the output format', () => {
+    const context = createTestContext({ chunks: [] });
+    const { systemPrompt } = buildSummaryOnlyPrompts(context);
+    expect(systemPrompt).toContain('REQUIRED — exactly one of: summary-only');
+  });
+
+  it('does not include any bug-hunting investigation strategy', () => {
+    const context = createTestContext({ chunks: [] });
+    const { systemPrompt } = buildSummaryOnlyPrompts(context);
+    expect(systemPrompt).not.toContain('Structural Analysis');
+    expect(systemPrompt).not.toContain('Edge Case Sweep');
+    expect(systemPrompt).not.toContain('Threshold / Boundary Change Check');
+    expect(systemPrompt).toContain('Diff-Only Summary');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scaleSummaryOnlyBudget
+// ---------------------------------------------------------------------------
+
+describe('scaleSummaryOnlyBudget', () => {
+  it('scales with diff size within the clamp range', () => {
+    const small = scaleSummaryOnlyBudget(new Map([['a.md', 'x'.repeat(4_000)]]), 'lean-model');
+    const bigger = scaleSummaryOnlyBudget(new Map([['a.md', 'x'.repeat(40_000)]]), 'lean-model');
+    expect(bigger).toBeGreaterThan(small);
+  });
+
+  it('clamps to the minimum for a tiny/absent diff', () => {
+    expect(scaleSummaryOnlyBudget(new Map(), 'lean-model')).toBe(6_000);
+    expect(scaleSummaryOnlyBudget(undefined, 'lean-model')).toBe(6_000);
+  });
+
+  it('clamps to the low ceiling for a huge diff — well below the normal 60K floor', () => {
+    const huge = scaleSummaryOnlyBudget(new Map([['a.md', 'x'.repeat(400_000)]]), 'lean-model');
+    expect(huge).toBe(20_000);
+    expect(huge).toBeLessThan(60_000);
+  });
+
+  it('applies the model multiplier (Kimi vs a lean model)', () => {
+    const patches = new Map([['a.md', 'x'.repeat(4_000)]]);
+    const lean = scaleSummaryOnlyBudget(patches, 'some/lean-model');
+    const kimi = scaleSummaryOnlyBudget(patches, DEFAULT_REVIEW_MODEL);
+    expect(kimi).toBeGreaterThanOrEqual(lean);
+  });
+
+  it('always returns an integer (the config schema requires int)', () => {
+    const odd = scaleSummaryOnlyBudget(
+      new Map([['a.md', 'x'.repeat(4_003)]]),
+      DEFAULT_REVIEW_MODEL,
+    );
+    expect(Number.isInteger(odd)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentReviewPlugin.shouldActivate — the exact triple condition
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPlugin.shouldActivate — summary-only gate', () => {
+  function ctxWith(config: Record<string, unknown>, chunks: unknown[] = []): ReviewContext {
+    return createTestContext({
+      chunks: chunks as ReviewContext['chunks'],
+      config,
+      pr: config.__patches
+        ? ({ patches: config.__patches } as ReviewContext['pr'])
+        : (undefined as unknown as ReviewContext['pr']),
+    });
+  }
+
+  const plugin = new AgentReviewPlugin();
+
+  it('is false with no apiKey, regardless of chunks/summary/patches', () => {
+    const context = ctxWith({ summaryEnabled: true, __patches: new Map([['a.md', 'd']]) });
+    expect(plugin.shouldActivate(context)).toBe(false);
+  });
+
+  it('is true when chunks are present and apiKey is set (unchanged normal path)', () => {
+    const context = ctxWith({ apiKey: 'k', summaryEnabled: false }, [{ content: 'code' }]);
+    expect(plugin.shouldActivate(context)).toBe(true);
+  });
+
+  it('is false with empty chunks when summary is disabled (even with patches)', () => {
+    const context = ctxWith({
+      apiKey: 'k',
+      summaryEnabled: false,
+      __patches: new Map([['a.md', 'd']]),
+    });
+    expect(plugin.shouldActivate(context)).toBe(false);
+  });
+
+  it('is false with empty chunks and summary enabled but NO patches', () => {
+    const context = ctxWith({ apiKey: 'k', summaryEnabled: true });
+    expect(plugin.shouldActivate(context)).toBe(false);
+  });
+
+  it('is true ONLY for the exact triple: empty chunks + summary enabled + patches present', () => {
+    const context = ctxWith({
+      apiKey: 'k',
+      summaryEnabled: true,
+      __patches: new Map([['a.md', 'diff content']]),
+    });
+    expect(plugin.shouldActivate(context)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentReviewPlugin.analyze — branch selection (integration, via fetch mock)
+// ---------------------------------------------------------------------------
+
+type ChatResponse = {
+  choices: Array<{ message: { role: string; content: string | null }; finish_reason: string }>;
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+};
+
+function stopTurn(content: string): ChatResponse {
+  return {
+    choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+  };
+}
+
+const CLEAN_JSON =
+  '```json\n' +
+  JSON.stringify({
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'fine', keyChanges: [] },
+  }) +
+  '\n```';
+
+/** Installs a fetch mock and returns the captured request bodies. */
+function mockFetch(): { bodies: Array<Record<string, unknown>> } {
+  const bodies: Array<Record<string, unknown>> = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: { body: string }) => {
+      bodies.push(JSON.parse(init.body));
+      const resp = stopTurn(CLEAN_JSON);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => resp,
+        text: async () => JSON.stringify(resp),
+      };
+    }),
+  );
+  return { bodies };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('AgentReviewPlugin.analyze — summary-only branch selection', () => {
+  const plugin = new AgentReviewPlugin();
+
+  it('takes the summary-only branch when chunks are empty and the gate is met', async () => {
+    const { bodies } = mockFetch();
+    const context = createTestContext({
+      chunks: [],
+      allChangedFiles: ['CLAUDE.md'],
+      config: {
+        apiKey: 'k',
+        provider: 'openai',
+        model: 'test-model',
+        baseUrl: 'http://mock.local',
+        maxTurns: 8,
+        maxTokenBudget: 20_000,
+        summaryEnabled: true,
+        docTruthPass: false,
+      },
+      pr: {
+        title: 'docs: remove stale line',
+        patches: new Map([['CLAUDE.md', '@@ -1,2 +1,1 @@\n-stale\n context']]),
+      } as ReviewContext['pr'],
+      repoRootDir: '/tmp/does-not-matter',
+    });
+
+    await plugin.analyze(context);
+
+    expect(bodies.length).toBeGreaterThan(0);
+    const systemPrompt = bodies[0].messages as Array<{ role: string; content: string }>;
+    const system = systemPrompt.find(m => m.role === 'system')!.content;
+    const user = systemPrompt.find(m => m.role === 'user')!.content;
+    expect(system).toContain('Diff-Only Summary');
+    expect(system).not.toContain('Structural Analysis');
+    expect(user).toContain('This PR has no analyzable code chunks.');
+    expect(user).toContain('stale');
+  });
+
+  it('does NOT take the summary-only branch on the normal (chunks-driven) path', async () => {
+    const { bodies } = mockFetch();
+    const context = createTestContext({
+      chunks: [
+        {
+          content: 'export function add(a, b) { return a + b; }',
+          metadata: { file: 'src/math.ts', language: 'typescript', symbolType: 'function' },
+        } as ReviewContext['chunks'][number],
+      ],
+      changedFiles: ['src/math.ts'],
+      repoChunks: [],
+      repoRootDir: '/tmp/does-not-matter',
+      config: {
+        apiKey: 'k',
+        provider: 'openai',
+        model: 'test-model',
+        baseUrl: 'http://mock.local',
+        maxTurns: 8,
+        maxTokenBudget: 60_000,
+        summaryEnabled: true,
+        docTruthPass: false,
+      },
+      pr: {
+        title: 'fix: math',
+        patches: new Map([['src/math.ts', '@@ diff @@']]),
+      } as ReviewContext['pr'],
+    });
+
+    await plugin.analyze(context);
+
+    expect(bodies.length).toBeGreaterThan(0);
+    const messages = bodies[0].messages as Array<{ role: string; content: string }>;
+    const system = messages.find(m => m.role === 'system')!.content;
+    expect(system).toContain('Structural Analysis');
+    expect(system).not.toContain('Diff-Only Summary');
+  });
+});
+
+describe('SUMMARY_ONLY_MAX_TURNS', () => {
+  it('is a small, non-zero cap', () => {
+    expect(SUMMARY_ONLY_MAX_TURNS).toBeGreaterThan(0);
+    expect(SUMMARY_ONLY_MAX_TURNS).toBeLessThanOrEqual(8);
+  });
+});

--- a/packages/review/test/review-pr-scope.test.ts
+++ b/packages/review/test/review-pr-scope.test.ts
@@ -105,6 +105,29 @@ describe('reviewPullRequest — scope.eligibilityPath', () => {
     await checkout.cleanup();
   });
 
+  it('is "summary_only_diff" when the PR touches no analyzable files, summary is on, AND the diff is non-empty (#572)', async () => {
+    githubApi.getPRChangedFiles.mockResolvedValue(['CLAUDE.md']);
+    githubApi.getPRPatchData.mockResolvedValue({
+      patches: new Map([['CLAUDE.md', '@@ -1,2 +1,1 @@\n-stale line\n context']]),
+      diffLines: new Map([['CLAUDE.md', new Set([1])]]),
+    });
+    const checkout = await makeCheckout();
+    cloneBySha.mockResolvedValueOnce(checkout);
+
+    const result = await reviewPullRequest(
+      baseCtx({
+        config: {
+          threshold: '15',
+          blockOnNewErrors: false,
+          reviewTypes: { complexity: true, summary: true, architectural: false, bugs: false },
+        },
+      }),
+    );
+
+    expect(result.attestation.scope.eligibilityPath).toBe('summary_only_diff');
+    await checkout.cleanup();
+  });
+
   it('is "normal" when the PR touches analyzable files', async () => {
     githubApi.getPRChangedFiles.mockResolvedValue(['foo.ts']);
     const headCheckout = await makeCheckout();


### PR DESCRIPTION
## Root cause

Issue #572's noise half was fixed in #754 (scoped `ComplexityPlugin` findings
on the zero-analyzable-files fallback path). The remaining half: the agent
**summary** also never fires on a PR that touches only non-indexed files
(docs/config/shell).

`AgentReviewPlugin.shouldActivate` (`packages/review/src/plugins/agent/index.ts`)
has always required `context.chunks.length > 0`. `runAnalysisPhase`'s
zero-analyzable-files fallback (`review-pr.ts`) already calls
`tryFetchPRPatches` when `summary` is enabled, but hardcodes `chunks: []` — so
the plugin never even activates, and the PR description gets an empty
`> [!NOTE]\n> **Low Risk**` shell with no overview. Live repro: PR #766
(CLAUDE.md one-line removal) shipped with exactly this empty shell.

## The fix: a strictly-gated summary-only mode

New module `packages/review/src/plugins/agent/summary-only-pass.ts` (mirrors
`doc-truth-pass.ts`'s shape — gate + prompt builder + budget as pure/testable
pieces):

- **Gate** — `isSummaryOnlyEligible(noAnalyzableChunks, summaryEnabled, hasPatches)`,
  true only for the exact triple. `AgentReviewPlugin.shouldActivate` extends
  with one new branch; every existing condition (apiKey, `chunks.length > 0`)
  is untouched.
- **Diff-only prompt** — `buildSummaryOnlyPrompts` reuses `buildSystemPrompt`
  with a single dedicated `summary-only` rule (no bug-hunting rules compete
  for the findings list) and a new `buildSummaryOnlyInitialMessage` that
  renders `<pr_metadata>`/`<changed_files>`/`<diff>` from `pr.patches`
  instead of chunks, with its own truncation cap (12K chars) + note for huge
  diffs.
- **Budget** — `scaleSummaryOnlyBudget` scales proportionally to diff size,
  clamped to **6K–20K tokens** (vs. the normal path's 60K floor via
  `scaleAgentBudget`) — this is a summary, not an investigation.
  `review-pr.ts`'s `resolveAgentBudget` picks this over `scaleAgentBudget`
  only under the same gate (`summaryOnlyEligibleFor`).
- `AgentReviewPlugin.analyze()` branches to a **new, separate**
  `analyzeSummaryOnly()` method at the very top (early return) rather than
  splicing logic into the existing body, so the normal path is provably
  unaffected. The doc-truth second pass still runs in this mode (its own gate
  reads `pr.patches` directly, not chunks — a docs-only PR is exactly its use
  case).

## Proof of non-regression: byte-diff census

Every committed fixture (`boundary-change/placeholder`, `doc-truth/accurate-doc`,
`doc-truth/renamed-stale-claim` — the only 3 `.fixture.json` tracked in git;
the rest are gitignored/regenerated from PRs) has `chunks.length >= 1`, so
none exercises the new branch. Ran `build-prompts.ts` for all 3 against
MERGE-BASE (`origin/main`, via `git stash`) and HEAD, byte-diffed the JSON output:

```
boundary-change/placeholder      IDENTICAL
doc-truth/accurate-doc           IDENTICAL
doc-truth/renamed-stale-claim    IDENTICAL
```

**3/3 (100%) identical.** Additionally structural: `build-prompts.ts` calls
`buildSystemPrompt`/`buildInitialMessage` directly — it never invokes
`AgentReviewPlugin` at all, so this new mode cannot leak into it by
construction.

**Harness-evidence gate note:** this PR adds one brand-new, dedicated
`summary-only` rule that is never added to `BUILTIN_RULES`/`selectRules` and
never competes with an existing rule's prompt — it only runs in the new
zero-chunks/diff-only branch, which no existing fixture exercises. No new
`--calibrate 10` run is needed for it: the byte-diff census above (3/3
identical) IS the evidence that every existing rule's prompt is untouched, so
each rule's last calibrate result remains valid unchanged.

## Attestation wiring (packages/review/src/attestation.ts, merged today via #768)

Extended `EligibilityPath` with `'summary_only_diff'` (was
`'normal' | 'zero_files_early_exit' | 'full_repo_fallback'`), set in
`runAnalysisPhase`'s fallback branch only when the summary-only gate is met
(patches present) — `full_repo_fallback` stays for patches-absent/summary-off.
`scope.eligibilityPath` now distinguishes "agent ran the diff-only summary"
from "agent didn't run at all". No changes to verdict derivation: a
summary-only run that fails (never-ran / incomplete) still flows through
the existing `neverRan`/`incomplete` machinery in `analyzeSummaryOnly` (shared
with the normal path's tail), so it attests `degraded:*`/`failed:*`, never
`delivered`.

## Dogfood (mandatory house law)

Captured **PR #766** (`docs: remove stale platform/runner reference from
CLAUDE.md`) via the harness's `capture-pr.ts` (real `gh pr diff`, real repo
index). Overrode `chunks: []` to match production's fallback shape exactly
(CLAUDE.md produces markdown doc-chunks in the whole-repo index, but is
**not** complexity-analyzable, so production's real `AnalysisPhaseResult.chunks`
is `[]` for this PR). Wired a real OpenRouter config
(`moonshotai/kimi-k2.7-code`, prod default) and called
`AgentReviewPlugin.analyze()` directly — **one live call**.

`shouldActivate` → `true`; `maxTokenBudget` → `6,000` (the floor, correctly,
for a 1-line diff). Verbatim summary produced:

> Removes one stale line from CLAUDE.md that described `platform/` and
> `packages/runner` as retired hosted-platform remnants still present in the
> tree. Those directories were already deleted in an earlier PR (#593), so
> the line was misleading. No code or behavior changes.
>
> - Deleted the outdated monorepo structure bullet referencing `platform/`
>   and `packages/runner` from CLAUDE.md

Zero bug findings (correct — no analyzable code). The doc-truth second pass
did not fire (the diff is a plain descriptive removal, no claim-shaped
prose — correctly gated off). Cost: not captured exactly (`analyze()` doesn't
surface `AgentResult.usage` to a bare caller outside `context.reportUsage`),
but bounded above by the 6,000-token ceiling actually used
(≤ ~$0.02 worst-case at Kimi's published per-token rates) — well under the
$0.30 cap. This is a live repro fix: #766 currently shows an empty
`Low Risk` shell in production; this summary is what it should have said.

## Tests

- `packages/review/test/plugins-agent-summary-only.test.ts` (29 tests, new):
  `isSummaryOnlyEligible`/`isSummaryOnlyMode` full gate truth table,
  `buildSummaryOnlyInitialMessage` (renders patches/changed-files/PR metadata,
  truncation + note for huge diffs), `buildSummaryOnlyPrompts` (only
  `summary-only` enumerated, no bug-hunting rule text), `scaleSummaryOnlyBudget`
  (proportional scaling + clamps + model multiplier), `shouldActivate`'s exact
  triple condition, and an integration test (mocked fetch, real
  `AgentReviewPlugin.analyze()`) proving the summary-only branch fires for the
  gated case and — critically — is **NOT** taken on the normal chunks-driven
  path (asserts the request's system prompt contains `Structural Analysis`
  and not `Diff-Only Summary`).
- `packages/review/test/plugins-agent-budget.test.ts`: `resolveAgentBudget`/
  `summaryOnlyEligibleFor` unit tests (low-capped budget under the gate,
  falls back to `scaleAgentBudget` outside it).
- `packages/review/test/review-pr-scope.test.ts`: new `'summary_only_diff'`
  eligibility-path case (existing `'full_repo_fallback'` case — empty
  patches — is untouched and still passes).

## Gate chain

`npm run format:check` / `npm run lint` (0 errors, 30 pre-existing warnings,
none in touched files) / `npm run typecheck` / `npm run build` / `npm test`
(parser 1052, core 374, review 891, cli 817, action 39 — all pass) /
`node packages/cli/dist/index.js delta` — **exit 0**, no new-over-threshold
crossings (3 pre-existing "worsened"/"pre-exist" entries on
`AgentReviewPlugin.shouldActivate`/`analyze`, `reviewPullRequest`,
`buildPluginConfigs`, all informational, not gate failures).

No changeset (`@liendev/review` is private/unpublished).

## Lien Review triage (this PR's own check)

Fetched via `gh run view <run-id> --log` (the PR-body stats badge got
clobbered by a later `gh pr edit` full-body replacement while fixing the
harness-gate check below — recovered from the Action log instead):

- **Agent-review (bug hunting): 0 findings** in 5 turns — clean bill of
  health, and its summary/keyChanges accurately described this PR's own
  change (dogfooding the fix on itself).
- **doc-truth pass: skipped** — "not a doc-touching PR (no doc claims)",
  correct (no `docs/**`/`CLAUDE.md`/guidance-surface files touched).
- **ComplexityPlugin: 4 violations (1 error, 3 warnings)** in touched files
  (`AgentReviewPlugin.analyze`, `reviewPullRequest`, etc.) — **dismissed,
  pre-existing**: the baseline (pre-PR) analysis in the same CI run found the
  identical count (4) in the same files, and the dedicated
  `Complexity delta vs base branch (lien delta --base)` CI check (delta-aware,
  new-crossings-only) passed. My own local `lien delta` run (below) confirms
  every flagged function is `pre-exist`/`worsened`-but-already-over, never
  `new`-over-threshold — consistent with CLAUDE.md's "improving, or merely
  touching, a pre-existing violation never fails the gate." Not refactoring
  unrelated pre-existing complexity debt here to keep this PR's diff
  minimal and the byte-diff census argument airtight.

Closes #572
