### PR TITLE
feat(review): deterministic changed-comparison signal for boundary-change

### DIFF
--- a/packages/review/src/comparison-change-signals.ts
+++ b/packages/review/src/comparison-change-signals.ts
@@ -1,0 +1,676 @@
+/**
+ * Deterministic "changed comparison" signal for PR reviews, feeding the
+ * `boundary-change` rule.
+ *
+ * Provenance / design principle: `boundary-change`'s entire domain is
+ * comparisons and threshold literals changing (`>` -> `>=`, `5` -> `6`,
+ * `&&` -> `||`, off-by-one index arithmetic, sign flips). Today the agent
+ * must NOTICE these shapes in the diff before it can even start the rule's
+ * MANDATORY investigation protocol — and the rule's own trigger-tuning
+ * history (#741/#743, see `rules.ts`'s `BOUNDARY_CHANGE.triggers`) shows
+ * noticing is the weak link, not judgment. This module precomputes the
+ * DISCOVERY step only — "here is every comparison-shaped edit in this
+ * diff" — and leaves judgment (intentional? disclosed? breaking?) to the
+ * agent, mirroring `stale-literal-signals.ts` / `catch-discrimination-signals.ts`.
+ *
+ * ## What this scans for, per changed-line pair
+ *
+ * The diff's hunks are walked and REMOVED lines are paired with ADDED
+ * lines within the same hunk (never across hunks — see "Conservative
+ * pairing" below). Each accepted pair is classified as one of:
+ *
+ *  (a) **Comparison operator change** — `<`<->`<=`, `>`<->`>=`,
+ *      `==`<->`===`, `!=`<->`!==`, `&&`<->`||`, or a bare logical negation
+ *      (`!`) added/removed — detected by tokenizing both lines with
+ *      {@link OPERATOR_TOKEN_RE}, stripping the matched tokens to form a
+ *      "skeleton", and requiring the skeletons match (mod whitespace) so
+ *      only the operator itself differs.
+ *  (b) **Numeric literal change in a conditional context** — a number
+ *      token changed (`5` -> `6`) via the same skeleton-diff technique,
+ *      gated on the line containing a conditional/comparison keyword
+ *      (`if`, `while`, `?`, `switch`, `case`, `.filter(`/`.some(`/`.every(`/
+ *      `.find(`, or any comparison/logical operator) — per the design,
+ *      literal changes with NO such keyword on the line (e.g. an unrelated
+ *      config default) are intentionally not flagged here.
+ *  (c) **Index-arithmetic off-by-one** — an identifier or `.length`
+ *      expression used as an array index gains, loses, or changes a
+ *      `+ N` / `- N` delta (`i` <-> `i + 1`, `.length` <-> `.length - 1`),
+ *      detected by comparing the per-base "delta signature" extracted from
+ *      each line via {@link INDEX_DELTA_RE} / {@link BARE_SUBSCRIPT_RE} /
+ *      {@link BARE_LENGTH_RE}.
+ *
+ * ## Conservative pairing
+ *
+ * A removed line is only paired with an added line when (1) they appear in
+ * the same diff hunk (proximity — pairing never crosses a `@@` boundary),
+ * and (2) they share > 70% token overlap (Jaccard over a word/number/
+ * punctuation-run tokenization) — see {@link tokenOverlap}. This is what
+ * keeps unrelated refactors from false-pairing: a line rewritten beyond
+ * recognition, or a wholly new line with no similar removed counterpart
+ * (new code, not a boundary *change*), never enters the classifiers.
+ * Pairing is greedy first-fit within a hunk's contiguous removed/added
+ * block, not a globally optimal matching — acceptable for a heuristic
+ * discovery aid, not a ground-truth diff algorithm.
+ *
+ * ## Known limitations (kept honest, not papered over)
+ *
+ *  - **Compound changes are invisible.** If BOTH the operator and the
+ *    literal change on the same line (`> 5` -> `>= 6`), neither classifier
+ *    fires: each requires everything OTHER than its own token category to
+ *    stay skeleton-identical. A real boundary change can therefore slip
+ *    through when it's more than one edit at once — the diff itself
+ *    (always rendered separately in `<diff>`) is the backstop.
+ *  - **`.length`-style index arithmetic is JS/TS-shaped.** Category (c)'s
+ *    `.length` pattern doesn't recognize Python's `len(x)`, Go's `len(x)`,
+ *    etc. — only a literal `.length` property access. Operator/negation
+ *    categories (a) generalize better across C-family languages, but
+ *    still miss Python's `and`/`or`/`not` keyword forms (no `&&`/`||`/`!`
+ *    in Python) and Ruby's `unless`. Cross-language coverage is partial by
+ *    construction, not a bug.
+ *  - **Single-line masking only.** {@link maskLine} strips string/template
+ *    literals and same-line `//`/`#` comments, but has no cross-line state
+ *    — a multi-line `/* ... *‍/` block comment is not recognized as a
+ *    comment on its continuation lines. A comparison-shaped token that
+ *    happens to sit inside such a continuation is a possible false
+ *    positive this scan cannot see.
+ *  - **Test-assertion noise is only trivially filtered.** A pair where
+ *    BOTH lines are `expect(...)`/`assert(...)` calls in a file matching
+ *    {@link TEST_FILE_RE} is skipped — this catches the common case but not
+ *    every assertion style (e.g. `.should.equal(...)`, bare `assert x == y`
+ *    without a call-like prefix).
+ *  - **Negation detection is a raw `!` count, not scope-aware.** Adding an
+ *    unrelated `!` elsewhere on an otherwise-similar line (rare in
+ *    practice, given the skeleton-equality gate) would still be classified
+ *    as a negation toggle.
+ */
+
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ComparisonChangeKind = 'operator' | 'literal' | 'index-arithmetic';
+
+/** A comparison/threshold-shaped edit this PR made, paired old -> new. */
+export interface ComparisonChangeCandidate {
+  file: string;
+  /** New-file line number of the added line in the pair. */
+  line: number;
+  kind: ComparisonChangeKind;
+  /** The old fragment (operator, literal, or index expression). */
+  oldFragment: string;
+  /** The new fragment. */
+  newFragment: string;
+  /** One-line explanation of what changed. */
+  reason: string;
+}
+
+/** Shared shape returned by each per-category classifier before `kind` is attached. */
+interface FragmentResult {
+  oldFragment: string;
+  newFragment: string;
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max candidates reported — keeps the prompt compact. */
+const MAX_CANDIDATES = 10;
+
+/** Minimum Jaccard token overlap for a removed/added line to be paired. */
+const PAIRING_OVERLAP_THRESHOLD = 0.7;
+
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/**
+ * Comparison/logical operator tokens, longest-first so the regex engine's
+ * left-to-right alternative order greedily prefers `===` over `==`, `!==`
+ * over `!=`, etc. A bare `!` is included as its own token (logical NOT) —
+ * distinguished from `!=`/`!==` only by alternative order, same trick.
+ */
+const OPERATOR_TOKEN_RE = /<=|>=|===|!==|==|!=|&&|\|\||<|>|!/g;
+
+/** A number literal, excluding digits embedded in a wider identifier/decimal chain. */
+const NUMBER_TOKEN_RE = /(?<![\w.])-?\d+(?:\.\d+)?(?![\w.])/g;
+
+/** Recognized unordered operator-change pairs — the domain from the module doc. */
+const OPERATOR_PAIRS = new Set<string>([
+  ['<', '<='].sort().join('|'),
+  ['>', '>='].sort().join('|'),
+  ['==', '==='].sort().join('|'),
+  ['!=', '!=='].sort().join('|'),
+  ['&&', '||'].sort().join('|'),
+]);
+
+/** Line contains a conditional/comparison keyword — gates the literal-change check (b). */
+const CONDITIONAL_CONTEXT_RE =
+  /\bif\b|\bwhile\b|\?|\bswitch\b|\bcase\b|\.filter\s*\(|\.some\s*\(|\.every\s*\(|\.find\s*\(|<=|>=|===?|!==?|&&|\|\||[<>]/;
+
+/** `base + N` / `base - N` where base is an identifier or `identifier.length`. */
+const INDEX_DELTA_RE = /\b([A-Za-z_$][\w$]*(?:\.length)?)\s*([+-])\s*(\d+)\b/g;
+
+/** A bare base used as an array subscript with no delta: `arr[i]`, `arr[n.length]`. */
+const BARE_SUBSCRIPT_RE = /\[\s*([A-Za-z_$][\w$]*(?:\.length)?)\s*\]/g;
+
+/** A bare `identifier.length` NOT followed by a delta (avoids double-counting with INDEX_DELTA_RE). */
+const BARE_LENGTH_RE = /\b([A-Za-z_$][\w$]*\.length)\b(?!\s*[+-]\s*\d)/g;
+
+/** Files whose assertion lines are filtered per the "test noise" limitation. */
+const TEST_FILE_RE = /\.(?:test|spec)\.[cm]?[jt]sx?$|(?:^|\/)test_[^/]+\.py$|_test\.py$|_spec\.rb$/;
+
+/** A trivially-detectable test-assertion line (see module doc limitations). */
+const TEST_ASSERTION_RE = /^\s*(?:expect|assert)\s*\(/;
+
+// ---------------------------------------------------------------------------
+// Diff hunk parsing — group removed/added lines into same-hunk change blocks
+// ---------------------------------------------------------------------------
+
+interface AddedLine {
+  text: string;
+  newLine: number;
+}
+
+interface ChangeBlock {
+  removed: string[];
+  added: AddedLine[];
+}
+
+/** Mutable state threaded through {@link processDiffLine} by {@link extractChangeBlocks}. */
+interface BlockState {
+  blocks: ChangeBlock[];
+  current: ChangeBlock | null;
+  newLine: number;
+}
+
+/** Close the pending block (if it qualifies — both sides non-empty) and clear it. */
+function flushBlock(state: BlockState): void {
+  if (state.current && state.current.removed.length > 0 && state.current.added.length > 0) {
+    state.blocks.push(state.current);
+  }
+  state.current = null;
+}
+
+/**
+ * Apply one raw unified-diff line to `state`: hunk headers reset the
+ * new-line cursor and close the pending block; `-`/`+` lines open or extend
+ * the pending block; a context line closes it. Split out of
+ * {@link extractChangeBlocks} so its own loop stays flat.
+ */
+function processDiffLine(raw: string, state: BlockState): void {
+  const header = raw.match(HUNK_HEADER_RE);
+  if (header) {
+    flushBlock(state);
+    state.newLine = parseInt(header[2], 10);
+    return;
+  }
+  if (raw.startsWith('+++') || raw.startsWith('---') || raw.startsWith('\\')) return;
+
+  if (raw.startsWith('-')) {
+    state.current ??= { removed: [], added: [] };
+    state.current.removed.push(raw.slice(1));
+    return;
+  }
+  if (raw.startsWith('+')) {
+    state.current ??= { removed: [], added: [] };
+    state.current.added.push({ text: raw.slice(1), newLine: state.newLine });
+    state.newLine++;
+    return;
+  }
+  // Context line: closes any pending block, and advances the cursor.
+  flushBlock(state);
+  state.newLine++;
+}
+
+/**
+ * Split one file's unified-diff patch into per-hunk change blocks: maximal
+ * runs of consecutive `-` lines immediately followed by consecutive `+`
+ * lines (the shape git/unified-diff emits for a "modified line"), each
+ * carrying the added lines' new-file line numbers. A context line or hunk
+ * boundary closes the current block. This is the "same hunk proximity"
+ * scope for pairing — blocks never span a `@@` header.
+ */
+function extractChangeBlocks(patch: string): ChangeBlock[] {
+  const state: BlockState = { blocks: [], current: null, newLine: 0 };
+  for (const raw of patch.split('\n')) processDiffLine(raw, state);
+  flushBlock(state);
+  return state.blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Line masking — hide string/template literals and same-line comments
+// ---------------------------------------------------------------------------
+
+function isQuoteChar(ch: string): boolean {
+  return ch === '"' || ch === "'" || ch === '`';
+}
+
+/**
+ * Mask the quoted region starting at `line[i]` (the opening quote) with
+ * same-length spaces, honoring backslash escapes. Returns the masked
+ * fragment and the index just past the closing quote (or end of line, for
+ * an unterminated string). Split out of {@link maskLine} so its own loop
+ * stays flat.
+ */
+function maskQuoted(line: string, i: number): { masked: string; next: number } {
+  const quote = line[i];
+  let masked = ' ';
+  let j = i + 1;
+  while (j < line.length && line[j] !== quote) {
+    if (line[j] === '\\' && j + 1 < line.length) {
+      masked += '  ';
+      j += 2;
+    } else {
+      masked += ' ';
+      j++;
+    }
+  }
+  if (j < line.length) {
+    masked += ' ';
+    j++;
+  }
+  return { masked, next: j };
+}
+
+/**
+ * Mask string/template-literal contents and a trailing same-line `//`/`#`
+ * comment with spaces (preserving length, so no offsets shift). Single-line
+ * only — see the module doc's "Single-line masking only" limitation.
+ */
+function maskLine(line: string): string {
+  let out = '';
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    if (isQuoteChar(ch)) {
+      const { masked, next } = maskQuoted(line, i);
+      out += masked;
+      i = next;
+      continue;
+    }
+    if ((ch === '/' && line[i + 1] === '/') || ch === '#') {
+      out += ' '.repeat(line.length - i);
+      break;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Pairing — token-overlap similarity gate
+// ---------------------------------------------------------------------------
+
+const TOKEN_RE = /[A-Za-z_$][\w$]*|\d+(?:\.\d+)?|[^\sA-Za-z0-9_$]+/g;
+
+function tokenSet(line: string): Set<string> {
+  return new Set(line.match(TOKEN_RE) ?? []);
+}
+
+/** Jaccard overlap between two lines' token sets. */
+function tokenOverlap(a: string, b: string): number {
+  const setA = tokenSet(a);
+  const setB = tokenSet(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  let intersection = 0;
+  for (const t of setA) if (setB.has(t)) intersection++;
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 1 : intersection / union;
+}
+
+interface LinePair {
+  oldLine: string;
+  newLine: string;
+  newLineNo: number;
+}
+
+/** Best unused added-line index for `removed` in `block`, or -1 if none clears the overlap bar. */
+function findBestAddedMatch(removed: string, block: ChangeBlock, usedAdded: Set<number>): number {
+  let bestIdx = -1;
+  let bestScore = PAIRING_OVERLAP_THRESHOLD;
+  block.added.forEach((added, idx) => {
+    if (usedAdded.has(idx)) return;
+    const score = tokenOverlap(removed, added.text);
+    if (score >= bestScore) {
+      bestScore = score;
+      bestIdx = idx;
+    }
+  });
+  return bestIdx;
+}
+
+/**
+ * Greedily pair each removed line with the best unused added line in the
+ * same block, requiring >= {@link PAIRING_OVERLAP_THRESHOLD} token overlap.
+ * Removed or added lines left over (no sufficiently similar counterpart)
+ * are simply not paired — an added line with no match is new code, not a
+ * changed line, per the module's scope.
+ */
+function pairBlock(block: ChangeBlock): LinePair[] {
+  const pairs: LinePair[] = [];
+  const usedAdded = new Set<number>();
+
+  for (const removed of block.removed) {
+    const bestIdx = findBestAddedMatch(removed, block, usedAdded);
+    if (bestIdx === -1) continue;
+    usedAdded.add(bestIdx);
+    pairs.push({
+      oldLine: removed,
+      newLine: block.added[bestIdx].text,
+      newLineNo: block.added[bestIdx].newLine,
+    });
+  }
+
+  return pairs;
+}
+
+// ---------------------------------------------------------------------------
+// Classifiers — (a) operator, (b) literal, (c) index-arithmetic
+// ---------------------------------------------------------------------------
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Tokenize with `re`, returning both the matched tokens (in order) and the
+ * residual "skeleton" with matches removed entirely (not replaced by a
+ * placeholder). Removal matters: a token like `!` that sits directly
+ * against an identifier with no surrounding space (`!isValid(x)`) would,
+ * if replaced by a space instead of deleted, leave a spurious gap on
+ * whichever side has the token and NOT the other — permanently breaking
+ * skeleton equality for exactly the negation-added/removed case this
+ * module needs to recognize. Deleting and then collapsing whitespace
+ * (via {@link normalizeWhitespace}) is symmetric for both spaced tokens
+ * (`a == b` vs `a === b`, both left with `a  b` -> `a b`) and unspaced
+ * ones (`!isValid` vs `isValid`, both left with `isValid`).
+ */
+function tokenizeAndStrip(line: string, re: RegExp): { tokens: string[]; skeleton: string } {
+  const tokens: string[] = [];
+  const skeleton = line.replace(re, m => {
+    tokens.push(m);
+    return '';
+  });
+  return { tokens, skeleton: normalizeWhitespace(skeleton) };
+}
+
+/**
+ * The single index where equal-length arrays `a`/`b` differ, or -1 when
+ * they're identical or differ in more than one position. Shared by the
+ * operator and literal classifiers — each requires exactly one changed
+ * token with everything else (the skeleton, already checked by the caller)
+ * unchanged.
+ */
+function findSingleDiffIndex(a: string[], b: string[]): number {
+  let diffIdx = -1;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === b[i]) continue;
+    if (diffIdx !== -1) return -1; // more than one difference
+    diffIdx = i;
+  }
+  return diffIdx;
+}
+
+/**
+ * Find the single index whose removal from `longer` makes it equal (by
+ * value) to `shorter`. Returns -1 if no such single-element removal exists.
+ * Used to locate an added/removed negation token when operator-token counts
+ * differ by exactly one.
+ */
+function findSingleInsertionIndex(shorter: string[], longer: string[]): number {
+  if (longer.length !== shorter.length + 1) return -1;
+  for (let skip = 0; skip < longer.length; skip++) {
+    let matches = true;
+    let si = 0;
+    for (let li = 0; li < longer.length; li++) {
+      if (li === skip) continue;
+      if (longer[li] !== shorter[si]) {
+        matches = false;
+        break;
+      }
+      si++;
+    }
+    if (matches) return skip;
+  }
+  return -1;
+}
+
+/** Equal-length operator-token arrays: exactly one changed slot, and it's a recognized pair. */
+function classifySameLengthOperatorChange(
+  oldTokens: string[],
+  newTokens: string[],
+): FragmentResult | null {
+  const i = findSingleDiffIndex(oldTokens, newTokens);
+  if (i === -1) return null;
+  const pairKey = [oldTokens[i], newTokens[i]].sort().join('|');
+  if (!OPERATOR_PAIRS.has(pairKey)) return null;
+  return {
+    oldFragment: oldTokens[i],
+    newFragment: newTokens[i],
+    reason: `comparison operator changed from \`${oldTokens[i]}\` to \`${newTokens[i]}\``,
+  };
+}
+
+/** Operator-token arrays differing by exactly one slot: a bare `!` (negation) added or removed. */
+function classifyNegationToggle(oldTokens: string[], newTokens: string[]): FragmentResult | null {
+  const oldIsShorter = oldTokens.length < newTokens.length;
+  const shorter = oldIsShorter ? oldTokens : newTokens;
+  const longer = oldIsShorter ? newTokens : oldTokens;
+
+  const insertionIdx = findSingleInsertionIndex(shorter, longer);
+  if (insertionIdx === -1 || longer[insertionIdx] !== '!') return null;
+
+  return oldIsShorter
+    ? { oldFragment: '(no negation)', newFragment: '!', reason: 'logical negation (`!`) added' }
+    : { oldFragment: '!', newFragment: '(no negation)', reason: 'logical negation (`!`) removed' };
+}
+
+/** (a) Comparison operator change, including negation added/removed. */
+function classifyOperatorChange(oldLine: string, newLine: string): FragmentResult | null {
+  const oldTok = tokenizeAndStrip(oldLine, OPERATOR_TOKEN_RE);
+  const newTok = tokenizeAndStrip(newLine, OPERATOR_TOKEN_RE);
+  if (oldTok.skeleton !== newTok.skeleton) return null;
+
+  return oldTok.tokens.length === newTok.tokens.length
+    ? classifySameLengthOperatorChange(oldTok.tokens, newTok.tokens)
+    : classifyNegationToggle(oldTok.tokens, newTok.tokens);
+}
+
+/** (b) Numeric literal change, gated on conditional/comparison context. */
+function classifyLiteralChange(oldLine: string, newLine: string): FragmentResult | null {
+  if (!CONDITIONAL_CONTEXT_RE.test(oldLine) && !CONDITIONAL_CONTEXT_RE.test(newLine)) return null;
+
+  const oldTok = tokenizeAndStrip(oldLine, NUMBER_TOKEN_RE);
+  const newTok = tokenizeAndStrip(newLine, NUMBER_TOKEN_RE);
+  if (oldTok.skeleton !== newTok.skeleton) return null;
+  if (oldTok.tokens.length !== newTok.tokens.length || oldTok.tokens.length === 0) return null;
+
+  const i = findSingleDiffIndex(oldTok.tokens, newTok.tokens);
+  if (i === -1) return null;
+  return {
+    oldFragment: oldTok.tokens[i],
+    newFragment: newTok.tokens[i],
+    reason: `numeric literal changed from \`${oldTok.tokens[i]}\` to \`${newTok.tokens[i]}\` in a conditional context`,
+  };
+}
+
+/** Per-base delta signature: `null` sign means "bare" (no +/- delta). */
+interface IndexSignature {
+  sign: '+' | '-' | null;
+  amount: number | null;
+}
+
+function findIndexSignatures(line: string): Map<string, IndexSignature> {
+  const sigs = new Map<string, IndexSignature>();
+
+  for (const m of line.matchAll(INDEX_DELTA_RE)) {
+    const [, base, sign, amount] = m;
+    sigs.set(base, { sign: sign as '+' | '-', amount: parseInt(amount, 10) });
+  }
+  for (const m of line.matchAll(BARE_SUBSCRIPT_RE)) {
+    if (!sigs.has(m[1])) sigs.set(m[1], { sign: null, amount: null });
+  }
+  for (const m of line.matchAll(BARE_LENGTH_RE)) {
+    if (!sigs.has(m[1])) sigs.set(m[1], { sign: null, amount: null });
+  }
+
+  return sigs;
+}
+
+function formatIndexFragment(base: string, sig: IndexSignature): string {
+  return sig.sign === null ? base : `${base} ${sig.sign} ${sig.amount}`;
+}
+
+/** (c) Index-arithmetic off-by-one: a base identifier/`.length`'s delta changed. */
+function classifyIndexArithmetic(oldLine: string, newLine: string): FragmentResult | null {
+  const oldSigs = findIndexSignatures(oldLine);
+  const newSigs = findIndexSignatures(newLine);
+
+  for (const [base, oldSig] of oldSigs) {
+    const newSig = newSigs.get(base);
+    if (!newSig) continue;
+    if (oldSig.sign === newSig.sign && oldSig.amount === newSig.amount) continue;
+
+    const oldFragment = formatIndexFragment(base, oldSig);
+    const newFragment = formatIndexFragment(base, newSig);
+    return {
+      oldFragment,
+      newFragment,
+      reason: `index arithmetic on \`${base}\` changed from \`${oldFragment}\` to \`${newFragment}\``,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Classify one masked old/new line pair against all three categories.
+ * Checked in this fixed order; exposed for direct unit testing of the
+ * heuristics, independent of diff/hunk plumbing. Returns null when none
+ * of the three classifiers recognize the pair.
+ */
+export function classifyLinePair(
+  oldLine: string,
+  newLine: string,
+): ({ kind: ComparisonChangeKind } & FragmentResult) | null {
+  const maskedOld = maskLine(oldLine);
+  const maskedNew = maskLine(newLine);
+
+  const op = classifyOperatorChange(maskedOld, maskedNew);
+  if (op) return { kind: 'operator', ...op };
+
+  const lit = classifyLiteralChange(maskedOld, maskedNew);
+  if (lit) return { kind: 'literal', ...lit };
+
+  const idx = classifyIndexArithmetic(maskedOld, maskedNew);
+  if (idx) return { kind: 'index-arithmetic', ...idx };
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+function isTestAssertionNoise(file: string, oldLine: string, newLine: string): boolean {
+  if (!TEST_FILE_RE.test(file)) return false;
+  return TEST_ASSERTION_RE.test(oldLine) && TEST_ASSERTION_RE.test(newLine);
+}
+
+/**
+ * Classify every paired line in one file's patch, pushing a candidate for
+ * each pair that isn't test-assertion noise and classifies as one of the
+ * three categories. Split out of {@link computeComparisonChanges} so its
+ * own loop stays flat.
+ */
+function collectCandidatesFromPatch(
+  file: string,
+  patch: string,
+  candidates: ComparisonChangeCandidate[],
+): void {
+  for (const block of extractChangeBlocks(patch)) {
+    for (const pair of pairBlock(block)) {
+      if (isTestAssertionNoise(file, pair.oldLine, pair.newLine)) continue;
+      const classified = classifyLinePair(pair.oldLine, pair.newLine);
+      if (!classified) continue;
+      candidates.push({ file, line: pair.newLineNo, ...classified });
+    }
+  }
+}
+
+/**
+ * Find every comparison/threshold-shaped edit in this PR's diff: paired
+ * removed/added lines (same hunk, > 70% token overlap) classified as an
+ * operator change, a conditional-context literal change, or an
+ * index-arithmetic off-by-one. Returns [] when there is no diff. Exposed
+ * for testing.
+ */
+export function computeComparisonChanges(context: ReviewContext): ComparisonChangeCandidate[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+
+  const candidates: ComparisonChangeCandidate[] = [];
+  for (const [file, patch] of patches) collectCandidatesFromPatch(file, patch, candidates);
+
+  candidates.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const HEADER =
+  'Pre-computed by a deterministic diff scan — the comparison/threshold-shaped ' +
+  'edit discovery is done for you; do not re-scan the whole diff line-by-line ' +
+  'looking for these. Each entry is a removed/added line pair this PR changed ' +
+  'that shifts a comparison operator, a numeric literal in a conditional ' +
+  'context, or index arithmetic adjacent to indexing. Discovery only — this ' +
+  'block does NOT judge whether the change is intentional, disclosed, or ' +
+  "breaking, and it does NOT substitute for the boundary-change protocol's " +
+  'MANDATORY get_files_context call: knowing the file:line here does not tell ' +
+  'you the test associations for that file, so you must still call ' +
+  'get_files_context on it to find and inspect the covering tests, per the ' +
+  'protocol. Apply the full protocol to each entry: identify the divergence ' +
+  'input, check test coverage for it via get_files_context, and consult ' +
+  '<blast_radius>. This scan can miss compound changes (operator AND literal ' +
+  'changed on the same line) — the <diff> section is still the ground truth.';
+
+function renderEntry(c: ComparisonChangeCandidate): string {
+  return `- ${c.file}:${c.line} — \`${c.oldFragment}\` → \`${c.newFragment}\` (${c.kind}): ${c.reason}`;
+}
+
+/**
+ * Render comparison-change candidates as a `<comparison_change_candidates>`
+ * block. Returns '' when there are none. Caps at MAX_CANDIDATES with an
+ * explicit omission note — never truncates silently. Exposed for testing.
+ */
+export function renderComparisonChangeCandidates(candidates: ComparisonChangeCandidate[]): string {
+  if (candidates.length === 0) return '';
+
+  const lines: string[] = ['<comparison_change_candidates>', HEADER];
+  const shown = candidates.slice(0, MAX_CANDIDATES);
+  for (const c of shown) lines.push(renderEntry(c));
+
+  const omitted = candidates.length - shown.length;
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more candidate(s) omitted to respect the input budget — inspect the diff for the rest]`,
+    );
+  }
+
+  lines.push('</comparison_change_candidates>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<comparison_change_candidates>` section from the review
+ * context. Returns '' when the PR's diff has no qualifying comparison
+ * change, or there's no diff at all.
+ */
+export function renderComparisonChangeSection(context: ReviewContext): string {
+  return renderComparisonChangeCandidates(computeComparisonChanges(context));
+}

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -17,6 +17,7 @@ import type { BlastRadiusReport } from '../../blast-radius.js';
 import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
 import { renderUndiscriminatedCatchSection } from '../../catch-discrimination-signals.js';
+import { renderComparisonChangeSection } from '../../comparison-change-signals.js';
 import { renderRemovedExportsSection } from '../../removed-export-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
@@ -206,6 +207,9 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderStaleLiteralSection(context));
   if (isRuleActive(opts.rules, 'error-swallowing')) {
     appendIfPresent(sections, renderUndiscriminatedCatchSection(context));
+  }
+  if (isRuleActive(opts.rules, 'boundary-change')) {
+    appendIfPresent(sections, renderComparisonChangeSection(context));
   }
   appendIfPresent(sections, renderUntrustedInputSection(context));
   appendIfPresent(sections, renderRenameSweepSection(context));

--- a/packages/review/test/comparison-change-signals.test.ts
+++ b/packages/review/test/comparison-change-signals.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect } from 'vitest';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { ReviewRule, ResolvedRules } from '../src/plugins/agent/types.js';
+import {
+  classifyLinePair,
+  computeComparisonChanges,
+  renderComparisonChangeCandidates,
+  renderComparisonChangeSection,
+} from '../src/comparison-change-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(patches?: Map<string, string>): ReviewContext {
+  return {
+    pr: patches ? { patches } : undefined,
+    chunks: [],
+    changedFiles: [],
+  } as unknown as ReviewContext;
+}
+
+function boundaryChangeRule(): ReviewRule {
+  return {
+    id: 'boundary-change',
+    name: 'Threshold / Boundary Condition Change',
+    description: 'test rule',
+    prompt: 'test prompt',
+    triggers: { always: true },
+    severity: 'warning',
+    category: 'logic_error',
+    enabled: true,
+    source: 'builtin',
+  };
+}
+
+function resolvedRulesWith(...ids: string[]): ResolvedRules {
+  return {
+    active: ids.map(id => ({ ...boundaryChangeRule(), id })),
+    skipped: [],
+  };
+}
+
+/** A single unified-diff hunk for one file: a `-`/`+` block plus optional surrounding context. */
+function patch(hunkHeader: string, ...lines: string[]): Map<string, string> {
+  return new Map([['src/example.ts', [hunkHeader, ...lines].join('\n')]]);
+}
+
+// ---------------------------------------------------------------------------
+// classifyLinePair — the pure heuristic, one positive case per category
+// ---------------------------------------------------------------------------
+
+describe('classifyLinePair — operator changes', () => {
+  it('flags `<` -> `<=`', () => {
+    const r = classifyLinePair('if (a < 5) {', 'if (a <= 5) {');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('operator');
+    expect(r?.oldFragment).toBe('<');
+    expect(r?.newFragment).toBe('<=');
+  });
+
+  it('flags `>` -> `>=` (the canonical ge-5-threshold-shift shape)', () => {
+    const r = classifyLinePair('if (dependentCount > 5) {', 'if (dependentCount >= 5) {');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('operator');
+    expect(r?.oldFragment).toBe('>');
+    expect(r?.newFragment).toBe('>=');
+  });
+
+  it('flags `==` -> `===`', () => {
+    const r = classifyLinePair('if (a == b) {', 'if (a === b) {');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('operator');
+    expect(r?.oldFragment).toBe('==');
+    expect(r?.newFragment).toBe('===');
+  });
+
+  it('flags `!=` -> `!==`', () => {
+    const r = classifyLinePair('if (a != b) {', 'if (a !== b) {');
+    expect(r).not.toBeNull();
+    expect(r?.oldFragment).toBe('!=');
+    expect(r?.newFragment).toBe('!==');
+  });
+
+  it('flags `&&` -> `||`', () => {
+    const r = classifyLinePair('if (a && b) {', 'if (a || b) {');
+    expect(r).not.toBeNull();
+    expect(r?.oldFragment).toBe('&&');
+    expect(r?.newFragment).toBe('||');
+  });
+
+  it('flags a negation added (`isValid(x)` -> `!isValid(x)`)', () => {
+    const r = classifyLinePair('if (isValid(x)) {', 'if (!isValid(x)) {');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('operator');
+    expect(r?.newFragment).toBe('!');
+    expect(r?.reason).toMatch(/negation.*added/);
+  });
+
+  it('flags a negation removed (`!isValid(x)` -> `isValid(x)`)', () => {
+    const r = classifyLinePair('if (!isValid(x)) {', 'if (isValid(x)) {');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('operator');
+    expect(r?.oldFragment).toBe('!');
+    expect(r?.reason).toMatch(/negation.*removed/);
+  });
+});
+
+describe('classifyLinePair — numeric literal changes', () => {
+  it('flags a literal change inside an `if` condition', () => {
+    const r = classifyLinePair('if (x > 5) {', 'if (x > 6) {');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('literal');
+    expect(r?.oldFragment).toBe('5');
+    expect(r?.newFragment).toBe('6');
+  });
+
+  it('flags a literal change inside a `.filter(` predicate', () => {
+    const r = classifyLinePair(
+      'const big = items.filter(n => n.size > 100);',
+      'const big = items.filter(n => n.size > 200);',
+    );
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('literal');
+    expect(r?.oldFragment).toBe('100');
+    expect(r?.newFragment).toBe('200');
+  });
+
+  it('does NOT flag a literal change with no conditional/comparison keyword on the line', () => {
+    // A config default changing — no `if`/`while`/`?`/comparison operator on
+    // this line, so per the module's scope this is out of bounds for (b).
+    const r = classifyLinePair(
+      'const DEFAULT_TIMEOUT_MS = 500;',
+      'const DEFAULT_TIMEOUT_MS = 1000;',
+    );
+    expect(r).toBeNull();
+  });
+});
+
+describe('classifyLinePair — index arithmetic', () => {
+  it('flags a bare index gaining a `+ 1` delta', () => {
+    const r = classifyLinePair('return arr[i];', 'return arr[i + 1];');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('index-arithmetic');
+    expect(r?.oldFragment).toBe('i');
+    expect(r?.newFragment).toBe('i + 1');
+  });
+
+  it('flags `.length` gaining a `- 1` delta', () => {
+    const r = classifyLinePair('return arr[arr.length];', 'return arr[arr.length - 1];');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('index-arithmetic');
+    expect(r?.oldFragment).toBe('arr.length');
+    expect(r?.newFragment).toBe('arr.length - 1');
+  });
+
+  it('flags a delta sign flip (`+ 1` -> `- 1`)', () => {
+    const r = classifyLinePair('const next = base[i + 1];', 'const next = base[i - 1];');
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('index-arithmetic');
+    expect(r?.oldFragment).toBe('i + 1');
+    expect(r?.newFragment).toBe('i - 1');
+  });
+});
+
+describe('classifyLinePair — negative cases', () => {
+  it('does not flag a comparison sitting inside a string literal', () => {
+    const r = classifyLinePair(
+      'const msg = "if (x > 5) return";',
+      'const msg = "if (x > 6) return";',
+    );
+    expect(r).toBeNull();
+  });
+
+  it('does not flag a comparison sitting inside a comment', () => {
+    const r = classifyLinePair('// if (x > 5) do it', '// if (x > 6) do it');
+    expect(r).toBeNull();
+  });
+
+  it('does not flag a pure identifier rename with no operator/literal/index change', () => {
+    const r = classifyLinePair('if (oldName > 5) {', 'if (newName > 5) {');
+    expect(r).toBeNull();
+  });
+
+  it('does not flag two structurally unrelated lines', () => {
+    const r = classifyLinePair('const timeout = 500;', "import { logger } from './logger';");
+    expect(r).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeComparisonChanges — diff + hunk wiring
+// ---------------------------------------------------------------------------
+
+describe('computeComparisonChanges', () => {
+  it('returns [] when there is no diff', () => {
+    expect(computeComparisonChanges(makeContext())).toEqual([]);
+  });
+
+  it('pairs a removed/added line within a hunk and reports the new-file line number', () => {
+    const patches = patch(
+      '@@ -10,3 +10,3 @@',
+      ' context line before',
+      '-  if (dependentCount > 5) {',
+      '+  if (dependentCount >= 5) {',
+      ' context line after',
+    );
+    const candidates = computeComparisonChanges(makeContext(patches));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].file).toBe('src/example.ts');
+    expect(candidates[0].kind).toBe('operator');
+    expect(candidates[0].line).toBe(11); // the `+` line's new-file line number
+  });
+
+  it('does not flag a wholly new (added-only) line — new code, not a boundary CHANGE', () => {
+    const patches = patch(
+      '@@ -5,0 +6,3 @@',
+      '+  if (dependentCount >= 5) {',
+      "+    return 'medium';",
+      '+  }',
+    );
+    expect(computeComparisonChanges(makeContext(patches))).toEqual([]);
+  });
+
+  it('does not pair two structurally unrelated removed/added lines in the same block', () => {
+    const patches = patch(
+      '@@ -1,2 +1,2 @@',
+      '-const timeout = 500;',
+      "+import { logger } from './logger';",
+      ' module.exports = {};',
+    );
+    expect(computeComparisonChanges(makeContext(patches))).toEqual([]);
+  });
+
+  it('never pairs a removed line in one hunk with an added line in a different hunk', () => {
+    // Same content that WOULD pair within a single hunk, split across two —
+    // "same hunk proximity" must be enforced, not just textual similarity.
+    const patches = patch(
+      '@@ -10,1 +10,1 @@',
+      '-  if (dependentCount > 5) {',
+      '@@ -50,1 +50,1 @@',
+      '+  if (dependentCount >= 5) {',
+    );
+    expect(computeComparisonChanges(makeContext(patches))).toEqual([]);
+  });
+
+  it('handles multiple hunks independently, pairing within each', () => {
+    const map = new Map([
+      [
+        'src/example.ts',
+        [
+          '@@ -10,1 +10,1 @@',
+          '-  if (a > 5) {',
+          '+  if (a >= 5) {',
+          '@@ -30,1 +30,1 @@',
+          '-  if (b < 10) {',
+          '+  if (b <= 10) {',
+        ].join('\n'),
+      ],
+    ]);
+    const candidates = computeComparisonChanges(makeContext(map));
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map(c => c.oldFragment).sort()).toEqual(['<', '>']);
+  });
+
+  it('skips a test-assertion-noise pair in a test file', () => {
+    const map = new Map([
+      [
+        'src/example.test.ts',
+        ['@@ -3,1 +3,1 @@', '-  expect(a > 5).toBe(true);', '+  expect(a > 6).toBe(true);'].join(
+          '\n',
+        ),
+      ],
+    ]);
+    expect(computeComparisonChanges(makeContext(map))).toEqual([]);
+  });
+
+  it('does NOT skip the same shape in a non-test file (proves the filter is scoped)', () => {
+    const map = new Map([
+      [
+        'src/example.ts',
+        ['@@ -3,1 +3,1 @@', '-  expect(a > 5).toBe(true);', '+  expect(a > 6).toBe(true);'].join(
+          '\n',
+        ),
+      ],
+    ]);
+    const candidates = computeComparisonChanges(makeContext(map));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].kind).toBe('literal');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderComparisonChangeCandidates — rendering + explicit truncation
+// ---------------------------------------------------------------------------
+
+describe('renderComparisonChangeCandidates', () => {
+  it('returns empty string for no candidates', () => {
+    expect(renderComparisonChangeCandidates([])).toBe('');
+  });
+
+  it('renders the block naming file:line, fragments, and kind', () => {
+    const rendered = renderComparisonChangeCandidates([
+      {
+        file: 'src/example.ts',
+        line: 11,
+        kind: 'operator',
+        oldFragment: '>',
+        newFragment: '>=',
+        reason: 'comparison operator changed from `>` to `>=`',
+      },
+    ]);
+    expect(rendered).toContain('<comparison_change_candidates>');
+    expect(rendered).toContain('src/example.ts:11');
+    expect(rendered).toContain('`>`');
+    expect(rendered).toContain('`>=`');
+    expect(rendered).toContain('(operator)');
+    expect(rendered).toContain('</comparison_change_candidates>');
+  });
+
+  it('caps at MAX_CANDIDATES (10) with an explicit omission note — never truncates silently', () => {
+    const many = Array.from({ length: 14 }, (_, i) => ({
+      file: `src/f${i}.ts`,
+      line: 10,
+      kind: 'operator' as const,
+      oldFragment: '>',
+      newFragment: '>=',
+      reason: 'x',
+    }));
+    const rendered = renderComparisonChangeCandidates(many);
+
+    for (let i = 0; i < 10; i++) expect(rendered).toContain(`src/f${i}.ts`);
+    expect(rendered).toContain('+4 more candidate(s) omitted');
+    expect(rendered).not.toContain('src/f13.ts');
+  });
+
+  it('omits the truncation note entirely when under the cap', () => {
+    const rendered = renderComparisonChangeCandidates([
+      {
+        file: 'src/a.ts',
+        line: 1,
+        kind: 'literal',
+        oldFragment: '5',
+        newFragment: '6',
+        reason: 'x',
+      },
+    ]);
+    expect(rendered).not.toContain('omitted');
+  });
+});
+
+describe('renderComparisonChangeSection', () => {
+  it("returns '' when there is no diff", () => {
+    expect(renderComparisonChangeSection(makeContext())).toBe('');
+  });
+
+  it('renders candidates found from context', () => {
+    const patches = patch('@@ -10,1 +10,1 @@', '-  if (a > 5) {', '+  if (a >= 5) {');
+    const rendered = renderComparisonChangeSection(makeContext(patches));
+    expect(rendered).toContain('<comparison_change_candidates>');
+    expect(rendered).toContain('src/example.ts:10');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage wiring — gated on the boundary-change rule
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection (rule-gated)', () => {
+  const patches = patch('@@ -10,1 +10,1 @@', '-  if (a > 5) {', '+  if (a >= 5) {');
+
+  it('includes the block when boundary-change is active and candidates exist', () => {
+    const context = makeContext(patches);
+    const message = buildInitialMessage(context, { rules: resolvedRulesWith('boundary-change') });
+    expect(message).toContain('<comparison_change_candidates>');
+  });
+
+  it('omits the block when rules are not provided at all', () => {
+    const context = makeContext(patches);
+    const message = buildInitialMessage(context);
+    expect(message).not.toContain('<comparison_change_candidates>');
+  });
+
+  it('omits the block when boundary-change is not among the active rules', () => {
+    const context = makeContext(patches);
+    const message = buildInitialMessage(context, {
+      rules: resolvedRulesWith('error-swallowing', 'edge-case-sweep'),
+    });
+    expect(message).not.toContain('<comparison_change_candidates>');
+  });
+
+  it('omits the block when the rule is active but no candidates are found', () => {
+    const context = makeContext();
+    const message = buildInitialMessage(context, { rules: resolvedRulesWith('boundary-change') });
+    expect(message).not.toContain('<comparison_change_candidates>');
+  });
+});


### PR DESCRIPTION
## Context

`boundary-change`'s entire domain is comparisons and threshold literals
changing (`>` → `>=`, `5` → `6`, `&&` → `||`, off-by-one index arithmetic,
sign flips). Today the agent has to *notice* these shapes in the diff
before it can even start the rule's MANDATORY investigation protocol — and
the rule's own trigger-tuning history (#741/#743) shows noticing is the
weak link, not judgment. This PR precomputes the discovery step only —
"here is every comparison-shaped edit in this diff" — and leaves judgment
(intentional? disclosed? breaking?) to the agent, following the same
deterministic-signal pattern as `stale-literal-signals.ts` /
`catch-discrimination-signals.ts` / `removed-export-signals.ts` (the #770
house doctrine).

## What it does

New module `packages/review/src/comparison-change-signals.ts` (pure,
zero-LLM). From the diff's patches, it pairs removed/added lines within the
same hunk (never across hunks) using a >70% token-overlap similarity gate,
then classifies each pair as one of:

- **(a) Comparison operator change** — `<`↔`<=`, `>`↔`>=`, `==`↔`===`,
  `!=`↔`!==`, `&&`↔`||`, or a bare logical negation (`!`) added/removed.
  Detected by tokenizing both lines, stripping the matched operator tokens
  to a "skeleton", and requiring the skeletons match so only the operator
  differs.
- **(b) Numeric literal change in a conditional context** — a number token
  changed (`5` → `6`), gated on the line containing a conditional/
  comparison keyword (`if`/`while`/`?`/`switch`/`case`/`.filter(`/`.some(`/
  `.every(`/`.find(`, or a comparison/logical operator). A literal change
  with no such keyword (e.g. an unrelated config default) is intentionally
  not flagged.
- **(c) Index-arithmetic off-by-one** — an identifier or `.length`
  expression used for indexing gains/loses/changes a `+ N` / `- N` delta
  (`i` ↔ `i + 1`, `.length` ↔ `.length - 1`).

Rendered as a `<comparison_change_candidates>` block, injected into the
initial message only when `boundary-change` is active (mirrors the
`error-swallowing`-gated `<undiscriminated_catch_candidates>` wiring in
`system-prompt.ts`).

### Known limitations (documented in the module, not papered over)

- **Compound changes are invisible.** If BOTH the operator and the literal
  change on the same line, neither classifier fires (each requires the
  *other* category's tokens to stay unchanged). The `<diff>` section is
  still the ground truth backstop.
- **`.length` arithmetic is JS/TS-shaped** — doesn't recognize Python/Go's
  `len(x)`. Operator/negation categories generalize better across
  C-family languages but miss Python's `and`/`or`/`not` (no `&&`/`||`/`!`)
  and Ruby's `unless`.
- **Single-line masking only** — strips string/template literals and
  same-line `//`/`#` comments; a multi-line `/* */` block comment isn't
  tracked across lines.
- **Test-assertion noise filter is trivial** — only catches the
  `expect(`/`assert(` prefix shape in files matching a test-file regex.
- **New code is out of scope by design** — a bug introduced in wholly new
  (added-only) lines is not a "changed comparison"; this signal only fires
  on paired removed/added lines.

## Byte-diff census (MERGE-BASE `180f62c2` vs HEAD, 18 fixtures)

Captured the full same-repo canary/negative-regression/documented-miss
corpus (12 fixtures) plus the crossrepo corpus (4: pr2191/pr2678/pr2017/
pr2334) plus boundary-change's own placeholder — 18 fixtures total. Ran
`build-prompts.ts` against every one on both the merge-base and this
branch, diffed byte-for-byte:

| Fixture | Gained the block? |
|---|---|
| `boundary-change/ge-5-threshold-shift` (canary) | **Yes** |
| `boundary-change/placeholder` | **Yes** |
| all other 16 fixtures (structural-analysis, edge-case-sweep, concurrency-race, incomplete-handling, error-swallowing ×4, stale-duplicate, untrusted-input-validation, doc-truth ×3, crossrepo pr2191/pr2678/pr2017/pr2334) | No — byte-identical |

No unexpected fixture gained the block. Notably, the crossrepo canaries
(pr2191 templateresponse off-by-one, pr2678/pr2017 werkzeug multipart bugs)
have `boundary-change` active but did **not** gain anything — inspected
their diffs directly: all three bugs live in wholesale newly-added code
(the buggy arithmetic/regex is on `+` lines with no paired `-` line), which
is out of scope for this signal by design (see "new code is out of scope"
above). This is expected, not a gap — those bugs are still reachable via
the rule's existing `<diff>` + blast-radius + test-coverage protocol, just
not via this discovery shortcut.

## Calibration (prod default model, `moonshotai/kimi-k2.7-code`)

Only one certified canary's prompt actually changed (per the census above):
`boundary-change/ge-5-threshold-shift`.

| Fixture | Tag | Before fix | After fix |
|---|---|---|---|
| `boundary-change/ge-5-threshold-shift` | canary | 8/10 ($0.2984) | **10/10** ($0.3056) |
| `boundary-change/placeholder` | placeholder | — | 1/1 ($0.0096) sanity check |

First calibration run came in at 8/10 — 2 votes skipped the rule's
MANDATORY `get_files_context` call, going straight to `read_file` instead.
Trace inspection (`.wip/traces/...`) showed the model's own stated plan:
"1. Read the full file... 2. Check tests... 3. Check blast radius... 4.
Check stale literal candidates" — no mention of `get_files_context` at
all. The new block's file:line discovery was apparently satisfying enough
that the model felt it didn't need to call the tool whose *actual* purpose
is locating test associations. Fixed by adding one sentence to the block's
header explicitly naming this: "it does NOT substitute for the
boundary-change protocol's MANDATORY get_files_context call: knowing the
file:line here does not tell you the test associations for that file, so
you must still call get_files_context on it." Re-ran: 10/10.

`crossrepo/pr2191` (canary), `pr2678`/`pr2017` (characterization) were
**not** recalibrated — their prompts are byte-identical before/after (see
census), so there is nothing to measure; spending calibration budget on an
unchanged prompt would just reproduce their existing certified/measured
results.

**Total harness spend: $0.614** (of a $2.00 cap).

## Dogfood (house law, #774)

Scratch-flipped a real guard in this repo —
`packages/parser/src/ast/languages/javascript.ts:87`,
`if (depth > 3) return null;` → `if (depth >= 3) return null;`
(a recursion-depth cutoff in `findFunctionInDeclaration`) — ran the module
directly against the real `git diff` output, captured the verbatim block,
then reverted:

```
<comparison_change_candidates>
Pre-computed by a deterministic diff scan — the comparison/threshold-shaped edit discovery is done for you; do not re-scan the whole diff line-by-line looking for these. Each entry is a removed/added line pair this PR changed that shifts a comparison operator, a numeric literal in a conditional context, or index arithmetic adjacent to indexing. Discovery only — this block does NOT judge whether the change is intentional, disclosed, or breaking, and it does NOT substitute for the boundary-change protocol's MANDATORY get_files_context call: knowing the file:line here does not tell you the test associations for that file, so you must still call get_files_context on it to find and inspect the covering tests, per the protocol. Apply the full protocol to each entry: identify the divergence input, check test coverage for it via get_files_context, and consult <blast_radius>. This scan can miss compound changes (operator AND literal changed on the same line) — the <diff> section is still the ground truth.
- packages/parser/src/ast/languages/javascript.ts:87 — `>` → `>=` (operator): comparison operator changed from `>` to `>=`
</comparison_change_candidates>
```

Verdict: clear and actionable — correctly located file:line and the exact
fragment change, reinforces the mandatory protocol step, and is honest
about being discovery-only. Scratch edit reverted (`git checkout --`),
confirmed clean via `git status`.

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors (30 pre-existing warnings, unrelated)
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` (root, all packages) — 817 + 39 passing (no regressions);
  `@liendev/review` alone: 892 passing including 35 new tests
- `lien delta` — exit 0 (all new functions well under threshold; one
  pre-existing function ticked cognitive 1→2, not a crossing)

No changeset (review package is private/unpublished).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic pre-computation signal (`comparison-change-signals.ts`) for the `boundary-change` rule and wires it into the agent's initial prompt when that rule is active. The new module is pure, well-tested, and explicitly scoped as a discovery aid with documented limitations. It does not alter existing behavior for prompts where `boundary-change` is inactive, and the injected block is gated and omitted when empty.
>
> - New `packages/review/src/comparison-change-signals.ts` module pairs removed/added lines within the same hunk and classifies operator, conditional-context literal, and index-arithmetic changes.
> - `system-prompt.ts` now appends a `<comparison_change_candidates>` block only when the `boundary-change` rule is active and candidates exist.
> - Comprehensive unit tests cover the classifiers, hunk pairing, rendering, and rule-gated injection.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 86e559c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->