### PR TITLE
feat(review): deterministic enum-variant consumer-sweep signal

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -288,7 +288,7 @@ When a function consumes a typed object (interface, type, config, options), chec
 - **Partial iteration**: A function iterates over some properties of a config/options object but skips others that affect behavior.
 - **Declared but unimplemented**: A type defines a contract (e.g., trigger conditions, handler map, feature flags), but the implementation only handles a subset. This is especially dangerous when the type is part of a public API or config schema — users will set the field expecting it to work.
 
-Focus on fields/variants introduced or modified in this PR. If a new field is added to a type, grep for all consumers and verify they handle it.`,
+Focus on fields/variants introduced or modified in this PR. A \`<variant_sweep_candidates>\` section may be in your initial message: when present, it pre-computes enum members / union arms / const-object keys this PR added, paired with switch/if-chain/mapping consumers elsewhere that enumerate the type's OTHER variants but omit the new one — confirm each entry (it may be an intentional catch-all default, or already disclosed) rather than re-grepping for consumers yourself. For interface/config fields (not enum/union variants) or a family not covered there, still grep for all consumers and verify they handle it.`,
   example: `### Good finding — interface field declared but never consumed:
 {
   "filepath": "src/rules.ts",

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -18,6 +18,7 @@ import { renderBlastRadiusMarkdown } from '../../blast-radius-render.js';
 import { renderStaleLiteralSection } from '../../stale-literal-signals.js';
 import { renderUndiscriminatedCatchSection } from '../../catch-discrimination-signals.js';
 import { renderRemovedExportsSection } from '../../removed-export-signals.js';
+import { renderVariantSweepSection } from '../../variant-sweep-signals.js';
 import { renderUntrustedInputSection } from '../../untrusted-input-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
@@ -206,6 +207,9 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderStaleLiteralSection(context));
   if (isRuleActive(opts.rules, 'error-swallowing')) {
     appendIfPresent(sections, renderUndiscriminatedCatchSection(context));
+  }
+  if (isRuleActive(opts.rules, 'incomplete-handling')) {
+    appendIfPresent(sections, renderVariantSweepSection(context));
   }
   appendIfPresent(sections, renderUntrustedInputSection(context));
   appendIfPresent(sections, renderRenameSweepSection(context));

--- a/packages/review/src/variant-sweep-signals.ts
+++ b/packages/review/src/variant-sweep-signals.ts
@@ -1,0 +1,986 @@
+/**
+ * Deterministic "enum/union-variant consumer sweep" signal for PR reviews.
+ *
+ * Provenance: the omission-pass design doc (`.wip/omission-pass-design.md`,
+ * §6 item 2) names this as the most promising, ready-to-build v1 item —
+ * `incomplete-handling`'s prompt today just tells the agent to "grep for all
+ * consumers" of a newly-added field/variant (`rules.ts`, the
+ * `INCOMPLETE_HANDLING` rule) — the exact grep-and-reason anti-pattern
+ * CLAUDE.md's design principle warns against, and the same anti-pattern
+ * `removed-export-signals.ts` and `catch-discrimination-signals.ts` already
+ * replaced for their own shapes (PR #770's catch-discrimination signal is
+ * the direct template for this module's wiring).
+ *
+ * The shape: a PR ADDS a member to an enum, a new arm to a union type, or a
+ * new key to a `const X = {...} as const` value-map — and a switch/if-chain/
+ * mapping-table elsewhere that enumerates the family's OTHER (pre-existing)
+ * members was never updated to cover it. This module pre-computes both
+ * halves of that fact deterministically:
+ *   1. `computeAddedVariants` — parse each changed file's diff for a member
+ *      added to an EXISTING enum/union/const-object declaration (a brand
+ *      new declaration has no prior consumers to go stale, so it's not a
+ *      candidate).
+ *   2. `computeVariantSweepContexts` — for each added variant, resolve the
+ *      family's full current (post-PR) membership from the changed-file
+ *      chunk, then sweep the head corpus (`repoChunks`) for a switch/
+ *      if-chain/mapping site that references >= 2 of the family's OTHER
+ *      members but never mentions the new one.
+ *
+ * Conservative by design: a consumer must reference at least two EXISTING
+ * members to count as "enumerating the family" — a single reference is far
+ * too common a coincidence (e.g. one specific case handled on purpose,
+ * unrelated identifier reuse) to be worth an agent's attention. Silence is
+ * the correct default; the agent's own judgment (documented/intentional,
+ * heuristic false positive) is the backstop for the rest, exactly per the
+ * design doc's §2 "LLM judgment's job."
+ *
+ * v1 scope, stated honestly:
+ *  - TS/JS only (this repo's own surface).
+ *  - Three family shapes: `enum X { ... }`, `type X = A | B | C` (single- or
+ *    simple multi-line pipe-style, arms that are bare string/numeric
+ *    literals or plain identifiers only — an inline object-shaped arm like
+ *    `{ kind: 'x' }` is NOT parsed, a documented gap), and `const X = {
+ *    ...} as const` value-maps (the `as const` suffix is REQUIRED — an
+ *    ordinary object literal without it is deliberately never treated as a
+ *    variant family, so a coincidental object literal with keys that happen
+ *    to match some other family's member names is never misread as one;
+ *    this directly satisfies the "non-enum object literals" case).
+ *  - Consumer detection requires a DOT-QUALIFIED reference (`TypeName.
+ *    Member`) for enum/const-object members — the idiomatic, high-precision
+ *    form (`case Color.Red:`, `x === Color.Red`, `[Color.Red]: ...`). Union
+ *    members (string/numeric literals, no natural qualifier) fall back to
+ *    the bare quoted/keyed literal value, which is lower precision by
+ *    construction — documented, not papered over.
+ *  - A consumer site is only ever a `case` label, an equality comparison
+ *    (`===`/`==`/`!==`/`!=`), an `instanceof` check (union-of-identifier
+ *    arms), or an object-literal key (bare or computed `[Type.Member]`) —
+ *    not a full control-flow/exhaustiveness analysis. A family member
+ *    referenced only through a helper function is invisible to this scan,
+ *    same caveat `catch-discrimination-signals.ts` documents for its own
+ *    shallow textual check.
+ *  - Brace/body extraction for enum and const-object bodies stops at the
+ *    FIRST unmatched-depth `}` via simple depth counting with string/
+ *    comment skipping — a member whose VALUE itself contains a nested
+ *    object is not expected for these idiomatic shapes and is a documented
+ *    limitation, not a crash.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type VariantFamilyKind = 'enum' | 'union' | 'const-object';
+
+/** A member/arm/key this PR adds to an existing enum, union, or const-object family. */
+export interface AddedVariant {
+  typeName: string;
+  variant: string;
+  file: string;
+  kind: VariantFamilyKind;
+}
+
+/** A site elsewhere in the head corpus that enumerates the family but omits the new variant. */
+export interface VariantConsumerSite {
+  file: string;
+  line: number;
+  /** The family's OTHER (pre-existing) members this site was found to reference. */
+  handledVariants: string[];
+}
+
+/** One added variant with the stale consumer sites found for it. */
+export interface VariantSweepContext {
+  typeName: string;
+  variant: string;
+  file: string;
+  kind: VariantFamilyKind;
+  consumers: VariantConsumerSite[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max (typeName, variant) entries rendered — keeps the block compact. */
+const MAX_ENTRIES = 12;
+/** Max consumer sites listed per added variant. */
+const MAX_CONSUMERS_PER_VARIANT = 5;
+/** Max existing-variant names listed per consumer site ("handles: A, B, ..."). */
+const MAX_HANDLED_LISTED = 6;
+/** Total block character budget. */
+const MAX_BLOCK_CHARS = 4_000;
+/** A consumer must reference at least this many EXISTING members to count as "enumerating the family". */
+const MIN_EXISTING_REFERENCES = 2;
+
+/** Files whose diffs/chunks we scan (this repo's TS/JS surface — v1 scope). */
+const TS_JS_FILE_RE = /\.(?:[cm]?[jt]sx?)$/;
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+const VALID_IDENT_RE = /^[A-Za-z_$][\w$]*$/;
+
+const ENUM_HEADER_RE =
+  /\b(?:export\s+)?(?:declare\s+)?(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)\s*\{/g;
+const CONST_OBJECT_HEADER_RE =
+  /\b(?:export\s+)?const\s+([A-Za-z_$][\w$]*)(?:\s*:\s*[^=\n]+)?\s*=\s*\{/g;
+const UNION_HEADER_RE = /\b(?:export\s+)?type\s+([A-Za-z_$][\w$]*)(?:\s*<[^=\n]*>)?\s*=\s*/g;
+
+// ---------------------------------------------------------------------------
+// Low-level text utilities
+// ---------------------------------------------------------------------------
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Skip a quoted string/template literal (`'`, `"`, or `` ` ``), returning the index after it. */
+function skipStringLike(text: string, i: number): number {
+  const quote = text[i];
+  i++;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+interface Span {
+  end: number;
+  kind: 'string' | 'comment';
+}
+
+/** If `text[i]` starts a string/template literal or a `//`/`/* *‍/` comment, its span; else null. */
+function classifySpan(text: string, i: number): Span | null {
+  const ch = text[i];
+  if (ch === '"' || ch === "'" || ch === '`')
+    return { end: skipStringLike(text, i), kind: 'string' };
+  if (ch === '/' && text[i + 1] === '/') {
+    const end = text.indexOf('\n', i);
+    return { end: end === -1 ? text.length : end, kind: 'comment' };
+  }
+  if (ch === '/' && text[i + 1] === '*') {
+    const end = text.indexOf('*/', i + 2);
+    return { end: end === -1 ? text.length : end + 2, kind: 'comment' };
+  }
+  return null;
+}
+
+/**
+ * Replace every span `shouldMask` accepts with same-length whitespace
+ * (preserving newlines, so line numbers computed from the result still
+ * match the original); spans it rejects are copied through unchanged.
+ * Shared by {@link maskComments} (strings kept — union member values are
+ * quoted literals) and {@link maskCommentsAndStrings} (used only to locate
+ * declaration HEADERS safely, since a docstring/fixture string quoting
+ * `enum Foo {` as prose must never be read as a real declaration).
+ */
+function maskSpans(text: string, shouldMask: (kind: Span['kind']) => boolean): string {
+  let i = 0;
+  let out = '';
+  while (i < text.length) {
+    const span = classifySpan(text, i);
+    if (span === null) {
+      out += text[i];
+      i++;
+      continue;
+    }
+    if (shouldMask(span.kind)) {
+      for (let k = i; k < span.end; k++) out += text[k] === '\n' ? '\n' : ' ';
+    } else {
+      out += text.slice(i, span.end);
+    }
+    i = span.end;
+  }
+  return out;
+}
+
+function maskComments(text: string): string {
+  return maskSpans(text, kind => kind === 'comment');
+}
+
+function maskCommentsAndStrings(text: string): string {
+  return maskSpans(text, () => true);
+}
+
+/**
+ * Find the index of the `}` matching the `{` at `openIdx`, skipping string
+ * literals. Depth-aware. Callers pass comment-MASKED text (comments are
+ * blanked to same-length whitespace upstream), so no comment span can hide a
+ * stray brace here — only strings need skipping.
+ */
+function findMatchingBraceFrom(content: string, openIdx: number): number {
+  let depth = 0;
+  let i = openIdx;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLike(content, i);
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      i++;
+      if (depth === 0) return i - 1;
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Find the index of the top-level `;` starting from `startIdx`, respecting
+ * bracket nesting and skipping string literals. -1 if none. Callers pass
+ * comment-masked text (see {@link findMatchingBraceFrom}).
+ */
+function findTopLevelSemicolon(content: string, startIdx: number): number {
+  let depth = 0;
+  let i = startIdx;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLike(content, i);
+      continue;
+    }
+    if ('{(['.includes(ch)) {
+      depth++;
+      i++;
+      continue;
+    }
+    if ('})]'.includes(ch)) {
+      depth--;
+      i++;
+      continue;
+    }
+    if (depth === 0 && ch === ';') return i;
+    i++;
+  }
+  return -1;
+}
+
+interface Segment {
+  text: string;
+  offset: number;
+}
+
+/**
+ * Split `text` on top-level occurrences of `sep` (a single character),
+ * respecting `{}`/`()`/`[]` nesting and skipping string/template literals.
+ * Each returned segment carries its start offset within `text` (before
+ * trimming) so callers can compute line numbers.
+ */
+function splitTopLevel(text: string, sep: string): Segment[] {
+  const segments: Segment[] = [];
+  let depth = 0;
+  let start = 0;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLike(text, i);
+      continue;
+    }
+    if ('{(['.includes(ch)) {
+      depth++;
+      i++;
+      continue;
+    }
+    if ('})]'.includes(ch)) {
+      depth--;
+      i++;
+      continue;
+    }
+    if (depth === 0 && ch === sep) {
+      segments.push({ text: text.slice(start, i), offset: start });
+      start = i + 1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  segments.push({ text: text.slice(start), offset: start });
+  return segments;
+}
+
+function countNewlines(text: string, upTo: number): number {
+  let n = 0;
+  for (let i = 0; i < upTo; i++) {
+    if (text[i] === '\n') n++;
+  }
+  return n;
+}
+
+/** The offset of the first non-whitespace character in `text` (its length if all whitespace). */
+function leadingWhitespaceLength(text: string): number {
+  return text.length - text.trimStart().length;
+}
+
+// ---------------------------------------------------------------------------
+// Family declaration extraction (static, post-PR chunk content)
+// ---------------------------------------------------------------------------
+
+interface FamilyMember {
+  name: string;
+  line: number;
+}
+
+interface FamilyDeclaration {
+  typeName: string;
+  kind: VariantFamilyKind;
+  members: FamilyMember[];
+  declStartLine: number;
+  declEndLine: number;
+}
+
+/** Extract a member's line number given the declaration body's start offset/line and a segment. */
+function memberLine(content: string, baseLine: number, bodyStart: number, seg: Segment): number {
+  const idx = bodyStart + seg.offset + leadingWhitespaceLength(seg.text);
+  return baseLine + countNewlines(content, idx);
+}
+
+function findEnumDeclarations(content: string, baseLine: number): FamilyDeclaration[] {
+  const out: FamilyDeclaration[] = [];
+  const headerMask = maskCommentsAndStrings(content);
+  const commentMasked = maskComments(content);
+  for (const m of headerMask.matchAll(ENUM_HEADER_RE)) {
+    const typeName = m[1];
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = findMatchingBraceFrom(commentMasked, openIdx);
+    if (closeIdx === -1) continue;
+
+    const bodyStart = openIdx + 1;
+    const body = commentMasked.slice(bodyStart, closeIdx);
+    const members: FamilyMember[] = [];
+    for (const seg of splitTopLevel(body, ',')) {
+      const t = seg.text.trim();
+      if (!t) continue;
+      const nm = t.match(/^([A-Za-z_$][\w$]*)/);
+      if (!nm) continue;
+      members.push({ name: nm[1], line: memberLine(content, baseLine, bodyStart, seg) });
+    }
+
+    out.push({
+      typeName,
+      kind: 'enum',
+      members,
+      declStartLine: baseLine + countNewlines(content, m.index),
+      declEndLine: baseLine + countNewlines(content, closeIdx),
+    });
+  }
+  return out;
+}
+
+/** Does `content` starting right after `closeIdx` read as `as const` (allowing whitespace)? */
+function hasAsConstMarker(content: string, closeIdx: number): boolean {
+  return /^\s*as\s+const\b/.test(content.slice(closeIdx + 1, closeIdx + 40));
+}
+
+function findConstObjectDeclarations(content: string, baseLine: number): FamilyDeclaration[] {
+  const out: FamilyDeclaration[] = [];
+  const headerMask = maskCommentsAndStrings(content);
+  const commentMasked = maskComments(content);
+  for (const m of headerMask.matchAll(CONST_OBJECT_HEADER_RE)) {
+    const typeName = m[1];
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = findMatchingBraceFrom(commentMasked, openIdx);
+    if (closeIdx === -1) continue;
+    // The `as const` suffix is the confidence marker that this object literal
+    // is meant as a variant family, not an ordinary config/options object —
+    // see the module doc's "non-enum object literals" note.
+    if (!hasAsConstMarker(content, closeIdx)) continue;
+
+    const bodyStart = openIdx + 1;
+    const body = commentMasked.slice(bodyStart, closeIdx);
+    const members: FamilyMember[] = [];
+    for (const seg of splitTopLevel(body, ',')) {
+      const t = seg.text.trim();
+      if (!t) continue;
+      const key = t.match(/^(?:['"]([^'"]+)['"]|([A-Za-z_$][\w$]*))\s*:/);
+      if (!key) continue;
+      members.push({ name: key[1] ?? key[2], line: memberLine(content, baseLine, bodyStart, seg) });
+    }
+
+    out.push({
+      typeName,
+      kind: 'const-object',
+      members,
+      declStartLine: baseLine + countNewlines(content, m.index),
+      declEndLine: baseLine + countNewlines(content, closeIdx),
+    });
+  }
+  return out;
+}
+
+/** Extract the variant name from a trimmed union arm, or null for an unsupported (complex/object) arm. */
+function unionArmVariant(armText: string): string | null {
+  const strLit = armText.match(/^['"]([^'"]*)['"]$/);
+  if (strLit) return strLit[1];
+  if (VALID_IDENT_RE.test(armText)) return armText;
+  return null;
+}
+
+function findUnionDeclarations(content: string, baseLine: number): FamilyDeclaration[] {
+  const out: FamilyDeclaration[] = [];
+  const headerMask = maskCommentsAndStrings(content);
+  const commentMasked = maskComments(content);
+  for (const m of headerMask.matchAll(UNION_HEADER_RE)) {
+    const typeName = m[1];
+    const bodyStart = m.index + m[0].length;
+    const semiIdx = findTopLevelSemicolon(commentMasked, bodyStart);
+    if (semiIdx === -1) continue;
+
+    const body = commentMasked.slice(bodyStart, semiIdx);
+    const members: FamilyMember[] = [];
+    for (const seg of splitTopLevel(body, '|')) {
+      const t = seg.text.trim();
+      if (!t) continue;
+      const variant = unionArmVariant(t);
+      if (variant === null) continue;
+      members.push({ name: variant, line: memberLine(content, baseLine, bodyStart, seg) });
+    }
+
+    out.push({
+      typeName,
+      kind: 'union',
+      members,
+      declStartLine: baseLine + countNewlines(content, m.index),
+      declEndLine: baseLine + countNewlines(content, semiIdx),
+    });
+  }
+  return out;
+}
+
+/** All enum/union/const-object family declarations found in one chunk's (TS/JS) content. */
+function findFamilyDeclarations(content: string, baseLine: number): FamilyDeclaration[] {
+  return [
+    ...findEnumDeclarations(content, baseLine),
+    ...findConstObjectDeclarations(content, baseLine),
+    ...findUnionDeclarations(content, baseLine),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Diff-side: which new-file lines did this PR add, and what did it remove?
+// ---------------------------------------------------------------------------
+
+interface FileDiffFacts {
+  /** New-file line numbers this PR added (`+` lines). */
+  addedLines: Set<number>;
+  /** Concatenated text of every `-` line — used both to tell a pure addition
+   *  from a same-identifier value edit ({@link isGenuinelyNew}) and to tell a
+   *  brand-new declaration from an existing one rewritten on one physical
+   *  line ({@link existedBefore}). */
+  removedText: string;
+}
+
+function computeFileDiffFacts(patch: string): FileDiffFacts {
+  const addedLines = new Set<number>();
+  const removedParts: string[] = [];
+  let newLine = 0;
+
+  for (const raw of patch.split('\n')) {
+    const hunk = raw.match(HUNK_HEADER_RE);
+    if (hunk) {
+      newLine = parseInt(hunk[1], 10);
+      continue;
+    }
+    if (raw.startsWith('+++') || raw.startsWith('---') || raw.startsWith('\\')) continue;
+
+    if (raw.startsWith('+')) {
+      addedLines.add(newLine);
+      newLine++;
+    } else if (raw.startsWith('-')) {
+      removedParts.push(raw.slice(1));
+    } else {
+      newLine++;
+    }
+  }
+
+  return { addedLines, removedText: removedParts.join('\n') };
+}
+
+/**
+ * A member is a genuine ADDITION (not a same-identifier value edit) when its
+ * identifier never appears on a removed line of this file's patch. A rename
+ * (old identifier removed, new one added) still counts as an addition here —
+ * intentional; a stale consumer that only knows the old name is a real gap
+ * whether or not `rename-sweep-signals.ts` also flags it (the design doc's
+ * §4 explicitly accepts this overlap between signals).
+ */
+function isGenuinelyNew(name: string, removedText: string): boolean {
+  return !new RegExp(`\\b${escapeRegExp(name)}\\b`).test(removedText);
+}
+
+/** The header regex for one family kind, as a fresh instance (matchAll needs its own `lastIndex`). */
+function headerRegexFor(kind: VariantFamilyKind): RegExp {
+  if (kind === 'enum') return new RegExp(ENUM_HEADER_RE.source, 'g');
+  if (kind === 'const-object') return new RegExp(CONST_OBJECT_HEADER_RE.source, 'g');
+  return new RegExp(UNION_HEADER_RE.source, 'g');
+}
+
+/** Does this file's removed text contain a header for this exact (kind, typeName)? */
+function headerWasRemoved(kind: VariantFamilyKind, typeName: string, removedText: string): boolean {
+  const masked = maskCommentsAndStrings(removedText);
+  for (const m of masked.matchAll(headerRegexFor(kind))) {
+    if (m[1] === typeName) return true;
+  }
+  return false;
+}
+
+/**
+ * Did this declaration exist BEFORE this PR? True whenever its header line
+ * was NOT itself added — the common case, whether the header sits far above
+ * the touched member (untouched, not even in the diff's context window) or
+ * right next to it (an unchanged context line). The one case where the
+ * header line IS an added line but the declaration still pre-existed is a
+ * single-line declaration rewritten wholesale (header and arms share one
+ * physical line, e.g. `type X = A | B;` -> `type X = A | B | C;`) — there,
+ * the OLD header text survives in a REMOVED line, so that's the fallback
+ * check.
+ */
+function existedBefore(decl: FamilyDeclaration, facts: FileDiffFacts): boolean {
+  if (!facts.addedLines.has(decl.declStartLine)) return true;
+  return headerWasRemoved(decl.kind, decl.typeName, facts.removedText);
+}
+
+// ---------------------------------------------------------------------------
+// computeAddedVariants
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate every family declaration found in one chunk against this file's
+ * diff facts, pushing an {@link AddedVariant} for each genuinely-new member
+ * whose line the diff touched. Split out of {@link computeAddedVariants} so
+ * its own loop stays flat (mirrors `collectCandidatesFromChunk` in
+ * `catch-discrimination-signals.ts`).
+ */
+function collectAddedVariantsFromChunk(
+  chunk: CodeChunk,
+  file: string,
+  facts: FileDiffFacts,
+  seen: Set<string>,
+  out: AddedVariant[],
+): void {
+  for (const decl of findFamilyDeclarations(chunk.content, chunk.metadata.startLine)) {
+    // A brand-new family this PR introduces has no prior consumers to go
+    // stale — only a member added to an ALREADY-existing declaration counts.
+    if (!existedBefore(decl, facts)) continue;
+
+    for (const member of decl.members) {
+      if (!facts.addedLines.has(member.line)) continue;
+      if (!isGenuinelyNew(member.name, facts.removedText)) continue;
+
+      const key = `${decl.kind}:${decl.typeName}:${member.name}:${file}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ typeName: decl.typeName, variant: member.name, file, kind: decl.kind });
+    }
+  }
+}
+
+/**
+ * Find every enum member / union arm / const-object-as-const key this PR
+ * adds to an EXISTING family declaration (a brand-new declaration has no
+ * prior consumers, so it's never a candidate). Exposed for testing.
+ */
+export function computeAddedVariants(context: ReviewContext): AddedVariant[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+  const chunks = context.chunks;
+  if (!chunks || chunks.length === 0) return [];
+
+  const out: AddedVariant[] = [];
+  const seen = new Set<string>();
+
+  for (const [file, patch] of patches) {
+    if (!TS_JS_FILE_RE.test(file)) continue;
+    const facts = computeFileDiffFacts(patch);
+    if (facts.addedLines.size === 0) continue;
+
+    for (const chunk of chunks) {
+      if (chunk.metadata.file === file)
+        collectAddedVariantsFromChunk(chunk, file, facts, seen, out);
+    }
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Resolving a family's full (post-PR) membership
+// ---------------------------------------------------------------------------
+
+interface ResolvedFamily {
+  existingVariants: string[];
+  declStartLine: number;
+  declEndLine: number;
+}
+
+/**
+ * Re-locate the family's current (post-PR) declaration in the changed
+ * file's chunks and return its members MINUS every variant this PR added to
+ * it (`addedNames`) — i.e. the pre-existing membership a consumer would
+ * have been written against. Null when the declaration can't be found
+ * (defensive; the diff-side scan and this static re-scan use the same
+ * parser, so this should only miss on exotic formatting). Exposed for
+ * testing.
+ */
+export function resolveFamilyExisting(
+  context: ReviewContext,
+  file: string,
+  kind: VariantFamilyKind,
+  typeName: string,
+  addedNames: Set<string>,
+): ResolvedFamily | null {
+  for (const chunk of context.chunks ?? []) {
+    if (chunk.metadata.file !== file) continue;
+    for (const decl of findFamilyDeclarations(chunk.content, chunk.metadata.startLine)) {
+      if (decl.kind !== kind || decl.typeName !== typeName) continue;
+      return {
+        existingVariants: decl.members.map(m => m.name).filter(n => !addedNames.has(n)),
+        declStartLine: decl.declStartLine,
+        declEndLine: decl.declEndLine,
+      };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Consumer-site token patterns
+// ---------------------------------------------------------------------------
+
+interface TokenPatterns {
+  /** `case X:` / equality-comparison / `instanceof X` style references. */
+  references: RegExp[];
+  /** Object-literal key style references (bare or computed). */
+  mappingKeys: RegExp[];
+}
+
+/** Enum / const-object members are referenced dot-qualified: `TypeName.Member`. */
+function buildQualifiedTokenPatterns(typeName: string, variant: string): TokenPatterns {
+  const dot = `\\b${escapeRegExp(typeName)}\\.${escapeRegExp(variant)}\\b`;
+  return {
+    references: [
+      new RegExp(`\\bcase\\s+${dot}\\s*:`),
+      new RegExp(`${dot}\\s*(?:===|==|!==|!=)`),
+      new RegExp(`(?:===|==|!==|!=)\\s*${dot}`),
+    ],
+    mappingKeys: [new RegExp(`\\[\\s*${dot}\\s*\\]\\s*:`)],
+  };
+}
+
+/**
+ * Union members (string/numeric literals or plain identifiers) have no
+ * dot-qualifier — fall back to the bare quoted/keyed literal value, plus
+ * `instanceof` for identifier arms (union-of-classes). Lower precision than
+ * the qualified form by construction; documented in the module doc.
+ */
+function buildUnionTokenPatterns(variant: string): TokenPatterns {
+  const v = escapeRegExp(variant);
+  const quoted = `['"]${v}['"]`;
+  const references = [
+    new RegExp(`\\bcase\\s+${quoted}\\s*:`),
+    new RegExp(`${quoted}\\s*(?:===|==|!==|!=)`),
+    new RegExp(`(?:===|==|!==|!=)\\s*${quoted}`),
+  ];
+  const mappingKeys = [new RegExp(`${quoted}\\s*:`)];
+  if (VALID_IDENT_RE.test(variant)) {
+    references.push(new RegExp(`\\binstanceof\\s+${v}\\b`));
+    mappingKeys.push(new RegExp(`\\b${v}\\s*:`));
+  }
+  return { references, mappingKeys };
+}
+
+function buildTokenPatterns(
+  kind: VariantFamilyKind,
+  typeName: string,
+  variant: string,
+): TokenPatterns {
+  return kind === 'union'
+    ? buildUnionTokenPatterns(variant)
+    : buildQualifiedTokenPatterns(typeName, variant);
+}
+
+/** For each variant in `tokenMap` that has a matching reference in `content`, its first matching line (0-based). */
+function collectMatchesInChunk(
+  content: string,
+  tokenMap: Map<string, TokenPatterns>,
+): Map<string, number> {
+  const masked = maskComments(content);
+  const lines = masked.split('\n');
+  const found = new Map<string, number>();
+
+  for (const [variant, patterns] of tokenMap) {
+    const all = [...patterns.references, ...patterns.mappingKeys];
+    for (let i = 0; i < lines.length; i++) {
+      if (all.some(re => re.test(lines[i]))) {
+        found.set(variant, i);
+        break;
+      }
+    }
+  }
+
+  return found;
+}
+
+function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart <= bEnd && bStart <= aEnd;
+}
+
+/** Cheap pre-check before running per-variant regexes against a chunk. */
+function chunkMightReferenceFamily(
+  chunk: CodeChunk,
+  kind: VariantFamilyKind,
+  typeName: string,
+  allVariantNames: string[],
+): boolean {
+  if (kind !== 'union') return chunk.content.includes(typeName);
+  return allVariantNames.some(v => chunk.content.includes(v));
+}
+
+// ---------------------------------------------------------------------------
+// computeVariantSweepContexts
+// ---------------------------------------------------------------------------
+
+interface AddedVariantGroup {
+  kind: VariantFamilyKind;
+  typeName: string;
+  file: string;
+  variants: string[];
+}
+
+function groupAddedVariants(added: AddedVariant[]): AddedVariantGroup[] {
+  const groups = new Map<string, AddedVariantGroup>();
+  for (const a of added) {
+    const key = `${a.kind}:${a.typeName}:${a.file}`;
+    const g = groups.get(key);
+    if (g) g.variants.push(a.variant);
+    else
+      groups.set(key, { kind: a.kind, typeName: a.typeName, file: a.file, variants: [a.variant] });
+  }
+  return [...groups.values()];
+}
+
+/** Sweep the head corpus for consumer sites of one added-variant group, split out to keep the orchestrator flat. */
+function buildFamilyTokenMap(
+  group: AddedVariantGroup,
+  family: ResolvedFamily,
+): Map<string, TokenPatterns> {
+  const tokenMap = new Map<string, TokenPatterns>();
+  for (const name of [...family.existingVariants, ...group.variants]) {
+    tokenMap.set(name, buildTokenPatterns(group.kind, group.typeName, name));
+  }
+  return tokenMap;
+}
+
+/** Is `chunk` the family's own declaration site (never a consumer of itself)? */
+function isDeclarationSite(
+  chunk: CodeChunk,
+  group: AddedVariantGroup,
+  family: ResolvedFamily,
+): boolean {
+  return (
+    chunk.metadata.file === group.file &&
+    rangesOverlap(
+      chunk.metadata.startLine,
+      chunk.metadata.endLine,
+      family.declStartLine,
+      family.declEndLine,
+    )
+  );
+}
+
+/**
+ * Evaluate one chunk against one added-variant group: if it enumerates
+ * enough of the family's existing members, record a consumer site for each
+ * added variant it does NOT also reference. Split out of
+ * {@link sweepGroupConsumers} so its own loop stays flat.
+ */
+function recordChunkConsumers(
+  chunk: CodeChunk,
+  group: AddedVariantGroup,
+  existingSet: Set<string>,
+  tokenMap: Map<string, TokenPatterns>,
+  byVariant: Map<string, VariantConsumerSite[]>,
+  seenSite: Set<string>,
+): void {
+  const matches = collectMatchesInChunk(chunk.content, tokenMap);
+  const matchedExisting = [...matches.keys()].filter(k => existingSet.has(k));
+  if (matchedExisting.length < MIN_EXISTING_REFERENCES) return;
+
+  const line = chunk.metadata.startLine + Math.min(...matchedExisting.map(v => matches.get(v)!));
+  const handled = [...matchedExisting].sort();
+
+  for (const variant of group.variants) {
+    if (matches.has(variant)) continue; // this consumer already handles the new variant
+    const siteKey = `${variant}:${chunk.metadata.file}:${line}`;
+    if (seenSite.has(siteKey)) continue;
+    seenSite.add(siteKey);
+    const list = byVariant.get(variant) ?? [];
+    list.push({ file: chunk.metadata.file, line, handledVariants: handled });
+    byVariant.set(variant, list);
+  }
+}
+
+function sweepGroupConsumers(
+  context: ReviewContext,
+  group: AddedVariantGroup,
+  family: ResolvedFamily,
+): Map<string, VariantConsumerSite[]> {
+  const tokenMap = buildFamilyTokenMap(group, family);
+  const existingSet = new Set(family.existingVariants);
+  const allNames = [...family.existingVariants, ...group.variants];
+
+  const byVariant = new Map<string, VariantConsumerSite[]>();
+  const seenSite = new Set<string>();
+
+  for (const chunk of context.repoChunks ?? []) {
+    if (isDeclarationSite(chunk, group, family)) continue;
+    if (!chunkMightReferenceFamily(chunk, group.kind, group.typeName, allNames)) continue;
+    recordChunkConsumers(chunk, group, existingSet, tokenMap, byVariant, seenSite);
+  }
+
+  return byVariant;
+}
+
+/**
+ * Build the (uncapped) `VariantSweepContext` list for one added-variant
+ * group — resolve its pre-existing membership, sweep for consumers, and
+ * emit one context per added variant that has at least one stale site.
+ * Split out of {@link computeVariantSweepContexts} so its own loop, and this
+ * one, both stay flat.
+ */
+function buildContextsForGroup(
+  context: ReviewContext,
+  group: AddedVariantGroup,
+): VariantSweepContext[] {
+  const addedNames = new Set(group.variants);
+  const family = resolveFamilyExisting(context, group.file, group.kind, group.typeName, addedNames);
+  if (!family || family.existingVariants.length === 0) return [];
+
+  const byVariant = sweepGroupConsumers(context, group, family);
+  const out: VariantSweepContext[] = [];
+
+  for (const variant of group.variants) {
+    const consumers = byVariant.get(variant);
+    if (!consumers || consumers.length === 0) continue;
+    consumers.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+    out.push({
+      typeName: group.typeName,
+      variant,
+      file: group.file,
+      kind: group.kind,
+      consumers: consumers.slice(0, MAX_CONSUMERS_PER_VARIANT),
+    });
+  }
+
+  return out;
+}
+
+/** Most-consumers-affected first, then deterministic tie-breaks by type/variant name. */
+function compareContexts(a: VariantSweepContext, b: VariantSweepContext): number {
+  const byCount = b.consumers.length - a.consumers.length;
+  if (byCount !== 0) return byCount;
+  const byType = a.typeName.localeCompare(b.typeName);
+  if (byType !== 0) return byType;
+  return a.variant.localeCompare(b.variant);
+}
+
+/**
+ * The full `<variant_sweep_candidates>` worklist: every enum/union/
+ * const-object variant this PR added, paired with the (capped) consumer
+ * sites found to enumerate the family's other members without it. Only
+ * variants with at least one such site are included — there's nothing for
+ * the agent to check otherwise. Exposed for testing.
+ */
+export function computeVariantSweepContexts(context: ReviewContext): VariantSweepContext[] {
+  const added = computeAddedVariants(context);
+  if (added.length === 0) return [];
+  if (!context.repoChunks || context.repoChunks.length === 0) return [];
+
+  const results = groupAddedVariants(added).flatMap(group => buildContextsForGroup(context, group));
+  results.sort(compareContexts);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const HEADER =
+  'Pre-computed by a deterministic diff scan — the added-variant discovery AND ' +
+  'the consumer sweep are done for you; do not re-grep for consumers. Each entry ' +
+  'is an enum member / union arm / const-object key this PR ADDED to an existing ' +
+  "family, with consumer site(s) elsewhere that reference >= 2 of the family's " +
+  'OTHER members (a switch/if-chain/mapping enumerating the type) but never ' +
+  'mention the new one. Confirm before reporting: if the consumer genuinely needs ' +
+  "to handle this variant and doesn't (e.g. it isn't just an intentional catch-all " +
+  'default, and the gap is not already disclosed in this PR), report it under ' +
+  'incomplete-handling. If the omission is a deliberate fallback or already handled ' +
+  'some other way, stay silent.';
+
+function renderHandled(names: string[]): string {
+  const shown = names.slice(0, MAX_HANDLED_LISTED);
+  const omitted = names.length - shown.length;
+  return omitted > 0 ? `${shown.join(', ')}, +${omitted} more` : shown.join(', ');
+}
+
+function renderContextEntry(c: VariantSweepContext): string {
+  const sites = c.consumers
+    .map(site => `${site.file}:${site.line} (handles: ${renderHandled(site.handledVariants)})`)
+    .join('; ');
+  return `- ${c.typeName}.${c.variant} (added in ${c.file}) — ${c.consumers.length} consumer site(s) not updated: ${sites}`;
+}
+
+/**
+ * Render variant-sweep contexts as a `<variant_sweep_candidates>` block for
+ * the agent's initial message. Returns '' when there are none so callers
+ * can append unconditionally. Caps at MAX_ENTRIES and MAX_BLOCK_CHARS with
+ * an explicit omission note — never truncates silently. Exposed for testing.
+ */
+export function renderVariantSweepCandidates(contexts: VariantSweepContext[]): string {
+  if (contexts.length === 0) return '';
+
+  const lines: string[] = ['<variant_sweep_candidates>', HEADER];
+  let used = lines.join('\n').length;
+  let rendered = 0;
+
+  for (const c of contexts.slice(0, MAX_ENTRIES)) {
+    const entry = renderContextEntry(c);
+    if (used + entry.length + 1 > MAX_BLOCK_CHARS) break;
+    lines.push(entry);
+    used += entry.length + 1;
+    rendered++;
+  }
+
+  const omitted = contexts.length - rendered;
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more added variant(s) omitted to respect the input budget — inspect the diff for the rest]`,
+    );
+  }
+
+  lines.push('</variant_sweep_candidates>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<variant_sweep_candidates>` section from the review context.
+ * Returns '' when the PR adds no enum/union/const-object variant with a
+ * stale consumer, or there's no diff/repo index to check against.
+ */
+export function renderVariantSweepSection(context: ReviewContext): string {
+  return renderVariantSweepCandidates(computeVariantSweepContexts(context));
+}

--- a/packages/review/src/variant-sweep-signals.ts
+++ b/packages/review/src/variant-sweep-signals.ts
@@ -47,9 +47,12 @@
  *    this directly satisfies the "non-enum object literals" case).
  *  - Consumer detection requires a DOT-QUALIFIED reference (`TypeName.
  *    Member`) for enum/const-object members — the idiomatic, high-precision
- *    form (`case Color.Red:`, `x === Color.Red`, `[Color.Red]: ...`). Union
- *    members (string/numeric literals, no natural qualifier) fall back to
- *    the bare quoted/keyed literal value, which is lower precision by
+ *    form (`case Color.Red:`, `x === Color.Red`, `[Color.Red]: ...`). A
+ *    const-object key that isn't a valid identifier (e.g. kebab-case) falls
+ *    back to bracket notation (`Editors['claude-code']`) instead, since dot
+ *    access isn't valid syntax for it. Union members (string/numeric
+ *    literals, no natural qualifier) fall back to the bare quoted/keyed
+ *    literal value (unquoted for numeric arms), which is lower precision by
  *    construction — documented, not papered over.
  *  - A consumer site is only ever a `case` label, an equality comparison
  *    (`===`/`==`/`!==`/`!=`), an `instanceof` check (union-of-identifier
@@ -63,6 +66,16 @@
  *    comment skipping — a member whose VALUE itself contains a nested
  *    object is not expected for these idiomatic shapes and is a documented
  *    limitation, not a crash.
+ *  - `isGenuinelyNew`'s "was this identifier ever removed" check scans the
+ *    WHOLE file's removed-diff-text, not just the lines belonging to this
+ *    variant's own family/declaration. A same-named member removed from an
+ *    unrelated declaration elsewhere in the same file's diff can therefore
+ *    suppress a genuine addition (false negative). Scoping this to the
+ *    owning declaration/hunk would need old-side-aware family parsing (the
+ *    diff-side scan is currently new-side only) — left as a known gap
+ *    rather than a v1 blocker; a coincidental same-named removal elsewhere
+ *    in the same file's diff is a narrow enough case that it wasn't judged
+ *    worth the parsing cost yet.
  */
 
 import type { CodeChunk } from '@liendev/parser';
@@ -120,6 +133,9 @@ const TS_JS_FILE_RE = /\.(?:[cm]?[jt]sx?)$/;
 const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
 const VALID_IDENT_RE = /^[A-Za-z_$][\w$]*$/;
+
+/** A bare (unquoted) numeric union arm — e.g. the `200`/`404` in `type Code = 200 | 404`. */
+const NUMERIC_LITERAL_RE = /^-?\d+(?:\.\d+)?$/;
 
 const ENUM_HEADER_RE =
   /\b(?:export\s+)?(?:declare\s+)?(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)\s*\{/g;
@@ -180,7 +196,10 @@ function classifySpan(text: string, i: number): Span | null {
  * declaration HEADERS safely, since a docstring/fixture string quoting
  * `enum Foo {` as prose must never be read as a real declaration).
  */
-function maskSpans(text: string, shouldMask: (kind: Span['kind']) => boolean): string {
+function maskSpans(
+  text: string,
+  shouldMask: (span: Span, start: number, text: string) => boolean,
+): string {
   let i = 0;
   let out = '';
   while (i < text.length) {
@@ -190,7 +209,7 @@ function maskSpans(text: string, shouldMask: (kind: Span['kind']) => boolean): s
       i++;
       continue;
     }
-    if (shouldMask(span.kind)) {
+    if (shouldMask(span, i, text)) {
       for (let k = i; k < span.end; k++) out += text[k] === '\n' ? '\n' : ' ';
     } else {
       out += text.slice(i, span.end);
@@ -201,11 +220,52 @@ function maskSpans(text: string, shouldMask: (kind: Span['kind']) => boolean): s
 }
 
 function maskComments(text: string): string {
-  return maskSpans(text, kind => kind === 'comment');
+  return maskSpans(text, span => span.kind === 'comment');
 }
 
 function maskCommentsAndStrings(text: string): string {
   return maskSpans(text, () => true);
+}
+
+/** Nearest non-whitespace character before index `i`, or '' at the start of `text`. */
+function prevNonSpace(text: string, i: number): string {
+  let k = i - 1;
+  while (k >= 0 && /\s/.test(text[k])) k--;
+  return k >= 0 ? text[k] : '';
+}
+
+/** Nearest non-whitespace character at/after index `i`, or '' at the end of `text`. */
+function nextNonSpace(text: string, i: number): string {
+  let k = i;
+  while (k < text.length && /\s/.test(text[k])) k++;
+  return k < text.length ? text[k] : '';
+}
+
+/**
+ * Is this string span a computed-member-access key — `Foo['bar']` — rather
+ * than a free-standing string expression? Recognized by its immediate
+ * bracket context (`[` before, `]` after, ignoring whitespace), not by
+ * position within a larger expression.
+ */
+function isBracketIndexString(span: Span, start: number, text: string): boolean {
+  return prevNonSpace(text, start) === '[' && nextNonSpace(text, span.end) === ']';
+}
+
+/**
+ * Mask comments and "prose" string literals, but NOT a string used as a
+ * computed member-access key (`Editors['claude-code']`) — that's syntax a
+ * qualified-reference scan must still be able to match, not prose that
+ * could coincidentally contain matching text. Used by
+ * {@link collectMatchesInChunk} for enum/const-object consumer scans, where
+ * {@link maskCommentsAndStrings}'s blanket string-masking would blind the
+ * scan to bracket-accessed non-identifier keys.
+ */
+function maskCommentsAndProseStrings(text: string): string {
+  return maskSpans(
+    text,
+    (span, start, t) =>
+      span.kind === 'comment' || (span.kind === 'string' && !isBracketIndexString(span, start, t)),
+  );
 }
 
 /**
@@ -427,6 +487,7 @@ function unionArmVariant(armText: string): string | null {
   const strLit = armText.match(/^['"]([^'"]*)['"]$/);
   if (strLit) return strLit[1];
   if (VALID_IDENT_RE.test(armText)) return armText;
+  if (NUMERIC_LITERAL_RE.test(armText)) return armText;
   return null;
 }
 
@@ -438,9 +499,12 @@ function findUnionDeclarations(content: string, baseLine: number): FamilyDeclara
     const typeName = m[1];
     const bodyStart = m.index + m[0].length;
     const semiIdx = findTopLevelSemicolon(commentMasked, bodyStart);
-    if (semiIdx === -1) continue;
+    // A union alias with no trailing semicolon (e.g. the last statement in a
+    // no-semicolon-style file/chunk) still has a real body — fall back to
+    // the end of the content rather than dropping the declaration entirely.
+    const bodyEnd = semiIdx === -1 ? commentMasked.length : semiIdx;
 
-    const body = commentMasked.slice(bodyStart, semiIdx);
+    const body = commentMasked.slice(bodyStart, bodyEnd);
     const members: FamilyMember[] = [];
     for (const seg of splitTopLevel(body, '|')) {
       const t = seg.text.trim();
@@ -455,7 +519,7 @@ function findUnionDeclarations(content: string, baseLine: number): FamilyDeclara
       kind: 'union',
       members,
       declStartLine: baseLine + countNewlines(content, m.index),
-      declEndLine: baseLine + countNewlines(content, semiIdx),
+      declEndLine: baseLine + countNewlines(content, bodyEnd),
     });
   }
   return out;
@@ -668,16 +732,26 @@ interface TokenPatterns {
   mappingKeys: RegExp[];
 }
 
-/** Enum / const-object members are referenced dot-qualified: `TypeName.Member`. */
+/**
+ * Enum / const-object members are usually referenced dot-qualified:
+ * `TypeName.Member`. A const-object key that isn't a valid identifier (e.g.
+ * a kebab-case string key) can't be dot-accessed at all — `Editors.claude-
+ * code` doesn't parse as a property access — so real consumer code is
+ * forced to use bracket notation (`Editors['claude-code']`) instead; fall
+ * back to that form when the variant name itself isn't a valid identifier.
+ */
 function buildQualifiedTokenPatterns(typeName: string, variant: string): TokenPatterns {
-  const dot = `\\b${escapeRegExp(typeName)}\\.${escapeRegExp(variant)}\\b`;
+  const typeEsc = escapeRegExp(typeName);
+  const qualified = VALID_IDENT_RE.test(variant)
+    ? `\\b${typeEsc}\\.${escapeRegExp(variant)}\\b`
+    : `\\b${typeEsc}\\s*\\[\\s*['"]${escapeRegExp(variant)}['"]\\s*\\]`;
   return {
     references: [
-      new RegExp(`\\bcase\\s+${dot}\\s*:`),
-      new RegExp(`${dot}\\s*(?:===|==|!==|!=)`),
-      new RegExp(`(?:===|==|!==|!=)\\s*${dot}`),
+      new RegExp(`\\bcase\\s+${qualified}\\s*:`),
+      new RegExp(`${qualified}\\s*(?:===|==|!==|!=)`),
+      new RegExp(`(?:===|==|!==|!=)\\s*${qualified}`),
     ],
-    mappingKeys: [new RegExp(`\\[\\s*${dot}\\s*\\]\\s*:`)],
+    mappingKeys: [new RegExp(`\\[\\s*${qualified}\\s*\\]\\s*:`)],
   };
 }
 
@@ -689,13 +763,16 @@ function buildQualifiedTokenPatterns(typeName: string, variant: string): TokenPa
  */
 function buildUnionTokenPatterns(variant: string): TokenPatterns {
   const v = escapeRegExp(variant);
-  const quoted = `['"]${v}['"]`;
+  // Numeric arms (`200`, `404`) are never quoted in real code — `case 200:`,
+  // not `case '200':` — so they need an unquoted, word-bounded literal
+  // pattern instead of the string-arm `quoted` form.
+  const literal = NUMERIC_LITERAL_RE.test(variant) ? `\\b${v}\\b` : `['"]${v}['"]`;
   const references = [
-    new RegExp(`\\bcase\\s+${quoted}\\s*:`),
-    new RegExp(`${quoted}\\s*(?:===|==|!==|!=)`),
-    new RegExp(`(?:===|==|!==|!=)\\s*${quoted}`),
+    new RegExp(`\\bcase\\s+${literal}\\s*:`),
+    new RegExp(`${literal}\\s*(?:===|==|!==|!=)`),
+    new RegExp(`(?:===|==|!==|!=)\\s*${literal}`),
   ];
-  const mappingKeys = [new RegExp(`${quoted}\\s*:`)];
+  const mappingKeys = [new RegExp(`${literal}\\s*:`)];
   if (VALID_IDENT_RE.test(variant)) {
     references.push(new RegExp(`\\binstanceof\\s+${v}\\b`));
     mappingKeys.push(new RegExp(`\\b${v}\\s*:`));
@@ -713,12 +790,22 @@ function buildTokenPatterns(
     : buildQualifiedTokenPatterns(typeName, variant);
 }
 
-/** For each variant in `tokenMap` that has a matching reference in `content`, its first matching line (0-based). */
+/**
+ * For each variant in `tokenMap` that has a matching reference in `content`,
+ * its first matching line (0-based). `kind` picks the masking strategy:
+ * enum/const-object patterns are dot- or bracket-qualified identifiers, so
+ * masking string contents too avoids a false consumer match from a string
+ * literal that merely CONTAINS matching text (e.g. `"case Color.Red:"` in a
+ * log message or test fixture). Union patterns are themselves quoted string
+ * literals, so masking strings would blind the scan to every real match —
+ * only comments are masked for that kind.
+ */
 function collectMatchesInChunk(
   content: string,
   tokenMap: Map<string, TokenPatterns>,
+  kind: VariantFamilyKind,
 ): Map<string, number> {
-  const masked = maskComments(content);
+  const masked = kind === 'union' ? maskComments(content) : maskCommentsAndProseStrings(content);
   const lines = masked.split('\n');
   const found = new Map<string, number>();
 
@@ -816,7 +903,7 @@ function recordChunkConsumers(
   byVariant: Map<string, VariantConsumerSite[]>,
   seenSite: Set<string>,
 ): void {
-  const matches = collectMatchesInChunk(chunk.content, tokenMap);
+  const matches = collectMatchesInChunk(chunk.content, tokenMap, group.kind);
   const matchedExisting = [...matches.keys()].filter(k => existingSet.has(k));
   if (matchedExisting.length < MIN_EXISTING_REFERENCES) return;
 

--- a/packages/review/test/variant-sweep-signals.test.ts
+++ b/packages/review/test/variant-sweep-signals.test.ts
@@ -200,6 +200,45 @@ describe('computeAddedVariants', () => {
     ]);
   });
 
+  it('detects a new numeric arm added to a numeric union type', () => {
+    const content = 'export type StatusCode = 200 | 404 | 500 | 503;';
+    const patches = new Map([
+      [
+        'src/status.ts',
+        patch(
+          '@@ -1,1 +1,1 @@',
+          '-export type StatusCode = 200 | 404 | 500;',
+          '+export type StatusCode = 200 | 404 | 500 | 503;',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/status.ts', 1, content)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'StatusCode', variant: '503', file: 'src/status.ts', kind: 'union' },
+    ]);
+  });
+
+  it('detects a new arm added to a union with no trailing semicolon (last statement in chunk)', () => {
+    // No trailing `;` — a no-semicolon style file/chunk boundary.
+    const content = "export type FailOn = 'error' | 'never' | 'any'";
+    const patches = new Map([
+      [
+        'src/inputs.ts',
+        patch(
+          '@@ -1,1 +1,1 @@',
+          "-export type FailOn = 'error' | 'never'",
+          "+export type FailOn = 'error' | 'never' | 'any'",
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/inputs.ts', 1, content)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'FailOn', variant: 'any', file: 'src/inputs.ts', kind: 'union' },
+    ]);
+  });
+
   it('detects a new arm added to a multi-line pipe-style union (EditorId shape)', () => {
     const content = EDITOR_ID_UNION;
     const patches = new Map([['src/init.ts', EDITOR_ID_UNION_PATCH]]);
@@ -404,6 +443,90 @@ describe('computeVariantSweepContexts', () => {
       'cursor',
       'windsurf',
     ]);
+  });
+
+  it('flags a stale switch over a numeric union that omits the new numeric arm', () => {
+    const patches = new Map([
+      [
+        'src/status.ts',
+        patch(
+          '@@ -1,1 +1,1 @@',
+          '-export type StatusCode = 200 | 404 | 500;',
+          '+export type StatusCode = 200 | 404 | 500 | 503;',
+        ),
+      ],
+    ]);
+    const chunks = [
+      makeChunk('src/status.ts', 1, 'export type StatusCode = 200 | 404 | 500 | 503;'),
+    ];
+    const consumer = [
+      'function describe(code: StatusCode): string {',
+      '  switch (code) {',
+      "    case 200: return 'OK';",
+      "    case 404: return 'Not Found';",
+      "    case 500: return 'Server Error';",
+      "    default: return 'Unknown';",
+      '  }',
+      '}',
+    ].join('\n');
+    const repoChunks = [makeChunk('src/consumer.ts', 1, consumer)];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toMatchObject({ typeName: 'StatusCode', variant: '503', kind: 'union' });
+    expect(contexts[0].consumers[0].handledVariants.sort()).toEqual(['200', '404', '500']);
+  });
+
+  it('flags a mapping table keyed by bracket-access for a non-identifier const-object key', () => {
+    const content = [
+      'export const Editors = {',
+      '  cursor: 1,',
+      "  'claude-code': 2,",
+      '  zed: 3,',
+      '} as const;',
+    ].join('\n');
+    const patches = new Map([
+      [
+        'src/editors.ts',
+        patch(
+          '@@ -1,3 +1,4 @@',
+          ' export const Editors = {',
+          '   cursor: 1,',
+          "   'claude-code': 2,",
+          '+  zed: 3,',
+          ' } as const;',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/editors.ts', 1, content)];
+    // References the non-identifier key via bracket access (the only valid
+    // syntax for it) and the identifier key via dot access — omits `zed`.
+    const consumer = [
+      'function cost(e: typeof Editors): number {',
+      '  if (e === Editors.cursor) return 1;',
+      "  if (e === Editors['claude-code']) return 2;",
+      '  return 0;',
+      '}',
+    ].join('\n');
+    const repoChunks = [makeChunk('src/cost.ts', 1, consumer)];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toMatchObject({
+      typeName: 'Editors',
+      variant: 'zed',
+      kind: 'const-object',
+    });
+    expect(contexts[0].consumers[0].handledVariants.sort()).toEqual(['claude-code', 'cursor']);
+  });
+
+  it('does not treat qualified-reference text INSIDE a string literal as a real consumer match', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    // Not real code — a log/fixture string that merely CONTAINS matching
+    // text. Must not be misread as a switch enumerating Red and Blue.
+    const stringOnly =
+      'const msg = "unhandled: case Color.Red: case Color.Blue: — check the switch";';
+    const repoChunks = [makeChunk('src/log.ts', 1, stringOnly)];
+    expect(computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }))).toEqual([]);
   });
 
   it('handles multiple independent families in the same PR without crosstalk', () => {

--- a/packages/review/test/variant-sweep-signals.test.ts
+++ b/packages/review/test/variant-sweep-signals.test.ts
@@ -1,0 +1,575 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { ReviewRule, ResolvedRules } from '../src/plugins/agent/types.js';
+import {
+  computeAddedVariants,
+  resolveFamilyExisting,
+  computeVariantSweepContexts,
+  renderVariantSweepCandidates,
+  renderVariantSweepSection,
+} from '../src/variant-sweep-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'block',
+      language: 'typescript',
+    },
+  } as unknown as CodeChunk;
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  chunks?: CodeChunk[];
+  repoChunks?: CodeChunk[];
+}): ReviewContext {
+  const pr = opts.patches ? { patches: opts.patches } : undefined;
+  return {
+    pr,
+    chunks: opts.chunks ?? [],
+    repoChunks: opts.repoChunks,
+    changedFiles: [],
+  } as unknown as ReviewContext;
+}
+
+function patch(...lines: string[]): string {
+  return lines.join('\n');
+}
+
+function incompleteHandlingRule(): ReviewRule {
+  return {
+    id: 'incomplete-handling',
+    name: 'Incomplete Interface/Type Handling',
+    description: 'test rule',
+    prompt: 'test prompt',
+    triggers: { always: true },
+    severity: 'error',
+    category: 'logic_error',
+    enabled: true,
+    source: 'builtin',
+  };
+}
+
+function resolvedRulesWith(...ids: string[]): ResolvedRules {
+  return {
+    active: ids.map(id => ({ ...incompleteHandlingRule(), id })),
+    skipped: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures reused across tests
+// ---------------------------------------------------------------------------
+
+const COLOR_ENUM = ['export enum Color {', '  Red,', '  Blue,', '  Green,', '}'].join('\n');
+
+const COLOR_ENUM_PATCH = patch(
+  '@@ -1,4 +1,5 @@',
+  ' export enum Color {',
+  '   Red,',
+  '   Blue,',
+  '+  Green,',
+  ' }',
+);
+
+const EDITOR_ID_UNION = [
+  'export type EditorId =',
+  "  | 'cursor'",
+  "  | 'claude-code'",
+  "  | 'windsurf'",
+  "  | 'zed';",
+].join('\n');
+
+// The old file's 'windsurf' arm carried the terminating `;`; the new file
+// moves it to the new 'zed' arm — a realistic Prettier-style multi-line
+// union reformat. 'windsurf' reappears on an added line too, but its
+// identifier also appears in the removed line, so `isGenuinelyNew` correctly
+// excludes it — only 'zed' is a genuine addition.
+const EDITOR_ID_UNION_PATCH = patch(
+  '@@ -1,4 +1,5 @@',
+  ' export type EditorId =',
+  "   | 'cursor'",
+  "   | 'claude-code'",
+  "-  | 'windsurf';",
+  "+  | 'windsurf'",
+  "+  | 'zed';",
+);
+
+function colorSwitchConsumer(withGreen = false): string {
+  const greenCase = withGreen ? "\n    case Color.Green:\n      return 'green';" : '';
+  return [
+    'function label(c: Color): string {',
+    '  switch (c) {',
+    '    case Color.Red:',
+    "      return 'red';",
+    '    case Color.Blue:',
+    "      return 'blue';" + greenCase,
+    '    default:',
+    "      return 'unknown';",
+    '  }',
+    '}',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// computeAddedVariants
+// ---------------------------------------------------------------------------
+
+describe('computeAddedVariants', () => {
+  it('detects a new enum member added to an existing enum', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'Color', variant: 'Green', file: 'src/color.ts', kind: 'enum' },
+    ]);
+  });
+
+  it('does not flag a brand-new enum (no prior consumers could exist)', () => {
+    const patches = new Map([
+      [
+        'src/new-enum.ts',
+        patch('@@ -0,0 +1,4 @@', '+export enum Status {', '+  Active,', '+  Inactive,', '+}'),
+      ],
+    ]);
+    const chunks = [
+      makeChunk('src/new-enum.ts', 1, 'export enum Status {\n  Active,\n  Inactive,\n}'),
+    ];
+    expect(computeAddedVariants(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('does not treat a same-identifier value edit as an addition', () => {
+    const content = ['export enum Color {', "  Red = 'crimson',", '  Blue,', '}'].join('\n');
+    const patches = new Map([
+      [
+        'src/color.ts',
+        patch(
+          '@@ -1,4 +1,4 @@',
+          ' export enum Color {',
+          "-  Red = 'red',",
+          "+  Red = 'crimson',",
+          '   Blue,',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/color.ts', 1, content)];
+    expect(computeAddedVariants(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('treats a renamed member as an addition (overlap with rename-sweep is accepted)', () => {
+    const content = ['export enum Color {', '  Red,', '  Cyan,', '}'].join('\n');
+    const patches = new Map([
+      [
+        'src/color.ts',
+        patch('@@ -1,3 +1,3 @@', ' export enum Color {', '   Red,', '-  Blue,', '+  Cyan,'),
+      ],
+    ]);
+    const chunks = [makeChunk('src/color.ts', 1, content)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'Color', variant: 'Cyan', file: 'src/color.ts', kind: 'enum' },
+    ]);
+  });
+
+  it('detects a new arm added to a single-line union type', () => {
+    const content = "export type FailOn = 'error' | 'never' | 'any';";
+    const patches = new Map([
+      [
+        'src/inputs.ts',
+        patch(
+          '@@ -1,1 +1,1 @@',
+          "-export type FailOn = 'error' | 'never';",
+          "+export type FailOn = 'error' | 'never' | 'any';",
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/inputs.ts', 1, content)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'FailOn', variant: 'any', file: 'src/inputs.ts', kind: 'union' },
+    ]);
+  });
+
+  it('detects a new arm added to a multi-line pipe-style union (EditorId shape)', () => {
+    const content = EDITOR_ID_UNION;
+    const patches = new Map([['src/init.ts', EDITOR_ID_UNION_PATCH]]);
+    const chunks = [makeChunk('src/init.ts', 1, content)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'EditorId', variant: 'zed', file: 'src/init.ts', kind: 'union' },
+    ]);
+  });
+
+  it('detects a new key added to a const-object-as-const value map', () => {
+    const content = [
+      'export const Editors = {',
+      "  cursor: 'Cursor',",
+      "  windsurf: 'Windsurf',",
+      "  zed: 'Zed',",
+      '} as const;',
+    ].join('\n');
+    const patches = new Map([
+      [
+        'src/editors.ts',
+        patch(
+          '@@ -1,4 +1,5 @@',
+          ' export const Editors = {',
+          "   cursor: 'Cursor',",
+          "   windsurf: 'Windsurf',",
+          "+  zed: 'Zed',",
+          ' } as const;',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/editors.ts', 1, content)];
+    const added = computeAddedVariants(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'Editors', variant: 'zed', file: 'src/editors.ts', kind: 'const-object' },
+    ]);
+  });
+
+  it('does not treat a plain object literal (no `as const`) as a variant family', () => {
+    const content = ['export const CONFIG = {', '  a: 1,', '  b: 2,', '  c: 3,', '};'].join('\n');
+    const patches = new Map([
+      [
+        'src/config.ts',
+        patch(
+          '@@ -1,3 +1,4 @@',
+          ' export const CONFIG = {',
+          '   a: 1,',
+          '   b: 2,',
+          '+  c: 3,',
+          ' };',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/config.ts', 1, content)];
+    expect(computeAddedVariants(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('returns [] when there is no diff or no chunks', () => {
+    expect(computeAddedVariants(makeContext({}))).toEqual([]);
+    expect(
+      computeAddedVariants(makeContext({ patches: new Map([['a.ts', 'x']]), chunks: [] })),
+    ).toEqual([]);
+  });
+
+  it('ignores non-TS/JS files', () => {
+    const patches = new Map([['src/color.rs', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.rs', 1, COLOR_ENUM)];
+    expect(computeAddedVariants(makeContext({ patches, chunks }))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFamilyExisting
+// ---------------------------------------------------------------------------
+
+describe('resolveFamilyExisting', () => {
+  it('returns existing members minus the added ones', () => {
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const context = makeContext({ chunks });
+    const family = resolveFamilyExisting(
+      context,
+      'src/color.ts',
+      'enum',
+      'Color',
+      new Set(['Green']),
+    );
+    expect(family?.existingVariants).toEqual(['Red', 'Blue']);
+  });
+
+  it('returns null when the declaration cannot be found', () => {
+    const context = makeContext({ chunks: [] });
+    expect(resolveFamilyExisting(context, 'src/color.ts', 'enum', 'Color', new Set())).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeVariantSweepContexts
+// ---------------------------------------------------------------------------
+
+describe('computeVariantSweepContexts', () => {
+  it('flags a stale switch that handles >= 2 existing variants but omits the new one', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const repoChunks = [makeChunk('src/consumer.ts', 1, colorSwitchConsumer(false))];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toMatchObject({ typeName: 'Color', variant: 'Green', kind: 'enum' });
+    expect(contexts[0].consumers).toHaveLength(1);
+    expect(contexts[0].consumers[0].file).toBe('src/consumer.ts');
+    expect(contexts[0].consumers[0].handledVariants.sort()).toEqual(['Blue', 'Red']);
+  });
+
+  it('does not flag a consumer already updated in the same diff (new variant present in head)', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const repoChunks = [makeChunk('src/consumer.ts', 1, colorSwitchConsumer(true))];
+    expect(computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }))).toEqual([]);
+  });
+
+  it('does not flag a consumer with only a default case (no variant enumerated)', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const defaultOnly = [
+      'function label(c: Color): string {',
+      '  switch (c) {',
+      '    default:',
+      "      return 'unknown';",
+      '  }',
+      '}',
+    ].join('\n');
+    const repoChunks = [makeChunk('src/consumer.ts', 1, defaultOnly)];
+    expect(computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }))).toEqual([]);
+  });
+
+  it('does not flag a consumer referencing only a single existing variant', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const single = 'function isRed(c: Color): boolean {\n  return c === Color.Red;\n}';
+    const repoChunks = [makeChunk('src/consumer.ts', 1, single)];
+    expect(computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }))).toEqual([]);
+  });
+
+  it('does not flag when the added variant is already handled elsewhere', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    // Two consumers: one stale (should be flagged), one that already handles Green.
+    const stale = colorSwitchConsumer(false);
+    const handled = colorSwitchConsumer(true);
+    const repoChunks = [
+      makeChunk('src/consumer-a.ts', 1, stale),
+      makeChunk('src/consumer-b.ts', 1, handled),
+    ];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].consumers.map(c => c.file)).toEqual(['src/consumer-a.ts']);
+  });
+
+  it('does not flag a non-enum object literal with coincidentally-matching bare keys', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    // Bare (non-computed) keys named after the enum members — NOT a `[Color.X]:`
+    // computed reference, so this must not match the enum's qualified token form.
+    const unrelated = 'const paintCosts = {\n  Red: 10,\n  Blue: 12,\n};';
+    const repoChunks = [makeChunk('src/paint.ts', 1, unrelated)];
+    expect(computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }))).toEqual([]);
+  });
+
+  it('flags a mapping table keyed by computed enum references', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const mapping = [
+      'const HEX: Record<Color, string> = {',
+      '  [Color.Red]: "#f00",',
+      '  [Color.Blue]: "#00f",',
+      '};',
+    ].join('\n');
+    const repoChunks = [makeChunk('src/hex.ts', 1, mapping)];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].consumers[0].handledVariants.sort()).toEqual(['Blue', 'Red']);
+  });
+
+  it('flags a mapping table keyed by quoted union-string literals (EditorId/EDITORS shape)', () => {
+    const patches = new Map([['src/init.ts', EDITOR_ID_UNION_PATCH]]);
+    const chunks = [makeChunk('src/init.ts', 1, EDITOR_ID_UNION)];
+    const editors = [
+      'const EDITORS: Record<EditorId, EditorDefinition> = {',
+      "  cursor: { name: 'Cursor' },",
+      "  'claude-code': { name: 'Claude Code' },",
+      "  windsurf: { name: 'Windsurf' },",
+      '};',
+    ].join('\n');
+    // Realistic placement: EDITORS lives further down the SAME file as
+    // EditorId, at a line range that does not overlap the union declaration.
+    const repoChunks = [makeChunk('src/init.ts', 20, editors)];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].typeName).toBe('EditorId');
+    expect(contexts[0].variant).toBe('zed');
+    expect(contexts[0].consumers[0].handledVariants.sort()).toEqual([
+      'claude-code',
+      'cursor',
+      'windsurf',
+    ]);
+  });
+
+  it('handles multiple independent families in the same PR without crosstalk', () => {
+    const sizeContent = "export type Size = 'small' | 'medium' | 'large' | 'xlarge';";
+    const patches = new Map([
+      ['src/color.ts', COLOR_ENUM_PATCH],
+      [
+        'src/size.ts',
+        patch(
+          '@@ -1,1 +1,1 @@',
+          "-export type Size = 'small' | 'medium' | 'large';",
+          "+export type Size = 'small' | 'medium' | 'large' | 'xlarge';",
+        ),
+      ],
+    ]);
+    const chunks = [
+      makeChunk('src/color.ts', 1, COLOR_ENUM),
+      makeChunk('src/size.ts', 1, sizeContent),
+    ];
+    const sizeConsumer = [
+      'function px(s: Size): number {',
+      "  if (s === 'small') return 8;",
+      "  if (s === 'medium') return 12;",
+      "  if (s === 'large') return 16;",
+      '  return 12;',
+      '}',
+    ].join('\n');
+    const repoChunks = [
+      makeChunk('src/consumer.ts', 1, colorSwitchConsumer(false)),
+      makeChunk('src/size-consumer.ts', 1, sizeConsumer),
+    ];
+    const contexts = computeVariantSweepContexts(makeContext({ patches, chunks, repoChunks }));
+    const byType = Object.fromEntries(contexts.map(c => [c.typeName, c]));
+    expect(byType.Color.variant).toBe('Green');
+    expect(byType.Size.variant).toBe('xlarge');
+    expect(byType.Color.consumers[0].file).toBe('src/consumer.ts');
+    expect(byType.Size.consumers[0].file).toBe('src/size-consumer.ts');
+  });
+
+  it('returns [] when there are no added variants or no repo index', () => {
+    expect(computeVariantSweepContexts(makeContext({}))).toEqual([]);
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    expect(computeVariantSweepContexts(makeContext({ patches, chunks }))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderVariantSweepCandidates
+// ---------------------------------------------------------------------------
+
+describe('renderVariantSweepCandidates', () => {
+  it('returns "" for no contexts', () => {
+    expect(renderVariantSweepCandidates([])).toBe('');
+  });
+
+  it('renders the block naming the type/variant/file and consumer sites', () => {
+    const md = renderVariantSweepCandidates([
+      {
+        typeName: 'Color',
+        variant: 'Green',
+        file: 'src/color.ts',
+        kind: 'enum',
+        consumers: [{ file: 'src/consumer.ts', line: 3, handledVariants: ['Blue', 'Red'] }],
+      },
+    ]);
+    expect(md).toContain('<variant_sweep_candidates>');
+    expect(md).toContain('</variant_sweep_candidates>');
+    expect(md).toContain('Color.Green (added in src/color.ts)');
+    expect(md).toContain('src/consumer.ts:3 (handles: Blue, Red)');
+  });
+
+  it('caps at MAX_ENTRIES (12) with an explicit omission note — never truncates silently', () => {
+    const contexts = Array.from({ length: 15 }, (_, i) => ({
+      typeName: `Type${i}`,
+      variant: 'New',
+      file: 'src/a.ts',
+      kind: 'enum' as const,
+      consumers: [{ file: 'src/b.ts', line: 1, handledVariants: ['X', 'Y'] }],
+    }));
+    const md = renderVariantSweepCandidates(contexts);
+    expect(md).toContain('more added variant(s) omitted');
+    expect(md).toContain('+3 more');
+  });
+
+  it('omits the truncation note when under the cap', () => {
+    const md = renderVariantSweepCandidates([
+      {
+        typeName: 'Color',
+        variant: 'Green',
+        file: 'src/color.ts',
+        kind: 'enum',
+        consumers: [{ file: 'src/consumer.ts', line: 3, handledVariants: ['Blue', 'Red'] }],
+      },
+    ]);
+    expect(md).not.toContain('omitted');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderVariantSweepSection
+// ---------------------------------------------------------------------------
+
+describe('renderVariantSweepSection', () => {
+  it("returns '' when the PR adds no variant with a stale consumer", () => {
+    expect(renderVariantSweepSection(makeContext({}))).toBe('');
+  });
+
+  it('renders candidates found from context', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const repoChunks = [makeChunk('src/consumer.ts', 1, colorSwitchConsumer(false))];
+    const section = renderVariantSweepSection(makeContext({ patches, chunks, repoChunks }));
+    expect(section).toContain('<variant_sweep_candidates>');
+    expect(section).toContain('Color.Green');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage injection (rule-gated, mirrors catch-discrimination)
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection (rule-gated)', () => {
+  function contextWithStaleSwitch(): ReviewContext {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const repoChunks = [makeChunk('src/consumer.ts', 1, colorSwitchConsumer(false))];
+    return {
+      ...makeContext({ patches, chunks, repoChunks }),
+      changedFiles: ['src/color.ts'],
+    } as ReviewContext;
+  }
+
+  it('includes the block when incomplete-handling is active and candidates exist', () => {
+    const message = buildInitialMessage(contextWithStaleSwitch(), {
+      blastRadius: null,
+      rules: resolvedRulesWith('incomplete-handling'),
+    });
+    expect(message).toContain('<variant_sweep_candidates>');
+    expect(message).toContain('Color.Green');
+  });
+
+  it('omits the block when rules are not provided at all', () => {
+    const message = buildInitialMessage(contextWithStaleSwitch(), { blastRadius: null });
+    expect(message).not.toContain('<variant_sweep_candidates>');
+  });
+
+  it('omits the block when incomplete-handling is not among the active rules', () => {
+    const message = buildInitialMessage(contextWithStaleSwitch(), {
+      blastRadius: null,
+      rules: resolvedRulesWith('error-swallowing'),
+    });
+    expect(message).not.toContain('<variant_sweep_candidates>');
+  });
+
+  it('omits the block when the rule is active but no candidates are found', () => {
+    const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+    const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+    const context = {
+      ...makeContext({ patches, chunks, repoChunks: [] }),
+      changedFiles: ['src/color.ts'],
+    } as ReviewContext;
+    const message = buildInitialMessage(context, {
+      blastRadius: null,
+      rules: resolvedRulesWith('incomplete-handling'),
+    });
+    expect(message).not.toContain('<variant_sweep_candidates>');
+  });
+});


### PR DESCRIPTION
## Doctrine context

Per `.wip/omission-pass-design.md` §6 item 2 (staged-doodling-piglet worktree,
read-only): the top v1 build item, ahead of the dedicated omission-pass
question entirely. `incomplete-handling`'s prompt today just tells the agent
to "grep for all consumers" of a newly-added enum/union variant
(`rules.ts:291`) — the grep-and-reason anti-pattern CLAUDE.md's design
principle warns against, the same one `removed-export-signals.ts` (PR #399)
and `catch-discrimination-signals.ts` (PR #770, 0→5/10 lift) already
replaced for their own shapes. This PR does the same for enum/union-variant
consumer sweeps: precompute the discovery, keep the LLM for judgment only.

## Heuristic + limits (stated honestly)

`packages/review/src/variant-sweep-signals.ts`:

1. **Added-variant detection** (diff-side, v1 TS/JS only): `enum X { NEW }`,
   `type X = A | B | NEW` (single-line and Prettier-style multi-line pipe
   unions), and `const X = { ...NEW } as const` value-maps. A declaration's
   own header line must NOT have been added by this diff — a brand-new
   family has no prior consumers to go stale. The one wrinkle: a
   single-line union rewritten wholesale (`type X = A | B;` →
   `type X = A | B | C;`) shows its header as an "added" line too (the whole
   line is replaced) — handled by falling back to "does the OLD header text
   survive on a removed line" for that case only (`existedBefore`).
   `const X = {...}` is ONLY treated as a family when suffixed `as const` —
   an ordinary config object is never misread as one (satisfies "non-enum
   object literals").
2. **Consumer sweep**: for each added variant, resolve the family's full
   current membership from the changed file's own chunk (not the diff — the
   diff's context window can be too narrow for large families), then scan
   `repoChunks` for a `case`/equality/`instanceof`/mapping-key site
   referencing >= 2 of the family's OTHER members with the new one absent.
   Enum/const-object references require dot-qualification (`Type.Member`) —
   high precision; union-of-string-literal references fall back to the bare
   quoted/keyed value — lower precision, documented as a real limitation.
3. **Known gaps, stated not papered over**: no full control-flow analysis
   (a member referenced only via a helper function is invisible); an
   inline discriminated-union object arm like `{ kind: 'x' }` is not parsed
   (only plain literal/identifier arms); brace/body extraction assumes a
   flat (non-nested) body.

## Census (gate 4)

`build-prompts.ts` over all 15 on-disk fixtures (12 regenerated via
`capture-pr.ts`, 3 hand-authored placeholders — `crossrepo/` excluded,
Python-only, guaranteed no-op for a TS/JS-scoped signal), MERGE-BASE
(`180f62c2`, = current `origin/main`) vs HEAD:

- **0 of 15 fixtures gain the `<variant_sweep_candidates>` block** —
  `initialMessage` is byte-identical for every fixture, including the
  CERTIFIED `incomplete-handling/enum-variant-removed` canary (PR #437 —
  correctly doesn't fire, since that's a REMOVED variant, out of this
  signal's scope).
- The only change across all 15 is a `systemPrompt` wording edit: replaced
  `INCOMPLETE_HANDLING`'s "grep for all consumers" sentence with one
  pointing at the new block (`rules.ts`). This touches every fixture where
  `incomplete-handling` is active (i.e. most TS-touching fixtures) since
  it's a rule-prompt change, not new evidence — `initialMessage` (the actual
  candidate content) is unaffected everywhere.

No fixture needs recalibration under the "gains a block" criterion.

**Addendum — re-verified post-merge (2026-07-16):** this branch was merged
with `origin/main` to pick up 8 same-morning merges, including two other
signals gated on rules this PR also touches — `sibling-surface` (#777,
`incomplete-handling`) and `comparison-change` (#779, `boundary-change`).
The only textual conflict was the insertion point in
`system-prompt.ts:buildInitialMessage` (both this PR and #779 appended a
new gated block at the same anchor); resolved as additive coexistence —
`variant-sweep` and `comparison-change` now both gate right after
`error-swallowing`'s block, `sibling-surface` stays where #777 put it
(after `test-coverage`, still gated on `incomplete-handling`). `rules.ts`
merged clean: #777 never touched `INCOMPLETE_HANDLING`'s prompt text, so
this PR's `<variant_sweep_candidates>` wording (added at `rules.ts:291`)
carried through untouched.

Re-ran the byte-diff census at the new merge-base — fixture directory
listing is unchanged (still the same 15 non-crossrepo fixtures; no other
same-morning PR added or removed one), so all 15 were regenerated via
`capture-pr.ts` and re-diffed, MERGE-BASE (`397ea27d`, current
`origin/main` post-merge) vs the merge commit:

- **0 of 15 fixtures gain the `<variant_sweep_candidates>` block** —
  `initialMessage` byte-identical for all 15 (verified programmatically,
  not just grepped), same conclusion as the original census.
- `systemPrompt` differs for all 15 by the same 4-line unified diff (one
  sentence swap in `INCOMPLETE_HANDLING`'s prompt) — identical shape to
  the original census, now confirmed to hold with `sibling-surface` and
  `comparison-change` also active in the prompt assembly.

No new fixture needs recalibration; the combined-state conclusion matches
the pre-merge one.

## Calibration (gate 5)

Per the byte-diff doctrine (`npm run test:harness -- --rule <rule-id>
--calibrate 10` is scoped to fixtures whose rendered PROMPT actually
changed), no fixture required a `--calibrate 10` run here: the census
(gate 4) shows 0/15 fixtures gain the `<variant_sweep_candidates>` block,
so there is no new evidence surface for any fixture to calibrate against.

As due diligence on the one thing that DID change — the `rules.ts` wording
edit, present in every `incomplete-handling`-active fixture's system prompt
even though it doesn't add a block — ran a lighter 3-vote spot-check
(not a full calibrate-10) on the one CERTIFIED canary for that rule:

```
incomplete-handling/enum-variant-removed — 3/3 passed · $0.0881
```

Confirms the prompt-text swap doesn't regress the existing canary.
**Total harness spend: $0.0881** (well under the $2 cap).

## Mining outcome (gate 6) — NEGATIVE

Spent ~75 min (over budget's low end, under its high end) searching:
this repo's own commit/PR/issue history, and honojs/hono, gin-gonic/gin,
pallets/werkzeug, encode/starlette (commit logs, `gh search`, release
bodies, targeted file-history digs on `mime.ts`/`http-status.ts`/
`binding.go`). Also synced with `mine-undisclosed-omission` (per the design
doc's pointer) — their mining was scoped to the sibling-surface signal
(reqwest #1550, Rust, mirror-directory duplicate function — wrong language
and wrong bug shape), no transferable lead.

**No real undisclosed enum/union-variant-omission regression found** in the
timebox. Closest misses: hono's `mime.ts` additions (#827, #1307) are
single-table completeness gaps with no separate family+consumer split;
hono's `StatusCode`/`Method` usages are structurally-typed (no runtime
switch/mapping to miss). Per the task's own fallback: **this signal ships
on census + calibration + dogfood alone**, not a mined fixture.

## Dogfood (gate 7) — mandatory

Constructed a synthetic branch in this worktree: added `| 'zed'` to the real
`EditorId` union in `packages/cli/src/cli/init.ts`, without touching the
`EDITORS: Record<EditorId, EditorDefinition>` map in the same file (found
via grep — a real, unmodified consumer). Ran `computeVariantSweepContexts`
+ `renderVariantSweepSection` directly against the real `git diff` + a real
AST-parsed chunk of the file (not a synthetic fixture). Verbatim output:

```
<variant_sweep_candidates>
Pre-computed by a deterministic diff scan — the added-variant discovery AND the consumer sweep are done for you; do not re-grep for consumers. Each entry is an enum member / union arm / const-object key this PR ADDED to an existing family, with consumer site(s) elsewhere that reference >= 2 of the family's OTHER members (a switch/if-chain/mapping enumerating the type) but never mention the new one. Confirm before reporting: if the consumer genuinely needs to handle this variant and doesn't (e.g. it isn't just an intentional catch-all default, and the gap is not already disclosed in this PR), report it under incomplete-handling. If the omission is a deliberate fallback or already handled some other way, stay silent.
- EditorId.zed (added in packages/cli/src/cli/init.ts) — 1 consumer site(s) not updated: packages/cli/src/cli/init.ts:26 (handles: antigravity, claude-code, cursor, kilo-code, opencode, windsurf)
</variant_sweep_candidates>
```

**Verdict: yes** — this points the agent at the exact right line (the
`EDITORS` map) with the exact right evidence (6 handled variants, the new
one absent), in a real repo file, no synthetic fixture massaging. (The
`choices: [{name, value}]` array in `promptForEditor` — a different,
array-of-objects consumer shape — is NOT caught; documented as a known
limitation, not silently missed.) Test branch reverted immediately after
capture; `packages/cli/src/cli/init.ts` is unchanged in this PR.

## Testing

- 32 new zero-LLM unit tests (`packages/review/test/variant-sweep-signals.test.ts`):
  positive (stale switch), negatives (consumer updated in the same diff,
  default-case-only, single-variant reference, variant added AND handled,
  non-enum object literal without `as const`, brand-new declaration, rename,
  same-identifier value edit), truncation-with-omission-note, multi-family
  independence, real-shape coverage (enum/single-line union/multi-line
  union/const-object-as-const), rule-gated `buildInitialMessage` wiring.
- Full gate chain green: `format:check`, `lint` (0 errors), `typecheck`,
  `build`, `test` (1745 tests across `review`/`cli`/`action`), `lien delta`
  (exit 0 — every new function is at/under the complexity threshold after
  refactoring for flatness; see commit history in this branch's working
  tree if reviewing incrementally).

No changeset (`packages/review` is private/unpublished).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR introduces a deterministic enum/union/const-object variant consumer-sweep signal (`variant-sweep-signals.ts`) and wires it into the agent's initial message under the `incomplete-handling` rule. The implementation is well-structured, extensively unit-tested, and documents its known limitations honestly. No breaking changes to existing callers or exports were found. The single untrusted-input site (`parseInt` on a hunk-header line number) is guarded by a strict regex that ensures the captured group is digits, so malformed input cannot produce NaN. The documented gaps (e.g., no full control-flow analysis, inline object-shaped union arms not parsed) are intentional v1 scope limits rather than silent bugs.
>
> - New `variant-sweep-signals.ts` module pre-computes added enum/union/const-object variants and stale consumer sites.
> - `buildInitialMessage` now appends a `<variant_sweep_candidates>` block when `incomplete-handling` is active.
> - The `incomplete-handling` rule prompt was updated to direct the agent to the pre-computed block instead of grepping manually.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9afafb9. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated detection of incomplete handling when new enum, union, or constant-object variants are introduced.
  * Review prompts now highlight likely consumer locations that may require updates.
  * Added targeted guidance for reviewing variant candidates and checking related interface or configuration consumers.

* **Bug Fixes**
  * Improved review accuracy by reducing false positives and excluding already-updated consumer sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->