### PR TITLE
test(review): mechanism-only keyword sweep across the fixture corpus

### DIFF
--- a/packages/review/test/harness/fixtures/concurrency-race/credit-service-toctou.assertions.ts
+++ b/packages/review/test/harness/fixtures/concurrency-race/credit-service-toctou.assertions.ts
@@ -35,6 +35,17 @@
  * previously-passing votes still pass with these Tier-2 checks; no widening
  * was needed. Certification against the >= 9/10 bar is pending a paid
  * calibrate-10 (the main session runs it).
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): gate (B) was bare-noun-heavy
+ * ('concurrent', 'negative', 'credit_balance', 'dispatch' alone) and
+ * false-passed a hand-written distractor (a real, *different* TOCTOU on
+ * `CreditService::purchaseCredits` — see the "Note" above) via assert-cli.ts.
+ * Tightened to the specific buggy function/call-chain identifiers and
+ * compound double-webhook/negative-balance phrases; gate (A) was left
+ * untouched (see the tightened gate's own comment for the full before/after).
+ * No stored vote traces exist to offline re-score (fresh worktree) — any
+ * PRIOR calibration number for this canary PREDATES this tightening; the
+ * upcoming corpus recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -61,21 +72,33 @@ const assertions: FixtureAssertions = {
       ],
       result,
     );
-    // (B) the credit-billing impact of the unguarded check.
+    // (B) the credit-billing impact of the unguarded check. Kept to the
+    // specific buggy function/call-chain identifiers (hasCredits,
+    // canRunReview, deductCredit, NATS dispatch) and compound
+    // double-webhook/negative-balance phrases — NOT bare 'concurrent',
+    // 'negative', 'credit_balance', or 'dispatch' alone, each of which a
+    // distractor about a *different* CreditService race (e.g. the
+    // purchaseCredits stripe_payment_intent_id idempotency gap noted above)
+    // also legitimately uses, without ever naming hasCredits or the
+    // webhook-dispatch mechanism. Verified via assert-cli.ts: a hand-written
+    // purchaseCredits distractor false-passed the original list and
+    // correctly fails against this one.
     h.expectFindingMentions(
       [
         'hascredits',
-        'credit_balance',
-        'credit balance',
-        'concurrent',
-        'negative',
-        'overdrawn',
-        'over-spend',
-        'overspend',
-        'nats',
         'canrunreview',
         'deductcredit',
-        'dispatch',
+        'nats',
+        'dispatch to nats',
+        'dispatching to nats',
+        'concurrent webhook',
+        'concurrent webhooks',
+        'two webhooks',
+        'both webhooks',
+        'balance going negative',
+        'balance negative',
+        'balance overdrawn',
+        'account overdrawn',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr2191-templateresponse-offbyone.assertions.ts
@@ -85,6 +85,17 @@
  * CALIBRATION (kimi-k2.7-code): CERTIFIED 2026-07-12 — --calibrate 10
  * scored 10/10 ($0.39). Prior evidence: 3/3 Kimi screen + blind-CC
  * catch (2026-07 Python round).
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the list included bare 'positional
+ * argument'/'positional arg' — the comment above them claimed they were
+ * "combined with index/positional-arg language" to require co-occurrence,
+ * but expectFindingMentions is a flat OR list, so either phrase alone
+ * false-passed a hand-written distractor via assert-cli.ts (a "callers
+ * should use keyword arguments only" API-design nit that never mentions
+ * args[2]/wrong index/scrambled). Dropped both; the remaining index/slot/
+ * scramble-specific terms are unaffected. This canary's 10/10 PREDATES this
+ * tightening; no stored vote traces exist in this worktree to offline
+ * re-score — the upcoming corpus recalibration sweep re-measures it.
  */
 import type { FixtureAssertions } from '../../assertions.js';
 
@@ -117,12 +128,15 @@ const assertions: FixtureAssertions = {
         'same index',
         'collide',
         'collision',
-        // The domain — combined with index/positional-arg language so a
-        // finding must be about the ARGUMENT PLUMBING, not just anything
-        // touching this function (e.g. a test-cleanup nit that happens to
-        // say "TemplateResponse" would not match any of these)
-        'positional argument',
-        'positional arg',
+        // The domain — kept to compound slot-collision phrases naming the
+        // actual argument-plumbing mechanism. Dropped bare 'positional
+        // argument'/'positional arg': despite the comment above originally
+        // intending these to require index/positional-arg language
+        // together, expectFindingMentions is a flat OR list, so either
+        // phrase alone let a distractor pass (verified via assert-cli.ts —
+        // a "callers should use keyword arguments only" API-design nit,
+        // never mentioning args[2]/wrong index/scrambled, matched via
+        // 'positional argument' alone).
         'headers slot',
         'status_code slot',
         'args tuple',

--- a/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
@@ -110,6 +110,24 @@
  * 2026-07-04 post-merge sweep (rename-sweep signal #663 + doc-truth rule
  * and guidance passthrough #665) showed 3/3 votes catching Finding A via
  * `doc-truth`. That 3-vote sweep is superseded by the calibrate-10 above.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): Finding A's list was bare-noun-heavy
+ * ('embeddings', 'search_code', 'find_similar', 'lexical', 'bm25',
+ * 'full-text', 'stale', 'no longer' — all central vocabulary for this
+ * 40-file rename PR) and false-passed a hand-written distractor about
+ * augment-explore-task.sh:64 that reached the WRONG, defensive conclusion
+ * ("the meaning-based guidance is fine, just incomplete") via assert-cli.ts
+ * — it matched purely on 'search_code', with no schema.ts anchor at all.
+ * Tightened Finding A to the file anchor + compound "reports as
+ * disabled"/correction phrases only; re-verified against both the literal
+ * schema.ts wording AND the null-embeddings.ts sibling variant (6/10 of the
+ * original calibration's votes per above) — both still pass. Finding B
+ * ('meaning-based') was left untouched per minimal-diff, though note it is
+ * itself stance-blind (matches a finding that *agrees* the guidance is
+ * accurate, not just one that falsifies it) — a residual worth a future
+ * pass, not fixed here. No stored vote traces exist to offline re-score
+ * (fresh worktree); this canary's 10/10 PREDATES this tightening — the
+ * upcoming corpus recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -120,27 +138,26 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
+    // Kept to the specific file anchor and compound phrases naming the
+    // EXACT false claim ("reports as disabled") or its correction — not bare
+    // 'embeddings' / 'search_code' / 'find_similar' / 'lexical' / 'bm25' /
+    // 'full-text' / 'stale' / 'no longer', each of which is central
+    // vocabulary for this entire 40-file rename PR and would be satisfied by
+    // an unrelated finding merely discussing the same rename theme (verified
+    // via assert-cli.ts: a distractor about augment-explore-task.sh's
+    // "meaning-based" line — reaching the WRONG, defensive conclusion that
+    // the guidance is fine — false-passed the original list purely via
+    // 'search_code'; it has no 'schema.ts'/'embeddings.enabled' anchor and
+    // correctly fails against this one).
     h.expectFindingMentions(
       [
-        // File / symbol anchors
         'schema.ts',
         'embeddings.enabled',
-        'embeddings',
-        // The specific stale claim and its correction
-        'search_code',
-        'find_similar',
         'report as disabled',
         'reports as disabled',
-        'lexical',
-        'bm25',
-        'full-text',
-        // Vocabulary the model reaches for when describing the drift
-        'stale',
-        'no longer',
         'disabled when embeddings',
         'does not depend on embeddings',
         "doesn't depend on embeddings",
-        '#657',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr667-worktree-doc-drift.assertions.ts
@@ -80,6 +80,22 @@
  * (~6-7/10), so the harness renders it as a non-gating `~` line and excludes it
  * from the exit code. The feature itself is certified on the canary corpus
  * (pr658 10/10, accurate-doc 10/10 precision with the strict language).
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the Tier-2 list above was
+ * bare-noun-heavy ('manifest', 'structural.db', 'resolveindexstrategy',
+ * 'hasmanifest', 'hasdb', 'overlay', 'gate', 'requires', 'only', 'both' —
+ * every one of them central vocabulary for this exact function) and
+ * false-passed a hand-written distractor via assert-cli.ts: an unguarded
+ * JSON.parse-crash finding about the SAME resolveIndexStrategy function,
+ * naming the same identifiers, but never stating the doc understates a
+ * two-condition gate as one. Tightened to compound phrases that state the
+ * two-vs-one-condition contrast itself. The 6-7/10 measured rate above
+ * PREDATES this tightening and almost certainly overstated the true rate —
+ * the fixture's own frontier framing (a real, hard-to-close gap) is
+ * unchanged, but the number itself needs a fresh measurement; no stored vote
+ * traces exist in this worktree to offline re-score. The corpus
+ * recalibration sweep should treat this fixture's rate as unknown, not 6-7/10,
+ * until re-run.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -92,30 +108,37 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
+    // Kept to compound phrases that state the TWO-VS-ONE-CONDITION contrast
+    // itself — not bare 'manifest'/'structural.db'/'resolveindexstrategy'/
+    // 'hasmanifest'/'hasdb'/'overlay'/'gate'/'requires'/'only'/'both', each
+    // of which is central vocabulary for this whole function and would be
+    // satisfied by an unrelated finding about a *different* bug in the same
+    // resolveIndexStrategy (verified via assert-cli.ts: a distractor about
+    // an unguarded JSON.parse crash on a corrupted manifest.json — a real,
+    // different bug in the same function — false-passed the original list
+    // purely via resolveindexstrategy/hasmanifest/hasdb/manifest.json/
+    // falls back/gate, without ever stating the doc understates a
+    // two-condition gate as one).
     h.expectFindingMentions(
       [
-        // The crux: the omitted second gate condition
-        'manifest.json',
-        'manifest',
-        // The doc's stated (narrow) gate
-        'structural.db',
-        'has an index',
-        // The code that enforces the real gate
-        'resolveindexstrategy',
-        'hasmanifest',
-        'hasdb',
-        // Vocabulary a correct finding reaches for
-        'overlay',
-        'worktree-aware-indexing',
-        'both',
-        'requires',
-        'standalone',
-        'fall back',
-        'falls back',
-        'base index',
-        'gate',
-        'incomplete',
-        'only',
+        'structural.db and manifest.json',
+        'structural.db AND manifest.json',
+        'has structural.db but no manifest.json',
+        'structural.db but no manifest.json',
+        'structural.db but not manifest.json',
+        'without a manifest.json',
+        'missing manifest.json',
+        'omits manifest.json',
+        'omit manifest.json',
+        'only requires structural.db',
+        'only checks structural.db',
+        'only says structural.db',
+        'says only structural.db',
+        'second condition',
+        'two conditions',
+        'both conditions',
+        'understates the gate',
+        'narrower gate',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr687-config-doc-drift.assertions.ts
@@ -59,6 +59,18 @@
  * in-prompt a strict reviewer might read it as "accurate as far as it goes".
  * Tagged `characterization` (not canary): the harness renders it as a
  * non-gating `~` line and excludes it from the exit code.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the Tier-2 list was bare-noun-heavy
+ * ('adr-011', 'config-system', 'retired', 'backend', 'qdrant', 'lancedb',
+ * 'dropped', 'incomplete', 'missing' — all vocabulary for the general
+ * retired-config-key topic this whole PR touches) and false-passed a
+ * hand-written distractor via assert-cli.ts: a real, different documentation
+ * gap (ADR-011 not specifying WHEN the config save is triggered) matched
+ * every generic term without ever naming the omitted embeddings.* /
+ * core.embeddingBatchSize keys. Tightened to those specific key identifiers
+ * plus compound omission phrases. The 0/10 and 1/10 pre-signal numbers above
+ * PREDATE this tightening; no stored vote traces exist in this worktree to
+ * offline re-score — the upcoming corpus recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -71,31 +83,34 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
+    // Kept to the specific omitted config-key identifiers and compound
+    // omission phrases — not bare 'adr-011'/'config-system'/'retired'/
+    // 'backend'/'qdrant'/'lancedb'/'dropped'/'incomplete'/'missing', each of
+    // which describes the general retired-config-key topic this whole PR
+    // touches and would be satisfied by an unrelated finding about a
+    // *different* gap in the same docs (verified via assert-cli.ts: a
+    // distractor about ADR-011 not specifying WHEN the config save is
+    // triggered — a real, different documentation gap — false-passed the
+    // original list via adr-011/backend/qdrant/dropped/incomplete, without
+    // ever naming the omitted embeddings.*/core.embeddingBatchSize keys).
     h.expectFindingMentions(
       [
-        // The omitted keys — the crux
-        'embeddings.*',
-        'embeddings',
         'core.embeddingbatchsize',
         'embeddingbatchsize',
-        // The docs in tension
-        'adr-011',
-        'config-system',
-        // The retired-key vocabulary both docs share
-        'retired',
-        'backend',
-        'qdrant',
-        'lancedb',
-        'still load',
-        'warn once',
-        'dropped',
-        'degrade',
-        // How a correct finding frames the gap
-        'omit',
-        'incomplete',
-        'inconsistent',
-        'does not mention',
-        'missing',
+        'embeddings.* is missing',
+        'embeddings.* is omitted',
+        'omits embeddings.*',
+        'omitting embeddings.*',
+        'missing embeddings.*',
+        'does not mention embeddings.*',
+        "doesn't mention embeddings.*",
+        'no mention of embeddings.*',
+        'lists only backend',
+        'only lists backend',
+        'only mentions backend',
+        'narrower than adr-011',
+        'incomplete compared to adr-011',
+        'adr-011 documents embeddings',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
@@ -58,6 +58,20 @@
  * understates it. Tagged `characterization` (not canary): the model declines it
  * consistently and defensibly, so the harness renders it as a non-gating `~`
  * line and excludes it from the exit code.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the Tier-2 list was bare-noun-heavy
+ * ('unchanged', 'public export', 'public api', 'breaking', 'removed',
+ * 'index.ts', 'lienerrorcode', 'patch', 'semver', 'major', 'minor',
+ * 'migration', and the single bare word 'export' — the worst offender)
+ * and false-passed a hand-written distractor via assert-cli.ts: a finding
+ * about a stale JSDoc subsystem-grouping comment listing the same removed
+ * enum members matched lienerrorcode/embedding_generation_failed/removed/
+ * export without ever touching the changeset's "otherwise unchanged" claim.
+ * Tightened to compound phrases quoting that claim or naming the
+ * EmbeddingError public-export removal specifically. The 0/10 pre-signal
+ * numbers above PREDATE this tightening; no stored vote traces exist in this
+ * worktree to offline re-score — the upcoming corpus recalibration sweep
+ * re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -70,32 +84,38 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
+    // Kept to compound phrases quoting the changeset's exact false claim
+    // ("otherwise unchanged") or naming the removed EmbeddingError export
+    // specifically — not bare 'unchanged'/'public export'/'public api'/
+    // 'breaking'/'removed'/'index.ts'/'lienerrorcode'/'patch'/'semver'/
+    // 'major'/'minor'/'migration'/'export', each of which is generic enough
+    // that an unrelated finding about a DIFFERENT part of this same tiny
+    // diff (e.g. a stale JSDoc subsystem-grouping comment listing the
+    // removed enum members) would also satisfy (verified via assert-cli.ts:
+    // exactly that distractor false-passed the original list via
+    // lienerrorcode/embedding_generation_failed/removed/export, without ever
+    // touching the changeset's "otherwise unchanged" claim or the
+    // EmbeddingError public-export removal).
     h.expectFindingMentions(
       [
-        // The removed public symbol — the crux
-        'embeddingerror',
-        // The false / understated claim
         'otherwise unchanged',
-        'unchanged',
-        'public error exports',
-        // The breaking-change framing a correct finding uses
-        'public export',
-        'public api',
-        'public-api',
-        'breaking',
-        'removed',
-        'no longer exported',
-        // Anchors
-        'index.ts',
-        'lienerrorcode',
-        'embedding_generation_failed',
-        // The semver angle (secondary)
-        'patch',
-        'semver',
-        'major',
-        'minor',
-        'migration',
-        'export',
+        'public error exports are otherwise unchanged',
+        'embeddingerror',
+        'removes embeddingerror',
+        'removed embeddingerror',
+        'embeddingerror is removed',
+        'embeddingerror was removed',
+        'embeddingerror is no longer exported',
+        'no longer exports embeddingerror',
+        'changeset says',
+        'changeset claims',
+        'patch bump understates',
+        'should be a major',
+        'should be a minor',
+        'this is a breaking change',
+        'this is breaking',
+        'breaking, not a patch',
+        'not just a patch',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr716-install-claim.assertions.ts
@@ -68,6 +68,19 @@
  * second-shakiest fixture (after pr687's truncation block). Tagged
  * `characterization` (not canary): the harness renders it as a non-gating `~`
  * line and excludes it from the exit code.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the Tier-2 list was bare-noun-heavy
+ * ('rust', 'cargo', 'toolchain', 'per-platform', 'published', 'prebuilt',
+ * 'fallback' — generic install-story vocabulary this whole docs PR uses)
+ * and false-passed a hand-written distractor via assert-cli.ts: a finding
+ * about the per-platform table not clarifying when Alpine/musl support
+ * shipped — a real, different documentation gap — matched via
+ * rust/cargo/per-platform/published/prebuilt/toolchain/build:native without
+ * ever naming index.js's fallback or quoting the "no compiler" claim.
+ * Tightened to compound phrases naming the loader fallback specifically or
+ * quoting the doc's exact claim. The 2/10 and 0/10 pre-signal numbers above
+ * PREDATE this tightening; no stored vote traces exist in this worktree to
+ * offline re-score — the upcoming corpus recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -80,31 +93,34 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
+    // Kept to compound phrases naming the loader's fallback specifically or
+    // quoting the doc's exact "no compiler/toolchain required" claim — not
+    // bare 'rust'/'cargo'/'toolchain'/'per-platform'/'published'/'prebuilt'/
+    // 'fallback', each of which is generic install-story vocabulary this
+    // whole docs PR uses and would be satisfied by an unrelated finding
+    // about a *different* gap in the same install docs (verified via
+    // assert-cli.ts: a distractor about the per-platform table not
+    // clarifying when Alpine/musl support was added — a real, different
+    // documentation gap — false-passed the original list via
+    // rust/cargo/per-platform/published/prebuilt/toolchain/build:native,
+    // without ever naming index.js's fallback or quoting the "no compiler"
+    // claim it contradicts).
     h.expectFindingMentions(
       [
-        // The falsifying loader fact
-        'build:native',
-        'parser-native',
-        'index.js',
-        'loadbinding',
-        'fallback',
-        'fall back',
-        'source build',
-        'local build',
-        'build from source',
-        // The claim being flagged
-        'prebuilt',
-        'no compiler',
-        'no toolchain',
-        'toolchain',
-        // Vocabulary a correct finding reaches for
-        'rust',
-        'cargo',
-        'optionaldependencies',
-        'per-platform',
-        'published',
-        'publishes',
-        'native binar',
+        'index.js falls back',
+        'index.js fall back',
+        'parser-native/index.js',
+        'loadbinding falls back',
+        'the loader falls back',
+        'falls back to a source build',
+        'falls back to building from source',
+        'no compiler or build toolchain required',
+        'no toolchain required',
+        'until the release pipeline publishes',
+        'until the release pipeline',
+        'requires the rust toolchain',
+        'needs the rust toolchain',
+        'still requires cargo',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.assertions.ts
@@ -19,6 +19,17 @@
  * sibling branch `test/capture-pr658-fixture` is the fixture to run
  * `--calibrate 10` against on kimi before shipping (≥ 9/10). This hand-authored
  * fixture is the free CC-mode smoke test, NOT the calibration gate.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the Tier-2 list was bare-noun-heavy
+ * ('lexical', 'bm25', 'fallback', 'disabled', 'still', 'outdated',
+ * 'resolvesearchmode' — all generic to any stale-comment finding on this
+ * same doc block) and false-passed a hand-written distractor via
+ * assert-cli.ts: a finding about a *different* stale claim on the same
+ * comment (config-level mode selection, not the disabled/no-results
+ * framing) matched via lexical/fallback/resolvesearchmode/outdated/still.
+ * Tightened to compound phrases that state the disabled-vs-still-active
+ * contradiction itself. Not a calibration gate (hand-authored CC-mode smoke
+ * fixture, no paid votes to re-score) — untagged/non-canary either way.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -30,24 +41,29 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
+    // Kept to compound phrases that state the CONTRADICTION itself (the
+    // "disabled" claim vs. the code still returning results) — not bare
+    // 'lexical'/'bm25'/'fallback'/'disabled'/'still'/'outdated'/
+    // 'resolvesearchmode', each of which a distractor about a *different*
+    // stale claim on the same resolveSearchMode comment (e.g. a claim about
+    // config-level mode SELECTION, not about the disabled/no-results
+    // framing) also legitimately uses. Verified via assert-cli.ts: such a
+    // distractor false-passed the original list via lexical/fallback/
+    // resolvesearchmode/outdated/still and correctly fails against this one.
     h.expectFindingMentions(
       [
-        // The true behavior the claim contradicts
-        'lexical',
-        'bm25',
-        'fall back',
-        'fallback',
-        // The false claim being flagged
-        'disabled',
-        'reports as',
-        'no results',
-        // Framing a correct finding tends to use
-        'resolvesearchmode',
-        'stale',
-        'contradict',
-        'falsif',
-        'still',
-        'outdated',
+        'reports as disabled, but',
+        'reports as disabled but',
+        'claims disabled but',
+        'disabled but returns',
+        'disabled but falls back',
+        'disabled but still',
+        'contradicts the disabled claim',
+        'the disabled claim is stale',
+        'is not actually disabled',
+        "isn't actually disabled",
+        'no longer disabled',
+        'search is not disabled',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/edge-case-sweep/percent-change-sign-flip.assertions.ts
+++ b/packages/review/test/harness/fixtures/edge-case-sweep/percent-change-sign-flip.assertions.ts
@@ -39,6 +39,18 @@
  * not fire) still fails at Tier 1, as expected. No widening was needed.
  * Certification against the >= 9/10 bar is pending a paid calibrate-10 (the
  * main session runs it).
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): gate (B) was bare-noun-heavy (bare
+ * 'negative', 'sign', 'direction', 'guard', 'silently', 'misleading',
+ * 'falls through') and false-passed a hand-written distractor via
+ * assert-cli.ts: a pure string-formatting readability nit ("hard to
+ * misplace the negative sign") matched via 'negative'+'sign' without
+ * describing any actual wrong-output boundary case. Tightened to the
+ * specific literal outputs/fix vocabulary and compound sign-flip/negative-
+ * baseline phrases; re-verified both real sibling-bug shapes documented
+ * above (the named sign-flip AND the zero-baseline/NaN/Infinity variant)
+ * still pass. This canary's prior offline re-score PREDATES this
+ * tightening — the upcoming corpus recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -53,28 +65,30 @@ const assertions: FixtureAssertions = {
       ['formatpercentchange', 'percent change', 'percentage change', 'percentchange'],
       result,
     );
-    // (B) an edge-case symptom on a boundary input (any of the sibling bugs).
+    // (B) an edge-case symptom on a boundary input (any of the sibling
+    // bugs). Dropped bare 'negative'/'sign'/'direction'/'guard'/'silently'/
+    // 'misleading'/'falls through' — a distractor about a pure
+    // string-formatting readability nit ("hard to misplace the negative
+    // sign") false-passed the original list via bare 'negative'+'sign',
+    // never describing an actual wrong-output boundary case (verified via
+    // assert-cli.ts).
     h.expectFindingMentions(
       [
         'nan',
         'infinity',
-        'negative',
         'zero-baseline',
         'zero baseline',
         'before === 0',
-        'sign',
-        'direction',
+        'negative baseline',
         'inverts',
         'inverted',
+        'sign flip',
+        'wrong sign',
+        'flips the sign',
         '+50%',
         '-50%',
         '∞',
         '0%',
-        'misleading',
-        'silently',
-        'falls through',
-        'fall-through',
-        'guard',
         'isfinite',
         'finite',
       ],

--- a/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
+++ b/packages/review/test/harness/fixtures/error-swallowing/payment-error-swallowed.assertions.ts
@@ -38,6 +38,20 @@
  * previously-passing votes still pass with these Tier-2 checks; no widening
  * was needed. Certification against the >= 9/10 bar is pending a paid
  * calibrate-10 (the main session runs it).
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): gate (B) was bare-noun-heavy (bare
+ * 'silent'/'silently'/'distinguish'/'orderservice'/'processorder'/
+ * 'checkoutservice'/'expresscheckout') and, combined with gate (A)'s
+ * legitimate 'charge'/'paymentservice' anchors, false-passed a hand-written
+ * distractor via assert-cli.ts: a finding about OrderService::processOrder
+ * not validating the order total is positive (a real, different bug)
+ * matched (A) via 'charge'/'paymentservice' and (B) via
+ * 'orderservice'+'silently', without ever describing the swallow's
+ * caller-facing masking effect. Tightened (B) to the specific
+ * failure-mode/propagation vocabulary; gate (A) was left untouched. This
+ * canary's 10/10 PREDATES this tightening; no stored vote traces exist in
+ * this worktree to offline re-score — the upcoming corpus recalibration
+ * sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -70,23 +84,27 @@ const assertions: FixtureAssertions = {
       ],
       result,
     );
-    // (B) the lost-exception-propagation / can't-distinguish impact.
+    // (B) the lost-exception-propagation / can't-distinguish impact. Dropped
+    // bare 'silent'/'silently'/'distinguish'/'orderservice'/'processorder'/
+    // 'checkoutservice'/'expresscheckout' — a distractor about a *different*
+    // bug (OrderService::processOrder not validating the order total is
+    // positive before calling charge) false-passed via 'orderservice' +
+    // 'silently' (and gate (A) via bare 'charge'/'paymentservice'), without
+    // ever describing the swallow's caller-facing masking effect (verified
+    // via assert-cli.ts).
     h.expectFindingMentions(
       [
         'runtimeexception',
         'exception propagation',
+        'lost exception',
         'error context',
         'already paid',
         'invalid total',
         'gateway failure',
         'gateway error',
-        'silent',
-        'silently',
-        'distinguish',
-        'orderservice',
-        'processorder',
-        'checkoutservice',
-        'expresscheckout',
+        "can't distinguish",
+        'cannot distinguish',
+        'can not distinguish',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/incomplete-handling/enum-variant-removed.assertions.ts
+++ b/packages/review/test/harness/fixtures/incomplete-handling/enum-variant-removed.assertions.ts
@@ -33,6 +33,17 @@
  * previously-passing votes still pass with these Tier-2 checks; no widening
  * was needed. Certification against the >= 9/10 bar is pending a paid
  * calibrate-10 (the main session runs it).
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): both gates were bare-noun-heavy
+ * ('switch', 'default branch', 'default case' in (A); bare 'silently' /
+ * 'empty array' / 'unhandled' in (B)) and false-passed a hand-written
+ * distractor via assert-cli.ts: a finding about createUser never assigning
+ * `role` (a real, different bug) matched (A) via 'switch'/'default branch'
+ * and (B) via bare 'silently', without ever naming getPermissionsForRole or
+ * Guest. Tightened both gates to drop the bare terms; see each gate's own
+ * comment. No stored vote traces exist in this worktree to offline
+ * re-score — this canary's prior calibration PREDATES this tightening; the
+ * upcoming corpus recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -42,37 +53,39 @@ const assertions: FixtureAssertions = {
   rule: 'incomplete-handling',
   expect: (result, h) => {
     h.expectRuleFired('incomplete-handling', result);
-    // (A) the switch / silent-default / exhaustiveness anchor.
+    // (A) the switch / silent-default / exhaustiveness anchor. Dropped bare
+    // 'switch', 'userrole', 'default case', 'default branch' — a distractor
+    // about a *different* function (createUser never assigning `role`,
+    // whose downstream impact is described as hitting "a switch statement's
+    // ... default branch") false-passed the original list via those bare
+    // terms without ever naming getPermissionsForRole or its specific
+    // silent-default code shape (verified via assert-cli.ts).
     h.expectFindingMentions(
       [
         'getpermissionsforrole',
-        'userrole',
         'default: return []',
         'silent default',
         'silent `default`',
-        'default case',
-        'default branch',
         'exhaustive',
         'exhaustiveness',
         'never check',
         ': never',
-        'switch',
       ],
       result,
     );
-    // (B) the silent-permission-loss impact.
+    // (B) the silent-permission-loss impact. Dropped bare 'silently' /
+    // 'empty array' / 'unhandled' — the same createUser distractor also
+    // false-passed this gate via bare 'silently' alone.
     h.expectFindingMentions(
       [
         'guest',
         'empty permission',
         'zero permission',
-        'empty array',
         'permission set',
         'silently receive',
+        'silently returns empty',
+        'silently return empty',
         'silently lose',
-        'silently return',
-        'silently',
-        'unhandled',
         'lose all access',
         'locked out',
         'no permissions',

--- a/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
+++ b/packages/review/test/harness/fixtures/stale-duplicate/model-partial-update.assertions.ts
@@ -25,6 +25,19 @@
  * runs traced to a broken capture (native parser unbuilt → markdown-only
  * corpus → <stale_literal_candidates> rendered "None" and suppressed the
  * finding). capture-pr.ts now rejects such partial captures loudly.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the widening list was bare-noun-heavy
+ * ('sonnet', 'stale', 'hardcoded', 'attribution', 'metadata', 'outside the
+ * diff', 'single source', 'one source of truth' — all generic
+ * stale-duplicate vocabulary) and false-passed a hand-written distractor via
+ * assert-cli.ts: a finding about a *different* hardcoded literal in the same
+ * file (a separately-duplicated default-model fallback string) matched via
+ * hardcoded/stale/outside the diff/single source, without ever naming
+ * adapterContext, line 300, or the claude-sonnet-4-6 literal. Tightened to
+ * the site anchor plus narrower model-string variants and compound hoist
+ * phrasing. This canary's 10/10 PREDATES this tightening; no stored vote
+ * traces exist in this worktree to offline re-score — the upcoming corpus
+ * recalibration sweep re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -34,25 +47,28 @@ const assertions: FixtureAssertions = {
   rule: 'stale-duplicate',
   expect: (result, h) => {
     h.expectRuleFired('stale-duplicate', result);
+    // Kept to the specific site anchor (adapterContext / line 300 / the
+    // literal model string) and compound hoist phrasing — not bare
+    // 'sonnet'/'stale'/'hardcoded'/'attribution'/'metadata'/'outside the
+    // diff'/'single source'/'one source of truth', each generic enough that
+    // an unrelated stale-duplicate finding about a *different* hardcoded
+    // literal elsewhere in the same file (e.g. a separately-hardcoded
+    // default-model fallback string) also satisfies (verified via
+    // assert-cli.ts: exactly that distractor false-passed the original list
+    // via hardcoded/stale/outside the diff/single source, without ever
+    // naming adapterContext, line 300, or the claude-sonnet-4-6 literal).
     h.expectFindingMentions(
       [
         'adaptercontext',
         'line 300',
         'claude-sonnet-4-6',
+        'claude-sonnet',
+        'sonnet-4-6',
         'selectedmodel',
         'hoist',
-        'single source',
-        'one source of truth',
-        // Widen to absorb phrasing drift across runs. Any correct
-        // rendering of this finding will use one of the above OR one
-        // of these — they're the synonyms the model reaches for when
-        // it doesn't echo the literal back.
-        'sonnet',
-        'stale',
-        'hardcoded',
-        'attribution',
-        'metadata',
-        'outside the diff',
+        'single source of truth for the model',
+        'one source of truth for the model',
+        'shared const for the model',
       ],
       result,
     );

--- a/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
+++ b/packages/review/test/harness/fixtures/untrusted-input-validation/harness-initial.assertions.ts
@@ -24,6 +24,20 @@
  * Tier 2: the finding mentions one of the four sub-pattern vocabulary
  * families. Set is wide because four sub-patterns can each render with
  * different language; any correct rendering of any one pattern will land.
+ *
+ * KEYWORD-INTEGRITY SWEEP (2026-07-16): the list included bare
+ * 'validate'/'validation'/'schema'/'shape'/'untrusted'/'runtime'/
+ * 'type-check'/'typeof'/'unguarded'/'unvalidated'/'cast' — generic enough
+ * that a distractor about a FOURTH, undocumented site (voting.ts reading
+ * `process.env.OPENROUTER_API_KEY` into a fetch header without validation —
+ * a real but different untrusted-input gap, not one of the three sites this
+ * fixture documents) false-passed via 'validation'/'runtime' alone
+ * (verified via assert-cli.ts). Tightened to the specific function/symbol/
+ * API names from the three documented sites; re-verified both the
+ * loadResult-cast and parseInt-NaN variants still pass. This canary's prior
+ * calibration PREDATES this tightening; no stored vote traces exist in this
+ * worktree to offline re-score — the upcoming corpus recalibration sweep
+ * re-measures it.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -36,32 +50,28 @@ const assertions: FixtureAssertions = {
   expect: (result, h) => {
     h.expectRuleFired('untrusted-input-validation', result);
     h.expectAnyToolCalled(['get_files_context', 'read_file'], result);
+    // Kept to the specific function/symbol/API names from the three
+    // documented buggy sites — not bare 'validate'/'validation'/'schema'/
+    // 'shape'/'untrusted'/'runtime'/'type-check'/'typeof'/'unguarded'/
+    // 'unvalidated'/'cast', each generic enough that an unrelated
+    // input-validation finding about a DIFFERENT harness file also
+    // satisfies (verified via assert-cli.ts: a distractor about voting.ts
+    // reading OPENROUTER_API_KEY without validation — a real, different
+    // untrusted-input gap, not one of the three documented sites — matched
+    // via 'validation'/'runtime' alone).
     h.expectFindingMentions(
       [
-        // Function/symbol names from the buggy code
         'loadresult',
         'fixtureshape',
         'parseflags',
-        // Vocabulary the model reaches for across the four sub-patterns
         'json.parse',
         'parseint',
-        'cast',
         'as partial',
         'as harnessresult',
-        'validate',
-        'validation',
-        'schema',
-        'shape',
-        'nan',
         'number.isinteger',
         'isfinite',
-        'untrusted',
-        'runtime',
-        'type-check',
-        'typeof',
-        'unguarded',
-        'unvalidated',
         'array.isarray',
+        'nan',
       ],
       result,
     );


### PR DESCRIPTION
## Summary

Owner-authorized keyword-integrity sweep across the whole harness fixture corpus, PRE-REQUISITE to a paid corpus-wide recalibration. Motivated by PR #776's discovery: pr2017's raw `--calibrate 10` was 10/10, but its Tier-2 keyword list leaned on bare domain nouns/identifiers (`multipart`, `boundary_re`) that ANY finding about the same file satisfies — a hand-written distractor false-passed; the honest re-score was 8/10. Weak keyword lists corrupt every calibration number built on them.

This PR audits every `.assertions.ts` under `packages/review/test/harness/fixtures/` (excluding pr2678/pr2017, already tightened by #776), classifies each Tier-2 keyword as mechanism-discriminating vs. bare-noun/identifier, and runs the offline distractor smoke test (zero LLM spend, `assert-cli.ts`) on every fixture whose list looked exploitable. **No `rule`/`ruleCandidates`/`tags`/expect-closure changes — keyword lists only.**

## Audit table (21 fixtures audited, 2 skipped)

| Fixture | Tag | Verdict |
|---|---|---|
| `boundary-change/ge-5-threshold-shift` | canary | OK — distractor correctly rejected |
| `boundary-change/placeholder` | placeholder | OK — Tier 1 only, no keyword list |
| `concurrency-race/credit-service-toctou` | **canary** | **tightened** |
| `crossrepo/pr2191-templateresponse-offbyone` | **canary** | **tightened** |
| `crossrepo/pr2334-etag-weak-indicator-strip` | characterization | OK — distractor correctly rejected |
| `crossrepo/pr2678-multipart-index-offset` | canary | **skipped** (already tightened by #776) |
| `crossrepo/pr2017-multipart-boundary-regex` | characterization | **skipped** (already tightened by #776) |
| `doc-truth/accurate-doc` | hand-authored | OK — `expectEmpty`, no keyword list |
| `doc-truth/pr658-search-code-rename` | **canary** | **tightened** |
| `doc-truth/pr667-worktree-doc-drift` | characterization | **tightened** |
| `doc-truth/pr687-config-doc-drift` | characterization | **tightened** |
| `doc-truth/pr711-changeset-export-claim` | characterization | **tightened** |
| `doc-truth/pr716-install-claim` | characterization | **tightened** |
| `doc-truth/renamed-stale-claim` | hand-authored | **tightened** |
| `edge-case-sweep/percent-change-sign-flip` | **canary** | **tightened** |
| `error-swallowing/harness-gitignore-convention-fp` | negative-regression | OK — `expectEmpty`, no keyword list |
| `error-swallowing/payment-error-swallowed` | **canary** | **tightened** |
| `error-swallowing/pr752-undiscriminated-catch-salvage` | characterization | OK — already exemplary (own documented 3-verdict smoke test) |
| `error-swallowing/scanall-null-guard-fp` | negative-regression | OK — `expectEmpty`, no keyword list |
| `incomplete-handling/enum-variant-removed` | **canary** | **tightened** |
| `stale-duplicate/model-partial-update` | **canary** | **tightened** |
| `structural-analysis/removed-export` | canary | OK — distractor correctly rejected (symbol anchor already specific) |
| `untrusted-input-validation/harness-initial` | **canary** | **tightened** |

**13 tightened (8 canaries, 4 characterization, 1 hand-authored), 8 confirmed OK, 2 skipped.**

## IMPORTANT — canary scores may move on recalibration

**8 of the 13 tightened fixtures are certified canaries** (`credit-service-toctou`, `pr2191`, `pr658`, `percent-change-sign-flip`, `payment-error-swallowed`, `enum-variant-removed`, `model-partial-update`, `untrusted-input-validation/harness-initial`). Every one of them false-passed a real, hand-written distractor under its *previous* keyword list — meaning their prior `--calibrate 10` certifications may have been measuring "mentioned the neighborhood" rather than "found the specific bug." **Their existing canary certification numbers predate this tightening and should not be trusted until re-measured.** This is expected and is exactly why this sweep runs before the paid corpus-wide recalibration, not after — re-certify all 8, don't assume they'll still show 9-10/10.

No stored vote traces exist in this fresh worktree (`.wip/traces/` — none present), so no offline re-scoring against real votes was possible; each tightened fixture's header now says so explicitly and records that its calibration number predates the tightening.

## Distractor evidence (3 representative examples; full set in the 13 file headers)

**`concurrency-race/credit-service-toctou`** (canary) — Group B was `['hascredits','credit_balance','credit balance','concurrent','negative','overdrawn','over-spend','overspend','nats','canrunreview','deductcredit','dispatch']`. Distractor: a real, *different* TOCTOU on `CreditService::purchaseCredits`'s `stripe_payment_intent_id` idempotency check (mentioned in the fixture's own header as a valid-but-not-required sibling finding) — **false-passed** via bare `concurrent`/`credit balance`, despite never mentioning `hasCredits` or the webhook-dispatch mechanism. Tightened to the specific call-chain identifiers (`hascredits`, `canrunreview`, `deductcredit`, `nats`) plus compound `concurrent webhook(s)`/`balance going negative` phrases. Post-fix: distractor **exit 2** (Tier 2 fail), perfect verdict **exit 0**.

**`doc-truth/pr658-search-code-rename`** (canary, 10/10 cert 2026-07-04) — Finding A's list included bare `embeddings`/`search_code`/`find_similar`/`lexical`/`bm25`/`stale`. A distractor about `augment-explore-task.sh:64` reaching the *wrong, defensive* conclusion ("the meaning-based guidance is fine, just incomplete") **false-passed** via bare `search_code` alone — worse, it also exposed that Finding B's `['meaning-based','meaning based']` check is stance-blind (matches agreement *or* disagreement with the claim). Tightened Finding A to the `schema.ts` file anchor plus compound "reports as disabled" phrases; Finding B left as-is (documented as a residual, not fixed here, per minimal-diff). Post-fix: both distractors **exit 2**, perfect verdict and the documented `null-embeddings.ts` sibling variant (6/10 of the original calibration's votes) both still **exit 0**.

**`incomplete-handling/enum-variant-removed`** (canary) — Group A had bare `switch`/`default branch`; Group B had bare `silently`. A distractor about `createUser` never assigning `this.role` (a real, different bug — its downstream impact literally described as "hitting a switch statement's default branch") **false-passed both gates** via `switch` + `silently`, never naming `getPermissionsForRole` or `Guest`. Tightened both gates to drop the bare terms. Post-fix: distractor **exit 2**, perfect verdict **exit 0**.

## Verification

- Every distractor + perfect + empty verdict re-run via `assert-cli.ts` (zero LLM) per the README's three-verdict protocol; results recorded in each tightened fixture's header.
- Real documented sibling-bug shapes (e.g. `percent-change-sign-flip`'s zero-baseline/NaN variant, `pr658`'s `null-embeddings.ts` variant, `untrusted-input-validation`'s loadResult-cast and parseInt-NaN variants) re-verified to still pass after tightening — recall preserved where evidenced.
- 8 non-flagged fixtures verified via the same distractor protocol to confirm they already discriminate (no touch).
- Full gate chain: `format:check` ✅, `lint` (0 errors) ✅, `typecheck` + `typecheck:harness` ✅, `build` ✅, `test` (857+817+39 passed) ✅, `lien delta` (exit 0, no crossings) ✅.

## This PR is the measuring-stick fix

**This PR does not itself run any paid calibration.** It fixes what "counts as a catch" so the upcoming corpus-wide recalibration sweep measures something real. Do not treat any fixture's pre-existing calibration number (including the 8 canaries above) as still valid — re-certify against these tightened lists.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a test-only keyword-integrity sweep across 13 harness fixture assertion files. It tightens Tier-2 `expectFindingMentions` keyword lists from bare domain nouns/identifiers to mechanism-specific compound phrases and symbol anchors, verified offline with `assert-cli.ts`. No production code, rule prompts, or harness infrastructure is changed. The sweep is explicitly framed as a prerequisite to recalibration, and the PR notes that prior calibration numbers for the affected canaries predate the tightening and must be re-measured.
>
> - Tightened Tier-2 keyword lists in 13 `.assertions.ts` fixtures to remove bare-noun/identifier false-pass vectors.
> - Added audit headers documenting the distractor tests that motivated each tightening and noting that prior calibration scores predate the change.
> - No changes to production code, rule logic, `expectFindingMentions` implementation, or fixture interfaces.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d6a4223. Updates automatically on new commits.</sup>
<!-- /lien-stats -->