### PR TITLE
test(review): repair doc-truth/pr711 fixture regeneration recipe

### DIFF
--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -627,6 +627,14 @@ corpus sweep). Before spending another round:
 - Calibration <9/10 with Tier 2 keyword check — widen the keyword set to
   include the phrasings the model actually produces. If you have to widen
   to >5 keywords, the prompt itself probably needs work.
+- `capture-pr.ts --sha <sha>` fails with `could not resolve sha "…": unknown
+  revision` — the pinned SHA belongs to a squash-merged PR branch, so a
+  fresh clone/worktree never has the commit object (only the single-parent
+  squash commit lands on the base branch's history). Not crossrepo-only —
+  this repo's own historical PRs hit it too (see
+  `doc-truth/pr711-changeset-export-claim.assertions.ts`'s header). Fix:
+  fetch the PR's own ref before capturing, `git fetch origin
+  refs/pull/<n>/head`, then re-run the capture command unchanged.
 
 ## Typechecking
 

--- a/packages/review/test/harness/capture-pr.ts
+++ b/packages/review/test/harness/capture-pr.ts
@@ -460,6 +460,23 @@ async function main(): Promise<void> {
     sh(`gh pr view ${prNumber} --json title,body,baseRefOid,headRefOid,files`),
   ) as PrMeta;
 
+  // `gh pr view`'s baseRefOid can drift for a MERGED PR: GitHub sometimes
+  // reports the base branch's tip near merge time rather than the branch's
+  // actual fork point, which can be a LATER commit than where the branch
+  // diverged (e.g. sibling PRs squash-merged into the base branch around the
+  // same time). Recomputing the true fork point locally is a no-op when
+  // baseRefOid already IS an ancestor of headRefOid (the common case for
+  // open or just-merged PRs), and self-heals the drifted case so downstream
+  // ancestor checks and diff ranges aren't silently computed against the
+  // wrong base. Left as-is if either sha isn't resolvable locally yet (e.g.
+  // a squash-merged PR needs `git fetch origin refs/pull/<n>/head` first) —
+  // resolveSha/assertShaInPrRange surface a clear error either way.
+  try {
+    meta.baseRefOid = sh(`git merge-base "${meta.headRefOid}" "${meta.baseRefOid}"`).trim();
+  } catch {
+    // leave meta.baseRefOid as reported; downstream checks will error clearly
+  }
+
   const headSha = shaOverride ? resolveSha(shaOverride) : meta.headRefOid;
   if (shaOverride) {
     assertShaInPrRange(meta, prNumber, headSha);

--- a/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts
@@ -43,9 +43,18 @@
  * the falsifying fact.
  *
  * Capture command (fixture carries pr.headSha 4480f85ed931…, base c7be7b68…):
- *   npx tsx packages/review/test/harness/capture-pr.ts 711 \
- *     packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.fixture.json \
- *     --sha 4480f85ed931e461a7591176d6a863a0aec750b8
+ *   PR #711 was squash-merged (single-parent merge commit ee2bee8), so its
+ *   branch commits — including this fixture's pinned 4480f85 — are NOT
+ *   reachable from origin/main and are absent from a fresh clone/worktree;
+ *   `git rev-parse --verify 4480f85...^{commit}` fails there with "unknown
+ *   revision", which is what surfaces as "stale SHA, couldn't regenerate".
+ *   GitHub still serves the branch's commits via the PR's own
+ *   `refs/pull/711/head` ref (same gotcha documented for the `crossrepo/`
+ *   fixtures in this harness's README), so fetch that first:
+ *     git fetch origin refs/pull/711/head
+ *     npx tsx packages/review/test/harness/capture-pr.ts 711 \
+ *       packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.fixture.json \
+ *       --sha 4480f85ed931e461a7591176d6a863a0aec750b8
  *
  * Structural note for calibration: `.changeset/**` is a doc-truth guidance
  * surface, so the changeset prose rides in <guidance_surface_changes>; the


### PR DESCRIPTION
## Root cause

The `doc-truth/pr711-changeset-export-claim` fixture's regen recipe was broken for two independent reasons — fetching alone was necessary but not sufficient:

1. **Stale SHA / missing pull-ref fetch.** PR #711 was squash-merged (`ee2bee8`, single parent). Its branch's own commits — including the fixture's pinned capture point `4480f85ed931e461a7591176d6a863a0aec750b8` — are **not** reachable from `origin/main` and are absent from a fresh clone/worktree; only the squash commit landed on main. `capture-pr.ts`'s `git rev-parse --verify <sha>^{commit}` fails there with "unknown revision", which is exactly what two builders reported this week as "stale SHA... couldn't regenerate". GitHub still serves the branch's own commits via `refs/pull/711/head` (the same gotcha already documented in this harness's README for the `crossrepo/` fixtures) — fetching that ref first makes the SHA resolve.

2. **`gh pr view --json baseRefOid` drift (a real capture-pr.ts bug, not just a stale ref).** Even after fetching, capture failed a second way: `gh pr view 711 --json baseRefOid` reports `a084e6330...` — but that commit is **not** an ancestor of the pinned `4480f85` commit. It turns out PR #709 squash-merged into `main` around the same time as PR #711's branch was created, and GitHub's `baseRefOid` field for an already-merged PR reflects the base branch's tip near merge time, not the branch's actual fork point. `capture-pr.ts`'s `assertShaInPrRange` guard (added for #545, correctly, to stop an unrelated SHA from being accepted) trusted `baseRefOid` as a strict ancestor bound and threw. The *actual* fork point — verified via `git merge-base(headRefOid, reportedBaseRefOid)` — is `c7be7b68225b3cfda3033223de0fb3e9d51d7b42`, matching the fixture header's own documented base, and *is* an ancestor of `4480f85`.

## Fix

- `packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.assertions.ts` — header now documents the `git fetch origin refs/pull/711/head` step before the capture command.
- `packages/review/test/harness/capture-pr.ts` — `main()` now recomputes `meta.baseRefOid` via `git merge-base(headRefOid, baseRefOid)` right after fetching PR metadata. This is a no-op when `baseRefOid` already is an ancestor of `headRefOid` (the common case for open or just-merged PRs — every other existing `--sha`-pinned fixture's capture range is unaffected), and self-heals the drifted case for already-merged PRs whose base has since moved. Fixes both the `assertShaInPrRange` guard and (previously silently wrong) the `git diff <base>..<sha>` range used to build the fixture's diff.
- `packages/review/test/harness/README.md` — added the failure mode + fix to "Common failure modes", generalized beyond crossrepo since this repo's own historical PRs hit it too.

## Regen proof (the dogfood)

Ran the corrected recipe end-to-end in a fresh worktree with the native parser built (`npm run build:native -w @liendev/parser-native`) and the repo built (`npm run build`):

```
$ git fetch origin refs/pull/711/head
From https://github.com/getlien/lien
 * branch              refs/pull/711/head -> FETCH_HEAD

$ npx tsx packages/review/test/harness/capture-pr.ts 711 \
    packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.fixture.json \
    --sha 4480f85ed931e461a7591176d6a863a0aec750b8
[capture] fetching PR 711 metadata
[capture] overriding head: 0956f9e2fd32d725df1c39708e7b198fcb4fcdc9 -> 4480f85ed931e461a7591176d6a863a0aec750b8
[capture] stripped lien-stats badge (reflects a later commit than --sha)
[capture] computing diff c7be7b68225b3cfda3033223de0fb3e9d51d7b42..4480f85ed931e461a7591176d6a863a0aec750b8
Preparing worktree (detached HEAD 4480f85e)
[capture] indexing worktree at /var/folders/.../lien-capture-4480f85ed931
[capture] indexed 6072 chunks
[capture] 56 chunks for changed files
[capture] analyzing complexity for 9 changed files
[capture] complexity: 0 violations, max=9
[capture] wrote .../fixtures/doc-truth/pr711-changeset-export-claim.fixture.json
```

Verified healthy:
- `pr.baseSha` in the written fixture = `c7be7b68225b3cfda3033223de0fb3e9d51d7b42` — matches the fixture header's documented base exactly (proof the base-drift fix computed the *correct* fork point, not just *a* fork point).
- 6072 total `repoChunks`, of which 4718 come from AST-parsed source extensions (non-Vue/Markdown) — proves the native parser binding is live, not silently dropped.
- `stripLienStatsBadge` fired ("stripped lien-stats badge...") and the written `pr.body` contains no `<!-- lien-stats -->`/`<!-- lien:… -->` marker — no spoiler leakage from the PR's later (fixed) state.
- `changedFiles` matches the 9 files the fixture's header describes (`.changeset/remove-embedding-error.md`, `packages/core/src/index.ts`, `packages/core/src/errors/codes.ts`, etc).

Rendered prompts successfully:

```
$ npx tsx packages/review/test/harness/build-prompts.ts \
    packages/review/test/harness/fixtures/doc-truth/pr711-changeset-export-claim.fixture.json
```
`ruleIds` includes `doc-truth` (active rule set: `structural-analysis, edge-case-sweep, incomplete-handling, boundary-change, stale-duplicate, doc-truth`) — confirms the fixture passes the #742 rule-coverage preflight (its `rule: 'doc-truth'` assertion is in the trigger-active set for this diff, so no vote would be wasted).

Offline sanity via `assert-cli.ts` against synthetic verdicts (three-verdict smoke test, per the harness README's protocol):
- **Perfect** verdict (finding names `EmbeddingError`, "otherwise unchanged", the breaking-change framing) → `exit 0`, `ok:true`.
- **Empty** verdict (no findings) → `exit 1`, Tier 1 fail (`expected rule 'doc-truth' to fire`), as expected.
- **Distractor** verdict (an on-diff but off-claim finding, about the removed test's isolation coverage) → `exit 2`, Tier 2 fail, correctly discriminated by the fixture's current (already-tightened-on-main by #784) keyword list.

## Gates

- `npm run format:check` — pass
- `npm run lint` — 0 errors (31 pre-existing warnings, unrelated)
- `npm run typecheck` (+ `typecheck:harness -w @liendev/review`) — pass
- `npm run build` — pass
- `npm test` — 48 test files / 832 tests pass (core+cli), 5/39 pass (action); no failures anywhere
- `lien delta` — exit 0 (one pre-existing-budget increase in `capture-pr.ts`'s `main`, cognitive 4→5, well under threshold; no new crossings)

Not merging per instructions — this is a proof-of-fix PR for review.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR repairs the regeneration recipe for a doc-truth harness fixture. The only code change is in `capture-pr.ts:main`, which recomputes `meta.baseRefOid` via `git merge-base(headRefOid, baseRefOid)` after fetching PR metadata. This correctly self-heals GitHub's drifted `baseRefOid` for merged PRs while remaining a no-op for open PRs, and the fallback catch block leaves the original value in place so downstream checks surface any residual error. The remaining changes are comment/README updates. No production code or public API is affected.
>
> - `capture-pr.ts` now recomputes the true PR fork point from `gh pr view`'s reported base/head OIDs
> - Fixture header and README document the `git fetch origin refs/pull/<n>/head` prerequisite for squash-merged PRs

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a2a219d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->