### PR TITLE
feat(review): raise agent token budget headroom (evidence-based)

### DIFF
--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -65,10 +65,12 @@ export const MAX_REVIEW_TOKEN_BUDGET = 250_000;
  * one-off. 1.5x was originally calibrated (#598) to the FLOOR of observed
  * need ("~160-180K for a real multi-file review"), leaving no headroom above
  * it; 2.0x moves the typical medium-PR budget from ~162K to ~216K, clearing
- * that range with margin. Cost impact is ~$0.00092/token and ONLY applies to
- * runs that actually use the extra headroom (a ceiling raise doesn't change
- * agent behavior on runs that already finish under budget) — a few cents on
- * the affected runs, nothing on the rest.
+ * that range with margin. Cost impact, at the observed blended rate of
+ * ~$0.92/million tokens (~$0.00092 per 1,000 tokens — job 87554927152's
+ * $0.1368/148,298 tokens), is a few cents on the runs that actually use the
+ * extra headroom (e.g. the cited job's 48,583-token increase: ~$0.045) — a
+ * ceiling raise doesn't change agent behavior on runs that already finish
+ * under budget, so those cost nothing extra.
  */
 export const REVIEW_TOKEN_BUDGET_MULTIPLIERS: Record<string, number> = {
   [DEFAULT_REVIEW_MODEL]: 2.0,

--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -54,9 +54,24 @@ export const MAX_REVIEW_TOKEN_BUDGET = 250_000;
  *
  * Keyed on the model slug so it tracks the actual model in use (incl. A/B
  * overrides), not just the default.
+ *
+ * Raised 1.5x → 2.0x (2026-07) after PR #781's job 87554927152 showed the
+ * 1.5x floor was too tight: the main pass hit the wrap-up nudge after just 3
+ * read_file turns (100,215 of 145,749 tokens, 68.8% — over the 60% nearBudget
+ * threshold), forcing it to abandon mid-verification of a real finding
+ * (numeric-union-arm consumer detection) and emit 0 findings. A 10-run sample
+ * of the workflow found the nudge fires in ~4 of 7 pass-instances on
+ * content-heavy small-file-count PRs — this is a routine failure mode, not a
+ * one-off. 1.5x was originally calibrated (#598) to the FLOOR of observed
+ * need ("~160-180K for a real multi-file review"), leaving no headroom above
+ * it; 2.0x moves the typical medium-PR budget from ~162K to ~216K, clearing
+ * that range with margin. Cost impact is ~$0.00092/token and ONLY applies to
+ * runs that actually use the extra headroom (a ceiling raise doesn't change
+ * agent behavior on runs that already finish under budget) — a few cents on
+ * the affected runs, nothing on the rest.
  */
 export const REVIEW_TOKEN_BUDGET_MULTIPLIERS: Record<string, number> = {
-  [DEFAULT_REVIEW_MODEL]: 1.5,
+  [DEFAULT_REVIEW_MODEL]: 2.0,
 };
 
 /** Budget multiplier for a model slug (1× when unknown). */

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -9,7 +9,11 @@ import {
 } from '../src/plugins/agent/index.js';
 import { scaleAgentBudget, resolveAgentBudget, summaryOnlyEligibleFor } from '../src/review-pr.js';
 import type { ReviewCoreContext } from '../src/review-pr.js';
-import { DEFAULT_REVIEW_MODEL, MAX_REVIEW_TOKEN_BUDGET } from '../src/defaults.js';
+import {
+  DEFAULT_REVIEW_MODEL,
+  MAX_REVIEW_TOKEN_BUDGET,
+  REVIEW_TOKEN_BUDGET_MULTIPLIERS,
+} from '../src/defaults.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
 import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
@@ -556,13 +560,31 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
   });
 
   it('always returns an integer budget (the config schema requires int)', () => {
-    // 40002 chars → ceil(/4)=10001 → base 76001 (odd). ×2.0 stays whole (152002),
-    // but Math.round in the implementation stays defensive for any future
-    // model with a fractional multiplier — this just guards the int contract.
+    // 40002 chars → ceil(/4)=10001 → base 76001 (odd). Kimi's ×2.0 stays whole
+    // (152002) on its own, so this only guards the int contract for Kimi's
+    // current multiplier — the rounding path itself is exercised below.
     const odd = [{ content: 'x'.repeat(40_002) }];
     const { maxTokenBudget } = scaleAgentBudget(5, odd, DEFAULT_REVIEW_MODEL);
     expect(Number.isInteger(maxTokenBudget)).toBe(true);
     expect(maxTokenBudget).toBe(152_002);
+  });
+
+  it('rounds a genuinely fractional multiplier to an integer', () => {
+    // Kimi's 2.0x can never produce a fraction (integer base * 2 is always
+    // integer), so it can't exercise Math.round. Register a synthetic model
+    // with a fractional multiplier to prove the rounding actually happens,
+    // not just that Kimi's current value happens to stay whole.
+    const testModel = 'test/fractional-multiplier-model';
+    REVIEW_TOKEN_BUDGET_MULTIPLIERS[testModel] = 1.3;
+    try {
+      // base 76001 (odd, from the 40002-char case above) × 1.3 = 98801.3.
+      const { maxTokenBudget } = scaleAgentBudget(5, [{ content: 'x'.repeat(40_002) }], testModel);
+      expect(Number.isInteger(maxTokenBudget)).toBe(true);
+      expect(maxTokenBudget).toBe(Math.round(76_001 * 1.3));
+      expect(maxTokenBudget).toBe(98_801);
+    } finally {
+      delete REVIEW_TOKEN_BUDGET_MULTIPLIERS[testModel];
+    }
   });
 
   it('produces a config the agent-review schema accepts', () => {

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -539,16 +539,16 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
   // base = 4000 + 10000 + 60000 + 2000 = 76000 (within [60K, ceiling], unclamped).
   const chunks = [{ content: 'x'.repeat(40_000) }];
 
-  it('scales the budget up ~1.5x for Kimi vs a lean model', () => {
+  it('scales the budget up ~2x for Kimi vs a lean model', () => {
     const lean = scaleAgentBudget(5, chunks, 'some/lean-model').maxTokenBudget;
     const kimi = scaleAgentBudget(5, chunks, DEFAULT_REVIEW_MODEL).maxTokenBudget;
     expect(lean).toBe(76_000);
-    expect(kimi).toBe(114_000);
-    expect(kimi).toBe(lean * 1.5);
+    expect(kimi).toBe(152_000);
+    expect(kimi).toBe(lean * 2.0);
   });
 
   it('clamps the scaled budget to the shared ceiling', () => {
-    // 15 files (maxTurns 12) + large content pushes base*1.5 past the ceiling.
+    // 15 files (maxTurns 12) + large content pushes base*2.0 past the ceiling.
     const big = [{ content: 'x'.repeat(400_000) }];
     expect(scaleAgentBudget(15, big, DEFAULT_REVIEW_MODEL).maxTokenBudget).toBe(
       MAX_REVIEW_TOKEN_BUDGET,
@@ -556,11 +556,13 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
   });
 
   it('always returns an integer budget (the config schema requires int)', () => {
-    // 40002 chars → ceil(/4)=10001 → base 76001 (odd); ×1.5 = 114001.5 must round.
+    // 40002 chars → ceil(/4)=10001 → base 76001 (odd). ×2.0 stays whole (152002),
+    // but Math.round in the implementation stays defensive for any future
+    // model with a fractional multiplier — this just guards the int contract.
     const odd = [{ content: 'x'.repeat(40_002) }];
     const { maxTokenBudget } = scaleAgentBudget(5, odd, DEFAULT_REVIEW_MODEL);
     expect(Number.isInteger(maxTokenBudget)).toBe(true);
-    expect(maxTokenBudget).toBe(114_002);
+    expect(maxTokenBudget).toBe(152_002);
   });
 
   it('produces a config the agent-review schema accepts', () => {


### PR DESCRIPTION
## Evidence

Job [87554927152](https://github.com/getlien/lien/actions/runs/29477936476/job/87554927152) (PR #781, run 29477936476) — the cited run — main pass, budget 145,749 tokens:

```
[agent] Turn 3: finish_reason=tool_calls, tokens=100215
[agent] Turn 3 tools: read_file
[agent] Turn 4: finish_reason=stop, tokens=148298
[agent] Turn 4 reasoning:
The user is telling me to stop investigating and output findings JSON now due to low budget. I need to synthesize what I've found from the investigation so far.
```

At turn 3 (100,215/145,749 = 68.8%, over the 60% wrap-up threshold) the agent was mid-verification of a real, previously-flagged finding (numeric-union-arm consumer detection — its own reasoning was actively checking whether `\b200\b`-style patterns correctly match negative/edge-case numeric literals) when the nudge fired. Forced to synthesize with no further tool calls, it produced **0 findings** — the investigation was abandoned, not concluded.

Attestation: `{"budget":{"allocatedTokens":145749,"spentTokens":148298,"starved":false}}` — note `starved:false` even though the run overshot its allocation; the flag doesn't capture this failure mode.

### Frequency (last ~10 review runs on this repo)

| Job | PR/branch | Pass | Budget | Spent | Nudge fired? |
|---|---|---|---|---|---|
| 87554927152 | #781 variant-sweep (cited) | main | 145,749 | 148,298 | **yes** (+1.7%) |
| 87551250898 | #781 earlier commit | main | 142,347 | 168,932 | **yes** (+18.7%) |
| 87559004452 | fix/parser-min-chunk-drop | main | ~99K | 109,515 | **yes** |
| 87559004452 | (same job) doc-truth | ~40K | 40,419 | **yes** |
| 87558889769 | test/fix-pr711-regen | main | 91,209 | 81,218 | no (89% used, natural stop) |
| 87551772536 | test/keyword-integrity-sweep | main | 146,712 | 58,314 | no (40% used) |
| 87551599096 | feat/signal-prompt-hygiene | main | 232,076 | 54,624 | no (24% used) |

**Nudge fired in 4 of 7 pass-instances (57%)** — a routine failure mode on content-heavy, small-file-count PRs, not a one-off. Every firing instance also *overshot* its allocation (the forced final turn has no cap), by 1.7%–18.7%.

## Root cause / knob chosen

`packages/review/src/defaults.ts`'s `REVIEW_TOKEN_BUDGET_MULTIPLIERS[DEFAULT_REVIEW_MODEL]` (Kimi) was **1.5x**, calibrated in #598 against data showing Kimi "needs ~160–180K for a real multi-file review" — i.e. tuned to the *floor* of that range, with zero margin above it. That's why routine PRs still starve two months later.

Ruled out:
- **`MAX_REVIEW_TOKEN_BUDGET` (250K cap)** — not binding here; the cited PR's budget (145,749) was well under the cap. Raising the cap wouldn't have helped this PR.
- **Base formula's `toolBudget` constant (6K/turn)** — that constant is the *slot size fed back per tool call*, already model-agnostic; the multiplier is the existing, designed-for-this lever.
- **`DOC_PASS_BUDGET_FRACTION` (0.4)** — multiplies `config.maxTokenBudget`, which already carries the model multiplier, so raising the multiplier automatically raises the doc-truth pass's budget too (0.4 × a bigger number). No separate change needed.

**Change: `1.5x` → `2.0x`.**

## Why 2.0x, and cost impact

Working backward from the cited job: to let it get one more real investigation turn before the nudge (turn 4's `read_file`, which the agent explicitly said it wanted to do) without exceeding budget, the main-pass budget needs to land in `(167025, 230390]` tokens (60% threshold past turn 3's 100,215, headroom for turn 4 + the final forced-synth turn's typical ~48K cost). `2.0x` gives this PR **194,332** tokens — squarely in that range. `1.5x` → `2.0x` also moves a "medium 5-file PR" from ~162K (the #598 floor) to ~216K, clearing the full "160–180K" range with margin instead of sitting at its bottom edge.

Cost is driven by **actual tokens spent**, not the allocated ceiling — a run that already finishes under budget (3 of the 7 samples above, some using as little as 24% of their allocation) spends *zero* extra, because raising the ceiling doesn't change what the agent chooses to investigate. The increase only engages on runs that would otherwise have been cut short — exactly the target failure mode. At the observed blended rate (~$9.2e-7/token, from job 87554927152's $0.1368/148,298 tokens), the extra headroom this PR grants (up to ~48K tokens on a previously-starved run) costs on the order of **$0.03–0.05 per affected run**. Typical review cost across the sample above ranges $0.05–$0.19; this is a few-cents delta, not a blanket multiplier on spend.

## Dogfood

Harness note: captured fixtures serialize `config: {}` (see `capture-pr.ts`), so the standard `npm run test:harness` invocation always runs at the harness's flat 100,000-token default, **not** `scaleAgentBudget`'s model-aware output — it doesn't exercise this multiplier at all unless the budget is explicitly overridden. (Worth a follow-up harness fidelity fix; out of scope here.)

To dogfood the actual change, re-captured the cited PR (#781 @ 9afafb9b) as a raw fixture and replayed it once through the real `AgentReviewPlugin` at each budget:

- **Old (145,749, the value that starved in prod):** 4 turns, nudge fires at turn 4 ("The user is telling me to stop investigating..."), **0 findings** — reproduces the exact prod failure. Cost $0.051.
- **New (194,332, this PR's value):** 2 turns, natural `stop` (58,273/194,332 = 30%, well under the 60% threshold — no nudge), **1 genuine finding** (a real edge case in `isGenuinelyNew`'s raw-diff-text scan). Cost $0.055.

Total dogfood spend: **$0.348** (includes an earlier exploratory 3-vote run against the large `doc-truth/pr667-worktree-doc-drift` characterization fixture, which confirmed the doc-truth pass's substantive finding was present and correct in 3/3 votes — the harness's strict Tier-2 keyword assertion still scored 0/3 due to a pre-existing phrasing-brittleness issue unrelated to this change), under the $0.50 cap.

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / full `npm test` (all 5 packages, 2318 tests) / `lien delta` (exit 0, no crossings) all green. Updated `plugins-agent-budget.test.ts`'s hardcoded 1.5x expectations to 2.0x.

## Note

This is the last budget/behavior change intended before the expensive corpus recalibration sweep — sized to evidence, not vibes, per that constraint.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR raises the Kimi token-budget multiplier from 1.5× to 2.0× in `packages/review/src/defaults.ts` and updates the corresponding test expectations. The change is a straightforward constant bump with bounded impact: `scaleAgentBudget` clamps the result to the existing 250K ceiling and 60K floor, and `scaleSummaryOnlyBudget` clamps to its own 6K–20K range. No function signatures, control flow, or caller contracts changed. The updated tests directly assert the new 2.0× values and the integer-budget invariant.
>
> - REVIEW_TOKEN_BUDGET_MULTIPLIERS[DEFAULT_REVIEW_MODEL] changed from 1.5 to 2.0
> - plugins-agent-budget.test.ts expectations updated from 1.5× to 2.0× values
> - Long explanatory comment added documenting the evidence and cost rationale

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bf9a99f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the available token budget for reviews using the default model, enabling more comprehensive analysis.
  * Updated budget handling to reflect the revised allocation while preserving limits and integer-valued budgets.
* **Bug Fixes**
  * Improved consistency in model-specific review budget calculations, including boundary and maximum-budget scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->