### PR TITLE
fix(cli): cap complexity headroom warning at 3 worst entries

### DIFF
--- a/.changeset/headroom-warning-cap.md
+++ b/.changeset/headroom-warning-cap.md
@@ -1,0 +1,5 @@
+---
+'@liendev/lien': patch
+---
+
+Cap the complexity headroom warning line at the 3 worst entries. A dogfood run of PR #772 surfaced a real 5-entry file rendering as a ~250-char single line — past 3-4 entries the warning became hard to read. The line now shows the 3 worst entries (over-threshold first, by highest overage ratio, then nearest-to-threshold) and folds anything beyond that into an explicit "… and N more at/near budget" remainder — never a silent truncation. The full, uncapped list is unaffected: `get_files_context`'s `complexityHeadroom` array still carries every near/over-budget entry; only the human-readable warning string is capped. Shared by both consumers (`get_files_context`'s `complexityHeadroomWarning` field and `lien annotate`'s printed nudge line) since both call the one formatter.

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -449,7 +449,71 @@ describe('formatComplexityHeadroomWarning', () => {
       [{ symbol: 'a', metric: 'cognitive', value: 18, threshold: 15 }],
       2,
     );
-    expect(warning).toContain('(+2 more near/over budget)');
+    expect(warning).toContain('… and 2 more at/near budget');
+  });
+
+  it('renders exactly 3 entries with no remainder', () => {
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'a', metric: 'cognitive', value: 18, threshold: 15 },
+      { symbol: 'b', metric: 'cognitive', value: 14, threshold: 15 },
+      { symbol: 'c', metric: 'cognitive', value: 13, threshold: 15 },
+    ]);
+    expect(warning).toBe(
+      '⚠ Lien: a cognitive 18/15 (over), b cognitive 14/15, c cognitive 13/15 — avoid adding complexity here; prefer extraction.',
+    );
+    expect(warning).not.toContain('more');
+  });
+
+  it('caps at 3 rendered entries and names the correct remainder count for 4+', () => {
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'a', metric: 'cognitive', value: 20, threshold: 15 },
+      { symbol: 'b', metric: 'cognitive', value: 18, threshold: 15 },
+      { symbol: 'c', metric: 'cognitive', value: 14, threshold: 15 },
+      { symbol: 'd', metric: 'cognitive', value: 13, threshold: 15 },
+    ]);
+    expect(warning).toBe(
+      '⚠ Lien: a cognitive 20/15 (over), b cognitive 18/15 (over), c cognitive 14/15, … and 1 more at/near budget — avoid adding complexity here; prefer extraction.',
+    );
+  });
+
+  it('caps a 5-entry file (the dogfood shape) at 3 with "… and 2 more"', () => {
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'a', metric: 'cognitive', value: 20, threshold: 15 },
+      { symbol: 'b', metric: 'cognitive', value: 18, threshold: 15 },
+      { symbol: 'c', metric: 'cognitive', value: 17, threshold: 15 },
+      { symbol: 'd', metric: 'cognitive', value: 14, threshold: 15 },
+      { symbol: 'e', metric: 'cognitive', value: 13, threshold: 15 },
+    ]);
+    expect(warning).toContain('… and 2 more at/near budget');
+    expect(warning).not.toContain(' d ');
+    expect(warning).not.toContain(' e ');
+  });
+
+  it('never drops an over-threshold entry in favor of a merely-near one, regardless of input order', () => {
+    // Deliberately scrambled input order (near entries first) proves the
+    // formatter re-sorts by ratio itself rather than trusting caller order.
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'near3', metric: 'cognitive', value: 12, threshold: 15 }, // ratio 0.80
+      { symbol: 'over1', metric: 'cognitive', value: 20, threshold: 15 }, // ratio 1.33
+      { symbol: 'near1', metric: 'cognitive', value: 14, threshold: 15 }, // ratio 0.93
+      { symbol: 'over2', metric: 'cognitive', value: 18, threshold: 15 }, // ratio 1.20
+      { symbol: 'near2', metric: 'cognitive', value: 13, threshold: 15 }, // ratio 0.87
+    ]);
+    // Both over-threshold entries must survive the cap even though they were
+    // not first in the input; the lowest-ratio near entries (near2, near3)
+    // are the ones dropped.
+    expect(warning).toBe(
+      '⚠ Lien: over1 cognitive 20/15 (over), over2 cognitive 18/15 (over), near1 cognitive 14/15, … and 2 more at/near budget — avoid adding complexity here; prefer extraction.',
+    );
+  });
+
+  it('renders a single entry unchanged (no remainder logic engaged)', () => {
+    const warning = formatComplexityHeadroomWarning([
+      { symbol: 'onlyOne', metric: 'cyclomatic', value: 16, threshold: 15 },
+    ]);
+    expect(warning).toBe(
+      '⚠ Lien: onlyOne cyclomatic 16/15 (over) — avoid adding complexity here; prefer extraction.',
+    );
   });
 });
 

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -278,6 +278,16 @@ export function findTestAssociations(
 const NEAR_BUDGET_RATIO = 0.8;
 /** Cap the per-file headroom list so the payload stays lean. */
 const MAX_HEADROOM_PER_FILE = 5;
+/**
+ * Cap on how many entries the human-readable WARNING LINE renders — tighter
+ * than `MAX_HEADROOM_PER_FILE` (5, the data-level cap on the `complexityHeadroom`
+ * array). A dogfood run surfaced a real 5-entry file rendering as a ~250-char
+ * line; readability degrades past 3-4 entries, so the string caps at the 3
+ * worst and names the rest instead of silently dropping them. The full,
+ * uncapped list still round-trips via `complexityHeadroom` — only the string
+ * is capped.
+ */
+const MAX_RENDERED_HEADROOM_ENTRIES = 3;
 
 /**
  * The metrics surfaced as headroom. Deliberately just cyclomatic + cognitive —
@@ -371,6 +381,15 @@ export function computeComplexityHeadroom(chunks: readonly HeadroomInputChunk[])
  * (`complexityHeadroomWarning`) and the CLI `annotate` command (which leads
  * its printed annotation with this same line — see `annotate-cmd.ts`).
  *
+ * Renders at most `MAX_RENDERED_HEADROOM_ENTRIES` (the 3 worst), re-sorted
+ * defensively by overage ratio (value/threshold) rather than trusting caller
+ * order — over-threshold entries (ratio >= 1) always sort ahead of merely-near
+ * ones, so a rendered entry is never bumped by a less-severe one. Anything cut
+ * from the render — both entries beyond the top 3 and the pre-existing
+ * `overflow` count beyond `computeComplexityHeadroom`'s own cap — is folded
+ * into one explicit "… and N more at/near budget" remainder; nothing is
+ * silently dropped.
+ *
  * Returns `undefined` when there's nothing to warn about, so callers can
  * `if (warning)` rather than checking `entries.length` themselves.
  */
@@ -379,11 +398,14 @@ export function formatComplexityHeadroomWarning(
   overflow = 0,
 ): string | undefined {
   if (entries.length === 0) return undefined;
-  const parts = entries.map(
+  const sorted = [...entries].sort((a, b) => b.value / b.threshold - a.value / a.threshold);
+  const rendered = sorted.slice(0, MAX_RENDERED_HEADROOM_ENTRIES);
+  const parts = rendered.map(
     e =>
       `${e.symbol} ${e.metric} ${e.value}/${e.threshold}${e.value >= e.threshold ? ' (over)' : ''}`,
   );
-  const more = overflow > 0 ? ` (+${overflow} more near/over budget)` : '';
+  const remainder = entries.length - rendered.length + overflow;
+  const more = remainder > 0 ? `, … and ${remainder} more at/near budget` : '';
   return `⚠ Lien: ${parts.join(', ')}${more} — avoid adding complexity here; prefer extraction.`;
 }
 


### PR DESCRIPTION
## Summary

Owner-directed UX fix from the PR #772 dogfood: `formatComplexityHeadroomWarning` (shared by `lien annotate`/the read hook and `get_files_context`'s `complexityHeadroomWarning` field) rendered every near-budget function on one line. A real 5-entry file produced a ~250-char line — readability degrades past 3-4 entries.

- Caps the rendered warning at the **3 worst entries**, ordered by severity: over-threshold entries first (highest overage ratio), then nearest-to-threshold. The formatter re-sorts by ratio itself (doesn't trust caller order), so an over-threshold entry is never bumped by a merely-near one.
- Anything beyond the top 3 — plus the pre-existing `overflow` count from `computeComplexityHeadroom`'s own 5-entry cap — is folded into one explicit remainder: `"… and N more at/near budget"`. No silent truncation.
- The closing imperative (`avoid adding complexity here; prefer extraction`) is unchanged, and it's still one line.
- **`get_files_context`'s `complexityHeadroom` array is unchanged** — the full (up to 5-entry) list still round-trips as structured data. Only the human-readable warning *string* is capped further.
- Fixed once in the shared formatter (`packages/cli/src/mcp/handlers/get-files-context.ts`) — both `annotate-cmd.ts` and `get_files_context` call it directly, so both consumers pick up the fix with no separate change. `plugins/claude`'s hook only consumes the printed annotation text, so it needs no changes either.

## Dogfood (before/after, verbatim)

Ran against the exact 5-entry file from the original PR #772 dogfood:

```
node packages/cli/dist/index.js annotate packages/review/src/rename-sweep-signals.ts
```

**Before** (~255 chars, one line):
```
⚠ Lien: scanDiff cognitive 30/15 (over), renderRenameSweepSignals cognitive 19/15 (over), inferSingleTokenSwap cognitive 15/15 (over), commentMarkerIndex cognitive 14/15, findSurvivors cognitive 14/15 — avoid adding complexity here; prefer extraction.
```

**After**:
```
⚠ Lien: scanDiff cognitive 30/15 (over), renderRenameSweepSignals cognitive 19/15 (over), inferSingleTokenSwap cognitive 15/15 (over), … and 2 more at/near budget — avoid adding complexity here; prefer extraction.
```

## Tests

Updated `formatComplexityHeadroomWarning`'s existing tests (old `(+2 more near/over budget)` phrasing → new `"… and 2 more at/near budget"`) and added:
- exactly 3 entries → no remainder
- 4+ entries → capped with correct remainder count
- 5-entry (dogfood) shape → "… and 2 more"
- ordering: over-threshold entries survive the cap even when scrambled ahead of near-threshold ones in input order
- 1 entry → unchanged (no remainder logic engaged)

## Gates

- `npm run format:check` — pass
- `npm run lint` — pass (0 errors; pre-existing warnings only)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — pass (all workspaces)
- `lien delta` — exit 0 (one `worsened` advisory on `formatComplexityHeadroomWarning` itself — estimated understand-time 11m→26m from the added sort/remainder logic; not a threshold crossing)
- Changeset: `@liendev/lien` patch

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] `lien delta` exit 0
- [x] Dogfood: `node packages/cli/dist/index.js annotate packages/review/src/rename-sweep-signals.ts` — before/after captured above

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR is a focused UX fix: it caps the human-readable complexity headroom warning at the 3 worst entries (sorted by value/threshold ratio) and folds the rest into an explicit remainder. The structured `complexityHeadroom` array remains uncapped. Both consumers (`lien annotate` and `get_files_context`) call the same shared formatter, so the fix applies uniformly. The change is well-covered by new tests for the 3/4/5-entry boundaries and ordering behavior, and no callers parse the warning string, so the format change is not a breaking change.
>
> - formatComplexityHeadroomWarning now sorts entries by overage ratio and renders at most 3
> - Remainder count combines capped rendered entries plus pre-existing overflow
> - Structured complexityHeadroom array unchanged; only the warning string is capped
> - Tests added for 3-entry, 4-entry, 5-entry, ordering, and single-entry cases

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 687d018. Updates automatically on new commits.</sup>
<!-- /lien-stats -->