### PR TITLE
docs(site): cross-editor agent setup — AGENTS.md and Copilot instructions templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Instructions
+
+Read [`CLAUDE.md`](./CLAUDE.md) first — it's this repo's full workflow contract, for
+any agent, not just Claude Code. The non-negotiables it defines, restated
+tool-agnostically for whichever coding agent you are:
+
+1. **Before editing any file**, call Lien's `get_files_context` MCP tool
+   (batch with `filepaths: [...]` for multi-file edits). Check
+   `testAssociations`, `imports`, `callSites`, and `complexityHeadroomWarning`
+   before you touch it.
+2. **Before renaming, removing, or changing the signature of an exported
+   symbol**, call `get_dependents`. A `riskLevel` of `high` or `critical`
+   means list the affected dependents before proceeding.
+3. **Before every commit**, run the full gate chain in CLAUDE.md's
+   "Before EVERY Commit" section, including `lien delta` — treat any new
+   complexity-threshold crossing as must-fix, not advisory.
+
+This file exists because Lien tells its own users to do the same in their
+repos (see [Cross-Editor Agent Setup](https://lien.dev/guide/cross-editor-setup));
+we ship what we use.

--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default withMermaid(
             items: [
               { text: 'MCP Tools', link: '/guide/mcp-tools' },
               { text: 'Claude Code Plugin', link: '/guide/claude-code-plugin' },
+              { text: 'Cross-Editor Agent Setup', link: '/guide/cross-editor-setup' },
               { text: 'CLI Commands', link: '/guide/cli-commands' },
               { text: 'Lien Review', link: '/guide/lien-review' },
               { text: 'Review Evidence', link: '/guide/review-evidence' },

--- a/packages/site/docs/guide/claude-code-plugin.md
+++ b/packages/site/docs/guide/claude-code-plugin.md
@@ -31,6 +31,14 @@ This is Claude Code-specific. For other MCP-compatible editors (Cursor,
 Windsurf, OpenCode, Kilo Code, Antigravity), see the
 [installation guide](/guide/installation).
 
+::: tip Not using Claude Code?
+Most other agentic editors read a plain instruction file instead of hooks.
+See [Cross-Editor Agent Setup](/guide/cross-editor-setup) for copy-paste
+`AGENTS.md`/`.github/copilot-instructions.md` blocks that carry the same
+mandate — with the same honesty caveat: rules-file compliance is best-effort,
+not the deterministic guarantee a hook gives you.
+:::
+
 ## What you get
 
 ### MCP tools

--- a/packages/site/docs/guide/cross-editor-setup.md
+++ b/packages/site/docs/guide/cross-editor-setup.md
@@ -1,0 +1,131 @@
+# Cross-Editor Agent Setup
+
+Not using Claude Code? The [Claude Code plugin](/guide/claude-code-plugin) wires
+Lien's nudges in via hooks — deterministic, fires on every matching tool call.
+Most other agentic editors don't have an equivalent hook integration from Lien
+yet, but nearly all of them read a plain instruction file already: a single
+`AGENTS.md` at your repo root is read natively by Codex CLI, Cursor, Windsurf
+(Cascade), GitHub Copilot, Devin, and Amp. `.github/copilot-instructions.md`
+covers every Copilot surface the same way. Two files, five-plus tools raised
+off the rules-file floor.
+
+## Be honest about what this buys you
+
+Lien's own [Claude Code plugin](/guide/claude-code-plugin#why-hooks-not-claude-md-rules)
+page makes the case for hooks over rules-file text: a hook fires
+deterministically regardless of what's still in the model's context, while a
+written instruction is a standing suggestion competing for attention across a
+long session, and a capable agent can still skip it under context pressure or
+by taking a shortcut (e.g. reading a file via a shell command instead of its
+native Read tool, which wouldn't trigger a hook either way even where hooks
+exist). That's design rationale, not a citation — so here's what's actually
+measured: a pre-registered A/B injecting Lien's real complexity warning into
+a coding-agent prompt (N=8/condition) found the agent crossed its complexity
+threshold in 8/8 control trials versus 3/8 with the warning present — every
+trial that avoided crossing did so by extracting a helper function, matching
+the warning's own wording, "prefer extraction" (see
+[`docs/development/nudge-behavioral-ab.md`](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md)).
+That study shows an injected signal changes behavior versus no signal at
+all — it isn't a head-to-head of rules-file prose against a hook carrying the
+identical instruction, and no such head-to-head is checked into this repo.
+So: the blocks below are genuinely useful, strictly better than nothing, and
+for the editors on this page they're currently the *only* nudge Lien can
+offer — but treat compliance as best-effort, not guaranteed, and don't read
+more evidence into that claim than exists above. If your editor gets a real
+hook port later (see the roadmap below), that will raise the floor further.
+
+## AGENTS.md — the universal block
+
+Drop this at your repo root (or append it to an existing `AGENTS.md`). It's
+plain markdown — copy it as-is:
+
+```markdown
+## Lien: query before you touch code
+
+This repo is indexed by [Lien](https://lien.dev) (MCP). Before editing any
+file, call `get_files_context` — check `testAssociations`, `imports`, and any
+`complexityHeadroomWarning` in the response before you touch it (batch with
+`filepaths: [...]` for multi-file edits). Before renaming, removing, or
+changing the signature of an exported symbol, call `get_dependents` — a
+`riskLevel` of `high` or `critical` means list the affected dependents before
+proceeding. Before committing, run `lien delta`; treat any new
+complexity-threshold crossing it reports as must-fix, not advisory.
+```
+
+That's the whole mandate — kept short deliberately. Every extra sentence
+competes with the rest of your rules file for the same limited attention.
+
+## GitHub Copilot — `.github/copilot-instructions.md`
+
+This file is GA today and needs no opt-in: Copilot includes it automatically
+in every chat request across VS Code, JetBrains, github.com, and Copilot CLI —
+the single highest-reach, lowest-effort artifact of the two on this page. Same
+content, same reasoning:
+
+```markdown
+## Lien: query before you touch code
+
+This repo is indexed by [Lien](https://lien.dev) (MCP). Before editing any
+file, call `get_files_context` — check `testAssociations`, `imports`, and any
+`complexityHeadroomWarning` in the response before you touch it (batch with
+`filepaths: [...]` for multi-file edits). Before renaming, removing, or
+changing the signature of an exported symbol, call `get_dependents` — a
+`riskLevel` of `high` or `critical` means list the affected dependents before
+proceeding. Before committing, run `lien delta`; treat any new
+complexity-threshold crossing it reports as must-fix, not advisory.
+```
+
+If you already have an `AGENTS.md`, Copilot reads that natively too — but
+`.github/copilot-instructions.md` is the file Copilot's docs commit to
+including in every chat request, so committing both removes any ambiguity
+about which surfaces pick which file up.
+
+## Windsurf / Cascade: one real caveat
+
+Cascade reads `AGENTS.md` dynamically as it navigates your repo, so the block
+above reaches it too — no extra file needed. The caveat, verified against
+Cascade's own hook docs: Cascade's hook system (`pre_write_code`,
+`pre_read_code`, and others) can log tool calls and hard-block them outright,
+but hook output is never injected back into the model's context. That means
+for Windsurf specifically, the `AGENTS.md` block above **is the entire nudge**
+— there's no hook backstop underneath it the way there is for Claude Code.
+Treat it as best-effort here more than anywhere else on this page.
+
+## Codex CLI: already reading AGENTS.md today
+
+Codex CLI auto-reads `AGENTS.md`, walking from its home directory down through
+the project tree and concatenating what it finds — nothing to configure.
+Codex's own hook system went stable in **v0.124.0 (April 23, 2026)**, with an
+event schema close enough to Claude Code's own `PostToolUse`/`PreToolUse` pair
+that a real port of Lien's hooks is plausible future work — not yet shipped.
+Until then, the `AGENTS.md` block above is Codex's nudge floor.
+
+## Cursor
+
+Cursor also reads `AGENTS.md` natively, so the universal block covers it
+without any extra setup. Cursor's hooks (introduced in Cursor 1.7,
+[October 2025](https://www.infoq.com/news/2025/10/cursor-hooks/), GA as of
+mid-2026) and its `.cursor/rules/*.mdc` targeting system are both richer than
+a flat `AGENTS.md` — tracked as follow-up work, not shipped today.
+
+## Roadmap: what's tracked next
+
+This page ships the rules-file floor (step 1 of Lien's cross-editor plan).
+Hook ports are follow-up work, in priority order:
+
+| Environment | Ships today | Tracked next |
+|---|---|---|
+| Codex CLI | Reads `AGENTS.md` natively | Hook port (stable API since v0.124.0) |
+| Cursor | Reads `AGENTS.md` natively | Hook port to `.cursor/hooks.json` (hooks GA as of mid-2026) |
+| GitHub Copilot | `.github/copilot-instructions.md` (GA) | Hooks — stable in Copilot CLI, [Preview in VS Code](https://code.visualstudio.com/docs/agent-customization/hooks) since its Feb 2026 release; worth a beta label or a wait for GA |
+| Windsurf/Cascade | Reads `AGENTS.md` natively | Optional `pre_write_code` hard-block script for the delta gate — additive, but can't carry the read-annotation nudge regardless (architecture limit, not effort) |
+| Aider | Nothing yet | Not planned — [no native MCP support](https://github.com/Aider-AI/aider/issues/4506) as of mid-2026; a `--lint-cmd` wrapper around `lien delta` is the only workaround worth a doc note |
+
+## Related pages
+
+- [Claude Code Plugin](/guide/claude-code-plugin) — the hook-driven version of
+  this same mandate, for Claude Code.
+- [MCP Tools](/guide/mcp-tools) — parameters and response shapes for
+  `get_files_context`, `get_dependents`, and the rest.
+- [Quick Start](/guide/getting-started) — per-editor `lien init` setup if you
+  haven't configured Lien's MCP server yet.

--- a/packages/site/docs/guide/getting-started.md
+++ b/packages/site/docs/guide/getting-started.md
@@ -37,7 +37,10 @@ lien init --editor kilo-code
 lien init --editor antigravity
 ```
 
-This writes the correct MCP config for your editor.
+This writes the correct MCP config for your editor. Once the MCP tools are
+wired up, see [Cross-Editor Agent Setup](/guide/cross-editor-setup) for a
+copy-paste `AGENTS.md` block that tells your agent to actually use them
+before editing — most non-Claude-Code editors read that file natively.
 
 ::: details What does `lien init` create?
 
@@ -135,5 +138,6 @@ lien serve --root /path/to/your/project
 - Learn about [configuration options](/guide/configuration)
 - Explore [MCP tools](/guide/mcp-tools)
 - Read about [CLI commands](/guide/cli-commands)
+- Not on Claude Code? See [Cross-Editor Agent Setup](/guide/cross-editor-setup)
 
 

--- a/packages/site/docs/guide/lien-review.md
+++ b/packages/site/docs/guide/lien-review.md
@@ -82,3 +82,9 @@ wasn't tuned on.
 ## Relationship to the MCP tools
 
 Lien Review is a separate product surface from the [MCP tools](/guide/mcp-tools): the MCP tools run locally inside your AI assistant, while Lien Review runs in CI against a pull request. Both share the same underlying AST parsing and complexity analysis (`@liendev/parser`), but Lien Review needs no local index and no `lien init` — it's a drop-in GitHub Action.
+
+Lien Review catches complexity regressions in CI either way, but the earlier
+and cheaper place to catch them is before the commit exists at all. If your
+agent isn't Claude Code, [Cross-Editor Agent Setup](/guide/cross-editor-setup)
+has the copy-paste instruction block that tells it to run `lien delta` and
+treat crossings as must-fix — a local backstop for the same signal.


### PR DESCRIPTION
## What

Step 1 of the cross-editor nudge plan (the rules-file floor): ship the mandate text users drop into their own repos, plus dogfood it in ours.

- **New guide page** `packages/site/docs/guide/cross-editor-setup.md` — copy-paste `AGENTS.md` and `.github/copilot-instructions.md` blocks instructing agents to call `get_files_context` before edits (and heed `complexityHeadroomWarning`), `get_dependents` before exported-symbol changes, and run `lien delta` before commits, treating crossings as must-fix. Kept deliberately short — every sentence in a rules file competes for the same contested attention budget.
- **Honesty section**: states the fidelity ladder plainly (hooks > rules files; rules-file compliance is best-effort). Cites the checked-in behavioral A/B (`docs/development/nudge-behavioral-ab.md`, 8/8 vs 3/8 crossings, N=8/condition) for what's actually measured, and explicitly bounds what that study does *not* show (it isn't a rules-file-vs-hook head-to-head).
- **Per-tool notes** with dates/versions from the July 2026 research pass: Windsurf hook-architecture caveat (hooks can't inject context — the AGENTS.md block *is* the entire nudge there), Codex CLI hook-port pointer (stable since v0.124.0), Cursor, Copilot (instructions file GA everywhere; hooks Preview in VS Code), Aider (no native MCP, not planned).
- **Sidebar registration** + cross-links from the Claude Code plugin page ("Not using Claude Code?"), quick-start, and Lien Review pages.
- **Dogfood**: `AGENTS.md` at this repo's root — a compact pointer to CLAUDE.md's non-negotiables (get_files_context / get_dependents / full gate chain incl. `lien delta`) for non-Claude-Code agents working on Lien itself. We ship what we use.

## Verification

- `npm run docs:build` green; rendered page served locally and inspected — sidebar entry, all internal links (including the `#why-hooks-not-claude-md-rules` anchor), and both template code fences verified copy-paste clean (plain markdown, no site-specific markup).
- Full gate chain green: format:check, lint (0 errors), typecheck, build, `npm test` (all packages), `lien delta` exit 0.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **2 issues found** · Low Risk
>
> This PR ships cross-editor agent-setup guidance: a new site guide page with copy-paste `AGENTS.md` / `.github/copilot-instructions.md` blocks, an `AGENTS.md` dogfood file at the repo root, and sidebar/cross-link updates. The only substantive issue is a doc-truth bug: the guidance tells agents to inspect `callSites` from `get_files_context`, but the MCP tool's metadata shaper explicitly removes `callSites` from the response, so the instruction is unfulfillable. Other behavioral claims (`complexityHeadroomWarning`, `riskLevel`, `lien delta`) match the code.
>
> - New packages/site/docs/guide/cross-editor-setup.md with per-editor notes and copy-paste instruction blocks
> - New repo-root AGENTS.md pointing non-Claude-Code agents at CLAUDE.md's non-negotiables
> - VitePress sidebar registration and cross-links from Claude Code plugin, quick-start, and Lien Review pages

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fe74921. Updates automatically on new commits.</sup>
<!-- /lien-stats -->