### PR TITLE
test(plugin): lock subagent tool-name coverage for the explore augmentation hook

### DIFF
--- a/docs/architecture/claude-code-hook-channels.md
+++ b/docs/architecture/claude-code-hook-channels.md
@@ -35,6 +35,27 @@ The subagent-launching tool is named `Agent` in current Claude Code, `Task` in
 older versions. Hook-dev docs and community examples often still say `Task`.
 Match both — `"matcher": "Agent|Task"` (`plugins/claude/hooks/hooks.json`).
 
+**Re-audited 2026-07-16, still correct.** The official tool reference
+(`code.claude.com/docs/en/tools-reference`, fetched the same day) lists
+`Agent` as the sole subagent-spawn tool; `Task` no longer exists as a tool
+name at all (the `Task*` family that remains — `TaskCreate`/`TaskGet`/
+`TaskList`/`TaskOutput`/`TaskStop`/`TaskUpdate` — is the unrelated
+session task-list feature, not the subagent launcher). The plugin's
+`"Agent|Task"` matcher already covers the current name, so
+`augment-explore-task.sh` fires normally — confirmed by replaying both
+`tool_name: "Agent"` and `tool_name: "Task"` payloads through the script,
+now covered permanently by `packages/cli/test/augment-explore-hook.test.ts`.
+`Task` stays in the matcher as a free legacy-version alias; no reason to
+remove it.
+
+Same audit also checked `delta-write.sh`'s `"Edit|Write|MultiEdit"` matcher:
+`Edit`/`Write` are current; `MultiEdit` was removed from Claude Code with no
+replacement tool name (its batch-edit use case folded into `Edit`'s
+`replace_all`). Same conclusion — harmless legacy alias, not a live bug,
+since `Edit`/`Write` alone already fire the hook on every current edit.
+`MultiEdit`'s presence is already exercised by `delta-write-hook.test.ts`
+and was left as-is.
+
 ## How to apply
 
 | Intent | Channel |

--- a/packages/cli/test/augment-explore-hook.test.ts
+++ b/packages/cli/test/augment-explore-hook.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the PreToolUse subagent-launch hook
+ * `plugins/claude/hooks/augment-explore-task.sh`.
+ *
+ * This hook's matcher (`hooks.json`: `"Agent|Task"`) and the script's own
+ * `tool_name` case statement are exactly the silent-failure class this suite
+ * guards against: Claude Code renamed its subagent-spawn tool from `Task` to
+ * `Agent` (see docs/architecture/claude-code-hook-channels.md — "The
+ * Agent-vs-Task matcher gotcha"). A matcher naming only the old tool would
+ * make the injection silently stop firing on any current Claude Code
+ * version — no error, no warning, nothing short of a live dogfood session
+ * to catch it. `delta-write.sh` already has this kind of coverage
+ * (`delta-write-hook.test.ts`); this hook didn't, despite being the one
+ * that already lived through exactly this rename once (PR #571). Exercise
+ * both tool names so a future rename regression fails CI instead of
+ * shipping silent.
+ *
+ * `lien` is stubbed on PATH with a shim that answers `path --store` with a
+ * directory this suite controls, so the "repo is indexed" gate
+ * (`structural.db` present/absent) can be flipped per test. Real `jq` is used.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import os from 'node:os';
+
+const HOOK = fileURLToPath(
+  new URL('../../../plugins/claude/hooks/augment-explore-task.sh', import.meta.url),
+);
+
+let shimDir: string;
+let storeDir: string;
+let hookPath: string; // PATH with the lien shim prepended (real jq stays resolvable)
+
+beforeAll(() => {
+  shimDir = mkdtempSync(path.join(os.tmpdir(), 'lien-explore-hook-shim-'));
+  storeDir = path.join(shimDir, 'store');
+  mkdirSync(storeDir, { recursive: true });
+  // `lien` shim: ignore all args (`path --store`), print the fixed store dir.
+  const shim = path.join(shimDir, 'lien');
+  writeFileSync(shim, `#!/usr/bin/env bash\necho "${storeDir}"\n`, 'utf-8');
+  chmodSync(shim, 0o755);
+  hookPath = `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`;
+});
+
+afterAll(() => {
+  rmSync(shimDir, { recursive: true, force: true });
+});
+
+const structuralDb = () => path.join(storeDir, 'structural.db');
+
+beforeEach(() => {
+  // Default: repo looks indexed, so the injection gate is open.
+  writeFileSync(structuralDb(), '', 'utf-8');
+});
+
+afterEach(() => {
+  if (existsSync(structuralDb())) rmSync(structuralDb());
+});
+
+/** Run the hook with a synthesized PreToolUse payload, returning trimmed stdout. */
+function runHook(
+  payload: Record<string, unknown>,
+  extraEnv: Record<string, string> = {},
+): { stdout: string; status: number | null } {
+  const res = spawnSync('bash', [HOOK], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: { ...process.env, PATH: hookPath, ...extraEnv },
+  });
+  return { stdout: res.stdout.trim(), status: res.status };
+}
+
+const explorePayload = (
+  toolName: string,
+  subagentType = 'Explore',
+  prompt = 'Find the auth flow',
+) => ({
+  session_id: 's1',
+  tool_name: toolName,
+  cwd: shimDir,
+  tool_input: { subagent_type: subagentType, description: 'explore', prompt },
+});
+
+/**
+ * Extract `updatedInput.prompt` from the hook's JSON stdout, failing with a
+ * readable message (rather than a bare JSON.parse stack) when the hook
+ * unexpectedly printed nothing or printed non-JSON.
+ */
+function updatedPrompt(stdout: string): string {
+  if (stdout === '') {
+    throw new Error('hook produced no stdout — expected an updatedInput envelope');
+  }
+  let parsed: { hookSpecificOutput?: { updatedInput?: { prompt?: unknown } } };
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(`hook stdout is not valid JSON: ${stdout}`);
+  }
+  const prompt = parsed.hookSpecificOutput?.updatedInput?.prompt;
+  if (typeof prompt !== 'string') {
+    throw new Error(`hook JSON has no string updatedInput.prompt: ${stdout}`);
+  }
+  return prompt;
+}
+
+describe('augment-explore-task.sh — fires on both current and legacy subagent-launch tool names', () => {
+  it.each(['Agent', 'Task'])(
+    'injects the Lien mandate when tool_name is %s and subagent_type is Explore',
+    toolName => {
+      const { stdout, status } = runHook(explorePayload(toolName));
+      expect(status).toBe(0);
+      const prompt = updatedPrompt(stdout);
+      expect(prompt).toContain('Find the auth flow');
+      expect(prompt).toContain('mcp__plugin_lien_lien__search_code');
+      expect(prompt).toContain('REQUIRED');
+    },
+  );
+
+  it.each(['lien:Explore', 'project:Explore'])(
+    'also injects for the namespaced Explore variant %s',
+    subagentType => {
+      const { stdout } = runHook(explorePayload('Agent', subagentType));
+      expect(updatedPrompt(stdout)).toContain('mcp__plugin_lien_lien__search_code');
+    },
+  );
+
+  it('echoes back every original tool_input field, mutating only prompt', () => {
+    const { stdout } = runHook({
+      session_id: 's1',
+      tool_name: 'Agent',
+      cwd: shimDir,
+      tool_input: {
+        subagent_type: 'Explore',
+        description: 'explore the auth module',
+        prompt: 'Find the auth flow',
+        custom_field: 'preserved',
+      },
+    });
+    const parsed = JSON.parse(stdout);
+    const updated = parsed.hookSpecificOutput.updatedInput;
+    expect(updated.subagent_type).toBe('Explore');
+    expect(updated.description).toBe('explore the auth module');
+    expect(updated.custom_field).toBe('preserved');
+    expect(updated.prompt).toContain('Find the auth flow');
+  });
+});
+
+describe('augment-explore-task.sh — stays silent (exit 0, no stdout)', () => {
+  it('when tool_name is neither Agent nor Task', () => {
+    const { stdout, status } = runHook({
+      tool_name: 'Bash',
+      cwd: shimDir,
+      tool_input: { command: 'ls' },
+    });
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+  });
+
+  it('when subagent_type is not an Explore variant', () => {
+    const { stdout } = runHook(explorePayload('Agent', 'general-purpose'));
+    expect(stdout).toBe('');
+  });
+
+  it('when the prompt already references a Lien MCP tool (idempotent)', () => {
+    const { stdout } = runHook(
+      explorePayload('Agent', 'Explore', 'Use mcp__plugin_lien_lien__search_code to look this up'),
+    );
+    expect(stdout).toBe('');
+  });
+
+  it('when no Lien index exists for the repo (no structural.db)', () => {
+    rmSync(structuralDb());
+    const { stdout, status } = runHook(explorePayload('Agent'));
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+  });
+
+  it('when the kill switch LIEN_EXPLORE_INJECT=off is set', () => {
+    const { stdout } = runHook(explorePayload('Agent'), { LIEN_EXPLORE_INJECT: 'off' });
+    expect(stdout).toBe('');
+  });
+
+  it('when the prompt is empty', () => {
+    const { stdout } = runHook(explorePayload('Agent', 'Explore', ''));
+    expect(stdout).toBe('');
+  });
+});


### PR DESCRIPTION
## Verdict: LIVE — the subagent-augmentation hook is not dead

Audit of whether `plugins/claude/hooks/augment-explore-task.sh` silently died after Claude Code's `Task` → `Agent` subagent-tool rename. It did not: both layers already match both names, and have since PR #571, where a live dogfood caught the original `Task`-only version and fixed it in the same PR (commit trailer: "0 Task tool_use blocks, 7 Agent tool_use blocks during this session").

**Current-name evidence:** the official tools reference ([code.claude.com/docs/en/tools-reference](https://code.claude.com/docs/en/tools-reference), fetched 2026-07-16) lists `Agent` as the sole subagent-spawn tool. `Task` does not exist as a tool name — the remaining `Task*` family (`TaskCreate`/`TaskGet`/`TaskList`/`TaskOutput`/`TaskStop`/`TaskUpdate`) is the session task-list feature, unrelated to subagent launch. `"Agent|Task"` therefore covers the current name, with `Task` as a free legacy alias.

## Matcher audit table

| Hook | Event | Matcher | Status |
| --- | --- | --- | --- |
| `augment-explore-task.sh` | PreToolUse | `Agent\|Task` | **LIVE** — `Agent` current, `Task` harmless legacy alias; script's own `case` also accepts both |
| `annotate-read.sh` | PostToolUse | `Read` | LIVE — current tool name |
| `delta-write.sh` | PostToolUse | `Edit\|Write\|MultiEdit` | LIVE — `Edit`/`Write` current; `MultiEdit` removed from CC (batch-edit folded into `Edit` `replace_all`) so it's a dead-but-harmless alias, not a coverage gap |
| `annotate-clean.sh` | SessionStart | (none) | LIVE — lifecycle event, no tool matcher |
| `annotate-end.sh` | SessionEnd | (none) | LIVE — lifecycle event, no tool matcher |

No stale matcher leaves a hook dead on current Claude Code. Nothing in `hooks.json` needed changing.

## Dogfood: simulated hook invocations, verbatim

Ran the script exactly as CC would — synthesized PreToolUse stdin JSON, `lien` shimmed to a store containing `structural.db` so the index gate is open.

**Input (`tool_name: "Agent"`):**

```json
{"tool_name":"Agent","tool_input":{"subagent_type":"Explore","description":"find auth","prompt":"Find where user authentication happens in this codebase"},"cwd":"<worktree>"}
```

**Output (exit 0):**

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "allow",
    "updatedInput": {
      "subagent_type": "Explore",
      "description": "find auth",
      "prompt": "Find where user authentication happens in this codebase\n\n[Lien] MCP tools are REQUIRED for keyword and structural codebase queries in this repo. Use Lien tools as your primary discovery mechanism — grep/glob/Read are fallbacks ONLY for exact-literal lookups (error strings, config keys, TODOs).\n\nRequired tools:\n  • mcp__plugin_lien_lien__search_code — REQUIRED for keyword/full-text discovery. Full-text (BM25) search: phrase queries with concrete keywords/identifiers/domain terms that appear in the code (\"chunk overlap config\", \"parse import statement\"), NOT full natural-language questions — there are no embeddings, so paraphrase queries score worse.\n  • mcp__plugin_lien_lien__list_functions — REQUIRED for \"find all X\" / pattern-based structural lookup (10× faster than grep).\n  • mcp__plugin_lien_lien__get_files_context — REQUIRED before reporting on any file you exploratively read (returns imports, callers, test associations).\n  • mcp__plugin_lien_lien__get_dependents — REQUIRED before reporting an exported symbol change is \"safe\" or complete.\n\nGrep/glob are only acceptable when the query is for an exact literal string."
    }
  }
}
```

**Input (`tool_name: "Task"`)** — identical payload with `"tool_name":"Task"` — produced byte-identical output (exit 0). Both names inject.

**Controls (all exit 0, empty stdout — fail-open holds):** `tool_name: "Bash"` → silent; `subagent_type: "general-purpose"` → silent; `structural.db` absent → silent.

## What this PR actually changes

The gap wasn't the matcher — it was that nothing would *catch* the next rename. `delta-write.sh` has a payload-replay unit suite (`delta-write-hook.test.ts`); the explore hook — the one script that already lived through exactly this rename once — had none. A future rename would fail silently again, discoverable only by live dogfood.

- **`packages/cli/test/augment-explore-hook.test.ts`** (new, 11 tests): injection fires for `Agent` and `Task` and all three Explore `subagent_type` variants; `tool_input` echo-back preserves unknown fields (the load-bearing `updatedInput` contract); all six silence paths stay fail-open (non-subagent tool, non-Explore type, idempotence on existing Lien mention, missing index, `LIEN_EXPLORE_INJECT=off`, empty prompt).
- **`docs/architecture/claude-code-hook-channels.md`**: dated re-audit note (2026-07-16) under the Agent-vs-Task gotcha, including the `MultiEdit` finding.

## Shipping/changeset note

No changeset: plugin hook files ship via the commit-pinned Claude Code plugin snapshot (`/plugin install lien@lien`), not npm; the test file is excluded from the published `@liendev/lien` package (`files: ["dist", ...]`). Precedent: #688 (test-only cli change, no changeset).

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `npm test` (parser-native 27, parser 1062, core 374, review 1006, cli 848 incl. the 11 new, action 39 — all green) / `lien delta` exit 0 (new test helpers only, all far under threshold).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a unit-test suite for the existing `augment-explore-task.sh` Claude Code hook and updates the architecture doc with a re-audit note. No production code or exported APIs are changed. The test correctly exercises both `Agent` and `Task` tool-name matchers, the three `Explore` subagent-type variants, field echo-back, and all fail-open silence paths. The doc claims match the hook matcher in `hooks.json` and the script's own `case` statement.
>
> - New test file `packages/cli/test/augment-explore-hook.test.ts` locks subagent tool-name coverage for the explore hook.
> - Doc update in `docs/architecture/claude-code-hook-channels.md` records the 2026-07-16 matcher re-audit.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4ecc904. Updates automatically on new commits.</sup>
<!-- /lien-stats -->