### PR TITLE
feat(cli,plugin): post-edit test-association reminder

### DIFF
--- a/.changeset/test-association-reminder.md
+++ b/.changeset/test-association-reminder.md
@@ -1,0 +1,8 @@
+---
+'@liendev/lien': minor
+---
+
+Add the post-edit test-association reminder — closing the read → write → verify loop the way the plan-time nudge closed read → write.
+
+- `lien annotate` gains a `--tests-only` flag: prints one compact line naming the tests associated with the file ("Lien: you changed \<file\> — associated tests: \<tests\>. Run them before completing."), or nothing when the file has no associated tests. It's the cheap path — a single index scan for test associations, skipping the full annotation's dependency-graph BFS and complexity analysis entirely.
+- The Claude Code plugin gains a `test-reminder.sh` hook on `PostToolUse:Edit|Write|MultiEdit` (a sibling of `delta-write.sh`, each script stays single-purpose) that surfaces that line via `additionalContext` after an edit. Silent when there are no associations or the repo has no index; TTL-suppressed per file per session (same touchfile pattern as `annotate-read.sh`, namespaced so the two never collide); fail-open throughout — hook errors never block the edit. Kill switch: `LIEN_TEST_REMINDER=off`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Local-first structural code search tool (lexical FTS5 search + dependency analys
 **Monorepo Structure:**
 - `packages/` — TypeScript packages: `parser` and `core` publish as `@liendev/parser`/`@liendev/core`; `cli` publishes as `@liendev/lien`; `review`, `action`, and `site` are private (unpublished).
 - Dependency chain: `parser` ← `core` ← `cli`; `review` depends on `parser` only (not `core`); `action` wraps `review` as a self-hostable GitHub Action ([ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)).
-- `plugins/claude/` — the dogfooded Claude Code plugin (MCP server config + hooks). Hooks auto-annotate reads and run the `lien delta` gate on writes, i.e. they automate two of this file's own MANDATORY policies — see `plugins/claude/README.md`.
+- `plugins/claude/` — the dogfooded Claude Code plugin (MCP server config + hooks). Hooks auto-annotate reads, and on writes run the `lien delta` gate plus a test-association reminder, i.e. they automate three of this file's own MANDATORY policies — see `plugins/claude/README.md`.
 - `lien-review-testbed/` — tracked, multi-language fixture app used by the review-agent test harness. Not a demo to clean up.
 
 **Package Structure:**

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
 import os from 'os';
 import * as coreModule from '@liendev/core';
+import * as dependencyAnalyzerModule from '../mcp/handlers/dependency-analyzer.js';
 import {
   annotateCommand,
   isTrivial,
   formatDependents,
   formatTests,
+  formatTestReminder,
   formatComplexity,
   withHeadroomWarning,
 } from './annotate-cmd.js';
@@ -20,6 +22,20 @@ vi.mock('@liendev/core', async () => {
   return {
     ...actual,
     createVectorDB: vi.fn(actual.createVectorDB),
+  };
+});
+
+// Spied (not replaced) so the `--tests-only` integration block below can
+// assert `findDependents` is never called on that path — it's the whole
+// point of `runTestsOnly` skipping the BFS/complexity work the full
+// annotation needs.
+vi.mock('../mcp/handlers/dependency-analyzer.js', async () => {
+  const actual = await vi.importActual<typeof import('../mcp/handlers/dependency-analyzer.js')>(
+    '../mcp/handlers/dependency-analyzer.js',
+  );
+  return {
+    ...actual,
+    findDependents: vi.fn(actual.findDependents),
   };
 });
 
@@ -139,6 +155,28 @@ describe('formatTests', () => {
   it('truncates extras with a (+N more) suffix', () => {
     expect(formatTests(['a.test.ts', 'b.test.ts', 'c.test.ts', 'd.test.ts'])).toBe(
       'Test coverage: a.test.ts, b.test.ts (+2 more).',
+    );
+  });
+});
+
+describe('formatTestReminder', () => {
+  it('renders the fixed reminder template for a single test', () => {
+    expect(formatTestReminder('src/foo.ts', ['src/foo.test.ts'])).toBe(
+      'Lien: you changed src/foo.ts — associated tests: src/foo.test.ts. Run them before completing.',
+    );
+  });
+
+  it('lists up to MAX_TESTS_LISTED tests inline', () => {
+    expect(formatTestReminder('src/foo.ts', ['a.test.ts', 'b.test.ts'])).toBe(
+      'Lien: you changed src/foo.ts — associated tests: a.test.ts, b.test.ts. Run them before completing.',
+    );
+  });
+
+  it('truncates extras with a (+N more) suffix', () => {
+    expect(
+      formatTestReminder('src/foo.ts', ['a.test.ts', 'b.test.ts', 'c.test.ts', 'd.test.ts']),
+    ).toBe(
+      'Lien: you changed src/foo.ts — associated tests: a.test.ts, b.test.ts (+2 more). Run them before completing.',
     );
   });
 });
@@ -284,5 +322,91 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
     const printed = logSpy.mock.calls[0][0] as string;
     expect(printed.split('\n')[0]).toBe(`Lien impact for ${target}:`);
     expect(printed).not.toContain('avoid adding complexity');
+  });
+});
+
+describe('annotateCommand — --tests-only (integration)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  // Same stable target as the plan-time-nudge block above.
+  const target = 'packages/cli/src/cli/index.ts';
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // Earlier describe blocks in this file also exercise the real
+    // `findDependents` (via the full, non-`testsOnly` path) without clearing
+    // it themselves, so its call history can carry calls made before this
+    // block ever runs. Reset here — not just in `afterEach` — so the first
+    // test in this block starts from a clean slate too.
+    vi.mocked(dependencyAnalyzerModule.findDependents).mockClear();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    vi.mocked(coreModule.createVectorDB).mockClear();
+    vi.mocked(dependencyAnalyzerModule.findDependents).mockClear();
+  });
+
+  it('prints the reminder line when a test imports the target file', async () => {
+    const testChunk = {
+      content: '',
+      metadata: {
+        file: 'packages/cli/src/cli/index.test.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'itWorks',
+        symbolType: 'function',
+        imports: [target],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      scanAll: vi.fn().mockResolvedValue([testChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCommand(target, { testsOnly: true });
+
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toBe(
+      `Lien: you changed ${target} — associated tests: packages/cli/src/cli/index.test.ts. Run them before completing.`,
+    );
+    // The whole point of --tests-only: skip findDependents's BFS entirely.
+    expect(dependencyAnalyzerModule.findDependents).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the target file has no associated tests', async () => {
+    const unrelatedChunk = {
+      content: '',
+      metadata: {
+        file: 'packages/cli/src/cli/index.test.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'itWorks',
+        symbolType: 'function',
+        imports: ['some/other/file.ts'],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      scanAll: vi.fn().mockResolvedValue([unrelatedChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCommand(target, { testsOnly: true });
+
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(dependencyAnalyzerModule.findDependents).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -22,6 +22,17 @@ import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/p
 const MAX_TESTS_LISTED = 2;
 const MAX_DEPS_LISTED = 4;
 
+export interface AnnotateOptions {
+  /**
+   * Skip the full impact summary (dependents/complexity/BFS) and print only
+   * the test-association reminder line, or nothing if the file has no
+   * associated tests. Used by the post-edit `test-reminder.sh` hook, which
+   * only needs test-association data, not the full read-time annotation —
+   * see `runTestsOnly`.
+   */
+  testsOnly?: boolean;
+}
+
 /**
  * Produce a short impact summary for a single file. Output is empty when
  * impact is trivial (no dependents, no complexity warnings, test coverage
@@ -31,12 +42,16 @@ const MAX_DEPS_LISTED = 4;
  * `get_files_context`'s `complexityHeadroomWarning`) — the plan-time nudge:
  * surfacing it on Read, before the agent edits, not after via `lien delta`.
  *
+ * With `options.testsOnly`, skips all of the above and prints only the
+ * post-edit test-association reminder (or nothing, if the file has no
+ * associated tests) — see `runTestsOnly`.
+ *
  * All errors result in empty stdout and exit 0, so a missing index or
  * unknown file never breaks the hook pipeline.
  */
-export async function annotateCommand(file: string): Promise<void> {
+export async function annotateCommand(file: string, options?: AnnotateOptions): Promise<void> {
   try {
-    await run(file);
+    await run(file, options);
   } catch {
     // Silent — never break the consuming hook.
   }
@@ -118,9 +133,15 @@ function adaptChunkImports(chunks: DependencyAnalysisChunk[]): CodeChunk[] {
 // signature honest without leaking the SearchResult import here.
 type DependencyAnalysisChunk = Awaited<ReturnType<typeof findDependents>>['allChunks'][number];
 
-async function run(file: string): Promise<void> {
+async function run(file: string, options?: AnnotateOptions): Promise<void> {
   const paths = resolvePaths(file);
   if (!paths) return;
+
+  if (options?.testsOnly) {
+    await runTestsOnly(paths);
+    return;
+  }
+
   const { originalCwd, rootDir, filepath } = paths;
 
   // Align cwd with the project root for the analysis pass. Lien's
@@ -198,6 +219,45 @@ async function run(file: string): Promise<void> {
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
+}
+
+/**
+ * The cheap path for the post-edit `test-reminder.sh` hook: test-association
+ * lookup only, skipping `findDependents`'s BFS over the import graph and the
+ * complexity/blast-radius computation the full annotation needs. A single
+ * `vectorDB.scanAll()` (the same column-projected full-table read
+ * `get_files_context` uses for its own test-association scan) is all this
+ * needs — reusing the index's existing knowledge, no new analysis.
+ *
+ * Prints nothing when the file has no associated tests (the signal for the
+ * hook to stay silent).
+ */
+async function runTestsOnly(paths: ResolvedPaths): Promise<void> {
+  const { originalCwd, rootDir, filepath } = paths;
+  const needsChdir = originalCwd !== rootDir;
+  if (needsChdir) process.chdir(rootDir);
+  try {
+    const vectorDB = await createVectorDB(rootDir);
+    await vectorDB.initialize();
+    const allChunks = adaptChunkImports(await vectorDB.scanAll());
+    const tests =
+      findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
+    if (tests.length === 0) return;
+    console.log(formatTestReminder(filepath, tests));
+  } finally {
+    if (needsChdir) process.chdir(originalCwd);
+  }
+}
+
+/**
+ * Render the one-line post-edit reminder. Pure and exported so the wording
+ * and truncation are unit-testable without indexing a real project.
+ */
+export function formatTestReminder(filepath: string, tests: string[]): string {
+  const shown = tests.slice(0, MAX_TESTS_LISTED).join(', ');
+  const extra =
+    tests.length > MAX_TESTS_LISTED ? ` (+${tests.length - MAX_TESTS_LISTED} more)` : '';
+  return `Lien: you changed ${filepath} — associated tests: ${shown}${extra}. Run them before completing.`;
 }
 
 /** Return type of `computeComplexityHeadroom` — the plan-time nudge data. */

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -140,6 +140,10 @@ program
 program
   .command('annotate <file>')
   .description('Print a short impact summary for a single file (for hook annotation)')
+  .option(
+    '--tests-only',
+    'Print only the post-edit test-association reminder line (for the write hook)',
+  )
   .action(annotateCommand);
 
 program

--- a/packages/site/docs/guide/claude-code-plugin.md
+++ b/packages/site/docs/guide/claude-code-plugin.md
@@ -1,10 +1,11 @@
 # Claude Code Plugin
 
-Installing Lien as a Claude Code plugin gets you more than an MCP config. Two
-`PostToolUse` hooks push structural context and complexity accounting into the
-agent's next turn automatically — after a read, before a commit — without the
-agent having to ask, and without depending on it remembering to. This page
-covers what ships and what each hook actually does.
+Installing Lien as a Claude Code plugin gets you more than an MCP config.
+Three `PostToolUse` hooks push structural context, complexity accounting, and
+test reminders into the agent's next turn automatically — after a read, after
+a write, before a commit — without the agent having to ask, and without
+depending on it remembering to. This page covers what ships and what each
+hook actually does.
 
 ## Install
 
@@ -119,6 +120,26 @@ flagged ("resolved after flag" — an honest presence/absence signal, not proof
 the warning caused the fix). Disable recording entirely with
 `LIEN_DELTA_EVENTS=off`.
 
+### The test reminder — close the loop after you write
+
+`test-reminder.sh` also fires on `PostToolUse:Edit|Write|MultiEdit`, alongside
+the write gate. It runs `lien annotate <path> --tests-only` — a cheap
+test-association-only lookup against the existing index, no dependency-graph
+walk — and, when the file you just changed has associated tests, injects one
+compact `additionalContext` line naming them:
+
+```
+Lien: you changed packages/review/src/github-api.ts — associated tests: packages/review/test/github-api.test.ts. Run them before completing.
+```
+
+This closes the read → write → verify loop: the read hook shows you test
+coverage before you edit, and this one reminds you to actually run those tests
+after — the step agents most often skip once the diff looks done. It stays
+silent when the file has no known test associations, and shares the read
+hook's per-file-per-session TTL suppression so an edit burst on one file only
+reminds once per window (default 5 minutes, `LIEN_ANNOTATE_TTL_MIN`). Disable
+with `LIEN_TEST_REMINDER=off`.
+
 ### Explore-agent nudge
 
 A third hook (`PreToolUse:Agent|Task`) appends a short Lien-tool mandate to the
@@ -135,10 +156,11 @@ Claude Code's built-in `Explore` subagent (or one installed the legacy way via
 A rule written into `CLAUDE.md` only helps if the agent remembers to follow
 it, and that gets less reliable as a session's context fills up. A
 `PostToolUse` hook fires deterministically on every matching tool call,
-regardless of what's still in context. Lien's own `CLAUDE.md` notes that this
-hook pair automates two of its own MANDATORY policies — checking file context
-before an edit, and running `lien delta` before a commit — which is also why
-the plugin runs on Lien's own development, not just its users' repos.
+regardless of what's still in context. Lien's own `CLAUDE.md` notes that these
+hooks automate three of its own MANDATORY policies — checking file context
+before an edit, running the associated tests after a change, and running
+`lien delta` before a commit — which is also why the plugin runs on Lien's
+own development, not just its users' repos.
 
 ## Configuration
 
@@ -147,8 +169,9 @@ internal error exits silently rather than blocking your tool call.
 
 | Env var | Effect |
 |---|---|
-| `LIEN_ANNOTATE_TTL_MIN` | Read-hook suppression window in minutes (default 5) |
+| `LIEN_ANNOTATE_TTL_MIN` | Read-hook and test-reminder suppression window in minutes (default 5) |
 | `LIEN_DELTA_HOOK=off` | Disables the write-time complexity gate |
+| `LIEN_TEST_REMINDER=off` | Disables the post-edit test-association reminder |
 | `LIEN_DELTA_EVENTS=off` | Disables local `lien delta` event recording (used by `lien stats`) |
 | `LIEN_EXPLORE_INJECT=off` | Disables the Explore-agent prompt nudge |
 

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -10,7 +10,7 @@ If you're developing Lien itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md#do
 
 ## Hooks
 
-`hooks/hooks.json` wires five scripts into the Claude Code hook lifecycle. All
+`hooks/hooks.json` wires six scripts into the Claude Code hook lifecycle. All
 are best-effort — a missing `lien`/`jq`, an unindexed repo, or any internal
 error just exits 0 silently, never blocking the underlying tool call. See
 [claude-code-hook-channels.md](../../docs/architecture/claude-code-hook-channels.md)
@@ -20,6 +20,7 @@ for which hook output channels actually reach the model.
 | --- | --- | --- | --- |
 | `annotate-read.sh` | PostToolUse: `Read` | Surfaces dependents/coverage/complexity for the file just read, as an `additionalContext` annotation. When a function in the file is at/near its complexity budget, the annotation *leads* with an imperative nudge line ("avoid adding complexity here; prefer extraction") — the plan-time nudge, surfaced before the agent edits rather than after via `delta-write.sh`. Suppressed per file per session within a TTL. | `LIEN_ANNOTATE_TTL_MIN=<minutes>` (default 5) |
 | `delta-write.sh` | PostToolUse: `Edit\|Write\|MultiEdit` | Runs `lien delta --file <path> --format json`; warns only when the edit pushed a function to a new complexity-threshold crossing. Silent on everything else (improvements, pre-existing violations, advisory movement). | `LIEN_DELTA_HOOK=off` |
+| `test-reminder.sh` | PostToolUse: `Edit\|Write\|MultiEdit` | Runs `lien annotate <path> --tests-only` (a cheap test-association-only lookup); when the edited file has associated tests, emits one compact `additionalContext` line naming them and asking the model to run them before completing. Silent when the file has no known tests. Shares `annotate-read.sh`'s per-file-per-session TTL suppression (same `annotated-sessions/` dir, namespaced hash) so an edit burst only reminds once per window. | `LIEN_TEST_REMINDER=off` |
 | `augment-explore-task.sh` | PreToolUse: `Agent\|Task` | When the subagent being launched is `Explore` (or `lien:Explore`/`project:Explore`), appends a Lien-tool-usage mandate to its prompt. Skips if the repo has no `structural.db` index yet, or the prompt already names a Lien MCP tool. | `LIEN_EXPLORE_INJECT=off` |
 | `annotate-clean.sh` | SessionStart | GCs `annotated-sessions/` dirs untouched for >24h; pre-warms the npx fallback in the background so the first real hook call of the session doesn't pay a cold `npx` install. | none |
 | `annotate-end.sh` | SessionEnd | Removes the current session's `annotated-sessions/` dir on graceful exit. Belt-and-braces — SessionStart's 24h GC is the load-bearing cleanup (covers crashes/force-quits). | none |

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Plus a write-time delta warning: after an Edit/Write, flags any function whose complexity newly crossed a threshold. Suppresses repeats per session for 5 minutes.",
+  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Plus write-time hooks: a delta warning (a function whose complexity newly crossed a threshold) and a test-association reminder (which tests to run). Suppresses repeats per session for 5 minutes.",
   "hooks": {
     "PreToolUse": [
       {
@@ -30,6 +30,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/delta-write.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/test-reminder.sh",
             "timeout": 5000
           }
         ]

--- a/plugins/claude/hooks/test-reminder.sh
+++ b/plugins/claude/hooks/test-reminder.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Edit|Write|MultiEdit: after an edit, remind the model
+# which test files are associated with the file it just changed. Closes the
+# read -> write -> verify loop the way `annotate-read.sh`'s plan-time nudge
+# (#772) closed read -> write: CLAUDE.md mandates checking `testAssociations`
+# and running those tests after a change, but nothing nudged it before this.
+#
+# Deliberately a sibling script, not folded into `delta-write.sh` — that
+# script's whole job is the complexity-delta gate; this one's is test
+# association. Both are separate hook entries on the same
+# `Edit|Write|MultiEdit` matcher in hooks.json and run independently.
+#
+# Uses `lien annotate <file> --tests-only`, the cheap test-association-only
+# path (a single `vectorDB.scanAll()`, no dependency-graph BFS) — see
+# `runTestsOnly` in annotate-cmd.ts. Silent when the file has no associated
+# tests. TTL-suppressed per file per session (same touchfile pattern and
+# `annotated-sessions/` directory as `annotate-read.sh`, so the existing
+# SessionStart/SessionEnd GC covers this too) so an edit burst on one file
+# only reminds once per window.
+#
+# Best-effort throughout — never fails the user's edit. Disable via
+# LIEN_TEST_REMINDER=off.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
+
+# Env kill switch.
+if [ "${LIEN_TEST_REMINDER:-}" = "off" ]; then
+  exit 0
+fi
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+case "$tool_name" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+[ -n "$file_path" ] || exit 0
+[ -n "$session_id" ] || exit 0
+
+# Defensive: session_id will be embedded in a filesystem path. Reject anything
+# outside [A-Za-z0-9_-] so a crafted value can't traverse out of the
+# session dir (same hardening as annotate-read.sh / annotate-end.sh).
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) exit 0;;
+esac
+
+# Resolve store from the session's cwd so multi-repo setups work correctly.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  store="$(cd "$cwd" && "${LIEN_CMD[@]}" path --store 2>/dev/null)"
+else
+  store="$("${LIEN_CMD[@]}" path --store 2>/dev/null)"
+fi
+# Gate on a real index existing, not just a resolvable store path — the
+# same "is this repo indexed?" signal augment-explore-task.sh uses.
+[ -n "$store" ] && [ -f "$store/structural.db" ] || exit 0
+
+# Per-session, per-file suppression, sharing annotate-read.sh's
+# `annotated-sessions/` directory (and therefore its SessionStart/SessionEnd
+# GC) but namespaced with a "test-reminder:" prefix before hashing, so this
+# hook's touchfile never collides with annotate-read.sh's own suppression
+# state for the same file.
+ttl_min="${LIEN_ANNOTATE_TTL_MIN:-5}"
+case "$ttl_min" in
+  ''|*[!0-9]*) ttl_min=5;;
+esac
+hash="$(printf '%s' "test-reminder:$file_path" | md5sum 2>/dev/null | awk '{print substr($1,1,8)}')"
+if [ -z "$hash" ]; then
+  hash="$(printf '%s' "test-reminder:$file_path" | md5 2>/dev/null | awk '{print substr($NF,1,8)}')"
+fi
+[ -n "$hash" ] || exit 0
+
+session_dir="$store/annotated-sessions/$session_id"
+touchfile="$session_dir/$hash"
+if [ -f "$touchfile" ]; then
+  if find "$touchfile" -mmin -"$ttl_min" 2>/dev/null | grep -q .; then
+    # Within TTL — already reminded for this file recently. Stay silent.
+    [ -d "$session_dir" ] && touch "$session_dir" 2>/dev/null
+    exit 0
+  fi
+fi
+
+# Invoke from cwd so resolveProjectRoot works under subdirectory cwds.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  reminder="$(cd "$cwd" && "${LIEN_CMD[@]}" annotate "$file_path" --tests-only 2>/dev/null)"
+else
+  reminder="$("${LIEN_CMD[@]}" annotate "$file_path" --tests-only 2>/dev/null)"
+fi
+
+# No associated tests → `lien annotate --tests-only` prints nothing → stay
+# silent (and don't mark the touchfile — nothing to suppress next time).
+[ -n "$reminder" ] || exit 0
+
+mkdir -p "$session_dir" 2>/dev/null || exit 0
+: > "$touchfile"
+touch "$session_dir" 2>/dev/null
+
+# additionalContext is the channel that actually reaches the model on the
+# next turn (verified in CC 2.1.142; matches annotate-read.sh/delta-write.sh).
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' \
+  "$(printf '%s' "$reminder" | jq -Rs .)"
+
+exit 0


### PR DESCRIPTION
## Why

CLAUDE.md mandates checking `testAssociations` and running those tests after changes — but nothing nudged it. The write hook only ran the delta gate, so the "verify" step of read → write → verify relied entirely on the agent remembering. #772 closed read → write with the plan-time nudge; this closes write → verify.

## What shipped

- **`lien annotate --tests-only`**: prints exactly one compact line — `Lien: you changed <file> — associated tests: <tests>. Run them before completing.` — or nothing when the file has no associated tests. It's the cheap path: a single `vectorDB.scanAll()` (the same column-projected full-table read `get_files_context` uses for its own test-association scan) feeding the existing `findTestAssociationsFromChunks`, skipping the full annotation's `findDependents` BFS and complexity analysis entirely. No new analysis — the index already knew this.
- **`test-reminder.sh`**: new plugin hook on `PostToolUse:Edit|Write|MultiEdit`. A *sibling* of `delta-write.sh` rather than an extension of it — that script's whole job is the complexity-delta gate, this one's is test association; hooks.json gains one appended matcher block (minimal diff, merges cleanly if another in-flight PR touches the matchers). Emits via `additionalContext` (the one channel verified to reach the model), gated on `structural.db` existing, fail-open throughout (any failure exits 0 silently — never blocks the edit). Kill switch: `LIEN_TEST_REMINDER=off`.
- **TTL suppression**: same touchfile pattern as `annotate-read.sh`, sharing its `annotated-sessions/<session_id>/` directory (so SessionStart/SessionEnd GC covers it for free) but hashing a `test-reminder:`-prefixed key so the two hooks' suppression state never collides for the same file.
- Docs: `plugins/claude/README.md` hook table row, site `claude-code-plugin.md` section + env-var table, CLAUDE.md monorepo note ("automate three" — doc-truth).

## Dogfood (this repo, real stdin shape, verbatim)

**1. First edit on a file with a test association** (`packages/review/src/github-api.ts`):

```
$ echo "$PAYLOAD" | bash plugins/claude/hooks/test-reminder.sh
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Lien: you changed packages/review/src/github-api.ts — associated tests: packages/review/test/github-api.test.ts. Run them before completing."}}
exit=0
```

**2. Edit burst, same file + session, within TTL** (three invocations back-to-back):

```
=== Capture 2a: first edit in burst (should emit) ===
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Lien: you changed packages/review/src/github-api.ts — associated tests: packages/review/test/github-api.test.ts. Run them before completing."}}
exit=0

=== Capture 2b: second edit, same file+session, within TTL (should be silent) ===
output=[]
exit=0

=== Capture 2c: third edit, same file+session, within TTL (should be silent) ===
output=[]
exit=0
```

**3. File with no test associations** (`packages/cli/src/cli/index.ts`):

```
=== Capture 3: edit on a file with NO test associations (should be silent) ===
output=[]
exit=0
```

Also verified: `LIEN_TEST_REMINDER=off` → silent exit 0; `delta-write.sh` runs unaffected on the same payload.

## Test plan

- [x] `formatTestReminder` unit tests (template, MAX_TESTS_LISTED truncation, `(+N more)` suffix)
- [x] `annotateCommand({ testsOnly: true })` integration: emits the reminder when a test chunk imports the target; silent when none does; asserts `findDependents` is **never called** on this path (the point of the cheap path)
- [x] Hook behavior verified by simulation with the real PostToolUse stdin shape (captures above)

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `npm test` (all 6 packages) / `npm run docs:build` (site changed) / `lien delta` exit 0 (only advisory movement: `run` cognitive 4→5, two small new functions well under threshold) — all green locally, re-verified after rebasing onto `origin/main` (#788 touched `get-files-context.ts`, which annotate-cmd imports from).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a post-edit test-association reminder via a new `--tests-only` path in `lien annotate` and a companion `test-reminder.sh` Claude Code hook. The implementation is deliberately cheap and fail-open: it reuses the existing `vectorDB.scanAll()` + `findTestAssociationsFromChunks` pipeline, skips the dependency-graph BFS, and silently exits on any error or when no tests are associated. The CLI option, TypeScript options interface, formatting helper, and hook wiring are consistent with the described behavior, and the new code is covered by unit and integration tests.
>
> - Added `AnnotateOptions.testsOnly` and `runTestsOnly` fast path to `annotate-cmd.ts`
> - Added `formatTestReminder` with `MAX_TESTS_LISTED = 2` truncation
> - Exposed `--tests-only` on the `lien annotate` CLI command
> - Added `plugins/claude/hooks/test-reminder.sh` and registered it in `hooks.json`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 239c93a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->