### PR TITLE
test(review): re-scope pr658 canary — Finding A to tracked characterization

### DIFF
--- a/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
@@ -8,7 +8,8 @@
  * asserted "user-facing docs were updated consistently". CodeRabbit's
  * review on the same PR caught two real findings that Lien Review missed:
  *
- * Finding A (asserted below, Tier 1 + Tier 2):
+ * Finding A (documented below; TRACKED CHARACTERIZATION as of 2026-07-16,
+ * see "OWNER RE-SCOPE DECISION" — no longer part of the certified gate):
  *   `packages/core/src/config/schema.ts:62`, the `embeddings.enabled` doc
  *   comment. The diff mechanically renamed the identifier in place:
  *     - "...keep working; semantic_search and find_similar report as disabled."
@@ -35,7 +36,8 @@
  *   catching this finding via doc-truth.) Corroborating GitHub
  *   thread: https://github.com/getlien/lien/pull/658#discussion_r3522630327
  *
- * Finding B (asserted below, Tier 2 — promoted 2026-07-04, see below):
+ * Finding B (asserted below, Tier 2 — promoted 2026-07-04, see below; still
+ * the CERTIFIED signal after the 2026-07-16 re-scope):
  *   `plugins/claude/hooks/augment-explore-task.sh:64` described
  *   `search_code` as "REQUIRED for meaning-based discovery" — the tool is
  *   keyword/BM25 search, not meaning-based, so the hook's own guidance
@@ -138,6 +140,125 @@
  * forced-turn/length degenerate-loop truncation shape (#787's target) and 1
  * Finding-A omission. #787 fixed the truncation shape; the Finding-A
  * omission remains the blocker.
+ *
+ * ---------------------------------------------------------------------
+ * OWNER RE-SCOPE DECISION (2026-07-16, post-PR-#792 screen; see PR #792
+ * body for the full 11-canary triage table this decision is drawn from):
+ *
+ * PR #792's 3-vote screen of this fixture measured 1/3 post-#787. Both
+ * misses are healthy, non-degenerate runs: doc-truth fires, produces 5 real
+ * findings, and Finding B (augment-explore-task.sh) is among them every
+ * time — but Finding A (schema.ts `embeddings.enabled`) is consistently
+ * absent from the model's findings list. This is the doc-truth arc's
+ * documented output-economy/omission frontier (see
+ * docs/development/review-harness-judgment.md, "The deterministic-signal
+ * pattern — and its limit": pre-computing the question and the answer isn't
+ * enough when a finding must still WIN a competition for a scarce findings
+ * slot; proven architecture-level by the Sonnet/Kimi model-swap in the
+ * gap-analysis campaign). This PR's diff touches 5+ doc surfaces that all
+ * restate the same rename-staleness theme; Finding A is real but is
+ * consistently the one that loses that competition inside the dedicated
+ * doc-truth pass itself — recurring even with rule competition removed,
+ * which makes it an architectural limit of the current single-pass
+ * findings list, not flakiness or a budget/prompt bug to chase further.
+ *
+ * Options considered:
+ *   1. Keep grinding the doc-truth prompt/coverage to force Finding A's
+ *      recall up. Rejected — this is the documented frontier, not a
+ *      reachability or budget bug; #787 already fixed the one budget-shaped
+ *      failure mode this fixture had. Further prompt tuning here would be
+ *      re-litigating a closed finding per the judgment guide's golden rules.
+ *   2. Tag the whole fixture `characterization` (non-gating). Rejected —
+ *      the harness's only non-gating mechanism is whole-fixture (see
+ *      run.ts: `passed = characterization || …`), which would also stop
+ *      gating on Finding B and "doc-truth fired at all" — throwing away the
+ *      one signal this pipeline DOES reliably deliver on this diff.
+ *   3. [DECISION] Split the gate: keep this fixture tagged `canary` and
+ *      CERTIFY on what the pipeline reliably does — doc-truth fires
+ *      (Tier 1, unchanged) AND Finding B is present, correctly framed as a
+ *      falsification rather than a vacuous mention (Tier 2, below). Finding
+ *      A becomes a TRACKED CHARACTERIZATION EXPECTATION: visible in this
+ *      header with a dated measured rate, but it no longer executes as a
+ *      pass/fail check and never gates the vote. The harness has no
+ *      per-check soft-probe primitive (only the fixture-level
+ *      `characterization` tag, ruled out above as too coarse) — inventing
+ *      one for a single fixture isn't warranted, so the honest
+ *      implementation is: the code simply doesn't check Finding A anymore,
+ *      and this comment is the record.
+ *
+ * Finding A's history, reconciled: it was part of the original 10/10
+ * cert (2026-07-04, see above) and survived the 2026-07-16 keyword-integrity
+ * sweep's re-verification — but both of those measurements ran against a
+ * keyword list broad enough that Finding A's Tier-2 check could pass
+ * without Finding A itself firing (the 4/10 runs, and the coattail-riding
+ * on Finding B's vocabulary, documented above and in the #784 PR body).
+ * After #784 tightened Finding A to the schema.ts file anchor specifically,
+ * NO fresh paid calibration ran against that tightened check before today
+ * — the 2026-07-16 screen above is the first real signal on it, and it's
+ * poor (0/3 pre-#787, 1/3 post-#787). Re-reading the post-#787 traces
+ * directly (`.wip/traces/2026-07-16T08-49-48Z-pr658-search-code-rename/`)
+ * for this PR: the one pass (vote 3) didn't even surface Finding A as its
+ * own finding — it appears only inside the *evidence* field of a different
+ * finding (the `find_similar` semantic-claim finding at
+ * packages/site/docs/guide/mcp-tools.md:103, whose evidence cites
+ * "schema.ts:60 comment groups search_code and find_similar as reporting
+ * disabled when the embedding worker is disabled"). So Finding A's true
+ * measured rate, on the tightened check, across the only 3 votes ever run
+ * against it, is best read as 1/3 (and that 1 a piggyback, not a dedicated
+ * finding) — consistent with "may never have been truly pinned" rather than
+ * a regression from a previously-solid 10/10.
+ *
+ * Follow-up: doc-truth v2 per-claim judgment (a dedicated per-claim
+ * verification step, rather than one shared findings list competing across
+ * every doc claim on the diff) is the structural fix for this class of
+ * omission — see the two-pass architecture note in
+ * docs/development/review-harness-judgment.md for the precedent ("if you
+ * add a rule that keeps losing the findings competition, this is the
+ * precedent to reach for — but only after proving competition is the
+ * bottleneck", which PR #792's screen now does for Finding A specifically).
+ * When that per-claim pass exists, re-add Finding A to this fixture's
+ * certified Tier 2 gate.
+ *
+ * Reference only — Finding A's last-known (pre-2026-07-16) keyword list,
+ * kept here so doc-truth v2's per-claim pass has a ready-made check to
+ * restore rather than re-deriving it from scratch:
+ *   ['schema.ts', 'embeddings.enabled', 'report as disabled',
+ *    'reports as disabled', 'disabled when embeddings',
+ *    'does not depend on embeddings', "doesn't depend on embeddings"]
+ *
+ * Finding B tightened alongside this re-scope (2026-07-16): now the SOLE
+ * certified Tier-2 signal, so its previously-documented stance-blind
+ * residual (matches a finding that *agrees* "meaning-based" framing is fine,
+ * not just one that falsifies it — flagged but explicitly left unfixed by
+ * the #784 sweep's minimal-diff scope) had to close rather than ride on
+ * Finding A's now-removed backstop. Added a second, AND'd
+ * `expectFindingMentions` requiring the correction/mechanism side of the
+ * claim (`lexical` / `bm25` / `no embeddings` / `not meaning-based` / `not
+ * semantic`) alongside the existing claim-naming keywords. Verified via the
+ * four-verdict offline smoke test below: the same defensive-conclusion
+ * distractor that exposed the residual still lacks these correction terms
+ * and now correctly fails Tier 2, while all 3 real post-#787 votes' Finding
+ * B wording ("performs lexical BM25 keyword search... not meaning-based")
+ * satisfies both keyword lists.
+ *
+ * FOUR-VERDICT SMOKE TEST (assert-cli.ts, zero LLM spend, 2026-07-16):
+ *   1. Perfect verdict (real vote 3 from the post-#787 screen trace, 9
+ *      findings incl. both Finding A's substance and Finding B) -> PASS.
+ *   2. Empty verdict (no findings) -> FAIL (Tier 1: doc-truth didn't fire).
+ *   3. Plausible-but-wrong distractor (reconstructed from this header's own
+ *      description above: augment-explore-task.sh:64, doc-truth category,
+ *      reaches the defensive "fine, just incomplete" conclusion, no
+ *      schema.ts anchor, no correction/mechanism wording) -> FAIL (Tier 2:
+ *      claim-naming keyword list has no anchor to fall back on now that
+ *      Finding A isn't checked, and the correction-phrase list catches the
+ *      stance-blind gap).
+ *   4. B-only verdict (real vote 1 from the post-#787 screen trace — 5
+ *      findings incl. Finding B, Finding A genuinely absent — the currently
+ *      common real shape per PR #792's screen) -> PASS. This is the point of
+ *      the re-scope: a vote the OLD assertion rejected now certifies,
+ *      because it correctly reflects what doc-truth reliably delivers on
+ *      this diff.
+ *   Verbatim assert-cli.ts output for all four in the PR body.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -148,37 +269,40 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
-    // Kept to the specific file anchor and compound phrases naming the
-    // EXACT false claim ("reports as disabled") or its correction — not bare
-    // 'embeddings' / 'search_code' / 'find_similar' / 'lexical' / 'bm25' /
-    // 'full-text' / 'stale' / 'no longer', each of which is central
-    // vocabulary for this entire 40-file rename PR and would be satisfied by
-    // an unrelated finding merely discussing the same rename theme (verified
-    // via assert-cli.ts: a distractor about augment-explore-task.sh's
-    // "meaning-based" line — reaching the WRONG, defensive conclusion that
-    // the guidance is fine — false-passed the original list purely via
-    // 'search_code'; it has no 'schema.ts'/'embeddings.enabled' anchor and
-    // correctly fails against this one).
+    // CERTIFIED Tier 2 (owner decision 2026-07-16 — see header "OWNER
+    // RE-SCOPE DECISION"): Finding B (augment-explore-task.sh:64) is what
+    // this pipeline reliably delivers post-#787; Finding A (schema.ts) is
+    // now a tracked characterization expectation documented above, not a
+    // pass/fail check. Two AND'd checks operationalize "a substantive,
+    // correctly-framed Finding B" rather than a vacuous keyword hit:
+    //   - the claim itself is named ("meaning-based")
+    //   - the correction/mechanism is named too (lexical/BM25/no
+    //     embeddings/"not meaning-based") — closing the stance-blind
+    //     residual the #784 sweep flagged but left unfixed, now required
+    //     since this is the sole certified Tier-2 signal.
+    // Together with Tier 1 (doc-truth fired, ruling out empty/degenerate
+    // runs), this pair is what "substantive findings" means for this gate.
+    h.expectFindingMentions(['meaning-based', 'meaning based'], result);
     h.expectFindingMentions(
       [
-        'schema.ts',
-        'embeddings.enabled',
-        'report as disabled',
-        'reports as disabled',
-        'disabled when embeddings',
-        'does not depend on embeddings',
-        "doesn't depend on embeddings",
+        'lexical',
+        'bm25',
+        'no embeddings',
+        'not meaning-based',
+        'not meaning based',
+        'not semantic',
       ],
       result,
     );
-    // Finding B — plugins/claude/hooks/augment-explore-task.sh:64 calling
-    // search_code "meaning-based" when it's lexical BM25. Promoted from
-    // documented-but-unasserted on 2026-07-04: build-prompts.ts confirmed the
-    // guidance_surface_changes passthrough (#665) now carries this hunk into
-    // the prompt, and 9/10 votes in the promotion calibrate-10 independently
-    // reproduced the claim, all quoting "meaning-based" verbatim. See the
-    // header comment's "Finding B" section for the full evidence chain.
-    h.expectFindingMentions(['meaning-based', 'meaning based'], result);
+    // Finding A (schema.ts `embeddings.enabled` stale claim) — TRACKED
+    // CHARACTERIZATION, NON-GATING as of 2026-07-16. See header for the
+    // measured rate (best-read 1/3, and that 1 a piggyback, not a
+    // dedicated finding) and the doc-truth-v2 follow-up that returns this
+    // to the certified gate. The harness has no per-check soft-probe
+    // primitive (only the whole-fixture `characterization` tag, which
+    // would also un-gate Finding B above) — the honest structure per the
+    // owner decision is that this check simply no longer runs; this
+    // comment plus the header are the record, not new harness machinery.
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts
@@ -231,15 +231,36 @@
  * residual (matches a finding that *agrees* "meaning-based" framing is fine,
  * not just one that falsifies it — flagged but explicitly left unfixed by
  * the #784 sweep's minimal-diff scope) had to close rather than ride on
- * Finding A's now-removed backstop. Added a second, AND'd
- * `expectFindingMentions` requiring the correction/mechanism side of the
- * claim (`lexical` / `bm25` / `no embeddings` / `not meaning-based` / `not
- * semantic`) alongside the existing claim-naming keywords. Verified via the
- * four-verdict offline smoke test below: the same defensive-conclusion
- * distractor that exposed the residual still lacks these correction terms
- * and now correctly fails Tier 2, while all 3 real post-#787 votes' Finding
- * B wording ("performs lexical BM25 keyword search... not meaning-based")
- * satisfies both keyword lists.
+ * Finding A's now-removed backstop. Requires a SINGLE finding to name both
+ * the claim ("meaning-based") and its correction/mechanism (`lexical` /
+ * `bm25` / `no embeddings` / `not meaning-based` / `not semantic`).
+ *
+ * FIRST DRAFT BUG (caught by CodeRabbit on this PR's own review, PR #794):
+ * the initial implementation used two separate `expectFindingMentions`
+ * calls for the claim and correction keyword lists. `expectFindingMentions`
+ * flattens every finding's text into one haystack before matching, so two
+ * separate calls check "the claim appears somewhere across all findings"
+ * AND "a correction term appears somewhere across all findings" —
+ * independently, not within the same finding. On this all-about-lexical-
+ * search rename PR, almost any multi-finding result contains "lexical" or
+ * "bm25" *somewhere* for reasons unrelated to Finding B, so a distractor
+ * finding that only mentions "meaning-based" (the defensive, wrong-
+ * conclusion shape this exact residual is about) would still false-pass
+ * as long as any sibling finding used the word "lexical" — reintroducing
+ * the stance-blind gap this tightening was meant to close, just one level
+ * indirected. Fixed by checking both keyword lists against each finding's
+ * own text (`result.findings.some(f => ...)`) via a direct
+ * `HarnessAssertionError` throw, so both terms must land in the SAME
+ * finding.
+ *
+ * Verified via the four-verdict offline smoke test below, PLUS a fifth
+ * adversarial check added specifically to prove the CodeRabbit fix: the
+ * defensive-conclusion distractor finding (no correction terms) alongside
+ * a second, unrelated real finding that legitimately uses "lexical BM25" —
+ * correctly FAILS post-fix (would have false-passed under the two-call
+ * draft). All 3 real post-#787 votes' Finding B wording ("performs lexical
+ * BM25 keyword search... not meaning-based") names both the claim and its
+ * correction within that one finding, so the fix doesn't cost any recall.
  *
  * FOUR-VERDICT SMOKE TEST (assert-cli.ts, zero LLM spend, 2026-07-16):
  *   1. Perfect verdict (real vote 3 from the post-#787 screen trace, 9
@@ -249,19 +270,33 @@
  *      description above: augment-explore-task.sh:64, doc-truth category,
  *      reaches the defensive "fine, just incomplete" conclusion, no
  *      schema.ts anchor, no correction/mechanism wording) -> FAIL (Tier 2:
- *      claim-naming keyword list has no anchor to fall back on now that
- *      Finding A isn't checked, and the correction-phrase list catches the
- *      stance-blind gap).
+ *      no single finding names both the claim and its correction).
  *   4. B-only verdict (real vote 1 from the post-#787 screen trace — 5
  *      findings incl. Finding B, Finding A genuinely absent — the currently
  *      common real shape per PR #792's screen) -> PASS. This is the point of
  *      the re-scope: a vote the OLD assertion rejected now certifies,
  *      because it correctly reflects what doc-truth reliably delivers on
  *      this diff.
- *   Verbatim assert-cli.ts output for all four in the PR body.
+ *   5. Adversarial cross-finding check (post-CodeRabbit-fix only): verdict 3's
+ *      distractor PLUS a second, unrelated real finding mentioning "lexical
+ *      BM25" for a different reason -> FAIL. Confirms the per-finding fix
+ *      actually closes the cross-finding leakage, not just the single-
+ *      finding case verdict 3 already covered.
+ *   Verbatim assert-cli.ts output for all five in the PR body.
  */
 
+import { HarnessAssertionError } from '../../assertions.js';
 import type { FixtureAssertions } from '../../assertions.js';
+
+const FINDING_B_CLAIM_KEYWORDS = ['meaning-based', 'meaning based'];
+const FINDING_B_CORRECTION_KEYWORDS = [
+  'lexical',
+  'bm25',
+  'no embeddings',
+  'not meaning-based',
+  'not meaning based',
+  'not semantic',
+];
 
 const assertions: FixtureAssertions = {
   description:
@@ -273,27 +308,35 @@ const assertions: FixtureAssertions = {
     // RE-SCOPE DECISION"): Finding B (augment-explore-task.sh:64) is what
     // this pipeline reliably delivers post-#787; Finding A (schema.ts) is
     // now a tracked characterization expectation documented above, not a
-    // pass/fail check. Two AND'd checks operationalize "a substantive,
-    // correctly-framed Finding B" rather than a vacuous keyword hit:
-    //   - the claim itself is named ("meaning-based")
-    //   - the correction/mechanism is named too (lexical/BM25/no
-    //     embeddings/"not meaning-based") — closing the stance-blind
-    //     residual the #784 sweep flagged but left unfixed, now required
-    //     since this is the sole certified Tier-2 signal.
-    // Together with Tier 1 (doc-truth fired, ruling out empty/degenerate
-    // runs), this pair is what "substantive findings" means for this gate.
-    h.expectFindingMentions(['meaning-based', 'meaning based'], result);
-    h.expectFindingMentions(
-      [
-        'lexical',
-        'bm25',
-        'no embeddings',
-        'not meaning-based',
-        'not meaning based',
-        'not semantic',
-      ],
-      result,
-    );
+    // pass/fail check. Require a SINGLE finding to name both the claim
+    // ("meaning-based") AND its correction/mechanism (lexical/BM25/no
+    // embeddings/"not meaning-based") — closing the stance-blind residual
+    // the #784 sweep flagged but left unfixed, now required since this is
+    // the sole certified Tier-2 signal. Checked per-finding rather than via
+    // two separate `expectFindingMentions` calls: those flatten every
+    // finding's text into one haystack, so a distractor finding merely
+    // mentioning "meaning-based" plus an unrelated sibling finding
+    // mentioning "lexical" (near-guaranteed on this all-about-lexical-search
+    // rename PR) would false-pass — caught by CodeRabbit on this PR's own
+    // review, see PR #794. Together with Tier 1 (doc-truth fired, ruling
+    // out empty/degenerate runs), this is what "substantive findings" means
+    // for this gate.
+    const hasCorrectlyFramedFindingB = result.findings.some(f => {
+      const haystack = [f.message, f.suggestion ?? '', f.evidence ?? ''].join('\n').toLowerCase();
+      return (
+        FINDING_B_CLAIM_KEYWORDS.some(kw => haystack.includes(kw)) &&
+        FINDING_B_CORRECTION_KEYWORDS.some(kw => haystack.includes(kw))
+      );
+    });
+    if (!hasCorrectlyFramedFindingB) {
+      throw new HarnessAssertionError(
+        `Tier 2: expected a single finding to mention both the claim ` +
+          `(${FINDING_B_CLAIM_KEYWORDS.map(k => `"${k}"`).join(' or ')}) and its ` +
+          `correction/mechanism (${FINDING_B_CORRECTION_KEYWORDS.map(k => `"${k}"`).join(' or ')}) ` +
+          `— no single finding satisfied both. Findings: ${result.findings.length}.`,
+        2,
+      );
+    }
     // Finding A (schema.ts `embeddings.enabled` stale claim) — TRACKED
     // CHARACTERIZATION, NON-GATING as of 2026-07-16. See header for the
     // measured rate (best-read 1/3, and that 1 a piggyback, not a


### PR DESCRIPTION
## Summary

Owner-decided re-scope of the `doc-truth/pr658-search-code-rename` canary
(assertions file only). PR #792's 3-vote screen measured this canary at
1/3 post-#787: both misses are healthy, non-degenerate runs — doc-truth
fires, produces 5 real findings, and Finding B (`augment-explore-task.sh`)
is among them every time — but Finding A (`schema.ts` `embeddings.enabled`)
is consistently absent. This is the doc-truth arc's documented
output-economy/omission frontier (see
`docs/development/review-harness-judgment.md`, "The deterministic-signal
pattern — and its limit": pre-computing the question and the answer isn't
enough when a finding must still win a competition for a scarce findings
slot; proven architecturally by the Sonnet/Kimi model-swap in the
gap-analysis campaign). It recurs *inside* the dedicated doc-truth pass
itself (rule competition already removed) — an architectural limit, not
flakiness, and not something further prompt/coverage tuning should chase
(the one budget-shaped failure mode this fixture had was already fixed by
#787).

**Decision:** split the gate. Keep the fixture tagged `canary` and CERTIFY
on what the pipeline reliably delivers — doc-truth fires (Tier 1,
unchanged) AND Finding B is present, now required to be a *substantive,
correctly-framed* match rather than a vacuous keyword hit (Tier 2, see
below). Finding A becomes a **tracked characterization expectation**:
documented in the file header with a dated measured rate, but it no longer
executes as a pass/fail check and never gates the vote.

Options considered (full writeup in the file header's "OWNER RE-SCOPE
DECISION" section):
1. Keep tuning the doc-truth prompt/coverage — rejected, this is the
   documented frontier, not a reachability/budget bug.
2. Tag the whole fixture `characterization` — rejected, the harness's only
   non-gating mechanism is whole-fixture (`run.ts`: `passed = characterization
   || …`), which would also stop gating on Finding B and "doc-truth fired at
   all," throwing away the one signal this pipeline does reliably deliver.
3. **[chosen]** Split the gate as described above. The harness has no
   per-check soft-probe primitive, so no new harness machinery was added —
   Finding A's check simply no longer runs; the header is the record.

Reconciled Finding A's history: it was part of the original 10/10 cert
(2026-07-04), but that measurement (and the 2026-07-16 keyword-integrity
sweep's re-verification) both ran against a keyword list broad enough that
Finding A's Tier-2 check could pass without Finding A itself firing (4/10
of the original 10 runs never fired *either* schema.ts or its sibling
variant; the check passed anyway by riding Finding B's vocabulary). After
#784 tightened Finding A to the schema.ts anchor, no fresh paid calibration
ran against that tightened check until this week's screen — so Finding A's
honest measured rate is best read as ~1/3 (and even that one hit was a
piggyback inside a *different* finding's evidence field, not a dedicated
Finding-A finding — see re-score detail below), not a regression from a
previously-solid number.

**Follow-up:** doc-truth v2 (a dedicated per-claim verification step
instead of one shared findings list competing across every doc claim on
the diff) is the structural fix for this class of omission. When that
per-claim pass exists, Finding A returns to the certified gate. Its
last-known keyword list is preserved as a reference comment in the fixture
header so v2 doesn't have to re-derive it.

## Why Finding B also changed

Now that Finding B is the *sole* certified Tier-2 signal, its
previously-documented stance-blind residual (flagged but explicitly left
unfixed by the #784 minimal-diff sweep — it matches a finding that *agrees*
the "meaning-based" framing is fine, not just one that falsifies it) could
no longer ride on Finding A's now-removed backstop. Added a second, AND'd
`expectFindingMentions` requiring the correction/mechanism side of the claim
(`lexical` / `bm25` / `no embeddings` / `not meaning-based` / `not
semantic`) alongside the existing claim-naming keywords. Together with Tier
1 (doc-truth fired, ruling out empty/degenerate runs), this pair is what
"substantive findings" means for the certified gate now.

## Four-verdict smoke test (assert-cli.ts, zero LLM spend)

Verbatim `assert-cli.ts` output against the NEW assertion:

**1. Perfect verdict** (real vote 3 from the post-#787 screen trace — 9
findings, includes both Finding B and Finding A's substance) — **PASS**:
```
{"ok":true,"rule":"doc-truth","description":"PR #658 b24fa33 — schema.ts embeddings.enabled doc comment falsely claims search_code reports as disabled (stale since #657); CodeRabbit caught it, Lien Review did not (pre-#663/#665)","findings":9,"turns":8}
exit: 0
```

**2. Empty verdict** (no findings) — **FAIL** (Tier 1, doc-truth never fired):
```
{"ok":false,"tier":1,"rule":"doc-truth", ... ,"message":"Tier 1: expected rule 'doc-truth' to fire. Got: (no findings)","findings":0,"turns":3}
exit: 1
```

**3. Plausible-but-wrong distractor** (reconstructed from the fixture
header's own description: `augment-explore-task.sh:64`, doc-truth
category, reaches the defensive "the meaning-based guidance is fine, just
incomplete" conclusion, no schema.ts anchor, no correction/mechanism
wording) — **FAIL** (Tier 2, the new correction-phrase check catches
exactly the stance-blind gap it was added to close):
```
{"ok":false,"tier":2,"rule":"doc-truth", ... ,"message":"Tier 2: expected at least one finding to mention any of [\"lexical\", \"bm25\", \"no embeddings\", \"not meaning-based\", \"not meaning based\", \"not semantic\"]. None matched. Findings: 1. ...","findings":1,"turns":4}
exit: 2
```

**4. B-only verdict** (real vote 1 from the post-#787 screen trace — 5
findings including Finding B, Finding A genuinely absent — the currently
common real shape) — **PASS**. This is the point of the re-scope: a vote
the OLD assertion rejected now correctly certifies:
```
{"ok":true,"rule":"doc-truth", ... ,"findings":5,"turns":7}
exit: 0
```

## Free validation — offline re-score of the post-#787 screen votes

Found the screen runner's post-#787 traces in a sibling worktree
(`.wip/traces/2026-07-16T08-49-48Z-pr658-search-code-rename/`, read-only,
not modified). Re-scored all 3 real votes against both the OLD (baseline,
pre-this-PR) and NEW assertion via `assert-cli.ts`, zero additional LLM
spend:

| Vote | OLD assertion | NEW assertion |
|---|---|---|
| vote-1 | FAIL (tier 2, exit 2) — Finding A keywords: none matched (5 findings) | **PASS** (exit 0) |
| vote-2 | FAIL (tier 2, exit 2) — Finding A keywords: none matched (5 findings) | **PASS** (exit 0) |
| vote-3 | PASS (exit 0) — 9 findings | **PASS** (exit 0) |

**1/3 → 3/3**, confirming the screen's own report and demonstrating the
re-scope resolves exactly the gap PR #792 identified, with no fabricated
data — these are the actual captured model outputs from the post-#787 run.

## Gates

- `npm run format:check` — pass
- `npm run lint` — pass (0 errors; pre-existing unrelated warnings only)
- `npm run typecheck` (+ `typecheck:harness -w @liendev/review`) — pass
- `npm run build` — pass
- `npm test` (full suite, native parser built via `build:native` for a
  clean run) — **860+39 and all other package suites passed, exit 0**
- `lien delta` — `lien delta — no complexity changes across 1 file(s) vs
  HEAD (38 ms)`, exit 0

No spend on this task — validation was entirely offline (`assert-cli.ts`
smoke tests + re-scoring existing traces from a sibling worktree). No fresh
paid vote was needed since healthy post-#787 traces already existed.

## Scope

Assertions/header text only — `packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.assertions.ts`.
No rule prompt, harness infrastructure, or other fixture changes.

## Update: CodeRabbit finding fixed (post-review)

CodeRabbit flagged a real bug in the first version of this PR: the two
separate `expectFindingMentions` calls for Finding B's claim and correction
keyword lists flatten every finding into one haystack each, so they check
"the claim appears *somewhere* across all findings" AND "a correction term
appears *somewhere* across all findings" — independently, not within the
same finding. On this all-about-lexical-search rename PR, almost any
multi-finding result contains "lexical" or "bm25" *somewhere* for reasons
unrelated to Finding B, so a distractor finding that only names the claim
(the exact defensive, wrong-conclusion shape this tightening targets) could
still false-pass via an unrelated sibling finding.

**Verified the bug was real** before fixing: built an adversarial verdict
(the defensive distractor + a second, unrelated finding mentioning "lexical
BM25") and confirmed it false-passed (exit 0) against the pre-fix code.

**Fixed** by checking both keyword lists against each finding's own text
via `result.findings.some(...)`, throwing `HarnessAssertionError` directly
to preserve the Tier 2 exit-code contract. The same adversarial verdict now
correctly fails (exit 2). Re-ran the full four-verdict suite plus the 3 real
post-#787 votes — all unchanged (3/3 real votes still pass; no recall lost).
Full gate chain (format/lint/typecheck/build/test/lien delta) re-run clean.
Replied to CodeRabbit's comment with verbatim before/after evidence.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR re-scopes a single doc-truth test fixture's assertions based on offline re-scoring of existing traces. It removes the flaky Finding A (schema.ts `embeddings.enabled`) from the certified gate and tightens Finding B (augment-explore-task.sh 'meaning-based') to require both claim-naming and correction/mechanism keywords within the same finding. The change is confined to one test fixture assertion file; no production code or harness infrastructure is modified. The assertion code matches the extensive header documentation, and the per-finding check correctly closes the cross-finding leakage gap identified in the first draft.
>
> - Removed Finding A keyword check from certified gate; retained as documented tracked-characterization expectation
> - Added per-finding AND check requiring both 'meaning-based' claim and correction terms ('lexical', 'bm25', 'no embeddings', 'not meaning-based', 'not semantic') in a single finding
> - Added HarnessAssertionError import for the custom Tier-2 failure path

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0eca93c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->