### PR TITLE
fix(review): recover trailing-prose verdicts and retry corrupted stop-turns

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -89,7 +89,12 @@ export function logTurn(logger: Logger, turn: TurnTrace | undefined, label?: str
  *  1. each ```json fence, LAST first — the model emits its verdict last, so a
  *     few-shot/example fence earlier in the prose must not win;
  *  2. the raw body (a response_format:json_object / forced-verdict turn);
- *  3. a JSON object embedded in surrounding prose (model ignored json_object).
+ *  3. the first balanced JSON object in the text (brace-depth scan — recovers
+ *     a complete, valid verdict followed by trailing prose, e.g. "Wait, I need
+ *     to double-check…" appended after the closing brace, #792's
+ *     incomplete-handling canary);
+ *  4. a naive first-open-to-last-close slice of the whole text (model ignored
+ *     json_object and wrapped the verdict in prose with no other braces).
  *
  * Prefer a candidate carrying a `summary` (the verdict marker) so an
  * `{"findings": [...]}`-only example can't beat the real verdict; fall back to
@@ -103,10 +108,21 @@ export function extractFindingsFromText(
   summary?: AgentSummary;
 } {
   const fences = [...text.matchAll(/```json\s*\n([\s\S]*?)\n\s*```/g)].map(m => m[1]).reverse();
-  const candidates = [...fences, text.trim(), embeddedJsonObject(text)];
+  // Each candidate carries an optional `recovered` label so a candidate that
+  // needed active recovery (vs. a plain fence/raw-body parse) logs a warning
+  // naming it — mirroring #775's corrupted-key recovery logging.
+  const candidates: Array<{ value: string | undefined; recovered?: string }> = [
+    ...fences.map(value => ({ value })),
+    { value: text.trim() },
+    {
+      value: firstBalancedJsonObject(text),
+      recovered: 'balanced-object extraction (trailing content after the closing brace)',
+    },
+    { value: embeddedJsonObject(text) },
+  ];
 
   let fallback: { findings: AgentFinding[] } | undefined;
-  for (const candidate of candidates) {
+  for (const { value: candidate, recovered } of candidates) {
     if (!candidate) continue;
     let parsed: unknown;
     try {
@@ -115,10 +131,25 @@ export function extractFindingsFromText(
       continue; // not parseable — try the next candidate
     }
     const { findings, summary } = readVerdict(parsed, logger);
-    if (summary) return { findings, summary };
-    if (findings.length > 0 && !fallback) fallback = { findings };
+    if (summary) {
+      logRecovery(logger, recovered, 'a verdict');
+      return { findings, summary };
+    }
+    if (findings.length > 0 && !fallback) {
+      logRecovery(logger, recovered, 'findings');
+      fallback = { findings };
+    }
   }
   return fallback ?? { findings: [] };
+}
+
+/** Logs a named-candidate recovery — mirroring #775's corrupted-key style. No-op when `recovered` is unset. */
+function logRecovery(
+  logger: Logger | undefined,
+  recovered: string | undefined,
+  what: 'a verdict' | 'findings',
+): void {
+  if (recovered) logger?.warning(`[agent] Recovered ${what} via ${recovered}`);
 }
 
 /**
@@ -230,6 +261,42 @@ export function embeddedJsonObject(content: string): string | undefined {
   const start = content.indexOf('{');
   const end = content.lastIndexOf('}');
   return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
+}
+
+/**
+ * Scan from the first `{` and track brace depth — respecting string literals
+ * and escapes — to find the first *complete, balanced* JSON object, stopping
+ * as soon as depth returns to zero and ignoring everything after.
+ *
+ * Recovers a verdict that is otherwise valid but has trailing content
+ * appended after its closing brace — observed on the incomplete-handling
+ * canary post-#787 (#792 3-vote screen): the model emits a complete, correct
+ * verdict, then appends "Wait, I need to double-check…" prose (which itself
+ * contains further `{`/`}` characters). `embeddedJsonObject`'s naive
+ * first-open/last-close slice overshoots into that trailing content and
+ * produces unparseable JSON; this stops at the first balanced close instead.
+ * Returns undefined if the text has no `{` or never balances (e.g. a
+ * genuinely truncated response) — never guesses at an unbalanced slice.
+ */
+/** Matches a double-quoted JSON string literal, escapes included. */
+const JSON_STRING_LITERAL = /"(?:\\.|[^"\\])*"/g;
+
+export function firstBalancedJsonObject(text: string): string | undefined {
+  const start = text.indexOf('{');
+  if (start === -1) return undefined;
+
+  // Mask string contents with same-length `"` filler so quotes/escapes never
+  // have to be tracked char-by-char in the scan below — braces inside a
+  // string literal (e.g. prose like "{user, token}") can't skew the depth
+  // count, and offsets into `masked` line up 1:1 with `text.slice(start)`.
+  const masked = text.slice(start).replace(JSON_STRING_LITERAL, m => '"'.repeat(m.length));
+
+  let depth = 0;
+  for (let i = 0; i < masked.length; i++) {
+    if (masked[i] === '{') depth++;
+    else if (masked[i] === '}' && --depth === 0) return text.slice(start, start + i + 1);
+  }
+  return undefined; // never balanced — no complete object found
 }
 
 /** Type guard to validate a summary object. */

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -294,7 +294,7 @@ export class AnthropicAgentClient {
       if (retry) {
         totalInputTokens += retry.inputTokens;
         totalOutputTokens += retry.outputTokens;
-        turnTraces.push(retry.traceTurn);
+        turnTraces.push(...retry.traceTurns);
         if (retry.parsed.summary || retry.parsed.findings.length > 0) {
           parsed = retry.parsed;
         }
@@ -381,27 +381,23 @@ export class AnthropicAgentClient {
   }
 
   /**
-   * Final cheap call asking the model to emit just the findings JSON
-   * after the main loop ran out of budget. Returns the parsed result,
-   * a TurnTrace for the retry call, and per-call token counts. Returns
-   * null if the retry itself fails (logged); the caller falls back to
-   * the (empty) findings already extracted.
+   * One forced-verdict completion attempt: a cheap call asking the model to
+   * emit just the findings JSON. Returns the parsed result, a TurnTrace, and
+   * per-call token counts — or null if the request itself fails (logged).
+   * Pulled out of `runSummaryRetry` so a second, bounded attempt (below) can
+   * reuse it without duplicating the request/trace-building logic.
    */
-  private async runSummaryRetry(
+  private async attemptVerdictCompletion(
     messages: Anthropic.Messages.MessageParam[],
-    lastResponse: Anthropic.Messages.Message,
-    turn: number,
     tools: Anthropic.Messages.Tool[],
     remainingBudget: number,
+    turnNumber: number,
   ): Promise<{
     parsed: { findings: AgentFinding[]; summary?: AgentSummary };
     traceTurn: TurnTrace;
     inputTokens: number;
     outputTokens: number;
   } | null> {
-    this.logger.info('[agent] No JSON output — requesting summary...');
-    await new Promise(resolve => setTimeout(resolve, 3_000));
-    appendRetryPrompt(messages, lastResponse);
     try {
       const response = await this.client.messages.create({
         model: this.model,
@@ -417,7 +413,7 @@ export class AnthropicAgentClient {
       const inputTokens = response.usage.input_tokens;
       const outputTokens = response.usage.output_tokens;
       const traceTurn: TurnTrace = {
-        turnNumber: turn + 1,
+        turnNumber,
         responseText: joinTextBlocks(response.content),
         reasoning: extractThinking(response.content),
         toolCalls: [],
@@ -433,6 +429,57 @@ export class AnthropicAgentClient {
       );
       return null;
     }
+  }
+
+  /**
+   * Final cheap call(s) asking the model to emit just the findings JSON
+   * after the main loop ran out of budget or ended without a verdict.
+   * Returns the parsed result, the TurnTrace(s) for the retry call(s), and
+   * per-call token counts. Returns null only if the first attempt's request
+   * itself fails (logged); the caller falls back to the (empty) findings
+   * already extracted.
+   *
+   * Makes ONE bounded extra attempt — not a retry loop — when the first
+   * retry's own response is itself unparseable/empty (no summary, no
+   * findings): a wholesale-corrupted stop-turn has no recoverable content
+   * (parity with the OpenAI client's #792 stale-duplicate fix), so the only
+   * useful move left is asking again, once, before surfacing `incomplete`
+   * (never a silent 0-findings-as-if-clean result — see `run()`'s
+   * `incomplete = !parsed.summary` computation).
+   */
+  private async runSummaryRetry(
+    messages: Anthropic.Messages.MessageParam[],
+    lastResponse: Anthropic.Messages.Message,
+    turn: number,
+    tools: Anthropic.Messages.Tool[],
+    remainingBudget: number,
+  ): Promise<{
+    parsed: { findings: AgentFinding[]; summary?: AgentSummary };
+    traceTurns: TurnTrace[];
+    inputTokens: number;
+    outputTokens: number;
+  } | null> {
+    this.logger.info('[agent] No JSON output — requesting summary...');
+    await new Promise(resolve => setTimeout(resolve, 3_000));
+    appendRetryPrompt(messages, lastResponse);
+
+    const first = await this.attemptVerdictCompletion(messages, tools, remainingBudget, turn + 1);
+    if (!first) return null;
+    if (first.parsed.summary || first.parsed.findings.length > 0) {
+      return { ...first, traceTurns: [first.traceTurn] };
+    }
+
+    this.logger.warning(
+      '[agent] Retry verdict was unparseable — attempting one more bounded retry',
+    );
+    const second = await this.attemptVerdictCompletion(messages, tools, remainingBudget, turn + 2);
+    if (!second) return { ...first, traceTurns: [first.traceTurn] };
+    return {
+      parsed: second.parsed,
+      traceTurns: [first.traceTurn, second.traceTurn],
+      inputTokens: first.inputTokens + second.inputTokens,
+      outputTokens: first.outputTokens + second.outputTokens,
+    };
   }
 }
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -420,7 +420,7 @@ export class OpenAIAgentClient {
       if (retry) {
         totalInputTokens += retry.inputTokens;
         totalOutputTokens += retry.outputTokens;
-        turnTraces.push(retry.traceTurn);
+        turnTraces.push(...retry.traceTurns);
         if (retry.parsed.summary || retry.parsed.findings.length > 0) {
           parsed = retry.parsed;
         }
@@ -514,24 +514,21 @@ export class OpenAIAgentClient {
   }
 
   /**
-   * Final cheap call asking the model to emit just the findings JSON
-   * after the main loop ran out of budget. Returns the parsed result,
-   * a TurnTrace for the retry call, and per-call token counts. Returns
-   * null if the retry itself fails (logged); the caller falls back to
-   * the (empty) findings already extracted.
+   * One forced-verdict completion attempt: a cheap call asking the model to
+   * emit just the findings JSON. Returns the parsed result, a TurnTrace, and
+   * per-call token counts — or null if the request itself fails (logged).
+   * Pulled out of `runSummaryRetry` so a second, bounded attempt (below) can
+   * reuse it without duplicating the request/trace-building logic.
    */
-  private async runSummaryRetry(
+  private async attemptVerdictCompletion(
     messages: ChatMessage[],
-    turn: number,
+    turnNumber: number,
   ): Promise<{
     parsed: { findings: AgentFinding[]; summary?: AgentSummary };
     traceTurn: TurnTrace;
     inputTokens: number;
     outputTokens: number;
   } | null> {
-    this.logger.info('[agent] No JSON output — requesting summary...');
-    await new Promise(resolve => setTimeout(resolve, 3_000));
-    messages.push({ role: 'user', content: RETRY_NUDGE });
     try {
       // forceVerdict: response_format:json_object guarantees a JSON response,
       // the reliable safety net when the loop bailed without a verdict.
@@ -540,7 +537,7 @@ export class OpenAIAgentClient {
       const outputTokens = response.usage?.completion_tokens ?? 0;
       const choice = response.choices[0];
       const traceTurn: TurnTrace = {
-        turnNumber: turn + 1,
+        turnNumber,
         responseText: choice?.message.content ?? '',
         reasoning: choice?.message.reasoning ?? undefined,
         toolCalls: [],
@@ -560,6 +557,55 @@ export class OpenAIAgentClient {
       );
       return null;
     }
+  }
+
+  /**
+   * Final cheap call(s) asking the model to emit just the findings JSON
+   * after the main loop ran out of budget or ended without a verdict.
+   * Returns the parsed result, the TurnTrace(s) for the retry call(s), and
+   * per-call token counts. Returns null only if the first attempt's request
+   * itself fails (logged); the caller falls back to the (empty) findings
+   * already extracted.
+   *
+   * Makes ONE bounded extra attempt — not a retry loop — when the first
+   * retry's own response is itself unparseable/empty (no summary, no
+   * findings): a wholesale-corrupted stop-turn (e.g.
+   * `{"findings":":[{",": ":", "}`, observed twice on the stale-duplicate
+   * canary, #792's 3-vote screen) has no recoverable content, so the only
+   * useful move left is asking again, once, before surfacing `incomplete`
+   * (never a silent 0-findings-as-if-clean result — see `run()`'s
+   * `incomplete = !parsed.summary` computation).
+   */
+  private async runSummaryRetry(
+    messages: ChatMessage[],
+    turn: number,
+  ): Promise<{
+    parsed: { findings: AgentFinding[]; summary?: AgentSummary };
+    traceTurns: TurnTrace[];
+    inputTokens: number;
+    outputTokens: number;
+  } | null> {
+    this.logger.info('[agent] No JSON output — requesting summary...');
+    await new Promise(resolve => setTimeout(resolve, 3_000));
+    messages.push({ role: 'user', content: RETRY_NUDGE });
+
+    const first = await this.attemptVerdictCompletion(messages, turn + 1);
+    if (!first) return null;
+    if (first.parsed.summary || first.parsed.findings.length > 0) {
+      return { ...first, traceTurns: [first.traceTurn] };
+    }
+
+    this.logger.warning(
+      '[agent] Retry verdict was unparseable — attempting one more bounded retry',
+    );
+    const second = await this.attemptVerdictCompletion(messages, turn + 2);
+    if (!second) return { ...first, traceTurns: [first.traceTurn] };
+    return {
+      parsed: second.parsed,
+      traceTurns: [first.traceTurn, second.traceTurn],
+      inputTokens: first.inputTokens + second.inputTokens,
+      outputTokens: first.outputTokens + second.outputTokens,
+    };
   }
 
   private async chatCompletion(

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -196,3 +196,111 @@ describe('AnthropicAgentClient never-ran (terminal API failure)', () => {
     expect(createMock).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #792's 3-vote screen: a natural-stop turn corrupted at the wire ("wholesale-
+// corrupted stop-turn", e.g. `{"findings":":[{",": ":", "}` — syntactically
+// valid JSON but shaped wrong, so extraction correctly rejects it) triggers
+// the existing summary-retry, same as any other missing-verdict bail. These
+// tests cover the NEW bounded second attempt inside that retry — parity with
+// the OpenAI client's fix for the same canary.
+// ---------------------------------------------------------------------------
+describe('AnthropicAgentClient — bounded second retry attempt for corrupted stop-turns (#792)', () => {
+  const CORRUPTED_STOP_TURN = '{"findings":":[{",": ":", "}';
+  const CLEAN_JSON =
+    '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"recovered","keyChanges":[]}}\n```';
+
+  it('makes a bounded second attempt when the first retry is also corrupted, and recovers', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CLEAN_JSON)], 50, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(1_000_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.incomplete).toBe(false);
+    expect(result.summary?.overview).toBe('recovered');
+    expect(createMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('surfaces incomplete (not a silent clean review) when both retry attempts stay corrupted', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(1_000_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.incomplete).toBe(true);
+    expect(result.summary).toBeUndefined();
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('is bounded — exactly 4 calls total, not an open retry loop', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    await makeClient(1_000_000, logger).run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    expect(createMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('logs a warning naming the bounded second-attempt retry', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CLEAN_JSON)], 50, 0, 'end_turn'));
+    const { logger, lines } = capturingLogger();
+
+    await makeClient(1_000_000, logger).run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    expect(lines.some(l => l.includes('attempting one more bounded retry'))).toBe(true);
+  });
+
+  it('does not make a second attempt when the first retry already recovers a verdict', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(CORRUPTED_STOP_TURN)], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(msg([textBlock(CLEAN_JSON)], 50, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(1_000_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.incomplete).toBe(false);
+    expect(createMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -391,6 +391,104 @@ describe('OpenAIAgentClient budget handling', () => {
   }, 20000);
 });
 
+// ---------------------------------------------------------------------------
+// #792's 3-vote screen: a natural-stop turn corrupted at the wire ("wholesale-
+// corrupted stop-turn", e.g. `{"findings":":[{",": ":", "}` — syntactically
+// valid JSON but shaped wrong, so readVerdict correctly rejects it) triggers
+// the existing summary-retry, same as any other missing-verdict bail. These
+// tests cover the NEW bounded second attempt inside that retry: one more
+// try when the first retry's own response is itself unrecoverable — never an
+// unbounded loop, and a still-failed pair must surface as `incomplete`, not a
+// silent clean 0-findings result.
+// ---------------------------------------------------------------------------
+describe('OpenAIAgentClient — bounded second retry attempt for corrupted stop-turns (#792)', () => {
+  // Verbatim payload from both stale-duplicate screen runs (shape B).
+  const CORRUPTED_STOP_TURN = '{"findings":":[{",": ":", "}';
+
+  it('makes a bounded second attempt when the first retry is also corrupted, and recovers', async () => {
+    mockFetch([
+      toolCallTurn(100), // turn 1: investigation
+      stopTurn(CORRUPTED_STOP_TURN, 50), // turn 2: natural stop, corrupted → triggers retry
+      stopTurn(CORRUPTED_STOP_TURN, 50), // retry attempt 1: corrupted again
+      stopTurn(CLEAN_JSON, 50), // retry attempt 2 (bounded): recovers
+    ]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(false);
+    expect(result.summary?.overview).toBe('All good');
+    // 2 main-loop turns + 2 retry attempts, all recorded on the trace.
+    expect(result.trace.turns).toHaveLength(4);
+  }, 15000);
+
+  it('surfaces incomplete (not a silent clean review) when both retry attempts stay corrupted', async () => {
+    mockFetch([
+      toolCallTurn(100),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+      stopTurn(CORRUPTED_STOP_TURN, 50), // retry attempt 1: corrupted
+      stopTurn(CORRUPTED_STOP_TURN, 50), // retry attempt 2 (bounded): also corrupted
+    ]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(true);
+    expect(result.summary).toBeUndefined();
+    expect(result.findings).toHaveLength(0);
+  }, 15000);
+
+  it('is bounded — does not keep retrying past the second attempt', async () => {
+    // Only 4 responses queued (2 main-loop + 2 retry). If the client tried a
+    // 3rd retry attempt, chatCompletion would hit the exhausted queue (empty
+    // body) and its own internal transient-failure retry, which would show up
+    // as extra request bodies. Assert exactly 4 requests were sent.
+    const { bodies } = mockFetch([
+      toolCallTurn(100),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+    ]);
+    const client = makeClient(1_000_000);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(bodies).toHaveLength(4);
+  }, 15000);
+
+  it('logs a warning naming the bounded second-attempt retry', async () => {
+    const { logger, lines } = capturingLogger();
+    mockFetch([
+      toolCallTurn(100),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+      stopTurn(CLEAN_JSON, 50),
+    ]);
+    const client = makeClient(1_000_000, logger);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(lines.some(l => l.includes('attempting one more bounded retry'))).toBe(true);
+  }, 15000);
+
+  it('does not make a second attempt when the first retry already recovers a verdict', async () => {
+    // Non-regression: the pre-existing single-retry path (budget test above,
+    // "recovers a verdict via the json-forced summary-retry after a bail")
+    // must not gain a spurious extra call when the first retry succeeds.
+    const { bodies } = mockFetch([
+      toolCallTurn(100),
+      stopTurn(CORRUPTED_STOP_TURN, 50),
+      stopTurn(CLEAN_JSON, 50), // retry attempt 1: recovers immediately
+    ]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(false);
+    expect(bodies).toHaveLength(3);
+  }, 15000);
+});
+
 /** Shared by both the `appendIncompleteNotice` and `hasProviderFailure` suites below. */
 function baseResult(overrides: Partial<AgentResult>): AgentResult {
   return {

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -7,6 +7,7 @@ import {
   extractFindingsWithReasoningFallback,
   readVerdict,
   embeddedJsonObject,
+  firstBalancedJsonObject,
   isValidSummary,
   isValidFinding,
   AGENT_LOG_MAX,
@@ -159,6 +160,43 @@ describe('embeddedJsonObject', () => {
   it('returns undefined when there is no object', () => {
     expect(embeddedJsonObject('no braces here')).toBeUndefined();
     expect(embeddedJsonObject('}{')).toBeUndefined(); // close precedes open
+  });
+});
+
+describe('firstBalancedJsonObject', () => {
+  it('finds a simple object with nothing around it', () => {
+    expect(firstBalancedJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('stops at the first balanced close, ignoring trailing content — even more braces', () => {
+    // The exact failure mode #792's incomplete-handling canary hit: naive
+    // first-{-to-last-} slicing (embeddedJsonObject) overshoots past the real
+    // verdict into trailing prose that has its own braces.
+    const text = '{"a":1} then some prose with a distractor {not json} in it';
+    expect(firstBalancedJsonObject(text)).toBe('{"a":1}');
+    expect(embeddedJsonObject(text)).toBe('{"a":1} then some prose with a distractor {not json}');
+  });
+
+  it('respects braces inside string literals (does not close early)', () => {
+    expect(firstBalancedJsonObject('{"a":"{ not a real close }"}')).toBe(
+      '{"a":"{ not a real close }"}',
+    );
+  });
+
+  it('respects escaped quotes inside strings', () => {
+    expect(firstBalancedJsonObject('{"a":"she said \\"hi\\""}')).toBe('{"a":"she said \\"hi\\""}');
+  });
+
+  it('handles nested objects, closing at the outermost brace', () => {
+    expect(firstBalancedJsonObject('{"a":{"b":2}} trailing junk')).toBe('{"a":{"b":2}}');
+  });
+
+  it('returns undefined when there is no opening brace', () => {
+    expect(firstBalancedJsonObject('no braces here')).toBeUndefined();
+  });
+
+  it('returns undefined when the braces never balance (truncated response)', () => {
+    expect(firstBalancedJsonObject('{"a": {"b": 1')).toBeUndefined();
   });
 });
 
@@ -350,6 +388,71 @@ describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
     const good = fence({ findings: [], summary });
     const out = extractFindingsFromText(`${good}\n${broken}`);
     expect(out.summary).toEqual(summary);
+  });
+
+  // ---------------------------------------------------------------------
+  // #792's 3-vote screen surfaced two natural-stop verdict corruption
+  // shapes neither #723 nor #775's corrupted-key recovery covers. Both
+  // reproduced here from the real captured traces
+  // (.wip/traces/2026-07-16T08-4[68]-*, shallow-canary-screen worktree).
+  // ---------------------------------------------------------------------
+
+  it('shape A (#792 incomplete-handling): recovers a complete verdict followed by trailing prose with its own braces', () => {
+    // Verbatim shape from the real retry-turn capture: a complete, valid
+    // verdict, then a stray "```" fence marker, then "Wait, I need to
+    // double-check…" prose that goes on to mention another (revised) verdict
+    // — i.e. more `{`/`}` characters AFTER the real one. The old
+    // embeddedJsonObject slice (first `{` … last `}`) spans across all of it
+    // and fails to parse; firstBalancedJsonObject stops at the first close.
+    const verdict = JSON.stringify({ findings: [finding], summary });
+    const text =
+      `\n${verdict}\n` +
+      '```\n\n' +
+      'Wait, I need to double-check the `requireAdmin` issue. Is it possible that ' +
+      'the intent is to keep email-based admin checks alongside roles? Let me ' +
+      'reconsider and produce a revised verdict: ' +
+      JSON.stringify({ findings: [], summary: { ...summary, overview: 'REVISED' } });
+    const out = extractFindingsFromText(text);
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(1);
+  });
+
+  it('shape B (#792 stale-duplicate): a wholesale-corrupted stop-turn stays unrecovered', () => {
+    // Verbatim 28-char corrupted payload from both stale-duplicate screen
+    // runs. It happens to be syntactically valid JSON (all the punctuation
+    // lands inside quoted strings), so it parses — but `findings` is a
+    // string, not an array, and no other key is summary-shaped, so
+    // readVerdict's validation correctly rejects it. Content recovery here
+    // is genuinely impossible; this must stay a `{findings: []}` non-verdict
+    // so the caller's retry path (see openai/anthropic-client tests) fires.
+    const corrupted = '{"findings":":[{",": ":", "}';
+    expect(extractFindingsFromText(corrupted)).toEqual({ findings: [] });
+  });
+
+  it('non-regression: still recovers a bare embedded object with no distractor braces (#775 path)', () => {
+    // Guards the pre-existing embeddedJsonObject-only path: when the trailing
+    // content has no extra braces, firstBalancedJsonObject and
+    // embeddedJsonObject agree, and the verdict is recovered either way.
+    const verdict = JSON.stringify({ findings: [], summary });
+    const out = extractFindingsFromText(`Here is my analysis.\n${verdict}\nThat's everything.`);
+    expect(out.summary).toEqual(summary);
+  });
+
+  it('logs a warning naming the balanced-object recovery (mirroring #775 style)', () => {
+    const warnings: string[] = [];
+    const logger = { ...silentLogger, warning: (m: string) => void warnings.push(m) };
+    const verdict = JSON.stringify({ findings: [finding], summary });
+    const text = `${verdict}\nWait, I need to double-check {this distractor}.`;
+    extractFindingsFromText(text, logger);
+    expect(warnings.some(m => m.includes('balanced-object extraction'))).toBe(true);
+  });
+
+  it('does not log a recovery warning for the plain raw-body / fence paths (no false positives)', () => {
+    const warnings: string[] = [];
+    const logger = { ...silentLogger, warning: (m: string) => void warnings.push(m) };
+    extractFindingsFromText(JSON.stringify({ findings: [finding], summary }), logger);
+    extractFindingsFromText(fence({ findings: [], summary }), logger);
+    expect(warnings).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Where each shape fell through (investigation)

Both shapes come from real Kimi votes captured in PR #792's 3-vote screen (traces read from the `shallow-canary-screen` worktree, `.wip/traces/`).

**Shape A — `incomplete-handling/enum-variant-removed`, vote-1.** The main-loop natural-stop turn (turnNumber 6) is pure prose that happens to start with a stray `{user, token}` — the existing `embeddedJsonObject` (first `{` … last `}`) grabs from that distractor brace to the end of the text and fails to parse, so the existing `runSummaryRetry` correctly fires. The retry's own response (turnNumber 7) **does** contain a complete, valid verdict (3 findings incl. `incomplete-handling`/`structural-analysis` + summary) — but it's followed by a stray ` ``` ` fence marker, "Wait, I need to double-check the `requireAdmin` issue…" prose, and a second, revised verdict. `embeddedJsonObject`'s first-`{`-to-last-`}` slice spans across all of that and fails to parse. Since `retry.parsed.summary` never validates, `parsed` stays empty and the harness scored this "Got: (no findings)" even though a fully valid verdict was sitting right there.

**Shape B — `stale-duplicate/model-partial-update`, vote-1.** Same mechanism up to a point: turn 6 (main loop) emits `{"findings":[]}` — syntactically valid but summary-less — so the retry fires (turnNumber 7 in the trace). That retry's own response is the ~28-char `{"findings":":[{",": ":", "}`. Non-obvious finding: this string is **syntactically valid JSON** (all the stray punctuation lands inside quoted string values — `JSON.parse` succeeds), so it isn't a parse failure. `readVerdict` correctly rejects it anyway: `findings` is a string, not an array, and no other key is summary-shaped, so `findingsUnderCorruptedKey`/`summaryUnderCorruptedKey` both decline. This is genuinely unrecoverable — the task description's "content recovery is impossible" is right — and the existing single retry already marks the run `incomplete: true` in this exact case (confirmed by re-deriving the code path; the "0 findings" in the harness's triage table is the harness's own `HarnessResult` type only carrying `{findings, toolCalls, turns}` — it drops `incomplete`/`summary` entirely, a pre-existing harness-reporting gap out of this PR's scope).

## The fix

1. **`agent-client-shared.ts`** — added `firstBalancedJsonObject`: masks string-literal contents with same-length `"` filler (so distractor braces inside prose/strings can't skew the count) then scans for the first brace pair that returns to depth 0, instead of naively slicing first-`{` to last-`}`. Wired in as a new candidate in `extractFindingsFromText`, ahead of the old `embeddedJsonObject` fallback. Logs `[agent] Recovered a verdict/findings via balanced-object extraction …` when it's the candidate that wins (mirrors #775's corrupted-key logging style).
2. **`openai-client.ts` / `anthropic-client.ts`** — `runSummaryRetry` now makes **one bounded second attempt** (never a loop) when its first attempt's own response is itself unrecoverable (no summary, no findings). Extracted the single-call logic into `attemptVerdictCompletion` so both clients stay in parity and neither `run()` method (already over its complexity budget) grew. A still-failed pair falls through to the pre-existing `incomplete = !parsed.summary` computation unchanged — never a silent 0-findings-as-clean result.

## Test evidence

58/58 `plugins-agent-client-shared.test.ts` (10 new: `firstBalancedJsonObject` unit cases, shape A/B integration cases with the verbatim shapes, recovery-warning logging, non-regression for #723/#775/plain-valid paths).
49/49 `plugins-agent-budget.test.ts` (5 new: bounded-second-attempt recovers, both-fail-stays-incomplete, exactly-bounded call count, warning log, no-spurious-second-call when the first retry already recovers).
15/15 `plugins-agent-anthropic.test.ts` (5 new, mirroring the OpenAI cases).
Full `npm test`: parser 27, core 1062, review 1028, cli 860, action 39 — all green, no regressions.

### Dogfood — real trace payloads replayed through the actual functions (unit-level, verbatim)

```
======================================================================
SHAPE B (stale-duplicate/model-partial-update, vote-1): 28-char corrupted stop-turn
======================================================================
Input (verbatim from real trace): "{\"findings\":\":[{\",\": \":\", \"}"
extractFindingsFromText(shapeB) => {"findings":[]}
(Expected: {"findings":[]} — no summary. Genuinely unrecoverable; retry path must fire.)

======================================================================
SHAPE A (incomplete-handling/enum-variant-removed, vote-1): retry-turn corrupted by trailing prose
======================================================================
Input: real retry-turn responseText, verbatim, 9830 chars
First 60 chars: "\n{\n  \"findings\": [\n    {\n      \"filepath\": \"lien-review-test"
...contains a stray "```" fence + "Wait, I need to double-check..." prose + a SECOND revised verdict after the real one.

extractFindingsFromText(realRetryTurn) =>
  findings.length = 3
  findings[].ruleId = ["incomplete-handling","incomplete-handling","structural-analysis"]
  summary.riskLevel = high
  summary.overview  = "This PR introduces a role-based permission system but leaves critical gaps: unhandled roles silently receive zero permissions, the admin check ignores the new role field, and the User interface's required role field breaks existing functions that construct User objects without role data. These issues combine to create both silent runtime permission degradation and compile-time breaking changes."
(Expected: 3 findings recovered + a valid summary — this run was previously scored 0 findings / Tier-1 fail.)
```

The retry-path fix (bounded second attempt + honest `incomplete` surfacing) is dogfooded via the new mocked-fetch unit tests above, exercising the real `run()`/`runSummaryRetry`/`attemptVerdictCompletion` code paths end-to-end.

## Harness-evidence gate (byte-diff prompt-render proof)

This PR touches `packages/review/src/plugins/agent/**` but is a pure extraction/retry-plumbing change — no prompt-affecting file (`rules.ts`, `system-prompt.ts`, `tools.ts`) was touched. Proof: rendered `build-prompts.ts` output (system prompt + initial message + rule selection, `fixturePath` field stripped) for all 3 fixtures currently on disk (`boundary-change/placeholder`, `doc-truth/accurate-doc`, `doc-truth/renamed-stale-claim`), `merge-base` (`5fcf6148`, = `origin/main`) vs this branch's `HEAD`, via a temporary detached worktree (no destructive checkout in this worktree; removed after, `git status` clean).

**3/3 byte-identical.**

## Calibration validity

No prompt/rule change — existing `--calibrate 10` certifications for all canaries remain valid as-is. This PR is the prerequisite the triage table called out: it fixes the parsing-failure noise so a future `--calibrate 10` on `stale-duplicate`/`incomplete-handling` measures real detection quality, not corruption-recovery gaps. No new paid calibration was run or is needed for this change itself.

## Gates

`npm run format:check` / `npm run lint` (0 errors) / `npm run typecheck` / `npm run build` / `npm test` (all packages) / `lien delta` (exit 0 — no new-over-threshold crossings; `firstBalancedJsonObject`, `attemptVerdictCompletion` land under threshold, `runSummaryRetry`'s cognitive bump 2→4 stays well under 15). No changeset (`@liendev/review` is private/unpublished).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +0 |
| 🧠 mental load | 3 | +0 |
| ⏱️ time to understand | 3 | +10 |
| 🐛 estimated bugs | 2 | +0.03 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it ended without emitting a parseable JSON verdict while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4b55ef6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->