### PR TITLE
fix(review): wire rename-sweep signal into doc-truth pass

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -21,6 +21,7 @@
 import type { ReviewContext } from '../../plugin-types.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
 import { extractDocClaims, renderDocClaimsSection } from '../../doc-claims-signals.js';
+import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
 import type { Logger } from '../../logger.js';
 
 import type { AgentConfig, AgentFinding, AgentResult, AgentTrace, ResolvedRules } from './types.js';
@@ -140,9 +141,13 @@ function renderPrHeader(context: ReviewContext): string | null {
 /**
  * Build the claims-only initial message: the PR header, the intro that scopes
  * the pass to doc-truth, the <doc_claims> worklist WITH its pre-fetched
- * evidence, and the <guidance_surface_changes> hunks (the isGuidanceSurface-
- * filtered, budget-capped diff of exactly the touched doc surfaces — the same
- * block the doc-truth rule and the doc_claims header reference by name). No
+ * evidence, the <rename_sweep> block when the diff carries a mechanical
+ * identifier-rename sweep (the doc-truth rule's protocol explicitly tells the
+ * agent to check for this block — see rules.ts — as a supplementary
+ * claim-verification worklist, so it must actually be rendered here), and the
+ * <guidance_surface_changes> hunks (the isGuidanceSurface-filtered,
+ * budget-capped diff of exactly the touched doc surfaces — the same block the
+ * doc-truth rule and the doc_claims header reference by name). No
  * blast-radius, complexity, or other-rule signals: no competition, no
  * distraction.
  */
@@ -151,6 +156,7 @@ export function buildDocTruthPassInitialMessage(context: ReviewContext): string 
   pushIfPresent(sections, renderPrHeader(context));
   sections.push(DOC_PASS_INTRO);
   pushIfPresent(sections, renderDocClaimsSection(context));
+  pushIfPresent(sections, renderRenameSweepSection(context));
   pushIfPresent(sections, renderGuidanceSurfaceSection(context));
   sections.push(
     'Verify each claim against the code, then output findings as JSON. If every ' +

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -7,6 +7,13 @@
  * subagent, and by run.ts (OpenRouter mode) to keep one source of truth
  * for prompt assembly.
  *
+ * Also emits the dedicated doc-truth SECOND pass's prompts (`docTruthPass`)
+ * when `shouldRunDocTruthPass` gates it on for the fixture — `runner.ts`
+ * exercises that pass for real (via `AgentReviewPlugin.analyze`), but CC
+ * iteration mode and any offline byte-diff of prompt assembly need it
+ * surfaced here too, since it is built by a separate function
+ * (`buildDocTruthPassPrompts`) from the main pass's `buildInitialMessage`.
+ *
  * Usage: tsx build-prompts.ts <fixture.json>
  */
 
@@ -14,6 +21,11 @@ import { resolve } from 'node:path';
 
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../../src/plugins/agent/rules.js';
 import { buildSystemPrompt, buildInitialMessage } from '../../src/plugins/agent/system-prompt.js';
+import {
+  shouldRunDocTruthPass,
+  buildDocTruthPassPrompts,
+} from '../../src/plugins/agent/doc-truth-pass.js';
+import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
 
@@ -32,12 +44,21 @@ async function main(): Promise<void> {
   const systemPrompt = buildSystemPrompt(rules);
   const initialMessage = buildInitialMessage(ctx, { blastRadius: null, rules });
 
+  const docTruthFires = shouldRunDocTruthPass(
+    ctx,
+    ctx.config as unknown as AgentConfig | undefined,
+  );
+  const docTruthPass = docTruthFires
+    ? { fires: true as const, ...buildDocTruthPassPrompts(ctx) }
+    : { fires: false as const };
+
   const output = {
     fixturePath,
     ruleIds: rules.active.map(r => r.id),
     skippedRules: rules.skipped,
     systemPrompt,
     initialMessage,
+    docTruthPass,
   };
 
   process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -45,6 +45,25 @@ const CODE_PATCH = `@@ -1,3 +1,4 @@
 +  return UNIQUE_CODE_MARKER_XYZ; // disabled when true
  }`;
 
+/**
+ * A single-token identifier swap landing inside a comment. Repeated across
+ * >= MIN_FILES files with >= MIN_OCCURRENCES total occurrences (see
+ * rename-sweep-signals.ts), this trips the rename-sweep detector: same glue,
+ * one differing identifier position, above both thresholds.
+ */
+const RENAME_SWEEP_PATCH = `@@ -1,2 +1,2 @@
+-// uses oldSearchToken to look up code
++// uses newSearchToken to look up code`;
+
+/** changedFiles carrying a rename-sweep patch across enough distinct files. */
+const RENAME_SWEEP_FILES: Array<[string, string]> = [
+  'packages/core/src/file1.ts',
+  'packages/core/src/file2.ts',
+  'packages/core/src/file3.ts',
+  'packages/core/src/file4.ts',
+  'packages/core/src/file5.ts',
+].map(f => [f, RENAME_SWEEP_PATCH]);
+
 function contextWithPatches(
   entries: Array<[string, string]>,
   extra?: Partial<ReviewContext>,
@@ -190,6 +209,42 @@ describe('buildDocTruthPassPrompts', () => {
     expect(message).not.toContain('<complexity_regressions>');
     expect(message).not.toContain('<stale_literal_candidates>');
     expect(message).not.toContain('<untrusted_input_sites>');
+    // No rename-sweep in THIS fixture — it carries no mechanical rename.
+    expect(message).not.toContain('<rename_sweep>');
+  });
+
+  // Regression coverage: the doc-truth rule text (rules.ts) explicitly tells
+  // the model to "check for a <rename_sweep> block" as a supplementary
+  // claim-verification worklist, but the block was never rendered into this
+  // pass's initial message — the rule promised a block that never arrived.
+  it('includes the <rename_sweep> block when the diff carries a mechanical rename sweep', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const message = buildDocTruthPassInitialMessage(ctx);
+
+    expect(message).toContain('<rename_sweep>');
+    expect(message).toContain('`oldSearchToken` → `newSearchToken`');
+    expect(message).toContain('</rename_sweep>');
+
+    // Positioned after <doc_claims> (a supplementary worklist), before the
+    // guidance-surface hunks.
+    const docClaimsIdx = message.indexOf('<doc_claims>');
+    const renameSweepIdx = message.indexOf('<rename_sweep>');
+    const guidanceIdx = message.indexOf('<guidance_surface_changes>');
+    expect(docClaimsIdx).toBeGreaterThan(-1);
+    expect(docClaimsIdx).toBeLessThan(renameSweepIdx);
+    expect(renameSweepIdx).toBeLessThan(guidanceIdx);
+  });
+
+  it('omits the <rename_sweep> block when the diff has no mechanical rename sweep', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ['packages/core/src/overlay.ts', CODE_PATCH],
+    ]);
+    const message = buildDocTruthPassInitialMessage(ctx);
+    expect(message).not.toContain('<rename_sweep>');
   });
 });
 


### PR DESCRIPTION
## Summary

- The `doc-truth` rule's text (`packages/review/src/plugins/agent/rules.ts`) explicitly instructs the model to check for a `<rename_sweep>` block "when present" and treat each item as a claim-verification worklist entry — but `buildDocTruthPassInitialMessage` in `packages/review/src/plugins/agent/doc-truth-pass.ts` never rendered that block into the dedicated doc-truth second pass's initial message. The rule promised a block that never arrived on every dedicated-pass run.
- Fix: render the rename-sweep signal into the doc-truth pass's initial message when it fires, reusing the exact same renderer the main pass already uses (`renderRenameSweepSection` from `packages/review/src/rename-sweep-signals.ts` — the same module PR #663 shipped). Inserted via the existing `pushIfPresent` pattern, positioned after `<doc_claims>` (a supplementary worklist) and before `<guidance_surface_changes>`.
- Also extended `packages/review/test/harness/build-prompts.ts` to additionally emit the doc-truth pass's own `{systemPrompt, initialMessage}` (gated on `shouldRunDocTruthPass`) as a `docTruthPass` field, since it's built by a separate function (`buildDocTruthPassPrompts`) than the main pass's `buildInitialMessage` — needed so offline prompt-assembly diffing (and future CC-iteration work) can see the second pass, not just the main one.
- Updated the doc-truth-pass.ts doc comment that said "No blast-radius, complexity, or other-rule signals" — no longer accurate now that `<rename_sweep>` is included.

This is pure wiring — no change to the renderer itself, no change to which PRs trigger the doc-truth pass.

## Evidence

### 1. Unit tests

Added to `packages/review/test/plugins-agent-doc-truth-pass.test.ts`:
- `includes the <rename_sweep> block when the diff carries a mechanical rename sweep` — asserts presence + correct ordering (after `<doc_claims>`, before `<guidance_surface_changes>`).
- `omits the <rename_sweep> block when the diff has no mechanical rename sweep` — asserts absence.
- Also added a `not.toContain('<rename_sweep>')` assertion to the existing "NO competing signals" test.

Full `@liendev/review` suite: **48 files / 1008 tests passed** (0 failures).

### 2. Byte-diff census

Ran a scratch script that loads every on-disk fixture under `packages/review/test/harness/fixtures/**` and renders `buildDocTruthPassInitialMessage` (when `shouldRunDocTruthPass` fires), then byte-diffed the output at merge-base vs this branch. Ran it twice: once at PR #794's merge commit (`0b070074`), and again after rebasing onto PR #795 (`ef0d213e`, merged mid-review) — same result both times:

```
identical:          13
gained-block-only:   1  (doc-truth/pr658-search-code-rename)
anything else:       0
```

14 fixtures on disk (9 canaries + 2 negative-regression + 3 doc-truth-specific, all regenerated via `capture-pr.ts` for this run since captured fixtures are gitignored). Of these, only `doc-truth/pr658-search-code-rename` both (a) fires the dedicated doc-truth pass (`shouldRunDocTruthPass` — the file touches actual guidance/doc surfaces) **and** (b) trips the rename-sweep detector (a mechanical `semantic_search` → `search_code` rename across 31+ files). The two hand-authored doc-truth fixtures (`accurate-doc`, `renamed-stale-claim`) correctly show `fires: false` for the dedicated pass — their claim lives in a comment in a regular `.ts` file, not a guidance surface, so they exercise the MAIN pass's doc-truth rule, not the second pass; this is existing, unrelated-to-this-fix behavior. For the one fixture that gained the block, the diff was **exactly one line** (the `initialMessage` field) — nothing else in the harness output changed.

### 3. 3-vote screen on `doc-truth/pr658-search-code-rename` (prod default model, no `--model` override)

```
npx tsx packages/review/test/harness/run.ts \
  --fixture packages/review/test/harness/fixtures/doc-truth/pr658-search-code-rename.fixture.json \
  --votes 3
```

Run twice (once pre-rebase at `0b070074`, once post-rebase at `ef0d213e` after PR #795 — a concurrent, unrelated verdict-recovery fix — landed mid-review):

```
✓ doc-truth/pr658-search-code-rename — 3/3 passed · $0.2705   (pre-rebase)
✓ doc-truth/pr658-search-code-rename — 3/3 passed · $0.2421   (post-rebase, final branch state)
```

**Total spend: $0.5126** (well under the $1.00 cap). Both runs are 3/3 — at or above every baseline recorded in the fixture's own header (the header's most recent recorded screen, from PR #792 post-#787, measured 1/3; the fixture's `passThreshold` is 9/10 on the full calibrate-10). The rename-sweep block did not regress the certified Finding B (`augment-explore-task.sh` "meaning-based" claim) signal.

### 4. Dogfood — verbatim `<rename_sweep>` block as rendered in the pr658 doc-truth pass prompt

Produced via the extended `build-prompts.ts` (`docTruthPass.initialMessage`) against the `doc-truth/pr658-search-code-rename` fixture:

````text
<rename_sweep>
Pre-computed by a deterministic diff scan (no grep needed — done for you). This PR applies one or more MECHANICAL identifier renames across many files. The risk is not the code swaps (the agent sees those) but token-swaps that landed inside comments, docstrings, or strings: those carry CLAIMS that were renamed but never re-verified (the classic rename-sweep miss). For each mapping below: (1) for every PROSE-TOUCHED line, read the post-image sentence and confirm the claim it now makes is still TRUE of the new name — emit a finding if the sentence is now stale or false; (2) for every SURVIVOR, decide whether that old-name reference should have been renamed too — emit a finding if the rename is incomplete. Stay silent on an item only after checking it. This is a text-match sweep, not a verified reading of the code: it does NOT substitute for the doc-truth protocol's get_files_context call on the described symbol — confirm each prose-touched sentence and each survivor against the actual current code before deciding a claim is stale or a rename is incomplete.

- Mapping `semantic_search` → `search_code` (94 occurrences across 31 files):
  Prose-touched lines — verify each claim still holds of `search_code`:
    - .claude-plugin/marketplace.json:9 (string)  `"description": "Local lexical (FTS5) code search and dependency analysis for your codebase via MCP. Ships the Explore agent plus Lien's MCP tools (search_code, `
    - .claude/skills/dogfood/SKILL.md:63 (doc)  `### search_code`
    - .claude/skills/dogfood/SKILL.md:67 (doc)  `- Broad: `search_code({ query: "indexing pipeline chunk batch" })``
    - .claude/skills/dogfood/SKILL.md:68 (doc)  `- Specific: `search_code({ query: "code chunk insert batch structural store" })``
    - .claude/skills/dogfood/SKILL.md:69 (doc)  `- Cross-cutting: `search_code({ query: "test file associations imports" })``
    - .claude/skills/dogfood/SKILL.md:127 (doc)  `| search_code | pass/warn/fail | ... |`
    - .claude/skills/dogfood/SKILL.md:177 (doc)  `2. **Verify against code** — use `search_code`, `list_functions`, `Grep`, and `Read` to check:`
    - .claude/skills/dogfood/SKILL.md:356 (doc)  `2. Use `search_code` to find key architectural components: indexing pipeline, MCP server, vector DB, config system`
    - .claude/skills/dogfood/SKILL.md:444 (doc)  `4. Use `search_code({ query: "MCP tool test coverage vi.mock handler" })` to find test patterns`
    - .claude/skills/dogfood/SKILL.md:512 (doc)  `- Can a malicious `query` string in `search_code` cause issues? (injection into vector DB queries)`
    - .claude/skills/dogfood/SKILL.md:542 (doc)  `3. Use `search_code({ query: "validate file path sanitize resolve" })` to find path validation code`
    - .claude/skills/dogfood/SKILL.md:635 (doc)  `5. Use `search_code({ query: "error handling CLI command throw catch" })` to find error handling patterns`
    - [+71 more prose-touched line(s) — scan the diff for the rest]
  Surviving `semantic_search` references — should these have been renamed too?
    - .changeset/rename-search-code.md:5  `**BREAKING:** the `semantic_search` MCP tool is renamed to `search_code`.`
    - .changeset/rename-search-code.md:7  `The old name promised embeddings-based semantic matching; since the switch to lexical FTS5 search it no longer does, so the name now says what the tool is: full`
    - CHANGELOG.md:401 (untouched file)  `- Now all MCP tools (`semantic_search`, `find_similar`, `get_file_context`) filter out empty strings from test association arrays`
    - CHANGELOG.md:574 (untouched file)  `- All tools (`semantic_search`, `find_similar`, `get_file_context`, `list_functions`) now return index metadata`
    - CHANGELOG.md:590 (untouched file)  `- This was the root cause of test associations appearing empty in `semantic_search` and `get_file_context``
    - CHANGELOG.md:642 (untouched file)  `- `semantic_search({ query: "..." })` - results include test metadata in each chunk`
    - packages/core/CHANGELOG.md:39 (untouched file)  `- `semantic_search` and `find_similar` return a clear `note` ("disabled — structural-only mode") instead of crashing or silently returning misleading empty resu`
    - packages/core/CHANGELOG.md:371 (untouched file)  `- **Improved MCP tool descriptions** - `semantic_search` now positioned as "complements grep" rather than replacement`
    - packages/core/CHANGELOG.md:437 (untouched file)  `- Works with `semantic_search`, `get_dependents`, and `get_complexity` MCP tools`
    - packages/core/CHANGELOG.md:446 (untouched file)  `- `semantic_search`: Added `crossRepo` and `repoIds` parameters`
    - packages/cli/CHANGELOG.md:43 (untouched file)  `- `semantic_search` and `find_similar` return a clear `note` ("disabled — structural-only mode") instead of crashing or silently returning misleading empty resu`
    - packages/cli/CHANGELOG.md:454 (untouched file)  `- Add diagnostic notes to empty search results so LLMs get actionable guidance to self-correct (semantic_search, find_similar, list_functions)`
    - [+5 more surviving reference(s) — grep `semantic_search` for the rest]

- Mapping `SemanticSearchSchema` → `SearchCodeSchema` (22 occurrences across 5 files):
  Prose-touched lines — verify each claim still holds of `SearchCodeSchema`:
    - packages/cli/src/mcp/schemas/schemas.test.ts:11 (string)  `describe('SearchCodeSchema', () => {`

- Mapping `semantic` → `code` (5 occurrences across 5 files):
  Prose-touched lines — verify each claim still holds of `code`:
    - packages/cli/package.json:57 (string)  `"code-search",`
    - packages/cli/src/mcp/schemas/search.schema.ts:59 (comment)  `* Inferred TypeScript type for code search input`
    - packages/cli/test/e2e/README.md:241 (doc)  `- [x] Add code search validation (requires MCP server) — see `mcp-roundtrip.test.ts``
    - packages/cli/test/e2e/real-projects.test.ts:608 (string)  `'should return relevant results for code search',`
    - packages/core/package.json:62 (string)  `"code-search",`
  Surviving `semantic` references — should these have been renamed too?
    - .changeset/rename-search-code.md:7  `The old name promised embeddings-based semantic matching; since the switch to lexical FTS5 search it no longer does, so the name now says what the tool is: full`
    - packages/cli/src/mcp/handlers/search-code.test.ts:0  `diff --git a/packages/cli/src/mcp/handlers/semantic-search.test.ts b/packages/cli/src/mcp/handlers/search-code.test.ts`
    - packages/cli/src/mcp/handlers/search-code.test.ts:2  `rename from packages/cli/src/mcp/handlers/semantic-search.test.ts`
    - packages/cli/src/mcp/handlers/search-code.ts:0  `diff --git a/packages/cli/src/mcp/handlers/semantic-search.ts b/packages/cli/src/mcp/handlers/search-code.ts`
    - packages/cli/src/mcp/handlers/search-code.ts:2  `rename from packages/cli/src/mcp/handlers/semantic-search.ts`
    - packages/core/src/embeddings/null-embeddings.ts:22  `* `mcp/handlers/semantic-search.ts` and `mcp/handlers/find-similar.ts`).`
    - packages/parser/src/liquid-chunker.ts:7 (untouched file)  `* and keeps them as single semantic units`
    - packages/parser/src/index.ts:1 (untouched file)  `// @liendev/parser - AST parsing, complexity analysis, and semantic chunking`
    - packages/parser/src/ast/types.ts:49 (untouched file)  `* AST-aware chunk with enhanced semantic metadata`
    - packages/parser/src/ast/symbols.ts:292 (untouched file)  `// Recurse into named children to skip punctuation and other non-semantic nodes`
    - packages/parser/src/ast/chunker.ts:150 (untouched file)  `* Chunk a file using AST-based semantic boundaries`
    - packages/parser/src/ast/chunker.ts:152 (untouched file)  `* Uses Tree-sitter to parse code into an AST and extract semantic chunks`
    - [+44 more surviving reference(s) — grep `semantic` for the rest]
</rename_sweep>
````

## Full gate chain (all green)

```
npm run format:check   — pass
npm run lint           — pass (0 errors, 32 pre-existing warnings unrelated to this change)
npm run typecheck      — pass
npm run build          — pass
npm test                — parser 27/27, core 1062/1062, review 1008/1008, cli 860/860, action 39/39
node packages/cli/dist/index.js delta — exit 0 (2 "worsened" metrics, no new-over-threshold crossings)
```

Rebased onto `origin/main` (`ef0d213e`, PR #795) before opening this PR; no conflicts.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a straightforward wiring fix: it renders the existing `<rename_sweep>` signal into the dedicated doc-truth second-pass initial message (using the same renderer the main pass already uses) and extends the test-harness prompt dumper to surface that second pass. The change is additive, gated by the existing rename-sweep detector, and covered by new unit tests asserting both presence/absence and correct ordering. No callers are broken: `buildDocTruthPassInitialMessage` is only consumed by `buildDocTruthPassPrompts`, and the harness output gains a backward-compatible `docTruthPass` field.
>
> - Wired `renderRenameSweepSection` into `buildDocTruthPassInitialMessage` between `<doc_claims>` and `<guidance_surface_changes>`
> - Extended `build-prompts.ts` harness to emit the doc-truth pass prompts when the gate fires
> - Added regression tests for rename-sweep block inclusion, exclusion, and ordering

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5ba5306. Updates automatically on new commits.</sup>
<!-- /lien-stats -->