### PR TITLE
feat(review): unread-field signal for incomplete-handling's third shape

### DIFF
--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -288,11 +288,12 @@ When a function consumes a typed object (interface, type, config, options), chec
 - **Partial iteration**: A function iterates over some properties of a config/options object but skips others that affect behavior.
 - **Declared but unimplemented**: A type defines a contract (e.g., trigger conditions, handler map, feature flags), but the implementation only handles a subset. This is especially dangerous when the type is part of a public API or config schema — users will set the field expecting it to work.
 
-Focus on fields/variants introduced or modified in this PR. Two precomputed signal blocks may be in your initial message, each covering a different omission shape:
+Focus on fields/variants introduced or modified in this PR. Three precomputed signal blocks may be in your initial message, each covering a different omission shape:
 - A \`<variant_sweep_candidates>\` section pre-computes enum members / union arms / const-object keys this PR added, paired with switch/if-chain/mapping consumers elsewhere that enumerate the type's OTHER variants but omit the new one — confirm each entry (it may be an intentional catch-all default, or already disclosed) rather than re-grepping for consumers yourself.
 - A \`<sibling_surfaces>\` section pre-computes a DIFFERENT shape: same-extension or "mirror" sibling files (e.g. other handlers/decoders/bindings in the same family) that silently lack a feature or call this PR added to one member. Confirm each entry against the sibling's actual code before reporting — no grep needed for these, they are already located; stay silent when the sibling structurally cannot support the omitted behavior.
+- A \`<unread_field_candidates>\` section pre-computes a THIRD shape: a plain interface member / type-literal property / class field this PR added that has no dot-access, bracket-access, or destructuring read anywhere else in the indexed codebase. Confirm each entry before reporting — it may be consumed wholesale by a caller you haven't checked, or intentionally external/public-API; stay silent rather than re-grepping from scratch.
 
-For interface/config fields (not enum/union variants) or a family neither block covers, still grep for all consumers and verify they handle it.`,
+For a field/family none of these three blocks covers, still grep for all consumers and verify they handle it.`,
   example: `### Good finding — interface field declared but never consumed:
 {
   "filepath": "src/rules.ts",

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -26,6 +26,7 @@ import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js'
 import { renderDocClaimsSection } from '../../doc-claims-signals.js';
 import { renderTestCoverageSection } from '../../test-coverage-signals.js';
 import { renderSiblingSurfacesSection } from '../../sibling-surface-signals.js';
+import { renderUnreadFieldSection } from '../../unread-field-signals.js';
 import type { ResolvedRules } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -183,11 +184,13 @@ export interface BuildInitialMessageOptions {
    * Rules active for this run. Used to gate rule-scoped signal injection —
    * e.g. `<undiscriminated_catch_candidates>` only makes sense to compute
    * and render when `error-swallowing` is actually active for this PR.
-   * `incomplete-handling` gates two signals: `<variant_sweep_candidates>`
-   * (an added enum/union variant whose consumer sites weren't updated) and
+   * `incomplete-handling` gates three signals: `<variant_sweep_candidates>`
+   * (an added enum/union variant whose consumer sites weren't updated),
    * `<sibling_surfaces>` (a sibling family member that didn't receive a
-   * mirrored change) — both are the same partial-implementation-gap shape
-   * that rule targets, just at different granularity (variant vs. field).
+   * mirrored change), and `<unread_field_candidates>` (an added interface/
+   * type-literal/class field with no read site anywhere in the corpus) —
+   * all three are the same partial-implementation-gap shape that rule
+   * targets, just at different granularity (variant vs. family vs. field).
    * `boundary-change` likewise gates `<comparison_change_candidates>`.
    * Omit (CLI callers that don't resolve rules) to skip that gating.
    */
@@ -229,6 +232,7 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderTestCoverageSection(context));
   if (isRuleActive(opts.rules, 'incomplete-handling')) {
     appendIfPresent(sections, renderSiblingSurfacesSection(context));
+    appendIfPresent(sections, renderUnreadFieldSection(context));
   }
   sections.push(
     'Investigate this PR. Use the investigation strategy described in your instructions, then output findings as JSON.',

--- a/packages/review/src/unread-field-signals.ts
+++ b/packages/review/src/unread-field-signals.ts
@@ -34,23 +34,39 @@
  * judgment still exists without the signal."
  *
  *  - **Wholesale consumption (spread / `JSON.stringify` / serialization).**
- *    If ANY corpus chunk that mentions the type name also spreads an object
- *    (`...x`) or calls `JSON.stringify(`, every field of that type is
- *    suppressed — we can't prove the field isn't consumed as part of a whole-
- *    object pass-through, so we don't claim it is unread. Coarse (type-level,
- *    not field-level; doesn't verify the SAME variable is spread) by design —
- *    a narrower per-field check would need real data-flow tracking this
- *    module deliberately doesn't attempt.
+ *    If a `: TypeName` annotation has a spread (`...x`) or `JSON.stringify(`
+ *    within `WHOLESALE_PROXIMITY_CHARS` characters after it anywhere in the
+ *    corpus, every field of that type is suppressed — we can't prove the
+ *    field isn't consumed as part of a whole-object pass-through, so we
+ *    don't claim it is unread. Deliberately type-level, not field-level (a
+ *    narrower per-field check would need real data-flow tracking this module
+ *    doesn't attempt), and proximity-based rather than a bare co-occurrence
+ *    check: an earlier version matched the type name and a spread/stringify
+ *    ANYWHERE in the same chunk, which false-fired on this module's OWN doc
+ *    comment naming `RuleTriggers` (found via dogfooding) — requiring an
+ *    actual type annotation, with comments masked out first, fixes that
+ *    specific false-suppression while keeping the check textual (not real
+ *    data-flow: the nearby spread/stringify need not touch the same
+ *    variable the annotation introduced).
  *  - **Exported "public API" types.** A field on a type that's re-exported by
- *    an `index.ts`/`index.js` barrel found anywhere in the corpus (a wildcard
- *    `export * from`, or a named mention of the type) is suppressed — its
- *    real consumers may live outside this indexed corpus (an external SDK
- *    consumer, or another package this review run didn't index). This is a
+ *    an `index.ts`/`index.js` barrel is suppressed — its real consumers may
+ *    live outside this indexed corpus (an external SDK consumer, or another
+ *    package this review run didn't index). Two ways in: a NAMED export
+ *    statement mentioning the type directly, or a wildcard `export * from
+ *    '<specifier>'` whose specifier's basename matches the declaring file's
+ *    own basename. That basename match is required, not optional — an
+ *    earlier version treated ANY wildcard barrel found ANYWHERE in the
+ *    corpus as evidence, which (found via dogfooding) suppressed every
+ *    candidate in the entire codebase the moment a single, wholly unrelated
+ *    package had its own ordinary `export * from './foo.js'` barrel — nearly
+ *    universal in real code, and fatal to the signal's recall. It's still a
  *    coarse, corpus-wide textual check, not a per-package public-surface
  *    resolution: it can't tell a PUBLISHED package's real npm-facing barrel
  *    from a PRIVATE monorepo package's own internal `index.ts` (both look
- *    identical texturally) — so it over-suppresses inside private packages
- *    too. A documented false-negative-prone simplification, not a bug: fewer
+ *    identical texturally), and a same-basename file in an unrelated
+ *    directory can still false-match the wildcard form — so it still
+ *    over-suppresses sometimes, just no longer catastrophically. A
+ *    documented false-negative-prone simplification, not a bug: fewer
  *    candidates, never a wrong one.
  *  - **Test-fixture files.** A field declared in a file matching the test-path
  *    convention (`*.test.ts`, `__tests__/`, etc.) is skipped entirely — test
@@ -164,6 +180,8 @@ const CLASS_PROPERTY_LINE_RE =
 
 /** A spread of an identifier, or a `JSON.stringify(` call — coarse wholesale-consumption evidence. */
 const WHOLESALE_RE = /\bJSON\.stringify\s*\(|\.\.\.\s*[A-Za-z_$]/;
+/** How close (chars) a spread/`JSON.stringify(` must be AFTER a `: typeName` annotation to count — see {@link chunkHasWholesaleConsumption}. */
+const WHOLESALE_PROXIMITY_CHARS = 400;
 
 // ---------------------------------------------------------------------------
 // Low-level text utilities (masking/brace-matching, mirrors variant-sweep-signals.ts)
@@ -619,48 +637,107 @@ export function computeAddedFields(context: ReviewContext): AddedField[] {
 // Suppression: exported "public API" barrel reachability + wholesale consumption
 // ---------------------------------------------------------------------------
 
+const WILDCARD_EXPORT_RE = /export\s*\*\s*from\s*['"]([^'"]+)['"]/g;
+
+/** File basename with its extension (and any TS/JS suffix on the specifier side) stripped. */
+function baseNameNoExt(file: string): string {
+  const base = file.slice(file.lastIndexOf('/') + 1);
+  return base.replace(/\.(?:[cm]?[jt]sx?)$/, '');
+}
+
 /**
- * Is `typeName` re-exported by an `index.ts`/`index.js` barrel found anywhere
- * in the corpus? A wildcard `export * from` counts too — we can't rule out
- * what it re-exports, so it's conservative to treat it as "might include this
- * type" rather than requiring a literal name match. See module doc's
- * "Exported public API types" note for the known over-suppression tradeoff.
+ * Does a wildcard `export * from '<specifier>'` module specifier plausibly
+ * point at the declaring file — i.e. does its last path segment (extension
+ * stripped) match the file's own basename? A barrel's wildcard target is
+ * usually a relative specifier (`./foo.js`, `../bar/foo.js`) whose basename
+ * mirrors the real file it re-exports; requiring that match is what stops
+ * an ENTIRELY UNRELATED barrel elsewhere in the corpus (any package's own
+ * `export * from './something-else.js'`) from suppressing every type in the
+ * whole codebase — the bug an earlier, unscoped version of this check hit
+ * during dogfooding (a schemas barrel in a different package suppressed a
+ * field on an unrelated type in another package entirely).
  */
-function isReachableFromIndexBarrel(typeName: string, repoChunks: CodeChunk[]): boolean {
+function wildcardSpecifierMatchesFile(specifier: string, fileBase: string): boolean {
+  return baseNameNoExt(specifier) === fileBase;
+}
+
+/**
+ * Is `typeName`, declared in `file`, re-exported by an `index.ts`/`index.js`
+ * barrel found anywhere in the corpus? Two ways in: a wildcard `export *
+ * from` whose specifier's basename matches `file`'s own basename (we can't
+ * resolve real module paths without a resolver, so a basename match is the
+ * scoped proxy — see {@link wildcardSpecifierMatchesFile}), or a named
+ * export statement that mentions `typeName` directly. See module doc's
+ * "Exported public API types" note for the remaining over-suppression
+ * tradeoff (a same-basename file in an unrelated directory can still
+ * false-match the wildcard form).
+ */
+function isReachableFromIndexBarrel(
+  typeName: string,
+  file: string,
+  repoChunks: CodeChunk[],
+): boolean {
+  const fileBase = baseNameNoExt(file);
   const nameRe = new RegExp(`\\bexport\\b[^;\\n]*\\b${escapeRegExp(typeName)}\\b`);
   for (const chunk of repoChunks) {
     if (!INDEX_BARREL_RE.test(chunk.metadata.file)) continue;
     const masked = maskComments(chunk.content);
-    if (/export\s*\*\s*from/.test(masked)) return true;
+    for (const m of masked.matchAll(new RegExp(WILDCARD_EXPORT_RE.source, 'g'))) {
+      if (wildcardSpecifierMatchesFile(m[1], fileBase)) return true;
+    }
     if (nameRe.test(masked)) return true;
   }
   return false;
 }
 
 /**
- * Does any corpus chunk that mentions `typeName` also spread an object or
- * call `JSON.stringify(`? Coarse, type-level, deliberately over-suppressing —
- * see module doc.
+ * Does a `: typeName` type annotation appear with a spread or
+ * `JSON.stringify(` within {@link WHOLESALE_PROXIMITY_CHARS} characters
+ * AFTER it, anywhere in this chunk? Requiring the annotation — not just the
+ * bare type name — matters: a doc comment or an unrelated field merely
+ * NAMING the type (`RuleTriggers.filePatterns` in a docstring, `triggers:
+ * RuleTriggers` three unrelated fields away from someone else's spread) is
+ * not evidence any VALUE of this type is ever spread/serialized. Comments
+ * are masked first, so a prose mention can't itself count as the
+ * annotation. Still coarse (proximity, not real data-flow — the nearby
+ * spread/stringify need not touch the SAME variable the annotation
+ * introduced), but far tighter than "the type name and a spread anywhere in
+ * the same file", which false-fired on this module's OWN doc comment
+ * mentioning `RuleTriggers` during dogfooding.
  */
+function chunkHasWholesaleConsumption(typeName: string, content: string): boolean {
+  const masked = maskComments(content);
+  const typedRe = new RegExp(`:\\s*${escapeRegExp(typeName)}\\b`, 'g');
+  for (const m of masked.matchAll(typedRe)) {
+    const windowStart = m.index + m[0].length;
+    const window = masked.slice(windowStart, windowStart + WHOLESALE_PROXIMITY_CHARS);
+    if (WHOLESALE_RE.test(window)) return true;
+  }
+  return false;
+}
+
+/** Does any corpus chunk show wholesale consumption evidence for `typeName`? */
 function hasWholesaleConsumption(typeName: string, repoChunks: CodeChunk[]): boolean {
   for (const chunk of repoChunks) {
     if (!chunk.content.includes(typeName)) continue;
-    if (WHOLESALE_RE.test(maskComments(chunk.content))) return true;
+    if (chunkHasWholesaleConsumption(typeName, chunk.content)) return true;
   }
   return false;
 }
 
 function isSuppressedType(
   typeName: string,
+  file: string,
   repoChunks: CodeChunk[],
   cache: Map<string, boolean>,
 ): boolean {
-  const cached = cache.get(typeName);
+  const key = `${file}:${typeName}`;
+  const cached = cache.get(key);
   if (cached !== undefined) return cached;
   const suppressed =
-    isReachableFromIndexBarrel(typeName, repoChunks) ||
+    isReachableFromIndexBarrel(typeName, file, repoChunks) ||
     hasWholesaleConsumption(typeName, repoChunks);
-  cache.set(typeName, suppressed);
+  cache.set(key, suppressed);
   return suppressed;
 }
 
@@ -751,7 +828,7 @@ function filterUnreadCandidates(
   for (const a of added) {
     const decl = declByKey.get(`${a.kind}:${a.typeName}:${a.file}`);
     if (!decl) continue;
-    if (isSuppressedType(a.typeName, repoChunks, suppressionCache)) continue;
+    if (isSuppressedType(a.typeName, a.file, repoChunks, suppressionCache)) continue;
     if (hasReadSite(a.field, a.file, decl, repoChunks)) continue;
     out.push({ typeName: a.typeName, field: a.field, file: a.file, line: a.line, kind: a.kind });
   }

--- a/packages/review/src/unread-field-signals.ts
+++ b/packages/review/src/unread-field-signals.ts
@@ -1,0 +1,839 @@
+/**
+ * Deterministic "unread field" signal for PR reviews — incomplete-handling's
+ * THIRD omission shape.
+ *
+ * Provenance: the per-rule-loops design review (`.wip/per-rule-loops-design.md`,
+ * gating-matrix row for `incomplete-handling`) names this as the one shape with
+ * ZERO signal coverage today: `variant-sweep-signals.ts` covers added enum/
+ * union/const-object VARIANTS, `sibling-surface-signals.ts` covers a feature
+ * silently missing from a FAMILY MEMBER file — but a plain interface member /
+ * type-literal property / class field that's declared and never read anywhere
+ * ("the plumbing to the consumer was forgotten") has no precomputed candidate
+ * list; the rule's own prompt (`rules.ts`, `INCOMPLETE_HANDLING`) just tells
+ * the agent to "grep for all consumers" — the exact grep-and-reason anti-
+ * pattern CLAUDE.md's design principle warns against, and this module's own
+ * motivating example (`RuleTriggers.filePatterns`, `rules.ts`'s `example`
+ * field) is EXACTLY this shape.
+ *
+ * The shape: a PR adds a member to an EXISTING or brand-new interface / type
+ * literal / class (TS/JS v1 scope) that has no dot-access, bracket-access, or
+ * destructuring reference anywhere else in the indexed corpus — only its own
+ * declaration. Two steps, both deterministic:
+ *   1. `computeAddedFields` — parse each changed file's diff for a genuinely
+ *      new interface member / type-literal property / class field.
+ *   2. `computeUnreadFieldCandidates` — for each added field, sweep the full
+ *      indexed corpus (`repoChunks`) for a read site; keep only fields with
+ *      none.
+ *
+ * ## Precision instrument, not recall instrument
+ *
+ * This is a "prove absence" signal, the hardest kind — a single missed read
+ * pattern anywhere in a multi-hundred-chunk corpus is a false positive. Every
+ * design choice below errs toward silence over a wrong candidate, per the
+ * design brief: "when in doubt, suppress the candidate — the rule's LLM
+ * judgment still exists without the signal."
+ *
+ *  - **Wholesale consumption (spread / `JSON.stringify` / serialization).**
+ *    If ANY corpus chunk that mentions the type name also spreads an object
+ *    (`...x`) or calls `JSON.stringify(`, every field of that type is
+ *    suppressed — we can't prove the field isn't consumed as part of a whole-
+ *    object pass-through, so we don't claim it is unread. Coarse (type-level,
+ *    not field-level; doesn't verify the SAME variable is spread) by design —
+ *    a narrower per-field check would need real data-flow tracking this
+ *    module deliberately doesn't attempt.
+ *  - **Exported "public API" types.** A field on a type that's re-exported by
+ *    an `index.ts`/`index.js` barrel found anywhere in the corpus (a wildcard
+ *    `export * from`, or a named mention of the type) is suppressed — its
+ *    real consumers may live outside this indexed corpus (an external SDK
+ *    consumer, or another package this review run didn't index). This is a
+ *    coarse, corpus-wide textual check, not a per-package public-surface
+ *    resolution: it can't tell a PUBLISHED package's real npm-facing barrel
+ *    from a PRIVATE monorepo package's own internal `index.ts` (both look
+ *    identical texturally) — so it over-suppresses inside private packages
+ *    too. A documented false-negative-prone simplification, not a bug: fewer
+ *    candidates, never a wrong one.
+ *  - **Test-fixture files.** A field declared in a file matching the test-path
+ *    convention (`*.test.ts`, `__tests__/`, etc.) is skipped entirely — test
+ *    fixture objects routinely carry properties the test itself never reads
+ *    back out, and that's not a production bug.
+ *  - **Dynamic/bracket access.** Read detection covers `obj.field`,
+ *    `obj['field']`/`obj["field"]` (bracket string-literal key access), and
+ *    both destructuring shapes (`const { field } = x`, `function f({ field })`)
+ *    — not just the naive dot-access form other signals use for qualified
+ *    enum/const-object references. A TRULY dynamic key (`obj[someVar]` where
+ *    `someVar` happens to equal the field name at runtime) is undetectable
+ *    statically and stays a documented gap.
+ *
+ * ## v1 scope, stated honestly
+ *
+ *  - TS/JS only (this repo's own surface, mirrors every other TS/JS-scoped
+ *    signal in this file set).
+ *  - Three declaration shapes: `interface X { field: T; }`, `type X = { field:
+ *    T; }` (a DIRECT object-type-literal assignment only — `type X = A & {
+ *    field: T }` or a generic-wrapped object type is not parsed, a documented
+ *    gap, same tradeoff `variant-sweep-signals.ts` makes for its union shape),
+ *    and a single-physical-line TYPED class property (`private readonly
+ *    field: T;`, `field?: T;`, `field: T = default;`) — an untyped inferred
+ *    field (`field = value;`, no `:`), a decorator-prefixed field
+ *    (`@Input() field: T;`), or a multi-line field type are not detected;
+ *    narrowing scope here trades recall for never misreading a getter/setter/
+ *    method as a field (see `CLASS_PROPERTY_LINE_RE`'s doc for why).
+ *  - Unlike `variant-sweep-signals.ts`, the containing declaration does NOT
+ *    need to have existed before this PR — a brand-new interface whose field
+ *    nobody reads is the same bug shape (the rule's own `RuleTriggers`
+ *    example could plausibly have introduced `filePatterns` alongside a
+ *    brand-new interface, not just added it to an old one).
+ *  - This module does not verify the field is ever POPULATED (an object
+ *    literal setting it, or a `.field = value` assignment) — it fires purely
+ *    on "declared + never read". A field that's also never populated is
+ *    arguably a smaller bug (dead code) than one that's silently populated
+ *    and dropped, but distinguishing the two needs a construction-site trace
+ *    this module doesn't attempt; left to the agent's own judgment.
+ *  - A member is a genuine ADDITION using the same `isGenuinelyNew` technique
+ *    `variant-sweep-signals.ts` uses: its identifier must not appear on a
+ *    REMOVED line of this file's diff. A rename (old field removed, new one
+ *    added) still counts as an addition — the same accepted overlap with
+ *    `rename-sweep-signals.ts` variant-sweep documents for its own shape.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type UnreadFieldKind = 'interface' | 'type-literal' | 'class';
+
+/** A field this PR adds to an interface / type literal / class with no read site found. */
+export interface UnreadFieldCandidate {
+  typeName: string;
+  field: string;
+  file: string;
+  line: number;
+  kind: UnreadFieldKind;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max candidates rendered — keeps the block compact, mirrors comparison-change/stale-literal. */
+const MAX_CANDIDATES = 10;
+/** Total block character budget. */
+const MAX_BLOCK_CHARS = 3_000;
+
+/** Files whose diffs/chunks we scan (this repo's TS/JS surface — v1 scope). */
+const TS_JS_FILE_RE = /\.(?:[cm]?[jt]sx?)$/;
+
+/**
+ * Broader than a leading-slash-only test regex — matches a root-level
+ * `tests/` directory and languages that keep tests alongside source (mirrors
+ * `sibling-surface-signals.ts`'s own `TEST_PATH_RE`, same rationale).
+ */
+const TEST_PATH_RE =
+  /(^|\/)(tests?|specs?|__tests__)(\/|$)|\.(test|spec)\.|_test\.\w+$|_spec\.\w+$|[A-Z]\w*Test\.\w+$/;
+
+/** An `index.ts`/`index.js` (or `.tsx`/`.jsx`) barrel file anywhere in the corpus. */
+const INDEX_BARREL_RE = /(^|\/)index\.[cm]?[jt]sx?$/;
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+const INTERFACE_HEADER_RE =
+  /\b(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)(?:\s*<[^{]*>)?(?:\s+extends\s+[^{]+)?\s*\{/g;
+const TYPE_LITERAL_HEADER_RE =
+  /\b(?:export\s+)?type\s+([A-Za-z_$][\w$]*)(?:\s*<[^=\n]*>)?\s*=\s*\{/g;
+const CLASS_HEADER_RE =
+  /\b(?:export\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)(?:\s*<[^{]*>)?(?:\s+extends\s+[^{]+)?(?:\s+implements\s+[^{]+)?\s*\{/g;
+
+/** A single interface/type-literal member: `field: Type` or `field?: Type`, never a call/construct/index signature. */
+const INTERFACE_MEMBER_RE = /^\s*(?:readonly\s+)?([A-Za-z_$][\w$]*)\??\s*:\s*[\s\S]+$/;
+
+/**
+ * A single PHYSICAL LINE typed class property. Requires the type annotation
+ * colon (excludes an untyped inferred field like `field = value;` — a
+ * documented v1 gap) and forbids `{`/`}` in the type (excludes an inline
+ * multi-line object-type field and prevents matching into a method's body by
+ * accident). No `get`/`set` in the modifier list is intentional: a getter/
+ * setter's name is followed by `(`, never `:`, so it can never match this
+ * pattern regardless — the same reasoning that already excludes a method
+ * signature (`foo(): T {`) without needing an explicit exclusion for it.
+ */
+const CLASS_PROPERTY_LINE_RE =
+  /^\s*(?:public\s+|private\s+|protected\s+|readonly\s+|static\s+|abstract\s+|override\s+|declare\s+)*([A-Za-z_$][\w$]*)\??\s*:\s*[^;\n{}]+;\s*$/;
+
+/** A spread of an identifier, or a `JSON.stringify(` call — coarse wholesale-consumption evidence. */
+const WHOLESALE_RE = /\bJSON\.stringify\s*\(|\.\.\.\s*[A-Za-z_$]/;
+
+// ---------------------------------------------------------------------------
+// Low-level text utilities (masking/brace-matching, mirrors variant-sweep-signals.ts)
+// ---------------------------------------------------------------------------
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function skipStringLike(text: string, i: number): number {
+  const quote = text[i];
+  i++;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+interface Span {
+  end: number;
+  kind: 'string' | 'comment';
+}
+
+function classifySpan(text: string, i: number): Span | null {
+  const ch = text[i];
+  if (ch === '"' || ch === "'" || ch === '`')
+    return { end: skipStringLike(text, i), kind: 'string' };
+  if (ch === '/' && text[i + 1] === '/') {
+    const end = text.indexOf('\n', i);
+    return { end: end === -1 ? text.length : end, kind: 'comment' };
+  }
+  if (ch === '/' && text[i + 1] === '*') {
+    const end = text.indexOf('*/', i + 2);
+    return { end: end === -1 ? text.length : end + 2, kind: 'comment' };
+  }
+  return null;
+}
+
+/** Replace every span `shouldMask` accepts with same-length whitespace (newlines kept, so line numbers still match). */
+function maskSpans(
+  text: string,
+  shouldMask: (span: Span, start: number, text: string) => boolean,
+): string {
+  let i = 0;
+  let out = '';
+  while (i < text.length) {
+    const span = classifySpan(text, i);
+    if (span === null) {
+      out += text[i];
+      i++;
+      continue;
+    }
+    if (shouldMask(span, i, text)) {
+      for (let k = i; k < span.end; k++) out += text[k] === '\n' ? '\n' : ' ';
+    } else {
+      out += text.slice(i, span.end);
+    }
+    i = span.end;
+  }
+  return out;
+}
+
+function maskComments(text: string): string {
+  return maskSpans(text, span => span.kind === 'comment');
+}
+
+function maskCommentsAndStrings(text: string): string {
+  return maskSpans(text, () => true);
+}
+
+function prevNonSpace(text: string, i: number): string {
+  let k = i - 1;
+  while (k >= 0 && /\s/.test(text[k])) k--;
+  return k >= 0 ? text[k] : '';
+}
+
+function nextNonSpace(text: string, i: number): string {
+  let k = i;
+  while (k < text.length && /\s/.test(text[k])) k++;
+  return k < text.length ? text[k] : '';
+}
+
+/** Is this string span a bracket-index key (`obj['field']`) rather than a free-standing prose string? */
+function isBracketIndexString(span: Span, start: number, text: string): boolean {
+  return prevNonSpace(text, start) === '[' && nextNonSpace(text, span.end) === ']';
+}
+
+/**
+ * Mask comments and prose strings, but NOT a bracket-index key — needed so
+ * `obj['field']` read detection still sees the quoted key, mirroring
+ * `variant-sweep-signals.ts`'s `maskCommentsAndProseStrings`.
+ */
+function maskCommentsAndProseStrings(text: string): string {
+  return maskSpans(
+    text,
+    (span, start, t) =>
+      span.kind === 'comment' || (span.kind === 'string' && !isBracketIndexString(span, start, t)),
+  );
+}
+
+function findMatchingBraceFrom(content: string, openIdx: number): number {
+  let depth = 0;
+  let i = openIdx;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLike(content, i);
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      i++;
+      if (depth === 0) return i - 1;
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+interface Segment {
+  text: string;
+  offset: number;
+}
+
+/** Split `text` on top-level `;`, respecting `{}`/`()`/`[]` nesting and skipping string/template literals. */
+function splitTopLevelSemicolons(text: string): Segment[] {
+  const segments: Segment[] = [];
+  let depth = 0;
+  let start = 0;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLike(text, i);
+      continue;
+    }
+    if ('{(['.includes(ch)) {
+      depth++;
+      i++;
+      continue;
+    }
+    if ('})]'.includes(ch)) {
+      depth--;
+      i++;
+      continue;
+    }
+    if (depth === 0 && ch === ';') {
+      segments.push({ text: text.slice(start, i), offset: start });
+      start = i + 1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  const rest = text.slice(start);
+  if (rest.trim().length > 0) segments.push({ text: rest, offset: start });
+  return segments;
+}
+
+function countNewlines(text: string, upTo: number): number {
+  let n = 0;
+  for (let i = 0; i < upTo; i++) {
+    if (text[i] === '\n') n++;
+  }
+  return n;
+}
+
+function leadingWhitespaceLength(text: string): number {
+  return text.length - text.trimStart().length;
+}
+
+// ---------------------------------------------------------------------------
+// Type declaration extraction (static, post-PR chunk content)
+// ---------------------------------------------------------------------------
+
+interface FieldMember {
+  name: string;
+  line: number;
+}
+
+interface TypeDeclaration {
+  typeName: string;
+  kind: UnreadFieldKind;
+  fields: FieldMember[];
+  declStartLine: number;
+  declEndLine: number;
+}
+
+function memberLine(content: string, baseLine: number, bodyStart: number, seg: Segment): number {
+  const idx = bodyStart + seg.offset + leadingWhitespaceLength(seg.text);
+  return baseLine + countNewlines(content, idx);
+}
+
+/** Shared body-member extraction for `interface`/type-literal declarations (both use `;`-separated members). */
+function findBraceBodyDeclarations(
+  content: string,
+  baseLine: number,
+  headerRe: RegExp,
+  kind: UnreadFieldKind,
+): TypeDeclaration[] {
+  const out: TypeDeclaration[] = [];
+  const headerMask = maskCommentsAndStrings(content);
+  const commentMasked = maskComments(content);
+  for (const m of headerMask.matchAll(headerRe)) {
+    const typeName = m[1];
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = findMatchingBraceFrom(commentMasked, openIdx);
+    if (closeIdx === -1) continue;
+
+    const bodyStart = openIdx + 1;
+    const body = commentMasked.slice(bodyStart, closeIdx);
+    const fields: FieldMember[] = [];
+    for (const seg of splitTopLevelSemicolons(body)) {
+      const t = seg.text.trim();
+      if (!t) continue;
+      const mem = t.match(INTERFACE_MEMBER_RE);
+      if (!mem) continue;
+      fields.push({ name: mem[1], line: memberLine(content, baseLine, bodyStart, seg) });
+    }
+
+    out.push({
+      typeName,
+      kind,
+      fields,
+      declStartLine: baseLine + countNewlines(content, m.index),
+      declEndLine: baseLine + countNewlines(content, closeIdx),
+    });
+  }
+  return out;
+}
+
+function findInterfaceDeclarations(content: string, baseLine: number): TypeDeclaration[] {
+  return findBraceBodyDeclarations(content, baseLine, new RegExp(INTERFACE_HEADER_RE), 'interface');
+}
+
+function findTypeLiteralDeclarations(content: string, baseLine: number): TypeDeclaration[] {
+  return findBraceBodyDeclarations(
+    content,
+    baseLine,
+    new RegExp(TYPE_LITERAL_HEADER_RE),
+    'type-literal',
+  );
+}
+
+/** Net bracket-depth change from one line — `{`/`(`/`[` open, `}`/`)`/`]` close. */
+function depthDelta(line: string): number {
+  let delta = 0;
+  for (const ch of line) {
+    if (ch === '{' || ch === '(' || ch === '[') delta++;
+    else if (ch === '}' || ch === ')' || ch === ']') delta--;
+  }
+  return delta;
+}
+
+/**
+ * Class member scan: a plain top-level `;`-split (like interfaces use) breaks
+ * on a class body, since a method's `}` isn't followed by a `;` — a method
+ * immediately followed by a property would merge into one unsplit segment
+ * spanning both, hiding the property from `INTERFACE_MEMBER_RE`. Scan
+ * line-by-line with brace-depth tracking instead: only test a line against
+ * {@link CLASS_PROPERTY_LINE_RE} when depth is 0 (top level of the class
+ * body, not inside a method's own body/params).
+ */
+function findClassPropertyMembers(
+  content: string,
+  baseLine: number,
+  bodyStart: number,
+  bodyEnd: number,
+): FieldMember[] {
+  const body = content.slice(bodyStart, bodyEnd);
+  const bodyStartLine = baseLine + countNewlines(content, bodyStart);
+  const lines = body.split('\n');
+  const out: FieldMember[] = [];
+  let depth = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (depth === 0) {
+      const m = line.match(CLASS_PROPERTY_LINE_RE);
+      if (m) out.push({ name: m[1], line: bodyStartLine + i });
+    }
+    depth += depthDelta(line);
+  }
+  return out;
+}
+
+function findClassDeclarations(content: string, baseLine: number): TypeDeclaration[] {
+  const out: TypeDeclaration[] = [];
+  const headerMask = maskCommentsAndStrings(content);
+  const commentMasked = maskComments(content);
+  for (const m of headerMask.matchAll(new RegExp(CLASS_HEADER_RE))) {
+    const typeName = m[1];
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = findMatchingBraceFrom(commentMasked, openIdx);
+    if (closeIdx === -1) continue;
+
+    out.push({
+      typeName,
+      kind: 'class',
+      fields: findClassPropertyMembers(content, baseLine, openIdx + 1, closeIdx),
+      declStartLine: baseLine + countNewlines(content, m.index),
+      declEndLine: baseLine + countNewlines(content, closeIdx),
+    });
+  }
+  return out;
+}
+
+/** All interface/type-literal/class declarations found in one chunk's (TS/JS) content. */
+function findTypeDeclarations(content: string, baseLine: number): TypeDeclaration[] {
+  return [
+    ...findInterfaceDeclarations(content, baseLine),
+    ...findTypeLiteralDeclarations(content, baseLine),
+    ...findClassDeclarations(content, baseLine),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Diff-side: which new-file lines did this PR add, and what did it remove?
+// ---------------------------------------------------------------------------
+
+interface FileDiffFacts {
+  addedLines: Set<number>;
+  removedText: string;
+}
+
+function computeFileDiffFacts(patch: string): FileDiffFacts {
+  const addedLines = new Set<number>();
+  const removedParts: string[] = [];
+  let newLine = 0;
+
+  for (const raw of patch.split('\n')) {
+    const hunk = raw.match(HUNK_HEADER_RE);
+    if (hunk) {
+      newLine = parseInt(hunk[1], 10);
+      continue;
+    }
+    if (raw.startsWith('+++') || raw.startsWith('---') || raw.startsWith('\\')) continue;
+
+    if (raw.startsWith('+')) {
+      addedLines.add(newLine);
+      newLine++;
+    } else if (raw.startsWith('-')) {
+      removedParts.push(raw.slice(1));
+    } else {
+      newLine++;
+    }
+  }
+
+  return { addedLines, removedText: removedParts.join('\n') };
+}
+
+/** Same technique `variant-sweep-signals.ts` uses: a rename still counts as an addition. */
+function isGenuinelyNew(name: string, removedText: string): boolean {
+  return !new RegExp(`\\b${escapeRegExp(name)}\\b`).test(removedText);
+}
+
+// ---------------------------------------------------------------------------
+// computeAddedFields
+// ---------------------------------------------------------------------------
+
+/** One field this PR genuinely added, with its containing declaration. */
+export interface AddedField {
+  typeName: string;
+  field: string;
+  file: string;
+  line: number;
+  kind: UnreadFieldKind;
+}
+
+interface AddedFieldEntry {
+  decl: TypeDeclaration;
+  field: FieldMember;
+  file: string;
+}
+
+function collectAddedFieldsFromChunk(
+  chunk: CodeChunk,
+  file: string,
+  facts: FileDiffFacts,
+  seen: Set<string>,
+  out: AddedFieldEntry[],
+): void {
+  for (const decl of findTypeDeclarations(chunk.content, chunk.metadata.startLine)) {
+    for (const field of decl.fields) {
+      if (!facts.addedLines.has(field.line)) continue;
+      if (!isGenuinelyNew(field.name, facts.removedText)) continue;
+
+      const key = `${decl.kind}:${decl.typeName}:${field.name}:${file}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ decl, field, file });
+    }
+  }
+}
+
+/** One changed file's worth of added-field collection, split out to keep {@link computeAddedFields} flat. */
+function collectAddedFieldsForFile(
+  file: string,
+  patch: string,
+  chunks: CodeChunk[],
+  seen: Set<string>,
+  out: AddedFieldEntry[],
+): void {
+  const facts = computeFileDiffFacts(patch);
+  if (facts.addedLines.size === 0) return;
+
+  for (const chunk of chunks) {
+    if (chunk.metadata.file === file) collectAddedFieldsFromChunk(chunk, file, facts, seen, out);
+  }
+}
+
+/**
+ * Find every interface member / type-literal property / class field this PR
+ * genuinely adds (unlike `variant-sweep-signals.ts`, the containing
+ * declaration need NOT have existed before this PR — see module doc). Exposed
+ * for testing.
+ */
+export function computeAddedFields(context: ReviewContext): AddedField[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+  const chunks = context.chunks;
+  if (!chunks || chunks.length === 0) return [];
+
+  const entries: AddedFieldEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const [file, patch] of patches) {
+    if (!TS_JS_FILE_RE.test(file)) continue;
+    if (TEST_PATH_RE.test(file)) continue; // FP trap: test-fixture files
+    collectAddedFieldsForFile(file, patch, chunks, seen, entries);
+  }
+
+  return entries.map(e => ({
+    typeName: e.decl.typeName,
+    field: e.field.name,
+    file: e.file,
+    line: e.field.line,
+    kind: e.decl.kind,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Suppression: exported "public API" barrel reachability + wholesale consumption
+// ---------------------------------------------------------------------------
+
+/**
+ * Is `typeName` re-exported by an `index.ts`/`index.js` barrel found anywhere
+ * in the corpus? A wildcard `export * from` counts too — we can't rule out
+ * what it re-exports, so it's conservative to treat it as "might include this
+ * type" rather than requiring a literal name match. See module doc's
+ * "Exported public API types" note for the known over-suppression tradeoff.
+ */
+function isReachableFromIndexBarrel(typeName: string, repoChunks: CodeChunk[]): boolean {
+  const nameRe = new RegExp(`\\bexport\\b[^;\\n]*\\b${escapeRegExp(typeName)}\\b`);
+  for (const chunk of repoChunks) {
+    if (!INDEX_BARREL_RE.test(chunk.metadata.file)) continue;
+    const masked = maskComments(chunk.content);
+    if (/export\s*\*\s*from/.test(masked)) return true;
+    if (nameRe.test(masked)) return true;
+  }
+  return false;
+}
+
+/**
+ * Does any corpus chunk that mentions `typeName` also spread an object or
+ * call `JSON.stringify(`? Coarse, type-level, deliberately over-suppressing —
+ * see module doc.
+ */
+function hasWholesaleConsumption(typeName: string, repoChunks: CodeChunk[]): boolean {
+  for (const chunk of repoChunks) {
+    if (!chunk.content.includes(typeName)) continue;
+    if (WHOLESALE_RE.test(maskComments(chunk.content))) return true;
+  }
+  return false;
+}
+
+function isSuppressedType(
+  typeName: string,
+  repoChunks: CodeChunk[],
+  cache: Map<string, boolean>,
+): boolean {
+  const cached = cache.get(typeName);
+  if (cached !== undefined) return cached;
+  const suppressed =
+    isReachableFromIndexBarrel(typeName, repoChunks) ||
+    hasWholesaleConsumption(typeName, repoChunks);
+  cache.set(typeName, suppressed);
+  return suppressed;
+}
+
+// ---------------------------------------------------------------------------
+// Read-site detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Read patterns for one field name. Excludes only a PLAIN simple assignment
+ * (`.field = value`, the pure-write/population shape) — compound assignment
+ * (`+=`) and increment/decrement (`++`/`--`) read-then-write, so they count
+ * as reads, same as an equality comparison (`===`).
+ */
+function buildFieldReadPatterns(name: string): RegExp[] {
+  const esc = escapeRegExp(name);
+  const notPlainWrite = `(?!\\s*=(?!=))`;
+  return [
+    // Dot-access read: `obj.field`, excluding `obj.field = value`.
+    new RegExp(`\\.${esc}\\b${notPlainWrite}`),
+    // Bracket string-literal access read: `obj['field']`/`obj["field"]`, excluding `obj['field'] = value`.
+    new RegExp(`\\[\\s*['"\`]${esc}['"\`]\\s*\\]${notPlainWrite}`),
+    // Destructuring assignment: `const { field } = obj;` / `const { field }: T = obj;`.
+    new RegExp(`\\{[^{}]*\\b${esc}\\b[^{}]*\\}\\s*(?::\\s*[\\w.<>[\\],\\s]+)?=(?!=)`),
+    // Destructuring function parameter: `function f({ field }: T)` / `({ field }) =>`.
+    new RegExp(`\\([^()]*\\{[^{}]*\\b${esc}\\b[^{}]*\\}`),
+  ];
+}
+
+function isDeclarationSite(chunk: CodeChunk, file: string, decl: TypeDeclaration): boolean {
+  return (
+    chunk.metadata.file === file &&
+    chunk.metadata.startLine <= decl.declEndLine &&
+    decl.declStartLine <= chunk.metadata.endLine
+  );
+}
+
+/** Is there any read site for `fieldName` in the corpus, outside the declaring type's own chunk(s)? */
+function hasReadSite(
+  fieldName: string,
+  file: string,
+  decl: TypeDeclaration,
+  repoChunks: CodeChunk[],
+): boolean {
+  const patterns = buildFieldReadPatterns(fieldName);
+  for (const chunk of repoChunks) {
+    if (isDeclarationSite(chunk, file, decl)) continue;
+    if (!chunk.content.includes(fieldName)) continue;
+    const masked = maskCommentsAndProseStrings(chunk.content);
+    if (patterns.some(re => re.test(masked))) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// computeUnreadFieldCandidates
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-derive each changed file's declarations, keyed by `kind:typeName:file`,
+ * for the read-site exclusion — cheap (bounded by the small number of changed
+ * files), and keeps `AddedField`'s public shape free of internal
+ * declaration-range bookkeeping. Split out to keep
+ * {@link computeUnreadFieldCandidates} flat.
+ */
+function buildDeclarationIndex(context: ReviewContext): Map<string, TypeDeclaration> {
+  const declByKey = new Map<string, TypeDeclaration>();
+  for (const file of context.pr?.patches?.keys() ?? []) {
+    if (!TS_JS_FILE_RE.test(file) || TEST_PATH_RE.test(file)) continue;
+    for (const chunk of context.chunks) {
+      if (chunk.metadata.file !== file) continue;
+      for (const decl of findTypeDeclarations(chunk.content, chunk.metadata.startLine)) {
+        declByKey.set(`${decl.kind}:${decl.typeName}:${file}`, decl);
+      }
+    }
+  }
+  return declByKey;
+}
+
+/** Keep only added fields whose type isn't suppressed and which have no read site. Split out to keep {@link computeUnreadFieldCandidates} flat. */
+function filterUnreadCandidates(
+  added: AddedField[],
+  declByKey: Map<string, TypeDeclaration>,
+  repoChunks: CodeChunk[],
+): UnreadFieldCandidate[] {
+  const suppressionCache = new Map<string, boolean>();
+  const out: UnreadFieldCandidate[] = [];
+
+  for (const a of added) {
+    const decl = declByKey.get(`${a.kind}:${a.typeName}:${a.file}`);
+    if (!decl) continue;
+    if (isSuppressedType(a.typeName, repoChunks, suppressionCache)) continue;
+    if (hasReadSite(a.field, a.file, decl, repoChunks)) continue;
+    out.push({ typeName: a.typeName, field: a.field, file: a.file, line: a.line, kind: a.kind });
+  }
+
+  return out;
+}
+
+/**
+ * The full `<unread_field_candidates>` worklist: every interface member /
+ * type-literal property / class field this PR added that has no read site
+ * anywhere else in the indexed corpus. Exposed for testing.
+ */
+export function computeUnreadFieldCandidates(context: ReviewContext): UnreadFieldCandidate[] {
+  const added = computeAddedFields(context);
+  if (added.length === 0) return [];
+  const repoChunks = context.repoChunks;
+  if (!repoChunks || repoChunks.length === 0) return [];
+
+  const declByKey = buildDeclarationIndex(context);
+  const out = filterUnreadCandidates(added, declByKey, repoChunks);
+  out.sort((x, y) => x.file.localeCompare(y.file) || x.line - y.line);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const HEADER =
+  'Pre-computed by a deterministic diff scan — the added-field discovery AND the ' +
+  'corpus-wide read-site sweep are done for you; do not re-grep for consumers. Each entry ' +
+  'is an interface member / type-literal property / class field this PR ADDED with no ' +
+  'dot-access, bracket-access, or destructuring reference anywhere else in the indexed ' +
+  'codebase — only its own declaration. Confirm before reporting: if the field is genuinely ' +
+  'never consumed by any caller, and the gap is not already disclosed in this PR or an ' +
+  'intentional part of an external/public-API contract, report it under incomplete-handling. ' +
+  'This is a textual match over a possibly-incomplete indexed snapshot, not a verified ' +
+  'judgment, and it does NOT substitute for incomplete-handling’s get_files_context / ' +
+  'read_file / grep_codebase calls on the field’s would-be consumers before deciding the ' +
+  'omission is a real gap rather than an intentional, external, or already-disclosed one.';
+
+function renderCandidateEntry(c: UnreadFieldCandidate): string {
+  return `- ${c.typeName}.${c.field} (${c.kind}, added in ${c.file}:${c.line}) — no read site found anywhere in the indexed codebase`;
+}
+
+/**
+ * Render unread-field candidates as an `<unread_field_candidates>` block for
+ * the agent's initial message. Returns '' when there are none so callers can
+ * append unconditionally. Caps at MAX_CANDIDATES and MAX_BLOCK_CHARS with an
+ * explicit omission note — never truncates silently. Exposed for testing.
+ */
+export function renderUnreadFieldCandidates(candidates: UnreadFieldCandidate[]): string {
+  if (candidates.length === 0) return '';
+
+  const lines: string[] = ['<unread_field_candidates>', HEADER];
+  let used = lines.join('\n').length;
+  let rendered = 0;
+
+  for (const c of candidates.slice(0, MAX_CANDIDATES)) {
+    const entry = renderCandidateEntry(c);
+    if (used + entry.length + 1 > MAX_BLOCK_CHARS) break;
+    lines.push(entry);
+    used += entry.length + 1;
+    rendered++;
+  }
+
+  const omitted = candidates.length - rendered;
+  if (omitted > 0) {
+    lines.push(
+      `- [+${omitted} more unread field candidate(s) omitted to respect the input budget — inspect the diff for the rest]`,
+    );
+  }
+
+  lines.push('</unread_field_candidates>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<unread_field_candidates>` section from the review context.
+ * Returns '' when the PR adds no interface/type-literal/class field with no
+ * read site, or there's no diff/repo index to check against.
+ */
+export function renderUnreadFieldSection(context: ReviewContext): string {
+  return renderUnreadFieldCandidates(computeUnreadFieldCandidates(context));
+}

--- a/packages/review/test/unread-field-signals.test.ts
+++ b/packages/review/test/unread-field-signals.test.ts
@@ -377,6 +377,23 @@ describe('computeUnreadFieldCandidates', () => {
     expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
   });
 
+  it('does NOT suppress on a bare co-occurrence of the type name and an unrelated spread (regression, found via dogfooding)', () => {
+    // A docstring mentioning the type by name, plus a wholly unrelated spread
+    // later in the same chunk, must not be read as "this type is spread" —
+    // there is no `: Options` type annotation anywhere near the spread. An
+    // earlier version matched on bare co-occurrence and false-suppressed this
+    // module's OWN doc comment naming `RuleTriggers.filePatterns`.
+    const consumer = [
+      '// See Options.timeout for the request timeout contract.',
+      'function mergeDefaults(a: Record<string, unknown>, b: Record<string, unknown>) {',
+      '  return { ...a, ...b };',
+      '}',
+    ].join('\n');
+    const repoChunks = [...optionsChunks(), makeChunk('src/unrelated.ts', 1, consumer)];
+    const candidates = computeUnreadFieldCandidates(baseContext(repoChunks));
+    expect(candidates).toHaveLength(1);
+  });
+
   it('suppresses a candidate when the type is re-exported by a wildcard barrel (FP trap: public API)', () => {
     const barrel = makeChunk('src/index.ts', 1, "export * from './options.js';");
     const repoChunks = [...optionsChunks(), barrel];
@@ -391,6 +408,19 @@ describe('computeUnreadFieldCandidates', () => {
 
   it('does not suppress when a barrel exists but never mentions this type', () => {
     const barrel = makeChunk('src/index.ts', 1, "export { Something } from './other.js';");
+    const repoChunks = [...optionsChunks(), barrel];
+    const candidates = computeUnreadFieldCandidates(baseContext(repoChunks));
+    expect(candidates).toHaveLength(1);
+  });
+
+  it('does NOT suppress via a wildcard barrel whose specifier targets an unrelated file (regression, found via dogfooding)', () => {
+    // An earlier version treated ANY `export * from` found ANYWHERE in the
+    // corpus as evidence the type might be re-exported, regardless of what
+    // the barrel actually points at — this suppressed every candidate in an
+    // entire real codebase the moment an unrelated package had its own
+    // ordinary barrel. The specifier here ('./other-module.js') shares no
+    // basename with the declaring file ('options.ts'), so it must not count.
+    const barrel = makeChunk('other/pkg/index.ts', 1, "export * from './other-module.js';");
     const repoChunks = [...optionsChunks(), barrel];
     const candidates = computeUnreadFieldCandidates(baseContext(repoChunks));
     expect(candidates).toHaveLength(1);

--- a/packages/review/test/unread-field-signals.test.ts
+++ b/packages/review/test/unread-field-signals.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { ReviewRule, ResolvedRules } from '../src/plugins/agent/types.js';
+import {
+  computeAddedFields,
+  computeUnreadFieldCandidates,
+  renderUnreadFieldCandidates,
+  renderUnreadFieldSection,
+} from '../src/unread-field-signals.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'block',
+      language: 'typescript',
+    },
+  } as unknown as CodeChunk;
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  chunks?: CodeChunk[];
+  repoChunks?: CodeChunk[];
+}): ReviewContext {
+  const pr = opts.patches ? { patches: opts.patches } : undefined;
+  return {
+    pr,
+    chunks: opts.chunks ?? [],
+    repoChunks: opts.repoChunks,
+    changedFiles: [],
+  } as unknown as ReviewContext;
+}
+
+function patch(...lines: string[]): string {
+  return lines.join('\n');
+}
+
+function incompleteHandlingRule(): ReviewRule {
+  return {
+    id: 'incomplete-handling',
+    name: 'Incomplete Interface/Type Handling',
+    description: 'test rule',
+    prompt: 'test prompt',
+    triggers: { always: true },
+    severity: 'error',
+    category: 'logic_error',
+    enabled: true,
+    source: 'builtin',
+  };
+}
+
+function resolvedRulesWith(...ids: string[]): ResolvedRules {
+  return {
+    active: ids.map(id => ({ ...incompleteHandlingRule(), id })),
+    skipped: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures reused across tests
+// ---------------------------------------------------------------------------
+
+const OPTIONS_INTERFACE = ['export interface Options {', '  timeout: number;', '}'].join('\n');
+
+// A brand-new interface — unlike variant-sweep, the containing declaration
+// need not have existed before this PR (see module doc).
+const OPTIONS_PATCH = patch(
+  '@@ -0,0 +1,3 @@',
+  '+export interface Options {',
+  '+  timeout: number;',
+  '+}',
+);
+
+function optionsChunks(): CodeChunk[] {
+  return [makeChunk('src/options.ts', 1, OPTIONS_INTERFACE)];
+}
+
+function optionsPatches(): Map<string, string> {
+  return new Map([['src/options.ts', OPTIONS_PATCH]]);
+}
+
+// ---------------------------------------------------------------------------
+// computeAddedFields
+// ---------------------------------------------------------------------------
+
+describe('computeAddedFields', () => {
+  it('detects a new field on a brand-new interface', () => {
+    const added = computeAddedFields(
+      makeContext({ patches: optionsPatches(), chunks: optionsChunks() }),
+    );
+    expect(added).toEqual([
+      { typeName: 'Options', field: 'timeout', file: 'src/options.ts', line: 2, kind: 'interface' },
+    ]);
+  });
+
+  it('detects a new field added to an EXISTING interface', () => {
+    const content = [
+      'export interface Options {',
+      '  timeout: number;',
+      '  retries: number;',
+      '}',
+    ].join('\n');
+    const patches = new Map([
+      [
+        'src/options.ts',
+        patch(
+          '@@ -1,3 +1,4 @@',
+          ' export interface Options {',
+          '   timeout: number;',
+          '+  retries: number;',
+          ' }',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/options.ts', 1, content)];
+    const added = computeAddedFields(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'Options', field: 'retries', file: 'src/options.ts', line: 3, kind: 'interface' },
+    ]);
+  });
+
+  it('detects a new property on a type-literal alias', () => {
+    const content = ['export type Config = {', '  timeout: number;', '}'].join('\n');
+    const patches = new Map([
+      [
+        'src/config.ts',
+        patch('@@ -0,0 +1,3 @@', '+export type Config = {', '+  timeout: number;', '+}'),
+      ],
+    ]);
+    const chunks = [makeChunk('src/config.ts', 1, content)];
+    const added = computeAddedFields(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      {
+        typeName: 'Config',
+        field: 'timeout',
+        file: 'src/config.ts',
+        line: 2,
+        kind: 'type-literal',
+      },
+    ]);
+  });
+
+  it('detects a new typed class field without merging a following property into a preceding method', () => {
+    // Regression fixture: a plain top-level `;`-split (like interfaces use)
+    // would merge `send()`'s body with whatever followed it, since a
+    // method's closing `}` isn't followed by a `;`. Placing `timeout` right
+    // after `constructor(){...}` proves the line-based depth-tracked scan
+    // doesn't hide it inside the merged segment.
+    const content = [
+      'export class Client {',
+      '  constructor() {',
+      '    this.value = 1;',
+      '  }',
+      '  timeout: number;',
+      '  send(): void {',
+      '    console.log(this.timeout);',
+      '  }',
+      '}',
+    ].join('\n');
+    const patches = new Map([
+      [
+        'src/client.ts',
+        patch(
+          '@@ -1,7 +1,8 @@',
+          ' export class Client {',
+          '   constructor() {',
+          '     this.value = 1;',
+          '   }',
+          '+  timeout: number;',
+          '   send(): void {',
+          '     console.log(this.timeout);',
+          '   }',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/client.ts', 1, content)];
+    const added = computeAddedFields(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'Client', field: 'timeout', file: 'src/client.ts', line: 5, kind: 'class' },
+    ]);
+  });
+
+  it('does not treat an interface method signature as a field', () => {
+    const content = ['export interface Handler {', '  handle(x: string): void;', '}'].join('\n');
+    const patches = new Map([
+      [
+        'src/handler.ts',
+        patch(
+          '@@ -0,0 +1,3 @@',
+          '+export interface Handler {',
+          '+  handle(x: string): void;',
+          '+}',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/handler.ts', 1, content)];
+    expect(computeAddedFields(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('does not treat a class getter as a field', () => {
+    const content = [
+      'export class Wrapper {',
+      '  private _value: number;',
+      '  get value(): number {',
+      '    return this._value;',
+      '  }',
+      '}',
+    ].join('\n');
+    const patches = new Map([
+      [
+        'src/wrapper.ts',
+        patch(
+          '@@ -0,0 +1,5 @@',
+          '+export class Wrapper {',
+          '+  private _value: number;',
+          '+  get value(): number {',
+          '+    return this._value;',
+          '+  }',
+          '+}',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/wrapper.ts', 1, content)];
+    const added = computeAddedFields(makeContext({ patches, chunks }));
+    expect(added.map(a => a.field)).toEqual(['_value']);
+  });
+
+  it('does not detect an untyped inferred class field (documented v1 gap)', () => {
+    const content = ['export class Foo {', '  bar = 5;', '}'].join('\n');
+    const patches = new Map([
+      ['src/foo.ts', patch('@@ -0,0 +1,3 @@', '+export class Foo {', '+  bar = 5;', '+}')],
+    ]);
+    const chunks = [makeChunk('src/foo.ts', 1, content)];
+    expect(computeAddedFields(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('does not treat a same-identifier value edit as an addition', () => {
+    const content = ['export interface Options {', '  timeout: number;', '}'].join('\n');
+    const patches = new Map([
+      [
+        'src/options.ts',
+        patch(
+          '@@ -1,3 +1,3 @@',
+          ' export interface Options {',
+          '-  timeout: string;',
+          '+  timeout: number;',
+          ' }',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/options.ts', 1, content)];
+    expect(computeAddedFields(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('treats a renamed field as an addition (overlap with rename-sweep is accepted)', () => {
+    const content = ['export interface Options {', '  retries: number;', '}'].join('\n');
+    const patches = new Map([
+      [
+        'src/options.ts',
+        patch(
+          '@@ -1,2 +1,2 @@',
+          ' export interface Options {',
+          '-  timeout: number;',
+          '+  retries: number;',
+        ),
+      ],
+    ]);
+    const chunks = [makeChunk('src/options.ts', 1, content)];
+    const added = computeAddedFields(makeContext({ patches, chunks }));
+    expect(added).toEqual([
+      { typeName: 'Options', field: 'retries', file: 'src/options.ts', line: 2, kind: 'interface' },
+    ]);
+  });
+
+  it('ignores a field declared in a test-fixture file', () => {
+    const content = ['export interface Options {', '  timeout: number;', '}'].join('\n');
+    const patches = new Map([['src/options.test.ts', OPTIONS_PATCH]]);
+    const chunks = [makeChunk('src/options.test.ts', 1, content)];
+    expect(computeAddedFields(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('ignores non-TS/JS files', () => {
+    const patches = new Map([['src/options.rs', OPTIONS_PATCH]]);
+    const chunks = [makeChunk('src/options.rs', 1, OPTIONS_INTERFACE)];
+    expect(computeAddedFields(makeContext({ patches, chunks }))).toEqual([]);
+  });
+
+  it('returns [] when there is no diff or no chunks', () => {
+    expect(computeAddedFields(makeContext({}))).toEqual([]);
+    expect(
+      computeAddedFields(makeContext({ patches: new Map([['a.ts', 'x']]), chunks: [] })),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeUnreadFieldCandidates
+// ---------------------------------------------------------------------------
+
+describe('computeUnreadFieldCandidates', () => {
+  function baseContext(repoChunks: CodeChunk[]): ReviewContext {
+    return makeContext({ patches: optionsPatches(), chunks: optionsChunks(), repoChunks });
+  }
+
+  it('flags a field with no read site anywhere in the corpus (only its own declaration)', () => {
+    const candidates = computeUnreadFieldCandidates(baseContext(optionsChunks()));
+    expect(candidates).toEqual([
+      { typeName: 'Options', field: 'timeout', file: 'src/options.ts', line: 2, kind: 'interface' },
+    ]);
+  });
+
+  it('does not flag a field read via dot access elsewhere', () => {
+    const consumer = 'function useOptions(o: Options): number {\n  return o.timeout * 2;\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('flags a field that is only ever WRITTEN (plain assignment), never read', () => {
+    const consumer = 'function setOptions(o: Options): void {\n  o.timeout = 5;\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    const candidates = computeUnreadFieldCandidates(baseContext(repoChunks));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].field).toBe('timeout');
+  });
+
+  it('does not flag compound-assignment/increment usage (read-then-write counts as a read)', () => {
+    const consumer = 'function bump(o: Options): void {\n  o.timeout += 1;\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('does not flag a field read via bracket-string access', () => {
+    const consumer = "function useOptions(o: Options): number {\n  return o['timeout'] * 2;\n}";
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('flags a field only ever written via bracket access, never read', () => {
+    const consumer = "function setOptions(o: Options): void {\n  o['timeout'] = 5;\n}";
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    const candidates = computeUnreadFieldCandidates(baseContext(repoChunks));
+    expect(candidates).toHaveLength(1);
+  });
+
+  it('does not flag a field read via destructuring assignment', () => {
+    const consumer =
+      'function useOptions(o: Options): number {\n  const { timeout } = o;\n  return timeout;\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('does not flag a field read via a destructured function parameter', () => {
+    const consumer = 'function useOptions({ timeout }: Options): number {\n  return timeout;\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('suppresses a candidate when the type is spread wholesale elsewhere (FP trap)', () => {
+    const consumer = 'function clone(o: Options): Options {\n  return { ...o };\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('suppresses a candidate when the type is JSON.stringify-ed elsewhere (FP trap)', () => {
+    const consumer = 'function log(o: Options): void {\n  console.log(JSON.stringify(o));\n}';
+    const repoChunks = [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('suppresses a candidate when the type is re-exported by a wildcard barrel (FP trap: public API)', () => {
+    const barrel = makeChunk('src/index.ts', 1, "export * from './options.js';");
+    const repoChunks = [...optionsChunks(), barrel];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('suppresses a candidate when the type is named in a barrel export (FP trap: public API)', () => {
+    const barrel = makeChunk('src/index.ts', 1, "export { Options } from './options.js';");
+    const repoChunks = [...optionsChunks(), barrel];
+    expect(computeUnreadFieldCandidates(baseContext(repoChunks))).toEqual([]);
+  });
+
+  it('does not suppress when a barrel exists but never mentions this type', () => {
+    const barrel = makeChunk('src/index.ts', 1, "export { Something } from './other.js';");
+    const repoChunks = [...optionsChunks(), barrel];
+    const candidates = computeUnreadFieldCandidates(baseContext(repoChunks));
+    expect(candidates).toHaveLength(1);
+  });
+
+  it('returns [] when there are no added fields or no repo index', () => {
+    expect(computeUnreadFieldCandidates(makeContext({}))).toEqual([]);
+    expect(
+      computeUnreadFieldCandidates(
+        makeContext({ patches: optionsPatches(), chunks: optionsChunks() }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderUnreadFieldCandidates
+// ---------------------------------------------------------------------------
+
+describe('renderUnreadFieldCandidates', () => {
+  it('returns "" for no candidates', () => {
+    expect(renderUnreadFieldCandidates([])).toBe('');
+  });
+
+  it('renders the block naming the type/field/file/line and kind', () => {
+    const md = renderUnreadFieldCandidates([
+      { typeName: 'Options', field: 'timeout', file: 'src/options.ts', line: 2, kind: 'interface' },
+    ]);
+    expect(md).toContain('<unread_field_candidates>');
+    expect(md).toContain('</unread_field_candidates>');
+    expect(md).toContain('Options.timeout (interface, added in src/options.ts:2)');
+  });
+
+  it('header does not let the match substitute for incomplete-handling’s tool calls', () => {
+    const md = renderUnreadFieldCandidates([
+      { typeName: 'Options', field: 'timeout', file: 'src/options.ts', line: 2, kind: 'interface' },
+    ]);
+    expect(md).toContain(
+      'it does NOT substitute for incomplete-handling’s get_files_context / read_file / grep_codebase calls',
+    );
+  });
+
+  it('caps at MAX_CANDIDATES (10) with an explicit omission note — never truncates silently', () => {
+    const candidates = Array.from({ length: 13 }, (_, i) => ({
+      typeName: `Type${i}`,
+      field: 'value',
+      file: 'src/a.ts',
+      line: 1,
+      kind: 'interface' as const,
+    }));
+    const md = renderUnreadFieldCandidates(candidates);
+    expect(md).toContain('more unread field candidate(s) omitted');
+    expect(md).toContain('+3 more');
+  });
+
+  it('omits the truncation note when under the cap', () => {
+    const md = renderUnreadFieldCandidates([
+      { typeName: 'Options', field: 'timeout', file: 'src/options.ts', line: 2, kind: 'interface' },
+    ]);
+    expect(md).not.toContain('omitted');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderUnreadFieldSection
+// ---------------------------------------------------------------------------
+
+describe('renderUnreadFieldSection', () => {
+  it("returns '' when the PR adds no field with no read site", () => {
+    expect(renderUnreadFieldSection(makeContext({}))).toBe('');
+  });
+
+  it('renders candidates found from context', () => {
+    const section = renderUnreadFieldSection(
+      makeContext({
+        patches: optionsPatches(),
+        chunks: optionsChunks(),
+        repoChunks: optionsChunks(),
+      }),
+    );
+    expect(section).toContain('<unread_field_candidates>');
+    expect(section).toContain('Options.timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialMessage injection (rule-gated, mirrors variant-sweep/sibling-surface)
+// ---------------------------------------------------------------------------
+
+describe('buildInitialMessage injection (rule-gated)', () => {
+  function contextWithUnreadField(): ReviewContext {
+    return {
+      ...makeContext({
+        patches: optionsPatches(),
+        chunks: optionsChunks(),
+        repoChunks: optionsChunks(),
+      }),
+      changedFiles: ['src/options.ts'],
+    } as ReviewContext;
+  }
+
+  it('includes the block when incomplete-handling is active and candidates exist', () => {
+    const message = buildInitialMessage(contextWithUnreadField(), {
+      blastRadius: null,
+      rules: resolvedRulesWith('incomplete-handling'),
+    });
+    expect(message).toContain('<unread_field_candidates>');
+    expect(message).toContain('Options.timeout');
+  });
+
+  it('omits the block when rules are not provided at all', () => {
+    const message = buildInitialMessage(contextWithUnreadField(), { blastRadius: null });
+    expect(message).not.toContain('<unread_field_candidates>');
+  });
+
+  it('omits the block when incomplete-handling is not among the active rules', () => {
+    const message = buildInitialMessage(contextWithUnreadField(), {
+      blastRadius: null,
+      rules: resolvedRulesWith('error-swallowing'),
+    });
+    expect(message).not.toContain('<unread_field_candidates>');
+  });
+
+  it('omits the block when the rule is active but no candidates are found', () => {
+    const consumer = 'function useOptions(o: Options): number {\n  return o.timeout * 2;\n}';
+    const context = {
+      ...makeContext({
+        patches: optionsPatches(),
+        chunks: optionsChunks(),
+        repoChunks: [...optionsChunks(), makeChunk('src/consumer.ts', 1, consumer)],
+      }),
+      changedFiles: ['src/options.ts'],
+    } as ReviewContext;
+    const message = buildInitialMessage(context, {
+      blastRadius: null,
+      rules: resolvedRulesWith('incomplete-handling'),
+    });
+    expect(message).not.toContain('<unread_field_candidates>');
+  });
+});


### PR DESCRIPTION
## What

Adds the **unread-field signal** (`<unread_field_candidates>`, `packages/review/src/unread-field-signals.ts`) — the third `incomplete-handling` omission shape, which previously had zero deterministic coverage: a PR adds a plain interface member / type-literal property / class field (TS/JS v1 scope) that has no dot-access, bracket-access, or destructuring read anywhere else in the indexed corpus ("declared and populated, but the plumbing to the consumer was forgotten"). The rule's own canonical example (`RuleTriggers.filePatterns` never read by `ruleMatchesTriggers`) is exactly this shape.

**Detection approach:** (1) `computeAddedFields` parses each changed TS/JS file's diff for a genuinely-new interface/type-literal/class member (same `isGenuinelyNew` technique as `variant-sweep-signals.ts` — a rename still counts as an addition); unlike variant-sweep, the containing declaration need not have existed before this PR. (2) `computeUnreadFieldCandidates` sweeps the full indexed corpus for a read site (dot access, bracket-string access, or either destructuring shape), excluding the declaration's own chunk, and keeps only fields with none.

Wired: gated on `incomplete-handling` being active in `system-prompt.ts` (alongside `<variant_sweep_candidates>` and `<sibling_surfaces>`); `rules.ts`'s `INCOMPLETE_HANDLING` prompt now references all three blocks by name, same pattern as the other two.

## FP traps handled

- **Wholesale consumption** (spread / `JSON.stringify`) — suppresses a type's candidates when a `: TypeName` annotation has a spread/stringify within ~400 chars after it anywhere in the corpus.
- **Exported "public API" types** — suppresses a field when its type is re-exported by an `index.ts`/`index.js` barrel (named export, or a wildcard `export * from` whose specifier's basename matches the declaring file).
- **Test-fixture files** — a field declared in a `*.test.ts`/`__tests__/`-style file is skipped entirely.
- **Dynamic/bracket access** — read detection explicitly covers `obj['field']` bracket-string access (not just dot access), and both destructuring shapes (`const { field } = x`, `function f({ field })`), so these don't false-fire as "unread".
- Read/write disambiguation: only a **plain** `.field = value` assignment is excluded as "not a read" — compound assignment (`+=`) and increment/decrement (`++`/`--`) read-then-write, so they count as reads.

**Two real over-suppression bugs were found and fixed during dogfooding** (see below) — an earlier version's wholesale-consumption check fired on any bare co-occurrence of the type name and a spread/stringify *anywhere in the same chunk* (including this module's own doc comment naming `RuleTriggers`), and the barrel check treated *any* wildcard `export * from` found *anywhere in the corpus* as evidence, regardless of what it re-exported — which would have suppressed every candidate in an entire real codebase the moment one unrelated package had an ordinary barrel file. Both are now scoped to require real proximity/specifier evidence tied to the declaring file, with regression tests locking in the fix.

39 unit tests (`packages/review/test/unread-field-signals.test.ts`): positive cases (interface/type-literal/class, brand-new vs. existing declarations), every FP trap above as a negative case (plus the two dogfooding-discovered regressions), rendering/capping, and rule-gated `buildInitialMessage` injection — mirroring `variant-sweep-signals.test.ts`'s style.

## Census / byte-diff

Ran the harness's `build-prompts.ts` at merge-base (`origin/main`, via a scratch worktree) and at branch tip across every fixture available in this environment:

- **3 on-disk fixtures** (`boundary-change/placeholder`, `doc-truth/accurate-doc`, `doc-truth/renamed-stale-claim`) — most of the corpus is gitignored and not captured in this worktree.
- **1 freshly-captured canary**: `incomplete-handling/enum-variant-removed` (PR #437), captured for free via `capture-pr.ts` (no LLM call — pure indexing) specifically to get real incomplete-handling-canary coverage.

Result: **4/4 fixtures byte-identical `initialMessage`** between base and tip — zero fixtures gained the new block (the signal computed zero candidates on all 4; none of them add an interface/type-literal/class field). Zero canary contamination. `systemPrompt` differs on the 3 fixtures where `incomplete-handling` is active, but only due to the intentional rule-text sentence referencing the new block — the same kind of expected diff variant-sweep/sibling-surface's own rule-text additions caused when they shipped.

## Dogfood (verbatim)

Per PR #437's own assertions, it's about a *removed* enum variant (variant-sweep's shape), confirming no on-disk fixture exemplifies the third shape — so per the budget, $0 was spent on the paid harness and no `--calibrate 10` run was performed (see Spend below).

Constructed a real dogfood scenario instead: in an isolated scratch worktree (not part of this branch), added a genuinely unread field to `RuleTriggers` in `packages/review/src/plugins/agent/types.ts` — the actual interface the rule's own canonical example targets — then ran the prompt builder against this repo's real, fully-indexed corpus (7365 chunks, native parser built). Verbatim rendered block:

```
<unread_field_candidates>
Pre-computed by a deterministic diff scan — the added-field discovery AND the corpus-wide read-site sweep are done for you; do not re-grep for consumers. Each entry is an interface member / type-literal property / class field this PR ADDED with no dot-access, bracket-access, or destructuring reference anywhere else in the indexed codebase — only its own declaration. Confirm before reporting: if the field is genuinely never consumed by any caller, and the gap is not already disclosed in this PR or an intentional part of an external/public-API contract, report it under incomplete-handling. This is a textual match over a possibly-incomplete indexed snapshot, not a verified judgment, and it does NOT substitute for incomplete-handling's get_files_context / read_file / grep_codebase calls on the field's would-be consumers before deciding the omission is a real gap rather than an intentional, external, or already-disclosed one.
- RuleTriggers.minChangedFiles (interface, added in packages/review/src/plugins/agent/types.ts:93) — no read site found anywhere in the indexed codebase
</unread_field_candidates>
```

This first run also *found* the two over-suppression bugs described above (both suppressed this exact candidate before the fix) — direct evidence of why the dogfood-before-shipping rule exists: small hand-authored unit fixtures didn't expose either bug, a real ~7k-chunk corpus did immediately.

## Spend

**$0, no `--calibrate 10` run.** No existing `incomplete-handling` fixture exemplifies the third shape (confirmed both by reading `enum-variant-removed`'s assertions — a removed-variant/missing-switch-case bug, variant-sweep's territory — and empirically, by capturing and running it: zero candidates fired). Per the budget, this means no paid harness calibration screen was warranted; fixture-mining a real third-shape example is noted as follow-up, matching how PR #781 (variant-sweep merge) shipped under the same condition.

## Gates

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` all green; `lien delta` exits 0 (new code stays under complexity thresholds; a handful of advisory "worsened" notes on pre-existing functions, no crossings).

`packages/review` is private/unpublished — no changeset needed.
