### PR TITLE
fix(review): stop error-swallowing's catch-signal from justifying via a sibling's docstring

### DIFF
--- a/packages/review/src/catch-discrimination-signals.ts
+++ b/packages/review/src/catch-discrimination-signals.ts
@@ -10,6 +10,21 @@
  * baseline: 0/3 — see
  * `test/harness/fixtures/error-swallowing/pr752-undiscriminated-catch-salvage`).
  *
+ * Follow-up (2026-07-16): a re-calibration on the prod default model found
+ * the fixture had plateaued at 0/10 (down from the 5/10 measured at ship
+ * time) — every vote visited the right catch, then excused it by reading the
+ * docstring on the ADJACENT `postBodyThenRetryCommentsIndividually` function
+ * (which legitimately justifies THAT function's own inner catch) and
+ * borrowing it for the DIFFERENT, actually-buggy catch in `postPRReview`.
+ * The HEADER below was sharpened to require judging the flagged catch on its
+ * own body, not a sibling's. Re-measured post-fix: still 0/10 (non-converging
+ * — see the fixture's header for the full before/after trace analysis), but
+ * the sibling-borrowing mistake itself was eliminated from every vote's
+ * reasoning (traces now correctly separate the two catches by line number);
+ * the plateau persists via an independently-reconstructed "it's reported via
+ * the return value, so it's not really swallowing" rationalization instead —
+ * a distinct failure mode from the one this fix targeted.
+ *
  * The rule asks the agent to notice, for each catch block, whether it
  * actually discriminates between error classes before choosing to degrade
  * instead of rethrow — a judgment call that's easy to skip when a catch's
@@ -595,8 +610,15 @@ const HEADER =
   'fallback/degrade path instead. Confirm before reporting: if the degrade path ' +
   'is only correct for ONE error class (e.g. one specific HTTP status) while ' +
   'other classes (auth, rate-limit, 5xx, network) take the identical path, ' +
-  'that is error-swallowing — report it. If the catch genuinely handles every ' +
-  'error the same way correctly, stay silent. This is a heuristic pointer, not ' +
+  'that is error-swallowing — report it. Judge the flagged catch on ITS OWN ' +
+  'body only: a docstring, comment, or naming on a DIFFERENT function — a ' +
+  'sibling it calls into, or an adjacent function nearby — that justifies ' +
+  "THAT function's own error handling does not justify this one. " +
+  '"Intentional degradation" means the code inside THIS catch\'s own body ' +
+  '(the line range above) discriminates error types or rethrows unexpected ' +
+  'ones — a nearby comment about a different catch accepting some failure is ' +
+  'not evidence for this one. If the catch genuinely handles every error the ' +
+  'same way correctly, stay silent. This is a heuristic pointer, not ' +
   "a verified verdict, and it does NOT substitute for reading the catch's " +
   'enclosing function in full (get_files_context or read_file): the `reason` ' +
   'field names the shape found, but only the surrounding code tells you what ' +

--- a/packages/review/test/catch-discrimination-signals.test.ts
+++ b/packages/review/test/catch-discrimination-signals.test.ts
@@ -351,6 +351,20 @@ describe('renderUndiscriminatedCatchCandidates', () => {
     );
   });
 
+  it("header forbids borrowing a sibling function's justification for the flagged catch (PR752 vote-plateau fix)", () => {
+    const rendered = renderUndiscriminatedCatchCandidates([
+      { file: 'src/a.ts', line: 1, endLine: 5, binding: 'err', reason: 'x' },
+    ]);
+    expect(rendered).toContain('Judge the flagged catch on ITS OWN body only');
+    expect(rendered).toContain(
+      'a sibling it calls into, or an adjacent function nearby — that justifies ' +
+        "THAT function's own error handling does not justify this one",
+    );
+    expect(rendered).toContain(
+      '"Intentional degradation" means the code inside THIS catch\'s own body',
+    );
+  });
+
   it('caps at MAX_CANDIDATES with an explicit omission note — never truncates silently', () => {
     const many = Array.from({ length: 14 }, (_, i) => ({
       file: `src/f${i}.ts`,


### PR DESCRIPTION
## Context — the measured failure (read first)

A calibrate-10 on `error-swallowing/pr752-undiscriminated-catch-salvage`
(prod default model, `moonshotai/kimi-k2.7-code`) had plateaued at **0/10**,
down from the **5/10** measured when PR #770 shipped the
`<undiscriminated_catch_candidates>` signal. Every vote's trace showed the
same mistake: the signal correctly pointed at `postPRReview`'s undiscriminated
catch in `github-api.ts`, every vote read the right code — and every vote
then excused it by reading the docstring on the *adjacent*
`postBodyThenRetryCommentsIndividually` function ("the body is a bonus, not
a precondition for it"), which legitimately justifies *that* function's own
inner catch, and borrowed it to justify the *different*, genuinely buggy
catch in `postPRReview` that unconditionally invokes the fallback for **any**
error (auth failures, rate limits, 5xx — not just the anchor-validation case
the docstring covers).

## The fix

Sharpened the rendered `<undiscriminated_catch_candidates>` block
(`packages/review/src/catch-discrimination-signals.ts`) to require judging
the flagged catch on its own body only — wording only, no change to the
extraction/classification logic, and the existing "heuristic pointer, not a
verified verdict" non-substitution sentence is untouched.

**Before → after** (the inserted sentences, dropped into the existing
`HEADER` right after "that is error-swallowing — report it."):

```diff
-  'that is error-swallowing — report it. If the catch genuinely handles every '
-  'error the same way correctly, stay silent. This is a heuristic pointer, not '
+  'that is error-swallowing — report it. Judge the flagged catch on ITS OWN '
+  'body only: a docstring, comment, or naming on a DIFFERENT function — a '
+  'sibling it calls into, or an adjacent function nearby — that justifies '
+  "THAT function's own error handling does not justify this one. "
+  '"Intentional degradation" means the code inside THIS catch\'s own body '
+  '(the line range above) discriminates error types or rethrows unexpected '
+  'ones — a nearby comment about a different catch accepting some failure is '
+  'not evidence for this one. If the catch genuinely handles every error the '
+  'same way correctly, stay silent. This is a heuristic pointer, not '
```

**Verbatim new rendered block** (from `build-prompts.ts` against the pr752
fixture):

```
<undiscriminated_catch_candidates>
Pre-computed by a deterministic diff scan — the catch-clause discovery is done for you; do not re-read every catch block from scratch looking for this. Each entry is a catch clause this PR added or modified that appears to treat every error class alike (no instanceof/.status/.code/.name check on the caught binding) and does not unconditionally rethrow — it falls through to a fallback/degrade path instead. Confirm before reporting: if the degrade path is only correct for ONE error class (e.g. one specific HTTP status) while other classes (auth, rate-limit, 5xx, network) take the identical path, that is error-swallowing — report it. Judge the flagged catch on ITS OWN body only: a docstring, comment, or naming on a DIFFERENT function — a sibling it calls into, or an adjacent function nearby — that justifies THAT function's own error handling does not justify this one. "Intentional degradation" means the code inside THIS catch's own body (the line range above) discriminates error types or rethrows unexpected ones — a nearby comment about a different catch accepting some failure is not evidence for this one. If the catch genuinely handles every error the same way correctly, stay silent. This is a heuristic pointer, not a verified verdict, and it does NOT substitute for reading the catch's enclosing function in full (get_files_context or read_file): the `reason` field names the shape found, but only the surrounding code tells you what the fallback path actually does for each error class — inspect it before deciding.
- packages/review/src/github-api.ts:272-287 — caught as `error`: treats every error class alike (no instanceof/.status/.code/.name check on the caught `error`) and degrades via a fallback instead of rethrowing
</undiscriminated_catch_candidates>
```

I considered also adding a sentence countering the vote-7-style
self-reversal pattern ("once you've confirmed the finding, report it — don't
un-conclude without new code evidence"), per the brief's suggestion — but
per "keep the change minimal and single-purpose," and since the paid
calibration below shows the sibling-borrowing sentence alone eliminated its
target failure mode cleanly, I'm reporting the residual gap rather than
piling on a second untested instruction in the same PR.

## Census (free, byte-diff, on-disk fixtures only)

Ran `build-prompts.ts` at merge-base vs this branch for every
`.fixture.json` present in a fresh worktree checkout, regenerating the
`error-swallowing` canary + both FP fixtures via `capture-pr.ts` so the rule's
full on-disk corpus was covered, not just the target fixture:

| Fixture | Tag | Prompt changed? |
|---|---|---|
| `error-swallowing/pr752-undiscriminated-catch-salvage` | characterization | **yes** (has an undiscriminated-catch candidate) |
| `error-swallowing/payment-error-swallowed` (PR #411) | **canary** | no — byte-identical |
| `error-swallowing/scanall-null-guard-fp` (PR #574) | negative-regression | no — byte-identical |
| `error-swallowing/harness-gitignore-convention-fp` (PR #575) | negative-regression | no — byte-identical |
| `boundary-change/placeholder` | — | no — byte-identical |
| `doc-truth/accurate-doc` | — | no — byte-identical |
| `doc-truth/renamed-stale-claim` | — | no — byte-identical |

The signal only renders where a candidate exists, so only the target
fixture's prompt changes. The certified `error-swallowing` canary is
byte-identical — no recertification needed, no stop-and-report trigger.

## Calibrate-10 result (prod default, `moonshotai/kimi-k2.7-code`, `--trace` kept)

**0/10 — unchanged from the measured 0/10 failure this PR addresses** (still
down from the 5/10 measured at #770's ship time). Per standing cost
discipline this was the one paid iteration; I'm reporting the real number
rather than chasing it with a second paid run.

Taxonomy from the 10 traces (`.wip/traces/pr752-catch-sharpen/`, not
committed — gitignored):

- **9/10 — Tier 1, empty findings.** The literal sibling-docstring-borrowing
  mistake is *gone*: every trace now explicitly separates the two catches by
  line number (e.g. vote 2: "The catch at line 319 in
  `postBodyThenRetryCommentsIndividually` ... this is intentional
  degradation ... The catch at line 272 in `postPRReview` ... this is the
  core fix" — correctly scoped, not conflated). But several traces (2, 3, 5,
  6) then independently re-derive the *substance* of the bug ("for non-anchor
  errors, the salvage path is unlikely to succeed... this could be
  considered silent degradation for errors where throwing would be more
  appropriate") and talk themselves back down with a **new**
  self-reversal: "this is observable degradation, not silent — the logs show
  warnings and the returned counts show dropped ... I think this is
  intentional and not a bug." That's a distinct failure mode from the one
  targeted here — the model no longer borrows someone else's justification,
  it reconstructs an equivalent one on its own for the correct catch.
- **1/10 — Tier 2 near-miss (vote 4).** Correctly named `postPRReview`,
  correctly cited lines 272-287, and its suggestion ("Discriminate GitHub's
  invalid-anchor batch rejection (422) before falling back; rethrow auth,
  rate-limit, and server errors") is nearly verbatim CodeRabbit's own
  same-SHA fix recommendation. Failed only on the assertion's Tier-2
  mechanism keyword list (`"not just 422"`, `"unconditionally falls
  back"`, `"blanket catch"`, etc.) — its phrasing ("catches every batch
  failure and routes it to the individual-comment fallback") is
  semantically identical but didn't hit an exact listed phrase. Known
  harness Tier-2 brittleness (matches phrasing, not substance), not a
  reasoning gap.

Net: this fix cleanly closes the specific mechanism the brief scoped it to
(sibling-justification borrowing — confirmed absent from all 10 traces), but
does not clear the fixture's bar by itself; a second, independent
self-reversal pattern remains open as a follow-up candidate (the "once
confirmed, report it" countering sentence considered above).

## Spend

$0.3548 (one calibrate-10 run) — well under the $1.00 cap. Free CC-mode
iteration (Claude via subagents, not billed to `OPENROUTER_API_KEY`) cost $0
and was discarded after surfacing a self-inflicted contamination risk in
this repo's own harness fixtures (documented in commit history / session
notes, not reflected in this diff).

## Verification

- `packages/review/test/catch-discrimination-signals.test.ts` — new test
  asserts the sharpened sentences are present in the rendered block (32/32
  passing, was 31).
- Full gate chain green: `format:check`, `lint` (0 errors), `typecheck`,
  `build`, `npm test` (all packages), `lien delta` (no complexity-affecting
  changes).
- Dogfooded via the actual harness: `build-prompts.ts` census (7 on-disk
  fixtures) + one real `npm run test:harness -w @liendev/review --
  --calibrate 10` run against OpenRouter, traces kept.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a narrow prompt-engineering fix: it sharpens the `<undiscriminated_catch_candidates>` header text so the reviewing agent judges each flagged catch on its own body rather than borrowing justification from adjacent/sibling functions. Only a string constant and its surrounding comment changed; no extraction, classification, or rendering logic was modified. A new test asserts the sharpened sentences are present in the rendered output. The certified error-swallowing canary remains byte-identical, and the change is additive with no caller-facing API or behavior change beyond the prompt wording.
>
> - Added 'judge the flagged catch on its own body only' language to the undiscriminated-catch signal header
> - Added a test verifying the new anti-sibling-justification wording is rendered

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 013d494. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified review guidance for evaluating flagged catches based solely on their own function body.
  * Documented updated calibration results and distinct failure modes.

* **Tests**
  * Added coverage to ensure rendered review guidance prevents borrowing justification from adjacent functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->