### PR TITLE
refactor(review): generalize doc-truth's second pass into a ReviewPass executor

### DIFF
--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -67,12 +67,13 @@ outputs:
     description: 'Number of error-severity findings.'
   attestation:
     description: >-
-      JSON-encoded delivery attestation (v1): provider health, token budget,
-      what was actually delivered (inline comments posted/dropped,
-      annotations, PR description badge), review scope, and an overall
-      verdict (delivered / degraded:<reason> / failed:<reason>). Observational
-      only in v1 — it does not change the exit code beyond the existing
-      provider-never-ran behavior.
+      JSON-encoded delivery attestation (v2): provider health per pass (the
+      main review, plus any extra pass like the doc-truth second pass — each
+      with its own token budget), what was actually delivered (inline
+      comments posted/dropped, annotations, PR description badge), review
+      scope, and an overall verdict (delivered / degraded:<reason> /
+      failed:<reason>). Observational only — it does not change the exit code
+      beyond the existing provider-never-ran behavior.
 
 runs:
   using: 'docker'

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -233,7 +233,7 @@ describe('finishRun', () => {
       const { readFile } = await import('node:fs/promises');
       const summary = await readFile(summaryPath, 'utf8');
       expect(summary).toContain('<summary>Delivery attestation</summary>');
-      expect(summary).toContain('"attestationVersion": 1');
+      expect(summary).toContain('"attestationVersion": 2');
       expect(summary).toContain('"verdict": "delivered"');
     });
 

--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -21,16 +21,29 @@ import type { ReviewFinding } from './plugin-types.js';
 import type { AgentStopReason } from './plugins/agent/types.js';
 
 // ---------------------------------------------------------------------------
-// Schema (v1)
+// Schema (v2)
 // ---------------------------------------------------------------------------
 
-export const ATTESTATION_VERSION = 1 as const;
+/**
+ * v2 (this generalization): `provider.passes[]` grows past length 1 for the
+ * first time — one entry per pass the agent-review plugin actually ran
+ * (main, plus any extra pass like doc-truth), not just the main pass — and
+ * `BudgetAttestation` gains a per-pass breakdown. Both are additive shape
+ * changes, but the version bump is a deliberate owner call (not the
+ * "additive fields don't bump it" convention) because this is the first time
+ * `passes`/`budget` carry more than one pass's worth of data; a consumer that
+ * assumed `passes.length <= 1` would have silently ignored real data before
+ * this bump. v1 attestations (`passes: [mainPass]` only) remain valid v2
+ * shapes — nothing about the v1 schema was removed or renamed.
+ */
+export const ATTESTATION_VERSION = 2 as const;
 
 /** `AgentStopReason` plus `'not_run'` for a pass that was never attempted. */
 export type ProviderStopReason = AgentStopReason | 'not_run';
 
 export interface ProviderPassAttestation {
-  name: 'main';
+  /** `'main'` for the primary investigation, or an extra pass's own name (e.g. `'doc-truth'`). */
+  name: string;
   ran: boolean;
   stopReason: ProviderStopReason;
   /** Every provider request failed terminally — zero completed turns. */
@@ -43,11 +56,29 @@ export interface SkippedPass {
   reason: string;
 }
 
-export interface BudgetAttestation {
+/** One pass's own token allocation/spend — the breakdown behind `BudgetAttestation`'s aggregate. */
+export interface PassBudgetAttestation {
+  name: string;
   allocatedTokens: number;
   spentTokens: number;
-  /** Ran out of budget before finishing — the main pass's `stopReason` was `'budget'`. */
+  /** This SPECIFIC pass ran out of budget before finishing (`stopReason === 'budget'`). */
   starved: boolean;
+}
+
+export interface BudgetAttestation {
+  /** Sum of every pass's `allocatedTokens`. */
+  allocatedTokens: number;
+  /** Sum of every pass's `spentTokens`. */
+  spentTokens: number;
+  /** True when ANY pass starved — see `passes[]` for which one. */
+  starved: boolean;
+  /**
+   * Per-pass breakdown. Before this field existed, a doc-truth-only budget
+   * starvation was only visible aggregated into the main pass's numbers —
+   * indistinguishable from the main pass itself starving. Empty when the
+   * agent-review plugin didn't run at all.
+   */
+  passes: PassBudgetAttestation[];
 }
 
 export interface InlineCommentsAttestation {
@@ -159,33 +190,53 @@ export function deriveMainPassAttestation(
 
 /**
  * Verdict precedence (most to least severe): a provider that never ran at all
- * outranks everything — nothing was analyzed. Budget starvation is a more
- * specific, more actionable diagnosis than the generic "partial" bucket, so
- * it's checked first among incomplete-stop reasons. Dropped inline comments
- * and other delivery failures only matter once the review itself came back
- * clean. `descriptionBadgeUpdated`/`outOfDiffReviewPosted` are checked against
- * `=== false` specifically (not falsy) — `null`/`undefined` means "nothing was
- * attempted this run", which is not a failure.
+ * outranks everything — nothing was analyzed. Among the passes that DID run,
+ * the first one (in `passes` order — main first, then any extra pass) whose
+ * `stopReason !== 'completed'` decides the degraded verdict: budget
+ * starvation is a more specific, more actionable diagnosis than the generic
+ * "partial" bucket, so a pass that stopped on `'budget'` reports
+ * `degraded:budget_starved` and anything else reports
+ * `degraded:provider_partial` — attributed to WHICHEVER pass actually
+ * stopped, not hardcoded to the main pass (the bug this generalization
+ * fixes: before per-pass attestation existed, a doc-truth-only budget
+ * starvation was folded into the main pass's own `stopReason` upstream — see
+ * `doc-truth-pass.ts`'s `mergeDocPassIntoResult` — so this verdict looked
+ * identical whether it was main or an extra pass that actually starved).
+ * Dropped inline comments and other delivery failures only matter once every
+ * pass came back clean. `descriptionBadgeUpdated`/`outOfDiffReviewPosted` are
+ * checked against `=== false` specifically (not falsy) — `null`/`undefined`
+ * means "nothing was attempted this run", which is not a failure.
  */
 export function computeVerdict(input: {
   pipelineFailed: boolean;
   providerFailure: boolean;
-  mainPass: ProviderPassAttestation;
-  budget: BudgetAttestation;
+  passes: ProviderPassAttestation[];
   inlineComments: InlineCommentsAttestation;
   descriptionBadgeUpdated?: boolean | null;
   outOfDiffReviewPosted?: boolean | null;
 }): AttestationVerdict {
   if (input.pipelineFailed) return 'failed:analysis_error';
   if (input.providerFailure) return 'failed:provider_never_ran';
-  if (input.mainPass.ran && input.mainPass.stopReason !== 'completed') {
-    return input.budget.starved ? 'degraded:budget_starved' : 'degraded:provider_partial';
+  const incompletePass = input.passes.find(p => p.ran && p.stopReason !== 'completed');
+  if (incompletePass) {
+    return incompletePass.stopReason === 'budget'
+      ? 'degraded:budget_starved'
+      : 'degraded:provider_partial';
   }
   if (input.inlineComments.dropped > 0) return 'degraded:comments_dropped';
   if (input.descriptionBadgeUpdated === false || input.outOfDiffReviewPosted === false) {
     return 'degraded:delivery_incomplete';
   }
   return 'delivered';
+}
+
+/** One extra pass's outcome + its own budget, as reported by `plugins/agent/review-pass.ts`'s `PassOutcome`. */
+export interface ExtraPassAttestationInput {
+  name: string;
+  stopReason: ProviderStopReason;
+  neverRan: boolean;
+  allocatedTokens: number;
+  spentTokens: number;
 }
 
 export interface AttestationInput {
@@ -197,8 +248,16 @@ export interface AttestationInput {
   agentAttempted: boolean;
   /** `hasProviderFailure(findings)` — the existing SSOT (see plugins/agent/index.ts). */
   providerFailure: boolean;
+  /** The MAIN pass's own allocated ceiling and spent tokens (not the run's aggregate — see `extraPasses`). */
   allocatedTokens: number;
   spentTokens: number;
+  /**
+   * Any pass beyond main that actually ran (e.g. doc-truth) — one entry per
+   * pass, each with its own outcome and budget. Defaults to `[]`: the common
+   * case (no extra pass fired, or none exists) needs nothing here. Ignored
+   * when `agentAttempted` is false (an extra pass can't run without main).
+   */
+  extraPasses?: ExtraPassAttestationInput[];
   passesSkipped: SkippedPass[];
   annotationsEmitted: number;
   inlineComments: InlineCommentsAttestation;
@@ -209,22 +268,68 @@ export interface AttestationInput {
   pipelineFailed?: boolean;
 }
 
+/** Build one pass's budget entry — shared between the main pass and every extra pass. */
+function passBudget(
+  name: string,
+  stopReason: ProviderStopReason,
+  allocated: number,
+  spent: number,
+): PassBudgetAttestation {
+  return { name, allocatedTokens: allocated, spentTokens: spent, starved: stopReason === 'budget' };
+}
+
+/**
+ * Build the full `passes[]` (main + extra) and the aggregated
+ * `BudgetAttestation` from them. Extracted from `assembleAttestation` to
+ * keep that function's own complexity down — this is the piece that grew
+ * when per-pass attestation generalized past a single hardcoded main pass.
+ * Both are empty/zeroed when the agent-review plugin was never attempted —
+ * an extra pass can't run without main (see `runExtraPasses`).
+ */
+function buildPassesAndBudget(
+  input: AttestationInput,
+  mainPass: ProviderPassAttestation,
+): { passes: ProviderPassAttestation[]; budget: BudgetAttestation } {
+  if (!input.agentAttempted) {
+    return {
+      passes: [],
+      budget: { allocatedTokens: 0, spentTokens: 0, starved: false, passes: [] },
+    };
+  }
+  const extraPasses = input.extraPasses ?? [];
+  const passes: ProviderPassAttestation[] = [
+    mainPass,
+    ...extraPasses.map(p => ({
+      name: p.name,
+      ran: true,
+      stopReason: p.stopReason,
+      neverRan: p.neverRan,
+    })),
+  ];
+  const passBudgets: PassBudgetAttestation[] = [
+    passBudget(mainPass.name, mainPass.stopReason, input.allocatedTokens, input.spentTokens),
+    ...extraPasses.map(p => passBudget(p.name, p.stopReason, p.allocatedTokens, p.spentTokens)),
+  ];
+  const budget: BudgetAttestation = {
+    allocatedTokens: passBudgets.reduce((sum, p) => sum + p.allocatedTokens, 0),
+    spentTokens: passBudgets.reduce((sum, p) => sum + p.spentTokens, 0),
+    starved: passBudgets.some(p => p.starved),
+    passes: passBudgets,
+  };
+  return { passes, budget };
+}
+
 export function assembleAttestation(input: AttestationInput): Attestation {
   const mainPass = deriveMainPassAttestation(
     input.findings,
     input.agentAttempted,
     input.providerFailure,
   );
-  const budget: BudgetAttestation = {
-    allocatedTokens: input.allocatedTokens,
-    spentTokens: input.spentTokens,
-    starved: mainPass.stopReason === 'budget',
-  };
+  const { passes, budget } = buildPassesAndBudget(input, mainPass);
   const verdict = computeVerdict({
     pipelineFailed: input.pipelineFailed ?? false,
     providerFailure: input.providerFailure,
-    mainPass,
-    budget,
+    passes,
     inlineComments: input.inlineComments,
     descriptionBadgeUpdated: input.descriptionBadgeUpdated,
     outOfDiffReviewPosted: input.outOfDiffReviewPosted,
@@ -233,7 +338,7 @@ export function assembleAttestation(input: AttestationInput): Attestation {
   return {
     attestationVersion: ATTESTATION_VERSION,
     run: { conclusion: input.conclusion, filesAnalyzed: input.filesAnalyzed },
-    provider: { passes: input.agentAttempted ? [mainPass] : [] },
+    provider: { passes },
     budget,
     passesSkipped: input.passesSkipped,
     delivery: {

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -50,6 +50,8 @@ export {
   type ProviderStopReason,
   type SkippedPass,
   type BudgetAttestation,
+  type PassBudgetAttestation,
+  type ExtraPassAttestationInput,
   type InlineCommentsAttestation,
   type DeliveryAttestation,
   type ScopeAttestation,

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -126,6 +126,27 @@ export interface ReviewContext {
    * the delivery attestation's `budget.allocatedTokens`.
    */
   reportBudget?: (allocatedTokens: number) => void;
+  /**
+   * Callback for an EXTRA pass (beyond the main investigation — see
+   * `plugins/agent/review-pass.ts`'s `ReviewPassSpec`/`runExtraPasses`) to
+   * report its own outcome once it has run: name, stop reason, whether it
+   * never completed a turn, and its own allocated/spent tokens. Distinct
+   * from `reportBudget`/`reportUsage` (which stay main-pass-only, reporting
+   * the run's AGGREGATE spend) so a pass's own incomplete/budget-starved
+   * outcome is attributable to THAT pass in the delivery attestation's
+   * `provider.passes[]` / `BudgetAttestation.passes[]`, instead of only being
+   * visible by having been folded into the main pass's own `incomplete`/
+   * `stopReason` (see `doc-truth-pass.ts`'s `mergeDocPassIntoResult`) — the
+   * fold that caused a doc-truth-only budget starvation to be misattributed
+   * to the main pass before this callback existed.
+   */
+  reportPassResult?: (result: {
+    name: string;
+    stopReason: import('./plugins/agent/types.js').AgentStopReason;
+    neverRan: boolean;
+    allocatedTokens: number;
+    spentTokens: number;
+  }) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -11,23 +11,25 @@
  * the doc-claim signals in the prompt — no blast radius, no complexity, no code
  * bugs to chase. Its findings fold back into the main review's output.
  *
- * The orchestration (running the client, merging usage/trace/findings) lives in
- * `index.ts`'s `analyze()`; this module holds the deterministic, LLM-free pieces
- * it composes: the gate, the prompt builder, and the merge helpers. The client
- * runner is injected into `runDocTruthPass` so failure isolation and gating are
- * unit-testable with zero LLM spend.
+ * This module holds doc-truth's deterministic, LLM-free pieces: the gate, the
+ * prompt builder, the budget, and the merge helpers. They are bundled at the
+ * bottom into `DOC_TRUTH_PASS_SPEC`, a `ReviewPassSpec` (see `review-pass.ts`)
+ * that the generic `runReviewPass`/`runExtraPasses` executor runs — that
+ * generic executor owns the client-run/failure-isolation/reporting plumbing
+ * this module used to own itself (`runDocTruthPass`, `appendDocTruthTurns`),
+ * so every piece here stays unit-testable with zero LLM spend.
  */
 
 import type { ReviewContext } from '../../plugin-types.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
 import { extractDocClaims, renderDocClaimsSection } from '../../doc-claims-signals.js';
 import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
-import type { Logger } from '../../logger.js';
 
-import type { AgentConfig, AgentFinding, AgentResult, AgentTrace, ResolvedRules } from './types.js';
+import type { AgentConfig, AgentFinding, AgentResult, ResolvedRules } from './types.js';
 import { DOC_TRUTH } from './rules.js';
 import { buildSystemPrompt } from './system-prompt.js';
 import { envDisabled } from './agent-client-shared.js';
+import type { ReviewPassSpec } from './review-pass.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -97,12 +99,13 @@ const DOC_PASS_INTRO =
 /**
  * Precisely why the doc-truth pass would not run right now, or null if it
  * should run. Kept separate from `shouldRunDocTruthPass`'s boolean so a
- * caller reporting the skip to the delivery attestation (see `runDocTruthPass`
- * below) can name the REAL reason — config-disabled, env-disabled, or no
- * doc claims are three different operational states that a bare boolean
- * collapses into one.
+ * caller reporting the skip to the delivery attestation (see this module's
+ * `DOC_TRUTH_PASS_SPEC.gateReason`, run by `review-pass.ts`'s
+ * `runReviewPass`) can name the REAL reason — config-disabled, env-disabled,
+ * or no doc claims are three different operational states that a bare
+ * boolean collapses into one.
  */
-function docTruthSkipReason(context: ReviewContext, config?: AgentConfig): string | null {
+export function docTruthSkipReason(context: ReviewContext, config?: AgentConfig): string | null {
   if (config?.docTruthPass === false) return 'disabled via config (docTruthPass: false)';
   if (envDisabled(process.env[DOC_PASS_ENV])) return `disabled via ${DOC_PASS_ENV} env var`;
   const patches = context.pr?.patches;
@@ -190,65 +193,8 @@ export function docTruthPassBudget(baseBudget: number): number {
   return Math.round(baseBudget * DOC_PASS_BUDGET_FRACTION);
 }
 
-// ---------------------------------------------------------------------------
-// Runner (client injected for zero-LLM testing)
-// ---------------------------------------------------------------------------
-
-/**
- * Runs the doc-truth client loop for the given prompts and budget. Injected
- * into `runDocTruthPass` so the gate, prompt build, and failure isolation are
- * unit-testable without a real client. `index.ts` supplies a closure over
- * `runAgentClient` (with the shared tool executor) as the production impl.
- */
-export type DocTruthClientRunner = (
-  systemPrompt: string,
-  initialMessage: string,
-  maxTokenBudget: number,
-  maxTurns: number,
-) => Promise<AgentResult>;
-
 /** Plugin name the doc-truth pass reports itself under in the delivery attestation. */
 const DOC_TRUTH_SKIP_PLUGIN = 'agent-review:doc-truth';
-
-/**
- * Run the second, claims-only doc-truth pass when the PR warrants it. Returns
- * the pass's AgentResult, or null when the pass is gated off OR when it fails —
- * a pass-2 error must never fail the whole review, so it is caught, logged, and
- * swallowed here (the caller keeps the main-pass findings).
- *
- * Reports its own outcome to `context.reportSkip` in both the gated-off and
- * failed cases — this is the one place that knows the REAL reason (the exact
- * gate that fired, or the caught error), so a caller doesn't need to duplicate
- * `shouldRunDocTruthPass`'s check just to guess why nothing came back. A run
- * that never reaches this function at all (the main pass never ran) is
- * reported by the caller instead — this pass is never invoked in that case.
- */
-export async function runDocTruthPass(
-  context: ReviewContext,
-  config: AgentConfig,
-  logger: Logger,
-  runClient: DocTruthClientRunner,
-): Promise<AgentResult | null> {
-  const skipReason = docTruthSkipReason(context, config);
-  if (skipReason) {
-    context.reportSkip?.({ plugin: DOC_TRUTH_SKIP_PLUGIN, reason: skipReason });
-    return null;
-  }
-  try {
-    const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(context);
-    const budget = docTruthPassBudget(config.maxTokenBudget);
-    const result = await runClient(systemPrompt, initialMessage, budget, DOC_PASS_MAX_TURNS);
-    logger.info(
-      `[agent] doc-truth pass: ${result.findings.length} finding(s) in ${result.turns} turn(s) ($${result.usage.cost.toFixed(4)})`,
-    );
-    return result;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.warning(`[agent] doc-truth pass failed: ${message}`);
-    context.reportSkip?.({ plugin: DOC_TRUTH_SKIP_PLUGIN, reason: `failed: ${message}` });
-    return null;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Merge helpers
@@ -323,21 +269,25 @@ export function mergeDocPassIntoResult(
   return main;
 }
 
+// ---------------------------------------------------------------------------
+// ReviewPassSpec (plugs doc-truth into the generalized executor)
+// ---------------------------------------------------------------------------
+
 /**
- * Append the doc pass's turns to the main trace so the single trace surfaced via
- * `reportTrace` carries BOTH passes: the harness derives tool calls and turn
- * count from `trace.turns`, so main-pass `expectToolCalled` assertions keep
- * working while the doc pass's tool calls also become visible. Doc turns are
- * renumbered to continue after the main pass and stamped `phase: 'doc-truth'`.
- * No-op when either trace is absent (production runners don't capture traces).
+ * Doc-truth bundled as a `ReviewPassSpec` (see `review-pass.ts`) — the first
+ * (and, before that generalization, only) entry in `index.ts`'s extra-pass
+ * list. Every field here is one of this module's own pure functions; the
+ * generic executor supplies the gate-check/run/failure-isolation/reporting
+ * plumbing that used to be doc-truth-specific (`runDocTruthPass`,
+ * `appendDocTruthTurns`).
  */
-export function appendDocTruthTurns(
-  mainTrace: AgentTrace | undefined,
-  docTrace: AgentTrace | undefined,
-): void {
-  if (!mainTrace || !docTrace) return;
-  const offset = mainTrace.turns.length;
-  for (const turn of docTrace.turns) {
-    mainTrace.turns.push({ ...turn, turnNumber: offset + turn.turnNumber, phase: 'doc-truth' });
-  }
-}
+export const DOC_TRUTH_PASS_SPEC: ReviewPassSpec = {
+  name: 'doc-truth',
+  skipPlugin: DOC_TRUTH_SKIP_PLUGIN,
+  gateReason: docTruthSkipReason,
+  buildPrompts: buildDocTruthPassPrompts,
+  budget: docTruthPassBudget,
+  maxTurns: DOC_PASS_MAX_TURNS,
+  mergeFindings: mergeDocTruthFindings,
+  mergeResultState: mergeDocPassIntoResult,
+};

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -24,12 +24,13 @@ import { OpenAIAgentClient, toOpenAITools } from './openai-client.js';
 import { buildSystemPrompt, buildInitialMessage } from './system-prompt.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
+import { DOC_TRUTH_PASS_SPEC } from './doc-truth-pass.js';
 import {
-  runDocTruthPass,
-  mergeDocTruthFindings,
-  mergeDocPassIntoResult,
-  appendDocTruthTurns,
-} from './doc-truth-pass.js';
+  runExtraPasses,
+  type ReviewPassSpec,
+  type PassClientRunner,
+  type PassOutcome,
+} from './review-pass.js';
 import {
   isSummaryOnlyMode,
   buildSummaryOnlyPrompts,
@@ -40,6 +41,14 @@ import {
   DEFAULT_OPENROUTER_BASE_URL,
   MAX_REVIEW_TOKEN_BUDGET,
 } from '../../defaults.js';
+
+/**
+ * The ordered list of extra passes `analyze()`/`analyzeSummaryOnly()` run
+ * after the main investigation (see `review-pass.ts`'s "N-pass plumbing").
+ * Doc-truth is the first (and, for now, only) entry — a future dedicated
+ * candidate-loop rule (per the per-rule-loops design doc) is added here.
+ */
+const EXTRA_PASSES: ReviewPassSpec[] = [DOC_TRUTH_PASS_SPEC];
 
 const configSchema = z.object({
   apiKey: z.string().min(1),
@@ -195,42 +204,31 @@ export class AgentReviewPlugin implements ReviewPlugin {
       maxTokenBudget,
     );
 
-    // Second, claims-only doc-truth pass for doc-touching PRs (issue #732).
-    // A dedicated pass with no competing rules keeps documentation drift from
-    // being out-competed by the PR's real code bugs in a single findings list.
-    // Its trace/usage fold into the main run; a failure returns null and leaves
-    // the main-pass output untouched. Skipped entirely when the main pass never
-    // ran (provider down) — a second pass would only fire more doomed requests,
-    // and its own incomplete state must not overwrite the never-ran marker.
-    // `runDocTruthPass` reports its own gated-off/failed outcome to the
-    // attestation; this is the one case it never even gets called for, so it's
-    // reported here instead.
-    if (result.neverRan) {
-      context.reportSkip?.({
-        plugin: 'agent-review:doc-truth',
-        reason: 'main pass never ran (provider failure)',
-      });
-    }
-    const docResult = result.neverRan
-      ? null
-      : await this.runSecondDocPass(context, config, apiKey, provider, logger, toolExecutor);
-    if (docResult) {
-      appendDocTruthTurns(result.trace, docResult.trace);
-      context.reportUsage?.(docResult.usage);
-    }
+    // Extra passes beyond the main investigation (doc-truth today; see
+    // `EXTRA_PASSES` and `review-pass.ts`'s "N-pass plumbing"). Each pass's
+    // trace/usage fold into the main run, and its findings/result-state
+    // (an unfinished pass, error-severity doc findings lifting the summary's
+    // risk level) fold into `result`/`agentFindings` in list order. A pass
+    // failure never fails the whole review — `runExtraPasses` catches and
+    // reports it, leaving the main-pass output untouched. Every extra pass
+    // is skipped entirely when the main pass never ran (provider down) — a
+    // second request would only fire more doomed calls, and a failure-
+    // isolated pass's own incomplete state must not overwrite the never-ran
+    // marker.
+    const { findings: agentFindings, outcomes } = await runExtraPasses(
+      EXTRA_PASSES,
+      context,
+      config,
+      logger,
+      result,
+      result.findings,
+      this.extraPassClientRunner(provider, config, apiKey, logger, toolExecutor),
+    );
 
     reportAgentRun(this.id, context, logger, result);
+    reportPassOutcomes(context, outcomes);
 
     const pluginId = this.id;
-    const agentFindings = mergeDocTruthFindings(result.findings, docResult?.findings ?? []);
-    // Fold doc-pass result state (an unfinished pass, error-severity doc
-    // findings) into the main result before the notices are appended: it lifts
-    // the PRIMARY summary's risk level for doc-truth errors, and marks the run
-    // incomplete so `appendIncompleteNotice` emits the doc-pass notice. The
-    // render path (`present`/`formatCheckSummary`) now renders every summary
-    // finding, so that appended notice is visible as its own section — this
-    // fold shapes the primary block, it no longer has to be the only summary.
-    mergeDocPassIntoResult(result, docResult, agentFindings);
     const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
     appendIncompleteNotice(findings, pluginId, result);
@@ -286,25 +284,20 @@ export class AgentReviewPlugin implements ReviewPlugin {
       maxTokenBudget,
     );
 
-    if (result.neverRan) {
-      context.reportSkip?.({
-        plugin: 'agent-review:doc-truth',
-        reason: 'main pass never ran (provider failure)',
-      });
-    }
-    const docResult = result.neverRan
-      ? null
-      : await this.runSecondDocPass(context, config, apiKey, provider, logger, toolExecutor);
-    if (docResult) {
-      appendDocTruthTurns(result.trace, docResult.trace);
-      context.reportUsage?.(docResult.usage);
-    }
+    const { findings: agentFindings, outcomes } = await runExtraPasses(
+      EXTRA_PASSES,
+      context,
+      config,
+      logger,
+      result,
+      result.findings,
+      this.extraPassClientRunner(provider, config, apiKey, logger, toolExecutor),
+    );
 
     reportAgentRun(this.id, context, logger, result);
+    reportPassOutcomes(context, outcomes);
 
     const pluginId = this.id;
-    const agentFindings = mergeDocTruthFindings(result.findings, docResult?.findings ?? []);
-    mergeDocPassIntoResult(result, docResult, agentFindings);
     const findings = agentFindings.map(f => mapToReviewFinding(f, pluginId));
     appendSummaryFinding(findings, pluginId, result.summary);
     appendIncompleteNotice(findings, pluginId, result);
@@ -313,20 +306,20 @@ export class AgentReviewPlugin implements ReviewPlugin {
   }
 
   /**
-   * Run the doc-truth second pass, wiring the shared tool executor into a client
-   * runner the pass can invoke with its own (smaller) turn/token budget. Returns
-   * null when the pass is gated off or fails — kept as a thin method so
-   * `analyze()` stays under its complexity budget.
+   * Build the client-runner factory `runExtraPasses` needs: a thin closure
+   * over the shared `runAgentClient`, substituting each pass's own turn cap.
+   * Shared by `analyze()` and `analyzeSummaryOnly()` — kept as a method (not
+   * inlined) so neither grows a duplicated closure and `analyze()` stays
+   * under its complexity budget.
    */
-  private runSecondDocPass(
-    context: ReviewContext,
+  private extraPassClientRunner(
+    provider: string,
     config: AgentConfig,
     apiKey: string,
-    provider: string,
     logger: Logger,
     toolExecutor: ToolExecutor,
-  ): Promise<AgentResult | null> {
-    return runDocTruthPass(context, config, logger, (sys, init, budget, maxTurns) =>
+  ): (spec: ReviewPassSpec) => PassClientRunner {
+    return () => (sys, init, budget, maxTurns) =>
       runAgentClient(
         provider,
         { ...config, maxTurns },
@@ -336,8 +329,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
         init,
         toolExecutor,
         budget,
-      ),
-    );
+      );
   }
 
   async present(findings: ReviewFinding[], context: PresentContext): Promise<void> {
@@ -460,6 +452,19 @@ function reportAgentRun(
   context.reportUsage?.(result.usage);
   if (result.trace) {
     context.reportTrace?.(result.trace);
+  }
+}
+
+/**
+ * Forward every extra pass's outcome to the delivery attestation via
+ * `context.reportPassResult` — see `plugin-types.ts`'s doc comment on that
+ * callback for why this is separate from `reportBudget`/`reportUsage` (those
+ * stay main-pass-only aggregates; this attributes an extra pass's own
+ * stop reason/tokens to that pass specifically).
+ */
+function reportPassOutcomes(context: ReviewContext, outcomes: PassOutcome[]): void {
+  for (const outcome of outcomes) {
+    context.reportPassResult?.(outcome);
   }
 }
 

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -1,0 +1,189 @@
+/**
+ * Generalized "extra pass" executor (per-rule-loops design, §1 — N-pass
+ * plumbing).
+ *
+ * Before this module existed, `doc-truth-pass.ts` was the only extra LLM
+ * call bolted onto the main agent-review run, and its gate/prompt/budget/
+ * runner/merge pieces were wired into `index.ts`'s `analyze()` by hand as a
+ * single hardcoded `docResult` variable. This module factors the GENERIC
+ * part of that shape — the gate-check, client-run, failure-isolation, trace-
+ * append, and reporting plumbing — into a `ReviewPassSpec` contract plus a
+ * `runExtraPasses` orchestrator, so `analyze()` can run an ORDERED LIST of
+ * extra passes instead of one bespoke variable. `doc-truth-pass.ts` keeps
+ * ownership of doc-truth's own gate/prompt/budget/merge functions (they stay
+ * pure and independently unit-tested) and exposes them bundled as a single
+ * `ReviewPassSpec` (`DOC_TRUTH_PASS_SPEC`) that plugs into this module.
+ *
+ * Execution is SERIAL for v1: `runExtraPasses` runs `specs` in array order,
+ * one at a time, awaiting each before starting the next. Doc-truth's pass has
+ * a real data dependency on the main pass's outcome (it must not run at all
+ * when the main pass never completed a turn — see the `neverRan` check
+ * below), and no second pass exists yet to make concurrent execution's added
+ * complexity (trace-offset races, interleaved budget reporting) worth paying
+ * for. Revisit only once ≥3 dedicated passes exist and latency is a measured
+ * problem (YAGNI).
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+import type { Logger } from '../../logger.js';
+import type {
+  AgentConfig,
+  AgentFinding,
+  AgentResult,
+  AgentStopReason,
+  AgentTrace,
+} from './types.js';
+
+/**
+ * One "extra" pass beyond the main investigation — a second (or third, …)
+ * LLM call scoped to a narrower question, whose output folds back into the
+ * main pass's findings/result. Mirrors `doc-truth-pass.ts`'s six pieces
+ * (gate, prompt builder, budget, runner, findings-merge, result-merge),
+ * generalized so a future dedicated pass (a candidate-loop rule, per the
+ * per-rule-loops design doc) can be added to an `EXTRA_PASSES` list without
+ * re-deriving the gate/failure-isolation/reporting plumbing doc-truth-pass.ts
+ * already worked out.
+ */
+export interface ReviewPassSpec {
+  /** Stable id — becomes the trace's `phase` tag and this pass's attestation name. */
+  name: string;
+  /** Plugin name this pass reports itself under via `context.reportSkip`. */
+  skipPlugin: string;
+  /** Why this pass would not run right now, or null if it should run. */
+  gateReason(context: ReviewContext, config: AgentConfig): string | null;
+  /** Build this pass's system + initial prompts. */
+  buildPrompts(context: ReviewContext): { systemPrompt: string; initialMessage: string };
+  /** This pass's token budget, computed from the main pass's base budget. */
+  budget(baseBudget: number): number;
+  /** Turn cap for this pass's client loop. */
+  maxTurns: number;
+  /** Fold this pass's findings into the running merged list. */
+  mergeFindings(mergedFindings: AgentFinding[], passFindings: AgentFinding[]): AgentFinding[];
+  /** Fold this pass's result-level state (incomplete/risk) into the main result. */
+  mergeResultState(
+    main: AgentResult,
+    passResult: AgentResult | null,
+    mergedFindings: AgentFinding[],
+  ): void;
+}
+
+/** A pass's client loop, closed over the pass-agnostic transport (provider/apiKey/toolExecutor). */
+export type PassClientRunner = (
+  systemPrompt: string,
+  initialMessage: string,
+  maxTokenBudget: number,
+  maxTurns: number,
+) => Promise<AgentResult>;
+
+/**
+ * Run one extra pass's client loop when it's gated on. Mirrors the shape
+ * `doc-truth-pass.ts`'s original `runDocTruthPass` had: gate check first
+ * (reporting the precise skip reason), then build+run, catching and
+ * swallowing any failure — a pass-2+ error must never fail the whole review.
+ */
+export async function runReviewPass(
+  spec: ReviewPassSpec,
+  context: ReviewContext,
+  config: AgentConfig,
+  logger: Logger,
+  runClient: PassClientRunner,
+): Promise<AgentResult | null> {
+  const skipReason = spec.gateReason(context, config);
+  if (skipReason) {
+    context.reportSkip?.({ plugin: spec.skipPlugin, reason: skipReason });
+    return null;
+  }
+  try {
+    const { systemPrompt, initialMessage } = spec.buildPrompts(context);
+    const budget = spec.budget(config.maxTokenBudget);
+    const result = await runClient(systemPrompt, initialMessage, budget, spec.maxTurns);
+    logger.info(
+      `[agent] ${spec.name} pass: ${result.findings.length} finding(s) in ${result.turns} turn(s) ($${result.usage.cost.toFixed(4)})`,
+    );
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warning(`[agent] ${spec.name} pass failed: ${message}`);
+    context.reportSkip?.({ plugin: spec.skipPlugin, reason: `failed: ${message}` });
+    return null;
+  }
+}
+
+/**
+ * Append a pass's turns to the main trace, renumbered to continue after the
+ * main pass and stamped with `phase`. Generalizes `doc-truth-pass.ts`'s
+ * original `appendDocTruthTurns` — same renumbering scheme, parameterized
+ * phase tag instead of the hardcoded `'doc-truth'` literal.
+ */
+export function appendPassTurns(
+  mainTrace: AgentTrace | undefined,
+  passTrace: AgentTrace | undefined,
+  phase: string,
+): void {
+  if (!mainTrace || !passTrace) return;
+  const offset = mainTrace.turns.length;
+  for (const turn of passTrace.turns) {
+    mainTrace.turns.push({ ...turn, turnNumber: offset + turn.turnNumber, phase });
+  }
+}
+
+/**
+ * One extra pass's outcome, reported for the delivery attestation
+ * (`attestation.ts`'s `provider.passes[]` / `BudgetAttestation`). Only
+ * produced for a pass that actually RAN — a gated-off or failed pass is
+ * already covered by `context.reportSkip`'s `passesSkipped` list, so it
+ * isn't duplicated here (see the per-rule-loops design doc §6).
+ */
+export interface PassOutcome {
+  name: string;
+  stopReason: AgentStopReason;
+  neverRan: boolean;
+  allocatedTokens: number;
+  spentTokens: number;
+}
+
+/**
+ * Run every extra pass in `specs`, IN ORDER (serial — see this module's doc
+ * comment), folding each pass's findings/result-state into `main`/
+ * `findings` before moving to the next. When the main pass never ran at all
+ * (every provider request failed), every extra pass is skipped without even
+ * evaluating its own gate — running one anyway would only fire a second
+ * doomed request, and a failure-isolated extra pass's own incomplete state
+ * must never overwrite the main pass's `neverRan` marker.
+ */
+export async function runExtraPasses(
+  specs: ReviewPassSpec[],
+  context: ReviewContext,
+  config: AgentConfig,
+  logger: Logger,
+  main: AgentResult,
+  findings: AgentFinding[],
+  runClientFor: (spec: ReviewPassSpec) => PassClientRunner,
+): Promise<{ findings: AgentFinding[]; outcomes: PassOutcome[] }> {
+  const outcomes: PassOutcome[] = [];
+  let merged = findings;
+  for (const spec of specs) {
+    if (main.neverRan) {
+      context.reportSkip?.({
+        plugin: spec.skipPlugin,
+        reason: 'main pass never ran (provider failure)',
+      });
+      continue;
+    }
+    const passResult = await runReviewPass(spec, context, config, logger, runClientFor(spec));
+    if (passResult) {
+      appendPassTurns(main.trace, passResult.trace, spec.name);
+      context.reportUsage?.(passResult.usage);
+      outcomes.push({
+        name: spec.name,
+        stopReason: passResult.stopReason,
+        neverRan: passResult.neverRan ?? false,
+        allocatedTokens: spec.budget(config.maxTokenBudget),
+        spentTokens: passResult.usage.totalTokens,
+      });
+    }
+    merged = spec.mergeFindings(merged, passResult?.findings ?? []);
+    spec.mergeResultState(main, passResult, merged);
+  }
+  return { findings: merged, outcomes };
+}

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -166,12 +166,13 @@ export interface ToolInvocation {
 export interface TurnTrace {
   turnNumber: number;
   /**
-   * Which review pass produced this turn. Absent means the main pass; the
-   * dedicated doc-truth second pass (issue #732) stamps its appended turns
-   * `'doc-truth'` so a merged trace stays interpretable. Optional/additive —
+   * Which review pass produced this turn. Absent means the main pass; an
+   * extra pass (see `review-pass.ts`'s `ReviewPassSpec.name` — the doc-truth
+   * second pass, issue #732, is the first) stamps its appended turns with its
+   * own pass name so a merged trace stays interpretable. Optional/additive —
    * existing consumers ignore it.
    */
-  phase?: 'main' | 'doc-truth';
+  phase?: string;
   /** Full assistant message content, captured before extractResponse. */
   responseText: string;
   /**

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -52,6 +52,7 @@ import {
   type Attestation,
   type EligibilityPath,
   type SkippedPass,
+  type ExtraPassAttestationInput,
 } from './attestation.js';
 import { cloneBySha, type CloneResult } from './clone.js';
 import {
@@ -327,6 +328,14 @@ interface RunTelemetry {
   agentUsage: AgentUsage;
   allocatedTokens: number;
   passesSkipped: SkippedPass[];
+  /**
+   * Any extra pass beyond main that actually ran (e.g. doc-truth), one entry
+   * per pass — see `reportPassResult` on `ReviewContext`. `agentUsage` above
+   * already sums every pass's spend (main + extras); this is the per-pass
+   * breakdown `buildRunAttestation` needs to attribute budget/outcome to the
+   * RIGHT pass instead of only ever the main one.
+   */
+  extraPasses: ExtraPassAttestationInput[];
 }
 
 /**
@@ -369,6 +378,7 @@ async function runEngineForReview(
     agentUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0 },
     allocatedTokens: 0,
     passesSkipped: [],
+    extraPasses: [],
   };
 
   telemetry.findings = await engine.run({
@@ -390,9 +400,26 @@ async function runEngineForReview(
       telemetry.allocatedTokens = tokens;
     },
     reportSkip: skip => telemetry.passesSkipped.push(skip),
+    reportPassResult: result => telemetry.extraPasses.push(result),
   });
   logger.info(`Engine produced ${telemetry.findings.length} total findings`);
   return telemetry;
+}
+
+/**
+ * The MAIN pass's own spent tokens, derived from the run's aggregate spend
+ * (`telemetry.agentUsage.totalTokens`, which sums main + every extra pass —
+ * see `accumulateUsage`) minus what the extra passes themselves reported
+ * spending. No new plumbing needed to track main's spend separately: as long
+ * as `reportUsage` fires exactly once per pass that ran (main via
+ * `reportAgentRun`, each extra pass via `runExtraPasses` — both true today),
+ * this subtraction is exact.
+ */
+export function deriveMainSpentTokens(
+  aggregateSpentTokens: number,
+  extraPasses: ExtraPassAttestationInput[],
+): number {
+  return aggregateSpentTokens - extraPasses.reduce((sum, p) => sum + p.spentTokens, 0);
 }
 
 /** Assemble the attestation from the run's telemetry + the present() delivery outcome. */
@@ -412,7 +439,8 @@ function buildRunAttestation(
     agentAttempted,
     providerFailure,
     allocatedTokens: telemetry.allocatedTokens,
-    spentTokens: telemetry.agentUsage.totalTokens,
+    spentTokens: deriveMainSpentTokens(telemetry.agentUsage.totalTokens, telemetry.extraPasses),
+    extraPasses: telemetry.extraPasses,
     passesSkipped: telemetry.passesSkipped,
     annotationsEmitted: presentation.delivery.annotationsEmitted,
     inlineComments: presentation.delivery.inlineComments,

--- a/packages/review/test/attestation.test.ts
+++ b/packages/review/test/attestation.test.ts
@@ -8,6 +8,7 @@ import {
   formatAttestationBadgeLine,
   ATTESTATION_VERSION,
   type AttestationInput,
+  type ExtraPassAttestationInput,
   type ReviewFinding,
 } from '../src/index.js';
 
@@ -56,9 +57,9 @@ function incompleteFinding(stopReason: 'budget' | 'max_turns'): ReviewFinding {
 }
 
 describe('assembleAttestation', () => {
-  it('is versioned as v1', () => {
+  it('is versioned as v2', () => {
     expect(assembleAttestation(baseInput()).attestationVersion).toBe(ATTESTATION_VERSION);
-    expect(ATTESTATION_VERSION).toBe(1);
+    expect(ATTESTATION_VERSION).toBe(2);
   });
 
   it('produces verdict "delivered" for a clean, fully-delivered run', () => {
@@ -71,6 +72,7 @@ describe('assembleAttestation', () => {
       allocatedTokens: 100_000,
       spentTokens: 12_000,
       starved: false,
+      passes: [{ name: 'main', allocatedTokens: 100_000, spentTokens: 12_000, starved: false }],
     });
   });
 
@@ -174,10 +176,96 @@ describe('assembleAttestation', () => {
     ]);
     expect(attestation.verdict).toBe('delivered');
   });
+
+  // ---------------------------------------------------------------------------
+  // Two-pass attestation (the per-rule-loops generalization this file's
+  // ATTESTATION_VERSION bump to 2 is for): a clean run where the doc-truth
+  // second pass also fired must get its OWN provider.passes[] entry and its
+  // OWN budget.passes[] breakdown — not folded into the main pass's numbers.
+  // ---------------------------------------------------------------------------
+  describe('two-pass attestation (main + doc-truth)', () => {
+    function docTruthPass(
+      overrides?: Partial<ExtraPassAttestationInput>,
+    ): ExtraPassAttestationInput {
+      return {
+        name: 'doc-truth',
+        stopReason: 'completed',
+        neverRan: false,
+        allocatedTokens: 40_000,
+        spentTokens: 8_000,
+        ...overrides,
+      };
+    }
+
+    it('reports a SEPARATE provider.passes[] entry for the extra pass, not just main', () => {
+      const attestation = assembleAttestation(baseInput({ extraPasses: [docTruthPass()] }));
+      expect(attestation.provider.passes).toEqual([
+        { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
+        { name: 'doc-truth', ran: true, stopReason: 'completed', neverRan: false },
+      ]);
+    });
+
+    it('aggregates budget.allocatedTokens/spentTokens across BOTH passes, with a per-pass breakdown', () => {
+      // Main: 100K allocated / 12K spent (baseInput's defaults). Doc-truth:
+      // 40K allocated / 8K spent. Before this generalization, allocatedTokens
+      // was main-only (100K) while spentTokens already summed both passes
+      // (20K) — an inconsistent, understated ceiling. Both now aggregate.
+      const attestation = assembleAttestation(baseInput({ extraPasses: [docTruthPass()] }));
+      expect(attestation.budget).toEqual({
+        allocatedTokens: 140_000,
+        spentTokens: 20_000,
+        starved: false,
+        passes: [
+          { name: 'main', allocatedTokens: 100_000, spentTokens: 12_000, starved: false },
+          { name: 'doc-truth', allocatedTokens: 40_000, spentTokens: 8_000, starved: false },
+        ],
+      });
+    });
+
+    it('attributes a doc-truth-only budget starvation to doc-truth, not main (the bug this fixes)', () => {
+      // Main pass finished cleanly (stopReason 'completed', no incomplete
+      // finding); ONLY the doc-truth pass ran out of budget. Before this
+      // generalization, the doc pass's incomplete state got folded into the
+      // MAIN pass's own stopReason upstream (mergeDocPassIntoResult), so this
+      // scenario was indistinguishable from the main pass itself starving.
+      const attestation = assembleAttestation(
+        baseInput({
+          extraPasses: [
+            docTruthPass({ stopReason: 'budget', allocatedTokens: 40_000, spentTokens: 40_000 }),
+          ],
+        }),
+      );
+      expect(attestation.verdict).toBe('degraded:budget_starved');
+      expect(attestation.provider.passes).toEqual([
+        { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
+        { name: 'doc-truth', ran: true, stopReason: 'budget', neverRan: false },
+      ]);
+      // Aggregate flags starved...
+      expect(attestation.budget.starved).toBe(true);
+      // ...and the per-pass breakdown shows exactly WHICH pass starved.
+      const [mainBudget, docTruthBudget] = attestation.budget.passes;
+      expect(mainBudget.starved).toBe(false);
+      expect(docTruthBudget.starved).toBe(true);
+    });
+
+    it('does not include extra passes at all when the agent-review plugin never ran', () => {
+      const attestation = assembleAttestation(
+        baseInput({ agentAttempted: false, extraPasses: [docTruthPass()] }),
+      );
+      expect(attestation.provider.passes).toEqual([]);
+      expect(attestation.budget.passes).toEqual([]);
+      expect(attestation.budget).toEqual({
+        allocatedTokens: 0,
+        spentTokens: 0,
+        starved: false,
+        passes: [],
+      });
+    });
+  });
 });
 
 describe('emptyAttestation', () => {
-  it('builds a "delivered" v1 attestation for the zero-files early-exit path', () => {
+  it('builds a "delivered" attestation for the zero-files early-exit path', () => {
     const attestation = emptyAttestation('success', 0, 'zero_files_early_exit');
     expect(attestation.verdict).toBe('delivered');
     expect(attestation.scope).toEqual({
@@ -230,11 +318,26 @@ describe('computeVerdict', () => {
     const verdict = computeVerdict({
       pipelineFailed: true,
       providerFailure: true,
-      mainPass: { name: 'main', ran: true, stopReason: 'budget', neverRan: false },
-      budget: { allocatedTokens: 1, spentTokens: 1, starved: true },
+      passes: [{ name: 'main', ran: true, stopReason: 'budget', neverRan: false }],
       inlineComments: { attempted: 1, posted: 0, dropped: 1, deduped: 0 },
     });
     expect(verdict).toBe('failed:analysis_error');
+  });
+
+  it('attributes budget_starved to whichever pass actually stopped on budget, not just passes[0]', () => {
+    // main completed cleanly; a LATER pass (e.g. doc-truth) is the one that
+    // starved — the verdict must still resolve to degraded:budget_starved,
+    // driven by that pass, not by main's own (clean) stopReason.
+    const verdict = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      passes: [
+        { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
+        { name: 'doc-truth', ran: true, stopReason: 'budget', neverRan: false },
+      ],
+      inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    });
+    expect(verdict).toBe('degraded:budget_starved');
   });
 });
 

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -280,8 +280,7 @@ describe('EMPTY_DELIVERY', () => {
     const verdict = computeVerdict({
       pipelineFailed: false,
       providerFailure: false,
-      mainPass: { name: 'main', ran: false, stopReason: 'not_run', neverRan: false },
-      budget: { allocatedTokens: 0, spentTokens: 0, starved: false },
+      passes: [{ name: 'main', ran: false, stopReason: 'not_run', neverRan: false }],
       inlineComments: EMPTY_DELIVERY.inlineComments,
       descriptionBadgeUpdated: EMPTY_DELIVERY.descriptionBadgeUpdated,
       outOfDiffReviewPosted: EMPTY_DELIVERY.outOfDiffReviewPosted,

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 
 import {
   shouldRunDocTruthPass,
@@ -6,21 +6,13 @@ import {
   buildDocTruthPassInitialMessage,
   mergeDocTruthFindings,
   mergeDocPassIntoResult,
-  appendDocTruthTurns,
   docTruthPassBudget,
-  runDocTruthPass,
+  DOC_TRUTH_PASS_SPEC,
   DOC_PASS_MAX_TURNS,
 } from '../src/plugins/agent/doc-truth-pass.js';
-import { createTestContext, silentLogger } from '../src/test-helpers.js';
+import { createTestContext } from '../src/test-helpers.js';
 import type { ReviewContext } from '../src/plugin-types.js';
-import type { Logger } from '../src/logger.js';
-import type {
-  AgentConfig,
-  AgentFinding,
-  AgentResult,
-  AgentTrace,
-  TurnTrace,
-} from '../src/plugins/agent/types.js';
+import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures / helpers
@@ -105,27 +97,6 @@ function fakeResult(findings: AgentFinding[] = [], trace?: AgentTrace): AgentRes
     incomplete: false,
     trace,
   };
-}
-
-function turn(turnNumber: number, toolNames: string[] = []): TurnTrace {
-  return {
-    turnNumber,
-    responseText: '',
-    toolCalls: toolNames.map(name => ({ name, input: {}, output: 'ok' })),
-    finishReason: 'stop',
-  };
-}
-
-function trace(turns: TurnTrace[]): AgentTrace {
-  return { systemPrompt: 's', initialMessage: 'i', model: 'm', turns };
-}
-
-function capturingLogger(): { logger: Logger; lines: string[] } {
-  const lines: string[] = [];
-  const record = (m: string): void => {
-    lines.push(m);
-  };
-  return { logger: { info: record, warning: record, error: record, debug: record }, lines };
 }
 
 afterEach(() => {
@@ -397,139 +368,34 @@ describe('mergeDocPassIntoResult', () => {
 });
 
 // ---------------------------------------------------------------------------
-// appendDocTruthTurns
+// DOC_TRUTH_PASS_SPEC (the ReviewPassSpec doc-truth plugs into the generic
+// executor with — see review-pass.ts for the gate/run/failure-isolation/
+// trace-append tests that used to live here as runDocTruthPass/
+// appendDocTruthTurns, now generalized and tested against synthetic specs)
 // ---------------------------------------------------------------------------
 
-describe('appendDocTruthTurns', () => {
-  it('appends renumbered, phase-labeled doc turns so both passes stay in one trace', () => {
-    const mainTrace = trace([turn(1, ['grep_codebase']), turn(2)]);
-    const docTrace = trace([turn(1, ['get_files_context']), turn(2)]);
-
-    appendDocTruthTurns(mainTrace, docTrace);
-
-    expect(mainTrace.turns).toHaveLength(4);
-    expect(mainTrace.turns[2].turnNumber).toBe(3);
-    expect(mainTrace.turns[2].phase).toBe('doc-truth');
-    expect(mainTrace.turns[3].turnNumber).toBe(4);
-    // Tool calls from BOTH passes are now flattenable (keeps expectToolCalled
-    // working for main-pass assertions AND surfaces the doc pass's tools).
-    const toolNames = mainTrace.turns.flatMap(t => t.toolCalls.map(c => c.name));
-    expect(toolNames).toContain('grep_codebase');
-    expect(toolNames).toContain('get_files_context');
+describe('DOC_TRUTH_PASS_SPEC', () => {
+  it('wires this module’s own pure functions into the ReviewPassSpec contract', () => {
+    expect(DOC_TRUTH_PASS_SPEC.name).toBe('doc-truth');
+    expect(DOC_TRUTH_PASS_SPEC.skipPlugin).toBe('agent-review:doc-truth');
+    expect(DOC_TRUTH_PASS_SPEC.maxTurns).toBe(DOC_PASS_MAX_TURNS);
+    expect(DOC_TRUTH_PASS_SPEC.budget(100_000)).toBe(docTruthPassBudget(100_000));
+    expect(DOC_TRUTH_PASS_SPEC.mergeFindings).toBe(mergeDocTruthFindings);
+    expect(DOC_TRUTH_PASS_SPEC.mergeResultState).toBe(mergeDocPassIntoResult);
   });
 
-  it('is a no-op when either trace is absent', () => {
-    const mainTrace = trace([turn(1)]);
-    expect(() => appendDocTruthTurns(undefined, trace([turn(1)]))).not.toThrow();
-    appendDocTruthTurns(mainTrace, undefined);
-    expect(mainTrace.turns).toHaveLength(1);
+  it('gateReason is docTruthSkipReason — null (should run) when claims are present', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    expect(DOC_TRUTH_PASS_SPEC.gateReason(ctx, cfg())).toBeNull();
   });
-});
 
-// ---------------------------------------------------------------------------
-// runDocTruthPass (client injected — zero LLM)
-// ---------------------------------------------------------------------------
-
-describe('runDocTruthPass', () => {
-  it('does not invoke the client and returns null when the pass is gated off', async () => {
+  it('gateReason names the real reason when gated off (not a generic boolean)', () => {
     const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]); // no claims
-    let called = false;
-    const res = await runDocTruthPass(ctx, cfg(), silentLogger, async () => {
-      called = true;
-      return fakeResult();
-    });
-    expect(res).toBeNull();
-    expect(called).toBe(false);
+    expect(DOC_TRUTH_PASS_SPEC.gateReason(ctx, cfg())).toContain('no doc claims');
   });
 
-  it('runs the client with the doc-pass budget/turns and returns its result', async () => {
+  it('buildPrompts delegates to buildDocTruthPassPrompts', () => {
     const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    const captured: { sys?: string; init?: string; budget?: number; maxTurns?: number } = {};
-    const res = await runDocTruthPass(
-      ctx,
-      cfg({ maxTokenBudget: 100_000 }),
-      silentLogger,
-      async (sys, init, budget, maxTurns) => {
-        Object.assign(captured, { sys, init, budget, maxTurns });
-        return fakeResult([finding({ filepath: 'docs/architecture/worktree.md', line: 2 })]);
-      },
-    );
-
-    expect(res).not.toBeNull();
-    expect(res!.findings).toHaveLength(1);
-    expect(captured.budget).toBe(40_000);
-    expect(captured.maxTurns).toBe(DOC_PASS_MAX_TURNS);
-    expect(captured.sys).toContain('doc-truth');
-    expect(captured.init).toContain('<doc_claims>');
-  });
-
-  it('isolates a pass failure: a throwing client yields null and a logged warning', async () => {
-    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    const { logger, lines } = capturingLogger();
-    const res = await runDocTruthPass(ctx, cfg(), logger, async () => {
-      throw new Error('boom');
-    });
-    expect(res).toBeNull();
-    expect(lines.some(l => l.includes('doc-truth pass failed') && l.includes('boom'))).toBe(true);
-  });
-
-  // Regression coverage for the CodeRabbit #768 finding: reportDocTruthPassSkip
-  // used to report a generic "no doc claims" reason for every gated-off case,
-  // and a thrown pass-2 error vanished from the attestation entirely (neither
-  // "ran" nor "skipped"). `runDocTruthPass` now reports its own precise reason
-  // for both the gate and the failure, straight from the one place that knows it.
-  it('reports the CONFIG-disabled reason, not the generic "no doc claims" one', async () => {
-    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    const reportSkip = vi.fn();
-    await runDocTruthPass(
-      { ...ctx, reportSkip },
-      cfg({ docTruthPass: false }),
-      silentLogger,
-      async () => fakeResult(),
-    );
-    expect(reportSkip).toHaveBeenCalledWith({
-      plugin: 'agent-review:doc-truth',
-      reason: expect.stringContaining('config'),
-    });
-  });
-
-  it('reports the ENV-disabled reason', async () => {
-    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    process.env.LIEN_REVIEW_DOC_PASS = '0';
-    const reportSkip = vi.fn();
-    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => fakeResult());
-    expect(reportSkip).toHaveBeenCalledWith({
-      plugin: 'agent-review:doc-truth',
-      reason: expect.stringContaining('LIEN_REVIEW_DOC_PASS'),
-    });
-  });
-
-  it('reports "no doc claims" only when that is the actual reason', async () => {
-    const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]); // no claims
-    const reportSkip = vi.fn();
-    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => fakeResult());
-    expect(reportSkip).toHaveBeenCalledWith({
-      plugin: 'agent-review:doc-truth',
-      reason: expect.stringContaining('no doc claims'),
-    });
-  });
-
-  it('reports a FAILED outcome (not silence) when the client throws', async () => {
-    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    const reportSkip = vi.fn();
-    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => {
-      throw new Error('boom');
-    });
-    expect(reportSkip).toHaveBeenCalledWith({
-      plugin: 'agent-review:doc-truth',
-      reason: expect.stringContaining('failed: boom'),
-    });
-  });
-
-  it('does not report anything when the pass runs to completion', async () => {
-    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    const reportSkip = vi.fn();
-    await runDocTruthPass({ ...ctx, reportSkip }, cfg(), silentLogger, async () => fakeResult());
-    expect(reportSkip).not.toHaveBeenCalled();
+    expect(DOC_TRUTH_PASS_SPEC.buildPrompts(ctx)).toEqual(buildDocTruthPassPrompts(ctx));
   });
 });

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  runReviewPass,
+  appendPassTurns,
+  runExtraPasses,
+  type ReviewPassSpec,
+} from '../src/plugins/agent/review-pass.js';
+import { createTestContext, silentLogger } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type {
+  AgentConfig,
+  AgentFinding,
+  AgentResult,
+  AgentTrace,
+  TurnTrace,
+} from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+function finding(overrides: Partial<AgentFinding> = {}): AgentFinding {
+  return {
+    filepath: 'a.ts',
+    line: 1,
+    severity: 'warning',
+    category: 'bug',
+    message: 'msg',
+    ...overrides,
+  };
+}
+
+function fakeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2, cost: 0.01 },
+    turns: 1,
+    stopReason: 'completed',
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+function turn(turnNumber: number, toolNames: string[] = []): TurnTrace {
+  return {
+    turnNumber,
+    responseText: '',
+    toolCalls: toolNames.map(name => ({ name, input: {}, output: 'ok' })),
+    finishReason: 'stop',
+  };
+}
+
+function trace(turns: TurnTrace[]): AgentTrace {
+  return { systemPrompt: 's', initialMessage: 'i', model: 'm', turns };
+}
+
+/** A minimal, fully-controllable spec for exercising the generic executor. */
+function makeSpec(overrides: Partial<ReviewPassSpec> = {}): ReviewPassSpec {
+  return {
+    name: 'test-pass',
+    skipPlugin: 'agent-review:test-pass',
+    gateReason: () => null,
+    buildPrompts: () => ({ systemPrompt: 'sys', initialMessage: 'init' }),
+    budget: base => Math.round(base * 0.5),
+    maxTurns: 4,
+    mergeFindings: (merged, passFindings) => [...merged, ...passFindings],
+    mergeResultState: (main, passResult) => {
+      if (passResult?.incomplete) main.incomplete = true;
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runReviewPass
+// ---------------------------------------------------------------------------
+
+describe('runReviewPass', () => {
+  it('does not invoke the client and returns null when the pass is gated off', async () => {
+    const ctx = createTestContext();
+    const spec = makeSpec({ gateReason: () => 'not eligible' });
+    let called = false;
+
+    const result = await runReviewPass(spec, ctx, cfg(), silentLogger, async () => {
+      called = true;
+      return fakeResult();
+    });
+
+    expect(result).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it('reports the precise gate reason via context.reportSkip', async () => {
+    const reportSkip = vi.fn();
+    const ctx = { ...createTestContext(), reportSkip };
+    const spec = makeSpec({ gateReason: () => 'no candidates found' });
+
+    await runReviewPass(spec, ctx, cfg(), silentLogger, async () => fakeResult());
+
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:test-pass',
+      reason: 'no candidates found',
+    });
+  });
+
+  it('runs the client with the pass-specific budget/turns and returns its result', async () => {
+    const ctx = createTestContext();
+    const spec = makeSpec({ maxTurns: 7, budget: base => base * 0.25 });
+    const captured: { sys?: string; init?: string; budget?: number; maxTurns?: number } = {};
+
+    const result = await runReviewPass(
+      spec,
+      ctx,
+      cfg({ maxTokenBudget: 80_000 }),
+      silentLogger,
+      async (sys, init, budget, maxTurns) => {
+        Object.assign(captured, { sys, init, budget, maxTurns });
+        return fakeResult({ findings: [finding()] });
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.findings).toHaveLength(1);
+    expect(captured).toEqual({ sys: 'sys', init: 'init', budget: 20_000, maxTurns: 7 });
+  });
+
+  it('isolates a pass failure: a throwing client yields null, logs a warning, reports the failure', async () => {
+    const reportSkip = vi.fn();
+    const ctx = { ...createTestContext(), reportSkip };
+    const spec = makeSpec();
+    const lines: string[] = [];
+    const logger = {
+      info: () => {},
+      warning: (m: string) => lines.push(m),
+      error: () => {},
+      debug: () => {},
+    };
+
+    const result = await runReviewPass(spec, ctx, cfg(), logger, async () => {
+      throw new Error('boom');
+    });
+
+    expect(result).toBeNull();
+    expect(lines.some(l => l.includes('test-pass pass failed') && l.includes('boom'))).toBe(true);
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:test-pass',
+      reason: 'failed: boom',
+    });
+  });
+
+  it('does not report anything when the pass runs to completion', async () => {
+    const reportSkip = vi.fn();
+    const ctx = { ...createTestContext(), reportSkip };
+    const spec = makeSpec();
+
+    await runReviewPass(spec, ctx, cfg(), silentLogger, async () => fakeResult());
+
+    expect(reportSkip).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendPassTurns
+// ---------------------------------------------------------------------------
+
+describe('appendPassTurns', () => {
+  it('appends renumbered turns stamped with the given phase', () => {
+    const mainTrace = trace([turn(1, ['grep_codebase']), turn(2)]);
+    const passTrace = trace([turn(1, ['get_files_context']), turn(2)]);
+
+    appendPassTurns(mainTrace, passTrace, 'stale-duplicate');
+
+    expect(mainTrace.turns).toHaveLength(4);
+    expect(mainTrace.turns[2].turnNumber).toBe(3);
+    expect(mainTrace.turns[2].phase).toBe('stale-duplicate');
+    expect(mainTrace.turns[3].turnNumber).toBe(4);
+    const toolNames = mainTrace.turns.flatMap(t => t.toolCalls.map(c => c.name));
+    expect(toolNames).toContain('grep_codebase');
+    expect(toolNames).toContain('get_files_context');
+  });
+
+  it('is a no-op when either trace is absent', () => {
+    const mainTrace = trace([turn(1)]);
+    expect(() => appendPassTurns(undefined, trace([turn(1)]), 'x')).not.toThrow();
+    appendPassTurns(mainTrace, undefined, 'x');
+    expect(mainTrace.turns).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runExtraPasses — the ordered-list orchestrator
+// ---------------------------------------------------------------------------
+
+describe('runExtraPasses', () => {
+  function mainResult(overrides: Partial<AgentResult> = {}): AgentResult {
+    return fakeResult({ findings: [finding({ message: 'main finding' })], ...overrides });
+  }
+
+  it('runs every eligible pass IN ORDER, serially (not concurrently)', async () => {
+    const order: string[] = [];
+    const specA = makeSpec({ name: 'pass-a', skipPlugin: 'agent-review:pass-a' });
+    const specB = makeSpec({ name: 'pass-b', skipPlugin: 'agent-review:pass-b' });
+    const ctx = createTestContext();
+    const main = mainResult();
+
+    const runClientFor = (spec: ReviewPassSpec) => async () => {
+      order.push(`${spec.name}-start`);
+      // A microtask delay proves B does not start until A's promise settles.
+      await new Promise(resolve => setTimeout(resolve, 5));
+      order.push(`${spec.name}-end`);
+      return fakeResult();
+    };
+
+    await runExtraPasses(
+      [specA, specB],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+    );
+
+    expect(order).toEqual(['pass-a-start', 'pass-a-end', 'pass-b-start', 'pass-b-end']);
+  });
+
+  it("merges each pass's findings into the running list, in list order", async () => {
+    const specA = makeSpec({ name: 'pass-a' });
+    const specB = makeSpec({ name: 'pass-b' });
+    const ctx = createTestContext();
+    const main = mainResult();
+    let call = 0;
+    const runClientFor = () => async () => {
+      call += 1;
+      return fakeResult({ findings: [finding({ message: `finding-${call}` })] });
+    };
+
+    const { findings } = await runExtraPasses(
+      [specA, specB],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+    );
+
+    expect(findings.map(f => f.message)).toEqual(['main finding', 'finding-1', 'finding-2']);
+  });
+
+  it('skips a pass that declines eligibility, recording the reason via reportSkip (feeds passesSkipped)', async () => {
+    const reportSkip = vi.fn();
+    const ctx = { ...createTestContext(), reportSkip };
+    const eligible = makeSpec({ name: 'eligible-pass' });
+    const declined = makeSpec({ name: 'declined-pass', gateReason: () => 'no work to do' });
+    const main = mainResult();
+    const ran: string[] = [];
+    const runClientFor = (spec: ReviewPassSpec) => async () => {
+      ran.push(spec.name);
+      return fakeResult();
+    };
+
+    const { outcomes } = await runExtraPasses(
+      [declined, eligible],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+    );
+
+    // The declined pass's client never ran, and only the eligible pass shows
+    // up as a real outcome — the declined one is reported via reportSkip only.
+    expect(ran).toEqual(['eligible-pass']);
+    expect(outcomes.map(o => o.name)).toEqual(['eligible-pass']);
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:test-pass',
+      reason: 'no work to do',
+    });
+  });
+
+  it('skips every pass without evaluating its gate when the main pass never ran', async () => {
+    const gateSpy = vi.fn(() => null);
+    const spec = makeSpec({ name: 'never-run-guard', gateReason: gateSpy });
+    const reportSkip = vi.fn();
+    const ctx = { ...createTestContext(), reportSkip };
+    const main = fakeResult({ neverRan: true, incomplete: true, stopReason: 'error' });
+
+    const { outcomes } = await runExtraPasses(
+      [spec],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      [],
+      () => async () => fakeResult(),
+    );
+
+    expect(gateSpy).not.toHaveBeenCalled();
+    expect(outcomes).toEqual([]);
+    expect(reportSkip).toHaveBeenCalledWith({
+      plugin: 'agent-review:test-pass',
+      reason: 'main pass never ran (provider failure)',
+    });
+  });
+
+  it('reports one outcome per pass that actually ran, with its own budget/stopReason', async () => {
+    const specA = makeSpec({ name: 'pass-a', budget: () => 10_000 });
+    const specB = makeSpec({ name: 'pass-b', budget: () => 5_000 });
+    const ctx = createTestContext();
+    const main = mainResult();
+    const runClientFor = (spec: ReviewPassSpec) => async () =>
+      spec.name === 'pass-b'
+        ? fakeResult({
+            stopReason: 'budget',
+            incomplete: true,
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 4_000, cost: 0.02 },
+          })
+        : fakeResult({
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 9_000, cost: 0.05 },
+          });
+
+    const { outcomes } = await runExtraPasses(
+      [specA, specB],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+    );
+
+    expect(outcomes).toEqual([
+      {
+        name: 'pass-a',
+        stopReason: 'completed',
+        neverRan: false,
+        allocatedTokens: 10_000,
+        spentTokens: 9_000,
+      },
+      {
+        name: 'pass-b',
+        stopReason: 'budget',
+        neverRan: false,
+        allocatedTokens: 5_000,
+        spentTokens: 4_000,
+      },
+    ]);
+  });
+
+  it('does not add an outcome for a pass whose client throws (failure-isolated)', async () => {
+    const spec = makeSpec();
+    const ctx = createTestContext();
+    const main = mainResult();
+
+    const { outcomes, findings } = await runExtraPasses(
+      [spec],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      () => async () => {
+        throw new Error('boom');
+      },
+    );
+
+    expect(outcomes).toEqual([]);
+    // The main-pass findings survive untouched — a pass-2+ error never fails the review.
+    expect(findings).toEqual(main.findings);
+  });
+});


### PR DESCRIPTION
## Summary

Prerequisite plumbing for the per-rule candidate-loop architecture (owner-approved design doc, cut-list items 1 and 3). Zero behavior change to prompts/findings, plus one attestation generalization that fixes a live misattribution bug.

**Part 1 — pass-executor generalization (`packages/review/src/plugins/agent/review-pass.ts`, new).**
Factors `doc-truth-pass.ts`'s gate/run/failure-isolation/trace-append plumbing (previously `runDocTruthPass` + `appendDocTruthTurns`, hardcoded to doc-truth) into a parameterized `ReviewPassSpec` + `runReviewPass`/`runExtraPasses` executor. `doc-truth-pass.ts` now only owns its own pure pieces (gate reason, prompt builder, budget fraction, merge functions) and exposes them bundled as `DOC_TRUTH_PASS_SPEC`. `index.ts`'s `analyze()`/`analyzeSummaryOnly()` run an ordered `EXTRA_PASSES: ReviewPassSpec[]` list (currently `[DOC_TRUTH_PASS_SPEC]`) instead of a single hardcoded `docResult` variable — serial execution for v1, per the design doc (doc-truth has a real data dependency on the main pass's outcome; no other pass exists yet to justify concurrency's complexity).

**Part 2 — per-pass attestation (`attestation.ts`, `review-pr.ts`).**
`provider.passes[]`/`BudgetAttestation` generalize from a hardcoded single main-pass entry to one entry per pass that actually ran. This fixes a real bug: today, an unfinished doc-truth pass folds its `stopReason` into the MAIN pass's own state (`mergeDocPassIntoResult`), so a doc-truth-only budget starvation was attested as `mainPass.stopReason === 'budget'` — correctly non-silent, but misattributed. `computeVerdict` now finds whichever pass actually stopped (main or extra) and attributes `degraded:budget_starved` to it specifically. **`ATTESTATION_VERSION` bumped 1 → 2** — an owner-reviewable call (not the "additive fields don't bump it" convention) because this is the first time `passes[]`/`budget` grow past one pass's worth of data; a consumer assuming `passes.length <= 1` would have silently ignored real data before this bump. Updated `action.yml`'s attestation output description and `finish-run.test.ts`'s version assertion to match — these were the only other places documenting/asserting the version.

## Executor shape

`ReviewPassSpec = { name, skipPlugin, gateReason(context, config), buildPrompts(context), budget(baseBudget), maxTurns, mergeFindings(merged, passFindings), mergeResultState(main, passResult, mergedFindings) }`. `runReviewPass` mirrors the original `runDocTruthPass`'s gate-check → build-prompts → run-client → catch-and-report-failure shape exactly, just parameterized. `runExtraPasses` is the new orchestrator: iterates `specs` in array order (serial `await`), skips every pass without even evaluating its gate when the main pass never ran, and folds each pass's findings/result-state into the running total before moving to the next — returning `{ findings, outcomes }` where `outcomes: PassOutcome[]` (name/stopReason/neverRan/allocatedTokens/spentTokens) feeds the new `reportPassResult` context callback for per-pass attestation.

## Byte-diff census (Part 1 proof obligation)

Ran `build-prompts.ts` (which since #796 emits the doc-truth pass's own prompts via the `docTruthPass` field) against every `*.fixture.json` on disk in this worktree, at the merge-base commit (`fafe4d14`, = `origin/main` at rebase time) vs this branch:

| Fixture | Result |
|---|---|
| `boundary-change/placeholder.fixture.json` | byte-identical (sha256 match) |
| `doc-truth/accurate-doc.fixture.json` | byte-identical (sha256 match) |
| `doc-truth/renamed-stale-claim.fixture.json` | byte-identical (sha256 match) |
| `doc-truth/pr658-search-code-rename.fixture.json` (docTruthPass fires: true) | byte-identical (sha256 match) |

**4/4 fixtures byte-identical**, both `systemPrompt`/`initialMessage` (main pass) and `docTruthPass.{systemPrompt,initialMessage}` fields, verified via `cmp` and `sha256sum` on both sides. (Only these 4 `.fixture.json` files exist on disk in this worktree — the rest are gitignored, per-worktree capture artifacts not present here; `pr658-search-code-rename.fixture.json` was copied in from a sibling worktree per the task brief since it's the doc-truth-firing canary and wasn't present locally.)

## Dogfood evidence (verbatim two-pass attestation)

Replayed `pr658-search-code-rename.fixture.json` through the **real** `AgentReviewPlugin.analyze()` pipeline (real rule selection, real budget scaling, real `runExtraPasses` → `DOC_TRUTH_PASS_SPEC` orchestration, real `assembleAttestation`), with a **mocked `fetch`** standing in for the LLM (zero paid spend — two canned "stop turn" responses, one per pass). Verbatim attestation JSON produced:

```json
{
  "attestationVersion": 2,
  "run": { "conclusion": "success", "filesAnalyzed": 43 },
  "provider": {
    "passes": [
      { "name": "main", "ran": true, "stopReason": "completed", "neverRan": false },
      { "name": "doc-truth", "ran": true, "stopReason": "completed", "neverRan": false }
    ]
  },
  "budget": {
    "allocatedTokens": 140000,
    "spentTokens": 10800,
    "starved": false,
    "passes": [
      { "name": "main", "allocatedTokens": 100000, "spentTokens": 5400, "starved": false },
      { "name": "doc-truth", "allocatedTokens": 40000, "spentTokens": 5400, "starved": false }
    ]
  },
  "passesSkipped": [],
  "delivery": {
    "annotationsEmitted": 0,
    "inlineComments": { "attempted": 0, "posted": 0, "dropped": 0, "deduped": 0 },
    "descriptionBadge": { "updated": null },
    "outOfDiffReviewPosted": null
  },
  "scope": { "eligibilityPath": "normal", "filesAnalyzed": 43 },
  "verdict": "delivered"
}
```

Diagnostics: 2 fetch calls (one per pass), 3 findings (main finding + doc-truth finding + summary), trace turns `main,doc-truth` (both phases present in one merged trace, confirming `appendPassTurns` wiring). `allocatedTokens` correctly aggregates main (100K) + doc-truth (40K, = 0.4 × 100K per `DOC_PASS_BUDGET_FRACTION`) = 140K — the exact number that used to understate to 100K before this fix.

## Tests

- `packages/review/test/plugins-agent-review-pass.test.ts` (new, 13 tests): the generic executor — gate on/off, client success/failure isolation, budget/turns wiring, trace-append renumbering, and `runExtraPasses`'s ordered-list/serial-execution/skip-recording/per-pass-outcome behavior (using synthetic specs, not doc-truth-specific).
- `packages/review/test/plugins-agent-doc-truth-pass.test.ts` (trimmed): removed the now-generalized `runDocTruthPass`/`appendDocTruthTurns` tests (superseded by the generic executor's own tests above), added a small `DOC_TRUTH_PASS_SPEC` wiring-check block.
- `packages/review/test/attestation.test.ts` (extended): new `describe('two-pass attestation (main + doc-truth)')` block — separate `provider.passes[]` entry per pass, aggregated + per-pass budget breakdown, and the regression case (doc-truth-only budget starvation attributed to doc-truth, not main). Updated the version assertion and the `computeVerdict`/`assembleAttestation` exact-shape assertions for the new `passes: [...]` fields.
- `packages/review/test/engine-delivery.test.ts`: fixed one direct `computeVerdict()` call site using the old `mainPass`/`budget` input shape.
- `packages/action/test/finish-run.test.ts`: updated the `"attestationVersion": 1` string assertion to `2`.

## Gates (all green)

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — 0 lint errors (33 pre-existing warnings, unchanged), full monorepo test suite green (parser-native 27, parser 1062, core 374, review 1082, cli 860, action 39 — all passed). `node packages/cli/dist/index.js delta` — exit 0, "no complexity-affecting changes vs HEAD" after rebase (three functions show `worsened` in an interim run — `computeVerdict`, `runEngineForReview`, `buildRunAttestation` — but all stayed under threshold, no new-over-threshold or crossed function; not silenced via `--soft`).

Note: `packages/review/test/analysis.test.ts` has 3 pre-existing failures in a fresh worktree until `@liendev/parser-native`'s Rust crate is built (`npm run build:native -w @liendev/parser-native`) — confirmed via `git stash` that they fail identically on `origin/main` before this change; unrelated to this diff, and green in the final `npm test` run above once the native binary was built.

## Merge status

Following the standing merge-on-green policy: will squash-merge once CI is green and the Lien Review check (lien-stats + inline comments) is triaged.

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 22. 4 pre-existing issues remain in touched files.
🔗 **Impact**: 1 high-risk file(s) with 7 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 4 | -22 |


> [!NOTE]
> **Low Risk**
>
> This PR refactors the doc-truth second pass into a generic `ReviewPass` executor and generalizes attestation to report per-pass outcomes/budgets. The implementation is sound: the new `runExtraPasses` orchestrator preserves serial execution, failure isolation, and skip reporting; the attestation version is consistently bumped to 2 across schema, tests, and action.yml; and the removed `runDocTruthPass`/`appendDocTruthTurns` symbols only survive as references inside doc comments, not live call sites. No behavior-affecting defects were identified.
>
> - Introduced `ReviewPassSpec`/`runExtraPasses` in `review-pass.ts` to generalize the doc-truth pass executor.
> - Bumped `ATTESTATION_VERSION` 1 → 2 and updated `provider.passes[]`/`budget.passes[]` to carry one entry per pass.
> - Fixed the doc-truth-only budget-starvation misattribution by attributing `degraded:budget_starved` to the pass that actually stopped.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 028ebca. Updates automatically on new commits.</sup>
<!-- /lien-stats -->