### PR TITLE
fix(review): tighten stale-literal signal precision

### DIFF
--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -52,6 +52,8 @@ export interface StaleSite {
   snippet: string;
   isComment: boolean;
   isTest: boolean;
+  /** Build/tooling config or manifest (tsup/vitest/eslint config, tsconfig, package.json). */
+  isConfig: boolean;
 }
 
 export interface StaleLiteralCandidate {
@@ -92,8 +94,17 @@ const LOW_SIGNAL_STRINGS = new Set([
 
 const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
 const COMMENT_RE = /^(\/\/|\/\*|\*|#|--|<!--)/;
-const TEST_PATH_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/)/;
+const TEST_PATH_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/|\/fixtures\/)/;
+const CONFIG_PATH_RE =
+  /(\.config\.|(^|\/)tsconfig[^/]*\.json$|(^|\/)package(-lock)?\.json$|(^|\/)pnpm-lock\.yaml$)/;
 const VALUE_EMITTING_RE = /[=:]|=>|\breturn\b/;
+
+/**
+ * Survivor sites span 3+ of these before a literal is treated as ubiquitous
+ * shared vocabulary (a file-extension list, a copied config default) rather
+ * than one feature's forgotten update site — see {@link isUbiquitousSharedConstant}.
+ */
+const UBIQUITY_AREA_THRESHOLD = 3;
 
 // ---------------------------------------------------------------------------
 // Literal extraction
@@ -288,6 +299,7 @@ function recordSurvivorsForLine(
   absLine: number,
   file: string,
   isTest: boolean,
+  isConfig: boolean,
   touchedValues: Set<string>,
   sitesByLiteral: Map<string, StaleSite[]>,
   seenSites: Set<string>,
@@ -306,7 +318,7 @@ function recordSurvivorsForLine(
     seenSites.add(siteKey);
 
     classified ??= classifySnippet(line);
-    const site: StaleSite = { file, line: absLine, ...classified, isTest };
+    const site: StaleSite = { file, line: absLine, ...classified, isTest, isConfig };
     if (sites) sites.push(site);
     else sitesByLiteral.set(value, [site]);
   }
@@ -341,6 +353,7 @@ function scanRepoForStaleSites(
     const file = chunk.metadata.file;
     const fileChanged = changedLines.get(file);
     const isTest = TEST_PATH_RE.test(file);
+    const isConfig = CONFIG_PATH_RE.test(file);
     const lines = chunk.content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
@@ -357,6 +370,7 @@ function scanRepoForStaleSites(
         absLine,
         file,
         isTest,
+        isConfig,
         touchedValues,
         sitesByLiteral,
         seenSites,
@@ -367,9 +381,60 @@ function scanRepoForStaleSites(
   return { sitesByLiteral, timedOut, chunksScanned };
 }
 
+/**
+ * Package (`packages/<name>`) or top-level directory a file lives under — a
+ * cheap proxy for "the same feature/module" that avoids needing the import
+ * graph. Root-level files with no directory fall back to the whole path.
+ */
+function projectArea(file: string): string {
+  const pkgMatch = file.match(/^packages\/([^/]+)\//);
+  if (pkgMatch) return `packages/${pkgMatch[1]}`;
+  const topMatch = file.match(/^([^/]+)\//);
+  return topMatch ? topMatch[1] : file;
+}
+
+/** Survivor sites that carry real signal: not a comment, not test/fixture code, not config. */
+function productionSites(sites: StaleSite[]): StaleSite[] {
+  return sites.filter(s => !s.isComment && !s.isTest && !s.isConfig);
+}
+
+/**
+ * A candidate whose only survivors are test/fixture or config code, while the
+ * literal itself was changed in ordinary production code, is almost always
+ * benign reuse — a fixture name shared across sibling test files, an
+ * entry-point path repeated in every package's build config — rather than a
+ * forgotten production update. Comment-only survivors don't count as
+ * "test/config only" here; they're a separate, already-low-confidence shape
+ * (see {@link scoreConfidence}). The carve-out below (skip when the changed
+ * literal is ITSELF test/config code) keeps this from silencing genuine
+ * test/config-internal duplication.
+ */
+function isTestOrConfigOnly(changedFile: string, sites: StaleSite[]): boolean {
+  if (TEST_PATH_RE.test(changedFile) || CONFIG_PATH_RE.test(changedFile)) return false;
+  return sites.every(s => s.isTest || s.isConfig);
+}
+
+/**
+ * A literal whose surviving PRODUCTION sites span {@link UBIQUITY_AREA_THRESHOLD}
+ * or more distinct project areas is shared vocabulary by design (a
+ * file-extension list, a copied config default) rather than one feature's
+ * forgotten update site — a genuine stale duplicate overwhelmingly survives
+ * within the same package as the change, not scattered across the repo.
+ */
+function isUbiquitousSharedConstant(sites: StaleSite[]): boolean {
+  const areas = new Set(productionSites(sites).map(s => projectArea(s.file)));
+  return areas.size >= UBIQUITY_AREA_THRESHOLD;
+}
+
+/** Does at least one production survivor live in the same project area as the change? */
+function hasSameAreaSurvivor(changedFile: string, sites: StaleSite[]): boolean {
+  const changedArea = projectArea(changedFile);
+  return productionSites(sites).some(s => projectArea(s.file) === changedArea);
+}
+
 function scoreConfidence(sites: StaleSite[]): StaleLiteralCandidate['confidence'] {
-  const realCode = sites.filter(s => !s.isComment && !s.isTest);
-  if (realCode.length === 0) return 'low'; // only comments/tests survive — weak signal
+  const realCode = productionSites(sites);
+  if (realCode.length === 0) return 'low'; // only comments/tests/config survive — weak signal
   return realCode.some(s => VALUE_EMITTING_RE.test(s.snippet)) ? 'high' : 'medium';
 }
 
@@ -409,33 +474,47 @@ export function computeStaleLiteralCandidates(context: ReviewContext): StaleLite
 
 /**
  * Turn scan results into the final ranked, capped candidate list: attach each
- * touched literal to its surviving sites (dropping literals with none), score
- * confidence, then sort highest-confidence-and-most-sites first.
+ * touched literal to its surviving sites (dropping literals with none),
+ * filter out the benign shapes handled by {@link isTestOrConfigOnly} and
+ * {@link isUbiquitousSharedConstant}, score confidence, then sort
+ * highest-confidence, same-project-area, most-sites first — the cap is
+ * always full on a busy PR, so ranking which 8 survive matters as much as
+ * filtering.
  */
 function buildRankedCandidates(
   literals: ChangedLiteral[],
   sitesByLiteral: Map<string, StaleSite[]>,
 ): StaleLiteralCandidate[] {
-  const candidates: StaleLiteralCandidate[] = [];
+  const scored: Array<{ candidate: StaleLiteralCandidate; sameArea: boolean }> = [];
+
   for (const lit of literals) {
     const staleSites = sitesByLiteral.get(lit.value);
     if (!staleSites || staleSites.length === 0) continue;
-    candidates.push({
-      literal: lit.display,
-      kind: lit.kind,
-      changedSite: { file: lit.file, line: lit.changedLine },
-      staleSites,
-      confidence: scoreConfidence(staleSites),
+    if (isTestOrConfigOnly(lit.file, staleSites)) continue;
+    if (isUbiquitousSharedConstant(staleSites)) continue;
+
+    scored.push({
+      candidate: {
+        literal: lit.display,
+        kind: lit.kind,
+        changedSite: { file: lit.file, line: lit.changedLine },
+        staleSites,
+        confidence: scoreConfidence(staleSites),
+      },
+      sameArea: hasSameAreaSurvivor(lit.file, staleSites),
     });
   }
 
-  candidates.sort((a, b) => {
-    const byConf = CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence];
+  scored.sort((a, b) => {
+    const byConf =
+      CONFIDENCE_RANK[b.candidate.confidence] - CONFIDENCE_RANK[a.candidate.confidence];
     if (byConf !== 0) return byConf;
-    return b.staleSites.length - a.staleSites.length;
+    const bySameArea = Number(b.sameArea) - Number(a.sameArea);
+    if (bySameArea !== 0) return bySameArea;
+    return b.candidate.staleSites.length - a.candidate.staleSites.length;
   });
 
-  return candidates.slice(0, MAX_CANDIDATES);
+  return scored.slice(0, MAX_CANDIDATES).map(s => s.candidate);
 }
 
 /** Log the budget-exceeded diagnostic: elapsed time, scan coverage, and touched-literal count. */
@@ -560,7 +639,11 @@ export function renderStaleLiteralCandidates(candidates: StaleLiteralCandidate[]
         `still present at [confidence: ${c.confidence}]:`,
     );
     for (const s of c.staleSites) {
-      const tags = [s.isComment ? 'comment' : null, s.isTest ? 'test' : null]
+      const tags = [
+        s.isComment ? 'comment' : null,
+        s.isTest ? 'test' : null,
+        s.isConfig ? 'config' : null,
+      ]
         .filter(Boolean)
         .join(', ');
       const suffix = tags ? ` (${tags})` : '';

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -237,7 +237,38 @@ describe('computeStaleLiteralCandidates', () => {
     expect(cand!.staleSites[0].isComment).toBe(true);
   });
 
-  it('marks survivors in test files', () => {
+  it('marks a test-file survivor site but still surfaces the candidate when a real-code survivor also exists', () => {
+    // A mixed candidate (one production survivor + one test-file echo) must
+    // NOT be dropped by isTestOrConfigOnly — that rule only fires when EVERY
+    // survivor is test/config. The test-file site still carries the isTest tag.
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const m = 'model-x-9000';\n+const m = pick();"],
+    ]);
+    const diffLines = new Map([['src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('src/a.ts', 1, 'const m = pick();'),
+      makeChunk('src/other.ts', 1, "adapterContext.model = 'model-x-9000';"),
+      makeChunk('src/a.test.ts', 5, "expect(m).toBe('model-x-9000');"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    const cand = candidates.find(c => c.literal === "'model-x-9000'");
+    expect(cand).toBeDefined();
+    const testSite = cand!.staleSites.find(s => s.file === 'src/a.test.ts');
+    expect(testSite?.isTest).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Precision tightening: suppress benign reuse, rank structurally-related
+// survivors first (see the module's isTestOrConfigOnly / isUbiquitousSharedConstant)
+// ---------------------------------------------------------------------------
+
+describe('isTestOrConfigOnly suppression', () => {
+  it('drops a candidate whose only survivor is a sibling test file', () => {
+    // Class 3 from the precision census: a literal reused only across
+    // sibling test files (e.g. a fixture name) is not a production duplicate.
     const patches = new Map([
       ['src/a.ts', "@@ -1,1 +1,1 @@\n-const m = 'model-x-9000';\n+const m = pick();"],
     ]);
@@ -249,8 +280,149 @@ describe('computeStaleLiteralCandidates', () => {
     const candidates = computeStaleLiteralCandidates(
       makeContext({ patches, repoChunks, diffLines }),
     );
-    const cand = candidates.find(c => c.literal === "'model-x-9000'");
-    expect(cand!.staleSites[0].isTest).toBe(true);
+    expect(candidates.find(c => c.literal === "'model-x-9000'")).toBeUndefined();
+  });
+
+  it('drops a candidate whose only survivors are config/manifest files', () => {
+    // Class 2: an entry-point path repeated across every package's build config.
+    const patches = new Map([
+      [
+        'src/a.ts',
+        "@@ -1,1 +1,1 @@\n-const entry = 'src/index.ts';\n+const entry = resolveEntry();",
+      ],
+    ]);
+    const diffLines = new Map([['src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('src/a.ts', 1, 'const entry = resolveEntry();'),
+      makeChunk('packages/core/tsup.config.ts', 4, "entry: ['src/index.ts'],"),
+      makeChunk('packages/cli/vitest.config.ts', 17, "include: ['src/index.ts'],"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'src/index.ts'")).toBeUndefined();
+  });
+
+  it('does NOT drop a test/config-only candidate when the changed literal is itself test/config code', () => {
+    // Carve-out: the touched literal's own site is a config file, so a
+    // config-only survivor may still be a genuine same-file/config duplicate.
+    const patches = new Map([
+      [
+        'packages/core/tsup.config.ts',
+        "@@ -3,1 +3,1 @@\n-  entry: 'src/legacy-entry.ts',\n+  entry: resolveEntry(),",
+      ],
+    ]);
+    const diffLines = new Map([['packages/core/tsup.config.ts', new Set([3])]]);
+    const repoChunks = [
+      makeChunk('packages/core/tsup.config.ts', 3, '  entry: resolveEntry(),'),
+      makeChunk('packages/core/vitest.config.ts', 10, "  entry: 'src/legacy-entry.ts',"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'src/legacy-entry.ts'")).toBeDefined();
+  });
+
+  it('keeps a comment-only survivor (not test/config-only, handled separately by confidence)', () => {
+    const patches = new Map([
+      ['src/a.ts', "@@ -1,1 +1,1 @@\n-const m = 'model-x-9000';\n+const m = pick();"],
+    ]);
+    const diffLines = new Map([['src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('src/a.ts', 1, 'const m = pick();'),
+      makeChunk('src/notes.ts', 5, "// historical default was 'model-x-9000'"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'model-x-9000'")).toBeDefined();
+  });
+});
+
+describe('isUbiquitousSharedConstant suppression', () => {
+  it('drops a candidate whose production survivors span 3+ unrelated project areas', () => {
+    // Class 1: a shared file-extension-style literal reused by design across
+    // unrelated packages, not a locally forgotten update.
+    const patches = new Map([
+      [
+        'packages/review/src/a.ts',
+        "@@ -1,1 +1,1 @@\n-const ext = '.widget-ext';\n+const ext = resolveExt();",
+      ],
+    ]);
+    const diffLines = new Map([['packages/review/src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('packages/review/src/a.ts', 1, 'const ext = resolveExt();'),
+      makeChunk('packages/parser/src/scanner.ts', 10, "const e = '.widget-ext';"),
+      makeChunk('packages/core/src/indexer.ts', 20, "const e = '.widget-ext';"),
+      makeChunk('docs/guide/formats.md', 5, 'Supported: `.widget-ext`'),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'.widget-ext'")).toBeUndefined();
+  });
+
+  it('keeps a candidate whose production survivors stay within the same project area as the change', () => {
+    // A genuine stale duplicate localized to one package (2 sibling files)
+    // must NOT be suppressed just because it has multiple survivor sites.
+    const patches = new Map([
+      [
+        'packages/review/src/a.ts',
+        "@@ -1,1 +1,1 @@\n-const model = 'model-y-2000';\n+const model = resolveModel();",
+      ],
+    ]);
+    const diffLines = new Map([['packages/review/src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('packages/review/src/a.ts', 1, 'const model = resolveModel();'),
+      makeChunk('packages/review/src/b.ts', 1, "const fallback = 'model-y-2000';"),
+      makeChunk('packages/review/src/c.ts', 1, "const legacy = 'model-y-2000';"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'model-y-2000'")).toBeDefined();
+  });
+
+  it('keeps a candidate spanning only 2 unrelated areas (below the ubiquity threshold)', () => {
+    // Below UBIQUITY_AREA_THRESHOLD (3) — a real duplicate that happens to
+    // span exactly two packages must still surface.
+    const patches = new Map([
+      [
+        'packages/review/src/a.ts',
+        "@@ -1,1 +1,1 @@\n-const model = 'model-z-3000';\n+const model = resolveModel();",
+      ],
+    ]);
+    const diffLines = new Map([['packages/review/src/a.ts', new Set([1])]]);
+    const repoChunks = [
+      makeChunk('packages/review/src/a.ts', 1, 'const model = resolveModel();'),
+      makeChunk('packages/cli/src/b.ts', 1, "const fallback = 'model-z-3000';"),
+    ];
+    const candidates = computeStaleLiteralCandidates(
+      makeContext({ patches, repoChunks, diffLines }),
+    );
+    expect(candidates.find(c => c.literal === "'model-z-3000'")).toBeDefined();
+  });
+});
+
+describe('ranking: same-project-area survivors first', () => {
+  it('ranks a candidate with a same-area production survivor above an equal-confidence, unrelated-area one', () => {
+    const patch =
+      "@@ -1,2 +1,2 @@\n-const a = 'sibling-alpha-token';\n-const b = 'distant-beta-token';\n+const a = f();\n+const b = g();";
+    const patches = new Map([['packages/review/src/a.ts', patch]]);
+    const repoChunks = [
+      // 'sibling-alpha-token' survives in the SAME area (packages/review).
+      makeChunk('packages/review/src/sibling.ts', 1, "const x = 'sibling-alpha-token';"),
+      // 'distant-beta-token' survives only in an unrelated area.
+      makeChunk('packages/cli/src/distant.ts', 1, "const y = 'distant-beta-token';"),
+    ];
+
+    const candidates = computeStaleLiteralCandidates(makeContext({ patches, repoChunks }));
+    const literals = candidates.map(c => c.literal);
+    // Both are 'high' confidence (value-emitting real code, single survivor
+    // each) — the same-area one must be ranked first.
+    expect(literals.indexOf("'sibling-alpha-token'")).toBeLessThan(
+      literals.indexOf("'distant-beta-token'"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Tightens `packages/review/src/stale-literal-signals.ts`'s precision per today's zero-LLM census (40 recent merged PRs): the signal fired 40/40, 33 at its 8-candidate cap, with a 47/32/205 low/med/high confidence split dominated by benign reuse (shared file-extension arrays, entry-point/config strings echoed in every package's build config, literals only reused across sibling test files) that the old `scoreConfidence` heuristic (looks for `=`/`:`/`=>`/`return`) couldn't tell apart from a real stale duplicate.

## Rules shipped

- **`isTestOrConfigOnly`** — drops a candidate whose *only* survivors are test/fixture/config files while the touched literal itself lives in ordinary production code. Carved out when the changed literal is itself test/config code (so genuine test/config-internal duplication still surfaces).
- **`isUbiquitousSharedConstant`** — drops a candidate whose production survivors span **3+ distinct project areas** (`packages/<name>` or top-level dir). A genuine stale duplicate overwhelmingly survives within the same package as the change; only shared vocabulary (file-extension lists, copied config defaults, package names) spreads this broadly. Threshold chosen to match the brief's own 3-file example and verified not to trip on a same-package 2–3-file duplicate.
- **`hasSameAreaSurvivor`** ranking tiebreaker — among equal-confidence candidates, one with a same-project-area production survivor now ranks above one without. The cap is always full on a busy PR, so which 8 candidates survive matters as much as filtering them.
- **`scoreConfidence` fix** — now excludes config-file survivors (alongside the pre-existing comment/test exclusion) from the "real code" check, so a config-only echo scores honestly as `low` instead of inheriting whatever `=`/`:` happened to appear on that config line.
- Widened `TEST_PATH_RE` to also match `/fixtures/` (parallel test-fixture reuse), added `CONFIG_PATH_RE` (`*.config.*`, `tsconfig*.json`, `package(-lock)?.json`, `pnpm-lock.yaml`), new `isConfig` field on `StaleSite` + `(config)` render tag.

## Unit tests (38 total, up from 17)

New coverage for every suppression/ranking rule, each against a synthetic benign-class fixture:
- Drops a test-only-survivor candidate; drops a config-only-survivor candidate; carve-out keeps a candidate when the changed literal is itself config code; keeps a comment-only survivor untouched (pre-existing behavior, unaffected).
- Drops a candidate spanning 3+ unrelated areas; **keeps** one whose survivors stay in the same area (even with multiple sibling-file sites); **keeps** one spanning only 2 areas (below threshold) — guards against over-suppressing a real cross-package duplicate.
- Ranking: same-area survivor ranked above an equal-confidence, unrelated-area one.
- Regression: a mixed candidate (test-file echo + real-code survivor) still surfaces with the test tag intact — proves the suppression only fires when *every* survivor is test/config, not on any test-tagged site.
- All pre-existing true-positive-shape tests (conditionalized-in-place literal, comment-only low confidence, single-pass restructure/dedup/budget tests) pass unchanged.

`lien delta`: exit 0 (no new-over-threshold or crossed functions; `buildRankedCandidates` cognitive 5→10 and a couple of `recordSurvivorsForLine`/`scanRepoForStaleSites` timing deltas are recorded as "worsened" but stay well under threshold).

## Census re-run (both persisted scripts, adapted import paths, run against this branch)

**Real-PR census** (same 40 merged PRs):

| Metric | Before | After |
|---|---|---|
| Firing rate | 40/40 (100%) | 40/40 (100%) — unchanged; nearly every PR touches at least one literal with *some* surviving copy |
| At MAX_CANDIDATES cap (8) | 33/40 | 31/40 |
| Confidence low/med/high | 47/32/205 | 49/41/186 |
| Total candidate instances | 284 | 276 |
| Distinct literals surfaced | 189 | 197 |

The aggregate shift is real but modest — the 8-slot cap refills from a large pool, so suppressing one benign literal usually just promotes the next candidate into its slot rather than shrinking the list. The qualitative change is where it shows: **`'@liendev/lien'` (the package name, 15 occurrences across the corpus — the single most common candidate) is now suppressed in 100% of them (15→0)**, along with `'node:path'`, `'src/index.ts'`, generic HTTP header names (`'headers'`, `'filename'`, `'Content-Type'`), and generic words (`'output'`, `'neutral'`) in the sampled PRs below. Eyeballed several full candidate dumps before/after; surviving high-confidence candidates (e.g. `'relevant'`/`'highly_relevant'` relevance-tier labels in PR #773, same-file model-literal duplicates) look like plausible review targets, not distractors.

**Fixture census** (all 19 harness fixtures, regenerated via `capture-pr.ts`/crossrepo clones): **14/19 fired, unchanged** — but composition changed under the hood for several (see byte-diff below).

## Byte-diff census (build-prompts.ts at merge-base vs branch, all 19 fixtures)

**12/19 byte-identical**, including the canonical stale-duplicate TP fixture. **7/19 changed:**

| Fixture | Tag | Change |
|---|---|---|
| `stale-duplicate/model-partial-update` | canary | **byte-identical** (systemPrompt + initialMessage) — the TP's single same-file survivor is untouched by either new rule |
| `incomplete-handling/enum-variant-removed` | canary | **reorder only** — same 2 candidates, `'delete'` (same-area survivor) now ranked above `'./types.js'` (no same-area survivor); block byte-length identical |
| `concurrency-race/credit-service-toctou` | canary | `'neutral'`/`'output'` (generic words) replaced by `'plan_tier'`/`'created_at'` within the same 8 slots |
| `crossrepo/pr2191-templateresponse-offbyone` | canary, certified 10/10 | `'index.html'`/`'request'`/`"headers"` removed, replaced by `"status_code"`/`"context"`/etc. |
| `doc-truth/pr658-search-code-rename` | canary | `'@liendev/lien'` removed, replaced by `'initializing'` |
| `untrusted-input-validation/harness-initial` | canary | `"findings"`/`"chunks"`/`"config"`/`'node:path'` (×3) removed, replaced by more specific candidates |
| `error-swallowing/scanall-null-guard-fp` | untagged, negative-regression (`expectEmpty` on `error-swallowing`) | `'src/index.ts'` removed, replaced by `'helper'` |
| `crossrepo/pr2017-multipart-boundary-regex` | characterization (non-gating) | `'filename'`/`'Content-Type'` removed, replaced by more specific literals |

Cross-checked every changed canary's `.assertions.ts`: none of their Tier-1/Tier-2 keyword lists reference the removed literals, and each assertion targets a *different* rule's finding (`concurrency-race`, `boundary-change`, `doc-truth`, `untrusted-input-validation`, `incomplete-handling`) for which `<stale_literal_candidates>` is auxiliary context, not the object under test. Removing benign distractors here is neutral-to-helpful, not a regression risk.

## Paid screen

Not run — **$0 spent**. The primary `stale-duplicate/model-partial-update` fixture's `systemPrompt` and `initialMessage` are byte-identical before/after (confirmed directly), so per the brief's guidance a screen isn't warranted.

## Verification

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` all green (1077/1077 `@liendev/review` tests, full monorepo suite). `lien delta` exit 0. Rebased onto latest `origin/main`.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR tightens the stale-literal signal by adding config/test-only suppression, a ubiquity threshold for shared constants, and same-area ranking tiebreakers. The logic is well-scoped, thoroughly unit-tested (38 tests), and the census shows the intended reduction in benign distractors without suppressing the canonical true-positive fixture. No breaking changes to exported APIs or caller contracts were introduced.
>
> - Added isConfig classification and CONFIG_PATH_RE to treat build/manifest files separately from production code
> - Added isTestOrConfigOnly and isUbiquitousSharedConstant filters plus hasSameAreaSurvivor ranking tiebreaker
> - Updated scoreConfidence to exclude config survivors from 'real code' detection

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4fc750b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->