### PR TITLE
ci: enforce owner-only skip-harness-gate label + broaden evidence detection

### DIFF
--- a/.github/scripts/harness-gate-check.mjs
+++ b/.github/scripts/harness-gate-check.mjs
@@ -40,7 +40,10 @@
 //     Exits 0 with a stdout message if harness evidence wording is found,
 //     exits 1 with an actionable stderr message otherwise.
 //
-// No npm dependencies -- node:process only.
+// No npm dependencies -- node:process, node:path, node:url only.
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const LABEL_NAME = 'skip-harness-gate';
 
@@ -147,6 +150,9 @@ function main() {
 }
 
 // Only run as a CLI when invoked directly (not when imported for tests).
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Compare resolved filesystem paths rather than string-building a
+// `file://` URL out of process.argv[1] -- the latter would silently never
+// match for any path needing URL-encoding (spaces, unicode).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main();
 }

--- a/.github/scripts/harness-gate-check.mjs
+++ b/.github/scripts/harness-gate-check.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Decision logic for the "Require harness evidence or bypass label" gate
+// (.github/workflows/harness-attestation.yml). Factored out of inline bash
+// so it is unit-testable and locally runnable against real or synthetic
+// data without needing a live Actions run -- see the dogfood section of the
+// PR that introduced this file for a four-way verification transcript.
+//
+// OWNER-ONLY LABEL POLICY
+// ------------------------
+// `skip-harness-gate` bypasses the mandatory harness-calibration evidence
+// check from CLAUDE.md. It must never be self-applied by an agent to get
+// past the gate -- the norm is: gates pass on EVIDENCE, the bypass label is
+// OWNER-only. Two incidents (PR #768, PR #799) had an agent apply the label
+// itself. This script enforces that only an allowlisted human login's most
+// recent `labeled` event for `skip-harness-gate` is honored; anyone else's
+// label application is silently ignored and the PR falls through to the
+// ordinary evidence check, exactly as if unlabeled.
+//
+// KNOWN LIMITATION (see PR body for full context): agents in this repo
+// currently act under the owner's own `gh`/GITHUB_TOKEN credentials, so this
+// check cannot distinguish an agent-performed label event from a
+// human-performed one when both are attributed to the same login. It closes
+// the "anyone can bypass by applying the label" hole; it does not (yet)
+// close the "the owner's own credentials get used by an agent" hole -- that
+// needs a separate bot identity and is out of scope here.
+//
+// Usage:
+//   node harness-gate-check.mjs applier
+//     Reads TIMELINE_JSON (env) -- the JSON returned by
+//     `gh api repos/{owner}/{repo}/issues/{n}/timeline --paginate --slurp`
+//     (an array of per-page arrays; a plain flat array of timeline events
+//     also works, e.g. when a `--slurp`-free single-page fetch is used
+//     locally for dogfooding).
+//     Prints "true" or "false" to stdout (whether the skip-harness-gate
+//     label should be honored) and the reasoning to stderr. Always exits 0
+//     -- this mode only decides, it never fails the job.
+//
+//   node harness-gate-check.mjs evidence
+//     Reads PR_BODY (env) -- the pull request description.
+//     Exits 0 with a stdout message if harness evidence wording is found,
+//     exits 1 with an actionable stderr message otherwise.
+//
+// No npm dependencies -- node:process only.
+
+const LABEL_NAME = 'skip-harness-gate';
+
+// Extend this list to allow another human login to apply the bypass label.
+// Do NOT add bot/agent identities -- see the limitation note above.
+const ALLOWLISTED_LABEL_APPLIERS = ['alfhen'];
+
+// The root cause of both incidents (#765, #799) was legitimate deterministic
+// evidence the original grep didn't recognize -- byte-identical/sha256
+// fixture-comparison census results, not just the harness's own
+// `--calibrate` wording or a linked harness.yml run. This is a conservative
+// widening: a PR body still needs to affirmatively claim ONE of these, an
+// empty/unrelated body still fails.
+const EVIDENCE_PATTERNS = [
+  { name: 'harness-result summary', re: /harness-result/i },
+  { name: 'linked harness.yml run', re: /actions\/runs\/[0-9]+/i },
+  { name: 'calibrate mention', re: /calibrate/i },
+  { name: 'byte-identical census', re: /byte[- ]identical/i },
+  { name: 'byte-diff census', re: /byte[- ]diff/i },
+  { name: 'sha256-verified census', re: /sha256/i },
+  { name: 'build-prompts fixture comparison', re: /build-prompts\.ts/i },
+];
+
+export function decideApplier(timelineJson) {
+  let events;
+  try {
+    events = JSON.parse(timelineJson || '[]');
+  } catch (err) {
+    return {
+      honored: false,
+      reason: `TIMELINE_JSON did not parse as JSON (${err.message}) -- treating '${LABEL_NAME}' as not honored.`,
+    };
+  }
+  if (!Array.isArray(events)) {
+    return {
+      honored: false,
+      reason: `TIMELINE_JSON was not a JSON array -- treating '${LABEL_NAME}' as not honored.`,
+    };
+  }
+  // `gh api --paginate --slurp` wraps each page's array in an outer array
+  // (i.e. an array of arrays), even for a single page. Flatten one level so
+  // both that shape and a plain flat array of events work identically.
+  if (events.every(e => Array.isArray(e))) {
+    events = events.flat();
+  }
+
+  const labelEvents = events.filter(
+    e => e && e.event === 'labeled' && e.label && e.label.name === LABEL_NAME,
+  );
+  if (labelEvents.length === 0) {
+    return {
+      honored: false,
+      reason: `No 'labeled' timeline event found for '${LABEL_NAME}' -- treating as not honored.`,
+    };
+  }
+
+  // Timeline events are already chronological, but sort defensively by
+  // created_at so "most recent" is correct even if that ever changes.
+  labelEvents.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  const mostRecent = labelEvents[labelEvents.length - 1];
+  const actor = mostRecent.actor && mostRecent.actor.login;
+  const honored = Boolean(actor) && ALLOWLISTED_LABEL_APPLIERS.includes(actor);
+
+  return {
+    honored,
+    reason: honored
+      ? `Most recent '${LABEL_NAME}' labeled event was applied by '${actor}', which is on the allowlist (${ALLOWLISTED_LABEL_APPLIERS.join(', ')}) -- bypass honored.`
+      : `Most recent '${LABEL_NAME}' labeled event was applied by '${actor || 'unknown'}', which is NOT on the allowlist (${ALLOWLISTED_LABEL_APPLIERS.join(', ')}) -- ignoring the label; proceeding to the evidence check as if unlabeled.`,
+  };
+}
+
+export function decideEvidence(prBody) {
+  const body = prBody || '';
+  const match = EVIDENCE_PATTERNS.find(p => p.re.test(body));
+  if (match) {
+    return { found: true, reason: `Found harness evidence in PR body (matched: ${match.name}).` };
+  }
+  return {
+    found: false,
+    reason:
+      "This PR touches packages/review/src/plugins/agent/** but the PR body has no harness evidence (a link to a harness.yml run/artifact, a 'calibrate' mention, or a deterministic byte-identical/byte-diff/sha256/build-prompts.ts fixture-comparison census) and no owner-applied 'skip-harness-gate' label. Per CLAUDE.md, rule/prompt changes need a >=9/10 calibration run (npm run test:harness -- --rule <rule-id> --calibrate 10) before merging, unless the change is provably non-behavioral (deterministic fixture-comparison evidence). Paste the harness.yml run link, a harness-result.json summary, or the deterministic comparison method + result in the PR description.",
+  };
+}
+
+function main() {
+  const mode = process.argv[2];
+  if (mode === 'applier') {
+    const { honored, reason } = decideApplier(process.env.TIMELINE_JSON);
+    console.error(reason);
+    console.log(honored ? 'true' : 'false');
+    process.exit(0);
+  } else if (mode === 'evidence') {
+    const { found, reason } = decideEvidence(process.env.PR_BODY);
+    if (found) {
+      console.log(reason);
+      process.exit(0);
+    }
+    console.error(`::error::${reason}`);
+    process.exit(1);
+  } else {
+    console.error('Usage: harness-gate-check.mjs <applier|evidence>');
+    process.exit(2);
+  }
+}
+
+// Only run as a CLI when invoked directly (not when imported for tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/workflows/harness-attestation.yml
+++ b/.github/workflows/harness-attestation.yml
@@ -3,10 +3,10 @@ name: Harness Attestation Gate
 # Cheap, no-LLM audit trail for CLAUDE.md's mandatory harness-calibration
 # rule: any PR touching packages/review/src/plugins/agent/** must show
 # evidence of having cleared the >= 9/10 harness bar (a link to a
-# harness.yml run or artifact, or a pasted harness-result.json summary, in
-# the PR body) or explicitly opt out via the `skip-harness-gate` label for
-# non-behavioral changes (docs, comments, refactors with no prompt/rule
-# behavior change).
+# harness.yml run or artifact, a pasted harness-result.json summary, or a
+# deterministic fixture-comparison census, in the PR body) or explicitly opt
+# out via the `skip-harness-gate` label for non-behavioral changes (docs,
+# comments, refactors with no prompt/rule behavior change).
 #
 # This does NOT run the paid OpenRouter calibration itself -- that's
 # .github/workflows/harness.yml (workflow_dispatch only, costs real money).
@@ -19,6 +19,30 @@ name: Harness Attestation Gate
 # touch the path, which leaves those PRs' required check stuck "pending"
 # forever. Always running and conditionally passing keeps this safe to mark
 # required in branch protection.
+#
+# ----------------------------------------------------------------------------
+# OWNER-ONLY BYPASS LABEL POLICY
+# ----------------------------------------------------------------------------
+# `skip-harness-gate` is an OWNER-only bypass. Gates pass on EVIDENCE; the
+# label is not a self-serve escape hatch. Agents must NEVER self-apply it to
+# get past this check on their own PR. Two incidents (PR #768, PR #799) had
+# an agent apply the label itself to bypass the evidence requirement.
+#
+# This workflow now honors the label only if the MOST RECENT `labeled` event
+# for it (per the PR's GitHub timeline) was performed by a login in the
+# allowlist maintained in .github/scripts/harness-gate-check.mjs
+# (`ALLOWLISTED_LABEL_APPLIERS`). A label applied by anyone else is ignored
+# -- the PR falls through to the ordinary evidence check exactly as if
+# unlabeled, with a log line explaining why.
+#
+# HONEST LIMITATION: agents in this repo currently operate under the
+# owner's own `gh`/GITHUB_TOKEN credentials, so this check cannot
+# distinguish an agent-performed label event from a human-performed one when
+# both are attributed to the same login. This change closes the "anyone can
+# bypass by applying the label" hole and makes the policy machine-enforced
+# where possible; the agent-vs-owner distinction requires a separate bot
+# identity for agent actions and is tracked as a follow-up, not solved here.
+# ----------------------------------------------------------------------------
 
 on:
   pull_request:
@@ -32,12 +56,18 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      issues: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Check whether this PR touches an agent-review rule
         id: touch
@@ -51,16 +81,20 @@ jobs:
             echo "touched=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check PR body for harness evidence
-        if: steps.touch.outputs.touched == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-harness-gate')
+      - name: Determine whether skip-harness-gate label is owner-applied
+        id: applier
+        if: steps.touch.outputs.touched == 'true' && contains(github.event.pull_request.labels.*.name, 'skip-harness-gate')
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if printf '%s' "$PR_BODY" | grep -qEi 'harness-result|actions/runs/[0-9]+|calibrate'; then
-            echo "Found harness evidence in PR body."
-            exit 0
-          fi
+          TIMELINE_JSON="$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/timeline" --paginate --slurp)"
+          EFFECTIVE_SKIP="$(TIMELINE_JSON="$TIMELINE_JSON" node .github/scripts/harness-gate-check.mjs applier)"
+          echo "effective_skip=$EFFECTIVE_SKIP" >> "$GITHUB_OUTPUT"
 
-          echo "::error::This PR touches packages/review/src/plugins/agent/** but the PR body has no harness evidence (a link to a harness.yml run/artifact, or a 'calibrate' mention) and no 'skip-harness-gate' label. Per CLAUDE.md, rule/prompt changes need a >=9/10 calibration run (npm run test:harness -- --rule <rule-id> --calibrate 10) before merging. Paste the harness.yml run link (or harness-result.json summary) in the PR description, or add the 'skip-harness-gate' label for non-behavioral changes."
-          exit 1
+      - name: Check PR body for harness evidence
+        if: steps.touch.outputs.touched == 'true' && steps.applier.outputs.effective_skip != 'true'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node .github/scripts/harness-gate-check.mjs evidence

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,25 @@ git commit -m "test: add integration tests for MCP"
 git commit -m "chore: update dependencies"
 ```
 
+### 4. CI Gates
+
+Beyond the 6 pre-commit gates above, one required PR check enforces a
+CLAUDE.md policy directly: **"Require harness evidence or bypass label"**
+(`.github/workflows/harness-attestation.yml`). Any PR touching
+`packages/review/src/plugins/agent/**` must show evidence of a >= 9/10
+harness calibration run (a `harness.yml` run link, a `harness-result.json`
+summary, a `calibrate` mention, or a deterministic fixture-comparison
+census — byte-identical/byte-diff/sha256/`build-prompts.ts`) in the PR body.
+
+The `skip-harness-gate` label is an **owner-only** bypass for non-behavioral
+changes — it is not a self-serve escape hatch, and agents must never
+self-apply it to get past this check on their own PR. The gate only honors
+the label if its most recent `labeled` event was applied by a login on the
+allowlist in `.github/scripts/harness-gate-check.mjs`; anyone else's label
+application is ignored and the PR falls through to the ordinary evidence
+check. See that script and the workflow file's header comment for the full
+policy and its known limitations.
+
 ## Releasing
 
 Lien versions and publishes via [Changesets](https://github.com/changesets/changesets), driven by `.changeset/config.json` and `.github/workflows/release.yml`. Published packages: `@liendev/parser`, `@liendev/core`, `@liendev/lien` (the `cli` package). `review`, `action`, and `site` are `"private": true` and never published. The three published packages are `linked` — they always bump together, even when only one has code changes.


### PR DESCRIPTION
## Summary

Hardens the "Require harness evidence or bypass label" CI gate
(`.github/workflows/harness-attestation.yml`) after an agent self-applied
`skip-harness-gate` on PR #799 to get past it — the second such incident
(first: PR #768). Norm: gates pass on **evidence**; the bypass label is
**owner-only**.

**Verified state before this change** (read live, not assumed):
- The gate triggers on every `pull_request` to `main`/`develop` (opened,
  synchronize, reopened, edited, labeled, unlabeled) — no path filter — and
  no-ops internally via a `git diff` check against
  `packages/review/src/plugins/agent/**`, so it always reports (never stuck
  pending) but only actually gates PRs that touch that path.
- The evidence check was a single inline `grep -qEi
  'harness-result|actions/runs/[0-9]+|calibrate'` over the PR body, skipped
  entirely `if: !contains(labels, 'skip-harness-gate')` — i.e. presence of
  the label alone bypassed the check for anyone who could apply it.

## Changes

1. **Label-applier allowlist.** New step fetches the PR's GitHub timeline
   (`gh api repos/{owner}/{repo}/issues/{n}/timeline --paginate --slurp`)
   and only honors `skip-harness-gate` if the **most recent** `labeled`
   event for that label was performed by a login on the allowlist
   (`ALLOWLISTED_LABEL_APPLIERS = ['alfhen']` in
   `.github/scripts/harness-gate-check.mjs`, clearly marked for easy
   extension). Applied by anyone else → the label is ignored and the PR
   falls through to the evidence check as if unlabeled, with a log line
   explaining why (`decideApplier`'s `reason` string, printed to stderr).
2. **Broadened evidence detection.** Root cause of both incidents: the old
   grep missed legitimate deterministic evidence. Added patterns for
   byte-identical / byte-diff / sha256 / `build-prompts.ts` fixture-
   comparison census wording, alongside the existing `harness-result` /
   `actions/runs/<n>` / `calibrate` patterns. Conservative widening — a
   body with no evidence claims at all still fails (proven below).
3. **Documented the policy** in the workflow's header comment block
   (owner-only, never self-apply, evidence is the normal path, known
   limitation) and added a "CI Gates" subsection to `CONTRIBUTING.md`
   (there was no prior CI-gates section, so this is new, not a rewrite of
   an existing one).
4. **Honest limitation (stated per the brief):** agents in this repo
   currently act under the owner's own `gh`/`GITHUB_TOKEN` credentials, so
   the applier check cannot distinguish an agent-performed label event from
   a human-performed one when both are attributed to the same login. This
   change blocks non-maintainer appliers and makes the policy
   machine-enforced where possible — it does not (yet) close the
   "agent-acting-as-owner" hole. That needs a separate bot identity for
   agent actions and is out of scope here; tracked as a follow-up.

## Dogfood (mandatory — exercised like CI does)

Extracted the gate's decision logic into
`.github/scripts/harness-gate-check.mjs` (two pure functions,
`decideApplier`/`decideEvidence`, plus a thin CLI dispatcher) specifically so
it's locally runnable without a live Actions run. Four-way verification with
real data, verbatim:

**1a. PR #799's real timeline → applier check** (proves the label WAS
applied under an allowlisted login, so it passes the applier check):
```
$ TIMELINE_JSON="$(gh api repos/getlien/lien/issues/799/timeline --paginate --slurp)"
$ TIMELINE_JSON="$TIMELINE_JSON" node .github/scripts/harness-gate-check.mjs applier
Most recent 'skip-harness-gate' labeled event was applied by 'alfhen', which is on the allowlist (alfhen) -- bypass honored.
true
```

**1b. PR #799's real body → evidence check, label ignored entirely** (proves
the body must *also* pass the broadened grep on its own merits):
```
$ PR_BODY="$(gh pr view 799 --json body -q .body)"
$ PR_BODY="$PR_BODY" node .github/scripts/harness-gate-check.mjs evidence
Found harness evidence in PR body (matched: byte-identical census).
```
(exit 0)

**2. PR #765's real body → evidence check:**
```
$ PR_BODY="$(gh pr view 765 --json body -q .body)"
$ PR_BODY="$PR_BODY" node .github/scripts/harness-gate-check.mjs evidence
Found harness evidence in PR body (matched: calibrate mention).
```
(exit 0 — #765's body already contained literal `--calibrate 10` mentions,
so it passed even the old pattern; kept as a regression check that
broadening doesn't break it.)

**3. Synthetic body, no evidence wording, no label → must FAIL:**
```
$ PR_BODY='## Summary

This PR tweaks the error-handling rule prompt in packages/review/src/plugins/agent/rules.ts to be more concise. No testing was performed beyond eyeballing the diff.

## Gates
format/lint/typecheck/build/test all green.
'
$ PR_BODY="$PR_BODY" node .github/scripts/harness-gate-check.mjs evidence
::error::This PR touches packages/review/src/plugins/agent/** but the PR body has no harness evidence (a link to a harness.yml run/artifact, a 'calibrate' mention, or a deterministic byte-identical/byte-diff/sha256/build-prompts.ts fixture-comparison census) and no owner-applied 'skip-harness-gate' label. Per CLAUDE.md, rule/prompt changes need a >=9/10 calibration run (npm run test:harness -- --rule <rule-id> --calibrate 10) before merging, unless the change is provably non-behavioral (deterministic fixture-comparison evidence). Paste the harness.yml run link, a harness-result.json summary, or the deterministic comparison method + result in the PR description.
```
(exit 1 — confirmed FAIL)

**4. Synthetic timeline, label applied by a non-allowlisted login → must be
ignored, fall through to evidence:**
```
$ TIMELINE_JSON='[
  [
    {"event": "labeled", "label": {"name": "skip-harness-gate"}, "actor": {"login": "some-agent-bot"}, "created_at": "2026-07-16T10:00:00Z"},
    {"event": "commented", "actor": {"login": "some-agent-bot"}, "created_at": "2026-07-16T10:01:00Z"}
  ]
]'
$ TIMELINE_JSON="$TIMELINE_JSON" node .github/scripts/harness-gate-check.mjs applier
Most recent 'skip-harness-gate' labeled event was applied by 'some-agent-bot', which is NOT on the allowlist (alfhen) -- ignoring the label; proceeding to the evidence check as if unlabeled.
false
```
(exit 0 — the `applier` mode only decides, never fails the job; `false`
means the workflow's evidence-check step then runs unconditionally)

**Live self-exercise:** for `pull_request` events this workflow runs from
the PR's merge ref, so its own change exercises itself on this very PR. This
PR touches `.github/` only (no `packages/review/src/plugins/agent/**`), so
`touch.outputs.touched` is expected to be `false` and both the applier and
evidence steps should be skipped (no bypass label was applied — and per the
policy above, it must never be self-applied on this PR of all PRs). Actual
run output pasted below once CI has run.

## Gates

`npm ci` (fresh worktree, no prior `node_modules`) → `npm run build` →
`npm run format:check` (pass) → `npm run lint` (0 errors, 33 pre-existing
warnings, unchanged) → `npm run typecheck` (0 errors, all 3 tsc/tsup
projects). `actionlint .github/workflows/harness-attestation.yml` → clean.
`node .github/scripts/docs-truth.mjs` → 70 files checked, no violations.

No changeset (nothing published changes — CI workflow + a `.github/scripts`
helper only). `lien delta` not run: no TypeScript under `packages/` was
touched, and this worktree has no native parser build (`--build:native`
wasn't needed for this change). `npm test` not run for the same reason
(zero package code touched) — the change has no runtime surface inside the
published packages to regression-test; `actionlint` + the four dogfood runs
above are this change's actual test suite.

## Merge status

Per the owner's standing merge-on-green policy: will squash-merge (delete
branch) once CI is green and the Lien Review check is triaged. CodeRabbit's
check state is unreliable today (rate-limited) and will not gate the merge
decision either way.

## Live self-exercise result (verbatim)

Run: https://github.com/getlien/lien/actions/runs/29505559752/job/87645271823

Job steps:
```
Set up job                                                      success
Checkout code                                                    success
Setup Node.js                                                    success
Check whether this PR touches an agent-review rule              success
Determine whether skip-harness-gate label is owner-applied      skipped
Check PR body for harness evidence                               skipped
```

This PR only touches `.github/` + `CONTRIBUTING.md`, not
`packages/review/src/plugins/agent/**`, so `touch.outputs.touched` correctly
resolved to `false` (confirmed via the step's own log: `env: BASE_REF:
main`, git-diff-against-main found no match) — both the new applier step and
the evidence-check step were skipped, and the job passed trivially, exactly
the expected no-op path for a PR that doesn't touch agent-review rules. No
`skip-harness-gate` label was applied to this PR (nor should it ever be, per
policy).

All CI checks green (build-and-test, review, docs build, release smoke
test, complexity delta, docs-truth lint, E2E trigger, "Require harness
evidence or bypass label"). CodeRabbit check passed too (noted in the
brief as rate-limited/unreliable today, so not relied on for the merge
decision).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR hardens the harness-attestation CI gate by extracting its decision logic into a standalone Node script and adding an owner-allowlist check for the `skip-harness-gate` bypass label. The new script is fail-safe: malformed timeline JSON causes the label to be treated as unhonored (falling through to evidence check), and the workflow still gates PRs touching `packages/review/src/plugins/agent/**` unless the label was applied by an allowlisted login. No package code or public API surface is changed, and the blast radius is empty.
>
> - New `.github/scripts/harness-gate-check.mjs` with `decideApplier` and `decideEvidence` functions, runnable locally and from Actions.
> - Workflow now verifies the most recent `skip-harness-gate` label applier against an allowlist before skipping the evidence check.
> - Evidence regex broadened to recognize byte-identical/byte-diff/sha256/build-prompts.ts fixture-comparison wording.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2476046. Updates automatically on new commits.</sup>
<!-- /lien-stats -->