### PR TITLE
ci: add agent bot-identity token helper and setup docs

### DIFF
--- a/docs/development/agent-bot-identity.md
+++ b/docs/development/agent-bot-identity.md
@@ -1,0 +1,254 @@
+# Agent Bot Identity (GitHub App)
+
+## Why this exists
+
+Agents working on `getlien/lien` currently perform every `gh`/API action
+(label, comment, merge, PR create) under the owner's own credentials
+(`alfhen`). The audit trail — label events, merge commits, PR comments —
+cannot distinguish "the owner did this" from "an agent did this," because
+both render as the same login.
+
+This bit us concretely on **PR #799**: an agent self-applied the
+`skip-harness-gate` label to get past the "Require harness evidence or
+bypass label" CI gate. The PR timeline shows:
+
+```
+$ gh api repos/getlien/lien/issues/799/timeline --jq \
+    '.[] | select(.event=="labeled") | {actor: .actor.login, created_at}'
+{"actor":"alfhen","created_at":"2026-07-16T13:53:32Z"}
+```
+
+Indistinguishable from a human maintainer applying the same label — which
+is exactly the problem. (It was also not the first occurrence; PR #768 hit
+the same gate the same way.)
+
+The concurrent gate-hardening PR (**#801**, "ci: enforce owner-only
+skip-harness-gate label + broaden evidence detection") makes the bypass
+label owner-login-only, but says so explicitly in its own body:
+
+> agents in this repo currently act under the owner's own `gh`/`GITHUB_TOKEN`
+> credentials, so the applier check cannot distinguish an agent-performed
+> label event from a human-performed one when both are attributed to the
+> same login. This change ... does not (yet) close the
+> "agent-acting-as-owner" hole. That needs a separate bot identity for agent
+> actions and is out of scope here; tracked as a follow-up.
+
+This document and `scripts/dev/agent-gh-token.mjs` are that follow-up.
+
+## Approach: a GitHub App under the `getlien` org
+
+Rationale, decided by the owner (Alf, `alfhen`) 2026-07-16:
+
+- **No second account to manage** — no separate email/2FA/seat to maintain,
+  unlike a classic "bot" user account.
+- **Unambiguous attribution** — GitHub renders GitHub App actions as
+  `lien-agents[bot]` in every timeline, comment, and commit-adjacent UI. That
+  suffix is the entire point: an agent-performed label/merge/comment is now
+  visibly distinct from `alfhen`.
+- **Org-owned and revocable** — lives under `getlien`, not a personal
+  account; the owner can suspend the installation or roll the private key
+  at any time without depending on a second person/account.
+- **Fine-grained permissions** — a GitHub App declares exactly which
+  repository permissions it needs (see the mapping below), unlike a PAT tied
+  to a full user account.
+
+Creating the App itself requires a human in a browser (GitHub exposes no
+API for App creation) — that step is the owner's, once. Everything else
+(minting installation tokens, docs, tests) is scripted here.
+
+## What this does NOT change: the SSH-push / commit-authorship seam
+
+Read this before assuming the bot identity covers everything:
+
+- **`git push` goes over SSH with the owner's key**, regardless of which
+  `gh`/API token an agent is using. The bot identity governs **API actions**
+  (PR create, merge via the API, label, comment) — it has no bearing on how
+  commits reach GitHub.
+- **Commit authorship comes from local git config** (`user.name`/`user.email`),
+  not from the token used for `gh` calls. Commits will keep showing
+  `alfhen` as author/committer unless git config itself changes (out of
+  scope here — the point of this work is API-action attribution, not commit
+  attribution).
+- Consequence: **CI is still push-triggered by `alfhen`** even after this
+  ships, because pushes go out over SSH under the owner's identity. Only
+  the follow-on API calls (opening the PR, labeling it, merging it,
+  commenting on it) will show `lien-agents[bot]`.
+
+State this honestly to anyone consuming this doc — it is a partial fix for
+API-action attribution, not a full agent-identity story.
+
+## Owner's app-creation checklist (one-time, requires the owner's browser)
+
+1. Go to the **`getlien` org** → **Settings** → **Developer settings** →
+   **GitHub Apps** → **New GitHub App**
+   (`https://github.com/organizations/getlien/settings/apps/new`).
+2. **GitHub App name**: `lien-agents` (this becomes the `lien-agents[bot]`
+   actor suffix everywhere).
+3. **Homepage URL**: any valid URL is required by the form; `https://lien.dev`
+   is fine.
+4. **Webhook**: uncheck **Active**. No webhook URL needed — this App only
+   ever mints installation tokens for outbound API calls; it never receives
+   events.
+5. **Repository permissions** (see the verified mapping below for why each
+   one is needed and no more):
+   - **Contents**: Read and write
+   - **Pull requests**: Read and write
+   - **Issues**: Read and write
+   - **Checks**: Read-only
+   - **Metadata**: Read-only (GitHub grants this to every App by default;
+     confirm it's set, nothing to add beyond that)
+   - Leave every other permission at "No access."
+6. **Where can this GitHub App be installed?**: **Only on this account**
+   (`getlien` — not public).
+7. Click **Create GitHub App**.
+8. On the resulting app page, note the **App ID** shown near the top —
+   you'll need it for `LIEN_AGENT_APP_ID`.
+9. Scroll to **Private keys** → **Generate a private key**. This downloads
+   a `.pem` file.
+10. Move the PEM **outside the repo**:
+    ```bash
+    mkdir -p ~/.config/lien
+    mv ~/Downloads/lien-agents.<date>.private-key.pem ~/.config/lien/agent-app.pem
+    chmod 600 ~/.config/lien/agent-app.pem
+    ```
+11. **Install the app**: from the app's page, click **Install App** (left
+    sidebar) → select the **`getlien`** org → **Only select repositories**
+    → choose **`lien`** → **Install**.
+12. Add two lines to the repo-root `.env` (gitignored; same file
+    `OPENROUTER_API_KEY` already lives in):
+    ```
+    LIEN_AGENT_APP_ID=<the App ID from step 8>
+    LIEN_AGENT_APP_KEY_PATH=~/.config/lien/agent-app.pem
+    ```
+
+## Permission-to-action mapping (verified against GitHub's own docs)
+
+Each row below was checked against the specific endpoint's listed
+fine-grained permission on
+`docs.github.com/en/rest/authentication/permissions-required-for-github-apps`
+(not assumed) — GitHub organizes that page as one table per permission, and
+several actions appear under **two** permissions where "any one permission
+from the set" suffices (GitHub calls this "Additional permissions").
+
+| Action | Endpoint | Required permission |
+|---|---|---|
+| Create / update a pull request | `POST/PATCH /repos/{o}/{r}/pulls` | **Pull requests: write** |
+| Merge a pull request | `PUT /repos/{o}/{r}/pulls/{n}/merge` | **Contents: write** (merging writes a commit to the base branch — this is *not* under Pull requests) |
+| Delete a branch | `DELETE /repos/{o}/{r}/git/refs/{ref}` | **Contents: write** |
+| Add/remove labels on an issue or PR | `POST/DELETE /repos/{o}/{r}/issues/{n}/labels[/...]` | **Issues: write** *or* **Pull requests: write** (either satisfies it; a PR's labels endpoint is the shared issues endpoint) |
+| Create / reply to a comment on an issue or PR | `POST /repos/{o}/{r}/issues/{n}/comments` | **Issues: write** *or* **Pull requests: write** |
+| Create a PR review / review comment | `POST /repos/{o}/{r}/pulls/{n}/reviews` etc. | **Pull requests: write** |
+| Read check-run / check-suite status (verifying CI before merge) | `GET /repos/{o}/{r}/check-runs/...`, `check-suites/...` | **Checks: read** |
+| Resolve the installation id / read repo & installation metadata | `GET /app/installations`, `GET /repos/{o}/{r}` | **Metadata: read** (this is the App-wide default permission; the `/app/installations` and `/app/installations/{id}/access_tokens` calls themselves are JWT-authenticated at the App level and aren't gated by a repository permission at all) |
+
+So: **Contents (write) + Pull requests (write) + Issues (write) + Checks
+(read) + Metadata (read)** — exactly the five permissions in the creation
+checklist above — covers every action this project needs an agent to take
+via the API. Nothing broader (no Administration, no Actions, no Secrets).
+
+## Usage pattern for agents/orchestrators
+
+Mutating `gh`/API calls get the bot token prefixed; read-only calls can stay
+on whatever auth is already configured (usually the owner's own `gh auth`):
+
+```bash
+# Mutating — use the bot identity
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr create --title "..." --body "..."
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr merge 123 --squash --delete-branch
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr edit 123 --add-label some-label
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr comment 123 --body "..."
+
+# Read-only — no need to mint a token
+gh pr view 123
+gh pr checks 123
+```
+
+The helper prints **only** the token to stdout (all diagnostics go to
+stderr), so it composes directly into `GH_TOKEN=$(...)`.
+
+**Never add `lien-agents` (or its App) to the `skip-harness-gate`
+allowlist.** The label must stay owner-(human)-only — see PR #801. Giving
+the bot identity bypass power over the harness gate would recreate exactly
+the hole this document exists to close, just with a different login name.
+
+## Security notes
+
+- The PEM is **never committed** — it lives outside the repo entirely
+  (`~/.config/lien/agent-app.pem`, `chmod 600`), matching the pattern
+  `.gitignore` already establishes for `.env`.
+- Installation tokens are **short-lived** (1 hour) and cached with their
+  expiry at `~/.cache/lien/agent-gh-token-cache.json` (also `chmod 600`);
+  `scripts/dev/agent-gh-token.mjs` refreshes automatically once under 5
+  minutes remain.
+- The signing JWT itself is even shorter-lived (9 minutes, under GitHub's
+  10-minute cap) and is only ever held in memory for the duration of the
+  token-exchange call.
+- If the key is ever suspected compromised: **Settings → Developer
+  settings → GitHub Apps → lien-agents → Generate a private key** (new key),
+  then delete the old one from the same page, then replace
+  `~/.config/lien/agent-app.pem` and delete the stale cache file.
+- The app must **not** be granted Administration, Secrets, or Actions
+  permissions — the mapping above is deliberately minimal.
+
+## Known risk & post-creation verification plan
+
+This repo's own history shows bot-actor workflow runs (`github-actions[bot]`
+on `changeset-release/main` pushes) landing in `action_required`, pending
+manual approval, because GitHub does not trigger `pull_request`-triggered
+workflows for some bot-authored refs/events by default. Two things suggest
+a **custom App with write access won't hit that specific gate**:
+
+1. That known case is specifically about **pushes performed by
+   `github-actions[bot]` using the default `GITHUB_TOKEN`** inside a
+   workflow run — a different mechanism from a **PR opened via the REST API
+   using an installation token**, which is the pattern this helper enables.
+2. Per the SSH-push seam above, **the actual `git push` here still happens
+   over SSH under `alfhen`'s key** — so the commit/ref-creation event that
+   triggers CI is push-triggered by the owner regardless of which identity
+   later opens/labels/merges the PR via the API.
+
+Reasoning is not proof. **This must be verified empirically once the App
+exists** — nothing here should be treated as confirmed until the recipe
+below has been run for real. Run it immediately after the owner completes
+the creation checklist:
+
+```bash
+# 1. Scratch branch + PR opened with the bot token
+git checkout -b scratch/bot-identity-verification
+echo "verification $(date -u +%FT%TZ)" >> .wip/bot-identity-verification.txt
+git add .wip/bot-identity-verification.txt
+git commit -m "chore: scratch commit for bot-identity verification"
+git push -u origin scratch/bot-identity-verification   # still SSH/alfhen — expected, see above
+
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr create \
+  --title "chore: bot-identity verification (scratch, do not merge as-is)" \
+  --body "Verifying the lien-agents GitHub App end-to-end. See docs/development/agent-bot-identity.md." \
+  --head scratch/bot-identity-verification
+
+# Confirm CI auto-started with no action_required:
+gh pr checks <PR_NUMBER> --watch
+
+# 2. Bot applies a test label; confirm the hardened harness gate
+#    ("Require harness evidence or bypass label", PR #801) ignores
+#    non-allowlisted appliers -- i.e. lien-agents[bot] must NOT be able to
+#    self-bypass the gate via skip-harness-gate.
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr edit <PR_NUMBER> --add-label skip-harness-gate
+gh api repos/getlien/lien/issues/<PR_NUMBER>/timeline --jq \
+  '.[] | select(.event=="labeled") | {actor: .actor.login, label: .label.name}'
+# Expect: actor "lien-agents[bot]" -- and, since this PR does not touch
+# packages/review/src/plugins/agent/**, the gate should no-op regardless.
+# If testing the allowlist itself, apply the label to a PR that DOES touch
+# that path and confirm the evidence-check step still runs (label ignored).
+# Then remove the label -- it must never stay applied by a non-owner login.
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr edit <PR_NUMBER> --remove-label skip-harness-gate
+
+# 3. Bot merges the scratch PR; confirm timeline shows lien-agents[bot]
+GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr merge <PR_NUMBER> --squash --delete-branch
+gh api repos/getlien/lien/issues/<PR_NUMBER>/timeline --jq \
+  '.[] | select(.event=="merged") | {actor: .actor.login}'
+# Expect: actor "lien-agents[bot]"
+```
+
+Record the actual output of each step (not just "it worked") wherever this
+verification is tracked — this is exactly the kind of claim the project's
+own dogfooding rule requires evidence for, not just a plausibility argument.

--- a/scripts/dev/agent-gh-token.mjs
+++ b/scripts/dev/agent-gh-token.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// Mints a short-lived GitHub App installation access token for agent-driven
+// `gh`/API calls against getlien/lien, so agent actions (label, comment,
+// merge, PR create) render as `lien-agents[bot]` in the audit trail instead
+// of the operator's own account. See docs/development/agent-bot-identity.md
+// for the app-creation checklist, the permission-to-action mapping, and the
+// post-creation verification recipe.
+//
+// Usage (composes into any `gh` invocation):
+//   GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr merge 123 --squash
+//
+// Prints ONLY the installation access token to stdout -- nothing else -- so
+// the command above works. All diagnostics go to stderr.
+//
+// Config (read from the environment, or from a repo-root .env -- same
+// convention as OPENROUTER_API_KEY; see packages/review/test/harness/run.ts):
+//   LIEN_AGENT_APP_ID       - the GitHub App's numeric ID
+//   LIEN_AGENT_APP_KEY_PATH - path to the App's PEM private key. The PEM
+//                             lives OUTSIDE the repo (e.g.
+//                             ~/.config/lien/agent-app.pem) -- never commit it.
+//
+// No npm dependencies: JWT signing uses node:crypto directly, and the
+// installation-token exchange uses the global fetch() built into Node 22+.
+
+import { createSign } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '../..');
+const DOCS_PATH = 'docs/development/agent-bot-identity.md';
+const GITHUB_ORG = 'getlien';
+const GITHUB_API = 'https://api.github.com';
+const CACHE_PATH = join(homedir(), '.cache', 'lien', 'agent-gh-token-cache.json');
+
+// GitHub caps JWT lifetime at 10 minutes (exp - "now", not exp - iat) and
+// recommends backdating `iat` by 60s to tolerate clock drift between this
+// machine and GitHub's servers. 9 minutes keeps a safety margin under the cap
+// even with the backdated `iat`. Source: GitHub's "Generating a JSON Web
+// Token (JWT) for a GitHub App" docs.
+const JWT_TTL_SECONDS = 9 * 60;
+const JWT_CLOCK_SKEW_SECONDS = 60;
+
+// Installation tokens last 1h; refresh once less than this remains.
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+const USER_AGENT = 'lien-agent-gh-token';
+
+// Auto-load .env from the repo root, same convention as the review harness
+// (packages/review/test/harness/run.ts). Node's loadEnvFile() does not
+// override variables already set in the environment, so an inline
+// `LIEN_AGENT_APP_ID=... node scripts/dev/agent-gh-token.mjs` still wins.
+try {
+  process.loadEnvFile(join(REPO_ROOT, '.env'));
+} catch {
+  /* no .env at repo root -- that's fine; rely on the inherited environment */
+}
+
+function fail(message) {
+  console.error(`[agent-gh-token] ${message}`);
+  console.error(`[agent-gh-token] See ${DOCS_PATH} for setup instructions.`);
+  process.exit(1);
+}
+
+function expandHome(path) {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/')) return join(homedir(), path.slice(2));
+  return path;
+}
+
+function base64url(input) {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buffer.toString('base64url');
+}
+
+/**
+ * Builds a signed RS256 JWT per GitHub's App-authentication spec. Exported
+ * (pure, no I/O) so it can be unit-tested against a throwaway RSA keypair
+ * without touching the network or a real App key.
+ */
+export function buildAppJwt({ appId, privateKeyPem, now = Date.now() }) {
+  const nowSeconds = Math.floor(now / 1000);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iat: nowSeconds - JWT_CLOCK_SKEW_SECONDS,
+    exp: nowSeconds + JWT_TTL_SECONDS,
+    iss: String(appId),
+  };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(privateKeyPem);
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+/**
+ * Returns true when a cached token has more than `marginMs` left before
+ * expiry. Pure and clock-injectable so cache-expiry logic is unit-testable
+ * without waiting on a real clock or minting a real token.
+ */
+export function isTokenFresh(cacheEntry, now = Date.now(), marginMs = TOKEN_REFRESH_MARGIN_MS) {
+  if (!cacheEntry || !cacheEntry.token || !cacheEntry.expiresAt) return false;
+  const expiresAtMs = Date.parse(cacheEntry.expiresAt);
+  if (Number.isNaN(expiresAtMs)) return false;
+  return expiresAtMs - now > marginMs;
+}
+
+/** Reads the token cache. Returns null on a missing or corrupt cache file. */
+export function readCache(cachePath) {
+  if (!existsSync(cachePath)) return null;
+  try {
+    return JSON.parse(readFileSync(cachePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Writes the token cache and locks it down to owner-only (0600) -- it holds
+ * a live, if short-lived, API token. `writeFileSync`'s `mode` option only
+ * applies when the file is newly created, so an explicit chmod covers the
+ * case where a looser-permissioned cache file already exists.
+ */
+export function writeCache(cachePath, data) {
+  mkdirSync(dirname(cachePath), { recursive: true });
+  writeFileSync(cachePath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+  chmodSync(cachePath, 0o600);
+}
+
+async function githubRequest(method, path, jwt, body) {
+  const res = await fetch(`${GITHUB_API}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': USER_AGENT,
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${method} ${path} -> ${res.status} ${res.statusText}: ${text}`);
+  }
+  return res.json();
+}
+
+/** Resolves the installation id for GITHUB_ORG via GET /app/installations. */
+async function resolveInstallationId(jwt) {
+  const installations = await githubRequest('GET', '/app/installations', jwt);
+  const match = installations.find(
+    installation => installation.account?.login?.toLowerCase() === GITHUB_ORG,
+  );
+  if (!match) {
+    const logins = installations.map(installation => installation.account?.login).join(', ');
+    throw new Error(
+      `no installation found for the "${GITHUB_ORG}" org (installations found: ${logins || '(none)'}). ` +
+        'Has the GitHub App been installed on the org yet?',
+    );
+  }
+  return match.id;
+}
+
+/** Exchanges the App JWT for an installation access token. */
+async function mintInstallationToken(jwt, installationId) {
+  return githubRequest('POST', `/app/installations/${installationId}/access_tokens`, jwt);
+}
+
+async function main() {
+  const appId = process.env.LIEN_AGENT_APP_ID;
+  const keyPathRaw = process.env.LIEN_AGENT_APP_KEY_PATH;
+
+  if (!appId || !keyPathRaw) {
+    fail(
+      'missing LIEN_AGENT_APP_ID and/or LIEN_AGENT_APP_KEY_PATH. ' +
+        'Set both in the environment, or add them to the repo-root .env file.',
+    );
+  }
+
+  const keyPath = expandHome(keyPathRaw);
+  if (!existsSync(keyPath)) {
+    fail(`LIEN_AGENT_APP_KEY_PATH points at "${keyPath}", but no file exists there.`);
+  }
+
+  const cache = readCache(CACHE_PATH);
+  if (isTokenFresh(cache)) {
+    process.stdout.write(cache.token + '\n');
+    return;
+  }
+
+  const privateKeyPem = readFileSync(keyPath, 'utf8');
+  const jwt = buildAppJwt({ appId, privateKeyPem });
+
+  let installationId = cache?.installationId;
+  if (!installationId) {
+    try {
+      installationId = await resolveInstallationId(jwt);
+    } catch (err) {
+      fail(`could not resolve the installation id: ${err.message}`);
+    }
+  }
+
+  let tokenResponse;
+  try {
+    tokenResponse = await mintInstallationToken(jwt, installationId);
+  } catch {
+    // The cached installation id may be stale (app reinstalled/uninstalled) --
+    // re-resolve once before giving up.
+    try {
+      installationId = await resolveInstallationId(jwt);
+      tokenResponse = await mintInstallationToken(jwt, installationId);
+    } catch (retryErr) {
+      fail(`could not mint an installation access token: ${retryErr.message}`);
+    }
+  }
+
+  writeCache(CACHE_PATH, {
+    installationId,
+    token: tokenResponse.token,
+    expiresAt: tokenResponse.expires_at,
+  });
+
+  process.stdout.write(tokenResponse.token + '\n');
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  main().catch(err => fail(err.message || String(err)));
+}

--- a/scripts/dev/agent-gh-token.test.mjs
+++ b/scripts/dev/agent-gh-token.test.mjs
@@ -1,0 +1,145 @@
+// Unit tests for agent-gh-token.mjs's pure/injectable pieces: JWT
+// construction and token-cache expiry/round-trip logic. No real GitHub API
+// calls and no real App key -- the JWT test signs against a throwaway RSA
+// keypair generated in-process, and the cache tests use a temp directory.
+//
+// Run: node --test scripts/dev/agent-gh-token.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createVerify, generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildAppJwt, isTokenFresh, readCache, writeCache } from './agent-gh-token.mjs';
+
+function decodeSegment(segment) {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+}
+
+test('buildAppJwt produces a header/payload/signature that verifies against the public key', () => {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const nowMs = Date.parse('2026-07-16T12:00:00.000Z');
+
+  const jwt = buildAppJwt({ appId: 123456, privateKeyPem: privateKey, now: nowMs });
+  const [headerSeg, payloadSeg, signatureSeg] = jwt.split('.');
+
+  const header = decodeSegment(headerSeg);
+  assert.equal(header.alg, 'RS256');
+  assert.equal(header.typ, 'JWT');
+
+  const payload = decodeSegment(payloadSeg);
+  const nowSeconds = Math.floor(nowMs / 1000);
+  assert.equal(payload.iss, '123456');
+  assert.equal(payload.iat, nowSeconds - 60, 'iat should be backdated 60s for clock drift');
+  assert.equal(
+    payload.exp,
+    nowSeconds + 9 * 60,
+    'exp should be 9 minutes out (under the 10min cap)',
+  );
+  assert.ok(payload.exp - payload.iat <= 600, "lifetime must not exceed GitHub's 10-minute cap");
+
+  const signingInput = `${headerSeg}.${payloadSeg}`;
+  const signature = Buffer.from(signatureSeg, 'base64url');
+  const verifier = createVerify('RSA-SHA256');
+  verifier.update(signingInput);
+  verifier.end();
+  assert.ok(verifier.verify(publicKey, signature), 'signature must verify against the public key');
+});
+
+test('buildAppJwt coerces a string appId into the iss claim unchanged', () => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwt = buildAppJwt({ appId: '999', privateKeyPem: privateKey, now: Date.now() });
+  const payload = decodeSegment(jwt.split('.')[1]);
+  assert.equal(payload.iss, '999');
+});
+
+test('isTokenFresh: null/undefined cache entries are never fresh', () => {
+  assert.equal(isTokenFresh(null), false);
+  assert.equal(isTokenFresh(undefined), false);
+  assert.equal(isTokenFresh({}), false);
+  assert.equal(isTokenFresh({ token: 'abc' }), false, 'missing expiresAt');
+  assert.equal(isTokenFresh({ expiresAt: '2026-07-16T12:00:00.000Z' }), false, 'missing token');
+});
+
+test('isTokenFresh: malformed expiresAt is treated as not fresh', () => {
+  const entry = { token: 'abc', expiresAt: 'not-a-date' };
+  assert.equal(isTokenFresh(entry, Date.now()), false);
+});
+
+test('isTokenFresh: respects the refresh margin with an injected clock', () => {
+  const now = Date.parse('2026-07-16T12:00:00.000Z');
+  const margin = 5 * 60 * 1000;
+
+  const wellWithinExpiry = {
+    token: 'abc',
+    expiresAt: new Date(now + 30 * 60 * 1000).toISOString(),
+  };
+  assert.equal(isTokenFresh(wellWithinExpiry, now, margin), true);
+
+  const withinMargin = { token: 'abc', expiresAt: new Date(now + 4 * 60 * 1000).toISOString() };
+  assert.equal(isTokenFresh(withinMargin, now, margin), false, '<5min left should not be fresh');
+
+  const alreadyExpired = { token: 'abc', expiresAt: new Date(now - 60 * 1000).toISOString() };
+  assert.equal(isTokenFresh(alreadyExpired, now, margin), false);
+
+  const exactlyAtMargin = { token: 'abc', expiresAt: new Date(now + margin).toISOString() };
+  assert.equal(
+    isTokenFresh(exactlyAtMargin, now, margin),
+    false,
+    'boundary must not count as fresh',
+  );
+});
+
+test('writeCache/readCache round-trip and lock the file to owner-only permissions', t => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-gh-token-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const cachePath = join(dir, 'nested', 'agent-gh-token-cache.json');
+
+  const data = { installationId: 42, token: 'ghs_fake', expiresAt: '2026-07-16T13:00:00.000Z' };
+  writeCache(cachePath, data);
+
+  assert.deepEqual(readCache(cachePath), data);
+
+  if (process.platform !== 'win32') {
+    const mode = statSync(cachePath).mode & 0o777;
+    assert.equal(mode, 0o600, 'cache file must be owner-read/write only');
+  }
+});
+
+test('readCache returns null for a missing file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-gh-token-test-'));
+  try {
+    assert.equal(readCache(join(dir, 'does-not-exist.json')), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readCache returns null for corrupt JSON instead of throwing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-gh-token-test-'));
+  try {
+    const cachePath = join(dir, 'corrupt.json');
+    writeFileSync(cachePath, '{ not valid json');
+    assert.equal(readCache(cachePath), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeCache overwrites permissions to 0600 even if the file pre-existed with looser perms', t => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX file mode assertions do not apply on win32');
+    return;
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'agent-gh-token-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const cachePath = join(dir, 'agent-gh-token-cache.json');
+
+  writeFileSync(cachePath, '{}', { mode: 0o644 });
+  writeCache(cachePath, { installationId: 1, token: 'x', expiresAt: '2026-07-16T13:00:00.000Z' });
+
+  const mode = statSync(cachePath).mode & 0o777;
+  assert.equal(mode, 0o600);
+});


### PR DESCRIPTION
## Summary

Plumbing for a distinct GitHub App bot identity for agents working on
`getlien/lien`, approved by the owner (Alf, `alfhen`) today. Problem: agents
currently perform every `gh`/API action under the owner's own credentials,
so the audit trail (label events, merges, comments) cannot distinguish
agent-performed actions from human ones. Confirmed concretely on **PR
#799**, where an agent self-applied `skip-harness-gate` and the timeline
showed `alfhen`:

```
$ gh api repos/getlien/lien/issues/799/timeline --jq \
    '.[] | select(.event=="labeled") | {actor: .actor.login, created_at}'
{"actor":"alfhen","created_at":"2026-07-16T13:53:32Z"}
```

The concurrent gate-hardening PR (#801) names this exact gap as its own
stated limitation ("agents ... act under the owner's own `gh`/`GITHUB_TOKEN`
credentials ... needs a separate bot identity for agent actions ... tracked
as a follow-up"). This PR is that follow-up: a **GitHub App under the
`getlien` org** — org-owned/revocable, no second account to manage, and
`[bot]`-suffixed actor rendering that's unambiguous in every timeline.

## What's in this PR (script + tests + docs only — no secrets)

- `scripts/dev/agent-gh-token.mjs` — zero-npm-dependency helper. Mints an
  RS256 JWT with `node:crypto`, exchanges it for a GitHub App installation
  access token (resolving+caching the `getlien` org's installation id),
  caches the token with its expiry (owner-only `0600` file under
  `~/.cache/lien/`), refreshes automatically when <5min remain, and prints
  **only** the token to stdout so it composes:
  `GH_TOKEN=$(node scripts/dev/agent-gh-token.mjs) gh pr merge ...`.
  Fails loudly and points at the docs file when config is missing.
- `scripts/dev/agent-gh-token.test.mjs` — 9 unit tests via Node's built-in
  `node:test` (no new devDependency): JWT construction verified against a
  throwaway RSA keypair generated in the test (header/claims/signature all
  checked), plus cache-expiry/round-trip logic tested with an injected
  clock and a temp directory. No real network calls.
- `docs/development/agent-bot-identity.md` — the owner's exact one-time
  app-creation checklist (App creation has no API — this step is manual),
  a permission-to-action mapping verified against GitHub's own docs (not
  assumed — see below), the usage pattern, the SSH-push/commit-authorship
  seam this does **not** change (pushes stay SSH/`alfhen`-attributed; only
  API actions get the bot identity), security notes, and the post-creation
  verification recipe.

## Permission mapping — verified, not assumed

Checked each endpoint against
`docs.github.com/en/rest/authentication/permissions-required-for-github-apps`
(parsed the actual permission tables, not summarized from memory):

| Action | Endpoint | Permission |
|---|---|---|
| Create/update a PR | `POST/PATCH .../pulls` | **Pull requests: write** |
| Merge a PR | `PUT .../pulls/{n}/merge` | **Contents: write** (not Pull requests — merging writes a commit) |
| Delete a branch | `DELETE .../git/refs/{ref}` | **Contents: write** |
| Add/remove labels | `POST/DELETE .../issues/{n}/labels` | **Issues: write** *or* **Pull requests: write** (either satisfies it) |
| Create/reply to comments | `POST .../issues/{n}/comments` | **Issues: write** *or* **Pull requests: write** |
| Read check status | `GET .../check-runs`, `check-suites` | **Checks: read** |
| Resolve installation id | `GET /app/installations` | **Metadata: read** (App-wide default; the installation-token endpoints themselves are JWT-authenticated at the App level, not gated by a repo permission) |

Five permissions (Contents/Pull requests/Issues: write, Checks/Metadata:
read) cover every action the project needs an agent to take. Full detail
and the owner's exact click-path is in the doc.

## Dogfood (mandatory per CLAUDE.md)

**Pre-merge end-to-end dogfooding is genuinely impossible for this PR**:
the GitHub App does not exist yet — its creation requires the owner's
browser (no API for App creation) and is the deliberate next step, not
something this PR can do. Stating this explicitly per the repo's
dogfood rule (silence is not an option).

What **was** exercised end-to-end, verbatim:

**1. Unit suite (JWT construction + cache logic), real run:**
```
$ node --test scripts/dev/agent-gh-token.test.mjs
...
# tests 9
# suites 0
# pass 9
# fail 0
# duration_ms 79.377833
```

**2. CLI failure paths — missing config, both fail loudly and point at the docs:**
```
$ env -u LIEN_AGENT_APP_ID -u LIEN_AGENT_APP_KEY_PATH node scripts/dev/agent-gh-token.mjs
[agent-gh-token] missing LIEN_AGENT_APP_ID and/or LIEN_AGENT_APP_KEY_PATH. Set both in the environment, or add them to the repo-root .env file.
[agent-gh-token] See docs/development/agent-bot-identity.md for setup instructions.
exit=1

$ LIEN_AGENT_APP_ID=123 LIEN_AGENT_APP_KEY_PATH=/tmp/does-not-exist.pem node scripts/dev/agent-gh-token.mjs
[agent-gh-token] LIEN_AGENT_APP_KEY_PATH points at "/tmp/does-not-exist.pem", but no file exists there.
[agent-gh-token] See docs/development/agent-bot-identity.md for setup instructions.
exit=1
```

**3. Real network call against the real GitHub API**, using a throwaway RSA
keypair generated locally and a fake (nonexistent) App ID — proves the JWT
is correctly constructed and signed, the HTTP request is correctly formed
(headers, endpoint), and GitHub's API is actually reached and parsed (a
structured 404 comes back, not a generic network/parse error):
```
$ LIEN_AGENT_APP_ID=999999999 LIEN_AGENT_APP_KEY_PATH=/tmp/fake-agent-app.pem node scripts/dev/agent-gh-token.mjs
[agent-gh-token] could not resolve the installation id: GET /app/installations -> 404 Not Found: {"message":"Integration not found","documentation_url":"https://docs.github.com/rest","status":"404"}
[agent-gh-token] See docs/development/agent-bot-identity.md for setup instructions.
exit=1
```

**4. `~`-expansion and repo-root `.env` auto-load**, both verified to reach
the same real-network-call point (same 404, proving the key path/`.env`
were actually read):
```
$ LIEN_AGENT_APP_ID=999999999 LIEN_AGENT_APP_KEY_PATH="~/.config/lien-test-scratch/agent-app.pem" node scripts/dev/agent-gh-token.mjs
[agent-gh-token] could not resolve the installation id: GET /app/installations -> 404 Not Found: ...

# and, with LIEN_AGENT_APP_ID/LIEN_AGENT_APP_KEY_PATH unset in the shell but present in repo-root .env:
$ env -u LIEN_AGENT_APP_ID -u LIEN_AGENT_APP_KEY_PATH node scripts/dev/agent-gh-token.mjs
[agent-gh-token] could not resolve the installation id: GET /app/installations -> 404 Not Found: ...
```
(all scratch keys/`.env`/cache files deleted afterward — nothing left behind, nothing committed)

**The post-merge dogfood is the verification recipe in
`docs/development/agent-bot-identity.md`'s "Known risk & post-creation
verification plan" section** — scratch branch + PR opened with the bot
token → confirm CI auto-starts (no `action_required`) → bot applies a test
label → confirm the hardened harness gate ("Require harness evidence or
bypass label", #801) ignores non-allowlisted appliers → bot merges the
scratch PR → confirm the timeline shows `lien-agents[bot]`. This is
intended to run **immediately** once the owner completes the app-creation
checklist — not deferred indefinitely.

## Gates (all green, this worktree)

```
npm run format:check   # pass
npm run lint           # 0 errors, 33 pre-existing warnings (unchanged, unrelated files)
npm run typecheck      # pass, all 3 tsc/tsup projects
npm run build          # pass
npm test               # 50+49+5 test files, 1082+860+39 tests, all passed
node packages/cli/dist/index.js delta   # exit 0 — only "new" functions reported (this is a brand-new file), no threshold crossings
```

`scripts/dev/` isn't covered by the root prettier/eslint globs
(`packages/*/src/` etc.), so it isn't part of `npm run format:check`/`lint`'s
scope — ran `npx prettier --check scripts/dev/*.mjs` manually to confirm
the same style regardless. No changeset: nothing published changes here.

## Merge status

Per the owner's standing merge-on-green policy (from Alf directly, as part
of this task's brief): will squash-merge with branch deletion once CI is
green and the Lien Review check is triaged (verifying findings
independently — CodeRabbit is rate-limited today per the brief, so its
state is not relied on). Never `--admin`.

**`skip-harness-gate` was deliberately not applied and should never be
needed here**: this PR touches only `scripts/dev/` and `docs/`, not
`packages/review/src/plugins/agent/**`, so the "Require harness evidence or
bypass label" gate's own touch-check should no-op on it.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR introduces a standalone developer helper (`scripts/dev/agent-gh-token.mjs`) that mints GitHub App installation access tokens for agent-driven API actions, plus unit tests and setup documentation. The code is self-contained: no existing callers are modified, and the new exports are only consumed by the bundled tests. Error handling is loud (`fail()` exits with a message and a docs pointer), cache corruption is treated as a cache miss, and the JWT construction follows GitHub's RS256 spec with a 9-minute expiry under the 10-minute cap. The retry-on-mint-failure path is broad but ultimately fails loudly rather than swallowing errors.
>
> - New `scripts/dev/agent-gh-token.mjs` helper for minting/caching GitHub App installation tokens
> - New `scripts/dev/agent-gh-token.test.mjs` unit tests covering JWT construction, signature verification, cache freshness boundaries, and file permissions
> - New `docs/development/agent-bot-identity.md` owner checklist and permission-to-action mapping

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 376217e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->