### PR TITLE
feat(review): stale-duplicate candidate-loop pass (pilot, default off)

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -26,6 +26,10 @@ import { BUILTIN_RULES, buildTriggerContext, selectRules } from './rules.js';
 import { AGENT_TOOLS, dispatchTool } from './tools.js';
 import { DOC_TRUTH_PASS_SPEC } from './doc-truth-pass.js';
 import {
+  STALE_DUPLICATE_PASS_SPEC,
+  applyStaleDuplicateMainOverride,
+} from './stale-duplicate-pass.js';
+import {
   runExtraPasses,
   type ReviewPassSpec,
   type PassClientRunner,
@@ -45,10 +49,14 @@ import {
 /**
  * The ordered list of extra passes `analyze()`/`analyzeSummaryOnly()` run
  * after the main investigation (see `review-pass.ts`'s "N-pass plumbing").
- * Doc-truth is the first (and, for now, only) entry — a future dedicated
- * candidate-loop rule (per the per-rule-loops design doc) is added here.
+ * Doc-truth is the proven precedent; the stale-duplicate candidate loop is
+ * the pilot (per-rule-loops design doc §4) — dark by default, see
+ * `stale-duplicate-pass.ts`'s own gate for why adding it here changes no
+ * default behavior. The two passes have no data dependency on each other,
+ * so declaration order doesn't matter for correctness (see review-pass.ts's
+ * "serial for v1" note) — doc-truth stays first as the longer-proven pass.
  */
-const EXTRA_PASSES: ReviewPassSpec[] = [DOC_TRUTH_PASS_SPEC];
+const EXTRA_PASSES: ReviewPassSpec[] = [DOC_TRUTH_PASS_SPEC, STALE_DUPLICATE_PASS_SPEC];
 
 const configSchema = z.object({
   apiKey: z.string().min(1),
@@ -88,6 +96,12 @@ const configSchema = z.object({
    * diff-only summary-only mode — see `summary-only-pass.ts`.
    */
   summaryEnabled: z.boolean().default(false),
+  /**
+   * Run the stale-duplicate candidate-loop PILOT (per-rule-loops design doc
+   * §4). Default false — dark-launched opt-in; set true (or env
+   * LIEN_STALE_DUP_PASS=on) to enable. See `stale-duplicate-pass.ts`.
+   */
+  staleDuplicatePass: z.boolean().default(false),
 });
 
 export interface AgentReviewPluginOptions {
@@ -146,9 +160,12 @@ export class AgentReviewPlugin implements ReviewPlugin {
         logger,
       });
 
-    // Select active rules based on PR content (languages, diff keywords)
+    // Select active rules based on PR content (languages, diff keywords).
+    // applyStaleDuplicateMainOverride is a no-op unless LIEN_STALE_DUP_MAIN=off
+    // (see stale-duplicate-pass.ts) — the pilot's future "loop only, no
+    // shared-loop backstop" A/B arm.
     const triggerCtx = buildTriggerContext(context);
-    const rules = selectRules(BUILTIN_RULES, triggerCtx);
+    const rules = applyStaleDuplicateMainOverride(selectRules(BUILTIN_RULES, triggerCtx));
     logger.info(
       `[${this.id}] Rules: ${rules.active.map(r => r.id).join(', ')} (skipped: ${rules.skipped.join(', ') || 'none'})`,
     );
@@ -519,8 +536,10 @@ export function scaleBudgetForBlastRadius(baseBudget: number, riskLevel?: string
  * A NEVER-RAN main pass (every provider request failed — infrastructure, not a
  * partial review) escalates to an `error` finding so the check concludes
  * `failure` rather than the passing `neutral` a `warning` maps to. A partial
- * run, or an incomplete that came only from the failure-isolated doc-truth
- * pass, stays a `warning` (fail-open) — but still never reads as clean.
+ * run, or an incomplete that came only from a failure-isolated extra pass
+ * (doc-truth, or the stale-duplicate loop via the generic
+ * `incompleteFromPass`), stays a `warning` (fail-open) — but still never
+ * reads as clean.
  */
 export function appendIncompleteNotice(
   findings: ReviewFinding[],
@@ -528,18 +547,24 @@ export function appendIncompleteNotice(
   result: AgentResult,
 ): void {
   if (!result.incomplete) return;
-  if (result.neverRan && !result.incompleteFromDocPass) {
+  if (result.neverRan && !result.incompleteFromDocPass && !result.incompleteFromPass) {
     appendNeverRanNotice(findings, pluginId, result);
     return;
   }
   const reason = describeIncompleteStop(result.stopReason);
-  // An incomplete that came only from the doc-truth SECOND pass must not
-  // imply the whole review is partial — the main pass finished normally.
+  // An incomplete that came only from an EXTRA pass (doc-truth, or a
+  // generically-named one via `incompleteFromPass`) must not imply the whole
+  // review is partial — the main pass finished normally. Doc-truth keeps its
+  // own dedicated branch (unchanged wording, already tested); any other
+  // named pass gets the same shape via the generic field.
   const message = result.incompleteFromDocPass
     ? `The documentation-truthfulness pass did not finish — it ${reason}. ` +
       `Doc-claim verification is partial; code findings are unaffected.`
-    : `Lien Review did not finish — it ${reason} while investigating. ` +
-      `Any findings shown are partial; re-run the review to retry.`;
+    : result.incompleteFromPass
+      ? `The ${result.incompleteFromPass} pass did not finish — it ${reason}. ` +
+        `That pass's findings are partial; the main review's findings are unaffected.`
+      : `Lien Review did not finish — it ${reason} while investigating. ` +
+        `Any findings shown are partial; re-run the review to retry.`;
   findings.push({
     pluginId,
     filepath: '',
@@ -560,6 +585,8 @@ function describeIncompleteStop(stopReason: AgentResult['stopReason']): string {
       return 'hit the turn limit';
     case 'completed':
       return 'ended without emitting a parseable JSON verdict';
+    case 'incomplete_verdict':
+      return 'did not produce a verdict for every candidate';
     default:
       return 'stopped unexpectedly';
   }

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -53,8 +53,15 @@ export interface ReviewPassSpec {
   gateReason(context: ReviewContext, config: AgentConfig): string | null;
   /** Build this pass's system + initial prompts. */
   buildPrompts(context: ReviewContext): { systemPrompt: string; initialMessage: string };
-  /** This pass's token budget, computed from the main pass's base budget. */
-  budget(baseBudget: number): number;
+  /**
+   * This pass's token budget, computed from the main pass's base budget.
+   * `context` is available for a candidate-loop pass that scales its budget
+   * by its own candidate count (per the per-rule-loops design doc §2) rather
+   * than a flat fraction — doc-truth's own `docTruthPassBudget` ignores it
+   * (a function declaring fewer parameters than an interface's function type
+   * is still a valid implementation of that type).
+   */
+  budget(baseBudget: number, context: ReviewContext): number;
   /** Turn cap for this pass's client loop. */
   maxTurns: number;
   /** Fold this pass's findings into the running merged list. */
@@ -65,6 +72,18 @@ export interface ReviewPassSpec {
     passResult: AgentResult | null,
     mergedFindings: AgentFinding[],
   ): void;
+  /**
+   * Optional post-processing hook run on this pass's raw client result
+   * before it is logged/returned to the caller. A candidate-loop pass whose
+   * output contract is "one verdict per candidate id" (per the per-rule-
+   * loops design doc §2/§4) uses this to (a) reduce the raw per-candidate
+   * verdict array down to real findings and (b) mark the result incomplete
+   * when the model's output didn't cover every candidate — even though the
+   * underlying client returned a syntactically complete verdict (has a
+   * summary). Identity (no post-processing) when omitted; doc-truth's own
+   * open findings-list shape needs nothing here.
+   */
+  postProcessResult?(result: AgentResult, context: ReviewContext): AgentResult;
 }
 
 /** A pass's client loop, closed over the pass-agnostic transport (provider/apiKey/toolExecutor). */
@@ -95,8 +114,9 @@ export async function runReviewPass(
   }
   try {
     const { systemPrompt, initialMessage } = spec.buildPrompts(context);
-    const budget = spec.budget(config.maxTokenBudget);
-    const result = await runClient(systemPrompt, initialMessage, budget, spec.maxTurns);
+    const budget = spec.budget(config.maxTokenBudget, context);
+    const rawResult = await runClient(systemPrompt, initialMessage, budget, spec.maxTurns);
+    const result = spec.postProcessResult ? spec.postProcessResult(rawResult, context) : rawResult;
     logger.info(
       `[agent] ${spec.name} pass: ${result.findings.length} finding(s) in ${result.turns} turn(s) ($${result.usage.cost.toFixed(4)})`,
     );
@@ -178,7 +198,7 @@ export async function runExtraPasses(
         name: spec.name,
         stopReason: passResult.stopReason,
         neverRan: passResult.neverRan ?? false,
-        allocatedTokens: spec.budget(config.maxTokenBudget),
+        allocatedTokens: spec.budget(config.maxTokenBudget, context),
         spentTokens: passResult.usage.totalTokens,
       });
     }

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -498,7 +498,7 @@ is not a qualifying test; an actual test file + line is.`,
   source: 'builtin',
 };
 
-const STALE_DUPLICATE: ReviewRule = {
+export const STALE_DUPLICATE: ReviewRule = {
   id: 'stale-duplicate',
   name: 'Stale Duplicate Literal',
   description:

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -1,0 +1,519 @@
+/**
+ * Dedicated stale-duplicate candidate-loop PILOT (per-rule-loops design doc
+ * §4, `.wip/per-rule-loops-design.md` in the design session's worktree).
+ *
+ * `stale-literal-signals.ts` already pre-computes a `<stale_literal_candidates>`
+ * block for the MAIN pass, unconditionally (the rule's trigger is
+ * `always: true`) — a 2026-07-16 real-PR census found that block renders on
+ * 40/40 recent PRs even after PR #800's precision tightening (the 8-slot cap
+ * simply refills from a large candidate pool). That's fine for the main
+ * pass (same LLM call either way), but wrong for a DEDICATED second pass:
+ * paying for an extra request on every PR would erase the "own budget, no
+ * competition" benefit this architecture exists for. This module adds a
+ * STRICTER loop-eligibility gate (`hasEligibleCandidate`, chosen threshold
+ * documented there) so the loop only fires on a genuinely selective subset —
+ * see the PR body's census table for the measured rate and the alternative
+ * thresholds considered.
+ *
+ * Ships DARK: `staleDuplicateSkipReason` refuses to run unless explicitly
+ * opted in (`config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on`) — this
+ * module changes no default production behavior. A second flag,
+ * `LIEN_STALE_DUP_MAIN`, lets a future A/B arm remove the main pass's
+ * stale-duplicate rule + signal block once the loop is proven (also
+ * default-unchanged).
+ *
+ * Follows `doc-truth-pass.ts`'s six-piece shape (gate / prompt / budget /
+ * merge findings / merge result state / `ReviewPassSpec` bundle), with two
+ * deliberate departures the design doc calls out for a candidate loop
+ * specifically:
+ *  - Trimmed tools (`read_file` + `grep_codebase` only, not the full 6-tool
+ *    `TOOLS_SECTION`) — hard-cut, not just prompt-discouraged.
+ *  - A per-candidate-ID-required output contract instead of an open findings
+ *    list (the pr658 Finding-A lesson: a long open worklist can still be
+ *    under-reported even inside a dedicated, single-rule pass). The verdict
+ *    array is still carried inside the standard `findings` JSON key (so the
+ *    shared client's existing parse/validate pipeline needs no changes) —
+ *    each entry is REQUIRED to carry `candidateId` + `verdict` alongside the
+ *    ordinary finding fields; `postProcessStaleDuplicateResult` reduces that
+ *    to real findings and marks the result honestly incomplete when any
+ *    candidate id never got a verdict (the honesty semantics #795's
+ *    verdict-recovery work established: a gap is surfaced, never silent).
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+
+import type { AgentConfig, AgentFinding, AgentResult, ResolvedRules } from './types.js';
+import { STALE_DUPLICATE } from './rules.js';
+import { envDisabled } from './agent-client-shared.js';
+import {
+  computeStaleLiteralCandidates,
+  type StaleLiteralCandidate,
+} from '../../stale-literal-signals.js';
+import type { ReviewPassSpec } from './review-pass.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Turn cap for the candidate-loop pass. Evidence is pre-fetched per candidate
+ * (literal, changed-site hunk, every surviving occurrence's snippet), and
+ * tools are hard-cut to read_file/grep_codebase — judging the worklist
+ * rarely needs more than a couple of tool calls before the verdict turn. */
+export const STALE_DUP_PASS_MAX_TURNS = 6;
+
+const STALE_DUP_BASE_OVERHEAD_TOKENS = 2_000;
+const STALE_DUP_PER_CANDIDATE_TOKENS = 800;
+const STALE_DUP_MIN_BUDGET = 4_000;
+const STALE_DUP_MAX_BUDGET = 30_000;
+/** Mirrors stale-literal-signals.ts's own MAX_CANDIDATES cap. */
+const STALE_DUP_SIGNAL_MAX_CANDIDATES = 8;
+
+/** Opt-IN env flag — this pilot is dark by default (see module doc). */
+const STALE_DUP_PASS_ENV = 'LIEN_STALE_DUP_PASS';
+/** Opt-OUT env flag for the future A/B's "loop only" arm (see module doc). */
+const STALE_DUP_MAIN_ENV = 'LIEN_STALE_DUP_MAIN';
+
+export const STALE_DUP_RULE_ID = 'stale-duplicate';
+
+/** Plugin name this pass reports itself under in the delivery attestation. */
+const STALE_DUP_SKIP_PLUGIN = 'agent-review:stale-duplicate-loop';
+
+/** Two findings on the same file within this many lines are the same location. */
+const DEDUPE_LINE_PROXIMITY = 2;
+
+const STALE_DUP_INTRO =
+  'This is a STALE-DUPLICATE-LITERAL candidate loop — a dedicated second pass ' +
+  'scoped to ONE rule, running only because a deterministic scan already found ' +
+  'at least one high-confidence candidate. Your ONLY job is to judge the ' +
+  '<stale_duplicate_candidates> worklist below; do not report anything else ' +
+  '(other bugs, style, doc drift — those are handled elsewhere).';
+
+const STALE_DUP_TOOLS_SECTION = `<tools>
+You have these tools to investigate the codebase:
+- read_file: Read file contents from the repo — use when a candidate's snippet doesn't give enough context to judge it (e.g. needs the surrounding function body).
+- grep_codebase: Search the entire repository working tree for a text pattern (regex) — use ONLY for a shape the worklist doesn't cover (the rule text's closing paragraph). Do NOT re-grep for literals the worklist already lists; that discovery work is already done.
+</tools>`;
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+/**
+ * A production (non-comment/non-test/non-config) site, matching
+ * `stale-literal-signals.ts`'s own private `productionSites` filter —
+ * reimplemented inline here rather than exported from that module, since
+ * it's a one-line predicate and exporting it would widen that module's
+ * public surface for a single caller.
+ */
+function isProductionSite(s: StaleLiteralCandidate['staleSites'][number]): boolean {
+  return !s.isComment && !s.isTest && !s.isConfig;
+}
+
+/**
+ * Loop eligibility — STRICTER than whether the `<stale_literal_candidates>`
+ * block renders in the main pass (that block renders on ~40/40 real PRs;
+ * see the module doc comment and the PR body's census table). Chosen
+ * threshold: at least one HIGH-confidence candidate with a production
+ * survivor in the SAME FILE as the changed site — the canonical
+ * "adapterContext.model on line 300, same file as the line-272 change"
+ * shape. Measured at 14/40 (35.0%) of real PRs, inside the "genuinely
+ * selective" 15–40% target range; the canonical true-positive fixture
+ * (stale-duplicate/model-partial-update, PR #539) clears it.
+ */
+function hasEligibleCandidate(candidates: StaleLiteralCandidate[]): boolean {
+  return candidates.some(
+    c =>
+      c.confidence === 'high' &&
+      c.staleSites.some(s => isProductionSite(s) && s.file === c.changedSite.file),
+  );
+}
+
+function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'on';
+}
+
+/** Whether the pilot is opted in — config takes precedence, then the env flag. */
+export function isStaleDuplicatePassEnabled(config?: AgentConfig): boolean {
+  if (config?.staleDuplicatePass === true) return true;
+  return envEnabled(process.env[STALE_DUP_PASS_ENV]);
+}
+
+/**
+ * Precisely why the stale-duplicate loop would not run right now, or null if
+ * it should run. Mirrors `docTruthSkipReason`'s pattern: a caller reporting
+ * the skip to the delivery attestation gets the REAL reason (pilot not
+ * opted in vs. no eligible candidate), not a generic boolean.
+ */
+export function staleDuplicateSkipReason(
+  context: ReviewContext,
+  config?: AgentConfig,
+): string | null {
+  if (!isStaleDuplicatePassEnabled(config)) {
+    return (
+      `disabled (pilot opt-in; set config.staleDuplicatePass or ${STALE_DUP_PASS_ENV}=on ` +
+      'to enable)'
+    );
+  }
+  const candidates = computeStaleLiteralCandidates(context);
+  if (!hasEligibleCandidate(candidates)) {
+    return 'no high-confidence, same-file stale-literal candidate (loop eligibility threshold not met)';
+  }
+  return null;
+}
+
+/** Whether to run the stale-duplicate loop. True iff `staleDuplicateSkipReason` is null. */
+export function shouldRunStaleDuplicatePass(context: ReviewContext, config?: AgentConfig): boolean {
+  return staleDuplicateSkipReason(context, config) === null;
+}
+
+// ---------------------------------------------------------------------------
+// Main-pass interaction override (v1 second flag — see module doc)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the MAIN pass's stale-duplicate rule + signal block should be
+ * suppressed — the future A/B's "loop only, no shared-loop backstop" arm.
+ * Default false (unchanged): per requirement 5 of the pilot brief, the main
+ * pass keeps the rule and its signal block regardless of whether the
+ * dedicated loop is enabled, until the owner explicitly runs that arm.
+ */
+export function isStaleDuplicateMainDisabled(): boolean {
+  const value = process.env[STALE_DUP_MAIN_ENV];
+  return value?.trim().toLowerCase() === 'off' || envDisabled(value);
+}
+
+/**
+ * Strip `stale-duplicate` out of the resolved rule set when the main-pass
+ * override is on. `system-prompt.ts`'s `isRuleActive` already gates the
+ * `<stale_literal_candidates>` block on rule activity for every OTHER
+ * signal-gated rule (error-swallowing, incomplete-handling, boundary-change)
+ * — stale-duplicate's `always: true` trigger just never needed that gate
+ * before. Routing this override through the SAME `isRuleActive` check means
+ * one change removes both the rule's prompt fragment and its signal block
+ * together, with no new gating mechanism to maintain.
+ */
+export function applyStaleDuplicateMainOverride(rules: ResolvedRules): ResolvedRules {
+  if (!isStaleDuplicateMainDisabled()) return rules;
+  return {
+    active: rules.active.filter(r => r.id !== STALE_DUP_RULE_ID),
+    skipped: [...rules.skipped, `${STALE_DUP_RULE_ID} (${STALE_DUP_MAIN_ENV}=off)`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+function candidateIds(candidates: StaleLiteralCandidate[]): string[] {
+  return candidates.map((_, i) => `candidate-${i + 1}`);
+}
+
+/** The PR title/body header, mirroring the main pass's <pr_metadata> block. */
+function renderPrHeader(context: ReviewContext): string | null {
+  if (!context.pr) return null;
+  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
+  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
+}
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/**
+ * Find the diff hunk (a `@@ ... @@` block and its lines) whose post-image
+ * line range contains `line`, from one file's raw unified-diff patch text.
+ * Returns undefined when the patch has no hunk covering that line (e.g. the
+ * literal was recorded from a `-` removed line whose hunk's new-range still
+ * covers neighbouring context — the common case — but a pathological diff
+ * could in principle miss).
+ */
+function extractHunkContaining(patch: string | undefined, line: number): string | undefined {
+  if (!patch) return undefined;
+  let hunkStart = -1;
+  let newLine = 0;
+  let hunkLines: string[] = [];
+
+  const flushIfMatch = (): string | undefined =>
+    hunkStart !== -1 && hunkStart <= line && line <= newLine ? hunkLines.join('\n') : undefined;
+
+  for (const raw of patch.split('\n')) {
+    const header = raw.match(HUNK_HEADER_RE);
+    if (header) {
+      const match = flushIfMatch();
+      if (match) return match;
+      hunkStart = parseInt(header[1], 10);
+      newLine = hunkStart - 1;
+      hunkLines = [raw];
+      continue;
+    }
+    if (hunkStart === -1) continue; // before the first hunk (file headers)
+    hunkLines.push(raw);
+    if (raw.startsWith('+') || raw.startsWith(' ')) newLine++;
+  }
+  return flushIfMatch();
+}
+
+/** Render one candidate's evidence block: literal, changed-site hunk, every surviving site. */
+function renderCandidate(id: string, c: StaleLiteralCandidate, patch: string | undefined): string {
+  const lines: string[] = [];
+  lines.push(
+    `<candidate id="${id}" literal=${JSON.stringify(c.literal)} confidence="${c.confidence}">`,
+  );
+  lines.push(`Changed site: ${c.changedSite.file}:${c.changedSite.line}`);
+  const hunk = extractHunkContaining(patch, c.changedSite.line);
+  if (hunk) {
+    lines.push('```diff');
+    lines.push(hunk);
+    lines.push('```');
+  }
+  lines.push('Surviving site(s):');
+  for (const s of c.staleSites) {
+    const tags = [s.isComment && 'comment', s.isTest && 'test', s.isConfig && 'config']
+      .filter(Boolean)
+      .join(', ');
+    lines.push(`  - ${s.file}:${s.line}${tags ? ` (${tags})` : ''}  \`${s.snippet}\``);
+  }
+  lines.push('</candidate>');
+  return lines.join('\n');
+}
+
+/** Build the `<stale_duplicate_candidates>` worklist — one entry per candidate id. */
+function renderWorklist(context: ReviewContext, candidates: StaleLiteralCandidate[]): string {
+  const patches = context.pr?.patches;
+  const ids = candidateIds(candidates);
+  const lines: string[] = [];
+  lines.push('<stale_duplicate_candidates>');
+  lines.push(
+    'One verdict is REQUIRED per candidate id below (see <output_format>) — ' +
+      `${ids.join(', ')}. Each candidate is a literal this PR changed at the CHANGED ` +
+      'SITE but that still appears unchanged at the SURVIVING SITE(S); judge whether ' +
+      'each surviving site should track the changed site.',
+  );
+  candidates.forEach((c, i) => {
+    lines.push('');
+    lines.push(renderCandidate(ids[i], c, patches?.get(c.changedSite.file)));
+  });
+  lines.push('</stale_duplicate_candidates>');
+  return lines.join('\n');
+}
+
+/** The per-candidate-verdict output contract (see module doc for why this
+ * stays inside the standard `findings` key rather than a separate one). */
+function buildOutputFormat(ids: string[]): string {
+  return `<output_format>
+Output EXACTLY one entry per candidate id in the \`findings\` array — one for EVERY
+id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
+
+{
+  "findings": [
+    {
+      "candidateId": "candidate-1",
+      "verdict": "stale | intentional-reuse | unverifiable",
+      "filepath": "relative/path.ts",
+      "line": 42,
+      "severity": "error | warning",
+      "category": "logic_error",
+      "message": "REQUIRED for every verdict. When stale: 1-2 sentences naming both locations and the wrong behavior. When intentional-reuse or unverifiable: 1 sentence saying why.",
+      "suggestion": "The fix (stale only) — hoist to a shared const, or apply the same change.",
+      "evidence": "One line citing the candidate (stale only)."
+    }
+  ],
+  "summary": {
+    "riskLevel": "low | medium | high | critical",
+    "overview": "One sentence.",
+    "keyChanges": []
+  }
+}
+
+EVERY entry requires candidateId, verdict, filepath, line, severity, and message —
+even for intentional-reuse/unverifiable verdicts (fill filepath/line from the
+candidate's changed site, severity "warning", message explaining the disposition).
+A missing candidateId for any worklist entry makes this pass's result incomplete.
+</output_format>`;
+}
+
+function buildSystemPrompt(ids: string[]): string {
+  return `${STALE_DUP_INTRO}
+
+${STALE_DUP_TOOLS_SECTION}
+
+<strategy>
+${STALE_DUPLICATE.prompt}
+</strategy>
+
+<examples>
+${STALE_DUPLICATE.example}
+</examples>
+
+${buildOutputFormat(ids)}`;
+}
+
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. */
+export function buildStaleDuplicatePassInitialMessage(context: ReviewContext): string {
+  const candidates = computeStaleLiteralCandidates(context);
+  const sections: string[] = [];
+  const header = renderPrHeader(context);
+  if (header) sections.push(header);
+  sections.push(renderWorklist(context, candidates));
+  sections.push('Judge every candidate above and output your verdicts as JSON.');
+  return sections.join('\n\n');
+}
+
+/** The system + initial prompts for the stale-duplicate candidate loop. */
+export function buildStaleDuplicatePassPrompts(context: ReviewContext): {
+  systemPrompt: string;
+  initialMessage: string;
+} {
+  const ids = candidateIds(computeStaleLiteralCandidates(context));
+  return {
+    systemPrompt: buildSystemPrompt(ids),
+    initialMessage: buildStaleDuplicatePassInitialMessage(context),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+/**
+ * Budget scaled by this pass's own candidate count (per the per-rule-loops
+ * design doc §2), clamped floor/ceiling — mirrors `summary-only-pass.ts`'s
+ * `scaleSummaryOnlyBudget` clamp pattern rather than doc-truth's flat
+ * fraction: a 1-candidate loop shouldn't pay the same budget as an 8-
+ * candidate one.
+ */
+export function staleDuplicatePassBudget(_baseBudget: number, context: ReviewContext): number {
+  const candidateCount = computeStaleLiteralCandidates(context).length;
+  const scaled =
+    STALE_DUP_BASE_OVERHEAD_TOKENS +
+    STALE_DUP_PER_CANDIDATE_TOKENS * Math.min(candidateCount, STALE_DUP_SIGNAL_MAX_CANDIDATES);
+  return Math.min(Math.max(scaled, STALE_DUP_MIN_BUDGET), STALE_DUP_MAX_BUDGET);
+}
+
+// ---------------------------------------------------------------------------
+// Post-processing (verdict reduction + honest completeness)
+// ---------------------------------------------------------------------------
+
+/** The raw per-candidate shape the model emits inside the standard `findings` array. */
+interface RawVerdictFinding extends AgentFinding {
+  candidateId?: string;
+  verdict?: 'stale' | 'intentional-reuse' | 'unverifiable';
+}
+
+/** Strip the loop-only `candidateId`/`verdict` fields, keeping the standard finding shape. */
+function toCleanFinding(f: RawVerdictFinding): AgentFinding {
+  return {
+    filepath: f.filepath,
+    line: f.line,
+    endLine: f.endLine,
+    symbolName: f.symbolName,
+    severity: f.severity,
+    category: f.category,
+    message: f.message,
+    suggestion: f.suggestion,
+    evidence: f.evidence,
+  };
+}
+
+/**
+ * Reduce this pass's raw per-candidate verdict array (still carried inside
+ * `result.findings`, tagged with `candidateId`/`verdict` — see module doc)
+ * down to real findings (`verdict === 'stale'` only, cleaned of the loop-
+ * only fields), and mark the result honestly incomplete when any worklist
+ * candidate id never received a verdict at all — the pr658 Finding-A lesson
+ * made machine-checkable: a missing id is a completeness failure the harness
+ * can assert on directly, not a semantic judgment call. When the underlying
+ * client result was ALREADY incomplete for a real reason (budget/max_turns/
+ * error), that reason is kept as-is (more specific than the generic
+ * coverage-gap marker); `incomplete_verdict` is only used when the model
+ * otherwise returned a syntactically complete verdict.
+ */
+export function postProcessStaleDuplicateResult(
+  result: AgentResult,
+  context: ReviewContext,
+): AgentResult {
+  const ids = candidateIds(computeStaleLiteralCandidates(context));
+  const raw = result.findings as RawVerdictFinding[];
+  const covered = new Set(
+    raw.map(f => f.candidateId).filter((id): id is string => typeof id === 'string'),
+  );
+  const coverageIncomplete = ids.some(id => !covered.has(id));
+  const wasAlreadyIncomplete = result.incomplete;
+
+  return {
+    ...result,
+    findings: raw.filter(f => f.verdict === 'stale').map(toCleanFinding),
+    incomplete: wasAlreadyIncomplete || coverageIncomplete,
+    stopReason:
+      !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers
+// ---------------------------------------------------------------------------
+
+function sameLocation(a: AgentFinding, b: AgentFinding): boolean {
+  return a.filepath === b.filepath && Math.abs(a.line - b.line) <= DEDUPE_LINE_PROXIMITY;
+}
+
+/**
+ * Fold the loop's findings (already reduced to `verdict === 'stale'` only by
+ * `postProcessStaleDuplicateResult`) into the main pass's. Unlike doc-truth's
+ * dedupe (main pass wins), requirement 5 of the pilot brief has the LOOP
+ * finding win: when a loop finding and a main-pass finding collide on
+ * location, the main-pass one is dropped — the loop finding carries the
+ * per-candidate evidence the shared loop's freeform grep pass doesn't.
+ * Returns a new array; inputs are not mutated.
+ */
+export function mergeStaleDuplicateFindings(
+  mainFindings: AgentFinding[],
+  loopFindings: AgentFinding[],
+): AgentFinding[] {
+  const forced = loopFindings.map(f => ({ ...f, ruleId: STALE_DUP_RULE_ID }));
+  const survivingMain = mainFindings.filter(mf => !forced.some(lf => sameLocation(mf, lf)));
+  return [...survivingMain, ...forced];
+}
+
+/**
+ * Fold the loop's result-level state into the main pass's. Only
+ * incomplete/stopReason propagate (unlike doc-truth's own risk-level lift,
+ * which is specific to a documentation-contradicts-code semantic that
+ * doesn't clearly apply here) — a still-incomplete loop marks the merged
+ * result incomplete, naming this pass via the generic `incompleteFromPass`
+ * (see types.ts) so `appendIncompleteNotice` (index.ts) doesn't imply the
+ * whole review is partial.
+ */
+export function mergeStaleDuplicateResultState(
+  main: AgentResult,
+  passResult: AgentResult | null,
+): AgentResult {
+  if (!passResult) return main;
+  if (passResult.incomplete && !main.incomplete) {
+    main.incomplete = true;
+    main.stopReason = passResult.stopReason;
+    main.incompleteFromPass = 'stale-duplicate';
+  }
+  return main;
+}
+
+// ---------------------------------------------------------------------------
+// ReviewPassSpec (plugs the loop into the generalized executor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stale-duplicate candidate loop bundled as a `ReviewPassSpec` (see
+ * `review-pass.ts`) — the pilot's plug-in point. Every field here is one of
+ * this module's own pure functions; the generic executor supplies the
+ * gate-check/run/failure-isolation/reporting plumbing.
+ */
+export const STALE_DUPLICATE_PASS_SPEC: ReviewPassSpec = {
+  name: 'stale-duplicate-loop',
+  skipPlugin: STALE_DUP_SKIP_PLUGIN,
+  gateReason: staleDuplicateSkipReason,
+  buildPrompts: buildStaleDuplicatePassPrompts,
+  budget: staleDuplicatePassBudget,
+  maxTurns: STALE_DUP_PASS_MAX_TURNS,
+  mergeFindings: mergeStaleDuplicateFindings,
+  mergeResultState: mergeStaleDuplicateResultState,
+  postProcessResult: postProcessStaleDuplicateResult,
+};

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -85,7 +85,7 @@ const STALE_DUP_INTRO =
   'This is a STALE-DUPLICATE-LITERAL candidate loop — a dedicated second pass ' +
   'scoped to ONE rule, running only because a deterministic scan already found ' +
   'at least one high-confidence candidate. Your ONLY job is to judge the ' +
-  '<stale_duplicate_candidates> worklist below; do not report anything else ' +
+  '<stale_literal_candidates> worklist below; do not report anything else ' +
   '(other bugs, style, doc drift — those are handled elsewhere).';
 
 const STALE_DUP_TOOLS_SECTION = `<tools>
@@ -276,12 +276,22 @@ function renderCandidate(id: string, c: StaleLiteralCandidate, patch: string | u
   return lines.join('\n');
 }
 
-/** Build the `<stale_duplicate_candidates>` worklist — one entry per candidate id. */
+/**
+ * Build the worklist — one entry per candidate id. Uses the SAME
+ * `<stale_literal_candidates>` tag name the shared `STALE_DUPLICATE.prompt`
+ * text (reused verbatim as this pass's `<strategy>`, below) instructs the
+ * model to look for — a real mismatch here (a different tag name than what
+ * the rule text promises) is exactly the "prompt promises a signal it
+ * doesn't inject" bug class the per-rule-loops design doc's §1 called out
+ * for the rename-sweep/doc-truth precedent. Safe to reuse across the main
+ * pass and this pass: they are separate, non-overlapping LLM calls, so the
+ * shared tag name never collides within a single turn.
+ */
 function renderWorklist(context: ReviewContext, candidates: StaleLiteralCandidate[]): string {
   const patches = context.pr?.patches;
   const ids = candidateIds(candidates);
   const lines: string[] = [];
-  lines.push('<stale_duplicate_candidates>');
+  lines.push('<stale_literal_candidates>');
   lines.push(
     'One verdict is REQUIRED per candidate id below (see <output_format>) — ' +
       `${ids.join(', ')}. Each candidate is a literal this PR changed at the CHANGED ` +
@@ -292,7 +302,7 @@ function renderWorklist(context: ReviewContext, candidates: StaleLiteralCandidat
     lines.push('');
     lines.push(renderCandidate(ids[i], c, patches?.get(c.changedSite.file)));
   });
-  lines.push('</stale_duplicate_candidates>');
+  lines.push('</stale_literal_candidates>');
   return lines.join('\n');
 }
 
@@ -393,10 +403,18 @@ export function staleDuplicatePassBudget(_baseBudget: number, context: ReviewCon
 // Post-processing (verdict reduction + honest completeness)
 // ---------------------------------------------------------------------------
 
+/** A verdict value the loop's output contract recognizes. */
+type Verdict = 'stale' | 'intentional-reuse' | 'unverifiable';
+const VALID_VERDICTS: ReadonlySet<string> = new Set<Verdict>([
+  'stale',
+  'intentional-reuse',
+  'unverifiable',
+]);
+
 /** The raw per-candidate shape the model emits inside the standard `findings` array. */
 interface RawVerdictFinding extends AgentFinding {
   candidateId?: string;
-  verdict?: 'stale' | 'intentional-reuse' | 'unverifiable';
+  verdict?: Verdict;
 }
 
 /** Strip the loop-only `candidateId`/`verdict` fields, keeping the standard finding shape. */
@@ -415,17 +433,48 @@ function toCleanFinding(f: RawVerdictFinding): AgentFinding {
 }
 
 /**
+ * True iff every expected candidate id appears in `raw` EXACTLY once, each
+ * with a RECOGNIZED verdict — and `raw` contains no entry with a missing/
+ * unknown candidateId or an unrecognized verdict. Checking candidateId
+ * presence alone (an earlier version of this function) let a malformed
+ * entry — a valid candidateId paired with a missing/garbage verdict — count
+ * as "covered" while still failing `toCleanFinding`'s `verdict === 'stale'`
+ * filter: it silently vanished from BOTH the coverage check and the
+ * findings array, exactly the "quiet gap" this pass's honesty contract
+ * exists to catch. A duplicate or unexpected-id entry is treated the same
+ * way — the contract is "one recognized verdict per expected id", not
+ * merely "every id mentioned somewhere".
+ */
+function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): boolean {
+  const expected = new Set(ids);
+  const verdictCounts = new Map<string, number>();
+  for (const { candidateId, verdict } of raw) {
+    if (
+      typeof candidateId !== 'string' ||
+      !expected.has(candidateId) ||
+      typeof verdict !== 'string' ||
+      !VALID_VERDICTS.has(verdict)
+    ) {
+      return false;
+    }
+    verdictCounts.set(candidateId, (verdictCounts.get(candidateId) ?? 0) + 1);
+  }
+  return ids.every(id => verdictCounts.get(id) === 1);
+}
+
+/**
  * Reduce this pass's raw per-candidate verdict array (still carried inside
  * `result.findings`, tagged with `candidateId`/`verdict` — see module doc)
  * down to real findings (`verdict === 'stale'` only, cleaned of the loop-
- * only fields), and mark the result honestly incomplete when any worklist
- * candidate id never received a verdict at all — the pr658 Finding-A lesson
- * made machine-checkable: a missing id is a completeness failure the harness
- * can assert on directly, not a semantic judgment call. When the underlying
- * client result was ALREADY incomplete for a real reason (budget/max_turns/
- * error), that reason is kept as-is (more specific than the generic
- * coverage-gap marker); `incomplete_verdict` is only used when the model
- * otherwise returned a syntactically complete verdict.
+ * only fields), and mark the result honestly incomplete when the verdict
+ * array doesn't cleanly cover the worklist (see `hasCompleteVerdictCoverage`)
+ * — the pr658 Finding-A lesson made machine-checkable: a coverage gap is a
+ * completeness failure the harness can assert on directly, not a semantic
+ * judgment call. When the underlying client result was ALREADY incomplete
+ * for a real reason (budget/max_turns/error), that reason is kept as-is
+ * (more specific than the generic coverage-gap marker); `incomplete_verdict`
+ * is only used when the model otherwise returned a syntactically complete
+ * verdict.
  */
 export function postProcessStaleDuplicateResult(
   result: AgentResult,
@@ -433,10 +482,7 @@ export function postProcessStaleDuplicateResult(
 ): AgentResult {
   const ids = candidateIds(computeStaleLiteralCandidates(context));
   const raw = result.findings as RawVerdictFinding[];
-  const covered = new Set(
-    raw.map(f => f.candidateId).filter((id): id is string => typeof id === 'string'),
-  );
-  const coverageIncomplete = ids.some(id => !covered.has(id));
+  const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
   const wasAlreadyIncomplete = result.incomplete;
 
   return {
@@ -463,6 +509,18 @@ function sameLocation(a: AgentFinding, b: AgentFinding): boolean {
  * finding win: when a loop finding and a main-pass finding collide on
  * location, the main-pass one is dropped — the loop finding carries the
  * per-candidate evidence the shared loop's freeform grep pass doesn't.
+ *
+ * Dropping is scoped to main-pass findings whose OWN `ruleId` is also
+ * `stale-duplicate` — i.e. only the shared loop's freeform backstop copy of
+ * the SAME rule, never an unrelated rule's finding that merely happens to
+ * land within `DEDUPE_LINE_PROXIMITY` lines. Proximity-only matching (an
+ * earlier version of this function) could silently drop a real finding from
+ * a completely different rule (e.g. `error-swallowing`) just because it sat
+ * near a stale-duplicate loop finding — a real correctness risk unique to
+ * this "loop wins" direction (doc-truth's "main wins" convention never
+ * risks discarding an unrelated finding, since the dropped side is always
+ * doc-truth's own).
+ *
  * Returns a new array; inputs are not mutated.
  */
 export function mergeStaleDuplicateFindings(
@@ -470,7 +528,9 @@ export function mergeStaleDuplicateFindings(
   loopFindings: AgentFinding[],
 ): AgentFinding[] {
   const forced = loopFindings.map(f => ({ ...f, ruleId: STALE_DUP_RULE_ID }));
-  const survivingMain = mainFindings.filter(mf => !forced.some(lf => sameLocation(mf, lf)));
+  const survivingMain = mainFindings.filter(
+    mf => mf.ruleId !== STALE_DUP_RULE_ID || !forced.some(lf => sameLocation(mf, lf)),
+  );
   return [...survivingMain, ...forced];
 }
 

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -215,7 +215,17 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderChangedFunctions(context));
   appendIfPresent(sections, renderBlastRadius(opts));
   appendIfPresent(sections, renderRemovedExportsSection(context));
-  appendIfPresent(sections, renderStaleLiteralSection(context));
+  // stale-duplicate's `always: true` trigger meant this rendered
+  // unconditionally before the candidate-loop pilot's LIEN_STALE_DUP_MAIN
+  // override existed (see stale-duplicate-pass.ts). Unlike the other gated
+  // signals below, an omitted `opts.rules` here still renders the block
+  // (isRuleActiveOrUnresolved) — preserving every existing caller that
+  // doesn't resolve rules at all (CLI callers, and the signal's own unit
+  // tests), so this is a no-op change unless a caller BOTH resolves rules
+  // AND sets the override flag.
+  if (isRuleActiveOrUnresolved(opts.rules, 'stale-duplicate')) {
+    appendIfPresent(sections, renderStaleLiteralSection(context));
+  }
   if (isRuleActive(opts.rules, 'error-swallowing')) {
     appendIfPresent(sections, renderUndiscriminatedCatchSection(context));
   }
@@ -253,6 +263,19 @@ function appendIfPresent(sections: string[], value: string | null): void {
  */
 function isRuleActive(rules: ResolvedRules | undefined, ruleId: string): boolean {
   return rules?.active.some(r => r.id === ruleId) ?? false;
+}
+
+/**
+ * Same as {@link isRuleActive}, but treats an OMITTED `rules` as "render it"
+ * rather than "skip it" — for a signal that rendered unconditionally before
+ * it grew a rule-gate (stale-duplicate's `<stale_literal_candidates>`, gated
+ * only so `LIEN_STALE_DUP_MAIN=off` can suppress it — see
+ * stale-duplicate-pass.ts). A caller that never resolves rules at all keeps
+ * getting the block exactly as before; only a caller that resolves rules AND
+ * strips stale-duplicate from `active` (the override) loses it.
+ */
+function isRuleActiveOrUnresolved(rules: ResolvedRules | undefined, ruleId: string): boolean {
+  return rules === undefined || isRuleActive(rules, ruleId);
 }
 
 function renderPrMetadata(context: ReviewContext): string | null {

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -58,6 +58,12 @@ export interface AgentConfig {
    * available — see `summary-only-pass.ts`'s `isSummaryOnlyMode`.
    */
   summaryEnabled?: boolean;
+  /**
+   * Run the stale-duplicate candidate-loop PILOT (per-rule-loops design doc
+   * §4). Default false — this is a dark-launched pilot; set true (or env
+   * LIEN_STALE_DUP_PASS=on) to enable it. See `stale-duplicate-pass.ts`.
+   */
+  staleDuplicatePass?: boolean;
 }
 
 /** A single finding produced by the agent during review. */
@@ -202,8 +208,15 @@ export interface AgentTrace {
   turns: TurnTrace[];
 }
 
-/** Why the agent's tool-use loop ended. */
-export type AgentStopReason = 'completed' | 'budget' | 'max_turns' | 'error';
+/**
+ * Why the agent's tool-use loop ended. `incomplete_verdict` is set by a
+ * candidate-loop pass's `postProcessResult` (see `review-pass.ts`) when the
+ * model returned a syntactically complete verdict (has a summary — the
+ * client's OWN `incomplete` check passes) but didn't cover every candidate
+ * id in its own worklist — a distinct honesty gap from budget/max_turns/error,
+ * which are all client-transport-level stops.
+ */
+export type AgentStopReason = 'completed' | 'budget' | 'max_turns' | 'error' | 'incomplete_verdict';
 
 /** Result of an agent review run, including findings, usage, and turn count. */
 export interface AgentResult {
@@ -245,6 +258,18 @@ export interface AgentResult {
    * the doc pass instead of implying the whole review is partial.
    */
   incompleteFromDocPass?: boolean;
+  /**
+   * Set by a candidate-loop pass's `mergeResultState` (e.g.
+   * `stale-duplicate-pass.ts`) to this pass's own `name` when ONLY that pass
+   * is incomplete and the main pass finished cleanly — the generic
+   * counterpart to `incompleteFromDocPass` for any pass beyond doc-truth, so
+   * `appendIncompleteNotice` (index.ts) can name the right pass in its
+   * notice instead of implying the whole review is partial. Doc-truth keeps
+   * its own dedicated boolean (unchanged, to avoid touching its already-
+   * tested wording); a future pass should prefer this generic field over
+   * adding another dedicated boolean.
+   */
+  incompleteFromPass?: string;
   /** Per-turn trace data — only populated when the caller wires up trace capture. */
   trace?: AgentTrace;
 }

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -14,6 +14,12 @@
  * surfaced here too, since it is built by a separate function
  * (`buildDocTruthPassPrompts`) from the main pass's `buildInitialMessage`.
  *
+ * Same for the stale-duplicate candidate-loop PILOT (`staleDuplicatePass`,
+ * per-rule-loops design doc §4) — dark by default, so `fires` is false
+ * unless the fixture's captured config (or LIEN_STALE_DUP_PASS=on in the
+ * environment this script runs in) opts in AND the loop-eligibility
+ * threshold is met.
+ *
  * Usage: tsx build-prompts.ts <fixture.json>
  */
 
@@ -25,6 +31,11 @@ import {
   shouldRunDocTruthPass,
   buildDocTruthPassPrompts,
 } from '../../src/plugins/agent/doc-truth-pass.js';
+import {
+  shouldRunStaleDuplicatePass,
+  buildStaleDuplicatePassPrompts,
+  applyStaleDuplicateMainOverride,
+} from '../../src/plugins/agent/stale-duplicate-pass.js';
 import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
@@ -37,19 +48,22 @@ async function main(): Promise<void> {
   }
   const fixturePath = resolve(fixtureArg);
   const ctx = await loadFixture(fixturePath);
+  const config = ctx.config as unknown as AgentConfig | undefined;
 
   const triggerCtx = buildTriggerContext(ctx);
-  const rules = selectRules(BUILTIN_RULES, triggerCtx);
+  const rules = applyStaleDuplicateMainOverride(selectRules(BUILTIN_RULES, triggerCtx));
 
   const systemPrompt = buildSystemPrompt(rules);
   const initialMessage = buildInitialMessage(ctx, { blastRadius: null, rules });
 
-  const docTruthFires = shouldRunDocTruthPass(
-    ctx,
-    ctx.config as unknown as AgentConfig | undefined,
-  );
+  const docTruthFires = shouldRunDocTruthPass(ctx, config);
   const docTruthPass = docTruthFires
     ? { fires: true as const, ...buildDocTruthPassPrompts(ctx) }
+    : { fires: false as const };
+
+  const staleDuplicateFires = shouldRunStaleDuplicatePass(ctx, config);
+  const staleDuplicatePass = staleDuplicateFires
+    ? { fires: true as const, ...buildStaleDuplicatePassPrompts(ctx) }
     : { fires: false as const };
 
   const output = {
@@ -59,6 +73,7 @@ async function main(): Promise<void> {
     systemPrompt,
     initialMessage,
     docTruthPass,
+    staleDuplicatePass,
   };
 
   process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -550,6 +550,28 @@ describe('appendIncompleteNotice — severity by run outcome', () => {
     expect(findings[0].message).toContain('code findings are unaffected');
   });
 
+  it('keeps a stale-duplicate-loop-only incomplete a WARNING, naming that pass generically', () => {
+    // The generic incompleteFromPass counterpart to incompleteFromDocPass —
+    // any future named extra pass (not just doc-truth) gets the same
+    // "that pass's findings are partial, main review unaffected" shape.
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({
+        neverRan: true,
+        incompleteFromPass: 'stale-duplicate',
+        stopReason: 'incomplete_verdict',
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toContain('The stale-duplicate pass did not finish');
+    expect(findings[0].message).toContain('did not produce a verdict for every candidate');
+    expect(findings[0].message).toContain("main review's findings are unaffected");
+  });
+
   it('is a no-op for a complete run', () => {
     const findings: ReviewFinding[] = [];
     appendIncompleteNotice(findings, 'agent-review', baseResult({ incomplete: false }));

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -130,6 +130,47 @@ describe('runReviewPass', () => {
     expect(captured).toEqual({ sys: 'sys', init: 'init', budget: 20_000, maxTurns: 7 });
   });
 
+  it('passes context through to budget() so a candidate-count-scaled pass can size itself', async () => {
+    const ctx = createTestContext({ changedFiles: ['marker.ts'] });
+    let seenContext: ReviewContext | undefined;
+    const spec = makeSpec({
+      budget: (base, context) => {
+        seenContext = context;
+        return base;
+      },
+    });
+
+    await runReviewPass(spec, ctx, cfg(), silentLogger, async () => fakeResult());
+
+    expect(seenContext).toBe(ctx);
+  });
+
+  it('runs postProcessResult on the raw client result before returning it', async () => {
+    const ctx = createTestContext();
+    const spec = makeSpec({
+      postProcessResult: (result, context) => ({
+        ...result,
+        findings: [finding({ message: `post-processed:${context.changedFiles.length}` })],
+      }),
+    });
+
+    const result = await runReviewPass(spec, ctx, cfg(), silentLogger, async () =>
+      fakeResult({ findings: [finding({ message: 'raw' })] }),
+    );
+
+    expect(result!.findings).toEqual([finding({ message: 'post-processed:0' })]);
+  });
+
+  it('is a pass-through identity when postProcessResult is omitted (doc-truth needs nothing here)', async () => {
+    const ctx = createTestContext();
+    const spec = makeSpec(); // no postProcessResult
+    const raw = fakeResult({ findings: [finding({ message: 'unchanged' })] });
+
+    const result = await runReviewPass(spec, ctx, cfg(), silentLogger, async () => raw);
+
+    expect(result).toEqual(raw);
+  });
+
   it('isolates a pass failure: a throwing client yields null, logs a warning, reports the failure', async () => {
     const reportSkip = vi.fn();
     const ctx = { ...createTestContext(), reportSkip };

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+
+import {
+  staleDuplicateSkipReason,
+  shouldRunStaleDuplicatePass,
+  buildStaleDuplicatePassPrompts,
+  buildStaleDuplicatePassInitialMessage,
+  staleDuplicatePassBudget,
+  postProcessStaleDuplicateResult,
+  mergeStaleDuplicateFindings,
+  mergeStaleDuplicateResultState,
+  isStaleDuplicateMainDisabled,
+  applyStaleDuplicateMainOverride,
+  STALE_DUPLICATE_PASS_SPEC,
+  STALE_DUP_PASS_MAX_TURNS,
+} from '../src/plugins/agent/stale-duplicate-pass.js';
+import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../src/plugins/agent/rules.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { createTestContext } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'function',
+      language: 'typescript',
+    },
+  };
+}
+
+// The canonical PR #539 shape (mirrors stale-literal-signals.test.ts): a
+// model literal is conditionalized in place at lines 11-13 of pr-review.ts,
+// while a SAME-FILE sibling site (line 20, a value-emitting assignment)
+// keeps it hardcoded — high confidence, same-file production survivor, so
+// this trips the loop's eligibility threshold.
+const CONDITIONALIZE_PATCH = `@@ -10,3 +10,4 @@
+   const cfg = load();
+-  const model = 'claude-sonnet-4-6';
++  const model = cfg.openrouterApiKey
++    ? 'gemini-3-flash'
++    : 'claude-sonnet-4-6';
+   return model;`;
+
+const PR_REVIEW_CONTENT = [
+  'const cfg = load();', // 10
+  'const model = cfg.openrouterApiKey', // 11
+  "  ? 'gemini-3-flash'", // 12
+  "  : 'claude-sonnet-4-6';", // 13
+  'return model;', // 14
+  '', // 15
+  'function reportMeta() {', // 16
+  '  // legacy attribution', // 17
+  '  const ctx = {};', // 18
+  '  ctx.provider = "openrouter";', // 19
+  "  adapterContext.model = 'claude-sonnet-4-6';", // 20
+].join('\n');
+
+/** An eligible context: the CONDITIONALIZE_PATCH shape, same-file high-confidence survivor. */
+function eligibleContext(extra?: Partial<ReviewContext>): ReviewContext {
+  const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+  const repoChunks = [makeChunk('src/pr-review.ts', 10, PR_REVIEW_CONTENT)];
+  return createTestContext({
+    changedFiles: ['src/pr-review.ts'],
+    chunks: [],
+    pr: {
+      title: 'Bump default model',
+      body: '',
+      patches,
+    } as unknown as ReviewContext['pr'],
+    repoChunks,
+    ...extra,
+  });
+}
+
+/** A context whose only survivor is a DIFFERENT file (fails the same-file threshold). */
+function differentFileOnlyContext(): ReviewContext {
+  const patches = new Map([['src/pr-review.ts', CONDITIONALIZE_PATCH]]);
+  const repoChunks = [
+    makeChunk(
+      'src/pr-review.ts',
+      10,
+      'const cfg = load();\nconst model = compute();\nreturn model;',
+    ),
+    makeChunk('src/other-file.ts', 1, "adapterContext.model = 'claude-sonnet-4-6';"),
+  ];
+  return createTestContext({
+    changedFiles: ['src/pr-review.ts'],
+    chunks: [],
+    pr: { title: 'Bump default model', body: '', patches } as unknown as ReviewContext['pr'],
+    repoChunks,
+  });
+}
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+function finding(overrides: Record<string, unknown> = {}): AgentFinding {
+  return {
+    filepath: 'src/pr-review.ts',
+    line: 20,
+    severity: 'warning',
+    category: 'logic_error',
+    message: 'msg',
+    ...overrides,
+  } as AgentFinding;
+}
+
+function fakeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2, cost: 0.01 },
+    turns: 1,
+    stopReason: 'completed',
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  delete process.env.LIEN_STALE_DUP_PASS;
+  delete process.env.LIEN_STALE_DUP_MAIN;
+});
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+describe('staleDuplicateSkipReason / shouldRunStaleDuplicatePass', () => {
+  it('is false (disabled) by default, even with an eligible candidate — pilot ships dark', () => {
+    const ctx = eligibleContext();
+    expect(shouldRunStaleDuplicatePass(ctx, cfg())).toBe(false);
+    expect(staleDuplicateSkipReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('is true when opted in via config AND an eligible candidate exists', () => {
+    const ctx = eligibleContext();
+    expect(shouldRunStaleDuplicatePass(ctx, cfg({ staleDuplicatePass: true }))).toBe(true);
+    expect(staleDuplicateSkipReason(ctx, cfg({ staleDuplicatePass: true }))).toBeNull();
+  });
+
+  it('is true when opted in via LIEN_STALE_DUP_PASS=on (no config flag)', () => {
+    process.env.LIEN_STALE_DUP_PASS = 'on';
+    const ctx = eligibleContext();
+    expect(shouldRunStaleDuplicatePass(ctx, cfg())).toBe(true);
+  });
+
+  it('is false when opted in but no candidate clears the eligibility threshold', () => {
+    const ctx = differentFileOnlyContext();
+    const reason = staleDuplicateSkipReason(ctx, cfg({ staleDuplicatePass: true }));
+    expect(reason).toContain('loop eligibility threshold not met');
+  });
+
+  it('is false when there are no patches at all, even when opted in', () => {
+    expect(
+      shouldRunStaleDuplicatePass(createTestContext(), cfg({ staleDuplicatePass: true })),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+describe('buildStaleDuplicatePassPrompts', () => {
+  it('hard-cuts the tool list to read_file + grep_codebase only', () => {
+    const { systemPrompt } = buildStaleDuplicatePassPrompts(eligibleContext());
+    expect(systemPrompt).toContain('read_file');
+    expect(systemPrompt).toContain('grep_codebase');
+    expect(systemPrompt).not.toContain('get_dependents');
+    expect(systemPrompt).not.toContain('get_files_context');
+    expect(systemPrompt).not.toContain('list_functions');
+    expect(systemPrompt).not.toContain('get_complexity');
+  });
+
+  it('includes the stale-duplicate rule strategy and example, scoped to this pass only', () => {
+    const { systemPrompt } = buildStaleDuplicatePassPrompts(eligibleContext());
+    expect(systemPrompt).toContain('Stale Duplicate Literal Check');
+    expect(systemPrompt).toContain('partial model bump leaves stale hardcoded copy');
+    expect(systemPrompt).not.toContain('Edge Case Sweep');
+    expect(systemPrompt).not.toContain('### Structural Analysis');
+  });
+
+  it('requires one findings-array entry per candidate id in the output format', () => {
+    const { systemPrompt } = buildStaleDuplicatePassPrompts(eligibleContext());
+    expect(systemPrompt).toContain('candidateId');
+    expect(systemPrompt).toContain('"verdict"');
+    expect(systemPrompt).toContain('candidate-1');
+  });
+
+  it('builds an initial message with the worklist, changed-site hunk, and surviving sites', () => {
+    const message = buildStaleDuplicatePassInitialMessage(eligibleContext());
+    expect(message).toContain('<pr_metadata>');
+    expect(message).toContain('<stale_duplicate_candidates>');
+    expect(message).toContain('candidate-1');
+    expect(message).toContain("'claude-sonnet-4-6'");
+    expect(message).toContain('Changed site: src/pr-review.ts:1');
+    expect(message).toContain('```diff');
+    expect(message).toContain('Surviving site(s):');
+    expect(message).toContain('src/pr-review.ts:20');
+  });
+
+  it('does not include competing signal blocks (blast radius, doc claims, etc.)', () => {
+    const message = buildStaleDuplicatePassInitialMessage(eligibleContext());
+    expect(message).not.toContain('<blast_radius>');
+    expect(message).not.toContain('<doc_claims>');
+    expect(message).not.toContain('<removed_exports>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+describe('staleDuplicatePassBudget', () => {
+  it('scales with candidate count, clamped to the floor for a single candidate', () => {
+    const budget = staleDuplicatePassBudget(100_000, eligibleContext());
+    // 1 candidate: 2000 + 800*1 = 2800, clamped up to the 4000 floor.
+    expect(budget).toBe(4_000);
+  });
+
+  it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {
+    const low = staleDuplicatePassBudget(10_000, eligibleContext());
+    const high = staleDuplicatePassBudget(500_000, eligibleContext());
+    expect(low).toBe(high);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postProcessStaleDuplicateResult
+// ---------------------------------------------------------------------------
+
+describe('postProcessStaleDuplicateResult', () => {
+  it('keeps only verdict:"stale" entries as real findings, stripping candidateId/verdict', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'stale', message: 'real bug' })],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toBe('real bug');
+    expect((result.findings[0] as Record<string, unknown>).candidateId).toBeUndefined();
+    expect((result.findings[0] as Record<string, unknown>).verdict).toBeUndefined();
+  });
+
+  it('drops intentional-reuse and unverifiable verdicts entirely', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'intentional-reuse', message: 'not stale' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('is complete when every candidate id got a verdict (single-candidate fixture)', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'unverifiable' })],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+  });
+
+  it('marks the result incomplete with stopReason "incomplete_verdict" when a candidate id is missing', () => {
+    const raw = fakeResult({ findings: [] }); // candidate-1 never got a verdict
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('keeps the ORIGINAL stopReason when the client was already incomplete for a real reason', () => {
+    const raw = fakeResult({ findings: [], incomplete: true, stopReason: 'budget' });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('budget'); // NOT overwritten to incomplete_verdict
+  });
+
+  it('does not mutate the input result', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'stale' })],
+    });
+    postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(raw.findings).toHaveLength(1);
+    expect((raw.findings[0] as Record<string, unknown>).candidateId).toBe('candidate-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeStaleDuplicateFindings — loop wins (opposite of doc-truth's dedupe)
+// ---------------------------------------------------------------------------
+
+describe('mergeStaleDuplicateFindings', () => {
+  it('drops a main-pass finding at the same location and keeps the loop finding', () => {
+    const main = [finding({ line: 20, ruleId: 'stale-duplicate', message: 'main freeform' })];
+    const loop = [finding({ line: 20, message: 'loop with evidence' })];
+
+    const merged = mergeStaleDuplicateFindings(main, loop);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('loop with evidence');
+    expect(merged[0].ruleId).toBe('stale-duplicate');
+  });
+
+  it('dedupes a nearby main finding (within ±2 lines) but keeps a distant one', () => {
+    const main = [
+      finding({ line: 21, message: 'near' }), // distance 1 from the loop finding at line 20 → dropped
+      finding({ line: 30, message: 'far' }), // distance 10 → kept
+    ];
+    const loop = [finding({ line: 20, message: 'loop' })];
+
+    const merged = mergeStaleDuplicateFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['far', 'loop'].sort());
+  });
+
+  it('forces ruleId to stale-duplicate on every loop finding', () => {
+    const loop = [finding({ ruleId: undefined, message: 'no-rule' })];
+    const merged = mergeStaleDuplicateFindings([], loop);
+    expect(merged[0].ruleId).toBe('stale-duplicate');
+  });
+
+  it('does not mutate the input arrays', () => {
+    const main = [finding({ filepath: 'a.ts', line: 1 })];
+    const loop = [finding({ filepath: 'b.ts', line: 1, ruleId: 'x' })];
+    mergeStaleDuplicateFindings(main, loop);
+    expect(loop[0].ruleId).toBe('x');
+    expect(main).toHaveLength(1);
+  });
+
+  it('appends a loop finding on a distinct file alongside an unrelated main finding', () => {
+    const main = [finding({ filepath: 'a.ts', line: 1, message: 'unrelated' })];
+    const loop = [finding({ filepath: 'b.ts', line: 1, message: 'loop' })];
+    const merged = mergeStaleDuplicateFindings(main, loop);
+    expect(merged.map(f => f.message).sort()).toEqual(['loop', 'unrelated']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeStaleDuplicateResultState
+// ---------------------------------------------------------------------------
+
+describe('mergeStaleDuplicateResultState', () => {
+  it('marks the merged result incomplete, naming this pass via incompleteFromPass', () => {
+    const main = fakeResult();
+    main.incomplete = false;
+    main.stopReason = 'completed';
+    const loop = fakeResult({ incomplete: true, stopReason: 'incomplete_verdict' });
+
+    mergeStaleDuplicateResultState(main, loop);
+
+    expect(main.incomplete).toBe(true);
+    expect(main.stopReason).toBe('incomplete_verdict');
+    expect(main.incompleteFromPass).toBe('stale-duplicate');
+  });
+
+  it('leaves an already-incomplete main pass untouched (no attribution overwrite)', () => {
+    const main = fakeResult({ incomplete: true, stopReason: 'max_turns' });
+    const loop = fakeResult({ incomplete: true, stopReason: 'budget' });
+
+    mergeStaleDuplicateResultState(main, loop);
+
+    expect(main.stopReason).toBe('max_turns');
+    expect(main.incompleteFromPass).toBeUndefined();
+  });
+
+  it('is a no-op when the loop pass is complete or null', () => {
+    const main = fakeResult();
+    mergeStaleDuplicateResultState(main, fakeResult());
+    expect(main.incomplete).toBe(false);
+
+    mergeStaleDuplicateResultState(main, null);
+    expect(main.incomplete).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Main-pass interaction override (LIEN_STALE_DUP_MAIN)
+// ---------------------------------------------------------------------------
+
+describe('applyStaleDuplicateMainOverride / isStaleDuplicateMainDisabled', () => {
+  it('is unchanged by default (flag unset)', () => {
+    expect(isStaleDuplicateMainDisabled()).toBe(false);
+    const ctx = eligibleContext();
+    const rules = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    const result = applyStaleDuplicateMainOverride(rules);
+    expect(result).toBe(rules); // same reference — true no-op
+    expect(result.active.map(r => r.id)).toContain('stale-duplicate');
+  });
+
+  it('strips stale-duplicate from active and records it as skipped when LIEN_STALE_DUP_MAIN=off', () => {
+    process.env.LIEN_STALE_DUP_MAIN = 'off';
+    expect(isStaleDuplicateMainDisabled()).toBe(true);
+    const ctx = eligibleContext();
+    const rules = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    const result = applyStaleDuplicateMainOverride(rules);
+    expect(result.active.map(r => r.id)).not.toContain('stale-duplicate');
+    expect(result.skipped.some(s => s.includes('stale-duplicate'))).toBe(true);
+  });
+
+  it('is unaffected by an unrelated env value', () => {
+    process.env.LIEN_STALE_DUP_MAIN = 'on';
+    expect(isStaleDuplicateMainDisabled()).toBe(false);
+  });
+
+  it("removes the main pass's <stale_literal_candidates> block end-to-end when the override strips the rule", () => {
+    const ctx = eligibleContext();
+    const rulesOn = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    expect(buildInitialMessage(ctx, { blastRadius: null, rules: rulesOn })).toContain(
+      '<stale_literal_candidates>',
+    );
+
+    process.env.LIEN_STALE_DUP_MAIN = 'off';
+    const rulesOff = applyStaleDuplicateMainOverride(
+      selectRules(BUILTIN_RULES, buildTriggerContext(ctx)),
+    );
+    expect(buildInitialMessage(ctx, { blastRadius: null, rules: rulesOff })).not.toContain(
+      '<stale_literal_candidates>',
+    );
+  });
+
+  it('a caller that never resolves rules (e.g. CLI mode) still gets the block regardless of the flag', () => {
+    process.env.LIEN_STALE_DUP_MAIN = 'off';
+    const ctx = eligibleContext();
+    expect(buildInitialMessage(ctx, { blastRadius: null })).toContain('<stale_literal_candidates>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STALE_DUPLICATE_PASS_SPEC (the ReviewPassSpec bundle)
+// ---------------------------------------------------------------------------
+
+describe('STALE_DUPLICATE_PASS_SPEC', () => {
+  it("wires this module's own pure functions into the ReviewPassSpec contract", () => {
+    expect(STALE_DUPLICATE_PASS_SPEC.name).toBe('stale-duplicate-loop');
+    expect(STALE_DUPLICATE_PASS_SPEC.skipPlugin).toBe('agent-review:stale-duplicate-loop');
+    expect(STALE_DUPLICATE_PASS_SPEC.maxTurns).toBe(STALE_DUP_PASS_MAX_TURNS);
+    expect(STALE_DUPLICATE_PASS_SPEC.mergeFindings).toBe(mergeStaleDuplicateFindings);
+    expect(STALE_DUPLICATE_PASS_SPEC.mergeResultState).toBe(mergeStaleDuplicateResultState);
+    expect(STALE_DUPLICATE_PASS_SPEC.postProcessResult).toBe(postProcessStaleDuplicateResult);
+  });
+
+  it('gateReason is staleDuplicateSkipReason', () => {
+    const ctx = eligibleContext();
+    expect(STALE_DUPLICATE_PASS_SPEC.gateReason(ctx, cfg({ staleDuplicatePass: true }))).toBeNull();
+    expect(STALE_DUPLICATE_PASS_SPEC.gateReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('buildPrompts delegates to buildStaleDuplicatePassPrompts', () => {
+    const ctx = eligibleContext();
+    expect(STALE_DUPLICATE_PASS_SPEC.buildPrompts(ctx)).toEqual(
+      buildStaleDuplicatePassPrompts(ctx),
+    );
+  });
+
+  it('budget delegates to staleDuplicatePassBudget', () => {
+    const ctx = eligibleContext();
+    expect(STALE_DUPLICATE_PASS_SPEC.budget(100_000, ctx)).toBe(
+      staleDuplicatePassBudget(100_000, ctx),
+    );
+  });
+});

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -202,7 +202,7 @@ describe('buildStaleDuplicatePassPrompts', () => {
   it('builds an initial message with the worklist, changed-site hunk, and surviving sites', () => {
     const message = buildStaleDuplicatePassInitialMessage(eligibleContext());
     expect(message).toContain('<pr_metadata>');
-    expect(message).toContain('<stale_duplicate_candidates>');
+    expect(message).toContain('<stale_literal_candidates>');
     expect(message).toContain('candidate-1');
     expect(message).toContain("'claude-sonnet-4-6'");
     expect(message).toContain('Changed site: src/pr-review.ts:1');
@@ -294,6 +294,59 @@ describe('postProcessStaleDuplicateResult', () => {
     expect(raw.findings).toHaveLength(1);
     expect((raw.findings[0] as Record<string, unknown>).candidateId).toBe('candidate-1');
   });
+
+  // Regression coverage for the CodeRabbit finding on this pass's initial
+  // version: candidateId-presence-only checking let a malformed entry
+  // (right id, missing/garbage verdict) count as "covered" while it was
+  // ALSO dropped from findings by the verdict==='stale' filter — a silent
+  // gap in both directions, the exact thing this pass's honesty contract
+  // exists to prevent.
+  it('is incomplete when a candidate id is present but its verdict is missing', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: undefined, message: 'no verdict' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0); // never silently promoted to a finding either
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is not a recognized value', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'maybe-stale' as never, message: 'bogus' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when the same candidate id is verdicted twice (duplicate, not "covered")', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable', message: 'first' }),
+        finding({ candidateId: 'candidate-1', verdict: 'stale', message: 'second' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when an entry names a candidate id outside the worklist', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
+        finding({ candidateId: 'candidate-99', verdict: 'stale', message: 'phantom candidate' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -312,16 +365,38 @@ describe('mergeStaleDuplicateFindings', () => {
     expect(merged[0].ruleId).toBe('stale-duplicate');
   });
 
-  it('dedupes a nearby main finding (within ±2 lines) but keeps a distant one', () => {
+  it('dedupes a nearby main-pass stale-duplicate finding (within ±2 lines) but keeps a distant one', () => {
     const main = [
-      finding({ line: 21, message: 'near' }), // distance 1 from the loop finding at line 20 → dropped
-      finding({ line: 30, message: 'far' }), // distance 10 → kept
+      // distance 1 from the loop finding at line 20, SAME rule → dropped
+      finding({ line: 21, ruleId: 'stale-duplicate', message: 'near' }),
+      finding({ line: 30, ruleId: 'stale-duplicate', message: 'far' }), // distance 10 → kept
     ];
     const loop = [finding({ line: 20, message: 'loop' })];
 
     const merged = mergeStaleDuplicateFindings(main, loop);
 
     expect(merged.map(f => f.message).sort()).toEqual(['far', 'loop'].sort());
+  });
+
+  // Regression coverage for the CodeRabbit finding on this pass's initial
+  // version: proximity-only matching could drop an UNRELATED rule's real
+  // finding just because it landed near a stale-duplicate loop finding.
+  it('does NOT drop a nearby main-pass finding from a DIFFERENT rule (proximity alone is not enough)', () => {
+    const main = [finding({ line: 20, ruleId: 'error-swallowing', message: 'unrelated real bug' })];
+    const loop = [finding({ line: 20, message: 'loop finding' })];
+
+    const merged = mergeStaleDuplicateFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unrelated real bug']);
+  });
+
+  it('does NOT drop a nearby main-pass finding with no ruleId at all', () => {
+    const main = [finding({ line: 20, ruleId: undefined, message: 'unattributed' })];
+    const loop = [finding({ line: 20, message: 'loop finding' })];
+
+    const merged = mergeStaleDuplicateFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unattributed']);
   });
 
   it('forces ruleId to stale-duplicate on every loop finding', () => {


### PR DESCRIPTION
## Summary

Builds the **stale-duplicate candidate-loop pilot** — the first real consumer of the `ReviewPassSpec` executor generalized today in #799, running against the tightened `stale-literal-signals.ts` from #800. Per `.wip/per-rule-loops-design.md` §4 (design session's worktree).

**Update**: CodeRabbit's first pass on this PR found 3 real bugs (a worklist tag-name mismatch against the reused rule text, a verdict-completeness check that could silently pass a malformed entry, and a dedupe that could drop an unrelated rule's finding) — all fixed in a follow-up commit; see the CodeRabbit thread replies for details. A 4th finding (demanding a live calibration run) was dismissed as out of scope per this build's explicit $0-spend directive. The numbers below reflect the post-fix state.

**Ships dark.** `config.staleDuplicatePass` (default `false`) or env `LIEN_STALE_DUP_PASS=on` opts in. A second flag, `LIEN_STALE_DUP_MAIN=off`, lets a future A/B arm strip the stale-duplicate rule + `<stale_literal_candidates>` block from the main pass entirely (also default-unchanged). Merging this PR changes no production behavior — see the byte-diff proof below.

## Pass spec summary

- **Gate** (`staleDuplicateSkipReason`): opt-in flag AND at least one candidate clearing the loop-eligibility threshold (below). Mirrors `docTruthSkipReason`'s "name the real reason" pattern.
- **Prompt**: bespoke (not `buildSystemPrompt` reuse) — trimmed tools (`read_file` + `grep_codebase` only, hard-cut per the design doc's §2), the `STALE_DUPLICATE` rule's own strategy/example text, and a per-candidate output contract.
- **Output contract**: one entry per candidate id, *inside* the standard `findings` JSON array (`candidateId` + `verdict: stale | intentional-reuse | unverifiable` as extra fields on each entry) — so the shared client's existing `readVerdict`/`isValidFinding` parsing needs zero changes. A new `ReviewPassSpec.postProcessResult` hook (added to `review-pass.ts`, optional, doc-truth doesn't need it) reduces that raw array to real findings and marks the result honestly incomplete (new `AgentStopReason: 'incomplete_verdict'`) when any worklist candidate never got a verdict — the pr658 Finding-A lesson made machine-checkable.
- **Budget**: candidate-count-scaled (`2000 + 800×min(candidates, 8)`, clamped 4000–30000), not a flat fraction — `ReviewPassSpec.budget` widened to receive `context` for this.
- **Merge**: loop finding **wins** over a colliding main-pass finding (opposite of doc-truth's dedupe) — it carries per-candidate evidence the shared loop's freeform grep doesn't.
- **Result state**: a still-incomplete loop marks the merged result incomplete via a new generic `AgentResult.incompleteFromPass` (pass-name-keyed), so `appendIncompleteNotice` names the right pass without yet another dedicated boolean like `incompleteFromDocPass`.

## Chosen eligibility threshold + census table

The main pass's `<stale_literal_candidates>` block is *not* a usable eligibility signal for a dedicated LLM call — a real-PR census (40 most recent merged PRs, zero LLM cost, signal code unmodified by this PR) shows it renders on the vast majority of PRs. I measured five threshold definitions against the same census, re-run twice for stability (identical both times):

| id | definition | real-PR firing rate |
|---|---|---:|
| A | any `confidence === 'high'` candidate | 33/40 (82.5%) |
| B | high confidence AND a production survivor in the same **project area** (`packages/<name>`) | 29/40 (72.5%) |
| C | B AND exactly one production survivor | 17/40 (42.5%) |
| **D (CHOSEN)** | **high confidence AND a production survivor in the SAME FILE as the changed site** | **14/40 (35.0%)** |
| E | D AND exactly one production survivor | 4/40 (10.0%) |

D lands inside the "genuinely selective" 15–40% band the brief asked for; E falls just below it. D is also the most semantically legible bar to explain ("the adapterContext.model-on-line-300-same-file-as-line-272 shape").

**Hard constraint verified**: the canonical true-positive fixture, `stale-duplicate/model-partial-update` (PR #539), clears **every** threshold including the strictest (E) — single production survivor, same file, high confidence.

Census script: `.wip/threshold-census.ts` in this session's worktree (not committed — zero-LLM, reproducible against `stale-literal-signals.ts` unmodified; re-run twice, byte-identical firing counts both times).

## Dogfood: verbatim pilot-pass worklist (flag ON, real fixture)

`LIEN_STALE_DUP_PASS=on`, `build-prompts.ts` against the regenerated `stale-duplicate/model-partial-update.fixture.json` (PR #539 @ `f780541`):

```
<stale_literal_candidates>
One verdict is REQUIRED per candidate id below (see <output_format>) — candidate-1. Each candidate is a literal this PR changed at the CHANGED SITE but that still appears unchanged at the SURVIVING SITE(S); judge whether each surviving site should track the changed site.

<candidate id="candidate-1" literal="'claude-sonnet-4-6'" confidence="high">
Changed site: packages/runner/src/handlers/pr-review.ts:272
```diff
@@ -269,10 +269,10 @@ export async function handlePRReview(
         'agent-review': {
           apiKey: config.openrouterApiKey || config.anthropicApiKey,
           provider: config.openrouterApiKey ? 'openai' : 'anthropic',
-          model: config.openrouterApiKey ? 'google/gemini-2.5-flash' : 'claude-sonnet-4-6',
+          model: config.openrouterApiKey ? 'google/gemini-3-flash-preview' : 'claude-sonnet-4-6',
           baseUrl: config.openrouterApiKey ? 'https://openrouter.ai/api/v1' : undefined,
-          inputCostPerMTok: config.openrouterApiKey ? 0.3 : 3,
-          outputCostPerMTok: config.openrouterApiKey ? 2.5 : 15,
+          inputCostPerMTok: config.openrouterApiKey ? 0.5 : 3,
+          outputCostPerMTok: config.openrouterApiKey ? 3 : 15,
           ...scaleAgentBudget(filesToAnalyze.length, chunks),
         },
       },
```
Surviving site(s):
  - packages/runner/src/handlers/pr-review.ts:300  `model: 'claude-sonnet-4-6',`
</candidate>
</stale_literal_candidates>

Judge every candidate above and output your verdicts as JSON.
```

This is the exact evidence a Sonnet/Kimi judge would see — the changed-site diff hunk plus the surviving occurrence, with no other candidate diluting its output budget. No paid LLM call was made against this (per the brief, the priced A/B is a separate owner-priced step). (Note: the tag is `<stale_literal_candidates>`, matching the reused rule text — the initial version of this pass had a mismatched tag name, caught by CodeRabbit and fixed; see the Summary.)

## Byte-diff neutrality proof (flag OFF)

`build-prompts.ts` (extended the same way #796 added `docTruthPass`, now also emits `staleDuplicatePass`) run against all 4 on-disk fixtures, at merge-base (`bf4841ff`, pre-pilot) vs this branch, flag OFF (default):

| fixture | systemPrompt | initialMessage | ruleIds | skippedRules | docTruthPass |
|---|---|---|---|---|---|
| `boundary-change/placeholder` | identical | identical | identical | identical | identical |
| `doc-truth/accurate-doc` | identical | identical | identical | identical | identical |
| `doc-truth/renamed-stale-claim` | identical | identical | identical | identical | identical |
| `stale-duplicate/model-partial-update` | identical | identical | identical | identical | identical |

**4/4 fixtures byte-identical** on every load-bearing prompt field. The only diff in the raw harness JSON is the new `staleDuplicatePass` diagnostic field itself, which reports `{"fires": false}` on all four (dark by default, as designed) — that field is new tooling output, not something fed to the LLM.

Mechanically: this required gating the main pass's `<stale_literal_candidates>` block on `isRuleActiveOrUnresolved` (system-prompt.ts) — a variant of the existing `isRuleActive` gate that treats an *omitted* `rules` argument as "render it" (preserving every caller, including the signal's own pre-existing unit tests, that never resolves rules at all) rather than "skip it". Only a caller that both resolves rules AND sets `LIEN_STALE_DUP_MAIN=off` loses the block — exercised directly in `plugins-agent-stale-duplicate-pass.test.ts`.

## Evidence (zero-LLM)

- **74 new/updated unit tests**, all passing: `plugins-agent-stale-duplicate-pass.test.ts` (41 — gate, prompt building incl. trimmed tools + worklist rendering, budget scaling, verdict post-processing incl. the honest-incompleteness path and the CodeRabbit-fix regressions for missing/invalid/duplicate/unknown verdict ids, loop-wins dedupe scoped to same-ruleId matches only, result-state merge, the `LIEN_STALE_DUP_MAIN` override end-to-end via `buildInitialMessage`, and the `ReviewPassSpec` bundle), `plugins-agent-review-pass.test.ts` (+3 — the new `postProcessResult` hook and `budget`'s widened `context` param), `plugins-agent-budget.test.ts` (+1 — `appendIncompleteNotice`'s generic `incompleteFromPass` branch).
- Full monorepo gate (re-run after the CodeRabbit fixup commit): `format:check` / `lint` (0 errors, 33 pre-existing warnings, none in new code) / `typecheck` / `build` / `test` (parser, core, review 1135, cli 860, action 39 — all green) / `lien delta` (exit 0, no new-over-threshold crossings).
- Byte-diff neutrality (below) and the verbatim worklist dogfood were both re-verified against the fixed-up code, not just the pre-fix version.
- Census + fixture-eligibility scripts and captured raw build-prompts JSON live in `.wip/` (gitignored, not committed) for anyone who wants to re-verify.

## Dogfood note

Per CLAUDE.md's mandatory dogfooding rule: the actual consumer here is `AgentReviewPlugin.analyze()`'s prompt-assembly pipeline, exercised end-to-end above via `build-prompts.ts` against a real captured PR fixture — both the flag-off (neutrality) and flag-on (worklist) paths. A live LLM call against this pass was **not** made; that's the separate, owner-priced `--calibrate 10` A/B this pilot's numbers are meant to price, per the brief ("do NOT run calibrations").

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green
- [x] `node packages/cli/dist/index.js delta` — exit 0
- [x] Byte-diff neutrality across all 4 on-disk fixtures, flag off
- [x] Verbatim worklist dogfood against the canonical fixture, flag on
- [x] Census table across 40 real PRs, threshold hard-constraint verified against the canonical fixture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an opt-in, dark-launched stale-duplicate pilot pass for candidate-loop duplicate detection, with configurable enablement via settings/env.
  * Added context-aware token budgeting and optional result post-processing for supplemental passes.
* **Bug Fixes**
  * Improved incomplete-review reporting to distinguish “main pass completed but extra pass incomplete,” including a new incomplete-verdict stop reason.
  * Enhanced merging so loop findings take precedence on location collisions.
* **Tests**
  * Added/extended test coverage for stale-duplicate gating, prompts, budgeting, post-processing, merging, and incomplete-review states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +1 |


> [!NOTE]
> **Low Risk**
>
> This PR introduces a dark-launched, opt-in stale-duplicate candidate-loop pilot and generalizes the extra-pass executor with a context-aware budget and an optional post-processing hook. The new pass is fully gated behind `config.staleDuplicatePass` / `LIEN_STALE_DUP_PASS=on`, the main-pass override is opt-out only, and the merge/incompleteness handling mirrors the existing doc-truth precedent. No concrete bugs producing wrong output or breaking callers were found in the inspected code.
>
> - Added STALE_DUPLICATE_PASS_SPEC wired after DOC_TRUTH_PASS_SPEC in EXTRA_PASSES
> - Extended ReviewPassSpec.budget to receive ReviewContext and added optional postProcessResult hook
> - Added AgentResult.incompleteFromPass and AgentStopReason 'incomplete_verdict' for generic extra-pass incompleteness
> - Gated the main pass's stale_literal_candidates block on isRuleActiveOrUnresolved so LIEN_STALE_DUP_MAIN=off can suppress it

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1379bb6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->