### PR TITLE
feat(review): incomplete-handling candidate-loop pass (default off)

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -29,7 +29,7 @@ import type { AgentConfig, AgentFinding, AgentResult, ResolvedRules } from './ty
 import { DOC_TRUTH } from './rules.js';
 import { buildSystemPrompt } from './system-prompt.js';
 import { envDisabled } from './agent-client-shared.js';
-import type { ReviewPassSpec } from './review-pass.js';
+import { renderPassPrHeader, type ReviewPassSpec } from './review-pass.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -134,13 +134,6 @@ function pushIfPresent(sections: string[], value: string | null | undefined): vo
   if (value) sections.push(value);
 }
 
-/** The PR title/body header, mirroring the main pass's <pr_metadata> block. */
-function renderPrHeader(context: ReviewContext): string | null {
-  if (!context.pr) return null;
-  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
-  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
-}
-
 /**
  * Build the claims-only initial message: the PR header, the intro that scopes
  * the pass to doc-truth, the <doc_claims> worklist WITH its pre-fetched
@@ -156,7 +149,7 @@ function renderPrHeader(context: ReviewContext): string | null {
  */
 export function buildDocTruthPassInitialMessage(context: ReviewContext): string {
   const sections: string[] = [];
-  pushIfPresent(sections, renderPrHeader(context));
+  pushIfPresent(sections, renderPassPrHeader(context));
   sections.push(DOC_PASS_INTRO);
   pushIfPresent(sections, renderDocClaimsSection(context));
   pushIfPresent(sections, renderRenameSweepSection(context));

--- a/packages/review/src/plugins/agent/incomplete-handling-pass.ts
+++ b/packages/review/src/plugins/agent/incomplete-handling-pass.ts
@@ -517,10 +517,16 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): bo
 
 /**
  * Reduce this pass's raw per-candidate verdict array down to real findings
- * (`verdict === 'incomplete'` only, cleaned of the loop-only fields), and
- * mark the result honestly incomplete when the verdict array doesn't
- * cleanly cover the worklist — same honesty contract as the pilot's
- * `postProcessStaleDuplicateResult`. When the underlying client result was
+ * (`verdict === 'incomplete'` AND `candidateId` names a real worklist entry
+ * only, cleaned of the loop-only fields), and mark the result honestly
+ * incomplete when the verdict array doesn't cleanly cover the worklist —
+ * same honesty contract as the pilot's `postProcessStaleDuplicateResult`.
+ * The candidateId check is required, not just the verdict value: a
+ * hallucinated/out-of-worklist id (`hasCompleteVerdictCoverage` already
+ * flags the RESULT incomplete for it) must not ALSO leak through as a real
+ * finding just because it happens to carry `verdict: 'incomplete'` — a
+ * phantom candidate is not a genuine one, regardless of the honesty flag
+ * (CodeRabbit finding on this PR). When the underlying client result was
  * ALREADY incomplete for a real reason (budget/max_turns/error), that
  * reason is kept as-is; `incomplete_verdict` is only used when the model
  * otherwise returned a syntactically complete verdict.
@@ -530,13 +536,21 @@ export function postProcessIncompleteHandlingResult(
   context: ReviewContext,
 ): AgentResult {
   const ids = candidateIds(computeIncompleteHandlingCandidates(context));
+  const expected = new Set(ids);
   const raw = result.findings as RawVerdictFinding[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
   const wasAlreadyIncomplete = result.incomplete;
 
   return {
     ...result,
-    findings: raw.filter(f => f.verdict === 'incomplete').map(toCleanFinding),
+    findings: raw
+      .filter(
+        f =>
+          f.verdict === 'incomplete' &&
+          typeof f.candidateId === 'string' &&
+          expected.has(f.candidateId),
+      )
+      .map(toCleanFinding),
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,

--- a/packages/review/src/plugins/agent/incomplete-handling-pass.ts
+++ b/packages/review/src/plugins/agent/incomplete-handling-pass.ts
@@ -1,0 +1,612 @@
+/**
+ * Dedicated incomplete-handling candidate-loop (per-rule-loops design doc
+ * §7 item 5, `.wip/per-rule-loops-design.md` in the design session's
+ * worktree) — the second candidate loop, structurally mirroring the
+ * stale-duplicate pilot (`stale-duplicate-pass.ts`, PR #803).
+ *
+ * `incomplete-handling` has THREE deterministic signals feeding the main
+ * pass today, each covering a different omission shape (system-prompt.ts's
+ * doc comment on `<incomplete-handling>` gating):
+ *  - `variant-sweep-signals.ts` — an added enum member / union arm /
+ *    const-object key whose consumer sites weren't updated.
+ *  - `sibling-surface-signals.ts` — a same-directory or mirror-directory
+ *    sibling file that didn't receive a matching change.
+ *  - `unread-field-signals.ts` — an added interface/type-literal/class
+ *    field with no read site anywhere in the indexed corpus.
+ *
+ * The design doc's gating-matrix row for this rule is explicit: build ONE
+ * candidate loop unifying all three shapes under the SAME `ruleId`, not
+ * three separate loops for one rule. This module does that: a single
+ * `<incomplete_handling_candidates>` worklist interleaves candidates from
+ * all three signals (each carrying its own `shape` tag and the evidence its
+ * signal already computed), judged with one per-candidate-id-required
+ * verdict contract — the same honesty mechanism the pilot's
+ * `postProcessStaleDuplicateResult` established for the pr658 Finding-A
+ * omission class (a long open worklist can under-report even inside a
+ * dedicated, single-rule pass).
+ *
+ * ## Verdict vocabulary: four values, not the pilot's three
+ *
+ * The pilot's `stale | intentional-reuse | unverifiable` doesn't fit this
+ * rule's three heterogeneous shapes as cleanly — a sibling-surface or
+ * variant-sweep candidate can turn out to be handled via a code path the
+ * signal's shallow textual match couldn't see (a helper function, a
+ * differently-named consumer), which is a distinct disposition from "the
+ * omission is deliberate" (an intentional catch-all default, a
+ * structurally-incapable sibling). This module uses:
+ *  - `incomplete` — the omission is real; converts to a finding.
+ *  - `handled` — investigation shows it IS actually handled, just not in a
+ *    way the textual signal could see (e.g. a dispatch table, a wrapper
+ *    that reads the field indirectly).
+ *  - `intentional` — the omission is a deliberate design choice (a
+ *    catch-all default, a sibling that structurally cannot support the
+ *    behavior, a documented gap).
+ *  - `unverifiable` — investigation couldn't confirm either way (budget,
+ *    or the evidence needed lives outside the indexed corpus).
+ * Only `incomplete` becomes a finding; the other three are silent
+ * dispositions the honesty contract still requires one of, per candidate.
+ *
+ * ## FP guard baked in from day one
+ *
+ * The stale-duplicate pilot's own eval found its loop wrongly flagging
+ * decorative test-double/mock/fixture data (2/51) — a known-avoidable FP
+ * class. This loop's prompt (`FP_GUARD` below) warns against it up front
+ * rather than discovering it the same way a second time.
+ *
+ * ## Toolset: read_file + get_files_context + grep_codebase
+ *
+ * Unlike the pilot's stale-literal candidates (which carry an inline
+ * snippet for every site), NONE of the three signals here attach a code
+ * snippet to a consumer/sibling/declaration site — only `file:line` plus
+ * metadata (which existing variants a consumer handles; which siblings
+ * lack/share a pattern). Judging a candidate therefore requires actually
+ * reading the referenced site, so `read_file` is load-bearing, not optional
+ * — a harder requirement than the pilot's "sometimes can't disambiguate
+ * from the snippet alone". `get_files_context` is added on top (not in the
+ * pilot's toolset) because this rule's omission shapes are inherently
+ * cross-file — "is the variant handled elsewhere?", "is the sibling
+ * updated?" — and a file's imports/call sites/test associations are exactly
+ * the structural view needed to judge whether an omission is handled via a
+ * different mechanism (a dispatch table, a wrapper) that the signal's
+ * token-level scan can't see. `grep_codebase` stays for the same reason the
+ * pilot keeps it: a documented escape hatch when the signal's own textual
+ * match (already a corpus-wide scan, more systematic than a one-off human
+ * grep) still leaves a specific candidate ambiguous — e.g. a dynamic/
+ * computed access the field-read patterns don't cover (see
+ * `unread-field-signals.ts`'s own documented gap). `get_dependents` /
+ * `list_functions` / `get_complexity` are still dropped: judging a handed
+ * candidate is not a symbol-search or complexity-triage task.
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+
+import type { AgentConfig, AgentFinding, AgentResult, ResolvedRules } from './types.js';
+import { INCOMPLETE_HANDLING } from './rules.js';
+import { envDisabled } from './agent-client-shared.js';
+import {
+  computeVariantSweepContexts,
+  type VariantSweepContext,
+} from '../../variant-sweep-signals.js';
+import { extractSiblingSurfaces, type SiblingSurfaceEntry } from '../../sibling-surface-signals.js';
+import {
+  computeUnreadFieldCandidates,
+  type UnreadFieldCandidate,
+} from '../../unread-field-signals.js';
+import { renderPassPrHeader, type ReviewPassSpec } from './review-pass.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn cap for the candidate-loop pass. Higher than the pilot's 6: unlike
+ * stale-literal's snippet-carrying candidates, every candidate here needs at
+ * least one read_file/get_files_context round trip before it can be judged
+ * (see module doc), so the loop needs headroom for that per-candidate cost.
+ */
+export const INCOMPLETE_PASS_MAX_TURNS = 8;
+
+const BASE_OVERHEAD_TOKENS = 2_500;
+const PER_CANDIDATE_TOKENS = 900;
+const MIN_BUDGET = 5_000;
+const MAX_BUDGET = 35_000;
+
+/** Mirrors variant-sweep-signals.ts's own MAX_ENTRIES cap — that module's compute()
+ * function is itself uncapped (its cap is applied only by its own renderer, which
+ * this unified pass does not use), so this pass re-applies the same cap locally. */
+const VARIANT_SWEEP_CAP = 12;
+/** Mirrors unread-field-signals.ts's own MAX_CANDIDATES cap, same reasoning. */
+const UNREAD_FIELD_CAP = 10;
+/** Combined worklist cap across all three shapes — bounds prompt size/budget even
+ * though sibling-surface's own compute() already self-caps at 15 (MAX_TOTAL_ENTRIES). */
+const MAX_TOTAL_CANDIDATES = 20;
+
+/** Opt-IN env flag — this loop ships dark by default, same as the pilot. */
+const INCOMPLETE_PASS_ENV = 'LIEN_INCOMPLETE_PASS';
+/** Opt-OUT env flag for the future A/B's "loop only" arm. */
+const INCOMPLETE_MAIN_ENV = 'LIEN_INCOMPLETE_MAIN';
+
+export const INCOMPLETE_HANDLING_RULE_ID = 'incomplete-handling';
+
+/** Plugin name this pass reports itself under in the delivery attestation. */
+const INCOMPLETE_SKIP_PLUGIN = 'agent-review:incomplete-handling-loop';
+
+/** Two findings on the same file within this many lines are the same location. */
+const DEDUPE_LINE_PROXIMITY = 2;
+
+const INCOMPLETE_INTRO =
+  'This is an INCOMPLETE-HANDLING candidate loop — a dedicated second pass scoped ' +
+  'to ONE rule, running only because deterministic scans already found at least ' +
+  'one high-confidence candidate. Your ONLY job is to judge the ' +
+  '<incomplete_handling_candidates> worklist below; do not report anything else ' +
+  '(other bugs, style, doc drift — those are handled elsewhere). The worklist mixes ' +
+  'THREE shapes, each labeled: `variant-sweep` (an added enum/union/const-object ' +
+  "member whose consumer sites weren't updated), `sibling-surface` (a family/mirror " +
+  'sibling file missing a matching change), and `unread-field` (an added field with ' +
+  'no read site anywhere in the indexed codebase).';
+
+const FP_GUARD =
+  'FALSE-POSITIVE GUARD: some candidates may point at test-double, mock, or fixture ' +
+  'data — inert scaffolding that mimics a production shape but is never exercised by ' +
+  'real runtime code. Before verdicting a candidate `incomplete`, confirm the omission ' +
+  'is in a REAL runtime consumer/sibling/field, not a test double or fixture standing ' +
+  "in for one. If the candidate's own site (or the sibling/consumer you inspect) is " +
+  'itself test/mock/fixture code, verdict `intentional` (a deliberate scaffolding gap) ' +
+  'rather than `incomplete`.';
+
+const INCOMPLETE_TOOLS_SECTION = `<tools>
+You have these tools to investigate the codebase:
+- read_file: Read file contents from the repo — REQUIRED for most candidates below, since none of the three signals attach a code snippet; you need the actual site's code to judge it.
+- get_files_context: Get imports, exports, and call sites for a file — use to check whether an omission is handled via a different mechanism (a dispatch table, a wrapper) the signal's textual scan couldn't see.
+- grep_codebase: Search the entire repository working tree for a text pattern (regex) — use ONLY to double-check a specific candidate the signal's own scan may have missed (e.g. dynamic/computed field access), not to re-discover candidates from scratch.
+</tools>`;
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Loop eligibility: at least one candidate from ANY of the three shapes.
+ * Unlike the stale-duplicate pilot (whose unconditional `always: true`
+ * trigger meant its raw signal block rendered on ~40/40 real PRs, forcing a
+ * stricter same-file/high-confidence threshold), this rule's real-PR firing
+ * rate is ALREADY selective: a 2026-07-16 census against this repo's last 40
+ * merged PRs found sibling-surface firing on 9/40 (22.5%), variant-sweep and
+ * unread-field firing on 0/40 each — so the union is still 9/40 (22.5%),
+ * inside the same "genuinely selective" range the pilot's own threshold
+ * targeted. No extra confidence tiering is needed on top of "any candidate
+ * exists" (see the PR body's census re-run for the up-to-date numbers).
+ */
+function hasEligibleCandidate(candidates: IncompleteHandlingCandidate[]): boolean {
+  return candidates.length > 0;
+}
+
+function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'on';
+}
+
+/** Whether the loop is opted in — config takes precedence, then the env flag. */
+export function isIncompleteHandlingPassEnabled(config?: AgentConfig): boolean {
+  if (config?.incompleteHandlingPass === true) return true;
+  return envEnabled(process.env[INCOMPLETE_PASS_ENV]);
+}
+
+/**
+ * Precisely why the incomplete-handling loop would not run right now, or
+ * null if it should run. Mirrors `staleDuplicateSkipReason`'s pattern.
+ */
+export function incompleteHandlingSkipReason(
+  context: ReviewContext,
+  config?: AgentConfig,
+): string | null {
+  if (!isIncompleteHandlingPassEnabled(config)) {
+    return (
+      `disabled (opt-in; set config.incompleteHandlingPass or ${INCOMPLETE_PASS_ENV}=on ` +
+      'to enable)'
+    );
+  }
+  const candidates = computeIncompleteHandlingCandidates(context);
+  if (!hasEligibleCandidate(candidates)) {
+    return 'no variant-sweep, sibling-surface, or unread-field candidate found';
+  }
+  return null;
+}
+
+/** Whether to run the incomplete-handling loop. True iff `incompleteHandlingSkipReason` is null. */
+export function shouldRunIncompleteHandlingPass(
+  context: ReviewContext,
+  config?: AgentConfig,
+): boolean {
+  return incompleteHandlingSkipReason(context, config) === null;
+}
+
+// ---------------------------------------------------------------------------
+// Main-pass interaction override (second flag, mirrors the pilot)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the MAIN pass's incomplete-handling rule + its three signal blocks
+ * should be suppressed — the future A/B's "loop only" arm. Default false: the
+ * main pass keeps the rule and its signals regardless of whether the
+ * dedicated loop is enabled, until the owner explicitly runs that arm.
+ */
+export function isIncompleteHandlingMainDisabled(): boolean {
+  const value = process.env[INCOMPLETE_MAIN_ENV];
+  return value?.trim().toLowerCase() === 'off' || envDisabled(value);
+}
+
+/**
+ * Strip `incomplete-handling` out of the resolved rule set when the
+ * main-pass override is on. Unlike stale-duplicate's `always: true` trigger
+ * (which needed a NEW `isRuleActiveOrUnresolved` gate added to
+ * system-prompt.ts, since its signal block rendered unconditionally before
+ * any override existed), `incomplete-handling`'s three signal blocks are
+ * ALREADY gated behind `isRuleActive(opts.rules, 'incomplete-handling')` in
+ * system-prompt.ts today — so removing this rule from `rules.active` is
+ * sufficient on its own to suppress `<variant_sweep_candidates>`,
+ * `<sibling_surfaces>`, and `<unread_field_candidates>` together; no change
+ * to system-prompt.ts's gating is needed for this override to work.
+ */
+export function applyIncompleteHandlingMainOverride(rules: ResolvedRules): ResolvedRules {
+  if (!isIncompleteHandlingMainDisabled()) return rules;
+  return {
+    active: rules.active.filter(r => r.id !== INCOMPLETE_HANDLING_RULE_ID),
+    skipped: [...rules.skipped, `${INCOMPLETE_HANDLING_RULE_ID} (${INCOMPLETE_MAIN_ENV}=off)`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unified candidate worklist
+// ---------------------------------------------------------------------------
+
+export type IncompleteHandlingShape = 'variant-sweep' | 'sibling-surface' | 'unread-field';
+
+/** One candidate from any of the three signal families, carrying its own shape's evidence. */
+export type IncompleteHandlingCandidate =
+  | { shape: 'variant-sweep'; variant: VariantSweepContext }
+  | { shape: 'sibling-surface'; sibling: SiblingSurfaceEntry }
+  | { shape: 'unread-field'; unreadField: UnreadFieldCandidate };
+
+/**
+ * Build the unified worklist: variant-sweep candidates first (rarest,
+ * most specific), then sibling-surface (this repo's dominant real-world
+ * producer, per the census), then unread-field — a fixed, deterministic
+ * order so candidate ids are stable across runs on the same PR. Each shape
+ * is capped locally (variant/unread — sibling-surface's own `compute()`
+ * already self-caps), then the combined list is capped at
+ * `MAX_TOTAL_CANDIDATES` with no further per-shape priority beyond this
+ * fixed ordering. Exposed for testing.
+ */
+export function computeIncompleteHandlingCandidates(
+  context: ReviewContext,
+): IncompleteHandlingCandidate[] {
+  const variants = computeVariantSweepContexts(context)
+    .slice(0, VARIANT_SWEEP_CAP)
+    .map((variant): IncompleteHandlingCandidate => ({ shape: 'variant-sweep', variant }));
+  const siblings = extractSiblingSurfaces(context).map(
+    (sibling): IncompleteHandlingCandidate => ({ shape: 'sibling-surface', sibling }),
+  );
+  const unread = computeUnreadFieldCandidates(context)
+    .slice(0, UNREAD_FIELD_CAP)
+    .map((unreadField): IncompleteHandlingCandidate => ({ shape: 'unread-field', unreadField }));
+
+  return [...variants, ...siblings, ...unread].slice(0, MAX_TOTAL_CANDIDATES);
+}
+
+function candidateIds(candidates: IncompleteHandlingCandidate[]): string[] {
+  return candidates.map((_, i) => `candidate-${i + 1}`);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction — per-shape candidate rendering
+// ---------------------------------------------------------------------------
+
+function renderHandled(names: string[]): string {
+  const MAX_LISTED = 6;
+  const shown = names.slice(0, MAX_LISTED);
+  const omitted = names.length - shown.length;
+  return omitted > 0 ? `${shown.join(', ')}, +${omitted} more` : shown.join(', ');
+}
+
+function renderVariantCandidate(id: string, v: VariantSweepContext): string {
+  const lines: string[] = [`<candidate id="${id}" shape="variant-sweep">`];
+  lines.push(`Added variant: ${v.typeName}.${v.variant} (added in ${v.file})`);
+  lines.push('Stale consumer site(s) not updated:');
+  for (const c of v.consumers) {
+    lines.push(`  - ${c.file}:${c.line} (handles: ${renderHandled(c.handledVariants)})`);
+  }
+  lines.push('</candidate>');
+  return lines.join('\n');
+}
+
+function renderSiblingCandidate(id: string, s: SiblingSurfaceEntry): string {
+  const siblingWord = s.isMirror ? 'mirror sibling' : 'sibling';
+  const siblingsList = s.siblings.join(', ');
+  const detail =
+    s.direction === 'unmirrored-addition'
+      ? `${s.display}${s.line ? ` (line ${s.line})` : ''} — added in ${s.file}, absent from ` +
+        `untouched ${siblingWord}(s): ${siblingsList}`
+      : `${s.display}(...) — shared by ${siblingWord}(s) ${siblingsList}, absent from ${s.file}`;
+  return `<candidate id="${id}" shape="sibling-surface" direction="${s.direction}">\n${detail}\n</candidate>`;
+}
+
+function renderUnreadFieldCandidate(id: string, u: UnreadFieldCandidate): string {
+  return (
+    `<candidate id="${id}" shape="unread-field">\n` +
+    `${u.typeName}.${u.field} (${u.kind}, added in ${u.file}:${u.line}) — no read site found ` +
+    'anywhere in the indexed codebase\n</candidate>'
+  );
+}
+
+function renderCandidate(id: string, c: IncompleteHandlingCandidate): string {
+  if (c.shape === 'variant-sweep') return renderVariantCandidate(id, c.variant);
+  if (c.shape === 'sibling-surface') return renderSiblingCandidate(id, c.sibling);
+  return renderUnreadFieldCandidate(id, c.unreadField);
+}
+
+/**
+ * Build the worklist — one entry per candidate id, interleaving all three
+ * shapes in the order `computeIncompleteHandlingCandidates` produces them.
+ */
+function renderWorklist(candidates: IncompleteHandlingCandidate[]): string {
+  const ids = candidateIds(candidates);
+  const lines: string[] = ['<incomplete_handling_candidates>'];
+  lines.push(
+    'One verdict is REQUIRED per candidate id below (see <output_format>) — ' +
+      `${ids.join(', ')}. Judge each candidate against its own shape's evidence; use ` +
+      'read_file/get_files_context to inspect the referenced site(s) before deciding.',
+  );
+  candidates.forEach((c, i) => {
+    lines.push('');
+    lines.push(renderCandidate(ids[i], c));
+  });
+  lines.push('</incomplete_handling_candidates>');
+  return lines.join('\n');
+}
+
+/** The per-candidate-verdict output contract — four verdicts (see module doc). */
+function buildOutputFormat(ids: string[]): string {
+  return `<output_format>
+Output EXACTLY one entry per candidate id in the \`findings\` array — one for EVERY
+id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
+
+{
+  "findings": [
+    {
+      "candidateId": "candidate-1",
+      "verdict": "incomplete | handled | intentional | unverifiable",
+      "filepath": "relative/path.ts",
+      "line": 42,
+      "severity": "error | warning",
+      "category": "logic_error",
+      "message": "REQUIRED for every verdict. When incomplete: 1-2 sentences naming the omission and its consequence. When handled/intentional/unverifiable: 1 sentence saying why.",
+      "suggestion": "The fix (incomplete only) — what to add so the omission is closed.",
+      "evidence": "One line citing the candidate and what you inspected to confirm it."
+    }
+  ],
+  "summary": {
+    "riskLevel": "low | medium | high | critical",
+    "overview": "One sentence.",
+    "keyChanges": []
+  }
+}
+
+EVERY entry requires candidateId, verdict, filepath, line, severity, and message —
+even for handled/intentional/unverifiable verdicts (fill filepath/line from the
+candidate's own site, severity "warning", message explaining the disposition).
+A missing candidateId for any worklist entry makes this pass's result incomplete.
+</output_format>`;
+}
+
+function buildSystemPrompt(ids: string[]): string {
+  return `${INCOMPLETE_INTRO}
+
+${FP_GUARD}
+
+${INCOMPLETE_TOOLS_SECTION}
+
+<strategy>
+${INCOMPLETE_HANDLING.prompt}
+</strategy>
+
+<examples>
+${INCOMPLETE_HANDLING.example}
+</examples>
+
+${buildOutputFormat(ids)}`;
+}
+
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. */
+export function buildIncompleteHandlingPassInitialMessage(context: ReviewContext): string {
+  const candidates = computeIncompleteHandlingCandidates(context);
+  const sections: string[] = [];
+  const header = renderPassPrHeader(context);
+  if (header) sections.push(header);
+  sections.push(renderWorklist(candidates));
+  sections.push('Judge every candidate above and output your verdicts as JSON.');
+  return sections.join('\n\n');
+}
+
+/** The system + initial prompts for the incomplete-handling candidate loop. */
+export function buildIncompleteHandlingPassPrompts(context: ReviewContext): {
+  systemPrompt: string;
+  initialMessage: string;
+} {
+  const ids = candidateIds(computeIncompleteHandlingCandidates(context));
+  return {
+    systemPrompt: buildSystemPrompt(ids),
+    initialMessage: buildIncompleteHandlingPassInitialMessage(context),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+/**
+ * Budget scaled by this pass's own combined candidate count (per the
+ * per-rule-loops design doc §2), clamped floor/ceiling — mirrors the
+ * pilot's `staleDuplicatePassBudget`.
+ */
+export function incompleteHandlingPassBudget(_baseBudget: number, context: ReviewContext): number {
+  const candidateCount = computeIncompleteHandlingCandidates(context).length;
+  const scaled =
+    BASE_OVERHEAD_TOKENS + PER_CANDIDATE_TOKENS * Math.min(candidateCount, MAX_TOTAL_CANDIDATES);
+  return Math.min(Math.max(scaled, MIN_BUDGET), MAX_BUDGET);
+}
+
+// ---------------------------------------------------------------------------
+// Post-processing (verdict reduction + honest completeness)
+// ---------------------------------------------------------------------------
+
+/** A verdict value the loop's output contract recognizes. */
+type Verdict = 'incomplete' | 'handled' | 'intentional' | 'unverifiable';
+const VALID_VERDICTS: ReadonlySet<string> = new Set<Verdict>([
+  'incomplete',
+  'handled',
+  'intentional',
+  'unverifiable',
+]);
+
+/** The raw per-candidate shape the model emits inside the standard `findings` array. */
+interface RawVerdictFinding extends AgentFinding {
+  candidateId?: string;
+  verdict?: Verdict;
+}
+
+/** Strip the loop-only `candidateId`/`verdict` fields, keeping the standard finding shape. */
+function toCleanFinding(f: RawVerdictFinding): AgentFinding {
+  return {
+    filepath: f.filepath,
+    line: f.line,
+    endLine: f.endLine,
+    symbolName: f.symbolName,
+    severity: f.severity,
+    category: f.category,
+    message: f.message,
+    suggestion: f.suggestion,
+    evidence: f.evidence,
+  };
+}
+
+/**
+ * True iff every expected candidate id appears in `raw` EXACTLY once, each
+ * with a RECOGNIZED verdict — and `raw` contains no entry with a missing/
+ * unknown candidateId or an unrecognized verdict. Same contract as the
+ * pilot's `hasCompleteVerdictCoverage` (see that module's doc for why
+ * candidateId-presence alone isn't enough): "one recognized verdict per
+ * expected id", not merely "every id mentioned somewhere".
+ */
+function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): boolean {
+  const expected = new Set(ids);
+  const verdictCounts = new Map<string, number>();
+  for (const { candidateId, verdict } of raw) {
+    if (
+      typeof candidateId !== 'string' ||
+      !expected.has(candidateId) ||
+      typeof verdict !== 'string' ||
+      !VALID_VERDICTS.has(verdict)
+    ) {
+      return false;
+    }
+    verdictCounts.set(candidateId, (verdictCounts.get(candidateId) ?? 0) + 1);
+  }
+  return ids.every(id => verdictCounts.get(id) === 1);
+}
+
+/**
+ * Reduce this pass's raw per-candidate verdict array down to real findings
+ * (`verdict === 'incomplete'` only, cleaned of the loop-only fields), and
+ * mark the result honestly incomplete when the verdict array doesn't
+ * cleanly cover the worklist — same honesty contract as the pilot's
+ * `postProcessStaleDuplicateResult`. When the underlying client result was
+ * ALREADY incomplete for a real reason (budget/max_turns/error), that
+ * reason is kept as-is; `incomplete_verdict` is only used when the model
+ * otherwise returned a syntactically complete verdict.
+ */
+export function postProcessIncompleteHandlingResult(
+  result: AgentResult,
+  context: ReviewContext,
+): AgentResult {
+  const ids = candidateIds(computeIncompleteHandlingCandidates(context));
+  const raw = result.findings as RawVerdictFinding[];
+  const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
+  const wasAlreadyIncomplete = result.incomplete;
+
+  return {
+    ...result,
+    findings: raw.filter(f => f.verdict === 'incomplete').map(toCleanFinding),
+    incomplete: wasAlreadyIncomplete || coverageIncomplete,
+    stopReason:
+      !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers
+// ---------------------------------------------------------------------------
+
+function sameLocation(a: AgentFinding, b: AgentFinding): boolean {
+  return a.filepath === b.filepath && Math.abs(a.line - b.line) <= DEDUPE_LINE_PROXIMITY;
+}
+
+/**
+ * Fold the loop's findings (already reduced to `verdict === 'incomplete'`
+ * only) into the main pass's. The LOOP finding wins on a same-location
+ * collision — same "loop wins" direction as the pilot, and scoped the same
+ * way: dropping is scoped to main-pass findings whose OWN `ruleId` is also
+ * `incomplete-handling`, never an unrelated rule's finding that merely lands
+ * within `DEDUPE_LINE_PROXIMITY` lines. Returns a new array; inputs are not
+ * mutated.
+ */
+export function mergeIncompleteHandlingFindings(
+  mainFindings: AgentFinding[],
+  loopFindings: AgentFinding[],
+): AgentFinding[] {
+  const forced = loopFindings.map(f => ({ ...f, ruleId: INCOMPLETE_HANDLING_RULE_ID }));
+  const survivingMain = mainFindings.filter(
+    mf => mf.ruleId !== INCOMPLETE_HANDLING_RULE_ID || !forced.some(lf => sameLocation(mf, lf)),
+  );
+  return [...survivingMain, ...forced];
+}
+
+/**
+ * Fold the loop's result-level state into the main pass's — only
+ * incomplete/stopReason propagate, naming this pass via the generic
+ * `incompleteFromPass` (see types.ts), same as the pilot.
+ */
+export function mergeIncompleteHandlingResultState(
+  main: AgentResult,
+  passResult: AgentResult | null,
+): AgentResult {
+  if (!passResult) return main;
+  if (passResult.incomplete && !main.incomplete) {
+    main.incomplete = true;
+    main.stopReason = passResult.stopReason;
+    main.incompleteFromPass = 'incomplete-handling';
+  }
+  return main;
+}
+
+// ---------------------------------------------------------------------------
+// ReviewPassSpec (plugs the loop into the generalized executor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Incomplete-handling candidate loop bundled as a `ReviewPassSpec` (see
+ * `review-pass.ts`). Every field here is one of this module's own pure
+ * functions; the generic executor supplies the gate-check/run/
+ * failure-isolation/reporting plumbing.
+ */
+export const INCOMPLETE_HANDLING_PASS_SPEC: ReviewPassSpec = {
+  name: 'incomplete-handling-loop',
+  skipPlugin: INCOMPLETE_SKIP_PLUGIN,
+  gateReason: incompleteHandlingSkipReason,
+  buildPrompts: buildIncompleteHandlingPassPrompts,
+  budget: incompleteHandlingPassBudget,
+  maxTurns: INCOMPLETE_PASS_MAX_TURNS,
+  mergeFindings: mergeIncompleteHandlingFindings,
+  mergeResultState: mergeIncompleteHandlingResultState,
+  postProcessResult: postProcessIncompleteHandlingResult,
+};

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -30,6 +30,10 @@ import {
   applyStaleDuplicateMainOverride,
 } from './stale-duplicate-pass.js';
 import {
+  INCOMPLETE_HANDLING_PASS_SPEC,
+  applyIncompleteHandlingMainOverride,
+} from './incomplete-handling-pass.js';
+import {
   runExtraPasses,
   type ReviewPassSpec,
   type PassClientRunner,
@@ -52,11 +56,19 @@ import {
  * Doc-truth is the proven precedent; the stale-duplicate candidate loop is
  * the pilot (per-rule-loops design doc §4) — dark by default, see
  * `stale-duplicate-pass.ts`'s own gate for why adding it here changes no
- * default behavior. The two passes have no data dependency on each other,
- * so declaration order doesn't matter for correctness (see review-pass.ts's
- * "serial for v1" note) — doc-truth stays first as the longer-proven pass.
+ * default behavior. The incomplete-handling candidate loop (design doc §7
+ * item 5) is the second build, unifying the variant-sweep/sibling-surface/
+ * unread-field signals into one dedicated pass — also dark by default, see
+ * `incomplete-handling-pass.ts`. None of these three passes has a data
+ * dependency on either of the others, so declaration order doesn't matter
+ * for correctness (see review-pass.ts's "serial for v1" note) — doc-truth
+ * stays first as the longer-proven pass.
  */
-const EXTRA_PASSES: ReviewPassSpec[] = [DOC_TRUTH_PASS_SPEC, STALE_DUPLICATE_PASS_SPEC];
+const EXTRA_PASSES: ReviewPassSpec[] = [
+  DOC_TRUTH_PASS_SPEC,
+  STALE_DUPLICATE_PASS_SPEC,
+  INCOMPLETE_HANDLING_PASS_SPEC,
+];
 
 const configSchema = z.object({
   apiKey: z.string().min(1),
@@ -102,6 +114,12 @@ const configSchema = z.object({
    * LIEN_STALE_DUP_PASS=on) to enable. See `stale-duplicate-pass.ts`.
    */
   staleDuplicatePass: z.boolean().default(false),
+  /**
+   * Run the incomplete-handling candidate loop (per-rule-loops design doc
+   * §7 item 5). Default false — dark-launched opt-in; set true (or env
+   * LIEN_INCOMPLETE_PASS=on) to enable. See `incomplete-handling-pass.ts`.
+   */
+  incompleteHandlingPass: z.boolean().default(false),
 });
 
 export interface AgentReviewPluginOptions {
@@ -161,11 +179,14 @@ export class AgentReviewPlugin implements ReviewPlugin {
       });
 
     // Select active rules based on PR content (languages, diff keywords).
-    // applyStaleDuplicateMainOverride is a no-op unless LIEN_STALE_DUP_MAIN=off
-    // (see stale-duplicate-pass.ts) — the pilot's future "loop only, no
-    // shared-loop backstop" A/B arm.
+    // applyStaleDuplicateMainOverride/applyIncompleteHandlingMainOverride are
+    // no-ops unless LIEN_STALE_DUP_MAIN=off / LIEN_INCOMPLETE_MAIN=off (see
+    // stale-duplicate-pass.ts / incomplete-handling-pass.ts) — each pass's
+    // future "loop only, no shared-loop backstop" A/B arm.
     const triggerCtx = buildTriggerContext(context);
-    const rules = applyStaleDuplicateMainOverride(selectRules(BUILTIN_RULES, triggerCtx));
+    const rules = applyIncompleteHandlingMainOverride(
+      applyStaleDuplicateMainOverride(selectRules(BUILTIN_RULES, triggerCtx)),
+    );
     logger.info(
       `[${this.id}] Rules: ${rules.active.map(r => r.id).join(', ')} (skipped: ${rules.skipped.join(', ') || 'none'})`,
     );

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -86,6 +86,19 @@ export interface ReviewPassSpec {
   postProcessResult?(result: AgentResult, context: ReviewContext): AgentResult;
 }
 
+/**
+ * The PR title/body header, mirroring the main pass's `<pr_metadata>` block.
+ * Shared by every extra pass's prompt builder (doc-truth, stale-duplicate,
+ * incomplete-handling) — extracted here on this module's third identical
+ * copy rather than left duplicated a third time (CLAUDE.md's DRY guidance:
+ * wait for the 3rd use).
+ */
+export function renderPassPrHeader(context: ReviewContext): string | null {
+  if (!context.pr) return null;
+  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
+  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
+}
+
 /** A pass's client loop, closed over the pass-agnostic transport (provider/apiKey/toolExecutor). */
 export type PassClientRunner = (
   systemPrompt: string,

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -276,7 +276,7 @@ For code with DB transactions, locks, or shared state:
   source: 'builtin',
 };
 
-const INCOMPLETE_HANDLING: ReviewRule = {
+export const INCOMPLETE_HANDLING: ReviewRule = {
   id: 'incomplete-handling',
   name: 'Incomplete Interface/Type Handling',
   description:

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -49,7 +49,7 @@ import {
   computeStaleLiteralCandidates,
   type StaleLiteralCandidate,
 } from '../../stale-literal-signals.js';
-import type { ReviewPassSpec } from './review-pass.js';
+import { renderPassPrHeader, type ReviewPassSpec } from './review-pass.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -209,13 +209,6 @@ function candidateIds(candidates: StaleLiteralCandidate[]): string[] {
   return candidates.map((_, i) => `candidate-${i + 1}`);
 }
 
-/** The PR title/body header, mirroring the main pass's <pr_metadata> block. */
-function renderPrHeader(context: ReviewContext): string | null {
-  if (!context.pr) return null;
-  const body = context.pr.body ? `\nDescription: ${context.pr.body}` : '';
-  return `<pr_metadata>\nTitle: ${context.pr.title}${body}\n</pr_metadata>`;
-}
-
 const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
 /**
@@ -361,7 +354,7 @@ ${buildOutputFormat(ids)}`;
 export function buildStaleDuplicatePassInitialMessage(context: ReviewContext): string {
   const candidates = computeStaleLiteralCandidates(context);
   const sections: string[] = [];
-  const header = renderPrHeader(context);
+  const header = renderPassPrHeader(context);
   if (header) sections.push(header);
   sections.push(renderWorklist(context, candidates));
   sections.push('Judge every candidate above and output your verdicts as JSON.');

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -64,6 +64,14 @@ export interface AgentConfig {
    * LIEN_STALE_DUP_PASS=on) to enable it. See `stale-duplicate-pass.ts`.
    */
   staleDuplicatePass?: boolean;
+  /**
+   * Run the incomplete-handling candidate loop (per-rule-loops design doc
+   * §7 item 5) — unifies the variant-sweep/sibling-surface/unread-field
+   * signals into one dedicated pass. Default false — dark-launched; set
+   * true (or env LIEN_INCOMPLETE_PASS=on) to enable it. See
+   * `incomplete-handling-pass.ts`.
+   */
+  incompleteHandlingPass?: boolean;
 }
 
 /** A single finding produced by the agent during review. */

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -15,10 +15,11 @@
  * (`buildDocTruthPassPrompts`) from the main pass's `buildInitialMessage`.
  *
  * Same for the stale-duplicate candidate-loop PILOT (`staleDuplicatePass`,
- * per-rule-loops design doc §4) — dark by default, so `fires` is false
- * unless the fixture's captured config (or LIEN_STALE_DUP_PASS=on in the
- * environment this script runs in) opts in AND the loop-eligibility
- * threshold is met.
+ * per-rule-loops design doc §4) and the incomplete-handling candidate loop
+ * (`incompleteHandlingPass`, design doc §7 item 5) — both dark by default,
+ * so `fires` is false unless the fixture's captured config (or the
+ * relevant env flag in the environment this script runs in) opts in AND
+ * that loop's own eligibility gate is met.
  *
  * Usage: tsx build-prompts.ts <fixture.json>
  */
@@ -36,6 +37,11 @@ import {
   buildStaleDuplicatePassPrompts,
   applyStaleDuplicateMainOverride,
 } from '../../src/plugins/agent/stale-duplicate-pass.js';
+import {
+  shouldRunIncompleteHandlingPass,
+  buildIncompleteHandlingPassPrompts,
+  applyIncompleteHandlingMainOverride,
+} from '../../src/plugins/agent/incomplete-handling-pass.js';
 import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
@@ -51,7 +57,9 @@ async function main(): Promise<void> {
   const config = ctx.config as unknown as AgentConfig | undefined;
 
   const triggerCtx = buildTriggerContext(ctx);
-  const rules = applyStaleDuplicateMainOverride(selectRules(BUILTIN_RULES, triggerCtx));
+  const rules = applyIncompleteHandlingMainOverride(
+    applyStaleDuplicateMainOverride(selectRules(BUILTIN_RULES, triggerCtx)),
+  );
 
   const systemPrompt = buildSystemPrompt(rules);
   const initialMessage = buildInitialMessage(ctx, { blastRadius: null, rules });
@@ -66,6 +74,11 @@ async function main(): Promise<void> {
     ? { fires: true as const, ...buildStaleDuplicatePassPrompts(ctx) }
     : { fires: false as const };
 
+  const incompleteHandlingFires = shouldRunIncompleteHandlingPass(ctx, config);
+  const incompleteHandlingPass = incompleteHandlingFires
+    ? { fires: true as const, ...buildIncompleteHandlingPassPrompts(ctx) }
+    : { fires: false as const };
+
   const output = {
     fixturePath,
     ruleIds: rules.active.map(r => r.id),
@@ -74,6 +87,7 @@ async function main(): Promise<void> {
     initialMessage,
     docTruthPass,
     staleDuplicatePass,
+    incompleteHandlingPass,
   };
 
   process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
+++ b/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
@@ -1,0 +1,829 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+
+import {
+  incompleteHandlingSkipReason,
+  shouldRunIncompleteHandlingPass,
+  computeIncompleteHandlingCandidates,
+  buildIncompleteHandlingPassPrompts,
+  buildIncompleteHandlingPassInitialMessage,
+  incompleteHandlingPassBudget,
+  postProcessIncompleteHandlingResult,
+  mergeIncompleteHandlingFindings,
+  mergeIncompleteHandlingResultState,
+  isIncompleteHandlingMainDisabled,
+  applyIncompleteHandlingMainOverride,
+  INCOMPLETE_HANDLING_PASS_SPEC,
+  INCOMPLETE_PASS_MAX_TURNS,
+} from '../src/plugins/agent/incomplete-handling-pass.js';
+import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../src/plugins/agent/rules.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { createTestContext } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'block',
+      language: file.endsWith('.php') ? 'php' : 'typescript',
+    },
+  } as unknown as CodeChunk;
+}
+
+// ---- variant-sweep shape (mirrors variant-sweep-signals.test.ts's Color enum) ----
+
+const COLOR_ENUM = ['export enum Color {', '  Red,', '  Blue,', '  Green,', '}'].join('\n');
+const COLOR_ENUM_PATCH = [
+  '@@ -1,4 +1,5 @@',
+  ' export enum Color {',
+  '   Red,',
+  '   Blue,',
+  '+  Green,',
+  ' }',
+].join('\n');
+
+function colorSwitchConsumer(): string {
+  return [
+    'function label(c: Color): string {',
+    '  switch (c) {',
+    '    case Color.Red:',
+    "      return 'red';",
+    '    case Color.Blue:',
+    "      return 'blue';",
+    '    default:',
+    "      return 'unknown';",
+    '  }',
+    '}',
+  ].join('\n');
+}
+
+// ---- sibling-surface shape (mirrors sibling-surface-signals.test.ts's guzzle #3740 shape) ----
+
+const CURL_HANDLER_PATCH = `@@ -1,7 +1,14 @@
+ <?php
+ class CurlHandler {
+     public function handle($options) {
+         $this->validateOptions($options);
++        if (isset($options['on_trailers'])) {
++            $this->assertOnTrailersCallable($options);
++        }
+     }
++
++    private function assertOnTrailersCallable($options) {
++        if (!is_callable($options['on_trailers'])) {
++            throw new InvalidArgumentException('on_trailers must be callable');
++        }
++    }
+ }`;
+
+const CURL_HANDLER_CONTENT = [
+  '<?php',
+  'class CurlHandler {',
+  '    public function handle($options) {',
+  '        $this->validateOptions($options);',
+  "        if (isset(\$options['on_trailers'])) {",
+  '            $this->assertOnTrailersCallable($options);',
+  '        }',
+  '    }',
+  '',
+  '    private function assertOnTrailersCallable($options) {',
+  "        if (!is_callable(\$options['on_trailers'])) {",
+  "            throw new InvalidArgumentException('on_trailers must be callable');",
+  '        }',
+  '    }',
+  '}',
+].join('\n');
+
+const STREAM_HANDLER_CONTENT = [
+  '<?php',
+  'class StreamHandler {',
+  '    public function handle($options) {',
+  '        $this->validateOptions($options);',
+  '    }',
+  '}',
+].join('\n');
+
+// ---- unread-field shape (mirrors unread-field-signals.test.ts's brand-new interface) ----
+
+const OPTIONS_INTERFACE = ['export interface Options {', '  timeout: number;', '}'].join('\n');
+const OPTIONS_PATCH = [
+  '@@ -0,0 +1,3 @@',
+  '+export interface Options {',
+  '+  timeout: number;',
+  '+}',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Single-shape eligible contexts
+// ---------------------------------------------------------------------------
+
+function variantOnlyContext(): ReviewContext {
+  const patches = new Map([['src/color.ts', COLOR_ENUM_PATCH]]);
+  const chunks = [makeChunk('src/color.ts', 1, COLOR_ENUM)];
+  const repoChunks = [...chunks, makeChunk('src/consumer.ts', 1, colorSwitchConsumer())];
+  return createTestContext({
+    changedFiles: ['src/color.ts'],
+    chunks,
+    repoChunks,
+    pr: { title: 'Add Green variant', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+function siblingOnlyContext(): ReviewContext {
+  const patches = new Map([['src/Handler/CurlHandler.php', CURL_HANDLER_PATCH]]);
+  const repoChunks = [
+    makeChunk('src/Handler/CurlHandler.php', 1, CURL_HANDLER_CONTENT),
+    makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+  ];
+  return createTestContext({
+    changedFiles: ['src/Handler/CurlHandler.php'],
+    chunks: [],
+    repoChunks,
+    pr: { title: 'Add on_trailers', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+function unreadFieldOnlyContext(): ReviewContext {
+  const patches = new Map([['src/options.ts', OPTIONS_PATCH]]);
+  const chunks = [makeChunk('src/options.ts', 1, OPTIONS_INTERFACE)];
+  return createTestContext({
+    changedFiles: ['src/options.ts'],
+    chunks,
+    repoChunks: chunks,
+    pr: { title: 'Add Options.timeout', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** Combines all three single-shape fixtures into one context — every shape fires. */
+function mixedContext(): ReviewContext {
+  const patches = new Map([
+    ['src/color.ts', COLOR_ENUM_PATCH],
+    ['src/Handler/CurlHandler.php', CURL_HANDLER_PATCH],
+    ['src/options.ts', OPTIONS_PATCH],
+  ]);
+  const chunks = [
+    makeChunk('src/color.ts', 1, COLOR_ENUM),
+    makeChunk('src/options.ts', 1, OPTIONS_INTERFACE),
+  ];
+  const repoChunks = [
+    ...chunks,
+    makeChunk('src/consumer.ts', 1, colorSwitchConsumer()),
+    makeChunk('src/Handler/CurlHandler.php', 1, CURL_HANDLER_CONTENT),
+    makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+  ];
+  return createTestContext({
+    changedFiles: ['src/color.ts', 'src/Handler/CurlHandler.php', 'src/options.ts'],
+    chunks,
+    repoChunks,
+    pr: { title: 'Mixed omission shapes', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** No signal fires at all — an ordinary PR with no omission-shaped diff. */
+function noCandidateContext(): ReviewContext {
+  const patches = new Map([['src/plain.ts', '@@ -1,1 +1,1 @@\n-const x = 1;\n+const x = 2;']]);
+  return createTestContext({
+    changedFiles: ['src/plain.ts'],
+    chunks: [],
+    repoChunks: [],
+    pr: { title: 'Trivial change', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+function finding(overrides: Record<string, unknown> = {}): AgentFinding {
+  return {
+    filepath: 'src/consumer.ts',
+    line: 3,
+    severity: 'warning',
+    category: 'logic_error',
+    message: 'msg',
+    ...overrides,
+  } as AgentFinding;
+}
+
+function fakeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2, cost: 0.01 },
+    turns: 1,
+    stopReason: 'completed',
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  delete process.env.LIEN_INCOMPLETE_PASS;
+  delete process.env.LIEN_INCOMPLETE_MAIN;
+});
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+describe('incompleteHandlingSkipReason / shouldRunIncompleteHandlingPass', () => {
+  it('is false (disabled) by default, even with an eligible candidate — ships dark', () => {
+    const ctx = siblingOnlyContext();
+    expect(shouldRunIncompleteHandlingPass(ctx, cfg())).toBe(false);
+    expect(incompleteHandlingSkipReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('is true when opted in via config AND a sibling-surface candidate exists', () => {
+    const ctx = siblingOnlyContext();
+    expect(shouldRunIncompleteHandlingPass(ctx, cfg({ incompleteHandlingPass: true }))).toBe(true);
+  });
+
+  it('is true when opted in via config AND a variant-sweep candidate exists', () => {
+    const ctx = variantOnlyContext();
+    expect(shouldRunIncompleteHandlingPass(ctx, cfg({ incompleteHandlingPass: true }))).toBe(true);
+  });
+
+  it('is true when opted in via config AND an unread-field candidate exists', () => {
+    const ctx = unreadFieldOnlyContext();
+    expect(shouldRunIncompleteHandlingPass(ctx, cfg({ incompleteHandlingPass: true }))).toBe(true);
+  });
+
+  it('is true when opted in via LIEN_INCOMPLETE_PASS=on (no config flag)', () => {
+    process.env.LIEN_INCOMPLETE_PASS = 'on';
+    const ctx = siblingOnlyContext();
+    expect(shouldRunIncompleteHandlingPass(ctx, cfg())).toBe(true);
+  });
+
+  it('is false when opted in but no candidate exists in any of the three shapes', () => {
+    const ctx = noCandidateContext();
+    const reason = incompleteHandlingSkipReason(ctx, cfg({ incompleteHandlingPass: true }));
+    expect(reason).toContain('no variant-sweep, sibling-surface, or unread-field candidate found');
+  });
+
+  it('is false when there are no patches at all, even when opted in', () => {
+    expect(
+      shouldRunIncompleteHandlingPass(createTestContext(), cfg({ incompleteHandlingPass: true })),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unified worklist building
+// ---------------------------------------------------------------------------
+
+describe('computeIncompleteHandlingCandidates', () => {
+  it('builds a single variant-sweep candidate from a variant-only context', () => {
+    const candidates = computeIncompleteHandlingCandidates(variantOnlyContext());
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].shape).toBe('variant-sweep');
+    if (candidates[0].shape === 'variant-sweep') {
+      expect(candidates[0].variant.typeName).toBe('Color');
+      expect(candidates[0].variant.variant).toBe('Green');
+    }
+  });
+
+  it('builds sibling-surface candidate(s) from a sibling-only context', () => {
+    const candidates = computeIncompleteHandlingCandidates(siblingOnlyContext());
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates.every(c => c.shape === 'sibling-surface')).toBe(true);
+    const onTrailers = candidates.find(
+      c => c.shape === 'sibling-surface' && c.sibling.display.includes('on_trailers'),
+    );
+    expect(onTrailers).toBeDefined();
+  });
+
+  it('builds a single unread-field candidate from an unread-field-only context', () => {
+    const candidates = computeIncompleteHandlingCandidates(unreadFieldOnlyContext());
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].shape).toBe('unread-field');
+    if (candidates[0].shape === 'unread-field') {
+      expect(candidates[0].unreadField.typeName).toBe('Options');
+      expect(candidates[0].unreadField.field).toBe('timeout');
+    }
+  });
+
+  it('returns [] for a context with no signal in any shape', () => {
+    expect(computeIncompleteHandlingCandidates(noCandidateContext())).toEqual([]);
+  });
+
+  it('combines all three shapes in a mixed context, in variant/sibling/unread order', () => {
+    const candidates = computeIncompleteHandlingCandidates(mixedContext());
+    const shapes = candidates.map(c => c.shape);
+    expect(shapes).toContain('variant-sweep');
+    expect(shapes).toContain('sibling-surface');
+    expect(shapes).toContain('unread-field');
+    // Fixed ordering: every variant-sweep entry precedes every sibling-surface
+    // entry, which precedes every unread-field entry — candidate ids must
+    // stay stable across runs on the same PR.
+    const firstSibling = shapes.indexOf('sibling-surface');
+    const firstUnread = shapes.indexOf('unread-field');
+    const lastVariant = shapes.lastIndexOf('variant-sweep');
+    const lastSibling = shapes.lastIndexOf('sibling-surface');
+    expect(lastVariant).toBeLessThan(firstSibling);
+    expect(lastSibling).toBeLessThan(firstUnread);
+  });
+
+  it("caps a single shape's own contribution (unread-field) at its own per-shape cap (10)", () => {
+    // 25 brand-new interface fields, none read anywhere — far more than any
+    // single real PR, but exercises the per-shape cap path deterministically.
+    const fieldLines = Array.from({ length: 25 }, (_, i) => `  field${i}: number;`);
+    const content = ['export interface Big {', ...fieldLines, '}'].join('\n');
+    const patchLines = [
+      '@@ -0,0 +1,27 @@',
+      '+export interface Big {',
+      ...fieldLines.map(l => `+${l}`),
+      '+}',
+    ];
+    const patches = new Map([['src/big.ts', patchLines.join('\n')]]);
+    const chunks = [makeChunk('src/big.ts', 1, content)];
+    const ctx = createTestContext({
+      changedFiles: ['src/big.ts'],
+      chunks,
+      repoChunks: chunks,
+      pr: { title: 'Add many fields', body: '', patches } as unknown as ReviewContext['pr'],
+    });
+    const candidates = computeIncompleteHandlingCandidates(ctx);
+    expect(candidates).toHaveLength(10);
+    expect(candidates.every(c => c.shape === 'unread-field')).toBe(true);
+  });
+
+  it('caps the COMBINED worklist at MAX_TOTAL_CANDIDATES (20) once two shapes together exceed it', () => {
+    // 2 pre-existing enum members + 12 newly-added ones, all left unhandled by
+    // a consumer that only enumerates the 2 pre-existing members — 12
+    // variant-sweep candidates (the per-shape cap for that signal). Combined
+    // with the 25-field (capped to 10) unread-field fixture above, that's
+    // 22 raw candidates — over MAX_TOTAL_CANDIDATES (20).
+    const addedMembers = Array.from({ length: 12 }, (_, i) => `Add${i + 1}`);
+    const enumContent = [
+      'export enum Color {',
+      '  Legacy1,',
+      '  Legacy2,',
+      ...addedMembers.map(m => `  ${m},`),
+      '}',
+    ].join('\n');
+    const enumPatch = [
+      '@@ -1,4 +1,16 @@',
+      ' export enum Color {',
+      '   Legacy1,',
+      '   Legacy2,',
+      ...addedMembers.map(m => `+  ${m},`),
+      ' }',
+    ].join('\n');
+    const consumerContent = [
+      'function label(c: Color): string {',
+      '  switch (c) {',
+      '    case Color.Legacy1:',
+      "      return 'a';",
+      '    case Color.Legacy2:',
+      "      return 'b';",
+      '    default:',
+      "      return 'unknown';",
+      '  }',
+      '}',
+    ].join('\n');
+
+    const fieldLines = Array.from({ length: 25 }, (_, i) => `  field${i}: number;`);
+    const fieldContent = ['export interface Big {', ...fieldLines, '}'].join('\n');
+    const fieldPatch = [
+      '@@ -0,0 +1,27 @@',
+      '+export interface Big {',
+      ...fieldLines.map(l => `+${l}`),
+      '+}',
+    ].join('\n');
+
+    const patches = new Map([
+      ['src/color.ts', enumPatch],
+      ['src/big.ts', fieldPatch],
+    ]);
+    const chunks = [
+      makeChunk('src/color.ts', 1, enumContent),
+      makeChunk('src/big.ts', 1, fieldContent),
+    ];
+    const repoChunks = [...chunks, makeChunk('src/consumer.ts', 1, consumerContent)];
+    const ctx = createTestContext({
+      changedFiles: ['src/color.ts', 'src/big.ts'],
+      chunks,
+      repoChunks,
+      pr: {
+        title: 'Add many variants and fields',
+        body: '',
+        patches,
+      } as unknown as ReviewContext['pr'],
+    });
+
+    const candidates = computeIncompleteHandlingCandidates(ctx);
+    expect(candidates).toHaveLength(20);
+    expect(candidates.filter(c => c.shape === 'variant-sweep')).toHaveLength(12);
+    expect(candidates.filter(c => c.shape === 'unread-field')).toHaveLength(8); // 10 capped, then trimmed to fit 20
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+describe('buildIncompleteHandlingPassPrompts', () => {
+  it('hard-cuts the tool list to read_file + get_files_context + grep_codebase', () => {
+    const { systemPrompt } = buildIncompleteHandlingPassPrompts(mixedContext());
+    expect(systemPrompt).toContain('read_file');
+    expect(systemPrompt).toContain('get_files_context');
+    expect(systemPrompt).toContain('grep_codebase');
+    expect(systemPrompt).not.toContain('get_dependents');
+    expect(systemPrompt).not.toContain('list_functions');
+    expect(systemPrompt).not.toContain('get_complexity');
+  });
+
+  it('includes the incomplete-handling rule strategy and example, scoped to this pass only', () => {
+    const { systemPrompt } = buildIncompleteHandlingPassPrompts(mixedContext());
+    expect(systemPrompt).toContain('Incomplete Handling Check');
+    expect(systemPrompt).toContain('RuleTriggers.filePatterns');
+    expect(systemPrompt).not.toContain('Stale Duplicate Literal Check');
+    expect(systemPrompt).not.toContain('### Structural Analysis');
+  });
+
+  it('includes the false-positive guard against test-double/mock/fixture data', () => {
+    const { systemPrompt } = buildIncompleteHandlingPassPrompts(mixedContext());
+    expect(systemPrompt).toContain('FALSE-POSITIVE GUARD');
+    expect(systemPrompt).toContain('test-double');
+  });
+
+  it('requires one findings-array entry per candidate id with the four-value verdict vocabulary', () => {
+    const { systemPrompt } = buildIncompleteHandlingPassPrompts(mixedContext());
+    expect(systemPrompt).toContain('candidateId');
+    expect(systemPrompt).toContain('incomplete | handled | intentional | unverifiable');
+    expect(systemPrompt).toContain('candidate-1');
+  });
+
+  it('builds an initial message with the worklist tagged by shape', () => {
+    const message = buildIncompleteHandlingPassInitialMessage(mixedContext());
+    expect(message).toContain('<pr_metadata>');
+    expect(message).toContain('<incomplete_handling_candidates>');
+    expect(message).toContain('shape="variant-sweep"');
+    expect(message).toContain('shape="sibling-surface"');
+    expect(message).toContain('shape="unread-field"');
+    expect(message).toContain('Color.Green');
+    expect(message).toContain('Options.timeout');
+  });
+
+  it('does not include competing signal blocks (blast radius, doc claims, stale literal, etc.)', () => {
+    const message = buildIncompleteHandlingPassInitialMessage(mixedContext());
+    expect(message).not.toContain('<blast_radius>');
+    expect(message).not.toContain('<doc_claims>');
+    expect(message).not.toContain('<removed_exports>');
+    expect(message).not.toContain('<stale_literal_candidates>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+describe('incompleteHandlingPassBudget', () => {
+  it('scales with combined candidate count, clamped to the floor for a single candidate', () => {
+    const budget = incompleteHandlingPassBudget(100_000, variantOnlyContext());
+    // 1 candidate: 2500 + 900*1 = 3400, clamped up to the 5000 floor.
+    expect(budget).toBe(5_000);
+  });
+
+  it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {
+    const low = incompleteHandlingPassBudget(10_000, mixedContext());
+    const high = incompleteHandlingPassBudget(500_000, mixedContext());
+    expect(low).toBe(high);
+  });
+
+  it('turn cap is exported and equals INCOMPLETE_PASS_MAX_TURNS', () => {
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.maxTurns).toBe(INCOMPLETE_PASS_MAX_TURNS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postProcessIncompleteHandlingResult
+// ---------------------------------------------------------------------------
+
+describe('postProcessIncompleteHandlingResult', () => {
+  it('keeps only verdict:"incomplete" entries as real findings, stripping candidateId/verdict', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'incomplete', message: 'real bug' }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toBe('real bug');
+    expect((result.findings[0] as Record<string, unknown>).candidateId).toBeUndefined();
+    expect((result.findings[0] as Record<string, unknown>).verdict).toBeUndefined();
+  });
+
+  it('drops handled/intentional/unverifiable verdicts entirely', () => {
+    for (const verdict of ['handled', 'intentional', 'unverifiable']) {
+      const raw = fakeResult({
+        findings: [finding({ candidateId: 'candidate-1', verdict, message: 'not a bug' })],
+      });
+      const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+      expect(result.findings).toHaveLength(0);
+    }
+  });
+
+  it('is complete when every candidate id got a recognized verdict (single-candidate fixture)', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'handled' })],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+  });
+
+  it('marks the result incomplete with stopReason "incomplete_verdict" when a candidate id is missing', () => {
+    const raw = fakeResult({ findings: [] }); // candidate-1 never got a verdict
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('keeps the ORIGINAL stopReason when the client was already incomplete for a real reason', () => {
+    const raw = fakeResult({ findings: [], incomplete: true, stopReason: 'budget' });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('budget');
+  });
+
+  it('does not mutate the input result', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'incomplete' })],
+    });
+    postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(raw.findings).toHaveLength(1);
+    expect((raw.findings[0] as Record<string, unknown>).candidateId).toBe('candidate-1');
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is missing', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: undefined, message: 'no verdict' }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is not a recognized value', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({
+          candidateId: 'candidate-1',
+          verdict: 'maybe-incomplete' as never,
+          message: 'bogus',
+        }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when the same candidate id is verdicted twice (duplicate, not "covered")', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable', message: 'first' }),
+        finding({ candidateId: 'candidate-1', verdict: 'incomplete', message: 'second' }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when an entry names a candidate id outside the worklist', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
+        finding({
+          candidateId: 'candidate-99',
+          verdict: 'incomplete',
+          message: 'phantom candidate',
+        }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('requires a verdict per id across a mixed (3-shape) worklist', () => {
+    const candidates = computeIncompleteHandlingCandidates(mixedContext());
+    expect(candidates.length).toBeGreaterThanOrEqual(3);
+    // Only the first candidate gets a verdict — the rest are missing.
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'incomplete' })],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, mixedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    // The one verdicted candidate still becomes a finding despite the honesty flag.
+    expect(result.findings).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeIncompleteHandlingFindings — loop wins (opposite of doc-truth's dedupe)
+// ---------------------------------------------------------------------------
+
+describe('mergeIncompleteHandlingFindings', () => {
+  it('drops a main-pass finding at the same location and keeps the loop finding', () => {
+    const main = [finding({ line: 20, ruleId: 'incomplete-handling', message: 'main freeform' })];
+    const loop = [finding({ line: 20, message: 'loop with evidence' })];
+
+    const merged = mergeIncompleteHandlingFindings(main, loop);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('loop with evidence');
+    expect(merged[0].ruleId).toBe('incomplete-handling');
+  });
+
+  it('dedupes a nearby main-pass incomplete-handling finding (within ±2 lines) but keeps a distant one', () => {
+    const main = [
+      finding({ line: 21, ruleId: 'incomplete-handling', message: 'near' }),
+      finding({ line: 30, ruleId: 'incomplete-handling', message: 'far' }),
+    ];
+    const loop = [finding({ line: 20, message: 'loop' })];
+
+    const merged = mergeIncompleteHandlingFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['far', 'loop'].sort());
+  });
+
+  it('does NOT drop a nearby main-pass finding from a DIFFERENT rule (proximity alone is not enough)', () => {
+    const main = [finding({ line: 20, ruleId: 'error-swallowing', message: 'unrelated real bug' })];
+    const loop = [finding({ line: 20, message: 'loop finding' })];
+
+    const merged = mergeIncompleteHandlingFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unrelated real bug']);
+  });
+
+  it('does NOT drop a nearby main-pass finding with no ruleId at all', () => {
+    const main = [finding({ line: 20, ruleId: undefined, message: 'unattributed' })];
+    const loop = [finding({ line: 20, message: 'loop finding' })];
+
+    const merged = mergeIncompleteHandlingFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unattributed']);
+  });
+
+  it('forces ruleId to incomplete-handling on every loop finding', () => {
+    const loop = [finding({ ruleId: undefined, message: 'no-rule' })];
+    const merged = mergeIncompleteHandlingFindings([], loop);
+    expect(merged[0].ruleId).toBe('incomplete-handling');
+  });
+
+  it('does not mutate the input arrays', () => {
+    const main = [finding({ filepath: 'a.ts', line: 1 })];
+    const loop = [finding({ filepath: 'b.ts', line: 1, ruleId: 'x' })];
+    mergeIncompleteHandlingFindings(main, loop);
+    expect(loop[0].ruleId).toBe('x');
+    expect(main).toHaveLength(1);
+  });
+
+  it('appends a loop finding on a distinct file alongside an unrelated main finding', () => {
+    const main = [finding({ filepath: 'a.ts', line: 1, message: 'unrelated' })];
+    const loop = [finding({ filepath: 'b.ts', line: 1, message: 'loop' })];
+    const merged = mergeIncompleteHandlingFindings(main, loop);
+    expect(merged.map(f => f.message).sort()).toEqual(['loop', 'unrelated']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeIncompleteHandlingResultState
+// ---------------------------------------------------------------------------
+
+describe('mergeIncompleteHandlingResultState', () => {
+  it('marks the merged result incomplete, naming this pass via incompleteFromPass', () => {
+    const main = fakeResult();
+    main.incomplete = false;
+    main.stopReason = 'completed';
+    const loop = fakeResult({ incomplete: true, stopReason: 'incomplete_verdict' });
+
+    mergeIncompleteHandlingResultState(main, loop);
+
+    expect(main.incomplete).toBe(true);
+    expect(main.stopReason).toBe('incomplete_verdict');
+    expect(main.incompleteFromPass).toBe('incomplete-handling');
+  });
+
+  it('leaves an already-incomplete main pass untouched (no attribution overwrite)', () => {
+    const main = fakeResult({ incomplete: true, stopReason: 'max_turns' });
+    const loop = fakeResult({ incomplete: true, stopReason: 'budget' });
+
+    mergeIncompleteHandlingResultState(main, loop);
+
+    expect(main.stopReason).toBe('max_turns');
+    expect(main.incompleteFromPass).toBeUndefined();
+  });
+
+  it('is a no-op when the loop pass is complete or null', () => {
+    const main = fakeResult();
+    mergeIncompleteHandlingResultState(main, fakeResult());
+    expect(main.incomplete).toBe(false);
+
+    mergeIncompleteHandlingResultState(main, null);
+    expect(main.incomplete).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Main-pass interaction override (LIEN_INCOMPLETE_MAIN)
+// ---------------------------------------------------------------------------
+
+describe('applyIncompleteHandlingMainOverride / isIncompleteHandlingMainDisabled', () => {
+  it('is unchanged by default (flag unset)', () => {
+    expect(isIncompleteHandlingMainDisabled()).toBe(false);
+    const ctx = variantOnlyContext();
+    const rules = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    const result = applyIncompleteHandlingMainOverride(rules);
+    expect(result).toBe(rules); // same reference — true no-op
+  });
+
+  it('strips incomplete-handling from active and records it as skipped when LIEN_INCOMPLETE_MAIN=off', () => {
+    process.env.LIEN_INCOMPLETE_MAIN = 'off';
+    expect(isIncompleteHandlingMainDisabled()).toBe(true);
+    const ctx = variantOnlyContext();
+    const rules = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    expect(rules.active.map(r => r.id)).toContain('incomplete-handling');
+    const result = applyIncompleteHandlingMainOverride(rules);
+    expect(result.active.map(r => r.id)).not.toContain('incomplete-handling');
+    expect(result.skipped.some(s => s.includes('incomplete-handling'))).toBe(true);
+  });
+
+  it('is unaffected by an unrelated env value', () => {
+    process.env.LIEN_INCOMPLETE_MAIN = 'on';
+    expect(isIncompleteHandlingMainDisabled()).toBe(false);
+  });
+
+  it('removes all three main-pass signal blocks end-to-end when the override strips the rule', () => {
+    const ctx = mixedContext();
+    const rulesOn = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    const messageOn = buildInitialMessage(ctx, { blastRadius: null, rules: rulesOn });
+    expect(messageOn).toContain('<variant_sweep_candidates>');
+    expect(messageOn).toContain('<sibling_surfaces>');
+    expect(messageOn).toContain('<unread_field_candidates>');
+
+    process.env.LIEN_INCOMPLETE_MAIN = 'off';
+    const rulesOff = applyIncompleteHandlingMainOverride(
+      selectRules(BUILTIN_RULES, buildTriggerContext(ctx)),
+    );
+    const messageOff = buildInitialMessage(ctx, { blastRadius: null, rules: rulesOff });
+    expect(messageOff).not.toContain('<variant_sweep_candidates>');
+    expect(messageOff).not.toContain('<sibling_surfaces>');
+    expect(messageOff).not.toContain('<unread_field_candidates>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INCOMPLETE_HANDLING_PASS_SPEC (the ReviewPassSpec bundle)
+// ---------------------------------------------------------------------------
+
+describe('INCOMPLETE_HANDLING_PASS_SPEC', () => {
+  it("wires this module's own pure functions into the ReviewPassSpec contract", () => {
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.name).toBe('incomplete-handling-loop');
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.skipPlugin).toBe('agent-review:incomplete-handling-loop');
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.maxTurns).toBe(INCOMPLETE_PASS_MAX_TURNS);
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.mergeFindings).toBe(mergeIncompleteHandlingFindings);
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.mergeResultState).toBe(mergeIncompleteHandlingResultState);
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.postProcessResult).toBe(
+      postProcessIncompleteHandlingResult,
+    );
+  });
+
+  it('gateReason is incompleteHandlingSkipReason', () => {
+    const ctx = variantOnlyContext();
+    expect(
+      INCOMPLETE_HANDLING_PASS_SPEC.gateReason(ctx, cfg({ incompleteHandlingPass: true })),
+    ).toBeNull();
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.gateReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('buildPrompts delegates to buildIncompleteHandlingPassPrompts', () => {
+    const ctx = mixedContext();
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.buildPrompts(ctx)).toEqual(
+      buildIncompleteHandlingPassPrompts(ctx),
+    );
+  });
+
+  it('budget delegates to incompleteHandlingPassBudget', () => {
+    const ctx = mixedContext();
+    expect(INCOMPLETE_HANDLING_PASS_SPEC.budget(100_000, ctx)).toBe(
+      incompleteHandlingPassBudget(100_000, ctx),
+    );
+  });
+});

--- a/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
+++ b/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { CodeChunk } from '@liendev/parser';
 
 import {
@@ -226,9 +226,25 @@ function fakeResult(overrides: Partial<AgentResult> = {}): AgentResult {
   };
 }
 
-afterEach(() => {
+// Restore caller state rather than unconditionally deleting — a preconfigured
+// value in the surrounding environment must survive this file's tests intact
+// (CodeRabbit finding on this PR).
+let previousIncompletePass: string | undefined;
+let previousIncompleteMain: string | undefined;
+
+beforeEach(() => {
+  previousIncompletePass = process.env.LIEN_INCOMPLETE_PASS;
+  previousIncompleteMain = process.env.LIEN_INCOMPLETE_MAIN;
   delete process.env.LIEN_INCOMPLETE_PASS;
   delete process.env.LIEN_INCOMPLETE_MAIN;
+});
+
+afterEach(() => {
+  if (previousIncompletePass === undefined) delete process.env.LIEN_INCOMPLETE_PASS;
+  else process.env.LIEN_INCOMPLETE_PASS = previousIncompletePass;
+
+  if (previousIncompleteMain === undefined) delete process.env.LIEN_INCOMPLETE_MAIN;
+  else process.env.LIEN_INCOMPLETE_MAIN = previousIncompleteMain;
 });
 
 // ---------------------------------------------------------------------------
@@ -618,6 +634,10 @@ describe('postProcessIncompleteHandlingResult', () => {
     const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
     expect(result.incomplete).toBe(true);
     expect(result.stopReason).toBe('incomplete_verdict');
+    // The phantom out-of-worklist entry must never leak through as a real
+    // finding despite carrying verdict:"incomplete" (CodeRabbit finding on
+    // this PR: the honesty flag alone doesn't prove it was discarded).
+    expect(result.findings).toHaveLength(0);
   });
 
   it('requires a verdict per id across a mixed (3-shape) worklist', () => {


### PR DESCRIPTION
## Summary

Builds the **incomplete-handling candidate-loop** — the second real consumer of the `ReviewPassSpec` executor (#799), and the second candidate loop overall after the stale-duplicate pilot (#803). Per `.wip/per-rule-loops-design.md` §7 item 5 (design session's worktree): unify the THREE deterministic signals feeding `incomplete-handling` today — `variant-sweep-signals.ts`, `sibling-surface-signals.ts`, `unread-field-signals.ts` — into ONE dedicated pass under the same `ruleId`, not three separate loops for one rule.

**Ships dark.** `config.incompleteHandlingPass` (default `false`) or env `LIEN_INCOMPLETE_PASS=on` opts in. A second flag, `LIEN_INCOMPLETE_MAIN=off`, lets a future A/B arm strip the incomplete-handling rule + its three signal blocks from the main pass entirely (also default-unchanged). Merging this PR changes no production behavior — see the byte-diff proof below.

This is a **$0 paid-spend build task** per the brief — no calibration or live-LLM run was made. The priced A/B against this mechanism is a separate, owner-priced follow-up task.

## Pass spec summary

- **Gate** (`incompleteHandlingSkipReason`): opt-in flag AND at least one candidate from ANY of the three shapes. Unlike the stale-duplicate pilot (whose unconditional `always: true` trigger needed a stricter same-file/high-confidence threshold to avoid firing on ~100% of PRs), this rule's real-PR firing rate is already sub-100% without extra tiering — see the census below for the actual measured number, which is higher than the brief's stated estimate.
- **Unified worklist** (`computeIncompleteHandlingCandidates`): one candidate list combining all three shapes, in a fixed deterministic order (variant-sweep → sibling-surface → unread-field) so candidate ids stay stable across runs on the same PR. Each shape is capped locally (variant-sweep 12, unread-field 10 — mirroring those modules' own render-time caps, which this pass bypasses since it renders candidates itself; sibling-surface self-caps at 15 inside its own `compute()`), then the combined list is capped at 20 total.
- **Verdict vocabulary — four values, not the pilot's three**: `incomplete` (real omission → finding) / `handled` (investigation shows it's actually handled via a mechanism the textual signal couldn't see) / `intentional` (deliberate design choice — catch-all default, structurally-incapable sibling, documented gap) / `unverifiable`. The pilot's `stale | intentional-reuse | unverifiable` doesn't fit this rule's three heterogeneous shapes as cleanly — `handled` vs `intentional` distinguishes "the signal's shallow match missed real coverage" from "the omission is deliberate," a distinction that matters more here since none of the three signals attach a code snippet (see toolset rationale below).
- **Toolset decision — `read_file` + `get_files_context` + `grep_codebase`** (all three, unlike the pilot's `read_file` + `grep_codebase`): none of the three signals attach an inline code snippet to a consumer/sibling/declaration site (only `file:line` + metadata), so `read_file` is load-bearing, not optional, for every candidate. `get_files_context` is added on top because this rule's omission shapes are inherently cross-file ("is the variant handled elsewhere?", "is the sibling updated?") — a file's imports/call sites/test associations are exactly the structural view needed to judge whether an omission is handled via a different mechanism (a dispatch table, a wrapper) the signal's token-level scan can't see. `grep_codebase` stays as the same documented escape hatch the pilot keeps, for a shape the signal's own textual match still leaves ambiguous (e.g. dynamic/computed field access). `get_dependents` / `list_functions` / `get_complexity` are dropped, same as the pilot.
- **FP guard from day one**: an explicit `FALSE-POSITIVE GUARD` paragraph in the prompt warns against verdicting test-double/mock/fixture data `incomplete` — baking in the stale-duplicate pilot's own post-hoc eval finding (2/51 wrong flags on decorative test data) before this loop's own eval can rediscover the same class.
- **Dedup**: loop finding wins over a main-pass finding at the same location, scoped to main findings whose own `ruleId` is `incomplete-handling` — same scoping lesson (and regression tests) as the pilot, so an unrelated rule's nearby finding is never silently dropped.
- **Budget**: `2500 + 900 × min(candidateCount, 20)`, clamped 5000–35000 — scaled by this pass's own combined candidate count, not a flat fraction of the main budget. Turn cap 8 (vs the pilot's 6) since every candidate here needs at least one read_file/get_files_context round trip before it can be judged.

**Also**: extracted `renderPrHeader` (identical in `doc-truth-pass.ts` and `stale-duplicate-pass.ts`) into a shared `renderPassPrHeader` in `review-pass.ts` on this module's third copy — CLAUDE.md's "wait for the 3rd use" DRY rule. Exported `INCOMPLETE_HANDLING` from `rules.ts` (was module-private) so this pass can reuse its strategy/example text, same as `STALE_DUPLICATE`/`DOC_TRUTH` already are.

## Measured real-PR eligibility rate — higher than the brief's estimate, reported honestly

Re-ran the real-PR firing census (40 most recent merged PRs, zero LLM cost, signal code unmodified) against this worktree, rebased onto latest `origin/main`:

| signal | fired | rate |
|---|---:|---:|
| variant-sweep | 0/40 | 0% |
| sibling-surface | 20/40 | 50% |
| unread-field | 0/40 | 0% |
| **union (any of 3) — this loop's gate** | **20/40** | **50%** |

This is **higher than the brief's stated 9/40 (22.5%)** from an earlier same-day census. I verified this isn't an artifact of my own uncommitted new files (which would inflate sibling-surface's same-directory family detection): re-ran the census twice — once against my branch as committed, once with my changes fully `git stash`ed so the corpus reflects only merged `origin/main` code — and got materially the same result both times (20/40 and 19/40 sibling-surface respectively). The real cause is that the census's corpus is deliberately "today's working tree" (an explicit, documented approximation in the script itself), and this repo's `packages/review/src/plugins/agent/` and sibling directories have grown substantially across today's 10-PR sequence (#794–#803) — more same-directory/mirror-directory family members now exist than when the earlier census ran, so more of the 40 historical PRs retroactively score a sibling-surface hit.

**Judgment call**: I did not add extra threshold tiering (e.g. mirroring the pilot's same-file+high-confidence gate) despite 50% being higher than expected, for three reasons: (1) this loop ships fully dark — zero production cost until the owner opts in, (2) tuning a threshold without calibration data to validate its precision would itself violate the "measure before designing" standing rule, and (3) the real firing-rate-driven cost/precision tradeoff is exactly what the owner's separate follow-up eval task is for. Flagging this explicitly as an open item for that follow-up rather than quietly shipping under the brief's stale estimate, or unilaterally inventing an unvalidated threshold.

## Byte-diff neutrality proof (flag OFF)

`build-prompts.ts` (extended the same way #796/#803 did, now also emits `incompleteHandlingPass`) run against 5 fixtures — the 4 on-disk fixtures plus a freshly-captured `incomplete-handling/enum-variant-removed` (PR #437, needed for the dogfood below) — comparing HEAD (`f2c0793a`, pre-this-PR) vs this branch, flag OFF (default):

| fixture | systemPrompt | initialMessage | ruleIds | skippedRules | docTruthPass | staleDuplicatePass |
|---|---|---|---|---|---|---|
| `boundary-change/placeholder` | identical | identical | identical | identical | identical | identical |
| `doc-truth/accurate-doc` | identical | identical | identical | identical | identical | identical |
| `doc-truth/renamed-stale-claim` | identical | identical | identical | identical | identical | identical |
| `stale-duplicate/model-partial-update` | identical | identical | identical | identical | identical | identical |
| `incomplete-handling/enum-variant-removed` | identical | identical | identical | identical | identical | identical |

**Byte-identical build-prompts census, 5/5 fixtures, flags off.** The only diff in the raw harness JSON on every fixture is the new `incompleteHandlingPass` diagnostic field itself, reporting `{"fires": false}` on all five (dark by default, as designed) — new tooling output, not anything fed to the LLM.

Mechanically, no change to `system-prompt.ts`'s gating was needed for this: unlike the pilot (whose `always: true` trigger needed a new `isRuleActiveOrUnresolved` variant added to suppress an otherwise-unconditional block), `incomplete-handling`'s three signal blocks are *already* gated behind `isRuleActive(opts.rules, 'incomplete-handling')` today — so `applyIncompleteHandlingMainOverride` stripping the rule id from `rules.active` is sufficient on its own to suppress `<variant_sweep_candidates>`, `<sibling_surfaces>`, and `<unread_field_candidates>` together when `LIEN_INCOMPLETE_MAIN=off`. Exercised end-to-end in `plugins-agent-incomplete-handling-pass.test.ts`.

## Dogfood: verbatim rendered worklist (flag ON, real fixture)

`LIEN_INCOMPLETE_PASS=on`, `build-prompts.ts` against `incomplete-handling/enum-variant-removed.fixture.json` (PR #437, freshly captured) — sibling-surface fires with 11 candidates (variant-sweep and unread-field don't fire on any of the 19 on-disk harness fixtures per a zero-LLM fixture-corpus census, so no real fixture exists yet to dogfood those two shapes directly — the unified-worklist unit tests cover their rendering with synthetic-but-realistic fixtures built from the same patterns those signals' own test suites use):

```
<incomplete_handling_candidates>
One verdict is REQUIRED per candidate id below (see <output_format>) — candidate-1, candidate-2, ..., candidate-11. Judge each candidate against its own shape's evidence; use read_file/get_files_context to inspect the referenced site(s) before deciding.

<candidate id="candidate-1" shape="sibling-surface" direction="unmirrored-addition">
UserRole (line 9) — added in lien-review-testbed/typescript/src/middleware.ts, absent from untouched sibling(s): lien-review-testbed/typescript/src/api-handler.ts, .../auth-service.ts, .../database.ts, .../index.ts, .../notification.ts, .../router.ts, .../user-service.ts, .../validator.ts
</candidate>

<candidate id="candidate-2" shape="sibling-surface" direction="unmirrored-addition">
getPermissionsForRole (line 146) — added in lien-review-testbed/typescript/src/middleware.ts, absent from untouched sibling(s): ...
</candidate>

... (candidates 3-5: 'manage_users', 'view_analytics', hasPermission — same unmirrored-addition shape)

<candidate id="candidate-6" shape="sibling-surface" direction="family-pattern-divergence">
getUser(...) — shared by sibling(s) api-handler.ts, auth-service.ts, notification.ts, user-service.ts, absent from middleware.ts
</candidate>

... (candidates 7, 9-11: sanitizeString/validateEmail divergence against middleware.ts and types.ts)

<candidate id="candidate-8" shape="sibling-surface" direction="unmirrored-addition">
UserRole (line 5) — added in lien-review-testbed/typescript/src/types.ts, absent from untouched sibling(s): ...
</candidate>
</incomplete_handling_candidates>

Judge every candidate above and output your verdicts as JSON.
```

This is the exact evidence a Sonnet/Kimi judge would see — every candidate carrying its `shape` and `direction`, with no other rule's findings diluting its output budget. No paid LLM call was made against this (per the brief, the priced A/B is a separate owner-priced step).

## Evidence (zero-LLM)

- **52 new unit tests**, all passing: `plugins-agent-incomplete-handling-pass.test.ts` — eligibility gating (config/env/no-candidate/no-patches), unified worklist building (each shape individually + mixed, ordering stability, per-shape and combined-cap enforcement incl. a 22-candidate case that exercises the 20-cap trim), prompt construction (trimmed tool list, FP guard, four-value verdict vocabulary, no competing signal blocks), budget scaling, verdict post-processing (all four verdicts, malformed/duplicate/unknown-id honesty checks mirroring the pilot's CodeRabbit-fix regressions, a 3-shape mixed-worklist completeness check), loop-wins dedupe scoped to same-ruleId matches only, result-state merge, the `LIEN_INCOMPLETE_MAIN` override end-to-end via `buildInitialMessage`, and the `ReviewPassSpec` bundle.
- Full monorepo gate: `format:check` / `lint` (0 errors, 33 pre-existing warnings, none in new code) / `typecheck` / `build` / `test` (parser 27, core 1062+374, review **1187** — up from 1135 pre-this-PR by exactly the 52 new tests, cli 860, action 39 — all green) / `lien delta` (exit 0, no new-over-threshold crossings — the only "worsened" flags are pre-existing violations in `index.ts`/`build-prompts.ts` that merely got marginally touched, never fails the gate per CLAUDE.md).
- Byte-diff neutrality and the verbatim worklist dogfood above.
- Census scripts and captured raw build-prompts JSON are zero-LLM and reproducible; not committed (temporary, per `.wip/` convention).

## Dogfood note

Per CLAUDE.md's mandatory dogfooding rule: the actual consumer here is `AgentReviewPlugin.analyze()`'s prompt-assembly pipeline, exercised end-to-end above via `build-prompts.ts` against a real captured PR fixture — both the flag-off (neutrality) and flag-on (worklist) paths. A live LLM call against this pass was **not** made; that's the separate, owner-priced A/B this build's numbers are meant to price, per the brief ("do NOT run calibrations").

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green
- [x] `node packages/cli/dist/index.js delta` (via `lien delta`) — exit 0
- [x] Byte-diff neutrality across 5 fixtures, flag off
- [x] Verbatim worklist dogfood against a real fixture, flag on
- [x] Real-PR eligibility census re-run against this branch's gate, discrepancy vs the brief's estimate reported honestly

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR dark-launches a third extra review pass that unifies variant-sweep, sibling-surface, and unread-field signals into one candidate-loop under ReviewPassSpec. The pass is gated behind config.incompleteHandlingPass (default false) and the LIEN_INCOMPLETE_PASS env flag, with a separate LIEN_INCOMPLETE_MAIN override for a future A/B arm. It mirrors the existing stale-duplicate pilot's structure: eligibility gate, per-candidate verdict post-processing, loop-wins dedupe scoped to the same ruleId, and result-state merge. The implementation is covered by 52 new unit tests and a byte-diff neutrality proof shows no production prompt change when the flag is off. No concrete bugs producing wrong output or breaking callers were identified in the changed code.
>
> - Added incomplete-handling-pass.ts as a ReviewPassSpec with gated eligibility, unified worklist, four-value verdict processing, and merge helpers
> - Wired the new pass into EXTRA_PASSES in index.ts and added incompleteHandlingPass to the agent config schema and AgentConfig type
> - Extracted renderPassPrHeader into review-pass.ts and updated doc-truth-pass.ts and stale-duplicate-pass.ts to use the shared helper
> - Exported INCOMPLETE_HANDLING from rules.ts for reuse by the new pass

<sup>Reviewed by [Lien Review](https://lien.dev) for commit df0ec22. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in “incomplete handling” review pass that checks for missed cases across variants, related interfaces, and unread fields.
  * Consolidated these checks into a candidate-based review flow with clearer, targeted findings.
  * Added configuration and environment controls to enable the pass or disable its corresponding main review rule.
  * Improved review metadata consistency for specialized review passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->