### PR TITLE
fix(review): guard stale-duplicate pass against test-double literals

### DIFF
--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -94,6 +94,36 @@ You have these tools to investigate the codebase:
 - grep_codebase: Search the entire repository working tree for a text pattern (regex) — use ONLY for a shape the worklist doesn't cover (the rule text's closing paragraph). Do NOT re-grep for literals the worklist already lists; that discovery work is already done.
 </tools>`;
 
+/**
+ * Guards against the one measured false-positive class in this loop: a
+ * confirmed FP probe on a real captured PR had this pass verdict "stale" on
+ * a test-helper mock that hardcoded a production rule's display `name` and
+ * `category` strings purely to build a fake object, reasoning about a
+ * hypothetical FUTURE rename desyncing the mock — even though nothing at
+ * runtime reads those strings today (rule gating is by id, never by name/
+ * category). The loop's prompt had no guidance telling it that inert
+ * test-double duplication and behavior-driving duplication are different
+ * things; this section adds exactly that.
+ */
+const STALE_DUP_VERDICT_GUIDANCE = `<verdict_guidance>
+Before verdicting a candidate "stale", check whether the surviving literal
+actually drives runtime behavior. A literal is a real stale-duplicate risk
+when the surviving site is production code that READS it to make a decision
+— a config value, a dispatch key, a threshold, or a user-facing string the
+changed site also drives — so a future edit to the changed site silently
+desyncs real behavior. A literal is NOT stale when the surviving site is a
+test double: a mock, stub, or fixture builder that hardcodes a name/category/
+id string purely to construct a fake object for test readability. Nothing at
+runtime consumes that copy, so drift between it and the production literal
+has zero behavioral consequence — verdict it "intentional-reuse", not
+"stale", even if renaming the production literal would someday leave the
+mock referencing a stale name. The one exception: if the surviving site is a
+test ASSERTION that exercises the CHANGED behavior itself and would keep
+passing against the pre-change (now-stale) expected value, that is a real
+bug — a test silently validating stale behavior — and should still be
+verdicted "stale".
+</verdict_guidance>`;
+
 // ---------------------------------------------------------------------------
 // Loop eligibility gate
 // ---------------------------------------------------------------------------
@@ -349,6 +379,8 @@ ${STALE_DUP_TOOLS_SECTION}
 <strategy>
 ${STALE_DUPLICATE.prompt}
 </strategy>
+
+${STALE_DUP_VERDICT_GUIDANCE}
 
 <examples>
 ${STALE_DUPLICATE.example}

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -199,6 +199,18 @@ describe('buildStaleDuplicatePassPrompts', () => {
     expect(systemPrompt).toContain('candidate-1');
   });
 
+  // Regression coverage for the confirmed FP probe finding on a real captured
+  // PR: this pass verdicted "stale" on a test-helper mock hardcoding a
+  // production rule's display name/category purely to build a fake object —
+  // reasoning about a hypothetical future rename, not actual runtime drift.
+  it('includes verdict guidance distinguishing runtime-behavior literals from inert test-double duplication', () => {
+    const { systemPrompt } = buildStaleDuplicatePassPrompts(eligibleContext());
+    expect(systemPrompt).toContain('<verdict_guidance>');
+    expect(systemPrompt).toContain('test double');
+    expect(systemPrompt).toContain('intentional-reuse');
+    expect(systemPrompt).toContain('test ASSERTION');
+  });
+
   it('builds an initial message with the worklist, changed-site hunk, and surviving sites', () => {
     const message = buildStaleDuplicatePassInitialMessage(eligibleContext());
     expect(message).toContain('<pr_metadata>');


### PR DESCRIPTION
## Summary

PR #803 shipped the stale-duplicate candidate-loop pass dark behind
`LIEN_STALE_DUP_PASS=on`. Today's pilot A/B FP probe (2 wrongful `stale`
verdicts of 51, on real captured PR #770) found the loop verdicting
`stale` on a test-helper mock (`errorSwallowingRule()` in a new test file)
that hardcodes `name: 'Silent Error Swallowing'` and `category:
'error_handling'` — literals matching the production rule's display
strings. Vote 3's own reasoning: "If the production rule name is renamed,
the helper will silently construct a mock for a non-existent rule" — a
hypothetical *future* rename, not actual runtime drift. Rule gating is by
rule **id** only (`isRuleActive`, `system-prompt.ts`), so the mock's
strings are decorative with zero drift risk.

This PR adds a wording-only `<verdict_guidance>` block to the loop's own
system prompt (`stale-duplicate-pass.ts`), distinguishing:
- literals that DRIVE runtime behavior (config values, dispatch keys,
  thresholds, user-facing strings the changed site also drives) → real
  stale-duplicate risk, verdict `stale`
- inert duplication in test doubles/mocks/fixtures that merely mirror
  production values for test readability → `intentional-reuse`, **unless**
  the surviving site is a test *assertion* that exercises the changed
  behavior itself and would pass against stale expectations (that narrower
  case is a real bug and stays `stale`)

Touches only `stale-duplicate-pass.ts` + its test, per the brief (a
concurrent agent is wiring a different pass into `index.ts` in the same
directory).

## Added prompt text

\`\`\`
<verdict_guidance>
Before verdicting a candidate "stale", check whether the surviving literal
actually drives runtime behavior. A literal is a real stale-duplicate risk
when the surviving site is production code that READS it to make a decision
— a config value, a dispatch key, a threshold, or a user-facing string the
changed site also drives — so a future edit to the changed site silently
desyncs real behavior. A literal is NOT stale when the surviving site is a
test double: a mock, stub, or fixture builder that hardcodes a name/category/
id string purely to construct a fake object for test readability. Nothing at
runtime consumes that copy, so drift between it and the production literal
has zero behavioral consequence — verdict it "intentional-reuse", not
"stale", even if renaming the production literal would someday leave the
mock referencing a stale name. The one exception: if the surviving site is a
test ASSERTION that exercises the CHANGED behavior itself and would keep
passing against the pre-change (now-stale) expected value, that is a real
bug — a test silently validating stale behavior — and should still be
verdicted "stale".
</verdict_guidance>
\`\`\`

## Evidence (dogfooded per CLAUDE.md)

1. **Unit test**: `plugins-agent-stale-duplicate-pass.test.ts` asserts the
   new guidance renders in the pass's system prompt (`<verdict_guidance>`,
   `test double`, `intentional-reuse`, `test ASSERTION`). 42/42 tests pass
   in that file; full suite 1136+860+39 tests pass across all packages.

2. **Byte-diff neutrality, flag OFF**: ran `build-prompts.ts` across all
   4 on-disk fixtures (`boundary-change/placeholder`,
   `doc-truth/accurate-doc`, `doc-truth/renamed-stale-claim`,
   `stale-duplicate/model-partial-update`) before and after this change,
   with `LIEN_STALE_DUP_PASS` unset — **byte-identical, 4/4, flag off**
   (expected: the loop never fires when disabled, so `buildSystemPrompt`
   is never even called).

3. **Recert, flag ON** (paid, OpenRouter, `moonshotai/kimi-k2.7-code`):
   - **Calibrate-10** on `stale-duplicate/model-partial-update` (the
     canonical true-positive, PR #539) with `LIEN_STALE_DUP_PASS=on`:
     **10/10 held** ($0.3471; today's pre-fix baseline was also 10/10 at
     $0.3184) — the added guidance did not over-suppress the real finding.
   - **Re-captured PR #770** via `capture-pr.ts` (free) and re-ran the FP
     probe: 3 votes, loop fired all 3 times, 8 candidates each. **0
     wrongful `stale` verdicts** (down from 2/3 candidates in today's
     pre-fix probe) — candidates 3 and 4 (the test-double literals) now
     verdict `intentional-reuse` in all 3 votes, and no `stale-duplicate`
     findings for those locations survive into the merged result.
   - **Total spend: $0.5575** of the $1.00 cap ($0.3471 calibrate-10 +
     $0.2104 FP-probe 3 votes).

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green
- [x] `node packages/cli/dist/index.js delta` — exit 0 (no new threshold crossings)
- [x] Calibrate-10 held 10/10 on the true-positive canary with the flag on
- [x] FP probe re-run: 0 wrongful `stale` verdicts on the test-double candidates (down from 2)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a wording-only `<verdict_guidance>` block to the stale-duplicate candidate-loop system prompt and a regression test asserting the guidance renders. No runtime logic, exports, thresholds, or data structures change. The new guidance distinguishes behavior-driving literal duplication (real stale-duplicate risk) from inert test-double/mock duplication (`intentional-reuse`), addressing a measured false-positive class without altering the pass's eligibility gate, verdict contract, or merge behavior.
>
> - Added `STALE_DUP_VERDICT_GUIDANCE` constant and interpolated it into `buildSystemPrompt`
> - Added regression test verifying the guidance text appears in the system prompt

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6293e16. Updates automatically on new commits.</sup>
<!-- /lien-stats -->