### PR TITLE
fix(review,action): fail the check on an incomplete main-pass review

### DIFF
--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -59,6 +59,7 @@ function exitCodeFor(
   errorCount: number,
   warningCount: number,
   providerFailure: boolean,
+  incompleteMainPass: boolean,
 ): number {
   // A total provider failure means the agent review never ran at all — an
   // operational failure, not an advisory finding. A user who enabled (and is
@@ -66,6 +67,19 @@ function exitCodeFor(
   // this fails regardless of `fail-on`, including the advisory default
   // `never`. See the "Fail-loudly guarantee" section of the action README.
   if (providerFailure) return 1;
+  // An incomplete MAIN pass (budget/turn exhaustion, or an unrecoverable
+  // corrupted stop-turn — see `hasIncompleteMainPass`) means the agent
+  // couldn't vouch for full coverage of the PR. It's a lesser degree of the
+  // same "operational shortfall, not an advisory finding" trust violation
+  // `providerFailure` guards above, so it gets the identical treatment: fail
+  // regardless of `fail-on`, including `never`. Without this, the exact bug
+  // this fixes recurs — an honestly-surfaced "review did not complete"
+  // notice (severity `warning`, conclusion `neutral`) exits 0 under the
+  // advisory default, presenting a degraded run as a clean pass. An
+  // EXTRA-pass-only incomplete (doc-truth, or a named pass) does NOT set
+  // this — the main pass's own coverage is intact, so it stays advisory
+  // (respects `fail-on` normally, below).
+  if (incompleteMainPass) return 1;
   if (failOn === 'never') return 0;
   // 'any' is strictly stricter than 'error': fail on a failure conclusion (e.g.
   // analysis failed with no findings) OR on any error/warning finding.
@@ -95,6 +109,26 @@ function logProviderFailure(findings: ReviewFinding[]): void {
 }
 
 /**
+ * Log a clear, actionable message naming why the review's coverage is only
+ * partial. Only called once `result.incompleteMainPass` (the authoritative
+ * signal from `@liendev/review`) is already known true — mirrors
+ * `logProviderFailure`'s shape for the lesser-degree "ran, but didn't finish"
+ * case.
+ */
+function logIncompleteMainPass(findings: ReviewFinding[]): void {
+  const notice = findings.find(
+    f => (f.metadata as { mainPassIncomplete?: boolean } | undefined)?.mainPassIncomplete,
+  );
+  const cause = notice?.message ?? 'the main review pass did not finish.';
+  actionLogger.error(
+    `Lien Review is incomplete: ${cause} This fails the check even with fail-on: never — an ` +
+      'incomplete review cannot vouch for full coverage of this PR, so it is not an advisory ' +
+      'finding. Re-run once the underlying issue (budget/turn limits, or a provider hiccup ' +
+      'mid-review) is resolved.',
+  );
+}
+
+/**
  * Build the ReviewCoreResult for when `reviewPullRequest()` itself throws
  * before returning one — e.g. a clone or GitHub API failure outside the
  * analysis-phase null-return path `emptyResult`/`pipelineFailed` already
@@ -111,6 +145,7 @@ export function buildCrashResult(message: string): ReviewCoreResult {
     filesAnalyzed: 0,
     usage: { totalTokens: 0, cost: 0 },
     providerFailure: false,
+    incompleteMainPass: false,
     attestation: emptyAttestation('failure', 0, 'normal', true),
   };
 }
@@ -128,6 +163,7 @@ export async function finishRun(
 ): Promise<number> {
   const errorCount = countErrors(result.findings);
   const providerFailure = result.providerFailure;
+  const incompleteMainPass = result.incompleteMainPass;
 
   await writeStepSummary(result);
   await writeOutputs({
@@ -142,13 +178,21 @@ export async function finishRun(
   // pull_request_target, which grants forks a writable token.
   if (forkReadOnly) emitForkWarning();
   if (providerFailure) logProviderFailure(result.findings);
+  if (incompleteMainPass) logIncompleteMainPass(result.findings);
 
   const warningCount = result.findings.filter(f => f.severity === 'warning').length;
   actionLogger.info(
     `Review complete: ${result.findings.length} findings (${errorCount} errors), ` +
       `conclusion=${result.conclusion}, files=${result.filesAnalyzed}`,
   );
-  return exitCodeFor(failOn, result.conclusion, errorCount, warningCount, providerFailure);
+  return exitCodeFor(
+    failOn,
+    result.conclusion,
+    errorCount,
+    warningCount,
+    providerFailure,
+    incompleteMainPass,
+  );
 }
 
 async function main(): Promise<void> {

--- a/packages/action/test/finish-run.test.ts
+++ b/packages/action/test/finish-run.test.ts
@@ -13,6 +13,7 @@ function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
     filesAnalyzed: 3,
     usage: { totalTokens: 0, cost: 0 },
     providerFailure: false,
+    incompleteMainPass: false,
     attestation: emptyAttestation('success', 3, 'normal'),
     ...overrides,
   };
@@ -154,10 +155,62 @@ describe('finishRun', () => {
     expect(exitCode).toBe(0);
   });
 
-  it('a PARTIAL incomplete run (budget/turn limit, not neverRan) stays advisory under fail-on=never', async () => {
-    // Some turns completed before the run bailed — this is a warning-severity
-    // notice (see appendIncompleteNotice), not the never-ran operational failure,
-    // so it must not force a failing exit code by itself.
+  // Regression coverage for the trust-residue fix (companion to #765/#764): a
+  // PARTIAL incomplete MAIN pass (budget/turn limit, or an unrecoverable
+  // corrupted stop-turn — #795) used to stay advisory under fail-on=never,
+  // reaching a green check on an honestly-surfaced "review did not finish"
+  // notice. `incompleteMainPass` is the authoritative signal from
+  // `@liendev/review` (see review-pr.ts's `hasIncompleteMainPass`) —
+  // `conclusion`/`findings` mirror what it would actually produce alongside
+  // it, but `finishRun` gates on `incompleteMainPass` directly, same as
+  // `providerFailure`.
+  function mainIncompleteFinding(): ReviewCoreResult['findings'][number] {
+    return {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message: 'Lien Review did not finish — it hit the token budget limit while investigating.',
+      metadata: { incomplete: true, stopReason: 'budget', mainPassIncomplete: true },
+    };
+  }
+
+  it('fails the check on a PARTIAL incomplete MAIN pass even under fail-on=never', async () => {
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    const error = vi.spyOn(actionLogger, 'error').mockImplementation(() => {});
+    const result = makeResult({
+      conclusion: 'neutral',
+      findings: [mainIncompleteFinding()],
+      incompleteMainPass: true,
+    });
+
+    const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
+
+    expect(exitCode).toBe(1);
+    expect(error).toHaveBeenCalled();
+    const logged = error.mock.calls.map(c => c[0]).join('\n');
+    expect(logged).toContain('fail-on: never');
+  });
+
+  it('still fails a PARTIAL incomplete MAIN pass under fail-on=error and fail-on=any', async () => {
+    vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
+    vi.spyOn(actionLogger, 'error').mockImplementation(() => {});
+    const result = makeResult({
+      conclusion: 'neutral',
+      findings: [mainIncompleteFinding()],
+      incompleteMainPass: true,
+    });
+
+    expect(await finishRun(result, false, 'error')).toBe(1);
+    expect(await finishRun(result, false, 'any')).toBe(1);
+  });
+
+  it('an EXTRA-pass-only incomplete (doc-truth) stays advisory under fail-on=never', async () => {
+    // The main pass ran fine — only doc-truth's second pass didn't finish.
+    // `incompleteMainPass` stays false (see `appendIncompleteNotice`'s
+    // `isExtraPassOnly` carve-out), so this must NOT force a failing exit
+    // code — coverage-preserving incompleteness stays advisory.
     vi.spyOn(actionLogger, 'info').mockImplementation(() => {});
     const result = makeResult({
       conclusion: 'neutral',
@@ -169,10 +222,12 @@ describe('finishRun', () => {
           severity: 'warning',
           category: 'summary',
           message:
-            'Lien Review did not finish — it hit the token budget limit while investigating.',
+            'The documentation-truthfulness pass did not finish — it hit the token budget limit. ' +
+            'Doc-claim verification is partial; code findings are unaffected.',
           metadata: { incomplete: true, stopReason: 'budget' },
         } as ReviewCoreResult['findings'][number],
       ],
+      incompleteMainPass: false,
     });
 
     const exitCode = await finishRun(result, /* forkReadOnly */ false, 'never');
@@ -191,6 +246,7 @@ describe('finishRun', () => {
 
       expect(result.conclusion).toBe('failure');
       expect(result.providerFailure).toBe(false);
+      expect(result.incompleteMainPass).toBe(false);
       expect(result.attestation.verdict).toBe('failed:analysis_error');
       expect(result.summaryMarkdown).toContain('clone failed: ENOTFOUND');
     });

--- a/packages/action/test/summary.test.ts
+++ b/packages/action/test/summary.test.ts
@@ -27,6 +27,7 @@ function makeResult(overrides?: Partial<ReviewCoreResult>): ReviewCoreResult {
     filesAnalyzed: 3,
     usage: { totalTokens: 0, cost: 0 },
     providerFailure: false,
+    incompleteMainPass: false,
     attestation: emptyAttestation('success', 3, 'normal'),
     ...overrides,
   };

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -60,7 +60,11 @@ export {
 
 // Built-in plugins
 export { ComplexityPlugin } from './plugins/complexity.js';
-export { AgentReviewPlugin, hasProviderFailure } from './plugins/agent/index.js';
+export {
+  AgentReviewPlugin,
+  hasProviderFailure,
+  hasIncompleteMainPass,
+} from './plugins/agent/index.js';
 
 // Dependency graph
 export {

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -578,6 +578,7 @@ export function appendIncompleteNotice(
   // review is partial — the main pass finished normally. Doc-truth keeps its
   // own dedicated branch (unchanged wording, already tested); any other
   // named pass gets the same shape via the generic field.
+  const isExtraPassOnly = !!result.incompleteFromDocPass || !!result.incompleteFromPass;
   const message = result.incompleteFromDocPass
     ? `The documentation-truthfulness pass did not finish — it ${reason}. ` +
       `Doc-claim verification is partial; code findings are unaffected.`
@@ -593,7 +594,17 @@ export function appendIncompleteNotice(
     severity: 'warning' as const,
     category: 'summary',
     message,
-    metadata: { incomplete: true, stopReason: result.stopReason, overview: message },
+    metadata: {
+      incomplete: true,
+      stopReason: result.stopReason,
+      overview: message,
+      // Only set for the MAIN pass itself stopping short of a verdict — an
+      // extra pass (doc-truth, or a generically-named one) being incomplete
+      // does NOT compromise the main pass's own bug-finding coverage, so it
+      // stays out of this flag. See `hasIncompleteMainPass`, the SSOT a
+      // conclusion-mapper keys off to distinguish the two.
+      ...(isExtraPassOnly ? {} : { mainPassIncomplete: true }),
+    },
   });
 }
 
@@ -657,6 +668,26 @@ function appendNeverRanNotice(
  */
 export function hasProviderFailure(findings: ReviewFinding[]): boolean {
   return findings.some(f => (f.metadata as { neverRan?: boolean } | undefined)?.neverRan === true);
+}
+
+/**
+ * True when `findings` contains a MAIN-pass incomplete notice — the agent's
+ * primary bug-finding pass stopped (budget/turn limit, or an unrecoverable
+ * corrupted/unparseable stop-turn — see `extractFindingsFromText`) without
+ * producing a usable verdict for the whole PR. Distinct from
+ * `hasProviderFailure` (the main pass never got a single response at all)
+ * and from an EXTRA pass alone being incomplete (doc-truth, or a
+ * generically-named pass): those don't compromise the main pass's own
+ * coverage, so `appendIncompleteNotice` never sets `mainPassIncomplete` for
+ * them. This is the single source of truth callers outside this module (the
+ * transport-agnostic review core, the GitHub Action) key off, mirroring
+ * `hasProviderFailure` — an honestly-partial review must not read as clean
+ * either, just via a distinct signal from a total non-run.
+ */
+export function hasIncompleteMainPass(findings: ReviewFinding[]): boolean {
+  return findings.some(
+    f => (f.metadata as { mainPassIncomplete?: boolean } | undefined)?.mainPassIncomplete === true,
+  );
 }
 
 /** Cap the provider error to a short, single-line cause for the notice. */

--- a/packages/review/src/review-pr.ts
+++ b/packages/review/src/review-pr.ts
@@ -40,6 +40,7 @@ import {
   ComplexityPlugin,
   AgentReviewPlugin,
   hasProviderFailure,
+  hasIncompleteMainPass,
   updatePRDescription,
   removePRDescriptionSection,
   EMPTY_DELIVERY,
@@ -123,6 +124,18 @@ export interface ReviewCoreResult {
    * enabled, or the pipeline failed before reaching the engine).
    */
   providerFailure: boolean;
+  /**
+   * True when the agent-review MAIN pass ran but stopped without a usable
+   * verdict for the whole PR — budget/turn exhaustion, or an unrecoverable
+   * corrupted/unparseable stop-turn (see `hasIncompleteMainPass` /
+   * `appendIncompleteNotice`). Distinct from `providerFailure` (the main pass
+   * never got a single response at all): this is a DEGRADED run, not a total
+   * non-run, but still an operational shortfall a caller should not silently
+   * present as a clean pass. Always `false` when only an EXTRA pass
+   * (doc-truth, or a named pass) was incomplete — that doesn't compromise the
+   * main pass's own coverage.
+   */
+  incompleteMainPass: boolean;
   /** Machine-readable receipt of this run — provider health, budget, delivery, verdict (v1). */
   attestation: Attestation;
 }
@@ -222,6 +235,7 @@ function emptyResult(
     filesAnalyzed,
     usage: { totalTokens: 0, cost: 0 },
     providerFailure: false,
+    incompleteMainPass: false,
     attestation: emptyAttestation(conclusion, filesAnalyzed, eligibilityPath, pipelineFailed),
   };
 }
@@ -311,6 +325,7 @@ interface PresentedReview {
   summaryMarkdown: string;
   usage: { totalTokens: number; cost: number };
   providerFailure: boolean;
+  incompleteMainPass: boolean;
   attestation: Attestation;
 }
 
@@ -487,6 +502,7 @@ async function analyzeAndPresent(
 
   const presentation = await presentFindings(engine, findings, adapterContext, logger);
   const providerFailure = hasProviderFailure(findings);
+  const incompleteMainPass = hasIncompleteMainPass(findings);
   const attestation = buildRunAttestation(
     analysis,
     filesToAnalyze,
@@ -504,6 +520,7 @@ async function analyzeAndPresent(
     summaryMarkdown: presentation.summary,
     usage: { totalTokens: agentUsage.totalTokens, cost: agentUsage.cost },
     providerFailure,
+    incompleteMainPass,
     attestation,
   };
 }

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -6,6 +6,7 @@ import {
   scaleBudgetForBlastRadius,
   clampText,
   hasProviderFailure,
+  hasIncompleteMainPass,
 } from '../src/plugins/agent/index.js';
 import { scaleAgentBudget, resolveAgentBudget, summaryOnlyEligibleFor } from '../src/review-pr.js';
 import type { ReviewCoreContext } from '../src/review-pr.js';
@@ -532,6 +533,9 @@ describe('appendIncompleteNotice — severity by run outcome', () => {
     expect(findings[0].severity).toBe('warning');
     expect(findings[0].message).toContain('did not finish');
     expect(findings[0].message).not.toContain('did not run');
+    // The MAIN pass itself stopped short of a verdict — `hasIncompleteMainPass`'s
+    // SSOT flag must be set so a conclusion-mapper can't silently read this as clean.
+    expect(findings[0].metadata).toMatchObject({ mainPassIncomplete: true });
   });
 
   it('keeps a doc-pass-only incomplete a WARNING even if that pass never ran', () => {
@@ -548,6 +552,9 @@ describe('appendIncompleteNotice — severity by run outcome', () => {
     expect(findings[0].severity).toBe('warning');
     expect(findings[0].message).toContain('documentation-truthfulness pass');
     expect(findings[0].message).toContain('code findings are unaffected');
+    // An EXTRA-pass-only incomplete must NOT set the main-pass flag — the main
+    // pass's own coverage is intact, so this stays advisory (see `hasIncompleteMainPass`).
+    expect(findings[0].metadata).not.toHaveProperty('mainPassIncomplete');
   });
 
   it('keeps a stale-duplicate-loop-only incomplete a WARNING, naming that pass generically', () => {
@@ -570,6 +577,7 @@ describe('appendIncompleteNotice — severity by run outcome', () => {
     expect(findings[0].message).toContain('The stale-duplicate pass did not finish');
     expect(findings[0].message).toContain('did not produce a verdict for every candidate');
     expect(findings[0].message).toContain("main review's findings are unaffected");
+    expect(findings[0].metadata).not.toHaveProperty('mainPassIncomplete');
   });
 
   it('is a no-op for a complete run', () => {
@@ -623,6 +631,76 @@ describe('hasProviderFailure — the single source of truth for #764-class detec
 
   it('is false for an empty findings list', () => {
     expect(hasProviderFailure([])).toBe(false);
+  });
+});
+
+describe('hasIncompleteMainPass — the trust-residue fix companion to hasProviderFailure', () => {
+  // Regression coverage for the "an honestly-incomplete review lands a GREEN
+  // check" trust residue (companion to #764/#765, observed live on #795): the
+  // action layer (and review-pr.ts's `ReviewCoreResult.incompleteMainPass`)
+  // both key off this function rather than re-deriving the signal from
+  // `metadata` shape or conclusion/summary text.
+  it('is true for a PARTIAL (budget) main-pass incomplete notice', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: false, stopReason: 'budget' }),
+    );
+    expect(hasIncompleteMainPass(findings)).toBe(true);
+  });
+
+  it('is true for an unrecoverable corrupted stop-turn (stopReason: completed, no verdict — #795)', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: false, stopReason: 'completed' }),
+    );
+    expect(hasIncompleteMainPass(findings)).toBe(true);
+  });
+
+  it('is false for a total never-ran provider failure (hasProviderFailure covers that instead)', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: true, errorMessage: 'API error (402): Insufficient credits' }),
+    );
+    expect(hasIncompleteMainPass(findings)).toBe(false);
+    expect(hasProviderFailure(findings)).toBe(true);
+  });
+
+  it('is false for a doc-pass-only incomplete notice (main pass ran fine)', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({ neverRan: true, incompleteFromDocPass: true, stopReason: 'error' }),
+    );
+    expect(hasIncompleteMainPass(findings)).toBe(false);
+  });
+
+  it('is false for a named-extra-pass-only incomplete notice (main pass ran fine)', () => {
+    const findings: ReviewFinding[] = [];
+    appendIncompleteNotice(
+      findings,
+      'agent-review',
+      baseResult({
+        neverRan: true,
+        incompleteFromPass: 'stale-duplicate',
+        stopReason: 'incomplete_verdict',
+      }),
+    );
+    expect(hasIncompleteMainPass(findings)).toBe(false);
+  });
+
+  it('is false for an ordinary error finding with no metadata at all', () => {
+    expect(hasIncompleteMainPass([{ severity: 'error' } as ReviewFinding])).toBe(false);
+  });
+
+  it('is false for an empty findings list', () => {
+    expect(hasIncompleteMainPass([])).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

An honestly-incomplete agent-review MAIN pass currently exits 0 (green
check) under the default `fail-on: never` — observed live on PR #795,
whose own review run hit a verdict-corruption instance, surfaced "review
did not complete" in its output, and still concluded SUCCESS. This is the
same trust family as #765 (a total provider failure presenting as green),
just one degree less severe: a *partial* non-delivery instead of a total
one.

## Root cause

`appendIncompleteNotice` (packages/review/src/plugins/agent/index.ts)
appends a `severity: 'warning'` finding for any incomplete main-pass stop
(budget/turn exhaustion, or an unrecoverable corrupted/unparseable
stop-turn — see #795's balanced-object-extraction + bounded-retry
recovery, which still surfaces `incomplete` when both attempts fail).
`determineConclusion` maps a warning-only finding set to `'neutral'`, and
`packages/action/src/index.ts`'s `exitCodeFor` returns 0 unconditionally
under `fail-on: never` — the only signal that bypasses `fail-on` today is
`providerFailure` (#765), which requires `neverRan` (zero completed
turns). A main pass that completed several turns and then hit an
unrecoverable stop-turn is `neverRan: false`, so it fell through to the
advisory path and exited 0.

## Fix

- `appendIncompleteNotice` now tags the finding's `metadata` with
  `mainPassIncomplete: true`, but **only** when the MAIN pass itself
  stopped short — not when only an extra pass (doc-truth, or a
  generically-named pass) is incomplete. An extra-pass-only incompleteness
  doesn't compromise the main pass's own bug-finding coverage (unchanged
  behavior, still advisory).
- New `hasIncompleteMainPass(findings)` — the SSOT, mirroring
  `hasProviderFailure`'s existing pattern exactly.
- `review-pr.ts` threads it onto `ReviewCoreResult.incompleteMainPass`.
- `packages/action`'s `exitCodeFor` forces exit 1 whenever it's true,
  **regardless of `fail-on`** — the identical precedent #765 set for
  `providerFailure`: "a user who enabled (and is paying for) the review
  deserves a red check when it didn't happen." An incomplete review can't
  vouch for full PR coverage either, so it's the same category of
  operational shortfall, not an advisory finding to be gated by
  `fail-on`.

**Conclusion-policy choice (neutral vs failure):** the GitHub Action posts
no Checks-API check run of its own (the workflow job *is* the single
status check — see the file's own header comment), so there is no
"neutral" grey-checkmark state available at the process-exit level the
way there is for `ReviewCoreResult.conclusion` in a GitHub-App/Checks-API
context. The only real choice for the Action is exit 0 (green) or exit 1
(red). Given the default `fail-on: never` is what let this bug reach
green in the first place, respecting `fail-on` normally (i.e. only failing
under `any`/`error`) would leave the *default* experience unfixed — the
exact complaint. So this follows #765's own choice byte-for-byte: force
failure unconditionally. An extra-pass-only incomplete deliberately does
**not** get this treatment — it stays advisory, respecting `fail-on`
normally, since main-pass coverage is intact there.

## Consumer audit

`packages/review/src/attestation.ts`'s `computeVerdict` already has a
*similar* signal (`degraded:provider_partial` / `degraded:budget_starved`
for ANY incomplete pass, main or extra) but it's a machine-readable
receipt, not wired to the exit code, and deliberately conflates main vs
extra-pass incompleteness (by design, for the attestation's own "was this
run 100% healthy" purpose). Reusing it directly for the exit-code gate
would have made an extra-pass-only incomplete run also fail unconditionally,
contradicting `appendIncompleteNotice`'s own established, tested
fail-open design for that case — so a separate, narrower
`hasIncompleteMainPass` was the right call instead of collapsing the two
concepts.

## Tests

- `plugins-agent-budget.test.ts`: new `hasIncompleteMainPass` suite (mirrors
  the existing `hasProviderFailure` suite) + updated `appendIncompleteNotice`
  assertions for the new `mainPassIncomplete` metadata flag (present for a
  main-pass stop, absent for doc-truth/named-extra-pass-only).
- `finish-run.test.ts`: flipped the pre-existing (buggy-behavior-encoding)
  test that asserted exit 0 for a partial main-pass incomplete under
  `fail-on: never` to now assert exit 1 (regardless of `fail-on`), and added
  a new test proving an extra-pass-only incomplete still exits 0 under
  `fail-on: never` (the coverage-preserving case stays advisory).

## Dogfood (byte-diff, zero LLM spend)

This diff touches `packages/review/src/plugins/agent/index.ts` but does
**not** touch any agent-facing prompt, rule definition, or LLM input —
confirmed by a **byte-diff** against `origin/main`:

```
$ git diff origin/main -- packages/review/src/plugins/agent/system-prompt.ts packages/review/src/plugins/agent/rules.ts | wc -l
0
```

The only changes in `plugins/agent/index.ts` are `appendIncompleteNotice`'s
metadata (one added boolean flag) and a new pure predicate function
(`hasIncompleteMainPass`) — both deterministic TypeScript, zero LLM calls,
covered by unit tests above.

Replayed the #795 "wholesale-corrupted stop-turn, no recoverable content"
payload shape (`neverRan: false`, `stopReason: 'completed'`, some turns
completed) through the real `finishRun`/`exitCodeFor` path, built from
`@liendev/action`'s actual dist, under `fail-on: never` (this repo's own
workflow default):

**Before** (pre-fix, HEAD `f2c0793a`):
```
hasProviderFailure: false
Review complete: 1 findings (0 errors), conclusion=neutral, files=12
--- fail-on: never (this repo's own default) ---
exit code: 0 (GREEN check)
```

**After** (this PR):
```
hasProviderFailure: false
hasIncompleteMainPass: true
::error::Lien Review is incomplete: ... This fails the check even with
fail-on: never — an incomplete review cannot vouch for full coverage of
this PR, so it is not an advisory finding. ...
Review complete: 1 findings (0 errors), conclusion=neutral, files=12
--- fail-on: never (this repo's own default) ---
exit code: 1 (RED check)
```

## Gates

- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green (full monorepo, incl. `@liendev/parser-native` rebuilt locally for this worktree).
- `node packages/cli/dist/index.js delta` — exit 0, no new-over-threshold crossings (a handful of pre-existing functions show a small "worsened" delta below their thresholds — see below — never `--soft`).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 11 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 4 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a trust-residue bug where an incomplete main-pass agent review could exit 0 under the default `fail-on: never`. It introduces a narrow `incompleteMainPass` signal (distinct from the existing `providerFailure` SSOT and from the attestation layer's deliberately-conflated degraded verdict) and forces exit 1 in the GitHub Action whenever that signal is true. The carve-out for extra-pass-only incompleteness (doc-truth, named passes) is preserved, so coverage-preserving partial runs stay advisory. The change is well-scoped, deterministic, and covered by updated unit tests in both `@liendev/review` and `@liendev/action`.
>
> - Added `hasIncompleteMainPass` SSOT predicate and `mainPassIncomplete` metadata flag, set only for main-pass stops.
> - Threaded `incompleteMainPass` through `ReviewCoreResult` and forced a failing exit code in the action regardless of `fail-on`.
> - Updated tests to pin main-pass failure under `fail-on: never` and preserve advisory behavior for extra-pass-only incompleteness.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3fdb022. Updates automatically on new commits.</sup>
<!-- /lien-stats -->