### PR TITLE
feat(review): doc-truth v2 per-claim verdicts (flag-gated)

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -18,12 +18,54 @@
  * generic executor owns the client-run/failure-isolation/reporting plumbing
  * this module used to own itself (`runDocTruthPass`, `appendDocTruthTurns`),
  * so every piece here stays unit-testable with zero LLM spend.
+ *
+ * ## v2 — per-claim verdict contract (flag-gated, default OFF)
+ *
+ * pr658's Finding A (the `schema.ts` `embeddings.enabled` doc comment) is the
+ * motivating case: doc-truth's open findings list lets a real contradiction
+ * lose the competition for a scarce findings slot even inside this ALREADY
+ * dedicated, single-rule pass (measured ~1/3 engagement — see that fixture's
+ * "OWNER RE-SCOPE DECISION" header). `stale-duplicate-pass.ts`'s candidate
+ * loop proved the fix for a narrower shape: require one verdict per worklist
+ * id instead of an open list an entry can silently be omitted from.
+ *
+ * Set `LIEN_DOC_TRUTH_V2=on` (see `isDocTruthV2Enabled`) to require exactly
+ * that here: every `<doc_claims>` entry and every `<rename_sweep>` item gets
+ * a stable `claim-N` id (`buildClaimWorklist`), and the model MUST emit one
+ * verdict (`accurate` | `contradicted` | `unverifiable`) per id, carried
+ * inside the standard `findings` array tagged with `claimId`/`verdict` — the
+ * same "verdict inside the ordinary findings key" shape stale-duplicate uses,
+ * so the shared client's parse/validate pipeline needs no changes. Unlike
+ * that candidate loop, this pass's contract stays OPEN beyond the worklist:
+ * an extra finding for a claim the model spotted itself (no `claimId`) is
+ * still legal and passes straight through — the rule text's existing "also
+ * skim the touched hunks for any [claim] not listed" allowance is unchanged.
+ * `postProcessDocTruthResult` reduces `contradicted`/`unverifiable` verdicts
+ * to real findings (dropping `accurate` ones, mirroring the "stay silent when
+ * confirmed" v1 instruction) and marks the result honestly
+ * `incomplete_verdict` when any listed id's verdict is missing, invalid,
+ * duplicated, or unrecognized (CodeRabbit-hardened honesty rigor — see
+ * `stale-duplicate-pass.ts`'s `hasCompleteVerdictCoverage` doc comment).
+ *
+ * When the flag is off, every v2 function is unreachable and
+ * `buildDocTruthPassPrompts`/`postProcessDocTruthResult` return exactly what
+ * they always did — this is an ADDITIVE contract, not a rewrite (see the
+ * byte-diff proof in this change's PR body).
  */
 
 import type { ReviewContext } from '../../plugin-types.js';
 import { renderGuidanceSurfaceSection } from '../../guidance-surface-signals.js';
-import { extractDocClaims, renderDocClaimsSection } from '../../doc-claims-signals.js';
-import { renderRenameSweepSection } from '../../rename-sweep-signals.js';
+import {
+  extractDocClaims,
+  attachEvidence,
+  renderDocClaimsSection,
+  type DocClaim,
+} from '../../doc-claims-signals.js';
+import {
+  computeRenameSweepSignals,
+  renderRenameSweepSection,
+  type RenameSweepSignal,
+} from '../../rename-sweep-signals.js';
 
 import type { AgentConfig, AgentFinding, AgentResult, ResolvedRules } from './types.js';
 import { DOC_TRUTH } from './rules.js';
@@ -166,15 +208,250 @@ export function buildDocTruthPassInitialMessage(context: ReviewContext): string 
  * standard agent prompt with ONLY the doc-truth rule active (so the output
  * format enumerates just `doc-truth` and no competing investigation strategies
  * appear).
+ *
+ * When `isDocTruthV2Enabled()` is true, the per-claim verdict contract (see
+ * this module's doc comment) is layered on top: the system prompt gets an
+ * appended override section requiring one verdict per worklist id, and the
+ * initial message's `<doc_claims>`/`<rename_sweep>` blocks are rebuilt with
+ * ids attached (`buildDocTruthPassInitialMessageV2`). With the flag off this
+ * function's return value is UNCHANGED from before v2 existed — same two
+ * function calls, nothing appended.
  */
 export function buildDocTruthPassPrompts(context: ReviewContext): {
   systemPrompt: string;
   initialMessage: string;
 } {
+  const systemPrompt = buildSystemPrompt(DOC_TRUTH_ONLY_RULES);
+  if (!isDocTruthV2Enabled()) {
+    return { systemPrompt, initialMessage: buildDocTruthPassInitialMessage(context) };
+  }
+  const worklist = buildClaimWorklist(context);
   return {
-    systemPrompt: buildSystemPrompt(DOC_TRUTH_ONLY_RULES),
-    initialMessage: buildDocTruthPassInitialMessage(context),
+    systemPrompt: `${systemPrompt}\n\n${buildV2OutputContractOverride(allClaimIds(worklist))}`,
+    initialMessage: buildDocTruthPassInitialMessageV2(context, worklist),
   };
+}
+
+// ---------------------------------------------------------------------------
+// v2 — per-claim verdict contract (flag-gated; see module doc comment)
+// ---------------------------------------------------------------------------
+
+/** Env opt-in for the v2 per-claim-verdict contract. Default OFF (unset/anything else). */
+const DOC_TRUTH_V2_ENV = 'LIEN_DOC_TRUTH_V2';
+
+function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'on';
+}
+
+/** Whether the v2 per-claim-verdict contract is active. Env-only opt-in (no config field — a
+ *  pilot flag, mirroring stale-duplicate-pass.ts's env-first pattern before it grew a config field). */
+export function isDocTruthV2Enabled(): boolean {
+  return envEnabled(process.env[DOC_TRUTH_V2_ENV]);
+}
+
+/** Cap on doc claims assigned an id — mirrors doc-claims-signals.ts's own MAX_CLAIMS render cap. */
+const DOC_TRUTH_V2_MAX_CLAIMS = 20;
+
+/** One rename-sweep mapping's prose-touched/survivor items, each paired with its assigned id
+ *  (same order as `RenameSweepSignal.proseTouched`/`.survivors` — see `buildClaimWorklist`). */
+interface RenameSignalWithIds {
+  signal: RenameSweepSignal;
+  proseIds: string[];
+  survivorIds: string[];
+}
+
+/** The full id-tagged claim worklist for one PR: every doc claim and rename-sweep item that
+ *  gets a stable `claim-N` id under the v2 contract. Ids are assigned in a single sequential
+ *  namespace (doc claims first, then rename-sweep items signal by signal, prose before
+ *  survivors) so `allClaimIds` and the render functions agree on the same order deterministically. */
+interface ClaimWorklist {
+  docClaims: DocClaim[];
+  /** Parallel to `docClaims` — `docClaimIds[i]` is `docClaims[i]`'s id. */
+  docClaimIds: string[];
+  renameSignals: RenameSignalWithIds[];
+  /** Doc claims beyond DOC_TRUTH_V2_MAX_CLAIMS that got no id (0 when none). */
+  overflowClaims: number;
+}
+
+/** Build the id-tagged worklist from the review context. Pure and deterministic — the same
+ *  compute functions the v1 render path uses (`extractDocClaims`/`attachEvidence`/
+ *  `computeRenameSweepSignals`), just with ids assigned alongside. Exposed for testing. */
+export function buildClaimWorklist(context: ReviewContext): ClaimWorklist {
+  const patches = context.pr?.patches;
+  const allClaims = patches ? attachEvidence(extractDocClaims(patches), context) : [];
+  const docClaims = allClaims.slice(0, DOC_TRUTH_V2_MAX_CLAIMS);
+
+  let n = 0;
+  const docClaimIds = docClaims.map(() => `claim-${++n}`);
+
+  const renameSignals: RenameSignalWithIds[] = computeRenameSweepSignals(context).map(signal => ({
+    signal,
+    proseIds: signal.proseTouched.map(() => `claim-${++n}`),
+    survivorIds: signal.survivors.map(() => `claim-${++n}`),
+  }));
+
+  return {
+    docClaims,
+    docClaimIds,
+    renameSignals,
+    overflowClaims: Math.max(0, allClaims.length - DOC_TRUTH_V2_MAX_CLAIMS),
+  };
+}
+
+/** Every id in a worklist, in worklist order — the expected-id set `postProcessDocTruthResult`
+ *  checks verdict coverage against, and what the prompt's contract text enumerates. */
+export function allClaimIds(worklist: ClaimWorklist): string[] {
+  return [
+    ...worklist.docClaimIds,
+    ...worklist.renameSignals.flatMap(s => [...s.proseIds, ...s.survivorIds]),
+  ];
+}
+
+/** Render one doc-claim entry with its id — same shape as doc-claims-signals.ts's
+ *  `renderClaimEntry`, minus that function's per-entry budget truncation (this worklist is
+ *  already capped at DOC_TRUTH_V2_MAX_CLAIMS entries, so the overflow note carries the same
+ *  role a byte-budget cutoff would). */
+function renderDocClaimEntryWithId(id: string, claim: DocClaim): string {
+  const header = `- [${id}] ${claim.file}: "${claim.claimText}"`;
+  if (!claim.evidence) {
+    return `${header}\n  (evidence: none located — find the described code yourself via get_files_context on the named symbols/files)`;
+  }
+  if (claim.evidence.citedPathMissing) {
+    return (
+      `${header}\n  (evidence: the cited file "${claim.evidence.file}" was not found in the ` +
+      'index — the citation itself may be stale)'
+    );
+  }
+  const { file, startLine, excerpt, fromDoc } = claim.evidence;
+  const label = fromDoc ? 'evidence (sibling doc)' : 'evidence';
+  return `${header}\n  ${label} — ${file}:${startLine}:\n  \`\`\`\n${excerpt}\n  \`\`\``;
+}
+
+const DOC_CLAIMS_V2_HEADER =
+  'Pre-computed, same claims as <doc_claims> would normally carry, each tagged with a stable ' +
+  '[claim-N] id. Per the PER-CLAIM VERDICT CONTRACT below, one verdict is REQUIRED for every id ' +
+  'here (and in <rename_sweep>, if present) — this is your primary claim inventory, not an ' +
+  'optional worklist. The scan can still miss claims and can list merely-descriptive prose, so ' +
+  'also skim the touched hunks for any claim not listed — report those as ordinary additional ' +
+  'findings (no id needed). Most entries carry an `evidence` excerpt: COMPARE the claim against ' +
+  'it (confirm the excerpt IS the described code first); for a no-evidence entry, locate the code ' +
+  'yourself via get_files_context on the named symbols.';
+
+/** Render the `<doc_claims>` block with ids — the v2 counterpart of
+ *  `renderDocClaimsSection`. Returns '' when there are no doc claims at all. */
+function renderDocClaimsV2(worklist: ClaimWorklist): string {
+  if (worklist.docClaims.length === 0 && worklist.overflowClaims === 0) return '';
+  const lines = ['<doc_claims>', DOC_CLAIMS_V2_HEADER];
+  worklist.docClaims.forEach((claim, i) =>
+    lines.push(renderDocClaimEntryWithId(worklist.docClaimIds[i], claim)),
+  );
+  if (worklist.overflowClaims > 0) {
+    lines.push(
+      `- [+${worklist.overflowClaims} more claim(s) omitted — no id assigned; skim the touched ` +
+        'doc hunks for any not listed]',
+    );
+  }
+  lines.push('</doc_claims>');
+  return lines.join('\n');
+}
+
+const RENAME_SWEEP_V2_LEAD =
+  'Pre-computed by a deterministic diff scan. This PR applies one or more MECHANICAL identifier ' +
+  'renames across many files; each prose-touched line and surviving old-name reference below is ' +
+  'tagged with a stable [claim-N] id and, per the PER-CLAIM VERDICT CONTRACT, needs exactly one ' +
+  'verdict. A prose-touched line asks "is the claim this sentence makes still TRUE of the new ' +
+  'name" (contradicted if the rename made it stale); a survivor asks "should this old-name ' +
+  'reference have been renamed too" (contradicted if the rename is incomplete).';
+
+/** Render the `<rename_sweep>` block with ids — the v2 counterpart of
+ *  `renderRenameSweepSection`. Returns '' when no rename sweep was detected. */
+function renderRenameSweepV2(worklist: ClaimWorklist): string {
+  if (worklist.renameSignals.length === 0) return '';
+  const lines = ['<rename_sweep>', RENAME_SWEEP_V2_LEAD];
+  for (const { signal, proseIds, survivorIds } of worklist.renameSignals) {
+    lines.push('');
+    lines.push(
+      `- Mapping \`${signal.mapping.from}\` → \`${signal.mapping.to}\` ` +
+        `(${signal.mapping.occurrenceCount} occurrences across ${signal.mapping.fileCount} files):`,
+    );
+    signal.proseTouched.forEach((p, i) => {
+      lines.push(`  - [${proseIds[i]}] ${p.file}:${p.line} (${p.kind})  \`${p.sentence}\``);
+    });
+    signal.survivors.forEach((v, i) => {
+      const tag = v.repoWide ? ' (untouched file)' : '';
+      lines.push(`  - [${survivorIds[i]}] ${v.file}:${v.line}${tag}  \`${v.snippet}\` (survivor)`);
+    });
+  }
+  lines.push('</rename_sweep>');
+  return lines.join('\n');
+}
+
+const DOC_TRUTH_V2_CONTRACT_NOTE =
+  'PER-CLAIM VERDICT CONTRACT (v2): every entry below carries a stable id in [brackets], e.g. ' +
+  '"claim-3". You MUST emit exactly one verdict per listed id — mandatory, not optional; do not ' +
+  'silently skip an id, including one you judge "accurate". See <output_format> for the exact ' +
+  'shape. You may ALSO still report additional findings for a claim you spot yourself that is ' +
+  'not in the worklist — those need no id and are evaluated as ordinary findings.';
+
+/** Build the v2 initial message: same shape as `buildDocTruthPassInitialMessage`, but the
+ *  doc-claims/rename-sweep blocks carry ids and a contract note is inserted after the intro. */
+export function buildDocTruthPassInitialMessageV2(
+  context: ReviewContext,
+  worklist: ClaimWorklist,
+): string {
+  const sections: string[] = [];
+  pushIfPresent(sections, renderPassPrHeader(context));
+  sections.push(DOC_PASS_INTRO);
+  sections.push(DOC_TRUTH_V2_CONTRACT_NOTE);
+  pushIfPresent(sections, renderDocClaimsV2(worklist));
+  pushIfPresent(sections, renderRenameSweepV2(worklist));
+  pushIfPresent(sections, renderGuidanceSurfaceSection(context));
+  sections.push(
+    'Judge every listed id and emit its required verdict, then output findings as JSON. If ' +
+      'every claim is accurate, every verdict is still required — just each with verdict ' +
+      '"accurate" and no additional finding.',
+  );
+  return sections.join('\n\n');
+}
+
+/** The v2 output-contract override, appended after the standard <output_format> section (see
+ *  `buildDocTruthPassPrompts`) — models read a prompt as one continuous document, so the LAST
+ *  instruction on output shape wins; this supersedes the standard open-list framing for THIS
+ *  pass only, without needing to rebuild `buildSystemPrompt`'s tools/rules/examples sections
+ *  (unlike stale-duplicate-pass.ts's from-scratch system prompt, which exists because that pass
+ *  ALSO hard-cuts the tool list — this pass keeps the full doc-truth tool access). */
+function buildV2OutputContractOverride(ids: string[]): string {
+  return `<output_format_v2_override>
+SUPERSEDES the <output_format> section above for THIS run. The \`findings\` array carries BOTH
+the mandatory per-claim verdicts AND any extra findings you spot beyond the worklist:
+
+{
+  "findings": [
+    {
+      "claimId": "claim-1",
+      "verdict": "accurate | contradicted | unverifiable",
+      "filepath": "relative/path.ts",
+      "line": 42,
+      "severity": "error | warning",
+      "category": "bug",
+      "message": "REQUIRED for every verdict. When contradicted: quote the claim and cite the falsifying fact (1-2 sentences). When accurate/unverifiable: 1 sentence saying why.",
+      "suggestion": "The fix (contradicted only).",
+      "evidence": "One line citing the falsifying code fact (contradicted only)."
+    }
+  ],
+  "summary": { "riskLevel": "low | medium | high | critical", "overview": "One sentence.", "keyChanges": [] }
+}
+
+EXACTLY one verdict entry is REQUIRED per id in ${ids.length > 0 ? ids.join(', ') : '(none — no worklist ids this run)'} —
+no more, no fewer per id. An extra finding for a claim NOT in the worklist is legal and unlimited
+— omit \`claimId\`/\`verdict\` on those; they need no verdict and are evaluated as ordinary
+findings. EVERY verdict entry requires claimId, verdict, filepath, line, severity, and message —
+even for accurate/unverifiable (use the claim's own file for filepath; best-effort line; severity
+"warning" unless contradicted, where the usual bug-severity judgment applies). A missing,
+duplicated, or unrecognized claimId, or a missing/invalid verdict on a claimed entry, makes this
+pass's result incomplete.
+</output_format_v2_override>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +540,117 @@ export function mergeDocPassIntoResult(
 }
 
 // ---------------------------------------------------------------------------
+// v2 post-processing — verdict reduction + honest completeness
+// ---------------------------------------------------------------------------
+
+/** A verdict value the v2 output contract recognizes. */
+type DocTruthVerdict = 'accurate' | 'contradicted' | 'unverifiable';
+const VALID_DOC_TRUTH_VERDICTS: ReadonlySet<string> = new Set<DocTruthVerdict>([
+  'accurate',
+  'contradicted',
+  'unverifiable',
+]);
+
+/** The raw per-claim shape the model MAY emit inside the standard `findings` array under v2 —
+ *  `claimId`/`verdict` are both optional because an ad hoc finding beyond the worklist (the
+ *  rule's existing "claim not listed" allowance) carries neither. */
+interface RawDocClaimVerdict extends AgentFinding {
+  claimId?: string;
+  verdict?: DocTruthVerdict;
+}
+
+/** Strip the v2-only `claimId`/`verdict` fields, keeping the standard finding shape — mirrors
+ *  `stale-duplicate-pass.ts`'s `toCleanFinding`. */
+function toCleanDocTruthFinding(f: RawDocClaimVerdict): AgentFinding {
+  return {
+    filepath: f.filepath,
+    line: f.line,
+    endLine: f.endLine,
+    symbolName: f.symbolName,
+    severity: f.severity,
+    category: f.category,
+    message: f.message,
+    suggestion: f.suggestion,
+    evidence: f.evidence,
+  };
+}
+
+/**
+ * True iff every id in `ids` has EXACTLY ONE recognized verdict among the entries that claim
+ * it, and no entry claims an id with an invalid/unknown id or an invalid/missing verdict.
+ * Entries with NO `claimId` at all are ad hoc findings (the rule's "claim not listed"
+ * allowance) and are exempt from this check entirely — the one deliberate difference from
+ * `stale-duplicate-pass.ts`'s `hasCompleteVerdictCoverage`, whose candidate loop has no such
+ * open-ended allowance and so requires every entry to carry a valid candidateId/verdict pair.
+ * A missing, duplicated, or unrecognized claimId — or a missing/invalid verdict on an entry
+ * that DOES carry a claimId — still fails the whole check, same honesty rigor as that sibling
+ * function (a malformed claimed entry must never quietly count as "covered").
+ */
+function hasCompleteVerdictCoverage(ids: string[], raw: RawDocClaimVerdict[]): boolean {
+  const expected = new Set(ids);
+  const verdictCounts = new Map<string, number>();
+  for (const { claimId, verdict } of raw) {
+    if (claimId === undefined) continue; // ad hoc finding beyond the worklist — exempt
+    if (
+      typeof claimId !== 'string' ||
+      !expected.has(claimId) ||
+      typeof verdict !== 'string' ||
+      !VALID_DOC_TRUTH_VERDICTS.has(verdict)
+    ) {
+      return false;
+    }
+    verdictCounts.set(claimId, (verdictCounts.get(claimId) ?? 0) + 1);
+  }
+  return ids.every(id => verdictCounts.get(id) === 1);
+}
+
+/**
+ * Reduce the raw v2 findings array to real findings: every ad hoc finding (no `claimId`) passes
+ * through unchanged, and every claimed entry is kept ONLY when its verdict is `contradicted` or
+ * `unverifiable` (cleaned of the v2-only fields) — mirroring v1's rule text ("a claim the code
+ * confirms needs no finding" / "a claim you cannot locate is reported as a warning"). An
+ * `accurate` verdict, or any claimed entry with an invalid/unrecognized verdict, is dropped
+ * rather than guess-promoted — the inclusion-list mirror of `stale-duplicate-pass.ts`'s
+ * `verdict === 'stale'` filter.
+ */
+function reduceDocTruthV2Findings(raw: RawDocClaimVerdict[]): AgentFinding[] {
+  return raw
+    .filter(
+      f => f.claimId === undefined || f.verdict === 'contradicted' || f.verdict === 'unverifiable',
+    )
+    .map(f => (f.claimId !== undefined ? toCleanDocTruthFinding(f) : f));
+}
+
+/**
+ * Post-process a doc-truth pass result under the v2 contract: reduce verdicts to real findings
+ * and mark the result honestly `incomplete_verdict` when coverage is incomplete (see
+ * `hasCompleteVerdictCoverage`). Identity (returns `result` unchanged, same reference) when the
+ * flag is off — this is what makes `DOC_TRUTH_PASS_SPEC.postProcessResult` safe to wire in
+ * unconditionally without touching v1 behavior. When the client result was ALREADY incomplete
+ * for a real reason (budget/max_turns/error), that reason is kept as-is, same precedent as
+ * `stale-duplicate-pass.ts`'s `postProcessStaleDuplicateResult`.
+ */
+export function postProcessDocTruthResult(
+  result: AgentResult,
+  context: ReviewContext,
+): AgentResult {
+  if (!isDocTruthV2Enabled()) return result;
+
+  const ids = allClaimIds(buildClaimWorklist(context));
+  const raw = result.findings as RawDocClaimVerdict[];
+  const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
+  const wasAlreadyIncomplete = result.incomplete;
+
+  return {
+    ...result,
+    findings: reduceDocTruthV2Findings(raw),
+    incomplete: wasAlreadyIncomplete || coverageIncomplete,
+    stopReason:
+      !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // ReviewPassSpec (plugs doc-truth into the generalized executor)
 // ---------------------------------------------------------------------------
 
@@ -272,7 +660,9 @@ export function mergeDocPassIntoResult(
  * list. Every field here is one of this module's own pure functions; the
  * generic executor supplies the gate-check/run/failure-isolation/reporting
  * plumbing that used to be doc-truth-specific (`runDocTruthPass`,
- * `appendDocTruthTurns`).
+ * `appendDocTruthTurns`). `postProcessResult` is always wired in — it's an
+ * identity no-op when `LIEN_DOC_TRUTH_V2` is off (see
+ * `postProcessDocTruthResult`), so this addition doesn't change v1 behavior.
  */
 export const DOC_TRUTH_PASS_SPEC: ReviewPassSpec = {
   name: 'doc-truth',
@@ -283,4 +673,5 @@ export const DOC_TRUTH_PASS_SPEC: ReviewPassSpec = {
   maxTurns: DOC_PASS_MAX_TURNS,
   mergeFindings: mergeDocTruthFindings,
   mergeResultState: mergeDocPassIntoResult,
+  postProcessResult: postProcessDocTruthResult,
 };

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -4,12 +4,19 @@ import {
   shouldRunDocTruthPass,
   buildDocTruthPassPrompts,
   buildDocTruthPassInitialMessage,
+  buildDocTruthPassInitialMessageV2,
   mergeDocTruthFindings,
   mergeDocPassIntoResult,
   docTruthPassBudget,
+  isDocTruthV2Enabled,
+  buildClaimWorklist,
+  allClaimIds,
+  postProcessDocTruthResult,
   DOC_TRUTH_PASS_SPEC,
   DOC_PASS_MAX_TURNS,
 } from '../src/plugins/agent/doc-truth-pass.js';
+import { buildSystemPrompt } from '../src/plugins/agent/system-prompt.js';
+import { DOC_TRUTH } from '../src/plugins/agent/rules.js';
 import { createTestContext } from '../src/test-helpers.js';
 import type { ReviewContext } from '../src/plugin-types.js';
 import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
@@ -101,7 +108,21 @@ function fakeResult(findings: AgentFinding[] = [], trace?: AgentTrace): AgentRes
 
 afterEach(() => {
   delete process.env.LIEN_REVIEW_DOC_PASS;
+  delete process.env.LIEN_DOC_TRUTH_V2;
 });
+
+/** A raw v2 verdict/finding entry — extends the plain `finding()` helper with the v2-only
+ *  `claimId`/`verdict` fields, mirroring stale-duplicate-pass.test.ts's `finding()` pattern. */
+function verdictFinding(overrides: Record<string, unknown> = {}): AgentFinding {
+  return {
+    filepath: 'docs/architecture/worktree.md',
+    line: 1,
+    severity: 'warning',
+    category: 'bug',
+    message: 'msg',
+    ...overrides,
+  } as AgentFinding;
+}
 
 // ---------------------------------------------------------------------------
 // shouldRunDocTruthPass
@@ -397,5 +418,274 @@ describe('DOC_TRUTH_PASS_SPEC', () => {
   it('buildPrompts delegates to buildDocTruthPassPrompts', () => {
     const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
     expect(DOC_TRUTH_PASS_SPEC.buildPrompts(ctx)).toEqual(buildDocTruthPassPrompts(ctx));
+  });
+
+  it('postProcessResult is postProcessDocTruthResult', () => {
+    expect(DOC_TRUTH_PASS_SPEC.postProcessResult).toBe(postProcessDocTruthResult);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v2 — per-claim verdict contract (flag-gated; LIEN_DOC_TRUTH_V2)
+// ---------------------------------------------------------------------------
+
+describe('isDocTruthV2Enabled', () => {
+  it('is false by default (env unset)', () => {
+    expect(isDocTruthV2Enabled()).toBe(false);
+  });
+
+  it.each(['on', '1', 'true', 'ON', 'TRUE'])('is true for LIEN_DOC_TRUTH_V2=%s', value => {
+    process.env.LIEN_DOC_TRUTH_V2 = value;
+    expect(isDocTruthV2Enabled()).toBe(true);
+  });
+
+  it.each(['off', '0', 'false', 'nonsense'])('is false for LIEN_DOC_TRUTH_V2=%s', value => {
+    process.env.LIEN_DOC_TRUTH_V2 = value;
+    expect(isDocTruthV2Enabled()).toBe(false);
+  });
+});
+
+describe('buildClaimWorklist / allClaimIds — id assignment stability', () => {
+  it('assigns one sequential id per doc claim, none for rename items when there are none', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const worklist = buildClaimWorklist(ctx);
+    expect(worklist.docClaimIds).toEqual(['claim-1']);
+    expect(worklist.renameSignals).toEqual([]);
+    expect(worklist.overflowClaims).toBe(0);
+    expect(allClaimIds(worklist)).toEqual(['claim-1']);
+  });
+
+  it('assigns ids across doc claims THEN rename-sweep items, prose before survivors, in one sequential namespace', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const worklist = buildClaimWorklist(ctx);
+
+    expect(worklist.docClaimIds).toEqual(['claim-1']);
+    expect(worklist.renameSignals).toHaveLength(1);
+    const { proseIds, survivorIds, signal } = worklist.renameSignals[0];
+    expect(signal.mapping.from).toBe('oldSearchToken');
+    expect(signal.mapping.to).toBe('newSearchToken');
+    expect(proseIds).toEqual(['claim-2', 'claim-3', 'claim-4', 'claim-5', 'claim-6']);
+    expect(survivorIds).toEqual([]); // this fixture's rename fully replaced the token — no survivors
+
+    expect(allClaimIds(worklist)).toEqual([
+      'claim-1',
+      'claim-2',
+      'claim-3',
+      'claim-4',
+      'claim-5',
+      'claim-6',
+    ]);
+  });
+
+  it('is stable across repeated calls on the same context (same ids, same order)', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    expect(allClaimIds(buildClaimWorklist(ctx))).toEqual(allClaimIds(buildClaimWorklist(ctx)));
+  });
+
+  it('caps doc claims at DOC_TRUTH_V2_MAX_CLAIMS (20) with an overflow count, no ids beyond the cap', () => {
+    // 25 distinct single-line claim patches on 25 distinct doc files — each trips the
+    // 'requirement' claim shape ("requires") independently.
+    const entries: Array<[string, string]> = Array.from({ length: 25 }, (_, i) => [
+      `docs/architecture/doc${i}.md`,
+      `@@ -1,1 +1,2 @@\n # Title\n+This step ${i} requires a fresh checkout.`,
+    ]);
+    const ctx = contextWithPatches(entries);
+    const worklist = buildClaimWorklist(ctx);
+    expect(worklist.docClaimIds).toHaveLength(20);
+    expect(worklist.overflowClaims).toBe(5);
+    expect(allClaimIds(worklist)).toHaveLength(20);
+  });
+});
+
+describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 contract rendering', () => {
+  it('is byte-identical to the pre-v2 prompts when the flag is off', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(ctx);
+    expect(systemPrompt).toBe(buildSystemPrompt({ active: [DOC_TRUTH], skipped: [] }));
+    expect(initialMessage).toBe(buildDocTruthPassInitialMessage(ctx));
+    expect(systemPrompt).not.toContain('output_format_v2_override');
+    expect(initialMessage).not.toContain('PER-CLAIM VERDICT CONTRACT');
+    expect(initialMessage).not.toContain('[claim-1]');
+  });
+
+  it('appends the v2 output-contract override to the system prompt, enumerating every claim id', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const { systemPrompt } = buildDocTruthPassPrompts(ctx);
+
+    expect(systemPrompt).toContain('<output_format_v2_override>');
+    expect(systemPrompt).toContain('SUPERSEDES the <output_format> section above');
+    expect(systemPrompt).toContain('claim-1, claim-2, claim-3, claim-4, claim-5, claim-6');
+    // The v1 output_format section is still present (appended AFTER, not replaced) — the
+    // supersession is a prompt-reading convention, not a text removal.
+    expect(systemPrompt).toContain('<output_format>');
+    // Full doc-truth tool access is unchanged (unlike stale-duplicate's hard tool cut).
+    expect(systemPrompt).toContain('get_dependents');
+    expect(systemPrompt).toContain('get_complexity');
+  });
+
+  it('renders <doc_claims> and <rename_sweep> with [claim-N] ids and the contract note', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const { initialMessage } = buildDocTruthPassPrompts(ctx);
+
+    expect(initialMessage).toContain('PER-CLAIM VERDICT CONTRACT');
+    expect(initialMessage).toContain('<doc_claims>');
+    expect(initialMessage).toContain('[claim-1] docs/architecture/worktree.md:');
+    expect(initialMessage).toContain('<rename_sweep>');
+    expect(initialMessage).toContain('[claim-2]');
+    expect(initialMessage).toContain('`oldSearchToken` → `newSearchToken`');
+    // Exactly one actual <doc_claims>/<rename_sweep> BLOCK renders (closing tags are a clean
+    // signal — DOC_PASS_INTRO's own prose mentions the opening tag name by name for guidance).
+    expect((initialMessage.match(/<\/doc_claims>/g) ?? []).length).toBe(1);
+    expect((initialMessage.match(/<\/rename_sweep>/g) ?? []).length).toBe(1);
+  });
+
+  it('buildDocTruthPassInitialMessageV2 omits <doc_claims>/<rename_sweep> entirely when the worklist is empty', () => {
+    const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]);
+    const message = buildDocTruthPassInitialMessageV2(ctx, buildClaimWorklist(ctx));
+    // DOC_PASS_INTRO's own prose still names "<doc_claims>" for guidance even when the block is
+    // absent (matching v1's intro wording); the closing tag is the reliable "block rendered" signal.
+    expect(message).not.toContain('</doc_claims>');
+    expect(message).not.toContain('</rename_sweep>');
+    expect(message).toContain('PER-CLAIM VERDICT CONTRACT');
+  });
+});
+
+describe('postProcessDocTruthResult', () => {
+  const singleClaimCtx = () =>
+    contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+
+  it('is the identity (same reference) when the flag is off', () => {
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'contradicted' })]);
+    expect(postProcessDocTruthResult(result, singleClaimCtx())).toBe(result);
+  });
+
+  it('drops an "accurate" verdict entirely (stays silent when confirmed)', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'accurate', message: 'confirmed' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.findings).toHaveLength(0);
+    expect(processed.incomplete).toBe(false);
+  });
+
+  it('keeps a "contradicted" verdict as a real finding, stripped of claimId/verdict', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'contradicted', message: 'stale claim' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.findings).toHaveLength(1);
+    expect(processed.findings[0].message).toBe('stale claim');
+    expect((processed.findings[0] as Record<string, unknown>).claimId).toBeUndefined();
+    expect((processed.findings[0] as Record<string, unknown>).verdict).toBeUndefined();
+    expect(processed.incomplete).toBe(false);
+  });
+
+  it('keeps an "unverifiable" verdict as a real (warning) finding', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'unverifiable', message: 'could not locate' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.findings).toHaveLength(1);
+    expect(processed.findings[0].message).toBe('could not locate');
+    expect(processed.incomplete).toBe(false);
+  });
+
+  it('passes an ad hoc finding (no claimId) through unchanged, alongside a required verdict', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
+      verdictFinding({ filepath: 'other.md', line: 9, message: 'spotted myself', ruleId: 'x' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.findings).toHaveLength(1);
+    expect(processed.findings[0].message).toBe('spotted myself');
+    expect(processed.incomplete).toBe(false);
+  });
+
+  it('marks the result incomplete with stopReason "incomplete_verdict" when the id is missing entirely', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([]); // claim-1 never got a verdict
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when a claimId is present but its verdict is missing/invalid', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: undefined })]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('incomplete_verdict');
+    expect(processed.findings).toHaveLength(0); // never guess-promoted either
+  });
+
+  it('is incomplete when a claimId is present but its verdict is not a recognized value', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'maybe' as never, message: 'bogus' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when the same claimId is verdicted twice (duplicate)', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'accurate', message: 'first' }),
+      verdictFinding({ claimId: 'claim-1', verdict: 'contradicted', message: 'second' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when an entry names a claimId outside the worklist', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
+      verdictFinding({ claimId: 'claim-99', verdict: 'contradicted', message: 'phantom' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('keeps the ORIGINAL stopReason when the client was already incomplete for a real reason', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([], undefined);
+    result.incomplete = true;
+    result.stopReason = 'budget';
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('budget'); // NOT overwritten to incomplete_verdict
+  });
+
+  it('does not mutate the input result', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'contradicted' })]);
+    postProcessDocTruthResult(result, singleClaimCtx());
+    expect(result.findings).toHaveLength(1);
+    expect((result.findings[0] as Record<string, unknown>).claimId).toBe('claim-1');
   });
 });


### PR DESCRIPTION
## Summary

Converts the doc-truth second pass's output contract from an open findings
list to **mandatory per-claim verdicts**, gated behind `LIEN_DOC_TRUTH_V2=on`
(default OFF, unset). This is the per-claim-verdict architecture the
`stale-duplicate-pass.ts` pilot (#803) proved out, applied to doc-truth —
the re-certification path documented in `pr658-search-code-rename.assertions.ts`'s
"OWNER RE-SCOPE DECISION" / "Follow-up: doc-truth v2 per-claim judgment" note.

**Design (entirely inside `doc-truth-pass.ts` — zero other files touched):**
- Every `<doc_claims>` entry and `<rename_sweep>` item gets a stable
  `claim-N` id (`buildClaimWorklist`/`allClaimIds`), assigned in one
  sequential namespace (doc claims first, then rename-sweep items signal by
  signal, prose before survivors), capped at 20 doc claims (mirrors v1's own
  cap) with an overflow note.
- The system prompt gets an **appended** `<output_format_v2_override>`
  section (models read a prompt as one continuous document — the LAST
  instruction on output shape wins) requiring exactly one verdict
  (`accurate | contradicted | unverifiable`) per listed id, carried inside
  the standard `findings` array tagged with `claimId`/`verdict` — same shape
  the stale-duplicate loop uses, so the shared client's parse/validate
  pipeline needed no changes.
- Unlike the stale-duplicate candidate loop, this pass's contract stays
  **open beyond the worklist**: an extra finding for a claim the model spots
  itself (no `claimId`) is still legal and passes straight through — the
  rule text's existing "also skim the touched hunks for any claim not
  listed" allowance is unchanged.
- `postProcessDocTruthResult` reduces `contradicted`/`unverifiable` verdicts
  to real findings (dropping `accurate` ones — "stay silent when confirmed",
  matching v1's own instruction) and marks the result honestly
  `incomplete_verdict` when any listed id's verdict is missing, invalid,
  duplicated, or unrecognized (CodeRabbit-hardened honesty rigor, same
  standard as `stale-duplicate-pass.ts`'s `hasCompleteVerdictCoverage` — a
  claimed entry with a bad verdict is a gap, not "covered", and is never
  guess-promoted into a finding).
- With the flag off, `buildDocTruthPassPrompts`/`postProcessDocTruthResult`
  return **exactly** what they always did — verified below.

No changes to `types.ts`, `rules.ts`, `system-prompt.ts`,
`doc-claims-signals.ts`, `rename-sweep-signals.ts`, `index.ts`, or
`build-prompts.ts` — the flag is read directly inside `doc-truth-pass.ts`'s
own functions, so no plumbing was needed elsewhere (also sidesteps the
`index.ts`/`build-prompts.ts` conflict zone the concurrent
incomplete-handling-pass PR (#804) was touching the same night).

## Unit tests (33 new, 57 total in the file, all passing)

Mirrors the stale-duplicate pilot's test rigor: flag gating
(`isDocTruthV2Enabled`, case-insensitive `on`/`1`/`true`), id-assignment
stability (sequential across doc-claims + rename-sweep, stable across
repeated calls, overflow cap), contract rendering (v1 byte-identity via a
direct `toBe` against `buildSystemPrompt({ active: [DOC_TRUTH], skipped: [] })`
+ `buildDocTruthPassInitialMessage`, and v2's appended override/ids), and
verdict reduction/coverage/incompleteness (accurate dropped, contradicted/
unverifiable kept+cleaned, ad hoc findings pass through, missing/duplicate/
unknown-id/invalid-verdict all mark `incomplete_verdict`, original
stopReason preserved when already incomplete for a real reason, no input
mutation, identity when flag off).

## Byte-diff census (flag OFF)

Ran `build-prompts.ts` across every on-disk fixture (`placeholder`,
`accurate-doc`, `renamed-stale-claim`, plus freshly captured
`pr658-search-code-rename` and `pr667-worktree-doc-drift`):

- **`LIEN_DOC_TRUTH_V2` unset === explicitly `off`** for every fixture (byte-identical).
- **Main pass systemPrompt/initialMessage: byte-identical off vs on, on EVERY fixture** —
  v2 is entirely scoped to the doc-truth SECOND pass, never touches the main pass.
- **`incompleteHandlingPass`/`staleDuplicatePass` blocks: byte-identical off vs on** —
  confirms this change doesn't interact with the other extra passes.
- doc-truth pass prompts: **byte-identical off vs on when the pass doesn't fire**
  (`accurate-doc`, `placeholder`, `renamed-stale-claim`).
- Differs substantively **only** when it fires:

  | Fixture | systemPrompt (off→on) | initialMessage (off→on) |
  |---|---|---|
  | pr658-search-code-rename | 9,685 → 11,704 chars | 30,831 → 30,142 chars |
  | pr667-worktree-doc-drift | 9,685 → 11,334 chars | 28,934 → 28,775 chars |

  (ids + output-contract-override appended to the system prompt; the
  initial message's id-tagged doc-claims/rename-sweep blocks are slightly
  more compact than v1's own render, since v1's rename-sweep section has
  extra sub-headers this worklist renderer doesn't repeat per mapping.)

## The paid screen (3 votes, `LIEN_DOC_TRUTH_V2=on`, prod default model — moonshotai/kimi-k2.7-code via OpenRouter)

**Spend: $0.3423 of the $0.75 cap** ($0.1177 + $0.1310 + $0.0936). Traces
persisted to `/Users/alfhenderson/.claude/jobs/535d2452/tmp/doctruth-v2-screen/traces/`.
This is a **3-vote screen**, not a calibration — the `--calibrate 10` decision
is the owner's call in the morning, informed by the measured rates below.

**(a) Finding B (the certified gate) — HELD, 3/3.** `augment-explore-task.sh:64`'s
"meaning-based" claim got `verdict: "contradicted"` in every vote, each
correctly naming both the claim and its lexical/BM25 correction in a single
finding (the exact shape the fixture's Tier-2 assertion requires). The
harness's own `allPassed: true` confirms it independently.

**(b) Verdict coverage — 48/48 ids, every vote, zero gaps.** This fixture's
worklist (6 doc claims + 42 rename-sweep prose/survivor items, driven by
the PR's 40-file mechanical rename) got **exactly one recognized verdict per
id in all 3 votes** — zero missing, zero duplicate, zero unrecognized ids.
`incomplete_verdict` never triggered. The mechanism is robust even on a
48-item worklist, well within the existing 6-turn cap (2–4 turns used).
Verdict mix: 44/4, 44/4, 46/2 (accurate/contradicted) across the 3 votes.

**(c) Finding A (schema.ts `embeddings.enabled`) — 0/3, did NOT get lifted.**

Traced why, and it is **not** the output-economy/competition hypothesis the
brief posited. `packages/core/src/config/schema.ts` is an **ordinary code
file**, not a guidance surface (`GUIDANCE_SURFACE_MATCHERS` in
`guidance-surface-signals.ts` only matches `CLAUDE.md`, `plugins/**/*.{sh,mdc}`,
`docs/**/*.md`, `packages/site/docs/**/*.md`, `.changeset/*.md`).
`extractDocClaims()` only scans `collectGuidanceSurfaceChanges()`'s output, so
schema.ts's diff/comment **never appears anywhere in the dedicated doc-truth
pass's prompt** — confirmed by string search: neither `config/schema.ts` nor
`embeddings.enabled` appears anywhere in the doc-truth pass's `initialMessage`,
in any of the 3 votes (its edit also didn't trip the rename-sweep token-swap
detector as a tracked mapping). The pass's tool budget (6 turns) would require
the model to spontaneously investigate a file it has zero textual hint
pointing to.

This means v2's per-claim mandatory-verdict mechanism **cannot lift Finding A
no matter how the contract is tuned** — the claim was never on the list. It
*is* the correct fix for a claim that's on the worklist but loses a
competition for a scarce slot inside the pass (exactly what it proved for
Finding B and for 100% coverage generally) — it just doesn't reach a claim
that's structurally invisible to the pass. For context: the MAIN pass (full
diff visibility, not gated on `isGuidanceSurface`) caught the closest sibling
claim, `null-embeddings.ts:19` (same underlying staleness, different file),
in 1/3 votes here — consistent with the fixture header's documented ~6/10
historical rate for that variant, and confirms the main pass — not the
dedicated second pass — is where Finding A's real competition problem lives.

## Recommendation for the morning `--calibrate 10` decision

Two separable decisions:

1. **Ship v2 on its own merits.** The mechanism is proven: 100% verdict
   coverage under a 48-item worklist across 3/3 votes, zero regression to
   the certified Finding B gate, byte-identical v1 path when off. This is
   the right fix for the "claim is listed but loses the findings
   competition" failure mode.
2. **Do NOT expect a `--calibrate 10` run on `pr658-search-code-rename` to
   move Finding A** — it structurally can't with this change alone, because
   Finding A's claim was never in the worklist to begin with. Re-certifying
   Finding A requires a *separate* follow-up: widening
   `doc-claims-signals.ts`'s file scope (or a parallel scan) beyond
   `isGuidanceSurface()` so an ordinary code file's doc comment can enter
   the worklist at all. Filing that as a follow-up issue rather than folding
   it into this pilot's scope.
3. If the owner wants a calibrate-10 to validate the lift hypothesis in
   general, a fixture where the target claim **is** listed but historically
   under-engaged would be the fair test bed — pr658/Finding A is not that
   fixture (the pr667/pr687/pr711/pr716 characterization fixtures, all
   guidance-surface claims, are worth screening as follow-up candidates).

## Gates

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
all green (1219 tests, 0 lint errors — 33 pre-existing warnings, none in
touched files). `lien delta`: exit 0, one informational `worsened` entry
(`buildDocTruthPassPrompts` cognitive 0→1, from the flag branch) plus 13 new
low-complexity functions (max cognitive 6) — no threshold crossings.

Rebased onto latest `main` (through #805) immediately before opening this
PR; the only overlap with the concurrent incomplete-handling-pass PR (#804)
was `renderPrHeader` being extracted to `review-pass.ts`'s
`renderPassPrHeader` — resolved by adopting that shared helper in this
change's new `buildDocTruthPassInitialMessageV2`.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not finish — it ended without emitting a parseable JSON verdict while investigating. Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e75dc06. Updates automatically on new commits.</sup>
<!-- /lien-stats -->