### PR TITLE
docs(architecture): per-rule candidate-loop ADR + pass-system doc

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -164,6 +164,25 @@ hook protocol changes.
 
 ---
 
+### 🔁 [Agent-Review Pass Architecture](./review-pass-architecture.md)
+**`ReviewPassSpec` and the extra-pass executor (Lien Review)**
+
+Explains how Lien Review's agent-review plugin runs additional dedicated LLM
+passes beyond the main investigation:
+- The `ReviewPassSpec` contract and the serial `runExtraPasses` orchestrator
+- The three shipped passes (doc-truth, stale-duplicate loop,
+  incomplete-handling loop) — gates, budgets, toolsets, verdict vocabularies
+- The per-candidate-verdict output contract and `incomplete_verdict` honesty semantics
+- Attestation v2 (`provider.passes[]` / `BudgetAttestation` per pass)
+- Which passes are production-on vs. dark-launched today
+
+**Read this** if you're adding a rule to the agent-review plugin or touching
+`packages/review/src/plugins/agent/review-pass.ts`. See also
+[ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the decision
+and its evidence.
+
+---
+
 ## 🎯 Quick Reference
 
 ### For New Contributors
@@ -187,6 +206,7 @@ hook protocol changes.
 | Worktree-shared indexing | [Worktree-Aware Indexing](./worktree-aware-indexing.md) |
 | Pre-commit complexity gate (`lien delta`) | [lien delta](./lien-delta.md) |
 | Plugin hook design (what reaches the model) | [Claude Code Hook Output Channels](./claude-code-hook-channels.md) |
+| Lien Review's extra LLM passes (doc-truth, candidate loops) | [Agent-Review Pass Architecture](./review-pass-architecture.md) |
 
 ### For Debugging
 
@@ -336,7 +356,8 @@ Our Mermaid diagrams follow these conventions:
 - ✅ Worktree-aware indexing shipped (0.55.0) and hardened for concurrency (0.59.0): a linked git worktree shares its main checkout's index instead of building a full independent copy — see [Worktree-Aware Indexing](./worktree-aware-indexing.md)
 - ✅ `lien delta` shipped in two phases (0.57.0-0.58.0): a pre-commit complexity-delta CLI gate, then a write-time edit-hook warning — see [lien delta](./lien-delta.md)
 - ✅ `lien gc` added (0.60.0): garbage-collects stale and orphaned `~/.lien/indices` directories
-- ✅ ADR-008 superseded by ADR-011; ADR-011, ADR-012 added
+- ✅ Lien Review's agent-review plugin generalized its doc-truth second pass into a reusable `ReviewPassSpec` executor, added two dedicated (dark-launched) candidate-loop passes, and bumped the delivery attestation to v2 — see [Agent-Review Pass Architecture](./review-pass-architecture.md) (ADR-014)
+- ✅ ADR-008 superseded by ADR-011; ADR-011, ADR-012, ADR-013, ADR-014 added
 
 ### v0.49.x
 - ✅ Docs resynced to match current package layout and product surface

--- a/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
+++ b/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
@@ -1,0 +1,286 @@
+# ADR-014: Per-Rule Candidate-Loop Passes for Agent Review
+
+**Status**: Accepted
+**Date**: 2026-07-16
+**Deciders**: Core Team
+**Related**: PR #799 (pass-executor generalization + attestation v2), PR #803
+(stale-duplicate candidate-loop pilot), PR #804 (incomplete-handling
+candidate loop), PR #805 (stale-duplicate FP-guard fix), `docs/architecture/review-pass-architecture.md`
+(the implementation-level companion to this ADR)
+
+## Context and Problem Statement
+
+Lien Review's agent-review plugin (`packages/review/src/plugins/agent/`)
+originally ran every active rule through one LLM call sharing one findings
+list. The doc-truth arc (PRs #722–#733, see
+`docs/development/review-harness-judgment.md`) proved this has a real,
+measured failure mode that input engineering cannot fix: on a PR carrying
+both documentation drift and juicier code bugs, the model's one findings
+list rationally favors the code bugs, and the loss holds even swapping
+Sonnet 5 for Kimi — an architectural bottleneck (output-list competition),
+not a model gap. The fix that shipped was a dedicated second pass: doc-truth
+alone, its own budget, no competing rules (`doc-truth-pass.ts`, since PR
+#733).
+
+That precedent raised the obvious next question: which *other* rules should
+get the same treatment? Two sub-problems had to be answered before
+generalizing:
+
+1. **The plumbing was doc-truth-specific.** `analyze()` hardcoded exactly
+   one optional second pass — a single `docResult` variable, gate/prompt/
+   budget/merge logic wired in by hand. Adding a second dedicated pass would
+   have meant copy-pasting that wiring a second time.
+2. **Not every rule fits the same shape.** Doc-truth's `<doc_claims>` is a
+   deterministic, boundable candidate worklist — every item enumerable in
+   advance, each with a small closed set of dispositions (confirms /
+   contradicts). Several other rules are **open investigations** with no
+   such worklist: `concurrency-race` needs lock-ordering reasoning with no
+   static-pattern signal; `edge-case-sweep` is "which inputs matter for this
+   function", a per-function judgment call; `untrusted-input-validation`
+   *does* have a candidate signal (`untrusted-input-signals.ts`), but
+   judging one candidate requires open multi-hop data-flow tracing through
+   arbitrary consumer code, not a bounded verdict. Forcing these into a
+   candidate-loop shape would mean either dropping the open-ended
+   investigation or silently reinventing it inside a "verdict" the loop
+   can't actually bound.
+
+A third question — could gating be signal-only, dropping the rule from the
+shared-loop trigger entirely once a dedicated pass exists? — has a concrete
+counter-example: `boundary-change`'s own deterministic signal
+(`comparison-change-signals.ts`) pairs a REMOVED diff line with an ADDED one
+within the same hunk to detect a shifted comparison. A purely *additive*
+bug — new code with no removed line to pair against — produces **zero**
+candidates by construction, no matter how good the signal gets. `boundary-
+change` also carries a 5-step MANDATORY protocol (test-coverage cross-check,
+blast-radius cross-check, changeset cross-check —
+`packages/review/src/plugins/agent/rules.ts` lines 379–420) that is richer
+than a closed real/intentional/false-positive verdict; collapsing it into a
+candidate loop would mean either dropping those cross-checks or reinventing
+the whole rule inside the loop, losing the "own budget, no competition"
+benefit either way.
+
+## Decision
+
+Generalize the doc-truth precedent into a reusable executor, and apply it
+**hybrid, per rule** — never as a blanket policy.
+
+**1. Generalize the plumbing.** `packages/review/src/plugins/agent/review-pass.ts`
+(new, PR #799) factors doc-truth's gate/prompt/budget/run/failure-isolation/
+trace-append shape into a `ReviewPassSpec` interface (name, `gateReason`,
+`buildPrompts`, `budget`, `maxTurns`, `mergeFindings`, `mergeResultState`,
+optional `postProcessResult`) plus a `runExtraPasses` orchestrator.
+`index.ts`'s `analyze()`/`analyzeSummaryOnly()` now run an ordered
+`EXTRA_PASSES: ReviewPassSpec[]` list instead of one hardcoded second-pass
+variable. Execution is **serial for v1** — no pass beyond doc-truth existed
+yet to justify concurrent execution's added complexity (trace-offset races,
+interleaved budget reporting), and doc-truth's own pass has a real data
+dependency on the main pass having completed at all (`runExtraPasses` skips
+every extra pass without evaluating its gate when the main pass never ran).
+See `docs/architecture/review-pass-architecture.md` for the full contract
+and file-level detail.
+
+**2. Give worklist-shaped rules a dedicated candidate-loop pass; leave
+open-investigation rules in the shared loop.** A rule qualifies for a
+dedicated pass when its signal produces an **enumerable, boundable
+candidate list** with a **closed verdict vocabulary** per candidate — the
+same shape doc-truth already had. Two such passes shipped as real
+consumers of the new executor:
+
+- **`stale-duplicate-pass.ts`** (PR #803) — the pilot. `stale-duplicate`'s
+  `always: true` trigger and `stale-literal-signals.ts`'s unconditional
+  signal made it the cleanest first case. Verdict vocabulary: `stale |
+  intentional-reuse | unverifiable`.
+- **`incomplete-handling-pass.ts`** (PR #804) — the second build. Unifies
+  THREE existing signals (`variant-sweep-signals.ts`, `sibling-surface-
+  signals.ts`, `unread-field-signals.ts`) that all feed the same rule into
+  ONE candidate loop under one `ruleId`, rather than three separate loops
+  for one rule. Verdict vocabulary: `incomplete | handled | intentional |
+  unverifiable` — a fourth value (`handled`) that the pilot's three-value
+  set didn't need, because this rule's candidates can turn out to be
+  covered by a mechanism the signal's textual scan couldn't see (a dispatch
+  table, a wrapper).
+
+Both new loops replace an open findings-list contract with a **per-
+candidate-ID-required verdict array**: the pass assigns each candidate a
+stable id and the model must return exactly one verdict per id. A missing
+or malformed id makes the pass's own result honestly incomplete
+(`AgentStopReason: 'incomplete_verdict'`) rather than silently under-
+reporting — turning the doc-truth arc's own pr658 Finding-A omission (a
+candidate silently dropped from a long open worklist, even inside a
+dedicated single-rule pass) into a machine-checkable completeness failure
+instead of a semantic judgment call.
+
+`concurrency-race`, `edge-case-sweep`, and `untrusted-input-validation`
+**stay in the shared loop** — no dedicated pass — because each is an open
+investigation, not a candidate-verdict task, per the reasoning in Context.
+`boundary-change` likewise stays in the shared loop for the reason above.
+`error-swallowing` has a working signal
+(`catch-discrimination-signals.ts`) that already measurably lifts recall
+*inside* the shared loop without a dedicated pass; building one now would
+be ahead of the evidence bar the other two loops needed to clear (see
+Evidence below), so it is explicitly deferred, not rejected.
+
+**3. Hybrid gating (trigger OR signal), never signal-only, for every new
+pass.** Each dedicated pass ships behind its own opt-in flag (config
+boolean, default `false`, or an env var) **AND** requires at least one
+real candidate before it fires — `staleDuplicateSkipReason`/
+`incompleteHandlingSkipReason` mirror `docTruthSkipReason`'s "name the real
+reason" pattern. The rule's own prompt text and signal block are **kept in
+the shared main pass** as a backstop in every case — a second, independent
+flag (`LIEN_STALE_DUP_MAIN=off` / `LIEN_INCOMPLETE_MAIN=off`) exists for a
+*future* A/B arm that would strip the rule from the main pass entirely, but
+that arm has not been run; today, merging either pass changes zero
+production behavior on its own (see Evidence). A **signal-only** gate
+(dropping the rule from the shared-loop trigger the moment a dedicated pass
+exists, relying purely on signal presence to decide whether the rule runs
+at all) was considered and rejected as a *general* policy: it only holds
+today for doc-truth's own dedicated pass, and doc-truth's signal
+(`doc-claims-signals.ts`) earns that by being deliberately over-inclusive —
+broad recall, relevance judgment left to the LLM — not by a proven 100%-
+recall corpus. No other rule's signal has that proof yet, and
+`boundary-change` is the concrete case where signal-only gating can
+*never* reach full recall, by construction (see Context). Every new
+dedicated pass therefore stays hybrid (trigger OR signal) for v1; graduating
+a specific rule to signal-only gating is a decision to make per-rule, later,
+once that rule's own candidate corpus proves the recall claim — not a
+default this ADR grants up front.
+
+**4. Generalize attestation alongside the executor, not as an afterthought.**
+Before PR #799, `provider.passes[]` and `BudgetAttestation` were hardcoded to
+a single main-pass entry — a real, already-shipping bug: an unfinished
+doc-truth pass folded its `stopReason` into the *main* pass's own state
+(`mergeDocPassIntoResult`), so a doc-truth-only budget starvation attested
+as `mainPass.stopReason === 'budget'` — correctly non-silent, but
+misattributed, and `budget.allocatedTokens` undercounted the real ceiling
+whenever doc-truth fired (it only ever reported the main pass's own
+allocation). `attestation.ts` generalizes `provider.passes[]` and
+`BudgetAttestation.passes[]` to one entry per pass that actually ran, and
+`computeVerdict` now attributes `degraded:budget_starved` to whichever pass
+actually stopped. `ATTESTATION_VERSION` bumps **1 → 2** — a deliberate,
+owner-reviewable call rather than the project's usual "additive fields
+don't bump it" convention, because this is the first time `passes`/`budget`
+carry more than one pass's worth of data; a consumer that assumed
+`passes.length <= 1` would have silently ignored real data before this
+bump. `packages/action/action.yml`'s attestation output description and
+`packages/action/test/finish-run.test.ts`'s version assertion were updated
+in the same PR.
+
+## Consequences
+
+### Positive
+
+- **The mechanism is proven end-to-end, not just designed.** PR #799's
+  byte-diff census re-ran `build-prompts.ts` against all 4 on-disk fixtures
+  before/after the refactor — byte-identical on both the main pass's and
+  doc-truth's own prompts — and a mocked-fetch dogfood run produced a
+  verbatim two-pass `attestationVersion: 2` JSON with independent
+  `main`/`doc-truth` entries in `provider.passes[]` and
+  `budget.passes[]`. PRs #803 and #804 repeated the same byte-diff-
+  neutrality proof for their own flags (off = zero behavior change).
+- **A long-worklist omission is now a machine-checkable bug, not a semantic
+  judgment call.** `incomplete_verdict` plus `hasCompleteVerdictCoverage`
+  (both `stale-duplicate-pass.ts` and `incomplete-handling-pass.ts`) treat
+  "one recognized verdict per expected candidate id" as a hard contract —
+  a gap surfaces as the pass's own incompleteness, never silently.
+- **Architecture risk and calibration risk are decoupled.** Both new loops
+  ship dark (config/env default off), so this ADR's mechanism can be
+  reviewed and merged independently of the separate, owner-priced decision
+  to turn either on in production.
+- **A live misattribution bug got fixed as a side effect**, not a follow-up:
+  budget-starvation attribution and `budget.allocatedTokens` were both
+  wrong for the *already-shipping* two-pass case (main + doc-truth) before
+  this generalization, not just a hypothetical future problem.
+
+### Negative / Risks
+
+- **Lift is unproven for both new loops.** No priced A/B exists yet
+  comparing a dedicated candidate loop against the shared loop's own
+  signal-augmented findings list on the same fixtures — #803 and #804 were
+  explicit $0-paid-LLM-spend build tasks (mechanism only, "do NOT run
+  calibrations" per their briefs). The one priced recalibration in this
+  arc, PR #805's stale-duplicate FP-guard fix, measured a *wording* fix's
+  effect (a `calibrate-10` held 10/10 on the canonical true-positive fixture
+  at $0.3471, and a 3-vote FP probe against captured PR #770 dropped from 2
+  wrongful `stale` verdicts to 0) — real evidence the guard works, but not
+  evidence the dedicated-loop *architecture* out-performs the shared loop
+  it sits beside. The pilot's own success criteria call for mining 2–3 more
+  stale-duplicate fixtures (cross-repo candidates were named but not yet
+  captured) before a statistically meaningful lift comparison is possible;
+  that mining has not happened as of this ADR.
+- **Per-PR firing-rate economics required real-PR census work, not
+  assumption, and produced a genuine surprise.** The raw `<stale_literal_
+  candidates>` block (unconditional signal, no loop-eligibility filter)
+  renders on the large majority of real PRs — unusable as a dedicated-pass
+  gate on its own. The shipped threshold (a high-confidence candidate with
+  a same-file production survivor) fires on 14/40 (35.0%) of this repo's
+  last 40 merged PRs, chosen from five candidate thresholds specifically to
+  land inside a "genuinely selective" 15–40% band (PR #803 body). For
+  `incomplete-handling`, a same-day re-census (PR #804 body) measured the
+  union of all three signals firing on 20/40 (50%) — markedly higher than
+  an earlier same-day estimate of 9/40 (22.5%) that the shipped code's own
+  comment (`incomplete-handling-pass.ts`) still cites, with an explicit
+  note pointing readers to the PR body for the up-to-date number. Firing
+  rate is not a constant property of a rule; it needs re-measuring per
+  signal change, and a stale inline estimate can outlive the PR that
+  superseded it.
+- **Concurrent pass execution is deliberately deferred**, so a PR that
+  fires every gated pass at once pays their token/latency cost serially.
+  Acceptable today (bounded added latency, no measured complaint) but
+  revisit once ≥3 dedicated passes are live and latency becomes a real
+  issue (YAGNI, per CLAUDE.md) — not before.
+
+### Neutral
+
+- `ATTESTATION_VERSION: 2` is additive-only in shape (a v1 attestation with
+  `passes: [mainPass]` remains a valid v2 shape); the version bump is a
+  signal to consumers that `passes`/`budget.passes` can now legitimately
+  exceed length 1, not a breaking schema change.
+- The rule's own prompt fragment and signal block are never removed from
+  the shared main pass by a dedicated loop shipping — only the (unused,
+  opt-out) `*_MAIN=off` flag can do that, and only for a future,
+  explicitly-run A/B arm.
+
+## Alternatives Considered
+
+- **Signal-only gating for every candidate-loop rule** (drop the rule from
+  the shared-loop trigger the moment its dedicated pass exists) — rejected
+  as a general policy. See Decision point 3: `boundary-change`'s additive-
+  only-bug blind spot is a structural counter-example, and no other rule's
+  signal has doc-truth's proven-over-inclusive-recall property. Left open
+  as a per-rule graduation path once a specific rule's corpus earns it.
+- **Concurrent (parallel) extra-pass execution** — rejected for v1. No
+  second pass existed when the executor was designed, so there was nothing
+  to parallelize against yet; building the concurrency-safe trace-offset
+  and budget-reporting machinery ahead of a real need would be speculative
+  complexity (YAGNI). Revisit once ≥3 dedicated passes are live and latency
+  is a measured complaint.
+- **A separate output key for candidate-loop verdicts** (instead of
+  carrying `candidateId`/`verdict` as extra fields inside the standard
+  `findings` array) — rejected. Reusing the existing `findings` JSON key
+  means the shared client's parse/validate pipeline (`readVerdict`,
+  `isValidFinding`) needs zero changes for a candidate-loop pass; the loop-
+  specific fields are stripped by each pass's own `postProcessResult` before
+  the findings re-enter the merged result.
+
+## References
+
+- `packages/review/src/plugins/agent/review-pass.ts` — the `ReviewPassSpec`
+  contract and `runExtraPasses` executor
+- `packages/review/src/plugins/agent/doc-truth-pass.ts`,
+  `stale-duplicate-pass.ts`, `incomplete-handling-pass.ts` — the three
+  shipped passes
+- `packages/review/src/attestation.ts` — attestation v2 schema and
+  derivation
+- `docs/architecture/review-pass-architecture.md` — implementation-level
+  companion doc (contract fields, gating flags, budget formulas, which
+  passes are production-on vs. dark)
+- `docs/development/review-harness-judgment.md` — the doc-truth arc's
+  competition-bottleneck evidence that motivated the original dedicated
+  pass
+- PR #799, #803, #804, #805 — the shipped implementation and its dogfood/
+  census evidence cited throughout this ADR
+- An unpublished, owner-approved per-rule-loops design memo prepared in a
+  parallel working session (not part of this repository's tracked history)
+  supplied the initial architecture proposal this ADR records the team's
+  decision on; this ADR — not that memo — is the durable, repo-tracked
+  record of what shipped and why.

--- a/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
+++ b/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
@@ -5,7 +5,9 @@
 **Deciders**: Core Team
 **Related**: PR #799 (pass-executor generalization + attestation v2), PR #803
 (stale-duplicate candidate-loop pilot), PR #804 (incomplete-handling
-candidate loop), PR #805 (stale-duplicate FP-guard fix), `docs/architecture/review-pass-architecture.md`
+candidate loop), PR #805 (stale-duplicate FP-guard fix), PR #807 (doc-truth
+v2 per-claim verdicts — backports this ADR's per-candidate-verdict contract
+into doc-truth's own pass, dark/env-only), `docs/architecture/review-pass-architecture.md`
 (the implementation-level companion to this ADR)
 
 ## Context and Problem Statement
@@ -190,6 +192,18 @@ in the same PR.
   budget-starvation attribution and `budget.allocatedTokens` were both
   wrong for the *already-shipping* two-pass case (main + doc-truth) before
   this generalization, not just a hypothetical future problem.
+- **The per-candidate-verdict contract generalized a third time, back onto
+  the pass that inspired it.** PR #807 (merged the same night, after this
+  ADR's initial evidence was gathered) backports the identical contract —
+  a stable id per worklist entry, an appended output-format override, the
+  same `postProcessResult`/`incomplete_verdict` honesty mechanism — into
+  doc-truth's own pass as a dark, env-only v2 mode (`LIEN_DOC_TRUTH_V2=on`,
+  no config field), entirely inside `doc-truth-pass.ts` with zero changes
+  to this ADR's executor/attestation plumbing. That it ported cleanly onto
+  the ORIGINAL pass the two new loops were modeled on, without touching
+  `review-pass.ts` or `attestation.ts`, is independent evidence the
+  contract is a property of the *pass*, not an artifact specific to either
+  loop's build.
 
 ### Negative / Risks
 
@@ -277,8 +291,8 @@ in the same PR.
 - `docs/development/review-harness-judgment.md` — the doc-truth arc's
   competition-bottleneck evidence that motivated the original dedicated
   pass
-- PR #799, #803, #804, #805 — the shipped implementation and its dogfood/
-  census evidence cited throughout this ADR
+- PR #799, #803, #804, #805, #807 — the shipped implementation and its
+  dogfood/census evidence cited throughout this ADR
 - An unpublished, owner-approved per-rule-loops design memo prepared in a
   parallel working session (not part of this repository's tracked history)
   supplied the initial architecture proposal this ADR records the team's

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -30,6 +30,7 @@ For more information, see [adr.github.io](https://adr.github.io/).
 | [ADR-011](0011-sqlite-structural-store-fts5-lexical-search.md) | Replace LanceDB + Embeddings with a SQLite Structural Store and FTS5 Lexical Search | 2026-07-04 | Accepted |
 | [ADR-012](0012-self-hostable-review-action.md) | Self-Hostable GitHub Action for PR Review | 2026-06-27 | Accepted |
 | [ADR-013](0013-prebuilt-native-parser-napi-rs.md) | Prebuilt Native Parser via napi-rs (`@liendev/parser-native`) | 2026-07-08 | Accepted |
+| [ADR-014](0014-per-rule-candidate-loop-passes.md) | Per-Rule Candidate-Loop Passes for Agent Review | 2026-07-16 | Accepted |
 
 ## ADR Format
 

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -1,0 +1,310 @@
+# Agent-review pass architecture — `ReviewPassSpec` and the extra-pass executor
+
+Status: generalized executor + attestation v2 shipped (PR #799, merged).
+Three passes plug into it today — **doc-truth is production-on by default**;
+the **stale-duplicate** and **incomplete-handling** candidate loops are
+built, merged, and dark (default-off; see "Which passes are live" below).
+See [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
+decision this doc implements and its evidence/economics.
+
+## Motivation
+
+`AgentReviewPlugin.analyze()` (`packages/review/src/plugins/agent/index.ts`)
+runs one LLM agent over a PR with up to nine rules
+(`packages/review/src/plugins/agent/rules.ts`) sharing one findings list.
+The doc-truth arc (PRs #722–#733) found a real, measured failure mode: on a
+PR with both doc drift and code bugs, the shared list rationally favors the
+code bugs, and swapping models didn't fix it — the bottleneck is the output
+list itself, not the prompt. The fix was a **dedicated second pass**: run
+doc-truth alone, on its own budget, with no competing rules. That shipped as
+a single hardcoded pass (`doc-truth-pass.ts`). This doc describes the
+generalization of that one pass into an ordered list of passes any rule with
+a suitable shape can plug into, and the two additional passes that have
+since been built against it.
+
+## The `ReviewPassSpec` contract
+
+`packages/review/src/plugins/agent/review-pass.ts` defines the interface
+every extra pass implements:
+
+```ts
+export interface ReviewPassSpec {
+  name: string;
+  skipPlugin: string;
+  gateReason(context: ReviewContext, config: AgentConfig): string | null;
+  buildPrompts(context: ReviewContext): { systemPrompt: string; initialMessage: string };
+  budget(baseBudget: number, context: ReviewContext): number;
+  maxTurns: number;
+  mergeFindings(mergedFindings: AgentFinding[], passFindings: AgentFinding[]): AgentFinding[];
+  mergeResultState(main: AgentResult, passResult: AgentResult | null, mergedFindings: AgentFinding[]): void;
+  postProcessResult?(result: AgentResult, context: ReviewContext): AgentResult;
+}
+```
+
+- **`gateReason`** returns *why* the pass would not run right now, or `null`
+  to run it — never a bare boolean, so the delivery attestation can record
+  the real reason (config-disabled, env-disabled, no eligible candidate).
+- **`budget`** takes the main pass's base budget *and* the `ReviewContext` —
+  doc-truth ignores the context (a flat fraction of base is enough for its
+  shape); both candidate loops use the context to scale budget by their own
+  candidate count (see "Budget scaling" below). A function that declares
+  fewer parameters than the interface's function type still satisfies it —
+  no ceremony needed for doc-truth's simpler case.
+- **`postProcessResult`** is optional and unused by doc-truth; both
+  candidate loops use it to reduce a raw per-candidate verdict array down
+  to real findings and mark the result honestly incomplete when the
+  worklist wasn't fully covered (see "Per-candidate verdict contract"
+  below).
+
+## Execution: `runExtraPasses`, serial, in `index.ts`'s `EXTRA_PASSES`
+
+```ts
+// packages/review/src/plugins/agent/index.ts
+const EXTRA_PASSES: ReviewPassSpec[] = [
+  DOC_TRUTH_PASS_SPEC,
+  STALE_DUPLICATE_PASS_SPEC,
+  INCOMPLETE_HANDLING_PASS_SPEC,
+];
+```
+
+`runExtraPasses` (`review-pass.ts`) iterates this list **in array order,
+serially** — each pass is fully awaited (gate check → build prompts → run
+client → fold findings/result-state into the running total) before the next
+one starts. Two things are true regardless of how many passes exist:
+
+- **If the main pass never ran** (every provider request failed), every
+  extra pass is skipped without even evaluating its own gate — a second
+  request would only fire more doomed calls, and a failure-isolated pass's
+  own incomplete state must never overwrite the main pass's `neverRan`
+  marker.
+- **A single pass's failure never fails the whole review.** `runReviewPass`
+  catches and reports (`context.reportSkip`) any thrown error from a pass's
+  client run; the main pass's own output is untouched.
+
+None of the three passes has a data dependency on either of the *other two*
+(only doc-truth's original dependency on the *main* pass completing at all
+survives the generalization), so declaration order among them doesn't
+affect correctness — doc-truth stays first as the longest-proven pass.
+Concurrent (parallel) execution was deliberately not built: no second pass
+existed when the executor was designed, and building the concurrency-safe
+machinery (trace-offset arithmetic that currently assumes the main trace is
+already complete; per-pass budget reporting that would need to interleave)
+ahead of a real latency complaint would be speculative (YAGNI per
+CLAUDE.md) — revisit once ≥3 dedicated passes are live and latency is
+measured as a problem.
+
+## The three passes
+
+| Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
+|---|---|---|---|---|---|---|
+| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | open findings list (not per-candidate) | **Production-on** (default true) |
+| stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
+| incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
+
+Every pass keeps its rule's prompt fragment and signal block in the shared
+main pass regardless of the dedicated pass's on/off state — a second,
+independent env flag per candidate loop (`LIEN_STALE_DUP_MAIN=off`,
+`LIEN_INCOMPLETE_MAIN=off`) exists to strip the rule from the main pass
+entirely for a *future* A/B arm, but that arm has not been run. Today,
+merging or enabling a candidate loop never removes its rule's shared-loop
+coverage.
+
+### doc-truth
+
+`buildDocTruthPassPrompts` builds a system prompt with **only** the
+doc-truth rule active (`DOC_TRUTH_ONLY_RULES`) and an initial message
+carrying the `<doc_claims>` worklist (with pre-fetched evidence),
+`<rename_sweep>` (a mechanical identifier-rename sweep, when present — this
+wiring was itself a bugfix, PR #796: the rule's own prompt text told the
+model to look for this block, but the pass didn't render it until then),
+and `<guidance_surface_changes>`. Merge: a doc-truth finding is dropped only
+when the main pass already reported one at the same location (same file,
+within 2 lines) *at least as severe* — main pass wins on a tie
+(`mergeDocTruthFindings`, `doc-truth-pass.ts:215`). Result-state merge lifts
+a low/absent risk level to `medium` when doc-truth found `error`-severity
+contradictions (`mergeDocPassIntoResult`).
+
+### stale-duplicate candidate loop
+
+`stale-literal-signals.ts`'s `<stale_literal_candidates>` block is
+unconditional (`stale-duplicate`'s trigger is `always: true`) and renders on
+the large majority of real PRs — too broad to gate a *dedicated* LLM call on
+directly. `hasEligibleCandidate` (`stale-duplicate-pass.ts:153`) applies a
+stricter threshold: at least one `confidence: 'high'` candidate with a
+production (non-comment/non-test/non-config) surviving site in the **same
+file** as the changed site. A real-PR census (this repo's last 40 merged
+PRs) measured this threshold firing on 14/40 (35.0%) — see
+[ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the full
+five-threshold comparison and why this one was chosen.
+
+The worklist reuses the shared `<stale_literal_candidates>` tag name (the
+`STALE_DUPLICATE` rule's own prompt text references it) and renders each
+candidate's literal, changed-site diff hunk, and every surviving site with
+its comment/test/config tags. The prompt's `<verdict_guidance>` block
+(added in PR #805, a targeted fix — not present in the original #803 pilot)
+distinguishes literals that drive real runtime behavior from inert
+duplication in test doubles/mocks/fixtures, after a measured false-positive
+class (2 wrongful `stale` verdicts of 51 judged, on a captured real PR) was
+found verdicting a test-helper mock that merely hardcoded a production
+rule's display strings. Merge: unlike doc-truth, **the loop wins** on a
+location collision — it carries per-candidate evidence the shared loop's
+freeform grep pass doesn't — but only against a main-pass finding whose own
+`ruleId` is also `stale-duplicate`, never an unrelated rule's finding that
+happens to land nearby (`mergeStaleDuplicateFindings`).
+
+### incomplete-handling candidate loop
+
+Unifies three previously-separate signals under one pass and one `ruleId`:
+`variant-sweep-signals.ts` (an added enum/union/const-object member whose
+consumer sites weren't updated), `sibling-surface-signals.ts` (a
+same-directory or mirror-directory sibling missing a matching change), and
+`unread-field-signals.ts` (an added interface/type-literal/class field with
+no read site anywhere in the indexed corpus).
+`computeIncompleteHandlingCandidates` (`incomplete-handling-pass.ts:281`)
+builds one combined, id-stable worklist in a fixed order (variant-sweep →
+sibling-surface → unread-field), each shape capped locally, the combined
+list capped at 20. Real-PR eligibility (union of all three signals) was
+measured at 20/40 (50%) — sibling-surface is this repo's dominant real-world
+producer (20/40 alone); variant-sweep and unread-field measured 0/40 each on
+this corpus. (The module's own inline comment still cites an earlier
+same-day estimate of 9/40 (22.5%) and explicitly defers to the PR body for
+the up-to-date number — see ADR-014's Negative/Risks section.)
+
+Toolset is `read_file` + `get_files_context` + `grep_codebase` — a superset
+of the pilot's two tools, because none of the three signals attach an
+inline code snippet the way `stale-literal-signals.ts` does; judging a
+candidate here always requires reading the referenced site, and
+`get_files_context` supplies the cross-file structural view needed to tell
+whether an omission is actually handled via a mechanism (a dispatch table,
+a wrapper) the signal's token-level scan couldn't see — the reason this
+loop's verdict vocabulary has a fourth value, `handled`, distinct from
+`intentional` (a deliberate design choice). An `FP_GUARD` prompt paragraph
+warns against verdicting test-double/mock/fixture omissions `incomplete`,
+baked in from the loop's first version rather than discovered post-hoc the
+way the stale-duplicate pilot's equivalent guard was.
+
+## Per-candidate verdict contract and `incomplete_verdict` honesty semantics
+
+Both candidate loops replace an open findings-list contract with **one
+verdict object required per candidate id**, carried as extra fields
+(`candidateId`, `verdict`) inside the standard `findings` JSON array — so
+the shared client's existing parse/validate pipeline needs zero changes.
+Each pass's `postProcessResult` hook (`postProcessStaleDuplicateResult`,
+`postProcessIncompleteHandlingResult`):
+
+1. Checks `hasCompleteVerdictCoverage`: every expected candidate id appears
+   **exactly once**, each with a recognized verdict value. A duplicate id,
+   an unrecognized verdict, or a missing id all fail this check — a
+   candidateId-presence-only check would let a malformed entry (valid id,
+   garbage verdict) silently vanish from both the coverage check *and* the
+   findings array, exactly the "quiet gap" this contract exists to prevent.
+2. Filters to only the "real finding" verdict(s) (`stale` for the pilot;
+   `incomplete` for the unified loop — and, for the latter, only when
+   `candidateId` also names a real worklist entry, closing a hallucinated-id
+   loophole a code reviewer caught during PR #804), stripping the
+   loop-only fields via `toCleanFinding`.
+3. Marks the pass's own result `incomplete` (stop reason
+   `'incomplete_verdict'`, a new `AgentStopReason` value,
+   `packages/review/src/plugins/agent/types.ts`) when coverage failed — but
+   only when the underlying client result wasn't *already* incomplete for a
+   more specific reason (budget/max_turns/error), which takes precedence.
+
+This is the mechanism-level fix for the doc-truth arc's own pr658
+Finding-A lesson: a single open findings list, even scoped to one rule, can
+still under-report unevenly across a long worklist. A per-candidate-ID-
+required contract turns that failure mode into a machine-checkable
+completeness assertion instead of a semantic judgment call the test harness
+would otherwise have to infer from prose.
+
+An incomplete extra pass (any reason) sets `AgentResult.incompleteFromPass`
+to the pass's own name (`'stale-duplicate'` / `'incomplete-handling'`) —
+doc-truth keeps its own dedicated `incompleteFromDocPass` boolean rather
+than using the generic field, since it predates it. `appendIncompleteNotice`
+(`index.ts`) reads whichever field is set to render a notice naming the
+*specific* pass that didn't finish, rather than implying the whole review
+is partial when only an extra pass was cut short.
+
+## Attestation v2
+
+`packages/review/src/attestation.ts`, `ATTESTATION_VERSION = 2`. Before this
+generalization, `provider.passes[]` and `BudgetAttestation` were hardcoded
+to exactly one entry (the main pass) — a real bug already live with zero
+candidate loops added: an unfinished doc-truth pass folded its `stopReason`
+into the *main* pass's own state, so a doc-truth-only budget starvation
+attested as `mainPass.stopReason === 'budget'` (correctly non-silent, but
+misattributed), and `budget.allocatedTokens` only ever reported the main
+pass's own ceiling even though `spentTokens` already summed every pass.
+
+- **`ProviderPassAttestation`** — `{ name, ran, stopReason, neverRan }`, one
+  entry per pass that was gated on (main always present; each extra pass
+  present iff it ran — a gated-off or failed pass is covered by
+  `passesSkipped` instead, not duplicated here).
+- **`PassBudgetAttestation`** — `{ name, allocatedTokens, spentTokens,
+  starved }`, one per pass; `BudgetAttestation.passes[]` is the breakdown,
+  `allocatedTokens`/`spentTokens`/`starved` at the top level are the sums/OR
+  across all passes.
+- **`computeVerdict`** finds the first pass (main first, then extras in
+  declaration order) whose `stopReason !== 'completed'` and attributes
+  `degraded:budget_starved` (if that pass stopped on `'budget'`) or
+  `degraded:provider_partial` (anything else) to it specifically — no
+  longer hardcoded to the main pass.
+
+Wiring: `plugins/agent/index.ts`'s `reportPassOutcomes` forwards each extra
+pass's `PassOutcome` (`{ name, stopReason, neverRan, allocatedTokens,
+spentTokens }`, computed by `runExtraPasses`) through
+`context.reportPassResult`, which `review-pr.ts`'s `runEngineForReview`
+collects into `RunTelemetry.extraPasses`. `buildRunAttestation` passes that
+array straight into `assembleAttestation`'s `extraPasses` input; the main
+pass's own spent tokens are derived by subtracting every extra pass's
+reported spend from the aggregate (`deriveMainSpentTokens`,
+`review-pr.ts:418`) rather than tracked separately, since `reportUsage`
+fires exactly once per pass that ran.
+
+## Budget scaling
+
+- **doc-truth**: flat fraction of the main pass's base budget —
+  `docTruthPassBudget = round(baseBudget × 0.4)`. Adequate because the
+  claims-only pass's input (pre-fetched evidence) rarely needs the tool
+  loop.
+- **stale-duplicate loop**: `clamp(2_000 + 800 × min(candidateCount, 8),
+  4_000, 30_000)` — scaled by this pass's own candidate count (mirroring
+  `summary-only-pass.ts`'s clamp pattern), not a flat fraction, so a
+  1-candidate run doesn't pay for an 8-candidate ceiling.
+- **incomplete-handling loop**: `clamp(2_500 + 900 × min(candidateCount,
+  20), 5_000, 35_000)` — same shape, higher per-candidate cost and turn cap
+  (8 vs. the pilot's 6) since every candidate here needs at least one
+  `read_file`/`get_files_context` round trip before it can be judged (none
+  of the three signals attach an inline snippet).
+
+## Which passes are live today
+
+- **doc-truth** — production-on, has been since PR #733. Kill-switches:
+  `config.docTruthPass: false` or `LIEN_REVIEW_DOC_PASS=0` (documented in
+  `packages/action/README.md` as the one Action-level tunable env var).
+- **stale-duplicate loop** — merged (PR #803, guard-fixed in PR #805) but
+  **dark**: `config.staleDuplicatePass` defaults `false`; opt in via that
+  config key or `LIEN_STALE_DUP_PASS=on`. Not exposed through
+  `packages/action`'s `action.yml` inputs — reachable only by setting the
+  env var directly on the Action step, same undocumented-by-design
+  mechanism as any other internal flag.
+- **incomplete-handling loop** — merged (PR #804) but **dark**:
+  `config.incompleteHandlingPass` defaults `false`; opt in via that config
+  key or `LIEN_INCOMPLETE_PASS=on`. Same non-exposure via `action.yml`.
+
+Both dark passes have proven mechanism (gate/prompt/budget/merge/attestation
+wiring, verified via unit tests and byte-diff-neutrality-when-off proofs)
+but **unproven lift** — no priced A/B has yet shown either dedicated loop
+finds more true positives or fewer false negatives than the shared loop's
+own signal-augmented prompt on the same fixtures. See
+[ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the full
+evidence state, the real-PR firing-rate census, and per-pass cost data.
+
+## Related
+
+- [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) — the
+  decision this doc implements, its rejected alternatives, and its
+  evidence/economics
+- `docs/development/review-harness-judgment.md` — the doc-truth arc's
+  competition-bottleneck evidence and harness judgment rules
+- `packages/review/test/harness/README.md` — harness mechanics for
+  calibrating any of these passes' rules

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -1,9 +1,11 @@
 # Agent-review pass architecture — `ReviewPassSpec` and the extra-pass executor
 
 Status: generalized executor + attestation v2 shipped (PR #799, merged).
-Three passes plug into it today — **doc-truth is production-on by default**;
-the **stale-duplicate** and **incomplete-handling** candidate loops are
-built, merged, and dark (default-off; see "Which passes are live" below).
+Three passes plug into it today — **doc-truth is production-on by default**
+(v1); the **stale-duplicate** and **incomplete-handling** candidate loops
+are built, merged, and dark (default-off), and doc-truth itself gained a
+dark, env-only v2 mode (PR #807) that backports the same per-candidate-
+verdict contract into its own pass — see "Which passes are live" below.
 See [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
 decision this doc implements and its evidence/economics.
 
@@ -97,7 +99,7 @@ measured as a problem.
 
 | Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
 |---|---|---|---|---|---|---|
-| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | open findings list (not per-candidate) | **Production-on** (default true) |
+| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | v1 (default): open findings list. v2 (`LIEN_DOC_TRUTH_V2=on`, dark): `accurate \| contradicted \| unverifiable` per claim id | **Production-on** (v1 default true; v2 dark, env-only) |
 | stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
 | incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
 
@@ -123,6 +125,28 @@ within 2 lines) *at least as severe* — main pass wins on a tie
 (`mergeDocTruthFindings`, `doc-truth-pass.ts:215`). Result-state merge lifts
 a low/absent risk level to `medium` when doc-truth found `error`-severity
 contradictions (`mergeDocPassIntoResult`).
+
+**v2 (PR #807, merged same night as the two candidate loops above): doc-truth
+backports the per-candidate-verdict contract into its own pass.** Env-only
+opt-in (`LIEN_DOC_TRUTH_V2=on`, no config field — `isDocTruthV2Enabled`,
+default off), entirely inside `doc-truth-pass.ts` with zero changes to
+`review-pass.ts`, `attestation.ts`, or `index.ts`'s `EXTRA_PASSES`. Every
+`<doc_claims>` entry and `<rename_sweep>` item gets a stable `claim-N` id
+(`buildClaimWorklist`), and the model must emit exactly one verdict
+(`accurate | contradicted | unverifiable`) per id via an appended
+`<output_format_v2_override>` system-prompt section — same
+`postProcessResult` mechanism the two candidate loops use
+(`postProcessDocTruthResult`, wired into `DOC_TRUTH_PASS_SPEC`), including
+the same `incomplete_verdict` honesty rigor for a missing/duplicate/
+unrecognized-id or invalid-verdict claim entry. One deliberate difference:
+unlike the two loops, v2's contract stays **open beyond the worklist** — an
+extra finding for a claim the model spots itself (no `claimId`) still passes
+through as an ordinary finding, matching the rule's existing "also skim for
+any claim not listed" allowance. With the flag off, every v2 function is
+verified byte-identical to v1's own output (PR #807's byte-diff census). This
+is now the third pass built on the per-candidate-verdict pattern — evidence
+the pattern generalizes beyond the two purpose-built loops it was designed
+for, back onto the original pass that inspired it.
 
 ### stale-duplicate candidate loop
 
@@ -185,12 +209,16 @@ way the stale-duplicate pilot's equivalent guard was.
 
 ## Per-candidate verdict contract and `incomplete_verdict` honesty semantics
 
-Both candidate loops replace an open findings-list contract with **one
-verdict object required per candidate id**, carried as extra fields
-(`candidateId`, `verdict`) inside the standard `findings` JSON array — so
-the shared client's existing parse/validate pipeline needs zero changes.
-Each pass's `postProcessResult` hook (`postProcessStaleDuplicateResult`,
-`postProcessIncompleteHandlingResult`):
+All three passes now use variants of the same contract: **one verdict
+object required per candidate/claim id**, carried as extra fields
+(`candidateId`/`claimId`, `verdict`) inside the standard `findings` JSON
+array — so the shared client's existing parse/validate pipeline needs zero
+changes. The two candidate loops closed the contract to the worklist
+entirely; doc-truth's v2 mode (above) keeps it open to ad hoc findings
+beyond the worklist, a deliberate difference reflecting that rule's own
+"also skim for anything not listed" allowance. Each pass's own
+`postProcessResult` hook (`postProcessStaleDuplicateResult`,
+`postProcessIncompleteHandlingResult`, `postProcessDocTruthResult`):
 
 1. Checks `hasCompleteVerdictCoverage`: every expected candidate id appears
    **exactly once**, each with a recognized verdict value. A duplicate id,
@@ -201,8 +229,10 @@ Each pass's `postProcessResult` hook (`postProcessStaleDuplicateResult`,
 2. Filters to only the "real finding" verdict(s) (`stale` for the pilot;
    `incomplete` for the unified loop — and, for the latter, only when
    `candidateId` also names a real worklist entry, closing a hallucinated-id
-   loophole a code reviewer caught during PR #804), stripping the
-   loop-only fields via `toCleanFinding`.
+   loophole a code reviewer caught during PR #804; `contradicted`/
+   `unverifiable` for doc-truth v2, dropping `accurate` ones and passing
+   any ad hoc no-`claimId` finding through unchanged), stripping the
+   loop-only fields via `toCleanFinding`/`toCleanDocTruthFinding`.
 3. Marks the pass's own result `incomplete` (stop reason
    `'incomplete_verdict'`, a new `AgentStopReason` value,
    `packages/review/src/plugins/agent/types.ts`) when coverage failed — but
@@ -280,7 +310,10 @@ fires exactly once per pass that ran.
 
 - **doc-truth** — production-on, has been since PR #733. Kill-switches:
   `config.docTruthPass: false` or `LIEN_REVIEW_DOC_PASS=0` (documented in
-  `packages/action/README.md` as the one Action-level tunable env var).
+  `packages/action/README.md` as the one Action-level tunable env var). Its
+  v2 per-claim-verdict contract (PR #807, `LIEN_DOC_TRUTH_V2=on`, env-only,
+  no config field) is a separate, **dark** opt-in layered on top — v1's
+  open-findings-list behavior is unchanged when v2 is off.
 - **stale-duplicate loop** — merged (PR #803, guard-fixed in PR #805) but
   **dark**: `config.staleDuplicatePass` defaults `false`; opt in via that
   config key or `LIEN_STALE_DUP_PASS=on`. Not exposed through

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -208,6 +208,8 @@ Lien Review is a separate product surface from the CLI/MCP pipeline above: a sel
 
 Critically, `packages/review` depends on **`@liendev/parser` only** — it does not import `@liendev/core`, so it carries none of the storage-layer dependency weight (this is the point of [ADR-009](decisions/0009-extract-parser-package.md)). See [`packages/action/README.md`](../../packages/action/README.md) for the full setup guide, or the [Lien Review site page](../../packages/site/docs/guide/lien-review.md).
 
+Beyond the main investigation, the agent review can run additional dedicated LLM passes (doc-truth is on by default; two candidate-loop passes exist dark-launched) via a generalized `ReviewPassSpec` executor — see [Agent-Review Pass Architecture](./review-pass-architecture.md) ([ADR-014](decisions/0014-per-rule-candidate-loop-passes.md)).
+
 **Retired**: the earlier hosted-SaaS shape for review — `packages/runner` (a NATS-based review runner) and `platform/` (a Laravel 12 control plane + its K8s infra) — was removed in favor of this self-hostable Action.
 
 ## Data Flow

--- a/docs/development/review-harness-judgment.md
+++ b/docs/development/review-harness-judgment.md
@@ -132,7 +132,13 @@ canary showed this can still happen even inside a dedicated, single-rule
 pass) becomes a machine-checkable completeness failure instead of a semantic
 judgment call the harness's assertions would otherwise have to infer. Both
 ship dark (default-off config/env flags) —
-mechanism proven, lift not yet calibrated. If you add a rule that keeps
+mechanism proven, lift not yet calibrated. The same contract has since been
+backported into doc-truth's own pass as an opt-in v2 mode
+(`LIEN_DOC_TRUTH_V2=on`, PR #807, also dark) — early paid screening there
+(3 votes) held the certified doc-truth canary and hit zero verdict-coverage
+gaps across a 48-id worklist, but per this guide's own golden rule 4, a
+screen is not a calibration; `--calibrate 10` on it is still the owner's
+call. If you add a rule that keeps
 losing the findings competition and its candidates are enumerable with a
 closed verdict set, a dedicated pass is the precedent to reach for — but
 only after proving competition is the bottleneck, and only for a rule that

--- a/docs/development/review-harness-judgment.md
+++ b/docs/development/review-harness-judgment.md
@@ -111,16 +111,37 @@ saturated — discovery, verification budget, or the findings list — before
 writing another prompt line. Traces answer this: does the model never see
 it, see it and run out of budget, or see it and decline?
 
-## The two-pass architecture
+## The extra-pass architecture
 
 Since PR #733, `analyze()` runs a second, claims-only pass when a PR's touched
 doc surfaces carry claim-shaped prose: doc-truth rule alone, evidence-carrying
 worklist, no competing rules, ~40% budget, findings deduped and merged,
 failure-isolated (an incomplete doc pass surfaces its own notice rather than
 reading as "no doc issues"). Kill-switches: config `docTruthPass: false` or
-`LIEN_REVIEW_DOC_PASS=0`. If you add a rule that keeps losing the findings
-competition, this is the precedent to reach for — but only after proving
-competition is the bottleneck.
+`LIEN_REVIEW_DOC_PASS=0`.
+
+PR #799 generalized that one hardcoded pass into a `ReviewPassSpec` contract
+plus a serial `runExtraPasses` executor, so any rule with a boundable,
+enumerable candidate worklist can get its own dedicated pass the same way.
+Two more have since been built this way — `stale-duplicate-pass.ts` (PR
+#803) and `incomplete-handling-pass.ts` (PR #804) — each replacing doc-truth's
+open findings list with a **per-candidate-ID-required verdict contract**: the
+model must return exactly one verdict per candidate id, so a candidate
+silently dropped from a long worklist (the `doc-truth/pr658-search-code-rename`
+canary showed this can still happen even inside a dedicated, single-rule
+pass) becomes a machine-checkable completeness failure instead of a semantic
+judgment call the harness's assertions would otherwise have to infer. Both
+ship dark (default-off config/env flags) —
+mechanism proven, lift not yet calibrated. If you add a rule that keeps
+losing the findings competition and its candidates are enumerable with a
+closed verdict set, a dedicated pass is the precedent to reach for — but
+only after proving competition is the bottleneck, and only for a rule that
+actually fits the candidate-loop shape (an open-investigation rule like
+`concurrency-race` or `boundary-change` does not — see
+[ADR-014](../architecture/decisions/0014-per-rule-candidate-loop-passes.md)
+for the full reasoning and evidence, and
+[Agent-Review Pass Architecture](../architecture/review-pass-architecture.md)
+for the contract-level detail).
 
 ## Known frontiers (don't re-litigate without new evidence)
 
@@ -139,7 +160,9 @@ competition is the bottleneck.
 - Harness mechanics + runbooks: `packages/review/test/harness/README.md`
 - Rules + trigger logic: `packages/review/src/plugins/agent/rules.ts`
 - Deterministic signals: `packages/review/src/*-signals.ts`
-- The doc-truth second pass: `packages/review/src/plugins/agent/doc-truth-pass.ts`
+- The extra-pass executor: `packages/review/src/plugins/agent/review-pass.ts`
+- The three shipped passes: `doc-truth-pass.ts`, `stale-duplicate-pass.ts`,
+  `incomplete-handling-pass.ts` (same directory)
 - Calibration driver: `packages/review/test/harness/run.ts` (`--calibrate`,
   `--trace`, `--fixture`, `--rule`, `--model`, `--bail`; traces persist to
   `.wip/traces/` by default)


### PR DESCRIPTION
## Summary

Permanent documentation for the pass architecture shipped today: PR #799
(`ReviewPassSpec` executor generalization + attestation v2), PR #803
(stale-duplicate candidate-loop pilot), PR #804 (incomplete-handling
candidate loop), PR #805 (stale-duplicate FP-guard fix) — plus doc-truth's
original dedicated pass (PR #733) as the precedent all of this generalizes.

Every claim in both new docs was verified against the actual code on
`origin/main` at HEAD (`29f78f7f`, PR #805) — not against the design memo
this work was based on, and not against the brief. Specifics I independently
confirmed by reading the source rather than trusting a secondary source:

- `review-pass.ts`'s `ReviewPassSpec` contract and `runExtraPasses` match the
  design doc's proposal exactly, including the "budget widened to take
  `ReviewContext`" detail.
- The rename-sweep wiring bug the design doc flagged as still-open is
  actually **fixed** in `doc-truth-pass.ts` (line 155,
  `renderRenameSweepSection` is called) — PR #796 shipped it.
- Attestation v2 (`ATTESTATION_VERSION = 2`, per-pass `provider.passes[]` /
  `BudgetAttestation.passes[]`, `computeVerdict` attributing
  `degraded:budget_starved` to whichever pass actually stopped) is real,
  wired end-to-end through `review-pr.ts`'s `reportPassResult` →
  `RunTelemetry.extraPasses` → `assembleAttestation`.
- `boundary-change`'s additive-only blind spot (the reason signal-only
  gating is rejected as a general policy) is real:
  `comparison-change-signals.ts` pairs REMOVED lines with ADDED lines
  within the same hunk, so a purely-additive bug produces zero candidates
  by construction — verified by reading the signal's own pairing logic, not
  just asserting the design doc's claim.
- The incomplete-handling loop's own shipped code comment
  (`incomplete-handling-pass.ts`) still cites an earlier same-day estimate
  (9/40, 22.5%) for its real-PR firing rate that PR #804's own body
  re-measured at 20/40 (50%) and explicitly flagged as higher — I cited the
  PR-body number as current and noted the stale inline comment in both docs
  (ADR-014's Negative/Risks, and the architecture doc), since it's a live
  micro-inconsistency in the merged code, not something I should paper over.

## Deliverables

1. **ADR-014** — `docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md`.
   Records the hybrid-architecture decision (dedicated candidate-loop passes
   for worklist-shaped rules, gated trigger-OR-signal; shared loop retained
   for open-investigation rules; signal-only gating rejected with the
   `boundary-change` counter-example), the honest evidence state (mechanism
   proven via byte-diff + dogfood; lift unproven — no priced A/B exists
   comparing a dedicated loop against the shared loop it sits beside), and
   the per-PR economics (both real-PR firing-rate censuses, cost data).
2. **Architecture doc** — `docs/architecture/review-pass-architecture.md`.
   The pass system as built: the `ReviewPassSpec` contract, `runExtraPasses`
   serial execution, all three passes with gates/budgets/toolsets/verdict
   vocabularies, the per-candidate-verdict contract and `incomplete_verdict`
   honesty semantics, attestation v2, budget-scaling formulas. States
   plainly which passes are production-on (doc-truth) vs. dark
   (stale-duplicate loop, incomplete-handling loop — both default-`false`,
   opt-in via config or an env flag, not exposed through the Action's
   `action.yml` inputs).
3. **Stale-doc fixes**:
   - `docs/development/review-harness-judgment.md` — the "two-pass
     architecture" section described exactly one hardcoded pass; renamed to
     "extra-pass architecture" and rewritten to reflect the generalized
     executor and both new candidate loops, plus updated its "Where things
     live" file list.
   - `docs/architecture/README.md` — added an index entry + Quick Reference
     row for the new architecture doc, and updated the ADR table/Version
     History for ADR-014 (also fixed a **pre-existing** gap while touching
     that exact line: ADR-013 was never added to the Version History list
     even though it's been merged since 2026-07-08 — folded into this edit
     since I was already there).
   - `docs/architecture/system-overview.md` — added a one-line pointer from
     the "Lien Review" section to the new architecture doc.
   - Everything else I checked (`packages/action/README.md`,
     `packages/site/docs/guide/lien-review.md`, `CONTRIBUTING.md`, the
     harness README) already accurately describes doc-truth as the one
     production-on extra pass and needed no changes — the two new loops are
     genuinely dark and not part of any documented public surface yet.

## Dogfood evidence

**`npm run docs:build`** (real output):
```
> @liendev/site@0.1.0 docs:build
> vitepress build docs

  vitepress v1.6.4
- building client + server bundles...
✓ building client + server bundles...
- rendering pages...
✓ rendering pages...
build complete in 4.58s.
```

**Scope note on "read the rendered output"**: `docs/architecture/*` (all 14
ADRs plus this directory's other docs) is **not** part of the VitePress
site's source tree (`packages/site/docs/`) — confirmed by grep: the site
only *links out* to specific ADRs as raw GitHub URLs (e.g.
`packages/site/docs/how-it-works.md:42,89,202` link to ADR-011/ADR-013 via
`https://github.com/getlien/lien/blob/main/docs/architecture/...`), the same
pattern my new ADR-014 fits with no site-side change needed. So
`docs:build`'s real dogfood value here is confirming the site still builds
clean with these files present (it does) — it doesn't render these specific
pages. For the two new pages specifically, I:
- Ran the CI-enforced docs-drift linter, `.github/scripts/docs-truth.mjs`
  (the actual mechanism that validates relative-link resolution, ADR-XXXX
  cross-references, and `npm run <script>` mentions for every tracked
  markdown file) **after** staging both new files, so they were genuinely
  checked: `docs-truth: 73 files checked, no violations.` (73 = the
  pre-existing 71 + these 2 new files; re-ran after `git add` specifically
  because `git ls-files`-based tools silently skip untracked files, and my
  first run before staging only covered the 71 pre-existing docs).
- Attempted a supplementary visual-render check by publishing ADR-014 to a
  private Claude Artifact and navigating to it via Playwright — the browser
  session isn't authenticated to `claude.ai`, so it hit a "Page not found"
  wall. Reporting this honestly rather than omitting the attempt: it didn't
  yield evidence either way, so I relied on the docs-truth lint pass plus a
  manual proofread of both files (verified balanced code fences, correct
  table pipe-escaping, and cross-checked every file:line citation against
  the actual source — e.g. `doc-truth-pass.ts:215`, `stale-duplicate-pass.ts:153`,
  `incomplete-handling-pass.ts:281`, `review-pr.ts:418` all confirmed exact).

**Rendered-content excerpt** (ADR-014, as GitHub will render it — verified
the table below has no unescaped `|` breaking column alignment):

> ### Decision
>
> Generalize the doc-truth precedent into a reusable executor, and apply it
> **hybrid, per rule** — never as a blanket policy.
>
> **1. Generalize the plumbing.** `packages/review/src/plugins/agent/review-pass.ts`
> (new, PR #799) factors doc-truth's gate/prompt/budget/run/failure-isolation/
> trace-append shape into a `ReviewPassSpec` interface (name, `gateReason`,
> `buildPrompts`, `budget`, `maxTurns`, `mergeFindings`, `mergeResultState`,
> optional `postProcessResult`) plus a `runExtraPasses` orchestrator...

## Gates (all green)

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`:
- format:check — clean (docs-only diff isn't in prettier's scoped globs anyway)
- lint — 0 errors, 33 pre-existing warnings (unchanged, none in touched files)
- typecheck — clean across parser/core/review/cli/action (required
  `npm run build:native -w @liendev/parser-native` first in this fresh
  worktree, per `docs/development/worktree-development.md`)
- build — clean
- test — parser-native 27, parser 1062, core 374, review 1188, cli 860,
  action 39 — all passing (all pre-existing; nothing added since this PR is
  docs-only)
- `node packages/cli/dist/index.js delta` — exit 0, no complexity-affecting
  changes vs HEAD (expected: docs-only)
- `npm run docs:build` — clean (above)
- `.github/scripts/docs-truth.mjs` — 73 files, 0 violations (above)

## Merge status

No changeset (docs-only). Following the standing merge-on-green policy:
will squash-merge once CI is green and the Lien Review check (lien-stats +
inline comments, including any doc-truth findings on this PR's own prose)
is triaged.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 497 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!WARNING]
> **3 issues found** · Low Risk
>
> Docs-only PR adding permanent architecture documentation for the recently-shipped agent-review pass system. Adds ADR-014 (per-rule candidate-loop passes decision) and `review-pass-architecture.md` (implementation companion), plus stale-doc fixes in `review-harness-judgment.md`, `architecture/README.md`, and `system-overview.md`. No code or runtime behavior changes.
>
> - Added ADR-014 documenting the hybrid dedicated-pass vs. shared-loop decision, evidence state, and per-PR economics
> - Added `review-pass-architecture.md` describing the `ReviewPassSpec` contract, `runExtraPasses` orchestration, the three passes, verdict contracts, and attestation v2
> - Updated `review-harness-judgment.md`, `architecture/README.md` (including ADR-013 version-history fix), and `system-overview.md` to point to the new docs and reflect the generalized extra-pass architecture

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1edbcb7. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 1/3 comments posted · 37K/28K tokens
<!-- /lien:attestation -->