### PR TITLE
fix(review): stop folding real post failures into the benign skipped count

### DIFF
--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -691,13 +691,31 @@ function buildPresentContext(
 
 /**
  * Ground truth for one `postInlineComments` call, feeding both the
- * plugin-facing `{posted, skipped}` contract and the delivery attestation.
- * Invariant: `attempted === posted + dropped + deduped`.
+ * plugin-facing `{posted, skipped, dropped}` contract and the delivery
+ * attestation. Invariant: `attempted === posted + dropped + deduped`.
+ *
+ * `skipped` and `dropped` answer different questions and must not be
+ * collapsed into one count: `skipped` is "was there a REASON not to post
+ * this, unrelated to whether posting would have worked?" (out of diff, or an
+ * equivalent comment already exists from a prior run — see `dedupSkipped`).
+ * `dropped` is "did GitHub actually reject an attempted post?" — a real
+ * delivery failure from `postPRReview`'s per-comment salvage path (#752).
+ * `dropped` also folds in the out-of-diff count for attestation purposes
+ * (nothing landed inline either way — see `InlineCommentsAttestation.dropped`'s
+ * own doc comment), but `skipped` must stay benign-only: it used to also
+ * have `dropped.length` folded in (the only way a `{posted, skipped}`-only
+ * contract, before `dropped` existed as its own field, could account for a
+ * real failure at all) — that silently re-merged "nothing to worry about"
+ * and "this actually failed" into the same number for any plugin reading
+ * `skipped`. Now every consumer that cares about a real failure reads
+ * `dropped` directly instead.
  */
 interface InlinePostOutcome {
   posted: number;
+  /** Benign: out of diff, or already commented (deduped). Never a delivery failure. */
   skipped: number;
   attempted: number;
+  /** A real delivery failure (GitHub rejected the post) — see the class comment above. */
   dropped: number;
   deduped: number;
 }
@@ -771,7 +789,10 @@ async function postPluginInlineComments(
   );
   return {
     posted,
-    skipped: skipped + dropped.length,
+    // `skipped` stays the benign-only count computed above — a real
+    // `dropped.length` GitHub rejection must NOT be folded back in here (see
+    // the class comment on `InlinePostOutcome`).
+    skipped,
     attempted,
     dropped: outOfDiffCount + dropped.length,
     deduped: dedupSkipped,

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -296,11 +296,19 @@ export interface PresentContext {
    * Post findings as inline PR review comments.
    * Handles diff-line filtering and deduplication automatically.
    * Only available in GitHub App context (pr + octokit present).
+   *
+   * `skipped` and `dropped` are distinct: `skipped` is benign (out of diff,
+   * or already commented from a prior run) — nothing to act on. `dropped` is
+   * a real delivery failure (GitHub rejected the post; see `postPRReview`'s
+   * per-comment salvage path, #752) — see `InlinePostOutcome` in engine.ts
+   * for the full rationale. A caller that only needs "how many landed" can
+   * ignore both; one that wants to distinguish "nothing to worry about" from
+   * "this actually failed" must read `dropped`, not `skipped`.
    */
   postInlineComments?(
     findings: ReviewFinding[],
     summaryBody: string,
-  ): Promise<{ posted: number; skipped: number }>;
+  ): Promise<{ posted: number; skipped: number; dropped: number }>;
 
   /**
    * Post a PR review with a summary body only (no inline comments — use

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -120,6 +120,102 @@ describe('ReviewEngine.present() delivery truth', () => {
     });
   });
 
+  // Regression coverage for the trust-residue fix: `postInlineComments`'s
+  // plugin-facing return used to fold a real GitHub post rejection into
+  // `skipped` (on top of it already being counted in `dropped`), destroying
+  // the "benign, nothing to worry about" vs "this actually failed" distinction
+  // for any plugin reading the return value directly (not just the engine's
+  // own `delivery.inlineComments`, which always read `dropped` and was never
+  // affected). Same batch-422-then-per-comment-salvage scenario as above, but
+  // this asserts on the RAW return value `ctx.postInlineComments!()` hands
+  // back to the calling plugin.
+  it("postInlineComments' own return keeps skipped (benign) and dropped (real failure) separate", async () => {
+    const patch = '@@ -1,2 +5,3 @@\n+line5\n+line6\n+line7';
+    const octokit = {
+      paginate: {
+        iterator: vi.fn((fn: unknown, _params: unknown) => {
+          if (fn === octokit.pulls.listFiles) {
+            return onePage([{ filename: 'src/a.ts', patch }]);
+          }
+          return onePage([]);
+        }),
+      },
+      pulls: {
+        listFiles: vi.fn(),
+        listReviewComments: vi.fn(),
+        createReview: vi.fn().mockRejectedValueOnce({ status: 422 }).mockResolvedValueOnce({}),
+        createReviewComment: vi
+          .fn()
+          .mockResolvedValueOnce({}) // comment 1: posted
+          .mockRejectedValueOnce(new Error('422 Unprocessable')), // comment 2: dropped
+      },
+    };
+
+    let rawOutcome: { posted: number; skipped: number; dropped: number } | undefined;
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          rawOutcome = await ctx.postInlineComments!(
+            [finding({ line: 5 }), finding({ line: 6 })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    // No out-of-diff findings and no dedup in this scenario, so `skipped`
+    // (benign-only) must be 0 — NOT 1, which is what folding the real
+    // `dropped` rejection in would have produced.
+    expect(rawOutcome).toEqual({ posted: 1, skipped: 0, attempted: 2, dropped: 1, deduped: 0 });
+  });
+
+  it('postInlineComments keeps a benign out-of-diff skip separate from a real dropped post', async () => {
+    // Three findings: one at line 100 (outside the diff — benign skip), two
+    // anchorable ones (lines 5, 6) where the batch 422s and the per-comment
+    // salvage posts one, drops one. `skipped` must reflect ONLY the
+    // out-of-diff finding; `dropped` must reflect ONLY the real rejection.
+    const patch = '@@ -1,2 +5,3 @@\n+line5\n+line6\n+line7';
+    const octokit = {
+      paginate: {
+        iterator: vi.fn((fn: unknown, _params: unknown) => {
+          if (fn === octokit.pulls.listFiles) {
+            return onePage([{ filename: 'src/a.ts', patch }]);
+          }
+          return onePage([]);
+        }),
+      },
+      pulls: {
+        listFiles: vi.fn(),
+        listReviewComments: vi.fn(),
+        createReview: vi.fn().mockRejectedValueOnce({ status: 422 }).mockResolvedValueOnce({}),
+        createReviewComment: vi
+          .fn()
+          .mockResolvedValueOnce({})
+          .mockRejectedValueOnce(new Error('422 Unprocessable')),
+      },
+    };
+
+    let rawOutcome: { posted: number; skipped: number; dropped: number } | undefined;
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          rawOutcome = await ctx.postInlineComments!(
+            [finding({ line: 100 }), finding({ line: 5 }), finding({ line: 6 })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(rawOutcome).toEqual({ posted: 1, skipped: 1, attempted: 3, dropped: 2, deduped: 0 });
+  });
+
   it('outOfDiffReviewPosted is true on a successful out-of-diff review comment', async () => {
     const octokit = {
       pulls: { createReview: vi.fn().mockResolvedValue({}) },


### PR DESCRIPTION
## Premise verification

CC-mode votes flagged `packages/review/src/engine.ts` (~line 620 in
capture-time code) for folding `dropped` (real GitHub API post failures
from #752's salvage path) into `skipped` (benign dedup/out-of-diff
skips). Checked current `origin/main` (through #805) before touching
anything: **the conflation is live**, not stale —

```ts
// postPluginInlineComments, final return (unchanged since #752, engine.ts:790-796)
return {
  posted,
  skipped: skipped + dropped.length,   // <-- folds a REAL failure into the BENIGN count
  attempted,
  dropped: outOfDiffCount + dropped.length,
  deduped: dedupSkipped,
};
```

`git blame`/history: `skipped: skipped + dropped.length` traces back to
#752 itself (`fix(review): stop silently dropping inline comments when
batch review fails`), from *before* `dropped` existed as its own tracked
field — at the time, folding a real drop into `skipped` was the only way
a `{posted, skipped}`-only return could account for it at all. #768
(delivery attestation) later added `dropped`/`deduped`/`attempted` as
proper first-class fields feeding the attestation correctly, but never
removed the now-redundant fold-in on `skipped` — so today a real GitHub
rejection is double-counted: once (correctly) in `dropped`, and again
(incorrectly) in `skipped`.

## Fix

- `postPluginInlineComments`'s final return: `skipped` now stays exactly
  the benign-only value already computed earlier in the function
  (`outOfDiffCount + dedupSkipped`) — no `+ dropped.length`. `dropped`'s
  composition is untouched.
- Widened the public `PresentContext.postInlineComments` contract
  (`plugin-types.ts`) from `Promise<{ posted, skipped }>` to
  `Promise<{ posted, skipped, dropped }>` so a plugin can actually
  distinguish "benign, nothing to worry about" from "this actually
  failed" instead of the two being inseparable in the one field it could
  previously see.
- Added a class-comment on `InlinePostOutcome` documenting the
  skipped-vs-dropped distinction so this doesn't regress a third time.

## Consumer audit (find-all-consumers before changing the shape)

Traced every reader of the delivery counts via `get_dependents`/grep
before touching the return shape:

- `createPostInlineComments` (engine.ts) → `deliveryTracker.inlineComments`
  → `PresentDelivery.inlineComments` → `assembleAttestation` →
  `Attestation.delivery.inlineComments` → `formatAttestationBadgeLine`
  (the PR-description "Attested: ..." badge / lien-stats) and the
  attestation JSON in the check-run summary / action outputs.
  **This entire chain reads `.dropped` (and `.posted`/`.attempted`/`.deduped`)
  directly — never `.skipped`.** `attestation.ts`'s own doc comment on
  `InlineCommentsAttestation.dropped` ("Failed to land: outside the diff,
  or dropped by GitHub on anchor validation") already correctly describes
  the *fixed* field's semantics. `computeVerdict` keys off
  `inlineComments.dropped > 0` for `degraded:comments_dropped` — also
  already correct, already unaffected.
- `AgentReviewPlugin.present()` (the only plugin that calls
  `context.postInlineComments()`) — `await context.postInlineComments(...)`
  — **discards the return value entirely**, so it was never affected
  either.
- Net effect: **zero current consumers were reading the buggy `skipped`
  value** — this was trust residue (a landmine for the next consumer that
  trusts the field's documented "benign" meaning), not an active behavioral
  bug in today's attestation/lien-stats/check-run output. The fix is a
  return-shape correction plus a widened, now-trustworthy public contract;
  no attestation/lien-stats/check-run output changes.

## Tests

`engine-delivery.test.ts`, two new tests alongside the existing
`inlineComments.{posted,dropped}` regression test (same batch-422 →
per-comment-salvage scenario as #752's own fixture):

1. `postInlineComments' own return keeps skipped (benign) and dropped
   (real failure) separate` — 2 anchorable findings, 1 posts, 1 is
   rejected by GitHub (no out-of-diff, no dedup): asserts the RAW return
   value is `{ posted: 1, skipped: 0, attempted: 2, dropped: 1, deduped: 0 }`
   — `skipped` must be 0, not 1 (which is what the fold-in bug would have
   produced).
2. `postInlineComments keeps a benign out-of-diff skip separate from a
   real dropped post` — mixes one out-of-diff finding with the same
   batch-422 scenario: asserts `{ posted: 1, skipped: 1, attempted: 3,
   dropped: 2, deduped: 0 }` — the benign out-of-diff skip and the real
   rejection land in the right, non-overlapping-in-meaning fields.

All 13 tests in the file pass (11 existing + 2 new), plus the full
`postPluginInlineComments`/`ReviewEngine.present()` suites
(`engine.test.ts`, `engine-comment-dedup.test.ts`,
`plugins-agent-out-of-diff.test.ts`) — 59 tests, all green, no
regressions.

## Dogfood

This is a pure bookkeeping/return-shape fix with no LLM/prompt
involvement (doesn't touch `packages/review/src/plugins/agent/**` at
all — confirmed by `git diff --name-only origin/main`, so the
harness-evidence gate does not fire on this PR), so there's no
harness/agent replay applicable. The real consumer this change is for is
`ReviewEngine.present()`'s actual GitHub-delivery flow, so the dogfood is
driving that flow for real (octokit mocked only at the HTTP boundary,
exactly like the pre-existing `#752`/`#768` regression tests in this same
file) and reading the exact values a calling plugin would see — that's
tests 1 and 2 above, both passing.

## Gates

- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green (full monorepo).
- `node packages/cli/dist/index.js delta` — exit 0. Only note: `postPluginInlineComments` shows a pre-existing `time` metric *improvement* (87m → 83m, tagged `pre-exist`, not a new/worsened crossing).

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 3. 2 pre-existing issues remain in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | -3 |


> [!NOTE]
> **Low Risk**
>
> This PR is a narrow bookkeeping fix in the review engine's inline-comment delivery counts. It stops folding real GitHub post rejections into the benign `skipped` count in `postPluginInlineComments`, and widens the public `PresentContext.postInlineComments` return type to include `dropped` so future plugins can distinguish failures from benign skips. The engine's own delivery attestation already reads `dropped` directly and is unaffected; the only production plugin that calls the method discards the return value. Two regression tests assert the corrected raw return shape. No callers are broken, the TypeScript contract is widened (not narrowed), and the invariant `attempted === posted + dropped + deduped` continues to hold on all return paths.
>
> - `postPluginInlineComments` now returns `skipped` as the benign-only count (`outOfDiffCount + dedupSkipped`) instead of adding `dropped.length`.
> - `PresentContext.postInlineComments` return type widened from `{posted, skipped}` to `{posted, skipped, dropped}`.
> - Added regression tests verifying the raw return value separates benign skips from real GitHub delivery failures.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 74df7b0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->