### PR TITLE
fix(review): eliminate catastrophic backtracking in string-literal extraction

### DIFF
--- a/packages/review/src/sibling-surface-signals.ts
+++ b/packages/review/src/sibling-surface-signals.ts
@@ -165,7 +165,11 @@ const MAX_TOTAL_ENTRIES = 15;
 /** Total block char budget — entries beyond this are dropped with an omission note. */
 const MAX_BLOCK_CHARS = 3000;
 
-const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
+// Note: see the identical fix + rationale in stale-literal-signals.ts's
+// STRING_RE — `(?!\1).` let a backslash match two ways, causing catastrophic
+// backtracking on an unmatched-quote line dense with backslashes. `[^\\]`
+// removes the ambiguity.
+const STRING_RE = /(['"`])((?:[^\\]|\\.)*?)\1/g;
 const CAMEL_ID_RE = /\b[A-Za-z][a-z0-9]*(?:[A-Z][a-z0-9]*)+\b/g;
 const SNAKE_ID_RE = /\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b/g;
 const CALL_RE = /\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;

--- a/packages/review/src/stale-literal-signals.ts
+++ b/packages/review/src/stale-literal-signals.ts
@@ -92,7 +92,15 @@ const LOW_SIGNAL_STRINGS = new Set([
   'function',
 ]);
 
-const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
+// Note: the inner group must not let a backslash match via two different
+// alternatives — `(?:\\.|(?!\1).)*?`'s two branches can BOTH consume a lone
+// backslash (`\\.` takes it + the next char; `(?!\1).` takes just it), which
+// gives the engine an exponential number of ways to fail to match on an
+// unmatched-quote line dense with backslashes (catastrophic backtracking,
+// confirmed to hang on a real dead-regex comment in zod's types.ts — see
+// packages/review/test/stale-literal-signals.test.ts). `[^\\]` removes the
+// ambiguity: a backslash can only ever be consumed by the `\\.` branch.
+const STRING_RE = /(['"`])((?:[^\\]|\\.)*?)\1/g;
 const COMMENT_RE = /^(\/\/|\/\*|\*|#|--|<!--)/;
 const TEST_PATH_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/|\/fixtures\/)/;
 const CONFIG_PATH_RE =

--- a/packages/review/test/sibling-surface-signals.test.ts
+++ b/packages/review/test/sibling-surface-signals.test.ts
@@ -236,6 +236,85 @@ describe('extractSiblingSurfaces — direction B (family-pattern divergence)', (
 });
 
 // ---------------------------------------------------------------------------
+// STRING_RE — ReDoS regression (same fix/rationale as stale-literal-signals.ts:
+// `(?:\\.|(?!\1).)*?`'s dual backslash-consuming branches caused catastrophic
+// backtracking; fixed to `(?:[^\\]|\\.)*?`). Exercised through
+// extractSiblingSurfaces since STRING_RE/collectStringTokens aren't exported.
+// ---------------------------------------------------------------------------
+
+describe('STRING_RE — ReDoS regression', () => {
+  // Reuses the guzzle-shaped family fixture (two siblings sharing
+  // `validateOptions(` clears the cohesion gate) so the pathological line,
+  // added to CurlHandler.php's patch, actually reaches collectStringTokens
+  // via extractUnmirroredAdditions's diff scan.
+  function contextWithAddedLine(extraLine: string): ReviewContext {
+    const patch = `@@ -1,4 +1,5 @@
+ <?php
+ class CurlHandler {
+     public function handle($options) {
+         $this->validateOptions($options);
++${extraLine}
+     }
+ }`;
+    const patches = new Map([['src/Handler/CurlHandler.php', patch]]);
+    const repoChunks = [
+      makeChunk('src/Handler/CurlHandler.php', 1, CURL_HANDLER_CONTENT),
+      makeChunk('src/Handler/StreamHandler.php', 1, STREAM_HANDLER_CONTENT),
+    ];
+    return makeContext({
+      patches,
+      repoChunks,
+      changedFiles: ['src/Handler/CurlHandler.php'],
+    });
+  }
+
+  it('extracts single-, double-, and backtick-quoted literals identically', () => {
+    const line =
+      '$a = \'feature-flag-alpha\'; $b = "src/config/app.json"; $c = `build-output-dir`;';
+    const entries = extractSiblingSurfaces(contextWithAddedLine(line));
+    const displays = entries.map(e => e.display);
+    expect(displays).toEqual(
+      expect.arrayContaining([
+        "'feature-flag-alpha'",
+        '"src/config/app.json"',
+        '`build-output-dir`',
+      ]),
+    );
+  });
+
+  it('extracts a literal containing an escaped quote of its own delimiter', () => {
+    const line = "$msg = 'it\\'s a config-value-here';";
+    const entries = extractSiblingSurfaces(contextWithAddedLine(line));
+    expect(entries.some(e => e.display.includes('config-value-here'))).toBe(true);
+  });
+
+  it('does not hang on a backslash-dense line with no matching closing quote', () => {
+    // Shape of the real-world trigger: packages/zod/src/v3/types.ts:607, a
+    // commented-out ~928-char regex literal with 133 backslashes and an
+    // opening backtick with no closing backtick before end-of-line. Bound is
+    // generous (500ms) to stay flake-proof in CI while still catching a
+    // regression to exponential blowup (17.6s+ at n=30 in the original bug).
+    const pathological = '// old regex: ' + '`' + '\\d'.repeat(400) + ' -- dead code, never closed';
+
+    const start = Date.now();
+    extractSiblingSurfaces(contextWithAddedLine(pathological));
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('does not hang on a large synthetic worst-case (20k+ chars, no closing quote)', () => {
+    const pathological = "x '" + '\\a'.repeat(10_000);
+
+    const start = Date.now();
+    extractSiblingSurfaces(contextWithAddedLine(pathological));
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Negative / noise cases
 // ---------------------------------------------------------------------------
 

--- a/packages/review/test/stale-literal-signals.test.ts
+++ b/packages/review/test/stale-literal-signals.test.ts
@@ -132,6 +132,72 @@ describe('extractChangedLiterals', () => {
 });
 
 // ---------------------------------------------------------------------------
+// STRING_RE — ReDoS regression (catastrophic backtracking, see
+// `(?:\\.|(?!\1).)*?`'s dual backslash-consuming branches, fixed to
+// `(?:[^\\]|\\.)*?`). Exercised through extractChangedLiterals since STRING_RE
+// itself isn't exported.
+// ---------------------------------------------------------------------------
+
+describe('STRING_RE — ReDoS regression', () => {
+  function patchOf(line: string): Map<string, string> {
+    return new Map([['src/a.ts', `@@ -1,1 +1,1 @@\n+${line}`]]);
+  }
+
+  it('extracts single-, double-, and backtick-quoted literals identically', () => {
+    const line = `const a = 'feature-flag-alpha'; const b = "src/config/app.json"; const c = \`build-output-dir\`;`;
+    const values = extractChangedLiterals(patchOf(line)).map(l => l.value);
+    expect(values).toEqual(
+      expect.arrayContaining(['feature-flag-alpha', 'src/config/app.json', 'build-output-dir']),
+    );
+  });
+
+  it('extracts a literal containing an escaped quote of its own delimiter', () => {
+    const line = `const msg = 'it\\'s a config-value-here';`;
+    const values = extractChangedLiterals(patchOf(line)).map(l => l.value);
+    expect(values).toContain("it\\'s a config-value-here");
+  });
+
+  it('extracts multiple distinct literals from one line', () => {
+    const line = `path.join('src/config', 'app.settings.json', 'defaults-v2');`;
+    const values = extractChangedLiterals(patchOf(line)).map(l => l.value);
+    expect(values).toEqual(
+      expect.arrayContaining(['src/config', 'app.settings.json', 'defaults-v2']),
+    );
+  });
+
+  it('does not hang on a backslash-dense line with no matching closing quote', () => {
+    // Shape of the real-world trigger: packages/zod/src/v3/types.ts:607, a
+    // commented-out ~928-char regex literal with 133 backslashes and an
+    // opening backtick with no closing backtick before end-of-line. The
+    // vulnerable regex explored an exponential number of ways to fail to
+    // match this (2^k for k backslashes); the fixed regex resolves it
+    // immediately. Bound is generous (500ms) to stay flake-proof in CI while
+    // still catching any regression back to exponential blowup (which took
+    // 17.6s+ at a much smaller n=30 in the original bug).
+    const pathological = 'x = `old regex: ' + '\\d'.repeat(400) + ' -- dead code, never closed';
+    const patches = patchOf(pathological);
+
+    const start = Date.now();
+    const values = extractChangedLiterals(patches);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+    expect(values).toEqual([]); // no closing backtick -> no literal extracted, not a crash
+  });
+
+  it('does not hang on a large synthetic worst-case (20k+ chars, no closing quote)', () => {
+    const pathological = "x '" + '\\a'.repeat(10_000);
+    const patches = patchOf(pathological);
+
+    const start = Date.now();
+    extractChangedLiterals(patches);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // computeStaleLiteralCandidates
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fixes a HIGH-severity, production-exposed ReDoS in the review engine's
  string-literal extraction regex (`STRING_RE`), duplicated in
  `packages/review/src/stale-literal-signals.ts:95` and
  `packages/review/src/sibling-surface-signals.ts:168`.
- `(?:\\.|(?!\1).)*?` let a lone backslash match via two different
  alternatives (`\\.` consumes it + the next char; `(?!\1).` consumes just
  it), giving the engine an exponential number of ways to fail to match on
  an unmatched-quote line dense with backslashes — classic catastrophic
  backtracking.
- Real, mundane trigger found in the wild: `zod`'s
  `packages/zod/src/v3/types.ts:607`, a commented-out dead "old email regex"
  with 928 chars / 133 backslashes and an opening backtick with no closing
  backtick before end-of-line. Both signal scans run **unconditionally over
  the full indexed repo corpus on nearly every PR**, synchronously, before
  the LLM is even invoked — the only existing guard
  (`STALE_LITERAL_TIME_BUDGET_MS = 5_000`) checks the deadline *between*
  lines, not *during* a single stuck regex call, so it cannot interrupt this.
  Any repo with a dead/commented regex, escaped JSON fixture, or generated
  lexer table anywhere in its tree would hang **every subsequent review**.

## The fix

```diff
- const STRING_RE = /(['"`])((?:\\.|(?!\1).)*?)\1/g;
+ const STRING_RE = /(['"`])((?:[^\\]|\\.)*?)\1/g;
```

Replacing the negative-lookahead alternative `(?!\1).` with the negated
character class `[^\\]` removes the dual-parse-path ambiguity — a backslash
can now only ever be consumed by the `\\.` branch, eliminating the
exponential partition space. Applied identically in both files (same
regex, same bug, independently duplicated).

## Sweep for other instances

Grepped all of `packages/` for the same backreference-negation-alternation
shape (`(?!\1)` and broader `(?!\<backref>)` patterns): **confirmed exactly
2 instances, both fixed — no third instance found.**

## Timing (independently re-verified, not just taken on faith)

Re-derived and re-ran the repro myself (`node`, no lien/zod deps):

| Input | Old regex | New regex |
|---|---|---|
| n=10 backslash-pairs (23 chars) | 0ms | — |
| n=15 (33 chars) | 3ms | — |
| n=20 (43 chars) | 74ms | — |
| n=25 (53 chars) | 2,320ms | — |
| n=30 (63 chars) | killed after 8,000ms timeout (still hung) | — |
| Real zod `types.ts:607` line (928 chars) | hangs (per original investigation) | **0ms** |
| Synthetic worst case, n=10,000 (20,003 chars) | n/a (would hang far longer) | **0ms** |
| Synthetic worst case, n=500,000 (1,000,003 chars) | n/a | **2ms** (confirms linear scaling, not just "fast at one size") |

Correctness: byte-identical extraction between old and new regex on every
case tried — plain strings, escaped-quote-inside-string, nested different
quote types, template literals, escaped backslashes, multiple literals per
line.

## Regression tests

Added to both `packages/review/test/stale-literal-signals.test.ts` and
`packages/review/test/sibling-surface-signals.test.ts` (new `STRING_RE —
ReDoS regression` describe blocks):
- Correctness: single/double/backtick-quoted literals, an escaped quote of
  the string's own delimiter, multiple literals on one line.
- Performance: the real-zod-shaped pathological line and a 10,000-backslash
  synthetic worst case both assert `< 500ms` (generous, CI-flake-proof
  bound vs. the 17.6s+ the old regex took at a *much smaller* n=30).

**Verified the tests are real regressions, not tautological**: reverted
just the two `src/` fixes (kept the new tests) and ran each new perf test
in a subprocess with a 15s hard kill — both hung past 15s on the unpatched
regex, confirming the tests genuinely catch this bug. Restored the fix
before committing.

## Byte-diff census (dogfood evidence — CLAUDE.md mandate)

Built `build-prompts.ts` output for all 3 fixtures actually on disk in this
worktree (the rest of the harness's canary corpus is gitignored/regenerated
via `capture-pr.ts`, not present locally) — merge-base vs. this branch:

```
placeholder: BYTE-IDENTICAL
accurate-doc: BYTE-IDENTICAL
renamed-stale-claim: BYTE-IDENTICAL
=== 3/3 byte-identical ===
```

SHA-256 of each fixture's build-prompts output matches exactly before vs.
after. The fix is behavior-neutral for every on-disk fixture.

## Pre-filter (line-length backstop) — not added

The scout's write-up suggested an optional line-length pre-filter as
defense-in-depth. Decided **against** adding it: the regex fix alone is
verified linear-time up to 1MB-long pathological lines (2ms), leaving no
plausible residual risk for *this* bug — a length cap would be speculative
insurance against a hypothetical future regex mistake, which is exactly
the case CLAUDE.md's YAGNI guidance says to skip. If a future regex
introduces a similar hazard, the right fix is the same one applied here
(remove the ambiguity), not a blunt length cap that would silently drop
legitimate long-line literals today.

## Gates

- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green (0 lint errors, only pre-existing unrelated warnings; 1237+860+374+1062+27+41 tests passed across all packages).
- `node packages/cli/dist/index.js delta` — exit 0, no complexity changes across 4 files vs HEAD.
- No changeset (packages/review is private/unpublished).

## Test plan

- [x] `npm run test -w @liendev/review -- test/stale-literal-signals.test.ts test/sibling-surface-signals.test.ts` green (71 tests)
- [x] New perf tests independently confirmed to hang (15s+) against the unpatched regex, then pass in ~9ms against the fix
- [x] Repo-wide sweep for the same regex shape: 2/2 instances found and fixed, no third
- [x] Byte-diff census: 3/3 on-disk fixtures byte-identical pre/post fix

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a production-exposed ReDoS in the review engine's string-literal extraction regex by replacing the ambiguous `(?:\\.|(?!\1).)*?` pattern with the unambiguous `(?:[^\\]|\\.)*?` in both `stale-literal-signals.ts` and `sibling-surface-signals.ts`. The change removes the dual-parse-path ambiguity that caused catastrophic backtracking on backslash-dense lines with unmatched quotes, and it is behavior-neutral for well-formed string literals. Regression tests with generous time bounds were added to both modules, and a repo-wide sweep confirmed no third instance of the vulnerable pattern remains in source code.
>
> - Replaced catastrophic-backtracking STRING_RE in two signal modules with a linear-time equivalent
> - Added ReDoS regression tests covering correctness and performance bounds
> - Verified no remaining `(?!\1)`-shaped regex instances in production code

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e489cbb. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quoted-string processing to remain responsive when handling complex or malformed input.
  * Preserved consistent extraction across supported quoting styles, escaped quotes, and multiple literals.

* **Tests**
  * Added regression coverage for large, backslash-heavy strings and inputs missing closing quotes.
  * Verified string extraction completes within expected time limits without hanging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->