### PR TITLE
ci: enable candidate-loop passes for this repo's reviews

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -74,3 +74,12 @@ jobs:
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Dedicated candidate-loop passes (stale-duplicate-pass.ts,
+          # incomplete-handling-pass.ts) — dark/opt-in for @liendev/review
+          # consumers by default; this repo's own reviews opt in here to
+          # dogfood them (see docs/architecture/review-pass-architecture.md's
+          # status line for the mechanism and evidence status). Both gates
+          # read these env vars directly via process.env — no action.yml
+          # input plumbing needed.
+          LIEN_STALE_DUP_PASS: 'on'
+          LIEN_INCOMPLETE_PASS: 'on'

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -3,11 +3,17 @@
 Status: generalized executor + attestation v2 shipped (PR #799, merged).
 Three passes plug into it today — **doc-truth is production-on by default**
 (v1); the **stale-duplicate** and **incomplete-handling** candidate loops
-are built, merged, and dark (default-off), and doc-truth itself gained a
-dark, env-only v2 mode (PR #807) that backports the same per-candidate-
-verdict contract into its own pass — see "Which passes are live" below.
-See [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
-decision this doc implements and its evidence/economics.
+are built, merged, and dark (default-off) for `@liendev/review`/
+`@liendev/action` consumers, and doc-truth itself gained a dark, env-only
+v2 mode (PR #807) that backports the same per-candidate-verdict contract
+into its own pass — see "Which passes are live" below. As of 2026-07-17,
+this monorepo's own `.github/workflows/lien-review.yml` opts both loops in
+on itself (`LIEN_STALE_DUP_PASS=on` / `LIEN_INCOMPLETE_PASS=on`) to dogfood
+them on its own PRs; the package/action defaults are unchanged. See
+[ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
+decision this doc implements and its evidence/economics — the evidence
+behind this opt-in is session-local so far and will be written up there
+once promoted into a durable fixture.
 
 ## Motivation
 


### PR DESCRIPTION
## Summary

- Sets `LIEN_STALE_DUP_PASS=on` and `LIEN_INCOMPLETE_PASS=on` on the `Run Lien Review` step in `.github/workflows/lien-review.yml`, opting **this repo's own** PR reviews into both dark/opt-in candidate-loop passes (`stale-duplicate-pass.ts`, PR #803; `incomplete-handling-pass.ts`, PR #804).
- Package/action defaults for external `@liendev/review` / `@liendev/action` consumers are **unchanged** — both loops stay dark (default-off) there.
- Updates the status line in `docs/architecture/review-pass-architecture.md` to record this repo's opt-in as of today, without baking specific eval numbers into the doc (session-local checks aren't yet a durable, citable fixture — see the doc's note pointing at ADR-014 for the eventual write-up).

## Mechanism verification

Both gates read their env var **directly via `process.env`** — no `action.yml` input plumbing exists or is needed:

- `stale-duplicate-pass.ts`: `isStaleDuplicatePassEnabled()` → `envEnabled(process.env['LIEN_STALE_DUP_PASS'])`
- `incomplete-handling-pass.ts`: `isIncompleteHandlingPassEnabled()` → `envEnabled(process.env['LIEN_INCOMPLETE_PASS'])`

Both accept `'1' | 'true' | 'on'` (case-insensitive). The YAML values are quoted (`'on'`) to avoid YAML 1.1's bareword `on`/`off` boolean-coercion footgun — belt-and-suspenders, since `envEnabled` also accepts the stringified-boolean form.

`packages/action/src/index.ts` / `inputs.ts` do not filter or allowlist environment variables passed to the child process, so anything set in the step's `env:` block reaches `process.env` unmodified.

## Dogfood

This is a workflow + docs-only diff. **Proof the flags reached the pass gates** — this PR's own Lien Review run ([29556714968](https://github.com/getlien/lien/actions/runs/29556714968/job/87810245132)) attestation:

```json
{
  "attestationVersion": 2,
  "run": { "conclusion": "neutral", "filesAnalyzed": 0 },
  "provider": {
    "passes": [
      { "name": "main", "ran": true, "stopReason": "completed", "neverRan": false },
      { "name": "doc-truth", "ran": true, "stopReason": "budget", "neverRan": false },
      { "name": "stale-duplicate-loop", "ran": true, "stopReason": "budget", "neverRan": false }
    ]
  },
  "passesSkipped": [
    { "plugin": "agent-review:incomplete-handling-loop", "reason": "no variant-sweep, sibling-surface, or unread-field candidate found" }
  ],
  "verdict": "degraded:budget_starved"
}
```

- **`stale-duplicate-loop` actually fired** (`ran: true`, 0 findings) — the literal `LIEN_STALE_DUP_PASS=on` appearing in both the workflow diff and the doc diff was enough to trip its own eligibility gate on this diff. Unintentional but conclusive: the flag reached `stale-duplicate-pass.ts`'s gate and the loop ran end-to-end.
- **`incomplete-handling-loop` gated out with a real, mechanism-specific reason** — `"no variant-sweep, sibling-surface, or unread-field candidate found"` is `incompleteHandlingSkipReason()`'s eligibility message, only reachable when `isIncompleteHandlingPassEnabled()` is already `true` (the disabled-path message is `"disabled (opt-in; set config.incompleteHandlingPass or LIEN_INCOMPLETE_PASS=on to enable)"` — not what's shown). So this pass was evaluated with the flag on, not silently absent.
- Raw CI log also shows the resolved env values directly: `LIEN_STALE_DUP_PASS: on` / `LIEN_INCOMPLETE_PASS: on` at the top of the `Run Lien Review` step.

The flip works. (The run's `degraded:budget_starved` verdict — both new loops competing with doc-truth for one shared budget pool — is a real cost/tuning signal worth a follow-up, not a blocker; this workflow's review stays advisory, `fail-on: never`.)

The one Lien Review finding this run produced (doc-truth, low risk, budget-exhaustion false-negative on its own verification of the workflow YAML) was triaged and dismissed with evidence in [this comment](https://github.com/getlien/lien/pull/811#issuecomment-4999222357).

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; pre-existing warnings only)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (parser-native, parser, core, review, cli, action — all pass)
- [x] `node packages/cli/dist/index.js delta` — exit 0, no complexity-affecting changes
- [x] `actionlint .github/workflows/lien-review.yml` — clean
- [x] Dogfood: this PR's own Lien Review run's attestation shows both passes evaluated (see above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that stale-duplicate and incomplete-handling review passes remain disabled by default for package and action consumers.
  * Documented the repository’s internal review configuration, which enables these passes for dogfooding.
  * Added details about the opt-in doc-truth v2 mode and related architecture guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 497 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!WARNING]
> **1 issue found** · Low Risk
>
> Opts this repository's own Lien Review workflow into two dark candidate-loop passes (stale-duplicate and incomplete-handling) by setting `LIEN_STALE_DUP_PASS=on` and `LIEN_INCOMPLETE_PASS=on` in `.github/workflows/lien-review.yml`. The change is scoped to this repo's self-reviews; external `@liendev/review` / `@liendev/action` consumers remain default-off. Documentation in `docs/architecture/review-pass-architecture.md` is updated to record the opt-in date and mechanism. No source code or package defaults are modified.
>
> - Added `LIEN_STALE_DUP_PASS: 'on'` and `LIEN_INCOMPLETE_PASS: 'on'` env vars to the Run Lien Review step
> - Quoted YAML values to avoid YAML 1.1 bareword boolean coercion
> - Updated review-pass-architecture.md status line to document this repo's dogfood opt-in

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ee97dd1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 1/1 comments posted · 33K/13K tokens
<!-- /lien:attestation -->
