### PR TITLE
test(review): promote drizzle variant-sweep fixture; docs: ADR-014 evidence

### DIFF
--- a/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
+++ b/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
@@ -207,20 +207,55 @@ in the same PR.
 
 ### Negative / Risks
 
-- **Lift is unproven for both new loops.** No priced A/B exists yet
-  comparing a dedicated candidate loop against the shared loop's own
-  signal-augmented findings list on the same fixtures — #803 and #804 were
-  explicit $0-paid-LLM-spend build tasks (mechanism only, "do NOT run
-  calibrations" per their briefs). The one priced recalibration in this
-  arc, PR #805's stale-duplicate FP-guard fix, measured a *wording* fix's
-  effect (a `calibrate-10` held 10/10 on the canonical true-positive fixture
-  at $0.3471, and a 3-vote FP probe against captured PR #770 dropped from 2
-  wrongful `stale` verdicts to 0) — real evidence the guard works, but not
-  evidence the dedicated-loop *architecture* out-performs the shared loop
-  it sits beside. The pilot's own success criteria call for mining 2–3 more
-  stale-duplicate fixtures (cross-repo candidates were named but not yet
-  captured) before a statistically meaningful lift comparison is possible;
-  that mining has not happened as of this ADR.
+- **Lift is now measured for `incomplete-handling`, on one fixture and one
+  of its three candidate shapes; `stale-duplicate`'s dedicated-loop-vs-
+  shared-loop lift remains unmeasured.** A same-day A/B against a real,
+  ground-truthed external bug — drizzle-team/drizzle-orm#4172, which added
+  6 Gel `ColumnDataType` variants (`dateDuration`, `duration`,
+  `relDuration`, `localTime`, `localDate`, `localDateTime`) that all four
+  downstream schema-integration packages' `columnToSchema` if-chains still
+  don't handle — measured the shared main pass converting the candidate to
+  a real finding on only 1/3 screened votes (the other 2/3 read all four
+  affected files, per their own tool-call trace, and still emitted nothing
+  of any rule), against the dedicated `incomplete-handling` loop converting
+  3/3, then holding 10/10 on `--calibrate 10` (one legitimate keyword-gate
+  widening was needed along the way; both re-verified against a
+  perfect/empty/distractor smoke test that never false-passed). Fixture:
+  `packages/review/test/harness/fixtures/crossrepo/
+  pr4172-columndatatype-gel-gap.assertions.ts` (promoted 2026-07-17; full
+  result history in its own header). This is the first controlled,
+  same-fixture comparison of a dedicated candidate loop against the shared
+  loop's own signal-augmented findings list — the gap #803 and #804
+  explicitly left open (both were $0-paid-LLM-spend build tasks, "do NOT
+  run calibrations" per their briefs). It is deliberately narrow evidence,
+  not a corpus-wide lift claim: one fixture, one candidate shape
+  (`variant-sweep`; the rule's other two shapes, `sibling-surface` and
+  `unread-field`, are untested by it), on the prod default model only.
+  `stale-duplicate`'s own dedicated-loop-vs-shared-loop lift is still
+  unmeasured — PR #805's stale-duplicate recalibration priced a *wording*
+  fix's effect (`calibrate-10` held 10/10 on the canonical true-positive
+  fixture at $0.3471, and a 3-vote FP probe against captured PR #770
+  dropped from 2 wrongful `stale` verdicts of 51 to 0 after the fix), not a
+  shared-vs-loop comparison. The pilot's own success criteria still call
+  for mining 2–3 more stale-duplicate fixtures (cross-repo candidates were
+  named but not yet captured) before a statistically meaningful lift
+  comparison is possible for that rule; that mining has not happened as of
+  this ADR.
+- **The FP guard shipped in both loops' prompts from day one (see Decision
+  point 2) has now been probed on both sides, clean on both.**
+  `stale-duplicate`'s guard (PR #805, above) dropped a real, observed
+  2-of-51 wrongful-`stale` rate against test-double literals to 0 after a
+  wording fix. `incomplete-handling`'s otherwise-identical guard was
+  separately probed the same day against two real, unrelated, loop-eligible
+  lien PRs (#772, #773 — chosen because their sibling-surface candidates
+  were judged benign in advance: deliberately-different modules sharing a
+  filename/directory pattern, not forgotten mirrors) and recorded **zero**
+  wrongful `incomplete` verdicts across 81 total candidate verdicts (3
+  votes × (15 + 12) candidates). That probe is an in-session measurement,
+  not yet landed as its own tracked artifact in this repository — cited
+  here for the same reason this ADR already cites an unpublished design
+  memo in References: an honest record of what was actually measured,
+  pending its own write-up.
 - **Per-PR firing-rate economics required real-PR census work, not
   assumption, and produced a genuine surprise.** The raw `<stale_literal_
   candidates>` block (unconditional signal, no loop-eligibility filter)
@@ -293,6 +328,10 @@ in the same PR.
   pass
 - PR #799, #803, #804, #805, #807 — the shipped implementation and its
   dogfood/census evidence cited throughout this ADR
+- `packages/review/test/harness/fixtures/crossrepo/
+  pr4172-columndatatype-gel-gap.assertions.ts` — the shared-vs-loop lift
+  fixture cited under Consequences/Negative (drizzle-team/drizzle-orm#4172,
+  promoted 2026-07-17); full result history in its own header
 - An unpublished, owner-approved per-rule-loops design memo prepared in a
   parallel working session (not part of this repository's tracked history)
   supplied the initial architecture proposal this ADR records the team's

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -122,16 +122,24 @@ npx tsx <lien>/packages/review/test/harness/capture-pr.ts 2334 \
 | encode/starlette | #2191 | `crossrepo/pr2191-templateresponse-offbyone` | positional-args index collision | **canary** (certified 10/10, 2026-07-12) |
 | pallets/werkzeug | #2678 | `crossrepo/pr2678-multipart-index-offset` | slice-relative index used as absolute | **canary** (certified 10/10, 2026-07-16) |
 | pallets/werkzeug | #2017 | `crossrepo/pr2017-multipart-boundary-regex` | unescaped client boundary in regex | characterization (measured 8/10 — below bar, see header) |
+| drizzle-team/drizzle-orm | #4172 | `crossrepo/pr4172-columndatatype-gel-gap` | 6 new Gel `ColumnDataType` variants unhandled by 4 downstream packages | **canary** (certified 10/10, 2026-07-17 — first TypeScript entry in this corpus; also the loop-vs-shared A/B fixture, see header) |
 
-The two remaining `characterization`-tagged entries are both below the ≥9/10
-bar, for different reasons: `pr2334-etag-weak-indicator-strip` has 3/3 Kimi
-vote evidence but scores 5/10 on `--calibrate 10` (borderline judgment, not a
-budget deferral). `pr2017-multipart-boundary-regex` raw-scored 10/10 on
-`--calibrate 10` (2026-07-16), but a post-cert dogfood assert-cli smoke test
-(perfect/empty/distractor, see below) found its keyword list's bare
-identifiers/domain nouns let 2 of the 10 votes false-pass on unrelated
-findings; re-scored against the corrected keyword list its true rate is
-8/10. See each header before spending more calibration budget or re-promoting.
+The two `characterization`-tagged starlette/werkzeug entries are both below
+the ≥9/10 bar, for different reasons: `pr2334-etag-weak-indicator-strip` has
+3/3 Kimi vote evidence but scores 5/10 on `--calibrate 10` (borderline
+judgment, not a budget deferral). `pr2017-multipart-boundary-regex`
+raw-scored 10/10 on `--calibrate 10` (2026-07-16), but a post-cert dogfood
+assert-cli smoke test (perfect/empty/distractor, see below) found its
+keyword list's bare identifiers/domain nouns let 2 of the 10 votes
+false-pass on unrelated findings; re-scored against the corrected keyword
+list its true rate is 8/10. See each header before spending more
+calibration budget or re-promoting.
+
+`pr4172-columndatatype-gel-gap` pins its fixture's `config` to
+`{ incompleteHandlingPass: true }` (baked into the captured `ReviewContext`,
+not an external env var) — see its header for why that needs zero harness
+plumbing changes, and for the same-fixture A/B evidence (shared main pass
+1/3 vs the dedicated loop 3/3 screen, 10/10 calibrated) that promoted it.
 
 ## Negative-regression fixtures
 

--- a/packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts
@@ -1,0 +1,357 @@
+/**
+ * drizzle-team/drizzle-orm PR #4172 ("Gel dialect") — ColumnDataType gains 6
+ * Gel/EdgeDB temporal variants (`dateDuration`, `duration`, `relDuration`,
+ * `localTime`, `localDate`, `localDateTime`) in `drizzle-orm/src/column-builder.ts`,
+ * but all FOUR downstream schema-integration packages'
+ * `columnToSchema` if-chains (`drizzle-arktype/src/column.ts`,
+ * `drizzle-zod/src/column.ts`, `drizzle-valibot/src/column.ts`,
+ * `drizzle-typebox/src/column.ts`) still only branch on the ORIGINAL 9
+ * members (`array`, `number`, `bigint`, `boolean`, `date`, `string`, `json`,
+ * `custom`, `buffer`) — none was ever updated for the 6 new ones. A Gel
+ * column of one of these types silently falls through every package's final
+ * `if (!schema) schema = type.unknown;` (or that package's equivalent),
+ * degrading to no real runtime validation instead of a proper schema.
+ *
+ * REAL, LIVE bug — ground-truthed directly against drizzle-orm's `main` HEAD
+ * (verified 2026-07-16 via `gh api repos/drizzle-team/drizzle-orm/contents/
+ * <path>?ref=<sha>` for all four downstream files + column-builder.ts). No
+ * open GitHub issue found describing it (`gh search issues` for "arktype
+ * gel", "arktype duration", "drizzle-arktype unknown" all empty) —
+ * ground-truthed by direct code cross-reference, not a linked fix commit.
+ * Reported upstream: drizzle-team/drizzle-orm#<ISSUE_NUMBER> (filed
+ * 2026-07-17, re-verified against main HEAD immediately before filing).
+ *
+ * CAPTURE NOTE (why this fixture is hand-trimmed, not `capture-pr.ts`'d
+ * wholesale): PR #4172's raw diff is ~23,200 additions across 104 files (a
+ * whole new SQL dialect implementation) — `gh pr diff` exceeds GitHub's
+ * 20,000-line API limit, and even a `--sha`-forced local-diff capture would
+ * embed all 104 files' patches plus a ~10.6K-chunk repo corpus (a ~47MB
+ * fixture, mostly irrelevant to this bug shape) — far past the harness
+ * README's "<500 changed lines" guidance. This fixture instead carries:
+ *   - `pr.patches`: ONLY the real, unmodified diff hunks touching
+ *     `column-builder.ts`'s `ColumnDataType`/`Dialect`/`BuildColumn`/
+ *     `BuildIndexColumn`/`ChangeColumnTableName` (verbatim from the PR).
+ *   - `chunks`/`repoChunks`: the REAL current-HEAD content of exactly 5
+ *     files — `column-builder.ts` (post-PR) plus the four downstream
+ *     `column.ts` files — fetched via `gh api
+ *     repos/drizzle-team/drizzle-orm/contents/<path>?ref=<sha>` and
+ *     AST-chunked for real via `performChunkOnlyIndex` (native parser
+ *     built), NOT hand-fabricated chunk objects.
+ *   - `pr.owner`/`repo`/pullNumber/baseSha/headSha are the real PR's
+ *     (drizzle-team/drizzle-orm#4172, base c27a9f24…, head 3fcc2db5…,
+ *     confirmed via `gh api repos/drizzle-team/drizzle-orm/pulls/4172`).
+ *   - `config.incompleteHandlingPass: true` — baked directly into the
+ *     fixture's `ReviewContext`, NOT an external env var. This pins the
+ *     canary to the loop-on configuration using an EXISTING mechanism —
+ *     `isIncompleteHandlingPassEnabled()` (`incomplete-handling-pass.ts`)
+ *     checks `config?.incompleteHandlingPass === true` BEFORE falling back
+ *     to `LIEN_INCOMPLETE_PASS=on`, and `runFixture` (`runner.ts`) already
+ *     spreads `ctx.config` straight into the plugin's config. No harness
+ *     code changes were needed or made to support this — the fixture-level
+ *     `config` field the harness already threads through was sufficient.
+ *     Verified for free via `build-prompts.ts` against this exact fixture
+ *     with NO env vars set: `incompleteHandlingPass.fires: true`. Replaying
+ *     `run.ts --fixture .../pr4172-columndatatype-gel-gap.fixture.json`
+ *     therefore reproduces the loop-arm result below with no external
+ *     env-var setup required.
+ *
+ * REGENERATE (fixture JSON is gitignored, per this harness's convention —
+ * see README's "Cross-repo corpus" section). This is a hand-trim, not a
+ * plain `capture-pr.ts` invocation (see CAPTURE NOTE above), so the exact
+ * recipe is the following self-contained script — save as a scratch .ts
+ * file (e.g. `.wip/capture-drizzle4172.ts`, gitignored, do not commit) and
+ * run with `npx tsx` from the repo root (native parser must be built first:
+ * `npm run build:native -w @liendev/parser-native`):
+ *
+ * ```ts
+ * import { promises as fs } from 'node:fs';
+ * import { execSync } from 'node:child_process';
+ * import { dirname, join } from 'node:path';
+ * import { performChunkOnlyIndex } from '@liendev/parser';
+ * import { runComplexityAnalysis } from '../../packages/review/src/analysis.js';
+ * import { silentLogger } from '../../packages/review/src/test-helpers.js';
+ * import { saveFixture } from '../../packages/review/test/harness/fixture-loader.js';
+ *
+ * const SNAPSHOT_DIR = '/tmp/drizzle4172-snapshot';
+ * const OUTPUT_PATH =
+ *   'packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.fixture.json';
+ * const REF = '9d6453215d18705986c2081124437bb6a03fb943'; // drizzle-orm main, 2026-07-16
+ * const FILES = [
+ *   'drizzle-orm/src/column-builder.ts',
+ *   'drizzle-arktype/src/column.ts',
+ *   'drizzle-zod/src/column.ts',
+ *   'drizzle-valibot/src/column.ts',
+ *   'drizzle-typebox/src/column.ts',
+ * ];
+ * const CHANGED_FILE = FILES[0];
+ *
+ * // Real diff hunk, `git diff c27a9f2477175a444efdb4012f50ad0894b22026..
+ * // 3fcc2db5b1351bafd2632fa20f7527713b3992e7 -- drizzle-orm/src/column-builder.ts`
+ * // against a real clone (or `git fetch origin refs/pull/4172/head` first if
+ * // squash-merge history has aged the branch tip out of default refs — same
+ * // gotcha as this README's other crossrepo fixtures).
+ * const COLUMN_BUILDER_PATCH = `diff --git a/drizzle-orm/src/column-builder.ts b/drizzle-orm/src/column-builder.ts
+ * index 6d6dfeeb..1cc4c5ae 100644
+ * --- a/drizzle-orm/src/column-builder.ts
+ * +++ b/drizzle-orm/src/column-builder.ts
+ * @@ -1,5 +1,6 @@
+ *  import { entityKind } from '~/entity.ts';
+ *  import type { Column } from './column.ts';
+ * +import type { GelColumn, GelExtraConfigColumn } from './gel-core/index.ts';
+ *  import type { MySqlColumn } from './mysql-core/index.ts';
+ *  import type { ExtraConfigColumn, PgColumn, PgSequenceOptions } from './pg-core/index.ts';
+ *  import type { SingleStoreColumn } from './singlestore-core/index.ts';
+ * @@ -16,9 +17,15 @@ export type ColumnDataType =
+ *  \t| 'date'
+ *  \t| 'bigint'
+ *  \t| 'custom'
+ * -\t| 'buffer';
+ * +\t| 'buffer'
+ * +\t| 'dateDuration'
+ * +\t| 'duration'
+ * +\t| 'relDuration'
+ * +\t| 'localTime'
+ * +\t| 'localDate'
+ * +\t| 'localDateTime';
+ *
+ * -export type Dialect = 'pg' | 'mysql' | 'sqlite' | 'singlestore' | 'common';
+ * +export type Dialect = 'pg' | 'mysql' | 'sqlite' | 'singlestore' | 'common' | 'gel';
+ *
+ *  export type GeneratedStorageMode = 'virtual' | 'stored';
+ *
+ * @@ -356,11 +363,18 @@ export type BuildColumn<
+ *  \t\t\t\t>
+ *  \t\t\t>
+ *  \t\t>
+ * +\t: TDialect extends 'gel' ? GelColumn<
+ * +\t\t\tMakeColumnConfig<TBuilder['_'], TTableName>,
+ * +\t\t\t{},
+ * +\t\t\tSimplify<Omit<TBuilder['_'], keyof MakeColumnConfig<TBuilder['_'], TTableName> | 'brand' | 'dialect'>>
+ * +\t\t>
+ *  \t: never;
+ *
+ *  export type BuildIndexColumn<
+ *  \tTDialect extends Dialect,
+ * -> = TDialect extends 'pg' ? ExtraConfigColumn : never;
+ * +> = TDialect extends 'pg' ? ExtraConfigColumn
+ * +\t: TDialect extends 'gel' ? GelExtraConfigColumn
+ * +\t: never;
+ *
+ *  // TODO
+ *  // try to make sql as well + indexRaw
+ * @@ -398,4 +412,5 @@ export type ChangeColumnTableName<TColumn extends Column, TAlias extends string,
+ *  \t\t: TDialect extends 'mysql' ? MySqlColumn<MakeColumnConfig<TColumn['_'], TAlias>>
+ *  \t\t: TDialect extends 'singlestore' ? SingleStoreColumn<MakeColumnConfig<TColumn['_'], TAlias>>
+ *  \t\t: TDialect extends 'sqlite' ? SQLiteColumn<MakeColumnConfig<TColumn['_'], TAlias>>
+ * +\t\t: TDialect extends 'gel' ? GelColumn<MakeColumnConfig<TColumn['_'], TAlias>>
+ *  \t\t: never;
+ * `;
+ *
+ * function extractPostImageLines(block: string): Set<number> {
+ *   const lines = new Set<number>();
+ *   let currentLine = 0;
+ *   for (const line of block.split('\n')) {
+ *     const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+ *     if (hunkMatch) { currentLine = parseInt(hunkMatch[1], 10); continue; }
+ *     if ((line.startsWith('+') || line.startsWith(' ')) && !line.startsWith('+++')) {
+ *       lines.add(currentLine);
+ *       currentLine++;
+ *     }
+ *   }
+ *   return lines;
+ * }
+ *
+ * async function main(): Promise<void> {
+ *   await fs.mkdir(SNAPSHOT_DIR, { recursive: true });
+ *   for (const f of FILES) {
+ *     const content = execSync(
+ *       `gh api repos/drizzle-team/drizzle-orm/contents/${f}?ref=${REF} --jq .content | base64 -d`,
+ *     ).toString();
+ *     const dest = join(SNAPSHOT_DIR, f);
+ *     await fs.mkdir(dirname(dest), { recursive: true });
+ *     await fs.writeFile(dest, content);
+ *   }
+ *   execSync(`git -C ${SNAPSHOT_DIR} init -q && git -C ${SNAPSHOT_DIR} add -A && git -C ${SNAPSHOT_DIR} commit -q -m snapshot`);
+ *
+ *   const indexResult = await performChunkOnlyIndex(SNAPSHOT_DIR);
+ *   if (!indexResult.success || !indexResult.chunks) throw new Error('index failed');
+ *   const repoChunks = indexResult.chunks;
+ *   const chunks = repoChunks.filter(c => c.metadata.file === CHANGED_FILE);
+ *
+ *   const complexityResult = await runComplexityAnalysis([CHANGED_FILE], '50', SNAPSHOT_DIR, silentLogger);
+ *   const complexityReport = complexityResult?.report ?? {
+ *     summary: { filesAnalyzed: 1, totalViolations: 0, bySeverity: { error: 0, warning: 0 }, avgComplexity: 0, maxComplexity: 0 },
+ *     files: {},
+ *   };
+ *
+ *   const patches = new Map([[CHANGED_FILE, COLUMN_BUILDER_PATCH.trimEnd()]]);
+ *   const diffLines = new Map([[CHANGED_FILE, extractPostImageLines(COLUMN_BUILDER_PATCH)]]);
+ *
+ *   await saveFixture(
+ *     {
+ *       chunks,
+ *       changedFiles: [CHANGED_FILE],
+ *       allChangedFiles: [CHANGED_FILE],
+ *       complexityReport,
+ *       baselineReport: null,
+ *       deltas: null,
+ *       pluginConfigs: {},
+ *       // Pins this canary to the loop-on configuration — see the header note
+ *       // above on why this needs no harness plumbing changes.
+ *       config: { incompleteHandlingPass: true },
+ *       pr: {
+ *         owner: 'drizzle-team',
+ *         repo: 'drizzle-orm',
+ *         pullNumber: 4172,
+ *         title: 'Gel dialect',
+ *         body: '',
+ *         baseSha: 'c27a9f2477175a444efdb4012f50ad0894b22026',
+ *         headSha: '3fcc2db5b1351bafd2632fa20f7527713b3992e7',
+ *         patches,
+ *         diffLines,
+ *       },
+ *       repoChunks,
+ *       repoRootDir: SNAPSHOT_DIR,
+ *     },
+ *     OUTPUT_PATH,
+ *   );
+ * }
+ *
+ * main();
+ * ```
+ *
+ * Verified before any calibration spend (free):
+ *   - Fixture loads via `loadFixture` (fixture-loader.ts's zod schema).
+ *   - `computeVariantSweepContexts` fires: all 6 added variants surface as
+ *     candidates, each with 4 consumer sites (all 4 downstream packages'
+ *     `columnToSchema` sites, each "handles: array, bigint, boolean,
+ *     buffer, custom, date, +3 more").
+ *   - `build-prompts.ts` with the fixture's own `config.incompleteHandlingPass:
+ *     true` (no env vars set) shows `incompleteHandlingPass.fires: true`,
+ *     worklist = candidate-1..6, all `shape="variant-sweep"` — the FIRST
+ *     fixture in this harness's corpus where variant-sweep candidates (not
+ *     sibling-surface) populate the loop's worklist.
+ *   - The SHARED (main-pass) prompt is NOT blind to this either: its
+ *     `initialMessage` also carries the `<variant_sweep_candidates>` block
+ *     (same 6 entries) — `incomplete-handling` is trigger-active for this
+ *     fixture regardless of the loop flag, so the A/B measures which ARM
+ *     converts the candidate to a real finding, not "does one arm see
+ *     evidence the other doesn't."
+ *
+ * Tier 2 keyword design (keyword-integrity discipline): anchors are the 5
+ * multi-syllable camelCase variant identifiers (`dateDuration`,
+ * `relDuration`, `localTime`, `localDate`, `localDateTime` — deliberately
+ * NOT bare `duration` alone, which collides with unrelated "how long did X
+ * take" prose) plus compound "gel"-qualified phrases, AND (separately) the
+ * unknown-schema-fallback impact phrasing. A finding must hit ONE anchor
+ * from EACH gate to pass.
+ */
+
+/**
+ * PROMOTED TO CANARY (2026-07-17): a same-day A/B (drizzle-ab campaign,
+ * spend $0.8012 of a $1.40 cap; full traces + raw harness JSON archived
+ * alongside the source material this fixture was promoted from) measured:
+ *
+ *   Shared arm  (flags off, main pass competing across 4 active rules):
+ *     3-vote screen: 1/3 converted to a real finding. The other 2/3 called
+ *     get_files_context + read_file on ALL FOUR downstream column.ts files
+ *     (confirmed via trace) yet emitted ZERO findings of any rule —
+ *     investigated the right code, then went silent.
+ *
+ *   Loop arm (`config.incompleteHandlingPass: true`, dedicated
+ *   incomplete-handling pass): 3-vote screen: 3/3 converted to a real
+ *   finding (the FIRST fixture in this harness's corpus where the loop's
+ *   worklist is populated by variant-sweep candidates rather than
+ *   sibling-surface). Escalated per the differentiating screen (1/3 vs
+ *   3/3) to `--calibrate 10`: Tier 1 (rule fired with a real finding about
+ *   THIS bug) was 10/10 — every run named the correct variants and the
+ *   correct 4 packages. Raw Tier-1+2 pass rate on the first widened
+ *   keyword set was 7/10; all 3 "failures" were correct, on-target
+ *   findings using a compact "unknown/any" phrasing the gate hadn't
+ *   anchored on yet (vs. the original per-package `type.unknown`/
+ *   `z.any()`/`v.any()`/`t.any()` forms — see gate (B) below). Added a
+ *   single `"unknown/any"` anchor and re-scored all 10 runs offline (free,
+ *   no new spend): 10/10. Re-verified the three-verdict smoke test
+ *   (perfect/empty/distractor) after each widening — distractor never
+ *   false-passed.
+ *
+ *   HEADLINE: the dedicated incomplete-handling loop reliably (10/10)
+ *   converts this real, live variant-sweep omission into a finding; the
+ *   shared/competing main pass, despite carrying the identical
+ *   `<variant_sweep_candidates>` evidence block and investigating the
+ *   correct files, goes silent roughly 2 times out of 3 on this fixture.
+ *
+ *   Smoke-test re-run offline (assert-cli.ts, this promoted assertions
+ *   file, zero LLM spend) against the campaign's saved perfect/empty/
+ *   distractor result JSONs: perfect passes, empty Tier-1-fails, distractor
+ *   Tier-2-fails (never false-passes) — see the PR body that promoted this
+ *   fixture for the literal `assert-cli.ts` output.
+ */
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'drizzle-orm PR #4172 (Gel dialect) — 6 new ColumnDataType Gel temporal variants unhandled by all 4 schema-integration packages',
+  rule: 'incomplete-handling',
+  expect: (result, h) => {
+    h.expectRuleFired('incomplete-handling', result);
+    // (A) names the specific omitted variant family — the new Gel temporal
+    // members, or an explicit "gel" + "columndatatype"/"column type" pairing.
+    // Bare 'duration' deliberately excluded (see header).
+    h.expectFindingMentions(
+      [
+        'dateduration',
+        'relduration',
+        'localtime',
+        'localdate',
+        'localdatetime',
+        'gel temporal',
+        'gel-specific column',
+        'new gel column',
+        'gel column types',
+        "columndatatype's new",
+      ],
+      result,
+    );
+    // (B) the silent-degradation impact: falls through to an `unknown`/`any`
+    // schema instead of a real validator. WIDENED 2026-07-16 after the first
+    // paid screen (offline re-score, zero new spend): vote 2 of the loop-arm
+    // 3-vote screen correctly named EACH package's own real fallback
+    // expression (`z.any()` for zod, `v.any()` for valibot, `t.Any()` for
+    // typebox — verified against the real fetched source, see header) rather
+    // than generically saying "type.unknown" for all four — MORE precise
+    // than the original gate assumed, not less correct. Widened a second
+    // time after `--calibrate 10`: 3 of 10 raw "failures" used the compact
+    // "unknown/any" construction instead of any per-package form — added a
+    // single `"unknown/any"` anchor and re-scored all 10 runs offline: 10/10.
+    h.expectFindingMentions(
+      [
+        'type.unknown',
+        'schema = type.unknown',
+        'z.any()',
+        'v.any()',
+        't.any()',
+        'unknown/any',
+        'falls through to unknown',
+        'fall through to unknown',
+        'degrades to unknown',
+        'degrade to unknown',
+        'silently degrades',
+        'silently degrade',
+        'silently accept',
+        'silently accepting',
+        'validated as unknown',
+        'validate any value',
+        'unknown schema instead',
+        'no real validation',
+        'no runtime validation',
+      ],
+      result,
+    );
+  },
+  votes: 3,
+  passThreshold: 9,
+  tags: ['canary', 'crossrepo', 'typescript'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts
+++ b/packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts
@@ -18,8 +18,10 @@
  * open GitHub issue found describing it (`gh search issues` for "arktype
  * gel", "arktype duration", "drizzle-arktype unknown" all empty) —
  * ground-truthed by direct code cross-reference, not a linked fix commit.
- * Reported upstream: drizzle-team/drizzle-orm#<ISSUE_NUMBER> (filed
- * 2026-07-17, re-verified against main HEAD immediately before filing).
+ * Reported upstream: drizzle-team/drizzle-orm#6027 (filed 2026-07-17,
+ * re-verified against main HEAD — still `9d6453215d18705986c2081124437bb6a03fb943`,
+ * unchanged since the 2026-07-16 ground-truth capture — immediately before
+ * filing).
  *
  * CAPTURE NOTE (why this fixture is hand-trimmed, not `capture-pr.ts`'d
  * wholesale): PR #4172's raw diff is ~23,200 additions across 104 files (a


### PR DESCRIPTION
## Summary

- Promotes the `drizzle-team/drizzle-orm#4172` ("Gel dialect") bug into the tracked crossrepo canary corpus: `packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts`. Real, live bug — 6 new Gel/EdgeDB temporal `ColumnDataType` variants added upstream, left unhandled by all four downstream schema-integration packages' `columnToSchema` if-chains (`drizzle-arktype`, `drizzle-zod`, `drizzle-valibot`, `drizzle-typebox`), ground-truthed directly against drizzle-orm's own `main` HEAD.
- First **TypeScript** entry in `fixtures/crossrepo/` (previously all Python/starlette+werkzeug), and the first same-fixture A/B in this harness comparing the `incomplete-handling` **shared main pass** against its **dedicated candidate loop** (ADR-014).
- Updates **ADR-014**'s evidence section to record this measured lift, plus the honest FP-guard record across both candidate loops shipped so far.
- No harness code changes. The fixture's `config.incompleteHandlingPass: true` is baked directly into its captured `ReviewContext` — an existing precedence check in `isIncompleteHandlingPassEnabled()` (`config` wins over the `LIEN_INCOMPLETE_PASS` env var) already honors this, so the fixture is a self-contained "loop-on" canary with zero new plumbing.

## Fixture status: canary (not characterization)

The per-fixture "loop-on" mechanism this task asked me to check for **already existed** — it did not need a trivial addition. `runner.ts`'s `runFixture` already spreads `ctx.config` into the plugin's config, and `isIncompleteHandlingPassEnabled(config)` already checks `config?.incompleteHandlingPass === true` before falling back to the env var. So the fixture is promoted straight to `tags: ['canary', 'crossrepo', 'typescript']`, pinned to the loop-on configuration, carrying the full calibrate-10 result history in its header rather than a "characterization, promotion TBD" placeholder.

Free verification of that mechanism (`build-prompts.ts`, **no env vars set**, this exact fixture):
```
$ unset LIEN_INCOMPLETE_PASS
$ npx tsx packages/review/test/harness/build-prompts.ts packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.fixture.json
fires: true
ruleIds: [ 'structural-analysis', 'edge-case-sweep', 'incomplete-handling', 'stale-duplicate' ]
```
`incomplete-handling` is in the active rule set (satisfies the harness's rule-coverage preflight) and the loop fires from the fixture's own `config` alone. Since this is an existing mechanism, not new plumbing, I did not spend any of the $0.50 paid-verification allowance on a confirmatory vote — the free check above plus the already-recorded 10/10 calibrate history (identical code path, `config`-driven enablement instead of env-driven) is sufficient proof.

## Smoke results (offline, `assert-cli.ts`, zero LLM spend)

Re-ran the three-verdict smoke test from the source campaign against the **promoted** assertions file:

```
=== perfect ===
{"ok":true,"rule":"incomplete-handling","findings":1,"turns":6}
exit: 0

=== empty ===
{"ok":false,"tier":1,"message":"Tier 1: expected rule 'incomplete-handling' to fire. Got: (no findings)","findings":0,"turns":1}
exit: 1

=== distractor ===
{"ok":false,"tier":2,"message":"Tier 2: expected at least one finding to mention any of [\"dateduration\", \"relduration\", \"localtime\", \"localdate\", \"localdatetime\", ...]. None matched. ...","findings":1,"turns":3}
exit: 2
```
Perfect passes, empty Tier-1-fails, distractor Tier-2-fails (never false-passes) — matches the fixture header's documented result history exactly.

## Result history (from the fixture header)

| Arm | 3-vote screen | Escalation |
|---|---|---|
| Shared (flags off) | 1/3 converted to a finding (other 2/3 read all 4 target files, emitted nothing) | not escalated |
| Loop (`config.incompleteHandlingPass: true`) | 3/3 | `--calibrate 10` → 10/10 (after one legitimate keyword-gate widening, re-scored offline for $0) |

## ADR-014 diff summary

- **Negative/Risks**: replaced the "lift is unproven for both new loops" bullet with a bullet reporting the now-measured `incomplete-handling` lift (this fixture: shared 1/3 vs loop 3/3 screen, 10/10 calibrated), explicitly scoped as one fixture / one candidate shape (`variant-sweep`) — not a corpus-wide claim — while keeping `stale-duplicate`'s own architecture-lift as still unmeasured (PR #805 priced a wording fix, not a shared-vs-loop comparison).
- Added a new bullet recording the FP-guard's health on both sides: `stale-duplicate` (PR #805, 2/51 wrongful `stale` verdicts pre-guard → 0 post-guard re-probe) and `incomplete-handling` (a same-day, in-session FP probe — 81 total candidate verdicts across two real, unrelated lien PRs, loop ON — 0 wrongful `incomplete` verdicts). The `incomplete-handling` probe is cited as an in-session measurement, not yet a tracked artifact, mirroring how this ADR already cites its own unpublished design memo in References.
- Added the fixture path to References.
- Every number in the diff traces to either this fixture's own header/result history or a merged PR (#805) — no new numbers invented.

## Gates

```
npm run format:check   # pass
npm run lint           # pass (0 errors, 33 pre-existing warnings, none in touched files)
npm run typecheck      # pass
npm run build          # pass
npm test               # pass — parser 27, core 1062, review 374, cli 860, action 41 (all green)
node packages/cli/dist/index.js delta   # exit 0 — no complexity changes across 1 file(s) vs HEAD
```
No changeset (test fixture + docs only, no package behavior change).

## Dogfood note (CLAUDE.md mandatory)

This PR's real consumer is the harness CLI itself: `build-prompts.ts` and `assert-cli.ts` were both run directly against the promoted fixture/assertions (verbatim output above), not just described. No live LLM calls were made — deliberately: the mechanism being certified (`config.incompleteHandlingPass`) is a pre-existing precedence branch, not new code, and the already-recorded 10/10 calibrate-10 history (same code path) is the calibration evidence. Full $0.50 paid-verification allowance left unspent.

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` — all green
- [x] `node packages/cli/dist/index.js delta` — exit 0
- [x] `build-prompts.ts` free check: `incompleteHandlingPass.fires: true` with zero env vars, from the fixture's own `config`
- [x] Three-verdict smoke test (perfect/empty/distractor) re-run offline against the promoted assertions — matches documented history
- [x] Rebased onto latest `origin/main` (includes #811) before opening

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a new cross-repo canary test fixture for drizzle-orm PR #4172 and updates ADR-014/README documentation to record the measured lift of the dedicated incomplete-handling loop. No production logic, public API, or threshold behavior changed. The only code-like addition is a test assertions file; the mechanism it relies on (`config.incompleteHandlingPass` precedence over the env var) is already implemented and correctly wired through `runner.ts` and `isIncompleteHandlingPassEnabled`.
>
> - Added TypeScript cross-repo canary fixture documenting 6 unhandled Gel ColumnDataType variants across 4 downstream schema-integration packages
> - Updated ADR-014 and harness README with shared-vs-dedicated-loop A/B results and fixture references

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 75a3054. Updates automatically on new commits.</sup>
<!-- /lien-stats -->