### PR TITLE
fix(review): realistic extra-pass budget floors + gated summary retry

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -71,7 +71,11 @@ import type { AgentConfig, AgentFinding, AgentResult, ResolvedRules } from './ty
 import { DOC_TRUTH } from './rules.js';
 import { buildSystemPrompt } from './system-prompt.js';
 import { envDisabled } from './agent-client-shared.js';
-import { renderPassPrHeader, type ReviewPassSpec } from './review-pass.js';
+import {
+  renderPassPrHeader,
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
+  type ReviewPassSpec,
+} from './review-pass.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -88,7 +92,15 @@ export const DOC_PASS_MAX_TURNS = 6;
 /**
  * The doc pass's token budget as a fraction of the main pass's base budget.
  * ~40% is ample for a claims-only pass whose input is the (already compact)
- * doc-claim signals rather than the full diff + all signals.
+ * doc-claim signals rather than the full diff + all signals — PROVIDED the
+ * base itself is normal-mode-sized (`scaleAgentBudget`'s ≥60K floor, where
+ * 40% is ≥24K). This fraction was never re-validated against summary-only
+ * mode's deliberately tiny 6,000-20,000 base (added by #572): 40% of a
+ * 6,054 base is 2,422 tokens — smaller than a single Kimi reasoning+tool
+ * turn (PR #811 measured 5,526-6,564/turn), so the pass hard-stopped before
+ * its first tool call ever dispatched. `docTruthPassBudget` now clamps this
+ * fraction to `EXTRA_PASS_MIN_BUDGET_TOKENS` so a tiny base can no longer
+ * starve it below one real round-trip.
  */
 export const DOC_PASS_BUDGET_FRACTION = 0.4;
 
@@ -458,9 +470,14 @@ pass's result incomplete.
 // Budget
 // ---------------------------------------------------------------------------
 
-/** The doc pass's token budget: a fraction of the main pass's base budget. */
+/**
+ * The doc pass's token budget: a fraction of the main pass's base budget,
+ * floored at `EXTRA_PASS_MIN_BUDGET_TOKENS` so a tiny base (summary-only
+ * mode) can't shrink it below one real tool round-trip (see PR #811 /
+ * `DOC_PASS_BUDGET_FRACTION`'s doc comment).
+ */
 export function docTruthPassBudget(baseBudget: number): number {
-  return Math.round(baseBudget * DOC_PASS_BUDGET_FRACTION);
+  return Math.max(Math.round(baseBudget * DOC_PASS_BUDGET_FRACTION), EXTRA_PASS_MIN_BUDGET_TOKENS);
 }
 
 /** Plugin name the doc-truth pass reports itself under in the delivery attestation. */

--- a/packages/review/src/plugins/agent/incomplete-handling-pass.ts
+++ b/packages/review/src/plugins/agent/incomplete-handling-pass.ts
@@ -92,7 +92,11 @@ import {
   computeUnreadFieldCandidates,
   type UnreadFieldCandidate,
 } from '../../unread-field-signals.js';
-import { renderPassPrHeader, type ReviewPassSpec } from './review-pass.js';
+import {
+  renderPassPrHeader,
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
+  type ReviewPassSpec,
+} from './review-pass.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -108,7 +112,6 @@ export const INCOMPLETE_PASS_MAX_TURNS = 8;
 
 const BASE_OVERHEAD_TOKENS = 2_500;
 const PER_CANDIDATE_TOKENS = 900;
-const MIN_BUDGET = 5_000;
 const MAX_BUDGET = 35_000;
 
 /** Mirrors variant-sweep-signals.ts's own MAX_ENTRIES cap — that module's compute()
@@ -447,13 +450,20 @@ export function buildIncompleteHandlingPassPrompts(context: ReviewContext): {
 /**
  * Budget scaled by this pass's own combined candidate count (per the
  * per-rule-loops design doc §2), clamped floor/ceiling — mirrors the
- * pilot's `staleDuplicatePassBudget`.
+ * pilot's `staleDuplicatePassBudget`. The floor is
+ * `EXTRA_PASS_MIN_BUDGET_TOKENS` (shared across all three extra passes —
+ * see that constant's doc comment / PR #811): unlike the stale-duplicate
+ * pilot, this pass's scaling ceiling (2,500 + 900×20 = 20,500) still sits
+ * above the floor, so real scaling shows through once combined candidate
+ * count exceeds ~9-10, while a 1-2 candidate run (this repo's real-PR
+ * census: sibling-surface firing on 9/40) gets the same one-real-round-trip
+ * floor doc-truth/stale-duplicate get.
  */
 export function incompleteHandlingPassBudget(_baseBudget: number, context: ReviewContext): number {
   const candidateCount = computeIncompleteHandlingCandidates(context).length;
   const scaled =
     BASE_OVERHEAD_TOKENS + PER_CANDIDATE_TOKENS * Math.min(candidateCount, MAX_TOTAL_CANDIDATES);
-  return Math.min(Math.max(scaled, MIN_BUDGET), MAX_BUDGET);
+  return Math.min(Math.max(scaled, EXTRA_PASS_MIN_BUDGET_TOKENS), MAX_BUDGET);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -34,6 +34,27 @@ const RETRY_NUDGE =
   'You ran out of budget. Output ONLY the JSON block now with your findings and summary. No tool calls.';
 
 /**
+ * Bound on the summary-retry's own completion request (`max_tokens`), scaled
+ * to whatever budget headroom remains when the main loop bails. Mirrors
+ * `AnthropicAgentClient`'s `requestMaxTokens`, which already does this for
+ * every request including its own retry — this client's retry previously
+ * requested a flat 24,576 unconditionally (see `chatCompletion`'s old
+ * default), regardless of how far over budget the loop already was. On
+ * PR #811's starved run that "cheap safety net" call cost MORE than the
+ * pass's entire original allocation in both starved passes (doc-truth:
+ * +11,388 tokens on a 2,422 budget; stale-duplicate: +5,695 on 4,400) — a
+ * real findings+summary verdict fits comfortably under
+ * RETRY_MIN_MAX_TOKENS even for a several-finding review, so the floor never
+ * starves the retry of room to complete; the ceiling matches the loop's
+ * normal per-request size. Exported for unit testing.
+ */
+const RETRY_MIN_MAX_TOKENS = 2_048;
+const RETRY_MAX_MAX_TOKENS = 24_576;
+export function retryMaxTokens(remainingBudget: number): number {
+  return Math.min(RETRY_MAX_MAX_TOKENS, Math.max(remainingBudget, RETRY_MIN_MAX_TOKENS));
+}
+
+/**
  * Transient-failure retry for the chat endpoint. OpenRouter/Kimi intermittently
  * returns a 200 with an empty/truncated body, a 429/5xx, or hangs the
  * connection — all recover on a retry. 2 attempts (one retry) absorbs flakes
@@ -416,7 +437,8 @@ export class OpenAIAgentClient {
     // Gated on a completed turn: a never-ran run (every request failed) has no
     // conversation to summarize, so skip the doomed retry (and its 3s sleep).
     if (!parsed.summary && completedTurns > 0) {
-      const retry = await this.runSummaryRetry(messages, turn);
+      const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
+      const retry = await this.runSummaryRetry(messages, turn, remainingBudget);
       if (retry) {
         totalInputTokens += retry.inputTokens;
         totalOutputTokens += retry.outputTokens;
@@ -523,6 +545,7 @@ export class OpenAIAgentClient {
   private async attemptVerdictCompletion(
     messages: ChatMessage[],
     turnNumber: number,
+    maxTokens: number,
   ): Promise<{
     parsed: { findings: AgentFinding[]; summary?: AgentSummary };
     traceTurn: TurnTrace;
@@ -532,7 +555,7 @@ export class OpenAIAgentClient {
     try {
       // forceVerdict: response_format:json_object guarantees a JSON response,
       // the reliable safety net when the loop bailed without a verdict.
-      const response = await this.chatCompletion(messages, [], true);
+      const response = await this.chatCompletion(messages, [], true, maxTokens);
       const inputTokens = response.usage?.prompt_tokens ?? 0;
       const outputTokens = response.usage?.completion_tokens ?? 0;
       const choice = response.choices[0];
@@ -579,6 +602,7 @@ export class OpenAIAgentClient {
   private async runSummaryRetry(
     messages: ChatMessage[],
     turn: number,
+    remainingBudget: number,
   ): Promise<{
     parsed: { findings: AgentFinding[]; summary?: AgentSummary };
     traceTurns: TurnTrace[];
@@ -589,7 +613,11 @@ export class OpenAIAgentClient {
     await new Promise(resolve => setTimeout(resolve, 3_000));
     messages.push({ role: 'user', content: RETRY_NUDGE });
 
-    const first = await this.attemptVerdictCompletion(messages, turn + 1);
+    // Computed once and reused for both attempts (parity with the Anthropic
+    // client's `remainingBudget` handling) — a badly-starved pass gets a
+    // small, bounded request instead of the flat 24,576-token ceiling.
+    const maxTokens = retryMaxTokens(remainingBudget);
+    const first = await this.attemptVerdictCompletion(messages, turn + 1, maxTokens);
     if (!first) return null;
     if (first.parsed.summary || first.parsed.findings.length > 0) {
       return { ...first, traceTurns: [first.traceTurn] };
@@ -598,7 +626,7 @@ export class OpenAIAgentClient {
     this.logger.warning(
       '[agent] Retry verdict was unparseable — attempting one more bounded retry',
     );
-    const second = await this.attemptVerdictCompletion(messages, turn + 2);
+    const second = await this.attemptVerdictCompletion(messages, turn + 2, maxTokens);
     if (!second) return { ...first, traceTurns: [first.traceTurn] };
     return {
       parsed: second.parsed,
@@ -612,13 +640,18 @@ export class OpenAIAgentClient {
     messages: ChatMessage[],
     tools: ToolDef[],
     forceVerdict = false,
+    // Overridable only by the summary-retry (see `runSummaryRetry`), which
+    // scales it down via `retryMaxTokens` once the loop has bailed — every
+    // other call site (every normal turn, including the in-loop forced-finish
+    // turn) keeps the unchanged flat default.
+    maxTokens = RETRY_MAX_MAX_TOKENS,
   ): Promise<ChatResponse> {
     const body: Record<string, unknown> = {
       model: this.model,
       messages,
       // Headroom so a multi-finding verdict completes instead of truncating
       // mid-JSON (a truncated verdict is unparseable and wastes the whole run).
-      max_tokens: 24_576,
+      max_tokens: maxTokens,
       temperature: 0,
       // High reasoning drives investigation quality, but on the forced-verdict
       // turn the findings are already decided — high effort there just makes the

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -87,6 +87,26 @@ export interface ReviewPassSpec {
 }
 
 /**
+ * Absolute floor (tokens) under every extra pass's own budget formula —
+ * whatever a pass computes (doc-truth's fraction of the main base,
+ * stale-duplicate/incomplete-handling's per-candidate scaling), the result
+ * is never allowed below this. Sized from PR #811's measured per-turn
+ * appetite on Kimi: a single reasoning + tool-request turn cost 5,526-6,564
+ * tokens BEFORE any tool result came back (`get_files_context`/`read_file`)
+ * — bigger than doc-truth's (2,422) and stale-duplicate's (4,400) entire
+ * pre-fix allocations, so either one hard-stopped the tool-calling loop
+ * before it ever dispatched the call it asked for. 11,000 affords one such
+ * turn plus a smaller follow-up/verdict turn with margin: "one real tool
+ * round-trip", not the ~24K+ headroom normal-mode's `scaleAgentBudget`
+ * passes enjoy. Shared across all three passes (this module's third
+ * identical floor rather than a fourth copy of the same constant + the same
+ * justifying comment — CLAUDE.md's DRY guidance: wait for the 3rd use). See
+ * the PR body's before/after table for the exact #811 numbers this floor
+ * fixes.
+ */
+export const EXTRA_PASS_MIN_BUDGET_TOKENS = 11_000;
+
+/**
  * The PR title/body header, mirroring the main pass's `<pr_metadata>` block.
  * Shared by every extra pass's prompt builder (doc-truth, stale-duplicate,
  * incomplete-handling) — extracted here on this module's third identical

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -49,7 +49,11 @@ import {
   computeStaleLiteralCandidates,
   type StaleLiteralCandidate,
 } from '../../stale-literal-signals.js';
-import { renderPassPrHeader, type ReviewPassSpec } from './review-pass.js';
+import {
+  renderPassPrHeader,
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
+  type ReviewPassSpec,
+} from './review-pass.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -63,7 +67,6 @@ export const STALE_DUP_PASS_MAX_TURNS = 6;
 
 const STALE_DUP_BASE_OVERHEAD_TOKENS = 2_000;
 const STALE_DUP_PER_CANDIDATE_TOKENS = 800;
-const STALE_DUP_MIN_BUDGET = 4_000;
 const STALE_DUP_MAX_BUDGET = 30_000;
 /** Mirrors stale-literal-signals.ts's own MAX_CANDIDATES cap. */
 const STALE_DUP_SIGNAL_MAX_CANDIDATES = 8;
@@ -414,14 +417,23 @@ export function buildStaleDuplicatePassPrompts(context: ReviewContext): {
  * design doc §2), clamped floor/ceiling — mirrors `summary-only-pass.ts`'s
  * `scaleSummaryOnlyBudget` clamp pattern rather than doc-truth's flat
  * fraction: a 1-candidate loop shouldn't pay the same budget as an 8-
- * candidate one.
+ * candidate one. The floor is `EXTRA_PASS_MIN_BUDGET_TOKENS` (shared with
+ * doc-truth/incomplete-handling — see that constant's doc comment): PR #811
+ * measured this loop's own turn 1 (3 candidates, 4 read_file requests) at
+ * 6,564 tokens against a THEN-floor of 4,000 — bigger than its entire
+ * allocation before any tool result came back. Since the per-candidate
+ * scaling here tops out at 8,400 (8 candidates × 800 + 2,000 base, per
+ * `STALE_DUP_SIGNAL_MAX_CANDIDATES`), the new floor dominates for every
+ * candidate count this loop can see today; the scaling term still exists so
+ * a future cap increase (more candidates) scales up past the floor rather
+ * than needing a second formula change.
  */
 export function staleDuplicatePassBudget(_baseBudget: number, context: ReviewContext): number {
   const candidateCount = computeStaleLiteralCandidates(context).length;
   const scaled =
     STALE_DUP_BASE_OVERHEAD_TOKENS +
     STALE_DUP_PER_CANDIDATE_TOKENS * Math.min(candidateCount, STALE_DUP_SIGNAL_MAX_CANDIDATES);
-  return Math.min(Math.max(scaled, STALE_DUP_MIN_BUDGET), STALE_DUP_MAX_BUDGET);
+  return Math.min(Math.max(scaled, EXTRA_PASS_MIN_BUDGET_TOKENS), STALE_DUP_MAX_BUDGET);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { OpenAIAgentClient, envDisabled } from '../src/plugins/agent/openai-client.js';
+import {
+  OpenAIAgentClient,
+  envDisabled,
+  retryMaxTokens,
+} from '../src/plugins/agent/openai-client.js';
 import {
   AgentReviewPlugin,
   appendIncompleteNotice,
@@ -202,6 +206,49 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.incomplete).toBe(false); // retry recovered a verdict
     expect(result.summary?.overview).toBe('recovered');
   }, 15000);
+
+  it('caps the summary-retry request to a small bounded max_tokens on a starved bail (#811)', async () => {
+    // Same starved shape as the test above, but this asserts the WIRE-LEVEL
+    // fix: turn 1 (2000 tokens) already blows the 1000-token budget, so the
+    // retry's remainingBudget is deeply negative — its request must carry
+    // the floored RETRY_MIN_MAX_TOKENS (2048), not the old flat 24,576.
+    const rawVerdict = JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: 'recovered', keyChanges: [] },
+    });
+    const { bodies } = mockFetch([toolCallTurn(2000), stopTurn(rawVerdict, 100)]);
+    const client = makeClient(1000);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(bodies[0].max_tokens).toBe(24_576); // turn 1: unaffected, normal ceiling
+    expect(bodies[1].max_tokens).toBe(2_048); // the retry: capped to the floor
+  }, 15000);
+
+  it('keeps the retry at the normal 24,576 ceiling when ample budget remains (no regression)', async () => {
+    // Forces the retry via max_turns (not budget) with a huge budget, so
+    // remainingBudget is deeply positive — the #792 suite below also uses a
+    // huge budget, but doesn't assert on max_tokens directly, so this makes
+    // the "unaffected when not starved" claim explicit for the retry path.
+    const rawVerdict = JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: 'recovered', keyChanges: [] },
+    });
+    const { bodies } = mockFetch([toolCallTurn(100), stopTurn(rawVerdict, 50)]);
+    const client = new OpenAIAgentClient({
+      apiKey: 'test',
+      baseUrl: 'http://mock.local',
+      model: 'test-model',
+      maxTurns: 1,
+      maxTokenBudget: 1_000_000,
+      logger: silentLogger,
+    });
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.summary?.overview).toBe('recovered'); // retry did fire and recover
+    expect(bodies[1].max_tokens).toBe(24_576);
+  });
 
   it('logs the last-turn reasoning when a run is incomplete', async () => {
     const { logger, lines } = capturingLogger();
@@ -716,6 +763,32 @@ describe('envDisabled (LIEN_REVIEW_LOG_AGENT parsing — logging on by default)'
     expect(envDisabled('true')).toBe(false);
     expect(envDisabled('')).toBe(false);
     expect(envDisabled(undefined)).toBe(false);
+  });
+});
+
+describe('retryMaxTokens — bounding the summary-retry request (#811)', () => {
+  it('floors to 2,048 when remaining budget is deeply negative (the starved case)', () => {
+    // #811's actual numbers: doc-truth's turn 1 alone spent 5,526 against a
+    // 2,422 budget (remaining -3,104); stale-dup's spent 6,564 against 4,400
+    // (remaining -2,164). Both must floor to the same small request cap.
+    expect(retryMaxTokens(-3_104)).toBe(2_048);
+    expect(retryMaxTokens(-2_164)).toBe(2_048);
+  });
+
+  it('floors to 2,048 at and just above zero remaining budget', () => {
+    expect(retryMaxTokens(0)).toBe(2_048);
+    expect(retryMaxTokens(1_000)).toBe(2_048);
+  });
+
+  it('passes remaining budget through unchanged between the floor and the ceiling', () => {
+    expect(retryMaxTokens(2_048)).toBe(2_048);
+    expect(retryMaxTokens(10_000)).toBe(10_000);
+    expect(retryMaxTokens(24_576)).toBe(24_576);
+  });
+
+  it('clamps to the 24,576 ceiling when ample budget remains (matches the old flat request)', () => {
+    expect(retryMaxTokens(24_577)).toBe(24_576);
+    expect(retryMaxTokens(999_900)).toBe(24_576); // e.g. a 1M-token-budget pass
   });
 });
 

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -15,6 +15,7 @@ import {
   DOC_TRUTH_PASS_SPEC,
   DOC_PASS_MAX_TURNS,
 } from '../src/plugins/agent/doc-truth-pass.js';
+import { EXTRA_PASS_MIN_BUDGET_TOKENS } from '../src/plugins/agent/review-pass.js';
 import { buildSystemPrompt } from '../src/plugins/agent/system-prompt.js';
 import { DOC_TRUTH } from '../src/plugins/agent/rules.js';
 import { createTestContext } from '../src/test-helpers.js';
@@ -245,9 +246,31 @@ describe('buildDocTruthPassPrompts', () => {
 // ---------------------------------------------------------------------------
 
 describe('docTruthPassBudget', () => {
-  it('is ~40% of the base budget, rounded to an integer', () => {
+  it('is ~40% of the base budget, rounded to an integer, when that clears the floor', () => {
     expect(docTruthPassBudget(100_000)).toBe(40_000);
     expect(docTruthPassBudget(50_001)).toBe(20_000); // round(20000.4)
+  });
+
+  it('clamps to EXTRA_PASS_MIN_BUDGET_TOKENS for the exact #811 summary-only base (regression)', () => {
+    // PR #811's measured main-pass (summary-only mode) allocation was 6,054 —
+    // 40% of that is 2,422, smaller than a single Kimi turn (5,526-6,564
+    // measured), which is exactly what starved doc-truth on that run.
+    expect(docTruthPassBudget(6_054)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+    expect(docTruthPassBudget(6_054)).toBeGreaterThanOrEqual(EXTRA_PASS_MIN_BUDGET_TOKENS);
+  });
+
+  it("clamps to the floor across summary-only mode's whole 6,000-20,000 base range", () => {
+    // scaleSummaryOnlyBudget's own clamp range (#572) — 40% of the top of
+    // that range (20,000 → 8,000) still sits under the floor.
+    expect(docTruthPassBudget(6_000)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+    expect(docTruthPassBudget(20_000)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+  });
+
+  it('the fraction takes over exactly where it first clears the floor', () => {
+    // 0.4 * 27,500 = 11,000 == the floor exactly; one base-unit higher, the
+    // fraction (rounded) exceeds it.
+    expect(docTruthPassBudget(27_500)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+    expect(docTruthPassBudget(27_510)).toBe(11_004); // round(27510 * 0.4)
   });
 });
 

--- a/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
+++ b/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
@@ -504,10 +504,11 @@ describe('buildIncompleteHandlingPassPrompts', () => {
 // ---------------------------------------------------------------------------
 
 describe('incompleteHandlingPassBudget', () => {
-  it('scales with combined candidate count, clamped to the floor for a single candidate', () => {
+  it('scales with combined candidate count, clamped to the shared one-round-trip floor for a single candidate', () => {
     const budget = incompleteHandlingPassBudget(100_000, variantOnlyContext());
-    // 1 candidate: 2500 + 900*1 = 3400, clamped up to the 5000 floor.
-    expect(budget).toBe(5_000);
+    // 1 candidate: 2500 + 900*1 = 3400, clamped up to the 11,000 floor (#811 fix —
+    // was 5,000, smaller than a single Kimi turn's measured 5,526-6,564 tokens).
+    expect(budget).toBe(11_000);
   });
 
   it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -4,6 +4,7 @@ import {
   runReviewPass,
   appendPassTurns,
   runExtraPasses,
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
   type ReviewPassSpec,
 } from '../src/plugins/agent/review-pass.js';
 import { createTestContext, silentLogger } from '../src/test-helpers.js';
@@ -76,6 +77,20 @@ function makeSpec(overrides: Partial<ReviewPassSpec> = {}): ReviewPassSpec {
     ...overrides,
   };
 }
+
+// ---------------------------------------------------------------------------
+// EXTRA_PASS_MIN_BUDGET_TOKENS
+// ---------------------------------------------------------------------------
+
+describe('EXTRA_PASS_MIN_BUDGET_TOKENS', () => {
+  it('is at least one measured Kimi turn (#811: 5,526-6,564 tokens/turn) with real margin', () => {
+    // Not a tautology on the current value — a regression that drops the
+    // floor back toward the old per-pass minimums (4,000/5,000) would fail
+    // this outright, since those are both below the measured per-turn cost.
+    expect(EXTRA_PASS_MIN_BUDGET_TOKENS).toBeGreaterThanOrEqual(10_000);
+    expect(EXTRA_PASS_MIN_BUDGET_TOKENS).toBeLessThanOrEqual(12_000);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // runReviewPass

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -236,10 +236,11 @@ describe('buildStaleDuplicatePassPrompts', () => {
 // ---------------------------------------------------------------------------
 
 describe('staleDuplicatePassBudget', () => {
-  it('scales with candidate count, clamped to the floor for a single candidate', () => {
+  it('scales with candidate count, clamped to the shared one-round-trip floor for a single candidate', () => {
     const budget = staleDuplicatePassBudget(100_000, eligibleContext());
-    // 1 candidate: 2000 + 800*1 = 2800, clamped up to the 4000 floor.
-    expect(budget).toBe(4_000);
+    // 1 candidate: 2000 + 800*1 = 2800, clamped up to the 11,000 floor (#811 fix —
+    // was 4,000, smaller than a single Kimi turn's measured 5,526-6,564 tokens).
+    expect(budget).toBe(11_000);
   });
 
   it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {


### PR DESCRIPTION
## Problem

PR #811 flipped the doc-truth / stale-duplicate / incomplete-handling extra
passes on for this repo's own reviews. Its own dogfood run measured Kimi at
**5,526-6,564 tokens for a single reasoning+tool-request turn** — bigger than
doc-truth's (2,422) and stale-duplicate's (4,400) *entire* pre-fix
allocations. Both passes hard-stopped before their first tool call ever
dispatched, fell into the unconditional `runSummaryRetry` safety net, and
that retry then cost *more than the pass's entire original allocation* in
both cases. Verdict: `degraded:budget_starved`.

Root cause (full diagnosis in the job notes, not repeated here): two
independent budget-scaler bugs plus an unconditional amplifier.

## The three changes

**1. Decoupled doc-truth's floor from the mode-specific main base**
(`doc-truth-pass.ts`). `docTruthPassBudget` was `round(baseBudget × 0.4)` —
fine when `baseBudget` is normal-mode-sized (`scaleAgentBudget`'s ≥60K
floor), catastrophic in summary-only mode (0.4 × 6,054 = 2,422, smaller than
one Kimi turn). Now: `Math.max(round(baseBudget × 0.4), EXTRA_PASS_MIN_BUDGET_TOKENS)`.

**2. Raised stale-duplicate's and incomplete-handling's floors** to the same
standard (`stale-duplicate-pass.ts`, `incomplete-handling-pass.ts`):
- stale-duplicate: `clamp(2000+800×min(n,8), 4000→11000, 30000)`
- incomplete-handling: `clamp(2500+900×min(n,20), 5000→11000, 35000)`

Per-candidate scaling and ceilings are unchanged (as scoped). One side
effect worth flagging: stale-duplicate's scaling ceiling (2,000+800×8=8,400)
now sits *entirely below* the new floor, so the floor dominates for every
candidate count the loop can see today (0-8) — the formula still scales
mathematically, it just doesn't show through until a future candidate-cap
increase. incomplete-handling's ceiling (2,500+900×20=20,500) stays above
the floor, so real scaling shows through past ~9-10 combined candidates.

**Shared constant, not tripled**: `EXTRA_PASS_MIN_BUDGET_TOKENS = 11_000` now
lives once in `review-pass.ts` (this module's 3rd identical floor — CLAUDE.md's
DRY "wait for the 3rd use"), justified directly from the measured 5,526-6,564
tokens/turn: one real investigation turn + a smaller follow-up/verdict turn,
with margin, short of the ~24K+ headroom normal-mode passes get.

**3. Budget-gated `runSummaryRetry`'s own request cost** (`openai-client.ts`).
The retry's completion request (`attemptVerdictCompletion` → `chatCompletion`)
always asked for a flat `max_tokens: 24,576`, regardless of how far over
budget the loop already was — the Anthropic client already scales this via
`requestMaxTokens(remainingBudget)`; the OpenAI client never did. New
`retryMaxTokens(remainingBudget)` mirrors that exactly:
`min(24_576, max(remainingBudget, 2_048))`. Wired through `runSummaryRetry` →
`attemptVerdictCompletion` → `chatCompletion`'s (now-parameterized) `maxTokens`
arg. Computed **once** per retry and reused for both the first and the
bounded second attempt (parity with the Anthropic client's own handling).

**Retry-gate design decision — did NOT add a "skip the full retry" path.**
I considered gating the retry to skip entirely (or drop to a trimmed-context
"cheaper" shape) when the loop is already over budget by a large factor, per
the brief's "and/or". Rejected: the existing regression test
`recovers a verdict via the json-forced summary-retry after a bail` exercises
a run at **2.0x over budget** (2,000 spent / 1,000 allocated) and requires the
retry to still fire and fully recover a verdict — any "skip when far over
budget" threshold would either have to sit above 2.0x (making it fire so
rarely it's not worth the added surface) or risk regressing that exact
#792/#795-protected path. The max_tokens cap alone already targets the
measured cost driver (the retry's own uncontrolled completion size) without
touching *whether* the retry runs — a smaller, correct fix beats a bundled
risky one. Flagging as a considered-and-rejected alternative, not a deferred
follow-up: floors 1+2 already remove the scenario that motivated the idea
(a single real turn no longer trivially blows either pass's budget).

## Evidence

### 1. Unit tests (all new, plus every existing test green — see below)
- `docTruthPassBudget`: exact #811 value (`docTruthPassBudget(6_054)` →
  `11_000`, was `2_422`), the whole summary-only range (6,000/20,000 → both
  floor), and the exact fraction/floor crossover point (27,500).
- `staleDuplicatePassBudget` / `incompleteHandlingPassBudget`: floor-boundary
  tests updated (4,000→11,000 / 5,000→11,000) plus the existing
  base-budget-independence tests (unaffected).
- `EXTRA_PASS_MIN_BUDGET_TOKENS`: bounded to [10_000, 12_000] — a regression
  that quietly drops the floor back toward the old per-pass minimums fails
  this directly.
- `retryMaxTokens`: floors at the deeply-negative #811 values (-3,104/-2,164),
  at/just-above zero, passthrough in the middle, and ceiling-clamps for an
  ample-budget pass.
- Two new integration tests on the real `OpenAIAgentClient`: one proves the
  retry's request body carries the capped `max_tokens` on a starved bail,
  one proves it stays at the old flat 24,576 when budget is ample (explicit
  non-regression for the #792/#795 path).
- **Every existing test in the touched files stays green, untouched** —
  all 20 #792/#795 verdict-recovery tests (OpenAI + Anthropic clients) pass
  with zero modifications, including the exact 2.0x-over-budget recovery
  case discussed above.

### 2. Byte-diff census (budgets don't render into prompts)
Ran `build-prompts.ts` against all 3 on-disk fixtures
(`doc-truth/accurate-doc`, `doc-truth/renamed-stale-claim`,
`boundary-change/placeholder`) at HEAD (via `git stash`) and on this branch,
diffed the JSON output byte-for-byte:

```
== accurate-doc ==          BYTE-IDENTICAL (25099 bytes both)
== renamed-stale-claim ==   BYTE-IDENTICAL (25269 bytes both)
== placeholder ==           BYTE-IDENTICAL (25487 bytes both)
```

### 3. Before/after allocation table (#811's measured inputs, deterministic)

| pass | input | old allocation | new allocation |
|---|---|---|---|
| main | base=6,054 (summary-only, untouched by this PR) | 6,054 | 6,054 |
| doc-truth | base=6,054 (imported `docTruthPassBudget` call) | 2,422 | **11,000** |
| stale-duplicate-loop | candidates=3 | 4,400 | **11,000** |

(incomplete-handling never ran on #811 — no eligible candidate that day —
so it has no "before" row; its own floor-boundary math is covered by the
unit tests above.)

### 4. Live dogfood — this PR's own review run (CI run 29558909072)

Normal mode, as expected (this PR touches `packages/review` source, not a
doc-only/summary-only diff). Main pass completed CLEANLY at turn 6
(`finish_reason=stop`, 213,625/250,000 tokens — well under budget, real
on-topic summary produced). The `incomplete-handling-loop` fired for real
this time (15 candidates — this PR's three near-identical "extra pass"
files trip its sibling-surface signal against each other) and is the
**genuinely interesting result**:

```
[agent] Turn 1: finish_reason=tool_calls, tokens=6733       (4 real read_file calls dispatched)
[agent] Turn 2: finish_reason=tool_calls, tokens=21490
##[warning][agent] Token budget exceeded (21490/16000), stopping
[agent] No JSON output — requesting summary...
##[warning][agent] Retry verdict was unparseable — attempting one more bounded retry
##[warning][agent] Review incomplete (stopReason=budget, no verdict/summary after 2 completed turn(s))
[agent] incomplete-handling-loop pass: 0 finding(s) in 2 turn(s) ($0.0519)
```

Attestation:
```json
{"attestationVersion":2,"run":{"conclusion":"failure","filesAnalyzed":10},
 "provider":{"passes":[
   {"name":"main","ran":true,"stopReason":"budget","neverRan":false},
   {"name":"incomplete-handling-loop","ran":true,"stopReason":"budget","neverRan":false}]},
 "budget":{"allocatedTokens":266000,"spentTokens":267313,"starved":true,"passes":[
   {"name":"main","allocatedTokens":250000,"spentTokens":213625,"starved":true},
   {"name":"incomplete-handling-loop","allocatedTokens":16000,"spentTokens":53688,"starved":true}]},
 "passesSkipped":[
   {"plugin":"agent-review:doc-truth","reason":"not a doc-touching PR (no doc claims)"},
   {"plugin":"agent-review:stale-duplicate-loop","reason":"no high-confidence, same-file stale-literal candidate (loop eligibility threshold not met)"}],
 "verdict":"degraded:budget_starved"}
```

**Reading this honestly** (main's `stopReason:"budget"` here is
`mergeIncompleteHandlingResultState` overwriting the merged result's
stopReason with the loop's — main's OWN client run finished cleanly; this
is the intentional cross-pass propagation, not main itself starving):

- The loop's own budget (2,500 + 900×15 = **16,000** — real per-candidate
  scaling above the new floor, not floor-dominated, confirming the "past
  ~9-10 candidates, scaling shows through" note above) still wasn't enough
  for THIS diff: turn 2 alone cost 21,490 tokens investigating 15
  candidates across the touched files.
- **Compared directly to #811's shape**: there, doc-truth/stale-duplicate's
  very FIRST tool-call request never even dispatched — the hard budget
  check tripped before any tool executed. Here, the loop got a full
  turn-1 investigation (4 real `read_file` calls executed, genuine
  candidate-by-candidate reasoning visible in the trace) before hitting
  budget on turn 2 — meaningfully more real work got done per token, even
  though a 15-candidate diff still exceeds even the scaled-up allocation.
- The retry-gate fix is visible in effect: `retryMaxTokens(16000 - 21490)`
  = `retryMaxTokens(-5490)` = capped to 2,048 (vs. the old flat 24,576) for
  both retry attempts — the bounded-second-retry mechanism (#792) then
  correctly fired, still couldn't recover a parseable verdict, and
  surfaced as an **honest 0-finding incomplete** (not a false-clean pass) —
  exactly the #795 honesty contract working as designed under real
  starvation.
- **This is not a masked failure**: the PR description's non-blocking
  warning (`⚠️ The incomplete-handling pass did not finish...the main
  review's findings are unaffected`) rendered correctly, the CI `review`
  check stayed green (`hasIncompleteMainPass` correctly does NOT escalate
  an extra-pass-only incomplete), and there were zero findings to
  triage/dismiss (lien-stats: "Stable - 7 pre-existing issues...none
  introduced").
- **Honest scope note**: this PR's floor fix targets the #811 shape (a
  handful of candidates starving on an unrealistically low floor); a
  15-candidate real investigation on an unusually candidate-rich diff
  exceeding even a correctly-scaled budget is a separate, pre-existing
  candidate-loop limitation (linear per-candidate token cost doesn't
  always match real per-candidate investigation cost) — out of this PR's
  scope, and not something the retry-gate or floor changes claim to fix.

## Gates
- `npm run format:check` / `lint` (0 errors) / `typecheck` / `build` — all green.
- `npm test` (all 6 packages) — **1,229 tests green** (860 cli + 249 review +
  374 core + 27 parser-native + parser + 41 action), zero modifications to
  any pre-existing test's expectations beyond the floor-boundary numbers
  documented above.
- `lien delta` — exit 0, no new complexity crossings (two touched functions
  in `openai-client.ts` were already over the complexity warn threshold at
  HEAD; touching them doesn't fail the gate per this repo's policy, but I
  kept the added branching minimal — one new local variable per call site,
  no new conditionals in either `run()` or `chatCompletion()`).

No changeset (review package is private/unpublished).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 7 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 2 | +12 |
| 🐛 estimated bugs | 1 | +0.035 |


> [!NOTE]
> **Low Risk**
>
> This PR raises the minimum token budgets for three extra review passes (doc-truth, stale-duplicate, incomplete-handling) and caps the OpenAI summary-retry's `max_tokens` to the remaining budget instead of unconditionally requesting 24,576 tokens. The changes are narrowly scoped, well-documented, and accompanied by targeted unit and integration tests. The budget formulas are deterministic, the shared constant is exported from a single location, and the retry cap mirrors the existing Anthropic client behavior. No correctness-breaking changes to callers were identified.
>
> - Introduced shared `EXTRA_PASS_MIN_BUDGET_TOKENS = 11_000` floor and applied it to doc-truth, stale-duplicate, and incomplete-handling pass budgets.
> - Added `retryMaxTokens(remainingBudget)` to bound the OpenAI summary-retry request, with floor 2,048 and ceiling 24,576.
> - Updated tests to pin the new floor boundaries and retry cap behavior.

⚠️ The incomplete-handling pass did not finish — it hit the token budget limit. That pass's findings are partial; the main review's findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bdc241e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 267K/266K tokens
<!-- /lien:attestation -->
