### PR TITLE
feat(review): widen doc-truth claim discovery to code files + referenced-file prefetch

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -34,11 +34,46 @@
  * should arrive pre-verified), and a citation that does NOT resolve gets a
  * one-line "not found" note instead — a stale citation is itself doc-truth
  * signal, not something to search around.
+ *
+ * `collectClaimSources`/`addedCodeCommentLines` widen extraction to changed CODE files (not just
+ * guidance/doc surfaces) — motivated by pr658's Finding A, the canonical case
+ * this widening exists to catch: the stale `embeddings.enabled` doc COMMENT
+ * in `packages/core/src/config/schema.ts`, an ordinary source file that
+ * `collectGuidanceSurfaceChanges` never looks at, so the claim was never
+ * LISTED for any contract (v1's open findings list or v2's per-claim one) to
+ * force engagement with. The scan stays tight to the same claim-shaped-prose
+ * discipline as the doc-surface scan, but the LINE shape narrows further: a
+ * changed code file's added line only counts when it reads as a comment,
+ * docstring, or description-valued string literal (`.describe(...)`,
+ * `description: "..."` — the zod/JSON-schema shape) — ordinary code is never
+ * scanned. TODOs, attribution lines, and doc-comment tags (`@param`, …) are
+ * excluded before classification even though they're comment-shaped: a TODO
+ * describes intended/future work, not a claim about current behavior (see
+ * `extractCommentProse`). Claims mined this way share the render/render-cap
+ * pipeline with doc-surface claims but are capped separately
+ * (`MAX_CODE_CLAIMS`) so a comment-heavy code diff can't crowd out the
+ * doc-surface claims that are the historically reliable signal.
+ *
+ * `findCitedPathDiffEvidence` widens evidence PREFETCH for a claim's own file
+ * citation (`DocClaim.citedPath`) to the PR's own diff, not just the indexed
+ * `repoChunks`. Motivated by PR #811's own review: a doc claim cited
+ * `.github/workflows/lien-review.yml`, which WAS part of that PR's diff but
+ * is not an AST-analyzable language, so it never appears in `repoChunks` —
+ * the doc-truth pass reported "not available in the review material… before
+ * budget exhaustion" instead of comparing against the one hunk that would
+ * have settled it in one read. When a citation names a file that's part of
+ * THIS PR, its diff hunk is fetched directly (byte-capped like every other
+ * signal) in preference to any indexed excerpt — the diff is the more
+ * PR-relevant material and needs no index entry to exist. Falls back to the
+ * existing indexed-chunk lookup when the cited file isn't part of the diff,
+ * and to the existing "not found" note (now naming both sources checked)
+ * when neither resolves — degrading loudly rather than silently omitting.
  */
 
 import type { CodeChunk } from '@liendev/parser';
 import type { ReviewContext } from './plugin-types.js';
-import { collectGuidanceSurfaceChanges } from './guidance-surface-signals.js';
+import { collectGuidanceSurfaceChanges, isGuidanceSurface } from './guidance-surface-signals.js';
+import { filterAnalyzableFiles } from './analysis.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,13 +116,22 @@ export interface DocClaimEvidence {
    */
   fromDoc: boolean;
   /**
-   * True when this entry is a one-line "cited file not found in the index"
-   * note rather than a located excerpt — the claim named its own evidence
-   * file (see `DocClaim.citedPath`) but that file doesn't resolve against
-   * `repoChunks`. `file` carries the cited (unresolved) path; `excerpt` is
-   * unused. A stale citation is itself doc-truth signal (issue #749).
+   * True when this entry is a one-line "cited file not found" note rather
+   * than a located excerpt — the claim named its own evidence file (see
+   * `DocClaim.citedPath`) but that file resolves against neither the PR's
+   * own diff nor `repoChunks`. `file` carries the cited (unresolved) path;
+   * `excerpt` is unused. A stale citation is itself doc-truth signal (issue
+   * #749).
    */
   citedPathMissing?: boolean;
+  /**
+   * True when this evidence is the cited file's raw PR diff hunk (referenced-
+   * file evidence prefetch) rather than an indexed chunk excerpt — the file
+   * is part of THIS PR's diff but was not necessarily analyzable/indexed
+   * (e.g. a workflow YAML, see PR #811). Always false alongside `fromDoc`
+   * (a diff hunk isn't chunk-sourced).
+   */
+  fromDiff?: boolean;
 }
 
 /**
@@ -132,6 +176,13 @@ export interface DocClaim {
 
 /** Cap the worklist so the prompt stays compact (protects the input budget). */
 const MAX_CLAIMS = 20;
+/**
+ * Separate, smaller cap on claims mined from changed CODE files (comments/
+ * docstrings/description literals — see `claimsFromSource`). Kept apart
+ * from `MAX_CLAIMS` so a comment-heavy code diff cannot crowd out doc-surface
+ * claims, the historically reliable signal, from the render cap above.
+ */
+const MAX_CODE_CLAIMS = 10;
 /** Per-claim character cap — a claim line is a pointer, not the whole hunk. */
 const MAX_CLAIM_CHARS = 200;
 /** Per-claim evidence excerpt cap — enough to carry the described code, not a hunk. */
@@ -290,10 +341,12 @@ function stripLinkTargets(text: string): string {
   return text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
 }
 
-/** Extract classified claim lines from one file's patch. */
-function extractClaimsFromPatch(file: string, patch: string): DocClaim[] {
+/** Extract classified claim lines already reduced to candidate prose (either a doc surface's
+ *  added prose lines, or a code file's added comment/docstring/description lines — see the two
+ *  callers below). */
+function extractClaims(file: string, lines: string[]): DocClaim[] {
   const claims: DocClaim[] = [];
-  for (const raw of addedProseLines(patch)) {
+  for (const raw of lines) {
     const text = stripLinkTargets(raw);
     const match = classifyClaim(text);
     if (!match) continue;
@@ -308,22 +361,169 @@ function extractClaimsFromPatch(file: string, patch: string): DocClaim[] {
   return claims;
 }
 
+// ---------------------------------------------------------------------------
+// Code-file comment/docstring/description-literal extraction (widened
+// claim-discovery surface — see this module's header for the pr658 motivation)
+// ---------------------------------------------------------------------------
+
+/** A `//` or `#` line comment — NOT a Rust/C++ doc-comment (`///`/`//!`, handled separately so
+ *  that convention stays visually distinguishable) or a shebang/preprocessor directive
+ *  (`#!`, `#include`, `#pragma`, `#region`/`#endregion`) — those aren't prose. */
+const LINE_COMMENT_RE = /^(?:\/\/(?![!/])|#(?!!|include\b|pragma\b|region\b|endregion\b))\s?(.*)$/;
+/** A Rust/C++ doc-comment: `///` (outer) or `//!` (inner). */
+const DOC_COMMENT_RE = /^\/\/[!/]\s?(.*)$/;
+/** A JSDoc/block-comment CONTINUATION line: a leading `*` that is not the comment's closing line. */
+const BLOCK_CONT_RE = /^\*(?!\/)\s?(.*)$/;
+/** A block-comment opener (`/**` or `/*`), with any same-line trailing text. */
+const BLOCK_OPEN_RE = /^\/\*\*?\s?(.*)$/;
+/** A Python/Rust-style triple-quoted docstring delimiter, with any same-line trailing text. */
+const TRIPLE_QUOTE_RE = /^(?:"""|''')\s?(.*)$/;
+
+/** Comment/docstring line shapes, most-specific first (first match wins). */
+const COMMENT_LINE_MATCHERS: readonly RegExp[] = [
+  DOC_COMMENT_RE,
+  LINE_COMMENT_RE,
+  BLOCK_CONT_RE,
+  BLOCK_OPEN_RE,
+  TRIPLE_QUOTE_RE,
+];
+
+/** A zod-style `.describe('...')` call — the config-schema-description shape (Finding A's
+ *  sibling case: a description string rather than a doc COMMENT). Single-line only (KISS) — a
+ *  description string that wraps onto its own line inside a multi-line `.describe(\n  '...'\n)`
+ *  call is not extracted; the canonical, acceptance-tested case (pr658's schema.ts) is a plain
+ *  comment line, not this shape. */
+const DESCRIBE_CALL_RE = /\.describe\(\s*(['"`])((?:(?!\1).)*)\1/;
+/** A `description: '...'` object-literal key — the JSON-schema-description shape. Same
+ *  single-line-only scope as `DESCRIBE_CALL_RE`. */
+const DESCRIPTION_KEY_RE = /\bdescription\s*:\s*(['"`])((?:(?!\1).)*)\1/;
+
 /**
- * Collect claim-shaped lines from every changed guidance/doc surface, smallest
- * hunk first (reusing `collectGuidanceSurfaceChanges`' ordering so a voluminous
- * doc can't crowd a small changeset's claims out of the cap downstream).
- * Identical claim lines are deduped. Returns ALL claims (uncapped); the render
- * layer caps and notes any overflow. Exposed for testing.
+ * Comment-shaped lines that are NOT the claim-shaped prose this scan wants, excluded before
+ * classification (the "when in doubt, exclude" discipline this module's header calls for on the
+ * newly-widened, noisier code-comment surface):
+ *  - a TODO/FIXME/XXX/HACK note — describes INTENDED/future work, not current behavior, so a
+ *    claim-shaped TODO ("TODO: should default to 32") would otherwise false-classify as a claim
+ *    about what the code does NOW;
+ *  - an attribution/authorship line;
+ *  - a doc-comment TAG (`@param`, `@returns`, `@example`, …) — structural metadata, not a
+ *    behavioral sentence, even though some tags read as imperative prose.
+ */
+const NOISE_LINE_RE = /^(?:TODO|FIXME|XXX|HACK)\b[:.]?/i;
+const ATTRIBUTION_RE = /^(?:copyright\b|co-authored-by|signed-off-by)/i;
+const TAG_LINE_RE = /^@\w+\b/;
+
+/**
+ * Extract claim-candidate prose from one line of a code file's patch, or undefined when the line
+ * is not a comment/docstring/description-literal shape (ordinary code) or is noise (see above). A
+ * `.describe(...)`/`description: "..."` match is checked FIRST since those lines are otherwise
+ * ordinary code; everything else must additionally read as a comment/docstring line. Exposed for
+ * testing.
+ */
+export function extractCommentProse(rawLine: string): string | undefined {
+  const line = rawLine.trim();
+  if (!line) return undefined;
+
+  const described = DESCRIBE_CALL_RE.exec(line) ?? DESCRIPTION_KEY_RE.exec(line);
+  const prose = described
+    ? described[2]
+    : COMMENT_LINE_MATCHERS.map(re => re.exec(line)?.[1]).find(p => p !== undefined);
+  if (prose === undefined) return undefined;
+
+  const trimmed = prose.trim();
+  if (
+    !trimmed ||
+    NOISE_LINE_RE.test(trimmed) ||
+    ATTRIBUTION_RE.test(trimmed) ||
+    TAG_LINE_RE.test(trimmed)
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/**
+ * The candidate-claim prose lines of one changed CODE file's patch: ADDED lines whose text is a
+ * comment, docstring, or description-valued string literal (see `extractCommentProse`) — never
+ * arbitrary code. This is the widened surface pr658's Finding A motivated: a JSDoc comment on a
+ * `LienConfig` field in `packages/core/src/config/schema.ts`, an ordinary source file the
+ * doc-surface-only scan could never see. Exposed for testing.
+ */
+export function addedCodeCommentLines(patch: string): string[] {
+  const out: string[] = [];
+  for (const { text, isAdded } of newFileLines(patch)) {
+    if (!isAdded) continue;
+    const prose = extractCommentProse(text);
+    if (prose) out.push(prose);
+  }
+  return out;
+}
+
+/** One claim source to scan: a changed file's patch, tagged with which line-extraction mode
+ *  applies (`addedProseLines` for a guidance/doc surface, `addedCodeCommentLines` for code). */
+interface ClaimSource {
+  file: string;
+  patch: string;
+  mode: 'guidance' | 'code';
+}
+
+/**
+ * Every changed file worth scanning for claims — guidance/doc surfaces (`collectGuidanceSurfaceChanges`)
+ * PLUS non-guidance changed files with an analyzable code extension (`filterAnalyzableFiles`,
+ * the same "code file" definition `review-pr.ts` uses) — merged into ONE smallest-hunk-first
+ * order. A single fairness ordering (rather than "all doc surfaces, then all code files") means a
+ * small, surgical code-comment change (pr658's schema.ts: one line) ranks ahead of a large
+ * doc-surface rewrite purely on hunk size, the same budget-fairness rationale
+ * `collectGuidanceSurfaceChanges` already documents.
+ */
+function collectClaimSources(patches: Map<string, string>): ClaimSource[] {
+  const guidance: ClaimSource[] = collectGuidanceSurfaceChanges(patches).map(c => ({
+    ...c,
+    mode: 'guidance',
+  }));
+  const codeFiles = filterAnalyzableFiles([...patches.keys()]).filter(f => !isGuidanceSurface(f));
+  const code: ClaimSource[] = codeFiles.map(file => ({
+    file,
+    patch: patches.get(file) ?? '',
+    mode: 'code',
+  }));
+  return [...guidance, ...code].sort((a, b) => a.patch.length - b.patch.length);
+}
+
+/**
+ * Extract the claims for one source, respecting `codeClaimBudget` (the number of code-derived
+ * claims still allowed — see `MAX_CODE_CLAIMS`) when `source.mode === 'code'`. Split out of
+ * `extractDocClaims` purely to keep that function's own branching shallow.
+ */
+function claimsFromSource(source: ClaimSource, codeClaimBudget: number): DocClaim[] {
+  if (source.mode === 'code' && codeClaimBudget <= 0) return [];
+  const lines =
+    source.mode === 'guidance'
+      ? addedProseLines(source.patch)
+      : addedCodeCommentLines(source.patch);
+  const claims = extractClaims(source.file, lines);
+  return source.mode === 'code' ? claims.slice(0, codeClaimBudget) : claims;
+}
+
+/**
+ * Collect claim-shaped lines from every changed guidance/doc surface AND changed code file
+ * (comments/docstrings/description literals only — see `collectClaimSources`), smallest hunk
+ * first. Identical claim lines are deduped across both sources. Code-derived claims are capped
+ * separately at `MAX_CODE_CLAIMS` so a comment-heavy code diff cannot crowd out doc-surface
+ * claims. Returns ALL claims up to that cap (uncapped for doc-surface claims — the render layer
+ * applies `MAX_CLAIMS` and notes any overflow). Exposed for testing.
  */
 export function extractDocClaims(patches: Map<string, string>): DocClaim[] {
   const claims: DocClaim[] = [];
   const seen = new Set<string>();
+  let codeClaimCount = 0;
 
-  for (const { file, patch } of collectGuidanceSurfaceChanges(patches)) {
-    for (const claim of extractClaimsFromPatch(file, patch)) {
+  for (const source of collectClaimSources(patches)) {
+    for (const claim of claimsFromSource(source, MAX_CODE_CLAIMS - codeClaimCount)) {
       if (seen.has(claim.claimText)) continue;
       seen.add(claim.claimText);
       claims.push(claim);
+      if (source.mode === 'code') codeClaimCount++;
     }
   }
 
@@ -657,21 +857,86 @@ function pickCitedChunk(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Referenced-file evidence prefetch (issue: PR #811's own review)
+// ---------------------------------------------------------------------------
+
+/** Cap on a prefetched referenced-file diff-hunk excerpt. Bigger than `MAX_EVIDENCE_CHARS`
+ *  since a raw hunk carries diff punctuation/context an indexed-chunk excerpt doesn't, but still
+ *  bounded — mirrors `guidance-surface-signals.ts`'s own per-file cap discipline for the same
+ *  shape of problem (one huge referenced file must not dominate the block). */
+const MAX_DIFF_EVIDENCE_CHARS = 800;
+
+/** The NEW-file starting line of a patch's FIRST hunk (`@@ -a,b +START,len @@`), or 0 when the
+ *  header can't be parsed — best-effort, since a raw hunk (unlike an indexed chunk) carries no
+ *  authoritative line-number metadata of its own. */
+function firstHunkNewStartLine(patch: string): number {
+  const m = /^@@ -\d+(?:,\d+)? \+(\d+)/m.exec(patch);
+  return m ? Number(m[1]) : 0;
+}
+
+/** Build diff-hunk evidence for a cited file that's part of THIS PR (see
+ *  `findCitedPathDiffEvidence`): the byte-capped raw patch, tagged `fromDiff` so the renderer
+ *  frames it as a diff rather than a plain source excerpt. */
+function buildDiffEvidence(file: string, patch: string): DocClaimEvidence {
+  const capped =
+    patch.length > MAX_DIFF_EVIDENCE_CHARS
+      ? `${patch.slice(0, MAX_DIFF_EVIDENCE_CHARS)}\n[diff truncated to respect the input budget]`
+      : patch;
+  return {
+    file,
+    startLine: firstHunkNewStartLine(patch),
+    excerpt: capped.replace(/```/g, "'''"),
+    anchor: file,
+    fromDoc: false,
+    fromDiff: true,
+  };
+}
+
 /**
- * Resolve a claim's own file citation (see `DocClaim.citedPath`) against the
- * repo index. A citation is authoritative — a claim that ships its own
- * pointer should arrive pre-verified — so a resolved hit is returned directly,
- * bypassing the generic anchor/tier scan entirely (it outranks every tier).
- * When the cited path does NOT resolve to any indexed chunk, returns a
- * one-line `citedPathMissing` note instead: a stale citation is itself
- * doc-truth signal, not something to search around (issue #749).
+ * Resolve a claim's file citation against the PR's OWN diff (`context.pr.patches`) — the
+ * referenced-file evidence prefetch this section is named for. Motivated by PR #811's own
+ * review: a doc claim cited `.github/workflows/lien-review.yml`, which WAS part of that PR's
+ * diff but isn't an AST-analyzable language, so it never reaches `repoChunks` and the indexed-
+ * chunk lookup below can never find it — yet the exact material to verify the claim was sitting
+ * in the diff the whole time. Resolution mirrors the indexed-chunk lookup's own leniency (exact
+ * path, or a path this cited path is a suffix of). Returns undefined when there is no `patches`
+ * map or the cited path isn't one of its keys, so the caller falls through to the indexed-chunk
+ * lookup (see `findCitedPathEvidence`).
+ */
+function findCitedPathDiffEvidence(
+  cited: DocClaimCitedPath,
+  patches: Map<string, string> | undefined,
+): DocClaimEvidence | undefined {
+  if (!patches) return undefined;
+  const matchedFile = [...patches.keys()].find(
+    f => f === cited.path || f.endsWith(`/${cited.path}`),
+  );
+  if (!matchedFile) return undefined;
+  return buildDiffEvidence(matchedFile, patches.get(matchedFile) ?? '');
+}
+
+/**
+ * Resolve a claim's own file citation (see `DocClaim.citedPath`) against, in priority order: the
+ * PR's own diff (`findCitedPathDiffEvidence` — the referenced-file evidence prefetch, preferred
+ * when available since it's the more PR-relevant material and needs no index entry to exist),
+ * then the repo index. A citation is authoritative — a claim that ships its own pointer should
+ * arrive pre-verified — so a resolved hit from EITHER source is returned directly, bypassing the
+ * generic anchor/tier scan entirely (it outranks every tier). When the cited path resolves
+ * against NEITHER, returns a one-line `citedPathMissing` note instead: a stale citation is itself
+ * doc-truth signal, not something to search around (issue #749) — degrading loudly rather than
+ * silently omitting.
  */
 function findCitedPathEvidence(
   cited: DocClaimCitedPath,
   claimText: string,
-  repoChunks: CodeChunk[],
+  repoChunks: CodeChunk[] | undefined,
+  patches: Map<string, string> | undefined,
 ): DocClaimEvidence {
-  const resolvedFile = repoChunks.find(
+  const diffEvidence = findCitedPathDiffEvidence(cited, patches);
+  if (diffEvidence) return diffEvidence;
+
+  const resolvedFile = repoChunks?.find(
     c => c.metadata.file === cited.path || c.metadata.file.endsWith(`/${cited.path}`),
   )?.metadata.file;
 
@@ -686,7 +951,7 @@ function findCitedPathEvidence(
     };
   }
 
-  const fileChunks = repoChunks.filter(c => c.metadata.file === resolvedFile);
+  const fileChunks = repoChunks!.filter(c => c.metadata.file === resolvedFile);
   const keywordAnchors = extractAnchors(claimText).filter(a => a !== cited.symbol);
   const { chunk, centerOn } = pickCitedChunk(fileChunks, cited.symbol, keywordAnchors);
   const built = buildExcerpt(chunk, centerOn, IDENTITY);
@@ -701,19 +966,25 @@ function findCitedPathEvidence(
 
 /**
  * Locate the code (or sibling doc) a single claim describes. An explicit
- * self-citation (`claim.citedPath`) is resolved first and, when present,
- * short-circuits the rest of this function — see `findCitedPathEvidence`.
- * Otherwise tries a case-sensitive anchor pass (identifiers/keys are
- * case-bearing), then a case-insensitive fallback. Returns undefined when no
- * anchor resolves or there is no repo index to search.
+ * self-citation (`claim.citedPath`) is resolved first — against the PR's own
+ * diff, then the repo index (see `findCitedPathEvidence`) — and, when
+ * present, short-circuits the rest of this function; this is the ONE path
+ * that can still produce evidence with no repo index at all (a citation
+ * resolving purely against `patches`). Otherwise tries a case-sensitive
+ * anchor pass against `repoChunks` (identifiers/keys are case-bearing), then
+ * a case-insensitive fallback. Returns undefined when no anchor resolves or
+ * there is no repo index to search.
  */
 export function findClaimEvidence(
   claim: DocClaim,
   repoChunks: CodeChunk[] | undefined,
   changed: Set<string>,
+  patches?: Map<string, string>,
 ): DocClaimEvidence | undefined {
+  if (claim.citedPath)
+    return findCitedPathEvidence(claim.citedPath, claim.claimText, repoChunks, patches);
+
   if (!repoChunks || repoChunks.length === 0) return undefined;
-  if (claim.citedPath) return findCitedPathEvidence(claim.citedPath, claim.claimText, repoChunks);
   const anchors = extractAnchors(claim.claimText);
   if (anchors.length === 0) return undefined;
 
@@ -745,9 +1016,10 @@ export function findClaimEvidence(
 export function attachEvidence(claims: DocClaim[], context: ReviewContext): DocClaim[] {
   const repoChunks = context.repoChunks;
   const changed = collectChangedFiles(context);
+  const patches = context.pr?.patches;
   return claims.map((claim, i) => {
     if (i >= MAX_CLAIMS) return claim; // beyond the render cap — evidence would never show
-    const evidence = findClaimEvidence(claim, repoChunks, changed);
+    const evidence = findClaimEvidence(claim, repoChunks, changed, patches);
     return evidence ? { ...claim, evidence } : claim;
   });
 }
@@ -758,12 +1030,15 @@ export function attachEvidence(claims: DocClaim[], context: ReviewContext): DocC
 
 const DOC_CLAIMS_HEADER =
   'Pre-computed: behavioral/structural claims this PR added to its touched ' +
-  'guidance/doc surfaces (ADRs, site guides, changesets, CLAUDE.md, hooks). ' +
-  'This is the doc-truth discovery step done for you — do NOT skip it; it is ' +
+  'guidance/doc surfaces (ADRs, site guides, changesets, CLAUDE.md, hooks) AND ' +
+  'to comments/docstrings/description strings in changed CODE files. This is ' +
+  'the doc-truth discovery step done for you — do NOT skip it; it is ' +
   'your primary claim inventory. The scan can miss claims and can list prose ' +
   'that is merely descriptive, so also skim the touched hunks for any not here. ' +
   'Most entries carry an `evidence` excerpt: the code (or a sibling doc, for ' +
-  'omission claims) the claim describes, located deterministically for you — ' +
+  'omission claims, or — when the claim cites a file that is itself part of ' +
+  "this PR — that file's own diff hunk) the claim describes, located " +
+  'deterministically for you — ' +
   'COMPARE the claim against that excerpt. The locator can pick the wrong site, ' +
   'so first confirm the excerpt IS the described code; then: if it CONFIRMS the ' +
   'claim, stay silent; if it CONTRADICTS the claim — or the diff changed the ' +
@@ -796,12 +1071,12 @@ function renderClaimEntry(claim: DocClaim, remaining: number): string[] {
   if (claim.evidence.citedPathMissing) {
     return [
       header,
-      `  (evidence: the cited file "${claim.evidence.file}" was not found in the index — the citation itself may be stale)`,
+      `  (evidence: the cited file "${claim.evidence.file}" was not found in the index or PR diff — the citation itself may be stale)`,
     ];
   }
 
-  const { file, startLine, excerpt, fromDoc } = claim.evidence;
-  const label = fromDoc ? 'evidence (sibling doc)' : 'evidence';
+  const { file, startLine, excerpt, fromDoc, fromDiff } = claim.evidence;
+  const label = fromDiff ? 'evidence (PR diff)' : fromDoc ? 'evidence (sibling doc)' : 'evidence';
   const block = [`  ${label} — ${file}:${startLine}:`, '  ```', excerpt, '  ```'].join('\n');
   if (block.length > remaining) {
     return [

--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -376,9 +376,11 @@ const DOC_COMMENT_RE = /^\/\/[!/]\s?(.*)$/;
 const BLOCK_CONT_RE = /^\*(?!\/)\s?(.*)$/;
 /** A block-comment opener (`/**` or `/*`), with any same-line trailing text. The trailing
  *  optional group strips a same-line CLOSING marker off a single-line block comment so it
- *  doesn't leak into the captured prose; a multi-line opener with no closer on this line (just
- *  trailing text) still captures correctly since that group is optional. */
-const BLOCK_OPEN_RE = /^\/\*\*?\s?(.*?)(?:\s*\*\/)?$/;
+ *  doesn't leak into the captured prose — `\*+` (one or more stars) so a closer with extra
+ *  stars (e.g. a doc-comment ending in a doubled star before the slash) is stripped in full
+ *  rather than leaving a stray star behind; a multi-line opener with no closer on this line
+ *  (just trailing text) still captures correctly since that group is optional. */
+const BLOCK_OPEN_RE = /^\/\*\*?\s?(.*?)(?:\s*\*+\/)?$/;
 /** A Python/Rust-style triple-quoted docstring delimiter, with any same-line trailing text. Same
  *  optional-trailing-closer handling as `BLOCK_OPEN_RE`, for a same-line one-liner docstring. */
 const TRIPLE_QUOTE_RE = /^(?:"""|''')\s?(.*?)(?:"""|''')?$/;
@@ -396,11 +398,12 @@ const COMMENT_LINE_MATCHERS: readonly RegExp[] = [
  *  sibling case: a description string rather than a doc COMMENT). Single-line only (KISS) — a
  *  description string that wraps onto its own line inside a multi-line `.describe(\n  '...'\n)`
  *  call is not extracted; the canonical, acceptance-tested case (pr658's schema.ts) is a plain
- *  comment line, not this shape. */
-const DESCRIBE_CALL_RE = /\.describe\(\s*(['"`])((?:(?!\1).)*)\1/;
+ *  comment line, not this shape. The alternation's first branch (`\\.`) consumes an escaped char
+ *  (e.g. `\'`) as a pair so the string doesn't appear to close early on an escaped quote. */
+const DESCRIBE_CALL_RE = /\.describe\(\s*(['"`])((?:\\.|(?!\1).)*)\1/;
 /** A `description: '...'` object-literal key — the JSON-schema-description shape. Same
- *  single-line-only scope as `DESCRIBE_CALL_RE`. */
-const DESCRIPTION_KEY_RE = /\bdescription\s*:\s*(['"`])((?:(?!\1).)*)\1/;
+ *  single-line-only scope and escaped-delimiter handling as `DESCRIBE_CALL_RE`. */
+const DESCRIPTION_KEY_RE = /\bdescription\s*:\s*(['"`])((?:\\.|(?!\1).)*)\1/;
 
 /**
  * Comment-shaped lines that are NOT the claim-shaped prose this scan wants, excluded before
@@ -494,40 +497,54 @@ function collectClaimSources(patches: Map<string, string>): ClaimSource[] {
   return [...guidance, ...code].sort((a, b) => a.patch.length - b.patch.length);
 }
 
-/**
- * Extract the claims for one source, respecting `codeClaimBudget` (the number of code-derived
- * claims still allowed — see `MAX_CODE_CLAIMS`) when `source.mode === 'code'`. Split out of
- * `extractDocClaims` purely to keep that function's own branching shallow.
- */
-function claimsFromSource(source: ClaimSource, codeClaimBudget: number): DocClaim[] {
-  if (source.mode === 'code' && codeClaimBudget <= 0) return [];
+/** Extract every candidate claim for one source — no cap, no dedup (see `extractDocClaims`,
+ *  which applies both, in that order, AFTER extraction so a duplicate never spends code-claim
+ *  budget it never needed). Split out of `extractDocClaims` purely to keep that function's own
+ *  branching shallow. */
+function claimsFromSource(source: ClaimSource): DocClaim[] {
   const lines =
     source.mode === 'guidance'
       ? addedProseLines(source.patch)
       : addedCodeCommentLines(source.patch);
-  const claims = extractClaims(source.file, lines);
-  return source.mode === 'code' ? claims.slice(0, codeClaimBudget) : claims;
+  return extractClaims(source.file, lines);
+}
+
+/**
+ * Build a per-extraction-run admit predicate: true (and records the claim as seen) iff `claim`
+ * is net-new (not a duplicate already admitted) AND, for a code-derived claim, still within the
+ * `MAX_CODE_CLAIMS` budget. Cap-checking runs AFTER the dedup check — not via a pre-dedup slice
+ * on each source's own candidate list — so a source's own duplicate of an already-seen claim
+ * (e.g. the same `.describe(...)` string copy-pasted across sibling schema files) never spends
+ * code-claim budget a later, genuinely new claim could have used.
+ */
+function claimAdmitter(): (claim: DocClaim, mode: ClaimSource['mode']) => boolean {
+  const seen = new Set<string>();
+  let codeClaimCount = 0;
+  return (claim, mode) => {
+    if (mode === 'code' && codeClaimCount >= MAX_CODE_CLAIMS) return false;
+    if (seen.has(claim.claimText)) return false;
+    seen.add(claim.claimText);
+    if (mode === 'code') codeClaimCount++;
+    return true;
+  };
 }
 
 /**
  * Collect claim-shaped lines from every changed guidance/doc surface AND changed code file
  * (comments/docstrings/description literals only — see `collectClaimSources`), smallest hunk
- * first. Identical claim lines are deduped across both sources. Code-derived claims are capped
- * separately at `MAX_CODE_CLAIMS` so a comment-heavy code diff cannot crowd out doc-surface
- * claims. Returns ALL claims up to that cap (uncapped for doc-surface claims — the render layer
- * applies `MAX_CLAIMS` and notes any overflow). Exposed for testing.
+ * first. Identical claim lines are deduped across both sources (see `claimAdmitter`).
+ * Code-derived claims are capped separately at `MAX_CODE_CLAIMS` so a comment-heavy code diff
+ * cannot crowd out doc-surface claims. Returns ALL claims up to that cap (uncapped for
+ * doc-surface claims — the render layer applies `MAX_CLAIMS` and notes any overflow). Exposed
+ * for testing.
  */
 export function extractDocClaims(patches: Map<string, string>): DocClaim[] {
   const claims: DocClaim[] = [];
-  const seen = new Set<string>();
-  let codeClaimCount = 0;
+  const admit = claimAdmitter();
 
   for (const source of collectClaimSources(patches)) {
-    for (const claim of claimsFromSource(source, MAX_CODE_CLAIMS - codeClaimCount)) {
-      if (seen.has(claim.claimText)) continue;
-      seen.add(claim.claimText);
-      claims.push(claim);
-      if (source.mode === 'code') codeClaimCount++;
+    for (const claim of claimsFromSource(source)) {
+      if (admit(claim, source.mode)) claims.push(claim);
     }
   }
 
@@ -908,14 +925,29 @@ function buildDiffEvidence(file: string, patch: string): DocClaimEvidence {
  * map or the cited path isn't one of its keys, so the caller falls through to the indexed-chunk
  * lookup (see `findCitedPathEvidence`).
  */
+/**
+ * Resolve `citedPath` against `candidates`: an EXACT match always wins (checked first,
+ * regardless of iteration order); otherwise a suffix match (`candidate.endsWith('/' + citedPath)`)
+ * is accepted only when EXACTLY ONE candidate qualifies — a citation ambiguous between two
+ * same-named files in different directories should attach to neither rather than an arbitrary
+ * one. Returns undefined when nothing (or more than one suffix candidate) qualifies.
+ */
+function resolveExactOrUniqueSuffix(
+  candidates: readonly string[],
+  citedPath: string,
+): string | undefined {
+  const exact = candidates.find(f => f === citedPath);
+  if (exact) return exact;
+  const suffixMatches = candidates.filter(f => f.endsWith(`/${citedPath}`));
+  return suffixMatches.length === 1 ? suffixMatches[0] : undefined;
+}
+
 function findCitedPathDiffEvidence(
   cited: DocClaimCitedPath,
   patches: Map<string, string> | undefined,
 ): DocClaimEvidence | undefined {
   if (!patches) return undefined;
-  const matchedFile = [...patches.keys()].find(
-    f => f === cited.path || f.endsWith(`/${cited.path}`),
-  );
+  const matchedFile = resolveExactOrUniqueSuffix([...patches.keys()], cited.path);
   if (!matchedFile) return undefined;
   return buildDiffEvidence(matchedFile, patches.get(matchedFile) ?? '');
 }

--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -374,10 +374,14 @@ const LINE_COMMENT_RE = /^(?:\/\/(?![!/])|#(?!!|include\b|pragma\b|region\b|endr
 const DOC_COMMENT_RE = /^\/\/[!/]\s?(.*)$/;
 /** A JSDoc/block-comment CONTINUATION line: a leading `*` that is not the comment's closing line. */
 const BLOCK_CONT_RE = /^\*(?!\/)\s?(.*)$/;
-/** A block-comment opener (`/**` or `/*`), with any same-line trailing text. */
-const BLOCK_OPEN_RE = /^\/\*\*?\s?(.*)$/;
-/** A Python/Rust-style triple-quoted docstring delimiter, with any same-line trailing text. */
-const TRIPLE_QUOTE_RE = /^(?:"""|''')\s?(.*)$/;
+/** A block-comment opener (`/**` or `/*`), with any same-line trailing text. The trailing
+ *  optional group strips a same-line CLOSING marker off a single-line block comment so it
+ *  doesn't leak into the captured prose; a multi-line opener with no closer on this line (just
+ *  trailing text) still captures correctly since that group is optional. */
+const BLOCK_OPEN_RE = /^\/\*\*?\s?(.*?)(?:\s*\*\/)?$/;
+/** A Python/Rust-style triple-quoted docstring delimiter, with any same-line trailing text. Same
+ *  optional-trailing-closer handling as `BLOCK_OPEN_RE`, for a same-line one-liner docstring. */
+const TRIPLE_QUOTE_RE = /^(?:"""|''')\s?(.*?)(?:"""|''')?$/;
 
 /** Comment/docstring line shapes, most-specific first (first match wins). */
 const COMMENT_LINE_MATCHERS: readonly RegExp[] = [

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -320,11 +320,11 @@ function renderDocClaimEntryWithId(id: string, claim: DocClaim): string {
   if (claim.evidence.citedPathMissing) {
     return (
       `${header}\n  (evidence: the cited file "${claim.evidence.file}" was not found in the ` +
-      'index — the citation itself may be stale)'
+      'index or PR diff — the citation itself may be stale)'
     );
   }
-  const { file, startLine, excerpt, fromDoc } = claim.evidence;
-  const label = fromDoc ? 'evidence (sibling doc)' : 'evidence';
+  const { file, startLine, excerpt, fromDoc, fromDiff } = claim.evidence;
+  const label = fromDiff ? 'evidence (PR diff)' : fromDoc ? 'evidence (sibling doc)' : 'evidence';
   return `${header}\n  ${label} — ${file}:${startLine}:\n  \`\`\`\n${excerpt}\n  \`\`\``;
 }
 

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -5,6 +5,8 @@ import {
   extractAnchors,
   extractCitedPath,
   extractDocClaims,
+  extractCommentProse,
+  addedCodeCommentLines,
   findClaimEvidence,
   attachEvidence,
   renderDocClaims,
@@ -684,5 +686,316 @@ describe('attachEvidence and renderer', () => {
     const md = renderDocClaims(claims);
     expect(md.match(/^- docs\//gm)).toHaveLength(20); // all claims survive
     expect(md).toContain('evidence located but omitted to respect the input budget');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCommentProse — code-file comment/docstring/description-literal shapes
+// ---------------------------------------------------------------------------
+
+describe('extractCommentProse', () => {
+  it("extracts a JSDoc/block-comment continuation line (pr658 Finding A's exact shape)", () => {
+    expect(
+      extractCommentProse('     * keep working; search_code and find_similar report as disabled.'),
+    ).toBe('keep working; search_code and find_similar report as disabled.');
+  });
+
+  it('extracts a // line comment', () => {
+    expect(extractCommentProse('// The batch size defaults to 32.')).toBe(
+      'The batch size defaults to 32.',
+    );
+  });
+
+  it('extracts a # line comment (Python/Ruby style)', () => {
+    expect(extractCommentProse('# The batch size defaults to 32.')).toBe(
+      'The batch size defaults to 32.',
+    );
+  });
+
+  it('extracts a Rust /// doc-comment', () => {
+    expect(extractCommentProse('/// The batch size defaults to 32.')).toBe(
+      'The batch size defaults to 32.',
+    );
+  });
+
+  it('extracts a .describe(...) call — the config-schema-description shape', () => {
+    expect(extractCommentProse(".describe('Defaults to 20 when omitted.'),")).toBe(
+      'Defaults to 20 when omitted.',
+    );
+  });
+
+  it('extracts a description: "..." object-literal key', () => {
+    expect(extractCommentProse('description: "Required when scope is set to file.",')).toBe(
+      'Required when scope is set to file.',
+    );
+  });
+
+  it('does not extract a shebang line', () => {
+    expect(extractCommentProse('#!/usr/bin/env node')).toBeUndefined();
+  });
+
+  it('does not extract a preprocessor directive or region marker', () => {
+    expect(extractCommentProse('#include <stdio.h>')).toBeUndefined();
+    expect(extractCommentProse('#region Constants')).toBeUndefined();
+  });
+
+  it('does not extract a plain code line with no comment/description shape', () => {
+    expect(extractCommentProse('const s = "search reports as disabled";')).toBeUndefined();
+  });
+
+  it('excludes a TODO comment even when it reads as claim-shaped', () => {
+    expect(extractCommentProse('// TODO: this should default to 32 eventually')).toBeUndefined();
+  });
+
+  it('excludes an attribution line', () => {
+    expect(extractCommentProse('// Copyright 2026, required for all files.')).toBeUndefined();
+  });
+
+  it('excludes a doc-comment tag line even when claim-shaped', () => {
+    expect(extractCommentProse('// @param batchSize - defaults to 32')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty/whitespace-only line', () => {
+    expect(extractCommentProse('   ')).toBeUndefined();
+  });
+});
+
+describe('addedCodeCommentLines', () => {
+  it('collects only ADDED comment-shaped lines from a patch, ignoring code and trailing comments', () => {
+    const patch = [
+      '@@ -1,3 +1,5 @@',
+      ' export function f() {',
+      '+  // The batch size defaults to 32.',
+      '+  return UNIQUE_MARKER; // trailing comment is not extracted',
+      '+}',
+    ].join('\n');
+    expect(addedCodeCommentLines(patch)).toEqual(['The batch size defaults to 32.']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDocClaims — widened to changed CODE files (pr658 Finding A)
+// ---------------------------------------------------------------------------
+
+describe('extractDocClaims — widened to changed CODE files', () => {
+  const SCHEMA_FILE = 'packages/core/src/config/schema.ts';
+  const SEARCH_SCHEMA_FILE = 'packages/cli/src/mcp/schemas/search.schema.ts';
+
+  it('ACCEPTANCE: extracts the exact pr658 Finding A claim from a JSDoc comment in a changed CODE file', () => {
+    // The real added line from PR #658's schema.ts hunk: the rename to `search_code` was
+    // textually correct but left the underlying "reports as disabled" claim stale (#657 made
+    // search_code lexical, not embedding-gated) — see this module's header and the pr658 fixture.
+    const patch = added('     * keep working; search_code and find_similar report as disabled.');
+    const claims = extractDocClaims(new Map([[SCHEMA_FILE, patch]]));
+    expect(claims).toHaveLength(1);
+    expect(claims[0]).toMatchObject({
+      file: SCHEMA_FILE,
+      shape: 'state',
+      claimText: 'keep working; search_code and find_similar report as disabled.',
+    });
+  });
+
+  it('still ignores an ordinary (non-comment) code line even when claim-shaped', () => {
+    const patch = added('  const s = "search reports as disabled";');
+    expect(extractDocClaims(new Map([[SCHEMA_FILE, patch]]))).toHaveLength(0);
+  });
+
+  it('extracts a .describe(...) claim from a zod schema file (the description-literal shape)', () => {
+    const patch = added("    .describe('Defaults to 20 when omitted.'),");
+    const claims = extractDocClaims(new Map([[SEARCH_SCHEMA_FILE, patch]]));
+    expect(claims).toHaveLength(1);
+    expect(claims[0]).toMatchObject({ file: SEARCH_SCHEMA_FILE, shape: 'default' });
+  });
+
+  it('extracts a citedPath from a code-comment claim (bridges into referenced-file prefetch)', () => {
+    const patch = added('// This flag defaults to on in .github/workflows/lien-review.yml.');
+    const claims = extractDocClaims(new Map([['packages/action/src/index.ts', patch]]));
+    expect(claims).toHaveLength(1);
+    expect(claims[0].citedPath).toEqual({ path: '.github/workflows/lien-review.yml' });
+  });
+
+  it('does NOT extract from a guidance surface via the code-file path (no double-scan)', () => {
+    // A .md guidance surface is scanned via addedProseLines already; confirm the widening doesn't
+    // also run the code-comment scan over it (which would be redundant, not wrong, but the
+    // dedupe-by-claimText would hide a double-scan bug for a claim whose PROSE line doesn't look
+    // like a comment at all — e.g. a bare markdown line never matches `extractCommentProse`).
+    const patch = added('The batch size defaults to 32.');
+    const claims = extractDocClaims(new Map([[DOC, patch]]));
+    expect(claims).toHaveLength(1);
+  });
+
+  it('negatives end-to-end: TODO / attribution / section-header / plain-code-string lines produce no claims', () => {
+    const patch = added(
+      '// TODO: should default to 32 eventually',
+      '// Copyright 2026, required for all files.',
+      '// ---- Configuration ----',
+      'const s = "search reports as disabled";',
+    );
+    expect(extractDocClaims(new Map([[SCHEMA_FILE, patch]]))).toHaveLength(0);
+  });
+
+  it('caps code-derived claims at MAX_CODE_CLAIMS (10), separately from doc-surface claims', () => {
+    const lines = Array.from({ length: 15 }, (_, i) => `// Feature${i} defaults to ${i}.`);
+    const patch = added(...lines);
+    expect(extractDocClaims(new Map([[SCHEMA_FILE, patch]]))).toHaveLength(10);
+  });
+
+  it('does not let a comment-heavy code diff crowd out doc-surface claims', () => {
+    const codeLines = Array.from({ length: 15 }, (_, i) => `// Feature${i} defaults to ${i}.`);
+    const patches = new Map([
+      [SCHEMA_FILE, added(...codeLines)],
+      [DOC, added('The batch size defaults to 32.')],
+    ]);
+    const claims = extractDocClaims(patches);
+    expect(claims).toHaveLength(11); // 10 code claims (capped) + 1 doc-surface claim
+    expect(claims.filter(c => c.file === DOC)).toHaveLength(1);
+    expect(claims.filter(c => c.file === SCHEMA_FILE)).toHaveLength(10);
+  });
+
+  it('ranks a small code-comment hunk ahead of a much larger doc-surface hunk (smallest-hunk-first fairness)', () => {
+    const bigDocPatch = added(
+      ...Array.from({ length: 30 }, (_, i) => `Some descriptive prose line number ${i}.`),
+      'The batch size defaults to 32.',
+    );
+    const tinyCodePatch = added(
+      '     * keep working; search_code and find_similar report as disabled.',
+    );
+    const claims = extractDocClaims(
+      new Map([
+        [DOC, bigDocPatch],
+        [SCHEMA_FILE, tinyCodePatch],
+      ]),
+    );
+    expect(claims[0].file).toBe(SCHEMA_FILE); // the tiny hunk sorts first
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaimEvidence — referenced-file diff prefetch (issue: PR #811's own review)
+// ---------------------------------------------------------------------------
+
+describe('findClaimEvidence — referenced-file diff prefetch', () => {
+  const WORKFLOW_FILE = '.github/workflows/lien-review.yml';
+
+  function workflowPatch(): string {
+    return added("  LIEN_STALE_DUP_PASS: 'on'", "  LIEN_INCOMPLETE_PASS: 'on'");
+  }
+
+  it('prefetches the diff hunk for a cited file that is part of the PR, even with NO repo index at all', () => {
+    const claim = claimWithCitedPath(
+      'sets `LIEN_STALE_DUP_PASS` in .github/workflows/lien-review.yml',
+      { path: WORKFLOW_FILE },
+    );
+    const patches = new Map([[WORKFLOW_FILE, workflowPatch()]]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    expect(ev.fromDiff).toBe(true);
+    expect(ev.fromDoc).toBe(false);
+    expect(ev.file).toBe(WORKFLOW_FILE);
+    expect(ev.excerpt).toContain('LIEN_STALE_DUP_PASS');
+    expect(ev.startLine).toBe(1);
+  });
+
+  it('resolves a cited path that is a suffix of a changed file key (leniency parity with the indexed-chunk lookup)', () => {
+    const claim = claimWithCitedPath('see workflows/lien-review.yml', {
+      path: 'workflows/lien-review.yml',
+    });
+    const patches = new Map([[WORKFLOW_FILE, workflowPatch()]]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    expect(ev.file).toBe(WORKFLOW_FILE);
+    expect(ev.fromDiff).toBe(true);
+  });
+
+  it('prefers the PR diff hunk over an indexed chunk when the cited file is both changed and indexed', () => {
+    const claim = claimWithCitedPath('see packages/review/src/defaults.ts', {
+      path: 'packages/review/src/defaults.ts',
+    });
+    const patches = new Map([
+      ['packages/review/src/defaults.ts', added('export const X = 1; // from diff')],
+    ]);
+    const chunks = [
+      chunk('packages/review/src/defaults.ts', 40, 'export const X = 2; // from index'),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set(), patches)!;
+    expect(ev.fromDiff).toBe(true);
+    expect(ev.excerpt).toContain('from diff');
+    expect(ev.excerpt).not.toContain('from index');
+  });
+
+  it('falls back to the indexed chunk when the cited file is not part of the PR diff', () => {
+    const claim = claimWithCitedPath('see packages/review/src/defaults.ts', {
+      path: 'packages/review/src/defaults.ts',
+    });
+    const patches = new Map([['some/other/file.ts', added('unrelated')]]);
+    const chunks = [chunk('packages/review/src/defaults.ts', 40, 'export const X = 2;')];
+    const ev = findClaimEvidence(claim, chunks, new Set(), patches)!;
+    expect(ev.fromDiff).toBeFalsy();
+    expect(ev.file).toBe('packages/review/src/defaults.ts');
+  });
+
+  it('degrades loudly, naming the index AND the PR diff, when the cited path resolves against neither', () => {
+    const claim = claimWithCitedPath('see packages/review/src/ghost.ts', {
+      path: 'packages/review/src/ghost.ts',
+    });
+    const patches = new Map([['some/other/file.ts', added('unrelated')]]);
+    const chunks = [chunk('packages/review/src/defaults.ts', 1, 'export const X = 1;')];
+    const ev = findClaimEvidence(claim, chunks, new Set(), patches)!;
+    expect(ev.citedPathMissing).toBe(true);
+
+    const md = renderDocClaims([{ ...claim, evidence: ev }]);
+    expect(md).toContain('was not found in the index or PR diff');
+    expect(md).not.toContain('```'); // a one-line note, not a fenced block
+  });
+
+  it('caps an oversized diff-hunk excerpt with a loud truncation note', () => {
+    const claim = claimWithCitedPath('see packages/review/src/big.ts', {
+      path: 'packages/review/src/big.ts',
+    });
+    const bigPatch = added('x '.repeat(500));
+    const patches = new Map([['packages/review/src/big.ts', bigPatch]]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    expect(ev.excerpt).toContain('[diff truncated to respect the input budget]');
+    expect(ev.excerpt.length).toBeLessThan(bigPatch.length);
+  });
+
+  it('renders the "evidence (PR diff)" label distinctly from sibling-doc/plain evidence', () => {
+    const claim = claimWithCitedPath('see .github/workflows/lien-review.yml', {
+      path: WORKFLOW_FILE,
+    });
+    const patches = new Map([[WORKFLOW_FILE, workflowPatch()]]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    const md = renderDocClaims([{ ...claim, evidence: ev }]);
+    expect(md).toContain('evidence (PR diff)');
+  });
+
+  it('backward-compatible: omitting the patches argument entirely preserves the pre-existing repoChunks-only behavior', () => {
+    const claim = claimWithCitedPath('see packages/review/src/defaults.ts', {
+      path: 'packages/review/src/defaults.ts',
+    });
+    const chunks = [
+      chunk('packages/review/src/defaults.ts', 12, 'export const DEFAULT_REVIEW_MODEL = 1;'),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set())!; // no 4th arg — old call shape
+    expect(ev.fromDiff).toBeUndefined();
+    expect(ev.file).toBe('packages/review/src/defaults.ts');
+  });
+});
+
+describe('attachEvidence — referenced-file diff prefetch wiring', () => {
+  it('passes context.pr.patches through so a citedPath claim gets diff evidence', () => {
+    const WORKFLOW_FILE = '.github/workflows/lien-review.yml';
+    const ctx = {
+      changedFiles: [],
+      chunks: [],
+      pr: { patches: new Map([[WORKFLOW_FILE, added("LIEN_STALE_DUP_PASS: 'on'")]]) },
+    } as unknown as ReviewContext;
+    const claims = attachEvidence(
+      [
+        claimWithCitedPath('sets LIEN_STALE_DUP_PASS in .github/workflows/lien-review.yml', {
+          path: WORKFLOW_FILE,
+        }),
+      ],
+      ctx,
+    );
+    expect(claims[0].evidence?.fromDiff).toBe(true);
   });
 });

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -718,6 +718,26 @@ describe('extractCommentProse', () => {
     );
   });
 
+  // Regression (Lien Review finding on this PR, #814): a same-line block-comment/triple-quote
+  // CLOSER must not leak into the captured prose.
+  it('strips the same-line closer off a single-line block comment (`/** ... */`)', () => {
+    expect(extractCommentProse('/** Defaults to true. */')).toBe('Defaults to true.');
+    expect(extractCommentProse('/* Defaults to true. */')).toBe('Defaults to true.');
+  });
+
+  it('still captures a block-comment opener with no closer on this line (multi-line JSDoc)', () => {
+    expect(extractCommentProse('/** Defaults to true')).toBe('Defaults to true');
+  });
+
+  it('strips the same-line closer off a single-line triple-quoted docstring', () => {
+    expect(extractCommentProse('"""Required."""')).toBe('Required.');
+    expect(extractCommentProse("'''Required.'''")).toBe('Required.');
+  });
+
+  it('still captures a triple-quote opener with no closer on this line (multi-line docstring)', () => {
+    expect(extractCommentProse('"""Required.')).toBe('Required.');
+  });
+
   it('extracts a .describe(...) call — the config-schema-description shape', () => {
     expect(extractCommentProse(".describe('Defaults to 20 when omitted.'),")).toBe(
       'Defaults to 20 when omitted.',

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -738,9 +738,24 @@ describe('extractCommentProse', () => {
     expect(extractCommentProse('"""Required.')).toBe('Required.');
   });
 
+  // Regression (Lien Review finding on this PR): a closer with an EXTRA star (`**/`, as opposed
+  // to the plain `*/`) must be stripped in full, not leave a stray trailing `*` behind.
+  it('strips a doubled-star closer (`**/`) in full, leaving no stray star', () => {
+    expect(extractCommentProse('/** Defaults to true. **/')).toBe('Defaults to true.');
+    expect(extractCommentProse('/* Defaults to true. **/')).toBe('Defaults to true.');
+  });
+
   it('extracts a .describe(...) call — the config-schema-description shape', () => {
     expect(extractCommentProse(".describe('Defaults to 20 when omitted.'),")).toBe(
       'Defaults to 20 when omitted.',
+    );
+  });
+
+  // Regression (CodeRabbit finding on this PR): an escaped quote inside the description string
+  // must not be mistaken for the closing delimiter.
+  it('does not truncate a .describe(...) string at an escaped quote', () => {
+    expect(extractCommentProse(".describe('User\\'s mode defaults to safe.'),")).toBe(
+      "User\\'s mode defaults to safe.",
     );
   });
 
@@ -860,6 +875,28 @@ describe('extractDocClaims — widened to changed CODE files', () => {
     expect(extractDocClaims(new Map([[SCHEMA_FILE, patch]]))).toHaveLength(10);
   });
 
+  // Regression (CodeRabbit finding on this PR): the cap must count NET-NEW code claims, not
+  // raw pre-dedup candidates — a source's own duplicate of an already-seen claim must not spend
+  // budget a later, genuinely unique claim from that same source needs.
+  it('code-claim cap counts net-new claims, not pre-dedup candidates', () => {
+    const dupLine = 'The batch size defaults to 32.';
+    const codeLines = [
+      ...Array.from({ length: 10 }, () => `// ${dupLine}`),
+      '// A totally separate claim requires special handling here.',
+    ];
+    const patches = new Map([
+      [DOC, added(dupLine)], // smaller hunk — sorts first, seeds `seen` before the code file
+      [SCHEMA_FILE, added(...codeLines)],
+    ]);
+    const claims = extractDocClaims(patches);
+    // Only 2 distinct claims survive: the guidance one, and the 11th code line's unique claim —
+    // the 10 duplicate code lines contribute nothing and must not have consumed the cap.
+    expect(claims).toHaveLength(2);
+    expect(claims.some(c => c.file === SCHEMA_FILE && c.claimText.includes('separate claim'))).toBe(
+      true,
+    );
+  });
+
   it('does not let a comment-heavy code diff crowd out doc-surface claims', () => {
     const codeLines = Array.from({ length: 15 }, (_, i) => `// Feature${i} defaults to ${i}.`);
     const patches = new Map([
@@ -923,6 +960,30 @@ describe('findClaimEvidence — referenced-file diff prefetch', () => {
     const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
     expect(ev.file).toBe(WORKFLOW_FILE);
     expect(ev.fromDiff).toBe(true);
+  });
+
+  // Regression (CodeRabbit finding on this PR): an EXACT path match must win over a suffix match
+  // regardless of Map iteration order, and an AMBIGUOUS suffix (two candidates share it) must
+  // resolve to neither rather than an arbitrary one.
+  it('prefers an exact path match over a same-suffix decoy, regardless of iteration order', () => {
+    const claim = claimWithCitedPath('see lien-review.yml', { path: 'lien-review.yml' });
+    const patches = new Map([
+      ['some/other/lien-review.yml', 'decoy patch'], // suffix match, but NOT exact — and first
+      ['lien-review.yml', 'the real one'], // exact match
+    ]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    expect(ev.file).toBe('lien-review.yml');
+    expect(ev.excerpt).toContain('the real one');
+  });
+
+  it('does not resolve an ambiguous suffix shared by two changed files', () => {
+    const claim = claimWithCitedPath('see lien-review.yml', { path: 'lien-review.yml' });
+    const patches = new Map([
+      ['a/lien-review.yml', 'patch A'],
+      ['b/lien-review.yml', 'patch B'],
+    ]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    expect(ev.citedPathMissing).toBe(true);
   });
 
   it('prefers the PR diff hunk over an indexed chunk when the cited file is both changed and indexed', () => {

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -556,6 +556,28 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
     expect((initialMessage.match(/<\/rename_sweep>/g) ?? []).length).toBe(1);
   });
 
+  // Referenced-file evidence prefetch (issue: PR #811's own review) — v2 render parity with v1's
+  // renderClaimEntry: a claim whose citation resolves against the PR's own diff must carry the
+  // "evidence (PR diff)" label here too, not just in the v1 renderer.
+  it('v2 worklist labels referenced-file evidence "evidence (PR diff)" when the citation resolves against the PR diff', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const WORKFLOW_FILE = '.github/workflows/lien-review.yml';
+    const docPatch = `@@ -1,2 +1,3 @@
+ # Review pass architecture
++By default, this repo's \`LIEN_STALE_DUP_PASS\` env var is set in \`${WORKFLOW_FILE}\`.`;
+    const workflowPatch = `@@ -10,1 +10,1 @@
+-  LIEN_STALE_DUP_PASS: 'off'
++  LIEN_STALE_DUP_PASS: 'on'`;
+    const ctx = contextWithPatches([
+      ['docs/architecture/review-pass-architecture.md', docPatch],
+      [WORKFLOW_FILE, workflowPatch],
+    ]);
+    const { initialMessage } = buildDocTruthPassPrompts(ctx);
+
+    expect(initialMessage).toContain('evidence (PR diff)');
+    expect(initialMessage).toContain("LIEN_STALE_DUP_PASS: 'on'");
+  });
+
   it('buildDocTruthPassInitialMessageV2 omits <doc_claims>/<rename_sweep> entirely when the worklist is empty', () => {
     const ctx = contextWithPatches([['packages/core/src/overlay.ts', CODE_PATCH]]);
     const message = buildDocTruthPassInitialMessageV2(ctx, buildClaimWorklist(ctx));


### PR DESCRIPTION
## Summary

Two deterministic widenings of doc-truth's claim-discovery layer, both addressing measured misses (signals doctrine: discovery = deterministic code, judgment = LLM).

**A. Claim extraction now scans changed CODE files, not just guidance/doc surfaces.** `extractDocClaims` previously called `collectGuidanceSurfaceChanges` only — an ordinary source file's comment was invisible to the worklist no matter how claim-shaped. pr658's Finding A (the `schema.ts` `embeddings.enabled` doc comment) is the canonical case this closes: it scored ~1/3 historically and 0/3 under the v2 per-claim contract because the claim was **never listed** for any contract to force engagement with. The widening scans ADDED lines of non-guidance analyzable code files for comment/docstring/description-literal shapes only (`//`, `#`, JSDoc `*` continuation, `/**`/`/*` openers, `"""`/`'''`, Rust `///`/`//!`, zod `.describe(...)`, `description: "..."`) — never arbitrary code — and excludes TODO/FIXME/attribution/doc-comment-tag lines even when comment-shaped (a TODO describes intended future work, not a current-behavior claim). Code-derived claims are capped separately (`MAX_CODE_CLAIMS = 10`) so a comment-heavy code diff can't crowd out doc-surface claims. Both sources are merged into one smallest-hunk-first order (same budget-fairness rationale `collectGuidanceSurfaceChanges` already uses), so a small surgical code-comment change (schema.ts: one line) ranks ahead of a large doc rewrite.

**B. Referenced-file evidence prefetch.** When a claim's own excerpt cites a concrete file path (`DocClaim.citedPath`, existing #749 mechanism) and that file is part of THIS PR's diff, its diff hunk is fetched directly (byte-capped, `MAX_DIFF_EVIDENCE_CHARS = 800`) in preference to the indexed-chunk lookup. Motivated by PR #811's own review: a doc claim cited `.github/workflows/lien-review.yml`, which WAS in that PR's diff but isn't AST-analyzable, so it never reaches `repoChunks` — the pass reported the claim "not available in the review material… before budget exhaustion" despite the settling material sitting in the diff the whole time. Falls back to the existing indexed lookup, then a loud "not found in the index or PR diff" note (never silent omission) when neither resolves.

Both changes apply to the v1 open findings list AND the v2 per-claim verdict contract (`LIEN_DOC_TRUTH_V2=on`) — discovery improvements benefit both, see census below.

## Design

- `packages/review/src/doc-claims-signals.ts`: `collectClaimSources` (unifies guidance + code-file sources, smallest-hunk-first), `extractCommentProse`/`addedCodeCommentLines` (the comment/docstring/description-literal line filter), `claimsFromSource` (per-source extraction respecting the code-claim budget), `findCitedPathDiffEvidence`/`buildDiffEvidence` (the diff-hunk prefetch), `DocClaimEvidence.fromDiff` (new field, renders as `evidence (PR diff)`).
- `packages/review/src/plugins/agent/doc-truth-pass.ts`: `renderDocClaimEntryWithId` (v2 renderer) updated for `fromDiff` label parity with v1.
- Both `findClaimEvidence`/`findCitedPathEvidence` take a new optional `patches` param — omitting it (existing call sites, e.g. all pre-existing tests) preserves prior repoChunks-only behavior exactly.

## Evidence

### 1. Unit tests (37 new, all passing; 159/159 total in the two touched test files, 1279/1279 in the whole `@liendev/review` package — includes the 5 regression tests added during review triage, see below)

- Extraction positives: pr658 Finding A's exact JSDoc-comment shape (acceptance test, see below), `.describe(...)` / `description: "..."` literals, `//`/`#`/`///`/`//!` comments, a citedPath extracted from a code comment referencing a workflow path.
- Extraction negatives: TODO/FIXME comments (even when claim-shaped), attribution/copyright lines, doc-comment tags (`@param`), plain code strings with no comment/description shape, shebangs, preprocessor directives, section-header dividers.
- `MAX_CODE_CLAIMS` cap + "doesn't crowd out doc-surface claims" + smallest-hunk-first fairness ordering.
- Prefetch present (diff hunk, even with zero repo index), prefetch preferred over an indexed chunk, prefetch absent (falls back to index), prefetch capped (oversized hunk truncated with a loud note), loud degradation (neither source resolves), backward-compatible 3-arg call shape.
- One v2-renderer parity test in `plugins-agent-doc-truth-pass.test.ts` confirming `evidence (PR diff)` renders in the per-claim worklist too.

### 2. Byte-diff census (build-prompts.ts, before/after, v1 and v2)

Ran `tsx build-prompts.ts <fixture>` against every on-disk fixture (the repo's 3 committed synthetic/placeholder fixtures, plus a fresh `capture-pr.ts 658` capture) with the OLD code (`git stash`) vs NEW code, both v1 (flag off) and v2 (`LIEN_DOC_TRUTH_V2=on`):

| Fixture | Rule | v1 changed? | v2 changed? |
|---|---|---|---|
| `boundary-change/placeholder` | boundary-change (unrelated) | **identical** (0 byte diff) | **identical** |
| `doc-truth/accurate-doc` | doc-truth | changed | changed |
| `doc-truth/renamed-stale-claim` | doc-truth | changed | changed |
| `doc-truth/pr658-search-code-rename` (fresh capture) | doc-truth | changed | changed |

Only doc-truth-firing fixtures changed; the unrelated rule's fixture is byte-identical, confirming no blast radius outside doc-truth's own signal.

**How they changed** (all three doc-truth fixtures share the same root cause): `accurate-doc` and `renamed-stale-claim` are both single-code-file diffs (a JSDoc comment on a status/schema function) with **no guidance surface touched at all**. Before this change, `extractDocClaims` found zero claims for both, so `shouldRunDocTruthPass`/`docTruthPass.fires` was `false` — the dedicated second pass never ran; only the main pass's keyword-triggered competing list could catch anything. After: the JSDoc comment is extracted, `docTruthPass.fires` flips `false → true` for both, and `<doc_claims>` now appears in the main pass too. `accurate-doc`'s existing certified assertion (`expectEmpty` — the claim is TRUE and must draw no finding) is unaffected in expectation: the dedicated pass now verifies the same true claim with LESS competition, not more, so silence should hold (not re-run under paid votes — out of the $0.75 budget scoped to pr658 only).

**pr658 (the real fixture)** — the acceptance-critical result: the v1 `<doc_claims>` block went from **7 claims (zero mentioning `schema.ts`)** to **9 claims, including exactly `packages/core/src/config/schema.ts: "keep working; search_code and find_similar report as disabled."`** — Finding A's real, verbatim claim text from the real PR #658 diff. The v2 per-claim worklist grew from 6 → 9 ids, with Finding A assigned **`claim-2`**. (A second bonus catch: `packages/cli/src/mcp/utils/zod-to-json-schema.ts: "'Full-text code search'"` and a test-file comment claim also newly appear — both legitimate comment-shaped claims the old scan couldn't see.) v1 message size: 99,814 → 101,545 bytes (+1,731, mostly the two new claim entries + evidence excerpts). v2 doc-truth-pass message: 181,955 → 185,496 bytes (+3,541).

### 3. The screen — 3 votes on pr658, `LIEN_DOC_TRUTH_V2=on` + this widening

Cost: **$0.298** (well under the $0.75 cap). Traces: `.claude/jobs/535d2452/tmp/docclaims-widening-screen/doc-truth/pr658-search-code-rename/vote-{1,2,3}.json`.

**(a) Finding A now LISTED as a claim id** — confirmed structurally (census above): `claim-2` in the v2 worklist, `packages/core/src/config/schema.ts`, verbatim claim text.

**(b) Per-vote engagement on claim-2 (Finding A)**, read from the doc-truth pass's own raw per-claim verdict (parsed directly from the trace, not just the merged output):
- Vote 1: verdict `contradicted` (correct catch)
- Vote 2: verdict `contradicted` (correct catch)
- Vote 3: verdict `accurate` (a miss — the model corroborated the stale claim against the neighboring `null-embeddings.ts` file, which carries the identical stale claim per the fixture's own header)

That's **2/3 correct at the dedicated-pass verdict level** — up from 0/3 (v2 baseline) and ~1/3 historical (and that 1 was a piggyback inside a different finding's evidence field, never its own dedicated finding — see the fixture header). In the FINAL merged output (main pass ∪ doc-truth pass), a `schema.ts` finding naming the same contradiction is present in **2/3 votes** (vote 2 via the dedicated pass; vote 3 via the MAIN pass independently catching it — its own competing list this run happened to include it, even though the dedicated pass's own verdict was a miss).

**Vote 1 diagnostic finding (pre-existing, not caused by this PR):** vote 1's claim-2 AND claim-7 (Finding B) verdicts were BOTH correctly `contradicted` in the raw doc-truth JSON, but neither survived into the final merged findings. Root cause, traced precisely: **all 5 non-`accurate` findings in vote 1's raw response omitted the `category` field**, and `agent-client-shared.ts`'s `isValidFinding` type guard requires `typeof obj.category === 'string'` — so every one of them was silently dropped by the existing validator. `buildV2OutputContractOverride`'s required-fields list (`claimId, verdict, filepath, line, severity, message`) never mentions `category`, which is likely why the model omitted it this run. This is a **pre-existing v2-contract prompt gap** (the override text and the validator disagree on what's required), symmetric across Finding A and Finding B, entirely inside code this PR does not touch (`agent-client-shared.ts`, `buildV2OutputContractOverride`) — not a regression this widening introduced. Filing as a follow-up rather than fixing here (out of scope, no same-file overlap, avoids scope creep this close to merge): add `category` to the v2 override's required-field list.

**(c) Finding B gate:** raw verdict on claim-7 (`augment-explore-task.sh`, "meaning-based" hook text) was correctly `contradicted` in **3/3** raw votes — the underlying mechanism (`guidance-surface-signals.ts`, completely untouched by this PR) still works. The harness's certified Tier-2 text-match assertion passed **2/3** (vote 1's correct verdict was lost to the pre-existing validation gap above, not a detection failure). Given the verdict-level signal is 3/3 and the loss mechanism is proven pre-existing and unrelated to this diff, this is not treated as a regression this PR introduced.

**(d) Verdict coverage:** **3/3 complete.** Manually cross-checked every vote's raw JSON against the full 51-id v2 worklist (9 doc claims + 42 rename-sweep prose/survivor items from PR #658's 40-file rename sweep): zero missing ids, zero duplicates, zero invalid verdicts, zero ad hoc-only claims masking a gap, in all three votes.

### 4. v1 flag-off note

Confirmed explicitly: v1 (flag off) also renders `<doc_claims>`, so this widening changes the v1 worklist too (see the census table/byte counts above) — intended, since discovery improvements should benefit both contracts, not just v2.

## Review triage (this PR's own Lien Review + CodeRabbit passes)

Per project policy, CI-green is not review-clean — triaged every finding before merge (both candidate loops are on for this repo's own reviews as of #811; this is live dogfood of that config).

**Fixed** (4 — all real, low-risk, isolated to code this PR introduced):
1. Lien Review: `BLOCK_OPEN_RE`'s closer group only stripped a single trailing `*`, so a doubled-star closer (an uncommon but valid block-comment ending) left a stray `*` in the captured prose. Now matches one-or-more trailing stars.
2. CodeRabbit: `DESCRIBE_CALL_RE`/`DESCRIPTION_KEY_RE` stopped at an escaped quote inside a description string (`.describe('User\'s mode...')`), truncating it early. Added an escaped-pair alternative to the capture group.
3. CodeRabbit: the code-claim cap was applied by slicing each source's candidates BEFORE deduping, so a source's own duplicate of an already-seen claim (e.g. the same `.describe(...)` string copy-pasted across sibling schema files) could consume budget a later, genuinely unique claim from that source needed. Restructured around a `claimAdmitter` closure that checks the budget AFTER the dedup check.
4. CodeRabbit: the new diff-based citedPath resolver's suffix match could pick an arbitrary candidate over an exact one depending on `Map` iteration order. Added `resolveExactOrUniqueSuffix`: exact match always wins; a suffix match is accepted only when it's unique among the candidates.

All four have regression tests (159 tests in the two touched test files now, up from 154; 1279/1279 in the whole `@liendev/review` package). `lien delta` after these fixes shows only IMPROVEMENTS (the `claimAdmitter` refactor reduced cognitive complexity in `extractDocClaims`, `claimsFromSource`, and `findCitedPathDiffEvidence` versus the first commit) — see the delta output below.

**Triaged as follow-ups, not fixed here** (2 — both explicitly "Heavy lift" per CodeRabbit's own tagging, architecture-level scope beyond this PR):
1. CodeRabbit: `addedCodeCommentLines` parses line-by-line and doesn't track open/close state across lines, so it misses claims on INTERIOR lines of a multi-line triple-quoted docstring or an unmarked-continuation block comment. This is a real recall gap, but it's consistent with this module's existing, already-accepted design philosophy (the render layer already tells the agent "the scan can miss claims... skim the touched hunks for any not here") — not a new regression, and fixing it properly requires delimiter-state tracking across `newFileLines`, a materially bigger change than this PR's scope.
2. CodeRabbit: `buildDiffEvidence` truncates the RAW patch's first 800 chars rather than centering on the hunk containing `cited.symbol`/claim anchors, so a multi-hunk file's relevant hunk could be missed if it's not first. The motivating #811 case (a workflow YAML) was single-hunk, so this doesn't affect the acceptance-critical scenario; hunk-aware centering needs patch-parsing + hunk-selection logic that's a separate, larger change.

## Gates

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` all green; `node packages/cli/dist/index.js delta` exit 0 (only improvements after the review-triage fixes — see below).

```
lien delta — complexity vs HEAD (after review-triage fixes, vs the pre-fix commit)

  packages/review/src/doc-claims-signals.ts
    · new       claimAdmitter             cognitive – → 4
    · new       resolveExactOrUniqueSuffix cognitive – → 2
    ✓ improved  claimsFromSource          cognitive 4 → 1
    ✓ improved  extractDocClaims          cognitive 9 → 6
    ✓ improved  findCitedPathDiffEvidence cognitive 3 → 2

  ✓ 3 improved · 2 files · exit 0
```

Original delta (first commit, vs `main`) for reference — no threshold crossings, all "worsened"/"new" entries well under threshold:

```
lien delta — complexity vs HEAD

  packages/review/src/doc-claims-signals.ts
    ⚠ worsened  extractDocClaims          cognitive 6 → 9
    ⚠ worsened  findCitedPathEvidence     cognitive 2 → 3
    ⚠ worsened  findClaimEvidence         time 35m → 37m
    ⚠ worsened  attachEvidence            time 7m → 9m
    ⚠ worsened  renderClaimEntry          cognitive 4 → 5
    · new       extractClaims             cognitive – → 4
    · new       extractCommentProse       cognitive – → 7
    · new       addedCodeCommentLines     cognitive – → 5
    · new       collectClaimSources       cyclomatic – → 1
    · new       claimsFromSource          cognitive – → 4
    · new       firstHunkNewStartLine     cognitive – → 1
    · new       buildDiffEvidence         cognitive – → 1
    · new       findCitedPathDiffEvidence cognitive – → 3
    · removed   extractClaimsFromPatch    cognitive 4 → –

  packages/review/src/plugins/agent/doc-truth-pass.ts
    ⚠ worsened  renderDocClaimEntryWithId cognitive 3 → 4

  ⚠ 6 worsened · 4 files · exit 0
```

## Not in scope / follow-ups

- Finding A's `calibrate --10` re-certification against the tightened fixture assertion is the owner's later decision (per the task brief) — this PR's screen numbers are the evidence, not a new certification.
- The `category`-field v2-contract gap found during the screen (see 3(b) above) is a separate, pre-existing issue — filing a follow-up rather than fixing here.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR widens doc-truth claim discovery to comment/docstring/description-literal lines in changed code files and adds diff-hunk prefetch for cited paths. The implementation is backward-compatible (optional `patches` parameter, existing 3-arg callers preserved) and well-guarded: code-derived claims are capped separately, duplicates are deduped before the cap is applied, and cited-path resolution falls back cleanly from diff to index to a loud 'not found' note. The one regex edge case noted in the PR description (stray `*` on `**/` block-comment closers) is already covered by regression tests. No current bugs, breaking changes, or unvalidated untrusted-input paths were found in the changed production code.
>
> - Claim extraction now scans added comment/docstring/description-literal lines in changed code files, capped at MAX_CODE_CLAIMS=10 and merged smallest-hunk-first with guidance/doc-surface claims.
> - Cited-path evidence resolution prefers the PR's own diff hunk over indexed chunks, with distinct 'evidence (PR diff)' labeling in both v1 and v2 renderers and a loud fallback when neither source resolves.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5fb23d4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 329K/310K tokens
<!-- /lien:attestation -->