### PR TITLE
ci(release): swap changesets/action to a PAT to skip bot-PR approval gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,15 @@ jobs:
       published: ${{ steps.changesets.outputs.published }}
       published-packages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
+      # Checked out (and the Version PR below opened/updated) with RELEASE_PAT
+      # rather than the default GITHUB_TOKEN: PRs authored by github-actions[bot]
+      # via GITHUB_TOKEN land `action_required` on every workflow run and need a
+      # human to click "Approve and run workflows" before CI can even start.
+      # Using a real account's PAT makes the Version Packages PR author a known
+      # contributor instead, so its own CI runs without that manual gate.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -145,7 +153,9 @@ jobs:
           # Version Packages PR lands with unsigned commits and can't merge.
           commitMode: github-api
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_PAT (see checkout step above), not the default GITHUB_TOKEN
+          # -- see the checkout step's comment for why.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           # No NPM_TOKEN needed - uses OIDC provenance
 
   registry-smoke:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.RELEASE_PAT }}
+          # Don't leave the write-capable PAT sitting in local git config for
+          # every later step in this job -- changesets/action authenticates
+          # its own git/API operations via the GITHUB_TOKEN env var below, so
+          # nothing downstream needs the checkout's persisted credential.
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -148,13 +153,14 @@ jobs:
           title: 'chore: version packages'
           commit: 'chore: version packages'
           # Push via the GitHub Contents API so commits/tags are auto-signed
-          # by the GITHUB_TOKEN's owner. Required by the main-branch
-          # `required_signatures` ruleset — without this, the auto-opened
-          # Version Packages PR lands with unsigned commits and can't merge.
+          # by the token owner below (RELEASE_PAT's account, not the default
+          # GITHUB_TOKEN). Required by the main-branch `required_signatures`
+          # ruleset — without this, the auto-opened Version Packages PR lands
+          # with unsigned commits and can't merge.
           commitMode: github-api
         env:
-          # RELEASE_PAT (see checkout step above), not the default GITHUB_TOKEN
-          # -- see the checkout step's comment for why.
+          # RELEASE_PAT, not the default GITHUB_TOKEN -- see the checkout
+          # step's comment above for why.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           # No NPM_TOKEN needed - uses OIDC provenance
 


### PR DESCRIPTION
## Summary

This PR is **fix path B** for the "every release PR needs a manual Approve-and-run click" problem — a contingency, not the primary fix. It stays **open, unmerged** until `RELEASE_PAT` exists as a repo secret; see recipe below.

**Primary fix (already applied, no code change needed):** repo setting `fork-pr-contributor-approval` was `first_time_contributors`, now `first_time_contributors_new_to_github` (narrowest available value — API-only, no UI toggle currently shows it). `github-actions[bot]` is an old, non-forked-PR-context account, so it should no longer match "new to GitHub" and its PR-triggered workflow runs should proceed without approval. **Unverified**: no Version Packages PR currently exists to test against (#782 was the last, already merged 2026-07-16) — the next real release PR is the actual test. If that setting change turns out insufficient (or gets reverted/overridden at the org level), this PR is the fallback.

## Why this diff

`changesets/action@v1` in `.github/workflows/release.yml` opens/updates the "Version Packages" PR using the default `secrets.GITHUB_TOKEN`, so the PR (and every workflow run on it) is authored by `github-actions[bot]`. Confirmed via the Actions API across the last ~10 release cycles: every run's `actor` and `triggering_actor` is `github-actions[bot]` and lands `conclusion: action_required` on the first attempt; every historical green run is attempt 2, with `triggering_actor: alfhen` after a manual approval click. This is not a fork-PR situation (`head_repository == repository` on every run) — it's the bot-authored-PR variant of the same gate.

Swapping the token so the PR is authored by a real, known contributor removes it from that check entirely, independent of the repo-setting fix above.

## What Alf needs to do (only path that requires owner action)

1. **Mint a fine-grained PAT** (Settings → Developer settings → Fine-grained personal access tokens → Generate new token), scoped to:
   - **Resource owner:** `getlien`
   - **Repository access:** Only select repositories → `getlien/lien`
   - **Permissions:** Repository permissions →
     - `Contents`: Read and write
     - `Pull requests`: Read and write
   - Expiration: your call (fine-grained PATs support custom/no-expiration per org policy).
2. **Add it as a repo secret**: Settings → Secrets and variables → Actions → New repository secret → name it exactly `RELEASE_PAT`, paste the token value.
3. Merge this PR.

Until step 2 is done, merging this PR would break the release workflow (`secrets.RELEASE_PAT` would resolve empty, breaking checkout/push auth) — **do not merge before the secret exists**.

## Security note

The PAT belongs to a real account and is scoped narrowly (contents + PRs, single repo) — no broader than what `GITHUB_TOKEN` already has via the job's `permissions:` block (`contents: write`, `pull-requests: write`). This does not change who can *merge* or *publish* — publishing still requires a human merging the Version Packages PR; this only changes who *opens* it.

## Test plan

- [ ] `actionlint .github/workflows/release.yml` — passed locally, no findings
- [ ] `npx prettier --check .github/workflows/release.yml` — passed locally
- [ ] Cannot dogfood end-to-end pre-merge: this only takes effect on the next `push` to `main` that triggers `changesets/action`. Real verification happens on the next release cycle — see "What to look for" below.
- [ ] Once merged (after the secret exists), on the next Version Packages PR check: `gh api repos/getlien/lien/actions/runs --jq '.workflow_runs[] | select(.head_branch=="changeset-release/main") | {conclusion, actor: .actor.login}'` — actor should now be the PAT owner's login (not `github-actions[bot]`), and `conclusion` should not be `action_required` on the first attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use a dedicated release credential for repository checkout and publishing.
  * Clarified release workflow comments and credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 498 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Medium Risk**
>
> Swaps the release workflow's authentication token from the default `secrets.GITHUB_TOKEN` to a dedicated `secrets.RELEASE_PAT` for both checkout and the `changesets/action` step. The goal is to make the automated "Version Packages" PR appear as authored by a real account rather than `github-actions[bot]`, bypassing the repository's bot-PR approval gate that currently stalls every release PR at `action_required`. The change is narrow and scoped to the same permissions (`contents: write`, `pull-requests: write`), but it is operationally sensitive: merging before the `RELEASE_PAT` secret exists would break the release workflow because both checkout and changesets would authenticate with an empty token.
>
> - Adds explanatory comments above the checkout and changesets steps documenting why `RELEASE_PAT` is used instead of `GITHUB_TOKEN`
> - Configures `actions/checkout@v4` with `token: ${{ secrets.RELEASE_PAT }}` and `persist-credentials: false` so the Version Packages PR is opened/updated under a real contributor account without leaving the PAT in git config
> - Changes the `GITHUB_TOKEN` environment variable passed to `changesets/action@v1` from `secrets.GITHUB_TOKEN` to `secrets.RELEASE_PAT`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5697bc1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->