### PR TITLE
fix(review): name category among the required fields in per-claim verdict contracts

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -458,11 +458,12 @@ the mandatory per-claim verdicts AND any extra findings you spot beyond the work
 EXACTLY one verdict entry is REQUIRED per id in ${ids.length > 0 ? ids.join(', ') : '(none — no worklist ids this run)'} —
 no more, no fewer per id. An extra finding for a claim NOT in the worklist is legal and unlimited
 — omit \`claimId\`/\`verdict\` on those; they need no verdict and are evaluated as ordinary
-findings. EVERY verdict entry requires claimId, verdict, filepath, line, severity, and message —
-even for accurate/unverifiable (use the claim's own file for filepath; best-effort line; severity
-"warning" unless contradicted, where the usual bug-severity judgment applies). A missing,
-duplicated, or unrecognized claimId, or a missing/invalid verdict on a claimed entry, makes this
-pass's result incomplete.
+findings. EVERY verdict entry requires claimId, verdict, filepath, line, severity, category, and
+message — even for accurate/unverifiable (use the claim's own file for filepath; best-effort
+line; severity "warning" unless contradicted, where the usual bug-severity judgment applies;
+category any short slug, e.g. "bug"). A missing category silently drops the ENTIRE entry, same as
+a missing claimId/verdict. A missing, duplicated, or unrecognized claimId, or a missing/invalid
+verdict or category on a claimed entry, makes this pass's result incomplete.
 </output_format_v2_override>`;
 }
 

--- a/packages/review/src/plugins/agent/incomplete-handling-pass.ts
+++ b/packages/review/src/plugins/agent/incomplete-handling-pass.ts
@@ -395,10 +395,11 @@ id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
   }
 }
 
-EVERY entry requires candidateId, verdict, filepath, line, severity, and message —
+EVERY entry requires candidateId, verdict, filepath, line, severity, category, and message —
 even for handled/intentional/unverifiable verdicts (fill filepath/line from the
-candidate's own site, severity "warning", message explaining the disposition).
-A missing candidateId for any worklist entry makes this pass's result incomplete.
+candidate's own site, severity "warning", category any short slug e.g. "logic_error", message
+explaining the disposition). A missing category silently drops the ENTIRE entry, same as a
+missing candidateId — both make this pass's result incomplete.
 </output_format>`;
 }
 

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -360,10 +360,11 @@ id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
   }
 }
 
-EVERY entry requires candidateId, verdict, filepath, line, severity, and message —
+EVERY entry requires candidateId, verdict, filepath, line, severity, category, and message —
 even for intentional-reuse/unverifiable verdicts (fill filepath/line from the
-candidate's changed site, severity "warning", message explaining the disposition).
-A missing candidateId for any worklist entry makes this pass's result incomplete.
+candidate's changed site, severity "warning", category any short slug e.g. "logic_error",
+message explaining the disposition). A missing category silently drops the ENTIRE entry, same as
+a missing candidateId — both make this pass's result incomplete.
 </output_format>`;
 }
 

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -133,6 +133,43 @@ describe('isValidFinding', () => {
     expect(isValidFinding({ ...finding, severity: 'info' })).toBe(false); // bad severity
     expect(isValidFinding({ ...finding, filepath: undefined })).toBe(false);
   });
+
+  /**
+   * Regression for the #814 doc-truth-v2 screen: a real captured vote (doc-truth v2, pr658
+   * fixture) had the model emit every one of its 48 per-claim verdict entries WITHOUT `category`
+   * — including the entry for the Finding B claim (`augment-explore-task.sh:64`,
+   * "meaning-based discovery") — while its two ad hoc findings beyond the worklist (not governed
+   * by the per-claim contract) both carried `category` normally. Root cause: the v2/stale-
+   * duplicate/incomplete-handling output contracts' "EVERY entry requires ..." sentence never
+   * named `category`, even though their own example JSON includes it — the model followed the
+   * explicit list literally and dropped exactly the one field missing from it. Since this
+   * validator silently filters any finding missing `category` (readVerdict's
+   * `.filter(isValidFinding)`), that vote lost every per-claim finding, including Finding B,
+   * before doc-truth's own verdict-coverage check ever saw them. Fixed by naming `category` in
+   * all three contracts' required-field sentences (doc-truth-pass.ts, stale-duplicate-pass.ts,
+   * incomplete-handling-pass.ts) rather than relaxing this validator — `category` is load-bearing
+   * for every OTHER consumer (engine.ts's dedupe key and rendering, sarif.ts's ruleId, index.ts's
+   * architectural/summary partitioning), so making it optional here would push `undefined`
+   * through call sites that assume it's always a string.
+   */
+  it('rejects a real captured per-claim verdict entry missing category (#814)', () => {
+    const capturedClaimFourFinding = {
+      claimId: 'claim-4',
+      verdict: 'contradicted',
+      filepath: 'plugins/claude/hooks/augment-explore-task.sh',
+      line: 64,
+      severity: 'warning',
+      // no `category` — this is the exact shape the model emitted for every claim in the
+      // affected vote, not a hypothetical.
+      message:
+        "The hook calls search_code 'REQUIRED for meaning-based discovery', but the tool is " +
+        "lexical full-text (BM25) keyword search with no embeddings; 'meaning-based' mislabels " +
+        'the mechanism.',
+    };
+    expect(isValidFinding(capturedClaimFourFinding)).toBe(false);
+    // Restoring the field the fixed prompt now explicitly requires is enough to pass.
+    expect(isValidFinding({ ...capturedClaimFourFinding, category: 'bug' })).toBe(true);
+  });
 });
 
 describe('isValidSummary', () => {

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -559,6 +559,23 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
     expect(systemPrompt).toContain('get_complexity');
   });
 
+  // Regression for the #814 doc-truth-v2 screen: a real captured vote had the model omit
+  // `category` from every one of its 48 per-claim verdict entries, silently dropping them all
+  // at `isValidFinding` (which requires `category`) — including the entry for the certified
+  // Finding B claim — because this sentence didn't name `category`, even though the example
+  // JSON above it does. The model followed the explicit required-field list literally.
+  it('names category among the required fields, not just in the illustrative example', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const { systemPrompt } = buildDocTruthPassPrompts(ctx);
+    const match = systemPrompt.replace(/\n/g, ' ').match(/EVERY verdict entry requires[^.]*\./);
+    expect(match).toBeTruthy();
+    expect(match?.[0]).toContain('category');
+  });
+
   it('renders <doc_claims> and <rename_sweep> with [claim-N] ids and the contract note', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const ctx = contextWithPatches([

--- a/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
+++ b/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
@@ -479,6 +479,20 @@ describe('buildIncompleteHandlingPassPrompts', () => {
     expect(systemPrompt).toContain('candidate-1');
   });
 
+  // Regression for the #814 doc-truth-v2 screen: a real captured vote had the model omit
+  // `category` from every per-claim verdict entry, silently dropping them all at
+  // `isValidFinding` (which requires `category`) — because the contract's "EVERY entry
+  // requires ..." sentence didn't name it, even though the example JSON above it does. This
+  // pass's contract shares the identical sentence shape, so it carried the same latent gap.
+  it('names category among the required fields, not just in the illustrative example', () => {
+    const { systemPrompt } = buildIncompleteHandlingPassPrompts(mixedContext());
+    const requiredFieldsSentence = systemPrompt
+      .split('\n')
+      .find(line => line.startsWith('EVERY entry requires'));
+    expect(requiredFieldsSentence).toBeDefined();
+    expect(requiredFieldsSentence).toContain('category');
+  });
+
   it('builds an initial message with the worklist tagged by shape', () => {
     const message = buildIncompleteHandlingPassInitialMessage(mixedContext());
     expect(message).toContain('<pr_metadata>');

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -199,6 +199,20 @@ describe('buildStaleDuplicatePassPrompts', () => {
     expect(systemPrompt).toContain('candidate-1');
   });
 
+  // Regression for the #814 doc-truth-v2 screen: a real captured vote had the model omit
+  // `category` from every per-claim verdict entry, silently dropping them all at
+  // `isValidFinding` (which requires `category`) — because the contract's "EVERY entry
+  // requires ..." sentence didn't name it, even though the example JSON above it does. This
+  // pass's contract shares the identical sentence shape, so it carried the same latent gap.
+  it('names category among the required fields, not just in the illustrative example', () => {
+    const { systemPrompt } = buildStaleDuplicatePassPrompts(eligibleContext());
+    const requiredFieldsSentence = systemPrompt
+      .split('\n')
+      .find(line => line.startsWith('EVERY entry requires'));
+    expect(requiredFieldsSentence).toBeDefined();
+    expect(requiredFieldsSentence).toContain('category');
+  });
+
   // Regression coverage for the confirmed FP probe finding on a real captured
   // PR: this pass verdicted "stale" on a test-helper mock hardcoding a
   // production rule's display name/category purely to build a fake object —


### PR DESCRIPTION
## Summary

`isValidFinding` (`agent-client-shared.ts`) requires `category: string` on
every finding, but the three per-claim verdict output contracts —
doc-truth v2 (`doc-truth-pass.ts`), stale-duplicate (`stale-duplicate-pass.ts`),
and incomplete-handling (`incomplete-handling-pass.ts`) — never named
`category` in their "EVERY entry requires ..." required-field sentence, even
though the illustrative example JSON directly above it includes one.

**Concrete evidence** (not hypothetical): a real captured doc-truth v2 vote
for the `pr658-search-code-rename` fixture (`.../doctruth-v2-screen/traces/doc-truth/pr658-search-code-rename/vote-2.json`)
shows the model following the explicit required-field list literally — it
omitted `category` from **every one of its 48 per-claim verdict entries**,
including the certified Finding B claim (`augment-explore-task.sh:64`,
"meaning-based discovery"), while its two ad hoc findings (not governed by
that list) both carried `category` normally. Since `readVerdict`'s
`.filter(isValidFinding)` runs before doc-truth's own verdict-coverage check
ever sees the raw findings, this silently drops the ENTIRE per-claim
findings list for that vote and marks the pass `incomplete_verdict`.

## Direction chosen

Fixed the **prompt text** (named `category` in all three contracts'
required-field sentences), not the validator. `category` is load-bearing
for other `isValidFinding` consumers that assume it's always a string with
no null-check: `engine.ts`'s finding dedupe key and category-derived
rendering, `sarif.ts`'s `ruleId`/`shortDescription`, and `index.ts`'s
architectural/summary partitioning. Relaxing the validator to make
`category` optional would push `undefined` through all of those call sites
for every rule in the system, not just these three passes — a much bigger
invariant to break than naming an already-illustrated field as required.

Checked all three verdict-contract passes for the same latent gap (asked
for in the brief) — confirmed present in all three, fixed consistently.

## Testing

- `packages/review/test/plugins-agent-client-shared.test.ts`: new
  regression test using the *actual* captured claim-4 finding shape from
  the vote-2.json trace above (missing `category`) — asserts
  `isValidFinding` rejects it, and that restoring `category` (what the
  fixed prompt now requires) makes it valid.
- `packages/review/test/plugins-agent-doc-truth-pass.test.ts`,
  `plugins-agent-stale-duplicate-pass.test.ts`,
  `plugins-agent-incomplete-handling-pass.test.ts`: new tests asserting
  each pass's built system prompt names `category` in its "EVERY [verdict]
  entry requires ..." sentence, not just in the example JSON.
- All 4 suites green (217 tests).

## Dogfood evidence (byte-diff census, per CLAUDE.md's review-engine gate)

Ran `test/harness/build-prompts.ts` against the tracked
`renamed-stale-claim.fixture.json` doc-truth fixture, before vs after this
change, with `LIEN_DOC_TRUTH_V2` off and on:

- **Flag OFF**: `diff before-off.json after-off.json` → **byte-identical**
  (v1 path is untouched — `buildV2OutputContractOverride` is unreachable
  when the flag is off).
- **Flag ON**: the diff is confined to the `systemPrompt` field's contract
  sentence — `initialMessage` and every other field are unchanged, and the
  only textual delta is `category` being added to the required-field list
  (plus a short clause on what a missing category now costs).

## Full gate chain (all green)

```
npm ci                      # this worktree had no node_modules — fresh install
npm run build:native -w @liendev/parser-native   # needed for packages/parser-native's own suite
npm run format:check        # pass
npm run lint                # pass (0 errors, pre-existing warnings only)
npm run typecheck            # pass
npm run build                 # pass
npm test                      # pass — 1293+860+374+41+27 = full monorepo suite green
node packages/cli/dist/index.js delta   # "no complexity changes across 7 file(s) vs HEAD (133 ms)", exit 0
```

## Coordination note

Checked for the concurrent doc-truth-v2 measurement work
(`runner-findingA-recert`) before opening this PR per the task brief: its
Finding-A re-certification job completed with **no PR opened** (missed the
bar for an unrelated evidence-attachment bug), and its in-progress v2
family screen is investigating an unrelated FP question (unverifiable-verdict
promotion). Neither has a completed cert that this change would invalidate.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a narrow prompt-text fix: it adds `category` to the explicit required-field sentence in the three per-claim verdict output contracts (doc-truth v2, stale-duplicate, incomplete-handling) so models no longer omit the field and have their verdict entries silently filtered by `isValidFinding`. The validator itself is unchanged, which is the correct call because `category` is load-bearing for engine.ts deduplication, SARIF output, and summary partitioning. The change is confined to system-prompt strings, has no signature/export changes, and is covered by four new regression tests including one using the real captured missing-category shape.
>
> - Added `category` to the 'EVERY entry requires ...' sentence in doc-truth-pass.ts, stale-duplicate-pass.ts, and incomplete-handling-pass.ts
> - Added regression tests verifying the prompt text and that `isValidFinding` rejects the captured missing-category shape

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 268db09. Updates automatically on new commits.</sup>
<!-- /lien-stats -->