### PR TITLE
fix(review): multiline claim tracking + hunk-aware evidence centering

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -421,6 +421,26 @@ const ATTRIBUTION_RE = /^(?:copyright\b|co-authored-by|signed-off-by)/i;
 const TAG_LINE_RE = /^@\w+\b/;
 
 /**
+ * Apply the shared claim-candidate noise filter (TODO/attribution/doc-tag — see the constants
+ * above) to already-extracted comment/docstring prose, returning the trimmed text or undefined
+ * when it's empty or noise. Split out of `extractCommentProse` so the multi-line CONTINUATION
+ * path in `addedCodeCommentLines` (see `OpenComment` below) can apply the identical exclusion
+ * rules to a line that never goes through `extractCommentProse`'s own single-line matchers.
+ */
+function filterNoiseProse(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (
+    !trimmed ||
+    NOISE_LINE_RE.test(trimmed) ||
+    ATTRIBUTION_RE.test(trimmed) ||
+    TAG_LINE_RE.test(trimmed)
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/**
  * Extract claim-candidate prose from one line of a code file's patch, or undefined when the line
  * is not a comment/docstring/description-literal shape (ordinary code) or is noise (see above). A
  * `.describe(...)`/`description: "..."` match is checked FIRST since those lines are otherwise
@@ -437,16 +457,62 @@ export function extractCommentProse(rawLine: string): string | undefined {
     : COMMENT_LINE_MATCHERS.map(re => re.exec(line)?.[1]).find(p => p !== undefined);
   if (prose === undefined) return undefined;
 
-  const trimmed = prose.trim();
-  if (
-    !trimmed ||
-    NOISE_LINE_RE.test(trimmed) ||
-    ATTRIBUTION_RE.test(trimmed) ||
-    TAG_LINE_RE.test(trimmed)
-  ) {
-    return undefined;
+  return filterNoiseProse(prose);
+}
+
+/**
+ * Which multi-line comment/docstring construct is still open after a line, carried forward to
+ * the NEXT line — `null` when not inside one. Tracking this (over `newFileLines`' full context +
+ * added view, mirroring `addedProseLines`' own `inFence` tracking) is what closes the deferred
+ * gap from PR #814 (CodeRabbit, "Heavy lift"): `extractCommentProse`'s per-line matchers require
+ * an interior line to repeat a marker (a leading `*` for a block comment, a `"""`/`'''` for a
+ * docstring) — so an UNMARKED continuation line, or a docstring's un-decorated body lines, match
+ * nothing and were silently dropped even though they're unambiguously still inside the comment.
+ */
+type OpenComment = { kind: 'block' } | { kind: 'docstring'; delim: '"""' | "'''" };
+
+/** A block-comment closer anywhere at the END of a (trimmed) line: one-or-more `*` then `/`,
+ *  optionally followed by trailing whitespace — the same shape `BLOCK_OPEN_RE`'s own optional
+ *  trailing group matches, reused here to detect a same-line close on a FRESH opener line and an
+ *  eventual close on a CONTINUATION line. */
+const BLOCK_CLOSE_AT_END_RE = /\*+\/\s*$/;
+
+/** Strip a conventional (optional) leading `*` continuation marker so a continuation line reads
+ *  the same whether or not it follows the JSDoc `* prose` convention — the fix must not REQUIRE
+ *  the marker, but a line that still carries it shouldn't leak a stray `*` into the prose. */
+function stripBlockMarker(text: string): string {
+  return text.replace(/^\*\s?/, '');
+}
+
+/**
+ * Does a FRESH (non-continuation) trimmed line OPEN a block-comment/docstring construct WITHOUT
+ * also closing it on the same line — i.e., is this the first line of a genuinely multi-line
+ * construct whose interior lines need continuation tracking? Returns the construct to carry
+ * forward, or null when the line isn't an opener at all, or opens and closes on one line (the
+ * pre-existing single-line-block/docstring shapes `extractCommentProse` already handles fully).
+ */
+function detectOpen(text: string): OpenComment | null {
+  if (BLOCK_OPEN_RE.test(text)) return BLOCK_CLOSE_AT_END_RE.test(text) ? null : { kind: 'block' };
+  for (const delim of ['"""', "'''"] as const) {
+    if (text.startsWith(delim)) {
+      return text.slice(delim.length).includes(delim) ? null : { kind: 'docstring', delim };
+    }
   }
-  return trimmed;
+  return null;
+}
+
+/**
+ * Does a CONTINUATION line (reached while `open` is already active) close its construct on this
+ * line, and if so, what's the prose BEFORE the closer? Returns undefined when the line does NOT
+ * close — the caller then treats the whole line as interior prose and keeps `open` active.
+ */
+function closingProse(text: string, open: OpenComment): string | undefined {
+  if (open.kind === 'block') {
+    const m = /^(.*?)\*+\/\s*$/.exec(text);
+    return m ? stripBlockMarker(m[1]).trim() : undefined;
+  }
+  const idx = text.indexOf(open.delim);
+  return idx === -1 ? undefined : text.slice(0, idx).trim();
 }
 
 /**
@@ -454,15 +520,36 @@ export function extractCommentProse(rawLine: string): string | undefined {
  * comment, docstring, or description-valued string literal (see `extractCommentProse`) — never
  * arbitrary code. This is the widened surface pr658's Finding A motivated: a JSDoc comment on a
  * `LienConfig` field in `packages/core/src/config/schema.ts`, an ordinary source file the
- * doc-surface-only scan could never see. Exposed for testing.
+ * doc-surface-only scan could never see.
+ *
+ * Tracks `OpenComment` state across the patch's full NEW-file view (context + added, like
+ * `addedProseLines`' fence tracking) so an interior CONTINUATION line — whether or not it repeats
+ * a `*`/triple-quote marker, and even when the construct's OPENING line was unmodified context —
+ * still contributes its prose (the multi-line gap this widening closes; see `OpenComment`).
+ * Exposed for testing.
  */
 export function addedCodeCommentLines(patch: string): string[] {
   const out: string[] = [];
+  let open: OpenComment | null = null;
+
   for (const { text, isAdded } of newFileLines(patch)) {
-    if (!isAdded) continue;
-    const prose = extractCommentProse(text);
-    if (prose) out.push(prose);
+    const trimmed = text.trim();
+    let prose: string | undefined;
+
+    if (open) {
+      const closed = closingProse(trimmed, open);
+      prose = filterNoiseProse(
+        closed ?? (open.kind === 'block' ? stripBlockMarker(trimmed) : trimmed),
+      );
+      if (closed !== undefined) open = null;
+    } else {
+      prose = extractCommentProse(text);
+      open = detectOpen(trimmed);
+    }
+
+    if (isAdded && prose) out.push(prose);
   }
+
   return out;
 }
 
@@ -689,6 +776,18 @@ const TEST_FILE_RE = /(\.test\.|\.spec\.|\/tests?\/|__tests__|\/spec\/)/;
  * match — that chunk is literally the named symbol. Test files always rank
  * last, even on a symbolName match: a same-named helper in a test fixture is a
  * collision, not the described behavior (see tierOf's early return).
+ *
+ * `SameFile` outranks everything (bar the Test demotion): for a CODE-sourced
+ * claim (a comment scanned from a changed code file — see
+ * `addedCodeCommentLines`), the file the comment itself lives in is the
+ * described field's own declaration, the strongest possible locate. Reachable
+ * only for a code claim file — `scanForEvidence` still excludes a GUIDANCE/doc
+ * surface's own chunks entirely (a doc citing its own paragraph proves
+ * nothing), so this tier never applies there. Bug found during Finding A's
+ * re-certification (post-#814): before this tier existed, `scanForEvidence`
+ * excluded the claim's own file unconditionally, so a schema.ts comment claim
+ * could be corroborated against an unrelated neighbor file that happened to
+ * share the same wording, instead of schema.ts's own field.
  */
 const enum EvidenceTier {
   Test = 0,
@@ -697,6 +796,7 @@ const enum EvidenceTier {
   ChangedDoc = 3,
   ChangedCode = 4,
   SymbolMatch = 5,
+  SameFile = 6,
 }
 
 /** The union of every path this PR changed (analyzable + non-code + patched). */
@@ -741,9 +841,17 @@ function matchChunk(
   return matched.length > 0 ? { matched, symbolMatched } : null;
 }
 
-/** Rank a matched chunk into an evidence tier (see EvidenceTier). */
-function tierOf(file: string, symbolMatched: boolean, changed: Set<string>): EvidenceTier {
+/** Rank a matched chunk into an evidence tier (see EvidenceTier). `claimFile` only ever equals
+ *  `file` here for a CODE-sourced claim — `scanForEvidence` excludes a guidance/doc surface's own
+ *  file before this is called, so `SameFile` never applies to a doc claim. */
+function tierOf(
+  file: string,
+  claimFile: string,
+  symbolMatched: boolean,
+  changed: Set<string>,
+): EvidenceTier {
   if (TEST_FILE_RE.test(file)) return EvidenceTier.Test;
+  if (file === claimFile) return EvidenceTier.SameFile;
   if (symbolMatched) return EvidenceTier.SymbolMatch;
   const isDoc = DOC_FILE_RE.test(file);
   const isChanged = changed.has(file);
@@ -763,7 +871,10 @@ interface EvidenceCandidate {
  * A single pass over `repoChunks` for the best evidence chunk: highest tier,
  * then most distinct anchors matched, keeping the FIRST such chunk in traversal
  * order (a stable, deterministic tiebreak). Chunks from `claimFile` are skipped
- * so a doc never cites itself as its own evidence.
+ * ONLY when `claimFile` is itself a guidance/doc surface, so a doc never cites
+ * itself as its own evidence — a CODE-sourced claim's own file stays eligible
+ * (and, per `tierOf`'s `SameFile` tier, wins outright) since that file is
+ * exactly where the comment's described code lives.
  */
 function scanForEvidence(
   anchors: string[],
@@ -772,12 +883,13 @@ function scanForEvidence(
   changed: Set<string>,
   compare: (s: string) => string,
 ): EvidenceCandidate | null {
+  const excludeSelf = isGuidanceSurface(claimFile);
   let best: EvidenceCandidate | null = null;
   for (const chunk of repoChunks) {
-    if (chunk.metadata.file === claimFile) continue;
+    if (excludeSelf && chunk.metadata.file === claimFile) continue;
     const m = matchChunk(chunk, anchors, compare);
     if (!m) continue;
-    const tier = tierOf(chunk.metadata.file, m.symbolMatched, changed);
+    const tier = tierOf(chunk.metadata.file, claimFile, m.symbolMatched, changed);
     const matchCount = m.matched.length;
     if (best && (tier < best.tier || (tier === best.tier && matchCount <= best.matchCount))) {
       continue; // strictly-better replaces only; ties keep the earlier chunk
@@ -896,18 +1008,85 @@ function firstHunkNewStartLine(patch: string): number {
   return m ? Number(m[1]) : 0;
 }
 
+/** One hunk of a unified-diff patch: its raw text (header + body, verbatim) and the NEW-file
+ *  starting line its header declares. */
+interface DiffHunk {
+  text: string;
+  newStartLine: number;
+}
+
+/** A unified-diff hunk header: `@@ -a,b +START,len @@`. */
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)/;
+
+/**
+ * Split a raw patch into its individual hunks, each starting at its own `@@ ... @@` header —
+ * needed so `buildDiffEvidence` can center the excerpt on the hunk relevant to the claim instead
+ * of always taking the patch's first `MAX_DIFF_EVIDENCE_CHARS` (the deferred PR #814 gap: a
+ * multi-hunk file's relevant hunk can sort anywhere, and the naive head-slice can miss it
+ * entirely). Falls back to treating the WHOLE patch as one hunk when no header is found
+ * (defensive — every real patch has at least one).
+ */
+function splitHunks(patch: string): DiffHunk[] {
+  const hunks: DiffHunk[] = [];
+  let current: string[] = [];
+  let currentStart = 0;
+
+  for (const line of patch.split('\n')) {
+    const m = HUNK_HEADER_RE.exec(line);
+    if (m) {
+      if (current.length > 0) hunks.push({ text: current.join('\n'), newStartLine: currentStart });
+      current = [line];
+      currentStart = Number(m[1]);
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) hunks.push({ text: current.join('\n'), newStartLine: currentStart });
+
+  return hunks.length > 0 ? hunks : [{ text: patch, newStartLine: firstHunkNewStartLine(patch) }];
+}
+
+/**
+ * Pick the hunk most relevant to `anchors` (the claim's cited symbol, or its extracted keyword
+ * anchors) — the hunk with the most anchor hits, ties keeping the FIRST/earliest hunk (a stable,
+ * deterministic tiebreak). Falls back to the first hunk when there are no anchors to rank by,
+ * preserving the pre-existing head-of-patch behavior for an anchor-less citation.
+ */
+function pickRelevantHunk(hunks: DiffHunk[], anchors: string[]): DiffHunk {
+  if (anchors.length === 0) return hunks[0];
+  let best = hunks[0];
+  let bestHits = -1;
+  for (const hunk of hunks) {
+    const hits = anchors.reduce((n, a) => n + (hunk.text.includes(a) ? 1 : 0), 0);
+    if (hits > bestHits) {
+      bestHits = hits;
+      best = hunk;
+    }
+  }
+  return best;
+}
+
 /** Build diff-hunk evidence for a cited file that's part of THIS PR (see
- *  `findCitedPathDiffEvidence`): the byte-capped raw patch, tagged `fromDiff` so the renderer
- *  frames it as a diff rather than a plain source excerpt. */
-function buildDiffEvidence(file: string, patch: string): DocClaimEvidence {
-  const capped =
-    patch.length > MAX_DIFF_EVIDENCE_CHARS
-      ? `${patch.slice(0, MAX_DIFF_EVIDENCE_CHARS)}\n[diff truncated to respect the input budget]`
-      : patch;
+ *  `findCitedPathDiffEvidence`): picks the hunk most relevant to `anchors` (the cited symbol, or
+ *  the claim's own keyword anchors — see `pickRelevantHunk`) rather than always the patch's
+ *  first bytes, then byte-caps that hunk centered on the anchor (`capCentered`, the same
+ *  centering primitive `buildExcerpt` uses for indexed-chunk evidence). Tagged `fromDiff` so the
+ *  renderer frames it as a diff rather than a plain source excerpt. */
+function buildDiffEvidence(file: string, patch: string, anchors: string[] = []): DocClaimEvidence {
+  const hunk = pickRelevantHunk(splitHunks(patch), anchors);
+  const needleIndex = anchors
+    .map(a => hunk.text.indexOf(a))
+    .filter(i => i >= 0)
+    .sort((a, b) => a - b)[0];
+  const capped = capCentered(hunk.text, needleIndex ?? 0, MAX_DIFF_EVIDENCE_CHARS);
+  const excerpt =
+    hunk.text.length > MAX_DIFF_EVIDENCE_CHARS
+      ? `${capped}\n[diff truncated to respect the input budget]`
+      : capped;
   return {
     file,
-    startLine: firstHunkNewStartLine(patch),
-    excerpt: capped.replace(/```/g, "'''"),
+    startLine: hunk.newStartLine,
+    excerpt: excerpt.replace(/```/g, "'''"),
     anchor: file,
     fromDoc: false,
     fromDiff: true,
@@ -944,12 +1123,14 @@ function resolveExactOrUniqueSuffix(
 
 function findCitedPathDiffEvidence(
   cited: DocClaimCitedPath,
+  claimText: string,
   patches: Map<string, string> | undefined,
 ): DocClaimEvidence | undefined {
   if (!patches) return undefined;
   const matchedFile = resolveExactOrUniqueSuffix([...patches.keys()], cited.path);
   if (!matchedFile) return undefined;
-  return buildDiffEvidence(matchedFile, patches.get(matchedFile) ?? '');
+  const anchors = cited.symbol ? [cited.symbol] : extractAnchors(claimText);
+  return buildDiffEvidence(matchedFile, patches.get(matchedFile) ?? '', anchors);
 }
 
 /**
@@ -969,7 +1150,7 @@ function findCitedPathEvidence(
   repoChunks: CodeChunk[] | undefined,
   patches: Map<string, string> | undefined,
 ): DocClaimEvidence {
-  const diffEvidence = findCitedPathDiffEvidence(cited, patches);
+  const diffEvidence = findCitedPathDiffEvidence(cited, claimText, patches);
   if (diffEvidence) return diffEvidence;
 
   const resolvedFile = repoChunks?.find(

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -475,10 +475,32 @@ describe('findClaimEvidence — ranking', () => {
     expect(ev?.file).toBe('packages/core/src/strategy.ts');
   });
 
-  it('never cites the claim’s own file as its evidence', () => {
+  it('never cites the claim’s own file as its evidence — WHEN the claim is a guidance/doc surface', () => {
     const claim = claimOf('`structural.db` exists', DOC);
     const chunks = [chunk(DOC, 2, 'the doc itself mentions structural.db here')];
     expect(findClaimEvidence(claim, chunks, new Set([DOC]))).toBeUndefined();
+  });
+
+  // Bug found during Finding A's re-certification (post-#814): the self-citation exclusion
+  // above is correct for a DOC file (quoting the same paragraph proves nothing) but was applied
+  // unconditionally, so a CODE-sourced claim (a comment scanned from a changed CODE file, see
+  // `addedCodeCommentLines`) could never match its OWN enclosing file either — even though that
+  // file is exactly where the comment's described field lives. pr658's actual failure: a stale
+  // comment in schema.ts was corroborated against an unrelated neighbor file that happened to
+  // carry the identical stale wording, instead of schema.ts's own declaration.
+  it('DOES cite the claim’s own file as evidence when the claim is CODE-sourced (not a guidance surface)', () => {
+    const SCHEMA = 'packages/core/src/config/schema.ts';
+    const NEIGHBOR = 'packages/core/src/config/null-embeddings.ts';
+    const claimText = 'keep working; search_code and find_similar report as disabled.';
+    const claim = claimOf(claimText, SCHEMA);
+    const chunks = [
+      // Listed FIRST and would win today's arbitrary first-wins tiebreak once schema.ts is
+      // (wrongly) excluded — the neighbor carries the exact same stale wording.
+      chunk(NEIGHBOR, 18, `// ${claimText}\nenabled: z.boolean().optional(),`),
+      chunk(SCHEMA, 40, `// ${claimText}\nenabled: z.boolean().optional(),`),
+    ];
+    const ev = findClaimEvidence(claim, chunks, new Set([SCHEMA, NEIGHBOR]));
+    expect(ev?.file).toBe(SCHEMA);
   });
 
   it('falls back to a case-insensitive match when nothing matches verbatim', () => {
@@ -806,6 +828,50 @@ describe('addedCodeCommentLines', () => {
     ].join('\n');
     expect(addedCodeCommentLines(patch)).toEqual(['The batch size defaults to 32.']);
   });
+
+  // Deferred finding from PR #814 (CodeRabbit, "Heavy lift"): addedCodeCommentLines parses
+  // line-by-line with no open/close state, so an INTERIOR line of a multi-line block comment
+  // that doesn't repeat the `*` continuation marker is silently dropped — even though it's
+  // unambiguously still inside the comment.
+  it('captures an UNMARKED continuation line inside a multi-line block comment (no leading `*`)', () => {
+    const patch = [
+      '@@ -1,1 +1,4 @@',
+      ' export function f() {',
+      '+  /**',
+      '+   This value defaults to 32 when omitted, no star on this line.',
+      '+   */',
+    ].join('\n');
+    expect(addedCodeCommentLines(patch)).toEqual([
+      'This value defaults to 32 when omitted, no star on this line.',
+    ]);
+  });
+
+  // Same gap, Python/Rust triple-quoted docstring shape: the body lines between the opening and
+  // closing `"""` carry no delimiter of their own at all.
+  it('captures INTERIOR lines of a multi-line triple-quoted docstring', () => {
+    const patch = [
+      '@@ -1,1 +1,4 @@',
+      ' def f():',
+      '+    """',
+      '+    This value defaults to 32 when omitted.',
+      '+    """',
+    ].join('\n');
+    expect(addedCodeCommentLines(patch)).toEqual(['This value defaults to 32 when omitted.']);
+  });
+
+  // The construct can OPEN on a context (unmodified) line — only an interior line is newly
+  // added — and the scan must still recognize it's inside the docstring using state carried
+  // across context lines, not just added ones.
+  it('captures an added interior line of a docstring whose OPENING line is unmodified context', () => {
+    const patch = [
+      '@@ -1,2 +1,3 @@',
+      ' def f():',
+      ' """',
+      '+    This value now defaults to 32 when omitted.',
+      ' """',
+    ].join('\n');
+    expect(addedCodeCommentLines(patch)).toEqual(['This value now defaults to 32 when omitted.']);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1036,6 +1102,36 @@ describe('findClaimEvidence — referenced-file diff prefetch', () => {
     const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
     expect(ev.excerpt).toContain('[diff truncated to respect the input budget]');
     expect(ev.excerpt.length).toBeLessThan(bigPatch.length);
+  });
+
+  // Deferred finding from PR #814 (CodeRabbit, "Heavy lift"): buildDiffEvidence truncated the
+  // RAW patch's first 800 chars rather than centering on the hunk relevant to the claim, so a
+  // multi-hunk file's relevant hunk could be missed entirely if it isn't first. Construct a
+  // patch whose FIRST hunk is large filler (>800 chars on its own) and whose SECOND hunk carries
+  // the claim's cited symbol — the naive head-slice never reaches the second hunk at all.
+  it('centers the diff-hunk excerpt on the hunk relevant to the cited symbol, not the patch head', () => {
+    const claim = claimWithCitedPath('see `resolveIndexStrategy` in packages/review/src/big.ts', {
+      path: 'packages/review/src/big.ts',
+      symbol: 'resolveIndexStrategy',
+    });
+    const filler = 'const fillerLine = "unrelated padding to blow the 800-char budget";';
+    const fillerHunk = [
+      '@@ -1,1 +1,12 @@',
+      ' export function unrelated() {',
+      ...Array.from({ length: 12 }, () => `+  ${filler}`),
+    ].join('\n');
+    const relevantHunk = [
+      '@@ -50,1 +62,2 @@',
+      ' export function resolveIndexStrategy() {',
+      '+  // resolveIndexStrategy now defaults to standalone when no index exists.',
+    ].join('\n');
+    const bigPatch = `${fillerHunk}\n${relevantHunk}`;
+    expect(bigPatch.length).toBeGreaterThan(800); // the filler hunk alone already exceeds the cap
+
+    const patches = new Map([['packages/review/src/big.ts', bigPatch]]);
+    const ev = findClaimEvidence(claim, undefined, new Set(), patches)!;
+    expect(ev.excerpt).toContain('resolveIndexStrategy');
+    expect(ev.excerpt).toContain('defaults to standalone');
   });
 
   it('renders the "evidence (PR diff)" label distinctly from sibling-doc/plain evidence', () => {


### PR DESCRIPTION
## Summary

Three deterministic follow-ups to #814's doc-claims-signals.ts widening. The first two are the "Heavy lift" findings #814 explicitly deferred; the third was found and reported mid-task by the Finding-A re-certification runner (owner-approved scope addition, folded in here per instruction).

Each item below was verified against a **failing test first** — none of these were assumed broken, all three were reproduced before being fixed.

### 1. Multiline interior-line tracking (deferred, CodeRabbit on #814)

`addedCodeCommentLines` parsed line-by-line with no open/close state, so an INTERIOR line of a multi-line block comment or triple-quoted docstring was silently dropped whenever it didn't repeat a `*`/triple-quote marker — even a docstring's plain, un-decorated body lines matched nothing in `extractCommentProse`.

**Fix:** track `OpenComment` state (`block` / `docstring`) across the patch's full NEW-file view (context + added lines, mirroring `addedProseLines`' own `inFence` tracking), so a continuation line contributes its prose regardless of marker, and even when the construct's *opening* line is unmodified context.

**Failing-test-first proof:** 3 new tests (unmarked block-comment continuation, docstring interior lines, docstring opened by unmodified context) — all failed (`expected [] to deeply equal [...]`) before the fix, all pass after.

### 2. Hunk-aware evidence centering (deferred, CodeRabbit on #814)

`buildDiffEvidence` truncated the RAW patch's first 800 chars rather than centering on the hunk relevant to the claim, so a multi-hunk cited file's relevant hunk could be missed entirely if it wasn't first.

**Fix:** `splitHunks` breaks the patch into its hunks; `pickRelevantHunk` picks the one with the most anchor hits (the cited symbol, or the claim's own keyword anchors) — ties keep the first hunk (deterministic, and preserves old behavior for an anchor-less citation); the excerpt is then `capCentered` on the matched anchor within that hunk.

**Failing-test-first proof:** new test constructs a patch whose first hunk is >800 chars of filler and whose second hunk carries the cited symbol — before the fix the excerpt was 100% filler (never reached the second hunk); after, it contains the relevant hunk in full.

### 3. Same-file evidence exclusion wrongly applied to code-sourced claims (found during Finding-A re-cert, folded in)

`scanForEvidence` excluded the claim's own file from evidence candidates unconditionally — correct for a guidance/doc surface (a doc citing its own paragraph proves nothing) but wrong for a CODE-sourced claim (#814's widening): a comment's own enclosing file is exactly where the described declaration lives. The recert runner traced this precisely: schema.ts's `embeddings.enabled` comment claim (pr658 Finding A) was being attached evidence from an unrelated neighbor file (`null-embeddings.ts`) that happened to share similar wording, instead of schema.ts's own field — causing models to report `unverifiable`/`accurate` instead of `contradicted` (5/10 raw verdict rate in the calibrate-10 run, well under the 9/10 bar).

**Fix:** `scanForEvidence` now only excludes the claim's own file when `isGuidanceSurface(claimFile)`; a new `EvidenceTier.SameFile` (above `SymbolMatch`) makes a code claim's own file win outright when eligible.

**Failing-test-first proof:** new test reproduces the exact shape (claim file + neighbor file both carrying the same wording, neighbor listed first) — before the fix, the neighbor won (matching the recert's traced bug); after, the claim's own file wins.

## Evidence

### Tests
37 new/updated tests across the three items (all failing before their respective fix, all passing after). Full `@liendev/review` suite: **1298/1298** (was 1294 pre-rebase onto #816; #816 landed its own tests during this work). Full monorepo suite green across all packages (parser, core, review, cli, action).

### Byte-diff census (`build-prompts.ts`, v1 and v2, before/after)

Ran the real committed fixtures plus a fresh `capture-pr.ts 658` capture, before vs after, both `LIEN_DOC_TRUTH_V2` off (v1) and on (v2):

| Fixture | v1 | v2 |
|---|---|---|
| `boundary-change/placeholder` | identical | identical |
| `doc-truth/accurate-doc` | identical | identical |
| `doc-truth/renamed-stale-claim` | identical | identical |
| `doc-truth/pr658-search-code-rename` (fresh capture) | **changed** | **changed** |

Only pr658 changes — none of the three synthetic fixtures exercise these three gaps (no multi-hunk citations, no same-file self-citation collisions, no unmarked continuation lines).

**pr658's diff, isolated to exactly two claim entries** (confirmed via full-message diff — nothing else in the ~101KB main-pass message or the ~32KB dedicated-pass message shifted, same rule selection, same system prompts):

1. Finding A (`schema.ts`'s `embeddings.enabled` comment claim) evidence: `packages/cli/src/mcp/tools.ts:18` (an unrelated MCP tool registration) → `packages/core/src/config/schema.ts:60` (the claim's own JSDoc block, verbatim — item 3's fix).
2. The `.changeset/rename-search-code.md` claim's cited-file evidence (`CLAUDE.md`): a raw patch head cut off mid-sentence (`-**\n[diff truncated...]`) → the complete, relevant hunk with no truncation (item 2's fix).

**Certified pr658 gate cross-check:** the assertions file's only hard checks are Tier 1 (`doc-truth` fired) and Tier 2 (a single finding naming both `meaning-based`/`meaning based` AND a lexical/BM25/no-embeddings correction — i.e. Finding B, `augment-explore-task.sh`). Finding A is explicitly **non-gating** as of the 2026-07-16 owner re-scope decision recorded in that file's own header. Finding B's claim entry is byte-identical before/after these fixes — untouched by any of the three changes. Gate unaffected.

### Dogfood (review-engine change — replayed through the harness per policy)
Captured pr658 fresh via `capture-pr.ts` (5018 chunks, 0 complexity violations — healthy capture) and ran `build-prompts.ts` against it before/after each fix, reading the actual rendered `<doc_claims>` block and the dedicated doc-truth-pass prompt — not just unit assertions. This is what surfaced the exact before/after excerpts quoted above.

## Coordination

Per the task brief, checked `findingA-recert`'s `PROGRESS.md` before merging: the recert runner is **DONE** (Job 1: Finding A re-cert, 5/10, missed the bar, no PR opened, root-caused the item-3 bug fixed here; Job 2: v2 family screens, complete, unrelated recommendations tracked separately). No calibration is in-flight — no merge-hold needed. The runner's own recommendation ("fix `findClaimEvidence`'s evidence attachment for code-sourced claims before attempting another Finding-A re-gating calibration") is exactly item 3 above.

Explicitly **out of scope** (per the coordinator's own instruction, tracked separately):
- Vote 10's budget-truncation coverage gap at ~51-claim worklists (candidate-overflow work).
- `unverifiable`-verdict-as-finding precision risk on `accurate-doc`/`renamed-stale-claim` (pre-existing, not v2-specific, not caused or touched by this PR).
- Finding A's own `calibrate --10` re-certification against the now-fixed evidence path — the owner's later decision, not this PR's job.

## Gates

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` all green (post-rebase onto #816). `node packages/cli/dist/index.js delta --base <pre-fix commit>` exit 0 — worsened-but-under-threshold only (max cognitive 11 vs a threshold of 15), no new-over-threshold or crossed function.

No changeset (packages/review is unpublished/private).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR delivers three deterministic follow-up fixes to #814's code-comment claim widening: multi-line comment/docstring interior-line tracking, hunk-aware diff evidence centering, and allowing code-sourced claims to cite their own enclosing file. All three changes are internal to `doc-claims-signals.ts`, are accompanied by targeted tests that reproduce the original failures, and do not alter exported APIs. The logic correctly handles block-comment and triple-quoted docstring open/close state, picks the most anchor-relevant diff hunk, and restricts self-citation exclusion to guidance/doc surfaces while giving code-sourced claims a `SameFile` tier. No wrong-output or caller-breaking issues were identified.
>
> - addedCodeCommentLines now tracks OpenComment state across patch lines so unmarked interior continuation lines and docstring bodies are captured
> - buildDiffEvidence splits hunks and centers the excerpt on the hunk most relevant to the claim's anchors instead of always taking the patch head
> - scanForEvidence only excludes the claim's own file for guidance/doc surfaces, and a new SameFile tier lets code-sourced claims win with their own file

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 218ddbc. Updates automatically on new commits.</sup>
<!-- /lien-stats -->