### PR TITLE
feat(review): removed-exports candidate-loop pass (default off)

### DIFF
--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -1,15 +1,18 @@
 # Agent-review pass architecture — `ReviewPassSpec` and the extra-pass executor
 
 Status: generalized executor + attestation v2 shipped (PR #799, merged).
-Three passes plug into it today — **doc-truth is production-on by default**
-(v1); the **stale-duplicate** and **incomplete-handling** candidate loops
-are built, merged, and dark (default-off) for `@liendev/review`/
-`@liendev/action` consumers, and doc-truth itself gained a dark, env-only
-v2 mode (PR #807) that backports the same per-candidate-verdict contract
-into its own pass — see "Which passes are live" below. As of 2026-07-17,
-this monorepo's own `.github/workflows/lien-review.yml` opts both loops in
-on itself (`LIEN_STALE_DUP_PASS=on` / `LIEN_INCOMPLETE_PASS=on`) to dogfood
-them on its own PRs; the package/action defaults are unchanged. See
+Four passes plug into it today — **doc-truth is production-on by default**
+(v1); the **stale-duplicate**, **incomplete-handling**, and
+**removed-exports** candidate loops are built, merged, and dark (default-off)
+for `@liendev/review`/`@liendev/action` consumers, and doc-truth itself
+gained a dark, env-only v2 mode (PR #807) that backports the same
+per-candidate-verdict contract into its own pass — see "Which passes are
+live" below. As of 2026-07-17, this monorepo's own
+`.github/workflows/lien-review.yml` opts the first two loops in on itself
+(`LIEN_STALE_DUP_PASS=on` / `LIEN_INCOMPLETE_PASS=on`) to dogfood them on its
+own PRs; removed-exports has not yet been opted into that workflow (a
+separate, later decision, same as the first two loops' own CI opt-in was) —
+the package/action defaults are unchanged for all three. See
 [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
 decision this doc implements and its evidence/economics — the evidence
 behind this opt-in is session-local so far and will be written up there
@@ -72,6 +75,7 @@ const EXTRA_PASSES: ReviewPassSpec[] = [
   DOC_TRUTH_PASS_SPEC,
   STALE_DUPLICATE_PASS_SPEC,
   INCOMPLETE_HANDLING_PASS_SPEC,
+  REMOVED_EXPORTS_PASS_SPEC,
 ];
 ```
 
@@ -89,7 +93,7 @@ one starts. Two things are true regardless of how many passes exist:
   catches and reports (`context.reportSkip`) any thrown error from a pass's
   client run; the main pass's own output is untouched.
 
-None of the three passes has a data dependency on either of the *other two*
+None of the four passes has a data dependency on any of the *other three*
 (only doc-truth's original dependency on the *main* pass completing at all
 survives the generalization), so declaration order among them doesn't
 affect correctness — doc-truth stays first as the longest-proven pass.
@@ -99,15 +103,17 @@ machinery (trace-offset arithmetic that currently assumes the main trace is
 already complete; per-pass budget reporting that would need to interleave)
 ahead of a real latency complaint would be speculative (YAGNI per
 CLAUDE.md) — revisit once ≥3 dedicated passes are live and latency is
-measured as a problem.
+measured as a problem (now true — four passes are live — but no latency
+complaint has been measured yet).
 
-## The three passes
+## The four passes
 
 | Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
 |---|---|---|---|---|---|---|
 | doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | v1 (default): open findings list. v2 (`LIEN_DOC_TRUTH_V2=on`, dark): `accurate \| contradicted \| unverifiable` per claim id | **Production-on** (v1 default true; v2 dark, env-only) |
 | stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
 | incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
+| removed-exports loop | `removed-exports-pass.ts` | `config.removedExportsPass` or `LIEN_REMOVED_EXPORTS_PASS=on` AND ≥1 removed public export | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `breaking \| intentional \| internal-only \| unverifiable` | **Dark** (default false) |
 
 Every pass keeps its rule's prompt fragment and signal block in the shared
 main pass regardless of the dedicated pass's on/off state — a second,
@@ -115,7 +121,11 @@ independent env flag per candidate loop (`LIEN_STALE_DUP_MAIN=off`,
 `LIEN_INCOMPLETE_MAIN=off`) exists to strip the rule from the main pass
 entirely for a *future* A/B arm, but that arm has not been run. Today,
 merging or enabling a candidate loop never removes its rule's shared-loop
-coverage.
+coverage. The removed-exports loop has NO such override — `structural-analysis`
+is ADR-014's one *hybrid* rule: only its removed-export-sweep half has a
+candidate shape, so its OTHER half (caller-impact-of-changed-behavior) must
+stay in the main pass unconditionally, forever, not just until a future A/B
+arm (see that pass's own module doc for the full reasoning).
 
 ### doc-truth
 
@@ -213,9 +223,61 @@ warns against verdicting test-double/mock/fixture omissions `incomplete`,
 baked in from the loop's first version rather than discovered post-hoc the
 way the stale-duplicate pilot's equivalent guard was.
 
+### removed-exports candidate loop
+
+Covers only the removed-export-sweep HALF of `structural-analysis`
+(ADR-014's gating matrix marks the rule **hybrid**: the other half — "check
+if callers handle new behavior correctly" for a CHANGED, not removed, export
+— is open investigation with no candidate shape and stays in the shared main
+pass, unconditionally, forever; see that pass's own module doc). Reuses
+`removed-export-signals.ts` (already computed for the main pass's
+`<removed_exports>` block and `boundary-change`'s changeset cross-check)
+rather than building a new signal: each candidate carries the removed
+symbol, its surviving cross-file reference(s) (a text-match corpus scan
+standing in for a live `get_dependents` call), and any `.changeset/*.md`
+mention. `computeRemovedExportsCandidates` (`removed-exports-pass.ts`) caps
+the shared signal's own sort order (breakage-first, then changeset-mentioned)
+at 15.
+
+A real-PR census (this repo's last 40 merged PRs, #776–#816, captured via
+`capture-pr.ts` + `build-prompts.ts` with the loop's opt-in flag on so
+`fires` reduces to pure candidate eligibility) measured this loop firing on
+only **1/40 (2.5%)** — PR #799 (the pass-executor generalization that
+renamed `runDocTruthPass`/`appendDocTruthTurns` away). This is markedly
+LOWER than the pilot's 35% or the second loop's 50%: an actual removed
+PUBLIC export is a genuinely rare event in this repo's real history compared
+to a stale duplicated literal or an unmirrored sibling file. Firing rate is
+not a constant property across rules (ADR-014's own Negative/Risks section
+already makes this point for the first two loops); this loop's number is
+lower still. PR #399 (the fixture behind
+`fixtures/structural-analysis/removed-export.assertions.ts`) is the
+dogfood/screen worklist cited below.
+
+Toolset is `read_file` + `grep_codebase` — the pilot's set, not the second
+loop's `get_files_context` superset — because judging a candidate here is
+"is this surviving reference real production usage" (a single-file
+question the pilot's tools already answer), not the second loop's "is this
+handled via a different mechanism entirely" cross-file question. The
+`<strategy>`/`<examples>` blocks are deliberately NOT `STRUCTURAL_ANALYSIS`'s
+rule text reused verbatim (unlike the other two loops reusing their own
+rule's full prompt/example) — that rule's full prompt names tools
+(`get_files_context`, `get_dependents`) this loop's hard-cut toolset doesn't
+provide, and its own example illustrates a CHANGED (not removed) export, the
+wrong shape for this loop's job. A `<verdict_guidance>` paragraph bakes in
+the two historical FP classes from day one (matching the second loop's
+"baked in, not discovered post-hoc" precedent): a changeset-documented
+removal verdicts `intentional`, and a surviving reference confined to
+test/fixture/internal-only code verdicts `internal-only` — only a
+production-code surviving reference with no changeset verdicts `breaking`.
+Merge: like the other two loops, **the loop wins** on a collision, scoped to
+main-pass findings whose own `ruleId` is also `structural-analysis` — but
+this loop ALSO matches on `symbolName` identity (not just line proximity),
+since a removed-export candidate carries a stable identity the pilot's
+literal-text candidates and the second loop's per-shape candidates don't.
+
 ## Per-candidate verdict contract and `incomplete_verdict` honesty semantics
 
-All three passes now use variants of the same contract: **one verdict
+All four passes now use variants of the same contract: **one verdict
 object required per candidate/claim id**, carried as extra fields
 (`candidateId`/`claimId`, `verdict`) inside the standard `findings` JSON
 array — so the shared client's existing parse/validate pipeline needs zero
@@ -311,6 +373,11 @@ fires exactly once per pass that ran.
   (8 vs. the pilot's 6) since every candidate here needs at least one
   `read_file`/`get_files_context` round trip before it can be judged (none
   of the three signals attach an inline snippet).
+- **removed-exports loop**: `clamp(2_000 + 800 × min(candidateCount, 15),
+  11_000, 30_000)` — same per-candidate shape as the pilot; the floor is
+  `EXTRA_PASS_MIN_BUDGET_TOKENS` (11,000, the shared #811 floor already
+  documented above), which dominates for every real-PR candidate count this
+  loop has measured so far (a 1-2 candidate run is the common case).
 
 ## Which passes are live today
 
@@ -329,12 +396,23 @@ fires exactly once per pass that ran.
 - **incomplete-handling loop** — merged (PR #804) but **dark**:
   `config.incompleteHandlingPass` defaults `false`; opt in via that config
   key or `LIEN_INCOMPLETE_PASS=on`. Same non-exposure via `action.yml`.
+- **removed-exports loop** — merged but **dark**: `config.removedExportsPass`
+  defaults `false`; opt in via that config key or
+  `LIEN_REMOVED_EXPORTS_PASS=on`. Same non-exposure via `action.yml`. Unlike
+  the other two, has no `*_MAIN=off` opt-out override (see its own table row
+  above) — `<removed_exports>` cannot be stripped from the main pass by
+  design, not just "not yet run."
 
-Both dark passes have proven mechanism (gate/prompt/budget/merge/attestation
-wiring, verified via unit tests and byte-diff-neutrality-when-off proofs)
-but **unproven lift** — no priced A/B has yet shown either dedicated loop
+All three dark passes have proven mechanism (gate/prompt/budget/merge/
+attestation wiring, verified via unit tests and byte-diff-neutrality-when-off
+proofs) but **unproven lift** — no priced A/B has yet shown a dedicated loop
 finds more true positives or fewer false negatives than the shared loop's
-own signal-augmented prompt on the same fixtures. See
+own signal-augmented prompt on the same fixtures. A 3-vote screen with
+removed-exports' flag ON against its own canary fixture
+(`structural-analysis/removed-export`, PR #399) held the fixture's
+already-documented 3/3 pass rate at $0.042 total — a regression smoke test,
+not a lift measurement (the main pass already covers this fixture on its
+own; the loop is an additive backstop, not yet isolated from it). See
 [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the full
 evidence state, the real-PR firing-rate census, and per-pass cost data.
 

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -33,6 +33,7 @@ import {
   INCOMPLETE_HANDLING_PASS_SPEC,
   applyIncompleteHandlingMainOverride,
 } from './incomplete-handling-pass.js';
+import { REMOVED_EXPORTS_PASS_SPEC } from './removed-exports-pass.js';
 import {
   runExtraPasses,
   type ReviewPassSpec,
@@ -59,8 +60,12 @@ import {
  * default behavior. The incomplete-handling candidate loop (design doc §7
  * item 5) is the second build, unifying the variant-sweep/sibling-surface/
  * unread-field signals into one dedicated pass — also dark by default, see
- * `incomplete-handling-pass.ts`. None of these three passes has a data
- * dependency on either of the others, so declaration order doesn't matter
+ * `incomplete-handling-pass.ts`. The removed-exports candidate loop
+ * (ADR-014's gating matrix — `structural-analysis` is hybrid; this covers
+ * only its removed-export sweep half, never the rule's broader caller-
+ * impact-of-changed-behavior job) is the fourth build — also dark by
+ * default, see `removed-exports-pass.ts`. None of these four passes has a
+ * data dependency on any of the others, so declaration order doesn't matter
  * for correctness (see review-pass.ts's "serial for v1" note) — doc-truth
  * stays first as the longer-proven pass.
  */
@@ -68,6 +73,7 @@ const EXTRA_PASSES: ReviewPassSpec[] = [
   DOC_TRUTH_PASS_SPEC,
   STALE_DUPLICATE_PASS_SPEC,
   INCOMPLETE_HANDLING_PASS_SPEC,
+  REMOVED_EXPORTS_PASS_SPEC,
 ];
 
 const configSchema = z.object({
@@ -120,6 +126,13 @@ const configSchema = z.object({
    * LIEN_INCOMPLETE_PASS=on) to enable. See `incomplete-handling-pass.ts`.
    */
   incompleteHandlingPass: z.boolean().default(false),
+  /**
+   * Run the removed-exports candidate loop (ADR-014's gating matrix —
+   * structural-analysis is hybrid). Default false — dark-launched opt-in;
+   * set true (or env LIEN_REMOVED_EXPORTS_PASS=on) to enable. See
+   * `removed-exports-pass.ts`.
+   */
+  removedExportsPass: z.boolean().default(false),
 });
 
 export interface AgentReviewPluginOptions {

--- a/packages/review/src/plugins/agent/removed-exports-pass.ts
+++ b/packages/review/src/plugins/agent/removed-exports-pass.ts
@@ -1,0 +1,690 @@
+/**
+ * Dedicated removed-exports candidate-loop pass (ADR-014's gating matrix,
+ * `docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md` —
+ * `structural-analysis` is marked **hybrid**: this pass covers the removed-
+ * export sweep half; the broader "check if callers handle new behavior
+ * correctly" caller-impact-of-changed-behavior half stays in the shared main
+ * pass, unconditionally, forever — see "Why hybrid, not full graduation"
+ * below). The fourth candidate loop, structurally mirroring the first two
+ * (`stale-duplicate-pass.ts`, PR #803; `incomplete-handling-pass.ts`, PR
+ * #804) — same six-piece `ReviewPassSpec` shape, same per-candidate-ID-
+ * required verdict contract.
+ *
+ * ## Reuses an existing signal, builds no new one
+ *
+ * `removed-export-signals.ts` already computes exactly the shape this loop
+ * needs: `computeRemovedExportContexts` extracts every public export a PR's
+ * diff removes, minus any re-added elsewhere (a moved/renamed-file export is
+ * not a removal — the rename-vs-remove disambiguation lives there, not
+ * here), then finds every SURVIVING cross-file reference in the indexed head
+ * corpus (the "dependents" proxy — see that module's own doc comment for why
+ * a corpus text-scan stands in for a live `get_dependents` call in this
+ * deterministic-signal context) and any `.changeset/*.md` entry that
+ * mentions the symbol. That module already serves two callers — the MAIN
+ * pass's `<removed_exports>` block (`structural-analysis`) and
+ * `boundary-change`'s changeset-contradiction cross-check — so this loop
+ * imports it rather than recomputing any of that (`computeRemovedExportContexts`
+ * is not called from a re-implementation here).
+ *
+ * ## Why hybrid, not full graduation (no `LIEN_REMOVED_EXPORTS_MAIN` override)
+ *
+ * Both prior loops ship a second, independent opt-out env flag
+ * (`LIEN_STALE_DUP_MAIN=off` / `LIEN_INCOMPLETE_MAIN=off`) for a *future* A/B
+ * arm that would strip the ENTIRE rule from the main pass once its dedicated
+ * loop is proven — because for both of those rules, the dedicated loop's
+ * candidate shape covers the WHOLE rule. `structural-analysis` is different:
+ * ADR-014's gating matrix marks it **hybrid** specifically because only ONE
+ * of its two jobs (the removed-export sweep) has a bounded candidate shape —
+ * the other (`rules.ts`'s "Check if callers handle new behavior correctly",
+ * judging a CHANGED, not removed, export's new semantics against its
+ * callers) is open investigation with no candidate list, the same reason
+ * `boundary-change` stays out of the candidate-loop pattern entirely (per
+ * the ADR's Context). Stripping `structural-analysis` out of the main pass's
+ * active rules — the mechanism `applyStaleDuplicateMainOverride` /
+ * `applyIncompleteHandlingMainOverride` use — would silently remove that
+ * OTHER half's coverage too, with no dedicated pass to replace it. This
+ * module therefore offers no main-pass-disable override: `<removed_exports>`
+ * stays in the main pass unconditionally regardless of this loop's on/off
+ * state, by design, not merely "not yet run."
+ *
+ * ## Verdict vocabulary: `breaking | intentional | internal-only | unverifiable`
+ *
+ * Adapted from the pilot's three-value set (`stale | intentional-reuse |
+ * unverifiable`) to name the two FP classes the #711-era "removed-export vs
+ * changeset" tuning history and this signal's own module doc already
+ * identify:
+ *  - `breaking` — a real, undisclosed breaking change. Converts to a finding.
+ *  - `intentional` — the removal is DELIBERATE and DISCLOSED: an
+ *    accompanying changeset entry describes this exact removal (or the
+ *    version bump it belongs to). A changeset-documented removal is the
+ *    historical FP source this loop must not flag — carrying the changeset
+ *    mention as EVIDENCE (never auto-suppressing) is what lets the model
+ *    still catch the inverse case: a changeset that misdescribes the break
+ *    as non-breaking is itself a `boundary-change`-flavored contradiction,
+ *    out of THIS pass's scope but exactly why the evidence is shown, not
+ *    hidden.
+ *  - `internal-only` — the surviving reference(s) are not a real external
+ *    breakage: test/fixture files, or consumers that never see this export
+ *    as public API. Test-only importers are the other historical FP class
+ *    named in the brief.
+ *  - `unverifiable` — investigation couldn't confirm either way (budget cut
+ *    short, or the export's real consumers are outside the indexed corpus —
+ *    e.g. a published package's external consumers, which no local corpus
+ *    scan can see).
+ * Only `breaking` becomes a finding; the other three are silent dispositions
+ * the honesty contract still requires exactly one of, per candidate.
+ *
+ * ## Toolset: read_file + grep_codebase (the pilot's set, not the second
+ * loop's three-tool set)
+ *
+ * Every candidate here already carries the removal's diff hunk (re-derived
+ * from the patch text — `removed-export-signals.ts`'s `RemovedExport` has no
+ * stored line number, only `symbol` + `file`, since it's a presentation-only
+ * need this module doesn't widen that shared shape for), every surviving
+ * reference's `file:line`, and any changeset mention. Judging a candidate is
+ * "is this surviving reference real production usage or not" — a single-file
+ * `read_file` question, not the second loop's "is this handled via a
+ * different mechanism entirely" cross-file structural question that justified
+ * `get_files_context` there. `grep_codebase` stays as the same documented
+ * escape hatch the rule's own prompt text already names ("Only grep_codebase
+ * for removed symbols NOT covered there — the scan can miss exotic export
+ * shapes").
+ *
+ * ## Dedupe: same-export identity, not just location proximity
+ *
+ * Unlike the pilot/second loop's proximity-only dedupe (same file, within a
+ * few lines), a removed-export candidate carries a STABLE identity — the
+ * removed symbol name — that a main-pass `structural-analysis` finding often
+ * also carries (`AgentFinding.symbolName`, per that rule's own example). This
+ * loop's merge matches on `symbolName` equality (same file) IN ADDITION TO
+ * line proximity, so a main-pass finding that cites a different surviving
+ * call site's line for the SAME removed symbol still dedupes correctly
+ * against this loop's own (better-evidenced) finding.
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+
+import type { AgentConfig, AgentFinding, AgentResult } from './types.js';
+import {
+  computeRemovedExportContexts,
+  type RemovedExportContext,
+} from '../../removed-export-signals.js';
+import {
+  renderPassPrHeader,
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
+  type ReviewPassSpec,
+} from './review-pass.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Turn cap for the candidate-loop pass. Every candidate needs at least one
+ * read_file round trip to confirm a surviving reference is real production
+ * usage (no inline snippet is attached, unlike the pilot's stale-literal
+ * candidates) — higher than the pilot's 6, matching the second loop's 8. */
+export const REMOVED_EXPORTS_PASS_MAX_TURNS = 8;
+
+const REMOVED_EXPORTS_BASE_OVERHEAD_TOKENS = 2_000;
+const REMOVED_EXPORTS_PER_CANDIDATE_TOKENS = 800;
+const REMOVED_EXPORTS_MAX_BUDGET = 30_000;
+/** Mirrors removed-export-signals.ts's own private MAX_ENTRIES cap (15) — that
+ * module's `computeRemovedExportContexts` is itself uncapped (its cap is only
+ * applied by its own renderer, which this pass does not use), so this pass
+ * re-applies the same cap locally, same reasoning as the second loop's
+ * VARIANT_SWEEP_CAP/UNREAD_FIELD_CAP. */
+const MAX_CANDIDATES = 15;
+
+/** Opt-IN env flag — this loop ships dark by default, same as its siblings. */
+const REMOVED_EXPORTS_PASS_ENV = 'LIEN_REMOVED_EXPORTS_PASS';
+
+export const STRUCTURAL_ANALYSIS_RULE_ID = 'structural-analysis';
+
+/** Plugin name this pass reports itself under in the delivery attestation. */
+const REMOVED_EXPORTS_SKIP_PLUGIN = 'agent-review:removed-exports-loop';
+
+/** Two findings on the same file within this many lines are the same location. */
+const DEDUPE_LINE_PROXIMITY = 2;
+
+const REMOVED_EXPORTS_INTRO =
+  'This is a REMOVED-EXPORTS candidate loop — a dedicated second pass scoped to ' +
+  'the removed-export-sweep half of ONE rule (structural-analysis), running only ' +
+  'because a deterministic diff scan already found at least one removed public ' +
+  'export. Your ONLY job is to judge the <removed_exports> worklist below; do not ' +
+  "report anything else (a changed-but-not-removed export's new behavior, other " +
+  'bugs, style, doc drift — those are handled elsewhere).';
+
+const REMOVED_EXPORTS_TOOLS_SECTION = `<tools>
+You have these tools to investigate the codebase:
+- read_file: Read file contents from the repo — use to inspect a surviving reference's actual site and confirm it is real production usage, not a comment, test, or unrelated string match.
+- grep_codebase: Search the entire repository working tree for a text pattern (regex) — use ONLY for an exotic export shape the worklist doesn't cover (the rule text's own closing note). Do NOT re-grep the symbols already listed below; that discovery and reference sweep is already done.
+</tools>`;
+
+/**
+ * Guards against the two FP classes the #711-era removed-export/changeset
+ * tuning history and this signal's own module doc already name. Baked in
+ * from day one, per the pilot's own lesson (its equivalent guard was only
+ * added in PR #805, after an FP was observed) and the second loop's (which
+ * baked its guard in from the start, avoiding a repeat).
+ */
+const VERDICT_GUIDANCE = `<verdict_guidance>
+Two classes of surviving reference are usually NOT a real breaking change — do not
+verdict a candidate "breaking" on these alone:
+1. A removal already DISCLOSED by an accompanying changeset entry (the candidate's
+   "Changeset:" line names one). A changeset-documented removal is a deliberate,
+   announced break — verdict "intentional", not "breaking" — UNLESS the changeset's
+   own wording contradicts what actually happened (e.g. it claims the symbol is
+   unchanged or non-breaking while a production caller still depends on it); that
+   contradiction is still worth naming in your message even though it verdicts
+   "intentional" here (a full changeset-vs-reality cross-check is boundary-change's
+   job, not this pass's).
+2. A surviving reference that lives ONLY in test files, fixtures, or internal-only
+   tooling that never sees this export as real public API — verdict "internal-only".
+A real "breaking" verdict requires at least one surviving reference in PRODUCTION
+code (not test/fixture/internal-only) with no changeset documenting the removal.
+</verdict_guidance>`;
+
+/**
+ * A condensed, LOOP-SCOPED strategy — deliberately NOT `STRUCTURAL_ANALYSIS.prompt`
+ * reused verbatim the way the pilot/second loop reuse their own rule's full text.
+ * That rule's full prompt is written for the MAIN pass's BROADER job (5 steps:
+ * get_files_context, get_dependents, the removed-export check, "check if callers
+ * handle new behavior correctly", read_file on every changed function) — only
+ * step 3 is this loop's job. Steps 1/2/4/5 name tools (`get_files_context`,
+ * `get_dependents`) this loop's hard-cut toolset (see module doc) doesn't
+ * provide and a broader investigation (changed-but-not-removed behavior) this
+ * loop must NOT attempt (that's the shared main pass's job, per ADR-014's
+ * hybrid gating). Verbatim reuse here would tell the model to use tools that
+ * don't exist for this pass — a real contradiction, not just unused prose.
+ */
+const REMOVED_EXPORTS_STRATEGY = `### Structural Analysis — removed-export sweep
+For each candidate in the <removed_exports> worklist below:
+1. If it lists surviving reference(s), use read_file to inspect each one and confirm
+   it is REAL production usage (an import, a call site, a type reference) — not a
+   comment, a test/fixture file, or an unrelated string match.
+2. Check whether a changeset already documents this removal (the candidate's
+   "Changeset:" line) — see <verdict_guidance> below for how that interacts with
+   your verdict.
+3. Removed exports are the #1 source of breaking changes in deletion PRs — do not
+   assume a removal is safe just because this repo's own callers were updated; a
+   consumer outside this repo's own type-checked boundary (a published package's
+   external user, a dynamically-loaded plugin) can still break silently and won't
+   show up as a surviving reference in this corpus.
+4. Only use grep_codebase for an export shape the worklist doesn't cover (the
+   scan can miss exotic shapes) — do NOT re-grep symbols already listed above.`;
+
+/** A removed-export-shaped example — `STRUCTURAL_ANALYSIS.example` illustrates a
+ * CHANGED (not removed) export's new behavior, the wrong shape for this loop. */
+const REMOVED_EXPORTS_EXAMPLE = `### Good finding — removed export, real caller breaks:
+{
+  "filepath": "src/consumer.ts",
+  "line": 4,
+  "symbolName": "fetchUser",
+  "severity": "error",
+  "category": "breaking_change",
+  "ruleId": "structural-analysis",
+  "message": "fetchUser was removed from src/api.ts but src/consumer.ts:4 still imports and calls it directly. This import will fail to resolve.",
+  "suggestion": "Restore fetchUser, or update src/consumer.ts to use its replacement.",
+  "evidence": "removed_exports worklist candidate; surviving reference confirmed via read_file at src/consumer.ts:4"
+}
+
+### Good finding — verdict is NOT breaking, changeset documents the removal:
+A candidate with a "Changeset: described in .changeset/silly-otters-jump.md" line
+whose changeset text explicitly announces this removal should verdict "intentional"
+— do not report it as a finding, even if a surviving reference exists.`;
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Loop eligibility: at least one removed-export candidate. Unlike the
+ * pilot's unconditional `always: true` signal (which renders on ~40/40 real
+ * PRs, forcing a stricter same-file/high-confidence threshold),
+ * `computeRemovedExportContexts` is ALREADY selective by construction — it
+ * returns [] unless the diff actually removes a public export, the same
+ * shape the second loop's `hasEligibleCandidate` relies on. No extra
+ * confidence tiering on top of "any candidate exists" (see the PR body's
+ * real-PR census for the measured firing rate).
+ */
+function hasEligibleCandidate(candidates: RemovedExportContext[]): boolean {
+  return candidates.length > 0;
+}
+
+function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'on';
+}
+
+/** Whether the loop is opted in — config takes precedence, then the env flag. */
+export function isRemovedExportsPassEnabled(config?: AgentConfig): boolean {
+  if (config?.removedExportsPass === true) return true;
+  return envEnabled(process.env[REMOVED_EXPORTS_PASS_ENV]);
+}
+
+/**
+ * Precisely why the removed-exports loop would not run right now, or null if
+ * it should run. Mirrors `staleDuplicateSkipReason`/`incompleteHandlingSkipReason`.
+ */
+export function removedExportsSkipReason(
+  context: ReviewContext,
+  config?: AgentConfig,
+): string | null {
+  if (!isRemovedExportsPassEnabled(config)) {
+    return (
+      `disabled (opt-in; set config.removedExportsPass or ${REMOVED_EXPORTS_PASS_ENV}=on ` +
+      'to enable)'
+    );
+  }
+  const candidates = computeRemovedExportsCandidates(context);
+  if (!hasEligibleCandidate(candidates)) {
+    return 'no removed public export found in this PR’s diff';
+  }
+  return null;
+}
+
+/** Whether to run the removed-exports loop. True iff `removedExportsSkipReason` is null. */
+export function shouldRunRemovedExportsPass(context: ReviewContext, config?: AgentConfig): boolean {
+  return removedExportsSkipReason(context, config) === null;
+}
+
+// ---------------------------------------------------------------------------
+// Candidate worklist (capped)
+// ---------------------------------------------------------------------------
+
+/**
+ * The capped removed-export candidate list this loop judges — the shared
+ * signal's own sort order (breakage-first, then changeset-mentioned, ties by
+ * symbol name) is preserved, just capped at `MAX_CANDIDATES` for prompt size.
+ * Exposed for testing.
+ */
+export function computeRemovedExportsCandidates(context: ReviewContext): RemovedExportContext[] {
+  return computeRemovedExportContexts(context).slice(0, MAX_CANDIDATES);
+}
+
+function candidateIds(candidates: RemovedExportContext[]): string[] {
+  return candidates.map((_, i) => `candidate-${i + 1}`);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(?:\d+)(?:,\d+)? @@/;
+const DEFAULT_PREFIX = 'default (';
+const BULK_PREFIX = "* (all re-exports of '";
+
+/** The bare identifier to search a hunk's removed lines for, or undefined for a
+ * default/bulk export (no stable declaration text a plain search can re-find). */
+function bareSymbolName(symbol: string): string | undefined {
+  if (symbol.startsWith(DEFAULT_PREFIX) || symbol.startsWith(BULK_PREFIX)) return undefined;
+  return symbol;
+}
+
+function wordBoundaryRe(name: string): RegExp {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\b`);
+}
+
+/**
+ * Find the diff hunk whose REMOVED (`-`) lines mention `symbol` — the hunk
+ * that actually deleted this export's declaration. `RemovedExport` carries no
+ * line number (only `symbol` + `file` — see module doc), so this re-derives
+ * the hunk from the diff text by content match rather than widening that
+ * shared shape for a presentation-only need. Returns undefined when no hunk's
+ * removed lines mention the symbol (default/bulk exports, or an exotic shape
+ * a plain search can't re-find).
+ */
+function findRemovalHunk(patch: string | undefined, symbol: string): string | undefined {
+  const bareName = bareSymbolName(symbol);
+  if (!patch || !bareName) return undefined;
+  const re = wordBoundaryRe(bareName);
+
+  let hunkLines: string[] = [];
+  let matched = false;
+  const flush = (): string | undefined => (matched ? hunkLines.join('\n') : undefined);
+
+  for (const raw of patch.split('\n')) {
+    if (HUNK_HEADER_RE.test(raw)) {
+      const prior = flush();
+      if (prior) return prior;
+      hunkLines = [raw];
+      matched = false;
+      continue;
+    }
+    if (hunkLines.length === 0) continue; // before the first hunk
+    hunkLines.push(raw);
+    if (raw.startsWith('-') && re.test(raw)) matched = true;
+  }
+  return flush();
+}
+
+/** Render one candidate's evidence block: removal hunk, surviving references, changeset. */
+function renderCandidate(id: string, c: RemovedExportContext, patch: string | undefined): string {
+  const lines: string[] = [`<candidate id="${id}" symbol=${JSON.stringify(c.symbol)}>`];
+  lines.push(`Removed from: ${c.file}`);
+  const hunk = findRemovalHunk(patch, c.symbol);
+  if (hunk) {
+    lines.push('```diff');
+    lines.push(hunk);
+    lines.push('```');
+  }
+  lines.push('Surviving reference(s):');
+  if (c.survivingReferences.length === 0) {
+    lines.push('  - none found in the head corpus');
+  } else {
+    for (const r of c.survivingReferences) lines.push(`  - ${r.file}:${r.line}`);
+  }
+  lines.push(
+    c.changesetFile
+      ? `Changeset: described in ${c.changesetFile}`
+      : 'Changeset: none found mentioning this symbol',
+  );
+  lines.push('</candidate>');
+  return lines.join('\n');
+}
+
+/**
+ * Build the worklist. Uses the SAME `<removed_exports>` tag name the shared
+ * `STRUCTURAL_ANALYSIS.prompt` text (in `rules.ts`, active in the MAIN pass)
+ * already instructs the model to look for — the exact "prompt promises a
+ * signal it doesn't inject" mismatch class ADR-014's design work called out
+ * for the rename-sweep/doc-truth precedent. Safe to reuse across the main
+ * pass and this pass: they are separate, non-overlapping LLM calls.
+ */
+function renderWorklist(context: ReviewContext, candidates: RemovedExportContext[]): string {
+  const patches = context.pr?.patches;
+  const ids = candidateIds(candidates);
+  const lines: string[] = ['<removed_exports>'];
+  lines.push(
+    'One verdict is REQUIRED per candidate id below (see <output_format>) — ' +
+      `${ids.join(', ')}. Each candidate is a public export this PR REMOVES, with any ` +
+      'surviving cross-file reference(s) and changeset mention already computed for you.',
+  );
+  candidates.forEach((c, i) => {
+    lines.push('');
+    lines.push(renderCandidate(ids[i], c, patches?.get(c.file)));
+  });
+  lines.push('</removed_exports>');
+  return lines.join('\n');
+}
+
+/** The per-candidate-verdict output contract (see module doc for the four values). */
+function buildOutputFormat(ids: string[]): string {
+  return `<output_format>
+Output EXACTLY one entry per candidate id in the \`findings\` array — one for EVERY
+id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
+
+{
+  "findings": [
+    {
+      "candidateId": "candidate-1",
+      "verdict": "breaking | intentional | internal-only | unverifiable",
+      "filepath": "relative/path.ts",
+      "line": 42,
+      "symbolName": "removedSymbolName",
+      "severity": "error | warning",
+      "category": "breaking_change",
+      "message": "REQUIRED for every verdict. When breaking: 1-2 sentences naming the removed export and the surviving caller(s) that will break. When intentional/internal-only/unverifiable: 1 sentence saying why.",
+      "suggestion": "The fix (breaking only) — restore the export, or update the surviving caller(s).",
+      "evidence": "One line citing the candidate and what you inspected to confirm it."
+    }
+  ],
+  "summary": {
+    "riskLevel": "low | medium | high | critical",
+    "overview": "One sentence.",
+    "keyChanges": []
+  }
+}
+
+EVERY entry requires candidateId, verdict, filepath, line, severity, and message —
+even for intentional/internal-only/unverifiable verdicts (fill filepath from the
+candidate's removal file, line from its first surviving reference or 1 if none,
+severity "warning", message explaining the disposition). ALWAYS set symbolName to
+the candidate's removed symbol on a breaking verdict — this pass's dedupe against
+the main pass's own structural-analysis findings matches on symbol identity, not
+just location.
+A missing candidateId for any worklist entry makes this pass's result incomplete.
+</output_format>`;
+}
+
+function buildSystemPrompt(ids: string[]): string {
+  return `${REMOVED_EXPORTS_INTRO}
+
+${REMOVED_EXPORTS_TOOLS_SECTION}
+
+<strategy>
+${REMOVED_EXPORTS_STRATEGY}
+</strategy>
+
+${VERDICT_GUIDANCE}
+
+<examples>
+${REMOVED_EXPORTS_EXAMPLE}
+</examples>
+
+${buildOutputFormat(ids)}`;
+}
+
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. */
+export function buildRemovedExportsPassInitialMessage(context: ReviewContext): string {
+  const candidates = computeRemovedExportsCandidates(context);
+  const sections: string[] = [];
+  const header = renderPassPrHeader(context);
+  if (header) sections.push(header);
+  sections.push(renderWorklist(context, candidates));
+  sections.push('Judge every candidate above and output your verdicts as JSON.');
+  return sections.join('\n\n');
+}
+
+/** The system + initial prompts for the removed-exports candidate loop. */
+export function buildRemovedExportsPassPrompts(context: ReviewContext): {
+  systemPrompt: string;
+  initialMessage: string;
+} {
+  const ids = candidateIds(computeRemovedExportsCandidates(context));
+  return {
+    systemPrompt: buildSystemPrompt(ids),
+    initialMessage: buildRemovedExportsPassInitialMessage(context),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+/**
+ * Budget scaled by this pass's own candidate count, clamped floor/ceiling —
+ * mirrors the pilot's `staleDuplicatePassBudget` formula shape. The floor is
+ * `EXTRA_PASS_MIN_BUDGET_TOKENS` (shared across all four extra passes — see
+ * that constant's doc comment / PR #811): a 1-2 candidate run (the common
+ * real-PR case) gets the same one-real-round-trip floor every other pass
+ * gets, while the scaling term still exists so a future cap increase scales
+ * up past the floor rather than needing a second formula change.
+ */
+export function removedExportsPassBudget(_baseBudget: number, context: ReviewContext): number {
+  const candidateCount = computeRemovedExportsCandidates(context).length;
+  const scaled =
+    REMOVED_EXPORTS_BASE_OVERHEAD_TOKENS +
+    REMOVED_EXPORTS_PER_CANDIDATE_TOKENS * Math.min(candidateCount, MAX_CANDIDATES);
+  return Math.min(Math.max(scaled, EXTRA_PASS_MIN_BUDGET_TOKENS), REMOVED_EXPORTS_MAX_BUDGET);
+}
+
+// ---------------------------------------------------------------------------
+// Post-processing (verdict reduction + honest completeness)
+// ---------------------------------------------------------------------------
+
+/** A verdict value the loop's output contract recognizes. */
+type Verdict = 'breaking' | 'intentional' | 'internal-only' | 'unverifiable';
+const VALID_VERDICTS: ReadonlySet<string> = new Set<Verdict>([
+  'breaking',
+  'intentional',
+  'internal-only',
+  'unverifiable',
+]);
+
+/** The raw per-candidate shape the model emits inside the standard `findings` array. */
+interface RawVerdictFinding extends AgentFinding {
+  candidateId?: string;
+  verdict?: Verdict;
+}
+
+/** Strip the loop-only `candidateId`/`verdict` fields, keeping the standard finding shape. */
+function toCleanFinding(f: RawVerdictFinding): AgentFinding {
+  return {
+    filepath: f.filepath,
+    line: f.line,
+    endLine: f.endLine,
+    symbolName: f.symbolName,
+    severity: f.severity,
+    category: f.category,
+    message: f.message,
+    suggestion: f.suggestion,
+    evidence: f.evidence,
+  };
+}
+
+/**
+ * True iff every expected candidate id appears in `raw` EXACTLY once, each
+ * with a RECOGNIZED verdict — and `raw` contains no entry with a missing/
+ * unknown candidateId or an unrecognized verdict. Same contract as the two
+ * siblings' `hasCompleteVerdictCoverage` (see either module's doc for why
+ * candidateId-presence alone isn't enough): "one recognized verdict per
+ * expected id", not merely "every id mentioned somewhere". This is a third
+ * copy of the same ~15-line shape rather than an extraction into a shared
+ * helper — deliberate: doing so would mean touching both sibling files
+ * (out of scope for this pass, and outside this session's collision-
+ * minimization brief), not a missed DRY opportunity.
+ */
+function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): boolean {
+  const expected = new Set(ids);
+  const verdictCounts = new Map<string, number>();
+  for (const { candidateId, verdict } of raw) {
+    if (
+      typeof candidateId !== 'string' ||
+      !expected.has(candidateId) ||
+      typeof verdict !== 'string' ||
+      !VALID_VERDICTS.has(verdict)
+    ) {
+      return false;
+    }
+    verdictCounts.set(candidateId, (verdictCounts.get(candidateId) ?? 0) + 1);
+  }
+  return ids.every(id => verdictCounts.get(id) === 1);
+}
+
+/**
+ * Reduce this pass's raw per-candidate verdict array down to real findings
+ * (`verdict === 'breaking'` AND `candidateId` names a real worklist entry
+ * only, cleaned of the loop-only fields), and mark the result honestly
+ * incomplete when the verdict array doesn't cleanly cover the worklist —
+ * same honesty contract as both siblings. The candidateId check guards
+ * against the same hallucinated-id loophole a code reviewer caught in PR
+ * #804: a phantom candidate id must not leak through as a real finding just
+ * because it carries `verdict: 'breaking'`. When the underlying client
+ * result was ALREADY incomplete for a real reason (budget/max_turns/error),
+ * that reason is kept as-is; `incomplete_verdict` is only used when the
+ * model otherwise returned a syntactically complete verdict.
+ */
+export function postProcessRemovedExportsResult(
+  result: AgentResult,
+  context: ReviewContext,
+): AgentResult {
+  const ids = candidateIds(computeRemovedExportsCandidates(context));
+  const expected = new Set(ids);
+  const raw = result.findings as RawVerdictFinding[];
+  const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
+  const wasAlreadyIncomplete = result.incomplete;
+
+  return {
+    ...result,
+    findings: raw
+      .filter(
+        f =>
+          f.verdict === 'breaking' &&
+          typeof f.candidateId === 'string' &&
+          expected.has(f.candidateId),
+      )
+      .map(toCleanFinding),
+    incomplete: wasAlreadyIncomplete || coverageIncomplete,
+    stopReason:
+      !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Two findings are the "same export collision" when they're in the same file
+ * AND either within `DEDUPE_LINE_PROXIMITY` lines OR share a non-empty
+ * `symbolName` — the stable removed-symbol identity this loop's candidates
+ * carry (see module doc's "Dedupe" section for why this loop adds identity
+ * matching on top of the siblings' proximity-only check).
+ */
+function sameExportCollision(a: AgentFinding, b: AgentFinding): boolean {
+  if (a.filepath !== b.filepath) return false;
+  if (Math.abs(a.line - b.line) <= DEDUPE_LINE_PROXIMITY) return true;
+  return !!a.symbolName && !!b.symbolName && a.symbolName === b.symbolName;
+}
+
+/**
+ * Fold the loop's findings (already reduced to `verdict === 'breaking'` only)
+ * into the main pass's. The LOOP finding wins on a same-export collision —
+ * same "loop wins" direction as both siblings — scoped to main-pass findings
+ * whose OWN `ruleId` is also `structural-analysis`, never an unrelated
+ * rule's finding that merely lands nearby. Returns a new array; inputs are
+ * not mutated.
+ */
+export function mergeRemovedExportsFindings(
+  mainFindings: AgentFinding[],
+  loopFindings: AgentFinding[],
+): AgentFinding[] {
+  const forced = loopFindings.map(f => ({ ...f, ruleId: STRUCTURAL_ANALYSIS_RULE_ID }));
+  const survivingMain = mainFindings.filter(
+    mf =>
+      mf.ruleId !== STRUCTURAL_ANALYSIS_RULE_ID || !forced.some(lf => sameExportCollision(mf, lf)),
+  );
+  return [...survivingMain, ...forced];
+}
+
+/**
+ * Fold the loop's result-level state into the main pass's — only
+ * incomplete/stopReason propagate, naming this pass via the generic
+ * `incompleteFromPass` (see types.ts), same as both siblings.
+ */
+export function mergeRemovedExportsResultState(
+  main: AgentResult,
+  passResult: AgentResult | null,
+): AgentResult {
+  if (!passResult) return main;
+  if (passResult.incomplete && !main.incomplete) {
+    main.incomplete = true;
+    main.stopReason = passResult.stopReason;
+    main.incompleteFromPass = 'removed-exports';
+  }
+  return main;
+}
+
+// ---------------------------------------------------------------------------
+// ReviewPassSpec (plugs the loop into the generalized executor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Removed-exports candidate loop bundled as a `ReviewPassSpec` (see
+ * `review-pass.ts`). Every field here is one of this module's own pure
+ * functions; the generic executor supplies the gate-check/run/
+ * failure-isolation/reporting plumbing.
+ */
+export const REMOVED_EXPORTS_PASS_SPEC: ReviewPassSpec = {
+  name: 'removed-exports-loop',
+  skipPlugin: REMOVED_EXPORTS_SKIP_PLUGIN,
+  gateReason: removedExportsSkipReason,
+  buildPrompts: buildRemovedExportsPassPrompts,
+  budget: removedExportsPassBudget,
+  maxTurns: REMOVED_EXPORTS_PASS_MAX_TURNS,
+  mergeFindings: mergeRemovedExportsFindings,
+  mergeResultState: mergeRemovedExportsResultState,
+  postProcessResult: postProcessRemovedExportsResult,
+};

--- a/packages/review/src/plugins/agent/removed-exports-pass.ts
+++ b/packages/review/src/plugins/agent/removed-exports-pass.ts
@@ -437,14 +437,15 @@ id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
   }
 }
 
-EVERY entry requires candidateId, verdict, filepath, line, severity, and message —
-even for intentional/internal-only/unverifiable verdicts (fill filepath from the
-candidate's removal file, line from its first surviving reference or 1 if none,
-severity "warning", message explaining the disposition). ALWAYS set symbolName to
-the candidate's removed symbol on a breaking verdict — this pass's dedupe against
-the main pass's own structural-analysis findings matches on symbol identity, not
-just location.
-A missing candidateId for any worklist entry makes this pass's result incomplete.
+EVERY entry requires candidateId, verdict, filepath, line, severity, category, and
+message — even for intentional/internal-only/unverifiable verdicts (fill filepath
+from the candidate's removal file, line from its first surviving reference or 1 if
+none, severity "warning", category any short slug e.g. "breaking_change", message
+explaining the disposition). A missing category silently drops the ENTIRE entry,
+same as a missing candidateId — both make this pass's result incomplete. ALWAYS set
+symbolName to the candidate's removed symbol on a breaking verdict — this pass's
+dedupe against the main pass's own structural-analysis findings matches on symbol
+identity, not just location.
 </output_format>`;
 }
 

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -72,6 +72,13 @@ export interface AgentConfig {
    * `incomplete-handling-pass.ts`.
    */
   incompleteHandlingPass?: boolean;
+  /**
+   * Run the removed-exports candidate loop (ADR-014's gating matrix —
+   * `structural-analysis` is hybrid; this covers only its removed-export
+   * sweep half). Default false — dark-launched; set true (or env
+   * LIEN_REMOVED_EXPORTS_PASS=on) to enable it. See `removed-exports-pass.ts`.
+   */
+  removedExportsPass?: boolean;
 }
 
 /** A single finding produced by the agent during review. */

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -15,11 +15,13 @@
  * (`buildDocTruthPassPrompts`) from the main pass's `buildInitialMessage`.
  *
  * Same for the stale-duplicate candidate-loop PILOT (`staleDuplicatePass`,
- * per-rule-loops design doc §4) and the incomplete-handling candidate loop
- * (`incompleteHandlingPass`, design doc §7 item 5) — both dark by default,
- * so `fires` is false unless the fixture's captured config (or the
- * relevant env flag in the environment this script runs in) opts in AND
- * that loop's own eligibility gate is met.
+ * per-rule-loops design doc §4), the incomplete-handling candidate loop
+ * (`incompleteHandlingPass`, design doc §7 item 5), and the removed-exports
+ * candidate loop (`removedExportsPass`, ADR-014's gating matrix —
+ * structural-analysis is hybrid) — all dark by default, so `fires` is false
+ * unless the fixture's captured config (or the relevant env flag in the
+ * environment this script runs in) opts in AND that loop's own eligibility
+ * gate is met.
  *
  * Usage: tsx build-prompts.ts <fixture.json>
  */
@@ -42,6 +44,10 @@ import {
   buildIncompleteHandlingPassPrompts,
   applyIncompleteHandlingMainOverride,
 } from '../../src/plugins/agent/incomplete-handling-pass.js';
+import {
+  shouldRunRemovedExportsPass,
+  buildRemovedExportsPassPrompts,
+} from '../../src/plugins/agent/removed-exports-pass.js';
 import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
@@ -79,6 +85,11 @@ async function main(): Promise<void> {
     ? { fires: true as const, ...buildIncompleteHandlingPassPrompts(ctx) }
     : { fires: false as const };
 
+  const removedExportsFires = shouldRunRemovedExportsPass(ctx, config);
+  const removedExportsPass = removedExportsFires
+    ? { fires: true as const, ...buildRemovedExportsPassPrompts(ctx) }
+    : { fires: false as const };
+
   const output = {
     fixturePath,
     ruleIds: rules.active.map(r => r.id),
@@ -88,6 +99,7 @@ async function main(): Promise<void> {
     docTruthPass,
     staleDuplicatePass,
     incompleteHandlingPass,
+    removedExportsPass,
   };
 
   process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/packages/review/test/plugins-agent-removed-exports-pass.test.ts
+++ b/packages/review/test/plugins-agent-removed-exports-pass.test.ts
@@ -315,6 +315,21 @@ describe('buildRemovedExportsPassPrompts', () => {
     expect(systemPrompt).toContain('candidate-1');
   });
 
+  // Regression for #816 (the pilot/second-loop/doc-truth-v2 fix): a real captured vote had the
+  // model omit `category` from every per-claim verdict entry, silently dropping them all at
+  // `isValidFinding` (which requires `category`) — because the contract's "EVERY entry
+  // requires ..." sentence didn't name it, even though the example JSON above it does. This
+  // pass's contract shares the identical sentence shape, so it carries the same latent gap if
+  // not fixed here too.
+  it('names category among the required fields, not just in the illustrative example', () => {
+    const { systemPrompt } = buildRemovedExportsPassPrompts(breakingOnlyContext());
+    const requiredFieldsSentence = systemPrompt
+      .split('\n')
+      .find(line => line.startsWith('EVERY entry requires'));
+    expect(requiredFieldsSentence).toBeDefined();
+    expect(requiredFieldsSentence).toContain('category');
+  });
+
   it('builds an initial message with the <removed_exports> worklist tag (matches the rule text)', () => {
     const message = buildRemovedExportsPassInitialMessage(breakingOnlyContext());
     expect(message).toContain('<pr_metadata>');

--- a/packages/review/test/plugins-agent-removed-exports-pass.test.ts
+++ b/packages/review/test/plugins-agent-removed-exports-pass.test.ts
@@ -1,0 +1,663 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+
+import {
+  removedExportsSkipReason,
+  shouldRunRemovedExportsPass,
+  isRemovedExportsPassEnabled,
+  computeRemovedExportsCandidates,
+  buildRemovedExportsPassPrompts,
+  buildRemovedExportsPassInitialMessage,
+  removedExportsPassBudget,
+  postProcessRemovedExportsResult,
+  mergeRemovedExportsFindings,
+  mergeRemovedExportsResultState,
+  REMOVED_EXPORTS_PASS_SPEC,
+  REMOVED_EXPORTS_PASS_MAX_TURNS,
+  STRUCTURAL_ANALYSIS_RULE_ID,
+} from '../src/plugins/agent/removed-exports-pass.js';
+import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../src/plugins/agent/rules.js';
+import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { createTestContext } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function makeChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'block',
+      language: 'typescript',
+    },
+  } as unknown as CodeChunk;
+}
+
+function patch(...lines: string[]): string {
+  return lines.join('\n');
+}
+
+// ---- breaking shape: removed export still called from a different file ----
+
+const API_REMOVE_PATCH = patch(
+  '@@ -1,3 +0,0 @@',
+  '-export function fetchUser(id: string) {',
+  '-  return db.get(id);',
+  '-}',
+);
+
+const CONSUMER_CONTENT = [
+  'function loadProfile(id: string) {',
+  '  return fetchUser(id);',
+  '}',
+].join('\n');
+
+function breakingOnlyContext(): ReviewContext {
+  const patches = new Map([['src/api.ts', API_REMOVE_PATCH]]);
+  const repoChunks = [makeChunk('src/consumer.ts', 1, CONSUMER_CONTENT)];
+  return createTestContext({
+    changedFiles: ['src/api.ts'],
+    chunks: [],
+    repoChunks,
+    pr: {
+      title: 'Remove fetchUser',
+      body: '',
+      patches,
+    } as unknown as ReviewContext['pr'],
+  });
+}
+
+// ---- changeset-documented shape: removal accompanied by a changeset entry ----
+
+const WIDGET_REMOVE_PATCH = patch('@@ -1,1 +0,0 @@', '-export function widget() {}');
+const CHANGESET_PATCH = patch(
+  '@@ -0,0 +1,4 @@',
+  '+---',
+  "+'@liendev/core': minor",
+  '+---',
+  '+',
+  '+Removed `widget` — use `newWidget` instead.',
+);
+
+function changesetDocumentedContext(): ReviewContext {
+  const patches = new Map([
+    ['src/widget.ts', WIDGET_REMOVE_PATCH],
+    ['.changeset/silly-otters-jump.md', CHANGESET_PATCH],
+  ]);
+  return createTestContext({
+    changedFiles: ['src/widget.ts', '.changeset/silly-otters-jump.md'],
+    chunks: [],
+    repoChunks: [],
+    pr: {
+      title: 'Remove widget (documented)',
+      body: '',
+      patches,
+    } as unknown as ReviewContext['pr'],
+  });
+}
+
+// ---- rename shape: removed in one file, re-added (same symbol) in another ----
+
+function renameContext(): ReviewContext {
+  const patches = new Map([
+    ['src/old.ts', patch('@@ -1,1 +0,0 @@', '-export function widget() {}')],
+    ['src/new.ts', patch('@@ -0,0 +1,1 @@', '+export function widget() {}')],
+  ]);
+  return createTestContext({
+    changedFiles: ['src/old.ts', 'src/new.ts'],
+    chunks: [],
+    repoChunks: [],
+    pr: { title: 'Move widget', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** No signal fires at all — an ordinary PR that removes nothing exported. */
+function noCandidateContext(): ReviewContext {
+  const patches = new Map([
+    ['src/plain.ts', patch('@@ -1,1 +1,1 @@', '-const x = 1;', '+const x = 2;')],
+  ]);
+  return createTestContext({
+    changedFiles: ['src/plain.ts'],
+    chunks: [],
+    repoChunks: [],
+    pr: { title: 'Trivial change', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** 20 independent removed exports (no surviving refs, no changesets) — exercises
+ * the MAX_CANDIDATES (15) cap deterministically via the shared signal's own
+ * alphabetical tiebreak (no refs/changeset to sort by). */
+function manyRemovalsContext(): ReviewContext {
+  const patches = new Map<string, string>();
+  for (let i = 0; i < 20; i++) {
+    const n = String(i).padStart(2, '0');
+    patches.set(`src/f${n}.ts`, patch('@@ -1,1 +0,0 @@', `-export function sym${n}() {}`));
+  }
+  return createTestContext({
+    changedFiles: [...patches.keys()],
+    chunks: [],
+    repoChunks: [],
+    pr: { title: 'Remove many exports', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+function finding(overrides: Record<string, unknown> = {}): AgentFinding {
+  return {
+    filepath: 'src/consumer.ts',
+    line: 4,
+    severity: 'error',
+    category: 'breaking_change',
+    message: 'msg',
+    ...overrides,
+  } as AgentFinding;
+}
+
+function fakeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2, cost: 0.01 },
+    turns: 1,
+    stopReason: 'completed',
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+// Restore caller state rather than unconditionally deleting.
+let previousRemovedExportsPass: string | undefined;
+
+beforeEach(() => {
+  previousRemovedExportsPass = process.env.LIEN_REMOVED_EXPORTS_PASS;
+  delete process.env.LIEN_REMOVED_EXPORTS_PASS;
+});
+
+afterEach(() => {
+  if (previousRemovedExportsPass === undefined) delete process.env.LIEN_REMOVED_EXPORTS_PASS;
+  else process.env.LIEN_REMOVED_EXPORTS_PASS = previousRemovedExportsPass;
+});
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+describe('removedExportsSkipReason / shouldRunRemovedExportsPass', () => {
+  it('is false (disabled) by default, even with an eligible candidate — ships dark', () => {
+    const ctx = breakingOnlyContext();
+    expect(shouldRunRemovedExportsPass(ctx, cfg())).toBe(false);
+    expect(removedExportsSkipReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('is true when opted in via config AND a removed export exists', () => {
+    const ctx = breakingOnlyContext();
+    expect(shouldRunRemovedExportsPass(ctx, cfg({ removedExportsPass: true }))).toBe(true);
+  });
+
+  it('is true when opted in via LIEN_REMOVED_EXPORTS_PASS=on (no config flag)', () => {
+    process.env.LIEN_REMOVED_EXPORTS_PASS = 'on';
+    const ctx = breakingOnlyContext();
+    expect(shouldRunRemovedExportsPass(ctx, cfg())).toBe(true);
+  });
+
+  it('is false when opted in but no export is removed', () => {
+    const ctx = noCandidateContext();
+    const reason = removedExportsSkipReason(ctx, cfg({ removedExportsPass: true }));
+    expect(reason).toContain('no removed public export');
+  });
+
+  it('is false for a rename (removed in one file, re-added elsewhere) even when opted in', () => {
+    const ctx = renameContext();
+    expect(shouldRunRemovedExportsPass(ctx, cfg({ removedExportsPass: true }))).toBe(false);
+  });
+
+  it('is false when there are no patches at all, even when opted in', () => {
+    expect(
+      shouldRunRemovedExportsPass(createTestContext(), cfg({ removedExportsPass: true })),
+    ).toBe(false);
+  });
+
+  it('isRemovedExportsPassEnabled: config takes precedence, then env', () => {
+    expect(isRemovedExportsPassEnabled(cfg())).toBe(false);
+    expect(isRemovedExportsPassEnabled(cfg({ removedExportsPass: true }))).toBe(true);
+    process.env.LIEN_REMOVED_EXPORTS_PASS = 'on';
+    expect(isRemovedExportsPassEnabled(cfg())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Candidate worklist (reuses removed-export-signals.ts; rename disambiguation)
+// ---------------------------------------------------------------------------
+
+describe('computeRemovedExportsCandidates', () => {
+  it('builds one candidate from a plain removed export', () => {
+    const candidates = computeRemovedExportsCandidates(breakingOnlyContext());
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].symbol).toBe('fetchUser');
+    expect(candidates[0].file).toBe('src/api.ts');
+  });
+
+  it('finds the surviving cross-file reference for a breaking-shaped candidate', () => {
+    const candidates = computeRemovedExportsCandidates(breakingOnlyContext());
+    expect(candidates[0].survivingReferences).toHaveLength(1);
+    expect(candidates[0].survivingReferences[0].file).toBe('src/consumer.ts');
+  });
+
+  it('records the changeset file for a documented removal', () => {
+    const candidates = computeRemovedExportsCandidates(changesetDocumentedContext());
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].symbol).toBe('widget');
+    expect(candidates[0].changesetFile).toBe('.changeset/silly-otters-jump.md');
+  });
+
+  it('excludes a rename (removed here, re-added elsewhere) — not a real removal', () => {
+    expect(computeRemovedExportsCandidates(renameContext())).toEqual([]);
+  });
+
+  it('returns [] for a context with no removed export', () => {
+    expect(computeRemovedExportsCandidates(noCandidateContext())).toEqual([]);
+  });
+
+  it('caps the candidate list at 15 (MAX_CANDIDATES)', () => {
+    const candidates = computeRemovedExportsCandidates(manyRemovalsContext());
+    expect(candidates).toHaveLength(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+describe('buildRemovedExportsPassPrompts', () => {
+  it('hard-cuts the tool list to read_file + grep_codebase only', () => {
+    const { systemPrompt } = buildRemovedExportsPassPrompts(breakingOnlyContext());
+    expect(systemPrompt).toContain('read_file');
+    expect(systemPrompt).toContain('grep_codebase');
+    expect(systemPrompt).not.toContain('get_files_context');
+    expect(systemPrompt).not.toContain('get_dependents');
+    expect(systemPrompt).not.toContain('list_functions');
+    expect(systemPrompt).not.toContain('get_complexity');
+  });
+
+  it("includes a loop-scoped strategy and a removed-export-shaped example, not the shared rule's broader prompt", () => {
+    const { systemPrompt } = buildRemovedExportsPassPrompts(breakingOnlyContext());
+    expect(systemPrompt).toContain('Structural Analysis');
+    expect(systemPrompt).toContain('removed export, real caller breaks');
+    // The shared rule's own broader-job prompt text names tools this loop's
+    // hard-cut toolset doesn't provide — must not leak in verbatim.
+    expect(systemPrompt).not.toContain('Use get_files_context on changed files');
+    expect(systemPrompt).not.toContain('Use get_dependents on every changed');
+    expect(systemPrompt).not.toContain('fetchUser now returns undefined');
+    expect(systemPrompt).not.toContain('Stale Duplicate Literal Check');
+    expect(systemPrompt).not.toContain('Incomplete Handling Check');
+  });
+
+  it('includes the changeset/test-only false-positive verdict guidance', () => {
+    const { systemPrompt } = buildRemovedExportsPassPrompts(breakingOnlyContext());
+    expect(systemPrompt).toContain('verdict_guidance');
+    expect(systemPrompt).toContain('changeset');
+    expect(systemPrompt).toContain('internal-only');
+  });
+
+  it('requires one findings-array entry per candidate id with the four-value verdict vocabulary', () => {
+    const { systemPrompt } = buildRemovedExportsPassPrompts(breakingOnlyContext());
+    expect(systemPrompt).toContain('candidateId');
+    expect(systemPrompt).toContain('breaking | intentional | internal-only | unverifiable');
+    expect(systemPrompt).toContain('candidate-1');
+  });
+
+  it('builds an initial message with the <removed_exports> worklist tag (matches the rule text)', () => {
+    const message = buildRemovedExportsPassInitialMessage(breakingOnlyContext());
+    expect(message).toContain('<pr_metadata>');
+    expect(message).toContain('<removed_exports>');
+    expect(message).toContain('fetchUser');
+    expect(message).toContain('src/consumer.ts:');
+  });
+
+  it('renders the removal diff hunk when the patch is available', () => {
+    const message = buildRemovedExportsPassInitialMessage(breakingOnlyContext());
+    expect(message).toContain('```diff');
+    expect(message).toContain('-export function fetchUser');
+  });
+
+  it('renders "none found" for a candidate with no surviving reference', () => {
+    const message = buildRemovedExportsPassInitialMessage(changesetDocumentedContext());
+    expect(message).toContain('none found in the head corpus');
+    expect(message).toContain('Changeset: described in .changeset/silly-otters-jump.md');
+  });
+
+  it('renders "none found" for the changeset line when no changeset mentions the symbol', () => {
+    const message = buildRemovedExportsPassInitialMessage(breakingOnlyContext());
+    expect(message).toContain('Changeset: none found mentioning this symbol');
+  });
+
+  it('does not include competing signal blocks (blast radius, doc claims, stale literal, etc.)', () => {
+    const message = buildRemovedExportsPassInitialMessage(breakingOnlyContext());
+    expect(message).not.toContain('<blast_radius>');
+    expect(message).not.toContain('<doc_claims>');
+    expect(message).not.toContain('<stale_literal_candidates>');
+    expect(message).not.toContain('<incomplete_handling_candidates>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+describe('removedExportsPassBudget', () => {
+  it('scales with candidate count, clamped to the shared one-round-trip floor for a single candidate', () => {
+    const budget = removedExportsPassBudget(100_000, breakingOnlyContext());
+    // 1 candidate: 2000 + 800*1 = 2800, clamped up to the 11,000 shared floor.
+    expect(budget).toBe(11_000);
+  });
+
+  it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {
+    const low = removedExportsPassBudget(10_000, manyRemovalsContext());
+    const high = removedExportsPassBudget(500_000, manyRemovalsContext());
+    expect(low).toBe(high);
+  });
+
+  it('scales past the floor once candidate count is high enough', () => {
+    // 15 candidates (the cap): 2000 + 800*15 = 14000 > 11,000 floor.
+    const budget = removedExportsPassBudget(100_000, manyRemovalsContext());
+    expect(budget).toBe(14_000);
+  });
+
+  it('turn cap is exported and equals REMOVED_EXPORTS_PASS_MAX_TURNS', () => {
+    expect(REMOVED_EXPORTS_PASS_SPEC.maxTurns).toBe(REMOVED_EXPORTS_PASS_MAX_TURNS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postProcessRemovedExportsResult
+// ---------------------------------------------------------------------------
+
+describe('postProcessRemovedExportsResult', () => {
+  it('keeps only verdict:"breaking" entries as real findings, stripping candidateId/verdict', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'breaking', message: 'real bug' })],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toBe('real bug');
+    expect((result.findings[0] as Record<string, unknown>).candidateId).toBeUndefined();
+    expect((result.findings[0] as Record<string, unknown>).verdict).toBeUndefined();
+  });
+
+  it('drops intentional/internal-only/unverifiable verdicts entirely', () => {
+    for (const verdict of ['intentional', 'internal-only', 'unverifiable']) {
+      const raw = fakeResult({
+        findings: [finding({ candidateId: 'candidate-1', verdict, message: 'not a bug' })],
+      });
+      const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+      expect(result.findings).toHaveLength(0);
+    }
+  });
+
+  it('is complete when the single candidate got a recognized verdict', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'intentional' })],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+  });
+
+  it('marks the result incomplete with stopReason "incomplete_verdict" when a candidate id is missing', () => {
+    const raw = fakeResult({ findings: [] }); // candidate-1 never got a verdict
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('keeps the ORIGINAL stopReason when the client was already incomplete for a real reason', () => {
+    const raw = fakeResult({ findings: [], incomplete: true, stopReason: 'budget' });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('budget');
+  });
+
+  it('does not mutate the input result', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'breaking' })],
+    });
+    postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(raw.findings).toHaveLength(1);
+    expect((raw.findings[0] as Record<string, unknown>).candidateId).toBe('candidate-1');
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is missing', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: undefined, message: 'no verdict' }),
+      ],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is not a recognized value', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({
+          candidateId: 'candidate-1',
+          verdict: 'maybe-breaking' as never,
+          message: 'bogus',
+        }),
+      ],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when the same candidate id is verdicted twice (duplicate, not "covered")', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable', message: 'first' }),
+        finding({ candidateId: 'candidate-1', verdict: 'breaking', message: 'second' }),
+      ],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when an entry names a candidate id outside the worklist, and the phantom never leaks through', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
+        finding({ candidateId: 'candidate-99', verdict: 'breaking', message: 'phantom candidate' }),
+      ],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeRemovedExportsFindings — loop wins, on same-export identity too
+// ---------------------------------------------------------------------------
+
+describe('mergeRemovedExportsFindings', () => {
+  it('drops a main-pass finding at the same location and keeps the loop finding', () => {
+    const main = [
+      finding({ line: 4, ruleId: STRUCTURAL_ANALYSIS_RULE_ID, message: 'main freeform' }),
+    ];
+    const loop = [finding({ line: 4, message: 'loop with evidence' })];
+
+    const merged = mergeRemovedExportsFindings(main, loop);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('loop with evidence');
+    expect(merged[0].ruleId).toBe(STRUCTURAL_ANALYSIS_RULE_ID);
+  });
+
+  it('dedupes a nearby main-pass structural-analysis finding (within ±2 lines) but keeps a distant one', () => {
+    const main = [
+      finding({ line: 5, ruleId: STRUCTURAL_ANALYSIS_RULE_ID, message: 'near' }),
+      finding({ line: 40, ruleId: STRUCTURAL_ANALYSIS_RULE_ID, message: 'far, unrelated symbol' }),
+    ];
+    const loop = [finding({ line: 4, message: 'loop' })];
+
+    const merged = mergeRemovedExportsFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['far, unrelated symbol', 'loop'].sort());
+  });
+
+  it('drops a same-file, DISTANT main-pass finding when symbolName matches (identity beats proximity)', () => {
+    const main = [
+      finding({
+        line: 300,
+        ruleId: STRUCTURAL_ANALYSIS_RULE_ID,
+        symbolName: 'fetchUser',
+        message: 'main, far away but same export',
+      }),
+    ];
+    const loop = [finding({ line: 4, symbolName: 'fetchUser', message: 'loop with evidence' })];
+
+    const merged = mergeRemovedExportsFindings(main, loop);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('loop with evidence');
+  });
+
+  it('does NOT drop a nearby main-pass finding from a DIFFERENT rule (proximity alone is not enough)', () => {
+    const main = [finding({ line: 4, ruleId: 'error-swallowing', message: 'unrelated real bug' })];
+    const loop = [finding({ line: 4, message: 'loop finding' })];
+
+    const merged = mergeRemovedExportsFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unrelated real bug']);
+  });
+
+  it('does NOT drop a nearby main-pass finding with no ruleId at all', () => {
+    const main = [finding({ line: 4, ruleId: undefined, message: 'unattributed' })];
+    const loop = [finding({ line: 4, message: 'loop finding' })];
+
+    const merged = mergeRemovedExportsFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unattributed']);
+  });
+
+  it('forces ruleId to structural-analysis on every loop finding', () => {
+    const loop = [finding({ ruleId: undefined, message: 'no-rule' })];
+    const merged = mergeRemovedExportsFindings([], loop);
+    expect(merged[0].ruleId).toBe(STRUCTURAL_ANALYSIS_RULE_ID);
+  });
+
+  it('does not mutate the input arrays', () => {
+    const main = [finding({ filepath: 'a.ts', line: 1 })];
+    const loop = [finding({ filepath: 'b.ts', line: 1, ruleId: 'x' })];
+    mergeRemovedExportsFindings(main, loop);
+    expect(loop[0].ruleId).toBe('x');
+    expect(main).toHaveLength(1);
+  });
+
+  it('appends a loop finding on a distinct file alongside an unrelated main finding', () => {
+    const main = [finding({ filepath: 'a.ts', line: 1, message: 'unrelated' })];
+    const loop = [finding({ filepath: 'b.ts', line: 1, message: 'loop' })];
+    const merged = mergeRemovedExportsFindings(main, loop);
+    expect(merged.map(f => f.message).sort()).toEqual(['loop', 'unrelated']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeRemovedExportsResultState
+// ---------------------------------------------------------------------------
+
+describe('mergeRemovedExportsResultState', () => {
+  it('marks the merged result incomplete, naming this pass via incompleteFromPass', () => {
+    const main = fakeResult();
+    main.incomplete = false;
+    main.stopReason = 'completed';
+    const loop = fakeResult({ incomplete: true, stopReason: 'incomplete_verdict' });
+
+    mergeRemovedExportsResultState(main, loop);
+
+    expect(main.incomplete).toBe(true);
+    expect(main.stopReason).toBe('incomplete_verdict');
+    expect(main.incompleteFromPass).toBe('removed-exports');
+  });
+
+  it('leaves an already-incomplete main pass untouched (no attribution overwrite)', () => {
+    const main = fakeResult({ incomplete: true, stopReason: 'max_turns' });
+    const loop = fakeResult({ incomplete: true, stopReason: 'budget' });
+
+    mergeRemovedExportsResultState(main, loop);
+
+    expect(main.stopReason).toBe('max_turns');
+    expect(main.incompleteFromPass).toBeUndefined();
+  });
+
+  it('is a no-op when the loop pass is complete or null', () => {
+    const main = fakeResult();
+    mergeRemovedExportsResultState(main, fakeResult());
+    expect(main.incomplete).toBe(false);
+
+    mergeRemovedExportsResultState(main, null);
+    expect(main.incomplete).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No main-pass override: <removed_exports> always stays in the main pass
+// ---------------------------------------------------------------------------
+
+describe('structural-analysis has no main-pass override (hybrid, not full graduation)', () => {
+  it('renders <removed_exports> in the main pass regardless of this loop being enabled', () => {
+    const ctx = breakingOnlyContext();
+    const rules = selectRules(BUILTIN_RULES, buildTriggerContext(ctx));
+    const message = buildInitialMessage(ctx, { blastRadius: null, rules });
+    expect(message).toContain('<removed_exports>');
+    expect(rules.active.map(r => r.id)).toContain('structural-analysis');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REMOVED_EXPORTS_PASS_SPEC (the ReviewPassSpec bundle)
+// ---------------------------------------------------------------------------
+
+describe('REMOVED_EXPORTS_PASS_SPEC', () => {
+  it("wires this module's own pure functions into the ReviewPassSpec contract", () => {
+    expect(REMOVED_EXPORTS_PASS_SPEC.name).toBe('removed-exports-loop');
+    expect(REMOVED_EXPORTS_PASS_SPEC.skipPlugin).toBe('agent-review:removed-exports-loop');
+    expect(REMOVED_EXPORTS_PASS_SPEC.maxTurns).toBe(REMOVED_EXPORTS_PASS_MAX_TURNS);
+    expect(REMOVED_EXPORTS_PASS_SPEC.mergeFindings).toBe(mergeRemovedExportsFindings);
+    expect(REMOVED_EXPORTS_PASS_SPEC.mergeResultState).toBe(mergeRemovedExportsResultState);
+    expect(REMOVED_EXPORTS_PASS_SPEC.postProcessResult).toBe(postProcessRemovedExportsResult);
+  });
+
+  it('gateReason is removedExportsSkipReason', () => {
+    const ctx = breakingOnlyContext();
+    expect(REMOVED_EXPORTS_PASS_SPEC.gateReason(ctx, cfg({ removedExportsPass: true }))).toBeNull();
+    expect(REMOVED_EXPORTS_PASS_SPEC.gateReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('buildPrompts delegates to buildRemovedExportsPassPrompts', () => {
+    const ctx = breakingOnlyContext();
+    expect(REMOVED_EXPORTS_PASS_SPEC.buildPrompts(ctx)).toEqual(
+      buildRemovedExportsPassPrompts(ctx),
+    );
+  });
+
+  it('budget delegates to removedExportsPassBudget', () => {
+    const ctx = breakingOnlyContext();
+    expect(REMOVED_EXPORTS_PASS_SPEC.budget(100_000, ctx)).toBe(
+      removedExportsPassBudget(100_000, ctx),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fourth and final candidate-loop pass from ADR-014's gating matrix: a dedicated `removed-exports` pass for the `structural-analysis` rule, mirroring `stale-duplicate-pass.ts` (#803) and `incomplete-handling-pass.ts` (#804). ADR-014 marks `structural-analysis` **hybrid** — this pass covers only the removed-export-sweep half; the rule's other half ("check if callers handle new behavior correctly" for a *changed*, not removed, export) is open investigation and stays in the shared main pass, unconditionally, with no override to strip it.

Ships **dark**: `config.removedExportsPass` (default `false`) or `LIEN_REMOVED_EXPORTS_PASS=on`.

## Signal: reused, not new

`removed-export-signals.ts` already computed exactly the shape this loop needs (it feeds the main pass's `<removed_exports>` block and `boundary-change`'s changeset cross-check today): for each export a PR's diff removes (minus any re-added elsewhere — the rename-vs-remove disambiguation happens there), it finds every surviving cross-file reference in the indexed corpus and any `.changeset/*.md` mention. No new signal module was built — `computeRemovedExportsCandidates` just caps that shared signal's own sort order (breakage-first, then changeset-mentioned) at 15.

## Verdict vocabulary: `breaking | intentional | internal-only | unverifiable`

Adapted from the pilot's three-value set to name the two historical FP classes:
- **`breaking`** — real, undisclosed breakage → finding.
- **`intentional`** — a changeset entry already discloses this exact removal.
- **`internal-only`** — the only surviving references are test/fixture/internal-only code, never real production usage.
- **`unverifiable`** — investigation couldn't confirm either way.

A `<verdict_guidance>` paragraph bakes both FP classes in from day one (matching the second loop's precedent, not the pilot's post-hoc discovery).

## Why no `LIEN_REMOVED_EXPORTS_MAIN` override (unlike its siblings)

Both prior loops ship a second opt-out flag for a future "loop replaces the rule in the main pass" A/B arm, because their entire rule graduated to the dedicated loop. `structural-analysis` didn't — only its removed-export sweep has a candidate shape. Stripping the rule from the main pass would also remove the *other* half's coverage, which this loop doesn't replace. `<removed_exports>` stays in the main pass unconditionally, by design.

## Dogfood: real merged PR (#399), flag on

```
LIEN_REMOVED_EXPORTS_PASS=on npx tsx test/harness/build-prompts.ts <captured PR #399 fixture>
```

Rendered worklist (verbatim):

```
<removed_exports>
One verdict is REQUIRED per candidate id below (see <output_format>) — candidate-1. ...

<candidate id="candidate-1" symbol="parse_input">
Removed from: lien-review-testbed/rust/src/parser.rs
```diff
@@ -12,52 +9,6 @@ pub struct ParsedInput {
...
-pub fn parse_input(path: &str, config: &Config) -> Result<ParsedInput, AnalyzerError> {
... (full removed function body) ...
-}
```
Surviving reference(s):
  - lien-review-testbed/rust/src/reporter.rs:203
  - lien-review-testbed/rust/src/main.rs:210
  - lien-review-testbed/rust/src/main.rs:264
Changeset: none found mentioning this symbol
</candidate>
</removed_exports>
```

## Real-PR firing-rate census (zero-LLM)

Last 40 merged PRs (#776–#816), captured via `capture-pr.ts` + `build-prompts.ts` with the flag on so `fires` reduces to pure candidate eligibility: **1/40 (2.5%)** fired — PR #799 (the pass-executor refactor that renamed `runDocTruthPass`/`appendDocTruthTurns`). Markedly lower than the pilot's 35% or the second loop's 50%: an actual removed *public* export is a genuinely rare event in this repo's real history. Firing rate is not a constant property across rules (ADR-014 already makes this point for the first two loops); this loop's number is lower still.

## Byte-diff neutrality (flag off)

Ran the pre-change `build-prompts.ts` (parent commit) and the post-change version (flag off, default) against all 44 available fixtures (the 40 census fixtures + PR #399 + the 3 committed on-disk fixtures). After stripping the new additive `removedExportsPass` key, every fixture's output is byte-identical. Flag off = zero behavior change.

## Optional screen (≤$0.50 cap): RUN

`fixtures/structural-analysis/removed-export.assertions.ts` (PR #399, this repo's own canonical removed-export canary — already documents a ≥9/10 bar) is loop-eligible, so I ran the 3-vote screen with the flag on against its documented baseline:

```
LIEN_REMOVED_EXPORTS_PASS=on npm run test:harness -w @liendev/review -- \
  --fixture test/harness/fixtures/structural-analysis/removed-export.fixture.json --votes 3 --json
```

Result: **3/3 passed**, `allPassed: true`, **total cost $0.0418** (well under the $0.50 cap). The dedicated loop independently verdicted the sole candidate `breaking`, correctly naming `parse_input` and all 3 surviving call sites after confirming each via `read_file` (no changeset present). This is a regression smoke test, not an isolated lift measurement — the main pass already covers this fixture on its own; the loop is an additive backstop.

## Bonus fix caught during rebase

Rebasing picked up #816 (category missing from the other three contracts' required-field prose, silently dropping findings at `isValidFinding`). This pass's `buildOutputFormat` had the identical latent gap — fixed here before it ever shipped, with a regression test mirroring #816's pattern.

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `test` (1351 tests, whole monorepo green) / `node packages/cli/dist/index.js delta` (exit 0, not `--soft`) all pass. No changeset (review is private).

## Test plan

- [x] Unit tests mirroring the siblings' suites: extraction reuse + rename-vs-remove disambiguation, gating (config/env precedence, no-candidate, no-patches), prompt construction (hard-cut toolset, loop-scoped strategy/example — not the shared rule's broader prompt), budget scaling + floor, verdict-coverage honesty (missing/duplicate/unknown-id/invalid-verdict → `incomplete_verdict`, phantom-candidate guard), merge (loop wins, ruleId-scoped, symbolName-identity dedupe in addition to line proximity), `ReviewPassSpec` wiring, and a regression proving `<removed_exports>` always renders in the main pass (no override exists).
- [x] Byte-diff neutrality across 44 fixtures (flag off).
- [x] Real-PR census (1/40).
- [x] Dogfood worklist against a real merged PR (#399).
- [x] Optional 3-vote screen against the fixture's documented baseline ($0.042).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a fourth dark-launched candidate loop (`removed-exports-pass.ts`) for the `structural-analysis` rule's removed-export sweep, mirroring the existing stale-duplicate and incomplete-handling passes. It reuses the precomputed `removed-export-signals.ts` signal, wires the pass into the generalized executor via `ReviewPassSpec`, adds the `removedExportsPass` config/env gate, and includes comprehensive unit tests. No output-breaking bugs, breaking changes to callers, or unvalidated untrusted-input paths were found. The pass is off by default, so default behavior is unchanged.
>
> - Added `removed-exports-pass.ts` with candidate capping, prompt construction, budget scaling, verdict post-processing, and merge logic scoped to `structural-analysis`.
> - Wired `REMOVED_EXPORTS_PASS_SPEC` into `EXTRA_PASSES` and added `removedExportsPass` to the Zod config schema and `AgentConfig` interface.
> - Updated test harness `build-prompts.ts` and architecture docs; added unit tests covering gating, prompts, budget, merge, and verdict completeness.

⚠️ The incomplete-handling pass did not finish — it hit the token budget limit. That pass's findings are partial; the main review's findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2d6b0ca. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 467K/300K tokens
<!-- /lien:attestation -->