### PR TITLE
feat(parser,core): YAML structural chunking for search_code

### DIFF
--- a/.changeset/yaml-config-chunking.md
+++ b/.changeset/yaml-config-chunking.md
@@ -1,0 +1,43 @@
+---
+'@liendev/parser': minor
+'@liendev/core': minor
+'@liendev/lien': minor
+---
+
+feat(parser,core): YAML structural chunking for `search_code`
+
+YAML files (`.yml`/`.yaml`) are now chunked by top-level mapping key instead
+of the generic fixed-size line window, so `search_code` / `get_files_context`
+can retrieve a coherent config section (e.g. a GitHub Actions `jobs.review`
+block) rather than an arbitrary 75-line slice.
+
+- **New chunk kind** (`packages/parser/src/yaml-chunker.ts`): YAML chunks are
+  tagged `type: 'config'`, `language: 'yaml'`, with `metadata.symbolName`
+  carrying a dotted key-path breadcrumb (e.g. `jobs.review.env`) built from an
+  indentation ancestor stack, analogous to the markdown chunker's heading
+  stack. Multi-document files (`---`/`...` separators) prefix breadcrumbs
+  with `doc[N]`. Pure line heuristics — no real YAML parser is invoked — so
+  the chunker never throws on malformed, partial, or templated (Helm/Jinja)
+  input; a document with zero top-level keys degrades to a single
+  whole-document chunk.
+- **`type: 'config'` is excluded from symbol-lookup** (`core`'s
+  `matchesSymbolFilter` and `review`'s `listFunctions`, mirroring the
+  existing `'doc'` exclusion): key-path breadcrumbs aren't code symbols, so
+  they never surface via `list_functions`/`querySymbols`, but remain fully
+  searchable via `search_code` and retrievable via `get_files_context`.
+- **CI workflow coverage**: the default include-pattern list now adds
+  `.github/**/*.yml` and `.github/**/*.yaml` alongside the plain `**/*.yml`/
+  `**/*.yaml` patterns. This is required, not cosmetic — glob's default
+  `dot:false` means a bare `**/*.yml` never descends into a dot-directory
+  like `.github/`, so without the explicit `.github/**` entries, CI workflow
+  YAML (`.github/workflows/*.yml`) would silently never be indexed. Other
+  dot-directory CI configs (`.circleci/`, a root `.gitlab-ci.yml`) remain
+  out of scope for now.
+- `pnpm-lock.yaml` is added to the always-ignored patterns (this repo uses
+  npm and has none, but the exclusion is defensive for consumers who do).
+
+Dogfooded against this repo's own index: previously-unindexable content in
+`.github/workflows/*.yml` and `packages/action/action.yml` (e.g. harness
+evidence-gate skip logic, review token-budget allocation) is now retrievable
+via `search_code`, with `get_files_context` showing `type: 'config'` chunks
+and `jobs`/`on`/`permissions`-style breadcrumbs.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ independent index for that worktree.
 
 ## Supported Languages
 
-TypeScript • JavaScript • Vue • Python • PHP • Liquid • Go • Rust • Java • C/C++ • Ruby • Swift • Kotlin • C# • Scala • Markdown
+TypeScript • JavaScript • Vue • Python • PHP • Liquid • Go • Rust • Java • C/C++ • Ruby • Swift • Kotlin • C# • Scala • Markdown • YAML
 
 **Ecosystem Presets:** 12 ecosystem presets including Node.js, Python, PHP, Laravel, Ruby, Rails, Rust, JVM, Swift, .NET, Django, and Astro (auto-detected)
 

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -36,6 +36,7 @@ import {
   getEcosystemExcludePatterns,
   chunkFile,
   computeContentHash,
+  DEFAULT_INDEX_INCLUDE_PATTERNS,
 } from '@liendev/parser';
 
 /**
@@ -101,12 +102,7 @@ export async function scanFilesToIndex(rootDir: string): Promise<string[]> {
 
   return scanCodebase({
     rootDir,
-    includePatterns: [
-      '**/*.{ts,tsx,js,jsx,mjs,cjs,vue,py,php,go,rs,java,kt,swift,rb,cs,liquid,scala,c,cpp,cc,cxx,h,hpp}',
-      '**/*.md',
-      '**/*.mdx',
-      '**/*.markdown',
-    ],
+    includePatterns: DEFAULT_INDEX_INCLUDE_PATTERNS,
     excludePatterns: ecosystemExcludes,
   });
 }

--- a/packages/core/src/vectordb/filters.test.ts
+++ b/packages/core/src/vectordb/filters.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { matchesSymbolFilter, type FilterableRecord } from './filters.js';
+
+function record(extra: Partial<FilterableRecord> = {}): FilterableRecord {
+  return {
+    file: 'src/foo.ts',
+    language: 'typescript',
+    type: 'function',
+    symbolName: 'doThing',
+    ...extra,
+  };
+}
+
+describe('matchesSymbolFilter', () => {
+  it('matches a plain code record with a symbolName', () => {
+    expect(matchesSymbolFilter(record(), {})).toBe(true);
+  });
+
+  it('excludes markdown "doc" chunks: prose breadcrumbs are not code symbols', () => {
+    expect(matchesSymbolFilter(record({ type: 'doc', symbolName: 'Guide > Install' }), {})).toBe(
+      false,
+    );
+  });
+
+  it('excludes YAML "config" chunks: key-path breadcrumbs are not code symbols', () => {
+    expect(matchesSymbolFilter(record({ type: 'config', symbolName: 'jobs.review' }), {})).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/src/vectordb/filters.ts
+++ b/packages/core/src/vectordb/filters.ts
@@ -10,7 +10,7 @@ export interface FilterableRecord {
   content?: string;
   file?: string;
   language?: string;
-  /** Chunk kind ('function' | 'class' | 'block' | 'template' | 'doc'). */
+  /** Chunk kind ('function' | 'class' | 'block' | 'template' | 'doc' | 'config'). */
   type?: string;
   symbolName?: string;
   symbolType?: string;
@@ -137,10 +137,12 @@ export function matchesSymbolFilter(
   { language, pattern, symbolType }: SymbolQueryOptions,
 ): boolean {
   // Markdown 'doc' chunks carry a heading-breadcrumb symbolName but are prose,
-  // not code symbols -- never surface them via the symbol-lookup path
-  // (list_functions / querySymbols). They remain fully searchable via
-  // search_code / scanAll / scanWithFilter, which don't route through here.
-  if (r.type === 'doc') {
+  // not code symbols; YAML 'config' chunks carry a dotted key-path
+  // symbolName but are config keys, not code symbols either -- neither
+  // should surface via the symbol-lookup path (list_functions /
+  // querySymbols). They remain fully searchable via search_code / scanAll /
+  // scanWithFilter, which don't route through here.
+  if (r.type === 'doc' || r.type === 'config') {
     return false;
   }
 

--- a/packages/core/src/vectordb/sqlite/fts-search.test.ts
+++ b/packages/core/src/vectordb/sqlite/fts-search.test.ts
@@ -207,6 +207,23 @@ describe('SqliteBackend.search (FTS5)', () => {
     expect(await db.search('uniquetoken', 5)).toEqual([]);
   });
 
+  it('indexes and retrieves a YAML config chunk (type:config, language:yaml)', async () => {
+    await insert(
+      db,
+      chunk('.github/workflows/ci.yml', 'jobs:\n  build:\n    zzzyamltoken: true\n', {
+        type: 'config',
+        language: 'yaml',
+        symbolName: 'jobs',
+      }),
+    );
+
+    const results = await db.search('zzzyamltoken', 5);
+    expect(results).toHaveLength(1);
+    expect(results[0].metadata.file).toBe('.github/workflows/ci.yml');
+    expect(results[0].metadata.type).toBe('config');
+    expect(results[0].metadata.language).toBe('yaml');
+  });
+
   it('attaches dependentCount to result metadata based on who imports the file', async () => {
     await insert(db, chunk('utils/logger.ts', 'export function zzzlogsearch() {}'));
     await insert(

--- a/packages/parser/src/chunk-only-index.ts
+++ b/packages/parser/src/chunk-only-index.ts
@@ -9,6 +9,7 @@ import { detectEcosystems, getEcosystemExcludePatterns } from './ecosystem-prese
 import {
   DEFAULT_CHUNK_SIZE,
   DEFAULT_CHUNK_OVERLAP,
+  DEFAULT_INDEX_INCLUDE_PATTERNS,
   getParseStageConcurrency,
 } from './constants.js';
 
@@ -41,12 +42,7 @@ async function scanFilesToIndex(rootDir: string): Promise<string[]> {
 
   return scanCodebase({
     rootDir,
-    includePatterns: [
-      '**/*.{ts,tsx,js,jsx,mjs,cjs,vue,py,php,go,rs,java,kt,swift,rb,cs,liquid,scala,c,cpp,cc,cxx,h,hpp}',
-      '**/*.md',
-      '**/*.mdx',
-      '**/*.markdown',
-    ],
+    includePatterns: DEFAULT_INDEX_INCLUDE_PATTERNS,
     excludePatterns: ecosystemExcludes,
   });
 }

--- a/packages/parser/src/chunker.ts
+++ b/packages/parser/src/chunker.ts
@@ -6,6 +6,7 @@ import { NativeBindingLoadError } from './ast/parser.js';
 import { chunkLiquidFile } from './liquid-chunker.js';
 import { chunkJSONTemplate } from './json-template-chunker.js';
 import { chunkMarkdownFile } from './markdown-chunker.js';
+import { chunkYamlFile } from './yaml-chunker.js';
 
 export interface ChunkOptions {
   chunkSize?: number;
@@ -52,6 +53,13 @@ function chunkSpecialCase(
   // "Install") rather than an arbitrary slice.
   if (/\.(md|mdx|markdown)$/i.test(filepath)) {
     return chunkMarkdownFile(filepath, content, chunkSize, chunkOverlap);
+  }
+
+  // YAML — chunk by top-level mapping key instead of a fixed-size line
+  // window, so search_code retrieves a coherent config section (e.g. a
+  // GitHub Actions job) rather than an arbitrary slice.
+  if (/\.(ya?ml)$/i.test(filepath)) {
+    return chunkYamlFile(filepath, content, chunkSize, chunkOverlap);
   }
 
   return undefined;

--- a/packages/parser/src/constants.ts
+++ b/packages/parser/src/constants.ts
@@ -7,6 +7,30 @@
 export const DEFAULT_CHUNK_SIZE = 75;
 export const DEFAULT_CHUNK_OVERLAP = 10;
 
+/**
+ * Default glob include patterns for a full-repo index scan: source languages,
+ * prose docs, and YAML config. Shared by `@liendev/core`'s `scanFilesToIndex`
+ * (real CLI/MCP indexing path) and `@liendev/parser`'s `chunk-only-index.ts`
+ * (review's repoChunks path) so the two stay byte-identical.
+ *
+ * The scanner globs with glob's default `dot:false`, so a bare `**\/*.yml`
+ * never descends into a dot-directory like `.github/`. The explicit
+ * `.github/**` entries below are required for CI workflow YAML (e.g.
+ * `.github/workflows/*.yml`) to be indexed at all -- a literal path segment
+ * (unlike a `**` wildcard) matches under `dot:false`. Other dot-dir CI
+ * configs (`.circleci/`, root `.gitlab-ci.yml`) are a known, YAGNI'd gap.
+ */
+export const DEFAULT_INDEX_INCLUDE_PATTERNS = [
+  '**/*.{ts,tsx,js,jsx,mjs,cjs,vue,py,php,go,rs,java,kt,swift,rb,cs,liquid,scala,c,cpp,cc,cxx,h,hpp}',
+  '**/*.md',
+  '**/*.mdx',
+  '**/*.markdown',
+  '**/*.yml',
+  '**/*.yaml',
+  '.github/**/*.yml',
+  '.github/**/*.yaml',
+];
+
 // File query estimation
 // Maximum chunks expected per file when sizing scan queries.
 export const MAX_CHUNKS_PER_FILE = 100;

--- a/packages/parser/src/gitignore.ts
+++ b/packages/parser/src/gitignore.ts
@@ -29,6 +29,9 @@ export const ALWAYS_IGNORE_PATTERNS = [
   '**/*.min.js',
   '*.min.css',
   '**/*.min.css',
+  // Generated lockfile: huge, no search value.
+  'pnpm-lock.yaml',
+  '**/pnpm-lock.yaml',
 ];
 
 /** Directories to skip during .gitignore discovery (no useful .gitignore inside) */

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -28,6 +28,7 @@ export {
   MAX_CHUNKS_PER_FILE,
   PARSE_STAGE_MAX_CONCURRENCY,
   getParseStageConcurrency,
+  DEFAULT_INDEX_INCLUDE_PATTERNS,
 } from './constants.js';
 
 // =============================================================================

--- a/packages/parser/src/scanner.test.ts
+++ b/packages/parser/src/scanner.test.ts
@@ -173,4 +173,23 @@ describe('scanCodebase', () => {
 
     expect(worktreeRelative).toContain(path.join('src', 'foo.ts'));
   });
+
+  // Regression lock for the dot-directory glob gap: glob's default `dot:false`
+  // means a bare `**/*.yml` never descends into `.github/`, so the default
+  // (no includePatterns) fallback must carry an explicit `.github/**` entry
+  // for CI workflow YAML to be scanned at all.
+  it('includes .github/workflows/*.yml under the default (no includePatterns) fallback', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-github-yaml-'));
+
+    await fs.mkdir(path.join(testDir, '.github', 'workflows'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, '.github', 'workflows', 'ci.yml'),
+      'name: CI\non: push\n',
+    );
+
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f));
+
+    expect(relative).toContain(path.join('.github', 'workflows', 'ci.yml'));
+  });
 });

--- a/packages/parser/src/scanner.ts
+++ b/packages/parser/src/scanner.ts
@@ -29,11 +29,18 @@ export async function scanCodebase(options: ScanOptions): Promise<string[]> {
   const ig = await loadGitignore(rootDir);
   ig.add([...ALWAYS_IGNORE_PATTERNS, ...excludePatterns]);
 
-  // Determine patterns to search for
+  // Determine patterns to search for. The `.github/**` entry is required
+  // alongside the brace pattern because glob's default `dot:false` blocks
+  // `**` from descending into dot-directories -- a bare `**/*.{...,yml,yaml}`
+  // never matches `.github/workflows/*.yml` (see DEFAULT_INDEX_INCLUDE_PATTERNS
+  // in constants.ts for the fuller, non-fallback include list).
   const patterns =
     includePatterns.length > 0
       ? includePatterns
-      : ['**/*.{ts,tsx,js,jsx,py,php,go,rs,java,cpp,c,cs,h,md,mdx}'];
+      : [
+          '**/*.{ts,tsx,js,jsx,py,php,go,rs,java,cpp,c,cs,h,md,mdx,yml,yaml}',
+          '.github/**/*.{yml,yaml}',
+        ];
 
   // Combine always-ignored patterns with exclude patterns for glob
   const globIgnorePatterns = [...ALWAYS_IGNORE_PATTERNS, ...excludePatterns];

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -7,7 +7,7 @@ export interface ChunkMetadata {
   file: string;
   startLine: number;
   endLine: number;
-  type: 'function' | 'class' | 'block' | 'template' | 'doc';
+  type: 'function' | 'class' | 'block' | 'template' | 'doc' | 'config'; // 'config' = YAML (and future JSON) config chunks
   language: string;
   // Extracted symbols for direct querying
   symbols?: {

--- a/packages/parser/src/yaml-chunker.test.ts
+++ b/packages/parser/src/yaml-chunker.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { chunkYamlFile } from './yaml-chunker.js';
+
+describe('chunkYamlFile', () => {
+  it('splits into one chunk per top-level key with correct breadcrumb, type, and language', () => {
+    const content = ['name: myapp', 'version: 1.0.0', 'description: test'].join('\n');
+
+    const chunks = chunkYamlFile('config.yaml', content);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks.map(c => c.metadata.symbolName)).toEqual(['name', 'version', 'description']);
+    chunks.forEach(chunk => {
+      expect(chunk.metadata.type).toBe('config');
+      expect(chunk.metadata.language).toBe('yaml');
+      expect(chunk.metadata.file).toBe('config.yaml');
+    });
+  });
+
+  it('carries a deep dotted breadcrumb on split pieces of an oversized nested section', () => {
+    const nestedLines = Array.from(
+      { length: 16 },
+      (_, i) => `      ${String.fromCharCode(65 + i)}: ${i}`,
+    );
+    const content = ['jobs:', '  review:', '    env:', ...nestedLines].join('\n');
+
+    const chunks = chunkYamlFile('workflow.yml', content, 5, 2);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach(chunk => expect(chunk.metadata.symbolName).toMatch(/^jobs/));
+    expect(chunks.some(c => c.metadata.symbolName?.includes('jobs.review.env'))).toBe(true);
+  });
+
+  it('splits an oversized top-level key into overlapping window chunks', () => {
+    const nestedLines = Array.from(
+      { length: 16 },
+      (_, i) => `      ${String.fromCharCode(65 + i)}: ${i}`,
+    );
+    const content = ['jobs:', '  review:', '    env:', ...nestedLines].join('\n');
+    const totalLines = 3 + nestedLines.length;
+
+    const chunks = chunkYamlFile('workflow.yml', content, 5, 2);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Overlap: second window starts before the first window ends.
+    expect(chunks[1].metadata.startLine).toBeLessThan(chunks[0].metadata.endLine);
+    // Last window reaches the end of the file.
+    expect(chunks[chunks.length - 1].metadata.endLine).toBe(totalLines);
+  });
+
+  it('yields exactly one chunk for a tiny non-empty file (#786 regression guard)', () => {
+    const content = ['app:', '  name: test', '  version: 1'].join('\n');
+
+    const chunks = chunkYamlFile('tiny.yaml', content);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('app');
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(3);
+  });
+
+  it('returns an empty array for a truly empty file', () => {
+    expect(chunkYamlFile('empty.yaml', '')).toEqual([]);
+  });
+
+  it('returns an empty array for a whitespace-only file', () => {
+    expect(chunkYamlFile('whitespace.yaml', '   \n\t\n   \n')).toEqual([]);
+  });
+
+  it('splits multi-document files and prefixes breadcrumbs with doc[N]', () => {
+    const content = [
+      '---',
+      'service: web',
+      'port: 8080',
+      '---',
+      'service: worker',
+      'queue: default',
+    ].join('\n');
+
+    const chunks = chunkYamlFile('multi.yaml', content);
+
+    expect(chunks.map(c => c.metadata.symbolName)).toEqual([
+      'doc[1] service',
+      'doc[1] port',
+      'doc[2] service',
+      'doc[2] queue',
+    ]);
+  });
+
+  it('does not produce an empty leading document for a leading "---"', () => {
+    const content = ['---', 'key: value'].join('\n');
+
+    const chunks = chunkYamlFile('single.yaml', content);
+
+    // Single document -> no doc[N] prefix.
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBe('key');
+  });
+
+  it('does not throw on Helm/Jinja templated YAML and still yields config chunks', () => {
+    const content = [
+      '{{- if .Values.enabled }}',
+      '{{- include "app.labels" . }}',
+      '{{- end }}',
+    ].join('\n');
+
+    expect(() => chunkYamlFile('templates/deployment.yaml', content)).not.toThrow();
+
+    const chunks = chunkYamlFile('templates/deployment.yaml', content);
+    expect(chunks.length).toBeGreaterThan(0);
+    chunks.forEach(chunk => expect(chunk.metadata.type).toBe('config'));
+  });
+
+  it('does not throw on templated YAML mixed with real top-level keys', () => {
+    const content = [
+      'apiVersion: v1',
+      'kind: ConfigMap',
+      'data:',
+      '  {{- range $key, $val := .Values.config }}',
+      '  {{ $key }}: {{ $val }}',
+      '  {{- end }}',
+    ].join('\n');
+
+    expect(() => chunkYamlFile('templates/configmap.yaml', content)).not.toThrow();
+    const chunks = chunkYamlFile('templates/configmap.yaml', content);
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  it('does not treat a block-scalar body line as a top-level section boundary', () => {
+    const content = ['script: |', '  fake: value', '  echo hello', 'next: value2'].join('\n');
+
+    const chunks = chunkYamlFile('script.yaml', content);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].metadata.symbolName).toBe('script');
+    expect(chunks[0].content).toContain('fake: value');
+    expect(chunks[1].metadata.symbolName).toBe('next');
+  });
+
+  it('creates a preamble chunk for comments before the first key, with no breadcrumb', () => {
+    const content = ['# This is a config file', '# Second comment line', 'app: value'].join('\n');
+
+    const chunks = chunkYamlFile('commented.yaml', content);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].metadata.symbolName).toBeUndefined();
+    expect(chunks[0].content).toBe('# This is a config file\n# Second comment line');
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(2);
+
+    expect(chunks[1].metadata.symbolName).toBe('app');
+    expect(chunks[1].metadata.startLine).toBe(3);
+    expect(chunks[1].metadata.endLine).toBe(3);
+  });
+
+  it('uses 1-based startLine/endLine for a simple multi-key file', () => {
+    const content = ['first: 1', 'second: 2', 'third: 3'].join('\n');
+
+    const chunks = chunkYamlFile('lines.yaml', content);
+
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[0].metadata.endLine).toBe(1);
+    expect(chunks[1].metadata.startLine).toBe(2);
+    expect(chunks[1].metadata.endLine).toBe(2);
+    expect(chunks[2].metadata.startLine).toBe(3);
+    expect(chunks[2].metadata.endLine).toBe(3);
+  });
+
+  it('does not crash on a top-level sequence file and yields a single chunk', () => {
+    const content = ['- a', '- b'].join('\n');
+
+    const chunks = chunkYamlFile('list.yaml', content);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.symbolName).toBeUndefined();
+    expect(chunks[0].metadata.type).toBe('config');
+    expect(chunks[0].content).toBe(content);
+  });
+});

--- a/packages/parser/src/yaml-chunker.ts
+++ b/packages/parser/src/yaml-chunker.ts
@@ -1,0 +1,360 @@
+import type { CodeChunk } from './types.js';
+
+/**
+ * YAML-specific chunking
+ *
+ * Splits YAML files by top-level mapping key instead of the generic
+ * fixed-size line window, so `search_code` can retrieve a coherent config
+ * section (e.g. a GitHub Actions `jobs.review` block) rather than an
+ * arbitrary 75-line slice.
+ *
+ * This is PURE LINE HEURISTICS -- no real YAML parser is ever invoked, so the
+ * chunker can never throw on malformed, partial, or templated (Helm/Jinja)
+ * input. A "top-level key" is any indent-0 line matching a mapping-key shape;
+ * because block-scalar bodies and nested content are always indented at
+ * least one column, they can never be mistaken for a section boundary.
+ *
+ * Rules:
+ * - The file is split into documents at column-0 `---` (doc-start) or `...`
+ *   (doc-end) markers. A leading `---` on line 0 never produces an empty
+ *   leading document. When more than one document is found, every chunk's
+ *   breadcrumb is prefixed with `doc[N] ` (1-based); a single document gets
+ *   no prefix.
+ * - Within a document, sections are a preamble (content before the first
+ *   top-level key, no breadcrumb) plus one section per top-level key,
+ *   running until the next top-level key or the end of the document.
+ * - `metadata.symbolName` carries a dotted key-path breadcrumb built from an
+ *   indentation ancestor stack (analogous to markdown-chunker's heading
+ *   stack), e.g. "jobs.review.env".
+ * - Sections larger than `chunkSize * 3` lines are split into overlapping
+ *   line-window sub-chunks (mirrors markdown-chunker's splitLargeSection);
+ *   each window's breadcrumb is the key-path open at its first line, falling
+ *   back to the section's top-level key when that line has no path of its
+ *   own.
+ * - A document with zero top-level keys (templated YAML, a top-level
+ *   sequence, a bare scalar) degrades to a single whole-document section
+ *   with no breadcrumb, window-split if oversized.
+ */
+
+/** One entry in the indentation ancestor stack: how deep, and the key name. */
+interface KeyStackEntry {
+  indent: number;
+  key: string;
+}
+
+/** A contiguous line range (0-based, `endLine` exclusive) for one YAML document. */
+interface DocRange {
+  startLine: number;
+  endLine: number;
+}
+
+/** A contiguous line range (0-based, `endLine` exclusive) with its key-path breadcrumb. */
+interface Section {
+  startLine: number;
+  endLine: number;
+  breadcrumb: string | undefined;
+}
+
+// Document markers, matched at column 0 only.
+const DOC_START_RE = /^---\s*(#.*)?$/;
+const DOC_END_RE = /^\.\.\.\s*$/;
+
+// A YAML mapping key: a non-space start, up to a colon, then EOL or a value.
+const KEY_LINE_RE = /^(\S[^:#]*):(\s.*)?$/;
+// A sequence item indicator ("- foo" or a bare "-"), never a mapping key.
+const SEQUENCE_ITEM_RE = /^-(\s|$)/;
+// A block-scalar value indicator ("key: |", "key: >-", "key: |2 # comment").
+const BLOCK_SCALAR_RE = /:\s*[|>][+-]?\d*\s*(#.*)?$/;
+
+/** Count of leading space characters (YAML indentation is never meaningfully tab-based). */
+function leadingSpaces(line: string): number {
+  return /^ */.exec(line)?.[0].length ?? 0;
+}
+
+/**
+ * Parse a line (already known to start at `indent`) as a mapping key, or
+ * return null if it's a comment, a sequence item, or not key-shaped.
+ */
+function parseKeyLine(line: string, indent: number): { key: string } | null {
+  const trimmed = line.slice(indent);
+  if (trimmed.length === 0 || trimmed.startsWith('#') || SEQUENCE_ITEM_RE.test(trimmed)) {
+    return null;
+  }
+  const match = KEY_LINE_RE.exec(trimmed);
+  return match ? { key: match[1].trim() } : null;
+}
+
+/** Whether a line is an indent-0 mapping key -- i.e. a section boundary. */
+function isTopLevelKeyLine(line: string): boolean {
+  return leadingSpaces(line) === 0 && parseKeyLine(line, 0) !== null;
+}
+
+/**
+ * Split the file into YAML documents at column-0 `---`/`...` markers. The
+ * markers themselves are excluded from every document; a marker at line 0
+ * never produces an empty leading document.
+ */
+function splitDocuments(lines: string[]): DocRange[] {
+  const docs: DocRange[] = [];
+  let docStart = 0;
+
+  lines.forEach((line, i) => {
+    if (!DOC_START_RE.test(line) && !DOC_END_RE.test(line)) return;
+    if (i > docStart) docs.push({ startLine: docStart, endLine: i });
+    docStart = i + 1;
+  });
+
+  if (docStart < lines.length) docs.push({ startLine: docStart, endLine: lines.length });
+
+  return docs;
+}
+
+/** Join the ancestor stack into a dotted key-path, or undefined if empty. */
+function stackPath(stack: KeyStackEntry[]): string | undefined {
+  return stack.length > 0 ? stack.map(entry => entry.key).join('.') : undefined;
+}
+
+/** Pop every ancestor at or deeper than `indent` (a sibling or dedent closes them). */
+function popStackTo(stack: KeyStackEntry[], indent: number): void {
+  while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+    stack.pop();
+  }
+}
+
+/** Whether `line` is still inside a block-scalar body opened at `blockScalarIndent`. */
+function isBlockScalarContinuation(
+  line: string,
+  indent: number,
+  blockScalarIndent: number,
+): boolean {
+  return line.trim().length === 0 || indent > blockScalarIndent;
+}
+
+/** Mutable per-document scan state threaded through {@link scanLine}. */
+interface ScanState {
+  stack: KeyStackEntry[];
+  blockScalarIndent: number | null;
+}
+
+/**
+ * Advance the ancestor-stack scan by one line, mutating `state` in place, and
+ * return the key-path open once this line has been processed. Lines inside a
+ * block-scalar body are never parsed as keys -- they just inherit the path.
+ */
+function scanLine(state: ScanState, line: string): string | undefined {
+  const indent = leadingSpaces(line);
+
+  if (state.blockScalarIndent !== null) {
+    if (isBlockScalarContinuation(line, indent, state.blockScalarIndent)) {
+      return stackPath(state.stack);
+    }
+    state.blockScalarIndent = null; // block-scalar body ended
+  }
+
+  const parsed = parseKeyLine(line, indent);
+  if (parsed) {
+    popStackTo(state.stack, indent);
+    state.stack.push({ indent, key: parsed.key });
+    if (BLOCK_SCALAR_RE.test(line.slice(indent))) {
+      state.blockScalarIndent = indent;
+    }
+  }
+
+  return stackPath(state.stack);
+}
+
+/**
+ * Compute, for every line in every document, the dotted key-path of the
+ * indentation ancestor stack open at that line (undefined outside any key).
+ * Non-key lines (values, list items, block-scalar bodies) inherit the
+ * current stack path. Resets independently per document.
+ */
+function computeLinePaths(lines: string[], docs: readonly DocRange[]): Array<string | undefined> {
+  const paths: Array<string | undefined> = new Array(lines.length).fill(undefined);
+
+  docs.forEach(doc => {
+    const state: ScanState = { stack: [], blockScalarIndent: null };
+    lines.slice(doc.startLine, doc.endLine).forEach((line, offset) => {
+      paths[doc.startLine + offset] = scanLine(state, line);
+    });
+  });
+
+  return paths;
+}
+
+/**
+ * Build the section boundaries for one document: a preamble (if any content
+ * precedes the first top-level key) plus one section per top-level key, each
+ * running until the next top-level key or the document end. A document with
+ * zero top-level keys (templated YAML, a top-level sequence/scalar) becomes
+ * one whole-document section with no breadcrumb.
+ */
+function findDocSections(
+  lines: string[],
+  doc: DocRange,
+  linePaths: Array<string | undefined>,
+): Section[] {
+  const topLevelKeyLines: number[] = [];
+  lines.slice(doc.startLine, doc.endLine).forEach((line, offset) => {
+    if (isTopLevelKeyLine(line)) topLevelKeyLines.push(doc.startLine + offset);
+  });
+
+  if (topLevelKeyLines.length === 0) {
+    return [{ startLine: doc.startLine, endLine: doc.endLine, breadcrumb: undefined }];
+  }
+
+  const sections: Section[] = [];
+  if (topLevelKeyLines[0] > doc.startLine) {
+    sections.push({
+      startLine: doc.startLine,
+      endLine: topLevelKeyLines[0],
+      breadcrumb: undefined,
+    });
+  }
+
+  topLevelKeyLines.forEach((lineIdx, idx) => {
+    const nextLine = idx + 1 < topLevelKeyLines.length ? topLevelKeyLines[idx + 1] : doc.endLine;
+    sections.push({ startLine: lineIdx, endLine: nextLine, breadcrumb: linePaths[lineIdx] });
+  });
+
+  return sections;
+}
+
+/** Prefix a breadcrumb with `doc[N] ` when the file has more than one document. */
+function withDocPrefix(
+  breadcrumb: string | undefined,
+  docCount: number,
+  docNumber: number,
+): string | undefined {
+  if (docCount <= 1) return breadcrumb;
+  return breadcrumb ? `doc[${docNumber}] ${breadcrumb}` : `doc[${docNumber}]`;
+}
+
+/**
+ * Create a YAML 'config' chunk with consistent metadata.
+ */
+function createConfigChunk(
+  content: string,
+  startLine: number,
+  endLine: number,
+  filepath: string,
+  symbolName: string | undefined,
+): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file: filepath,
+      startLine,
+      endLine,
+      language: 'yaml',
+      type: 'config',
+      symbolName,
+    },
+  };
+}
+
+/**
+ * Split an oversized section into overlapping line-window sub-chunks so no
+ * single chunk is unbounded. Mirrors markdown-chunker's splitLargeSection;
+ * each window's breadcrumb is the key-path open at its first line, falling
+ * back to the section's own breadcrumb (its top-level key) when undefined.
+ */
+function splitLargeSection(
+  lines: string[],
+  section: Section,
+  filepath: string,
+  chunkSize: number,
+  chunkOverlap: number,
+  linePaths: Array<string | undefined>,
+  docCount: number,
+  docNumber: number,
+): CodeChunk[] {
+  const chunks: CodeChunk[] = [];
+  const sectionLines = lines.slice(section.startLine, section.endLine);
+  const step = Math.max(1, chunkSize - chunkOverlap);
+
+  for (let offset = 0; offset < sectionLines.length; offset += step) {
+    const endOffset = Math.min(offset + chunkSize, sectionLines.length);
+    const chunkContent = sectionLines.slice(offset, endOffset).join('\n');
+
+    if (chunkContent.trim().length > 0) {
+      const windowStartLine = section.startLine + offset;
+      const breadcrumb = linePaths[windowStartLine] ?? section.breadcrumb;
+      chunks.push(
+        createConfigChunk(
+          chunkContent,
+          windowStartLine + 1,
+          section.startLine + endOffset,
+          filepath,
+          withDocPrefix(breadcrumb, docCount, docNumber),
+        ),
+      );
+    }
+
+    if (endOffset >= sectionLines.length) break;
+  }
+
+  return chunks;
+}
+
+/**
+ * Chunk a YAML file by top-level mapping key.
+ *
+ * @param filepath - File path, used as chunk metadata.
+ * @param content - Raw file content.
+ * @param chunkSize - Max lines per chunk before an oversized section is split
+ *   into windows; also the window size used when splitting (default 75).
+ * @param chunkOverlap - Line overlap between windows when splitting an
+ *   oversized section (default 10).
+ */
+export function chunkYamlFile(
+  filepath: string,
+  content: string,
+  chunkSize: number = 75,
+  chunkOverlap: number = 10,
+): CodeChunk[] {
+  const lines = content.split('\n');
+  if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === '')) {
+    return [];
+  }
+
+  const docs = splitDocuments(lines);
+  const docCount = docs.length;
+  const linePaths = computeLinePaths(lines, docs);
+  const maxSectionSize = chunkSize * 3;
+
+  return docs.flatMap((doc, docIdx) => {
+    const docNumber = docIdx + 1;
+    const sections = findDocSections(lines, doc, linePaths);
+
+    return sections.flatMap(section => {
+      const sectionLineCount = section.endLine - section.startLine;
+      const sectionContent = lines.slice(section.startLine, section.endLine).join('\n');
+
+      if (sectionContent.trim().length === 0) return [];
+
+      if (sectionLineCount <= maxSectionSize) {
+        return [
+          createConfigChunk(
+            sectionContent,
+            section.startLine + 1,
+            section.endLine,
+            filepath,
+            withDocPrefix(section.breadcrumb, docCount, docNumber),
+          ),
+        ];
+      }
+
+      return splitLargeSection(
+        lines,
+        section,
+        filepath,
+        chunkSize,
+        chunkOverlap,
+        linePaths,
+        docCount,
+        docNumber,
+      );
+    });
+  });
+}

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -163,10 +163,13 @@ export function listFunctions(input: Record<string, unknown>, ctx: AgentToolCont
       MAX_FUNCTIONS_LIMIT,
     );
 
-    // Exclude markdown 'doc' chunks: they carry a heading-breadcrumb symbolName
-    // but are prose sections, not real code symbols (mirrors core's
-    // matchesSymbolFilter, which review can't import across the package boundary).
-    let results = ctx.repoChunks.filter(c => !!c.metadata.symbolName && c.metadata.type !== 'doc');
+    // Exclude markdown 'doc' and YAML 'config' chunks: they carry a
+    // heading-breadcrumb / key-path symbolName but are prose or config keys,
+    // not real code symbols (mirrors core's matchesSymbolFilter, which
+    // review can't import across the package boundary).
+    let results = ctx.repoChunks.filter(
+      c => !!c.metadata.symbolName && c.metadata.type !== 'doc' && c.metadata.type !== 'config',
+    );
 
     if (symbolType) {
       results = results.filter(c => c.metadata.symbolType === symbolType);

--- a/packages/review/test/plugins-agent-listfunctions.test.ts
+++ b/packages/review/test/plugins-agent-listfunctions.test.ts
@@ -52,6 +52,20 @@ const docChunk = createTestChunk({
   },
 });
 
+// A YAML 'config' chunk carries a dotted key-path symbolName but is a config
+// section, not a code symbol. It must not appear in list_functions results.
+const configChunk = createTestChunk({
+  content: 'jobs:\n  review:\n    runs-on: ubuntu-latest\n',
+  metadata: {
+    file: '.github/workflows/lien-review.yml',
+    startLine: 1,
+    endLine: 3,
+    type: 'config',
+    symbolName: 'jobs.review',
+    language: 'yaml',
+  },
+});
+
 describe('listFunctions — markdown doc chunks are not treated as symbols', () => {
   it('lists real code symbols but excludes doc-heading breadcrumbs', () => {
     const res = run([codeChunk, docChunk]);
@@ -74,5 +88,17 @@ describe('listFunctions — markdown doc chunks are not treated as symbols', () 
     const names = (res.results ?? []).map(r => r.symbolName);
     expect(names).not.toContain('Guide > Install');
     expect(res.count).toBe(0);
+  });
+});
+
+describe('listFunctions — YAML config chunks are not treated as symbols', () => {
+  it('lists real code symbols but excludes config key-path breadcrumbs', () => {
+    const res = run([codeChunk, configChunk]);
+    const names = (res.results ?? []).map(r => r.symbolName);
+
+    expect(res.error).toBeUndefined();
+    expect(names).toContain('doThing');
+    expect(names).not.toContain('jobs.review');
+    expect(res.count).toBe(1);
   });
 });

--- a/packages/site/docs/guide/configuration.md
+++ b/packages/site/docs/guide/configuration.md
@@ -158,6 +158,10 @@ Detected via `astro.config.*`. Indexes:
 
 Liquid (`.liquid`) files are indexed via the default scan pattern—no ecosystem preset or auto-detection is required. They work out of the box alongside all other supported file types.
 
+### YAML
+
+YAML (`.yml`/`.yaml`) files are indexed via the default scan pattern, chunked by top-level key into `search_code`-able config sections (e.g. a GitHub Actions `jobs.review` block). This includes `.github/**` explicitly, so CI workflow files under `.github/workflows/` are indexed even though the default scan otherwise skips dot-directories. Other dot-directory CI configs (e.g. `.circleci/config.yml`, a root `.gitlab-ci.yml`) are **not yet indexed**—only `.github/**` is covered today.
+
 ### Monorepos
 
 Lien automatically detects multiple ecosystems in monorepos. For example, a repo with both `package.json` and `backend/composer.json` will index both Node.js and Laravel code with appropriate patterns.

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -69,6 +69,7 @@ Find code with terms: jwt token validation verify
 - "payment transaction charge refund"
 - "parse json response body"
 - "authorization middleware guard"
+- "harness evidence gate skip label" (also matches YAML config, e.g. a GitHub Actions workflow step)
 
 **Poor queries:**
 - "how does login work?" (a question — use the code's own terms instead)

--- a/packages/site/docs/how-it-works.md
+++ b/packages/site/docs/how-it-works.md
@@ -124,7 +124,7 @@ Lien indexes and understands code in:
 - Swift
 
 **Indexed for lexical search** (chunking + FTS5):
-- All of the above, plus C/C++, Vue, Scala, Markdown, and more!
+- All of the above, plus C/C++, Vue, Scala, Markdown, YAML (config sections, e.g. GitHub Actions workflows), and more!
 
 ## Complexity Analysis
 


### PR DESCRIPTION
## What & why

Lien indexed code (AST-chunked) and Markdown (heading-chunked, `type:'doc'`) but **not** `.yml`/`.yaml`. YAML holds high-value truth — CI workflows, `action.yml`, compose/k8s manifests — that `search_code` and `get_files_context` were blind to. Two concrete motivators this week: a doc-truth claim referencing `.github/workflows/lien-review.yml` couldn't be verified from indexed material, and `search_code` couldn't answer "where is the review's env / candidate-loop flags set."

This adds a **lightweight structural YAML chunker** (no tree-sitter, no native build, no e2e language matrix) modeled on the existing Markdown heading-chunker.

## Design decisions

**D1 — New `type:'config'` (not reuse `'doc'`).** Only two consumers branch on chunk `type` (`matchesSymbolFilter`, review's `listFunctions` — both exclude `'doc'` from symbol lookup); ranking (#773), `get_files_context`, and the stale-literal scan are type-agnostic. Chose a semantically honest `'config'` over overloading `'doc'` (prose): a `get_files_context` result labeled `config` is true and useful, and `'config'` is the forward-compatible umbrella for the future JSON-config path. Cost was two one-line filter edits + one additive union member (no exhaustive switch anywhere — typecheck confirms).

**D2 — Granularity.** Sections = top-level mapping keys; `symbolName` carries a dotted key-path breadcrumb (`jobs.review.env`) from an indentation ancestor stack. Oversized sections (> `chunkSize*3` lines) window-split like the markdown chunker, deep breadcrumb preserved. Tiny non-empty files → exactly one chunk (no `minChunkSize` floor — #786 lesson). Multi-doc (`---`) supported with a `doc[N]` breadcrumb prefix. **Templated YAML (Helm/Jinja) can't fail us**: the chunker is pure line heuristics — no real YAML parser — so it never throws; a doc with zero top-level keys degrades to one whole-doc chunk.

**D3 — Exclusions.** `pnpm-lock.yaml` added to `ALWAYS_IGNORE_PATTERNS` (defensive; this repo uses npm and has none). No new per-file size-skip (YAGNI) — chunk-level window-split + existing node_modules/dist/vendor filters suffice; large OpenAPI specs are legitimately wanted (split, not skipped).

**D3b — Dot-directory glob gap (found in dogfood).** The scanner globs with glob's default `dot:false`, so a bare `**/*.yml` **never descends into `.github/`** — verified: it matched 0 files there. Without a fix, the #1 motivator (`.github/workflows/*.yml`) would silently never index. Fix: add explicit `.github/**/*.{yml,yaml}` patterns (a literal path segment matches under `dot:false`; a `**` wildcard doesn't). Chosen over a global `dot:true` (which drags in `.playwright-mcp` junk and changes behavior for all file types on a 46-importer scanner). Other dot-dir CI configs (`.circleci/`, root `.gitlab-ci.yml`) are a documented, YAGNI'd gap. Locked with a scanner regression test.

**D4 — Review pipeline: no change to `isConfig`/`CONFIG_PATH_RE`.** YAML chunks now enter `repoChunks` and are swept by the (type-agnostic) stale-literal signal — intended: stale duplicates in hand-written CI/k8s YAML are real bugs worth surfacing. I deliberately did **not** broaden `CONFIG_PATH_RE` to blanket-downrank YAML as config: (a) blanket suppression would defeat that motivating bug class; (b) the one YAML where config-downranking clearly applies (`pnpm-lock.yaml`) is excluded from indexing anyway; (c) any stale-literal precision change must clear the review harness calibration gate (≥9/10, real OpenRouter spend) per CLAUDE.md — out of scope for a deterministic, zero-LLM parser+core PR. Deferred to a follow-up gated on harness calibration **if** dogfooding shows FP noise.

**Replay-invariance:** the review harness replays fixtures from **frozen captured chunks** (via `loadFixture()`, no re-chunk at replay), and no existing fixture contains a captured `.yml`/`.yaml` chunk — so existing canaries are unaffected by this change until someone recaptures a fixture that includes YAML.

## Dogfood (verbatim, against this repo's own fresh index)

**Before** (live MCP plugin, main index): `search_code` surfaced only prose/code for these questions — no `.github/workflows/*.yml` at all (YAML was not indexed; `origin/main`'s scan patterns matched 0 YAML files).

**After** (fresh index of this branch — YAML answerable queries surface the workflow at rank 0 with structural breadcrumbs):

```
QUERY: "workflow concurrency cancel in progress pull request review"
  [0] .github/workflows/lien-review.yml   type=config sym=concurrency   highly_relevant
  [4] .github/workflows/deploy-docs.yml   type=config sym=concurrency   highly_relevant

QUERY: "ready_for_review synchronize reopened pull request trigger types"
  [0] .github/workflows/lien-review.yml        type=config sym=on   highly_relevant
  [2] .github/workflows/harness-attestation.yml type=config sym=on  relevant

QUERY: "OPENROUTER_API_KEY secret run lien review action env"   (≈ "where is the review env set")
  [0] .github/workflows/lien-review.yml   type=config sym=jobs   highly_relevant

QUERY: "harness evidence gate skip label bypass"
  [1] .github/workflows/harness-attestation.yml  type=config sym=name   highly_relevant
  [2] .github/workflows/harness-attestation.yml  type=config sym=jobs   highly_relevant

QUERY: "dogfood LIEN_STALE_DUP_PASS LIEN_INCOMPLETE_PASS opt in reviews"
  [1] .github/workflows/lien-review.yml   type=config sym=jobs   highly_relevant
```

**get_files_context** on `.github/workflows/lien-review.yml` (previously the unverifiable doc-truth claim; now returns 5 structural chunks):

```
[0] type=config lang=yaml sym=name          lines 1-28
[1] type=config lang=yaml sym=on            lines 29-32
[2] type=config lang=yaml sym=permissions   lines 33-36
[3] type=config lang=yaml sym=concurrency   lines 37-40
[4] type=config lang=yaml sym=jobs          lines 41-86   (contains LIEN_STALE_DUP_PASS: 'on')
```

**Honest caveat:** for queries whose vocabulary is *also* dense in the repo's TS/MD (e.g. bare "review token budget", or "candidate loop pass" — which this repo documents heavily in ADR-014 / review-pass-architecture.md), the YAML is indexed and findable but legitimately outranked by those richer sources. That's expected BM25 corpus-density behavior (documented in the `search_code` tool itself), not an indexing defect — the chunks are present and surface with targeted queries.

## Tests & gates

- New: `yaml-chunker.test.ts` (14 cases: multi-key, deep breadcrumb, oversize window-split, tiny-file #786 guard, empty/whitespace, multi-doc `doc[N]`, Helm/Jinja templated, block-scalar body containment, preamble, 1-based lines, top-level sequence), `filters.test.ts` (config excluded from symbol lookup), a core FTS `type:config` retrieval test, a scanner `.github/**` regression test, and a review `listFunctions` config-exclusion case.
- Gates: `format:check` ✓ · `lint` 0 errors ✓ · `typecheck` 0 errors ✓ · `build` ✓ · `docs:build` ✓ · `npm test` all pass (parser 1077, core 378, cli 1290, review 860, action 27) · `lien delta` **exit 0** (only sub-threshold ticks in `matchesSymbolFilter` 10→11 and `chunkSpecialCase` 4→5; no new crossings).

## Changeset

`.changeset/yaml-config-chunking.md` → `@liendev/parser`, `@liendev/core`, `@liendev/lien` all **minor** (cli-exposed `search_code` behavior changes; matches the #773 precedent).

## Notes for reviewer / owner

- DRY: the two byte-identical include-pattern lists are now a shared `DEFAULT_INDEX_INCLUDE_PATTERNS` const in `@liendev/parser` (rule-of-three; prevents future drift).
- After merge, a version-packages release PR will spawn — it needs the **owner's** manual "Approve and run workflows" click. This PR does not touch it.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 6 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 6 | +3 |


> [!NOTE]
> **Low Risk**
>
> This PR adds YAML structural chunking (`type: 'config'`) and updates scan patterns to index `.github/workflows/*.yml` under glob's `dot:false` default. The new chunker is a pure line-heuristic implementation with no parser that can throw, and it is correctly excluded from symbol-lookup paths in both core and review. All behavioral claims in touched docs/comments are consistent with the code, and the new code is well-covered by dedicated tests.
>
> - New `chunkYamlFile` heuristic chunker produces `type: 'config'`, `language: 'yaml'` chunks with dotted key-path breadcrumbs.
> - `matchesSymbolFilter` and `listFunctions` now exclude `type: 'config'` chunks, mirroring the existing `'doc'` exclusion.
> - Default include patterns moved to shared `DEFAULT_INDEX_INCLUDE_PATTERNS`; scanner fallback and core/parser indexers now include `.github/**/*.yml`/`.yaml` to work around glob's dot-directory behavior.
> - `pnpm-lock.yaml` added to `ALWAYS_IGNORE_PATTERNS`.

⚠️ The incomplete-handling pass did not finish — it hit the token budget limit. That pass's findings are partial; the main review's findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 24dc37c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 410K/359K tokens
<!-- /lien:attestation -->