### PR TITLE
feat(review): candidate-overflow rank-and-cap with attested deferral

### DIFF
--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -48,6 +48,23 @@ export interface ProviderPassAttestation {
   stopReason: ProviderStopReason;
   /** Every provider request failed terminally — zero completed turns. */
   neverRan: boolean;
+  /**
+   * How many of this pass's eligible candidates were excluded from its
+   * worklist by this run's rank-and-cap ceiling (candidate-overflow
+   * handling — see `plugins/agent/review-pass.ts`'s
+   * `affordableCandidateCeiling`) — 0 for the main pass (no candidate loop)
+   * or any pass whose full candidate list fit. This is an ADDITIVE field on
+   * the existing v2 shape; `ATTESTATION_VERSION` is unchanged (see that
+   * constant's doc comment) — unlike the v1→v2 bump, which fixed a genuine
+   * cardinality assumption a consumer could silently get wrong
+   * (`passes.length <= 1`), no existing consumer reads this field at all
+   * yet, so there is no prior assumption for it to violate by not knowing
+   * about it. A future field that changes an EXISTING assumption would still
+   * warrant its own version bump; a new, previously-absent field does not.
+   */
+  candidatesDeferred: number;
+  /** Best-effort human-readable labels for the deferred candidates (capped short list). */
+  deferredCandidateIds?: string[];
 }
 
 /** A plugin (or a plugin's internal sub-pass) that didn't run this turn, and why. */
@@ -173,19 +190,31 @@ export function deriveMainPassAttestation(
   providerFailure: boolean,
 ): ProviderPassAttestation {
   if (!agentAttempted) {
-    return { name: 'main', ran: false, stopReason: 'not_run', neverRan: false };
+    return {
+      name: 'main',
+      ran: false,
+      stopReason: 'not_run',
+      neverRan: false,
+      candidatesDeferred: 0,
+    };
   }
   if (providerFailure) {
-    return { name: 'main', ran: true, stopReason: 'error', neverRan: true };
+    return { name: 'main', ran: true, stopReason: 'error', neverRan: true, candidatesDeferred: 0 };
   }
   const incompleteFinding = findings.find(
     f => (f.metadata as AgentSummaryMetadata | undefined)?.incomplete === true,
   );
   if (incompleteFinding) {
     const stopReason = (incompleteFinding.metadata as AgentSummaryMetadata).stopReason ?? 'error';
-    return { name: 'main', ran: true, stopReason, neverRan: false };
+    return { name: 'main', ran: true, stopReason, neverRan: false, candidatesDeferred: 0 };
   }
-  return { name: 'main', ran: true, stopReason: 'completed', neverRan: false };
+  return {
+    name: 'main',
+    ran: true,
+    stopReason: 'completed',
+    neverRan: false,
+    candidatesDeferred: 0,
+  };
 }
 
 /**
@@ -237,6 +266,10 @@ export interface ExtraPassAttestationInput {
   neverRan: boolean;
   allocatedTokens: number;
   spentTokens: number;
+  /** How many eligible candidates this pass excluded from its worklist via rank-and-cap. */
+  candidatesDeferred: number;
+  /** Best-effort human-readable labels for the deferred candidates (capped short list). */
+  deferredCandidateIds?: string[];
 }
 
 export interface AttestationInput {
@@ -304,6 +337,8 @@ function buildPassesAndBudget(
       ran: true,
       stopReason: p.stopReason,
       neverRan: p.neverRan,
+      candidatesDeferred: p.candidatesDeferred ?? 0,
+      deferredCandidateIds: p.deferredCandidateIds,
     })),
   ];
   const passBudgets: PassBudgetAttestation[] = [

--- a/packages/review/src/plugin-types.ts
+++ b/packages/review/src/plugin-types.ts
@@ -146,6 +146,8 @@ export interface ReviewContext {
     neverRan: boolean;
     allocatedTokens: number;
     spentTokens: number;
+    candidatesDeferred: number;
+    deferredCandidateIds?: string[];
   }) => void;
 }
 

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -74,6 +74,9 @@ import { envDisabled } from './agent-client-shared.js';
 import {
   renderPassPrHeader,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
+  affordableCandidateCeiling,
+  MAX_DEFERRED_LABELS,
+  renderDeferralNote,
   type ReviewPassSpec,
 } from './review-pass.js';
 
@@ -228,8 +231,19 @@ export function buildDocTruthPassInitialMessage(context: ReviewContext): string 
  * ids attached (`buildDocTruthPassInitialMessageV2`). With the flag off this
  * function's return value is UNCHANGED from before v2 existed — same two
  * function calls, nothing appended.
+ *
+ * `budget` is this pass's own final allocated budget (see
+ * `ReviewPassSpec.buildPrompts`'s doc comment) — under v2, it drives
+ * rank-and-cap candidate-overflow handling (`capClaimWorklistToCeiling`):
+ * the Finding-A calibrate's ~51-claim worklist is the motivating case this
+ * closes. Defaults to unlimited so every existing call site that doesn't
+ * pass one (tests, and the v1 path, which has no id-based worklist to cap)
+ * is byte-identical to before this feature existed.
  */
-export function buildDocTruthPassPrompts(context: ReviewContext): {
+export function buildDocTruthPassPrompts(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): {
   systemPrompt: string;
   initialMessage: string;
 } {
@@ -237,10 +251,12 @@ export function buildDocTruthPassPrompts(context: ReviewContext): {
   if (!isDocTruthV2Enabled()) {
     return { systemPrompt, initialMessage: buildDocTruthPassInitialMessage(context) };
   }
-  const worklist = buildClaimWorklist(context);
+  const full = buildClaimWorklist(context);
+  const ceiling = affordableCandidateCeiling(budget, DOC_TRUTH_TOKENS_PER_CLAIM);
+  const { worklist, deferredCount } = capClaimWorklistToCeiling(full, ceiling);
   return {
     systemPrompt: `${systemPrompt}\n\n${buildV2OutputContractOverride(allClaimIds(worklist))}`,
-    initialMessage: buildDocTruthPassInitialMessageV2(context, worklist),
+    initialMessage: buildDocTruthPassInitialMessageV2(context, worklist, deferredCount),
   };
 }
 
@@ -318,6 +334,141 @@ export function allClaimIds(worklist: ClaimWorklist): string[] {
     ...worklist.docClaimIds,
     ...worklist.renameSignals.flatMap(s => [...s.proseIds, ...s.survivorIds]),
   ];
+}
+
+// ---------------------------------------------------------------------------
+// Candidate-overflow handling (rank-and-cap with attested deferral)
+// ---------------------------------------------------------------------------
+
+/**
+ * Realistic per-claim cost for the ceiling formula (see
+ * `affordableCandidateCeiling`). A claim entry carries a pre-fetched evidence
+ * excerpt (or a short "no evidence located" note), so judging it is a
+ * COMPARISON, not an investigation — the rule's own budget-discipline
+ * instruction explicitly forbids re-reading via tools when evidence is
+ * attached (`DOC_PASS_INTRO`: "do NOT re-read that file with tools; spend
+ * tool calls ONLY on claims with no attached evidence"). Same order of
+ * magnitude as stale-duplicate's own evidence-inline PER_CANDIDATE_TOKENS
+ * (800) — a little lighter, since a doc claim's excerpt is typically shorter
+ * than stale-duplicate's full diff hunk plus multiple surviving-site
+ * snippets.
+ */
+export const DOC_TRUTH_TOKENS_PER_CLAIM = 500;
+
+/** A short, human-readable label for one dropped worklist item — for the delivery attestation's
+ *  `deferredCandidateIds`, not the pass's own `claim-N` ids. */
+function truncateForLabel(text: string): string {
+  const MAX_LABEL_CHARS = 80;
+  const trimmed = text.trim();
+  return trimmed.length > MAX_LABEL_CHARS ? `${trimmed.slice(0, MAX_LABEL_CHARS - 1)}…` : trimmed;
+}
+
+/** The result of rank-and-capping a `ClaimWorklist` to an affordable ceiling. */
+export interface ClaimWorklistOverflow {
+  /** The capped worklist — safe to render with the EXISTING v2 render functions unchanged. */
+  worklist: ClaimWorklist;
+  /** How many listed ids were excluded by the cap (0 when the full worklist fit). */
+  deferredCount: number;
+  /** Best-effort human-readable labels for the deferred items (capped short list). */
+  deferredIds: string[];
+}
+
+/** A running "how many more ids can we afford" counter plus the deferred-label collector both
+ *  `capDocClaims`/`capRenameSignal` share — extracted so `capClaimWorklistToCeiling` itself stays
+ *  a short orchestrator (lien delta: Halstead effort budget). */
+interface CapBudget {
+  remaining: number;
+  pushDeferred: (label: string) => void;
+}
+
+/** Cap `full.docClaims`/`docClaimIds` to what `budget.remaining` affords, decrementing it and
+ *  recording every dropped claim's text as a deferred label. */
+function capDocClaims(
+  full: ClaimWorklist,
+  budget: CapBudget,
+): Pick<ClaimWorklist, 'docClaims' | 'docClaimIds'> {
+  const keepCount = Math.min(full.docClaims.length, budget.remaining);
+  budget.remaining -= keepCount;
+  full.docClaims.slice(keepCount).forEach(c => budget.pushDeferred(c.claimText));
+  return {
+    docClaims: full.docClaims.slice(0, keepCount),
+    docClaimIds: full.docClaimIds.slice(0, keepCount),
+  };
+}
+
+/** Cap one rename-sweep signal's prose/survivor items to what `budget.remaining` affords
+ *  (prose before survivors, matching `allClaimIds`' own order), decrementing it and recording
+ *  every dropped item's text as a deferred label. Returns null when nothing of this signal
+ *  fits — the whole mapping is deferred, nothing to render. */
+function capRenameSignal(s: RenameSignalWithIds, budget: CapBudget): RenameSignalWithIds | null {
+  const proseKeep = Math.min(s.proseIds.length, budget.remaining);
+  budget.remaining -= proseKeep;
+  const survivorKeep = Math.min(s.survivorIds.length, budget.remaining);
+  budget.remaining -= survivorKeep;
+
+  s.signal.proseTouched.slice(proseKeep).forEach(p => budget.pushDeferred(p.sentence));
+  s.signal.survivors.slice(survivorKeep).forEach(v => budget.pushDeferred(v.snippet));
+
+  if (proseKeep === 0 && survivorKeep === 0) return null;
+  return {
+    signal: {
+      ...s.signal,
+      proseTouched: s.signal.proseTouched.slice(0, proseKeep),
+      survivors: s.signal.survivors.slice(0, survivorKeep),
+    },
+    proseIds: s.proseIds.slice(0, proseKeep),
+    survivorIds: s.survivorIds.slice(0, survivorKeep),
+  };
+}
+
+/**
+ * Trim a `ClaimWorklist` down to at most `ceiling` total ids, preserving the
+ * EXISTING order `allClaimIds` already walks (doc claims first in their own
+ * extraction order, then each rename mapping's prose-touched lines then
+ * survivors, mappings in `computeRenameSweepSignals`'s own most-repeated-first
+ * order) — nothing is re-ranked, only truncated, per candidate-overflow
+ * handling's "reuse each signal's own order; don't invent new scoring".
+ *
+ * Scoped to the ceiling this run's BUDGET affords — the pre-existing local
+ * caps each signal already applies (`DOC_TRUTH_V2_MAX_CLAIMS`, rename-sweep's
+ * own `MAX_PROSE_LINES`/`MAX_SURVIVORS`/`MAX_MAPPINGS`) are untouched and are
+ * a separate, already-silent truncation this function does not attempt to
+ * fix — see the PR body for that scoping call. Returns the ORIGINAL worklist
+ * object unchanged when `ceiling` already covers every id (the common case),
+ * so a well-resourced run is byte-identical to before this feature existed.
+ */
+export function capClaimWorklistToCeiling(
+  full: ClaimWorklist,
+  ceiling: number,
+): ClaimWorklistOverflow {
+  const totalIds = allClaimIds(full).length;
+  if (totalIds <= ceiling) {
+    return { worklist: full, deferredCount: 0, deferredIds: [] };
+  }
+
+  const deferredIds: string[] = [];
+  const budget: CapBudget = {
+    remaining: Math.max(0, ceiling),
+    pushDeferred: label => {
+      if (deferredIds.length < MAX_DEFERRED_LABELS) deferredIds.push(truncateForLabel(label));
+    },
+  };
+
+  const cappedDocClaims = capDocClaims(full, budget);
+  const keptSignals = full.renameSignals
+    .map(s => capRenameSignal(s, budget))
+    .filter((s): s is RenameSignalWithIds => s !== null);
+
+  return {
+    worklist: {
+      ...cappedDocClaims,
+      renameSignals: keptSignals,
+      overflowClaims:
+        full.overflowClaims + (full.docClaims.length - cappedDocClaims.docClaims.length),
+    },
+    deferredCount: totalIds - ceiling,
+    deferredIds,
+  };
 }
 
 /** Render one doc-claim entry with its id — same shape as doc-claims-signals.ts's
@@ -407,10 +558,14 @@ const DOC_TRUTH_V2_CONTRACT_NOTE =
   'not in the worklist — those need no id and are evaluated as ordinary findings.';
 
 /** Build the v2 initial message: same shape as `buildDocTruthPassInitialMessage`, but the
- *  doc-claims/rename-sweep blocks carry ids and a contract note is inserted after the intro. */
+ *  doc-claims/rename-sweep blocks carry ids and a contract note is inserted after the intro.
+ *  `deferredCount` (0 by default) renders a candidate-overflow note when `worklist` was
+ *  rank-and-capped (see `capClaimWorklistToCeiling`) — omitted when nothing was deferred, so
+ *  every existing call site is byte-identical to before this feature existed. */
 export function buildDocTruthPassInitialMessageV2(
   context: ReviewContext,
   worklist: ClaimWorklist,
+  deferredCount = 0,
 ): string {
   const sections: string[] = [];
   pushIfPresent(sections, renderPassPrHeader(context));
@@ -419,6 +574,7 @@ export function buildDocTruthPassInitialMessageV2(
   pushIfPresent(sections, renderDocClaimsV2(worklist));
   pushIfPresent(sections, renderRenameSweepV2(worklist));
   pushIfPresent(sections, renderGuidanceSurfaceSection(context));
+  pushIfPresent(sections, renderDeferralNote(deferredCount));
   sections.push(
     'Judge every listed id and emit its required verdict, then output findings as JSON. If ' +
       'every claim is accurate, every verdict is still required — just each with verdict ' +
@@ -647,14 +803,26 @@ function reduceDocTruthV2Findings(raw: RawDocClaimVerdict[]): AgentFinding[] {
  * unconditionally without touching v1 behavior. When the client result was ALREADY incomplete
  * for a real reason (budget/max_turns/error), that reason is kept as-is, same precedent as
  * `stale-duplicate-pass.ts`'s `postProcessStaleDuplicateResult`.
+ *
+ * Coverage is checked against the RANK-AND-CAPPED worklist
+ * (`capClaimWorklistToCeiling(buildClaimWorklist(context), ceiling)`), not the
+ * full pre-cap worklist — a deferred claim was never listed, so it is
+ * correctly exempt from the honesty contract (candidate-overflow handling's
+ * point 3: deferral is not incompleteness). `budget` must be the SAME value
+ * `buildDocTruthPassPrompts` used — `review-pass.ts`'s `runReviewPass`
+ * guarantees this by threading one computed budget through both calls.
  */
 export function postProcessDocTruthResult(
   result: AgentResult,
   context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
 ): AgentResult {
   if (!isDocTruthV2Enabled()) return result;
 
-  const ids = allClaimIds(buildClaimWorklist(context));
+  const full = buildClaimWorklist(context);
+  const ceiling = affordableCandidateCeiling(budget, DOC_TRUTH_TOKENS_PER_CLAIM);
+  const { worklist, deferredCount, deferredIds } = capClaimWorklistToCeiling(full, ceiling);
+  const ids = allClaimIds(worklist);
   const raw = result.findings as RawDocClaimVerdict[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
   const wasAlreadyIncomplete = result.incomplete;
@@ -665,6 +833,8 @@ export function postProcessDocTruthResult(
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+    candidatesDeferred: deferredCount,
+    deferredCandidateIds: deferredCount > 0 ? deferredIds : undefined,
   };
 }
 

--- a/packages/review/src/plugins/agent/incomplete-handling-pass.ts
+++ b/packages/review/src/plugins/agent/incomplete-handling-pass.ts
@@ -95,6 +95,11 @@ import {
 import {
   renderPassPrHeader,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
+  OBSERVED_TOKENS_PER_TURN,
+  affordableCandidateCeiling,
+  capCandidatesToCeiling,
+  deferredCandidateLabels,
+  renderDeferralNote,
   type ReviewPassSpec,
 } from './review-pass.js';
 
@@ -302,6 +307,39 @@ function candidateIds(candidates: IncompleteHandlingCandidate[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Candidate-overflow handling (rank-and-cap with attested deferral)
+// ---------------------------------------------------------------------------
+
+/** Best-effort short label for a candidate, shape-specific — for the delivery attestation's
+ *  `deferredCandidateIds`, not the pass's own `candidate-N` worklist ids. */
+function incompleteHandlingLabel(c: IncompleteHandlingCandidate): string {
+  if (c.shape === 'variant-sweep') return `${c.variant.typeName}.${c.variant.variant}`;
+  if (c.shape === 'sibling-surface') return c.sibling.display;
+  return `${c.unreadField.typeName}.${c.unreadField.field}`;
+}
+
+/** This run's actual worklist after rank-and-cap. Unlike the pilot's stale-literal candidates,
+ *  NONE of this rule's three shapes attach an inline code snippet (module doc: "you need the
+ *  actual site's code to judge it") — read_file/get_files_context is load-bearing for most
+ *  candidates, so the realistic per-candidate cost is `OBSERVED_TOKENS_PER_TURN`, not this pass's
+ *  own (prompt-sizing) PER_CANDIDATE_TOKENS constant. `budget` defaults to unlimited so every
+ *  existing call site that doesn't pass one is byte-identical to before this feature existed.
+ *  Exposed for testing. */
+export function computeIncompleteHandlingWorklist(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): { candidates: IncompleteHandlingCandidate[]; deferredCount: number; deferredIds: string[] } {
+  const all = computeIncompleteHandlingCandidates(context);
+  const ceiling = affordableCandidateCeiling(budget, OBSERVED_TOKENS_PER_TURN);
+  const { kept, deferred } = capCandidatesToCeiling(all, ceiling);
+  return {
+    candidates: kept,
+    deferredCount: deferred.length,
+    deferredIds: deferredCandidateLabels(deferred, incompleteHandlingLabel),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Prompt construction — per-shape candidate rendering
 // ---------------------------------------------------------------------------
 
@@ -421,26 +459,39 @@ ${INCOMPLETE_HANDLING.example}
 ${buildOutputFormat(ids)}`;
 }
 
-/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. */
-export function buildIncompleteHandlingPassInitialMessage(context: ReviewContext): string {
-  const candidates = computeIncompleteHandlingCandidates(context);
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. `budget`
+ *  drives rank-and-cap overflow handling (see `computeIncompleteHandlingWorklist`) — defaults to
+ *  unlimited so existing callers that don't pass one are unaffected. */
+export function buildIncompleteHandlingPassInitialMessage(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): string {
+  const { candidates, deferredCount } = computeIncompleteHandlingWorklist(context, budget);
   const sections: string[] = [];
   const header = renderPassPrHeader(context);
   if (header) sections.push(header);
   sections.push(renderWorklist(candidates));
+  const deferralNote = renderDeferralNote(deferredCount);
+  if (deferralNote) sections.push(deferralNote);
   sections.push('Judge every candidate above and output your verdicts as JSON.');
   return sections.join('\n\n');
 }
 
-/** The system + initial prompts for the incomplete-handling candidate loop. */
-export function buildIncompleteHandlingPassPrompts(context: ReviewContext): {
+/** The system + initial prompts for the incomplete-handling candidate loop. `budget` is this
+ *  pass's own final allocated budget (see `ReviewPassSpec.buildPrompts`'s doc comment) — defaults
+ *  to unlimited so existing callers unaware of overflow handling are byte-identical to before. */
+export function buildIncompleteHandlingPassPrompts(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): {
   systemPrompt: string;
   initialMessage: string;
 } {
-  const ids = candidateIds(computeIncompleteHandlingCandidates(context));
+  const { candidates } = computeIncompleteHandlingWorklist(context, budget);
+  const ids = candidateIds(candidates);
   return {
     systemPrompt: buildSystemPrompt(ids),
-    initialMessage: buildIncompleteHandlingPassInitialMessage(context),
+    initialMessage: buildIncompleteHandlingPassInitialMessage(context, budget),
   };
 }
 
@@ -541,12 +592,26 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): bo
  * ALREADY incomplete for a real reason (budget/max_turns/error), that
  * reason is kept as-is; `incomplete_verdict` is only used when the model
  * otherwise returned a syntactically complete verdict.
+ *
+ * Coverage is checked against the RANK-AND-CAPPED worklist (from
+ * `computeIncompleteHandlingWorklist(context, budget)`), not the full pre-cap
+ * candidate set — a deferred candidate was never listed, so it is correctly
+ * exempt from the honesty contract (candidate-overflow handling's point 3:
+ * deferral is not incompleteness). `budget` must be the SAME value
+ * `buildIncompleteHandlingPassPrompts` used — `review-pass.ts`'s
+ * `runReviewPass` guarantees this by threading one computed budget through
+ * both calls.
  */
 export function postProcessIncompleteHandlingResult(
   result: AgentResult,
   context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
 ): AgentResult {
-  const ids = candidateIds(computeIncompleteHandlingCandidates(context));
+  const { candidates, deferredCount, deferredIds } = computeIncompleteHandlingWorklist(
+    context,
+    budget,
+  );
+  const ids = candidateIds(candidates);
   const expected = new Set(ids);
   const raw = result.findings as RawVerdictFinding[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
@@ -565,6 +630,8 @@ export function postProcessIncompleteHandlingResult(
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+    candidatesDeferred: deferredCount,
+    deferredCandidateIds: deferredCount > 0 ? deferredIds : undefined,
   };
 }
 

--- a/packages/review/src/plugins/agent/removed-exports-pass.ts
+++ b/packages/review/src/plugins/agent/removed-exports-pass.ts
@@ -112,6 +112,11 @@ import {
 import {
   renderPassPrHeader,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
+  OBSERVED_TOKENS_PER_TURN,
+  affordableCandidateCeiling,
+  capCandidatesToCeiling,
+  deferredCandidateLabels,
+  renderDeferralNote,
   type ReviewPassSpec,
 } from './review-pass.js';
 
@@ -307,6 +312,36 @@ function candidateIds(candidates: RemovedExportContext[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Candidate-overflow handling (rank-and-cap with attested deferral)
+// ---------------------------------------------------------------------------
+
+/** Best-effort short label for a candidate — for the delivery attestation's
+ *  `deferredCandidateIds`, not the pass's own `candidate-N` worklist ids. */
+function removedExportsLabel(c: RemovedExportContext): string {
+  return c.symbol;
+}
+
+/** This run's actual worklist after rank-and-cap. No candidate here carries an inline snippet
+ *  (module doc: "no inline snippet is attached, unlike the pilot's stale-literal candidates") —
+ *  confirming a surviving reference is real production usage requires read_file, so the
+ *  realistic per-candidate cost is `OBSERVED_TOKENS_PER_TURN`, not this pass's own (prompt-sizing)
+ *  PER_CANDIDATE_TOKENS constant. `budget` defaults to unlimited so every existing call site that
+ *  doesn't pass one is byte-identical to before this feature existed. Exposed for testing. */
+export function computeRemovedExportsWorklist(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): { candidates: RemovedExportContext[]; deferredCount: number; deferredIds: string[] } {
+  const all = computeRemovedExportsCandidates(context);
+  const ceiling = affordableCandidateCeiling(budget, OBSERVED_TOKENS_PER_TURN);
+  const { kept, deferred } = capCandidatesToCeiling(all, ceiling);
+  return {
+    candidates: kept,
+    deferredCount: deferred.length,
+    deferredIds: deferredCandidateLabels(deferred, removedExportsLabel),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Prompt construction
 // ---------------------------------------------------------------------------
 
@@ -467,26 +502,39 @@ ${REMOVED_EXPORTS_EXAMPLE}
 ${buildOutputFormat(ids)}`;
 }
 
-/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. */
-export function buildRemovedExportsPassInitialMessage(context: ReviewContext): string {
-  const candidates = computeRemovedExportsCandidates(context);
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. `budget`
+ *  drives rank-and-cap overflow handling (see `computeRemovedExportsWorklist`) — defaults to
+ *  unlimited so existing callers that don't pass one are unaffected. */
+export function buildRemovedExportsPassInitialMessage(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): string {
+  const { candidates, deferredCount } = computeRemovedExportsWorklist(context, budget);
   const sections: string[] = [];
   const header = renderPassPrHeader(context);
   if (header) sections.push(header);
   sections.push(renderWorklist(context, candidates));
+  const deferralNote = renderDeferralNote(deferredCount);
+  if (deferralNote) sections.push(deferralNote);
   sections.push('Judge every candidate above and output your verdicts as JSON.');
   return sections.join('\n\n');
 }
 
-/** The system + initial prompts for the removed-exports candidate loop. */
-export function buildRemovedExportsPassPrompts(context: ReviewContext): {
+/** The system + initial prompts for the removed-exports candidate loop. `budget` is this pass's
+ *  own final allocated budget (see `ReviewPassSpec.buildPrompts`'s doc comment) — defaults to
+ *  unlimited so existing callers unaware of overflow handling are byte-identical to before. */
+export function buildRemovedExportsPassPrompts(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): {
   systemPrompt: string;
   initialMessage: string;
 } {
-  const ids = candidateIds(computeRemovedExportsCandidates(context));
+  const { candidates } = computeRemovedExportsWorklist(context, budget);
+  const ids = candidateIds(candidates);
   return {
     systemPrompt: buildSystemPrompt(ids),
-    initialMessage: buildRemovedExportsPassInitialMessage(context),
+    initialMessage: buildRemovedExportsPassInitialMessage(context, budget),
   };
 }
 
@@ -586,12 +634,22 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): bo
  * result was ALREADY incomplete for a real reason (budget/max_turns/error),
  * that reason is kept as-is; `incomplete_verdict` is only used when the
  * model otherwise returned a syntactically complete verdict.
+ *
+ * Coverage is checked against the RANK-AND-CAPPED worklist (from
+ * `computeRemovedExportsWorklist(context, budget)`), not the full pre-cap
+ * candidate set — a deferred candidate was never listed, so it is correctly
+ * exempt from the honesty contract (candidate-overflow handling's point 3:
+ * deferral is not incompleteness). `budget` must be the SAME value
+ * `buildRemovedExportsPassPrompts` used — `review-pass.ts`'s `runReviewPass`
+ * guarantees this by threading one computed budget through both calls.
  */
 export function postProcessRemovedExportsResult(
   result: AgentResult,
   context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
 ): AgentResult {
-  const ids = candidateIds(computeRemovedExportsCandidates(context));
+  const { candidates, deferredCount, deferredIds } = computeRemovedExportsWorklist(context, budget);
+  const ids = candidateIds(candidates);
   const expected = new Set(ids);
   const raw = result.findings as RawVerdictFinding[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
@@ -610,6 +668,8 @@ export function postProcessRemovedExportsResult(
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+    candidatesDeferred: deferredCount,
+    deferredCandidateIds: deferredCount > 0 ? deferredIds : undefined,
   };
 }
 

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -51,8 +51,20 @@ export interface ReviewPassSpec {
   skipPlugin: string;
   /** Why this pass would not run right now, or null if it should run. */
   gateReason(context: ReviewContext, config: AgentConfig): string | null;
-  /** Build this pass's system + initial prompts. */
-  buildPrompts(context: ReviewContext): { systemPrompt: string; initialMessage: string };
+  /**
+   * Build this pass's system + initial prompts. `budget` is this pass's own
+   * FINAL allocated budget (already computed via this same spec's `budget()`
+   * below) — a candidate-loop pass uses it to rank-and-cap its worklist to
+   * what this invocation can actually afford (see `affordableCandidateCeiling`
+   * below); a pass with no overflow handling ignores the parameter (a
+   * function declaring fewer parameters than an interface's function type is
+   * still a valid implementation of that type — same precedent as `budget`'s
+   * own doc comment below).
+   */
+  buildPrompts(
+    context: ReviewContext,
+    budget: number,
+  ): { systemPrompt: string; initialMessage: string };
   /**
    * This pass's token budget, computed from the main pass's base budget.
    * `context` is available for a candidate-loop pass that scales its budget
@@ -81,9 +93,14 @@ export interface ReviewPassSpec {
    * when the model's output didn't cover every candidate — even though the
    * underlying client returned a syntactically complete verdict (has a
    * summary). Identity (no post-processing) when omitted; doc-truth's own
-   * open findings-list shape needs nothing here.
+   * open findings-list shape needs nothing here. `budget` is the SAME
+   * allocated-budget value `buildPrompts` received — a pass with overflow
+   * handling recomputes the identical rank-and-cap worklist from it here (to
+   * check verdict coverage against exactly what was LISTED, not the full
+   * pre-cap candidate set) and stamps `candidatesDeferred`/
+   * `deferredCandidateIds` on the returned result.
    */
-  postProcessResult?(result: AgentResult, context: ReviewContext): AgentResult;
+  postProcessResult?(result: AgentResult, context: ReviewContext, budget: number): AgentResult;
 }
 
 /**
@@ -105,6 +122,130 @@ export interface ReviewPassSpec {
  * fixes.
  */
 export const EXTRA_PASS_MIN_BUDGET_TOKENS = 11_000;
+
+// ---------------------------------------------------------------------------
+// Candidate-overflow handling (rank-and-cap with attested deferral)
+// ---------------------------------------------------------------------------
+
+/**
+ * Realistic cost (tokens) of ONE turn that dispatches a real tool call and
+ * receives its result — PR #811/#813's measured envelope (5,526-6,564
+ * tokens/turn on Kimi, the same measurement `EXTRA_PASS_MIN_BUDGET_TOKENS`
+ * above is derived from) rounded to a clean number. This is the REALISTIC
+ * per-candidate cost for a candidate-loop pass whose candidates carry no
+ * inline evidence and so need a fresh read_file/get_files_context round-trip
+ * to judge (incomplete-handling, removed-exports) — a much bigger number
+ * than either pass's own PER_CANDIDATE_TOKENS budget-SIZING constant
+ * (800-900), which only accounts for the candidate's rendered PROMPT text,
+ * not the tool round-trip needed to actually investigate it. PR #813 is the
+ * proof this gap matters: incomplete-handling's 15-candidate worklist got a
+ * budget "correctly" scaled to 16,000 tokens under that prompt-sizing
+ * formula and still ran out on turn 2, mid-investigation — the formula sized
+ * the PROMPT, not the INVESTIGATION. A pass whose candidates carry
+ * pre-fetched evidence (stale-duplicate's snippet, doc-truth's excerpt)
+ * doesn't pay this cost per candidate — those callers pass their own nominal
+ * per-candidate constant to `affordableCandidateCeiling` instead.
+ */
+export const OBSERVED_TOKENS_PER_TURN = 6_000;
+
+/**
+ * Tokens reserved off the top of a pass's budget for its own final
+ * verdict-emission turn — synthesizing and emitting the JSON verdict array
+ * once every listed candidate has been judged. Smaller than a full
+ * investigative round-trip (no new tool dispatch, just synthesis), which is
+ * exactly how `EXTRA_PASS_MIN_BUDGET_TOKENS` (11,000) was already derived:
+ * "one such [investigative] turn plus a SMALLER follow-up/verdict turn with
+ * margin" (see that constant's doc comment). This is that already-implied
+ * "smaller" number, made explicit: 11,000 total minus the one investigative
+ * turn `OBSERVED_TOKENS_PER_TURN` accounts for.
+ */
+export const VERDICT_EMISSION_RESERVE_TOKENS =
+  EXTRA_PASS_MIN_BUDGET_TOKENS - OBSERVED_TOKENS_PER_TURN;
+
+/**
+ * How many candidates THIS invocation's allocated budget can afford an
+ * EVIDENCE-BACKED verdict for — the rank-and-cap ceiling every candidate-loop
+ * pass inverts its own budget math against (per-rule-loops candidate-overflow
+ * handling; see PR #813's 15-candidate incomplete-handling run and the
+ * Finding-A calibrate's ~51-claim doc-truth worklist, both of which exceeded
+ * what their invocation could actually afford). `budget` is deliberately NOT
+ * reduced by each pass's own fixed prompt overhead (BASE_OVERHEAD_TOKENS-style
+ * constants) a second time here — that overhead is already what sized the
+ * budget number in the first place (each pass's own `budget()` formula), and
+ * PR #811's per-turn measurement that grounds `OBSERVED_TOKENS_PER_TURN`
+ * already reflects a real turn's total cost (system prompt + worklist +
+ * response), not just the tool-call delta. Only `VERDICT_EMISSION_RESERVE_TOKENS`
+ * is reserved on top, for the pass's own closing turn.
+ *
+ * `tokensPerCandidate` is the caller's judgment call on realistic per-candidate
+ * cost, not this function's: pass `OBSERVED_TOKENS_PER_TURN` itself for a loop
+ * whose candidates typically need a fresh tool round-trip to judge (no inline
+ * evidence attached), or the pass's own nominal PER_CANDIDATE_* budget-sizing
+ * constant for a loop whose candidates carry pre-fetched evidence (a
+ * comparison, not an investigation) — see each pass's own call site for which
+ * applies. Floored at 0; given every pass's budget floor
+ * (`EXTRA_PASS_MIN_BUDGET_TOKENS` = 11,000 > `VERDICT_EMISSION_RESERVE_TOKENS`
+ * + any tokensPerCandidate used today), the ceiling is always ≥1 in practice —
+ * a pass that passed its own eligibility gate (≥1 real candidate exists) never
+ * gets capped down to a vacuous, zero-candidate worklist.
+ */
+export function affordableCandidateCeiling(budget: number, tokensPerCandidate: number): number {
+  const investigable = budget - VERDICT_EMISSION_RESERVE_TOKENS;
+  return Math.max(0, Math.floor(investigable / tokensPerCandidate));
+}
+
+/** The result of capping a candidate array to an affordable ceiling. */
+export interface CandidateCap<T> {
+  /** Candidates that fit within the ceiling — this run's actual worklist. */
+  kept: T[];
+  /** Candidates beyond the ceiling — excluded from the worklist, attested as deferred. */
+  deferred: T[];
+}
+
+/**
+ * Cap a candidate array — already in its OWN signal's existing priority/score
+ * order (highest-confidence or most-repeated first; see each pass's own
+ * `compute*Candidates` doc comment) — to the first `ceiling` entries. No new
+ * ranking is invented: this only truncates an already-ordered list, per the
+ * per-rule-loops candidate-overflow design ("each signal already has an
+ * internal sort order — reuse; don't invent new scoring").
+ */
+export function capCandidatesToCeiling<T>(candidates: T[], ceiling: number): CandidateCap<T> {
+  if (candidates.length <= ceiling) return { kept: candidates, deferred: [] };
+  return { kept: candidates.slice(0, ceiling), deferred: candidates.slice(ceiling) };
+}
+
+/** Cap on how many deferred-candidate labels are attested (attestation stays short). */
+export const MAX_DEFERRED_LABELS = 10;
+
+/** Best-effort human-readable labels for a (possibly capped) deferred list — for the delivery
+ *  attestation's `deferredCandidateIds`, NOT the pass's own `candidate-N` worklist ids (those are
+ *  only ever assigned to KEPT/listed candidates — a deferred candidate never gets one). */
+export function deferredCandidateLabels<T>(deferred: T[], labelFor: (item: T) => string): string[] {
+  return deferred.slice(0, MAX_DEFERRED_LABELS).map(labelFor);
+}
+
+/**
+ * The prompt note telling the model its worklist was capped — the honesty
+ * half of candidate-overflow handling (per-rule-loops design point 2/3): the
+ * model must know deferral happened so its summary doesn't imply exhaustive
+ * coverage, while still being told every LISTED candidate is mandatory (a
+ * capped-but-complete run is a clean verdict, not incompleteness — see
+ * `incomplete_verdict`'s own doc comment on `AgentStopReason`). Returns ''
+ * when nothing was deferred (the common case), so callers can push it
+ * unconditionally alongside the worklist with `pushIfPresent`-style helpers.
+ */
+export function renderDeferralNote(deferredCount: number): string {
+  if (deferredCount <= 0) return '';
+  return (
+    `NOTE — CANDIDATE OVERFLOW: ${deferredCount} additional eligible candidate(s) exist beyond ` +
+    "this run's worklist below. They were DEFERRED — excluded, not silently investigated — " +
+    "because this invocation's budget cannot afford an evidence-backed verdict for all of them. " +
+    'This is a deliberate, attested cap, not incompleteness: you must still judge every ' +
+    'candidate actually LISTED below (per <output_format>), and your summary must not describe ' +
+    'or imply exhaustive coverage of every candidate that exists — only of the ones listed.'
+  );
+}
 
 /**
  * The PR title/body header, mirroring the main pass's `<pr_metadata>` block.
@@ -146,10 +287,12 @@ export async function runReviewPass(
     return null;
   }
   try {
-    const { systemPrompt, initialMessage } = spec.buildPrompts(context);
     const budget = spec.budget(config.maxTokenBudget, context);
+    const { systemPrompt, initialMessage } = spec.buildPrompts(context, budget);
     const rawResult = await runClient(systemPrompt, initialMessage, budget, spec.maxTurns);
-    const result = spec.postProcessResult ? spec.postProcessResult(rawResult, context) : rawResult;
+    const result = spec.postProcessResult
+      ? spec.postProcessResult(rawResult, context, budget)
+      : rawResult;
     logger.info(
       `[agent] ${spec.name} pass: ${result.findings.length} finding(s) in ${result.turns} turn(s) ($${result.usage.cost.toFixed(4)})`,
     );
@@ -193,6 +336,17 @@ export interface PassOutcome {
   neverRan: boolean;
   allocatedTokens: number;
   spentTokens: number;
+  /**
+   * How many of this pass's eligible candidates were excluded from its
+   * worklist by the rank-and-cap ceiling (see `affordableCandidateCeiling`) —
+   * 0 for a pass with no overflow handling, or one whose full candidate list
+   * fit inside this run's budget (the common case). Read straight off the
+   * pass's own `AgentResult.candidatesDeferred` (set by its
+   * `postProcessResult`).
+   */
+  candidatesDeferred: number;
+  /** Best-effort human-readable labels for the deferred candidates (capped short list). */
+  deferredCandidateIds?: string[];
 }
 
 /**
@@ -233,6 +387,8 @@ export async function runExtraPasses(
         neverRan: passResult.neverRan ?? false,
         allocatedTokens: spec.budget(config.maxTokenBudget, context),
         spentTokens: passResult.usage.totalTokens,
+        candidatesDeferred: passResult.candidatesDeferred ?? 0,
+        deferredCandidateIds: passResult.deferredCandidateIds,
       });
     }
     merged = spec.mergeFindings(merged, passResult?.findings ?? []);

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -52,6 +52,10 @@ import {
 import {
   renderPassPrHeader,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
+  affordableCandidateCeiling,
+  capCandidatesToCeiling,
+  deferredCandidateLabels,
+  renderDeferralNote,
   type ReviewPassSpec,
 } from './review-pass.js';
 
@@ -242,6 +246,43 @@ function candidateIds(candidates: StaleLiteralCandidate[]): string[] {
   return candidates.map((_, i) => `candidate-${i + 1}`);
 }
 
+// ---------------------------------------------------------------------------
+// Candidate-overflow handling (rank-and-cap with attested deferral)
+// ---------------------------------------------------------------------------
+
+/** This pass's own candidates carry inline evidence (the literal, the changed-site diff hunk,
+ *  every surviving occurrence's snippet — see `renderCandidate`), so judging one is a comparison,
+ *  not a fresh investigation (module doc: "rarely needs more than a couple of tool calls before
+ *  the verdict turn"). The realistic per-candidate cost is therefore this pass's own nominal
+ *  PER_CANDIDATE_TOKENS budget-sizing constant, not `OBSERVED_TOKENS_PER_TURN` — see
+ *  `affordableCandidateCeiling`'s own doc comment for the read-heavy-vs-evidence-inline split. */
+const STALE_DUP_TOKENS_PER_CANDIDATE = STALE_DUP_PER_CANDIDATE_TOKENS;
+
+function staleDuplicateLabel(c: StaleLiteralCandidate): string {
+  return c.literal;
+}
+
+/** This run's actual worklist after rank-and-cap: `computeStaleLiteralCandidates`'s own
+ *  confidence-ordered candidates, truncated to what `budget` can afford an evidence-backed
+ *  verdict for (see `affordableCandidateCeiling`). `budget` defaults to unlimited so every
+ *  existing call site that doesn't pass one (tests, and any caller unaware of overflow handling)
+ *  is byte-identical to before this feature existed — capping only kicks in when a REAL,
+ *  budget-constrained caller (review-pass.ts's `runReviewPass`) supplies one. Exposed for
+ *  testing. */
+export function computeStaleDuplicateWorklist(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): { candidates: StaleLiteralCandidate[]; deferredCount: number; deferredIds: string[] } {
+  const all = computeStaleLiteralCandidates(context);
+  const ceiling = affordableCandidateCeiling(budget, STALE_DUP_TOKENS_PER_CANDIDATE);
+  const { kept, deferred } = capCandidatesToCeiling(all, ceiling);
+  return {
+    candidates: kept,
+    deferredCount: deferred.length,
+    deferredIds: deferredCandidateLabels(deferred, staleDuplicateLabel),
+  };
+}
+
 const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
 /**
@@ -386,26 +427,39 @@ ${STALE_DUPLICATE.example}
 ${buildOutputFormat(ids)}`;
 }
 
-/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. */
-export function buildStaleDuplicatePassInitialMessage(context: ReviewContext): string {
-  const candidates = computeStaleLiteralCandidates(context);
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. `budget`
+ *  drives rank-and-cap overflow handling (see `computeStaleDuplicateWorklist`) — defaults to
+ *  unlimited so existing callers that don't pass one are unaffected. */
+export function buildStaleDuplicatePassInitialMessage(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): string {
+  const { candidates, deferredCount } = computeStaleDuplicateWorklist(context, budget);
   const sections: string[] = [];
   const header = renderPassPrHeader(context);
   if (header) sections.push(header);
   sections.push(renderWorklist(context, candidates));
+  const deferralNote = renderDeferralNote(deferredCount);
+  if (deferralNote) sections.push(deferralNote);
   sections.push('Judge every candidate above and output your verdicts as JSON.');
   return sections.join('\n\n');
 }
 
-/** The system + initial prompts for the stale-duplicate candidate loop. */
-export function buildStaleDuplicatePassPrompts(context: ReviewContext): {
+/** The system + initial prompts for the stale-duplicate candidate loop. `budget` is this pass's
+ *  own final allocated budget (see `ReviewPassSpec.buildPrompts`'s doc comment) — defaults to
+ *  unlimited so existing callers unaware of overflow handling are byte-identical to before. */
+export function buildStaleDuplicatePassPrompts(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): {
   systemPrompt: string;
   initialMessage: string;
 } {
-  const ids = candidateIds(computeStaleLiteralCandidates(context));
+  const { candidates } = computeStaleDuplicateWorklist(context, budget);
+  const ids = candidateIds(candidates);
   return {
     systemPrompt: buildSystemPrompt(ids),
-    initialMessage: buildStaleDuplicatePassInitialMessage(context),
+    initialMessage: buildStaleDuplicatePassInitialMessage(context, budget),
   };
 }
 
@@ -513,12 +567,23 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): bo
  * (more specific than the generic coverage-gap marker); `incomplete_verdict`
  * is only used when the model otherwise returned a syntactically complete
  * verdict.
+ *
+ * Coverage is checked against the RANK-AND-CAPPED worklist (`ids`, from
+ * `computeStaleDuplicateWorklist(context, budget)`), not the full pre-cap
+ * candidate set — a deferred candidate was never listed, so it is correctly
+ * exempt from the honesty contract (candidate-overflow handling's point 3:
+ * deferral is not incompleteness). `budget` must be the SAME value
+ * `buildStaleDuplicatePassPrompts` used, so both sides agree on exactly which
+ * candidates were listed — `review-pass.ts`'s `runReviewPass` guarantees this
+ * by threading one computed budget through both calls.
  */
 export function postProcessStaleDuplicateResult(
   result: AgentResult,
   context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
 ): AgentResult {
-  const ids = candidateIds(computeStaleLiteralCandidates(context));
+  const { candidates, deferredCount, deferredIds } = computeStaleDuplicateWorklist(context, budget);
+  const ids = candidateIds(candidates);
   const raw = result.findings as RawVerdictFinding[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
   const wasAlreadyIncomplete = result.incomplete;
@@ -529,6 +594,8 @@ export function postProcessStaleDuplicateResult(
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+    candidatesDeferred: deferredCount,
+    deferredCandidateIds: deferredCount > 0 ? deferredIds : undefined,
   };
 }
 

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -285,6 +285,23 @@ export interface AgentResult {
    * adding another dedicated boolean.
    */
   incompleteFromPass?: string;
+  /**
+   * How many of this pass's eligible candidates were excluded from its
+   * worklist because they exceeded this run's affordable-candidate ceiling
+   * — rank-and-cap candidate-overflow handling (see `review-pass.ts`'s
+   * `affordableCandidateCeiling`). Set by a candidate-loop pass's
+   * `postProcessResult`; 0/absent for the main pass and for any pass whose
+   * full candidate list fit inside its budget (the common case). Deferral is
+   * NOT incompleteness: a capped-but-complete run (every LISTED candidate
+   * verdicted) keeps `incomplete: false` regardless of this value.
+   */
+  candidatesDeferred?: number;
+  /**
+   * Best-effort human-readable labels for the deferred candidates (capped
+   * short list) — omitted when `candidatesDeferred` is 0/absent, or the
+   * pass's candidate shape has no natural short label.
+   */
+  deferredCandidateIds?: string[];
   /** Per-turn trace data — only populated when the caller wires up trace capture. */
   trace?: AgentTrace;
 }

--- a/packages/review/test/attestation.test.ts
+++ b/packages/review/test/attestation.test.ts
@@ -66,7 +66,7 @@ describe('assembleAttestation', () => {
     const attestation = assembleAttestation(baseInput());
     expect(attestation.verdict).toBe('delivered');
     expect(attestation.provider.passes).toEqual([
-      { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
+      { name: 'main', ran: true, stopReason: 'completed', neverRan: false, candidatesDeferred: 0 },
     ]);
     expect(attestation.budget).toEqual({
       allocatedTokens: 100_000,
@@ -86,6 +86,7 @@ describe('assembleAttestation', () => {
       ran: true,
       stopReason: 'error',
       neverRan: true,
+      candidatesDeferred: 0,
     });
   });
 
@@ -193,6 +194,7 @@ describe('assembleAttestation', () => {
         neverRan: false,
         allocatedTokens: 40_000,
         spentTokens: 8_000,
+        candidatesDeferred: 0,
         ...overrides,
       };
     }
@@ -200,8 +202,21 @@ describe('assembleAttestation', () => {
     it('reports a SEPARATE provider.passes[] entry for the extra pass, not just main', () => {
       const attestation = assembleAttestation(baseInput({ extraPasses: [docTruthPass()] }));
       expect(attestation.provider.passes).toEqual([
-        { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
-        { name: 'doc-truth', ran: true, stopReason: 'completed', neverRan: false },
+        {
+          name: 'main',
+          ran: true,
+          stopReason: 'completed',
+          neverRan: false,
+          candidatesDeferred: 0,
+        },
+        {
+          name: 'doc-truth',
+          ran: true,
+          stopReason: 'completed',
+          neverRan: false,
+          candidatesDeferred: 0,
+          deferredCandidateIds: undefined,
+        },
       ]);
     });
 
@@ -237,8 +252,21 @@ describe('assembleAttestation', () => {
       );
       expect(attestation.verdict).toBe('degraded:budget_starved');
       expect(attestation.provider.passes).toEqual([
-        { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
-        { name: 'doc-truth', ran: true, stopReason: 'budget', neverRan: false },
+        {
+          name: 'main',
+          ran: true,
+          stopReason: 'completed',
+          neverRan: false,
+          candidatesDeferred: 0,
+        },
+        {
+          name: 'doc-truth',
+          ran: true,
+          stopReason: 'budget',
+          neverRan: false,
+          candidatesDeferred: 0,
+          deferredCandidateIds: undefined,
+        },
       ]);
       // Aggregate flags starved...
       expect(attestation.budget.starved).toBe(true);
@@ -291,6 +319,7 @@ describe('deriveMainPassAttestation', () => {
       ran: false,
       stopReason: 'not_run',
       neverRan: false,
+      candidatesDeferred: 0,
     });
   });
 
@@ -309,6 +338,7 @@ describe('deriveMainPassAttestation', () => {
       ran: true,
       stopReason: 'error',
       neverRan: false,
+      candidatesDeferred: 0,
     });
   });
 });

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -33,24 +33,38 @@ import { buildSystemPrompt, buildInitialMessage } from '../../src/plugins/agent/
 import {
   shouldRunDocTruthPass,
   buildDocTruthPassPrompts,
+  docTruthPassBudget,
 } from '../../src/plugins/agent/doc-truth-pass.js';
 import {
   shouldRunStaleDuplicatePass,
   buildStaleDuplicatePassPrompts,
+  staleDuplicatePassBudget,
   applyStaleDuplicateMainOverride,
 } from '../../src/plugins/agent/stale-duplicate-pass.js';
 import {
   shouldRunIncompleteHandlingPass,
   buildIncompleteHandlingPassPrompts,
+  incompleteHandlingPassBudget,
   applyIncompleteHandlingMainOverride,
 } from '../../src/plugins/agent/incomplete-handling-pass.js';
 import {
   shouldRunRemovedExportsPass,
   buildRemovedExportsPassPrompts,
+  removedExportsPassBudget,
 } from '../../src/plugins/agent/removed-exports-pass.js';
 import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
+
+/** One extra pass's `{fires, ...prompts}` output shape (see `main`'s output object). Extracted
+ *  so `main` itself stays a short orchestrator (lien delta: Halstead effort budget) instead of
+ *  repeating the same fires-ternary-plus-spread four times. */
+function passOutput(
+  fires: boolean,
+  build: () => { systemPrompt: string; initialMessage: string },
+): { fires: true; systemPrompt: string; initialMessage: string } | { fires: false } {
+  return fires ? { fires: true, ...build() } : { fires: false };
+}
 
 async function main(): Promise<void> {
   const fixtureArg = process.argv[2];
@@ -70,25 +84,24 @@ async function main(): Promise<void> {
   const systemPrompt = buildSystemPrompt(rules);
   const initialMessage = buildInitialMessage(ctx, { blastRadius: null, rules });
 
-  const docTruthFires = shouldRunDocTruthPass(ctx, config);
-  const docTruthPass = docTruthFires
-    ? { fires: true as const, ...buildDocTruthPassPrompts(ctx) }
-    : { fires: false as const };
+  // The main pass's own base budget — used to derive each extra pass's REAL
+  // allocated budget (mirroring review-pass.ts's runReviewPass) so this
+  // harness's prompt output reflects candidate-overflow rank-and-cap exactly
+  // as production would apply it, not an always-uncapped worklist.
+  const baseBudget = config?.maxTokenBudget ?? 100_000;
 
-  const staleDuplicateFires = shouldRunStaleDuplicatePass(ctx, config);
-  const staleDuplicatePass = staleDuplicateFires
-    ? { fires: true as const, ...buildStaleDuplicatePassPrompts(ctx) }
-    : { fires: false as const };
-
-  const incompleteHandlingFires = shouldRunIncompleteHandlingPass(ctx, config);
-  const incompleteHandlingPass = incompleteHandlingFires
-    ? { fires: true as const, ...buildIncompleteHandlingPassPrompts(ctx) }
-    : { fires: false as const };
-
-  const removedExportsFires = shouldRunRemovedExportsPass(ctx, config);
-  const removedExportsPass = removedExportsFires
-    ? { fires: true as const, ...buildRemovedExportsPassPrompts(ctx) }
-    : { fires: false as const };
+  const docTruthPass = passOutput(shouldRunDocTruthPass(ctx, config), () =>
+    buildDocTruthPassPrompts(ctx, docTruthPassBudget(baseBudget)),
+  );
+  const staleDuplicatePass = passOutput(shouldRunStaleDuplicatePass(ctx, config), () =>
+    buildStaleDuplicatePassPrompts(ctx, staleDuplicatePassBudget(baseBudget, ctx)),
+  );
+  const incompleteHandlingPass = passOutput(shouldRunIncompleteHandlingPass(ctx, config), () =>
+    buildIncompleteHandlingPassPrompts(ctx, incompleteHandlingPassBudget(baseBudget, ctx)),
+  );
+  const removedExportsPass = passOutput(shouldRunRemovedExportsPass(ctx, config), () =>
+    buildRemovedExportsPassPrompts(ctx, removedExportsPassBudget(baseBudget, ctx)),
+  );
 
   const output = {
     fixturePath,

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -11,11 +11,15 @@ import {
   isDocTruthV2Enabled,
   buildClaimWorklist,
   allClaimIds,
+  capClaimWorklistToCeiling,
   postProcessDocTruthResult,
   DOC_TRUTH_PASS_SPEC,
   DOC_PASS_MAX_TURNS,
 } from '../src/plugins/agent/doc-truth-pass.js';
-import { EXTRA_PASS_MIN_BUDGET_TOKENS } from '../src/plugins/agent/review-pass.js';
+import {
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
+  VERDICT_EMISSION_RESERVE_TOKENS,
+} from '../src/plugins/agent/review-pass.js';
 import { buildSystemPrompt } from '../src/plugins/agent/system-prompt.js';
 import { DOC_TRUTH } from '../src/plugins/agent/rules.js';
 import { createTestContext } from '../src/test-helpers.js';
@@ -524,6 +528,99 @@ describe('buildClaimWorklist / allClaimIds — id assignment stability', () => {
     expect(worklist.overflowClaims).toBe(5);
     expect(allClaimIds(worklist)).toHaveLength(20);
   });
+
+  // The Finding-A calibrate's own motivating shape: many more claims than one
+  // pass invocation could afford. 55 single-line claim patches (well past the
+  // 20-claim doc-claim cap AND the ~51 the calibrate hit).
+  it('sanity check: 55 distinct claim patches yield a 20-id worklist with 35 tracked as overflow', () => {
+    const entries: Array<[string, string]> = Array.from({ length: 55 }, (_, i) => [
+      `docs/architecture/doc${i}.md`,
+      `@@ -1,1 +1,2 @@\n # Title\n+This step ${i} requires a fresh checkout.`,
+    ]);
+    const worklist = buildClaimWorklist(contextWithPatches(entries));
+    expect(allClaimIds(worklist)).toHaveLength(20);
+    expect(worklist.overflowClaims).toBe(35);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capClaimWorklistToCeiling — candidate-overflow rank-and-cap
+// ---------------------------------------------------------------------------
+
+describe('capClaimWorklistToCeiling', () => {
+  /** 1 doc claim (claim-1) + a 5-file rename-sweep mapping with 5 prose-touched
+   *  ids (claim-2..claim-6), no survivors — 6 ids total, spanning BOTH shapes
+   *  this pass's worklist mixes. */
+  function combinedCtx(): ReviewContext {
+    return contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+  }
+
+  it('returns the ORIGINAL worklist (same reference) and defers nothing when the ceiling covers every id', () => {
+    const full = buildClaimWorklist(combinedCtx());
+    const result = capClaimWorklistToCeiling(full, 6);
+    expect(result.worklist).toBe(full);
+    expect(result.deferredCount).toBe(0);
+    expect(result.deferredIds).toEqual([]);
+  });
+
+  it('also treats an INFINITE ceiling as "everything fits" — the default, unlimited-budget case', () => {
+    const full = buildClaimWorklist(combinedCtx());
+    const result = capClaimWorklistToCeiling(full, Number.POSITIVE_INFINITY);
+    expect(result.worklist).toBe(full);
+    expect(result.deferredCount).toBe(0);
+  });
+
+  it('truncates only the rename-sweep items when doc claims already fit within the ceiling', () => {
+    const full = buildClaimWorklist(combinedCtx());
+    const { worklist, deferredCount, deferredIds } = capClaimWorklistToCeiling(full, 3);
+    expect(worklist.docClaimIds).toEqual(['claim-1']); // untouched — doc claims fit
+    expect(worklist.renameSignals).toHaveLength(1);
+    expect(worklist.renameSignals[0].proseIds).toEqual(['claim-2', 'claim-3']);
+    expect(worklist.renameSignals[0].signal.proseTouched).toHaveLength(2); // parallel arrays stay in sync
+    expect(allClaimIds(worklist)).toEqual(['claim-1', 'claim-2', 'claim-3']);
+    expect(deferredCount).toBe(3);
+    expect(deferredIds).toHaveLength(3);
+  });
+
+  it('defers an ENTIRE rename-sweep mapping when no budget remains for it after doc claims', () => {
+    const full = buildClaimWorklist(combinedCtx());
+    const { worklist, deferredCount } = capClaimWorklistToCeiling(full, 1);
+    expect(worklist.docClaimIds).toEqual(['claim-1']);
+    expect(worklist.renameSignals).toEqual([]); // nothing of it fit — omitted, not an empty stub
+    expect(deferredCount).toBe(5);
+  });
+
+  it('truncates doc claims themselves when the ceiling is smaller than the doc-claim count alone', () => {
+    const full = buildClaimWorklist(combinedCtx());
+    const { worklist, deferredCount, deferredIds } = capClaimWorklistToCeiling(full, 0);
+    expect(worklist.docClaimIds).toEqual([]);
+    expect(worklist.renameSignals).toEqual([]);
+    expect(deferredCount).toBe(6);
+    expect(deferredIds).toHaveLength(6);
+    // overflowClaims folds in the newly-dropped doc claim on top of whatever
+    // buildClaimWorklist's own static 20-cap already tracked (0 here).
+    expect(worklist.overflowClaims).toBe(1);
+  });
+
+  it('preserves order exactly as allClaimIds already walks it — doc claims, then prose before survivors', () => {
+    const full = buildClaimWorklist(combinedCtx());
+    const { worklist } = capClaimWorklistToCeiling(full, 4);
+    expect(allClaimIds(worklist)).toEqual(['claim-1', 'claim-2', 'claim-3', 'claim-4']);
+  });
+
+  it('caps deferredIds at MAX_DEFERRED_LABELS even when more claims were dropped', () => {
+    const entries: Array<[string, string]> = Array.from({ length: 25 }, (_, i) => [
+      `docs/architecture/doc${i}.md`,
+      `@@ -1,1 +1,2 @@\n # Title\n+This step ${i} requires a fresh checkout.`,
+    ]);
+    const full = buildClaimWorklist(contextWithPatches(entries));
+    const { deferredCount, deferredIds } = capClaimWorklistToCeiling(full, 5);
+    expect(deferredCount).toBe(15); // 20 in the worklist - 5 kept
+    expect(deferredIds).toHaveLength(10); // MAX_DEFERRED_LABELS
+  });
 });
 
 describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 contract rendering', () => {
@@ -626,6 +723,74 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
     expect(message).not.toContain('</doc_claims>');
     expect(message).not.toContain('</rename_sweep>');
     expect(message).toContain('PER-CLAIM VERDICT CONTRACT');
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: contract text differs ONLY when the worklist was capped
+  // -------------------------------------------------------------------------
+
+  function manyClaimsCtx(n: number): ReviewContext {
+    const entries: Array<[string, string]> = Array.from({ length: n }, (_, i) => [
+      `docs/architecture/doc${i}.md`,
+      `@@ -1,1 +1,2 @@\n # Title\n+This step ${i} requires a fresh checkout.`,
+    ]);
+    return contextWithPatches(entries);
+  }
+
+  it('is byte-identical to before this feature existed when the budget is not passed (default unlimited)', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = manyClaimsCtx(6);
+    const withBudget = buildDocTruthPassPrompts(ctx, Number.POSITIVE_INFINITY);
+    const withoutBudget = buildDocTruthPassPrompts(ctx);
+    expect(withoutBudget).toEqual(withBudget);
+    expect(withoutBudget.initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
+
+  it('lists only the affordable claims and appends the overflow note when the budget caps the worklist', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = manyClaimsCtx(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // affords 2 of 6 (500/claim)
+    const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(ctx, budget);
+    expect(systemPrompt).toContain('claim-1');
+    expect(systemPrompt).toContain('claim-2');
+    expect(systemPrompt).not.toContain('claim-3');
+    expect(initialMessage).toContain('[claim-1]');
+    expect(initialMessage).toContain('[claim-2]');
+    expect(initialMessage).not.toContain('[claim-3]');
+    expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('4 additional eligible candidate(s)');
+  });
+
+  it('reproduces the Finding-A shape: a ~51-claim worklist at the floor budget still defers most claims', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    // 55 distinct claim patches -> 20-id worklist (buildClaimWorklist's own
+    // static cap) at the shared floor budget (11,000 — the common real-PR
+    // case per every sibling pass's own budget-floor tests).
+    const ctx = manyClaimsCtx(55);
+    const budget = docTruthPassBudget(6_000); // summary-only-sized base -> floors to 11,000
+    expect(budget).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+    const { initialMessage } = buildDocTruthPassPrompts(ctx, budget);
+    expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('[claim-1]');
+    expect(initialMessage).not.toContain('[claim-13]'); // ceiling well under 20
+  });
+
+  it('does not append the overflow note when the v1 (non-candidate-loop) path is used, even with a tiny budget', () => {
+    // v1 has no id-based worklist to cap — this feature is scoped to v2 only.
+    const ctx = manyClaimsCtx(6);
+    const { initialMessage } = buildDocTruthPassPrompts(ctx, 0);
+    expect(initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
+
+  // Byte-diff census: a realistic (single-claim) real-PR shape at its ACTUAL
+  // production budget must produce prompt output byte-identical to the
+  // pre-feature default call — overflow handling changes nothing on the
+  // common case.
+  it('byte-diff census: the ordinary single-claim real-PR shape is unaffected at the real (100K-base) budget', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    const realBudget = docTruthPassBudget(100_000);
+    expect(buildDocTruthPassPrompts(ctx, realBudget)).toEqual(buildDocTruthPassPrompts(ctx));
   });
 });
 
@@ -749,5 +914,69 @@ describe('postProcessDocTruthResult', () => {
     postProcessDocTruthResult(result, singleClaimCtx());
     expect(result.findings).toHaveLength(1);
     expect((result.findings[0] as Record<string, unknown>).claimId).toBe('claim-1');
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: deferral is attested, NOT incompleteness
+  // -------------------------------------------------------------------------
+
+  function manyClaimsCtx(n: number): ReviewContext {
+    const entries: Array<[string, string]> = Array.from({ length: n }, (_, i) => [
+      `docs/architecture/doc${i}.md`,
+      `@@ -1,1 +1,2 @@\n # Title\n+This step ${i} requires a fresh checkout.`,
+    ]);
+    return contextWithPatches(entries);
+  }
+
+  it('stamps candidatesDeferred/deferredCandidateIds when the budget capped the worklist', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = manyClaimsCtx(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // affords 2 of 6
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
+      verdictFinding({ claimId: 'claim-2', verdict: 'accurate' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, ctx, budget);
+    expect(processed.candidatesDeferred).toBe(4);
+    expect(processed.deferredCandidateIds).toHaveLength(4);
+  });
+
+  it('a capped-but-complete run (every LISTED claim verdicted) stays incomplete:false — deferral is not incompleteness', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = manyClaimsCtx(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // affords 2 of 6
+    const result = fakeResult([
+      verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
+      verdictFinding({ claimId: 'claim-2', verdict: 'accurate' }),
+    ]);
+    const processed = postProcessDocTruthResult(result, ctx, budget);
+    expect(processed.incomplete).toBe(false);
+    expect(processed.stopReason).toBe('completed');
+    expect(processed.candidatesDeferred).toBe(4);
+  });
+
+  it('still requires coverage of every LISTED (kept) claim — omitting one is incomplete_verdict, cap or not', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const ctx = manyClaimsCtx(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // lists claim-1/claim-2 only
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'accurate' })]); // claim-2 missing
+    const processed = postProcessDocTruthResult(result, ctx, budget);
+    expect(processed.incomplete).toBe(true);
+    expect(processed.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('reports candidatesDeferred: 0 and no deferredCandidateIds when nothing was capped (default budget)', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'accurate' })]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.candidatesDeferred).toBe(0);
+    expect(processed.deferredCandidateIds).toBeUndefined();
+  });
+
+  it('is identity (candidatesDeferred untouched) when the v1 flag is off, even with a tiny budget', () => {
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'accurate' })]);
+    const processed = postProcessDocTruthResult(result, manyClaimsCtx(6), 0);
+    expect(processed).toBe(result);
+    expect(processed.candidatesDeferred).toBeUndefined();
   });
 });

--- a/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
+++ b/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
@@ -5,6 +5,7 @@ import {
   incompleteHandlingSkipReason,
   shouldRunIncompleteHandlingPass,
   computeIncompleteHandlingCandidates,
+  computeIncompleteHandlingWorklist,
   buildIncompleteHandlingPassPrompts,
   buildIncompleteHandlingPassInitialMessage,
   incompleteHandlingPassBudget,
@@ -18,6 +19,7 @@ import {
 } from '../src/plugins/agent/incomplete-handling-pass.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../src/plugins/agent/rules.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { VERDICT_EMISSION_RESERVE_TOKENS } from '../src/plugins/agent/review-pass.js';
 import { createTestContext } from '../src/test-helpers.js';
 import type { ReviewContext } from '../src/plugin-types.js';
 import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
@@ -196,6 +198,29 @@ function noCandidateContext(): ReviewContext {
     chunks: [],
     repoChunks: [],
     pr: { title: 'Trivial change', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** `n` independent unread-field candidates (one interface, `n` never-read fields) — the same
+ *  shape the "caps a single shape's own contribution" test above uses, parametrized for
+ *  rank-and-cap overflow testing. `n` should stay <= UNREAD_FIELD_CAP (10) so every requested
+ *  field actually becomes a candidate (this helper does not exercise that per-shape cap itself). */
+function manyUnreadFieldsContext(n: number): ReviewContext {
+  const fieldLines = Array.from({ length: n }, (_, i) => `  field${i}: number;`);
+  const content = ['export interface Big {', ...fieldLines, '}'].join('\n');
+  const patchLines = [
+    '@@ -0,0 +1,27 @@',
+    '+export interface Big {',
+    ...fieldLines.map(l => `+${l}`),
+    '+}',
+  ];
+  const patches = new Map([['src/big.ts', patchLines.join('\n')]]);
+  const chunks = [makeChunk('src/big.ts', 1, content)];
+  return createTestContext({
+    changedFiles: ['src/big.ts'],
+    chunks,
+    repoChunks: chunks,
+    pr: { title: 'Add many fields', body: '', patches } as unknown as ReviewContext['pr'],
   });
 }
 
@@ -444,6 +469,73 @@ describe('computeIncompleteHandlingCandidates', () => {
 });
 
 // ---------------------------------------------------------------------------
+// computeIncompleteHandlingWorklist — candidate-overflow rank-and-cap
+// ---------------------------------------------------------------------------
+
+describe('computeIncompleteHandlingWorklist', () => {
+  it('defaults to unlimited budget — defers nothing (byte-identical to before this feature existed)', () => {
+    const { candidates, deferredCount, deferredIds } = computeIncompleteHandlingWorklist(
+      manyUnreadFieldsContext(6),
+    );
+    expect(candidates).toHaveLength(6);
+    expect(deferredCount).toBe(0);
+    expect(deferredIds).toEqual([]);
+  });
+
+  it("caps to the ceiling and defers the remainder, preserving the signal's own (fixed-shape) order", () => {
+    const ctx = manyUnreadFieldsContext(6);
+    // reserve + 2*OBSERVED_TOKENS_PER_TURN(6000) leaves room for exactly 2 read-heavy candidates.
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000;
+    const { candidates, deferredCount, deferredIds } = computeIncompleteHandlingWorklist(
+      ctx,
+      budget,
+    );
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map(c => (c.shape === 'unread-field' ? c.unreadField.field : null))).toEqual([
+      'field0',
+      'field1',
+    ]);
+    expect(deferredCount).toBe(4);
+    expect(deferredIds).toEqual(['Big.field2', 'Big.field3', 'Big.field4', 'Big.field5']);
+  });
+
+  it('reproduces the #813 shape: a 10-candidate run at its own scaled budget still defers most of them', () => {
+    // 10 unread-field candidates: incompleteHandlingPassBudget scales to
+    // 2,500 + 900*10 = 11,500 — a "correctly scaled" budget by the OLD
+    // prompt-sizing formula, yet each candidate needs a real read_file/
+    // get_files_context round-trip (module doc: "read_file is load-bearing,
+    // not optional"), so the realistic ceiling is far smaller than 10.
+    const ctx = manyUnreadFieldsContext(10);
+    const budget = incompleteHandlingPassBudget(100_000, ctx);
+    expect(budget).toBe(11_500);
+    const { candidates, deferredCount } = computeIncompleteHandlingWorklist(ctx, budget);
+    expect(candidates.length).toBeLessThan(10);
+    expect(candidates.length + deferredCount).toBe(10);
+    expect(deferredCount).toBeGreaterThan(0);
+  });
+
+  it("a small (1-2 candidate) run is never capped at this pass's own real (floor) budget", () => {
+    const ctx = variantOnlyContext();
+    const budget = incompleteHandlingPassBudget(100_000, ctx);
+    const { candidates, deferredCount } = computeIncompleteHandlingWorklist(ctx, budget);
+    expect(candidates).toHaveLength(1);
+    expect(deferredCount).toBe(0);
+  });
+
+  // Byte-diff census: a realistic (low-candidate) real-PR shape at its ACTUAL
+  // production budget must produce prompt output byte-identical to the
+  // pre-feature default call — overflow handling changes nothing on the
+  // common case.
+  it('byte-diff census: the ordinary single-candidate real-PR shape is unaffected at the real budget', () => {
+    const ctx = variantOnlyContext();
+    const realBudget = incompleteHandlingPassBudget(100_000, ctx);
+    expect(buildIncompleteHandlingPassPrompts(ctx, realBudget)).toEqual(
+      buildIncompleteHandlingPassPrompts(ctx),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Prompt construction
 // ---------------------------------------------------------------------------
 
@@ -510,6 +602,32 @@ describe('buildIncompleteHandlingPassPrompts', () => {
     expect(message).not.toContain('<doc_claims>');
     expect(message).not.toContain('<removed_exports>');
     expect(message).not.toContain('<stale_literal_candidates>');
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: contract text differs ONLY when the worklist was capped
+  // -------------------------------------------------------------------------
+
+  it('is byte-identical to before this feature existed when the budget is not passed (default unlimited)', () => {
+    const ctx = manyUnreadFieldsContext(6);
+    const withBudget = buildIncompleteHandlingPassPrompts(ctx, Number.POSITIVE_INFINITY);
+    const withoutBudget = buildIncompleteHandlingPassPrompts(ctx);
+    expect(withoutBudget).toEqual(withBudget);
+    expect(withoutBudget.initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
+
+  it('lists only the affordable candidates and appends the overflow note when the budget caps the worklist', () => {
+    const ctx = manyUnreadFieldsContext(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 6
+    const { systemPrompt, initialMessage } = buildIncompleteHandlingPassPrompts(ctx, budget);
+    expect(systemPrompt).toContain('candidate-1');
+    expect(systemPrompt).toContain('candidate-2');
+    expect(systemPrompt).not.toContain('candidate-3');
+    expect(initialMessage).toContain('field0');
+    expect(initialMessage).toContain('field1');
+    expect(initialMessage).not.toContain('field2');
+    expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('4 additional eligible candidate(s)');
   });
 });
 
@@ -667,6 +785,53 @@ describe('postProcessIncompleteHandlingResult', () => {
     expect(result.stopReason).toBe('incomplete_verdict');
     // The one verdicted candidate still becomes a finding despite the honesty flag.
     expect(result.findings).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: deferral is attested, NOT incompleteness
+  // -------------------------------------------------------------------------
+
+  it('stamps candidatesDeferred/deferredCandidateIds when the budget capped the worklist', () => {
+    const ctx = manyUnreadFieldsContext(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 6
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'intentional' }),
+        finding({ candidateId: 'candidate-2', verdict: 'intentional' }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, ctx, budget);
+    expect(result.candidatesDeferred).toBe(4);
+    expect(result.deferredCandidateIds).toEqual([
+      'Big.field2',
+      'Big.field3',
+      'Big.field4',
+      'Big.field5',
+    ]);
+  });
+
+  it('a capped-but-complete run (every LISTED candidate verdicted) stays incomplete:false — deferral is not incompleteness', () => {
+    const ctx = manyUnreadFieldsContext(6);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 6
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'intentional' }),
+        finding({ candidateId: 'candidate-2', verdict: 'intentional' }),
+      ],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, ctx, budget);
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+    expect(result.candidatesDeferred).toBe(4);
+  });
+
+  it('reports candidatesDeferred: 0 and no deferredCandidateIds when nothing was capped (default budget)', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'intentional' })],
+    });
+    const result = postProcessIncompleteHandlingResult(raw, variantOnlyContext());
+    expect(result.candidatesDeferred).toBe(0);
+    expect(result.deferredCandidateIds).toBeUndefined();
   });
 });
 

--- a/packages/review/test/plugins-agent-removed-exports-pass.test.ts
+++ b/packages/review/test/plugins-agent-removed-exports-pass.test.ts
@@ -6,6 +6,7 @@ import {
   shouldRunRemovedExportsPass,
   isRemovedExportsPassEnabled,
   computeRemovedExportsCandidates,
+  computeRemovedExportsWorklist,
   buildRemovedExportsPassPrompts,
   buildRemovedExportsPassInitialMessage,
   removedExportsPassBudget,
@@ -18,6 +19,7 @@ import {
 } from '../src/plugins/agent/removed-exports-pass.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../src/plugins/agent/rules.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
+import { VERDICT_EMISSION_RESERVE_TOKENS } from '../src/plugins/agent/review-pass.js';
 import { createTestContext } from '../src/test-helpers.js';
 import type { ReviewContext } from '../src/plugin-types.js';
 import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
@@ -274,6 +276,74 @@ describe('computeRemovedExportsCandidates', () => {
 });
 
 // ---------------------------------------------------------------------------
+// computeRemovedExportsWorklist — candidate-overflow rank-and-cap
+// ---------------------------------------------------------------------------
+
+describe('computeRemovedExportsWorklist', () => {
+  it('defaults to unlimited budget — defers nothing (byte-identical to before this feature existed)', () => {
+    const { candidates, deferredCount, deferredIds } =
+      computeRemovedExportsWorklist(manyRemovalsContext());
+    expect(candidates).toHaveLength(15);
+    expect(deferredCount).toBe(0);
+    expect(deferredIds).toEqual([]);
+  });
+
+  it("caps to the ceiling and defers the remainder, preserving the signal's own (alphabetical) order", () => {
+    const ctx = manyRemovalsContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2
+    const { candidates, deferredCount, deferredIds } = computeRemovedExportsWorklist(ctx, budget);
+    expect(candidates.map(c => c.symbol)).toEqual(['sym00', 'sym01']);
+    expect(deferredCount).toBe(13);
+    expect(deferredIds).toEqual([
+      'sym02',
+      'sym03',
+      'sym04',
+      'sym05',
+      'sym06',
+      'sym07',
+      'sym08',
+      'sym09',
+      'sym10',
+      'sym11',
+    ]); // capped at MAX_DEFERRED_LABELS (10) even though 13 were deferred
+  });
+
+  it("reproduces the #813-shaped overflow: 15 candidates at this pass's own scaled budget still defer most of them", () => {
+    // 15 candidates: removedExportsPassBudget scales to 2,000 + 800*15 =
+    // 14,000 — a "correctly scaled" budget by the OLD prompt-sizing formula,
+    // yet confirming each surviving reference needs a real read_file
+    // round-trip (module doc: "no inline snippet is attached"), so the
+    // realistic ceiling is far smaller than 15.
+    const ctx = manyRemovalsContext();
+    const budget = removedExportsPassBudget(100_000, ctx);
+    expect(budget).toBe(14_000);
+    const { candidates, deferredCount } = computeRemovedExportsWorklist(ctx, budget);
+    expect(candidates.length).toBeLessThan(15);
+    expect(candidates.length + deferredCount).toBe(15);
+  });
+
+  it("a single-candidate context is never capped at this pass's own real (floor) budget", () => {
+    const ctx = breakingOnlyContext();
+    const budget = removedExportsPassBudget(100_000, ctx);
+    const { candidates, deferredCount } = computeRemovedExportsWorklist(ctx, budget);
+    expect(candidates).toHaveLength(1);
+    expect(deferredCount).toBe(0);
+  });
+
+  // Byte-diff census: a realistic (low-candidate) real-PR shape at its ACTUAL
+  // production budget must produce prompt output byte-identical to the
+  // pre-feature default call — overflow handling changes nothing on the
+  // common case.
+  it('byte-diff census: the ordinary single-candidate real-PR shape is unaffected at the real budget', () => {
+    const ctx = breakingOnlyContext();
+    const realBudget = removedExportsPassBudget(100_000, ctx);
+    expect(buildRemovedExportsPassPrompts(ctx, realBudget)).toEqual(
+      buildRemovedExportsPassPrompts(ctx),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Prompt construction
 // ---------------------------------------------------------------------------
 
@@ -361,6 +431,32 @@ describe('buildRemovedExportsPassPrompts', () => {
     expect(message).not.toContain('<doc_claims>');
     expect(message).not.toContain('<stale_literal_candidates>');
     expect(message).not.toContain('<incomplete_handling_candidates>');
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: contract text differs ONLY when the worklist was capped
+  // -------------------------------------------------------------------------
+
+  it('is byte-identical to before this feature existed when the budget is not passed (default unlimited)', () => {
+    const ctx = manyRemovalsContext();
+    const withBudget = buildRemovedExportsPassPrompts(ctx, Number.POSITIVE_INFINITY);
+    const withoutBudget = buildRemovedExportsPassPrompts(ctx);
+    expect(withoutBudget).toEqual(withBudget);
+    expect(withoutBudget.initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
+
+  it('lists only the affordable candidates and appends the overflow note when the budget caps the worklist', () => {
+    const ctx = manyRemovalsContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 15
+    const { systemPrompt, initialMessage } = buildRemovedExportsPassPrompts(ctx, budget);
+    expect(systemPrompt).toContain('candidate-1');
+    expect(systemPrompt).toContain('candidate-2');
+    expect(systemPrompt).not.toContain('candidate-3');
+    expect(initialMessage).toContain('sym00');
+    expect(initialMessage).toContain('sym01');
+    expect(initialMessage).not.toContain('sym02');
+    expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('13 additional eligible candidate(s)');
   });
 });
 
@@ -500,6 +596,49 @@ describe('postProcessRemovedExportsResult', () => {
     expect(result.incomplete).toBe(true);
     expect(result.stopReason).toBe('incomplete_verdict');
     expect(result.findings).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: deferral is attested, NOT incompleteness
+  // -------------------------------------------------------------------------
+
+  it('stamps candidatesDeferred/deferredCandidateIds when the budget capped the worklist', () => {
+    const ctx = manyRemovalsContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 15
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'internal-only' }),
+        finding({ candidateId: 'candidate-2', verdict: 'internal-only' }),
+      ],
+    });
+    const result = postProcessRemovedExportsResult(raw, ctx, budget);
+    expect(result.candidatesDeferred).toBe(13);
+    expect(result.deferredCandidateIds).toHaveLength(10); // capped at MAX_DEFERRED_LABELS
+    expect(result.deferredCandidateIds![0]).toBe('sym02');
+  });
+
+  it('a capped-but-complete run (every LISTED candidate verdicted) stays incomplete:false — deferral is not incompleteness', () => {
+    const ctx = manyRemovalsContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 15
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'internal-only' }),
+        finding({ candidateId: 'candidate-2', verdict: 'internal-only' }),
+      ],
+    });
+    const result = postProcessRemovedExportsResult(raw, ctx, budget);
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+    expect(result.candidatesDeferred).toBe(13);
+  });
+
+  it('reports candidatesDeferred: 0 and no deferredCandidateIds when nothing was capped (default budget)', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'internal-only' })],
+    });
+    const result = postProcessRemovedExportsResult(raw, breakingOnlyContext());
+    expect(result.candidatesDeferred).toBe(0);
+    expect(result.deferredCandidateIds).toBeUndefined();
   });
 });
 

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -5,6 +5,13 @@ import {
   appendPassTurns,
   runExtraPasses,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
+  OBSERVED_TOKENS_PER_TURN,
+  VERDICT_EMISSION_RESERVE_TOKENS,
+  MAX_DEFERRED_LABELS,
+  affordableCandidateCeiling,
+  capCandidatesToCeiling,
+  deferredCandidateLabels,
+  renderDeferralNote,
   type ReviewPassSpec,
 } from '../src/plugins/agent/review-pass.js';
 import { createTestContext, silentLogger } from '../src/test-helpers.js';
@@ -89,6 +96,124 @@ describe('EXTRA_PASS_MIN_BUDGET_TOKENS', () => {
     // this outright, since those are both below the measured per-turn cost.
     expect(EXTRA_PASS_MIN_BUDGET_TOKENS).toBeGreaterThanOrEqual(10_000);
     expect(EXTRA_PASS_MIN_BUDGET_TOKENS).toBeLessThanOrEqual(12_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// affordableCandidateCeiling — candidate-overflow rank-and-cap ceiling
+// ---------------------------------------------------------------------------
+
+describe('affordableCandidateCeiling', () => {
+  it('derives the reserve as EXTRA_PASS_MIN_BUDGET_TOKENS minus one observed turn', () => {
+    expect(VERDICT_EMISSION_RESERVE_TOKENS).toBe(
+      EXTRA_PASS_MIN_BUDGET_TOKENS - OBSERVED_TOKENS_PER_TURN,
+    );
+  });
+
+  it('returns 0 when budget does not even cover the verdict-emission reserve', () => {
+    expect(affordableCandidateCeiling(VERDICT_EMISSION_RESERVE_TOKENS - 1, 800)).toBe(0);
+    expect(affordableCandidateCeiling(0, 800)).toBe(0);
+  });
+
+  it('returns 0 exactly AT the reserve boundary (nothing left to invest per-candidate)', () => {
+    expect(affordableCandidateCeiling(VERDICT_EMISSION_RESERVE_TOKENS, 800)).toBe(0);
+  });
+
+  it('floors a non-exact division rather than rounding up', () => {
+    // reserve + 1500 leaves exactly 1500 investigable at 800/candidate = 1.875 -> 1
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 1_500;
+    expect(affordableCandidateCeiling(budget, 800)).toBe(1);
+  });
+
+  it('reproduces the #813 shape: a 15-candidate incomplete-handling run at its own scaled budget affords ~1', () => {
+    // BASE_OVERHEAD_TOKENS(2,500) + PER_CANDIDATE_TOKENS(900) * 15 = 16,000 —
+    // the "correctly scaled" budget #813 measured. Read-heavy candidates cost
+    // OBSERVED_TOKENS_PER_TURN each, not the pass's own 900 prompt-sizing constant.
+    const measuredBudget = 16_000;
+    expect(affordableCandidateCeiling(measuredBudget, OBSERVED_TOKENS_PER_TURN)).toBe(1);
+  });
+
+  it('never returns negative, however small the budget', () => {
+    expect(affordableCandidateCeiling(-5_000, 800)).toBe(0);
+  });
+
+  it('scales up with a larger budget for the same per-candidate cost', () => {
+    const small = affordableCandidateCeiling(EXTRA_PASS_MIN_BUDGET_TOKENS, 500);
+    const large = affordableCandidateCeiling(EXTRA_PASS_MIN_BUDGET_TOKENS * 4, 500);
+    expect(large).toBeGreaterThan(small);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capCandidatesToCeiling — rank-and-cap, preserving the caller's own order
+// ---------------------------------------------------------------------------
+
+describe('capCandidatesToCeiling', () => {
+  it('keeps everything and defers nothing when the list already fits', () => {
+    const result = capCandidatesToCeiling(['a', 'b', 'c'], 5);
+    expect(result).toEqual({ kept: ['a', 'b', 'c'], deferred: [] });
+  });
+
+  it('keeps everything and defers nothing at the exact boundary (length === ceiling)', () => {
+    const result = capCandidatesToCeiling(['a', 'b', 'c'], 3);
+    expect(result).toEqual({ kept: ['a', 'b', 'c'], deferred: [] });
+  });
+
+  it('truncates to the first `ceiling` entries, preserving order — no re-ranking', () => {
+    const result = capCandidatesToCeiling(['a', 'b', 'c', 'd', 'e'], 2);
+    expect(result.kept).toEqual(['a', 'b']);
+    expect(result.deferred).toEqual(['c', 'd', 'e']);
+  });
+
+  it('defers everything when the ceiling is 0', () => {
+    const result = capCandidatesToCeiling(['a', 'b'], 0);
+    expect(result.kept).toEqual([]);
+    expect(result.deferred).toEqual(['a', 'b']);
+  });
+
+  it('is a pure function — does not mutate the input array', () => {
+    const input = ['a', 'b', 'c'];
+    capCandidatesToCeiling(input, 1);
+    expect(input).toEqual(['a', 'b', 'c']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deferredCandidateLabels — attestation labels, capped short
+// ---------------------------------------------------------------------------
+
+describe('deferredCandidateLabels', () => {
+  it('maps every deferred item through labelFor', () => {
+    const labels = deferredCandidateLabels(['a', 'b'], s => s.toUpperCase());
+    expect(labels).toEqual(['A', 'B']);
+  });
+
+  it('caps at MAX_DEFERRED_LABELS even when more were deferred', () => {
+    const deferred = Array.from({ length: MAX_DEFERRED_LABELS + 5 }, (_, i) => `item-${i}`);
+    const labels = deferredCandidateLabels(deferred, s => s);
+    expect(labels).toHaveLength(MAX_DEFERRED_LABELS);
+    expect(labels).toEqual(deferred.slice(0, MAX_DEFERRED_LABELS));
+  });
+
+  it('returns [] for an empty deferred list', () => {
+    expect(deferredCandidateLabels([], s => s)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderDeferralNote — the honesty half of candidate-overflow handling
+// ---------------------------------------------------------------------------
+
+describe('renderDeferralNote', () => {
+  it('is empty when nothing was deferred', () => {
+    expect(renderDeferralNote(0)).toBe('');
+  });
+
+  it('names the count and instructs the model not to claim exhaustive coverage', () => {
+    const note = renderDeferralNote(7);
+    expect(note).toContain('7');
+    expect(note).toMatch(/deferred/i);
+    expect(note).toMatch(/not incompleteness/i);
   });
 });
 
@@ -218,6 +343,30 @@ describe('runReviewPass', () => {
     await runReviewPass(spec, ctx, cfg(), silentLogger, async () => fakeResult());
 
     expect(reportSkip).not.toHaveBeenCalled();
+  });
+
+  it('threads the SAME computed budget into both buildPrompts and postProcessResult (candidate-overflow consistency)', async () => {
+    // A capping pass must rank-and-cap its worklist identically at prompt-build
+    // time and at post-process time, or the verdict-coverage check would judge
+    // a DIFFERENT worklist than the one actually shown to the model. Both call
+    // sites must observe the exact same budget value — computed once.
+    const ctx = createTestContext();
+    const seenBudgets: number[] = [];
+    const spec = makeSpec({
+      budget: () => 12_345,
+      buildPrompts: (_context, budget) => {
+        seenBudgets.push(budget);
+        return { systemPrompt: 'sys', initialMessage: 'init' };
+      },
+      postProcessResult: (result, _context, budget) => {
+        seenBudgets.push(budget);
+        return result;
+      },
+    });
+
+    await runReviewPass(spec, ctx, cfg(), silentLogger, async () => fakeResult());
+
+    expect(seenBudgets).toEqual([12_345, 12_345]);
   });
 });
 
@@ -400,6 +549,8 @@ describe('runExtraPasses', () => {
         neverRan: false,
         allocatedTokens: 10_000,
         spentTokens: 9_000,
+        candidatesDeferred: 0,
+        deferredCandidateIds: undefined,
       },
       {
         name: 'pass-b',
@@ -407,8 +558,55 @@ describe('runExtraPasses', () => {
         neverRan: false,
         allocatedTokens: 5_000,
         spentTokens: 4_000,
+        candidatesDeferred: 0,
+        deferredCandidateIds: undefined,
       },
     ]);
+  });
+
+  it('reads candidatesDeferred/deferredCandidateIds straight off the pass result (candidate-overflow attestation)', async () => {
+    const spec = makeSpec({ name: 'capped-pass' });
+    const ctx = createTestContext();
+    const main = mainResult();
+    const runClientFor = () => async () =>
+      fakeResult({ candidatesDeferred: 3, deferredCandidateIds: ['x', 'y', 'z'] });
+
+    const { outcomes } = await runExtraPasses(
+      [spec],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+    );
+
+    expect(outcomes).toEqual([
+      expect.objectContaining({
+        name: 'capped-pass',
+        candidatesDeferred: 3,
+        deferredCandidateIds: ['x', 'y', 'z'],
+      }),
+    ]);
+  });
+
+  it('defaults candidatesDeferred to 0 when the pass result does not set it (no overflow handling)', async () => {
+    const spec = makeSpec();
+    const ctx = createTestContext();
+    const main = mainResult();
+
+    const { outcomes } = await runExtraPasses(
+      [spec],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      () => async () => fakeResult(),
+    );
+
+    expect(outcomes[0].candidatesDeferred).toBe(0);
+    expect(outcomes[0].deferredCandidateIds).toBeUndefined();
   });
 
   it('does not add an outcome for a pass whose client throws (failure-isolated)', async () => {

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -8,6 +8,7 @@ import {
   buildStaleDuplicatePassInitialMessage,
   staleDuplicatePassBudget,
   postProcessStaleDuplicateResult,
+  computeStaleDuplicateWorklist,
   mergeStaleDuplicateFindings,
   mergeStaleDuplicateResultState,
   isStaleDuplicateMainDisabled,
@@ -15,6 +16,7 @@ import {
   STALE_DUPLICATE_PASS_SPEC,
   STALE_DUP_PASS_MAX_TURNS,
 } from '../src/plugins/agent/stale-duplicate-pass.js';
+import { VERDICT_EMISSION_RESERVE_TOKENS } from '../src/plugins/agent/review-pass.js';
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../src/plugins/agent/rules.js';
 import { buildInitialMessage } from '../src/plugins/agent/system-prompt.js';
 import { createTestContext } from '../src/test-helpers.js';
@@ -97,6 +99,49 @@ function differentFileOnlyContext(): ReviewContext {
     changedFiles: ['src/pr-review.ts'],
     chunks: [],
     pr: { title: 'Bump default model', body: '', patches } as unknown as ReviewContext['pr'],
+    repoChunks,
+  });
+}
+
+/** `n` independent same-file, high-confidence stale-duplicate candidates — each file mirrors
+ *  `eligibleContext`'s own CONDITIONALIZE_PATCH/PR_REVIEW_CONTENT shape with a distinct literal,
+ *  so the shared signal's own confidence/same-area scoring ties on everything except insertion
+ *  order (stable sort) — deterministic for rank-and-cap overflow testing. */
+function manyCandidatesContext(n: number): ReviewContext {
+  const patches = new Map<string, string>();
+  const repoChunks: CodeChunk[] = [];
+  for (let i = 0; i < n; i++) {
+    const literal = `token-${i}`;
+    const file = `src/pr-review-${i}.ts`;
+    patches.set(
+      file,
+      `@@ -10,3 +10,4 @@
+   const cfg = load();
+-  const model = '${literal}';
++  const model = cfg.openrouterApiKey
++    ? 'gemini-3-flash'
++    : '${literal}';
+   return model;`,
+    );
+    const content = [
+      'const cfg = load();', // 10
+      'const model = cfg.openrouterApiKey', // 11
+      "  ? 'gemini-3-flash'", // 12
+      `  : '${literal}';`, // 13
+      'return model;', // 14
+      '',
+      'function reportMeta() {',
+      '  // legacy attribution',
+      '  const ctx = {};',
+      '  ctx.provider = "openrouter";',
+      `  adapterContext.model = '${literal}';`, // 20
+    ].join('\n');
+    repoChunks.push(makeChunk(file, 10, content));
+  }
+  return createTestContext({
+    changedFiles: [...patches.keys()],
+    chunks: [],
+    pr: { title: 'Bump default models', body: '', patches } as unknown as ReviewContext['pr'],
     repoChunks,
   });
 }
@@ -243,6 +288,39 @@ describe('buildStaleDuplicatePassPrompts', () => {
     expect(message).not.toContain('<doc_claims>');
     expect(message).not.toContain('<removed_exports>');
   });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: contract text differs ONLY when the worklist was capped
+  // -------------------------------------------------------------------------
+
+  it('is byte-identical to before this feature existed when the budget is not passed (default unlimited)', () => {
+    const ctx = manyCandidatesContext(5);
+    const withBudget = buildStaleDuplicatePassPrompts(ctx, Number.POSITIVE_INFINITY);
+    const withoutBudget = buildStaleDuplicatePassPrompts(ctx);
+    expect(withoutBudget).toEqual(withBudget);
+    expect(withoutBudget.initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
+
+  it('lists only the affordable candidates and appends the overflow note when the budget caps the worklist', () => {
+    const ctx = manyCandidatesContext(5);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 800; // affords 2 of 5
+    const { systemPrompt, initialMessage } = buildStaleDuplicatePassPrompts(ctx, budget);
+    expect(systemPrompt).toContain('candidate-1');
+    expect(systemPrompt).toContain('candidate-2');
+    expect(systemPrompt).not.toContain('candidate-3');
+    expect(initialMessage).toContain('candidate-1');
+    expect(initialMessage).toContain('candidate-2');
+    expect(initialMessage).not.toContain('candidate-3');
+    expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('3 additional eligible candidate(s)');
+  });
+
+  it('does not append the overflow note when the full worklist fits inside the budget', () => {
+    const ctx = manyCandidatesContext(2);
+    const budget = staleDuplicatePassBudget(100_000, ctx);
+    const { initialMessage } = buildStaleDuplicatePassPrompts(ctx, budget);
+    expect(initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -261,6 +339,64 @@ describe('staleDuplicatePassBudget', () => {
     const low = staleDuplicatePassBudget(10_000, eligibleContext());
     const high = staleDuplicatePassBudget(500_000, eligibleContext());
     expect(low).toBe(high);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStaleDuplicateWorklist — candidate-overflow rank-and-cap
+// ---------------------------------------------------------------------------
+
+describe('computeStaleDuplicateWorklist', () => {
+  it('sanity check: manyCandidatesContext(3) yields 3 candidates in insertion order', () => {
+    const { candidates } = computeStaleDuplicateWorklist(manyCandidatesContext(3));
+    expect(candidates.map(c => c.literal)).toEqual(["'token-0'", "'token-1'", "'token-2'"]);
+  });
+
+  it('defaults to unlimited budget — defers nothing (byte-identical to before this feature existed)', () => {
+    const { candidates, deferredCount, deferredIds } = computeStaleDuplicateWorklist(
+      manyCandidatesContext(5),
+    );
+    expect(candidates).toHaveLength(5);
+    expect(deferredCount).toBe(0);
+    expect(deferredIds).toEqual([]);
+  });
+
+  it("a single-candidate context is never capped at this pass's own real (floor) budget", () => {
+    const ctx = eligibleContext();
+    const realBudget = staleDuplicatePassBudget(100_000, ctx);
+    const { candidates, deferredCount } = computeStaleDuplicateWorklist(ctx, realBudget);
+    expect(candidates).toHaveLength(1);
+    expect(deferredCount).toBe(0);
+  });
+
+  // Byte-diff census: a realistic (low-candidate) real-PR shape at its ACTUAL
+  // production budget must produce prompt output byte-identical to the
+  // pre-feature default call — overflow handling changes nothing on the
+  // common case.
+  it('byte-diff census: the ordinary single-candidate real-PR shape is unaffected at the real budget', () => {
+    const ctx = eligibleContext();
+    const realBudget = staleDuplicatePassBudget(100_000, ctx);
+    expect(buildStaleDuplicatePassPrompts(ctx, realBudget)).toEqual(
+      buildStaleDuplicatePassPrompts(ctx),
+    );
+  });
+
+  it("caps to the ceiling and defers the REMAINDER, preserving the signal's own order", () => {
+    const ctx = manyCandidatesContext(5);
+    // reserve + 2*800 leaves room for exactly 2 candidates at this pass's own
+    // evidence-inline per-candidate cost (800).
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 800;
+    const { candidates, deferredCount, deferredIds } = computeStaleDuplicateWorklist(ctx, budget);
+    expect(candidates.map(c => c.literal)).toEqual(["'token-0'", "'token-1'"]);
+    expect(deferredCount).toBe(3);
+    expect(deferredIds).toEqual(["'token-2'", "'token-3'", "'token-4'"]);
+  });
+
+  it('defers everything when the budget cannot even cover the verdict-emission reserve', () => {
+    const ctx = manyCandidatesContext(2);
+    const { candidates, deferredCount } = computeStaleDuplicateWorklist(ctx, 0);
+    expect(candidates).toEqual([]);
+    expect(deferredCount).toBe(2);
   });
 });
 
@@ -373,6 +509,59 @@ describe('postProcessStaleDuplicateResult', () => {
     const result = postProcessStaleDuplicateResult(raw, eligibleContext());
     expect(result.incomplete).toBe(true);
     expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: deferral is attested, NOT incompleteness
+  // -------------------------------------------------------------------------
+
+  it('stamps candidatesDeferred/deferredCandidateIds on the result when the budget capped the worklist', () => {
+    const ctx = manyCandidatesContext(5);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 800; // affords 2 of 5
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
+        finding({ candidateId: 'candidate-2', verdict: 'unverifiable' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, ctx, budget);
+    expect(result.candidatesDeferred).toBe(3);
+    expect(result.deferredCandidateIds).toEqual(["'token-2'", "'token-3'", "'token-4'"]);
+  });
+
+  it('a capped-but-complete run (every LISTED candidate verdicted) stays incomplete:false — deferral is not incompleteness', () => {
+    const ctx = manyCandidatesContext(5);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 800; // affords 2 of 5
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
+        finding({ candidateId: 'candidate-2', verdict: 'unverifiable' }),
+      ],
+    });
+    const result = postProcessStaleDuplicateResult(raw, ctx, budget);
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+    expect(result.candidatesDeferred).toBe(3);
+  });
+
+  it('still requires coverage of every LISTED (kept) candidate — omitting one is incomplete_verdict, cap or not', () => {
+    const ctx = manyCandidatesContext(5);
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 800; // lists candidate-1/candidate-2 only
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'unverifiable' })], // candidate-2 missing
+    });
+    const result = postProcessStaleDuplicateResult(raw, ctx, budget);
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('reports candidatesDeferred: 0 and no deferredCandidateIds when nothing was capped (default budget)', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'unverifiable' })],
+    });
+    const result = postProcessStaleDuplicateResult(raw, eligibleContext());
+    expect(result.candidatesDeferred).toBe(0);
+    expect(result.deferredCandidateIds).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

Two measured cases showed a candidate-loop pass can be handed more eligible candidates than one invocation's budget can actually afford an evidence-backed verdict for, even after #813's "starved before evidence" floor fix:

- **PR #813's own review**: the incomplete-handling loop drew 15 candidates, got a budget "correctly" scaled (by the old prompt-sizing formula) to 16K, dispatched real reads, and still ran out on turn 2 — honest-but-incomplete.
- **Finding A's calibrate (vote 10)**: a ~51-claim doc-truth worklist hit budget truncation mid-coverage.

This is the next class up from #813: not "starved before any evidence," but "more candidates than this invocation can afford, period." The fix is rank-and-cap with **attested, honest deferral** — never silent truncation.

## Design

Each of the four candidate-loop passes (`stale-duplicate-pass.ts`, `incomplete-handling-pass.ts`, `removed-exports-pass.ts`, `doc-truth-pass.ts`) now inverts its own budget math into an **affordable-candidate ceiling**, caps its worklist to the top-N (reusing each signal's own existing priority order — nothing re-ranked), and defers the rest with an explicit, attested count.

### Ceiling formula (shared, `review-pass.ts`)

```
VERDICT_EMISSION_RESERVE_TOKENS = EXTRA_PASS_MIN_BUDGET_TOKENS(11,000) - OBSERVED_TOKENS_PER_TURN(6,000) = 5,000
affordableCandidateCeiling(budget, tokensPerCandidate) = floor((budget - 5,000) / tokensPerCandidate)
```

`OBSERVED_TOKENS_PER_TURN` (6,000) is PR #811's measured real-tool-round-trip cost — the realistic per-candidate price for a loop whose candidates carry **no inline evidence** (must `read_file`/`get_files_context` to judge). A loop whose candidates carry **pre-fetched evidence** (a snippet, an excerpt) pays its own smaller nominal per-candidate constant instead, since judging there is comparison, not investigation:

| Pass | Candidate shape | `tokensPerCandidate` | Why |
|---|---|---|---|
| incomplete-handling | no inline evidence | `OBSERVED_TOKENS_PER_TURN` (6,000) | read_file/get_files_context load-bearing for most candidates |
| removed-exports | no inline evidence | `OBSERVED_TOKENS_PER_TURN` (6,000) | read_file needed to confirm a surviving reference is real |
| stale-duplicate | inline (snippet + diff hunk) | own `PER_CANDIDATE_TOKENS` (800) | judged mostly by comparison |
| doc-truth (v2) | inline (excerpt) | new `DOC_TRUTH_TOKENS_PER_CLAIM` (500) | rule text forbids re-reading when evidence is attached |

The floor (`EXTRA_PASS_MIN_BUDGET_TOKENS` = 11,000) always exceeds the reserve + one candidate's cost for every constant used today, so the ceiling is **always ≥ 1** — a pass that already cleared its own eligibility gate never degenerates to a vacuous, zero-candidate worklist.

### Deferral attestation shape

- `AgentResult` gains `candidatesDeferred?: number` / `deferredCandidateIds?: string[]` (same pattern as the existing `incompleteFromPass`), set by each pass's `postProcessResult`.
- `PassOutcome` / `ExtraPassAttestationInput` / `ProviderPassAttestation` gain the same two fields, threaded through `runExtraPasses` → the delivery attestation's `provider.passes[]`.
- **`ATTESTATION_VERSION` stays at 2** — not bumped. The v1→v2 bump existed because `passes[]` grew past length 1 for the first time, breaking a real cardinality assumption (`passes.length <= 1`) an existing consumer could get silently wrong. This is a plain additive field on an already-list-shaped structure; no consumer reads it yet, so there's no prior assumption to violate. Documented inline on `ProviderPassAttestation`.
- `computeVerdict` needed no change: deferral never touches `stopReason`, so a capped-but-complete run (every LISTED candidate verdicted) keeps `stopReason: 'completed'` → verdict stays `'delivered'`. That's the whole point — deferral is not incompleteness.

### Budget threading

`ReviewPassSpec.buildPrompts`/`postProcessResult` now both receive the pass's own final allocated `budget` (computed once in `runReviewPass`, reused for both calls) — so a pass's prompt and its verdict-coverage check always agree on exactly which candidates were listed. Every new parameter defaults to `Number.POSITIVE_INFINITY`, so every existing call site (tests, the harness) that doesn't pass one is byte-identical to before this feature existed.

## Evidence

### Unit tests (314 new/updated assertions across the 4 pass files + review-pass.ts + attestation.ts)
Per pass: ceiling math at boundaries, rank-and-cap preserving the signal's own order, deferral attestation shape, contract text (capped vs not), `incomplete_verdict` unaffected by capping, byte-diff census (default vs real production budget on the ordinary low-candidate case).

### Byte-diff census
- Flag/budget omitted (`Number.POSITIVE_INFINITY` default) → prompt output identical to pre-feature code (asserted per pass).
- Real production budget on the ordinary (1-candidate / 1-claim) real-PR shape → byte-identical to the default call (explicit `toEqual` assertion per pass — "flags off" case unaffected).
- Real captured harness fixture dogfood (`test/harness/fixtures/doc-truth/renamed-stale-claim.fixture.json`, both `LIEN_DOC_TRUTH_V2` on and off): ran `build-prompts.ts` end-to-end, `docTruthPass.initialMessage` contains no "CANDIDATE OVERFLOW" note — confirms the real harness pipeline is unaffected for an ordinary-sized fixture.
- Prompt diff is confined to capped-worklist cases only, demonstrated with the two synthetic high-candidate replays below.

### Replay of the two motivating shapes (deterministic — build-prompts + budget math, no LLM)

**Shape 1 — incomplete-handling (#813 class, 10-candidate reconstruction — UNREAD_FIELD_CAP caps a single shape at 10; same mechanism/failure mode as the real 15):**
```
Candidates eligible:        10
Allocated budget (scaled):  11500 tokens
Ceiling (OBSERVED_TOKENS_PER_TURN=6000): 1 candidate(s)

BEFORE (no overflow handling): Listed 10, deferred 0, no overflow note
AFTER  (rank-and-cap):         Listed 1,  deferred 9, overflow note shown:
  "NOTE — CANDIDATE OVERFLOW: 9 additional eligible candidate(s) exist beyond
  this run's worklist below. They were DEFERRED — excluded, not silently
  investigated — because this invocation's budget cannot afford an
  evidence-backed verdict for all of them. This is a deliberate, attested
  cap, not incompleteness: you must still judge every candidate actually
  LISTED below..."
```

**Shape 2 — doc-truth (Finding-A class, 51 raw claim patches):**
```
Raw claim patches:             51
After doc-claims' own 20-cap:   20 (overflowClaims=31)
Allocated budget (floor-bound): 11000 tokens
Ceiling (DOC_TRUTH_TOKENS_PER_CLAIM=500): 12 claim(s)

BEFORE (no overflow handling): Listed 20, deferred 0, no overflow note
AFTER  (rank-and-cap):         Listed 12, deferred 8, overflow note shown
```

## Multi-batch alternative (NOT built — a morning decision for the owner)

Instead of deferring the remainder, a second invocation could process the deferred candidates in a follow-up pass:

- **Cost**: one additional LLM call per overflow event, sized the same way (`EXTRA_PASS_MIN_BUDGET_TOKENS` floor, ~11K tokens minimum) — roughly doubling spend on any PR that overflows. Given the per-shape/per-signal caps already bound worst-case candidate counts (8-20 depending on pass), overflow is the exception, not the rule (see the byte-diff census: an ordinary real PR never triggers it).
- **Complexity**: needs a second attestation entry per pass per run, a decision on whether the second batch shares the first's turn budget or gets its own, and a merge step for two verdict arrays instead of one.
- **When to prefer it**: only once real-PR telemetry shows overflow firing often enough that silently-deferred candidates are costing real missed findings — i.e., only after this rank-and-cap ships and the attestation data shows the actual overflow rate. Building it now would be optimizing for a shape we haven't yet measured.

## Scoping note

The pre-existing per-signal local caps (rename-sweep's 12/12/5, doc-claims' 20, stale-literal's 8, sibling-surface's 15, variant-sweep's 12, unread-field's 10, removed-export's 15) are untouched — they're a separate, already-silent truncation concern (some already tracked via `overflowClaims`/`proseOverflow`/`survivorOverflow`, never attested). This PR adds BUDGET-derived deferral on top of those, attested explicitly; unifying the two truncation mechanisms is future work, not in scope here.

## Gates

- `npm run format:check` / `npm run lint` (0 errors) / `npm run typecheck` / `npm run build` / `npm test` — all green across parser/core/review/cli/action.
- `lien delta` — exit 0 (no new-over-threshold crossings; a few functions show minor "worsened" time/cognitive deltas from the added budget parameter and label helpers, none crossing their threshold — one function, `capClaimWorklistToCeiling`, was refactored into smaller helpers mid-build specifically to stay under its Halstead-effort budget).

No changeset (review package is private/unpublished). No AI attribution.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Medium Risk**
>
> This PR introduces rank-and-cap candidate-overflow handling across four extra review passes (doc-truth, incomplete-handling, removed-exports, stale-duplicate), threading each pass's allocated budget into both prompt construction and post-processing so the worklist and verdict-coverage check always agree. It adds attested deferral fields (`candidatesDeferred`, `deferredCandidateIds`) to `AgentResult`, `PassOutcome`, and the provider attestation while keeping `ATTESTATION_VERSION` at 2. Existing call sites remain byte-identical via `Number.POSITIVE_INFINITY` defaults on the new budget parameters. The change is additive and backward-compatible, but it touches core attestation shapes and budget math, so it warrants careful integration testing.
>
> - Four candidate-loop passes now cap their worklists using `affordableCandidateCeiling(budget, tokensPerCandidate)` and emit an explicit deferral note plus attested deferred-candidate counts.
> - `ReviewPassSpec.buildPrompts` and `postProcessResult` now receive the pass's final allocated `budget` so prompt rendering and verdict-coverage checks use the same capped worklist.
> - Attestation types gain `candidatesDeferred`/`deferredCandidateIds` fields without bumping `ATTESTATION_VERSION`, on the rationale that no existing consumer reads the new fields.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a56aeed. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 360K/377K tokens
<!-- /lien:attestation -->