### PR TITLE
fix(review): empirical per-candidate budget for incomplete-handling loop

### DIFF
--- a/packages/review/src/plugins/agent/incomplete-handling-pass.ts
+++ b/packages/review/src/plugins/agent/incomplete-handling-pass.ts
@@ -95,7 +95,7 @@ import {
 import {
   renderPassPrHeader,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
-  OBSERVED_TOKENS_PER_TURN,
+  VERDICT_EMISSION_RESERVE_TOKENS,
   affordableCandidateCeiling,
   capCandidatesToCeiling,
   deferredCandidateLabels,
@@ -115,9 +115,43 @@ import {
  */
 export const INCOMPLETE_PASS_MAX_TURNS = 8;
 
-const BASE_OVERHEAD_TOKENS = 2_500;
-const PER_CANDIDATE_TOKENS = 900;
-const MAX_BUDGET = 35_000;
+/**
+ * This pass's OWN per-candidate cost — no longer shared with `review-pass.ts`'s generic
+ * `OBSERVED_TOKENS_PER_TURN` (6,000), which the removed-exports-loop still uses. Derived from
+ * PR #813/#814/#819/#820/#822's five STARVED production firings: `spentTokens ÷ candidateCount`
+ * ranged 3,579-29,988/candidate (mean ≈11,586 — see the PR body's full arithmetic). The old
+ * `PER_CANDIDATE_TOKENS` (900, a prompt-SIZING estimate — just the rendered candidate text) and
+ * the borrowed `OBSERVED_TOKENS_PER_TURN` (6,000, one bare tool-dispatch turn) both undercounted
+ * this pass's REAL per-candidate cost: judging one candidate here needs a read_file +
+ * get_files_context round-trip (sometimes grep_codebase too — module doc), each turn re-sending
+ * accumulated conversation context. 12,000 rounds the empirical mean up for margin. This is a
+ * point-in-time estimate from 5 (truncated, hence lower-bound) production samples, not a proven
+ * ceiling — revisit if production firings keep starving at this rate.
+ */
+const INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE = 12_000;
+
+/**
+ * Base overhead for this pass's budget scaler — deliberately set equal to
+ * `VERDICT_EMISSION_RESERVE_TOKENS`, not an independent guess. Before this fix, the scaler's own
+ * base (2,500) and the overflow ceiling's reserve (5,000, in `affordableCandidateCeiling`) were
+ * two DIFFERENT numbers computed independently — so even a `budget()` "sized for n candidates"
+ * would only ever come out `affordableCandidateCeiling` as n-1 or worse, deferring one MORE
+ * candidate than the scaler itself claimed to fund (see PR #822's own dogfood: a 15-candidate,
+ * 16,000-token budget still only afforded 1). Reusing the reserve as the base makes the scaler
+ * the exact algebraic inverse of the ceiling: `budget(n) = RESERVE + RATE*n` <=>
+ * `affordableCandidateCeiling(budget(n), RATE) === n` (whenever budget isn't clamped) — cap and
+ * budget now agree by construction, per PR body's arithmetic.
+ */
+const BASE_OVERHEAD_TOKENS = VERDICT_EMISSION_RESERVE_TOKENS;
+/**
+ * Raised from 35,000 (see PR body): at the new 12,000/candidate rate, 35,000 only affords 2-3
+ * candidates before real cost overruns it (still below every observed starved-run spend). 65,000
+ * affords 5 fully-investigated candidates before rank-and-cap (#822) honestly defers the rest —
+ * a deliberate cost/completeness trade-off, not an attempt to fund every production firing's full
+ * worklist (some see 15; funding all 15 at this rate would cost ~185,000 tokens, disproportionate
+ * to a second-order single-rule loop).
+ */
+const MAX_BUDGET = 65_000;
 
 /** Mirrors variant-sweep-signals.ts's own MAX_ENTRIES cap — that module's compute()
  * function is itself uncapped (its cap is applied only by its own renderer, which
@@ -321,16 +355,17 @@ function incompleteHandlingLabel(c: IncompleteHandlingCandidate): string {
 /** This run's actual worklist after rank-and-cap. Unlike the pilot's stale-literal candidates,
  *  NONE of this rule's three shapes attach an inline code snippet (module doc: "you need the
  *  actual site's code to judge it") — read_file/get_files_context is load-bearing for most
- *  candidates, so the realistic per-candidate cost is `OBSERVED_TOKENS_PER_TURN`, not this pass's
- *  own (prompt-sizing) PER_CANDIDATE_TOKENS constant. `budget` defaults to unlimited so every
- *  existing call site that doesn't pass one is byte-identical to before this feature existed.
- *  Exposed for testing. */
+ *  candidates, so the realistic per-candidate cost is this pass's OWN
+ *  `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE` (empirically derived — see that constant's doc
+ *  comment), the SAME rate `incompleteHandlingPassBudget` scales the allocation by, so the
+ *  ceiling and the budget agree. `budget` defaults to unlimited so every existing call site that
+ *  doesn't pass one is byte-identical to before this feature existed. Exposed for testing. */
 export function computeIncompleteHandlingWorklist(
   context: ReviewContext,
   budget = Number.POSITIVE_INFINITY,
 ): { candidates: IncompleteHandlingCandidate[]; deferredCount: number; deferredIds: string[] } {
   const all = computeIncompleteHandlingCandidates(context);
-  const ceiling = affordableCandidateCeiling(budget, OBSERVED_TOKENS_PER_TURN);
+  const ceiling = affordableCandidateCeiling(budget, INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE);
   const { kept, deferred } = capCandidatesToCeiling(all, ceiling);
   return {
     candidates: kept,
@@ -502,19 +537,20 @@ export function buildIncompleteHandlingPassPrompts(
 /**
  * Budget scaled by this pass's own combined candidate count (per the
  * per-rule-loops design doc §2), clamped floor/ceiling — mirrors the
- * pilot's `staleDuplicatePassBudget`. The floor is
- * `EXTRA_PASS_MIN_BUDGET_TOKENS` (shared across all three extra passes —
- * see that constant's doc comment / PR #811): unlike the stale-duplicate
- * pilot, this pass's scaling ceiling (2,500 + 900×20 = 20,500) still sits
- * above the floor, so real scaling shows through once combined candidate
- * count exceeds ~9-10, while a 1-2 candidate run (this repo's real-PR
- * census: sibling-surface firing on 9/40) gets the same one-real-round-trip
- * floor doc-truth/stale-duplicate get.
+ * pilot's `staleDuplicatePassBudget`, but with this pass's OWN empirically-derived rate (see
+ * `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE`'s doc comment) instead of a flat
+ * prompt-sizing constant. The floor is `EXTRA_PASS_MIN_BUDGET_TOKENS` (shared across all three
+ * extra passes — see that constant's doc comment / PR #811); in practice it no longer binds here
+ * (even a single candidate scales to 17,000, above the 11,000 floor) but stays as a defensive
+ * lower bound. `MAX_BUDGET` (65,000) caps full funding at 5 candidates (see that constant's doc
+ * comment) — a real-PR firing with more than that gets the rest honestly deferred via
+ * `computeIncompleteHandlingWorklist`'s rank-and-cap, not silently starved.
  */
 export function incompleteHandlingPassBudget(_baseBudget: number, context: ReviewContext): number {
   const candidateCount = computeIncompleteHandlingCandidates(context).length;
   const scaled =
-    BASE_OVERHEAD_TOKENS + PER_CANDIDATE_TOKENS * Math.min(candidateCount, MAX_TOTAL_CANDIDATES);
+    BASE_OVERHEAD_TOKENS +
+    INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE * Math.min(candidateCount, MAX_TOTAL_CANDIDATES);
   return Math.min(Math.max(scaled, EXTRA_PASS_MIN_BUDGET_TOKENS), MAX_BUDGET);
 }
 

--- a/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
+++ b/packages/review/test/plugins-agent-incomplete-handling-pass.test.ts
@@ -484,8 +484,9 @@ describe('computeIncompleteHandlingWorklist', () => {
 
   it("caps to the ceiling and defers the remainder, preserving the signal's own (fixed-shape) order", () => {
     const ctx = manyUnreadFieldsContext(6);
-    // reserve + 2*OBSERVED_TOKENS_PER_TURN(6000) leaves room for exactly 2 read-heavy candidates.
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000;
+    // reserve + 2*INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE(12000) leaves room for exactly 2
+    // read-heavy candidates.
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 12_000;
     const { candidates, deferredCount, deferredIds } = computeIncompleteHandlingWorklist(
       ctx,
       budget,
@@ -499,19 +500,19 @@ describe('computeIncompleteHandlingWorklist', () => {
     expect(deferredIds).toEqual(['Big.field2', 'Big.field3', 'Big.field4', 'Big.field5']);
   });
 
-  it('reproduces the #813 shape: a 10-candidate run at its own scaled budget still defers most of them', () => {
-    // 10 unread-field candidates: incompleteHandlingPassBudget scales to
-    // 2,500 + 900*10 = 11,500 — a "correctly scaled" budget by the OLD
-    // prompt-sizing formula, yet each candidate needs a real read_file/
-    // get_files_context round-trip (module doc: "read_file is load-bearing,
-    // not optional"), so the realistic ceiling is far smaller than 10.
+  it('reproduces the #820 shape: a 10-candidate run still defers most of them, now at a bounded MAX_BUDGET', () => {
+    // 10 unread-field candidates — #820's real production shape (YAML chunking PR, 16 files
+    // touched): incompleteHandlingPassBudget scales to 5,000 + 12,000*10 = 125,000, clamped to
+    // MAX_BUDGET (65,000). Even at the new, empirically-derived per-candidate rate, funding all
+    // 10 outright would cost more than this pass is worth — rank-and-cap honestly defers the
+    // rest instead of silently starving (#820's real run: 89,120 spent against an old 11,500
+    // budget, never completing).
     const ctx = manyUnreadFieldsContext(10);
     const budget = incompleteHandlingPassBudget(100_000, ctx);
-    expect(budget).toBe(11_500);
+    expect(budget).toBe(65_000);
     const { candidates, deferredCount } = computeIncompleteHandlingWorklist(ctx, budget);
-    expect(candidates.length).toBeLessThan(10);
-    expect(candidates.length + deferredCount).toBe(10);
-    expect(deferredCount).toBeGreaterThan(0);
+    expect(candidates).toHaveLength(5);
+    expect(deferredCount).toBe(5);
   });
 
   it("a small (1-2 candidate) run is never capped at this pass's own real (floor) budget", () => {
@@ -618,7 +619,7 @@ describe('buildIncompleteHandlingPassPrompts', () => {
 
   it('lists only the affordable candidates and appends the overflow note when the budget caps the worklist', () => {
     const ctx = manyUnreadFieldsContext(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 6
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 12_000; // affords 2 of 6
     const { systemPrompt, initialMessage } = buildIncompleteHandlingPassPrompts(ctx, budget);
     expect(systemPrompt).toContain('candidate-1');
     expect(systemPrompt).toContain('candidate-2');
@@ -636,11 +637,11 @@ describe('buildIncompleteHandlingPassPrompts', () => {
 // ---------------------------------------------------------------------------
 
 describe('incompleteHandlingPassBudget', () => {
-  it('scales with combined candidate count, clamped to the shared one-round-trip floor for a single candidate', () => {
+  it('scales with combined candidate count at its own empirically-derived per-candidate rate', () => {
     const budget = incompleteHandlingPassBudget(100_000, variantOnlyContext());
-    // 1 candidate: 2500 + 900*1 = 3400, clamped up to the 11,000 floor (#811 fix —
-    // was 5,000, smaller than a single Kimi turn's measured 5,526-6,564 tokens).
-    expect(budget).toBe(11_000);
+    // 1 candidate: VERDICT_EMISSION_RESERVE_TOKENS(5,000) + 12,000*1 = 17,000 — above the
+    // 11,000 shared floor, which no longer binds at this pass's own (higher) rate.
+    expect(budget).toBe(17_000);
   });
 
   it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {
@@ -651,6 +652,101 @@ describe('incompleteHandlingPassBudget', () => {
 
   it('turn cap is exported and equals INCOMPLETE_PASS_MAX_TURNS', () => {
     expect(INCOMPLETE_HANDLING_PASS_SPEC.maxTurns).toBe(INCOMPLETE_PASS_MAX_TURNS);
+  });
+
+  // -------------------------------------------------------------------------
+  // The 6 production firings (PR #813/#814/#816/#819/#820/#822) — cap and
+  // budget now agree by construction (see INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE's
+  // and BASE_OVERHEAD_TOKENS's doc comments). See the PR body's sanity table
+  // for the full before/after per-firing accounting.
+  // -------------------------------------------------------------------------
+
+  describe('production firing shapes', () => {
+    it('#814/#816 shape (3 candidates): fully funded, nothing deferred', () => {
+      const ctx = manyUnreadFieldsContext(3);
+      const budget = incompleteHandlingPassBudget(100_000, ctx);
+      // 5,000 + 12,000*3 = 41,000 — comfortably above #814's real observed spend (35,191) for
+      // this exact candidate count, the one directly-validated data point in the PR body.
+      expect(budget).toBe(41_000);
+      const { candidates, deferredCount } = computeIncompleteHandlingWorklist(ctx, budget);
+      expect(candidates).toHaveLength(3);
+      expect(deferredCount).toBe(0);
+    });
+
+    it('#820 shape (10 candidates): clamped to MAX_BUDGET, half the worklist honestly deferred', () => {
+      const ctx = manyUnreadFieldsContext(10);
+      const budget = incompleteHandlingPassBudget(100_000, ctx);
+      expect(budget).toBe(65_000);
+      const { candidates, deferredCount } = computeIncompleteHandlingWorklist(ctx, budget);
+      expect(candidates).toHaveLength(5);
+      expect(deferredCount).toBe(5);
+    });
+
+    it('#813/#819/#822 shape (15 candidates): clamped to MAX_BUDGET, 10 honestly deferred', () => {
+      // 5 variant-sweep + 10 unread-field = 15, mirroring the combined-worklist test above.
+      const addedMembers = Array.from({ length: 5 }, (_, i) => `Add${i + 1}`);
+      const enumContent = [
+        'export enum Color {',
+        '  Legacy1,',
+        '  Legacy2,',
+        ...addedMembers.map(m => `  ${m},`),
+        '}',
+      ].join('\n');
+      const enumPatch = [
+        '@@ -1,4 +1,9 @@',
+        ' export enum Color {',
+        '   Legacy1,',
+        '   Legacy2,',
+        ...addedMembers.map(m => `+  ${m},`),
+        ' }',
+      ].join('\n');
+      const consumerContent = [
+        'function label(c: Color): string {',
+        '  switch (c) {',
+        '    case Color.Legacy1:',
+        "      return 'a';",
+        '    case Color.Legacy2:',
+        "      return 'b';",
+        '    default:',
+        "      return 'unknown';",
+        '  }',
+        '}',
+      ].join('\n');
+      const fieldLines = Array.from({ length: 10 }, (_, i) => `  field${i}: number;`);
+      const fieldContent = ['export interface Big {', ...fieldLines, '}'].join('\n');
+      const fieldPatch = [
+        '@@ -0,0 +1,12 @@',
+        '+export interface Big {',
+        ...fieldLines.map(l => `+${l}`),
+        '+}',
+      ].join('\n');
+      const patches = new Map([
+        ['src/color.ts', enumPatch],
+        ['src/big.ts', fieldPatch],
+      ]);
+      const chunks = [
+        makeChunk('src/color.ts', 1, enumContent),
+        makeChunk('src/big.ts', 1, fieldContent),
+      ];
+      const repoChunks = [...chunks, makeChunk('src/consumer.ts', 1, consumerContent)];
+      const ctx = createTestContext({
+        changedFiles: ['src/color.ts', 'src/big.ts'],
+        chunks,
+        repoChunks,
+        pr: {
+          title: 'Add many variants and fields',
+          body: '',
+          patches,
+        } as unknown as ReviewContext['pr'],
+      });
+      expect(computeIncompleteHandlingCandidates(ctx)).toHaveLength(15);
+
+      const budget = incompleteHandlingPassBudget(100_000, ctx);
+      expect(budget).toBe(65_000);
+      const { candidates, deferredCount } = computeIncompleteHandlingWorklist(ctx, budget);
+      expect(candidates).toHaveLength(5);
+      expect(deferredCount).toBe(10);
+    });
   });
 });
 
@@ -793,7 +889,7 @@ describe('postProcessIncompleteHandlingResult', () => {
 
   it('stamps candidatesDeferred/deferredCandidateIds when the budget capped the worklist', () => {
     const ctx = manyUnreadFieldsContext(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 6
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 12_000; // affords 2 of 6
     const raw = fakeResult({
       findings: [
         finding({ candidateId: 'candidate-1', verdict: 'intentional' }),
@@ -812,7 +908,7 @@ describe('postProcessIncompleteHandlingResult', () => {
 
   it('a capped-but-complete run (every LISTED candidate verdicted) stays incomplete:false — deferral is not incompleteness', () => {
     const ctx = manyUnreadFieldsContext(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 6
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 12_000; // affords 2 of 6
     const raw = fakeResult({
       findings: [
         finding({ candidateId: 'candidate-1', verdict: 'intentional' }),


### PR DESCRIPTION
## Problem

Per the loop production-behavior report, the incomplete-handling candidate
loop starved in **5 of its 6 production firings (83%)** across both the
#813 budget-floor era and the #822 overflow-cap era:

| PR | shape | old allocated | old spent | stopReason |
|---|---|---|---|---|
| #813 | 15 candidates | 16,000 | 53,688 | budget |
| #814 | 3 candidates | 11,000 | 35,191 | budget |
| #816 | 3 candidates | 11,000 | 18,283 | **completed** (the only clean run) |
| #819 | 15 candidates | 16,000 | 55,835 | budget |
| #820 | 10 candidates | 11,500 | 89,120 | budget |
| #822 | 15 candidates (1 kept post-cap) | 16,000 | 29,988 | budget |

**Root cause: two independently-derived rates that disagree with each other.**

- The budget *scaler* (`incompleteHandlingPassBudget`) sized the allocation
  as `2,500 + 900×n` — `900`/candidate is a **prompt-sizing** estimate (just
  the rendered candidate text).
- The overflow *ceiling* (`affordableCandidateCeiling`, added in #822) capped
  the worklist using the **shared** `OBSERVED_TOKENS_PER_TURN` = `6,000`/
  candidate — a real investigation-turn cost, borrowed from
  doc-truth/stale-duplicate's original #811 measurement.
- These numbers don't agree (900 vs 6,000), and on top of that the scaler's
  base overhead (2,500) never matched the ceiling's own reserve constant
  (`VERDICT_EMISSION_RESERVE_TOKENS` = 5,000). Net effect, confirmed by
  #822's own self-review: a budget "scaled for 15 candidates" (16,000
  tokens) could only ever afford **1** under the ceiling math — and even
  that one candidate blew through the budget (29,988 spent, still
  `stopReason: budget`).

## Empirical per-candidate cost

`spentTokens ÷ candidateCount` for each of the 5 starved runs (`candidateCount`
is the PRE-cap worklist size — for pre-#822 runs this is exact, inferred from
the old scaler formula and confirmed against each run's own investigation
notes; for #822 it's the post-cap kept count, 1, since that's the only
population that was actually served):

| PR | candidates | spent | spent ÷ candidates |
|---|---|---|---|
| #813 | 15 | 53,688 | 3,579 |
| #814 | 3 | 35,191 | 11,730 |
| #819 | 15 | 55,835 | 3,722 |
| #820 | 10 | 89,120 | 8,912 |
| #822 | 1 (kept) | 29,988 | 29,988 |

Range: **3,579 – 29,988 tokens/candidate**, mean **≈11,586**. All 5 values
are *truncated* — every one of these runs hit `stopReason: budget` before
finishing, so `spent` is a **lower bound** on the true cost to fully
investigate that many candidates, not the true total. The one independent,
non-truncated cross-check we have is #816 (`stopReason: completed`, 3
candidates, 18,283 spent → **6,094/candidate**) — a real, unrescued
completion, and reassuringly in the same range.

**Reconciling #816 "clean but over its 11,000 allocation" (18,283 spent):**
the runtime budget check only fires *between* turns (before dispatching the
next tool call), not mid-generation. A final turn that emits a complete,
valid JSON verdict is never truncated mid-flight, even if the running total
crosses the allocation while it's being generated — so `stopReason:
completed` and `spent > allocated` are not a contradiction; it just means
the last turn's cost pushed the ledger over a ceiling that was never
actually enforced against it.

Picked **12,000** (mean, rounded up for margin) as this pass's own rate —
see the constant's doc comment in `incomplete-handling-pass.ts`.

## The fix

`packages/review/src/plugins/agent/incomplete-handling-pass.ts`:

1. **New own constant**, no longer sharing `review-pass.ts`'s generic
   `OBSERVED_TOKENS_PER_TURN` (which `removed-exports-loop` keeps using,
   untouched):
   ```ts
   const INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE = 12_000;
   ```
2. **Scaler's base overhead now equals the ceiling's reserve**
   (`VERDICT_EMISSION_RESERVE_TOKENS` = 5,000), replacing the independent
   `2,500` — this makes `incompleteHandlingPassBudget` the exact algebraic
   inverse of `affordableCandidateCeiling`: `budget(n) = RESERVE + RATE×n`
   <=> `affordableCandidateCeiling(budget(n), RATE) === n` whenever the
   budget isn't clamped. Cap and budget agree by construction now, not by
   accident.
3. **`MAX_BUDGET` raised 35,000 → 65,000** — funds 5 candidates fully
   before rank-and-cap (#822) honestly defers the rest. Funding every
   observed firing's full worklist (15 candidates) at 12,000/candidate
   would cost ~185,000 tokens — disproportionate to a second-order,
   single-rule loop, so the design leans on honest deferral instead of
   ever-growing budgets.
4. The overflow ceiling call in `computeIncompleteHandlingWorklist` now
   passes `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE` instead of the shared
   `OBSERVED_TOKENS_PER_TURN`.

## Sanity table — all 6 production firings, new constants

| PR | candidates | NEW allocated | NEW ceiling (kept) | deferred | plausibly complete? |
|---|---|---|---|---|---|
| #813 | 15 | 65,000 (clamped) | 5 | 10 | **Yes (honestly-deferred)** — this run's own historical rate (3,579/candidate) × 5 ≈ 17,895, well inside 65,000 |
| #814 | 3 | 41,000 | 3 (none deferred) | 0 | **Yes — directly validated**: real observed spend 35,191 ≤ 41,000 |
| #816 | 3 | 41,000 | 3 | 0 | Still clean; real spend 18,283 now has ~2.2x headroom instead of ~1.6x |
| #819 | 15 | 65,000 (clamped) | 5 | 10 | **Yes (honestly-deferred)** — own rate (3,722/candidate) × 5 ≈ 18,610, comfortably under 65,000 |
| #820 | 10 | 65,000 (clamped) | 5 | 5 | **Yes (honestly-deferred)** — own rate (8,912/candidate) × 5 ≈ 44,560, under 65,000; also *lowers* worst-case exposure vs. the old uncapped 89,120 |
| #822 | 15 (self-review) | 65,000 (clamped) | 5 | 10 | **Flagged, not a confident flip** — this run's own single retained candidate cost 29,988 alone; if its remaining candidates are similarly expensive (plausible: they're self-referential, about `review-pass.ts`'s own new internals), 5×~30,000 would still exceed 65,000. Formula says plausible; production data says "watch this one." |

**4 of 5 starved runs flip to confidently plausible-complete** (#813, #814,
#819, #820) — #814 via direct empirical validation, the other three by
construction plus their own historical per-candidate rate sitting
comfortably under 12,000. **#822 is flagged rather than forced** — its own
observed per-candidate cost (29,988) is 2.5x the new rate, and I'm not
going to paper over that with a bigger constant tuned to one meta/
self-referential outlier. Worth watching in production; if it keeps
starving, the next move is probably a `removed-exports`-style investigation
into *why* review-pass.ts's own internals are unusually expensive to judge,
not another blind rate bump.

## Cost implication

- 54.5% firing rate (6/11 eligible PRs since #811) × new avg allocated
  (57,000 tokens/firing, mean of the NEW-allocated column above) ≈
  **31,065 tokens/PR**, properly budgeted.
- For context: the OLD real (uncontrolled, overshooting) average spend was
  already 47,017.5 tokens/firing → 54.5% × that ≈ **25,625 tokens/PR** was
  *already* being spent, silently, off-ledger, before this fix.
- **Net real increase: ≈5,440 tokens/PR (~21%)** — most of the sticker
  shock in the allocated numbers (13,583 → 57,000 avg) is the ledger
  catching up to reality, not new spend. In exchange: worst-case exposure
  per firing is now *bounded* at 65,000 (the old #820 run alone hit 89,120,
  uncapped) and every overflow is now an attested, honest deferral instead
  of a silent starve.
- Rough $ translation at OpenRouter's $0.74/Mtok input rate (most of these
  tokens are prompt/context, not completion): ~$0.023/PR new, ~$0.019/PR
  already-happening, net ≈ **$0.004/PR** — immaterial in dollar terms even
  though the token delta looks large.

## Evidence ($0 — no LLM calls)

- **Unit tests** for the new constants/ceiling math at the 6 production
  shapes (`packages/review/test/plugins-agent-incomplete-handling-pass.test.ts`,
  new `production firing shapes` describe block + updated existing budget/
  worklist tests): `npm run test -w @liendev/review -- test/plugins-agent-incomplete-handling-pass.test.ts`
  → 66/66 passing.
- **Byte-diff census**: `grep` over the module confirms
  `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE`/`BASE_OVERHEAD_TOKENS`/
  `MAX_BUDGET` are used *only* inside the two arithmetic functions
  (`incompleteHandlingPassBudget`, `computeIncompleteHandlingWorklist`'s
  ceiling calc) — never in any `render*`/`build*Prompt` function. The
  existing "byte-diff census" tests (unaffected by this change, still
  passing) independently confirm prompt text is identical regardless of
  budget value, aside from the deferral note when a worklist is actually
  capped.
- **Full gates**, run against this worktree (rebased onto latest `main`,
  which already includes #822):
  - `npm run format:check` — pass
  - `npm run lint` — pass (0 errors; pre-existing warnings elsewhere, none
    in touched files)
  - `npm run typecheck` — pass (0 errors)
  - `npm run build` — pass
  - `npm run test -w @liendev/review` — 1368/1368 passing outside 3
    pre-existing, unrelated failures in `analysis.test.ts`
    (`runComplexityAnalysis`) caused by `@liendev/parser-native` not being
    built in this worktree (the Rust crate isn't built by `npm ci` at all —
    confirmed pre-existing via `git stash` on the same worktree before this
    change).
  - `lien delta` — **exit 0**, "no complexity changes across 2 file(s) vs
    HEAD".

No harness/OpenRouter calibration run — this is a deterministic
constants-and-arithmetic fix with no prompt-text or model-behavior change,
fully covered by the unit tests above; no LLM spend needed to verify it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Review processing now supports investigating more candidates within a single pass.
  * Candidate handling and deferral decisions are more accurately aligned with available processing capacity.
  * Larger workloads are better balanced, reducing unnecessary deferrals while preserving budget limits.

* **Bug Fixes**
  * Improved overflow handling for incomplete reviews.
  * Review results now consistently report deferred candidates and completion status when limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a deterministic constants-and-arithmetic fix for the incomplete-handling candidate loop's budget starvation. It replaces two disagreeing per-candidate rates (900 prompt-sizing and 6,000 borrowed from review-pass) with a single empirically-derived 12,000/candidate rate, aligns the budget scaler's base overhead with the ceiling's reserve (5,000), and raises the max budget from 35,000 to 65,000. The change is confined to two arithmetic sites, fully covered by updated unit tests including the six production firing shapes, and leaves all other passes' constants untouched. No exports were removed and no callers are broken.
>
> - Introduced pass-specific INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE = 12_000 derived from production firings
> - Made BASE_OVERHEAD_TOKENS equal to VERDICT_EMISSION_RESERVE_TOKENS so budget scaler and affordableCandidateCeiling are algebraic inverses
> - Raised MAX_BUDGET to 65_000, capping full funding at 5 candidates with honest deferral of the rest

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d41948d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

