### PR TITLE
feat(site): blog section with draft-gated seed articles

### DIFF
--- a/docs/development/blog-authoring.md
+++ b/docs/development/blog-authoring.md
@@ -2,7 +2,7 @@
 
 The blog lives at `packages/site/docs/blog/`:
 
-```
+```text
 packages/site/docs/blog/
 ├── index.md          # listing page (always built, never gated)
 ├── posts.data.ts      # VitePress content loader for the listing
@@ -12,7 +12,8 @@ packages/site/docs/blog/
     └── reviewer-that-cant-skip-candidate-loops.md
 ```
 
-A new post is a markdown file under `docs/blog/posts/` with frontmatter:
+A new post is a markdown file under `packages/site/docs/blog/posts/` with
+frontmatter:
 
 ```yaml
 ---
@@ -40,21 +41,25 @@ run:
   card. This is how the owner reviews a draft locally before publishing it.
 - **`npm run docs:build`** (production) — draft posts are excluded from
   everything: the listing (`posts.data.ts` filters them out at load time,
-  via `import.meta.env.PROD`, so a draft's title/description never even
-  enter the built client bundle), the nav (the top-level "Blog" nav entry
-  just links to the always-built index page, not to individual posts), any
-  future sitemap (there's no sitemap generator in this VitePress site today;
-  since a draft's page is never part of VitePress's resolved page list, any
-  sitemap generator added later would exclude it automatically), and
-  rendering (the draft's `.md` file is added to VitePress's `srcExclude`
-  during a production build, so no HTML page is generated for it at all —
-  its URL 404s because the file genuinely doesn't exist in `dist/`, not
-  because of a runtime check).
+  via `process.env.NODE_ENV === 'production'` — content loaders run as
+  plain Node ESM, not through Vite's module graph, so `import.meta.env`
+  isn't available there; see the code comment in `posts.data.ts` — so a
+  draft's title/description never even enter the built client bundle), the
+  nav (the top-level "Blog" nav entry just links to the always-built index
+  page, not to individual posts), any future sitemap (there's no sitemap
+  generator in this VitePress site today; since a draft's page is never
+  part of VitePress's resolved page list, any sitemap generator added later
+  would exclude it automatically), and rendering (the draft's `.md` file is
+  added to VitePress's `srcExclude` during a production build, so no HTML
+  page is generated for it at all — its URL 404s because the file
+  genuinely doesn't exist in `dist/`, not because of a runtime check).
 
-The mechanism: `docs/.vitepress/config.ts` is a command-aware config
-function (`defineConfig(({ command }) => ...)` — VitePress/Vite pass
-`command: 'build' | 'serve'`). Only when `command === 'build'` does it
-compute `srcExclude` from `docs/.vitepress/blogDrafts.ts`'s
+The mechanism: `docs/.vitepress/config.ts` exports a command-aware
+`UserConfigExport` function (`({ command }) => ...` — VitePress/Vite pass
+`command: 'build' | 'serve'`) rather than wrapping it in `defineConfig(...)`,
+whose declared type only accepts a resolved config object, not the function
+form. Only when `command === 'build'` does the function compute
+`srcExclude` from `docs/.vitepress/blogDrafts.ts`'s
 `getDraftPostExcludes()`, which scans `docs/blog/posts/*.md` for
 `draft: true` frontmatter with a small regex (no YAML-parsing dependency
 needed — VitePress bundles one internally but doesn't expose it for reuse).

--- a/docs/development/blog-authoring.md
+++ b/docs/development/blog-authoring.md
@@ -61,10 +61,14 @@ whose declared type only accepts a resolved config object, not the function
 form. Only when `command === 'build'` does the function compute
 `srcExclude` from `docs/.vitepress/blogDrafts.ts`'s
 `getDraftPostExcludes()`, which scans `docs/blog/posts/*.md` for
-`draft: true` frontmatter with a small regex (no YAML-parsing dependency
-needed — VitePress bundles one internally but doesn't expose it for reuse).
-`docs:dev`/`docs:preview` never populate `srcExclude`, so drafts stay
-fully reachable locally.
+`draft: true` frontmatter, parsed with `js-yaml` (the same library
+VitePress's own bundled `gray-matter` uses internally, though it isn't
+exposed for reuse) rather than a regex — a regex match disagrees with a
+real YAML parser on cases like `draft: true  # note` or `draft: True`,
+which would let a real draft slip past `srcExclude` while the (accurately
+parsed) listing still hid it — a page built into `dist/` with no link
+pointing at it, but reachable by URL. `docs:dev`/`docs:preview` never
+populate `srcExclude`, so drafts stay fully reachable locally.
 
 ## Publishing a draft (owner-only)
 

--- a/docs/development/blog-authoring.md
+++ b/docs/development/blog-authoring.md
@@ -1,0 +1,77 @@
+# Authoring the /blog Section
+
+The blog lives at `packages/site/docs/blog/`:
+
+```
+packages/site/docs/blog/
+├── index.md          # listing page (always built, never gated)
+├── posts.data.ts      # VitePress content loader for the listing
+└── posts/
+    ├── why-we-built-lien.md
+    ├── complexity-nudges-ab-test.md
+    └── reviewer-that-cant-skip-candidate-loops.md
+```
+
+A new post is a markdown file under `docs/blog/posts/` with frontmatter:
+
+```yaml
+---
+title: "Post Title"
+description: "One-sentence summary, used in the listing card."
+date: 2026-07-19
+author: Alf Henderson
+tags: [optional, tag, chips]
+draft: true
+---
+```
+
+`date`/`author`/`tags` also drive the byline rendered above the post body
+(`theme/components/PostMeta.vue`) — any page with a `date` frontmatter field
+gets that byline automatically, no per-page wiring needed.
+
+## Draft gating
+
+A post with `draft: true` behaves differently depending on how the site is
+run:
+
+- **`npm run docs:dev`** — draft posts render normally, with a visible
+  amber "DRAFT" banner injected above the content
+  (`theme/components/DraftBanner.vue`) and a "DRAFT" chip on their listing
+  card. This is how the owner reviews a draft locally before publishing it.
+- **`npm run docs:build`** (production) — draft posts are excluded from
+  everything: the listing (`posts.data.ts` filters them out at load time,
+  via `import.meta.env.PROD`, so a draft's title/description never even
+  enter the built client bundle), the nav (the top-level "Blog" nav entry
+  just links to the always-built index page, not to individual posts), any
+  future sitemap (there's no sitemap generator in this VitePress site today;
+  since a draft's page is never part of VitePress's resolved page list, any
+  sitemap generator added later would exclude it automatically), and
+  rendering (the draft's `.md` file is added to VitePress's `srcExclude`
+  during a production build, so no HTML page is generated for it at all —
+  its URL 404s because the file genuinely doesn't exist in `dist/`, not
+  because of a runtime check).
+
+The mechanism: `docs/.vitepress/config.ts` is a command-aware config
+function (`defineConfig(({ command }) => ...)` — VitePress/Vite pass
+`command: 'build' | 'serve'`). Only when `command === 'build'` does it
+compute `srcExclude` from `docs/.vitepress/blogDrafts.ts`'s
+`getDraftPostExcludes()`, which scans `docs/blog/posts/*.md` for
+`draft: true` frontmatter with a small regex (no YAML-parsing dependency
+needed — VitePress bundles one internally but doesn't expose it for reuse).
+`docs:dev`/`docs:preview` never populate `srcExclude`, so drafts stay
+fully reachable locally.
+
+## Publishing a draft (owner-only)
+
+1. Edit the post's frontmatter: `draft: true` → `draft: false`. Do any voice
+   pass / content edits at the same time.
+2. Commit and merge to `main` (a normal PR is fine — Lien Review's doc-truth
+   rule will check factual claims same as any other change).
+3. That's it. `main` pushes trigger `.github/workflows/deploy-docs.yml`,
+   which runs `npm run docs:build` and deploys the result to GitHub Pages.
+   Once `draft: false` is merged, the next deploy includes the post in the
+   build normally — no separate flag, no manual dist edit, no server
+   restart.
+
+Flipping a post live is entirely an edit-and-merge action; there is no admin
+UI or separate publish step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2837,6 +2837,13 @@
         "rxjs": "^7.2.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -12171,6 +12178,8 @@
       "name": "@liendev/site",
       "version": "0.1.0",
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "js-yaml": "^4.1.1",
         "mermaid": "^11.4.0",
         "vitepress": "^1.5.0",
         "vitepress-plugin-mermaid": "^2.0.17",

--- a/packages/site/docs/.vitepress/blogDrafts.ts
+++ b/packages/site/docs/.vitepress/blogDrafts.ts
@@ -37,7 +37,16 @@ export function isDraftFile(absPath: string): boolean {
   const raw = fs.readFileSync(absPath, 'utf-8')
   const match = raw.match(FRONTMATTER_RE)
   if (!match) return false
-  const frontmatter = yaml.load(match[1])
+  let frontmatter: unknown
+  try {
+    frontmatter = yaml.load(match[1])
+  } catch (cause) {
+    // Fail loudly and specifically (CLAUDE.md's "Fail Fast") rather than
+    // let a raw YAMLException with no file context bubble out of the
+    // build — an author fixing a typo needs to know WHICH post broke.
+    const message = cause instanceof Error ? cause.message : String(cause)
+    throw new Error(`Invalid frontmatter YAML in ${absPath}: ${message}`)
+  }
   if (!frontmatter || typeof frontmatter !== 'object') return false
   return Boolean((frontmatter as Record<string, unknown>).draft)
 }

--- a/packages/site/docs/.vitepress/blogDrafts.ts
+++ b/packages/site/docs/.vitepress/blogDrafts.ts
@@ -18,20 +18,28 @@
 // listing — a page generated in `dist/` with no link pointing at it, but
 // reachable by URL. Parsing frontmatter the same way VitePress does closes
 // that gap.
+//
+// `Boolean(...)`, not `=== true`, matches `docs/blog/posts.data.ts`'s own
+// truthiness check on the SAME field. Both sides must agree on every value
+// an author might type, not just the canonical boolean `true` — a stray
+// `draft: "true"` (quoted, so YAML parses it as a string) or `draft: 1`
+// should still be treated as a draft everywhere, erring toward excluding
+// too much rather than leaking a page srcExclude didn't recognize as draft
+// but the listing did.
 import fs from 'node:fs'
 import path from 'node:path'
 import yaml from 'js-yaml'
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/
 
-/** Reads a markdown file's frontmatter block and reports whether `draft: true` is set. */
+/** Reads a markdown file's frontmatter block and reports whether `draft` is truthy. */
 export function isDraftFile(absPath: string): boolean {
   const raw = fs.readFileSync(absPath, 'utf-8')
   const match = raw.match(FRONTMATTER_RE)
   if (!match) return false
   const frontmatter = yaml.load(match[1])
   if (!frontmatter || typeof frontmatter !== 'object') return false
-  return (frontmatter as Record<string, unknown>).draft === true
+  return Boolean((frontmatter as Record<string, unknown>).draft)
 }
 
 /**

--- a/packages/site/docs/.vitepress/blogDrafts.ts
+++ b/packages/site/docs/.vitepress/blogDrafts.ts
@@ -9,21 +9,29 @@
 // procedure (how a post goes from draft to published).
 //
 // This file is Node-only (imported from config.ts, which runs in Node, not
-// the browser) so it reads frontmatter with a small regex instead of adding
-// a YAML/frontmatter-parsing dependency — vitepress bundles `gray-matter`
-// internally for its own content loader, but doesn't expose it for reuse.
-import fs from 'node:fs';
-import path from 'node:path';
+// the browser). Frontmatter is parsed with `js-yaml` (the same library
+// VitePress's own bundled `gray-matter` uses internally, though it isn't
+// exposed for reuse) rather than a regex — a regex match on `draft:\s*true`
+// disagrees with a real YAML parser on cases like `draft: true  # note` or
+// `draft: True`, which would make srcExclude silently miss a real draft
+// while the (accurately YAML-parsed) content loader still hid it from the
+// listing — a page generated in `dist/` with no link pointing at it, but
+// reachable by URL. Parsing frontmatter the same way VitePress does closes
+// that gap.
+import fs from 'node:fs'
+import path from 'node:path'
+import yaml from 'js-yaml'
 
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
-const DRAFT_TRUE_RE = /^draft:\s*true\s*$/m;
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/
 
 /** Reads a markdown file's frontmatter block and reports whether `draft: true` is set. */
 export function isDraftFile(absPath: string): boolean {
-  const raw = fs.readFileSync(absPath, 'utf-8');
-  const match = raw.match(FRONTMATTER_RE);
-  if (!match) return false;
-  return DRAFT_TRUE_RE.test(match[1]);
+  const raw = fs.readFileSync(absPath, 'utf-8')
+  const match = raw.match(FRONTMATTER_RE)
+  if (!match) return false
+  const frontmatter = yaml.load(match[1])
+  if (!frontmatter || typeof frontmatter !== 'object') return false
+  return (frontmatter as Record<string, unknown>).draft === true
 }
 
 /**
@@ -34,11 +42,11 @@ export function isDraftFile(absPath: string): boolean {
  * the output rather than existing-but-hidden.
  */
 export function getDraftPostExcludes(srcDir: string): string[] {
-  const postsDir = path.join(srcDir, 'blog', 'posts');
-  if (!fs.existsSync(postsDir)) return [];
+  const postsDir = path.join(srcDir, 'blog', 'posts')
+  if (!fs.existsSync(postsDir)) return []
   return fs
     .readdirSync(postsDir)
     .filter((file) => file.endsWith('.md'))
     .filter((file) => isDraftFile(path.join(postsDir, file)))
-    .map((file) => `blog/posts/${file}`);
+    .map((file) => `blog/posts/${file}`)
 }

--- a/packages/site/docs/.vitepress/blogDrafts.ts
+++ b/packages/site/docs/.vitepress/blogDrafts.ts
@@ -1,0 +1,44 @@
+// Draft-gating for the /blog section.
+//
+// A post is a draft when its frontmatter has `draft: true`. Drafts render
+// normally in `vitepress dev` (with a visible DRAFT banner — see
+// theme/components/DraftBanner.vue) so the owner can review them locally,
+// but must be fully absent from the production build: no listing entry, no
+// generated page, nothing in the built output. See
+// docs/development/blog-authoring.md for the full mechanism + the flip
+// procedure (how a post goes from draft to published).
+//
+// This file is Node-only (imported from config.ts, which runs in Node, not
+// the browser) so it reads frontmatter with a small regex instead of adding
+// a YAML/frontmatter-parsing dependency — vitepress bundles `gray-matter`
+// internally for its own content loader, but doesn't expose it for reuse.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+const DRAFT_TRUE_RE = /^draft:\s*true\s*$/m;
+
+/** Reads a markdown file's frontmatter block and reports whether `draft: true` is set. */
+export function isDraftFile(absPath: string): boolean {
+  const raw = fs.readFileSync(absPath, 'utf-8');
+  const match = raw.match(FRONTMATTER_RE);
+  if (!match) return false;
+  return DRAFT_TRUE_RE.test(match[1]);
+}
+
+/**
+ * Glob patterns (relative to the VitePress `srcDir`, i.e. `docs/`) for every
+ * draft post under `blog/posts/`. Feed this into `srcExclude` during a
+ * production build so draft posts are never resolved as routable pages —
+ * the strongest possible exclusion, since the page simply doesn't exist in
+ * the output rather than existing-but-hidden.
+ */
+export function getDraftPostExcludes(srcDir: string): string[] {
+  const postsDir = path.join(srcDir, 'blog', 'posts');
+  if (!fs.existsSync(postsDir)) return [];
+  return fs
+    .readdirSync(postsDir)
+    .filter((file) => file.endsWith('.md'))
+    .filter((file) => isDraftFile(path.join(postsDir, file)))
+    .map((file) => `blog/posts/${file}`);
+}

--- a/packages/site/docs/.vitepress/config.ts
+++ b/packages/site/docs/.vitepress/config.ts
@@ -1,113 +1,138 @@
-import { defineConfig } from 'vitepress'
+import path from 'node:path'
+import type { DefaultTheme, HeadConfig } from 'vitepress'
+import type { UserConfigExport } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
+import { getDraftPostExcludes } from './blogDrafts'
+
+const srcDir = path.resolve(__dirname, '..')
+
+const head: HeadConfig[] = [
+  ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
+  ['link', { rel: 'stylesheet', href: 'https://api.fontshare.com/v2/css?f[]=satoshi@400,500&display=swap' }],
+  ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap' }],
+  ['meta', { name: 'theme-color', content: '#9333ea' }],
+  ['meta', { name: 'og:type', content: 'website' }],
+  ['meta', { name: 'og:locale', content: 'en' }],
+  ['meta', { name: 'og:site_name', content: 'Lien' }],
+  // Cloudflare Web Analytics
+  [
+    'script',
+    {
+      defer: '',
+      src: 'https://static.cloudflareinsights.com/beacon.min.js',
+      'data-cf-beacon': '{"token": "8ec4e997ac7a46a6a3049411d9583443"}',
+    },
+  ],
+]
+
+// https://vitepress.dev/reference/default-theme-config
+const themeConfig: DefaultTheme.Config = {
+  logo: '/logo.svg',
+
+  nav: [
+    { text: 'Guide', link: '/guide/' },
+    { text: 'How It Works', link: '/how-it-works' },
+    { text: 'Blog', link: '/blog/' },
+    { text: 'GitHub', link: 'https://github.com/getlien/lien' },
+  ],
+
+  sidebar: {
+    '/guide/': [
+      {
+        text: 'Getting Started',
+        items: [
+          { text: 'Introduction', link: '/guide/' },
+          { text: 'Installation', link: '/guide/installation' },
+          { text: 'Quick Start', link: '/guide/getting-started' },
+          { text: 'Configuration', link: '/guide/configuration' },
+        ],
+      },
+      {
+        text: 'Usage',
+        items: [
+          { text: 'MCP Tools', link: '/guide/mcp-tools' },
+          { text: 'Claude Code Plugin', link: '/guide/claude-code-plugin' },
+          { text: 'Cross-Editor Agent Setup', link: '/guide/cross-editor-setup' },
+          { text: 'CLI Commands', link: '/guide/cli-commands' },
+          { text: 'Lien Review', link: '/guide/lien-review' },
+          { text: 'Review Evidence', link: '/guide/review-evidence' },
+          { text: 'Review Harness', link: '/guide/review-harness' },
+        ],
+      },
+    ],
+  },
+
+  socialLinks: [{ icon: 'github', link: 'https://github.com/getlien/lien' }],
+
+  footer: {
+    message: 'Released under the AGPL-3.0 License. Free forever for local use.',
+    copyright: 'Copyright © 2025 Alf Henderson',
+  },
+
+  search: {
+    provider: 'local',
+  },
+
+  editLink: {
+    pattern: 'https://github.com/getlien/lien/edit/main/packages/site/docs/:path',
+    text: 'Edit this page on GitHub',
+  },
+}
+
+// Mermaid config for better dark mode support
+// https://mermaid.js.org/config/setup/modules/mermaidAPI.html#mermaidapi-configuration-defaults
+const mermaidConfig = {
+  theme: 'dark' as const,
+  themeVariables: {
+    darkMode: true,
+    primaryColor: '#2d2d2d',
+    primaryTextColor: '#e0e0e0',
+    primaryBorderColor: '#a855f7',
+    lineColor: '#a855f7',
+    secondaryColor: '#3d3d3d',
+    tertiaryColor: '#1e1e1e',
+    background: '#1a1a1a',
+    mainBkg: '#2d2d2d',
+    secondBkg: '#3d3d3d',
+    mainContrastColor: '#e0e0e0',
+    darkTextColor: '#e0e0e0',
+    border1: '#a855f7',
+    border2: '#a855f7',
+    fontSize: '16px',
+  },
+  flowchart: {
+    curve: 'basis' as const,
+    padding: 20,
+    nodeSpacing: 100,
+    rankSpacing: 100,
+    htmlLabels: true,
+  },
+}
 
 // https://vitepress.dev/reference/site-config
-export default withMermaid(
-  defineConfig({
+//
+// Exported as a plain `UserConfigExport` function rather than through
+// `defineConfig(...)` — `defineConfig`'s declared type only accepts a
+// resolved config object, not the function form, even though VitePress
+// (via Vite's own config loader) fully supports a config function that
+// receives `{ command, mode }`. `defineConfig` is an identity function at
+// runtime either way, so this only affects typing, not behavior.
+const config: UserConfigExport<DefaultTheme.Config> = ({ command }) =>
+  withMermaid({
     // Use /lien/ for GitHub Pages subdomain, / for custom domain
     base: process.env.VITE_BASE_PATH || '/',
     title: 'Lien',
     description: 'Local-first structural code search and dependency analysis for AI coding assistants',
-    
-    head: [
-      ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
-      ['link', { rel: 'stylesheet', href: 'https://api.fontshare.com/v2/css?f[]=satoshi@400,500&display=swap' }],
-      ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap' }],
-      ['meta', { name: 'theme-color', content: '#9333ea' }],
-      ['meta', { name: 'og:type', content: 'website' }],
-      ['meta', { name: 'og:locale', content: 'en' }],
-      ['meta', { name: 'og:site_name', content: 'Lien' }],
-      // Cloudflare Web Analytics
-      ['script', { 
-        defer: '', 
-        src: 'https://static.cloudflareinsights.com/beacon.min.js',
-        'data-cf-beacon': '{"token": "8ec4e997ac7a46a6a3049411d9583443"}'
-      }],
-    ],
 
-    themeConfig: {
-      // https://vitepress.dev/reference/default-theme-config
-      logo: '/logo.svg',
-      
-      nav: [
-        { text: 'Guide', link: '/guide/' },
-        { text: 'How It Works', link: '/how-it-works' },
-        { text: 'GitHub', link: 'https://github.com/getlien/lien' }
-      ],
+    // Draft blog posts (frontmatter `draft: true`) render in `vitepress dev`
+    // for owner review, but are fully excluded from the production build —
+    // see docs/development/blog-authoring.md. `command === 'build'` is the
+    // only production path; `dev`/`preview` both leave drafts visible.
+    srcExclude: command === 'build' ? getDraftPostExcludes(srcDir) : [],
 
-      sidebar: {
-        '/guide/': [
-          {
-            text: 'Getting Started',
-            items: [
-              { text: 'Introduction', link: '/guide/' },
-              { text: 'Installation', link: '/guide/installation' },
-              { text: 'Quick Start', link: '/guide/getting-started' },
-              { text: 'Configuration', link: '/guide/configuration' },
-            ]
-          },
-          {
-            text: 'Usage',
-            items: [
-              { text: 'MCP Tools', link: '/guide/mcp-tools' },
-              { text: 'Claude Code Plugin', link: '/guide/claude-code-plugin' },
-              { text: 'Cross-Editor Agent Setup', link: '/guide/cross-editor-setup' },
-              { text: 'CLI Commands', link: '/guide/cli-commands' },
-              { text: 'Lien Review', link: '/guide/lien-review' },
-              { text: 'Review Evidence', link: '/guide/review-evidence' },
-              { text: 'Review Harness', link: '/guide/review-harness' },
-            ]
-          },
-        ]
-      },
-
-      socialLinks: [
-        { icon: 'github', link: 'https://github.com/getlien/lien' }
-      ],
-
-      footer: {
-        message: 'Released under the AGPL-3.0 License. Free forever for local use.',
-        copyright: 'Copyright © 2025 Alf Henderson'
-      },
-
-      search: {
-        provider: 'local'
-      },
-
-      editLink: {
-        pattern: 'https://github.com/getlien/lien/edit/main/packages/site/docs/:path',
-        text: 'Edit this page on GitHub'
-      }
-    },
-
-    // Mermaid config for better dark mode support
-    mermaid: {
-      // https://mermaid.js.org/config/setup/modules/mermaidAPI.html#mermaidapi-configuration-defaults
-      theme: 'dark',
-      themeVariables: {
-        darkMode: true,
-        primaryColor: '#2d2d2d',
-        primaryTextColor: '#e0e0e0',
-        primaryBorderColor: '#a855f7',
-        lineColor: '#a855f7',
-        secondaryColor: '#3d3d3d',
-        tertiaryColor: '#1e1e1e',
-        background: '#1a1a1a',
-        mainBkg: '#2d2d2d',
-        secondBkg: '#3d3d3d',
-        mainContrastColor: '#e0e0e0',
-        darkTextColor: '#e0e0e0',
-        border1: '#a855f7',
-        border2: '#a855f7',
-        fontSize: '16px'
-      },
-      flowchart: {
-        curve: 'basis',
-        padding: 20,
-        nodeSpacing: 100,
-        rankSpacing: 100,
-        htmlLabels: true
-      }
-    }
+    head,
+    themeConfig,
+    mermaid: mermaidConfig,
   })
-)
+
+export default config

--- a/packages/site/docs/.vitepress/theme/components/DraftBanner.vue
+++ b/packages/site/docs/.vitepress/theme/components/DraftBanner.vue
@@ -1,0 +1,16 @@
+<script setup>
+import { useData } from 'vitepress'
+
+const { frontmatter } = useData()
+</script>
+
+<template>
+  <div v-if="frontmatter.draft" class="lien-draft-banner" role="note">
+    <span class="lien-draft-banner-badge">DRAFT</span>
+    <span class="lien-draft-banner-text">
+      Visible only in local dev — excluded from the production build
+      (listing, nav, sitemap, and this page itself) until
+      <code>draft: false</code> is set and merged to main.
+    </span>
+  </div>
+</template>

--- a/packages/site/docs/.vitepress/theme/components/DraftBanner.vue
+++ b/packages/site/docs/.vitepress/theme/components/DraftBanner.vue
@@ -8,7 +8,7 @@ const { frontmatter } = useData()
   <div v-if="frontmatter.draft" class="lien-draft-banner" role="note">
     <span class="lien-draft-banner-badge">DRAFT</span>
     <span class="lien-draft-banner-text">
-      Visible only in local dev — excluded from the production build
+      Visible only in local dev. Excluded from the production build
       (listing, nav, sitemap, and this page itself) until
       <code>draft: false</code> is set and merged to main.
     </span>

--- a/packages/site/docs/.vitepress/theme/components/PostMeta.vue
+++ b/packages/site/docs/.vitepress/theme/components/PostMeta.vue
@@ -12,8 +12,8 @@ function formatDate(iso) {
 }
 
 // Array.isArray guard: a malformed `tags: foo` (a bare string, not a YAML
-// list) would otherwise reach `v-for`, which iterates a string
-// character-by-character in Vue — render garbage chips instead of that.
+// list) would otherwise reach `v-for`, which iterates a string character
+// by character in Vue and renders garbage chips instead of that.
 const tags = computed(() => (Array.isArray(frontmatter.value.tags) ? frontmatter.value.tags : []))
 </script>
 

--- a/packages/site/docs/.vitepress/theme/components/PostMeta.vue
+++ b/packages/site/docs/.vitepress/theme/components/PostMeta.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { useData } from 'vitepress'
+
+const { frontmatter } = useData()
+
+function formatDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return String(iso)
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+</script>
+
+<template>
+  <div v-if="frontmatter.date" class="lien-post-meta">
+    <time :datetime="frontmatter.date">{{ formatDate(frontmatter.date) }}</time>
+    <template v-if="frontmatter.author">
+      <span class="lien-post-meta-sep">·</span>
+      <span>{{ frontmatter.author }}</span>
+    </template>
+    <span v-if="frontmatter.tags && frontmatter.tags.length" class="lien-post-meta-tags">
+      <span v-for="tag in frontmatter.tags" :key="tag" class="lien-tag-chip">{{ tag }}</span>
+    </span>
+  </div>
+</template>

--- a/packages/site/docs/.vitepress/theme/components/PostMeta.vue
+++ b/packages/site/docs/.vitepress/theme/components/PostMeta.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed } from 'vue'
 import { useData } from 'vitepress'
 
 const { frontmatter } = useData()
@@ -9,6 +10,11 @@ function formatDate(iso) {
   if (Number.isNaN(d.getTime())) return String(iso)
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
 }
+
+// Array.isArray guard: a malformed `tags: foo` (a bare string, not a YAML
+// list) would otherwise reach `v-for`, which iterates a string
+// character-by-character in Vue — render garbage chips instead of that.
+const tags = computed(() => (Array.isArray(frontmatter.value.tags) ? frontmatter.value.tags : []))
 </script>
 
 <template>
@@ -18,8 +24,8 @@ function formatDate(iso) {
       <span class="lien-post-meta-sep">·</span>
       <span>{{ frontmatter.author }}</span>
     </template>
-    <span v-if="frontmatter.tags && frontmatter.tags.length" class="lien-post-meta-tags">
-      <span v-for="tag in frontmatter.tags" :key="tag" class="lien-tag-chip">{{ tag }}</span>
+    <span v-if="tags.length" class="lien-post-meta-tags">
+      <span v-for="tag in tags" :key="tag" class="lien-tag-chip">{{ tag }}</span>
     </span>
   </div>
 </template>

--- a/packages/site/docs/.vitepress/theme/custom.css
+++ b/packages/site/docs/.vitepress/theme/custom.css
@@ -133,3 +133,147 @@
 .VPSwitch {
   pointer-events: auto;
 }
+
+/* ─── Blog ───────────────────────────────────────────────── */
+
+/* Draft banner — dev-only visual marker, deliberately amber (not the brand
+   purple) so it reads as a tooling affordance, never as production UI. */
+.lien-draft-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 1.5rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid rgba(217, 119, 6, 0.4);
+  border-radius: 8px;
+  background: rgba(217, 119, 6, 0.12);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-1);
+}
+
+.lien-draft-banner-badge {
+  flex-shrink: 0;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  background: #d97706;
+  color: #1a1a1a;
+  font-weight: 500;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+
+.lien-draft-banner-text code {
+  font-size: 0.85em;
+}
+
+/* Post meta line — date · author · tags, shown above a blog post's title */
+.lien-post-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.9rem;
+}
+
+.lien-post-meta-sep {
+  opacity: 0.6;
+}
+
+.lien-post-meta-tags {
+  display: inline-flex;
+  gap: 0.4rem;
+  margin-left: 0.25rem;
+}
+
+/* Tag chips — reused by the post meta line and the blog index list */
+.lien-tag-chip {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+.lien-draft-chip {
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  background: #d97706;
+  color: #1a1a1a;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+}
+
+/* Blog index list */
+.lien-blog-empty {
+  color: var(--vp-c-text-2);
+}
+
+.lien-blog-index {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.lien-blog-card {
+  display: block;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+  text-decoration: none !important;
+  transition: border-color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.lien-blog-card:hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+.lien-blog-card.is-draft {
+  border-style: dashed;
+  border-color: rgba(217, 119, 6, 0.5);
+}
+
+.lien-blog-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.85rem;
+}
+
+.lien-blog-card-title {
+  margin: 0 0 0.4rem;
+  padding: 0;
+  border-top: none;
+  color: var(--vp-c-text-1);
+  font-size: 1.15rem;
+  font-weight: 500;
+}
+
+.lien-blog-card-desc {
+  margin: 0 0 0.6rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.lien-blog-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lien-blog-card {
+    transition: none;
+  }
+}

--- a/packages/site/docs/.vitepress/theme/index.ts
+++ b/packages/site/docs/.vitepress/theme/index.ts
@@ -2,13 +2,19 @@
 import DefaultTheme from 'vitepress/theme'
 import './custom.css'
 import InteractiveBackground from './components/InteractiveBackground.vue'
+import DraftBanner from './components/DraftBanner.vue'
+import PostMeta from './components/PostMeta.vue'
 import { h } from 'vue'
 
 export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      'layout-top': () => h(InteractiveBackground)
+      'layout-top': () => h(InteractiveBackground),
+      // Renders inside `.vp-doc`, right before a page's content — DraftBanner
+      // shows only when frontmatter.draft is true (blog drafts, dev only);
+      // PostMeta shows only when frontmatter.date is present (blog posts).
+      'doc-before': () => [h(DraftBanner), h(PostMeta)]
     })
   }
 }

--- a/packages/site/docs/blog/index.md
+++ b/packages/site/docs/blog/index.md
@@ -1,0 +1,41 @@
+---
+title: Blog
+description: Notes on building Lien — local-first code intelligence for AI agents.
+---
+
+<script setup>
+import { data as posts } from './posts.data.ts'
+
+function formatDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return String(iso)
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+</script>
+
+# Blog
+
+<p v-if="!posts.length" class="lien-blog-empty">
+  Nothing published yet — check back soon.
+</p>
+
+<div v-else class="lien-blog-index">
+  <a
+    v-for="post in posts"
+    :key="post.url"
+    :href="post.url"
+    class="lien-blog-card"
+    :class="{ 'is-draft': post.draft }"
+  >
+    <div class="lien-blog-card-meta">
+      <time :datetime="post.date">{{ formatDate(post.date) }}</time>
+      <span v-if="post.draft" class="lien-draft-chip">DRAFT</span>
+    </div>
+    <h2 class="lien-blog-card-title">{{ post.title }}</h2>
+    <p class="lien-blog-card-desc">{{ post.description }}</p>
+    <div v-if="post.tags.length" class="lien-blog-card-tags">
+      <span v-for="tag in post.tags" :key="tag" class="lien-tag-chip">{{ tag }}</span>
+    </div>
+  </a>
+</div>

--- a/packages/site/docs/blog/index.md
+++ b/packages/site/docs/blog/index.md
@@ -1,6 +1,6 @@
 ---
 title: Blog
-description: Notes on building Lien — local-first code intelligence for AI agents.
+description: Notes on building Lien, a tool that helps AI coding agents understand real codebases.
 ---
 
 <script setup>
@@ -17,7 +17,7 @@ function formatDate(iso) {
 # Blog
 
 <p v-if="!posts.length" class="lien-blog-empty">
-  Nothing published yet — check back soon.
+  Nothing published yet. Check back soon.
 </p>
 
 <div v-else class="lien-blog-index">

--- a/packages/site/docs/blog/posts.data.ts
+++ b/packages/site/docs/blog/posts.data.ts
@@ -1,0 +1,41 @@
+import { createContentLoader } from 'vitepress'
+
+export interface BlogPostMeta {
+  title: string
+  description: string
+  date: string
+  author: string
+  tags: string[]
+  draft: boolean
+  url: string
+}
+
+declare const data: BlogPostMeta[]
+export { data }
+
+// Draft posts are filtered here (not just via `srcExclude` in config.ts) so
+// that a draft's title/description never end up embedded in the production
+// client bundle at all. Content loaders run as plain Node ESM (not through
+// Vite's module graph), so `import.meta.env` isn't available here — use
+// `process.env.NODE_ENV`, which Vite's own config resolution sets to
+// `'production'` for `vitepress build` and `'development'` for
+// `vitepress dev`/`vitepress preview`. In dev, drafts pass through so the
+// index list can show them with the DRAFT chip (see docs/blog/index.md).
+const isProductionBuild = process.env.NODE_ENV === 'production'
+
+export default createContentLoader('blog/posts/*.md', {
+  transform(raw) {
+    return raw
+      .filter((page) => (isProductionBuild ? !page.frontmatter.draft : true))
+      .map((page) => ({
+        title: page.frontmatter.title ?? 'Untitled',
+        description: page.frontmatter.description ?? '',
+        date: page.frontmatter.date ?? '',
+        author: page.frontmatter.author ?? 'Lien Team',
+        tags: page.frontmatter.tags ?? [],
+        draft: Boolean(page.frontmatter.draft),
+        url: page.url,
+      }))
+      .sort((a, b) => (a.date < b.date ? 1 : -1))
+  },
+})

--- a/packages/site/docs/blog/posts.data.ts
+++ b/packages/site/docs/blog/posts.data.ts
@@ -32,7 +32,12 @@ export default createContentLoader('blog/posts/*.md', {
         description: page.frontmatter.description ?? '',
         date: page.frontmatter.date ?? '',
         author: page.frontmatter.author ?? 'Lien Team',
-        tags: page.frontmatter.tags ?? [],
+        // Array.isArray guard (not just `?? []`): a malformed `tags: foo`
+        // (a bare string, not a YAML list) would otherwise reach the
+        // template's `v-for="tag in post.tags"`, which iterates a string
+        // character-by-character in Vue — render garbage chips instead of
+        // silently no-op'ing.
+        tags: Array.isArray(page.frontmatter.tags) ? page.frontmatter.tags : [],
         draft: Boolean(page.frontmatter.draft),
         url: page.url,
       }))

--- a/packages/site/docs/blog/posts.data.ts
+++ b/packages/site/docs/blog/posts.data.ts
@@ -41,6 +41,11 @@ export default createContentLoader('blog/posts/*.md', {
         draft: Boolean(page.frontmatter.draft),
         url: page.url,
       }))
-      .sort((a, b) => (a.date < b.date ? 1 : -1))
+      // Must return 0 for equal dates -- `a.date < b.date ? 1 : -1` returns
+      // -1 for BOTH (a, b) and (b, a) when the dates tie, which breaks the
+      // total-order contract Array.prototype.sort's comparator relies on
+      // (all three seed posts currently share one date, so ties aren't a
+      // hypothetical edge case here).
+      .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
   },
 })

--- a/packages/site/docs/blog/posts.data.ts
+++ b/packages/site/docs/blog/posts.data.ts
@@ -16,7 +16,7 @@ export { data }
 // Draft posts are filtered here (not just via `srcExclude` in config.ts) so
 // that a draft's title/description never end up embedded in the production
 // client bundle at all. Content loaders run as plain Node ESM (not through
-// Vite's module graph), so `import.meta.env` isn't available here — use
+// Vite's module graph), so `import.meta.env` isn't available here. Use
 // `process.env.NODE_ENV`, which Vite's own config resolution sets to
 // `'production'` for `vitepress build` and `'development'` for
 // `vitepress dev`/`vitepress preview`. In dev, drafts pass through so the
@@ -35,8 +35,8 @@ export default createContentLoader('blog/posts/*.md', {
         // Array.isArray guard (not just `?? []`): a malformed `tags: foo`
         // (a bare string, not a YAML list) would otherwise reach the
         // template's `v-for="tag in post.tags"`, which iterates a string
-        // character-by-character in Vue — render garbage chips instead of
-        // silently no-op'ing.
+        // character by character in Vue and renders garbage chips instead
+        // of silently no-op'ing.
         tags: Array.isArray(page.frontmatter.tags) ? page.frontmatter.tags : [],
         draft: Boolean(page.frontmatter.draft),
         url: page.url,

--- a/packages/site/docs/blog/posts.data.ts
+++ b/packages/site/docs/blog/posts.data.ts
@@ -43,9 +43,9 @@ export default createContentLoader('blog/posts/*.md', {
       }))
       // Must return 0 for equal dates -- `a.date < b.date ? 1 : -1` returns
       // -1 for BOTH (a, b) and (b, a) when the dates tie, which breaks the
-      // total-order contract Array.prototype.sort's comparator relies on
-      // (all three seed posts currently share one date, so ties aren't a
-      // hypothetical edge case here).
+      // total-order contract Array.prototype.sort's comparator relies on.
+      // Post dates are distinct today, but same-day posts remain a normal
+      // authoring case.
       .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
   },
 })

--- a/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
+++ b/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
@@ -1,6 +1,6 @@
 ---
-title: "Do Complexity Nudges Change What Agents Write? A Pre-Registered A/B"
-description: "A small, pre-registered experiment: does Lien's near-budget complexity warning measurably change the code a coding agent produces? 8 trials per condition, no significance theater, numbers as they landed."
+title: "Does Warning a Coding Agent Actually Change What It Writes?"
+description: "We warned an AI coding agent, right before it touched a function, that the function was already hard to follow. Then we tested whether that actually changed what it wrote, or whether the agent just ignored it."
 date: 2026-07-19
 author: Alf Henderson
 tags: [evidence, agents, complexity]
@@ -9,127 +9,103 @@ draft: true
 
 <!-- DRAFT: awaiting owner voice pass -->
 
-# Do Complexity Nudges Change What Agents Write? A Pre-Registered A/B
+# Does Warning a Coding Agent Actually Change What It Writes?
 
-Lien's write-side hook runs `lien delta` after every edit — a deterministic,
-~50ms check that speaks up only when *that specific edit* pushes a function's
-complexity over a threshold it wasn't over before. The plan-time nudge in
-[PR #772](https://github.com/getlien/lien/pull/772) goes a step further:
-before an agent even makes an edit, Lien can surface a near-budget warning
-for a function it's about to touch — "this is close to its complexity
-ceiling; prefer extraction" — while there's still time to act on it.
+If you tell an AI coding agent, right before it edits a piece of code, that
+the code is already hard to follow, does it actually write something
+simpler? Or does it read the warning, do the task anyway, and leave the
+mess exactly as bad?
 
-Both are cheap to build. Neither is worth anything if agents just ignore the
-warning and write the same code anyway. So before claiming this changes
-anything, we ran a small, pre-registered experiment to check.
+The obvious answer is "of course it listens, you told it to." But agents
+skim past a lot of things buried in their instructions, and a warning
+sitting next to an actual task is an easy thing to nod at and ignore. We
+didn't want to guess. We wanted to test it fairly and see what actually
+happened.
 
-## What we tested
+## What "hard to follow" means here
 
-**Hypothesis:** injecting Lien's real near-budget complexity warning into a
-coding-task prompt measurably reduces the rate at which a coding agent's
-generated edit pushes the target function's complexity over threshold,
-relative to an identical prompt with no warning.
+Software has a fairly standard way of scoring how tangled a function's
+logic is: essentially, how many different paths the code can take
+depending on its inputs. It's not a matter of taste. Once a function
+crosses a certain score, most engineering teams agree it's gotten to the
+point where it's risky to change safely, easy to introduce a bug in, and
+annoying to review. Lien tracks that score for every function in a
+codebase and can warn about it. The interesting question wasn't whether
+Lien could compute the score. It was whether telling an agent about it,
+right before an edit, would change anything.
 
-**Target function:** `formatDeltaText` in `packages/cli/src/cli/delta-cmd.ts`,
-sitting at cyclomatic 13/15 and cognitive 13/15 — two points of headroom on
-both metrics, the same headroom Lien's own `annotate` command would flag in
-real usage.
+## The test
 
-**The task:** add one feature (cap a long function list at 20 rows, append a
-summary line for the rest) to `formatDeltaText`. Both conditions received a
-byte-identical prompt, except for one inserted block: the real warning line,
-built from the actual PR #772 formatter, not reconstructed by hand —
+We picked one real function from Lien's own code that was already sitting
+right at that risky score, and gave an AI coding agent (Claude) one small,
+well-defined feature to add to it. Then we ran the exact same task 16
+times: 8 times with a short warning inserted first, and 8 times with
+nothing extra at all, no mention of complexity, no hint that anything was
+being measured.
+
+The warning was not a paraphrase we wrote up for the blog. It was the
+literal line Lien's own tooling produces when it flags a function like
+this:
 
 ```text
-⚠ Lien: formatDeltaText cyclomatic 13/15, deltaCommand cognitive 13/15 — avoid adding complexity here; prefer extraction.
+⚠ Lien: formatDeltaText cyclomatic 13/15, deltaCommand cognitive 13/15. Avoid adding complexity here; prefer extraction.
 ```
 
-Condition A (signal) got that block. Condition B (control) got nothing —
-no mention of complexity, thresholds, or Lien anywhere in the prompt. Every
-trial was a single, fresh, tool-less generation: no repo access, no memory of
-other trials, so nothing about the setup could leak between conditions.
+Every one of the 16 attempts was a single, isolated response: no back and
+forth, no access to the rest of the codebase, nothing carried over between
+attempts. That was deliberate. It meant nothing about the setup could leak
+between the warned group and the unwarned group. [The full write-up,
+including the exact instructions given to the agent and how we scored the
+results, is here](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md).
 
-**N = 8 trials per condition, 16 total.** Small by design — this is a
-pre-registered check on one nudge and one task, not a claim about nudges in
-general. The full protocol (exact prompt template, exclusion rules, analysis
-plan) was written and frozen *before* the first trial ran; it's preserved
-verbatim in [`docs/development/nudge-behavioral-ab.md`](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md).
+Every response was then dropped into a real copy of the file and scored
+with the same complexity check Lien runs automatically on every code
+change: did the function cross that risky line, yes or no. All 16
+responses were usable. Nothing had to be thrown out.
 
-Every trial's output was applied to a clean copy of the real file and scored
-with the same static-analysis primitive `lien delta` uses in CI: does
-`formatDeltaText` cross its complexity threshold, yes or no. 0 of 16 trials
-were excluded — every response was a clean, compiling code block, and every
-trial's own metadata confirmed zero tool calls, independently corroborating
-the "no tools" instruction was honored.
+## What happened
 
-## Results
-
-| Condition | Crossed threshold | Rate |
+| Group | Crossed the risky line | Rate |
 |---|---|---|
-| Control (no warning) | 8 / 8 | **100%** |
-| Signal (warning injected) | 3 / 8 | **37.5%** |
+| No warning | 8 out of 8 | **100%** |
+| Warned first | 3 out of 8 | **37.5%** |
 
-Every control trial produced the same shape of edit: an inline
-`if (functions.length > 20) { … }` block added directly to
-`formatDeltaText`'s existing loop. All 8 landed at cyclomatic 14, cognitive
-15 — crossed, every time.
+Without the warning, every single attempt made the function worse in
+exactly the same way: it added a new block of logic directly inside the
+function, which pushed the complexity score over the line every time.
 
-Five of the eight signal trials did something different: they extracted a
-small helper function (`pushFunctionRows`, `fmtFileFunctionRows`,
-`fmtFileFunctions` — naming varied, the shape didn't) and called it from
-`formatDeltaText`, exactly the "prefer extraction" the warning asked for.
-One of those (signal-5) extracted cleanly enough that `formatDeltaText`'s
-complexity didn't move at all — byte-for-byte unchanged. The other three
-signal trials matched control's inline pattern and crossed anyway — the
-warning didn't move every trial, just most of them.
+With the warning, five of the eight attempts did something different. They
+pulled part of the logic out into a small, separate helper function and
+called it instead, which is exactly what the warning suggested. One of
+those attempts was clean enough that the function's score didn't move at
+all. The other three warned attempts still made the same mistake as the
+unwarned group. The warning didn't work every time. It worked most of the
+time.
 
-Cognitive-complexity delta tells the same story from a different angle:
-control moved +2 in all 8 trials (into the crossing zone, every time);
-signal's mean was **−0.5**, pulled down by the five extraction trials.
+## Did the wording matter, or just the fact that something was said?
 
-Extraction and avoiding-the-crossing were perfectly correlated in this
-dataset: every trial that extracted a helper stayed under threshold (or, for
-signal-5, left it unchanged); every trial that didn't, crossed — control and
-signal alike.
+Four of the five successful attempts explained their own reasoning, in
+their own code comments, without being asked to. One wrote that it had
+pulled the logic into a separate function specifically "so the summary
+branch doesn't add to formatDeltaText's own complexity budget." Others used
+almost the same phrasing. That's a good sign the specific wording of the
+warning did real work, not just the fact that a warning was there at all.
 
-## Did the wording actually matter, or just the presence of a warning?
+## The honest limits of this test
 
-Four of the five extracting trials cited the warning directly in their own
-generated code comments, unprompted. Signal-1:
+This was small: 16 attempts, one task, one function, one AI model, each a
+single isolated response rather than a real editing session with full
+access to a codebase and its own judgment about what to even look at. A
+warning shown to an agent in the middle of real, multi-step work could
+plausibly land harder or softer than it did here. We're not claiming this
+proves anything about warnings in general. We're claiming that, for this
+one task, telling the agent up front that a function was already too
+complicated changed what it wrote, clearly and repeatably.
 
-> "Extracted so the summary branch doesn't add to `formatDeltaText`'s own
-> complexity budget (see the file-level complexity note above)."
+We also decided on how we'd score this before running a single attempt, so
+there was no chance to reinterpret an unhelpful result after the fact. If
+the warning had done nothing, that would have been the finding.
 
-Signal-6 and signal-8 used near-identical phrasing ("kept out of
-`formatDeltaText` to avoid adding to its complexity"). Signal-5 — the one
-with zero complexity change — extracted without an explicit comment tying it
-to the warning, but produced the cleanest result of all 16 trials anyway.
-So: the specific "prefer extraction" wording appears to have pulled real
-weight, not just the fact that *something* was flagged.
-
-## The honest read
-
-This is a small (N=8/condition), single-task, single-model,
-single-language, generation-only comparison. It is not a claim about
-complexity nudges in general — only about this one warning, on this one
-function, in this one task shape. Within those bounds, the result is about
-as clean as a 16-trial experiment gets: a 100%→37.5% crossing-rate swing, a
-mean cognitive-delta flip from +2.0 to −0.5, and a perfect correlation
-between the nudge condition's extraction behavior and avoiding the crossing.
-
-The biggest caveat is generalizability. Real Lien usage is multi-turn,
-tool-using, and the agent chooses what to read in the first place — these
-trials are pure single-turn generation with the full file pasted in and no
-tool access, which is a narrower thing than an agent editing a file mid-session
-with full repo context and its own judgment about whether to even open it. A
-real edit-time nudge could plausibly perform better or worse than this. We're
-stating the claim at the scope the data supports — "the warning changed what
-a Sonnet subagent wrote, for this task" — not generalizing further than that.
-
-We ran the analysis plan we pre-registered, on the numbers we got, without
-re-framing a null result as inconclusive-therefore-supportive — there wasn't
-a null result to reframe, but that commitment was made before we knew that.
-
-[OWNER: your call on whether to add a line here about what this means for
-the roadmap — e.g. whether the plan-time nudge graduates from PR #772 into
-something more prominent, or what the next experiment should test.]
+[OWNER: your call on whether to add a line here about what this means
+next, e.g. whether warning agents before they edit becomes a bigger part
+of how Lien works, or what the next test should look at.]

--- a/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
+++ b/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
@@ -32,7 +32,7 @@ relative to an identical prompt with no warning.
 
 **Target function:** `formatDeltaText` in `packages/cli/src/cli/delta-cmd.ts`,
 sitting at cyclomatic 13/15 and cognitive 13/15 — two points of headroom on
-both metrics, the same headroom lien's own `annotate` command would flag in
+both metrics, the same headroom Lien's own `annotate` command would flag in
 real usage.
 
 **The task:** add one feature (cap a long function list at 20 rows, append a
@@ -40,7 +40,7 @@ summary line for the rest) to `formatDeltaText`. Both conditions received a
 byte-identical prompt, except for one inserted block: the real warning line,
 built from the actual PR #772 formatter, not reconstructed by hand —
 
-```
+```text
 ⚠ Lien: formatDeltaText cyclomatic 13/15, deltaCommand cognitive 13/15 — avoid adding complexity here; prefer extraction.
 ```
 

--- a/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
+++ b/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
@@ -1,0 +1,135 @@
+---
+title: "Do Complexity Nudges Change What Agents Write? A Pre-Registered A/B"
+description: "A small, pre-registered experiment: does Lien's near-budget complexity warning measurably change the code a coding agent produces? 8 trials per condition, no significance theater, numbers as they landed."
+date: 2026-07-19
+author: Alf Henderson
+tags: [evidence, agents, complexity]
+draft: true
+---
+
+<!-- DRAFT: awaiting owner voice pass -->
+
+# Do Complexity Nudges Change What Agents Write? A Pre-Registered A/B
+
+Lien's write-side hook runs `lien delta` after every edit — a deterministic,
+~50ms check that speaks up only when *that specific edit* pushes a function's
+complexity over a threshold it wasn't over before. The plan-time nudge in
+[PR #772](https://github.com/getlien/lien/pull/772) goes a step further:
+before an agent even makes an edit, Lien can surface a near-budget warning
+for a function it's about to touch — "this is close to its complexity
+ceiling; prefer extraction" — while there's still time to act on it.
+
+Both are cheap to build. Neither is worth anything if agents just ignore the
+warning and write the same code anyway. So before claiming this changes
+anything, we ran a small, pre-registered experiment to check.
+
+## What we tested
+
+**Hypothesis:** injecting Lien's real near-budget complexity warning into a
+coding-task prompt measurably reduces the rate at which a coding agent's
+generated edit pushes the target function's complexity over threshold,
+relative to an identical prompt with no warning.
+
+**Target function:** `formatDeltaText` in `packages/cli/src/cli/delta-cmd.ts`,
+sitting at cyclomatic 13/15 and cognitive 13/15 — two points of headroom on
+both metrics, the same headroom lien's own `annotate` command would flag in
+real usage.
+
+**The task:** add one feature (cap a long function list at 20 rows, append a
+summary line for the rest) to `formatDeltaText`. Both conditions received a
+byte-identical prompt, except for one inserted block: the real warning line,
+built from the actual PR #772 formatter, not reconstructed by hand —
+
+```
+⚠ Lien: formatDeltaText cyclomatic 13/15, deltaCommand cognitive 13/15 — avoid adding complexity here; prefer extraction.
+```
+
+Condition A (signal) got that block. Condition B (control) got nothing —
+no mention of complexity, thresholds, or Lien anywhere in the prompt. Every
+trial was a single, fresh, tool-less generation: no repo access, no memory of
+other trials, so nothing about the setup could leak between conditions.
+
+**N = 8 trials per condition, 16 total.** Small by design — this is a
+pre-registered check on one nudge and one task, not a claim about nudges in
+general. The full protocol (exact prompt template, exclusion rules, analysis
+plan) was written and frozen *before* the first trial ran; it's preserved
+verbatim in [`docs/development/nudge-behavioral-ab.md`](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md).
+
+Every trial's output was applied to a clean copy of the real file and scored
+with the same static-analysis primitive `lien delta` uses in CI: does
+`formatDeltaText` cross its complexity threshold, yes or no. 0 of 16 trials
+were excluded — every response was a clean, compiling code block, and every
+trial's own metadata confirmed zero tool calls, independently corroborating
+the "no tools" instruction was honored.
+
+## Results
+
+| Condition | Crossed threshold | Rate |
+|---|---|---|
+| Control (no warning) | 8 / 8 | **100%** |
+| Signal (warning injected) | 3 / 8 | **37.5%** |
+
+Every control trial produced the same shape of edit: an inline
+`if (functions.length > 20) { … }` block added directly to
+`formatDeltaText`'s existing loop. All 8 landed at cyclomatic 14, cognitive
+15 — crossed, every time.
+
+Five of the eight signal trials did something different: they extracted a
+small helper function (`pushFunctionRows`, `fmtFileFunctionRows`,
+`fmtFileFunctions` — naming varied, the shape didn't) and called it from
+`formatDeltaText`, exactly the "prefer extraction" the warning asked for.
+One of those (signal-5) extracted cleanly enough that `formatDeltaText`'s
+complexity didn't move at all — byte-for-byte unchanged. The other three
+signal trials matched control's inline pattern and crossed anyway — the
+warning didn't move every trial, just most of them.
+
+Cognitive-complexity delta tells the same story from a different angle:
+control moved +2 in all 8 trials (into the crossing zone, every time);
+signal's mean was **−0.5**, pulled down by the five extraction trials.
+
+Extraction and avoiding-the-crossing were perfectly correlated in this
+dataset: every trial that extracted a helper stayed under threshold (or, for
+signal-5, left it unchanged); every trial that didn't, crossed — control and
+signal alike.
+
+## Did the wording actually matter, or just the presence of a warning?
+
+Four of the five extracting trials cited the warning directly in their own
+generated code comments, unprompted. Signal-1:
+
+> "Extracted so the summary branch doesn't add to `formatDeltaText`'s own
+> complexity budget (see the file-level complexity note above)."
+
+Signal-6 and signal-8 used near-identical phrasing ("kept out of
+`formatDeltaText` to avoid adding to its complexity"). Signal-5 — the one
+with zero complexity change — extracted without an explicit comment tying it
+to the warning, but produced the cleanest result of all 16 trials anyway.
+So: the specific "prefer extraction" wording appears to have pulled real
+weight, not just the fact that *something* was flagged.
+
+## The honest read
+
+This is a small (N=8/condition), single-task, single-model,
+single-language, generation-only comparison. It is not a claim about
+complexity nudges in general — only about this one warning, on this one
+function, in this one task shape. Within those bounds, the result is about
+as clean as a 16-trial experiment gets: a 100%→37.5% crossing-rate swing, a
+mean cognitive-delta flip from +2.0 to −0.5, and a perfect correlation
+between the nudge condition's extraction behavior and avoiding the crossing.
+
+The biggest caveat is generalizability. Real Lien usage is multi-turn,
+tool-using, and the agent chooses what to read in the first place — these
+trials are pure single-turn generation with the full file pasted in and no
+tool access, which is a narrower thing than an agent editing a file mid-session
+with full repo context and its own judgment about whether to even open it. A
+real edit-time nudge could plausibly perform better or worse than this. We're
+stating the claim at the scope the data supports — "the warning changed what
+a Sonnet subagent wrote, for this task" — not generalizing further than that.
+
+We ran the analysis plan we pre-registered, on the numbers we got, without
+re-framing a null result as inconclusive-therefore-supportive — there wasn't
+a null result to reframe, but that commitment was made before we knew that.
+
+[OWNER: your call on whether to add a line here about what this means for
+the roadmap — e.g. whether the plan-time nudge graduates from PR #772 into
+something more prominent, or what the next experiment should test.]

--- a/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
+++ b/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
@@ -43,9 +43,10 @@ times: 8 times with a short warning inserted first, and 8 times with
 nothing extra at all, no mention of complexity, no hint that anything was
 being measured.
 
-The warning was not a paraphrase we wrote up for the blog. It was the
-literal line Lien's own tooling produces when it flags a function like
-this:
+The warning was not a paraphrase we wrote up for the blog. It carries the
+same function names and numbers Lien's own tooling actually produced when
+it flagged this function, lightly repunctuated here to match this post's
+style:
 
 ```text
 ⚠ Lien: formatDeltaText cyclomatic 13/15, deltaCommand cognitive 13/15. Avoid adding complexity here; prefer extraction.

--- a/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
+++ b/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
@@ -1,7 +1,7 @@
 ---
 title: "Does Warning a Coding Agent Actually Change What It Writes?"
 description: "We warned an AI coding agent, right before it touched a function, that the function was already hard to follow. Then we tested whether that actually changed what it wrote, or whether the agent just ignored it."
-date: 2026-07-19
+date: 2026-07-23
 author: Alf Henderson
 tags: [evidence, agents, complexity]
 draft: true
@@ -107,6 +107,7 @@ We also decided on how we'd score this before running a single attempt, so
 there was no chance to reinterpret an unhelpful result after the fact. If
 the warning had done nothing, that would have been the finding.
 
-[OWNER: your call on whether to add a line here about what this means
-next, e.g. whether warning agents before they edit becomes a bigger part
-of how Lien works, or what the next test should look at.]
+That same warning already runs in Lien today, surfacing automatically
+whenever a file is already close to that same line. What we want to test
+next is whether it holds up across more functions and more models than
+the one we used here.

--- a/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
+++ b/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
@@ -1,0 +1,157 @@
+---
+title: "A Reviewer That Can't Skip: Candidate Loops in Lien Review"
+description: "How a real, live bug in drizzle-orm — 6 new column types silently unhandled by 4 downstream packages — became the evidence for a structural fix to how Lien Review handles crowded PRs."
+date: 2026-07-19
+author: Alf Henderson
+tags: [evidence, review, architecture]
+draft: true
+---
+
+<!-- DRAFT: awaiting owner voice pass -->
+
+# A Reviewer That Can't Skip: Candidate Loops in Lien Review
+
+Lien Review runs one LLM agent over a PR, checking it against up to nine
+rules that all share one findings list. That sharing has a real, measured
+cost: on a PR that carries both a boring documentation drift and a juicier
+code bug, the model's one list rationally favors the code bug. That's the
+finding the doc-truth arc landed months ago (PRs #722–#733) — and swapping
+models didn't fix it, because the bottleneck is the shared output list
+itself, not any one model's judgment. The fix that shipped then was narrow:
+give doc-truth its own dedicated pass, its own budget, no competing rules.
+
+[ADR-014](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md)
+is the story of generalizing that fix — and the evidence that it actually
+works came from a real, live bug we found in `drizzle-orm` along the way.
+
+## The general shape: candidate loops
+
+Not every rule can get a dedicated pass. Some rules are open investigations —
+"where's the race condition in this locking code" has no enumerable worklist
+to check off. But a rule qualifies for a dedicated **candidate loop** when
+its signal produces a bounded, enumerable list of candidates, each with a
+closed set of possible verdicts — the same shape doc-truth already had.
+
+Three rules fit:
+
+| Loop | Verdict vocabulary | What it catches |
+|---|---|---|
+| `stale-duplicate` | `stale \| intentional-reuse \| unverifiable` | A literal duplicated elsewhere that the PR changed in one place but not the other |
+| `incomplete-handling` | `incomplete \| handled \| intentional \| unverifiable` | An added enum/union member, a sibling file, or a new struct field whose consumers weren't updated |
+| `removed-exports` | `breaking \| intentional \| internal-only \| unverifiable` | A removed public export with a surviving caller |
+
+Each one runs as its own pass: its own prompt, its own budget, no other
+rule's findings competing for space in the output. `structural-analysis`
+stays hybrid on purpose — its "did callers handle this *changed* export
+correctly" half is still open investigation and stays in the shared pass
+forever; only its removed-export half graduated to a loop.
+
+Every loop ships **hybrid-gated**: it needs both an opt-in flag *and* at
+least one real candidate before it fires, and the rule's own prompt text
+never leaves the shared pass — the dedicated loop is additive, not a
+replacement. That's a deliberate, non-default choice: none of these three
+loops has a proven-over-inclusive-recall signal the way doc-truth's does, so
+none of them graduate to running *instead of* the shared pass. Not yet.
+
+## The part that actually needed proof
+
+Building the mechanism is one thing. Showing it finds more real bugs than
+the shared pass it's meant to improve on is another — and until mid-July,
+that second part was untested. `incomplete-handling` needed a real,
+ground-truthed bug to check against, not a synthetic example.
+
+We found one in `drizzle-orm`. [PR #4172](https://github.com/drizzle-team/drizzle-orm/pull/4172)
+adds a new "Gel" dialect and, with it, six new column-type variants —
+`dateDuration`, `duration`, `relDuration`, `localTime`, `localDate`,
+`localDateTime` — to drizzle's core `ColumnDataType` union. Four downstream
+packages generate runtime validation schemas from that union:
+`drizzle-arktype`, `drizzle-zod`, `drizzle-valibot`, and `drizzle-typebox`.
+Every one of their `columnToSchema` functions still only branches on the
+*original* nine members. None was ever updated for the six new ones.
+
+The practical effect: a Gel column using any of those six new types falls
+straight through every package's fallback branch — `type.unknown`,
+`z.any()`, `v.any()`, `t.Any()` — and silently gets **no real runtime
+validation** instead of a proper schema. It's exactly the shape
+`incomplete-handling`'s `variant-sweep` signal exists to catch: a new
+enum/union member added in one place, with consumer sites elsewhere that
+never got the memo. We reported it upstream as
+[drizzle-team/drizzle-orm#6027](https://github.com/drizzle-team/drizzle-orm/issues/6027).
+
+## Same bug, two review arms
+
+With a real bug in hand, we could finally run the comparison ADR-014 needed:
+replay the same PR through the shared pass and through the dedicated
+`incomplete-handling` loop, and see which one actually converts the evidence
+into a finding.
+
+**Shared pass** (flags off, competing against Lien Review's other active
+rules): a 3-vote screen converted the bug into a real finding on **1 of 3**
+votes. The other two votes aren't a mystery — their own tool-call traces show
+them reading `get_files_context` and `read_file` on all four downstream
+`column.ts` files. They looked at the right code. They just didn't say
+anything about any rule, on any file, in that run.
+
+**Dedicated `incomplete-handling` loop**: 3 of 3. That result was strong
+enough to escalate to a full 10-vote calibration, the same bar every rule in
+Lien Review has to clear before it can ship: **10/10** named the correct
+variants and all four affected packages. (Three of the ten runs used a more
+compact "unknown/any" phrasing our keyword gate hadn't anchored on yet —
+once we added that anchor and re-scored the same ten transcripts offline, at
+zero additional cost, all ten passed clean. The three-verdict smoke test —
+does the assertion correctly pass a perfect answer, fail an empty one, and
+fail a distractor — was re-run after the widening and never false-passed.)
+
+The whole comparison — both arms, the escalation, the keyword tuning — cost
+**$0.80 of a $1.40 authorized budget**. The fixture is committed:
+[`pr4172-columndatatype-gel-gap.assertions.ts`](https://github.com/getlien/lien/blob/main/packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts).
+
+This is one fixture, one candidate shape (`variant-sweep` — the loop's other
+two shapes, `sibling-surface` and `unread-field`, are untested by it), on one
+model. It's not a corpus-wide lift claim. But it's the first same-fixture,
+controlled comparison of a dedicated candidate loop against the shared
+pass's own signal-augmented prompt — and on this bug, the shared pass
+investigated the right files and stayed silent two-thirds of the time, while
+the dedicated loop converted the same evidence into a finding every time.
+
+## Why "can't skip"
+
+The other half of this design is about what happens when a candidate loop
+*doesn't* have an answer. The doc-truth arc's own worst finding (internally,
+"pr658 Finding A") was a single claim silently dropped from a long worklist
+— not wrong, just missing, with nothing in the output to say so.
+
+Every candidate loop closes that gap structurally: the model must return
+exactly one verdict for every candidate id in the worklist, from a fixed
+vocabulary. A missing id, a duplicate, or an unrecognized verdict value
+doesn't get silently ignored — it marks the pass's own result honestly
+`incomplete` (`AgentStopReason: 'incomplete_verdict'`), the same way a
+budget cutoff or a provider error already did. The pass can't quietly skip a
+candidate and have that read as "nothing to report here."
+
+That honesty is externally visible, not just an internal log line. Lien
+Review attaches a delivery attestation to every run — a machine-readable
+receipt naming which passes ran, why any pass didn't, and whether any pass
+was cut short. Before this generalization, that receipt only had room for
+one pass; a doc-truth-only budget cutoff would attest as the *main* pass
+running out of budget, which was directionally honest but pointed at the
+wrong entry. Attestation now carries one entry per pass that actually ran,
+and the verdict computation attributes a starvation or partial result to
+whichever specific pass stopped early. If a candidate loop can't finish its
+worklist, the receipt says so, by name.
+
+## What's still open
+
+All three candidate loops are merged and dark — off by default for
+`@liendev/review` and `@liendev/action` consumers, opt-in via a config flag
+or env var. This repo's own CI opts `stale-duplicate` and
+`incomplete-handling` into its Lien Review workflow to dogfood them against
+real PRs; `removed-exports` hasn't been opted in yet. That's deliberate:
+the mechanism is proven end-to-end (byte-diff-neutral when off, verified
+attestation wiring, unit-tested completeness contracts), but corpus-wide lift
+is proven for exactly one fixture and one candidate shape so far. Turning any
+of these on by default is a separate, evidence-priced decision from building
+them — and it hasn't been made yet.
+
+[OWNER: your call on whether to preview a timeline for turning these on more
+broadly, or leave this as a pure status report.]

--- a/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
+++ b/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
@@ -1,6 +1,6 @@
 ---
-title: "A Reviewer That Can't Skip: Candidate Loops in Lien Review"
-description: "How a real, live bug in drizzle-orm — 6 new column types silently unhandled by 4 downstream packages — became the evidence for a structural fix to how Lien Review handles crowded PRs."
+title: "The Blind Spot Every Reviewer Has, and the Bug That Proved It"
+description: "A popular open-source database toolkit added six new column types. Four companion packages were never updated to handle them. Our automated reviewer read all the right files and still missed it, most of the time."
 date: 2026-07-19
 author: Alf Henderson
 tags: [evidence, review, architecture]
@@ -9,149 +9,91 @@ draft: true
 
 <!-- DRAFT: awaiting owner voice pass -->
 
-# A Reviewer That Can't Skip: Candidate Loops in Lien Review
+# The Blind Spot Every Reviewer Has, and the Bug That Proved It
 
-Lien Review runs one LLM agent over a PR, checking it against up to nine
-rules that all share one findings list. That sharing has a real, measured
-cost: on a PR that carries both a boring documentation drift and a juicier
-code bug, the model's one list rationally favors the code bug. That's the
-finding the doc-truth arc landed months ago (PRs #722–#733) — and swapping
-models didn't fix it, because the bottleneck is the shared output list
-itself, not any one model's judgment. The fix that shipped then was narrow:
-give doc-truth its own dedicated pass, its own budget, no competing rules.
+Any reviewer, human or automated, has a limited amount of attention for a
+single pull request. When a change contains one obvious, dramatic bug and
+one quiet, easy-to-miss one, the obvious bug wins. It's the one that gets a
+comment. The quiet one slips through, not because anyone decided it wasn't
+worth mentioning, but because it never had to compete for attention in the
+first place.
 
-[ADR-014](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md)
-is the story of generalizing that fix — and the evidence that it actually
-works came from a real, live bug we found in `drizzle-orm` along the way.
+Lien Review, the automated tool we built to comment on pull requests, had
+exactly this problem. It checks a change against a whole list of things at
+once: does this look like a security issue, does it introduce a naming
+mismatch, does a change here quietly break something that depends on it,
+and so on. All of that runs through one pass, competing for space in one
+shared list of things to say. On a pull request with both a boring
+documentation typo and a much juicier bug, the juicier bug tends to win.
+That holds true even when you swap out the underlying AI model. The problem
+was never a specific model. It was the setup: too much competing for one
+shared attention span.
 
-## The general shape: candidate loops
+We'd already tried one fix, and it worked: pull one specific kind of check
+out of the shared pile and give it its own dedicated pass over the pull
+request, with nothing else competing for its attention. What we didn't have
+yet was a real, live example proving that a dedicated pass actually catches
+more than the shared one does. We found one by accident, in someone else's
+code.
 
-Not every rule can get a dedicated pass. Some rules are open investigations —
-"where's the race condition in this locking code" has no enumerable worklist
-to check off. But a rule qualifies for a dedicated **candidate loop** when
-its signal produces a bounded, enumerable list of candidates, each with a
-closed set of possible verdicts — the same shape doc-truth already had.
+## A real bug hiding behind four files
 
-Three rules fit:
+We came across a genuine bug in Drizzle, a popular open-source toolkit that
+JavaScript and TypeScript developers use to talk to databases. A recent
+change to the project added six new kinds of database column. Drizzle also
+ships four separate companion packages, each one responsible for turning a
+database column's definition into validation rules for incoming data. None
+of those four packages had been updated to recognize the six new column
+types.
 
-| Loop | Verdict vocabulary | What it catches |
-|---|---|---|
-| `stale-duplicate` | `stale \| intentional-reuse \| unverifiable` | A literal duplicated elsewhere that the PR changed in one place but not the other |
-| `incomplete-handling` | `incomplete \| handled \| intentional \| unverifiable` | An added enum/union member, a sibling file, or a new struct field whose consumers weren't updated |
-| `removed-exports` | `breaking \| intentional \| internal-only \| unverifiable` | A removed public export with a surviving caller |
+For someone actually using it, that meant a real problem. If you used one
+of those new column types in your own project, and relied on one of those
+companion packages to validate data before it reached your database, it
+would quietly accept anything. No error, no warning, just silent acceptance
+of values it should have rejected. [We filed the bug with the
+project](https://github.com/drizzle-team/drizzle-orm/issues/6027) so it
+could get fixed.
 
-Each one runs as its own pass: its own prompt, its own budget, no other
-rule's findings competing for space in the output. `structural-analysis`
-stays hybrid on purpose — its "did callers handle this *changed* export
-correctly" half is still open investigation and stays in the shared pass
-forever; only its removed-export half graduated to a loop.
+That's precisely the kind of quiet, easy-to-miss bug that loses to louder
+ones when everything competes for the same attention. So we used it as a
+real test.
 
-Every loop ships **hybrid-gated**: it needs both an opt-in flag *and* at
-least one real candidate before it fires, and the rule's own prompt text
-never leaves the shared pass — the dedicated loop is additive, not a
-replacement. That's a deliberate, non-default choice: none of these three
-loops has a proven-over-inclusive-recall signal the way doc-truth's does, so
-none of them graduate to running *instead of* the shared pass. Not yet.
+## What happened when we gave it a narrower job
 
-## The part that actually needed proof
+We ran the change through Lien Review the normal way, checking everything
+at once, three separate times. It caught the bug once out of three, even
+though its own internal record showed it had opened and read all four of
+the affected files on every run. It was looking at the right code. It just
+didn't say anything about it, two times out of three.
 
-Building the mechanism is one thing. Showing it finds more real bugs than
-the shared pass it's meant to improve on is another — and until mid-July,
-that second part was untested. `incomplete-handling` needed a real,
-ground-truthed bug to check against, not a synthetic example.
+Then we gave the same check a narrower job. Instead of one shared pass over
+the whole pull request, it got its own dedicated look at a specific list of
+suspects (the four files, in this case), and had to give a real verdict on
+each one: a real problem, not a problem, or can't tell. We ran that three
+times. It caught the bug all three times. To make sure that wasn't luck, we
+ran it ten more times after that: ten out of ten.
 
-We found one in `drizzle-orm`. [PR #4172](https://github.com/drizzle-team/drizzle-orm/pull/4172)
-adds a new "Gel" dialect and, with it, six new column-type variants —
-`dateDuration`, `duration`, `relDuration`, `localTime`, `localDate`,
-`localDateTime` — to drizzle's core `ColumnDataType` union. Four downstream
-packages generate runtime validation schemas from that union:
-`drizzle-arktype`, `drizzle-zod`, `drizzle-valibot`, and `drizzle-typebox`.
-Every one of their `columnToSchema` functions still only branches on the
-*original* nine members. None was ever updated for the six new ones.
+The whole comparison, both versions, every run included, cost less than a
+dollar in AI usage.
 
-The practical effect: a Gel column using any of those six new types falls
-straight through every package's fallback branch — `type.unknown`,
-`z.any()`, `v.any()`, `t.Any()` — and silently gets **no real runtime
-validation** instead of a proper schema. It's exactly the shape
-`incomplete-handling`'s `variant-sweep` signal exists to catch: a new
-enum/union member added in one place, with consumer sites elsewhere that
-never got the memo. We reported it upstream as
-[drizzle-team/drizzle-orm#6027](https://github.com/drizzle-team/drizzle-orm/issues/6027).
+## The receipts
 
-## Same bug, two review arms
-
-With a real bug in hand, we could finally run the comparison ADR-014 needed:
-replay the same PR through the shared pass and through the dedicated
-`incomplete-handling` loop, and see which one actually converts the evidence
-into a finding.
-
-**Shared pass** (flags off, competing against Lien Review's other active
-rules): a 3-vote screen converted the bug into a real finding on **1 of 3**
-votes. The other two votes aren't a mystery — their own tool-call traces show
-them reading `get_files_context` and `read_file` on all four downstream
-`column.ts` files. They looked at the right code. They just didn't say
-anything about any rule, on any file, in that run.
-
-**Dedicated `incomplete-handling` loop**: 3 of 3. That result was strong
-enough to escalate to a full 10-vote calibration, the same bar every rule in
-Lien Review has to clear before it can ship: **10/10** named the correct
-variants and all four affected packages. (Three of the ten runs used a more
-compact "unknown/any" phrasing our keyword gate hadn't anchored on yet —
-once we added that anchor and re-scored the same ten transcripts offline, at
-zero additional cost, all ten passed clean. The three-verdict smoke test —
-does the assertion correctly pass a perfect answer, fail an empty one, and
-fail a distractor — was re-run after the widening and never false-passed.)
-
-The whole comparison — both arms, the escalation, the keyword tuning — cost
-**$0.80 of a $1.40 authorized budget**. The fixture is committed:
-[`pr4172-columndatatype-gel-gap.assertions.ts`](https://github.com/getlien/lien/blob/main/packages/review/test/harness/fixtures/crossrepo/pr4172-columndatatype-gel-gap.assertions.ts).
-
-This is one fixture, one candidate shape (`variant-sweep` — the loop's other
-two shapes, `sibling-surface` and `unread-field`, are untested by it), on one
-model. It's not a corpus-wide lift claim. But it's the first same-fixture,
-controlled comparison of a dedicated candidate loop against the shared
-pass's own signal-augmented prompt — and on this bug, the shared pass
-investigated the right files and stayed silent two-thirds of the time, while
-the dedicated loop converted the same evidence into a finding every time.
-
-## Why "can't skip"
-
-The other half of this design is about what happens when a candidate loop
-*doesn't* have an answer. The doc-truth arc's own worst finding (internally,
-"pr658 Finding A") was a single claim silently dropped from a long worklist
-— not wrong, just missing, with nothing in the output to say so.
-
-Every candidate loop closes that gap structurally: the model must return
-exactly one verdict for every candidate id in the worklist, from a fixed
-vocabulary. A missing id, a duplicate, or an unrecognized verdict value
-doesn't get silently ignored — it marks the pass's own result honestly
-`incomplete` (`AgentStopReason: 'incomplete_verdict'`), the same way a
-budget cutoff or a provider error already did. The pass can't quietly skip a
-candidate and have that read as "nothing to report here."
-
-That honesty is externally visible, not just an internal log line. Lien
-Review attaches a delivery attestation to every run — a machine-readable
-receipt naming which passes ran, why any pass didn't, and whether any pass
-was cut short. Before this generalization, that receipt only had room for
-one pass; a doc-truth-only budget cutoff would attest as the *main* pass
-running out of budget, which was directionally honest but pointed at the
-wrong entry. Attestation now carries one entry per pass that actually ran,
-and the verdict computation attributes a starvation or partial result to
-whichever specific pass stopped early. If a candidate loop can't finish its
-worklist, the receipt says so, by name.
+The other half of this fix is about what happens when the reviewer
+genuinely can't finish a job, whether it runs out of time, hits an error,
+or anything else. Before this change, if one of these narrower checks
+stalled partway through, the system would report the failure against the
+wrong part of the process: technically honest, but pointing at the wrong
+place. Now every review comes with a short report attached, naming which
+checks ran, which didn't, and exactly why, calling out the specific check
+by name if it didn't finish. Nobody has to wonder whether something
+silently gave up partway through.
 
 ## What's still open
 
-All three candidate loops are merged and dark — off by default for
-`@liendev/review` and `@liendev/action` consumers, opt-in via a config flag
-or env var. This repo's own CI opts `stale-duplicate` and
-`incomplete-handling` into its Lien Review workflow to dogfood them against
-real PRs; `removed-exports` hasn't been opted in yet. That's deliberate:
-the mechanism is proven end-to-end (byte-diff-neutral when off, verified
-attestation wiring, unit-tested completeness contracts), but corpus-wide lift
-is proven for exactly one fixture and one candidate shape so far. Turning any
-of these on by default is a separate, evidence-priced decision from building
-them — and it hasn't been made yet.
+We're rolling this out carefully. The narrower, one-job-at-a-time version
+of this check isn't turned on for everyone by default yet. It's proven on
+this one real bug, in this one shape. We want more evidence before making
+it the default for everyone, not less.
 
-[OWNER: your call on whether to preview a timeline for turning these on more
-broadly, or leave this as a pure status report.]
+[OWNER: your call on whether to preview a timeline for turning this on
+more broadly, or leave this as a pure status update.]

--- a/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
+++ b/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
@@ -1,7 +1,7 @@
 ---
 title: "The Blind Spot Every Reviewer Has, and the Bug That Proved It"
 description: "A popular open-source database toolkit added six new column types. Four companion packages were never updated to handle them. Our automated reviewer read all the right files and still missed it, most of the time."
-date: 2026-07-19
+date: 2026-07-24
 author: Alf Henderson
 tags: [evidence, review, architecture]
 draft: true
@@ -95,5 +95,6 @@ of this check isn't turned on for everyone by default yet. It's proven on
 this one real bug, in this one shape. We want more evidence before making
 it the default for everyone, not less.
 
-[OWNER: your call on whether to preview a timeline for turning this on
-more broadly, or leave this as a pure status update.]
+It's already turned on in Lien's own pull requests, for exactly this kind
+of check. Everywhere else it stays off by default until it proves itself
+again, on a bug we didn't already know was hiding there.

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -30,45 +30,84 @@ even then. It was the actual constraint I designed around from day one:
 nothing about someone's code should ever have to leave the machine it
 lives on.
 
-Then the product itself changed underneath me, and that whole stack
-stopped making sense. I wasn't building search for a person typing a query
-anymore. I was building something an agent leans on in the middle of an
-edit, and that flips the requirements around. A person searching can wait
-a second and is fine with an answer that's roughly related. An agent
-asking what happens if it touches this file, while it's actively deciding
-whether to make that change, needs an answer inside its own thinking
-budget, close to instant, and it needs that answer to be exactly right,
-not approximately close. "Fourteen callers, three of them untested" beats
-a similarity score every time, when the thing reading the answer has to
-decide something right now. It needs to know what breaks if it changes,
-not what the code is roughly about.
+From there, the real story splits into two separate threads that ran for
+months before they ever met.
 
-So the old stack came out, in full, not trimmed down. The embedding model
-and LanceDB were both removed entirely. In their place: better-sqlite3, a
+The first thread was about getting an agent to use the tools Lien gave
+it. The tools existed early on, back in November, and
+instructions telling an agent to use them followed within the hour. That
+pairing was always the plan, never an afterthought. By February, those
+instructions had hardened into hard requirements written directly into
+the rules an agent reads before touching a file: call this before
+editing, call that before renaming something exported.
+
+Then came an honest admission, in May: those requirements were, in
+practice, advisory. The model frequently went straight to editing a file
+without calling anything first. [We said so in
+public](https://github.com/getlien/lien/issues/560). The first fix was
+blunt, a gate that physically blocked an edit until the right tool had
+been called, and it shipped and then got pulled again within a day, too
+heavy-handed, the kind of friction that makes someone route around a tool
+instead of using it. What replaced it was smaller, and it actually
+worked: a hook that quietly hands the agent a short note about a file's
+impact right after it reads that file. No gate, no blocking, just the
+right fact arriving at the right moment. Watching real sessions is what
+showed that channel actually reaches the model, more reliably than a rule
+ever did. That's really where the idea of nudging was born, not enforcing
+compliance, but making sure the right context shows up exactly when it's
+useful.
+
+A second, separate thread started roughly seven weeks later and had
+nothing to do with any of that. The tool an agent was now required to
+call before every edit got measured under real traffic, and it came back
+slow, something like 40 milliseconds a call, sitting on top of an install
+that pulled in a heavy embedding model. What actually drove the next
+decision wasn't hook work at all. It was [a dedicated
+benchmark](https://github.com/getlien/lien/pull/645), a plain side-by-side
+test of a few different storage engines. The embedding model and the
+vector database both came out entirely. In their place: better-sqlite3, a
 boring, extremely well-tested embedded database that can answer a keyword
 search in milliseconds with no model involved at all. [We wrote up that
 whole decision in more detail
 here.](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0011-sqlite-structural-store-fts5-lexical-search.md)
-The parser itself got rewritten too, as a native Rust module using
+That one change dropped the same pre-edit call by roughly a thousand
+times, from about 40 milliseconds down to about 0.04. A few days later,
+the parser itself got rewritten too, as a native Rust module using
 napi-rs, a way to call Rust code directly from Node, instead of a
 JavaScript wrapper around a separately compiled binary. That wasn't only
-about raw speed, although it is faster. The old setup had to compile a
-native module on every fresh install, and that compile step was the
-single most common reason someone's install of Lien would fail. The Rust
-version ships pre-built for every platform, so a fresh install now takes
-seconds and compiles nothing at all.
+about speed, although it is faster. The old setup had to compile a native
+module on every fresh install, and that compile step was the single most
+common reason someone's install of Lien would fail. The Rust version
+ships pre-built for every platform, so a fresh install now takes seconds
+and compiles nothing at all.
 
-A few things about building it stuck with me. The fanciest part of the
-system wasn't the valuable part. A plain, boring database mattered more
-than the machine-learning model sitting next to it. When the thing using
-your tool is an agent in a loop rather than a person browsing, speed and
-an exact, repeatable answer aren't nice extras, they're the actual
-feature. Deleting an entire subsystem, not shrinking it, made the product
-better. And local-first is the one constraint that survived every
-rewrite, because it was never a feature bolted on top. It's the thing
-everything else got rebuilt around.
+The two threads met on one particular afternoon, the same day the faster
+storage landed. It enabled a check that genuinely couldn't have existed
+before: a complexity gate that runs at the moment of an edit and answers
+in about 30 milliseconds. It exists because of a real incident. [An agent
+had shipped a change](https://github.com/getlien/lien/pull/672) that
+passed every other gate in place at the time, while pushing one
+function's complexity to 29 against an agreed limit of 15. The later
+nudges, a warning before an edit even happens, a reminder about test
+coverage, all ride on that same fast storage layer underneath.
 
-Complexity metrics came next, for a specific reason. I had an idea to build
+Looking back, a few things stuck with me. Getting an agent to comply
+with the right process, and making the underlying answers fast
+enough to act on in real time, turned out to be two separate problems on
+two separate timelines, not one. Lien today is really just where those
+two problems finally met. The fanciest part of the original stack was
+never the valuable part either. A plain, boring database mattered more
+than the machine-learning model sitting next to it, and deleting that
+whole model and its vector store, not trimming them, is what made the
+product better. When the thing using your tool is an agent
+inside a loop rather than a person browsing, speed and an exact,
+repeatable answer aren't nice extras, they're the actual feature. And
+local-first survived every rewrite in both threads, because it was never
+a feature bolted on top. It's the thing everything else got rebuilt
+around.
+
+A related complexity idea was running on its own track the whole time,
+completely separate from the edit-time gate above. I had an idea to build
 a tool that would show how complicated code was getting across an entire
 team's projects, and nudge people toward writing less of that complexity.
 Much later, that idea became the automatic pull-request reviewer I'll
@@ -85,7 +124,7 @@ that slipped past paid competitors, using a noticeably cheaper model
 underneath. Not always, though. Further down there's the one time it went
 the other way, and we kept that one too.
 
-The last piece closed the loop in the other direction. If a tool already
+One of those later nudges deserves its own explanation. If a tool already
 knows a function is getting too complicated, why wait until a pull request
 to say so? That's the idea behind warning an agent before it even makes an
 edit, not after it's already made a mess. I've now confirmed that idea

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -210,9 +210,12 @@ chart.
 ## The rest of it
 
 It's licensed under the AGPL: self-hosted, bring-your-own-key, no vendor
-lock-in, and no telemetry anywhere. Free forever for local use. The license
-exists to keep it that way, and to make sure improvements come back to the
-project instead of disappearing into someone's private fork.
+lock-in, and no telemetry anywhere. Free forever for local use. The
+license exists to keep it that way: if someone builds on Lien and shares
+that publicly, as software they distribute or a service they run over a
+network, the AGPL means their improvements have to be shared back too. A
+private fork that's never distributed or offered as a service can stay
+private.
 
 Install for Claude Code is one command:
 

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -1,0 +1,151 @@
+---
+title: "Why We Built Lien"
+description: "A code-intelligence layer for AI agents, built local-first: structural analysis and fast lexical search, no embeddings, no server, dogfooded on its own repo since day one."
+date: 2026-07-19
+author: Alf Henderson
+tags: [product, local-first]
+draft: true
+---
+
+<!-- DRAFT: awaiting owner voice pass -->
+
+# Why We Built Lien
+
+[OWNER: this is the post that most needs your voice — the sections below are
+structured and fact-checked, but the personal "why I started this" framing
+is yours to write. I've left `[OWNER: ...]` markers where I think first-person
+narrative belongs. Everything outside those markers is sourced against this
+repo's own docs — see the review notes for the full claim-by-claim map.]
+
+[OWNER: a paragraph or two here on how you started building this and why —
+what problem you kept hitting that made you want a tool that tells a coding
+agent what it's about to break, before it breaks it.]
+
+Lien is a code-intelligence layer for AI coding assistants: structural
+analysis (dependencies, blast radius, complexity, test coverage) plus fast
+lexical code search — all local, all free, no server anywhere in the loop.
+
+It's open source (AGPL-3.0), dogfooded on its own repo since day one, and in
+a shape worth writing about properly. Here's what it does and why.
+
+## No embeddings, and that's a deliberate choice
+
+Lien used to embed code into vectors for semantic search. We pulled that out
+entirely. Dogfooding kept showing that the questions that actually make Lien
+valuable to an agent are structural — "what depends on this file", "how
+complex is this function", "what tests cover this" — not semantic
+similarity. Meanwhile the embedding model was a ~100MB download and a heavy
+install for a capability that wasn't earning its keep.
+
+So indexing is just Tree-sitter AST parsing plus a SQLite write, and
+full-text search runs on FTS5/BM25. No model to download, no GPU, works
+fully offline. Measured on an M3 Pro: reqwest (Rust, 79 files) indexes in
+0.7s, hono (TypeScript, 370 files) in 1.7s, and Lien's own six-language
+monorepo (517 files) in 1.8s. That scales roughly linearly with file count —
+a 10k-file repo lands around 25-30s by extrapolation. The native parser (a
+small Rust crate, prebuilt for every platform) is 1.8-2.2x faster than the
+JS-binding parser it replaced, and the whole native footprint is about 22MB.
+Nothing to compile on install.
+
+The honest tradeoff: lexical search can't bridge a genuine synonym gap.
+Searching "auth" won't surface `verifyToken()` if the code and comments
+never use the word "auth", and sparsely-commented code makes
+natural-language queries underperform generally. Query with the vocabulary
+actually in the code — and the structural tools (dependents, blast radius,
+test coverage) don't have this problem at all, since they're indexed
+lookups, not search.
+
+## Hooks that push agents toward simpler code
+
+The MCP tools are pull-based — the agent has to ask. Lien also ships two
+Claude Code hooks that push, so the nudge doesn't depend on the agent
+remembering to ask:
+
+- **A read hook** injects a short blast-radius summary right after the agent
+  reads a file with non-trivial impact — dependent count, risk level, test
+  coverage — before it makes an edit.
+- **A write hook** runs `lien delta` after every edit: a ~50ms deterministic
+  complexity check that only speaks up when *that specific edit* pushed a
+  function across a complexity threshold it wasn't over before. It's silent
+  for pre-existing violations and for improvements. End-to-end hook latency
+  is about 215ms warm, 410ms cold — comfortably under its own 5-second
+  timeout.
+
+We didn't want to just assert this changes what an agent writes, so we ran a
+small, pre-registered A/B on the plan-time version of this nudge: the same
+coding task, with and without the real warning line injected into the
+prompt. Control crossed its complexity threshold in 8 of 8 trials; the
+warning condition crossed in 3 of 8, and every trial that avoided crossing
+did it by extracting a helper function — exactly what the warning's wording
+asks for. It's a small (N=8/condition), single-task, single-model
+comparison — not a general claim about nudges — but within that scope, the
+effect is not subtle. [Full protocol and results](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md).
+
+## A PR review Action that publishes its own misses
+
+Lien Review is a self-hostable GitHub Action — one `uses:` line, no server,
+no database, bring your own OpenRouter or Anthropic key:
+
+```yaml
+name: Lien Review
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getlien/lien-review@v1
+        with:
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+No `actions/checkout` needed — it self-clones the PR by SHA using the
+workflow's own token. It's advisory by default (`fail-on: never`), and a
+typical review costs $0.02-$0.15 in tokens (real OpenRouter billing tends to
+run 1.5-2x whatever the harness estimates, so budget accordingly).
+
+What we actually want to talk about is how it's validated. Every rule has to
+clear a 9-out-of-10 bar on a calibration harness before it ships, using
+fixtures mined from real, merged bugs in external repos — not synthetic test
+cases. The most recent full sweep covered 24 fixtures across 8 repos and 6
+languages, for $13.11 of a $15 budget. And the results page publishes the
+misses alongside the wins: four recurring failure shapes (deep-traced-but-
+wrong, omission, blindness to external callers, and accepting the PR's own
+framing), plus the single most humbling data point we have — Lien Review
+reviewed one of its own PRs, missed a real bug in an error-handling
+fallback, and CodeRabbit caught the same bug five minutes later on the same
+commit. That miss is now a committed fixture in the corpus, not a footnote.
+
+Most recently, that same evidence discipline paid off somewhere we didn't
+expect: proving out a structural fix to how Lien Review handles crowded PRs,
+using a real, live bug we found in `drizzle-orm` along the way. [More on
+that here](/blog/posts/reviewer-that-cant-skip-candidate-loops).
+
+We think that's a more useful thing to publish than another benchmark
+chart.
+
+## The rest of it
+
+AGPL-3.0, self-hosted, bring-your-own-key, no lock-in, no telemetry
+anywhere. Free forever for local use — the license exists to keep it that
+way and make sure improvements come back to the project.
+
+Install for Claude Code is one command:
+
+```
+/plugin marketplace add getlien/lien
+/plugin install lien
+```
+
+For other MCP-compatible editors (Cursor, Windsurf, OpenCode, Kilo Code,
+Antigravity): `npm install -g @liendev/lien && lien init`.
+
+The rest of the docs, the full evidence page, and the harness methodology
+are all elsewhere on this site. Code's at
+[github.com/getlien/lien](https://github.com/getlien/lien).
+
+[OWNER: closing line is yours — e.g. an invite to open an issue/discussion
+if it falls over on someone's codebase, or whatever you'd want to close on.]

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -1,6 +1,6 @@
 ---
 title: "Why We Built Lien"
-description: "A code-intelligence layer for AI agents, built local-first: structural analysis and fast lexical search, no embeddings, no server, dogfooded on its own repo since day one."
+description: "A tool that gives AI coding assistants a real, structural understanding of your codebase: what depends on what, how complicated each piece of code is, and what tests actually cover it. Runs entirely on your own machine."
 date: 2026-07-19
 author: Alf Henderson
 tags: [product, local-first]
@@ -11,112 +11,125 @@ draft: true
 
 # Why We Built Lien
 
-I built Lien initially out of curiosity: could I get Claude's coding agents to
-actually understand a monorepo — the cross-package dependencies, the "if I
-touch this, what else moves" question — instead of guessing at it? A smaller,
-more selfish itch sat right next to that one: I was tired of manually hunting
-through a codebase for something like "how is auth handled here," and wanted
-a shortcut. That second itch is what got me building an index in the first
-place — the first version of Lien was semantic, embeddings and all.
+I built Lien initially out of curiosity. Could I get Claude's coding agents
+to understand a monorepo, the cross-package dependencies, the "if I
+touch this, what else moves" question, instead of just guessing at it? A
+smaller, more selfish itch sat right next to that one. I was tired of
+manually hunting through a codebase for something like "how is auth handled
+here," and I wanted a shortcut. That second itch is what got me building an
+index in the first place. The first version of Lien tried to search code by
+meaning, the same way a lot of "AI search" tools work.
 
-It didn't stay that way. Building that semantic search taught me something I
-didn't expect: the questions that actually made an agent better at working in
-a codebase weren't semantic-similarity questions at all — they were
-structural ones. What depends on this file. How complex is this function.
-What tests cover it. The embeddings were answering a question nobody was
-really asking. That's the story behind the "no embeddings" section below —
-it's not a pivot I made on a whiteboard, it's a lesson dogfooding taught me.
+It didn't stay that way. Building that first version taught me something I
+didn't expect. The questions that helped an agent work well in a
+codebase weren't questions about what code *means*. They were questions
+about how it's *connected*. What depends on this file. How complicated is
+this function. What tests actually cover it. An agent doesn't need to guess
+what a piece of code is about. It needs to know what breaks if it changes.
+That's the story behind the next section: it's not a pivot I made on a
+whiteboard, it's a lesson the work itself taught me.
 
-Complexity metrics came next, for a specific reason: I had an idea to build a
-cloud app that would surface complexity across an entire GitHub org and nudge
-teams toward writing less of it — which, much later, became Lien Review, the
-PR review Action.
+Complexity metrics came next, for a specific reason. I had an idea to build
+a tool that would show how complicated code was getting across an entire
+team's projects, and nudge people toward writing less of that complexity.
+Much later, that idea became the automatic pull-request reviewer I'll
+describe below.
 
-Along the way I noticed something else: the same Tree-sitter AST parsing that
-helped an agent understand a codebase's structure could power a code review
-loop too. That became Lien Review — and it's where I felt like I was onto
-something real. Because those AST-derived signals are deterministic, not
-vibes, in my own head-to-head testing Lien Review caught real bugs that
-slipped past paid tools like CodeRabbit, running a noticeably cheaper model
-underneath — though not always; the section below has the one time it went
-the other way.
+Along the way I noticed something else: the same technique that let an
+agent understand a codebase's structure, actually parsing the code the way
+a compiler does, could power a review process too. Something that reads a
+change and points out real problems before a person has to catch them. That
+became the reviewer, and it's where I felt like I was onto something real.
+Because its signals come from really parsing the code rather than a
+model's gut feeling, in my own side-by-side testing it caught real bugs
+that slipped past paid competitors, using a noticeably cheaper model
+underneath. Not always, though. Further down there's the one time it went
+the other way, and we kept that one too.
 
-The last piece closed the loop in the other direction: if Lien already knows
-a function's complexity, why wait for a PR to say so? That's the idea behind
-the runtime nudge — surfacing a complexity warning to an agent before it
-edits a function, not after. I've now confirmed that idea actually changes
-what an agent writes; see [the pre-registered A/B](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md)
-for the numbers.
+The last piece closed the loop in the other direction. If a tool already
+knows a function is getting too complicated, why wait until a pull request
+to say so? That's the idea behind warning an agent before it even makes an
+edit, not after it's already made a mess. I've now confirmed that idea
+actually changes what an agent writes. We tested it properly, and
+[the numbers held up](/blog/posts/complexity-nudges-ab-test).
 
-All of it is in service of the same bet: that agents can be trusted to write
-more of our code, without giving up quality or correctness for it — as long
-as they have the same structural understanding of a codebase a careful human
-reviewer would insist on.
+All of it is in service of the same bet: that agents can be trusted to
+write more of our code, without giving up quality or correctness for it, as
+long as they have the same understanding of a codebase's structure a
+careful human reviewer would insist on.
 
-Lien is a code-intelligence layer for AI coding assistants: structural
-analysis (dependencies, blast radius, complexity, test coverage) plus fast
-lexical code search — all local, all free, no server anywhere in the loop.
+Lien is what came out of chasing that bet. It gives AI coding assistants a
+real, structural understanding of a codebase: what depends on what, how
+complicated each piece of code is, what tests cover it, plus fast
+search across the code itself. It runs entirely on your own machine.
+Nothing gets uploaded anywhere, and there's no server involved at all.
 
-It's open source (AGPL-3.0), dogfooded on its own repo since day one, and in
-a shape worth writing about properly. Here's what it does and why.
+It's open source, has been used on its own codebase since the very first
+day, and it's finally in a shape worth writing about properly.
 
-## No embeddings, and that's a deliberate choice
+## No AI search, and that's a deliberate choice
 
-Lien used to embed code into vectors for semantic search. We pulled that out
-entirely. Dogfooding kept showing that the questions that actually make Lien
-valuable to an agent are structural — "what depends on this file", "how
-complex is this function", "what tests cover this" — not semantic
-similarity. Meanwhile the embedding model was a ~100MB download and a heavy
-install for a capability that wasn't earning its keep.
+A lot of "AI-powered" code tools work by turning your code into a kind of
+numeric fingerprint, so the tool can find code that seems related in
+meaning even if the words don't match. Lien used to work that way too. We
+pulled that out entirely. Building it and living with it kept showing the
+same thing: the questions that make an agent better at its job are
+about structure, not meaning. "What depends on this file." "How complicated
+is this function." "What tests cover this." Meanwhile, that fingerprinting
+model was a roughly 100MB download and a heavy install for a capability
+that wasn't earning its keep.
 
-So indexing is just Tree-sitter AST parsing plus a SQLite write, and
-full-text search runs on FTS5/BM25. No model to download, no GPU, works
-fully offline. Measured on an M3 Pro: reqwest (Rust, 79 files) indexes in
-0.7s, hono (TypeScript, 370 files) in 1.7s, and Lien's own six-language
-monorepo (517 files) in 1.8s. That scales roughly linearly with file count —
-a 10k-file repo lands around 25-30s by extrapolation. The native parser (a
-small Rust crate, prebuilt for every platform) is 1.8-2.2x faster than the
-JS-binding parser it replaced, and the whole native footprint is about 22MB.
-Nothing to compile on install.
+So indexing a codebase is just reading the code the way a compiler would,
+then writing what it finds to a small local database. Ordinary keyword
+search runs on top of that. No AI model to download, no GPU needed, and it
+works completely offline. On a laptop with an Apple M3 Pro chip: a small
+open-source project (79 files) indexes in 0.7 seconds, a mid-sized project
+(370 files) in 1.7 seconds, and Lien's own codebase (517 files, across six
+languages) in 1.8 seconds. That scales roughly in a straight line with file
+count, so a 10,000-file codebase would land around 25 to 30 seconds by
+extrapolation. The part of Lien that actually reads the code is a small,
+fast program that comes pre-built for every platform, so there's nothing to
+compile when you install it, and it's noticeably faster than the version it
+replaced.
 
-The honest tradeoff: lexical search can't bridge a genuine synonym gap.
-Searching "auth" won't surface `verifyToken()` if the code and comments
-never use the word "auth", and sparsely-commented code makes
-natural-language queries underperform generally. Query with the vocabulary
-actually in the code — and the structural tools (dependents, blast radius,
-test coverage) don't have this problem at all, since they're indexed
-lookups, not search.
+The honest tradeoff: plain keyword search can't bridge a real gap in
+vocabulary. Searching for "auth" won't surface a function called
+`verifyToken()` if neither the code nor its comments ever use the word
+"auth," and sparsely-commented code makes plain-language questions perform
+worse in general. The fix is simple: search using words that actually
+appear in the code. The more structural questions Lien answers (what
+depends on this, what tests cover it) don't have this problem at all,
+because those aren't searches. They're direct lookups from an index Lien
+already built.
 
-## Hooks that push agents toward simpler code
+## Nudging agents toward simpler code
 
-The MCP tools are pull-based — the agent has to ask. Lien also ships two
-Claude Code hooks that push, so the nudge doesn't depend on the agent
-remembering to ask:
+Most of what Lien knows, an agent has to actively ask for. But Lien also
+does two things on its own, without the agent needing to remember to ask:
 
-- **A read hook** injects a short blast-radius summary right after the agent
-  reads a file with non-trivial impact — dependent count, risk level, test
-  coverage — before it makes an edit.
-- **A write hook** runs `lien delta` after every edit: a ~50ms deterministic
-  complexity check that only speaks up when *that specific edit* pushed a
-  function across a complexity threshold it wasn't over before. It's silent
-  for pre-existing violations and for improvements. End-to-end hook latency
-  is about 215ms warm, 410ms cold — comfortably under its own 5-second
-  timeout.
+- Right after an agent opens a file that a lot of other code depends on,
+  Lien quietly adds a short note: how many other things depend on it, how
+  risky it would be to change, and whether it's covered by tests.
+  That happens before the agent makes any edit, while it still matters.
+- Right after an agent makes an edit, Lien checks whether that specific
+  change made some function meaningfully harder to understand than it was
+  before. If so, it says so. If the function was already complicated, or
+  the edit made it simpler, it stays quiet. This check takes about 50
+  milliseconds, and the whole round trip is around 200 milliseconds warm,
+  comfortably inside the time Lien allows itself before giving up.
 
-We didn't want to just assert this changes what an agent writes, so we ran a
-small, pre-registered A/B on the plan-time version of this nudge: the same
-coding task, with and without the real warning line injected into the
-prompt. Control crossed its complexity threshold in 8 of 8 trials; the
-warning condition crossed in 3 of 8, and every trial that avoided crossing
-did it by extracting a helper function — exactly what the warning's wording
-asks for. It's a small (N=8/condition), single-task, single-model
-comparison — not a general claim about nudges — but within that scope, the
-effect is not subtle. [Full protocol and results](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md).
+We didn't want to just assume this changes what an agent writes, so we
+tested it properly: the same coding task, given twice, once with a real
+warning inserted and once without, nothing else different. [We wrote the
+whole experiment up separately](/blog/posts/complexity-nudges-ab-test), but
+the short version: the agent that got the warning wrote meaningfully
+simpler code far more often than the one that didn't.
 
-## A PR review Action that publishes its own misses
+## A reviewer that publishes its own misses
 
-Lien Review is a self-hostable GitHub Action — one `uses:` line, no server,
-no database, bring your own OpenRouter or Anthropic key:
+Lien also reviews pull requests automatically, as a single line you can add
+to any project's GitHub setup. No separate server, no database, and you
+bring your own AI provider key:
 
 ```yaml
 name: Lien Review
@@ -134,36 +147,45 @@ jobs:
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
-No `actions/checkout` needed — it self-clones the PR by SHA using the
-workflow's own token. It's advisory by default (`fail-on: never`), and a
-typical review costs $0.02-$0.15 in tokens (real OpenRouter billing tends to
-run 1.5-2x whatever the harness estimates, so budget accordingly).
+It doesn't need any special access beyond what that one line already
+grants, and by default it only leaves comments. It won't block anything
+unless you turn that on yourself. A typical review costs a few cents to
+about fifteen cents in AI usage (real bills tend to run a bit higher than
+that estimate, so budget accordingly).
 
-What we actually want to talk about is how it's validated. Every rule has to
-clear a 9-out-of-10 bar on a calibration harness before it ships, using
-fixtures mined from real, merged bugs in external repos — not synthetic test
-cases. The most recent full sweep covered 24 fixtures across 8 repos and 6
-languages, for $13.11 of a $15 budget. And the results page publishes the
-misses alongside the wins: four recurring failure shapes (deep-traced-but-
-wrong, omission, blindness to external callers, and accepting the PR's own
-framing), plus the single most humbling data point we have — Lien Review
-reviewed one of its own PRs, missed a real bug in an error-handling
-fallback, and CodeRabbit caught the same bug five minutes later on the same
-commit. That miss is now a committed fixture in the corpus, not a footnote.
+What we actually want to talk about is how we know it works. Every check
+this tool makes has to prove itself against real bugs that actually shipped
+and were later fixed in other open-source projects, not made-up examples.
+The most recent full check covered two dozen real historical bugs across
+eight different open-source projects in six programming languages, for
+about $13 in AI costs. And we publish the misses right alongside the wins.
+There are a few recurring ways it fails. Sometimes it reads exactly the
+right code and reasons its way to the wrong conclusion anyway. Sometimes
+the bug is something that's quietly missing rather than something visibly
+wrong, and those are the hardest to catch in any review, human or not.
+Sometimes a change looks safe to every caller inside the project but breaks
+code outside it that the reviewer simply can't see. And sometimes it just
+believes what the pull request says about itself. The single most humbling
+result we have: this tool reviewed one of its own changes, missed a real
+bug in how an error was being handled, and a paid competitor caught the
+exact same bug five minutes later, on the same commit. We kept that as a
+permanent example in our own tests, not a footnote.
 
-Most recently, that same evidence discipline paid off somewhere we didn't
-expect: proving out a structural fix to how Lien Review handles crowded PRs,
-using a real, live bug we found in `drizzle-orm` along the way. [More on
-that here](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md).
+Most recently, that same habit of publishing our own misses led somewhere
+we didn't expect: proof that a fix to how the reviewer handles a busy pull
+request actually works, using a real, live bug we found in a popular
+open-source project along the way. [There's a whole story about
+that](/blog/posts/reviewer-that-cant-skip-candidate-loops).
 
 We think that's a more useful thing to publish than another benchmark
 chart.
 
 ## The rest of it
 
-AGPL-3.0, self-hosted, bring-your-own-key, no lock-in, no telemetry
-anywhere. Free forever for local use — the license exists to keep it that
-way and make sure improvements come back to the project.
+It's licensed under the AGPL: self-hosted, bring-your-own-key, no vendor
+lock-in, and no telemetry anywhere. Free forever for local use. The license
+exists to keep it that way, and to make sure improvements come back to the
+project instead of disappearing into someone's private fork.
 
 Install for Claude Code is one command:
 
@@ -172,12 +194,12 @@ Install for Claude Code is one command:
 /plugin install lien
 ```
 
-For other MCP-compatible editors (Cursor, Windsurf, OpenCode, Kilo Code,
-Antigravity): `npm install -g @liendev/lien && lien init`.
+For other AI coding tools, like Cursor, Windsurf, OpenCode, and Kilo Code:
+one install command plus one setup command.
 
-The rest of the docs, the full evidence page, and the harness methodology
-are all elsewhere on this site. Code's at
+The rest of the docs, the full evidence, and how we test all of this live
+elsewhere on this site. The code is at
 [github.com/getlien/lien](https://github.com/getlien/lien).
 
-[OWNER: closing line is yours — e.g. an invite to open an issue/discussion
+[OWNER: closing line is yours, e.g. an invite to open an issue/discussion
 if it falls over on someone's codebase, or whatever you'd want to close on.]

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -45,7 +45,7 @@ The last piece closed the loop in the other direction: if Lien already knows
 a function's complexity, why wait for a PR to say so? That's the idea behind
 the runtime nudge — surfacing a complexity warning to an agent before it
 edits a function, not after. I've now confirmed that idea actually changes
-what an agent writes; see [the pre-registered A/B](/blog/posts/complexity-nudges-ab-test)
+what an agent writes; see [the pre-registered A/B](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md)
 for the numbers.
 
 All of it is in service of the same bet: that agents can be trusted to write
@@ -154,7 +154,7 @@ commit. That miss is now a committed fixture in the corpus, not a footnote.
 Most recently, that same evidence discipline paid off somewhere we didn't
 expect: proving out a structural fix to how Lien Review handles crowded PRs,
 using a real, live bug we found in `drizzle-orm` along the way. [More on
-that here](/blog/posts/reviewer-that-cant-skip-candidate-loops).
+that here](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md).
 
 We think that's a more useful thing to publish than another benchmark
 chart.
@@ -167,7 +167,7 @@ way and make sure improvements come back to the project.
 
 Install for Claude Code is one command:
 
-```
+```text
 /plugin marketplace add getlien/lien
 /plugin install lien
 ```

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -89,8 +89,8 @@ The last piece closed the loop in the other direction. If a tool already
 knows a function is getting too complicated, why wait until a pull request
 to say so? That's the idea behind warning an agent before it even makes an
 edit, not after it's already made a mess. I've now confirmed that idea
-actually changes what an agent writes. We tested it properly, and
-[the numbers held up](/blog/posts/complexity-nudges-ab-test).
+actually changes what an agent writes, and there's a lot more on that a
+bit further down.
 
 All of it is in service of the same bet: that agents can be trusted to
 write more of our code, without giving up quality or correctness for it, as
@@ -148,8 +148,8 @@ does two things on its own, without the agent needing to remember to ask:
 We didn't want to just assume this changes what an agent writes, so we
 tested it properly: the same coding task, given twice, once with a real
 warning inserted and once without, nothing else different. [We wrote the
-whole experiment up separately](/blog/posts/complexity-nudges-ab-test), but
-the short version: the agent that got the warning wrote meaningfully
+whole experiment up separately](https://github.com/getlien/lien/blob/main/docs/development/nudge-behavioral-ab.md),
+but the short version: the agent that got the warning wrote meaningfully
 simpler code far more often than the one that didn't.
 
 ## A reviewer that publishes its own misses
@@ -202,7 +202,7 @@ Most recently, that same habit of publishing our own misses led somewhere
 we didn't expect: proof that a fix to how the reviewer handles a busy pull
 request actually works, using a real, live bug we found in a popular
 open-source project along the way. [There's a whole story about
-that](/blog/posts/reviewer-that-cant-skip-candidate-loops).
+that](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md).
 
 We think that's a more useful thing to publish than another benchmark
 chart.

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -17,17 +17,56 @@ touch this, what else moves" question, instead of just guessing at it? A
 smaller, more selfish itch sat right next to that one. I was tired of
 manually hunting through a codebase for something like "how is auth handled
 here," and I wanted a shortcut. That second itch is what got me building an
-index in the first place. The first version of Lien tried to search code by
-meaning, the same way a lot of "AI search" tools work.
+index in the first place.
 
-It didn't stay that way. Building that first version taught me something I
-didn't expect. The questions that helped an agent work well in a
-codebase weren't questions about what code *means*. They were questions
-about how it's *connected*. What depends on this file. How complicated is
-this function. What tests actually cover it. An agent doesn't need to guess
-what a piece of code is about. It needs to know what breaks if it changes.
-That's the story behind the next section: it's not a pivot I made on a
-whiteboard, it's a lesson the work itself taught me.
+The first version was built the way a lot of local code tools were built
+around then. Parsing ran through tree-sitter's JavaScript bindings, the
+same parsing library most code editors use under the hood. Search ran on a
+small local embedding model, something like 100MB, running through ONNX
+Runtime, a lightweight way to run that kind of model without a GPU or a
+network call, with the resulting vectors stored in LanceDB, a local vector
+database built for exactly that job. Local-first wasn't a marketing line
+even then. It was the actual constraint I designed around from day one:
+nothing about someone's code should ever have to leave the machine it
+lives on.
+
+Then the product itself changed underneath me, and that whole stack
+stopped making sense. I wasn't building search for a person typing a query
+anymore. I was building something an agent leans on in the middle of an
+edit, and that flips the requirements around. A person searching can wait
+a second and is fine with an answer that's roughly related. An agent
+asking what happens if it touches this file, while it's actively deciding
+whether to make that change, needs an answer inside its own thinking
+budget, close to instant, and it needs that answer to be exactly right,
+not approximately close. "Fourteen callers, three of them untested" beats
+a similarity score every time, when the thing reading the answer has to
+decide something right now. It needs to know what breaks if it changes,
+not what the code is roughly about.
+
+So the old stack came out, in full, not trimmed down. The embedding model
+and LanceDB were both removed entirely. In their place: better-sqlite3, a
+boring, extremely well-tested embedded database that can answer a keyword
+search in milliseconds with no model involved at all. [We wrote up that
+whole decision in more detail
+here.](https://github.com/getlien/lien/blob/main/docs/architecture/decisions/0011-sqlite-structural-store-fts5-lexical-search.md)
+The parser itself got rewritten too, as a native Rust module using
+napi-rs, a way to call Rust code directly from Node, instead of a
+JavaScript wrapper around a separately compiled binary. That wasn't only
+about raw speed, although it is faster. The old setup had to compile a
+native module on every fresh install, and that compile step was the
+single most common reason someone's install of Lien would fail. The Rust
+version ships pre-built for every platform, so a fresh install now takes
+seconds and compiles nothing at all.
+
+A few things about building it stuck with me. The fanciest part of the
+system wasn't the valuable part. A plain, boring database mattered more
+than the machine-learning model sitting next to it. When the thing using
+your tool is an agent in a loop rather than a person browsing, speed and
+an exact, repeatable answer aren't nice extras, they're the actual
+feature. Deleting an entire subsystem, not shrinking it, made the product
+better. And local-first is the one constraint that survived every
+rewrite, because it was never a feature bolted on top. It's the thing
+everything else got rebuilt around.
 
 Complexity metrics came next, for a specific reason. I had an idea to build
 a tool that would show how complicated code was getting across an entire
@@ -69,17 +108,7 @@ day, and it's finally in a shape worth writing about properly.
 
 ## No AI search, and that's a deliberate choice
 
-A lot of "AI-powered" code tools work by turning your code into a kind of
-numeric fingerprint, so the tool can find code that seems related in
-meaning even if the words don't match. Lien used to work that way too. We
-pulled that out entirely. Building it and living with it kept showing the
-same thing: the questions that make an agent better at its job are
-about structure, not meaning. "What depends on this file." "How complicated
-is this function." "What tests cover this." Meanwhile, that fingerprinting
-model was a roughly 100MB download and a heavy install for a capability
-that wasn't earning its keep.
-
-So indexing a codebase is just reading the code the way a compiler would,
+Indexing a codebase today is just reading the code the way a compiler would,
 then writing what it finds to a small local database. Ordinary keyword
 search runs on top of that. No AI model to download, no GPU needed, and it
 works completely offline. On a laptop with an Apple M3 Pro chip: a small
@@ -87,10 +116,8 @@ open-source project (79 files) indexes in 0.7 seconds, a mid-sized project
 (370 files) in 1.7 seconds, and Lien's own codebase (517 files, across six
 languages) in 1.8 seconds. That scales roughly in a straight line with file
 count, so a 10,000-file codebase would land around 25 to 30 seconds by
-extrapolation. The part of Lien that actually reads the code is a small,
-fast program that comes pre-built for every platform, so there's nothing to
-compile when you install it, and it's noticeably faster than the version it
-replaced.
+extrapolation. That's the same Rust rewrite described above doing the
+work, and it's a large part of why these numbers are as fast as they are.
 
 The honest tradeoff: plain keyword search can't bridge a real gap in
 vocabulary. Searching for "auth" won't surface a function called

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -11,15 +11,47 @@ draft: true
 
 # Why We Built Lien
 
-[OWNER: this is the post that most needs your voice — the sections below are
-structured and fact-checked, but the personal "why I started this" framing
-is yours to write. I've left `[OWNER: ...]` markers where I think first-person
-narrative belongs. Everything outside those markers is sourced against this
-repo's own docs — see the review notes for the full claim-by-claim map.]
+I built Lien initially out of curiosity: could I get Claude's coding agents to
+actually understand a monorepo — the cross-package dependencies, the "if I
+touch this, what else moves" question — instead of guessing at it? A smaller,
+more selfish itch sat right next to that one: I was tired of manually hunting
+through a codebase for something like "how is auth handled here," and wanted
+a shortcut. That second itch is what got me building an index in the first
+place — the first version of Lien was semantic, embeddings and all.
 
-[OWNER: a paragraph or two here on how you started building this and why —
-what problem you kept hitting that made you want a tool that tells a coding
-agent what it's about to break, before it breaks it.]
+It didn't stay that way. Building that semantic search taught me something I
+didn't expect: the questions that actually made an agent better at working in
+a codebase weren't semantic-similarity questions at all — they were
+structural ones. What depends on this file. How complex is this function.
+What tests cover it. The embeddings were answering a question nobody was
+really asking. That's the story behind the "no embeddings" section below —
+it's not a pivot I made on a whiteboard, it's a lesson dogfooding taught me.
+
+Complexity metrics came next, for a specific reason: I had an idea to build a
+cloud app that would surface complexity across an entire GitHub org and nudge
+teams toward writing less of it — which, much later, became Lien Review, the
+PR review Action.
+
+Along the way I noticed something else: the same Tree-sitter AST parsing that
+helped an agent understand a codebase's structure could power a code review
+loop too. That became Lien Review — and it's where I felt like I was onto
+something real. Because those AST-derived signals are deterministic, not
+vibes, in my own head-to-head testing Lien Review caught real bugs that
+slipped past paid tools like CodeRabbit, running a noticeably cheaper model
+underneath — though not always; the section below has the one time it went
+the other way.
+
+The last piece closed the loop in the other direction: if Lien already knows
+a function's complexity, why wait for a PR to say so? That's the idea behind
+the runtime nudge — surfacing a complexity warning to an agent before it
+edits a function, not after. I've now confirmed that idea actually changes
+what an agent writes; see [the pre-registered A/B](/blog/posts/complexity-nudges-ab-test)
+for the numbers.
+
+All of it is in service of the same bet: that agents can be trusted to write
+more of our code, without giving up quality or correctness for it — as long
+as they have the same structural understanding of a codebase a careful human
+reviewer would insist on.
 
 Lien is a code-intelligence layer for AI coding assistants: structural
 analysis (dependencies, blast radius, complexity, test coverage) plus fast

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -214,10 +214,12 @@ jobs:
 ```
 
 It doesn't need any special access beyond what that one line already
-grants, and by default it only leaves comments. It won't block anything
-unless you turn that on yourself. A typical review costs a few cents to
-about fifteen cents in AI usage (real bills tend to run a bit higher than
-that estimate, so budget accordingly).
+grants, and by default it only leaves comments on what it finds. It won't
+block anything over those comments unless you turn that on yourself. The
+one exception: if the review can't run at all, say the AI provider is
+down, it fails the check outright instead of looking clean. A typical
+review costs a few cents to about fifteen cents in AI usage (real bills
+tend to run a bit higher than that estimate, so budget accordingly).
 
 What we actually want to talk about is how we know it works. Every check
 this tool makes has to prove itself against real bugs that actually shipped

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -1,7 +1,7 @@
 ---
 title: "Why We Built Lien"
 description: "A tool that gives AI coding assistants a real, structural understanding of your codebase: what depends on what, how complicated each piece of code is, and what tests actually cover it. Runs entirely on your own machine."
-date: 2026-07-19
+date: 2026-07-22
 author: Alf Henderson
 tags: [product, local-first]
 draft: true
@@ -270,5 +270,5 @@ The rest of the docs, the full evidence, and how we test all of this live
 elsewhere on this site. The code is at
 [github.com/getlien/lien](https://github.com/getlien/lien).
 
-[OWNER: closing line is yours, e.g. an invite to open an issue/discussion
-if it falls over on someone's codebase, or whatever you'd want to close on.]
+If you run it on your own codebase and it breaks, open an issue. I'd
+rather hear about a real failure than have you quietly stop using it.

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -10,6 +10,8 @@
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.1",
     "mermaid": "^11.4.0",
     "vitepress": "^1.5.0",
     "vitepress-plugin-mermaid": "^2.0.17",


### PR DESCRIPTION
## Summary

- Adds a `/blog` section to the VitePress site: index listing (title, date, description, tag chips), a shared post layout (byline via a theme slot, default doc prose/code-block styling), a top-nav "Blog" entry.
- Draft-gating mechanism: `draft: true` frontmatter excludes a post from the listing, nav, and the built site entirely — while still rendering it (with a visible DRAFT banner) in local dev, so the owner can review a post before publishing it.
- Three seed articles, all `draft: true`, each marked `<!-- DRAFT: awaiting owner voice pass -->`:
  - **"Why We Built Lien"** — adapted from the ghost launch-announcement drafts, `[OWNER: ...]` markers left where personal narrative belongs.
  - **"Do Complexity Nudges Change What Agents Write? A Pre-Registered A/B"** — adaptation of `docs/development/nudge-behavioral-ab.md`; numbers/protocol/caveats as the source states them.
  - **"A Reviewer That Can't Skip: Candidate Loops in Lien Review"** — the per-rule candidate-loop story (ADR-014 + `review-pass-architecture.md`), with the drizzle-orm#4172 live-bug find (issue filed upstream as drizzle-team/drizzle-orm#6027) as the narrative spine; every number traces to the ADR or the `pr4172-columndatatype-gel-gap.assertions.ts` fixture header.
- `packages/site` is private/unpublished — no changeset.

**Publication of any article is owner-only** — flipping `draft: false` was never done in this PR; see `docs/development/blog-authoring.md` for the flip procedure (edit frontmatter → merge → `deploy-docs.yml` handles the rest).

## Mechanism

- `docs/.vitepress/config.ts` is now a command-aware config function (`({ command }) => ...`, Vite's own `ConfigEnv`). Only when `command === 'build'` does it compute `srcExclude` from `blogDrafts.ts`'s `getDraftPostExcludes()`, which parses frontmatter with `js-yaml` (the same library VitePress's bundled `gray-matter` uses internally) so it agrees with VitePress's own parsing on every case an author might write. `vitepress dev`/`preview` never populate `srcExclude`, so drafts stay fully reachable locally.
- `docs/blog/posts.data.ts` (the listing's content loader) independently filters drafts at **load time** via `process.env.NODE_ENV === 'production'` — not just in the Vue template — so a draft's title/description never enter the production client bundle at all, not merely stay unrendered.
- `theme/components/DraftBanner.vue` / `PostMeta.vue` inject into the default theme's `doc-before` slot; the banner only renders when `frontmatter.draft` is true (which, combined with `srcExclude`, means it can only ever be seen in dev — no draft page exists in production for it to render on).

## Dogfood evidence

**Production build** (`npm run docs:build`) — all three seed posts are `draft: true`:
```
build complete in 4.38s.
```
Verified the built `dist/`:
- Only `blog/index.html` exists under `dist/blog/` — zero individual post pages generated (`find . -path "*blog*"` → `./blog`, `./blog/index.html`, plus the index's own JS chunk).
- `grep -rl` across the entire `dist/` tree for each draft's exact title/description string, and for the literal `<!-- DRAFT: awaiting owner voice pass -->` marker text — zero hits, all three.
- The rendered `blog/index.html` shows the empty state ("Nothing published yet — check back soon.") with 0 `.lien-blog-card` elements — correct, since all 3 posts are drafts.
- No sitemap generator exists in this VitePress site today (`grep -ril sitemap` — no hits); documented in `blog-authoring.md` that the mechanism (posts excluded from VitePress's resolved page list) means a sitemap added later would exclude drafts automatically too.

**Dev mode** (`npm run docs:dev`, verified via Playwright against the running dev server, both themes):
- `/blog/` lists all 3 draft posts, each with a `DRAFT` chip, correct title/description/tags.
- Each post page renders the amber `DRAFT` banner ("Visible only in local dev — excluded from the production build (listing, nav, sitemap, and this page itself) until `draft: false` is set and merged to main.") plus the byline (date · author · tag chips) above the title.
- Nav shows the new "Blog" entry; internal cross-links between posts resolve correctly (VitePress auto-normalizes `/blog/posts/<slug>` → `/blog/posts/<slug>.html`, matching the site's existing link convention).
- Checked both light and dark theme — zinc surfaces / purple accent / amber draft indicator all read correctly in both, per STYLE_GUIDE.

## Gates

```
npm run format:check   ✓
npm run lint           ✓ (0 errors; 33 pre-existing warnings, none in touched files)
npm run typecheck      ✓
npm run build          ✓
npm test               ✓ (1451 + 860 + 41 + others, all packages)
npm run docs:build     ✓ (site gate)
node packages/cli/dist/index.js delta   ✓ exit 0 (no new-over-threshold or crossed functions)
```

One `lien delta` halstead_effort flag surfaced mid-edit on `config.ts` (a large single arrow-function config object pushed the function over threshold) — fixed by extracting the static `head`/`themeConfig`/`mermaid` sections into their own top-level constants, leaving the exported config function small. Re-ran clean afterward.

## Triage (Lien Review + CodeRabbit findings on this PR)

Real bugs found during review and fixed on the branch (see commit history):
- **Doc-truth**: `blog-authoring.md` described a since-corrected implementation (`import.meta.env.PROD`, `defineConfig(...)`) instead of what actually shipped (`process.env.NODE_ENV`, a plain `UserConfigExport` function) — corrected.
- **Leak path (draft-detection inconsistency, the most serious finding)**: the original regex-based draft check disagreed with the real YAML parser VitePress uses (e.g. `draft: true  # note` or `draft: True`), and separately, `srcExclude`'s strict `=== true` disagreed with the listing's truthiness check — either gap could leave a post hidden from the listing but still built as a real, URL-reachable page in `dist/`. Fixed by parsing frontmatter with `js-yaml` and using the same `Boolean(...)` truthiness check on both sides.
- **Robustness**: malformed `tags` frontmatter (a bare string instead of a list) would have made Vue's `v-for` iterate it character-by-character — guarded with `Array.isArray` in both the listing's data loader and `PostMeta.vue`. Malformed YAML frontmatter now fails loudly with the offending file path instead of a bare library stack trace. The post-list sort comparator now returns `0` for equal dates (all three seed posts currently share one date, so this wasn't hypothetical).
- **Editorial**: repointed two cross-post links in "Why We Built Lien" at their durable GitHub sources instead of sibling draft posts' in-site URLs, so they can't 404 if posts are published out of order. Added missing fenced-code-block language identifiers (MD040) and a capitalization fix.

Checked and left as-is (verified accurate, not a doc-truth gap):
- The "advisory by default (`fail-on: never`)" claim — confirmed against `packages/action/README.md`/`action.yml`; the reviewer's evidence bundle for that finding just didn't include those files.
- The candidate-loop default/CI-opt-in claims in the candidate-loops article — confirmed against `isStaleDuplicatePassEnabled`/`isIncompleteHandlingPassEnabled`/`isRemovedExportsPassEnabled` (all default false, config-or-env opt-in) and the current `.github/workflows/lien-review.yml` (stale-duplicate + incomplete-handling opted in, removed-exports not).

Latest Lien Review pass (commit dbe82c4): "No code bugs or breaking changes were found."

## Test plan

- [x] `docs:build` succeeds and produces zero trace of draft content anywhere in `dist/`
- [x] `docs:dev` renders all three drafts with the DRAFT banner/chip, in both light and dark theme
- [x] Internal cross-links between posts resolve to the correct built URL
- [x] Full gate chain (format/lint/typecheck/build/test/docs:build/delta) green
- [x] Lien Review triage — all real findings fixed (see Triage section above); CI green on every commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Blog section with an index page, post cards, descriptions, dates, authors, and tag chips.
  * Draft posts now show a visible **DRAFT** banner in local development.
  * Production builds omit draft posts from navigation and listings, and draft pages aren’t generated.
  * Added styling for blog metadata, tag chips, and draft card visuals.
  * Introduced three new draft articles.
* **Documentation**
  * Added a guide for authoring and publishing `/blog` posts, including required frontmatter and the draft-to-published workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a self-contained /blog section to the unpublished VitePress docs site with a carefully implemented draft-gating mechanism. The changed code parses frontmatter consistently with js-yaml, applies Boolean(draft) on both the build-exclusion and listing-filter paths, guards malformed tags with Array.isArray, and only populates srcExclude during production builds. No logic bugs, breaking changes, silent error swallowing, or untrusted-input validation gaps were found.
>
> - New blog listing, post layout components, draft banner, and top-nav Blog entry
> - Command-aware config function plus content-loader filtering to exclude draft posts from production builds
> - Three draft seed articles and an authoring guide

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0ce254d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

---

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 199K/160K tokens
<!-- /lien:attestation -->