### PR TITLE
feat(review): docs-drift rule — deterministic blast-radius for untouched docs (dark)

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -229,7 +229,7 @@ export const FENCE_RE = /^(?:```|~~~)/;
  *    almost always a developer imperative ("never run npm install", "must echo
  *    back"), not a falsifiable claim about the code the diff touches.
  */
-export const CLAIM_SHAPES: ReadonlyArray<{ shape: DocClaimShape; re: RegExp; near?: RegExp }> = [
+const CLAIM_SHAPES: ReadonlyArray<{ shape: DocClaimShape; re: RegExp; near?: RegExp }> = [
   {
     shape: 'mechanism',
     re: /\b(?:meaning-based|semantic(?:ally)?|lexical|keyword-based|embedding-based|bm25|full-text|substring)\b/i,

--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -187,9 +187,10 @@ const MAX_CODE_CLAIMS = 10;
 const MAX_CLAIM_CHARS = 200;
 /** Per-claim evidence excerpt cap — enough to carry the described code, not a hunk. */
 const MAX_EVIDENCE_CHARS = 400;
-/** Lines of context above / below the anchor line in an evidence excerpt (~6-line window). */
-const EVIDENCE_LINES_BEFORE = 2;
-const EVIDENCE_LINES_AFTER = 3;
+/** Lines of context above / below the anchor line in an evidence excerpt (~6-line window).
+ *  Exported for reuse by docs-drift-signals.ts's own excerpt/tier windowing. */
+export const EVIDENCE_LINES_BEFORE = 2;
+export const EVIDENCE_LINES_AFTER = 3;
 /**
  * Total budget for the whole `<doc_claims>` block. Evidence excerpts are
  * dropped (with an inline note) before any claim is dropped, so the worklist
@@ -198,8 +199,10 @@ const EVIDENCE_LINES_AFTER = 3;
 const MAX_DOC_CLAIMS_CHARS = 8_000;
 
 const HUNK_META_RE = /^(?:\+\+\+|---)/;
-/** A fenced code block opener/closer — claims are prose, not code samples. */
-const FENCE_RE = /^(?:```|~~~)/;
+/** A fenced code block opener/closer — claims are prose, not code samples. Exported for reuse
+ *  by docs-drift-signals.ts, which tracks fence state over a plain doc chunk the same way this
+ *  module tracks it over a diff's post-image lines. */
+export const FENCE_RE = /^(?:```|~~~)/;
 
 /**
  * Claim-shaped prose matchers, most-specific first (first match wins the
@@ -226,7 +229,7 @@ const FENCE_RE = /^(?:```|~~~)/;
  *    almost always a developer imperative ("never run npm install", "must echo
  *    back"), not a falsifiable claim about the code the diff touches.
  */
-const CLAIM_SHAPES: ReadonlyArray<{ shape: DocClaimShape; re: RegExp; near?: RegExp }> = [
+export const CLAIM_SHAPES: ReadonlyArray<{ shape: DocClaimShape; re: RegExp; near?: RegExp }> = [
   {
     shape: 'mechanism',
     re: /\b(?:meaning-based|semantic(?:ally)?|lexical|keyword-based|embedding-based|bm25|full-text|substring)\b/i,
@@ -255,8 +258,9 @@ const CLAIM_SHAPES: ReadonlyArray<{ shape: DocClaimShape; re: RegExp; near?: Reg
 // Extraction
 // ---------------------------------------------------------------------------
 
-/** Return the first matching claim shape for a prose line, or null. */
-function classifyClaim(text: string): { shape: DocClaimShape; matchIndex: number } | null {
+/** Return the first matching claim shape for a prose line, or null. Exported (behavior-neutral)
+ *  for reuse as docs-drift-signals.ts's Tier-1 behavioral-claim detector — see that module. */
+export function classifyClaim(text: string): { shape: DocClaimShape; matchIndex: number } | null {
   for (const { shape, re, near } of CLAIM_SHAPES) {
     const m = re.exec(text);
     if (m && (!near || near.test(text))) return { shape, matchIndex: m.index };

--- a/packages/review/src/docs-drift-signals.ts
+++ b/packages/review/src/docs-drift-signals.ts
@@ -1,0 +1,512 @@
+/**
+ * Deterministic "blast-radius for untouched docs" signal for PR reviews.
+ *
+ * doc-truth (see `doc-claims-signals.ts`) verifies the docs a PR TOUCHED against the code it
+ * changed. This module covers the inverse, structurally symmetric gap: a PR REMOVES or RENAMES a
+ * code symbol, or deletes a file/directory, and some OTHER doc — one the PR never opened — still
+ * describes the old form as if it were current. That doc silently rots.
+ *
+ * Mirrors the `<removed_exports>` / `<rename_sweep>` / `<stale_literal_candidates>` precedents:
+ * pre-compute the structural facts (which old forms are provably GONE, and which untouched
+ * doc/config lines still name them) instead of asking the agent to grep-and-reason across the
+ * whole repo on every PR. Three referand kinds, each backed by an existing extractor or a small
+ * new one:
+ *   - a removed exported symbol (`extractRemovedExports`, `removed-export-signals.ts`);
+ *   - a renamed identifier's old name (`detectRenameSweeps`, `rename-sweep-signals.ts`);
+ *   - a deleted file/directory path (new: `isFullFileDeletion` below, parsed straight off the
+ *     hunk headers `getPRPatchData` already gives every plugin — no `diff --git` header needed,
+ *     since production patches are hunk-only).
+ *
+ * The raw signal — "some doc mentions some changed identifier" — fires on nearly every PR and is
+ * useless as a gate on its own, the same trap `stale-literal-signals.ts`'s confidence tiering
+ * exists to avoid. Two independent, deliberately narrow gates keep this selective: (1) the
+ * referand set is restricted to REMOVED/RENAMED/DELETED forms, not merely changed ones — most PRs
+ * add and modify but don't remove public surface; (2) each surviving reference is tiered by WHERE
+ * in the doc it sits (a falsifiable behavioral claim, or a structural heading/bullet naming a now-
+ * gone symbol/path) and, when in doubt, SUPPRESSED (fenced code samples, changelog/changeset
+ * entries, link targets, and past-tense/historical prose are never candidates — that is the
+ * single biggest false-positive class for this shape of signal).
+ *
+ * This module only computes candidates; it injects no `<...>` prompt block and has no pass wired
+ * to it yet (see the docs-drift design doc, `.wip/docs-drift-design.md`, §3-6) — that is later
+ * work. `classifyRawDocReferences` exists purely so the zero-LLM census (design doc §4) can show
+ * how much this tiering collapses the raw ~100%-of-PRs signal down to a selective candidate rate.
+ */
+
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from './plugin-types.js';
+import { extractRemovedExports } from './removed-export-signals.js';
+import { detectRenameSweeps } from './rename-sweep-signals.js';
+import {
+  classifyClaim,
+  FENCE_RE,
+  EVIDENCE_LINES_BEFORE,
+  EVIDENCE_LINES_AFTER,
+} from './doc-claims-signals.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Which deterministic extractor produced a referand's "the old form is gone" fact. */
+export type ReferandKind = 'removed-export' | 'renamed-identifier' | 'deleted-path';
+
+/** Where in the doc a surviving reference sits — the precision-tiering axis (see module header). */
+export type PositionTier = 'behavioral-claim' | 'structural-mention';
+
+/**
+ * A surviving untouched-doc reference to a removed/renamed/deleted referand, tiered and past every
+ * suppression check. The code-side hunk that proves the referand is gone is deliberately NOT
+ * carried here — it is cheap to re-derive from `context.pr.patches` when a pass actually consumes
+ * this candidate (mirrors `findRemovalHunk` in `removed-exports-pass.ts`), so this stays a minimal,
+ * easily-serializable worklist entry.
+ */
+export interface DocsDriftCandidate {
+  /** The old-form token this doc still names (a symbol, an old identifier, or a path). */
+  referand: string;
+  referandKind: ReferandKind;
+  docFile: string;
+  /** 1-based line in the doc file's current (head) content. */
+  docLine: number;
+  positionTier: PositionTier;
+  /** A short window around the reference line, for a reviewer to judge without re-opening the file. */
+  excerpt: string;
+}
+
+/** One referand to sweep the untouched-doc corpus for. `altToken` is a shorter alternate spelling
+ *  (currently only a deleted directory's trailing segment, e.g. `packages/runner` -> `runner`)
+ *  that a doc might use instead of the full token. */
+interface Referand {
+  token: string;
+  kind: ReferandKind;
+  altToken?: string;
+}
+
+/** One raw word-boundary match of a referand inside an untouched doc/config chunk. */
+interface MatchSite {
+  chunk: CodeChunk;
+  lines: string[];
+  lineIndex: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max candidates returned — keeps a future prompt block compact (mirrors sibling signals). */
+const MAX_CANDIDATES = 15;
+/** Max surviving references swept per referand before the candidate-building cap kicks in. */
+const MAX_REFS_PER_REFERAND = 5;
+/** Wall-clock backstop for the untouched-doc sweep, mirroring stale-literal-signals.ts's own
+ *  budget — this runs unconditionally on every PR, before any LLM call. */
+const DOCS_DRIFT_TIME_BUDGET_MS = 5_000;
+/** Shortest deleted-path trailing segment worth treating as an alternate search token. */
+const MIN_TRAILING_SEGMENT_CHARS = 4;
+/** Cap on a rendered excerpt window. */
+const MAX_EXCERPT_CHARS = 400;
+
+const DOC_CHUNK_TYPES = new Set(['doc', 'config']);
+/** A changelog or changeset entry — a correct historical record, never a drift candidate. */
+const CHANGELOG_OR_CHANGESET_RE = /(?:^|\/)CHANGELOG[^/]*(?:\.md)?$|(?:^|\/)\.changeset\//i;
+/** A markdown link target or bare URL on the line — link targets, not prose claims. */
+const LINK_OR_URL_RE = /\]\(|https?:\/\//;
+/** Past-tense / historical / retirement note — the primary false-positive class (module header). */
+const HISTORICAL_GUARD_RE =
+  /\b(?:was|were)\s+(?:removed|renamed|deleted|retired|dropped)\b|\b(?:retired|formerly|deprecated|previously|prior to|no longer|used to)\b/i;
+const HEADING_RE = /^#{1,6}\s/;
+const STRUCTURE_BULLET_RE = /^\s*[-*]\s/;
+/** A unified-diff hunk header, capturing the NEW-side start. A full-file deletion's every hunk
+ *  starts its new side at line 0 (`@@ -a,b +0,0 @@`) — see `isFullFileDeletion`. */
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+/** A plain identifier — used to reject the `default (X)` / `* (all re-exports of '…')` synthetic
+ *  spellings `extractRemovedExports` uses for un-searchable removals (mirrors that module's own
+ *  `searchableName`, whose constants are private to it). */
+const PLAIN_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/;
+
+// ---------------------------------------------------------------------------
+// Referand extraction — removed exports / renamed identifiers
+// ---------------------------------------------------------------------------
+
+/** Removed-export referands: the plain-identifier removed exports (skips the default/bulk
+ *  synthetic spellings, which have no stable searchable name). */
+function referandsFromRemovedExports(patches: Map<string, string>): Referand[] {
+  return extractRemovedExports(patches)
+    .filter(r => PLAIN_IDENTIFIER_RE.test(r.symbol))
+    .map(r => ({ token: r.symbol, kind: 'removed-export' as const }));
+}
+
+/** Renamed-identifier referands: the OLD name of each detected mechanical rename sweep. */
+function referandsFromRenames(patches: Map<string, string>): Referand[] {
+  return detectRenameSweeps(patches).map(m => ({
+    token: m.from,
+    kind: 'renamed-identifier' as const,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Referand extraction — deleted paths
+// ---------------------------------------------------------------------------
+
+/**
+ * True iff `patch` is a full-file deletion: it has at least one hunk, and EVERY hunk header's
+ * new-side start is `0` (`@@ -a,b +0,0 @@`) — the shape a whole-file removal always produces,
+ * whether or not the patch also carries a `diff --git`/`deleted file mode` header. Production
+ * patches from `getPRPatchData` (`github-api.ts`, via `octokit.pulls.listFiles`) are HUNK-ONLY —
+ * no such header is ever present — so this is the only extractor shape that works in both prod
+ * and a fixture's full-header capture. Exposed for testing.
+ */
+export function isFullFileDeletion(patch: string): boolean {
+  let hunkCount = 0;
+  for (const line of patch.split('\n')) {
+    const m = HUNK_HEADER_RE.exec(line);
+    if (!m) continue;
+    hunkCount++;
+    if (m[1] !== '0') return false;
+  }
+  return hunkCount > 0;
+}
+
+/** The `packages/<name>` grouping a deleted file lives under, else its top-level directory, else
+ *  null for a root-level file. Mirrors `stale-literal-signals.ts`'s `projectArea` helper. */
+function candidateDirectoryReferand(file: string): string | null {
+  const pkgMatch = file.match(/^packages\/([^/]+)\//);
+  if (pkgMatch) return `packages/${pkgMatch[1]}`;
+  const topMatch = file.match(/^([^/]+)\//);
+  return topMatch ? topMatch[1] : null;
+}
+
+/**
+ * True when no chunk in the head corpus lives under `dir/` — i.e. `dir` is genuinely gone, not
+ * merely missing the one deleted file. Without this check, deleting a single file from an
+ * otherwise-intact package would wrongly promote that whole package directory to "deleted".
+ */
+function directoryIsGone(dir: string, repoChunks: CodeChunk[] | undefined): boolean {
+  if (!repoChunks) return true;
+  const prefix = `${dir}/`;
+  return !repoChunks.some(c => c.metadata.file.startsWith(prefix));
+}
+
+/** The referand's shorter alternate token — its last path segment — when distinctive enough and
+ *  different from the referand itself (e.g. `packages/runner` -> `runner`). */
+function trailingSegment(path: string): string | undefined {
+  const seg = path.split('/').filter(Boolean).pop();
+  return seg && seg !== path && seg.length >= MIN_TRAILING_SEGMENT_CHARS ? seg : undefined;
+}
+
+/**
+ * Deleted-path referands: every fully-deleted file, grouped up to its containing package/top-level
+ * directory when that whole directory is confirmed gone (see `directoryIsGone`) — the shape a
+ * removed CLAUDE.md structure bullet describes (a directory, not one of its files) — else left as
+ * the individual file's own path. Deduped. Exposed for testing.
+ */
+export function extractDeletedPaths(
+  patches: Map<string, string>,
+  repoChunks: CodeChunk[] | undefined,
+): Referand[] {
+  const deletedFiles = [...patches.entries()]
+    .filter(([, patch]) => isFullFileDeletion(patch))
+    .map(([file]) => file);
+  if (deletedFiles.length === 0) return [];
+
+  const paths = new Set<string>();
+  for (const file of deletedFiles) {
+    const dir = candidateDirectoryReferand(file);
+    paths.add(dir && directoryIsGone(dir, repoChunks) ? dir : file);
+  }
+
+  return [...paths].map(path => {
+    const alt = trailingSegment(path);
+    return { token: path, kind: 'deleted-path' as const, ...(alt && { altToken: alt }) };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Referand collection
+// ---------------------------------------------------------------------------
+
+/** Every referand this PR's diff produces, deduped by (kind, token). */
+function collectReferands(context: ReviewContext): Referand[] {
+  const patches = context.pr?.patches;
+  if (!patches || patches.size === 0) return [];
+
+  const seen = new Set<string>();
+  const out: Referand[] = [];
+  const push = (r: Referand): void => {
+    const key = `${r.kind}:${r.token}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(r);
+  };
+
+  referandsFromRemovedExports(patches).forEach(push);
+  referandsFromRenames(patches).forEach(push);
+  extractDeletedPaths(patches, context.repoChunks).forEach(push);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Untouched doc/config corpus
+// ---------------------------------------------------------------------------
+
+/** The union of every path this PR changed (mirrors `doc-claims-signals.ts`'s own
+ *  `collectChangedFiles`, duplicated locally since that helper is private to its module). */
+function collectChangedFileSet(context: ReviewContext): Set<string> {
+  const files = new Set<string>(context.changedFiles ?? []);
+  for (const f of context.allChangedFiles ?? []) files.add(f);
+  for (const f of context.pr?.patches?.keys() ?? []) files.add(f);
+  return files;
+}
+
+function isDocOrConfigChunk(chunk: CodeChunk): boolean {
+  return DOC_CHUNK_TYPES.has(chunk.metadata.type);
+}
+
+/** Doc/config chunks from a file this PR did NOT touch — the entire point (a touched doc is
+ *  doc-truth's job, not this module's). */
+function collectUntouchedDocChunks(chunks: CodeChunk[], changed: Set<string>): CodeChunk[] {
+  return chunks.filter(c => isDocOrConfigChunk(c) && !changed.has(c.metadata.file));
+}
+
+// ---------------------------------------------------------------------------
+// Word-boundary sweep
+// ---------------------------------------------------------------------------
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function wordBoundaryRe(token: string): RegExp {
+  return new RegExp(`\\b${escapeForRegex(token)}\\b`);
+}
+
+/** Cheap pre-check before the per-line regex: does `chunk`'s raw content contain the referand's
+ *  token or alternate token at all? (fast reject, mirrors `removed-export-signals.ts`'s own). */
+function chunkMayContainReferand(chunk: CodeChunk, referand: Referand): boolean {
+  if (chunk.content.includes(referand.token)) return true;
+  return !!referand.altToken && chunk.content.includes(referand.altToken);
+}
+
+/** Collect word-boundary matches of `referand` within one already-fast-rejected chunk into
+ *  `sites`, stopping once the shared `cap` is reached. Split out of `sweepReferand` to keep that
+ *  function's own branching shallow. */
+function collectMatchesInChunk(
+  chunk: CodeChunk,
+  referand: Referand,
+  re: RegExp,
+  altRe: RegExp | null,
+  cap: number,
+  sites: MatchSite[],
+): void {
+  const lines = chunk.content.split('\n');
+  for (let i = 0; i < lines.length && sites.length < cap; i++) {
+    if (re.test(lines[i]) || (altRe && altRe.test(lines[i]))) {
+      sites.push({ chunk, lines, lineIndex: i });
+    }
+  }
+}
+
+/**
+ * Sweep `chunks` for word-boundary occurrences of `referand` (its primary token, or its alternate
+ * token when present), fast-rejecting each chunk via a plain `includes` check before the per-line
+ * regex (mirrors `removed-export-signals.ts`'s `collectRefsFromChunk`). Stops early once `cap`
+ * sites are found or the shared `deadline` passes. Pass `cap: Infinity` for an uncapped count (used
+ * only by the census helper, `classifyRawDocReferences`).
+ */
+function sweepReferand(
+  referand: Referand,
+  chunks: CodeChunk[],
+  deadline: number,
+  cap: number,
+): MatchSite[] {
+  const sites: MatchSite[] = [];
+  const re = wordBoundaryRe(referand.token);
+  const altRe = referand.altToken ? wordBoundaryRe(referand.altToken) : null;
+
+  for (const chunk of chunks) {
+    if (sites.length >= cap || Date.now() > deadline) break;
+    if (!chunkMayContainReferand(chunk, referand)) continue;
+    collectMatchesInChunk(chunk, referand, re, altRe, cap, sites);
+  }
+
+  return sites;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression + tiering
+// ---------------------------------------------------------------------------
+
+/** Fence state entering `lineIndex` — toggled on every fence delimiter strictly before it (mirrors
+ *  `doc-claims-signals.ts`'s own `inFence` tracking, applied over a plain doc chunk's lines). */
+function isInsideFence(lines: string[], lineIndex: number): boolean {
+  let inFence = false;
+  for (let i = 0; i < lineIndex; i++) {
+    if (FENCE_RE.test(lines[i].trim())) inFence = !inFence;
+  }
+  return inFence;
+}
+
+/**
+ * When in doubt, suppress (module header): a changelog/changeset entry, a fenced code sample, a
+ * link/URL line, or a past-tense/historical note are never candidates — the primary false-positive
+ * class for this signal shape.
+ */
+function isSuppressed(file: string, lines: string[], lineIndex: number): boolean {
+  if (CHANGELOG_OR_CHANGESET_RE.test(file)) return true;
+  if (isInsideFence(lines, lineIndex)) return true;
+  const line = lines[lineIndex];
+  return LINK_OR_URL_RE.test(line) || HISTORICAL_GUARD_RE.test(line);
+}
+
+/** Does the reference line, or a line in its evidence window, read as a falsifiable behavioral
+ *  claim (`classifyClaim`, the doc-truth Tier-1 detector)? */
+function matchesClaimWindow(lines: string[], lineIndex: number): boolean {
+  const from = Math.max(0, lineIndex - EVIDENCE_LINES_BEFORE);
+  const to = Math.min(lines.length - 1, lineIndex + EVIDENCE_LINES_AFTER);
+  for (let i = from; i <= to; i++) {
+    if (classifyClaim(lines[i])) return true;
+  }
+  return false;
+}
+
+/** Tier-1 (behavioral claim) beats Tier-2 (heading/structural bullet); neither -> not a candidate. */
+function classifyPositionTier(lines: string[], lineIndex: number): PositionTier | null {
+  if (matchesClaimWindow(lines, lineIndex)) return 'behavioral-claim';
+  const line = lines[lineIndex];
+  if (HEADING_RE.test(line) || STRUCTURE_BULLET_RE.test(line)) return 'structural-mention';
+  return null;
+}
+
+/** A ~6-line window around the reference line (mirrors `doc-claims-signals.ts`'s evidence window). */
+function buildExcerpt(lines: string[], lineIndex: number): string {
+  const from = Math.max(0, lineIndex - EVIDENCE_LINES_BEFORE);
+  const to = Math.min(lines.length - 1, lineIndex + EVIDENCE_LINES_AFTER);
+  const window = lines.slice(from, to + 1).join('\n');
+  return window.length > MAX_EXCERPT_CHARS ? `${window.slice(0, MAX_EXCERPT_CHARS)}…` : window;
+}
+
+// ---------------------------------------------------------------------------
+// Candidate assembly
+// ---------------------------------------------------------------------------
+
+function buildCandidate(referand: Referand, match: MatchSite): DocsDriftCandidate | null {
+  const { chunk, lines, lineIndex } = match;
+  if (isSuppressed(chunk.metadata.file, lines, lineIndex)) return null;
+  const tier = classifyPositionTier(lines, lineIndex);
+  if (!tier) return null;
+
+  return {
+    referand: referand.token,
+    referandKind: referand.kind,
+    docFile: chunk.metadata.file,
+    docLine: chunk.metadata.startLine + lineIndex,
+    positionTier: tier,
+    excerpt: buildExcerpt(lines, lineIndex),
+  };
+}
+
+const TIER_RANK: Record<PositionTier, number> = { 'behavioral-claim': 0, 'structural-mention': 1 };
+
+/** Deterministic sort: Tier-1 before Tier-2, then referand, then doc file:line. */
+function compareCandidates(a: DocsDriftCandidate, b: DocsDriftCandidate): number {
+  const byTier = TIER_RANK[a.positionTier] - TIER_RANK[b.positionTier];
+  if (byTier !== 0) return byTier;
+  const byReferand = a.referand.localeCompare(b.referand);
+  if (byReferand !== 0) return byReferand;
+  const byFile = a.docFile.localeCompare(b.docFile);
+  if (byFile !== 0) return byFile;
+  return a.docLine - b.docLine;
+}
+
+interface SweepSetup {
+  referands: Referand[];
+  docChunks: CodeChunk[];
+}
+
+/** Shared setup for both `computeDocsDriftCandidates` and `classifyRawDocReferences`: the
+ *  referands to sweep for and the untouched doc/config corpus to sweep, or null when either is
+ *  empty (nothing to compute). */
+function setupSweep(context: ReviewContext): SweepSetup | null {
+  const patches = context.pr?.patches;
+  const repoChunks = context.repoChunks;
+  if (!patches || patches.size === 0 || !repoChunks || repoChunks.length === 0) return null;
+
+  const referands = collectReferands(context);
+  if (referands.length === 0) return null;
+
+  const changed = collectChangedFileSet(context);
+  const docChunks = collectUntouchedDocChunks(repoChunks, changed);
+  if (docChunks.length === 0) return null;
+
+  return { referands, docChunks };
+}
+
+/**
+ * Compute the docs-drift candidates for a review: untouched doc/config lines that still name a
+ * symbol this PR removed, an identifier it renamed, or a path it deleted — tiered by position and
+ * past every suppression check (module header). Returns `[]` when there's no diff, no
+ * removed/renamed/deleted referand, or no untouched doc/config corpus to sweep. Capped at
+ * `MAX_CANDIDATES`, sorted deterministically (Tier-1 first, then referand, then doc file:line).
+ */
+export function computeDocsDriftCandidates(context: ReviewContext): DocsDriftCandidate[] {
+  const setup = setupSweep(context);
+  if (!setup) return [];
+
+  const deadline = Date.now() + DOCS_DRIFT_TIME_BUDGET_MS;
+  const candidates: DocsDriftCandidate[] = [];
+
+  for (const referand of setup.referands) {
+    if (Date.now() > deadline) break;
+    const matches = sweepReferand(referand, setup.docChunks, deadline, MAX_REFS_PER_REFERAND);
+    for (const match of matches) {
+      const candidate = buildCandidate(referand, match);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+
+  candidates.sort(compareCandidates);
+  return candidates.slice(0, MAX_CANDIDATES);
+}
+
+/** Raw (untiered/unsuppressed) reference tally — see `classifyRawDocReferences`. */
+export interface RawDocReferenceTally {
+  total: number;
+  tier1: number;
+  tier2: number;
+  suppressed: number;
+}
+
+/** Tally one raw match into `tally` (suppressed, tier-1, tier-2, or neither). Split out of
+ *  `classifyRawDocReferences` to keep that function's own nesting shallow. */
+function tallyRawMatch(match: MatchSite, tally: RawDocReferenceTally): void {
+  tally.total++;
+  if (isSuppressed(match.chunk.metadata.file, match.lines, match.lineIndex)) {
+    tally.suppressed++;
+    return;
+  }
+  const tier = classifyPositionTier(match.lines, match.lineIndex);
+  if (tier === 'behavioral-claim') tally.tier1++;
+  else if (tier === 'structural-mention') tally.tier2++;
+}
+
+/**
+ * Census/debugging helper (not used by any pass): classifies every RAW word-boundary reference to
+ * a removed/renamed/deleted referand in the untouched doc/config corpus — uncapped by
+ * `MAX_REFS_PER_REFERAND` or `MAX_CANDIDATES` — into tier-1 / tier-2 / suppressed / (neither tier).
+ * Exists so the zero-LLM docs-drift census can show how far the tiering discipline collapses the
+ * raw reference count down to the selective candidate rate. `total` is the same count
+ * `computeDocsDriftCandidates` would sweep before its own per-referand cap and position filtering.
+ */
+export function classifyRawDocReferences(context: ReviewContext): RawDocReferenceTally {
+  const tally: RawDocReferenceTally = { total: 0, tier1: 0, tier2: 0, suppressed: 0 };
+  const setup = setupSweep(context);
+  if (!setup) return tally;
+
+  const deadline = Date.now() + DOCS_DRIFT_TIME_BUDGET_MS;
+  for (const referand of setup.referands) {
+    if (Date.now() > deadline) break;
+    const matches = sweepReferand(referand, setup.docChunks, deadline, Infinity);
+    for (const match of matches) tallyRawMatch(match, tally);
+  }
+
+  return tally;
+}

--- a/packages/review/src/docs-drift-signals.ts
+++ b/packages/review/src/docs-drift-signals.ts
@@ -284,8 +284,24 @@ function escapeForRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function wordBoundaryRe(token: string): RegExp {
-  return new RegExp(`\\b${escapeForRegex(token)}\\b`);
+/**
+ * The characters that would extend a matched token into a DIFFERENT, longer identifier or path
+ * segment — used as a negative lookaround so a referand match doesn't spuriously fire inside a
+ * larger token it's merely a substring of (e.g. `packages/runner` inside `packages/runner-hosted`
+ * or `sub-packages/runner`; `fetchUser` inside `my-fetchUser` or `fetchUser.old`). Plain `\b` alone
+ * is insufficient: `-` and `.` are non-word characters, so `\b` treats them as legitimate
+ * boundaries even though this codebase's identifier/path conventions use them to continue the same
+ * token. `/` is deliberately NOT in this set — a leading/trailing `/` is a legitimate path
+ * continuation (`packages/runner/README.md` still names the same now-deleted directory), and this
+ * repo's own paths are `/`-delimited. (Adversarial review finding — packages/review/src/... #427.)
+ */
+const CONTINUATION_CHARS = '[A-Za-z0-9_.-]';
+
+/** A word/path-boundary regex for `token` — see `CONTINUATION_CHARS` for why this is stricter than
+ *  plain `\b`. Pass `flags: 'g'` for a reusable global-match regex (`matchAll`). */
+function wordBoundaryRe(token: string, flags = ''): RegExp {
+  const escaped = escapeForRegex(token);
+  return new RegExp(`(?<!${CONTINUATION_CHARS})${escaped}(?!${CONTINUATION_CHARS})`, flags);
 }
 
 /** Cheap pre-check before the per-line regex: does `chunk`'s raw content contain the referand's
@@ -376,7 +392,7 @@ function referandOnlyInsideLinkOrUrl(referand: Referand, line: string): boolean 
   const spans = linkOrUrlSpans(line);
   if (spans.length === 0) return false;
 
-  const re = new RegExp(`\\b${escapeForRegex(referand.token)}\\b`, 'g');
+  const re = wordBoundaryRe(referand.token, 'g');
   const positions = [...line.matchAll(re)]
     .map(m => m.index)
     .filter((i): i is number => i !== undefined);

--- a/packages/review/src/docs-drift-signals.ts
+++ b/packages/review/src/docs-drift-signals.ts
@@ -24,13 +24,31 @@
  * add and modify but don't remove public surface; (2) each surviving reference is tiered by WHERE
  * in the doc it sits (a falsifiable behavioral claim, or a structural heading/bullet naming a now-
  * gone symbol/path) and, when in doubt, SUPPRESSED (fenced code samples, changelog/changeset
- * entries, link targets, and past-tense/historical prose are never candidates — that is the
- * single biggest false-positive class for this shape of signal).
+ * entries, a referand that sits ONLY inside a link/URL span, and past-tense/historical prose are
+ * never candidates — that is the single biggest false-positive class for this shape of signal).
+ * The link/URL suppression is deliberately NARROW — it fires only when the referand's own
+ * occurrence sits inside the link markup, not merely because the line contains a link ANYWHERE
+ * (this repo's dominant doc idiom cites an ADR link — `(see [ADR-012](docs/.../0012-...md))` —
+ * right next to a genuine structural bullet; a blanket "line has a link" suppression silently ate
+ * real deletion-drift candidates until this was narrowed).
  *
- * This module only computes candidates; it injects no `<...>` prompt block and has no pass wired
- * to it yet (see the docs-drift design doc, `.wip/docs-drift-design.md`, §3-6) — that is later
- * work. `classifyRawDocReferences` exists purely so the zero-LLM census (design doc §4) can show
- * how much this tiering collapses the raw ~100%-of-PRs signal down to a selective candidate rate.
+ * Referand tokens are deliberately the FULL path/identifier only — no generic shorter alternate
+ * spelling is swept (a prior "trailing path segment" alt-token for deleted directories, e.g.
+ * `packages/runner` -> `runner`, was tried and removed: a bare segment is often a common English
+ * word — this repo's own packages include `core`/`cli`/`site`/`action`/`runner` — and produced
+ * false candidates on unrelated ambient prose, e.g. a CI workflow comment about the GitHub Actions
+ * "hosted runner" machine). Residual known limit, not fixed here: a bare TOP-LEVEL-directory
+ * referand (e.g. `platform`) is itself already a single common word, so it carries the same
+ * generic-word false-positive risk the removed alt-token had — a future distinctiveness/stopword
+ * filter (minimum length, excluding common English words, requiring a directory-listing context)
+ * is the natural fast-follow; precision-first v1 accepts this narrow residual risk rather than
+ * building that filter now.
+ *
+ * This module only computes candidates; the dedicated pass that judges them
+ * (`plugins/agent/docs-drift-pass.ts`, dark by default) lives separately (see the docs-drift
+ * design doc, `.wip/docs-drift-design.md`, §2-3). `classifyRawDocReferences` exists purely so the
+ * zero-LLM census (design doc §4) can show how much this tiering collapses the raw ~100%-of-PRs
+ * signal down to a selective candidate rate.
  */
 
 import type { CodeChunk } from '@liendev/parser';
@@ -73,13 +91,12 @@ export interface DocsDriftCandidate {
   excerpt: string;
 }
 
-/** One referand to sweep the untouched-doc corpus for. `altToken` is a shorter alternate spelling
- *  (currently only a deleted directory's trailing segment, e.g. `packages/runner` -> `runner`)
- *  that a doc might use instead of the full token. */
+/** One referand to sweep the untouched-doc corpus for — the FULL path/identifier only, no shorter
+ *  alternate spelling (see module header for why a generic trailing-segment alt-token was tried
+ *  and removed). */
 interface Referand {
   token: string;
   kind: ReferandKind;
-  altToken?: string;
 }
 
 /** One raw word-boundary match of a referand inside an untouched doc/config chunk. */
@@ -100,16 +117,17 @@ const MAX_REFS_PER_REFERAND = 5;
 /** Wall-clock backstop for the untouched-doc sweep, mirroring stale-literal-signals.ts's own
  *  budget — this runs unconditionally on every PR, before any LLM call. */
 const DOCS_DRIFT_TIME_BUDGET_MS = 5_000;
-/** Shortest deleted-path trailing segment worth treating as an alternate search token. */
-const MIN_TRAILING_SEGMENT_CHARS = 4;
 /** Cap on a rendered excerpt window. */
 const MAX_EXCERPT_CHARS = 400;
 
 const DOC_CHUNK_TYPES = new Set(['doc', 'config']);
 /** A changelog or changeset entry — a correct historical record, never a drift candidate. */
 const CHANGELOG_OR_CHANGESET_RE = /(?:^|\/)CHANGELOG[^/]*(?:\.md)?$|(?:^|\/)\.changeset\//i;
-/** A markdown link target or bare URL on the line — link targets, not prose claims. */
-const LINK_OR_URL_RE = /\]\(|https?:\/\//;
+/** A markdown link's full `[display](target)` markup — used to find link SPANS (see
+ *  `linkOrUrlSpans`), not to blanket-suppress a whole line merely for containing one. */
+const MARKDOWN_LINK_RE = /\[[^\]]*\]\([^)]*\)/g;
+/** A bare `http(s)://` URL — same span-based use as `MARKDOWN_LINK_RE`. */
+const BARE_URL_RE = /https?:\/\/\S+/g;
 /** Past-tense / historical / retirement note — the primary false-positive class (module header). */
 const HISTORICAL_GUARD_RE =
   /\b(?:was|were)\s+(?:removed|renamed|deleted|retired|dropped)\b|\b(?:retired|formerly|deprecated|previously|prior to|no longer|used to)\b/i;
@@ -186,18 +204,12 @@ function directoryIsGone(dir: string, repoChunks: CodeChunk[] | undefined): bool
   return !repoChunks.some(c => c.metadata.file.startsWith(prefix));
 }
 
-/** The referand's shorter alternate token — its last path segment — when distinctive enough and
- *  different from the referand itself (e.g. `packages/runner` -> `runner`). */
-function trailingSegment(path: string): string | undefined {
-  const seg = path.split('/').filter(Boolean).pop();
-  return seg && seg !== path && seg.length >= MIN_TRAILING_SEGMENT_CHARS ? seg : undefined;
-}
-
 /**
  * Deleted-path referands: every fully-deleted file, grouped up to its containing package/top-level
  * directory when that whole directory is confirmed gone (see `directoryIsGone`) — the shape a
  * removed CLAUDE.md structure bullet describes (a directory, not one of its files) — else left as
- * the individual file's own path. Deduped. Exposed for testing.
+ * the individual file's own path. Deduped. Full path only — no trailing-segment alt-token (see
+ * module header). Exposed for testing.
  */
 export function extractDeletedPaths(
   patches: Map<string, string>,
@@ -214,10 +226,7 @@ export function extractDeletedPaths(
     paths.add(dir && directoryIsGone(dir, repoChunks) ? dir : file);
   }
 
-  return [...paths].map(path => {
-    const alt = trailingSegment(path);
-    return { token: path, kind: 'deleted-path' as const, ...(alt && { altToken: alt }) };
-  });
+  return [...paths].map(path => ({ token: path, kind: 'deleted-path' as const }));
 }
 
 // ---------------------------------------------------------------------------
@@ -280,37 +289,32 @@ function wordBoundaryRe(token: string): RegExp {
 }
 
 /** Cheap pre-check before the per-line regex: does `chunk`'s raw content contain the referand's
- *  token or alternate token at all? (fast reject, mirrors `removed-export-signals.ts`'s own). */
+ *  token at all? (fast reject, mirrors `removed-export-signals.ts`'s own). */
 function chunkMayContainReferand(chunk: CodeChunk, referand: Referand): boolean {
-  if (chunk.content.includes(referand.token)) return true;
-  return !!referand.altToken && chunk.content.includes(referand.altToken);
+  return chunk.content.includes(referand.token);
 }
 
-/** Collect word-boundary matches of `referand` within one already-fast-rejected chunk into
- *  `sites`, stopping once the shared `cap` is reached. Split out of `sweepReferand` to keep that
- *  function's own branching shallow. */
+/** Collect word-boundary matches of `re` within one already-fast-rejected chunk into `sites`,
+ *  stopping once the shared `cap` is reached. Split out of `sweepReferand` to keep that function's
+ *  own branching shallow. */
 function collectMatchesInChunk(
   chunk: CodeChunk,
-  referand: Referand,
   re: RegExp,
-  altRe: RegExp | null,
   cap: number,
   sites: MatchSite[],
 ): void {
   const lines = chunk.content.split('\n');
   for (let i = 0; i < lines.length && sites.length < cap; i++) {
-    if (re.test(lines[i]) || (altRe && altRe.test(lines[i]))) {
-      sites.push({ chunk, lines, lineIndex: i });
-    }
+    if (re.test(lines[i])) sites.push({ chunk, lines, lineIndex: i });
   }
 }
 
 /**
- * Sweep `chunks` for word-boundary occurrences of `referand` (its primary token, or its alternate
- * token when present), fast-rejecting each chunk via a plain `includes` check before the per-line
- * regex (mirrors `removed-export-signals.ts`'s `collectRefsFromChunk`). Stops early once `cap`
- * sites are found or the shared `deadline` passes. Pass `cap: Infinity` for an uncapped count (used
- * only by the census helper, `classifyRawDocReferences`).
+ * Sweep `chunks` for word-boundary occurrences of `referand`'s full token, fast-rejecting each
+ * chunk via a plain `includes` check before the per-line regex (mirrors
+ * `removed-export-signals.ts`'s `collectRefsFromChunk`). Stops early once `cap` sites are found or
+ * the shared `deadline` passes. Pass `cap: Infinity` for an uncapped count (used only by the census
+ * helper, `classifyRawDocReferences`).
  */
 function sweepReferand(
   referand: Referand,
@@ -320,12 +324,11 @@ function sweepReferand(
 ): MatchSite[] {
   const sites: MatchSite[] = [];
   const re = wordBoundaryRe(referand.token);
-  const altRe = referand.altToken ? wordBoundaryRe(referand.altToken) : null;
 
   for (const chunk of chunks) {
     if (sites.length >= cap || Date.now() > deadline) break;
     if (!chunkMayContainReferand(chunk, referand)) continue;
-    collectMatchesInChunk(chunk, referand, re, altRe, cap, sites);
+    collectMatchesInChunk(chunk, re, cap, sites);
   }
 
   return sites;
@@ -345,16 +348,59 @@ function isInsideFence(lines: string[], lineIndex: number): boolean {
   return inFence;
 }
 
+/** Character spans on `line` that are link/URL markup, not literal prose: a markdown link's full
+ *  `[display](target)` markup, or a bare `http(s)://` URL. Used to narrow the link/URL suppression
+ *  to "the referand's own occurrence sits inside one of these", not "the line merely contains a
+ *  link ANYWHERE" — see module header for the bug this fixes (an ADR-citing structural bullet was
+ *  blanket-suppressed even though the referand itself sat in plain prose, not the link). */
+function linkOrUrlSpans(line: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  for (const m of line.matchAll(MARKDOWN_LINK_RE)) {
+    if (m.index !== undefined) spans.push([m.index, m.index + m[0].length]);
+  }
+  for (const m of line.matchAll(BARE_URL_RE)) {
+    if (m.index !== undefined) spans.push([m.index, m.index + m[0].length]);
+  }
+  return spans;
+}
+
+/**
+ * True iff EVERY word-boundary occurrence of `referand.token` on `line` falls inside a link/URL
+ * span (see `linkOrUrlSpans`) — the narrow "the referand only appears as a link target" case (e.g.
+ * `[helper](./packages/oldFunc/README.md)`, where `oldFunc` names the file the link points AT).
+ * False when the referand also appears in plain prose on the same line, even alongside an
+ * unrelated link/ADR citation elsewhere on that line — that occurrence is a real claim, not a link
+ * artifact, and must not be suppressed just because a link happens to share the line.
+ */
+function referandOnlyInsideLinkOrUrl(referand: Referand, line: string): boolean {
+  const spans = linkOrUrlSpans(line);
+  if (spans.length === 0) return false;
+
+  const re = new RegExp(`\\b${escapeForRegex(referand.token)}\\b`, 'g');
+  const positions = [...line.matchAll(re)]
+    .map(m => m.index)
+    .filter((i): i is number => i !== undefined);
+  if (positions.length === 0) return false;
+
+  return positions.every(pos => spans.some(([start, end]) => pos >= start && pos < end));
+}
+
 /**
  * When in doubt, suppress (module header): a changelog/changeset entry, a fenced code sample, a
- * link/URL line, or a past-tense/historical note are never candidates — the primary false-positive
- * class for this signal shape.
+ * referand that sits ONLY inside a link/URL span, or a past-tense/historical note are never
+ * candidates — the primary false-positive class for this signal shape.
  */
-function isSuppressed(file: string, lines: string[], lineIndex: number): boolean {
+function isSuppressed(
+  referand: Referand,
+  file: string,
+  lines: string[],
+  lineIndex: number,
+): boolean {
   if (CHANGELOG_OR_CHANGESET_RE.test(file)) return true;
   if (isInsideFence(lines, lineIndex)) return true;
   const line = lines[lineIndex];
-  return LINK_OR_URL_RE.test(line) || HISTORICAL_GUARD_RE.test(line);
+  if (HISTORICAL_GUARD_RE.test(line)) return true;
+  return referandOnlyInsideLinkOrUrl(referand, line);
 }
 
 /** Does the reference line, or a line in its evidence window, read as a falsifiable behavioral
@@ -390,7 +436,7 @@ function buildExcerpt(lines: string[], lineIndex: number): string {
 
 function buildCandidate(referand: Referand, match: MatchSite): DocsDriftCandidate | null {
   const { chunk, lines, lineIndex } = match;
-  if (isSuppressed(chunk.metadata.file, lines, lineIndex)) return null;
+  if (isSuppressed(referand, chunk.metadata.file, lines, lineIndex)) return null;
   const tier = classifyPositionTier(lines, lineIndex);
   if (!tier) return null;
 
@@ -477,9 +523,9 @@ export interface RawDocReferenceTally {
 
 /** Tally one raw match into `tally` (suppressed, tier-1, tier-2, or neither). Split out of
  *  `classifyRawDocReferences` to keep that function's own nesting shallow. */
-function tallyRawMatch(match: MatchSite, tally: RawDocReferenceTally): void {
+function tallyRawMatch(referand: Referand, match: MatchSite, tally: RawDocReferenceTally): void {
   tally.total++;
-  if (isSuppressed(match.chunk.metadata.file, match.lines, match.lineIndex)) {
+  if (isSuppressed(referand, match.chunk.metadata.file, match.lines, match.lineIndex)) {
     tally.suppressed++;
     return;
   }
@@ -505,7 +551,7 @@ export function classifyRawDocReferences(context: ReviewContext): RawDocReferenc
   for (const referand of setup.referands) {
     if (Date.now() > deadline) break;
     const matches = sweepReferand(referand, setup.docChunks, deadline, Infinity);
-    for (const match of matches) tallyRawMatch(match, tally);
+    for (const match of matches) tallyRawMatch(referand, match, tally);
   }
 
   return tally;

--- a/packages/review/src/plugins/agent/docs-drift-pass.ts
+++ b/packages/review/src/plugins/agent/docs-drift-pass.ts
@@ -1,0 +1,685 @@
+/**
+ * Dedicated docs-drift candidate-loop pass (per-rule-loops design doc §2/§3,
+ * `.wip/docs-drift-design.md`). The fifth candidate loop, structurally
+ * mirroring the fourth (`removed-exports-pass.ts`) — same six-piece
+ * `ReviewPassSpec` shape, same per-candidate-ID-required verdict contract.
+ *
+ * ## New rule, dedicated-pass-only (no `BUILTIN_RULES` entry)
+ *
+ * Unlike every prior loop, docs-drift has NO shared-main-pass rule fragment
+ * to backstop. doc-truth already covers the TOUCHED-doc drift shape ("the
+ * diff itself just changed the described behavior and left the prose
+ * describing the OLD behavior"); docs-drift covers the inverse — an UNTOUCHED
+ * doc that silently rots after this PR removes/renames/deletes the thing it
+ * describes. Reviewing every untouched doc on every PR is exactly the
+ * output-list competition the pass architecture exists to kill (ADR-014), so
+ * this rule has no main-pass presence to strip — it ships as the pass and
+ * only the pass (design §2).
+ *
+ * ## Reuses an existing signal, builds no new one
+ *
+ * `docs-drift-signals.ts`'s `computeDocsDriftCandidates` already computes
+ * exactly the shape this loop needs: untouched doc/config lines that still
+ * word-boundary-reference a symbol this PR's diff removed
+ * (`removed-export-signals.ts`), an identifier it mechanically renamed
+ * (`rename-sweep-signals.ts`), or a file/directory it fully deleted (that
+ * module's own `isFullFileDeletion`) — already tiered (behavioral-claim vs
+ * structural-mention) and suppressed on fenced code, changelog/changeset
+ * entries, link targets, and past-tense/historical prose. This loop imports
+ * that function rather than recomputing any of it.
+ *
+ * ## Verdict vocabulary: `drifted | historical | intentional | unverifiable`
+ *
+ * - `drifted` — the untouched doc presents the removed/renamed/deleted
+ *   referand as current; a reader is misled. Converts to a finding.
+ * - `historical` — the reference is a correct past-tense / changelog /
+ *   migration / "retired" note. The primary FP class this loop's deterministic
+ *   suppression already filters HARD on, but a model call still sees prose
+ *   the deterministic guard didn't quite match — silent.
+ * - `intentional` — the referand wasn't semantically removed (only its
+ *   export dropped while the definition stays for internal use), or the doc
+ *   names a different same-named thing — silent.
+ * - `unverifiable` — investigation inconclusive (budget cut, or the doc's
+ *   subject is outside the indexed corpus) — silent.
+ * Only `drifted` becomes a finding; the other three are silent dispositions
+ * the honesty contract still requires exactly one of, per candidate.
+ *
+ * ## Toolset: read_file + grep_codebase (the removed-exports set)
+ *
+ * Both sides of a candidate are already inline (the doc excerpt + position
+ * tier, and — when re-derivable from the diff — the removal/rename/deletion
+ * hunk), so judging a candidate is a COMPARISON, not an investigation:
+ * `read_file` confirms the doc line isn't inside a historical section the
+ * excerpt's short window clipped; `grep_codebase` confirms the referand is
+ * truly gone repo-wide, not re-added under an alias the diff-only scan
+ * missed. No broader toolset is needed.
+ *
+ * ## Dedupe: own-ruleId collision, PLUS a doc-truth cross-dedup
+ *
+ * docs-drift has no symbol/export identity the way removed-exports does (a
+ * doc line, not a code declaration), so this loop's own-collision check is
+ * location-only (mirrors the pilot/second-loop's proximity dedupe, minus the
+ * identity match). It ALSO drops a candidate finding that collides in
+ * location with an EXISTING `doc-truth`-ruleId finding — doc-truth wins,
+ * since it saw the touched hunk directly (design §2's "both-fire case":
+ * docs-drift's own untouched-file filter already makes the two disjoint on
+ * the doc-FILE axis by construction; this is only a belt-and-suspenders
+ * backstop for a location collision that construction alone didn't catch).
+ */
+
+import type { ReviewContext } from '../../plugin-types.js';
+
+import type { AgentConfig, AgentFinding, AgentResult } from './types.js';
+import {
+  computeDocsDriftCandidates,
+  isFullFileDeletion,
+  type DocsDriftCandidate,
+} from '../../docs-drift-signals.js';
+import {
+  renderPassPrHeader,
+  EXTRA_PASS_MIN_BUDGET_TOKENS,
+  OBSERVED_TOKENS_PER_TURN,
+  affordableCandidateCeiling,
+  capCandidatesToCeiling,
+  deferredCandidateLabels,
+  renderDeferralNote,
+  type ReviewPassSpec,
+} from './review-pass.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Turn cap for the candidate-loop pass — same as removed-exports (a confirm-historical read may
+ *  be needed, per design §3). */
+export const DOCS_DRIFT_PASS_MAX_TURNS = 8;
+
+const DOCS_DRIFT_BASE_OVERHEAD_TOKENS = 2_000;
+const DOCS_DRIFT_PER_CANDIDATE_TOKENS = 800;
+const DOCS_DRIFT_MAX_BUDGET = 30_000;
+/** Mirrors `docs-drift-signals.ts`'s own `MAX_CANDIDATES` — `computeDocsDriftCandidates` is
+ *  already capped there, so this is only used for this pass's own budget-scaling formula, not a
+ *  re-slice (see `computeDocsDriftPassCandidates`). */
+const MAX_CANDIDATES = 15;
+
+/** Opt-IN env flag — this loop ships dark by default, same as its siblings. */
+const DOCS_DRIFT_PASS_ENV = 'LIEN_DOCS_DRIFT_PASS';
+
+export const DOCS_DRIFT_RULE_ID = 'docs-drift';
+
+/** Plugin name this pass reports itself under in the delivery attestation. */
+const DOCS_DRIFT_SKIP_PLUGIN = 'agent-review:docs-drift-loop';
+
+/** Two findings on the same file within this many lines are the same location. */
+const DEDUPE_LINE_PROXIMITY = 2;
+
+/** The doc-truth loop's own ruleId (see `doc-truth-pass.ts` — not exported as a constant there,
+ *  so this is the same literal that module's own merge forces onto its findings). doc-truth wins
+ *  a same-location collision, since it saw the touched hunk directly (module doc's "Dedupe"). */
+const DOC_TRUTH_RULE_ID = 'doc-truth';
+
+const DOCS_DRIFT_INTRO =
+  'This is a DOCS-DRIFT candidate loop — a dedicated pass scoped to untouched documentation ' +
+  'that still references code this PR REMOVED, RENAMED, or DELETED, running only because a ' +
+  'deterministic corpus sweep already found at least one such surviving reference. Your ONLY ' +
+  'job is to judge the <docs_drift> worklist below; do not report anything else (a doc this PR ' +
+  "itself TOUCHED is doc-truth's job, and any other bug is out of scope for this pass).";
+
+const DOCS_DRIFT_TOOLS_SECTION = `<tools>
+You have these tools to investigate the codebase:
+- read_file: Read file contents from the repo — use to check a candidate's doc line isn't part of a historical/changelog section the excerpt's short window clipped (e.g. a "## Migration notes" heading just above it).
+- grep_codebase: Search the entire repository working tree for a text pattern (regex) — use ONLY to confirm a referand is genuinely gone repo-wide, not re-added under a different name/alias the diff-only scan couldn't see. Do NOT re-grep the candidates already listed below; that discovery is already done.
+</tools>`;
+
+/**
+ * Guards against the two FP classes design §3 names explicitly. Baked in from day one, per the
+ * removed-exports/incomplete-handling precedent of baking the FP guard in rather than discovering
+ * it post-hoc.
+ */
+const VERDICT_GUIDANCE = `<verdict_guidance>
+Two classes of surviving doc reference are usually NOT real drift — do not verdict a candidate
+"drifted" on these alone:
+1. A reference in a changelog, migration guide, or past-tense "was removed/retired/formerly" note.
+   That doc is CORRECTLY describing history, not claiming the referand is current — verdict
+   "historical". (The deterministic scan already suppresses most of these before they ever reach
+   you; a candidate here means the suppression regex didn't quite match this prose's phrasing —
+   look for the same historical shape by eye.)
+2. A referand whose DEFINITION survives (only its export was dropped while the declaration stays
+   for internal use, or the doc names a different same-named thing) — verdict "intentional": the
+   referand isn't semantically gone, only its removed/renamed/deleted SHAPE looked that way to the
+   deterministic scan.
+A "drifted" verdict REQUIRES BOTH: the referand is genuinely gone (use grep_codebase if in doubt)
+AND the doc presents it as current, not past.
+</verdict_guidance>`;
+
+const DOCS_DRIFT_STRATEGY = `### Docs Drift — untouched-doc blast radius
+For each candidate in the <docs_drift> worklist below:
+1. Compare the DOC side (the untouched excerpt + its position tier — a falsifiable behavioral
+   claim, or a structural heading/bullet) against the CODE side (the removal/rename/deletion hunk,
+   shown when re-derivable from the diff) — the doc line was accurate when the referand was still
+   current; your job is to judge whether it still reads that way now that it's gone.
+2. Use read_file on the doc file when the excerpt alone doesn't settle whether the surrounding
+   section is historical (see <verdict_guidance>).
+3. Use grep_codebase only to confirm the referand is truly gone repo-wide when in doubt — not to
+   re-discover candidates already listed.
+4. Verdict "drifted" ONLY if the doc presents the referand as CURRENT.`;
+
+/** A docs-drift-shaped example — illustrates the four-value vocabulary's two silent classes
+ *  alongside the one that converts to a finding. */
+const DOCS_DRIFT_EXAMPLE = `### Good finding — untouched doc presents a removed symbol as current:
+{
+  "filepath": "docs/architecture/api.md",
+  "line": 40,
+  "severity": "warning",
+  "category": "docs_drift",
+  "ruleId": "docs-drift",
+  "message": "docs/architecture/api.md:40 still describes fetchUser as the way to load a user, but fetchUser was removed from src/api.ts by this PR. A reader following this doc will call a function that no longer exists.",
+  "suggestion": "Update or remove this doc's reference to fetchUser.",
+  "evidence": "docs_drift candidate; fetchUser removed in src/api.ts, no re-export found repo-wide"
+}
+
+### Good finding — verdict is NOT drifted, the doc is a correct historical note:
+A candidate whose doc line reads "fetchUser was removed in v2 in favor of getUser" should verdict
+"historical" — do not report it as a finding, even though the removed symbol is named.`;
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+function envEnabled(value: string | undefined): boolean {
+  const v = value?.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'on';
+}
+
+/** Whether the loop is opted in — config takes precedence, then the env flag. */
+export function isDocsDriftPassEnabled(config?: AgentConfig): boolean {
+  if (config?.docsDriftPass === true) return true;
+  return envEnabled(process.env[DOCS_DRIFT_PASS_ENV]);
+}
+
+/**
+ * Precisely why the docs-drift loop would not run right now, or null if it should run. Mirrors
+ * `removedExportsSkipReason` — signal-only gating (design §1e): the trigger is "a tiered candidate
+ * exists", not a keyword/filePattern.
+ */
+export function docsDriftSkipReason(context: ReviewContext, config?: AgentConfig): string | null {
+  if (!isDocsDriftPassEnabled(config)) {
+    return `disabled (opt-in; set config.docsDriftPass or ${DOCS_DRIFT_PASS_ENV}=on to enable)`;
+  }
+  if (computeDocsDriftCandidates(context).length === 0) {
+    return 'no untouched-doc reference to a removed/renamed/deleted referand in this PR';
+  }
+  return null;
+}
+
+/** Whether to run the docs-drift loop. True iff `docsDriftSkipReason` is null. */
+export function shouldRunDocsDriftPass(context: ReviewContext, config?: AgentConfig): boolean {
+  return docsDriftSkipReason(context, config) === null;
+}
+
+// ---------------------------------------------------------------------------
+// Candidate worklist (already capped by the shared signal)
+// ---------------------------------------------------------------------------
+
+/**
+ * The docs-drift candidate list this loop judges — `computeDocsDriftCandidates` already sorts
+ * (Tier-1 first, then referand, then doc file:line) and caps at 15, so this is a direct pass-
+ * through. Exposed for testing.
+ */
+export function computeDocsDriftPassCandidates(context: ReviewContext): DocsDriftCandidate[] {
+  return computeDocsDriftCandidates(context);
+}
+
+function candidateIds(candidates: DocsDriftCandidate[]): string[] {
+  return candidates.map((_, i) => `candidate-${i + 1}`);
+}
+
+// ---------------------------------------------------------------------------
+// Candidate-overflow handling (rank-and-cap with attested deferral)
+// ---------------------------------------------------------------------------
+
+/** Best-effort short label for a candidate — for the delivery attestation's `deferredCandidateIds`,
+ *  not the pass's own `candidate-N` worklist ids. */
+function docsDriftLabel(c: DocsDriftCandidate): string {
+  return c.referand;
+}
+
+/** This run's actual worklist after rank-and-cap. Each candidate needs at least a confirm-
+ *  historical read to judge (module doc: comparison, not open investigation), but a doc/code side
+ *  is already inline — still realistically a tool round-trip when in doubt, so this uses
+ *  `OBSERVED_TOKENS_PER_TURN` like removed-exports, not this pass's own prompt-sizing constant.
+ *  `budget` defaults to unlimited so every existing call site that doesn't pass one is byte-
+ *  identical to before this feature existed. Exposed for testing. */
+export function computeDocsDriftWorklist(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): { candidates: DocsDriftCandidate[]; deferredCount: number; deferredIds: string[] } {
+  const all = computeDocsDriftPassCandidates(context);
+  const ceiling = affordableCandidateCeiling(budget, OBSERVED_TOKENS_PER_TURN);
+  const { kept, deferred } = capCandidatesToCeiling(all, ceiling);
+  return {
+    candidates: kept,
+    deferredCount: deferred.length,
+    deferredIds: deferredCandidateLabels(deferred, docsDriftLabel),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Code-side hunk re-derivation
+// ---------------------------------------------------------------------------
+
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(?:\d+)(?:,\d+)? @@/;
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function wordBoundaryRe(token: string): RegExp {
+  return new RegExp(`\\b${escapeForRegex(token)}\\b`);
+}
+
+/** Split a unified-diff patch into its individual hunks (header + body, verbatim). */
+function splitPatchHunks(patch: string): string[] {
+  const hunks: string[] = [];
+  let current: string[] = [];
+  for (const raw of patch.split('\n')) {
+    if (HUNK_HEADER_RE.test(raw)) {
+      if (current.length > 0) hunks.push(current.join('\n'));
+      current = [raw];
+    } else if (current.length > 0) {
+      current.push(raw);
+    }
+  }
+  if (current.length > 0) hunks.push(current.join('\n'));
+  return hunks;
+}
+
+/** True iff `hunk`'s REMOVED (`-`) lines mention `token` (word-boundary). */
+function hunkRemovesToken(hunk: string, re: RegExp): boolean {
+  return hunk.split('\n').some(line => line.startsWith('-') && re.test(line));
+}
+
+/** Find the hunk (within one patch) whose REMOVED lines mention `token` — mirrors
+ *  `removed-exports-pass.ts`'s `findRemovalHunk`, generalized to any token (a removed-export
+ *  symbol or a renamed identifier's old name). */
+function findTokenRemovalHunk(patch: string, token: string): string | undefined {
+  const re = wordBoundaryRe(token);
+  return splitPatchHunks(patch).find(hunk => hunkRemovesToken(hunk, re));
+}
+
+/** The code-side evidence for a candidate: which file, and which hunk/patch text. */
+interface ReferandHunk {
+  file: string;
+  hunk: string;
+}
+
+/** A deleted-path candidate's own deletion patch — the first patch that IS a full-file deletion
+ *  whose file matches (or nests under) the referand path. */
+function findDeletedPathHunk(
+  patches: Map<string, string>,
+  referand: string,
+): ReferandHunk | undefined {
+  const entry = [...patches].find(
+    ([file, patch]) =>
+      isFullFileDeletion(patch) && (file === referand || file.startsWith(`${referand}/`)),
+  );
+  return entry ? { file: entry[0], hunk: entry[1] } : undefined;
+}
+
+/** A removed-export/renamed-identifier candidate's removal hunk — the first hunk, across every
+ *  patch, whose removed lines mention the referand token. */
+function findTokenHunkAcrossPatches(
+  patches: Map<string, string>,
+  referand: string,
+): ReferandHunk | undefined {
+  for (const [file, patch] of patches) {
+    const hunk = findTokenRemovalHunk(patch, referand);
+    if (hunk) return { file, hunk };
+  }
+  return undefined;
+}
+
+/**
+ * Locate the code-side hunk that proves a candidate's referand is gone — re-derived from the PR's
+ * patches (`DocsDriftCandidate` deliberately doesn't carry this; see that type's own doc comment).
+ * Returns undefined when no matching hunk is found (an exotic shape the deterministic re-derivation
+ * can't recover — the candidate is still judged on its doc-side excerpt alone).
+ */
+function findReferandHunk(
+  patches: Map<string, string> | undefined,
+  candidate: DocsDriftCandidate,
+): ReferandHunk | undefined {
+  if (!patches) return undefined;
+  return candidate.referandKind === 'deleted-path'
+    ? findDeletedPathHunk(patches, candidate.referand)
+    : findTokenHunkAcrossPatches(patches, candidate.referand);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+/** Render one candidate's evidence block: doc-side excerpt + tier, code-side removal hunk. */
+function renderCandidate(
+  id: string,
+  c: DocsDriftCandidate,
+  patches: Map<string, string> | undefined,
+): string {
+  const lines: string[] = [`<candidate id="${id}" referand=${JSON.stringify(c.referand)}>`];
+  lines.push(`Kind: ${c.referandKind}`);
+  lines.push(`Untouched doc: ${c.docFile}:${c.docLine} (${c.positionTier})`);
+  lines.push('```');
+  lines.push(c.excerpt.replace(/```/g, "'''")); // defang so a doc excerpt can't break this fence
+  lines.push('```');
+
+  const ref = findReferandHunk(patches, c);
+  if (ref) {
+    lines.push(`Code side — ${ref.file}:`);
+    lines.push('```diff');
+    lines.push(ref.hunk);
+    lines.push('```');
+  }
+  lines.push('</candidate>');
+  return lines.join('\n');
+}
+
+/** Build the `<docs_drift>` worklist. */
+function renderWorklist(context: ReviewContext, candidates: DocsDriftCandidate[]): string {
+  const patches = context.pr?.patches;
+  const ids = candidateIds(candidates);
+  const lines: string[] = ['<docs_drift>'];
+  lines.push(
+    'One verdict is REQUIRED per candidate id below (see <output_format>) — ' +
+      `${ids.join(', ')}. Each candidate is an UNTOUCHED doc/config line that still references a ` +
+      'symbol/path this PR removed, renamed, or deleted, already tiered and past every ' +
+      'suppression check.',
+  );
+  candidates.forEach((c, i) => {
+    lines.push('');
+    lines.push(renderCandidate(ids[i], c, patches));
+  });
+  lines.push('</docs_drift>');
+  return lines.join('\n');
+}
+
+/** The per-candidate-verdict output contract (see module doc for the four values). */
+function buildOutputFormat(ids: string[]): string {
+  return `<output_format>
+Output EXACTLY one entry per candidate id in the \`findings\` array — one for EVERY
+id in ${ids.join(', ')}, no more, no fewer — in a \`\`\`json code fence:
+
+{
+  "findings": [
+    {
+      "candidateId": "candidate-1",
+      "verdict": "drifted | historical | intentional | unverifiable",
+      "filepath": "docs/path/to/file.md",
+      "line": 42,
+      "severity": "error | warning",
+      "category": "docs_drift",
+      "message": "REQUIRED for every verdict. When drifted: 1-2 sentences naming the removed/renamed/deleted referand and how the doc presents it as current. When historical/intentional/unverifiable: 1 sentence saying why.",
+      "suggestion": "The fix (drifted only) — update or remove the stale reference.",
+      "evidence": "One line citing the candidate and what you inspected to confirm it."
+    }
+  ],
+  "summary": {
+    "riskLevel": "low | medium | high | critical",
+    "overview": "One sentence.",
+    "keyChanges": []
+  }
+}
+
+EVERY entry requires candidateId, verdict, filepath, line, severity, category, and
+message — even for historical/intentional/unverifiable verdicts (fill filepath from
+the candidate's docFile, line from its docLine, severity "warning", category any
+short slug e.g. "docs_drift", message explaining the disposition). A missing category
+silently drops the ENTIRE entry, same as a missing candidateId — both make this
+pass's result incomplete.
+</output_format>`;
+}
+
+function buildSystemPrompt(ids: string[]): string {
+  return `${DOCS_DRIFT_INTRO}
+
+${DOCS_DRIFT_TOOLS_SECTION}
+
+<strategy>
+${DOCS_DRIFT_STRATEGY}
+</strategy>
+
+${VERDICT_GUIDANCE}
+
+<examples>
+${DOCS_DRIFT_EXAMPLE}
+</examples>
+
+${buildOutputFormat(ids)}`;
+}
+
+/** Build the candidate-loop's initial message: PR header + worklist + a closing nudge. `budget`
+ *  drives rank-and-cap overflow handling (see `computeDocsDriftWorklist`) — defaults to unlimited
+ *  so existing callers that don't pass one are unaffected. */
+export function buildDocsDriftPassInitialMessage(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): string {
+  const { candidates, deferredCount } = computeDocsDriftWorklist(context, budget);
+  const sections: string[] = [];
+  const header = renderPassPrHeader(context);
+  if (header) sections.push(header);
+  sections.push(renderWorklist(context, candidates));
+  const deferralNote = renderDeferralNote(deferredCount);
+  if (deferralNote) sections.push(deferralNote);
+  sections.push('Judge every candidate above and output your verdicts as JSON.');
+  return sections.join('\n\n');
+}
+
+/** The system + initial prompts for the docs-drift candidate loop. `budget` is this pass's own
+ *  final allocated budget (see `ReviewPassSpec.buildPrompts`'s doc comment) — defaults to unlimited
+ *  so existing callers unaware of overflow handling are byte-identical to before. */
+export function buildDocsDriftPassPrompts(
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): {
+  systemPrompt: string;
+  initialMessage: string;
+} {
+  const { candidates } = computeDocsDriftWorklist(context, budget);
+  const ids = candidateIds(candidates);
+  return {
+    systemPrompt: buildSystemPrompt(ids),
+    initialMessage: buildDocsDriftPassInitialMessage(context, budget),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+/**
+ * Budget scaled by this pass's own candidate count, clamped floor/ceiling — mirrors
+ * `removedExportsPassBudget`'s formula shape. Floor is `EXTRA_PASS_MIN_BUDGET_TOKENS` (shared
+ * across every extra pass): a 1-2 candidate run (the common real-PR case, per the census) gets the
+ * same one-real-round-trip floor every other pass gets.
+ */
+export function docsDriftPassBudget(_baseBudget: number, context: ReviewContext): number {
+  const candidateCount = computeDocsDriftPassCandidates(context).length;
+  const scaled =
+    DOCS_DRIFT_BASE_OVERHEAD_TOKENS +
+    DOCS_DRIFT_PER_CANDIDATE_TOKENS * Math.min(candidateCount, MAX_CANDIDATES);
+  return Math.min(Math.max(scaled, EXTRA_PASS_MIN_BUDGET_TOKENS), DOCS_DRIFT_MAX_BUDGET);
+}
+
+// ---------------------------------------------------------------------------
+// Post-processing (verdict reduction + honest completeness)
+// ---------------------------------------------------------------------------
+
+/** A verdict value the loop's output contract recognizes. */
+type Verdict = 'drifted' | 'historical' | 'intentional' | 'unverifiable';
+const VALID_VERDICTS: ReadonlySet<string> = new Set<Verdict>([
+  'drifted',
+  'historical',
+  'intentional',
+  'unverifiable',
+]);
+
+/** The raw per-candidate shape the model emits inside the standard `findings` array. */
+interface RawVerdictFinding extends AgentFinding {
+  candidateId?: string;
+  verdict?: Verdict;
+}
+
+/** Strip the loop-only `candidateId`/`verdict` fields, keeping the standard finding shape. */
+function toCleanFinding(f: RawVerdictFinding): AgentFinding {
+  return {
+    filepath: f.filepath,
+    line: f.line,
+    endLine: f.endLine,
+    symbolName: f.symbolName,
+    severity: f.severity,
+    category: f.category,
+    message: f.message,
+    suggestion: f.suggestion,
+    evidence: f.evidence,
+  };
+}
+
+/**
+ * True iff every expected candidate id appears in `raw` EXACTLY once, each with a RECOGNIZED
+ * verdict — and `raw` contains no entry with a missing/unknown candidateId or an unrecognized
+ * verdict. Same contract as the sibling loops' `hasCompleteVerdictCoverage`.
+ */
+function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): boolean {
+  const expected = new Set(ids);
+  const verdictCounts = new Map<string, number>();
+  for (const { candidateId, verdict } of raw) {
+    if (
+      typeof candidateId !== 'string' ||
+      !expected.has(candidateId) ||
+      typeof verdict !== 'string' ||
+      !VALID_VERDICTS.has(verdict)
+    ) {
+      return false;
+    }
+    verdictCounts.set(candidateId, (verdictCounts.get(candidateId) ?? 0) + 1);
+  }
+  return ids.every(id => verdictCounts.get(id) === 1);
+}
+
+/**
+ * Reduce this pass's raw per-candidate verdict array down to real findings (`verdict ===
+ * 'drifted'` AND `candidateId` names a real worklist entry only, cleaned of the loop-only fields),
+ * and mark the result honestly incomplete when the verdict array doesn't cleanly cover the
+ * worklist — same honesty contract as every sibling loop. The candidateId check guards against the
+ * hallucinated-id loophole a code reviewer caught in PR #804: a phantom candidate id must not leak
+ * through as a real finding just because it carries `verdict: 'drifted'`.
+ *
+ * Coverage is checked against the RANK-AND-CAPPED worklist (from `computeDocsDriftWorklist(context,
+ * budget)`), not the full pre-cap candidate set — a deferred candidate was never listed, so it is
+ * correctly exempt from the honesty contract. `budget` must be the SAME value
+ * `buildDocsDriftPassPrompts` used — `review-pass.ts`'s `runReviewPass` guarantees this by
+ * threading one computed budget through both calls.
+ */
+export function postProcessDocsDriftResult(
+  result: AgentResult,
+  context: ReviewContext,
+  budget = Number.POSITIVE_INFINITY,
+): AgentResult {
+  const { candidates, deferredCount, deferredIds } = computeDocsDriftWorklist(context, budget);
+  const ids = candidateIds(candidates);
+  const expected = new Set(ids);
+  const raw = result.findings as RawVerdictFinding[];
+  const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
+  const wasAlreadyIncomplete = result.incomplete;
+
+  return {
+    ...result,
+    findings: raw
+      .filter(
+        f =>
+          f.verdict === 'drifted' &&
+          typeof f.candidateId === 'string' &&
+          expected.has(f.candidateId),
+      )
+      .map(toCleanFinding),
+    incomplete: wasAlreadyIncomplete || coverageIncomplete,
+    stopReason:
+      !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,
+    candidatesDeferred: deferredCount,
+    deferredCandidateIds: deferredCount > 0 ? deferredIds : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers
+// ---------------------------------------------------------------------------
+
+/** Two findings on the same file within `DEDUPE_LINE_PROXIMITY` lines are the same location. */
+function sameLocation(a: AgentFinding, b: AgentFinding): boolean {
+  return a.filepath === b.filepath && Math.abs(a.line - b.line) <= DEDUPE_LINE_PROXIMITY;
+}
+
+/** True when `finding` collides in location with an EXISTING `doc-truth`-ruleId finding in
+ *  `mainFindings` — doc-truth wins (module doc's "Dedupe": it saw the touched hunk directly). */
+function collidesWithDocTruth(finding: AgentFinding, mainFindings: AgentFinding[]): boolean {
+  return mainFindings.some(mf => mf.ruleId === DOC_TRUTH_RULE_ID && sameLocation(mf, finding));
+}
+
+/**
+ * Fold the loop's findings (already reduced to `verdict === 'drifted'` only) into the main pass's.
+ * The LOOP finding wins on a same-location collision scoped to `docs-drift`-ruleId main findings
+ * (mirrors every sibling loop) — though docs-drift has no main-pass presence to collide with in
+ * practice, this keeps the same shape for consistency and future-proofing. A candidate that
+ * collides in location with an EXISTING `doc-truth` finding is dropped instead — doc-truth wins
+ * that one (see `collidesWithDocTruth`). Returns a new array; inputs are not mutated.
+ */
+export function mergeDocsDriftFindings(
+  mainFindings: AgentFinding[],
+  loopFindings: AgentFinding[],
+): AgentFinding[] {
+  const forced = loopFindings
+    .map(f => ({ ...f, ruleId: DOCS_DRIFT_RULE_ID }))
+    .filter(f => !collidesWithDocTruth(f, mainFindings));
+  const survivingMain = mainFindings.filter(
+    mf => mf.ruleId !== DOCS_DRIFT_RULE_ID || !forced.some(lf => sameLocation(mf, lf)),
+  );
+  return [...survivingMain, ...forced];
+}
+
+/**
+ * Fold the loop's result-level state into the main pass's — only incomplete/stopReason propagate,
+ * naming this pass via the generic `incompleteFromPass` (see types.ts), same as every sibling loop.
+ */
+export function mergeDocsDriftResultState(
+  main: AgentResult,
+  passResult: AgentResult | null,
+): AgentResult {
+  if (!passResult) return main;
+  if (passResult.incomplete && !main.incomplete) {
+    main.incomplete = true;
+    main.stopReason = passResult.stopReason;
+    main.incompleteFromPass = 'docs-drift';
+  }
+  return main;
+}
+
+// ---------------------------------------------------------------------------
+// ReviewPassSpec (plugs the loop into the generalized executor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Docs-drift candidate loop bundled as a `ReviewPassSpec` (see `review-pass.ts`). Every field here
+ * is one of this module's own pure functions; the generic executor supplies the gate-check/run/
+ * failure-isolation/reporting plumbing.
+ */
+export const DOCS_DRIFT_PASS_SPEC: ReviewPassSpec = {
+  name: 'docs-drift-loop',
+  skipPlugin: DOCS_DRIFT_SKIP_PLUGIN,
+  gateReason: docsDriftSkipReason,
+  buildPrompts: buildDocsDriftPassPrompts,
+  budget: docsDriftPassBudget,
+  maxTurns: DOCS_DRIFT_PASS_MAX_TURNS,
+  mergeFindings: mergeDocsDriftFindings,
+  mergeResultState: mergeDocsDriftResultState,
+  postProcessResult: postProcessDocsDriftResult,
+};

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -34,6 +34,7 @@ import {
   applyIncompleteHandlingMainOverride,
 } from './incomplete-handling-pass.js';
 import { REMOVED_EXPORTS_PASS_SPEC } from './removed-exports-pass.js';
+import { DOCS_DRIFT_PASS_SPEC } from './docs-drift-pass.js';
 import {
   runExtraPasses,
   type ReviewPassSpec,
@@ -64,16 +65,22 @@ import {
  * (ADR-014's gating matrix — `structural-analysis` is hybrid; this covers
  * only its removed-export sweep half, never the rule's broader caller-
  * impact-of-changed-behavior job) is the fourth build — also dark by
- * default, see `removed-exports-pass.ts`. None of these four passes has a
- * data dependency on any of the others, so declaration order doesn't matter
- * for correctness (see review-pass.ts's "serial for v1" note) — doc-truth
- * stays first as the longer-proven pass.
+ * default, see `removed-exports-pass.ts`. The docs-drift candidate loop
+ * (per-rule-loops design doc §2/§3, `.wip/docs-drift-design.md`) — untouched
+ * documentation that still references code this PR removed/renamed/deleted —
+ * is the fifth build and the first with NO shared-main-pass rule fragment to
+ * backstop (dedicated-pass-only); also dark by default, see
+ * `docs-drift-pass.ts`. None of these five passes has a data dependency on
+ * any of the others, so declaration order doesn't matter for correctness
+ * (see review-pass.ts's "serial for v1" note) — doc-truth stays first as the
+ * longer-proven pass.
  */
 const EXTRA_PASSES: ReviewPassSpec[] = [
   DOC_TRUTH_PASS_SPEC,
   STALE_DUPLICATE_PASS_SPEC,
   INCOMPLETE_HANDLING_PASS_SPEC,
   REMOVED_EXPORTS_PASS_SPEC,
+  DOCS_DRIFT_PASS_SPEC,
 ];
 
 const configSchema = z.object({
@@ -133,6 +140,13 @@ const configSchema = z.object({
    * `removed-exports-pass.ts`.
    */
   removedExportsPass: z.boolean().default(false),
+  /**
+   * Run the docs-drift candidate loop (per-rule-loops design doc §2/§3) —
+   * untouched documentation that still references code this PR removed,
+   * renamed, or deleted. Default false — dark-launched opt-in; set true (or
+   * env LIEN_DOCS_DRIFT_PASS=on) to enable. See `docs-drift-pass.ts`.
+   */
+  docsDriftPass: z.boolean().default(false),
 });
 
 export interface AgentReviewPluginOptions {

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -70,10 +70,19 @@ import {
  * documentation that still references code this PR removed/renamed/deleted —
  * is the fifth build and the first with NO shared-main-pass rule fragment to
  * backstop (dedicated-pass-only); also dark by default, see
- * `docs-drift-pass.ts`. None of these five passes has a data dependency on
- * any of the others, so declaration order doesn't matter for correctness
- * (see review-pass.ts's "serial for v1" note) — doc-truth stays first as the
- * longer-proven pass.
+ * `docs-drift-pass.ts`.
+ *
+ * ORDER MATTERS for docs-drift, unlike the other four: its
+ * `mergeDocsDriftFindings` cross-dedup (`collidesWithDocTruth`) drops a
+ * docs-drift finding that collides in location with an EXISTING
+ * `doc-truth`-ruleId finding — doc-truth wins, since it saw the touched hunk
+ * directly (design §2's "both-fire case" backstop). `runExtraPasses`
+ * (`review-pass.ts`) folds each pass's findings into the running merged list
+ * SERIALLY, in array order, so `DOC_TRUTH_PASS_SPEC` must appear BEFORE
+ * `DOCS_DRIFT_PASS_SPEC` below — otherwise doc-truth's findings wouldn't be
+ * in the merged list yet when docs-drift's own merge step runs, and the
+ * cross-dedup would silently never fire. The other four passes have no such
+ * ordering dependency on each other or on docs-drift.
  */
 const EXTRA_PASSES: ReviewPassSpec[] = [
   DOC_TRUTH_PASS_SPEC,

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -79,6 +79,14 @@ export interface AgentConfig {
    * LIEN_REMOVED_EXPORTS_PASS=on) to enable it. See `removed-exports-pass.ts`.
    */
   removedExportsPass?: boolean;
+  /**
+   * Run the docs-drift candidate loop (per-rule-loops design doc §2/§3,
+   * `.wip/docs-drift-design.md`) — untouched documentation that still
+   * references code this PR removed, renamed, or deleted. Default false —
+   * dark-launched; set true (or env LIEN_DOCS_DRIFT_PASS=on) to enable it.
+   * See `docs-drift-pass.ts`.
+   */
+  docsDriftPass?: boolean;
 }
 
 /** A single finding produced by the agent during review. */

--- a/packages/review/test/docs-drift-pass.test.ts
+++ b/packages/review/test/docs-drift-pass.test.ts
@@ -1,0 +1,727 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+
+import {
+  docsDriftSkipReason,
+  shouldRunDocsDriftPass,
+  isDocsDriftPassEnabled,
+  computeDocsDriftPassCandidates,
+  computeDocsDriftWorklist,
+  buildDocsDriftPassPrompts,
+  buildDocsDriftPassInitialMessage,
+  docsDriftPassBudget,
+  postProcessDocsDriftResult,
+  mergeDocsDriftFindings,
+  mergeDocsDriftResultState,
+  DOCS_DRIFT_PASS_SPEC,
+  DOCS_DRIFT_PASS_MAX_TURNS,
+  DOCS_DRIFT_RULE_ID,
+} from '../src/plugins/agent/docs-drift-pass.js';
+import { VERDICT_EMISSION_RESERVE_TOKENS } from '../src/plugins/agent/review-pass.js';
+import { createTestContext } from '../src/test-helpers.js';
+import type { ReviewContext } from '../src/plugin-types.js';
+import type { AgentConfig, AgentFinding, AgentResult } from '../src/plugins/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function makeDocChunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'doc',
+      language: 'markdown',
+    },
+  } as unknown as CodeChunk;
+}
+
+function patch(...lines: string[]): string {
+  return lines.join('\n');
+}
+
+// ---- drifted shape: removed export still named as current in an untouched doc ----
+
+const API_REMOVE_PATCH = patch('@@ -1,1 +0,0 @@', '-export function oldFunc() {}');
+
+function driftedContext(): ReviewContext {
+  const patches = new Map([['src/util.ts', API_REMOVE_PATCH]]);
+  const repoChunks = [
+    makeDocChunk('docs/util-guide.md', 10, 'The `oldFunc` helper requires a valid config object.'),
+  ];
+  return createTestContext({
+    changedFiles: ['src/util.ts'],
+    chunks: [],
+    repoChunks,
+    pr: {
+      title: 'Remove oldFunc',
+      body: '',
+      patches,
+    } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** No signal fires at all — an ordinary PR that removes nothing exported. */
+function noCandidateContext(): ReviewContext {
+  const patches = new Map([
+    ['src/plain.ts', patch('@@ -1,1 +1,1 @@', '-const x = 1;', '+const x = 2;')],
+  ]);
+  return createTestContext({
+    changedFiles: ['src/plain.ts'],
+    chunks: [],
+    repoChunks: [],
+    pr: { title: 'Trivial change', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+/** 20 independent removed exports, each named once in its own untouched doc file — exercises the
+ *  MAX_CANDIDATES (15) cap docs-drift-signals.ts already applies, via its own alphabetical-referand
+ *  tiebreak (all Tier-1, no other ordering signal). */
+function manyCandidatesContext(): ReviewContext {
+  const patches = new Map<string, string>();
+  const repoChunks: CodeChunk[] = [];
+  for (let i = 0; i < 20; i++) {
+    const n = String(i).padStart(2, '0');
+    patches.set(`src/f${n}.ts`, patch('@@ -1,1 +0,0 @@', `-export function sym${n}() {}`));
+    repoChunks.push(
+      makeDocChunk(`docs/notes-${n}.md`, 1, `The \`sym${n}\` helper requires review.`),
+    );
+  }
+  return createTestContext({
+    changedFiles: [...patches.keys()],
+    chunks: [],
+    repoChunks,
+    pr: { title: 'Remove many exports', body: '', patches } as unknown as ReviewContext['pr'],
+  });
+}
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+function finding(overrides: Record<string, unknown> = {}): AgentFinding {
+  return {
+    filepath: 'docs/util-guide.md',
+    line: 10,
+    severity: 'warning',
+    category: 'docs_drift',
+    message: 'msg',
+    ...overrides,
+  } as AgentFinding;
+}
+
+function fakeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    findings: [],
+    summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2, cost: 0.01 },
+    turns: 1,
+    stopReason: 'completed',
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+// Restore caller state rather than unconditionally deleting.
+let previousDocsDriftPass: string | undefined;
+
+beforeEach(() => {
+  previousDocsDriftPass = process.env.LIEN_DOCS_DRIFT_PASS;
+  delete process.env.LIEN_DOCS_DRIFT_PASS;
+});
+
+afterEach(() => {
+  if (previousDocsDriftPass === undefined) delete process.env.LIEN_DOCS_DRIFT_PASS;
+  else process.env.LIEN_DOCS_DRIFT_PASS = previousDocsDriftPass;
+});
+
+// ---------------------------------------------------------------------------
+// Loop eligibility gate
+// ---------------------------------------------------------------------------
+
+describe('docsDriftSkipReason / shouldRunDocsDriftPass', () => {
+  it('is false (disabled) by default, even with an eligible candidate — ships dark', () => {
+    const ctx = driftedContext();
+    expect(shouldRunDocsDriftPass(ctx, cfg())).toBe(false);
+    expect(docsDriftSkipReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('is true when opted in via config AND a docs-drift candidate exists', () => {
+    const ctx = driftedContext();
+    expect(shouldRunDocsDriftPass(ctx, cfg({ docsDriftPass: true }))).toBe(true);
+  });
+
+  it('is true when opted in via LIEN_DOCS_DRIFT_PASS=on (no config flag)', () => {
+    process.env.LIEN_DOCS_DRIFT_PASS = 'on';
+    const ctx = driftedContext();
+    expect(shouldRunDocsDriftPass(ctx, cfg())).toBe(true);
+  });
+
+  it('is false when opted in but no untouched-doc reference exists', () => {
+    const ctx = noCandidateContext();
+    const reason = docsDriftSkipReason(ctx, cfg({ docsDriftPass: true }));
+    expect(reason).toContain('no untouched-doc reference');
+  });
+
+  it('is false when there are no patches at all, even when opted in', () => {
+    expect(shouldRunDocsDriftPass(createTestContext(), cfg({ docsDriftPass: true }))).toBe(false);
+  });
+
+  it('isDocsDriftPassEnabled: config takes precedence, then env', () => {
+    expect(isDocsDriftPassEnabled(cfg())).toBe(false);
+    expect(isDocsDriftPassEnabled(cfg({ docsDriftPass: true }))).toBe(true);
+    process.env.LIEN_DOCS_DRIFT_PASS = 'on';
+    expect(isDocsDriftPassEnabled(cfg())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Candidate worklist (reuses docs-drift-signals.ts; already capped/sorted)
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftPassCandidates', () => {
+  it('builds one candidate from a removed export named in an untouched claim line', () => {
+    const candidates = computeDocsDriftPassCandidates(driftedContext());
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].referand).toBe('oldFunc');
+    expect(candidates[0].referandKind).toBe('removed-export');
+    expect(candidates[0].docFile).toBe('docs/util-guide.md');
+  });
+
+  it('returns [] for a context with no docs-drift candidate', () => {
+    expect(computeDocsDriftPassCandidates(noCandidateContext())).toEqual([]);
+  });
+
+  it('caps the candidate list at 15 (docs-drift-signals.ts MAX_CANDIDATES)', () => {
+    const candidates = computeDocsDriftPassCandidates(manyCandidatesContext());
+    expect(candidates).toHaveLength(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDocsDriftWorklist — candidate-overflow rank-and-cap
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftWorklist', () => {
+  it('defaults to unlimited budget — defers nothing (byte-identical to before this feature existed)', () => {
+    const { candidates, deferredCount, deferredIds } =
+      computeDocsDriftWorklist(manyCandidatesContext());
+    expect(candidates).toHaveLength(15);
+    expect(deferredCount).toBe(0);
+    expect(deferredIds).toEqual([]);
+  });
+
+  it("caps to the ceiling and defers the remainder, preserving the signal's own (referand) order", () => {
+    const ctx = manyCandidatesContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2
+    const { candidates, deferredCount, deferredIds } = computeDocsDriftWorklist(ctx, budget);
+    expect(candidates.map(c => c.referand)).toEqual(['sym00', 'sym01']);
+    expect(deferredCount).toBe(13);
+    expect(deferredIds).toEqual([
+      'sym02',
+      'sym03',
+      'sym04',
+      'sym05',
+      'sym06',
+      'sym07',
+      'sym08',
+      'sym09',
+      'sym10',
+      'sym11',
+    ]); // capped at MAX_DEFERRED_LABELS (10) even though 13 were deferred
+  });
+
+  it("a single-candidate context is never capped at this pass's own real (floor) budget", () => {
+    const ctx = driftedContext();
+    const budget = docsDriftPassBudget(100_000, ctx);
+    const { candidates, deferredCount } = computeDocsDriftWorklist(ctx, budget);
+    expect(candidates).toHaveLength(1);
+    expect(deferredCount).toBe(0);
+  });
+
+  // Byte-diff census: a realistic (low-candidate) real-PR shape at its ACTUAL production budget
+  // must produce prompt output byte-identical to the pre-feature default call.
+  it('byte-diff census: the ordinary single-candidate real-PR shape is unaffected at the real budget', () => {
+    const ctx = driftedContext();
+    const realBudget = docsDriftPassBudget(100_000, ctx);
+    expect(buildDocsDriftPassPrompts(ctx, realBudget)).toEqual(buildDocsDriftPassPrompts(ctx));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+describe('buildDocsDriftPassPrompts', () => {
+  it('hard-cuts the tool list to read_file + grep_codebase only', () => {
+    const { systemPrompt } = buildDocsDriftPassPrompts(driftedContext());
+    expect(systemPrompt).toContain('read_file');
+    expect(systemPrompt).toContain('grep_codebase');
+    expect(systemPrompt).not.toContain('get_files_context');
+    expect(systemPrompt).not.toContain('get_dependents');
+    expect(systemPrompt).not.toContain('list_functions');
+    expect(systemPrompt).not.toContain('get_complexity');
+  });
+
+  it("includes a loop-scoped strategy and a docs-drift-shaped example, not another pass's prompt", () => {
+    const { systemPrompt } = buildDocsDriftPassPrompts(driftedContext());
+    expect(systemPrompt).toContain('Docs Drift');
+    expect(systemPrompt).toContain('untouched doc presents a removed symbol as current');
+    expect(systemPrompt).not.toContain('Structural Analysis');
+    expect(systemPrompt).not.toContain('Stale Duplicate Literal Check');
+    expect(systemPrompt).not.toContain('Incomplete Handling Check');
+  });
+
+  it('includes the historical/intentional false-positive verdict guidance', () => {
+    const { systemPrompt } = buildDocsDriftPassPrompts(driftedContext());
+    expect(systemPrompt).toContain('verdict_guidance');
+    expect(systemPrompt).toContain('historical');
+    expect(systemPrompt).toContain('intentional');
+  });
+
+  it('requires one findings-array entry per candidate id with the four-value verdict vocabulary', () => {
+    const { systemPrompt } = buildDocsDriftPassPrompts(driftedContext());
+    expect(systemPrompt).toContain('candidateId');
+    expect(systemPrompt).toContain('drifted | historical | intentional | unverifiable');
+    expect(systemPrompt).toContain('candidate-1');
+  });
+
+  it('names category among the required fields, not just in the illustrative example', () => {
+    const { systemPrompt } = buildDocsDriftPassPrompts(driftedContext());
+    const requiredFieldsSentence = systemPrompt
+      .split('\n')
+      .find(line => line.startsWith('EVERY entry requires'));
+    expect(requiredFieldsSentence).toBeDefined();
+    expect(requiredFieldsSentence).toContain('category');
+  });
+
+  it('builds an initial message with the <docs_drift> worklist tag', () => {
+    const message = buildDocsDriftPassInitialMessage(driftedContext());
+    expect(message).toContain('<pr_metadata>');
+    expect(message).toContain('<docs_drift>');
+    expect(message).toContain('oldFunc');
+    expect(message).toContain('docs/util-guide.md:10');
+  });
+
+  it('renders the removal diff hunk (code side) when re-derivable from the diff', () => {
+    const message = buildDocsDriftPassInitialMessage(driftedContext());
+    expect(message).toContain('```diff');
+    expect(message).toContain('-export function oldFunc');
+  });
+
+  it('renders the doc excerpt in a fence', () => {
+    const message = buildDocsDriftPassInitialMessage(driftedContext());
+    expect(message).toContain('requires a valid config object');
+  });
+
+  it('does not include competing signal blocks (blast radius, doc claims, stale literal, etc.)', () => {
+    const message = buildDocsDriftPassInitialMessage(driftedContext());
+    expect(message).not.toContain('<blast_radius>');
+    expect(message).not.toContain('<doc_claims>');
+    expect(message).not.toContain('<stale_literal_candidates>');
+    expect(message).not.toContain('<removed_exports>');
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: contract text differs ONLY when the worklist was capped
+  // -------------------------------------------------------------------------
+
+  it('is byte-identical to before this feature existed when the budget is not passed (default unlimited)', () => {
+    const ctx = manyCandidatesContext();
+    const withBudget = buildDocsDriftPassPrompts(ctx, Number.POSITIVE_INFINITY);
+    const withoutBudget = buildDocsDriftPassPrompts(ctx);
+    expect(withoutBudget).toEqual(withBudget);
+    expect(withoutBudget.initialMessage).not.toContain('CANDIDATE OVERFLOW');
+  });
+
+  it('lists only the affordable candidates and appends the overflow note when the budget caps the worklist', () => {
+    const ctx = manyCandidatesContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 15
+    const { systemPrompt, initialMessage } = buildDocsDriftPassPrompts(ctx, budget);
+    expect(systemPrompt).toContain('candidate-1');
+    expect(systemPrompt).toContain('candidate-2');
+    expect(systemPrompt).not.toContain('candidate-3');
+    expect(initialMessage).toContain('sym00');
+    expect(initialMessage).toContain('sym01');
+    expect(initialMessage).not.toContain('sym02');
+    expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('13 additional eligible candidate(s)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+describe('docsDriftPassBudget', () => {
+  it('scales with candidate count, clamped to the shared one-round-trip floor for a single candidate', () => {
+    const budget = docsDriftPassBudget(100_000, driftedContext());
+    // 1 candidate: 2000 + 800*1 = 2800, clamped up to the 11,000 shared floor.
+    expect(budget).toBe(11_000);
+  });
+
+  it('is independent of the main pass base budget (candidate-count driven, not a fraction)', () => {
+    const low = docsDriftPassBudget(10_000, manyCandidatesContext());
+    const high = docsDriftPassBudget(500_000, manyCandidatesContext());
+    expect(low).toBe(high);
+  });
+
+  it('scales past the floor once candidate count is high enough', () => {
+    // 15 candidates (the cap): 2000 + 800*15 = 14000 > 11,000 floor.
+    const budget = docsDriftPassBudget(100_000, manyCandidatesContext());
+    expect(budget).toBe(14_000);
+  });
+
+  it('turn cap is exported and equals DOCS_DRIFT_PASS_MAX_TURNS', () => {
+    expect(DOCS_DRIFT_PASS_SPEC.maxTurns).toBe(DOCS_DRIFT_PASS_MAX_TURNS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postProcessDocsDriftResult
+// ---------------------------------------------------------------------------
+
+describe('postProcessDocsDriftResult', () => {
+  it('keeps only verdict:"drifted" entries as real findings, stripping candidateId/verdict', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'drifted', message: 'real drift' }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toBe('real drift');
+    expect((result.findings[0] as Record<string, unknown>).candidateId).toBeUndefined();
+    expect((result.findings[0] as Record<string, unknown>).verdict).toBeUndefined();
+  });
+
+  it('drops historical/intentional/unverifiable verdicts entirely', () => {
+    for (const verdict of ['historical', 'intentional', 'unverifiable']) {
+      const raw = fakeResult({
+        findings: [finding({ candidateId: 'candidate-1', verdict, message: 'not drift' })],
+      });
+      const result = postProcessDocsDriftResult(raw, driftedContext());
+      expect(result.findings).toHaveLength(0);
+    }
+  });
+
+  it('is complete when the single candidate got a recognized verdict', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'intentional' })],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+  });
+
+  it('marks the result incomplete with stopReason "incomplete_verdict" when a candidate id is missing', () => {
+    const raw = fakeResult({ findings: [] }); // candidate-1 never got a verdict
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('keeps the ORIGINAL stopReason when the client was already incomplete for a real reason', () => {
+    const raw = fakeResult({ findings: [], incomplete: true, stopReason: 'budget' });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('budget');
+  });
+
+  it('does not mutate the input result', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'drifted' })],
+    });
+    postProcessDocsDriftResult(raw, driftedContext());
+    expect(raw.findings).toHaveLength(1);
+    expect((raw.findings[0] as Record<string, unknown>).candidateId).toBe('candidate-1');
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is missing', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: undefined, message: 'no verdict' }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('is incomplete when a candidate id is present but its verdict is not a recognized value', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({
+          candidateId: 'candidate-1',
+          verdict: 'maybe-drifted' as never,
+          message: 'bogus',
+        }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when the same candidate id is verdicted twice (duplicate, not "covered")', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable', message: 'first' }),
+        finding({ candidateId: 'candidate-1', verdict: 'drifted', message: 'second' }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+  });
+
+  it('is incomplete when an entry names a candidate id outside the worklist, and the phantom never leaks through', () => {
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
+        finding({ candidateId: 'candidate-99', verdict: 'drifted', message: 'phantom candidate' }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.incomplete).toBe(true);
+    expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate-overflow: deferral is attested, NOT incompleteness
+  // -------------------------------------------------------------------------
+
+  it('stamps candidatesDeferred/deferredCandidateIds when the budget capped the worklist', () => {
+    const ctx = manyCandidatesContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 15
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'intentional' }),
+        finding({ candidateId: 'candidate-2', verdict: 'intentional' }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, ctx, budget);
+    expect(result.candidatesDeferred).toBe(13);
+    expect(result.deferredCandidateIds).toHaveLength(10); // capped at MAX_DEFERRED_LABELS
+    expect(result.deferredCandidateIds![0]).toBe('sym02');
+  });
+
+  it('a capped-but-complete run (every LISTED candidate verdicted) stays incomplete:false — deferral is not incompleteness', () => {
+    const ctx = manyCandidatesContext();
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 6_000; // affords 2 of 15
+    const raw = fakeResult({
+      findings: [
+        finding({ candidateId: 'candidate-1', verdict: 'intentional' }),
+        finding({ candidateId: 'candidate-2', verdict: 'intentional' }),
+      ],
+    });
+    const result = postProcessDocsDriftResult(raw, ctx, budget);
+    expect(result.incomplete).toBe(false);
+    expect(result.stopReason).toBe('completed');
+    expect(result.candidatesDeferred).toBe(13);
+  });
+
+  it('reports candidatesDeferred: 0 and no deferredCandidateIds when nothing was capped (default budget)', () => {
+    const raw = fakeResult({
+      findings: [finding({ candidateId: 'candidate-1', verdict: 'intentional' })],
+    });
+    const result = postProcessDocsDriftResult(raw, driftedContext());
+    expect(result.candidatesDeferred).toBe(0);
+    expect(result.deferredCandidateIds).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeDocsDriftFindings — loop wins on own-ruleId collision; doc-truth wins cross-dedup
+// ---------------------------------------------------------------------------
+
+describe('mergeDocsDriftFindings', () => {
+  it('drops a same-ruleId main-pass finding at the same location and keeps the loop finding', () => {
+    const main = [finding({ line: 10, ruleId: DOCS_DRIFT_RULE_ID, message: 'stale main copy' })];
+    const loop = [finding({ line: 10, message: 'loop with evidence' })];
+
+    const merged = mergeDocsDriftFindings(main, loop);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('loop with evidence');
+    expect(merged[0].ruleId).toBe(DOCS_DRIFT_RULE_ID);
+  });
+
+  it('dedupes a nearby same-ruleId main-pass finding (within ±2 lines) but keeps a distant one', () => {
+    const main = [
+      finding({ line: 11, ruleId: DOCS_DRIFT_RULE_ID, message: 'near' }),
+      finding({ line: 40, ruleId: DOCS_DRIFT_RULE_ID, message: 'far, unrelated' }),
+    ];
+    const loop = [finding({ line: 10, message: 'loop' })];
+
+    const merged = mergeDocsDriftFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['far, unrelated', 'loop'].sort());
+  });
+
+  it('does NOT drop a nearby main-pass finding from a DIFFERENT rule (proximity alone is not enough)', () => {
+    const main = [finding({ line: 10, ruleId: 'error-swallowing', message: 'unrelated real bug' })];
+    const loop = [finding({ line: 10, message: 'loop finding' })];
+
+    const merged = mergeDocsDriftFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unrelated real bug']);
+  });
+
+  it('does NOT drop a nearby main-pass finding with no ruleId at all', () => {
+    const main = [finding({ line: 10, ruleId: undefined, message: 'unattributed' })];
+    const loop = [finding({ line: 10, message: 'loop finding' })];
+
+    const merged = mergeDocsDriftFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual(['loop finding', 'unattributed']);
+  });
+
+  it('forces ruleId to docs-drift on every loop finding', () => {
+    const loop = [finding({ ruleId: undefined, message: 'no-rule' })];
+    const merged = mergeDocsDriftFindings([], loop);
+    expect(merged[0].ruleId).toBe(DOCS_DRIFT_RULE_ID);
+  });
+
+  it('does not mutate the input arrays', () => {
+    const main = [finding({ filepath: 'a.md', line: 1 })];
+    const loop = [finding({ filepath: 'b.md', line: 1, ruleId: 'x' })];
+    mergeDocsDriftFindings(main, loop);
+    expect(loop[0].ruleId).toBe('x');
+    expect(main).toHaveLength(1);
+  });
+
+  it('appends a loop finding on a distinct file alongside an unrelated main finding', () => {
+    const main = [finding({ filepath: 'a.md', line: 1, message: 'unrelated' })];
+    const loop = [finding({ filepath: 'b.md', line: 1, message: 'loop' })];
+    const merged = mergeDocsDriftFindings(main, loop);
+    expect(merged.map(f => f.message).sort()).toEqual(['loop', 'unrelated']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cross-dedup vs doc-truth: doc-truth wins (design §2's "both-fire case" backstop)
+  // -------------------------------------------------------------------------
+
+  it('drops a docs-drift loop finding whose location collides with an existing doc-truth finding', () => {
+    const main = [
+      finding({
+        filepath: 'docs/util-guide.md',
+        line: 10,
+        ruleId: 'doc-truth',
+        message: 'doc-truth saw it first',
+      }),
+    ];
+    const loop = [
+      finding({ filepath: 'docs/util-guide.md', line: 11, message: 'docs-drift also flagged it' }),
+    ];
+
+    const merged = mergeDocsDriftFindings(main, loop);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].message).toBe('doc-truth saw it first');
+    expect(merged[0].ruleId).toBe('doc-truth');
+  });
+
+  it('keeps a docs-drift loop finding that does NOT collide with any doc-truth finding', () => {
+    const main = [
+      finding({
+        filepath: 'docs/other.md',
+        line: 5,
+        ruleId: 'doc-truth',
+        message: 'unrelated doc-truth finding',
+      }),
+    ];
+    const loop = [finding({ filepath: 'docs/util-guide.md', line: 10, message: 'real drift' })];
+
+    const merged = mergeDocsDriftFindings(main, loop);
+
+    expect(merged.map(f => f.message).sort()).toEqual([
+      'real drift',
+      'unrelated doc-truth finding',
+    ]);
+  });
+
+  it('keeps the doc-truth main finding itself untouched by the cross-dedup', () => {
+    const main = [
+      finding({ filepath: 'docs/util-guide.md', line: 10, ruleId: 'doc-truth', message: 'kept' }),
+    ];
+    const merged = mergeDocsDriftFindings(main, []);
+    expect(merged).toEqual(main);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeDocsDriftResultState
+// ---------------------------------------------------------------------------
+
+describe('mergeDocsDriftResultState', () => {
+  it('marks the merged result incomplete, naming this pass via incompleteFromPass', () => {
+    const main = fakeResult();
+    main.incomplete = false;
+    main.stopReason = 'completed';
+    const loop = fakeResult({ incomplete: true, stopReason: 'incomplete_verdict' });
+
+    mergeDocsDriftResultState(main, loop);
+
+    expect(main.incomplete).toBe(true);
+    expect(main.stopReason).toBe('incomplete_verdict');
+    expect(main.incompleteFromPass).toBe('docs-drift');
+  });
+
+  it('leaves an already-incomplete main pass untouched (no attribution overwrite)', () => {
+    const main = fakeResult({ incomplete: true, stopReason: 'max_turns' });
+    const loop = fakeResult({ incomplete: true, stopReason: 'budget' });
+
+    mergeDocsDriftResultState(main, loop);
+
+    expect(main.stopReason).toBe('max_turns');
+    expect(main.incompleteFromPass).toBeUndefined();
+  });
+
+  it('is a no-op when the loop pass is complete or null', () => {
+    const main = fakeResult();
+    mergeDocsDriftResultState(main, fakeResult());
+    expect(main.incomplete).toBe(false);
+
+    mergeDocsDriftResultState(main, null);
+    expect(main.incomplete).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DOCS_DRIFT_PASS_SPEC (the ReviewPassSpec bundle)
+// ---------------------------------------------------------------------------
+
+describe('DOCS_DRIFT_PASS_SPEC', () => {
+  it("wires this module's own pure functions into the ReviewPassSpec contract", () => {
+    expect(DOCS_DRIFT_PASS_SPEC.name).toBe('docs-drift-loop');
+    expect(DOCS_DRIFT_PASS_SPEC.skipPlugin).toBe('agent-review:docs-drift-loop');
+    expect(DOCS_DRIFT_PASS_SPEC.maxTurns).toBe(DOCS_DRIFT_PASS_MAX_TURNS);
+    expect(DOCS_DRIFT_PASS_SPEC.mergeFindings).toBe(mergeDocsDriftFindings);
+    expect(DOCS_DRIFT_PASS_SPEC.mergeResultState).toBe(mergeDocsDriftResultState);
+    expect(DOCS_DRIFT_PASS_SPEC.postProcessResult).toBe(postProcessDocsDriftResult);
+  });
+
+  it('gateReason is docsDriftSkipReason', () => {
+    const ctx = driftedContext();
+    expect(DOCS_DRIFT_PASS_SPEC.gateReason(ctx, cfg({ docsDriftPass: true }))).toBeNull();
+    expect(DOCS_DRIFT_PASS_SPEC.gateReason(ctx, cfg())).toContain('disabled');
+  });
+
+  it('buildPrompts delegates to buildDocsDriftPassPrompts', () => {
+    const ctx = driftedContext();
+    expect(DOCS_DRIFT_PASS_SPEC.buildPrompts(ctx, docsDriftPassBudget(100_000, ctx))).toEqual(
+      buildDocsDriftPassPrompts(ctx, docsDriftPassBudget(100_000, ctx)),
+    );
+  });
+
+  it('budget delegates to docsDriftPassBudget', () => {
+    const ctx = driftedContext();
+    expect(DOCS_DRIFT_PASS_SPEC.budget(100_000, ctx)).toBe(docsDriftPassBudget(100_000, ctx));
+  });
+});

--- a/packages/review/test/docs-drift-signals.test.ts
+++ b/packages/review/test/docs-drift-signals.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import type { ReviewContext } from '../src/plugin-types.js';
+import {
+  computeDocsDriftCandidates,
+  classifyRawDocReferences,
+  isFullFileDeletion,
+  extractDeletedPaths,
+} from '../src/docs-drift-signals.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function patch(...lines: string[]): string {
+  return lines.join('\n');
+}
+
+function makeChunk(
+  file: string,
+  startLine: number,
+  content: string,
+  type: CodeChunk['metadata']['type'] = 'doc',
+): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type,
+      language: 'markdown',
+    },
+  } as CodeChunk;
+}
+
+function makeContext(opts: {
+  patches?: Map<string, string>;
+  repoChunks?: CodeChunk[];
+  changedFiles?: string[];
+}): ReviewContext {
+  const patches = opts.patches ?? new Map<string, string>();
+  return {
+    pr: { patches },
+    repoChunks: opts.repoChunks ?? [],
+    changedFiles: opts.changedFiles ?? [...patches.keys()],
+    chunks: [],
+  } as unknown as ReviewContext;
+}
+
+/** A hunk-only, PRODUCTION-SHAPED full-file-deletion patch: no `diff --git`/`deleted file
+ *  mode`/`+++ /dev/null` header — exactly what `getPRPatchData` (octokit `pulls.listFiles`)
+ *  hands every plugin in prod. */
+function hunkOnlyDeletion(...removedLines: string[]): string {
+  return patch(`@@ -1,${removedLines.length} +0,0 @@`, ...removedLines.map(l => `-${l}`));
+}
+
+// ---------------------------------------------------------------------------
+// isFullFileDeletion
+// ---------------------------------------------------------------------------
+
+describe('isFullFileDeletion', () => {
+  it('is true for a hunk-only patch whose every hunk new-side starts at 0', () => {
+    expect(isFullFileDeletion(hunkOnlyDeletion('function old() {}', 'export default old;'))).toBe(
+      true,
+    );
+  });
+
+  it('is false when a hunk new-side start is non-zero (a partial-file edit)', () => {
+    const p = patch('@@ -1,3 +1,1 @@', '-a', '-b', ' c');
+    expect(isFullFileDeletion(p)).toBe(false);
+  });
+
+  it('is false when there are no hunk headers at all', () => {
+    expect(isFullFileDeletion('')).toBe(false);
+    expect(isFullFileDeletion('not a diff')).toBe(false);
+  });
+
+  it('is true even when a fixture carries full diff --git / deleted-file-mode headers', () => {
+    const p = patch(
+      'diff --git a/foo.ts b/foo.ts',
+      'deleted file mode 100644',
+      'index abc123..0000000',
+      '--- a/foo.ts',
+      '+++ /dev/null',
+      '@@ -1,2 +0,0 @@',
+      '-a',
+      '-b',
+    );
+    expect(isFullFileDeletion(p)).toBe(true);
+  });
+
+  it('is false when only some hunks of a multi-hunk file zero out (not a whole-file deletion)', () => {
+    const p = patch('@@ -1,2 +0,0 @@', '-a', '-b', '@@ -10,2 +8,2 @@', '-c', '-d', '+c2', '+d2');
+    expect(isFullFileDeletion(p)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDeletedPaths
+// ---------------------------------------------------------------------------
+
+describe('extractDeletedPaths', () => {
+  it('groups a fully-deleted file under its package directory when the whole directory is gone', () => {
+    const patches = new Map([
+      ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+    ]);
+    const referands = extractDeletedPaths(patches, []);
+    expect(referands).toEqual([
+      { token: 'packages/runner', kind: 'deleted-path', altToken: 'runner' },
+    ]);
+  });
+
+  it('falls back to the file itself when the directory is NOT fully gone', () => {
+    const patches = new Map([
+      ['packages/review/src/old-helper.ts', hunkOnlyDeletion('export function oldHelper() {}')],
+    ]);
+    const stillThere = [
+      makeChunk('packages/review/src/other.ts', 1, 'export const x = 1;', 'block'),
+    ];
+    const referands = extractDeletedPaths(patches, stillThere);
+    expect(referands).toEqual([
+      {
+        token: 'packages/review/src/old-helper.ts',
+        kind: 'deleted-path',
+        altToken: 'old-helper.ts',
+      },
+    ]);
+  });
+
+  it('has no altToken when the referand IS its own trailing segment (a root-level file)', () => {
+    const patches = new Map([['README-old.md', hunkOnlyDeletion('# Old readme')]]);
+    const referands = extractDeletedPaths(patches, []);
+    expect(referands).toEqual([{ token: 'README-old.md', kind: 'deleted-path' }]);
+  });
+
+  it('returns [] when no patch is a full-file deletion', () => {
+    const patches = new Map([
+      ['src/a.ts', patch('@@ -1,1 +1,1 @@', '-const a = 1;', '+const a = 2;')],
+    ]);
+    expect(extractDeletedPaths(patches, [])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDocsDriftCandidates — positives
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftCandidates — positives', () => {
+  it('fires Tier-1 (behavioral-claim) on a removed export named in an untouched claim line', () => {
+    const patches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +0,0 @@', '-export function oldFunc() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/util-guide.md', 10, 'The `oldFunc` helper requires a valid config object.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+
+    const candidates = computeDocsDriftCandidates(ctx);
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        referand: 'oldFunc',
+        referandKind: 'removed-export',
+        docFile: 'docs/util-guide.md',
+        docLine: 10,
+        positionTier: 'behavioral-claim',
+      }),
+    ]);
+  });
+
+  it(
+    'fires Tier-2 (structural-mention) on a deleted directory named in an untouched structure ' +
+      'bullet, discovered via a PRODUCTION-SHAPED hunk-only patch (no diff headers)',
+    () => {
+      const patches = new Map([
+        ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+      ]);
+      const repoChunks = [
+        makeChunk(
+          'CLAUDE.md',
+          40,
+          '- `packages/runner` — internal build runner package used by CI',
+        ),
+      ];
+      const ctx = makeContext({ patches, repoChunks });
+
+      const candidates = computeDocsDriftCandidates(ctx);
+      expect(candidates).toEqual([
+        expect.objectContaining({
+          referand: 'packages/runner',
+          referandKind: 'deleted-path',
+          docFile: 'CLAUDE.md',
+          docLine: 40,
+          positionTier: 'structural-mention',
+        }),
+      ]);
+    },
+  );
+
+  it('fires on a renamed identifier (mapping.from) named in an untouched claim line', () => {
+    const patches = new Map(
+      Array.from({ length: 5 }, (_, i) => [
+        `src/a${i}.ts`,
+        patch('@@ -1,1 +1,1 @@', '-const oldWidget = 1;', '+const newWidget = 1;'),
+      ]),
+    );
+    const repoChunks = [
+      makeChunk(
+        'docs/widgets.md',
+        3,
+        'The `oldWidget` component is required for legacy rendering.',
+      ),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+
+    const candidates = computeDocsDriftCandidates(ctx);
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        referand: 'oldWidget',
+        referandKind: 'renamed-identifier',
+        docFile: 'docs/widgets.md',
+        docLine: 3,
+        positionTier: 'behavioral-claim',
+      }),
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDocsDriftCandidates — suppression negatives
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftCandidates — suppression negatives', () => {
+  const patches = new Map([
+    ['src/util.ts', patch('@@ -1,1 +0,0 @@', '-export function oldFunc() {}')],
+  ]);
+
+  it('suppresses a reference inside a fenced code block', () => {
+    const repoChunks = [
+      makeChunk(
+        'docs/util-guide.md',
+        1,
+        ['# Guide', '```', 'oldFunc() // example call requires nothing', '```'].join('\n'),
+      ),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('suppresses a reference in a CHANGELOG file', () => {
+    const repoChunks = [
+      makeChunk('CHANGELOG.md', 1, 'The `oldFunc` helper requires a config object.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('suppresses a reference in a .changeset entry', () => {
+    const repoChunks = [
+      makeChunk('.changeset/some-change.md', 1, 'The `oldFunc` helper requires a config object.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('suppresses a past-tense / historical / retirement note', () => {
+    const repoChunks = [
+      makeChunk('docs/util-guide.md', 1, 'The `oldFunc` helper was removed and replaced.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('suppresses a reference that sits inside a markdown link target', () => {
+    const repoChunks = [
+      makeChunk(
+        'docs/util-guide.md',
+        1,
+        'See [the helper](./packages/oldFunc/README.md) requires review.',
+      ),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('excludes a doc file the PR itself touched (untouched-only sweep)', () => {
+    const touchedFile = 'docs/util-guide.md';
+    const patchesWithTouchedDoc = new Map(patches);
+    patchesWithTouchedDoc.set(touchedFile, patch('@@ -1,1 +1,1 @@', '-old line', '+new line'));
+    const repoChunks = [
+      makeChunk(touchedFile, 1, 'The `oldFunc` helper requires a valid config object.'),
+    ];
+    const ctx = makeContext({ patches: patchesWithTouchedDoc, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('returns [] when the PR removes/renames/deletes nothing (no referand)', () => {
+    const noopPatches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +1,1 @@', '-const x = 1;', '+const x = 2;')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/guide.md', 1, 'This mentions oldFunc but nothing removed.'),
+    ];
+    const ctx = makeContext({ patches: noopPatches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDocsDriftCandidates — determinism + cap
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftCandidates — determinism + cap', () => {
+  it('caps at 15, sorted deterministically (tier, then referand, then docFile:line)', () => {
+    // 4 removed exports, each named in 5 separate untouched doc files' claim lines — 20 raw
+    // candidates (all Tier-1), collapsed to the 15-candidate cap.
+    const patches = new Map(
+      Array.from({ length: 4 }, (_, i) => [
+        `src/mod${i}.ts`,
+        patch('@@ -1,1 +0,0 @@', `-export function oldFunc${i}() {}`),
+      ]),
+    );
+    const repoChunks = Array.from({ length: 5 }, (_, j) =>
+      makeChunk(
+        `docs/notes-${j}.md`,
+        1,
+        Array.from({ length: 4 }, (_, i) => `The \`oldFunc${i}\` helper requires review.`).join(
+          '\n',
+        ),
+      ),
+    );
+    const ctx = makeContext({ patches, repoChunks });
+
+    const first = computeDocsDriftCandidates(ctx);
+    const second = computeDocsDriftCandidates(ctx);
+
+    expect(first).toHaveLength(15);
+    expect(first).toEqual(second); // deterministic across repeated calls
+    // Sorted by referand name — oldFunc0/1/2 (15 total) survive, oldFunc3 is dropped by the cap.
+    expect(first.every(c => c.referand !== 'oldFunc3')).toBe(true);
+    expect(new Set(first.map(c => c.referand))).toEqual(
+      new Set(['oldFunc0', 'oldFunc1', 'oldFunc2']),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyRawDocReferences — the census helper
+// ---------------------------------------------------------------------------
+
+describe('classifyRawDocReferences', () => {
+  it('tallies suppressed vs tiered raw matches for the same referand', () => {
+    const patches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +0,0 @@', '-export function oldFunc() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/a.md', 1, 'The `oldFunc` helper requires a config object.'), // tier1
+      makeChunk('docs/b.md', 1, 'The `oldFunc` helper was removed and replaced.'), // suppressed
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+
+    expect(classifyRawDocReferences(ctx)).toEqual({
+      total: 2,
+      tier1: 1,
+      tier2: 0,
+      suppressed: 1,
+    });
+  });
+
+  it('returns all-zero tallies when there is no referand', () => {
+    const noopPatches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +1,1 @@', '-const x = 1;', '+const x = 2;')],
+    ]);
+    const ctx = makeContext({ patches: noopPatches, repoChunks: [] });
+    expect(classifyRawDocReferences(ctx)).toEqual({ total: 0, tier1: 0, tier2: 0, suppressed: 0 });
+  });
+});

--- a/packages/review/test/docs-drift-signals.test.ts
+++ b/packages/review/test/docs-drift-signals.test.ts
@@ -350,6 +350,92 @@ describe('computeDocsDriftCandidates — suppression negatives', () => {
 });
 
 // ---------------------------------------------------------------------------
+// computeDocsDriftCandidates — boundary precision (adversarial review finding: plain \b treats
+// `-`/`.` as boundaries even though they continue the same identifier/path in this codebase's
+// conventions, producing false matches inside a longer, unrelated token)
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftCandidates — boundary precision (no substring false-matches)', () => {
+  it('does NOT match a deleted-path referand as a prefix of a hyphen-suffixed longer path', () => {
+    const patches = new Map([
+      ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk(
+        'docs/guide.md',
+        1,
+        '- `packages/runner-hosted` — an unrelated package that merely shares a prefix.',
+      ),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('does NOT match a deleted-path referand as a suffix of a hyphen-prefixed longer path', () => {
+    const patches = new Map([
+      ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk(
+        'docs/guide.md',
+        1,
+        '- `sub-packages/runner` — an unrelated package that merely shares a suffix.',
+      ),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('DOES match a deleted-path referand when followed by / (a legitimate sub-path reference)', () => {
+    const patches = new Map([
+      ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/guide.md', 1, '- `packages/runner/README.md` — see this for details.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    const candidates = computeDocsDriftCandidates(ctx);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].referand).toBe('packages/runner');
+  });
+
+  it('does NOT match a removed-export referand adjacent to a hyphen (a different identifier)', () => {
+    const patches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +0,0 @@', '-export function fetchUser() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/guide.md', 1, 'The `my-fetchUser` helper requires a config object.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('does NOT match a removed-export referand adjacent to a period (a different identifier)', () => {
+    const patches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +0,0 @@', '-export function fetchUser() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/guide.md', 1, 'The `fetchUser.old` helper requires a config object.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('still matches the exact removed-export referand surrounded by plain prose/punctuation', () => {
+    const patches = new Map([
+      ['src/util.ts', patch('@@ -1,1 +0,0 @@', '-export function fetchUser() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk('docs/guide.md', 1, 'The `fetchUser` helper requires a config object.'),
+    ];
+    const ctx = makeContext({ patches, repoChunks });
+    const candidates = computeDocsDriftCandidates(ctx);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].referand).toBe('fetchUser');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // computeDocsDriftCandidates — determinism + cap
 // ---------------------------------------------------------------------------
 

--- a/packages/review/test/docs-drift-signals.test.ts
+++ b/packages/review/test/docs-drift-signals.test.ts
@@ -106,9 +106,9 @@ describe('extractDeletedPaths', () => {
       ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
     ]);
     const referands = extractDeletedPaths(patches, []);
-    expect(referands).toEqual([
-      { token: 'packages/runner', kind: 'deleted-path', altToken: 'runner' },
-    ]);
+    // Full path only — no trailing-segment alt-token (dropped: a bare segment like "runner" is
+    // often a generic English word and produced false candidates on unrelated ambient prose).
+    expect(referands).toEqual([{ token: 'packages/runner', kind: 'deleted-path' }]);
   });
 
   it('falls back to the file itself when the directory is NOT fully gone', () => {
@@ -120,15 +120,11 @@ describe('extractDeletedPaths', () => {
     ];
     const referands = extractDeletedPaths(patches, stillThere);
     expect(referands).toEqual([
-      {
-        token: 'packages/review/src/old-helper.ts',
-        kind: 'deleted-path',
-        altToken: 'old-helper.ts',
-      },
+      { token: 'packages/review/src/old-helper.ts', kind: 'deleted-path' },
     ]);
   });
 
-  it('has no altToken when the referand IS its own trailing segment (a root-level file)', () => {
+  it('a root-level deleted file is its own referand (no path grouping possible)', () => {
     const patches = new Map([['README-old.md', hunkOnlyDeletion('# Old readme')]]);
     const referands = extractDeletedPaths(patches, []);
     expect(referands).toEqual([{ token: 'README-old.md', kind: 'deleted-path' }]);
@@ -194,6 +190,38 @@ describe('computeDocsDriftCandidates — positives', () => {
           positionTier: 'structural-mention',
         }),
       ]);
+    },
+  );
+
+  it(
+    'fires a deleted-path/structural-mention candidate on an untouched bullet that ALSO cites an ' +
+      'unrelated ADR link on the same line (regression: link suppression is narrow — only the ' +
+      "referand's own occurrence inside a link span suppresses, not merely a link ANYWHERE on the line)",
+    () => {
+      const patches = new Map([
+        ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+      ]);
+      const repoChunks = [
+        makeChunk(
+          'CLAUDE.md',
+          40,
+          '- `platform/` and `packages/runner` — hosted-platform remnants (see ' +
+            '[ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)); safe to ignore.',
+        ),
+      ];
+      const ctx = makeContext({ patches, repoChunks });
+
+      const candidates = computeDocsDriftCandidates(ctx);
+      const runnerCandidate = candidates.find(c => c.referand === 'packages/runner');
+      expect(runnerCandidate).toEqual(
+        expect.objectContaining({
+          referand: 'packages/runner',
+          referandKind: 'deleted-path',
+          docFile: 'CLAUDE.md',
+          docLine: 40,
+          positionTier: 'structural-mention',
+        }),
+      );
     },
   );
 
@@ -280,6 +308,21 @@ describe('computeDocsDriftCandidates — suppression negatives', () => {
       ),
     ];
     const ctx = makeContext({ patches, repoChunks });
+    expect(computeDocsDriftCandidates(ctx)).toEqual([]);
+  });
+
+  it('suppresses a deleted-path referand that sits ONLY inside a link target (narrow suppression, not blanket)', () => {
+    const deletedPathPatches = new Map([
+      ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+    ]);
+    const repoChunks = [
+      makeChunk(
+        'docs/guide.md',
+        1,
+        'See [the runner package](./packages/runner/README.md) for details.',
+      ),
+    ];
+    const ctx = makeContext({ patches: deletedPathPatches, repoChunks });
     expect(computeDocsDriftCandidates(ctx)).toEqual([]);
   });
 

--- a/packages/review/test/harness-rule-coverage.test.ts
+++ b/packages/review/test/harness-rule-coverage.test.ts
@@ -8,10 +8,18 @@
  * is the pure decision logic; these tests cover it with zero network/LLM
  * spend by hand-building `{ rule, ruleCandidates }` inputs and an active-rule
  * id list, rather than replaying a real fixture through `selectRules`.
+ *
+ * `withDocsDriftRuleId` (docs-drift design doc §2/§3) covers the one
+ * dedicated-pass-only exception: `docs-drift` has no `BUILTIN_RULES` entry,
+ * so `selectRules` never includes it in `activeRuleIds` — without this union,
+ * every docs-drift fixture would be flagged unpassable-by-construction even
+ * when the pass is genuinely enabled for it (`run.ts`'s
+ * `validateFixtureRuleCoverage`).
  */
 import { describe, expect, it } from 'vitest';
 
-import { checkRuleCoverage } from './harness/rule-coverage.js';
+import { checkRuleCoverage, withDocsDriftRuleId } from './harness/rule-coverage.js';
+import type { AgentConfig } from '../src/plugins/agent/types.js';
 
 describe('checkRuleCoverage', () => {
   it('passes when `rule` is in the active set', () => {
@@ -59,5 +67,56 @@ describe('checkRuleCoverage', () => {
   it('reports "(none)" for the active set when no rules are active at all', () => {
     const result = checkRuleCoverage({ rule: 'doc-truth' }, []);
     expect(result).toContain('(none)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withDocsDriftRuleId — the docs-drift dedicated-pass-only exception
+// ---------------------------------------------------------------------------
+
+function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'm', maxTurns: 15, maxTokenBudget: 100_000, ...overrides };
+}
+
+describe('withDocsDriftRuleId', () => {
+  it('unions in docs-drift when config.docsDriftPass is true', () => {
+    const result = withDocsDriftRuleId(['structural-analysis'], cfg({ docsDriftPass: true }));
+    expect(result).toEqual(['structural-analysis', 'docs-drift']);
+  });
+
+  it('leaves activeRuleIds untouched when the pass is disabled', () => {
+    const result = withDocsDriftRuleId(['structural-analysis'], cfg());
+    expect(result).toEqual(['structural-analysis']);
+  });
+
+  it('leaves activeRuleIds untouched when config is undefined', () => {
+    const result = withDocsDriftRuleId(['structural-analysis'], undefined);
+    expect(result).toEqual(['structural-analysis']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['structural-analysis'];
+    withDocsDriftRuleId(input, cfg({ docsDriftPass: true }));
+    expect(input).toEqual(['structural-analysis']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Combined with checkRuleCoverage: the exact scenario the preflight fix targets
+  // -------------------------------------------------------------------------
+
+  it('a docs-drift fixture passes the preflight once the union is applied (pass enabled)', () => {
+    const activeRuleIds = withDocsDriftRuleId(
+      ['structural-analysis'],
+      cfg({ docsDriftPass: true }),
+    );
+    const result = checkRuleCoverage({ rule: 'docs-drift' }, activeRuleIds);
+    expect(result).toBeNull();
+  });
+
+  it('a docs-drift fixture is flagged unpassable when the pass is NOT enabled (no union applied)', () => {
+    const activeRuleIds = withDocsDriftRuleId(['structural-analysis'], cfg());
+    const result = checkRuleCoverage({ rule: 'docs-drift' }, activeRuleIds);
+    expect(result).not.toBeNull();
+    expect(result).toContain("rule 'docs-drift'");
   });
 });

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -16,12 +16,13 @@
  *
  * Same for the stale-duplicate candidate-loop PILOT (`staleDuplicatePass`,
  * per-rule-loops design doc §4), the incomplete-handling candidate loop
- * (`incompleteHandlingPass`, design doc §7 item 5), and the removed-exports
+ * (`incompleteHandlingPass`, design doc §7 item 5), the removed-exports
  * candidate loop (`removedExportsPass`, ADR-014's gating matrix —
- * structural-analysis is hybrid) — all dark by default, so `fires` is false
- * unless the fixture's captured config (or the relevant env flag in the
- * environment this script runs in) opts in AND that loop's own eligibility
- * gate is met.
+ * structural-analysis is hybrid), and the docs-drift candidate loop
+ * (`docsDriftPass`, design doc §2/§3 — untouched-doc blast radius) — all dark
+ * by default, so `fires` is false unless the fixture's captured config (or
+ * the relevant env flag in the environment this script runs in) opts in AND
+ * that loop's own eligibility gate is met.
  *
  * Usage: tsx build-prompts.ts <fixture.json>
  */
@@ -52,6 +53,11 @@ import {
   buildRemovedExportsPassPrompts,
   removedExportsPassBudget,
 } from '../../src/plugins/agent/removed-exports-pass.js';
+import {
+  shouldRunDocsDriftPass,
+  buildDocsDriftPassPrompts,
+  docsDriftPassBudget,
+} from '../../src/plugins/agent/docs-drift-pass.js';
 import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import { loadFixture } from './fixture-loader.js';
@@ -102,6 +108,9 @@ async function main(): Promise<void> {
   const removedExportsPass = passOutput(shouldRunRemovedExportsPass(ctx, config), () =>
     buildRemovedExportsPassPrompts(ctx, removedExportsPassBudget(baseBudget, ctx)),
   );
+  const docsDriftPass = passOutput(shouldRunDocsDriftPass(ctx, config), () =>
+    buildDocsDriftPassPrompts(ctx, docsDriftPassBudget(baseBudget, ctx)),
+  );
 
   const output = {
     fixturePath,
@@ -113,6 +122,7 @@ async function main(): Promise<void> {
     staleDuplicatePass,
     incompleteHandlingPass,
     removedExportsPass,
+    docsDriftPass,
   };
 
   process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts
+++ b/packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts
@@ -25,85 +25,84 @@
  *    This captures the real deletion of `packages/runner/**` (21 files) and
  *    `platform/**` (271 files) — every file's patch is a genuine full-file
  *    deletion (`isFullFileDeletion` true for all 21 `packages/runner/` files;
- *    all-but-a-few `platform/` files, verified via a debug script this
- *    session — the handful of exceptions don't prevent the directory-level
- *    grouping, which only needs ONE confirmed deletion under the prefix AND
- *    zero surviving repoChunks under it, both true here).
+ *    all-but-a-few `platform/` files — the handful of exceptions don't
+ *    prevent the directory-level grouping, which only needs ONE confirmed
+ *    deletion under the prefix AND zero surviving repoChunks under it, both
+ *    true here).
  *
  * 2. DISCOVERED: the real PR #593 diff ALSO touches CLAUDE.md (removing the
  *    exact stale bullets: "- `packages/` — ...(..., runner, site)" and
  *    "- `platform/` — Laravel 12 web app..."). Since docs-drift's own
  *    untouched-only filter (by design) excludes any file in `pr.patches` /
  *    `changedFiles` / `allChangedFiles`, CLAUDE.md was NOT eligible as an
- *    "untouched doc" in the raw capture — confirmed via a debug script this
- *    session (`CLAUDE.md in changed set: true`). To honestly stage the
- *    counterfactual design §5.A asks for ("what if this bullet had survived,
- *    unedited, in an UNTOUCHED CLAUDE.md"), CLAUDE.md's entry was removed
- *    from `pr.patches`, `pr.diffLines`, `changedFiles`, `allChangedFiles`,
- *    and the changed-files-only `chunks` array (299->298 patches, 36->3
- *    chunks) — leaving CLAUDE.md's 33 `repoChunks` doc chunks (the post-
- *    deletion, head-state content) as the untouched corpus docs-drift sweeps.
+ *    "untouched doc" in the raw capture. To honestly stage the counterfactual
+ *    design §5.A asks for ("what if this bullet had survived, unedited, in an
+ *    UNTOUCHED CLAUDE.md"), CLAUDE.md's entry was removed from `pr.patches`,
+ *    `pr.diffLines`, `changedFiles`, `allChangedFiles`, and the changed-
+ *    files-only `chunks` array (299->298 patches, 36->3 chunks) — leaving
+ *    CLAUDE.md's 33 `repoChunks` doc chunks (the post-deletion, head-state
+ *    content) as the untouched corpus docs-drift sweeps.
  *
- * 3. INJECTED the variant bullet into CLAUDE.md's "## What is Lien?" chunk
+ * 3. INJECTED the bullet into CLAUDE.md's "## What is Lien?" chunk
  *    (repoChunks entry, startLine 3), right after the existing "Monorepo
  *    Structure:" bullet, bumping that chunk's endLine 38->39:
- *      - `platform/` and `packages/runner` — hosted-platform remnants; safe to ignore.
- *    CRITICAL — the "retired" resolution (locked precedence: the suppression
- *    guard stays BROAD, the FIXTURE adapts): the real #766 bullet
- *    ("retired hosted-platform remnants") contains "retired", which
- *    `HISTORICAL_GUARD_RE` correctly suppresses by design (the primary FP
- *    class docs-drift exists to filter). This variant carries none of
- *    HISTORICAL_GUARD_RE's trigger words (was/were+verb, retired, formerly,
- *    deprecated, previously, prior to, no longer, used to) while staying
- *    equally implausible as a *current*, accurate description — a reader
- *    would still be misled into thinking `platform/` and `packages/runner`
- *    exist.
+ *      - `platform/` and `packages/runner` — hosted-platform remnants (see
+ *        [ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md));
+ *        safe to ignore.
+ *    Two deliberate design choices baked into this exact wording:
+ *      a. The "retired" resolution (locked precedence: the suppression guard
+ *         stays BROAD, the FIXTURE adapts) — the real #766 bullet ("retired
+ *         hosted-platform remnants") contains "retired", which
+ *         `HISTORICAL_GUARD_RE` correctly suppresses by design (the primary
+ *         FP class docs-drift exists to filter). This variant carries none
+ *         of that guard's trigger words (was/were+verb, retired, formerly,
+ *         deprecated, previously, prior to, no longer, used to) while
+ *         staying equally implausible as a *current*, accurate description —
+ *         a reader would still be misled into thinking `platform/` and
+ *         `packages/runner` exist.
+ *      b. The ADR-cited link — `(see [ADR-012](...))` — is the fix-#1
+ *         regression test for the link-suppression NARROWING: this repo's
+ *         dominant doc idiom cites an ADR link right next to a genuine
+ *         structural bullet. A prior blanket "line has a link ANYWHERE"
+ *         suppression silently ate this exact shape (found by adversarial
+ *         review of this fixture); the narrowed suppression
+ *         (`referandOnlyInsideLinkOrUrl` in `docs-drift-signals.ts`) only
+ *         suppresses when the referand's OWN occurrence sits inside the
+ *         link markup — `packages/runner`/`platform` sit in plain prose
+ *         here, not inside `[ADR-012](...)`, so this bullet correctly FIRES.
  *
- * 4. PRUNED one incidental noise chunk: `.github/workflows/release.yml`
- *    (untouched, unrelated to PR #593) contains an ambient comment
- *    ("the runner's Node 22...", "hosted runner image") about the CI
- *    hosted-runner MACHINE — a coincidental, unrelated hit on the
- *    `packages/runner` referand's trailing-segment alt-token ("runner").
- *    Verified this session: left in, it becomes a `behavioral-claim`-tier
- *    candidate that SORTS AHEAD of the intended `structural-mention`-tier
- *    CLAUDE.md candidate (Tier-1 beats Tier-2 in `computeDocsDriftCandidates`'s
- *    sort), and at this pass's realistic production budget floor
- *    (`docsDriftPassBudget` -> `EXTRA_PASS_MIN_BUDGET_TOKENS` = 11,000 ->
- *    `affordableCandidateCeiling` affords exactly 1 candidate for this
- *    referand count), it would have crowded the CLAUDE.md candidate OUT of
- *    the rendered `<docs_drift>` worklist entirely. This is real, honestly-
- *    documented evidence of a genuine (narrow) precision gap in the
- *    trailing-segment alt-token heuristic (`docs-drift-signals.ts`'s
- *    `trailingSegment`) — worth a future follow-up, not hidden. Pruning this
- *    ONE ambient, unrelated repoChunk from an already-extensively-hand-staged
- *    synthetic fixture (not touching the shipped signal or suppression code)
- *    is the fixture-side fix per the locked precedence.
- *
- * 5. `config.docsDriftPass` set to `true` (capture-pr.ts never sets
+ * 4. `config.docsDriftPass` set to `true` (capture-pr.ts never sets
  *    pass-specific config; the pass is dark by default).
  *
- * RESULT (verified this session): `computeDocsDriftCandidates` returns
- * exactly 2 candidates, both citing CLAUDE.md:14 (structural-mention) —
- * `{referand:"packages/runner", ...}` and `{referand:"platform", ...}`.
+ * No other repoChunks were pruned or altered — an earlier iteration of this fixture also removed
+ * `.github/workflows/release.yml` (an ambient, unrelated CI comment about the GitHub Actions
+ * "hosted runner" machine coincidentally matched the `packages/runner` referand's trailing-segment
+ * ALT-TOKEN). That alt-token was removed from the signal entirely (design's precision-first fix:
+ * `docs-drift-signals.ts` no longer sweeps a bare trailing path segment, only the full path), so
+ * the false match no longer occurs and release.yml no longer needs pruning — fewer hand-edits, a
+ * more honest fixture.
  *
- * OFFLINE PROOF (zero-LLM, no OpenRouter spend — see PR body for the
- * verbatim run): `LIEN_DOCS_DRIFT_PASS=on npx tsx
- * packages/review/test/harness/build-prompts.ts <this fixture>` ->
- * `docsDriftPass: {"fires":true}`, with candidate-1 = referand
- * "packages/runner", "Untouched doc: CLAUDE.md:14 (structural-mention)",
- * the injected bullet in the doc-side excerpt, and the real
- * `packages/runner/Dockerfile` deletion hunk as the code-side evidence. (The
- * "platform" candidate is deferred by the same realistic budget ceiling —
- * `computeDocsDriftWorklist` affords exactly 1 of the 2 eligible candidates —
- * an authentic demonstration of the rank-and-cap overflow mechanism, not a
- * fixture defect.)
+ * RESULT (verified this session): `computeDocsDriftCandidates` returns exactly 2 candidates, both
+ * citing CLAUDE.md:14 (structural-mention) — `{referand:"packages/runner", ...}` and
+ * `{referand:"platform", ...}`. `.github/workflows/release.yml` produces zero candidates (no
+ * alt-token to false-match on).
  *
- * SHIPPED THIS SESSION: the candidate-FIRES proof above (deterministic,
- * zero-LLM). NOT shipped: any real `drifted` verdict — no paid calibration
- * ran this session (cost discipline; per the overseer's explicit scope). The
- * Tier-1/Tier-2 assertions below are written as the FUTURE calibration
- * target (a `--calibrate 10` run, pending owner greenlight) — a real vote
- * against this fixture has not yet been observed to pass or fail them.
+ * OFFLINE PROOF (zero-LLM, no OpenRouter spend — see PR body for the verbatim run):
+ * `LIEN_DOCS_DRIFT_PASS=on npx tsx packages/review/test/harness/build-prompts.ts <this fixture>`
+ * -> `docsDriftPass: {"fires":true}`, with candidate-1 = referand "packages/runner", "Untouched
+ * doc: CLAUDE.md:14 (structural-mention)", the ADR-cited bullet in the doc-side excerpt (NOT
+ * suppressed by the link), and the real `packages/runner/Dockerfile` deletion hunk as the code-side
+ * evidence. (The "platform" candidate is deferred by this pass's realistic budget ceiling —
+ * `computeDocsDriftWorklist` affords exactly 1 of the 2 eligible candidates at the floor budget —
+ * an authentic demonstration of the rank-and-cap overflow mechanism, not a fixture defect.)
+ *
+ * SHIPPED THIS SESSION: the candidate-FIRES proof above (deterministic, zero-LLM), PLUS a durable
+ * unit-test regression (`docs-drift-signals.test.ts`) covering the same ADR-cited-bullet shape with
+ * inline synthetic input — independent of this gitignored fixture JSON. NOT shipped: any real
+ * `drifted` verdict — no paid calibration ran this session (cost discipline; per the overseer's
+ * explicit scope). The Tier-1/Tier-2 assertions below are written as the FUTURE calibration target
+ * (a `--calibrate 10` run, pending owner greenlight) — a real vote against this fixture has not yet
+ * been observed to pass or fail them.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';
@@ -111,8 +110,9 @@ import type { FixtureAssertions } from '../../assertions.js';
 const assertions: FixtureAssertions = {
   description:
     'Synthetic — real PR #593 packages/runner + platform/ deletion, hand-staged with an ' +
-    'injected untouched CLAUDE.md bullet ("hosted-platform remnants; safe to ignore", no ' +
-    'historical-guard trigger words) naming the now-deleted paths as if still current',
+    'injected untouched CLAUDE.md bullet ("hosted-platform remnants (see [ADR-012](...)); safe ' +
+    'to ignore", no historical-guard trigger words, an ADR link that must NOT blanket-suppress) ' +
+    'naming the now-deleted paths as if still current',
   rule: 'docs-drift',
   expect: (result, h) => {
     h.expectRuleFired('docs-drift', result);

--- a/packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts
+++ b/packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts
@@ -1,0 +1,138 @@
+/**
+ * SYNTHETIC shape fixture (docs-drift design doc §5.A, `.wip/docs-drift-design.md`).
+ *
+ * Tagged `synthetic`, NOT `canary` — this exercises the deleted-path referand
+ * + structural-mention tier end-to-end, but is honestly hand-staged, not a
+ * clean captured-real-PR positive. Design §0.1 established why no single real
+ * PR captures "code deletion + a coincident stale UNTOUCHED doc": the real
+ * code deletion (PR #593, "retire packages/runner and the platform/ Laravel
+ * app") updated CLAUDE.md's stale bullets IN THE SAME DIFF, so there is no
+ * real PR where that doc is genuinely untouched.
+ *
+ * HAND-STAGING HISTORY (every edit, in order — so this fixture's provenance
+ * is auditable):
+ *
+ * 1. BASE CAPTURE — real PR #593 deletion. `capture-pr.ts`'s `--sha` requires
+ *    a commit within the PR's OWN branch lineage; the merge commit `06cf2b6a`
+ *    the design doc cites is main's SQUASH-MERGE commit, not an ancestor of
+ *    the PR branch's own head, so (mirroring the same fix needed for the
+ *    pr799 boundary fixture) the actual PR branch head SHA was used instead —
+ *    fetched via `git fetch origin refs/pull/593/head` (needed since a
+ *    squash-merged branch's commits aren't otherwise reachable locally):
+ *      npx tsx packages/review/test/harness/capture-pr.ts 593 \
+ *        packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.fixture.json \
+ *        --sha 2aa87b3044fc0ea08768206df4152df17f273a20
+ *    This captures the real deletion of `packages/runner/**` (21 files) and
+ *    `platform/**` (271 files) — every file's patch is a genuine full-file
+ *    deletion (`isFullFileDeletion` true for all 21 `packages/runner/` files;
+ *    all-but-a-few `platform/` files, verified via a debug script this
+ *    session — the handful of exceptions don't prevent the directory-level
+ *    grouping, which only needs ONE confirmed deletion under the prefix AND
+ *    zero surviving repoChunks under it, both true here).
+ *
+ * 2. DISCOVERED: the real PR #593 diff ALSO touches CLAUDE.md (removing the
+ *    exact stale bullets: "- `packages/` — ...(..., runner, site)" and
+ *    "- `platform/` — Laravel 12 web app..."). Since docs-drift's own
+ *    untouched-only filter (by design) excludes any file in `pr.patches` /
+ *    `changedFiles` / `allChangedFiles`, CLAUDE.md was NOT eligible as an
+ *    "untouched doc" in the raw capture — confirmed via a debug script this
+ *    session (`CLAUDE.md in changed set: true`). To honestly stage the
+ *    counterfactual design §5.A asks for ("what if this bullet had survived,
+ *    unedited, in an UNTOUCHED CLAUDE.md"), CLAUDE.md's entry was removed
+ *    from `pr.patches`, `pr.diffLines`, `changedFiles`, `allChangedFiles`,
+ *    and the changed-files-only `chunks` array (299->298 patches, 36->3
+ *    chunks) — leaving CLAUDE.md's 33 `repoChunks` doc chunks (the post-
+ *    deletion, head-state content) as the untouched corpus docs-drift sweeps.
+ *
+ * 3. INJECTED the variant bullet into CLAUDE.md's "## What is Lien?" chunk
+ *    (repoChunks entry, startLine 3), right after the existing "Monorepo
+ *    Structure:" bullet, bumping that chunk's endLine 38->39:
+ *      - `platform/` and `packages/runner` — hosted-platform remnants; safe to ignore.
+ *    CRITICAL — the "retired" resolution (locked precedence: the suppression
+ *    guard stays BROAD, the FIXTURE adapts): the real #766 bullet
+ *    ("retired hosted-platform remnants") contains "retired", which
+ *    `HISTORICAL_GUARD_RE` correctly suppresses by design (the primary FP
+ *    class docs-drift exists to filter). This variant carries none of
+ *    HISTORICAL_GUARD_RE's trigger words (was/were+verb, retired, formerly,
+ *    deprecated, previously, prior to, no longer, used to) while staying
+ *    equally implausible as a *current*, accurate description — a reader
+ *    would still be misled into thinking `platform/` and `packages/runner`
+ *    exist.
+ *
+ * 4. PRUNED one incidental noise chunk: `.github/workflows/release.yml`
+ *    (untouched, unrelated to PR #593) contains an ambient comment
+ *    ("the runner's Node 22...", "hosted runner image") about the CI
+ *    hosted-runner MACHINE — a coincidental, unrelated hit on the
+ *    `packages/runner` referand's trailing-segment alt-token ("runner").
+ *    Verified this session: left in, it becomes a `behavioral-claim`-tier
+ *    candidate that SORTS AHEAD of the intended `structural-mention`-tier
+ *    CLAUDE.md candidate (Tier-1 beats Tier-2 in `computeDocsDriftCandidates`'s
+ *    sort), and at this pass's realistic production budget floor
+ *    (`docsDriftPassBudget` -> `EXTRA_PASS_MIN_BUDGET_TOKENS` = 11,000 ->
+ *    `affordableCandidateCeiling` affords exactly 1 candidate for this
+ *    referand count), it would have crowded the CLAUDE.md candidate OUT of
+ *    the rendered `<docs_drift>` worklist entirely. This is real, honestly-
+ *    documented evidence of a genuine (narrow) precision gap in the
+ *    trailing-segment alt-token heuristic (`docs-drift-signals.ts`'s
+ *    `trailingSegment`) — worth a future follow-up, not hidden. Pruning this
+ *    ONE ambient, unrelated repoChunk from an already-extensively-hand-staged
+ *    synthetic fixture (not touching the shipped signal or suppression code)
+ *    is the fixture-side fix per the locked precedence.
+ *
+ * 5. `config.docsDriftPass` set to `true` (capture-pr.ts never sets
+ *    pass-specific config; the pass is dark by default).
+ *
+ * RESULT (verified this session): `computeDocsDriftCandidates` returns
+ * exactly 2 candidates, both citing CLAUDE.md:14 (structural-mention) —
+ * `{referand:"packages/runner", ...}` and `{referand:"platform", ...}`.
+ *
+ * OFFLINE PROOF (zero-LLM, no OpenRouter spend — see PR body for the
+ * verbatim run): `LIEN_DOCS_DRIFT_PASS=on npx tsx
+ * packages/review/test/harness/build-prompts.ts <this fixture>` ->
+ * `docsDriftPass: {"fires":true}`, with candidate-1 = referand
+ * "packages/runner", "Untouched doc: CLAUDE.md:14 (structural-mention)",
+ * the injected bullet in the doc-side excerpt, and the real
+ * `packages/runner/Dockerfile` deletion hunk as the code-side evidence. (The
+ * "platform" candidate is deferred by the same realistic budget ceiling —
+ * `computeDocsDriftWorklist` affords exactly 1 of the 2 eligible candidates —
+ * an authentic demonstration of the rank-and-cap overflow mechanism, not a
+ * fixture defect.)
+ *
+ * SHIPPED THIS SESSION: the candidate-FIRES proof above (deterministic,
+ * zero-LLM). NOT shipped: any real `drifted` verdict — no paid calibration
+ * ran this session (cost discipline; per the overseer's explicit scope). The
+ * Tier-1/Tier-2 assertions below are written as the FUTURE calibration
+ * target (a `--calibrate 10` run, pending owner greenlight) — a real vote
+ * against this fixture has not yet been observed to pass or fail them.
+ */
+
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'Synthetic — real PR #593 packages/runner + platform/ deletion, hand-staged with an ' +
+    'injected untouched CLAUDE.md bullet ("hosted-platform remnants; safe to ignore", no ' +
+    'historical-guard trigger words) naming the now-deleted paths as if still current',
+  rule: 'docs-drift',
+  expect: (result, h) => {
+    h.expectRuleFired('docs-drift', result);
+    // Tier 2 (future-calibration target — see header): a correct finding names the deleted
+    // path(s) and/or the stale bullet's own wording, and cites the doc file.
+    h.expectFindingMentions(
+      [
+        'packages/runner',
+        'platform/',
+        'hosted-platform remnants',
+        'monorepo structure',
+        'claude.md',
+        'safe to ignore',
+      ],
+      result,
+    );
+  },
+  votes: 10,
+  passThreshold: 9,
+  tags: ['synthetic'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.assertions.ts
+++ b/packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.assertions.ts
@@ -78,7 +78,7 @@ const assertions: FixtureAssertions = {
     'renamed runDocTruthPass/appendDocTruthTurns functions) — docs-drift correctly finds ZERO ' +
     'candidates (conceptual/architectural drift is the permanent scope ceiling, design §0.2/§5.B)',
   rule: 'docs-drift',
-  expect: (result, h) => {
+  expect: result => {
     const docsDriftFinding = result.findings.find(f => f.ruleId === 'docs-drift');
     if (docsDriftFinding) {
       throw new HarnessAssertionError(

--- a/packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.assertions.ts
+++ b/packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.assertions.ts
@@ -1,0 +1,97 @@
+/**
+ * Boundary fixture (docs-drift design doc §0.2, §5.B, `.wip/docs-drift-design.md`).
+ *
+ * Captured PR #799 ("refactor(review): generalize doc-truth's second pass
+ * into a ReviewPass executor") at its own branch head SHA
+ * `028ebca4bd57ed5572ab29a3643d9786c83227ea` — the commit `3e4af932` the
+ * design doc cites is the SQUASH-MERGE commit on `main`, which is not an
+ * ancestor of the PR's own branch lineage that `capture-pr.ts`'s
+ * `assertShaInPrRange` validates against; both commits carry the identical
+ * tree, so this SHA is the equivalent, capturable one.
+ *
+ * Capture command:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 799 \
+ *     packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.fixture.json \
+ *     --sha 028ebca4bd57ed5572ab29a3643d9786c83227ea
+ * The fixture's `config` was then hand-edited to add `docsDriftPass: true`
+ * (capture-pr.ts never sets pass-specific config; the pass is dark by
+ * default and this loop is genuinely enabled for this fixture's proof).
+ *
+ * THE SCOPE-CEILING CASE this fixture locks in: at this SHA,
+ * `docs/development/review-harness-judgment.md` still reads (verified via
+ * `git show 028ebca4:docs/development/review-harness-judgment.md`):
+ *
+ *   ## The two-pass architecture
+ *   Since PR #733, `analyze()` runs a second, claims-only pass when a PR's
+ *   touched doc surfaces carry claim-shaped prose: ...
+ *   ...
+ *   - The doc-truth second pass: `packages/review/src/plugins/agent/doc-truth-pass.ts`
+ *
+ * PR #799 (`3e4af932`) generalized two-pass -> N-pass in CODE and renamed
+ * `runDocTruthPass` -> `runReviewPass`, `appendDocTruthTurns` -> `appendPassTurns`
+ * — but the stale doc references the FILE `doc-truth-pass.ts` (which still
+ * exists — the module wasn't deleted, only two of its internal functions were
+ * renamed/generalized) and the CONCEPT "two-pass architecture" (now
+ * conceptually stale — it's N-pass), not either renamed function by name.
+ *
+ * docs-drift is a deterministic identifier/path referand sweep
+ * (removed-export-signals.ts / rename-sweep-signals.ts / this module's own
+ * isFullFileDeletion) — it has no token to anchor on here: `doc-truth-pass.ts`
+ * was never deleted (isFullFileDeletion is false for it), and neither
+ * `runDocTruthPass` nor `appendDocTruthTurns` is named anywhere in the stale
+ * prose for the rename-sweep referand to match against. A reader-visible
+ * concept going stale with no removed/renamed/deleted TOKEN present in the
+ * prose is structurally invisible to this signal — the permanent scope
+ * ceiling design §0.2/§5.B accepts (a prose-behavioral-claim tier over
+ * untouched docs is explicitly deferred, design §6.5 — the "input engineering
+ * can't fix output economy" trap).
+ *
+ * Independently reproduced by the zero-LLM 40-PR census (.wip/docs-drift-census/
+ * SUMMARY.txt): PR #799 is one of only 2/40 PRs with ANY removed-export/
+ * renamed-identifier/deleted-path referand at all (three renamed functions:
+ * `DocTruthClientRunner`, `runDocTruthPass`, `appendDocTruthTurns`), yet its
+ * raw reference count against the untouched doc/config corpus is 0 — no doc
+ * anywhere names those three tokens. This fixture is the offline (zero-LLM)
+ * lock-in of that same finding: the pass must gate OFF entirely (skipReason
+ * non-null, zero candidates), so no `docs-drift` finding is even POSSIBLE,
+ * paid or not.
+ *
+ * OFFLINE PROOF (zero-LLM, no OpenRouter spend — see PR body for the
+ * verbatim run): `LIEN_DOCS_DRIFT_PASS=on npx tsx
+ * packages/review/test/harness/build-prompts.ts <this fixture>` ->
+ * `docsDriftPass: {"fires":false}`; `docsDriftSkipReason(ctx, config)` ->
+ * "no untouched-doc reference to a removed/renamed/deleted referand in this
+ * PR"; `computeDocsDriftPassCandidates(ctx)` -> `[]`.
+ *
+ * This fixture is `tags: ['boundary']`, not `canary` — it locks in a NEGATIVE
+ * (docs-drift correctly does not fire), marking the permanent scope ceiling
+ * rather than certifying a positive detection.
+ */
+
+import { HarnessAssertionError } from '../../assertions.js';
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #799 028ebca4 — two-pass->N-pass generalization; review-harness-judgment.md still says ' +
+    '"## The two-pass architecture" and names the still-existing doc-truth-pass.ts file (not the ' +
+    'renamed runDocTruthPass/appendDocTruthTurns functions) — docs-drift correctly finds ZERO ' +
+    'candidates (conceptual/architectural drift is the permanent scope ceiling, design §0.2/§5.B)',
+  rule: 'docs-drift',
+  expect: (result, h) => {
+    const docsDriftFinding = result.findings.find(f => f.ruleId === 'docs-drift');
+    if (docsDriftFinding) {
+      throw new HarnessAssertionError(
+        'Tier 1: expected docs-drift NOT to fire on this boundary fixture (conceptual drift with ' +
+          'no removed/renamed/deleted token is structurally out of scope, design §0.2/§5.B). Got ' +
+          `a docs-drift finding: ${docsDriftFinding.message}`,
+        1,
+      );
+    }
+  },
+  votes: 1,
+  passThreshold: 1,
+  tags: ['boundary'],
+};
+
+export default assertions;

--- a/packages/review/test/harness/rule-coverage.ts
+++ b/packages/review/test/harness/rule-coverage.ts
@@ -13,6 +13,28 @@
  */
 
 import type { FixtureAssertions } from './assertions.js';
+import {
+  isDocsDriftPassEnabled,
+  DOCS_DRIFT_RULE_ID,
+} from '../../src/plugins/agent/docs-drift-pass.js';
+import type { AgentConfig } from '../../src/plugins/agent/types.js';
+
+/**
+ * Extend `activeRuleIds` with `docs-drift` when the fixture's own captured config opted that
+ * loop in. `docs-drift` is dedicated-pass-only (design doc §2 — no `BUILTIN_RULES` entry), so
+ * `selectRules` alone never includes it in a fixture's active-rule set; without this, a
+ * docs-drift fixture would be flagged unpassable-by-construction (below) even when the pass is
+ * genuinely enabled for it. Scoped to this one dedicated-pass-only rule, not a general
+ * BUILTIN_RULES-bypass — every other rule this preflight checks genuinely lives in
+ * `BUILTIN_RULES`. Lives in this pure, side-effect-free module (not `run.ts`, a CLI entrypoint
+ * whose top-level `main()` call would fire on import) so it stays trivially unit-testable.
+ */
+export function withDocsDriftRuleId(
+  activeRuleIds: string[],
+  config: AgentConfig | undefined,
+): string[] {
+  return isDocsDriftPassEnabled(config) ? [...activeRuleIds, DOCS_DRIFT_RULE_ID] : activeRuleIds;
+}
 
 /**
  * Returns a human-actionable message when neither `assertions.rule` nor any

--- a/packages/review/test/harness/run.ts
+++ b/packages/review/test/harness/run.ts
@@ -29,6 +29,7 @@ import { dirname, basename, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { BUILTIN_RULES, buildTriggerContext, selectRules } from '../../src/plugins/agent/rules.js';
+import type { AgentConfig } from '../../src/plugins/agent/types.js';
 
 import type { FixtureAssertions } from './assertions.js';
 import { vote, calibrate } from './voting.js';
@@ -36,7 +37,7 @@ import type { AssertedRun } from './voting.js';
 import type { RunnerOptions } from './runner.js';
 import { reportVote, reportCalibrate } from './reporter.js';
 import { loadFixture } from './fixture-loader.js';
-import { checkRuleCoverage } from './rule-coverage.js';
+import { checkRuleCoverage, withDocsDriftRuleId } from './rule-coverage.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_ROOT = resolve(HERE, 'fixtures');
@@ -248,8 +249,9 @@ async function validateFixtureRuleCoverage(fixtures: FixturePair[]): Promise<str
         loadAssertions(f.assertionsPath),
         loadFixture(f.fixturePath),
       ]);
-      const activeRuleIds = selectRules(BUILTIN_RULES, buildTriggerContext(ctx)).active.map(
-        r => r.id,
+      const activeRuleIds = withDocsDriftRuleId(
+        selectRules(BUILTIN_RULES, buildTriggerContext(ctx)).active.map(r => r.id),
+        ctx.config as unknown as AgentConfig | undefined,
       );
       const violation = checkRuleCoverage(assertions, activeRuleIds);
       if (violation) violations.push(`${label}: ${violation}`);


### PR DESCRIPTION
## Summary
The fifth dedicated candidate-loop pass (ADR-014 / review-pass architecture). doc-truth checks the docs-CHANGED direction; docs-drift is the inverse — a PR changes CODE (removes an export, renames an identifier, deletes a path) and an UNTOUCHED doc describing the old thing silently rots. Deterministic "blast-radius for docs" signal + a dedicated LLM pass, **dark by default** (`config.docsDriftPass` / `LIEN_DOCS_DRIFT_PASS`, default false). New rule id `docs-drift`, dedicated-pass-only (no BUILTIN_RULES entry — design §2). Grounded in `.wip/docs-drift-design.md`.

## Dark + byte-neutral (flag off)

With the flag off the pass gates off — production `analyze()` output is unchanged. Verified against the true pre-feature baseline (`origin/main`, `7c366d5d`) on two real captured PRs, via `build-prompts.ts`:

```
PR #820 byte-identical after removing docsDriftPass key: true
docsDriftPass value: {"fires":false}
before length: 146208  after(minus key) length: 146208

PR #799 (census fixture) byte-identical after removing docsDriftPass key: true
docsDriftPass value: {"fires":false}
```

Every pre-existing field (`systemPrompt`, `initialMessage`, `ruleIds`, `skippedRules`, `docTruthPass`, `staleDuplicatePass`, `incompleteHandlingPass`, `removedExportsPass`) is byte-for-byte identical; the only change to the harness JSON is the additive `docsDriftPass:{fires:false}` key — not production output, not any committed fixture.

## Census (zero-LLM, last 40 merged PRs) — the GO/NO-GO

```
=== docs-drift zero-LLM census ===
PRs requested: 40, captured: 40, capture failed: 0

RAW firing rate (>=1 raw reference to a removed/renamed/deleted referand): 0/40
TIERED firing rate (>=1 candidate survives suppression+tiering):          0/40

Total raw references across corpus: 0
  tier distribution — tier1 (behavioral-claim): 0, tier2 (structural-mention): 0, suppressed: 0, (neither tier: 0)

Tiered candidates per FIRING PR — mean: 0.00, max: 0

--- Independent cross-check (referand extraction alone, ignoring doc-corpus overlap) ---
Only 2/40 PRs contain ANY removed/renamed/deleted referand at all (before checking whether any
untouched doc/config chunk happens to mention it):
  PR #821 (chore: version packages / changesets release): deletedPaths=[".changeset"]
    (every individual .changeset/*.md entry is deleted as part of the release; grouped to the
    top-level ".changeset" directory referand since no repoChunks file survives under it)
  PR #799 (feat(review): two-pass -> N-pass generalization, 3e4af932): removedExports=
    ["DocTruthClientRunner","runDocTruthPass","appendDocTruthTurns"]
    This is the exact #799/#808 case the design doc (.wip/docs-drift-design.md, §0.2) predicted as
    OUT OF SCOPE: at PR #808's parent, docs/development/review-harness-judgment.md's stale prose
    named the FILE "doc-truth-pass.ts" (which still exists) and the *concept* "two-pass
    architecture" -- not these renamed FUNCTION names. My census independently reproduces the
    design's own prediction: PR #799 has real removed-export referands, but raw=0 -- no untouched
    doc/config chunk anywhere in the repo mentions "DocTruthClientRunner", "runDocTruthPass", or
    "appendDocTruthTurns" by name.

Net: on this specific 40-PR window (dense, recent, mostly-additive review-package development),
neither referand existence nor referand-plus-doc-mention correlation was common enough to produce
a single organic firing -- consistent with (if at the extreme low end of) the design doc's own
prediction of a "LOW (single-digit to low-double-digit percent)" firing rate.
```

RAW 0/40, TIERED 0/40 organic firings. Only 2/40 PRs carry ANY removed/renamed/deleted referand (#821 `.changeset`, #799 renamed doc-truth fns), NEITHER with a surviving doc reference — a real selectivity result (0 false positives), and it independently reproduced the design's own #799 "conceptual drift is out of deterministic reach" prediction. → No organic canary exists in this window → **no paid calibration ran** (zero OpenRouter spend). Ships DARK with a shape + boundary fixture and an honest **primary calibration pending fixture** note; the owner decides future paid calibration + CI opt-in.

## Fixtures (offline-proven, zero-LLM)

- **Boundary (#799, negative):** stale "two-pass architecture" prose names the still-existing FILE `doc-truth-pass.ts`, not the renamed functions → docs-drift correctly yields 0 candidates (the permanent scope ceiling).
  ```
  $ LIEN_DOCS_DRIFT_PASS=on npx tsx packages/review/test/harness/build-prompts.ts \
      packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.fixture.json
  docsDriftPass: {"fires":false}
  ```

- **Shape (#766, synthetic deleted-path):** hand-staged from real #593 runner/platform deletion + an injected untouched ADR-cited CLAUDE.md bullet → fires a deleted-path/structural-mention candidate. Durable inline regression also in `docs-drift-signals.test.ts`.
  ```
  $ LIEN_DOCS_DRIFT_PASS=on npx tsx packages/review/test/harness/build-prompts.ts \
      packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.fixture.json
  fires: true
  ```
  ```
  <docs_drift>
  One verdict is REQUIRED per candidate id below (see <output_format>) — candidate-1. Each candidate is an UNTOUCHED doc/config line that still references a symbol/path this PR removed, renamed, or deleted, already tiered and past every suppression check.

  <candidate id="candidate-1" referand="packages/runner">
  Kind: deleted-path
  Untouched doc: CLAUDE.md:14 (structural-mention)
  ```
  **Monorepo Structure:**
  - `packages/` — TypeScript packages (parser, core, review, cli, action, site)
  - `platform/` and `packages/runner` — hosted-platform remnants (see [ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)); safe to ignore.

  **Package Structure:**
  '''
  ```
  Code side — packages/runner/Dockerfile:
  ```diff
  diff --git a/packages/runner/Dockerfile b/packages/runner/Dockerfile
  deleted file mode 100644
  index d5643e09..00000000
  --- a/packages/runner/Dockerfile
  +++ /dev/null
  @@ -1,69 +0,0 @@
  -FROM node:22-slim AS builder
  ... [full real deletion hunk] ...
  -CMD ["node", "packages/runner/dist/index.js"]
  ```
  </candidate>
  </docs_drift>
  ```

## Adversarial review found + fixed 2 precision gaps (with regression tests)

1. `LINK_OR_URL_RE` over-suppressed on ANY link on a line → ADR-cited structural bullets (this repo's dominant idiom) never fired. Narrowed to "referand only inside a link span."
2. Deleted-path trailing-segment alt-token (`packages/runner`→`runner`) false-matched unrelated prose (this repo's packages are generic words) → dropped entirely; full-path referand only. Residual single-word-dir risk → fast-follow.
3. Misleading "pass order doesn't matter" comment corrected — docs-drift's doc-truth cross-dedup depends on doc-truth preceding it in EXTRA_PASSES.

## Tests + gates

88 new tests (signal 24, pass 58, preflight 6), all green. Full gate chain green (`format:check`/`lint`/`typecheck`/`build`/`test`); `lien delta` exit 0 (net simplification). No changeset (review is private).

## Fast-follows (owner decisions)

- Paid calibration of the synthetic shape fixture and/or a future census-mined canary (owner greenlight — zero paid spend this session).
- CI opt-in: enabling docs-drift in this repo's own `lien-review.yml` (separate priced decision, as the prior loops did).
- Precision: a distinctiveness/stopword filter for single-word path referands (e.g. `platform`).
- `build-prompts.ts` main() loop refactor (Halstead relief — 5 near-identical passOutput blocks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in documentation drift review pass that identifies untouched documentation referencing removed, renamed, or deleted code.
  * Review findings include relevant document locations and evidence excerpts.
  * Added suppression for historical notes, changelogs, code blocks, and link-only references to reduce false positives.
  * Added configuration support and deterministic candidate limits for the new pass.

* **Tests**
  * Added comprehensive coverage for detection, filtering, budgeting, deduplication, and review-pass behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR introduces the docs-drift candidate-loop pass: a deterministic signal that finds untouched docs/config still referencing removed, renamed, or deleted code, plus a dedicated LLM pass to judge those candidates. The feature is dark by default (`docsDriftPass`/`LIEN_DOCS_DRIFT_PASS` default false), so production `analyze()` output is unchanged. The implementation mirrors the existing extra-pass architecture, reuses the doc-claims signal tiering, and includes suppression for changelog/changeset entries, fenced code, link-only references, and historical prose. No correctness bugs were found in the deterministic signal, pass gating, prompt construction, or merge/dedup logic.
>
> - Added `docs-drift-signals.ts` with deterministic referand extraction (removed exports, renamed identifiers, deleted paths) and tiered/suppressed candidate sweep
> - Added `plugins/agent/docs-drift-pass.ts` as a dedicated dark-by-default candidate-loop pass with drifted/historical/intentional/unverifiable verdict vocabulary
> - Wired the pass into `plugins/agent/index.ts` `EXTRA_PASSES`, with doc-truth ordered before docs-drift to make cross-dedup work
> - Extended `AgentConfig` and the Zod schema with `docsDriftPass: z.boolean().default(false)`

⚠️ The documentation-truthfulness pass did not finish — it hit the token budget limit. Doc-claim verification is partial; code findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a3beb02. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 426K/415K tokens
<!-- /lien:attestation -->