### PR TITLE
fix(review): require independent verification for same-file claim evidence

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -132,6 +132,21 @@ export interface DocClaimEvidence {
    * (a diff hunk isn't chunk-sourced).
    */
   fromDiff?: boolean;
+  /**
+   * True when this excerpt was located in the CLAIM'S OWN file — the
+   * `EvidenceTier.SameFile` tier (see `tierOf`), reachable only for a
+   * CODE-sourced claim (a comment scanned from a changed code file, see
+   * `addedCodeCommentLines`). Flagged so the render layer can mark it
+   * distinctly: this excerpt is the same text the claim itself was drawn
+   * from, so it can only confirm what the claim SAYS, never whether it is
+   * TRUE — unlike every other tier, which is a genuinely independent
+   * location. Motivated by pr658 Finding A's post-#817 re-certification
+   * (6/10): with the wrong-file bug fixed, several votes still verdicted
+   * a same-file-evidence claim `unverifiable` instead of chasing the
+   * actual implementing code, because nothing distinguished "restates the
+   * claim" evidence from "proves the claim" evidence.
+   */
+  sameFile?: boolean;
 }
 
 /**
@@ -1222,6 +1237,7 @@ export function findClaimEvidence(
     excerpt: built.excerpt,
     anchor: built.anchor,
     fromDoc: DOC_FILE_RE.test(candidate.chunk.metadata.file),
+    sameFile: candidate.tier === EvidenceTier.SameFile,
   };
 }
 

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -486,8 +486,14 @@ function renderDocClaimEntryWithId(id: string, claim: DocClaim): string {
       'index or PR diff — the citation itself may be stale)'
     );
   }
-  const { file, startLine, excerpt, fromDoc, fromDiff } = claim.evidence;
-  const label = fromDiff ? 'evidence (PR diff)' : fromDoc ? 'evidence (sibling doc)' : 'evidence';
+  const { file, startLine, excerpt, fromDoc, fromDiff, sameFile } = claim.evidence;
+  const label = fromDiff
+    ? 'evidence (PR diff)'
+    : fromDoc
+      ? 'evidence (sibling doc)'
+      : sameFile
+        ? 'evidence (same file as claim)'
+        : 'evidence';
   return `${header}\n  ${label} — ${file}:${startLine}:\n  \`\`\`\n${excerpt}\n  \`\`\``;
 }
 
@@ -499,7 +505,17 @@ const DOC_CLAIMS_V2_HEADER =
   'also skim the touched hunks for any claim not listed — report those as ordinary additional ' +
   'findings (no id needed). Most entries carry an `evidence` excerpt: COMPARE the claim against ' +
   'it (confirm the excerpt IS the described code first); for a no-evidence entry, locate the code ' +
-  'yourself via get_files_context on the named symbols.';
+  'yourself via get_files_context on the named symbols.\n\n' +
+  "An entry labeled `evidence (same file as claim)` is drawn from the claim's OWN file — it " +
+  'establishes what the claim SAYS, not whether it is TRUE, since it is the very text the claim ' +
+  'was mined from and so cannot independently corroborate itself. For those entries, verdicting ' +
+  '`accurate` or `contradicted` REQUIRES you to also locate and check the code that IMPLEMENTS ' +
+  'the described behavior (get_files_context / search_code on the described symbol) before ' +
+  'deciding; verdict `unverifiable` only when you attempted that independent check and the ' +
+  'implementing code was genuinely not locatable — not merely because the same-file text agrees ' +
+  'with itself. Every other evidence label (`evidence (PR diff)`, `evidence (sibling doc)`, or a ' +
+  'plain `evidence` excerpt from a DIFFERENT file) already IS that independent check — compare ' +
+  'against it directly as before.';
 
 /** Render the `<doc_claims>` block with ids — the v2 counterpart of
  *  `renderDocClaimsSection`. Returns '' when there are no doc claims at all. */

--- a/packages/review/test/doc-claims-signals.test.ts
+++ b/packages/review/test/doc-claims-signals.test.ts
@@ -503,6 +503,31 @@ describe('findClaimEvidence — ranking', () => {
     expect(ev?.file).toBe(SCHEMA);
   });
 
+  // Fourth root-cause layer, post-#817: with the wrong-file bug fixed, same-file evidence still
+  // merely restates the claim rather than proving it — several pr658 re-cert votes verdicted
+  // `unverifiable` instead of chasing the implementing code because nothing marked the excerpt
+  // as self-referential. `sameFile` is the deterministic marker the v2 render layer anchors its
+  // "independent check required" instruction to (see doc-truth-pass.ts's DOC_CLAIMS_V2_HEADER).
+  it('marks evidence located in the claim’s OWN file with sameFile: true', () => {
+    const SCHEMA = 'packages/core/src/config/schema.ts';
+    const claimText = 'keep working; search_code and find_similar report as disabled.';
+    const claim = claimOf(claimText, SCHEMA);
+    const chunks = [chunk(SCHEMA, 40, `// ${claimText}\nenabled: z.boolean().optional(),`)];
+    const ev = findClaimEvidence(claim, chunks, new Set([SCHEMA]));
+    expect(ev?.sameFile).toBe(true);
+  });
+
+  it('does NOT mark cross-file evidence as sameFile', () => {
+    const SCHEMA = 'packages/core/src/config/schema.ts';
+    const HANDLER = 'packages/cli/src/mcp/handlers/search-code.ts';
+    const claimText = 'search_code and find_similar report as disabled.';
+    const claim = claimOf(claimText, SCHEMA);
+    const chunks = [chunk(HANDLER, 100, `// ${claimText}\nreturn new Float32Array(0);`)];
+    const ev = findClaimEvidence(claim, chunks, new Set([SCHEMA, HANDLER]));
+    expect(ev?.file).toBe(HANDLER);
+    expect(ev?.sameFile).toBeFalsy();
+  });
+
   it('falls back to a case-insensitive match when nothing matches verbatim', () => {
     const claim = claimOf('the `OverlayBackend` merges rows');
     const chunks = [chunk('packages/core/src/x.ts', 1, 'class overlaybackend {}')];

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
 
 import {
   shouldRunDocTruthPass,
@@ -82,6 +83,21 @@ function contextWithPatches(
     } as unknown as ReviewContext['pr'],
     ...extra,
   });
+}
+
+/** Build a synthetic repo chunk for same-file-evidence rendering tests (mirrors
+ *  doc-claims-signals.test.ts's own `chunk` helper). */
+function chunk(file: string, startLine: number, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine,
+      endLine: startLine + content.split('\n').length - 1,
+      type: 'block',
+      language: 'typescript',
+    },
+  } as CodeChunk;
 }
 
 function cfg(overrides: Partial<AgentConfig> = {}): AgentConfig {
@@ -713,6 +729,61 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
 
     expect(initialMessage).toContain('evidence (PR diff)');
     expect(initialMessage).toContain("LIEN_STALE_DUP_PASS: 'on'");
+  });
+
+  // Fourth root-cause layer, post-#817 (pr658 Finding A re-certification, 6/10): same-file
+  // evidence restates the claim but doesn't prove it, and votes verdicted `unverifiable` instead
+  // of chasing the implementing code. The v2 worklist must label a same-file excerpt distinctly
+  // AND carry an instruction requiring the independent code check for entries so labeled.
+  it('v2 worklist labels same-file evidence "evidence (same file as claim)" and requires independent verification', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const SCHEMA = 'packages/core/src/config/schema.ts';
+    const claimText = 'keep working; search_code and find_similar report as disabled.';
+    const patch = `@@ -1,2 +1,3 @@
+ export const schema = z.object({
++  /** ${claimText} */
+   enabled: z.boolean().optional(),
+ });`;
+    const ctx = contextWithPatches([[SCHEMA, patch]], {
+      repoChunks: [chunk(SCHEMA, 40, `// ${claimText}\nenabled: z.boolean().optional(),`)],
+    });
+    const { initialMessage } = buildDocTruthPassPrompts(ctx);
+
+    // The rendered ENTRY shape (`label — file:line:`), not bare substring containment — the
+    // header's own explanatory prose also mentions the label, so this pins it to the actual entry.
+    expect(initialMessage).toContain(`evidence (same file as claim) — ${SCHEMA}:`);
+    // The per-claim instruction anchored to that label — one paragraph, no rider pile.
+    expect(initialMessage).toContain(
+      "is drawn from the claim's OWN file — it establishes what the claim SAYS, not whether it is TRUE",
+    );
+    expect(initialMessage).toContain(
+      'REQUIRES you to also locate and check the code that IMPLEMENTS the described behavior',
+    );
+    expect(initialMessage).toContain(
+      'verdict `unverifiable` only when you attempted that independent check',
+    );
+  });
+
+  it('does NOT label cross-file evidence as "same file as claim"', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    const SCHEMA = 'packages/core/src/config/schema.ts';
+    const HANDLER = 'packages/cli/src/mcp/handlers/search-code.ts';
+    const claimText = 'search_code and find_similar report as disabled.';
+    const patch = `@@ -1,2 +1,3 @@
+ export const schema = z.object({
++  /** ${claimText} */
+   enabled: z.boolean().optional(),
+ });`;
+    const ctx = contextWithPatches([[SCHEMA, patch]], {
+      repoChunks: [chunk(HANDLER, 100, `// ${claimText}\nreturn new Float32Array(0);`)],
+    });
+    const { initialMessage } = buildDocTruthPassPrompts(ctx);
+
+    expect(initialMessage).toContain(`evidence — ${HANDLER}`);
+    // The instructional paragraph (in DOC_CLAIMS_V2_HEADER) always names the label by way of
+    // explanation — assert on the rendered ENTRY shape (`label — file:line:`), not bare substring
+    // containment, so this test can't pass merely because the header mentions the label.
+    expect(initialMessage).not.toContain('evidence (same file as claim) —');
   });
 
   it('buildDocTruthPassInitialMessageV2 omits <doc_claims>/<rename_sweep> entirely when the worklist is empty', () => {


### PR DESCRIPTION
## Context — 4th root-cause layer on pr658 Finding A

FINAL owner-approved iteration on pr658's Finding A (the `schema.ts`
`embeddings.enabled` doc-truth claim), per the pre-agreed protocol:
implement → zero-LLM census → ONE calibrate-10 → execute the predetermined
outcome branch. History: ~1/3 (never listed, fixed by #814) → 5/10
(wrong-file evidence, fixed by #817) → 6/10 (current pre-this-fix baseline —
same-file evidence restates the claim but doesn't prove it; the model must
independently chase the implementing code).

## The fix

- `packages/review/src/doc-claims-signals.ts`: `DocClaimEvidence` gains
  `sameFile?: boolean`, set in `findClaimEvidence` when the resolved tier is
  `EvidenceTier.SameFile`.
- `packages/review/src/plugins/agent/doc-truth-pass.ts`: the v2 render layer
  labels such an excerpt `evidence (same file as claim)` (vs plain
  `evidence`, `evidence (PR diff)`, `evidence (sibling doc)`), and
  `DOC_CLAIMS_V2_HEADER` gains one paragraph requiring the model to
  independently locate and check the implementing code before verdicting
  `accurate`/`contradicted` on a same-file-evidence entry — `unverifiable`
  only when that independent check was attempted and genuinely inconclusive.

## Zero-LLM evidence

- `LIEN_DOC_TRUTH_V2=off`: `build-prompts.ts` output against a fresh pr658
  capture is **byte-for-byte identical** before/after this change.
- `LIEN_DOC_TRUTH_V2=on`: only `docTruthPass.initialMessage` differs (not
  even `docTruthPass.systemPrompt`); the diff is confined to exactly two
  hunks — the new paragraph, and claim-2's evidence label changing to
  `evidence (same file as claim)`.
- New unit tests (4) for the marker + label + instruction text. Full
  `@liendev/review` suite: 1455/1455 passing.
- Full gate chain: format/lint/typecheck/build/test all green; `lien delta`
  exit 0 (2 non-blocking "worsened" notes, no new-over-threshold crossing).

## Paid calibration (ONE calibrate-10, prod default model `moonshotai/kimi-k2.7-code`, fresh capture)

Cost: **$0.9576** (of the $1.50 cap). Traces kept at
`/Users/alfhenderson/.claude/jobs/535d2452/tmp/findingA-final/calibrate10-traces/`.

Harness `allPassed: true`. Finding B (`augment-explore-task.sh`
"meaning-based" — this fixture's sole certified Tier-2 signal since the
2026-07-16 re-scope) held **10/10**, no regression.

| vote | Finding B | Finding A (claim-2) explicit verdict | read |
|---|---|---|---|
| 1 | pass | **contradicted** | independent evidence: `search-code.ts:102-116` |
| 2 | pass | unverifiable | read `search-code.ts` (engaged!) but reasoned "no disabling gate found" = inconclusive, not falsifying |
| 3 | pass | **contradicted** | independent evidence: `search-code.ts:102-136` + `server.ts` |
| 4 | pass | *(dedicated pass budget-exhausted, no valid JSON)* | recovered via MAIN pass — strict miss, loose hit |
| 5 | pass | **contradicted** | independent evidence: `search-code.ts` + `find-similar.ts` |
| 6 | pass | **contradicted** | independent evidence: `search-code.ts:102-120` |
| 7 | pass | **contradicted** | independent evidence: `search-code.ts:102-136` |
| 8 | pass | unverifiable | same "gate not located" reasoning frontier as vote 2 |
| 9 | pass | unverifiable *(in a turn that itself got length-truncated)* | no recovery — real miss |
| 10 | pass | *(dedicated pass budget-exhausted, 0 output)* | recovered via MAIN pass — strict miss, loose hit |

**Finding A, strict (dedicated per-claim pass's own explicit `contradicted` —
the metric this whole arc has used throughout): 5/10.** Loose reading (final
shipped review contains the correct, evidenced contradiction regardless of
source pass): 7/10.

**Comparison to baseline: prior post-#817 measurement was 6/10. This run is
5/10 — not an improvement.**

### Taxonomy
1. **New reasoning frontier (votes 2, 8)**: the fix's own mechanism worked —
   both votes independently read `search-code.ts` specifically because the
   new paragraph told them to. But they still verdicted `unverifiable`,
   reasoning that "no disabling gate located" is inconclusive rather than
   recognizing the absence of a gate as the falsification itself. Vote 2's
   own words: *"the evidence is same file as claim... I need to find where
   the disabled behavior is implemented. I didn't... Given budget,
   unverifiable."* This is the documented whack-a-mole pattern (pr752
   precedent) — the old failure (never checking) closed; a narrower one
   (requiring proof of absence, not just absence-from-what-was-read) took
   its place. Per the pre-agreed protocol, this is the frontier, not a
   prompt bug to chase further in this PR.
2. **Budget/coverage layer grew (1/10 → 3/10, votes 4, 9, 10)**: all three
   hit `finishReason: "length"` inside the dedicated pass's own turn. Two of
   three were rescued by the main pass independently catching the same
   finding correctly — nothing shipped wrong — but the dedicated per-claim
   contract itself never produced a verdict, a strict miss either way.
   Plausibly a modest real side effect of the added paragraph's token cost
   on an already-tight `DOC_PASS_BUDGET_FRACTION=0.4` budget, though not
   distinguishable from ordinary n=10 variance alone.
3. **Clean wins (5/10, votes 1, 3, 5, 6, 7)**: every one cites
   `search-code.ts`'s actual implementation, not the same-file JSDoc —
   exactly the behavior change targeted, working cleanly whenever the pass
   completes within budget.

## Outcome

**Flat or worse** per the pre-agreed decision framework (5/10 strict vs. 6/10
baseline). Closing this PR unmerged per that predetermined branch — the
frontier is accepted, no second calibration was run (hard cost cap already
near-exhausted: no further paid iteration under any reasoning). Full record:
`/Users/alfhenderson/.claude/jobs/535d2452/tmp/findingA-final/PROGRESS.md`.

## Test plan

- [x] `npm run test -w @liendev/review` — 1455/1455 passing
- [x] `npm test` (root) — cli 860/860, action 41/41 passing
- [x] `npm run format:check` / `npm run lint` / `npm run typecheck` / `npm run build` — all clean
- [x] `lien delta` — exit 0
- [x] Byte-diff census (flag off byte-identical, flag on confined to the two expected hunks)
- [x] calibrate-10 against pr658, fresh capture, traces kept

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a narrow, flag-gated prompt-layer fix for the doc-truth v2 pass. It adds a deterministic `sameFile` marker to `DocClaimEvidence` when evidence resolves to the claim's own file, renders that case as `evidence (same file as claim)`, and adds instructions requiring the model to independently locate and verify the implementing code before verdicting `accurate`/`contradicted`. The change is confined to the v2 renderer and does not affect v1 output (confirmed byte-identical when the flag is off).
>
> - `DocClaimEvidence` gains optional `sameFile?: boolean`, set only when the resolved evidence tier is `EvidenceTier.SameFile` (i.e., a code-sourced claim whose evidence is in the same file).
> - The v2 doc-truth renderer labels same-file evidence distinctly and adds a paragraph requiring independent verification of the implementing code.
> - Four new unit tests cover the marker, label, and instruction text; full test suites pass.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1880163. Updates automatically on new commits.</sup>
<!-- /lien-stats -->