### PR TITLE
fix(review): cap the in-loop forced-finish turn's max_tokens to remaining budget

### DIFF
--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -34,24 +34,52 @@ const RETRY_NUDGE =
   'You ran out of budget. Output ONLY the JSON block now with your findings and summary. No tool calls.';
 
 /**
- * Bound on the summary-retry's own completion request (`max_tokens`), scaled
- * to whatever budget headroom remains when the main loop bails. Mirrors
+ * Bound on a "just emit the decided JSON verdict, no tools" completion
+ * request's `max_tokens`, scaled to whatever budget headroom remains. Mirrors
  * `AnthropicAgentClient`'s `requestMaxTokens`, which already does this for
- * every request including its own retry — this client's retry previously
- * requested a flat 24,576 unconditionally (see `chatCompletion`'s old
- * default), regardless of how far over budget the loop already was. On
- * PR #811's starved run that "cheap safety net" call cost MORE than the
- * pass's entire original allocation in both starved passes (doc-truth:
- * +11,388 tokens on a 2,422 budget; stale-duplicate: +5,695 on 4,400) — a
- * real findings+summary verdict fits comfortably under
- * RETRY_MIN_MAX_TOKENS even for a several-finding review, so the floor never
- * starves the retry of room to complete; the ceiling matches the loop's
- * normal per-request size. Exported for unit testing.
+ * every request including its own retry.
+ *
+ * Two call sites share this, both added incrementally:
+ * 1. The post-loop summary-retry (`runSummaryRetry` / #813) — this client's
+ *    retry previously requested a flat 24,576 unconditionally (see
+ *    `chatCompletion`'s old default), regardless of how far over budget the
+ *    loop already was. On PR #811's starved run that "cheap safety net" call
+ *    cost MORE than the pass's entire original allocation in both starved
+ *    passes (doc-truth: +11,388 tokens on a 2,422 budget; stale-duplicate:
+ *    +5,695 on 4,400).
+ * 2. The in-loop forced-finish turn (`run()`'s `forceFinish` branch / #825
+ *    fast-follow) — structurally the same "no tools, decided verdict" shape
+ *    as the retry, but #813 didn't wire it up, so it kept the flat,
+ *    budget-blind 24,576 ceiling. PR #825's doc-truth pass hit exactly this
+ *    gap: its forced-finish turn requested the full flat ceiling with only a
+ *    few thousand tokens of budget left, then finished with
+ *    `finish_reason:'stop'` — which exits `run()`'s loop as `'completed'`
+ *    *before* the post-response budget check ever runs — so the pass spent
+ *    117,724/100,000 tokens (+18%) without ever being flagged `starved`
+ *    (that field is `stopReason === 'budget'`, not a spent-vs-allocated
+ *    comparison — see `attestation.ts`'s `passBudget`).
+ *
+ * A real findings+summary verdict fits comfortably under RETRY_MIN_MAX_TOKENS
+ * even for a several-finding review, so the floor never starves either call
+ * site of room to complete; the ceiling matches the loop's normal
+ * per-request size. Exported for unit testing.
  */
 const RETRY_MIN_MAX_TOKENS = 2_048;
 const RETRY_MAX_MAX_TOKENS = 24_576;
 export function retryMaxTokens(remainingBudget: number): number {
   return Math.min(RETRY_MAX_MAX_TOKENS, Math.max(remainingBudget, RETRY_MIN_MAX_TOKENS));
+}
+
+/**
+ * The `max_tokens` to request for one main-loop turn: budget-scaled (call
+ * site 2 above) on the forced-finish turn, or `undefined` (falls through to
+ * `chatCompletion`'s flat default) for an ordinary investigative turn, which
+ * needs the full headroom. Pulled out of `run()`'s loop body — a bare
+ * ternary inline would add a branch to a function already over its
+ * cognitive-complexity budget.
+ */
+function turnMaxTokens(forceFinish: boolean, remainingBudget: number): number | undefined {
+  return forceFinish ? retryMaxTokens(remainingBudget) : undefined;
 }
 
 /**
@@ -334,9 +362,14 @@ export class OpenAIAgentClient {
     while (turn < this.maxTurns) {
       turn++;
 
+      const maxTokens = turnMaxTokens(
+        forceFinish,
+        this.maxTokenBudget - (totalInputTokens + totalOutputTokens),
+      );
+
       let response: ChatResponse;
       try {
-        response = await this.chatCompletion(messages, tools, forceFinish);
+        response = await this.chatCompletion(messages, tools, forceFinish, maxTokens);
       } catch (err) {
         // Transient failures are already retried inside chatCompletion; a throw
         // here means it gave up. End the run gracefully (stopReason 'error' → no

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -190,6 +190,46 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(bodies[0].max_tokens).toBe(24_576);
   });
 
+  it('bounds the in-loop forced-finish turn to remaining budget (#825 overshoot fix)', async () => {
+    // Same shape as "forces a JSON verdict...once near budget" above, but
+    // this asserts the WIRE-LEVEL fix: before this fix, the forced-finish
+    // turn (bodies[1]) requested the flat 24,576 ceiling regardless of how
+    // little budget (10,000 - 7,000 = 3,000) remained. PR #825's doc-truth
+    // pass hit exactly this gap — its forced-finish turn's uncapped request
+    // pushed total spend to 117,724/100,000 (+18%), then finished with
+    // finish_reason:'stop' (stopReason 'completed' below), which exits the
+    // loop *before* the post-response budget check ever runs — a silent
+    // overshoot never flagged as budget-starved.
+    const { bodies } = mockFetch([toolCallTurn(7000), stopTurn(CLEAN_JSON, 1000)]);
+    const client = makeClient(10_000);
+    const tools = [
+      { type: 'function', function: { name: 'read_file', description: 'd', parameters: {} } },
+    ];
+
+    const result = await client.run('sys', 'init', tools as never, noopTool);
+
+    expect(result.stopReason).toBe('completed'); // matches #825: completed, not flagged starved
+    expect(bodies[0].max_tokens).toBe(24_576); // turn 1 (not forced): unaffected, normal ceiling
+    expect(bodies[1].max_tokens).toBe(3_000); // forced-finish turn: capped to remaining budget
+  });
+
+  it('floors the in-loop forced-finish turn at 2,048 when remaining budget is tiny (#825)', async () => {
+    // Turn 1 (6,800 tokens) crosses the 0.6 wrap-up threshold on a 7,000
+    // budget but stays under the hard cap, leaving only 200 tokens of
+    // budget for the forced-finish turn — below RETRY_MIN_MAX_TOKENS, so it
+    // must floor at 2,048 (parity with the retry's own floor, #811) rather
+    // than request a near-zero or negative max_tokens.
+    const { bodies } = mockFetch([toolCallTurn(6_800), stopTurn(CLEAN_JSON, 100)]);
+    const client = makeClient(7_000);
+    const tools = [
+      { type: 'function', function: { name: 'read_file', description: 'd', parameters: {} } },
+    ];
+
+    await client.run('sys', 'init', tools as never, noopTool);
+
+    expect(bodies[1].max_tokens).toBe(2_048);
+  });
+
   it('recovers a verdict via the json-forced summary-retry after a bail', async () => {
     // Loop bails on budget with no verdict; the retry returns raw JSON (as
     // response_format:json_object would) and must be parsed into a summary.


### PR DESCRIPTION
## Harness evidence (this is a client-plumbing fix, not a rule/prompt change)

This PR touches `packages/review/src/plugins/agent/openai-client.ts` (request
shaping in the OpenAI HTTP client), which lives under the harness-gated
directory, but changes no rule, no prompt, and no fixture-visible behavior:
`build-prompts.ts` -- the harness's own prompt-assembly entrypoint -- never
imports `openai-client.js` at all (it only imports `rules.js`,
`system-prompt.js`, and the per-pass prompt builders), so this change cannot
affect anything a harness calibration run measures.

Deterministic byte-diff census, run via `build-prompts.ts` against two
on-disk fixtures, comparing this branch (commit `24c3fb11`) to its parent on
`main` (`7c366d5d`) in a clean sibling worktree:

```
$ npx tsx test/harness/build-prompts.ts test/harness/fixtures/doc-truth/accurate-doc.fixture.json
# sha256 of output, excluding the run-environment's absolute `fixturePath` line:
before (7c366d5d): b89ecafedf5818e6fbc4cbdbfe1359ddcf578a54920225a4ed2658be60602129
after  (24c3fb11): b89ecafedf5818e6fbc4cbdbfe1359ddcf578a54920225a4ed2658be60602129   <- byte-identical

$ npx tsx test/harness/build-prompts.ts test/harness/fixtures/boundary-change/placeholder.fixture.json
before (7c366d5d): a762e6471ca2bee3efdc3661e0c607e8c8482e174c6488aeabed126282447085
after  (24c3fb11): a762e6471ca2bee3efdc3661e0c607e8c8482e174c6488aeabed126282447085   <- byte-identical
```

Both fixtures' prompt-assembly output is byte-identical before/after (the
only literal diff in the raw stdout is the absolute `fixturePath`, which
embeds each worktree's own filesystem path -- an environment artifact, not
prompt content). No `--calibrate` run needed: there is no rule/prompt
surface for one to calibrate.

## Problem

PR #825's own review run spent 117,724 tokens against doc-truth's
100,000-token allocation (+17,724, ~+18%) -- completed, not starved.

## Diagnosis

`OpenAIAgentClient.run()`'s per-turn loop calls `chatCompletion(messages,
tools, forceFinish)` with no `maxTokens` argument, so every turn -- including
the in-loop "forced-finish" turn that fires once `nearBudget`/`lastTurn`
trips -- requests the flat `RETRY_MAX_MAX_TOKENS` (24,576) ceiling,
regardless of how little budget actually remains.

The forced-finish turn is structurally identical to the post-loop
summary-retry (`runSummaryRetry` -> `attemptVerdictCompletion`): no tools,
`reasoning: { effort: 'low' }`, `response_format: json_object` -- "the
verdict is decided, just serialize it." #813 already fixed the overshoot
risk for the *retry* call site via `retryMaxTokens(remainingBudget)`, but
never wired the same scaling into this in-loop call, which #813's own PR
body didn't touch.

Compounding this, `run()`'s `finish_reason === 'stop'` check (natural
completion) runs *before* the `totalTokens >= this.maxTokenBudget` check --
so a forced-finish turn that successfully emits its JSON within the
uncapped 24,576-token ceiling exits the loop as `stopReason: 'completed'`,
never `'budget'`. Per `attestation.ts`'s `passBudget`, a pass is only
flagged `starved` when `stopReason === 'budget'` -- a raw
spent-vs-allocated comparison never happens. That's exactly why #825's
overshoot surfaced as "completed" rather than a budget-starved warning: a
forced-finish turn's own request cost (full accumulated conversation
history as input, plus up to 24,576 tokens of output) pushed the pass's
total well past its 100,000-token line, silently.

## Before/after arithmetic (#825's numbers)

| | allocation | spend | delta |
|---|---|---|---|
| doc-truth pass (observed, PR #825) | 100,000 | 117,724 | +17,724 (+17.7%) |

With this fix, the forced-finish turn's own `max_tokens` is bounded to
`retryMaxTokens(remainingBudget)` (floor 2,048, ceiling 24,576) instead of
the flat 24,576 -- e.g. if the forced-finish turn fired with ~5,000 tokens
of budget left, its own completion is now capped to ~5,000 tokens instead
of being allowed the full 24,576-token ceiling. This bounds the single
largest uncontrolled lever (completion size) on the one call site #813
didn't cover; it does not (and #813 didn't either) bound the *input*/prompt
side of that same request, which is a separate, larger architectural
question (conversation-history growth) out of scope for this fix.

## What this does NOT change

- **Does not skip or gate the mandatory retry.** #813 explicitly considered
  and rejected a "skip the retry when far over budget" path, because the
  existing `recovers a verdict via the json-forced summary-retry after a
  bail` test requires the retry to still fire and fully recover a verdict
  at 2.0x over budget. Nothing here touches that: the retry's own
  `runSummaryRetry` / `attemptVerdictCompletion` call sites and their
  `retryMaxTokens` wiring are untouched.
- **Does not change ordinary (non-forced) investigative turns.** Those keep
  the flat 24,576 ceiling -- `turnMaxTokens` returns `undefined` when
  `forceFinish` is false, falling through to `chatCompletion`'s existing
  default. This preserves the existing `forces a JSON verdict...` test's
  `bodies[0].max_tokens === 24_576` assertion (turn 1, not forced) exactly
  as before; investigative turns still get full headroom so genuine
  tool-calling isn't starved mid-investigation.
- **#795's verdict-recovery tests are untouched and still green** -- see
  gates below.

## Fix

`turnMaxTokens(forceFinish, remainingBudget)` (new, `openai-client.ts`)
reuses the existing `retryMaxTokens` for the forced-finish turn; extracted
as its own function rather than an inline ternary in `run()`, which Lien
flagged as already over its cognitive-complexity budget (34/15) --
`lien delta` confirms the extraction adds zero complexity to `run()` itself
(the new `turnMaxTokens` is a fresh, trivially-simple function: cognitive 1).

## Tests

Two new unit tests in `plugins-agent-budget.test.ts` reproducing the exact
overshoot shape:
- `bounds the in-loop forced-finish turn to remaining budget (#825
  overshoot fix)` -- 10,000-token budget, turn 1 costs 7,000 (crosses the
  0.6 wrap-up threshold), asserts the forced-finish turn's own
  `max_tokens` is capped to the 3,000 tokens actually remaining (not the
  flat 24,576), and that `stopReason` is `'completed'` (matching #825's
  "completed, not starved" shape).
- `floors the in-loop forced-finish turn at 2,048 when remaining budget is
  tiny (#825)` -- remaining budget of only 200 tokens still floors at
  2,048 (parity with the retry's own floor, #811), not a near-zero/negative
  request.

All existing tests pass unmodified, including the `bodies[0].max_tokens
=== 24_576` (turn 1, non-forced) assertion and the full `#792`/`#795`
verdict-recovery suite (both OpenAI and Anthropic clients).

## Gates

- `npm run format:check` / `lint` (0 errors, pre-existing warnings only) /
  `typecheck` / `build` -- all green.
- `npm test` (all 6 packages) -- 1453 review + 1077 core + 378 parser + 27
  parser-native + 860 cli + 41 action, all green.
- `lien delta` -- exit 0. One pre-existing violation
  (`OpenAIAgentClient.run`, already over threshold at HEAD) shows a `time`
  metric shift (394m -> 407m, not the gated metric) from the loop's new
  `maxTokens` computation; no NEW crossing. The new `turnMaxTokens`
  function is well under threshold (cognitive 1).

No changeset (review package is private/unpublished).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 7 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 2 | +13 |
| 🐛 estimated bugs | 1 | +0.042 |


> [!NOTE]
> **Low Risk**
>
> This PR caps the in-loop forced-finish turn's `max_tokens` to the remaining budget in `OpenAIAgentClient.run()`, mirroring the existing post-loop summary-retry behavior. The change is narrowly scoped: ordinary investigative turns still get the flat 24,576 ceiling, while forced-finish turns now use `retryMaxTokens(remainingBudget)` (floor 2,048, ceiling 24,576). The implementation correctly handles negative, zero, and large remaining budgets, and the new unit tests pin both the cap-to-remaining-budget case and the floor-at-2,048 case. No callers are broken, no exports are removed, and the Anthropic sibling intentionally uses a different scaling mechanism (`requestMaxTokens`) that already covers every request.
>
> - Added `turnMaxTokens(forceFinish, remainingBudget)` to scale the in-loop forced-finish turn's `max_tokens` to remaining budget.
> - Updated `OpenAIAgentClient.run()` to compute and pass `maxTokens` into `chatCompletion` each turn.
> - Added two unit tests covering the budget-cap and floor behavior for the forced-finish turn.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 24c3fb1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
