### PR TITLE
fix(review): doc-truth unverifiable-verdict precision + Tier-2 keyword repair

### DIFF
--- a/packages/review/src/doc-claims-signals.ts
+++ b/packages/review/src/doc-claims-signals.ts
@@ -1264,9 +1264,10 @@ const DOC_CLAIMS_HEADER =
   'with NO evidence, locate the code yourself using material already in your ' +
   'prompt (the diff hunks, <changed_functions>, and get_files_context on the ' +
   'described symbols — it reads indexed chunks, so it works even when ' +
-  'grep_codebase/read_file are blind); if it is a genuine behavioral claim you ' +
-  'still cannot locate, report a warning "unverifiable behavioral claim in ' +
-  'touched prose". An entry that is plainly descriptive prose (not a ' +
+  'grep_codebase/read_file are blind); if, after that genuine attempt, you ' +
+  'still cannot locate it, stay silent — an unconfirmed claim is not evidence ' +
+  'of a false one, and reporting "I could not verify this" as a finding is ' +
+  'noise, not a catch. An entry that is plainly descriptive prose (not a ' +
   'falsifiable claim about this code) needs no finding — do NOT report ' +
   'wording/style nits or manufacture a contradiction the code does not support.';
 

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -40,12 +40,24 @@
  * an extra finding for a claim the model spotted itself (no `claimId`) is
  * still legal and passes straight through — the rule text's existing "also
  * skim the touched hunks for any [claim] not listed" allowance is unchanged.
- * `postProcessDocTruthResult` reduces `contradicted`/`unverifiable` verdicts
- * to real findings (dropping `accurate` ones, mirroring the "stay silent when
- * confirmed" v1 instruction) and marks the result honestly
+ * `postProcessDocTruthResult` reduces ONLY `contradicted` verdicts to real
+ * findings — `accurate` AND `unverifiable` are both dropped (mirroring v1's
+ * "stay silent unless you have proof" instruction, and matching every
+ * sibling candidate-loop pass: `stale-duplicate-pass.ts` keeps only `stale`,
+ * `removed-exports-pass.ts` keeps only `breaking`, `incomplete-handling-
+ * pass.ts` keeps only `incomplete` — none of them promote their own
+ * "couldn't verify" verdict either). A thin-evidence claim honestly verdicted
+ * `unverifiable` is real signal (see `hasCompleteVerdictCoverage` below) but
+ * is not a reader-facing finding: "I couldn't check" is not the same
+ * deliverable as "the code contradicts this," and treating them the same
+ * turned a precision-guard fixture with thin evidence into a false positive
+ * (accurate-doc, 3/3 — see this change's PR body). The result marks
  * `incomplete_verdict` when any listed id's verdict is missing, invalid,
  * duplicated, or unrecognized (CodeRabbit-hardened honesty rigor — see
- * `stale-duplicate-pass.ts`'s `hasCompleteVerdictCoverage` doc comment).
+ * `stale-duplicate-pass.ts`'s `hasCompleteVerdictCoverage` doc comment) —
+ * that check reads the RAW per-claim verdict list, so an `unverifiable`
+ * verdict still counts as honest coverage even though it never becomes a
+ * finding.
  *
  * When the flag is off, every v2 function is unreachable and
  * `buildDocTruthPassPrompts`/`postProcessDocTruthResult` return exactly what
@@ -780,18 +792,22 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawDocClaimVerdict[]): b
 
 /**
  * Reduce the raw v2 findings array to real findings: every ad hoc finding (no `claimId`) passes
- * through unchanged, and every claimed entry is kept ONLY when its verdict is `contradicted` or
- * `unverifiable` (cleaned of the v2-only fields) — mirroring v1's rule text ("a claim the code
- * confirms needs no finding" / "a claim you cannot locate is reported as a warning"). An
- * `accurate` verdict, or any claimed entry with an invalid/unrecognized verdict, is dropped
- * rather than guess-promoted — the inclusion-list mirror of `stale-duplicate-pass.ts`'s
- * `verdict === 'stale'` filter.
+ * through unchanged, and every claimed entry is kept ONLY when its verdict is `contradicted`
+ * (cleaned of the v2-only fields) — mirroring v1's rule text (stay silent unless you have proof
+ * of a contradiction) and the exact inclusion-list pattern every sibling candidate-loop pass
+ * uses: `stale-duplicate-pass.ts` keeps `verdict === 'stale'` only, `removed-exports-pass.ts`
+ * keeps `'breaking'` only, `incomplete-handling-pass.ts` keeps `'incomplete'` only. Both
+ * `accurate` and `unverifiable` are dropped rather than guess-promoted: `accurate` because the
+ * claim checked out, `unverifiable` because "I couldn't check" is not proof of a contradiction —
+ * promoting it made a thin-evidence claim look like a real finding (see the `accurate-doc`
+ * precision-guard fixture, which this reduction previously false-fired on 3/3). Coverage
+ * honesty is unaffected: `hasCompleteVerdictCoverage` (below) reads the RAW, pre-reduction list,
+ * so a claim honestly verdicted `unverifiable` still counts as covered even though it never
+ * surfaces here.
  */
 function reduceDocTruthV2Findings(raw: RawDocClaimVerdict[]): AgentFinding[] {
   return raw
-    .filter(
-      f => f.claimId === undefined || f.verdict === 'contradicted' || f.verdict === 'unverifiable',
-    )
+    .filter(f => f.claimId === undefined || f.verdict === 'contradicted')
     .map(f => (f.claimId !== undefined ? toCleanDocTruthFinding(f) : f));
 }
 

--- a/packages/review/src/plugins/agent/rules.ts
+++ b/packages/review/src/plugins/agent/rules.ts
@@ -788,10 +788,15 @@ MANDATORY protocol when this rule is active:
    stale/false claim and state the actual behavior; the \`evidence\` must
    cite the code fact that falsifies it (file:line, signature, return value,
    or the specific diff hunk) — not "the comment looks wrong".
-4. Stay silent on a claim only after locating the code and confirming it
-   still matches. A claim you genuinely could not locate is reported as a
-   \`warning\` "unverifiable behavioral claim in touched prose" — do not
-   silently pass it.`,
+4. Stay silent on a claim after locating the code and confirming it still
+   matches, OR after making a genuine attempt to locate it and failing. An
+   unconfirmed claim is not the same as a false one: only step 3's PROOF-of-
+   contradiction bar earns a finding. Do NOT report "I could not verify this
+   claim" as a finding — that turns thin evidence into a deliverable and
+   trains readers to ignore doc-truth noise. Do the verification work (step
+   2) first; then, whether you confirm, contradict, or genuinely cannot
+   locate the code, silence is correct for every outcome except a confirmed
+   contradiction.`,
   example: `### Good finding — mechanical rename left a doc comment describing removed behavior:
 {
   "filepath": "packages/core/src/config/schema.ts",

--- a/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.assertions.ts
+++ b/packages/review/test/harness/fixtures/doc-truth/renamed-stale-claim.assertions.ts
@@ -30,9 +30,47 @@
  * Tightened to compound phrases that state the disabled-vs-still-active
  * contradiction itself. Not a calibration gate (hand-authored CC-mode smoke
  * fixture, no paid votes to re-score) — untagged/non-canary either way.
+ *
+ * KEYWORD-INTEGRITY REPAIR (2026-07-19): the 2026-07-16 tightening traded one
+ * brittleness for another. Its compound phrases required an EXACT contiguous
+ * substring across a punctuation boundary — e.g. "reports as disabled, but"
+ * needs a comma immediately after "disabled" with nothing between. Real model
+ * output routinely wraps the quoted claim term in its own quote mark or
+ * backtick right before that comma ("...reports as disabled', but
+ * resolveSearchMode returns..." / "...reports as disabled\", but
+ * `resolveSearchMode`..."), which breaks every phrase in the old list — a
+ * correct, substantively-right finding false-FAILED on formatting alone
+ * (measured 0/3 under both `LIEN_DOC_TRUTH_V2=on` and `=off`, see this
+ * change's PR body; all 3 votes in each screen correctly identified the
+ * contradiction, just phrased with a quote mark the phrase list didn't
+ * anticipate).
+ *
+ * Repaired per the keyword-integrity discipline (see
+ * pr658-search-code-rename.assertions.ts's claim+correction split, "single
+ * finding must name both" pattern): instead of one contiguous phrase, require
+ * the SAME finding to (a) mention the claim term "disabled" (bare word — safe
+ * here because this fixture has exactly one claim, so "disabled" cannot
+ * collide with an unrelated claim the way it could on a multi-claim fixture
+ * like pr658), (b) name the specific function ("resolvesearchmode"), AND (c)
+ * state the actual returned value via a punctuation-tolerant regex
+ * (`/returns\s*[`'"]*lexical\b/i` — matches "returns 'lexical'", "returns
+ * `'lexical'`", "returns lexical", any quote/backtick noise in between,
+ * without caring which punctuation the model chose). All three together are
+ * substantially harder to satisfy by accident than any one bare noun: the
+ * 2026-07-16 sweep's distractor (discussing "config-level mode selection,"
+ * not the disabled/no-results claim) does not state that resolveSearchMode
+ * RETURNS lexical — it reasons about a different, invented override — so it
+ * still fails condition (c). Verified via a reconstructed version of that
+ * exact distractor in the offline smoke test below.
  */
 
+import { HarnessAssertionError } from '../../assertions.js';
 import type { FixtureAssertions } from '../../assertions.js';
+
+/** Matches "returns 'lexical'", "returns `'lexical'`", "returns lexical" — any
+ *  quote-mark/backtick punctuation between "returns" and "lexical", so the
+ *  check survives whichever way a model chooses to quote the return value. */
+const RETURNS_LEXICAL = /returns\s*[`'"]*\s*lexical\b/i;
 
 const assertions: FixtureAssertions = {
   description:
@@ -41,32 +79,29 @@ const assertions: FixtureAssertions = {
   rule: 'doc-truth',
   expect: (result, h) => {
     h.expectRuleFired('doc-truth', result);
-    // Kept to compound phrases that state the CONTRADICTION itself (the
-    // "disabled" claim vs. the code still returning results) — not bare
-    // 'lexical'/'bm25'/'fallback'/'disabled'/'still'/'outdated'/
-    // 'resolvesearchmode', each of which a distractor about a *different*
-    // stale claim on the same resolveSearchMode comment (e.g. a claim about
-    // config-level mode SELECTION, not about the disabled/no-results
-    // framing) also legitimately uses. Verified via assert-cli.ts: such a
-    // distractor false-passed the original list via lexical/fallback/
-    // resolvesearchmode/outdated/still and correctly fails against this one.
-    h.expectFindingMentions(
-      [
-        'reports as disabled, but',
-        'reports as disabled but',
-        'claims disabled but',
-        'disabled but returns',
-        'disabled but falls back',
-        'disabled but still',
-        'contradicts the disabled claim',
-        'the disabled claim is stale',
-        'is not actually disabled',
-        "isn't actually disabled",
-        'no longer disabled',
-        'search is not disabled',
-      ],
-      result,
-    );
+    // Require ONE finding to name the claim ("disabled"), the specific function
+    // ("resolvesearchmode"), AND the falsifying return value ("returns ...
+    // lexical", punctuation-tolerant) — all three, in the SAME finding, rather
+    // than an exact contiguous phrase. See header's KEYWORD-INTEGRITY REPAIR.
+    const hasCorrectlyFramedContradiction = result.findings.some(f => {
+      const haystack = [f.message, f.suggestion ?? '', f.evidence ?? ''].join('\n').toLowerCase();
+      return (
+        haystack.includes('disabled') &&
+        haystack.includes('resolvesearchmode') &&
+        RETURNS_LEXICAL.test(haystack)
+      );
+    });
+    if (!hasCorrectlyFramedContradiction) {
+      throw new HarnessAssertionError(
+        'Tier 2: expected a single finding to name the claim ("disabled"), the function ' +
+          '("resolveSearchMode"), and the falsifying return value (a "returns ... lexical" ' +
+          `pattern, quote/backtick-tolerant) — none did. Findings: ${result.findings.length}.` +
+          (result.findings.length > 0
+            ? ` First message: "${result.findings[0]?.message?.slice(0, 200) ?? ''}"`
+            : ''),
+        2,
+      );
+    }
   },
   votes: 3,
   passThreshold: 9,

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -826,14 +826,15 @@ describe('postProcessDocTruthResult', () => {
     expect(processed.incomplete).toBe(false);
   });
 
-  it('keeps an "unverifiable" verdict as a real (warning) finding', () => {
+  it('drops an "unverifiable" verdict entirely (thin evidence is not proof of a contradiction)', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const result = fakeResult([
       verdictFinding({ claimId: 'claim-1', verdict: 'unverifiable', message: 'could not locate' }),
     ]);
     const processed = postProcessDocTruthResult(result, singleClaimCtx());
-    expect(processed.findings).toHaveLength(1);
-    expect(processed.findings[0].message).toBe('could not locate');
+    expect(processed.findings).toHaveLength(0);
+    // Coverage honesty is unaffected: a claim honestly verdicted "unverifiable" still counts
+    // as covered (not incomplete) even though it never becomes a finding.
     expect(processed.incomplete).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Two sequential doc-truth precision fixes found by the v2 family screens
(`accurate-doc` false-firing 3/3 under both configs; `renamed-stale-claim`
false-failing 0/3 under both configs). Fix 1 changes what Fix 2 measures, so
they're sequential commits on one branch/PR.

## Fix 1 — unverifiable-verdict policy (commit 1)

**Root cause:** an `unverifiable` doc-truth verdict (thin/no evidence for a
claim) was being promoted to a reader-facing finding by BOTH:
- v1's rule prompt (`rules.ts` DOC_TRUTH step 4 + the shared `<doc_claims>`
  header in `doc-claims-signals.ts`, consumed by the main pass AND the v1
  dedicated pass): *"A claim you genuinely could not locate is reported as a
  `warning` 'unverifiable behavioral claim in touched prose' — do not
  silently pass it."*
- v2's per-claim reduction (`doc-truth-pass.ts`'s `reduceDocTruthV2Findings`):
  `verdict === 'contradicted' || verdict === 'unverifiable'`.

"I couldn't check" is not proof of a contradiction. Confirmed this is a real,
already-observed bug (not speculation): re-reading previously-captured trace
data (`findingA-recert/job2-screens/renamed-stale-claim{,-v1off}`), 2 of 6
votes emitted a bogus SECOND "unverifiable" finding for the exact same claim
a sibling vote correctly resolved as `contradicted`, purely because the rule
text instructed it to.

**Policy chosen:** drop the `unverifiable` → finding promotion entirely, no
high-stakes exception.
- v2: `reduceDocTruthV2Findings` narrowed to `verdict === 'contradicted'`
  only. This makes doc-truth-pass.ts match **every** sibling candidate-loop
  pass exactly — `stale-duplicate-pass.ts` keeps only `'stale'`,
  `removed-exports-pass.ts` keeps only `'breaking'`,
  `incomplete-handling-pass.ts` keeps only `'incomplete'`. doc-truth-pass.ts
  was the sole outlier also promoting its "couldn't verify" verdict.
- v1: `rules.ts` step 4 and `doc-claims-signals.ts`'s `DOC_CLAIMS_HEADER`
  reworded to stay silent after a genuine-but-failed verification attempt.
- **Honesty is unaffected**: `hasCompleteVerdictCoverage` reads the RAW
  pre-reduction verdict list, so a claim honestly verdicted `unverifiable`
  still counts as covered (not `incomplete_verdict`) — it just never becomes
  a finding. This is exactly "recorded in the verdict list, attestation can
  count it, not a reader-facing finding" without new plumbing.
- **No high-stakes/evidence-quality exception**: nothing in the output
  contract distinguishes "genuinely attempted, inconclusive" from "declined
  to check" — building that gate would require text-sniffing the model's
  freeform message/evidence for keywords, i.e. exactly the Tier-2-keyword-
  brittleness failure mode Fix 2 exists to repair. Precision-first, per the
  task's own fallback clause: when the exception can't be made crisp, drop it.

### Zero-LLM verification
- `npm run test -w @liendev/review -- test/plugins-agent-doc-truth-pass.test.ts test/doc-claims-signals.test.ts test/plugins-agent-rules.test.ts` — 318 tests, all green (one test rewritten: "keeps an unverifiable verdict as a real finding" → "drops it entirely").
- Byte-diff census (`build-prompts.ts`, git-stash before/after, zero LLM cost): confirms the change is **exactly** the two prompt sentences, for both `LIEN_DOC_TRUTH_V2=off` and `=on` — nothing else in the rendered system/initial prompts moved. Also confirmed the v2 dedicated pass's own system prompt (built from the same `DOC_TRUTH` rule) inherited the rules.ts fix too.

### Fix 1 validation screen — `accurate-doc`, 3 votes, both configs
| config | before | after |
|---|---|---|
| `LIEN_DOC_TRUTH_V2=on` | 3/3 **false positive** (`doc-truth@…/status.ts:18`) | **3/3 pass, 0 findings** — cost $0.0436 |
| `LIEN_DOC_TRUTH_V2=off` | 3/3 **false positive** (same) | **3/3 pass, 0 findings** — cost $0.0538 |

Target met (0 false findings, the fixture's entire purpose) on both configs.

## Fix 2 — Tier-2 keyword brittleness repair (commit 2)

Scope check: only `renamed-stale-claim.assertions.ts` has a Tier-2 keyword
problem. `accurate-doc.assertions.ts` uses `expectEmpty` (Tier 1, no
keywords) — its false-fire was entirely Fix 1's bug, already closed above.
No edit made to it.

**Root cause:** the old 12-phrase list (`'reports as disabled, but'`,
`'disabled but returns'`, …) required an exact *contiguous* substring across
a punctuation boundary. Real model output routinely wraps the claim term in
its own quote mark or backtick right before that punctuation — `"...disabled',
but resolveSearchMode..."` / `"...disabled\", but \`resolveSearchMode\`..."`
— which breaks every phrase in the list. This is not a detection gap: all 6
pre-fix votes (3 v2-on, 3 v1-off) correctly identified the contradiction;
they just phrased the quote mark differently than the list anticipated.

**Repair:** replaced the phrase list with a per-finding AND of three
substance anchors, mirroring `pr658-search-code-rename.assertions.ts`'s
claim+correction split (single-finding stance, requiring both the false
claim AND its correction/mechanism in the SAME finding, not flattened across
findings):
1. `"disabled"` (the claim term — a safe bare word here because this
   fixture has exactly one claim, unlike pr658's 40-file sweep where a bare
   noun could collide with an unrelated claim)
2. `"resolvesearchmode"` (function identity)
3. `/returns\s*[`'"]*\s*lexical\b/i` (the falsifying fact — "returns"
   followed by "lexical" tolerating any quote/backtick noise in between —
   this is the specific punctuation tolerance the old list lacked)

### Offline zero-LLM smoke test (`assert-cli.ts`, git-stash before/after)
| case | OLD | NEW |
|---|---|---|
| 1. perfect (real correct vote) | **FAIL (Tier 2)** — the brittleness bug caught live | **PASS** |
| 2. empty | FAIL (Tier 1) | FAIL (Tier 1) — unchanged |
| 3. distractor (reconstructed "config-level mode selection" staleness — same bare-noun vocabulary, wrong claim) | FAIL (Tier 2) | **FAIL (Tier 2)** — still correctly rejected |
| 4. quote-mark variant (the exact real-world shape that motivated this) | **FAIL (Tier 2)** | **PASS** |

### Fix 2 validation screens — `renamed-stale-claim`, 3 votes, both configs
| config | before | after |
|---|---|---|
| `LIEN_DOC_TRUTH_V2=on` | 0/3 (Tier-2 phrasing) | **3/3 pass** — cost $0.0836 |
| `LIEN_DOC_TRUTH_V2=off` | 0/3 (Tier-2 phrasing) | **3/3 pass** — cost $0.0716 |

Spot-checked full finding text on every passing vote (not just the
pass/fail flag) — all substantively correct, e.g.: *"...but the function
actually returns 'lexical'... resolveSearchMode returns hasEmbeddings ?
'semantic' : 'lexical' (schema.ts:43)"*.

`accurate-doc` re-confirmation: not re-run as a fresh paid screen — no
source change occurred to its path between the Fix 1 screens (6/6 votes
passed, both configs) and now; Fix 2 touched only `renamed-stale-claim`'s
assertions file. Treating the Fix 1 screens as already satisfying this
check rather than re-spending on an identical measurement.

## Spend

$0.2526 of the $1.25 cap (fix1 accurate-doc screens $0.0974 + fix2
renamed-stale-claim screens $0.1552). All harness-reported costs; no
`--calibrate` full sweep run (screens only, per the task's own budget).

## Dogfood evidence (per CLAUDE.md's mandatory pre-merge dogfooding — review-engine changes replay through the harness)

This whole PR **is** the harness replay: every claim above is a real
`npx tsx packages/review/test/harness/run.ts --fixture … --votes 3 --json`
invocation against OpenRouter (not build-prompts-only), or a real
`assert-cli.ts` invocation against real captured model output. Traces and
logs on disk under `/Users/alfhenderson/.claude/jobs/535d2452/tmp/doctruth-precision/`
(`fix1-screen/`, `fix2-screen/`, `fix2-smoke/`, `census/`).

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors (33 pre-existing warnings, untouched files)
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` (parser+core+review 1451 tests, cli 860 tests excl. e2e, action
  41 tests) — all green
- `lien delta` — exit 0, 1 improvement (`reduceDocTruthV2Findings` cyclomatic
  4→3 from simplifying the OR condition), no crossings

No changeset (internal review-engine test/prompt fix, not a published
package API change).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR tightens doc-truth precision by dropping `unverifiable` verdicts from reader-facing findings (they still count as honest coverage) and repairs a brittle Tier-2 keyword assertion in the `renamed-stale-claim` fixture. The code, tests, and guidance prose are internally consistent: `reduceDocTruthV2Findings` now keeps only `contradicted` verdicts, `hasCompleteVerdictCoverage` still accepts `unverifiable` as valid coverage, and the v1/v2 prompt text both instruct silence after a genuine-but-inconclusive verification attempt. The assertion regex `/returns\s*[`'"]\s*lexical\b/i` correctly tolerates the quote-mark/backtick variants described in the PR body.
>
> - Doc-truth v2 reduction now drops both `accurate` and `unverifiable` verdicts, keeping only `contradicted`
> - Coverage honesty preserved: `unverifiable` still counts toward `hasCompleteVerdictCoverage`
> - Renamed-stale-claim fixture replaced exact compound-phrase list with a punctuation-tolerant three-anchor check (disabled + resolvesearchmode + returns lexical)

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9cf926a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->