### PR TITLE
feat(review): distinctiveness gate for bare directory referands in docs-drift

### DIFF
--- a/packages/review/src/docs-drift-signals.ts
+++ b/packages/review/src/docs-drift-signals.ts
@@ -205,11 +205,72 @@ function directoryIsGone(dir: string, repoChunks: CodeChunk[] | undefined): bool
 }
 
 /**
+ * A neighbor character that marks a `token` occurrence as PATH-context (a directory/file listing)
+ * rather than ordinary prose: a path separator, or the backtick this repo's own docs use to mark a
+ * bare directory/file token (e.g. CLAUDE.md's own `` `packages/` `` / `` `platform/` `` bullets).
+ */
+const PATH_CONTEXT_NEIGHBOR_RE = /[/`]/;
+
+/** True iff the `token`-length occurrence starting at `index` in `line` sits directly against a
+ *  `/` or a backtick on either side — i.e. reads as a path/identifier, not a word in a sentence. */
+function isPathContextOccurrence(line: string, index: number, tokenLength: number): boolean {
+  const before = index > 0 ? line[index - 1] : '';
+  const after = line[index + tokenLength] ?? '';
+  return PATH_CONTEXT_NEIGHBOR_RE.test(before) || PATH_CONTEXT_NEIGHBOR_RE.test(after);
+}
+
+/**
+ * True iff EVERY word-boundary occurrence of a BARE top-level directory referand (e.g. `platform`,
+ * no `packages/` prefix) across the repo's doc/config corpus reads as a path/identifier — never as
+ * ordinary prose describing something unrelated (e.g. "supports every platform", "the existing
+ * platform .env"). A single prose hit disqualifies the referand: when in doubt, suppress (the same
+ * precision-first posture as `isSuppressed`).
+ *
+ * This is the fast-follow the module header flags as a residual risk: a bare single-word directory
+ * name is, by construction, generic-word risk that a `packages/<name>` grouped referand or an
+ * individual file path never carries (both always contain a `/`, so neither can spuriously match a
+ * plain English word in the middle of a sentence).
+ *
+ * Corpus-driven rather than a hardcoded stopword list: a fixed word list needs constant upkeep and
+ * still misses whatever wasn't anticipated — this repo's own `platform`/`runner` (see #593's real
+ * deletion, the motivating case) are generic SOFTWARE nouns, not classic linguistic stopwords, so an
+ * off-the-shelf English stopword list would miss them entirely. Checking what THIS repo's own docs
+ * actually do with the word is self-maintaining and needs no list to keep up to date — verified
+ * against this repo's own corpus, `platform` reads as ordinary prose in both `STYLE_GUIDE.md`
+ * ("...documentation site, platform app...") and this package's own harness `README.md` ("...the
+ * existing platform .env...") — exactly the false-positive risk this gate exists to close. Exposed
+ * for testing.
+ */
+export function isDistinctiveBareDirectory(token: string, docChunks: CodeChunk[]): boolean {
+  const re = wordBoundaryRe(token, 'g');
+  return docChunks.every(
+    chunk => !chunk.content.includes(token) || everyLineIsPathContextOnly(chunk, re, token.length),
+  );
+}
+
+/** True iff every occurrence of `re` across `chunk`'s lines sits in path-context (see
+ *  `isPathContextOccurrence`). Split out of `isDistinctiveBareDirectory` to keep that function's
+ *  own nesting shallow (mirrors `collectMatchesInChunk`'s split out of `sweepReferand`). */
+function everyLineIsPathContextOnly(chunk: CodeChunk, re: RegExp, tokenLength: number): boolean {
+  return chunk.content
+    .split('\n')
+    .every(line =>
+      [...line.matchAll(re)].every(
+        m => m.index === undefined || isPathContextOccurrence(line, m.index, tokenLength),
+      ),
+    );
+}
+
+/**
  * Deleted-path referands: every fully-deleted file, grouped up to its containing package/top-level
  * directory when that whole directory is confirmed gone (see `directoryIsGone`) — the shape a
  * removed CLAUDE.md structure bullet describes (a directory, not one of its files) — else left as
- * the individual file's own path. Deduped. Full path only — no trailing-segment alt-token (see
- * module header). Exposed for testing.
+ * the individual file's own path. A BARE top-level directory (grouped outside `packages/`, so its
+ * token carries no `/`) additionally must pass `isDistinctiveBareDirectory` against the repo's own
+ * doc/config corpus — failing that, this falls back to the individual file's own path (still full
+ * recall for that file, just not the risky generic grouping). A `packages/<name>` grouping is never
+ * gated: it always carries a `/`, so it never risks matching incidental prose. Deduped. Full path
+ * only — no trailing-segment alt-token (see module header). Exposed for testing.
  */
 export function extractDeletedPaths(
   patches: Map<string, string>,
@@ -220,10 +281,14 @@ export function extractDeletedPaths(
     .map(([file]) => file);
   if (deletedFiles.length === 0) return [];
 
+  const docChunks = (repoChunks ?? []).filter(isDocOrConfigChunk);
   const paths = new Set<string>();
   for (const file of deletedFiles) {
     const dir = candidateDirectoryReferand(file);
-    paths.add(dir && directoryIsGone(dir, repoChunks) ? dir : file);
+    const dirGone = dir !== null && directoryIsGone(dir, repoChunks);
+    const useGroupedDir =
+      dirGone && (dir!.includes('/') || isDistinctiveBareDirectory(dir!, docChunks));
+    paths.add(useGroupedDir ? dir! : file);
   }
 
   return [...paths].map(path => ({ token: path, kind: 'deleted-path' as const }));

--- a/packages/review/test/docs-drift-signals.test.ts
+++ b/packages/review/test/docs-drift-signals.test.ts
@@ -6,6 +6,7 @@ import {
   classifyRawDocReferences,
   isFullFileDeletion,
   extractDeletedPaths,
+  isDistinctiveBareDirectory,
 } from '../src/docs-drift-signals.js';
 
 // ---------------------------------------------------------------------------
@@ -136,6 +137,99 @@ describe('extractDeletedPaths', () => {
     ]);
     expect(extractDeletedPaths(patches, [])).toEqual([]);
   });
+
+  it(
+    'falls back to the individual file when a BARE top-level directory referand (no `packages/` ' +
+      'prefix, e.g. `platform`) fails distinctiveness — the same word reads as ordinary prose ' +
+      'elsewhere in the doc/config corpus (#593 real deletion history)',
+    () => {
+      const patches = new Map([
+        ['platform/src/index.ts', hunkOnlyDeletion('export function boot() {}')],
+      ]);
+      const docCorpus = [
+        makeChunk(
+          'STYLE_GUIDE.md',
+          1,
+          'Design identity for all Lien properties (documentation site, platform app).',
+        ),
+      ];
+      const referands = extractDeletedPaths(patches, docCorpus);
+      expect(referands).toEqual([{ token: 'platform/src/index.ts', kind: 'deleted-path' }]);
+    },
+  );
+
+  it(
+    'still groups a BARE top-level directory referand when it IS distinctive — nothing in the ' +
+      'doc/config corpus uses the word as ordinary prose',
+    () => {
+      const patches = new Map([
+        ['zznovelplatform/src/index.ts', hunkOnlyDeletion('export function boot() {}')],
+      ]);
+      const referands = extractDeletedPaths(patches, []);
+      expect(referands).toEqual([{ token: 'zznovelplatform', kind: 'deleted-path' }]);
+    },
+  );
+
+  it(
+    'a `packages/<name>` grouped referand is never gated on distinctiveness (it always carries a ' +
+      '`/`, so it can never spuriously match a plain word in prose) — fires even though the ' +
+      'directory basename alone is a common English word',
+    () => {
+      const patches = new Map([
+        ['packages/core/src/index.ts', hunkOnlyDeletion('export function boot() {}')],
+      ]);
+      const docCorpus = [makeChunk('README.md', 1, 'This is the very core of the whole design.')];
+      const referands = extractDeletedPaths(patches, docCorpus);
+      expect(referands).toEqual([{ token: 'packages/core', kind: 'deleted-path' }]);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// isDistinctiveBareDirectory
+// ---------------------------------------------------------------------------
+
+describe('isDistinctiveBareDirectory', () => {
+  it('is false when the token also reads as ordinary prose elsewhere in the corpus (#593 platform case)', () => {
+    const docChunks = [
+      makeChunk(
+        'CLAUDE.md',
+        14,
+        '- `platform/` and `packages/runner` — hosted-platform remnants (see ' +
+          '[ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)); safe to ignore.',
+      ),
+      makeChunk(
+        'STYLE_GUIDE.md',
+        1,
+        'Design identity for all Lien properties (documentation site, platform app).',
+      ),
+    ];
+    expect(isDistinctiveBareDirectory('platform', docChunks)).toBe(false);
+  });
+
+  it('is false on a single prose hit even when every OTHER occurrence is path-context', () => {
+    const docChunks = [
+      makeChunk('CLAUDE.md', 14, '- `platform/` — hosted-platform remnants; safe to ignore.'),
+      makeChunk(
+        'packages/review/test/harness/README.md',
+        1,
+        '# One-time setup (or use the existing platform .env)',
+      ),
+    ];
+    expect(isDistinctiveBareDirectory('platform', docChunks)).toBe(false);
+  });
+
+  it('is true (distinctive counter-example) when every occurrence sits in path context', () => {
+    const docChunks = [
+      makeChunk('CLAUDE.md', 20, '- `zznovelplatform/` — internal tooling, safe to ignore.'),
+      makeChunk('docs/guide.md', 5, 'See `zznovelplatform/README.md` for the deprecation notice.'),
+    ];
+    expect(isDistinctiveBareDirectory('zznovelplatform', docChunks)).toBe(true);
+  });
+
+  it('is true (vacuously) when the token never appears in the corpus at all', () => {
+    expect(isDistinctiveBareDirectory('somewordneverpresent', [])).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -252,6 +346,71 @@ describe('computeDocsDriftCandidates — positives', () => {
       }),
     ]);
   });
+});
+
+// ---------------------------------------------------------------------------
+// computeDocsDriftCandidates — bare-directory distinctiveness gate
+// ---------------------------------------------------------------------------
+
+describe('computeDocsDriftCandidates — bare-directory distinctiveness gate', () => {
+  it(
+    'suppresses a BARE top-level directory referand (`platform`, no `packages/` prefix) when the ' +
+      'same word ALSO reads as ordinary prose elsewhere in the doc/config corpus (#593 real ' +
+      'deletion history — "retire packages/runner and the platform/ Laravel app") — the ' +
+      '`packages/runner` referand, which always carries a `/`, is unaffected and still fires',
+    () => {
+      const patches = new Map([
+        ['packages/runner/src/index.ts', hunkOnlyDeletion('export function run() {}')],
+        ['platform/src/index.ts', hunkOnlyDeletion('export function boot() {}')],
+      ]);
+      const repoChunks = [
+        makeChunk(
+          'CLAUDE.md',
+          14,
+          '**Monorepo Structure:**\n' +
+            '- `platform/` and `packages/runner` — hosted-platform remnants (see ' +
+            '[ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)); safe to ignore.',
+        ),
+        // Ambient, unrelated prose elsewhere in the corpus using the SAME word for something else
+        // — the real shape found in this very repo's own STYLE_GUIDE.md.
+        makeChunk(
+          'STYLE_GUIDE.md',
+          1,
+          'Design identity for all Lien properties (documentation site, platform app).',
+        ),
+      ];
+      const ctx = makeContext({ patches, repoChunks });
+
+      const candidates = computeDocsDriftCandidates(ctx);
+      const referands = candidates.map(c => c.referand);
+      expect(referands).toContain('packages/runner');
+      expect(referands).not.toContain('platform');
+    },
+  );
+
+  it(
+    'still fires a BARE top-level directory referand (distinctive counter-example) when nothing ' +
+      'in the doc/config corpus uses the word as ordinary prose',
+    () => {
+      const patches = new Map([
+        ['zznovelplatform/src/index.ts', hunkOnlyDeletion('export function boot() {}')],
+      ]);
+      const repoChunks = [
+        makeChunk('CLAUDE.md', 20, '- `zznovelplatform/` — internal tooling, safe to ignore.'),
+      ];
+      const ctx = makeContext({ patches, repoChunks });
+
+      const candidates = computeDocsDriftCandidates(ctx);
+      expect(candidates).toEqual([
+        expect.objectContaining({
+          referand: 'zznovelplatform',
+          referandKind: 'deleted-path',
+          docFile: 'CLAUDE.md',
+          docLine: 20,
+        }),
+      ]);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Design

`docs-drift-signals.ts`'s own module header flagged a residual precision
risk (added by #825, not fixed there): `extractDeletedPaths` groups a
deleted file up to its containing top-level directory when that whole
directory is confirmed gone. For a `packages/<name>` grouping this is safe
(`packages/runner`, `packages/core` — always carries a `/`, so it can never
spuriously match a plain English word mid-sentence). But when the deleted
directory sits OUTSIDE `packages/` (e.g. `platform/`), the grouped referand
is a BARE single word — and #593's real deletion history ("retire
packages/runner and the platform/ Laravel app") is exactly this shape:
`platform` is a common English/software word that risks false-positive
sweeps the moment such a directory is deleted.

**The check**: `isDistinctiveBareDirectory(token, docChunks)` — a bare
referand must have EVERY word-boundary occurrence across the repo's own
doc/config corpus sit in path context (immediately touching a `/` or a
backtick — this repo's own idiom for citing a bare directory/file, e.g.
CLAUDE.md's `` `packages/` ``/`` `platform/` `` bullets). A single prose hit
(the referand used as an ordinary word, not a path) disqualifies it — same
precision-first "when in doubt, suppress" posture as the module's existing
`isSuppressed`. When it fails, `extractDeletedPaths` falls back to the
individual file's own path instead of the risky grouping (still full
recall for that file). A `packages/<name>` grouped referand or a plain
file path is never gated -- both always carry a `/`.

**Why corpus-driven, not a hardcoded stopword list**: the module header
suggested "excluding common English words" as one candidate design. I
rejected a fixed list: it needs constant upkeep and still misses whatever
wasn't anticipated -- verified directly against this repo, `platform`
and `runner` are generic SOFTWARE nouns, not classic linguistic stopwords,
so an off-the-shelf English stopword list (the kind used for search/NLP)
would not contain either of them. Checking what THIS repo's own docs
actually do with the word is self-maintaining and needs no list to keep
up to date. Concretely, in this repo's real corpus today:

```
$ grep -rn '\bplatform\b' --include='*.md' -- (word-boundary matches)
STYLE_GUIDE.md:  "...documentation site, platform app)."          <- prose
packages/review/test/harness/README.md: "...the existing platform .env)" <- prose
CLAUDE.md (docs-drift's own hand-staged pr766 fixture bullet): "`platform/`..." <- path context
```

Two real, independent prose hits for the exact `platform` case -- this
isn't a hypothetical, it's the fixture's own corpus.

## Full-path referand keeps recall

`extractDeletedPaths` never gates a `packages/<name>` grouping or an
individual file path -- only the bare top-level-directory grouping. The
new tests confirm a `packages/core` deletion still groups and fires even
though "core" alone is also a common English word appearing in unrelated
prose ("the very core of the whole design") -- because the referand
carries a `/`, it was never at risk.

## Tests

`packages/review/test/docs-drift-signals.test.ts` (+159 lines, all new):
- `isDistinctiveBareDirectory` (4 cases): the #593 `platform` case (false,
  two independent prose hits), false on a single prose hit even amid
  otherwise-clean path-context occurrences, a **distinctive counter-example
  that must still fire** (`zznovelplatform`, every occurrence path-context
  -> true), and the vacuous case (token absent from the corpus -> true).
- `extractDeletedPaths` (3 new cases): falls back to the individual file
  when the bare directory fails distinctiveness; still groups a distinctive
  bare directory; a `packages/<name>` grouping is never gated (fires
  despite "core" being common prose elsewhere).
- `computeDocsDriftCandidates` end-to-end (2 new cases, new describe
  block "bare-directory distinctiveness gate"): the full #593 shape
  (`packages/runner` + `platform` both deleted, CLAUDE.md's real bullet
  naming both, plus real ambient `platform` prose elsewhere) -> only
  `packages/runner` survives as a candidate; the distinctive counter-example
  still fires end-to-end.

All existing tests pass unmodified -- none of them exercise the bare
top-level-directory grouping path (the only pre-existing "platform" mention
in the test file is inside a test that only deletes a `packages/runner/`
file, never anything under a bare `platform/`, so it never produced a bare
"platform" referand to begin with).

## Byte-diff: both docs-drift fixtures' offline proofs still hold

The two fixtures (`pr766-deleted-path-shape.fixture.json`,
`pr799-two-pass-boundary.fixture.json`) are gitignored (large captured
JSON) and weren't included in #825's diff -- regenerated locally per the
exact recipe documented in each fixture's own `.assertions.ts` header
(`capture-pr.ts` against the cited PR branch SHA, then the documented
hand-edits: pr766 needed CLAUDE.md stripped from patches/diffLines/
changedFiles/chunks and the ADR-cited bullet re-injected into repoChunks;
pr799 only needed the `docsDriftPass: true` config flag).

```
$ npx tsx test/harness/build-prompts.ts test/harness/fixtures/docs-drift/pr766-deleted-path-shape.fixture.json
BEFORE this PR (raw computeDocsDriftCandidates): 2 candidates
  {referand:"packages/runner", tier:"structural-mention", line:14}
  {referand:"platform",        tier:"structural-mention", line:14}
AFTER this PR:                                    1 candidate
  {referand:"packages/runner", tier:"structural-mention", line:14}
  ("platform" now correctly excluded -- real ambient prose hits in this
  repo's own STYLE_GUIDE.md and harness README.md)

LIEN_DOCS_DRIFT_PASS=on ... build-prompts.ts <pr766 fixture>
  BEFORE: docsDriftPass: {"fires":true}  (candidate-1 = packages/runner;
          "platform" deferred by budget rank-and-cap, not by this gate)
  AFTER:  docsDriftPass: {"fires":true}  <- UNCHANGED, byte-identical outcome
          (packages/runner was already the sole affordable candidate;
          removing the always-deferred "platform" from the raw list
          changes nothing observable at the pass level)

LIEN_DOCS_DRIFT_PASS=on ... build-prompts.ts <pr799 fixture>
  BEFORE: docsDriftPass: {"fires":false}
  AFTER:  docsDriftPass: {"fires":false}  <- UNCHANGED (#799 has zero
          removed/renamed/deleted referands at all; this PR's gate only
          touches the deleted-path bare-directory grouping, never invoked)
```

Both requirements hold: #766 still fires, #799 still doesn't.

## Gates

- `npm run format:check` / `lint` (0 errors, pre-existing warnings only) /
  `typecheck` / `build` -- all green.
- `npm test` (all 6 packages) -- 1556 review (was 1517 pre-existing +
  39 new/changed in this file) + 1077 core + 378 parser + 27 parser-native +
  860 cli + 41 action, all green.
- `lien delta` -- exit 0. `extractDeletedPaths` shows a `worsened` cognitive
  metric (4 -> 6, well under the 15 threshold, not a new crossing); the
  three new functions (`isPathContextOccurrence`, `isDistinctiveBareDirectory`,
  `everyLineIsPathContextOnly`) are trivially simple (cognitive 1-2) --
  `isDistinctiveBareDirectory` was extracted/split once already during
  development to stay under threshold (the hook flagged an initial nested-loop
  version at cognitive 16/15).

No changeset (review package is private/unpublished). No harness-evidence
gate expected: the touched files (`docs-drift-signals.ts`,
`docs-drift-signals.test.ts`) sit outside `packages/review/src/plugins/agent/`
(the gate's path filter), and this is a deterministic zero-LLM signal
refinement with no prompt/rule wording change -- docs-drift stays dark by
default (`docsDriftPass` config unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation drift detection to avoid flagging generic words as deleted directories when they are used as ordinary prose.
  * Preserved detection for distinctive directory names and explicit paths such as `packages/runner`.
  * Added fallback handling for bare directory references to improve candidate accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a precision gate for bare top-level directory referands in docs-drift. When a deleted directory sits outside `packages/` (e.g. `platform`), the new `isDistinctiveBareDirectory` check verifies that every occurrence of that bare word in the repo's doc/config corpus appears in path context (touching `/` or a backtick); if any prose hit exists, the grouping falls back to the individual file path. The implementation is conservative, well-tested, and the blast radius is confined to the docs-drift signal module. No breaking changes or wrong-output bugs were found.
>
> - Added `isDistinctiveBareDirectory` gate with path-context detection for bare directory tokens
> - Updated `extractDeletedPaths` to fall back to individual file paths when a bare top-level directory fails distinctiveness
> - Added comprehensive unit and end-to-end tests covering the #593 `platform` case, distinctive counter-examples, and `packages/<name>` exemptions

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ef1d118. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

