### PR TITLE
ci(review): enable docs-drift candidate loop for this repo's reviews

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -83,3 +83,13 @@ jobs:
           # input plumbing needed.
           LIEN_STALE_DUP_PASS: 'on'
           LIEN_INCOMPLETE_PASS: 'on'
+          # docs-drift-pass.ts — same dark/opt-in mechanism as the two above;
+          # this repo opts in as of 2026-07-23 to dogfood it on its own PRs.
+          # Still dark/off for every other @liendev/review / @liendev/action
+          # consumer. A synthetic calibration run scored 1/10 against the
+          # prod default model (see the status line + docs-drift subsection
+          # in docs/architecture/review-pass-architecture.md, and the
+          # fixture's own assertions header) — dark mechanism proven via
+          # unit tests independent of that score; this opt-in is itself the
+          # real-PR evidence-gathering step, not a claim of a passed bar.
+          LIEN_DOCS_DRIFT_PASS: 'on'

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -295,8 +295,12 @@ the pass. Reuses `docs-drift-signals.ts`'s `computeDocsDriftCandidates`
 (itself layered on `removed-export-signals.ts`/`rename-sweep-signals.ts`/
 `isFullFileDeletion`) rather than computing a new signal — candidates are
 already tiered (behavioral-claim vs. structural-mention) and suppressed on
-fenced code, changelog/changeset entries, link targets, and past-tense/
-historical prose before this loop ever sees them.
+fenced code, changelog/changeset entries, link targets, and prose matching
+`HISTORICAL_GUARD_RE`'s past-tense/historical trigger words before this loop
+ever sees them — a regex match, not a semantic judgment, so it only catches
+phrasing that hits its specific trigger-word list (see "Calibration" below
+for a documented case that reads as past-tense to a model without matching
+the regex).
 
 Verdict vocabulary is `drifted | historical | intentional | unverifiable` —
 only `drifted` becomes a finding; `historical` is the primary FP class the
@@ -338,7 +342,8 @@ entirely; doc-truth's v2 mode (above) keeps it open to ad hoc findings
 beyond the worklist, a deliberate difference reflecting that rule's own
 "also skim for anything not listed" allowance. Each pass's own
 `postProcessResult` hook (`postProcessStaleDuplicateResult`,
-`postProcessIncompleteHandlingResult`, `postProcessDocTruthResult`):
+`postProcessIncompleteHandlingResult`, `postProcessDocTruthResult`,
+`postProcessRemovedExportsResult`, `postProcessDocsDriftResult`):
 
 1. Checks `hasCompleteVerdictCoverage`: every expected candidate id appears
    **exactly once**, each with a recognized verdict value. A duplicate id,

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -1,21 +1,26 @@
 # Agent-review pass architecture — `ReviewPassSpec` and the extra-pass executor
 
 Status: generalized executor + attestation v2 shipped (PR #799, merged).
-Four passes plug into it today — **doc-truth is production-on by default**
-(v1); the **stale-duplicate**, **incomplete-handling**, and
-**removed-exports** candidate loops are built, merged, and dark (default-off)
+Five passes plug into it today — **doc-truth is production-on by default**
+(v1); the **stale-duplicate**, **incomplete-handling**, **removed-exports**,
+and **docs-drift** candidate loops are built, merged, and dark (default-off)
 for `@liendev/review`/`@liendev/action` consumers, and doc-truth itself
 gained a dark, env-only v2 mode (PR #807) that backports the same
 per-candidate-verdict contract into its own pass — see "Which passes are
 live" below. As of 2026-07-17, this monorepo's own
 `.github/workflows/lien-review.yml` opts the first two loops in on itself
 (`LIEN_STALE_DUP_PASS=on` / `LIEN_INCOMPLETE_PASS=on`) to dogfood them on its
-own PRs; removed-exports has not yet been opted into that workflow (a
-separate, later decision, same as the first two loops' own CI opt-in was) —
-the package/action defaults are unchanged for all three. See
+own PRs; as of 2026-07-23, this repo ALSO opts docs-drift in
+(`LIEN_DOCS_DRIFT_PASS=on`) — dark for every other consumer (see the fixture
+calibration record in
+`packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts`
+for the honest synthetic-shape score behind this opt-in). removed-exports
+has not yet been opted into that workflow (a separate, later decision, same
+as the other loops' own CI opt-in was) — the package/action defaults are
+unchanged for all four dark loops. See
 [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
 decision this doc implements and its evidence/economics — the evidence
-behind this opt-in is session-local so far and will be written up there
+behind these opt-ins is session-local so far and will be written up there
 once promoted into a durable fixture.
 
 ## Motivation
@@ -76,6 +81,7 @@ const EXTRA_PASSES: ReviewPassSpec[] = [
   STALE_DUPLICATE_PASS_SPEC,
   INCOMPLETE_HANDLING_PASS_SPEC,
   REMOVED_EXPORTS_PASS_SPEC,
+  DOCS_DRIFT_PASS_SPEC,
 ];
 ```
 
@@ -93,7 +99,7 @@ one starts. Two things are true regardless of how many passes exist:
   catches and reports (`context.reportSkip`) any thrown error from a pass's
   client run; the main pass's own output is untouched.
 
-None of the four passes has a data dependency on any of the *other three*
+None of the five passes has a data dependency on any of the *other four*
 (only doc-truth's original dependency on the *main* pass completing at all
 survives the generalization), so declaration order among them doesn't
 affect correctness — doc-truth stays first as the longest-proven pass.
@@ -103,10 +109,10 @@ machinery (trace-offset arithmetic that currently assumes the main trace is
 already complete; per-pass budget reporting that would need to interleave)
 ahead of a real latency complaint would be speculative (YAGNI per
 CLAUDE.md) — revisit once ≥3 dedicated passes are live and latency is
-measured as a problem (now true — four passes are live — but no latency
+measured as a problem (now true — five passes are live — but no latency
 complaint has been measured yet).
 
-## The four passes
+## The five passes
 
 | Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
 |---|---|---|---|---|---|---|
@@ -114,6 +120,7 @@ complaint has been measured yet).
 | stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
 | incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
 | removed-exports loop | `removed-exports-pass.ts` | `config.removedExportsPass` or `LIEN_REMOVED_EXPORTS_PASS=on` AND ≥1 removed public export | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `breaking \| intentional \| internal-only \| unverifiable` | **Dark** (default false) |
+| docs-drift loop | `docs-drift-pass.ts` | `config.docsDriftPass` or `LIEN_DOCS_DRIFT_PASS=on` AND ≥1 untouched-doc reference to a removed/renamed/deleted referand | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `drifted \| historical \| intentional \| unverifiable` | **Dark for consumers; this repo opts in as of 2026-07-23** |
 
 Every pass keeps its rule's prompt fragment and signal block in the shared
 main pass regardless of the dedicated pass's on/off state — a second,
@@ -275,9 +282,54 @@ this loop ALSO matches on `symbolName` identity (not just line proximity),
 since a removed-export candidate carries a stable identity the pilot's
 literal-text candidates and the second loop's per-shape candidates don't.
 
+### docs-drift candidate loop
+
+The fifth loop, and the first with **no `BUILTIN_RULES` entry / no shared
+main-pass rule fragment to backstop** (`docs-drift-pass.ts`'s own module
+doc): doc-truth already covers a TOUCHED doc's prose going stale in the same
+diff; docs-drift covers the inverse — an UNTOUCHED doc that silently rots
+after this PR removes, renames, or deletes the thing it describes. Reviewing
+every untouched doc on every PR is exactly the output-list competition the
+pass architecture exists to kill, so this rule ships as the pass and only
+the pass. Reuses `docs-drift-signals.ts`'s `computeDocsDriftCandidates`
+(itself layered on `removed-export-signals.ts`/`rename-sweep-signals.ts`/
+`isFullFileDeletion`) rather than computing a new signal — candidates are
+already tiered (behavioral-claim vs. structural-mention) and suppressed on
+fenced code, changelog/changeset entries, link targets, and past-tense/
+historical prose before this loop ever sees them.
+
+Verdict vocabulary is `drifted | historical | intentional | unverifiable` —
+only `drifted` becomes a finding; `historical` is the primary FP class the
+deterministic suppression already filters hard on (a model call still sees
+prose the regex guard didn't quite match); `intentional` covers a referand
+whose definition survives (only its export/shape changed); `unverifiable`
+is an inconclusive investigation. Toolset is `read_file` + `grep_codebase` —
+the removed-exports set — since both sides of a candidate (doc excerpt +
+position tier, and the removal/rename/deletion hunk when re-derivable from
+the diff) are already inline, making this a comparison, not an open
+investigation. Dedupe is location-only against its own ruleId (no symbol
+identity the way removed-exports has), PLUS a cross-pass rule: a candidate
+finding that collides in location with an EXISTING `doc-truth` finding is
+dropped — doc-truth wins, since it saw the touched hunk directly.
+
+Calibration: a synthetic hand-staged fixture
+(`fixtures/docs-drift/pr766-deleted-path-shape`, real PR #593's
+`packages/runner`/`platform/` deletion with an injected untouched CLAUDE.md
+bullet) scored 1/10 on a `--calibrate 10` run against the prod default model
+(2026-07-23, $0.4870) — well below the 9/10 bar. Recorded as a
+characterization, not a certification, per that fixture's own assertions
+header (per-vote taxonomy: a ground-truth mismatch between the hand-staged
+excerpt and this repo's real, evolved `CLAUDE.md` when the model calls
+`read_file` to verify, plus a genuine judgment-frontier gap around
+historical-sounding phrasing that carries none of `HISTORICAL_GUARD_RE`'s
+trigger words). Deterministic mechanism (candidate computation, budget,
+merge, gate) is separately unit-tested and proven independent of that paid
+score. This repo opts the pass into its own CI regardless (see status line
+above) to dogfood the mechanism and gather real-PR evidence going forward.
+
 ## Per-candidate verdict contract and `incomplete_verdict` honesty semantics
 
-All four passes now use variants of the same contract: **one verdict
+All five passes now use variants of the same contract: **one verdict
 object required per candidate/claim id**, carried as extra fields
 (`candidateId`/`claimId`, `verdict`) inside the standard `findings` JSON
 array — so the shared client's existing parse/validate pipeline needs zero
@@ -402,8 +454,17 @@ fires exactly once per pass that ran.
   the other two, has no `*_MAIN=off` opt-out override (see its own table row
   above) — `<removed_exports>` cannot be stripped from the main pass by
   design, not just "not yet run."
+- **docs-drift loop** — merged but **dark for `@liendev/review`/
+  `@liendev/action` consumers**: `config.docsDriftPass` defaults `false`;
+  opt in via that config key or `LIEN_DOCS_DRIFT_PASS=on`. Same non-exposure
+  via `action.yml`. As of 2026-07-23 this monorepo's own
+  `.github/workflows/lien-review.yml` sets `LIEN_DOCS_DRIFT_PASS: 'on'`, so
+  this repo's own PR reviews run it — the only one of the four dark loops
+  currently opted into this repo's own CI alongside the first two. No
+  `*_MAIN=off` override exists (docs-drift has no main-pass presence to
+  strip in the first place — see its own subsection above).
 
-All three dark passes have proven mechanism (gate/prompt/budget/merge/
+All four dark passes have proven mechanism (gate/prompt/budget/merge/
 attestation wiring, verified via unit tests and byte-diff-neutrality-when-off
 proofs) but **unproven lift** — no priced A/B has yet shown a dedicated loop
 finds more true positives or fewer false negatives than the shared loop's
@@ -412,7 +473,10 @@ removed-exports' flag ON against its own canary fixture
 (`structural-analysis/removed-export`, PR #399) held the fixture's
 already-documented 3/3 pass rate at $0.042 total — a regression smoke test,
 not a lift measurement (the main pass already covers this fixture on its
-own; the loop is an additive backstop, not yet isolated from it). See
+own; the loop is an additive backstop, not yet isolated from it). docs-drift
+has no such canary yet (its only fixture is the synthetic, sub-bar
+`pr766-deleted-path-shape` shape above) — this repo's CI opt-in is itself
+the evidence-gathering step, not a claim of proven lift. See
 [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the full
 evidence state, the real-PR firing-rate census, and per-pass cost data.
 

--- a/packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts
+++ b/packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts
@@ -98,11 +98,43 @@
  *
  * SHIPPED THIS SESSION: the candidate-FIRES proof above (deterministic, zero-LLM), PLUS a durable
  * unit-test regression (`docs-drift-signals.test.ts`) covering the same ADR-cited-bullet shape with
- * inline synthetic input — independent of this gitignored fixture JSON. NOT shipped: any real
- * `drifted` verdict — no paid calibration ran this session (cost discipline; per the overseer's
- * explicit scope). The Tier-1/Tier-2 assertions below are written as the FUTURE calibration target
- * (a `--calibrate 10` run, pending owner greenlight) — a real vote against this fixture has not yet
- * been observed to pass or fail them.
+ * inline synthetic input — independent of this gitignored fixture JSON.
+ *
+ * CALIBRATION RECORD (owner-ordered, 2026-07-23): `npm run test:harness -w @liendev/review -- --fixture
+ * test/harness/fixtures/docs-drift/pr766-deleted-path-shape.fixture.json --calibrate 10` (prod default
+ * model, `moonshotai/kimi-k2.7-code`) scored **1/10 (10%)** for **$0.4870** — well below the 9/10 bar.
+ * NOT certified; recorded here as a characterization, per cost discipline (no prompt iteration; a
+ * second calibration run was NOT spent chasing the bar — see per-vote taxonomy below). Scope: this
+ * result characterizes the synthetic hand-staged shape only, not production behavior on real captured
+ * PRs (the fixture is tagged `synthetic`, not `canary`).
+ *
+ * PER-VOTE TAXONOMY (from `.wip/traces/2026-07-23T10-22-28Z-pr766-deleted-path-shape/`, 10 votes):
+ *   - PASS (1/10, vote 6) — verdict "drifted", correctly reasoned from the candidate excerpt +
+ *     `grep_codebase` confirmation that `packages/runner`/`platform/` are genuinely gone; did not
+ *     second-guess the excerpt against the live file.
+ *   - FAIL bucket A — "ground-truth contradiction via read_file" (6/10: votes 1, 3, 4, 5, 8, 10,
+ *     verdicts "intentional" x5 + "unverifiable" x1) — the model calls `read_file` on CLAUDE.md,
+ *     which (being a HAND-STAGED synthetic excerpt, not a real repoRootDir capture) returns THIS
+ *     repo's actual real-world CLAUDE.md — which has evolved past both the pre-PR and the
+ *     injected-bullet state and contains neither the `packages/runner` bullet nor the ADR-012
+ *     citation. The model treats that mismatch as proof the doc was "already updated" (verdict
+ *     "intentional") or flags it as internally inconsistent (verdict "unverifiable"), rather than
+ *     trusting the candidate's stated doc excerpt as the fixture's ground truth. This is a
+ *     synthetic-fixture authenticity gap, not a production reasoning bug: a real captured PR's
+ *     `read_file` would return the doc content as it stood at capture time, matching the candidate;
+ *     only a hand-staged injection can diverge from the live repo like this.
+ *   - FAIL bucket B — "historical mis-classification despite no guard keywords" (3/10: votes 2, 7, 9,
+ *     verdict "historical") — the fixture's design (§3.a above) deliberately avoids every
+ *     `HISTORICAL_GUARD_RE` trigger word specifically to test whether the deterministic regex's
+ *     narrow scope leaves a gap the LLM should still catch. Instead, the model's own semantic
+ *     judgment independently pattern-matches "hosted-platform remnants ... safe to ignore" as
+ *     self-evidently past-tense/historical framing and downgrades to "historical" — the opposite of
+ *     the fixture's intent (this phrasing should read as a plausible-looking CURRENT maintenance
+ *     note, not an obvious retirement notice). This is a genuine judgment-frontier gap worth tracking
+ *     if docs-drift calibration is revisited, not a fixture defect.
+ *
+ * The Tier-1/Tier-2 assertions below remain the calibration target for a future prompt-tuning pass;
+ * per owner instruction this session does NOT iterate the prompt in response to the score above.
  */
 
 import type { FixtureAssertions } from '../../assertions.js';


### PR DESCRIPTION
## Summary

- Sets `LIEN_DOCS_DRIFT_PASS: 'on'` on the Lien Review workflow's own review step, opting this repo's PR reviews into the docs-drift candidate loop (untouched docs that still reference a removed/renamed/deleted referand). Read directly via `process.env` in `docs-drift-pass.ts`'s gate function — no `action.yml` input plumbing needed. Package/action defaults for external consumers are unchanged (still dark/off).
- Updates `docs/architecture/review-pass-architecture.md`'s status line + adds a docs-drift subsection (the doc previously described only four passes even though docs-drift already ships as the fifth in `EXTRA_PASSES` — a stale-doc gap, fittingly, in the docs-drift PR itself).
- Records the honest calibration result in the fixture's own assertions header (see below).

## Step 1 — calibration result (owner-ordered, before this PR)

Regenerated the gitignored `pr766-deleted-path-shape.fixture.json` from its documented hand-staging recipe (real PR #593's `packages/runner`/`platform/` deletion + an injected untouched CLAUDE.md bullet + `config.docsDriftPass: true` baked in, per the #812/drizzle precedent). Verified the deterministic offline proof first (`fires: true`, matching the header's documented candidate exactly), then ran the paid calibration:

```
npm run test:harness -w @liendev/review -- --fixture test/harness/fixtures/docs-drift/pr766-deleted-path-shape.fixture.json --calibrate 10
✗ docs-drift/pr766-deleted-path-shape — 1/10 passed (10%) · $0.4870
```

**1/10 (10%), $0.4870, 2026-07-23 — well below the 9/10 bar.** Per owner instruction: not iterated, recorded as a characterization (not certified), synthetic-shape scope only. Per-vote taxonomy (from `.wip/traces/`, not committed):

- **Bucket A (6/10)** — the model's `read_file` call on CLAUDE.md returns THIS repo's real, evolved current file (not the hand-staged synthetic content), which doesn't contain the injected bullet. The model treats that mismatch as proof the doc was "already updated" (verdict `intentional`, 5 votes) or flags it `unverifiable` (1 vote) instead of trusting the candidate's stated excerpt. This is a synthetic-fixture authenticity artifact, not a production bug — a real captured PR's `read_file` would match the candidate.
- **Bucket B (3/10)** — verdict `historical`: despite the fixture deliberately avoiding every `HISTORICAL_GUARD_RE` trigger word, the model's own semantic judgment still pattern-matches "hosted-platform remnants ... safe to ignore" as past-tense framing — a genuine judgment-frontier gap, not a fixture defect.
- **Pass (1/10)** — verdict `drifted`, correctly reasoned from the candidate excerpt + `grep_codebase`, without re-verifying CLAUDE.md's live content.

Full record + reasoning is in the fixture's own assertions header (`packages/review/test/harness/fixtures/docs-drift/pr766-deleted-path-shape.assertions.ts`).

## Dogfood evidence

This PR's own Lien Review run (job `review`, run 29999590953) evaluated the docs-drift pass and gated it out with a **live reason**, not "disabled" — proving the env var wiring took effect end-to-end (the gate function actually ran against this PR's real diff/context, it just found no eligible untouched-doc candidate in a CI/docs/comment-only PR):

```json
{
  "attestationVersion": 2,
  "run": { "conclusion": "success", "filesAnalyzed": 1 },
  "provider": {
    "passes": [
      { "name": "main", "ran": true, "stopReason": "completed", "neverRan": false, "candidatesDeferred": 0 },
      { "name": "doc-truth", "ran": true, "stopReason": "completed", "neverRan": false, "candidatesDeferred": 0 },
      { "name": "stale-duplicate-loop", "ran": true, "stopReason": "budget", "neverRan": false, "candidatesDeferred": 1, "deferredCandidateIds": ["`historical`"] }
    ]
  },
  "passesSkipped": [
    { "plugin": "complexity", "reason": "shouldActivate returned false" },
    { "plugin": "agent-review:incomplete-handling-loop", "reason": "no variant-sweep, sibling-surface, or unread-field candidate found" },
    { "plugin": "agent-review:removed-exports-loop", "reason": "disabled (opt-in; set config.removedExportsPass or LIEN_REMOVED_EXPORTS_PASS=on to enable)" },
    { "plugin": "agent-review:docs-drift-loop", "reason": "no untouched-doc reference to a removed/renamed/deleted referand in this PR" }
  ],
  "verdict": "degraded:budget_starved"
}
```

Compare `removed-exports-loop`'s skip reason (`"disabled (opt-in; ...)"` — the flag is genuinely off, mechanism never invoked) against `docs-drift-loop`'s (`"no untouched-doc reference..."` — the SAME shape `docsDriftSkipReason` returns when the pass IS enabled but finds zero candidates; see `docs-drift-pass.ts`'s `isDocsDriftPassEnabled` short-circuit vs. `computeDocsDriftCandidates` check). This is the live-evaluated path, not the disabled one — `LIEN_DOCS_DRIFT_PASS=on` is confirmed wired end-to-end in this repo's CI. (The run's `degraded:budget_starved` verdict is unrelated to docs-drift — `stale-duplicate-loop` hit its own budget ceiling on this PR's large diff; pre-existing behavior, not caused by this change.)

## Test plan

- [x] `npm run format:check` / `npm run lint` (0 errors, pre-existing warnings only) / `npm run typecheck` / `npm run build` — all green
- [x] `npm test` (excludes cli e2e) — 1556 + 860 + 41 tests passed
- [x] `lien delta` — no complexity changes vs HEAD
- [x] Dogfood: this PR's own CI review run shows docs-drift evaluated (gated-out with a live reason — attestation excerpt above)


---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR opts the monorepo's own CI reviews into the already-built docs-drift candidate loop by setting `LIEN_DOCS_DRIFT_PASS=on` in `.github/workflows/lien-review.yml`, and updates the architecture doc plus a fixture assertions header to reflect five passes and an honest 1/10 synthetic calibration result. No code behavior changes: the docs-drift gate, budget, merge, and prompt code are untouched, the `EXTRA_PASSES` ordering already places doc-truth before docs-drift as required for cross-dedup, and external consumer defaults remain dark.
>
> - Workflow enables `LIEN_DOCS_DRIFT_PASS=on` for this repo's own PR reviews only
> - Architecture doc updated from four to five passes with docs-drift subsection and calibration record
> - Fixture assertions header records the 1/10 synthetic-shape calibration result as a characterization, not a certification

⚠️ The stale-duplicate pass did not finish — it hit the token budget limit. That pass's findings are partial; the main review's findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 250f1c2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 192K/170K tokens
<!-- /lien:attestation -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation drift checks are now enabled for pull request reviews in the project’s CI workflow.
  * Review coverage now includes an additional pass for identifying inconsistencies between documentation and code.

* **Documentation**
  * Updated architecture documentation to describe the expanded review process and documentation consistency checks.
  * Added calibration and evaluation notes for documentation drift scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
