### PR TITLE
feat(review): doc-truth v2 per-claim contract default-on

### DIFF
--- a/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
+++ b/docs/architecture/decisions/0014-per-rule-candidate-loop-passes.md
@@ -193,17 +193,24 @@ in the same PR.
   wrong for the *already-shipping* two-pass case (main + doc-truth) before
   this generalization, not just a hypothetical future problem.
 - **The per-candidate-verdict contract generalized a third time, back onto
-  the pass that inspired it.** PR #807 (merged the same night, after this
-  ADR's initial evidence was gathered) backports the identical contract —
-  a stable id per worklist entry, an appended output-format override, the
-  same `postProcessResult`/`incomplete_verdict` honesty mechanism — into
-  doc-truth's own pass as a dark, env-only v2 mode (`LIEN_DOC_TRUTH_V2=on`,
-  no config field), entirely inside `doc-truth-pass.ts` with zero changes
-  to this ADR's executor/attestation plumbing. That it ported cleanly onto
-  the ORIGINAL pass the two new loops were modeled on, without touching
+  the pass that inspired it — and this one didn't stay dark.** PR #807
+  (merged the same night, after this ADR's initial evidence was gathered)
+  backports the identical contract — a stable id per worklist entry, an
+  appended output-format override, the same `postProcessResult`/
+  `incomplete_verdict` honesty mechanism — into doc-truth's own pass as a
+  v2 mode, entirely inside `doc-truth-pass.ts` with zero changes to this
+  ADR's executor/attestation plumbing. That it ported cleanly onto the
+  ORIGINAL pass the two new loops were modeled on, without touching
   `review-pass.ts` or `attestation.ts`, is independent evidence the
   contract is a property of the *pass*, not an artifact specific to either
-  loop's build.
+  loop's build. Unlike `stale-duplicate`/`incomplete-handling` (still dark
+  as of this writing), v2 shipped opt-in, HELD once its mechanism was proven
+  (48/48 verdict coverage) but its negative baseline (`accurate-doc`) wasn't
+  yet trustworthy, then — once #828 fixed that baseline (3/3 clean under
+  both configs) — was promoted to the DEFAULT by owner order (2026-07-23):
+  `isDocTruthV2Enabled` now defaults true, opt-out via `config.docTruthV2:
+  false` or `LIEN_DOC_TRUTH_V2=off`/`0`/`false`. This is the first of the
+  candidate-loop-pattern passes to graduate from dark to production-on.
 
 ### Negative / Risks
 

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -1,13 +1,14 @@
 # Agent-review pass architecture — `ReviewPassSpec` and the extra-pass executor
 
 Status: generalized executor + attestation v2 shipped (PR #799, merged).
-Five passes plug into it today — **doc-truth is production-on by default**
-(v1); the **stale-duplicate**, **incomplete-handling**, **removed-exports**,
-and **docs-drift** candidate loops are built, merged, and dark (default-off)
-for `@liendev/review`/`@liendev/action` consumers, and doc-truth itself
-gained a dark, env-only v2 mode (PR #807) that backports the same
-per-candidate-verdict contract into its own pass — see "Which passes are
-live" below. As of 2026-07-17, this monorepo's own
+Five passes plug into it today — **doc-truth is production-on by default**,
+including its per-claim-verdict v2 contract (PR #807), promoted to the
+DEFAULT as of 2026-07-23 once #828 closed the negative-baseline trust gap on
+top of v2's already-proven mechanism; the **stale-duplicate**,
+**incomplete-handling**, **removed-exports**, and **docs-drift** candidate
+loops are built, merged, and dark (default-off) for `@liendev/review`/
+`@liendev/action` consumers — see "Which passes are live" below. As of
+2026-07-17, this monorepo's own
 `.github/workflows/lien-review.yml` opts the first two loops in on itself
 (`LIEN_STALE_DUP_PASS=on` / `LIEN_INCOMPLETE_PASS=on`) to dogfood them on its
 own PRs; as of 2026-07-23, this repo ALSO opts docs-drift in
@@ -116,7 +117,7 @@ complaint has been measured yet).
 
 | Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
 |---|---|---|---|---|---|---|
-| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | v1 (default): open findings list. v2 (`LIEN_DOC_TRUTH_V2=on`, dark): `accurate \| contradicted \| unverifiable` per claim id | **Production-on** (v1 default true; v2 dark, env-only) |
+| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | v2 (default as of 2026-07-23): `accurate \| contradicted \| unverifiable` per claim id. v1 (opt-out via `config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`): open findings list | **Production-on** (both the pass and its v2 contract default true) |
 | stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
 | incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
 | removed-exports loop | `removed-exports-pass.ts` | `config.removedExportsPass` or `LIEN_REMOVED_EXPORTS_PASS=on` AND ≥1 removed public export | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `breaking \| intentional \| internal-only \| unverifiable` | **Dark** (default false) |
@@ -150,10 +151,18 @@ a low/absent risk level to `medium` when doc-truth found `error`-severity
 contradictions (`mergeDocPassIntoResult`).
 
 **v2 (PR #807, merged same night as the two candidate loops above): doc-truth
-backports the per-candidate-verdict contract into its own pass.** Env-only
-opt-in (`LIEN_DOC_TRUTH_V2=on`, no config field — `isDocTruthV2Enabled`,
-default off), entirely inside `doc-truth-pass.ts` with zero changes to
-`review-pass.ts`, `attestation.ts`, or `index.ts`'s `EXTRA_PASSES`. Every
+backports the per-candidate-verdict contract into its own pass — DEFAULT ON
+as of 2026-07-23.** Shipped dark, env-only (`LIEN_DOC_TRUTH_V2=on`, no config
+field, default off) and stayed dark through a HOLD: the mechanism was proven
+(48/48 verdict coverage across the calibration corpus) but the negative
+baseline wasn't yet trustworthy — `accurate-doc`, the precision-guard fixture
+that proves v2 doesn't fire on a claim with nothing wrong, wasn't clean under
+v2 until #828 fixed it (now 3/3 clean under both v1 and v2). With both sides
+proven, the owner ordered v2 promoted to the default. It's still entirely
+inside `doc-truth-pass.ts` with zero changes to `review-pass.ts`,
+`attestation.ts`, or `index.ts`'s `EXTRA_PASSES` — only `isDocTruthV2Enabled`'s
+own default inverted, and it gained a `config.docTruthV2` field (checked
+before the env var) alongside the pre-existing env-only opt-in. Every
 `<doc_claims>` entry and `<rename_sweep>` item gets a stable `claim-N` id
 (`buildClaimWorklist`), and the model must emit exactly one verdict
 (`accurate | contradicted | unverifiable`) per id via an appended
@@ -165,11 +174,14 @@ unrecognized-id or invalid-verdict claim entry. One deliberate difference:
 unlike the two loops, v2's contract stays **open beyond the worklist** — an
 extra finding for a claim the model spots itself (no `claimId`) still passes
 through as an ordinary finding, matching the rule's existing "also skim for
-any claim not listed" allowance. With the flag off, every v2 function is
-verified byte-identical to v1's own output (PR #807's byte-diff census). This
-is now the third pass built on the per-candidate-verdict pattern — evidence
-the pattern generalizes beyond the two purpose-built loops it was designed
-for, back onto the original pass that inspired it.
+any claim not listed" allowance. With the flag explicitly disabled
+(`config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`/`0`/`false`), every v2
+function is still verified byte-identical to v1's own output (PR #807's
+byte-diff census still holds on that opt-out path — only the default
+changed, not the off-path behavior). This is now the third pass built on the
+per-candidate-verdict pattern — evidence the pattern generalizes beyond the
+two purpose-built loops it was designed for, back onto the original pass
+that inspired it.
 
 ### stale-duplicate candidate loop
 
@@ -440,10 +452,12 @@ fires exactly once per pass that ran.
 
 - **doc-truth** — production-on, has been since PR #733. Kill-switches:
   `config.docTruthPass: false` or `LIEN_REVIEW_DOC_PASS=0` (documented in
-  `packages/action/README.md` as the one Action-level tunable env var). Its
-  v2 per-claim-verdict contract (PR #807, `LIEN_DOC_TRUTH_V2=on`, env-only,
-  no config field) is a separate, **dark** opt-in layered on top — v1's
-  open-findings-list behavior is unchanged when v2 is off.
+  `packages/action/README.md` as one of two Action-level tunable env vars).
+  Its v2 per-claim-verdict contract (PR #807) is now **also production-on by
+  default** as of 2026-07-23 (owner-ordered flip, once #828 closed the
+  negative-baseline trust gap on top of v2's already-proven 48/48 verdict-
+  coverage mechanism) — opt back into v1's open-findings-list behavior via
+  `config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`/`0`/`false`.
 - **stale-duplicate loop** — merged (PR #803, guard-fixed in PR #805) but
   **dark**: `config.staleDuplicatePass` defaults `false`; opt in via that
   config key or `LIEN_STALE_DUP_PASS=on`. Not exposed through

--- a/docs/development/review-harness-judgment.md
+++ b/docs/development/review-harness-judgment.md
@@ -133,12 +133,14 @@ pass) becomes a machine-checkable completeness failure instead of a semantic
 judgment call the harness's assertions would otherwise have to infer. Both
 ship dark (default-off config/env flags) —
 mechanism proven, lift not yet calibrated. The same contract has since been
-backported into doc-truth's own pass as an opt-in v2 mode
-(`LIEN_DOC_TRUTH_V2=on`, PR #807, also dark) — early paid screening there
-(3 votes) held the certified doc-truth canary and hit zero verdict-coverage
-gaps across a 48-id worklist, but per this guide's own golden rule 4, a
-screen is not a calibration; `--calibrate 10` on it is still the owner's
-call. If you add a rule that keeps
+backported into doc-truth's own pass as a v2 mode (PR #807) — early paid
+screening there (3 votes) held the certified doc-truth canary and hit zero
+verdict-coverage gaps across a 48-id worklist. Unlike the two dark loops
+above, v2 did NOT stay dark: it shipped opt-in (`LIEN_DOC_TRUTH_V2=on`), held
+while the negative baseline (`accurate-doc`) wasn't yet trustworthy under it,
+and — once #828 closed that gap (3/3 clean under both configs) — was
+promoted to the DEFAULT by owner order (2026-07-23; opt out via
+`config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`). If you add a rule that keeps
 losing the findings competition and its candidates are enumerable with a
 closed verdict set, a dedicated pass is the precedent to reach for — but
 only after proving competition is the bottleneck, and only for a rule that

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -129,6 +129,7 @@ variable on the action step, not a formal input:
 - uses: getlien/lien-review@v1
   env:
     LIEN_REVIEW_DOC_PASS: '0' # disable the doc-truth second pass
+    LIEN_DOC_TRUTH_V2: 'off' # opt back into the pass's older open-findings-list behavior
   with:
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
@@ -137,6 +138,13 @@ variable on the action step, not a formal input:
   doc-truth second pass, a claims-only re-review that runs only on PRs
   touching documentation/guidance surfaces and checks their prose against the
   code. On by default.
+- **`LIEN_DOC_TRUTH_V2=off`** (or `0`/`false`) — opts the doc-truth pass back
+  into its v1 open-findings-list behavior. On by default: v2 requires exactly
+  one verdict (`accurate | contradicted | unverifiable`) per detected doc
+  claim instead of leaving each one free to be silently omitted from an open
+  list — see [Agent-Review Pass Architecture](https://github.com/getlien/lien/blob/main/docs/architecture/review-pass-architecture.md).
+  Only takes effect when the doc-truth pass itself is enabled (i.e., not
+  overridden by `LIEN_REVIEW_DOC_PASS` above).
 
 There is currently no `model` input — the OpenRouter path pins the calibrated
 default deliberately, since the calibration evidence backing this review

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -19,7 +19,7 @@
  * this module used to own itself (`runDocTruthPass`, `appendDocTruthTurns`),
  * so every piece here stays unit-testable with zero LLM spend.
  *
- * ## v2 — per-claim verdict contract (flag-gated, default OFF)
+ * ## v2 — per-claim verdict contract (DEFAULT ON as of the owner-ordered flip)
  *
  * pr658's Finding A (the `schema.ts` `embeddings.enabled` doc comment) is the
  * motivating case: doc-truth's open findings list lets a real contradiction
@@ -29,8 +29,13 @@
  * loop proved the fix for a narrower shape: require one verdict per worklist
  * id instead of an open list an entry can silently be omitted from.
  *
- * Set `LIEN_DOC_TRUTH_V2=on` (see `isDocTruthV2Enabled`) to require exactly
- * that here: every `<doc_claims>` entry and every `<rename_sweep>` item gets
+ * v2 shipped dark (PR #807) and stayed dark through a HOLD: the mechanism was
+ * proven (48/48 verdict coverage across the calibration corpus) but the
+ * negative baseline (`accurate-doc`, the precision-guard fixture proving v2
+ * doesn't fire on a claim with nothing wrong) was not yet trustworthy. #828
+ * closed that gap (`accurate-doc` now 3/3 clean under both v1 and v2). With
+ * both sides proven, the owner ordered v2 promoted to the default here —
+ * every `<doc_claims>` entry and every `<rename_sweep>` item gets
  * a stable `claim-N` id (`buildClaimWorklist`), and the model MUST emit one
  * verdict (`accurate` | `contradicted` | `unverifiable`) per id, carried
  * inside the standard `findings` array tagged with `claimId`/`verdict` — the
@@ -59,10 +64,11 @@
  * verdict still counts as honest coverage even though it never becomes a
  * finding.
  *
- * When the flag is off, every v2 function is unreachable and
- * `buildDocTruthPassPrompts`/`postProcessDocTruthResult` return exactly what
- * they always did — this is an ADDITIVE contract, not a rewrite (see the
- * byte-diff proof in this change's PR body).
+ * Opt back into v1's open-findings-list behavior via `config.docTruthV2: false`
+ * or `LIEN_DOC_TRUTH_V2=off`/`0`/`false` (see `isDocTruthV2Enabled`) — with v2
+ * off, `buildDocTruthPassPrompts`/`postProcessDocTruthResult` return exactly
+ * what they always did pre-flip (the byte-diff-neutrality-when-off proof from
+ * PR #807 still holds; only the DEFAULT changed, not the off-path behavior).
  */
 
 import type { ReviewContext } from '../../plugin-types.js';
@@ -236,13 +242,14 @@ export function buildDocTruthPassInitialMessage(context: ReviewContext): string 
  * format enumerates just `doc-truth` and no competing investigation strategies
  * appear).
  *
- * When `isDocTruthV2Enabled()` is true, the per-claim verdict contract (see
- * this module's doc comment) is layered on top: the system prompt gets an
- * appended override section requiring one verdict per worklist id, and the
- * initial message's `<doc_claims>`/`<rename_sweep>` blocks are rebuilt with
- * ids attached (`buildDocTruthPassInitialMessageV2`). With the flag off this
- * function's return value is UNCHANGED from before v2 existed — same two
- * function calls, nothing appended.
+ * When `isDocTruthV2Enabled(config)` is true (the default), the per-claim
+ * verdict contract (see this module's doc comment) is layered on top: the
+ * system prompt gets an appended override section requiring one verdict per
+ * worklist id, and the initial message's `<doc_claims>`/`<rename_sweep>`
+ * blocks are rebuilt with ids attached (`buildDocTruthPassInitialMessageV2`).
+ * With the flag explicitly disabled, this function's return value is
+ * UNCHANGED from before v2 existed — same two function calls, nothing
+ * appended (the byte-diff-neutrality-when-off proof from PR #807).
  *
  * `budget` is this pass's own final allocated budget (see
  * `ReviewPassSpec.buildPrompts`'s doc comment) — under v2, it drives
@@ -260,7 +267,7 @@ export function buildDocTruthPassPrompts(
   initialMessage: string;
 } {
   const systemPrompt = buildSystemPrompt(DOC_TRUTH_ONLY_RULES);
-  if (!isDocTruthV2Enabled()) {
+  if (!isDocTruthV2Enabled(context.config as unknown as AgentConfig)) {
     return { systemPrompt, initialMessage: buildDocTruthPassInitialMessage(context) };
   }
   const full = buildClaimWorklist(context);
@@ -276,18 +283,24 @@ export function buildDocTruthPassPrompts(
 // v2 — per-claim verdict contract (flag-gated; see module doc comment)
 // ---------------------------------------------------------------------------
 
-/** Env opt-in for the v2 per-claim-verdict contract. Default OFF (unset/anything else). */
+/** Env opt-OUT for the v2 per-claim-verdict contract, now the DEFAULT (owner-ordered flip — v2's
+ *  mechanism was proven at 48/48 verdict coverage, and the earlier HOLD was a negative-baseline
+ *  trust gap #828 closed). Default ON (unset/anything else); '0'/'false'/'off' (case-insensitive)
+ *  opts back into v1's open-findings-list behavior. */
 const DOC_TRUTH_V2_ENV = 'LIEN_DOC_TRUTH_V2';
 
-function envEnabled(value: string | undefined): boolean {
+function envDisablesDocTruthV2(value: string | undefined): boolean {
   const v = value?.trim().toLowerCase();
-  return v === '1' || v === 'true' || v === 'on';
+  return v === '0' || v === 'false' || v === 'off';
 }
 
-/** Whether the v2 per-claim-verdict contract is active. Env-only opt-in (no config field — a
- *  pilot flag, mirroring stale-duplicate-pass.ts's env-first pattern before it grew a config field). */
-export function isDocTruthV2Enabled(): boolean {
-  return envEnabled(process.env[DOC_TRUTH_V2_ENV]);
+/** Whether the v2 per-claim-verdict contract is active. `config.docTruthV2: false` takes
+ *  precedence; otherwise ON unless `LIEN_DOC_TRUTH_V2` explicitly disables it. `config` is
+ *  optional (defaults to fully on) so every existing call site that predates the config field
+ *  (tests, the harness) keeps its current behavior unless it starts passing one. */
+export function isDocTruthV2Enabled(config?: AgentConfig): boolean {
+  if (config?.docTruthV2 === false) return false;
+  return !envDisablesDocTruthV2(process.env[DOC_TRUTH_V2_ENV]);
 }
 
 /** Cap on doc claims assigned an id — mirrors doc-claims-signals.ts's own MAX_CLAIMS render cap. */
@@ -833,7 +846,7 @@ export function postProcessDocTruthResult(
   context: ReviewContext,
   budget = Number.POSITIVE_INFINITY,
 ): AgentResult {
-  if (!isDocTruthV2Enabled()) return result;
+  if (!isDocTruthV2Enabled(context.config as unknown as AgentConfig)) return result;
 
   const full = buildClaimWorklist(context);
   const ceiling = affordableCandidateCeiling(budget, DOC_TRUTH_TOKENS_PER_CLAIM);
@@ -864,9 +877,11 @@ export function postProcessDocTruthResult(
  * list. Every field here is one of this module's own pure functions; the
  * generic executor supplies the gate-check/run/failure-isolation/reporting
  * plumbing that used to be doc-truth-specific (`runDocTruthPass`,
- * `appendDocTruthTurns`). `postProcessResult` is always wired in — it's an
- * identity no-op when `LIEN_DOC_TRUTH_V2` is off (see
- * `postProcessDocTruthResult`), so this addition doesn't change v1 behavior.
+ * `appendDocTruthTurns`). `postProcessResult` is always wired in — it applies
+ * the v2 per-claim reduction by default now, and is an identity no-op only
+ * when v2 is explicitly disabled (`config.docTruthV2: false` or
+ * `LIEN_DOC_TRUTH_V2=off`/`0`/`false` — see `postProcessDocTruthResult`),
+ * which preserves exact v1 behavior on that opt-out path.
  */
 export const DOC_TRUTH_PASS_SPEC: ReviewPassSpec = {
   name: 'doc-truth',

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -126,6 +126,13 @@ const configSchema = z.object({
    */
   docTruthPass: z.boolean().default(true),
   /**
+   * Whether doc-truth's per-claim verdict contract (v2) is active. Default
+   * true as of the v2 default-on flip; set false (or env
+   * LIEN_DOC_TRUTH_V2=off/0/false) to opt back into v1's open-findings-list
+   * behavior. See `doc-truth-pass.ts`'s `isDocTruthV2Enabled`.
+   */
+  docTruthV2: z.boolean().default(true),
+  /**
    * Whether the `summary` review type is enabled (issue #572). Gates the
    * diff-only summary-only mode — see `summary-only-pass.ts`.
    */

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -52,6 +52,17 @@ export interface AgentConfig {
    */
   docTruthPass?: boolean;
   /**
+   * Whether doc-truth's per-claim verdict contract (v2) is active (issue
+   * #732 follow-up). Default true as of the v2 default-on flip — every
+   * `<doc_claims>`/`<rename_sweep>` entry requires exactly one verdict,
+   * closing the open-findings-list competition v1 lost Finding A to. Set
+   * false (or env LIEN_DOC_TRUTH_V2=off/0/false) to opt back into v1's
+   * open-findings-list behavior. Only consulted when `docTruthPass` itself
+   * is enabled — this doesn't gate the pass, only which contract it uses.
+   * See `doc-truth-pass.ts`'s `isDocTruthV2Enabled`.
+   */
+  docTruthV2?: boolean;
+  /**
    * Whether the `summary` review type is enabled for this run (issue #572).
    * Gates the diff-only summary-only mode: with zero analyzable chunks, the
    * plugin only activates when this is true AND the PR's patches are

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -457,18 +457,35 @@ describe('DOC_TRUTH_PASS_SPEC', () => {
 // ---------------------------------------------------------------------------
 
 describe('isDocTruthV2Enabled', () => {
-  it('is false by default (env unset)', () => {
-    expect(isDocTruthV2Enabled()).toBe(false);
-  });
-
-  it.each(['on', '1', 'true', 'ON', 'TRUE'])('is true for LIEN_DOC_TRUTH_V2=%s', value => {
-    process.env.LIEN_DOC_TRUTH_V2 = value;
+  it('is true by default (env unset, no config)', () => {
     expect(isDocTruthV2Enabled()).toBe(true);
   });
 
-  it.each(['off', '0', 'false', 'nonsense'])('is false for LIEN_DOC_TRUTH_V2=%s', value => {
+  it.each(['on', '1', 'true', 'ON', 'TRUE', 'nonsense'])(
+    'stays true for LIEN_DOC_TRUTH_V2=%s (only an explicit disable value opts out)',
+    value => {
+      process.env.LIEN_DOC_TRUTH_V2 = value;
+      expect(isDocTruthV2Enabled()).toBe(true);
+    },
+  );
+
+  it.each(['off', '0', 'false', 'OFF', 'FALSE'])('is false for LIEN_DOC_TRUTH_V2=%s', value => {
     process.env.LIEN_DOC_TRUTH_V2 = value;
     expect(isDocTruthV2Enabled()).toBe(false);
+  });
+
+  it('is false when config.docTruthV2 is false, even with no env var set', () => {
+    expect(isDocTruthV2Enabled({ docTruthV2: false } as AgentConfig)).toBe(false);
+  });
+
+  it('config.docTruthV2: false wins even when the env var would otherwise enable it', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'on';
+    expect(isDocTruthV2Enabled({ docTruthV2: false } as AgentConfig)).toBe(false);
+  });
+
+  it('is true when config.docTruthV2 is true (explicit) or undefined (unset)', () => {
+    expect(isDocTruthV2Enabled({ docTruthV2: true } as AgentConfig)).toBe(true);
+    expect(isDocTruthV2Enabled({} as AgentConfig)).toBe(true);
   });
 });
 
@@ -625,6 +642,7 @@ describe('capClaimWorklistToCeiling', () => {
 
 describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 contract rendering', () => {
   it('is byte-identical to the pre-v2 prompts when the flag is off', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'off';
     const ctx = contextWithPatches([
       ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
       ...RENAME_SWEEP_FILES,
@@ -635,6 +653,25 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
     expect(systemPrompt).not.toContain('output_format_v2_override');
     expect(initialMessage).not.toContain('PER-CLAIM VERDICT CONTRACT');
     expect(initialMessage).not.toContain('[claim-1]');
+  });
+
+  it('uses the v2 contract with no env var and no config at all (the new default)', () => {
+    const ctx = contextWithPatches([
+      ['docs/architecture/worktree.md', DOC_CLAIM_PATCH],
+      ...RENAME_SWEEP_FILES,
+    ]);
+    const { systemPrompt } = buildDocTruthPassPrompts(ctx);
+    expect(systemPrompt).toContain('<output_format_v2_override>');
+  });
+
+  it('config.docTruthV2: false (via context.config) opts back into the v1 prompt shape', () => {
+    const ctx = contextWithPatches(
+      [['docs/architecture/worktree.md', DOC_CLAIM_PATCH], ...RENAME_SWEEP_FILES],
+      { config: cfg({ docTruthV2: false }) as unknown as Record<string, unknown> },
+    );
+    const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(ctx);
+    expect(systemPrompt).not.toContain('output_format_v2_override');
+    expect(initialMessage).toBe(buildDocTruthPassInitialMessage(ctx));
   });
 
   it('appends the v2 output-contract override to the system prompt, enumerating every claim id', () => {
@@ -777,6 +814,7 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
 
   it('does not append the overflow note when the v1 (non-candidate-loop) path is used, even with a tiny budget', () => {
     // v1 has no id-based worklist to cap — this feature is scoped to v2 only.
+    process.env.LIEN_DOC_TRUTH_V2 = 'off';
     const ctx = manyClaimsCtx(6);
     const { initialMessage } = buildDocTruthPassPrompts(ctx, 0);
     expect(initialMessage).not.toContain('CANDIDATE OVERFLOW');
@@ -799,8 +837,23 @@ describe('postProcessDocTruthResult', () => {
     contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
 
   it('is the identity (same reference) when the flag is off', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'off';
     const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'contradicted' })]);
     expect(postProcessDocTruthResult(result, singleClaimCtx())).toBe(result);
+  });
+
+  it('reduces verdicts with no env var and no config at all (the new default)', () => {
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'contradicted' })]);
+    const processed = postProcessDocTruthResult(result, singleClaimCtx());
+    expect(processed.findings).toHaveLength(1);
+  });
+
+  it('is the identity when context.config.docTruthV2 is false, no env var needed', () => {
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]], {
+      config: cfg({ docTruthV2: false }) as unknown as Record<string, unknown>,
+    });
+    const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'contradicted' })]);
+    expect(postProcessDocTruthResult(result, ctx)).toBe(result);
   });
 
   it('drops an "accurate" verdict entirely (stays silent when confirmed)', () => {
@@ -975,6 +1028,7 @@ describe('postProcessDocTruthResult', () => {
   });
 
   it('is identity (candidatesDeferred untouched) when the v1 flag is off, even with a tiny budget', () => {
+    process.env.LIEN_DOC_TRUTH_V2 = 'off';
     const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'accurate' })]);
     const processed = postProcessDocTruthResult(result, manyClaimsCtx(6), 0);
     expect(processed).toBe(result);


### PR DESCRIPTION
## Summary

- Flips `isDocTruthV2Enabled`'s default: doc-truth's per-claim verdict contract (`accurate | contradicted | unverifiable`, one required per `<doc_claims>`/`<rename_sweep>` id) is now **ON by default** — opt back into v1's open-findings-list behavior via `config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`/`0`/`false`.
- `isDocTruthV2Enabled` gained an optional `AgentConfig` parameter (config takes precedence over the env var) plus a corresponding `docTruthV2` config field (types.ts + the zod schema in index.ts, both default `true`). Both call sites (`buildDocTruthPassPrompts`, `postProcessDocTruthResult`) now read it from `context.config as unknown as AgentConfig` — the same cast `index.ts` already uses to resolve `AgentConfig` from `ReviewContext.config` — so no `ReviewPassSpec` interface change was needed.
- Updates `docs/architecture/review-pass-architecture.md` (top status line, the pass table, the doc-truth v2 subsection, "Which passes are live today"), ADR-014, and `docs/development/review-harness-judgment.md`'s status lines.
- Updates `packages/action/README.md` with the new opt-out env var — see "Published re-export check" below for why this matters.

## Context (why now)

v2 shipped dark in PR #807 with its mechanism already proven (**48/48 verdict-id coverage**, zero gaps, across the calibration corpus — cited verbatim in that PR's body). It stayed on HOLD because the negative baseline wasn't yet trustworthy: `accurate-doc` (the precision-guard fixture proving v2 doesn't fire on a claim with nothing wrong) was false-firing 3/3. **PR #828 closed that gap** — `accurate-doc` is now 3/3 clean under both v1 and v2 (verified fresh again below). With both the positive mechanism and the negative baseline proven, the owner ordered v2 promoted to the default.

## Unit tests

`packages/review/test/plugins-agent-doc-truth-pass.test.ts`: 6 pre-existing tests assumed v1-was-default (asserted `isDocTruthV2Enabled()` → `false` with no env var, or exercised "the flag is off" paths with no explicit disable) — all 6 now explicitly set `LIEN_DOC_TRUTH_V2=off` since that behavior requires opting out. Rewrote the `isDocTruthV2Enabled` describe block for the new semantics (default true; `'0'|'false'|'off'` disable; `'nonsense'` no longer disables — only an explicit disable value does now) and added integration tests proving `context.config.docTruthV2: false` flows through both `buildDocTruthPassPrompts` and `postProcessDocTruthResult` end-to-end, not just at the `isDocTruthV2Enabled` unit level. Net: 80 → 89 tests in that file, all green. Full `packages/review` suite: 1565 tests green (was 1556).

## Byte-diff — every doc-truth-firing fixture changes to v2 prompts BY DEFAULT (expected, the point)

Verified zero-LLM via `build-prompts.ts` (`LIEN_DOC_TRUTH_V2=off` vs. unset/default) against all 7 fixtures where `docTruthPass.fires === true`:

| fixture | v1 (explicit off) | default (no env var) |
|---|---|---|
| `doc-truth/accurate-doc` (committed) | v1 shape | **v2 shape** |
| `doc-truth/renamed-stale-claim` (committed) | v1 shape | **v2 shape** |
| `doc-truth/pr658-search-code-rename` (regenerated via `capture-pr.ts 658`) | v1 shape | **v2 shape** |
| `doc-truth/pr667-worktree-doc-drift` (regenerated, `--sha 1882b38d`) | v1 shape | **v2 shape** |
| `doc-truth/pr687-config-doc-drift` (regenerated, `--sha a26e480b`) | v1 shape | **v2 shape** |
| `doc-truth/pr711-changeset-export-claim` (regenerated, `--sha 4480f85e`) | v1 shape | **v2 shape** |
| `doc-truth/pr716-install-claim` (regenerated, `--sha 4c805ea7`) | v1 shape | **v2 shape** |

("v2 shape" = system prompt contains `output_format_v2_override`.) The 5 real-PR fixtures are gitignored (regenerated locally per their assertions headers' documented capture commands, not committed — `git status` confirms no change under `fixtures/doc-truth/`).

## Validation screens (3 votes each, real OpenRouter calls, run under the actual new default — no env var set)

- **`pr658-search-code-rename`** (the certified canary — Tier 1 doc-truth-fired + Tier 2 Finding B claim+correction, Finding A tracked as non-gating characterization per the 2026-07-16 owner re-scope): **3/3 passed, $0.3417**. The gate holds under v2 by default.
- **`accurate-doc`** (must stay 0-findings — the precision guard): **3/3 passed, $0.0447**.

No regression on either — proceeding to merge. (Note: I could not independently re-derive the specific "10/10 under v2 on 2026-07-19" prior validation citation from git/PR history in this session — possibly concurrent fleet work not yet visible here. The fresh 3/3 screen above is this PR's own operative evidence for the merge decision.)

## Published re-export check (no changeset, but verified)

`packages/review` and `packages/action` are both `"private": true` — neither publishes to the npm registry, so no changeset is needed (matches PR #828's precedent: "internal review-engine test/prompt fix, not a published package API change"). **However**: `packages/action`'s GHCR image + the `getlien/lien-review` dist repo (built from this monorepo's source at release time, per `publish-action.yml`) DO bundle `@liendev/review`'s compiled code — that's a real redistribution path this default reaches, just not an npm one. Concretely: `publish-action.yml` triggers on the `Release` workflow completing and republishes a new image tagged to `@liendev/lien`'s (the CLI's) version whenever that version doesn't already have a GHCR image — so this flip **will** reach external `uses: getlien/lien-review@v1` consumers on the next such release, with no explicit per-consumer opt-in ceremony (unlike every dark candidate-loop pass, which stays off for them by construction). Documented the `LIEN_DOC_TRUTH_V2` opt-out lever in `packages/action/README.md`'s "Advanced configuration" section so those consumers have a way to opt back into v1 if they want it.

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors (33 pre-existing warnings, untouched files)
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` (parser+core+review 1565+ tests, cli 860 tests excl. e2e, action 41 tests) — all green
- `lien delta` — exit 0. 3 minor worsenings (all well under threshold): `buildDocTruthPassPrompts`/`postProcessDocTruthResult` time-complexity 6m/14m → 7m/15m from the added config lookup, `isDocTruthV2Enabled` cognitive 0 → 1 from the new config-precedence branch. New `envDisablesDocTruthV2` helper (cognitive 1) replaces the removed `envEnabled` (cognitive 1) — a straight swap, not new complexity surface.

No changeset (see "Published re-export check" above).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR promotes doc-truth's per-claim verdict v2 contract from dark/opt-in to default-on. The core code change is minimal and well-contained: `isDocTruthV2Enabled` now defaults to true, accepts an optional `AgentConfig` parameter with config precedence over the env var, and the env var semantics flip from opt-in (`on`/`1`/`true`) to opt-out (`off`/`0`/`false`). Both call sites (`buildDocTruthPassPrompts`, `postProcessDocTruthResult`) thread `context.config` through the same `as unknown as AgentConfig` cast already used elsewhere in `index.ts`. The Zod schema and `AgentConfig` interface both add `docTruthV2: boolean` defaulting to `true`. Tests were updated to cover the new default, config precedence, and end-to-end prompt/post-processing behavior. No breaking changes for callers: the function signature remains backward-compatible (`config?` optional), and v1 behavior is preserved on the explicit opt-out path.
>
> - `isDocTruthV2Enabled` defaults to true; `config.docTruthV2: false` takes precedence over `LIEN_DOC_TRUTH_V2` env var
> - Env var semantics inverted: only `off`/`0`/`false` disable v2; all other values leave v2 on
> - `AgentConfig` and Zod schema gain `docTruthV2?: boolean` defaulting to `true`
> - Documentation and tests updated to reflect the new default-on contract

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4c4e7a8. Updates automatically on new commits.</sup>
<!-- /lien-stats -->