### PR TITLE
fix(review): reallocate budget and fix reporting for doc-truth starvation

### DIFF
--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -114,27 +114,28 @@ concurrent-execution alternative.
 main pass completes, `analyze()`/`analyzeSummaryOnly()`
 (`plugins/agent/index.ts`) compute `unspentMainBudget(mainAllocatedTokens,
 mainSpentTokens)` (`review-pass.ts` — allocated minus spent, floored at 0)
-and pass it to `runExtraPasses` as `rolledOverBudget`. `runReviewPass` adds
-it on top of whatever `spec.budget()` computes for each pass, and
-`runExtraPasses` reflects the same bumped figure in the reported
-`allocatedTokens` (so the delivery attestation shows the real ceiling a pass
-ran with). A docs-heavy PR's main pass often has nothing to analyze and
-barely spends — PR #835's receipt: 20,000 allocated, 7,771 spent, +12,229
-rolled over. Honest caveat: every pass's `budget()` today is candidate/claim-
-count-scaled and ignores its `baseBudget` parameter (doc-truth's own formula
-switched to this shape in the same change — see "Budget scaling" below), so
-this rollover has no LIVE effect on any of the five passes right now; #835's
-own starvation is fixed by doc-truth's claim-scaled budget directly, not by
-this mechanism. The rollover stays wired in as a general, independently
-unit-tested executor capability for a future pass (or re-tuning) whose
-formula wants the extra headroom, not dead code — see `review-pass.ts`'s
-`unspentMainBudget` doc comment.
+and pass it to `runExtraPasses` as `rolledOverBudget`. `runReviewPass`
+computes `spec.budget(baseBudget, context) + rolledOverBudget` — an
+UNCONDITIONAL addition applied AFTER `spec.budget()` returns, so it changes
+every gated-on pass's final allocation whenever `rolledOverBudget` is
+nonzero, regardless of whether that pass's own formula reads its
+`baseBudget` parameter (every candidate/claim-count-scaled loop today,
+including doc-truth's own post-#836 formula, ignores that parameter — see
+"Budget scaling" below — but that is independent of this separate, always-
+applied top-up). `runExtraPasses` reflects the same bumped figure in the
+reported `allocatedTokens` (so the delivery attestation shows the real
+ceiling a pass ran with). A docs-heavy PR's main pass often has nothing to
+analyze and barely spends — PR #835's receipt: 20,000 allocated, 7,771
+spent, +12,229 rolled over onto EVERY gated-on extra pass's own budget,
+including doc-truth's, which can push it past its own `DOC_TRUTH_MAX_BUDGET`
+ceiling (65,000) — deliberately: these are tokens the main pass never spent,
+not tokens taken from anywhere else.
 
 ## The five passes
 
 | Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
 |---|---|---|---|---|---|---|
-| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `round(base × 0.4)` | full 6-tool set (same as main pass) | v2 (default as of 2026-07-23): `accurate \| contradicted \| unverifiable` per claim id. v1 (opt-out via `config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`): open findings list | **Production-on** (both the pass and its v2 contract default true) |
+| doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `clamp(RESERVE + 3_500×claimCount, 11_000, 65_000)` | full 6-tool set (same as main pass) | v2 (default as of 2026-07-23): `accurate \| contradicted \| unverifiable` per claim id. v1 (opt-out via `config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`): open findings list | **Production-on** (both the pass and its v2 contract default true) |
 | stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
 | incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
 | removed-exports loop | `removed-exports-pass.ts` | `config.removedExportsPass` or `LIEN_REMOVED_EXPORTS_PASS=on` AND ≥1 removed public export | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `breaking \| intentional \| internal-only \| unverifiable` | **Dark** (default false) |

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -110,6 +110,26 @@ latency is measured as a problem: that pass count is true today, but no
 latency complaint has been measured yet. See ADR-014 for the rejected
 concurrent-execution alternative.
 
+**Rolling unspent main-pass budget into the pool (issue #836).** After the
+main pass completes, `analyze()`/`analyzeSummaryOnly()`
+(`plugins/agent/index.ts`) compute `unspentMainBudget(mainAllocatedTokens,
+mainSpentTokens)` (`review-pass.ts` — allocated minus spent, floored at 0)
+and pass it to `runExtraPasses` as `rolledOverBudget`. `runReviewPass` adds
+it on top of whatever `spec.budget()` computes for each pass, and
+`runExtraPasses` reflects the same bumped figure in the reported
+`allocatedTokens` (so the delivery attestation shows the real ceiling a pass
+ran with). A docs-heavy PR's main pass often has nothing to analyze and
+barely spends — PR #835's receipt: 20,000 allocated, 7,771 spent, +12,229
+rolled over. Honest caveat: every pass's `budget()` today is candidate/claim-
+count-scaled and ignores its `baseBudget` parameter (doc-truth's own formula
+switched to this shape in the same change — see "Budget scaling" below), so
+this rollover has no LIVE effect on any of the five passes right now; #835's
+own starvation is fixed by doc-truth's claim-scaled budget directly, not by
+this mechanism. The rollover stays wired in as a general, independently
+unit-tested executor capability for a future pass (or re-tuning) whose
+formula wants the extra headroom, not dead code — see `review-pass.ts`'s
+`unspentMainBudget` doc comment.
+
 ## The five passes
 
 | Pass | File | Gate (opt-in AND eligibility) | Budget formula | Toolset | Verdict vocabulary | Production status |
@@ -406,6 +426,24 @@ non-silent, but misattributed), and `budget.allocatedTokens` only ever
 reported the main pass's own ceiling even though `spentTokens` already
 summed every pass.
 
+**Residual misattribution, fixed by issue #836.** v2 gave doc-truth (and
+every later candidate loop) its OWN `provider.passes[]`/`budget.passes[]`
+entry, but `deriveMainPassAttestation`'s own predicate for the MAIN pass's
+entry stayed too broad: it matched ANY `metadata.incomplete === true`
+finding in the merged list, including one caused solely by an extra pass
+(every extra pass's `mergeResultState` borrows `main.stopReason` from the
+extra pass when the extra pass is incomplete and main wasn't already — see
+"Per-candidate verdict contract" above). PR #835's main pass (7,771/20,000
+spent, well within budget) inherited doc-truth's own `stopReason: 'budget'`
+this way and reported `starved: true` on its OWN `PassBudgetAttestation`
+entry. The fix keys the predicate on `mainPassIncomplete === true` — the
+same SSOT flag `appendIncompleteNotice` (`index.ts`) already sets ONLY when
+the incompleteness is genuinely the main pass's own (mirroring
+`hasIncompleteMainPass`) — so an extra-pass-only incomplete notice no
+longer misattributes to main; main correctly reports `stopReason:
+'completed'` (hence `starved: false`) while the run-level aggregate and the
+starved pass's own entry stay `starved: true`.
+
 - **`ProviderPassAttestation`**: `{ name, ran, stopReason, neverRan }`, one
   entry per pass that was gated on (main always present; each extra pass
   present iff it ran; a gated-off or failed pass is covered by
@@ -436,10 +474,19 @@ fires exactly once per pass that ran.
 
 ## Budget scaling
 
-- **doc-truth**: flat fraction of the main pass's base budget:
-  `docTruthPassBudget = round(baseBudget × 0.4)`. Adequate because the
-  claims-only pass's input (pre-fetched evidence) rarely needs the tool
-  loop.
+- **doc-truth**: scaled by this pass's OWN claim count (issue #836), like
+  every other loop below, not a flat fraction of the main pass's base
+  budget: `clamp(VERDICT_EMISSION_RESERVE_TOKENS + 3_500 × claimCount,
+  EXTRA_PASS_MIN_BUDGET_TOKENS, 65_000)` (`docTruthPassBudget`,
+  `doc-truth-pass.ts`). The flat `round(baseBudget × 0.4)` formula this
+  replaced floored out at `EXTRA_PASS_MIN_BUDGET_TOKENS` for any
+  summary-only-sized base regardless of claim count — exactly what starved
+  PR #835's 20-claim worklist to 11,000 tokens and, worse, sized its own
+  rank-and-cap ceiling off a 500-tokens/claim PROMPT-sizing estimate instead
+  of the ~3,092 tokens/claim a real claim investigation costs (see
+  `DOC_TRUTH_TOKENS_PER_CLAIM`'s own doc comment for the full derivation and
+  its single-receipt caveat). The 65,000 ceiling still bounds a 100-file
+  docs PR from running away.
 - **stale-duplicate loop**: `clamp(2_000 + 800 × min(candidateCount, 8),
   4_000, 30_000)`, scaled by this pass's own candidate count (mirroring
   `summary-only-pass.ts`'s clamp pattern), not a flat fraction, so a

--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -175,6 +175,18 @@ interface AgentSummaryMetadata {
   incomplete?: boolean;
   neverRan?: boolean;
   stopReason?: AgentStopReason;
+  /**
+   * Set by `appendIncompleteNotice` (plugins/agent/index.ts) ONLY when the
+   * MAIN pass itself stopped short of a verdict — absent when the incomplete
+   * notice was caused SOLELY by an extra pass (doc-truth via
+   * `incompleteFromDocPass`, or any named candidate loop via
+   * `incompleteFromPass`). This is the SSOT signal `deriveMainPassAttestation`
+   * keys off below (mirrors `hasIncompleteMainPass`, `plugins/agent/index.ts`),
+   * deliberately narrower than a bare `incomplete === true` check — see that
+   * function's own doc comment for the misattribution bug this field closes
+   * (issue #836).
+   */
+  mainPassIncomplete?: boolean;
 }
 
 /**
@@ -183,6 +195,24 @@ interface AgentSummaryMetadata {
  * exhaustive: a neverRan or incomplete run always leaves a marked summary
  * finding, and a run that completed cleanly leaves neither — so their
  * absence IS the "completed" signal, not just a default.
+ *
+ * Keys on `mainPassIncomplete === true`, NOT a bare `incomplete === true`
+ * (issue #836's starved-field reporting fix). Before this fix, ANY incomplete
+ * finding in the merged findings list — including one caused SOLELY by an
+ * extra pass (e.g. doc-truth budget-starving while the main pass itself
+ * completed cleanly within budget) — had its `stopReason` misattributed to
+ * the MAIN pass's own `ProviderPassAttestation`. Every extra pass's own
+ * `mergeResultState` (`mergeDocPassIntoResult` and its four siblings)
+ * borrows `main.stopReason` from the extra pass when the extra pass is
+ * incomplete and main wasn't already (`main.stopReason = passResult.
+ * stopReason`), so PR #835's main pass — 7,771/20,000 tokens spent, well
+ * within budget — inherited doc-truth's OWN `stopReason: 'budget'` this way,
+ * and `passBudget`'s `starved: stopReason === 'budget'` check then falsely
+ * reported the MAIN pass's own budget entry as starved. `mainPassIncomplete`
+ * is only ever set when the incompleteness is genuinely the main pass's own
+ * (see `appendIncompleteNotice`'s `isExtraPassOnly` check), so a finding
+ * caused only by an extra pass no longer matches here — main correctly falls
+ * through to the `stopReason: 'completed'` branch below instead.
  */
 export function deriveMainPassAttestation(
   findings: ReviewFinding[],
@@ -202,7 +232,7 @@ export function deriveMainPassAttestation(
     return { name: 'main', ran: true, stopReason: 'error', neverRan: true, candidatesDeferred: 0 };
   }
   const incompleteFinding = findings.find(
-    f => (f.metadata as AgentSummaryMetadata | undefined)?.incomplete === true,
+    f => (f.metadata as AgentSummaryMetadata | undefined)?.mainPassIncomplete === true,
   );
   if (incompleteFinding) {
     const stopReason = (incompleteFinding.metadata as AgentSummaryMetadata).stopReason ?? 'error';

--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -92,6 +92,7 @@ import { envDisabled } from './agent-client-shared.js';
 import {
   renderPassPrHeader,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
+  VERDICT_EMISSION_RESERVE_TOKENS,
   affordableCandidateCeiling,
   MAX_DEFERRED_LABELS,
   renderDeferralNote,
@@ -109,21 +110,6 @@ import {
  * keeps a doc-heavy PR from spending main-pass-sized budget on the second call.
  */
 export const DOC_PASS_MAX_TURNS = 6;
-
-/**
- * The doc pass's token budget as a fraction of the main pass's base budget.
- * ~40% is ample for a claims-only pass whose input is the (already compact)
- * doc-claim signals rather than the full diff + all signals — PROVIDED the
- * base itself is normal-mode-sized (`scaleAgentBudget`'s ≥60K floor, where
- * 40% is ≥24K). This fraction was never re-validated against summary-only
- * mode's deliberately tiny 6,000-20,000 base (added by #572): 40% of a
- * 6,054 base is 2,422 tokens — smaller than a single Kimi reasoning+tool
- * turn (PR #811 measured 5,526-6,564/turn), so the pass hard-stopped before
- * its first tool call ever dispatched. `docTruthPassBudget` now clamps this
- * fraction to `EXTRA_PASS_MIN_BUDGET_TOKENS` so a tiny base can no longer
- * starve it below one real round-trip.
- */
-export const DOC_PASS_BUDGET_FRACTION = 0.4;
 
 /** Env kill-switch (parity with the client's LIEN_REVIEW_LOG_AGENT style). */
 const DOC_PASS_ENV = 'LIEN_REVIEW_DOC_PASS';
@@ -366,19 +352,37 @@ export function allClaimIds(worklist: ClaimWorklist): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Realistic per-claim cost for the ceiling formula (see
- * `affordableCandidateCeiling`). A claim entry carries a pre-fetched evidence
- * excerpt (or a short "no evidence located" note), so judging it is a
- * COMPARISON, not an investigation — the rule's own budget-discipline
- * instruction explicitly forbids re-reading via tools when evidence is
- * attached (`DOC_PASS_INTRO`: "do NOT re-read that file with tools; spend
- * tool calls ONLY on claims with no attached evidence"). Same order of
- * magnitude as stale-duplicate's own evidence-inline PER_CANDIDATE_TOKENS
- * (800) — a little lighter, since a doc claim's excerpt is typically shorter
- * than stale-duplicate's full diff hunk plus multiple surviving-site
- * snippets.
+ * This pass's OWN per-claim cost, used both for the rank-and-cap ceiling
+ * (`affordableCandidateCeiling`, via `buildDocTruthPassPrompts`/
+ * `postProcessDocTruthResult` below) and for `docTruthPassBudget`'s own
+ * per-claim scaling — mirrors `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE`'s
+ * "one real empirical rate, used everywhere per-claim cost matters" shape
+ * (incomplete-handling-pass.ts), rather than keeping a separate prompt-
+ * sizing estimate.
+ *
+ * Previously 500 — a PROMPT-sizing estimate (just the rendered claim +
+ * evidence text) — which is exactly why issue #836's PR #835 (55-file
+ * docs-only PR) overspent 3.4x: the ceiling used that 500 figure to decide
+ * 12 claims were "affordable" under an 11,000-token budget
+ * (`EXTRA_PASS_MIN_BUDGET_TOKENS`), but the pass actually spent 37,106
+ * tokens investigating those same 12 claims — i.e. the ceiling sized the
+ * PROMPT, not the real judging cost (the same class of gap
+ * `OBSERVED_TOKENS_PER_TURN`'s own doc comment names for the two candidate
+ * loops). 37,106 ÷ 12 kept claims ≈ 3,092 tokens/claim — this repo's only
+ * real production doc-truth receipt with both `spentTokens` and
+ * `candidatesDeferred` (a SINGLE data point, unlike
+ * `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE`'s 5-PR mean — see that
+ * constant's own doc comment for the precedent this mirrors). Rounded up to
+ * 3,500 for margin given the n=1 sample size. Still well below incomplete-
+ * handling's 12,000: doc-truth's claims carry pre-fetched evidence (a
+ * COMPARISON, per `DOC_PASS_INTRO`'s explicit "do NOT re-read that file with
+ * tools" instruction), unlike incomplete-handling's candidates, which always
+ * need a fresh read_file/get_files_context round-trip (an INVESTIGATION) —
+ * so a materially lower per-claim rate is the expected direction, not just
+ * an artifact of the single sample. Revisit if more production receipts
+ * carrying both figures become available.
  */
-export const DOC_TRUTH_TOKENS_PER_CLAIM = 500;
+export const DOC_TRUTH_TOKENS_PER_CLAIM = 3_500;
 
 /** A short, human-readable label for one dropped worklist item — for the delivery attestation's
  *  `deferredCandidateIds`, not the pass's own `claim-N` ids. */
@@ -653,13 +657,55 @@ verdict or category on a claimed entry, makes this pass's result incomplete.
 // ---------------------------------------------------------------------------
 
 /**
- * The doc pass's token budget: a fraction of the main pass's base budget,
- * floored at `EXTRA_PASS_MIN_BUDGET_TOKENS` so a tiny base (summary-only
- * mode) can't shrink it below one real tool round-trip (see PR #811 /
- * `DOC_PASS_BUDGET_FRACTION`'s doc comment).
+ * Base overhead for this pass's budget scaler — deliberately set equal to
+ * `VERDICT_EMISSION_RESERVE_TOKENS`, not an independent guess (mirrors
+ * `incompleteHandlingPassBudget`'s own `BASE_OVERHEAD_TOKENS`, see that
+ * constant's doc comment): it makes `docTruthPassBudget(n)` the exact
+ * algebraic inverse of `affordableCandidateCeiling` — `budget(n) = RESERVE +
+ * RATE*n` <=> `affordableCandidateCeiling(budget(n), RATE) === n` (whenever
+ * budget isn't clamped) — so the ceiling and the allocation agree by
+ * construction instead of two independently-tuned numbers drifting apart.
  */
-export function docTruthPassBudget(baseBudget: number): number {
-  return Math.max(Math.round(baseBudget * DOC_PASS_BUDGET_FRACTION), EXTRA_PASS_MIN_BUDGET_TOKENS);
+const DOC_TRUTH_BASE_OVERHEAD_TOKENS = VERDICT_EMISSION_RESERVE_TOKENS;
+
+/**
+ * Hard ceiling on doc-truth's own budget, so a 100-file docs PR (a huge
+ * claim count) can't run away. 65,000 mirrors `incompleteHandlingPassBudget`'s
+ * own `MAX_BUDGET` (same number, same shape of trade-off — see that
+ * constant's doc comment): at `DOC_TRUTH_TOKENS_PER_CLAIM` (3,500), it fully
+ * funds `(65,000 - 5,000) / 3,500 ≈ 17` claims before rank-and-cap
+ * (`affordableCandidateCeiling`) honestly defers the rest — a deliberate
+ * cost/completeness trade-off, not an attempt to fund every real worklist in
+ * full (issue #836's PR #835 worklist alone was 20 claims; funding all 20 at
+ * this rate would cost ~75,000, disproportionate to a single extra pass).
+ */
+const DOC_TRUTH_MAX_BUDGET = 65_000;
+
+/**
+ * The doc pass's token budget, scaled by this pass's OWN claim count (per
+ * the per-rule-loops design doc §2, mirroring every candidate-count-scaled
+ * loop — `incompleteHandlingPassBudget`, `staleDuplicatePassBudget`,
+ * `removedExportsPassBudget` — rather than a flat fraction of the main
+ * pass's base budget). `baseBudget` is intentionally unused (same precedent
+ * as those three siblings): the flat-fraction formula this replaces was
+ * never a good predictor of doc-truth's real workload — a summary-only
+ * mode's tiny base (`scaleSummaryOnlyBudget`'s 6,000-20,000 range) floored
+ * out at `EXTRA_PASS_MIN_BUDGET_TOKENS` regardless of how many claims a
+ * docs-heavy PR actually carried, which is exactly the shape that starved
+ * PR #835's 20-claim worklist (issue #836). Clamped floor/ceiling: never
+ * below `EXTRA_PASS_MIN_BUDGET_TOKENS` (one real round-trip, PR #811), never
+ * above `DOC_TRUTH_MAX_BUDGET` (this pass's own runaway guard).
+ *
+ * `buildClaimWorklist`/`allClaimIds` are pure and flag-independent (they
+ * just compute doc claims + rename-sweep signals and assign ids), so this
+ * counts the real claim count identically whether v2 is on or off — v1 has
+ * no id-based worklist to RENDER, but "how many claims exist" is still a
+ * well-defined, useful budget-sizing question under v1 too.
+ */
+export function docTruthPassBudget(_baseBudget: number, context: ReviewContext): number {
+  const claimCount = allClaimIds(buildClaimWorklist(context)).length;
+  const scaled = DOC_TRUTH_BASE_OVERHEAD_TOKENS + DOC_TRUTH_TOKENS_PER_CLAIM * claimCount;
+  return Math.min(Math.max(scaled, EXTRA_PASS_MIN_BUDGET_TOKENS), DOC_TRUTH_MAX_BUDGET);
 }
 
 /** Plugin name the doc-truth pass reports itself under in the delivery attestation. */

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -37,6 +37,7 @@ import { REMOVED_EXPORTS_PASS_SPEC } from './removed-exports-pass.js';
 import { DOCS_DRIFT_PASS_SPEC } from './docs-drift-pass.js';
 import {
   runExtraPasses,
+  unspentMainBudget,
   type ReviewPassSpec,
   type PassClientRunner,
   type PassOutcome,
@@ -296,6 +297,12 @@ export class AgentReviewPlugin implements ReviewPlugin {
     // second request would only fire more doomed calls, and a failure-
     // isolated pass's own incomplete state must not overwrite the never-ran
     // marker.
+    //
+    // The main pass's own unspent allocation (issue #836) rolls into every
+    // extra pass's own budget — a docs-heavy PR's main pass often has
+    // nothing to analyze and barely spends, while doc-truth (the pass that
+    // matters most for that PR shape) starves under its own budget alone.
+    const rolledOverBudget = unspentMainBudget(maxTokenBudget, result.usage.totalTokens);
     const { findings: agentFindings, outcomes } = await runExtraPasses(
       EXTRA_PASSES,
       context,
@@ -304,6 +311,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
       result,
       result.findings,
       this.extraPassClientRunner(provider, config, apiKey, logger, toolExecutor),
+      rolledOverBudget,
     );
 
     reportAgentRun(this.id, context, logger, result);
@@ -365,6 +373,10 @@ export class AgentReviewPlugin implements ReviewPlugin {
       maxTokenBudget,
     );
 
+    // See analyze()'s own comment: the main pass's unspent allocation
+    // (issue #836) rolls into every extra pass's own budget — this mode is
+    // the motivating case (a summary-only main pass typically barely spends).
+    const rolledOverBudget = unspentMainBudget(maxTokenBudget, result.usage.totalTokens);
     const { findings: agentFindings, outcomes } = await runExtraPasses(
       EXTRA_PASSES,
       context,
@@ -373,6 +385,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
       result,
       result.findings,
       this.extraPassClientRunner(provider, config, apiKey, logger, toolExecutor),
+      rolledOverBudget,
     );
 
     reportAgentRun(this.id, context, logger, result);

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -71,15 +71,58 @@ export function retryMaxTokens(remainingBudget: number): number {
 }
 
 /**
- * The `max_tokens` to request for one main-loop turn: budget-scaled (call
- * site 2 above) on the forced-finish turn, or `undefined` (falls through to
- * `chatCompletion`'s flat default) for an ordinary investigative turn, which
- * needs the full headroom. Pulled out of `run()`'s loop body — a bare
- * ternary inline would add a branch to a function already over its
- * cognitive-complexity budget.
+ * Floor for an ORDINARY (non-forced-finish) turn's max_tokens once budget
+ * scaling (below) pulls it under the flat ceiling — higher than
+ * `RETRY_MIN_MAX_TOKENS` (2,048, the forced-finish floor) because an
+ * investigative turn still needs room to reason (`effort:'high'`) and
+ * dispatch a tool call, not just emit a short JSON verdict. 8,192 is roughly
+ * 4x the forced-finish floor: enough for a real reasoning burst plus a
+ * tool_calls response, while still meaningfully bounding the worst case for
+ * a SMALL pass budget (the extra-pass floor, 11,000) — see `turnMaxTokens`'s
+ * own doc comment for the gap this closes.
  */
-function turnMaxTokens(forceFinish: boolean, remainingBudget: number): number | undefined {
-  return forceFinish ? retryMaxTokens(remainingBudget) : undefined;
+const ORDINARY_TURN_MIN_MAX_TOKENS = 8_192;
+
+/**
+ * The `max_tokens` to request for one main-loop turn, scaled to the budget
+ * remaining — for BOTH the forced-finish turn (unchanged, `retryMaxTokens`)
+ * and an ordinary investigative turn (issue #836 fix, below). Pulled out of
+ * `run()`'s loop body — a bare branch inline would add complexity to a
+ * function already over its cognitive-complexity budget; this function's own
+ * body absorbs that instead, with zero change to the call site.
+ *
+ * GAP THIS CLOSES (issue #836's overspend investigation): before this fix,
+ * only the forced-finish branch scaled its ceiling to `remainingBudget` (via
+ * `retryMaxTokens`, #825) — an ORDINARY (non-forced) turn fell through to
+ * `chatCompletion`'s flat, budget-BLIND default (24,576), unconditionally,
+ * even when the pass's ENTIRE allocation was much smaller (the extra-pass
+ * floor, 11,000). `AnthropicAgentClient.run()` never had this asymmetry: its
+ * own `requestMaxTokens(remainingBudget)` (anthropic-client.ts) is called for
+ * EVERY turn unconditionally, not gated on a forced-finish flag. On issue
+ * #836's PR #835, doc-truth's (11,000-allocated) v2 per-claim contract gives
+ * its ordinary FIRST turn up to a 24,576-token completion ceiling to fill —
+ * over TWICE the pass's entire budget in output tokens alone, before its own
+ * (separately-uncapped) input tokens from the rendered claim worklist are even
+ * counted — and the post-response `totalTokens >= maxTokenBudget` check only
+ * fires BETWEEN turns, never mid-turn. This is the concrete mechanism behind
+ * the observed 37,106/11,000 (3.4x) overspend: a REAL gap in the cap, not
+ * merely expected between-turn lumpiness.
+ *
+ * Scaling every turn's ceiling to remaining budget bounds that failure mode
+ * substantially; it does NOT fully eliminate overshoot, since input tokens
+ * (the worklist + growing tool-result history, re-sent every turn) are not
+ * bounded by `max_tokens` at all — a residual, BOUNDED overshoot remains
+ * possible on a large-worklist pass's very first turn. See
+ * `EXTRA_PASS_MIN_BUDGET_TOKENS`'s doc comment and `docTruthPassBudget`'s own
+ * claim-count scaling (also issue #836) for the complementary fix: sizing the
+ * ALLOCATION itself to the real workload so this ceiling rarely needs to bind.
+ * A large main-pass budget (60K+) is unaffected either way — `remainingBudget`
+ * there always exceeds the flat ceiling until near the very end of the run,
+ * same as before this fix.
+ */
+function turnMaxTokens(forceFinish: boolean, remainingBudget: number): number {
+  if (forceFinish) return retryMaxTokens(remainingBudget);
+  return Math.min(RETRY_MAX_MAX_TOKENS, Math.max(remainingBudget, ORDINARY_TURN_MIN_MAX_TOKENS));
 }
 
 /**

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -283,17 +283,18 @@ export type PassClientRunner = (
  * doc-truth, the single most relevant pass for that PR shape, starves under
  * its own independently-sized budget. Rather than let that surplus simply
  * evaporate, it becomes additional headroom every extra pass can draw on.
- * Deliberately a PLAIN top-up, not folded into any one pass's own formula: a
- * pass whose `budget()` ignores its `baseBudget` parameter entirely is
- * unaffected by construction. Honest note: as of this same change, that is
- * ALL FIVE passes — doc-truth's own `docTruthPassBudget` was ALSO switched to
- * a claim-count-scaled formula that ignores `baseBudget` (issue #836's other
- * fix; see review-pass-architecture.md's "Budget scaling"), so this rollover
- * has no LIVE effect on any pass today. It stays wired in as a general,
- * independently-tested executor capability (not doc-truth-specific plumbing)
- * for a future pass whose formula wants the extra headroom, or a future
- * re-tuning of an existing one — see this module's own unit tests for the
- * mechanism proof independent of any current pass's formula choices.
+ *
+ * This is an UNCONDITIONAL additive top-up, not folded into any one pass's
+ * own `budget()` formula: `runReviewPass` computes `spec.budget(baseBudget,
+ * context) + rolledOverBudget` — the addition happens AFTER `spec.budget()`
+ * returns, so it changes every gated-on pass's final allocation whenever
+ * `rolledOverBudget` is nonzero, REGARDLESS of whether that pass's own
+ * formula reads its `baseBudget` parameter (a separate, independent
+ * question — see review-pass-architecture.md's "Budget scaling" for which
+ * passes do). It can push a pass's final allocation past its own documented
+ * ceiling (e.g. `docTruthPassBudget`'s `DOC_TRUTH_MAX_BUDGET`) — that's the
+ * point: these are tokens the main pass never spent, not tokens taken from
+ * anywhere else (see `runReviewPass`'s own comment on the same rationale).
  */
 export function unspentMainBudget(mainAllocatedTokens: number, mainSpentTokens: number): number {
   return Math.max(0, mainAllocatedTokens - mainSpentTokens);

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -268,11 +268,48 @@ export type PassClientRunner = (
   maxTurns: number,
 ) => Promise<AgentResult>;
 
+// ---------------------------------------------------------------------------
+// Rolling unspent main-pass budget into the extra-pass pool (issue #836)
+// ---------------------------------------------------------------------------
+
+/**
+ * The main pass's own unspent allocation (allocated minus spent, floored at
+ * 0) — the surplus `runReviewPass`/`runExtraPasses` roll into every extra
+ * pass's own computed budget (see their `rolledOverBudget` parameter below).
+ *
+ * Motivation (issue #836, PR #835's receipt): on a docs-heavy PR the main
+ * pass often has almost nothing to analyze and barely spends (that receipt's
+ * main pass: 20,000 allocated, 7,771 spent — 12,229 left on the table), while
+ * doc-truth, the single most relevant pass for that PR shape, starves under
+ * its own independently-sized budget. Rather than let that surplus simply
+ * evaporate, it becomes additional headroom every extra pass can draw on.
+ * Deliberately a PLAIN top-up, not folded into any one pass's own formula: a
+ * pass whose `budget()` ignores its `baseBudget` parameter entirely is
+ * unaffected by construction. Honest note: as of this same change, that is
+ * ALL FIVE passes — doc-truth's own `docTruthPassBudget` was ALSO switched to
+ * a claim-count-scaled formula that ignores `baseBudget` (issue #836's other
+ * fix; see review-pass-architecture.md's "Budget scaling"), so this rollover
+ * has no LIVE effect on any pass today. It stays wired in as a general,
+ * independently-tested executor capability (not doc-truth-specific plumbing)
+ * for a future pass whose formula wants the extra headroom, or a future
+ * re-tuning of an existing one — see this module's own unit tests for the
+ * mechanism proof independent of any current pass's formula choices.
+ */
+export function unspentMainBudget(mainAllocatedTokens: number, mainSpentTokens: number): number {
+  return Math.max(0, mainAllocatedTokens - mainSpentTokens);
+}
+
 /**
  * Run one extra pass's client loop when it's gated on. Mirrors the shape
  * `doc-truth-pass.ts`'s original `runDocTruthPass` had: gate check first
  * (reporting the precise skip reason), then build+run, catching and
  * swallowing any failure — a pass-2+ error must never fail the whole review.
+ *
+ * `rolledOverBudget` (default 0, additive, issue #836) is added ON TOP of
+ * whatever `spec.budget()` computes — after, not instead of, so it never
+ * fights that formula's own floor/ceiling clamp; it can push the final
+ * allocation past a pass's normal ceiling, which is the point: these are
+ * tokens the main pass never spent, not tokens taken from anywhere else.
  */
 export async function runReviewPass(
   spec: ReviewPassSpec,
@@ -280,6 +317,7 @@ export async function runReviewPass(
   config: AgentConfig,
   logger: Logger,
   runClient: PassClientRunner,
+  rolledOverBudget = 0,
 ): Promise<AgentResult | null> {
   const skipReason = spec.gateReason(context, config);
   if (skipReason) {
@@ -287,7 +325,7 @@ export async function runReviewPass(
     return null;
   }
   try {
-    const budget = spec.budget(config.maxTokenBudget, context);
+    const budget = spec.budget(config.maxTokenBudget, context) + rolledOverBudget;
     const { systemPrompt, initialMessage } = spec.buildPrompts(context, budget);
     const rawResult = await runClient(systemPrompt, initialMessage, budget, spec.maxTurns);
     const result = spec.postProcessResult
@@ -357,6 +395,12 @@ export interface PassOutcome {
  * evaluating its own gate — running one anyway would only fire a second
  * doomed request, and a failure-isolated extra pass's own incomplete state
  * must never overwrite the main pass's `neverRan` marker.
+ *
+ * `rolledOverBudget` (default 0, issue #836 — see `unspentMainBudget`) is the
+ * main pass's own unspent allocation, threaded through to every pass's own
+ * budget computation AND reflected in its reported `allocatedTokens` (so the
+ * delivery attestation shows the REAL allocation a pass ran with, not an
+ * understated pre-rollover figure).
  */
 export async function runExtraPasses(
   specs: ReviewPassSpec[],
@@ -366,6 +410,7 @@ export async function runExtraPasses(
   main: AgentResult,
   findings: AgentFinding[],
   runClientFor: (spec: ReviewPassSpec) => PassClientRunner,
+  rolledOverBudget = 0,
 ): Promise<{ findings: AgentFinding[]; outcomes: PassOutcome[] }> {
   const outcomes: PassOutcome[] = [];
   let merged = findings;
@@ -377,7 +422,14 @@ export async function runExtraPasses(
       });
       continue;
     }
-    const passResult = await runReviewPass(spec, context, config, logger, runClientFor(spec));
+    const passResult = await runReviewPass(
+      spec,
+      context,
+      config,
+      logger,
+      runClientFor(spec),
+      rolledOverBudget,
+    );
     if (passResult) {
       appendPassTurns(main.trace, passResult.trace, spec.name);
       context.reportUsage?.(passResult.usage);
@@ -385,7 +437,7 @@ export async function runExtraPasses(
         name: spec.name,
         stopReason: passResult.stopReason,
         neverRan: passResult.neverRan ?? false,
-        allocatedTokens: spec.budget(config.maxTokenBudget, context),
+        allocatedTokens: spec.budget(config.maxTokenBudget, context) + rolledOverBudget,
         spentTokens: passResult.usage.totalTokens,
         candidatesDeferred: passResult.candidatesDeferred ?? 0,
         deferredCandidateIds: passResult.deferredCandidateIds,

--- a/packages/review/test/attestation.test.ts
+++ b/packages/review/test/attestation.test.ts
@@ -44,6 +44,8 @@ function neverRanFinding(): ReviewFinding {
   };
 }
 
+/** Represents the MAIN pass's own incompleteness (mainPassIncomplete:true) — distinct from an
+ *  extra-pass-only incomplete notice, which omits that flag (see the #836 tests below). */
 function incompleteFinding(stopReason: 'budget' | 'max_turns'): ReviewFinding {
   return {
     pluginId: 'agent-review',
@@ -52,7 +54,7 @@ function incompleteFinding(stopReason: 'budget' | 'max_turns'): ReviewFinding {
     severity: 'warning',
     category: 'summary',
     message: 'Lien Review did not finish.',
-    metadata: { incomplete: true, stopReason },
+    metadata: { incomplete: true, stopReason, mainPassIncomplete: true },
   };
 }
 
@@ -324,6 +326,9 @@ describe('deriveMainPassAttestation', () => {
   });
 
   it('defaults an unlabeled incomplete finding to stopReason "error" rather than throwing', () => {
+    // mainPassIncomplete:true marks this as genuinely the MAIN pass's own
+    // incompleteness (see that field's doc comment) — the malformed part
+    // being guarded here is the MISSING stopReason, not the attribution.
     const malformed: ReviewFinding = {
       pluginId: 'agent-review',
       filepath: '',
@@ -331,7 +336,7 @@ describe('deriveMainPassAttestation', () => {
       severity: 'warning',
       category: 'summary',
       message: 'incomplete, no stopReason',
-      metadata: { incomplete: true },
+      metadata: { incomplete: true, mainPassIncomplete: true },
     };
     expect(deriveMainPassAttestation([malformed], true, false)).toEqual({
       name: 'main',
@@ -340,6 +345,109 @@ describe('deriveMainPassAttestation', () => {
       neverRan: false,
       candidatesDeferred: 0,
     });
+  });
+
+  // Regression coverage for issue #836's starved-field reporting blind spot:
+  // an incomplete finding caused SOLELY by an extra pass (doc-truth here)
+  // must NOT have its stopReason misattributed to the main pass, even though
+  // it is the only "incomplete: true" finding in the merged list.
+  it('reports the main pass as completed when only an extra pass caused the incomplete notice (#836)', () => {
+    const docTruthOnlyIncomplete: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message:
+        'The documentation-truthfulness pass did not finish — it hit the token budget limit.',
+      // incompleteFromDocPass is true, so appendIncompleteNotice omits
+      // mainPassIncomplete — main's own stopReason is 'budget' here (borrowed
+      // from doc-truth by mergeDocPassIntoResult), exactly PR #835's shape.
+      metadata: { incomplete: true, stopReason: 'budget' },
+    };
+    expect(deriveMainPassAttestation([docTruthOnlyIncomplete], true, false)).toEqual({
+      name: 'main',
+      ran: true,
+      stopReason: 'completed',
+      neverRan: false,
+      candidatesDeferred: 0,
+    });
+  });
+
+  it('still attributes stopReason to main when mainPassIncomplete is genuinely set', () => {
+    const mainIncomplete: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message: 'Lien Review did not finish.',
+      metadata: { incomplete: true, stopReason: 'max_turns', mainPassIncomplete: true },
+    };
+    expect(deriveMainPassAttestation([mainIncomplete], true, false)).toEqual({
+      name: 'main',
+      ran: true,
+      stopReason: 'max_turns',
+      neverRan: false,
+      candidatesDeferred: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #835's exact receipt shape end-to-end: main 7,771/20,000 (well within
+// budget) must report starved:false even though doc-truth (an extra pass)
+// starved on its own 11,000-token allocation — the run-level aggregate
+// still reports starved:true (doc-truth's own entry), just correctly
+// attributed. See issue #836's "starved-field reporting blind spot".
+// ---------------------------------------------------------------------------
+describe('assembleAttestation — PR #835 receipt shape (issue #836)', () => {
+  it('main reports starved:false while the run-level budget.starved stays true', () => {
+    const docTruthIncompleteFinding: ReviewFinding = {
+      pluginId: 'agent-review',
+      filepath: '',
+      line: 0,
+      severity: 'warning',
+      category: 'summary',
+      message:
+        'The documentation-truthfulness pass did not finish — it hit the token budget limit.',
+      metadata: { incomplete: true, stopReason: 'budget' },
+    };
+    const attestation = assembleAttestation(
+      baseInput({
+        conclusion: 'neutral',
+        findings: [docTruthIncompleteFinding],
+        allocatedTokens: 20_000,
+        spentTokens: 7_771,
+        extraPasses: [
+          {
+            name: 'doc-truth',
+            stopReason: 'budget',
+            neverRan: false,
+            allocatedTokens: 11_000,
+            spentTokens: 37_106,
+            candidatesDeferred: 8,
+          },
+        ],
+      }),
+    );
+
+    const [mainBudget, docTruthBudget] = attestation.budget.passes;
+    expect(mainBudget).toEqual({
+      name: 'main',
+      allocatedTokens: 20_000,
+      spentTokens: 7_771,
+      starved: false,
+    });
+    expect(docTruthBudget).toEqual({
+      name: 'doc-truth',
+      allocatedTokens: 11_000,
+      spentTokens: 37_106,
+      starved: true,
+    });
+    // Run-level aggregate is still true — doc-truth genuinely starved.
+    expect(attestation.budget.starved).toBe(true);
+    expect(attestation.verdict).toBe('degraded:budget_starved');
   });
 });
 

--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -97,7 +97,7 @@ async function main(): Promise<void> {
   const baseBudget = config?.maxTokenBudget ?? 100_000;
 
   const docTruthPass = passOutput(shouldRunDocTruthPass(ctx, config), () =>
-    buildDocTruthPassPrompts(ctx, docTruthPassBudget(baseBudget)),
+    buildDocTruthPassPrompts(ctx, docTruthPassBudget(baseBudget, ctx)),
   );
   const staleDuplicatePass = passOutput(shouldRunStaleDuplicatePass(ctx, config), () =>
     buildStaleDuplicatePassPrompts(ctx, staleDuplicatePassBudget(baseBudget, ctx)),

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -187,7 +187,13 @@ describe('OpenAIAgentClient budget handling', () => {
     // effort (findings already decided) so it emits the JSON without rambling.
     expect(bodies[0].reasoning).toEqual({ effort: 'high' });
     expect(bodies[1].reasoning).toEqual({ effort: 'low' });
-    expect(bodies[0].max_tokens).toBe(24_576);
+    // Turn 1 (not forced) is ALSO budget-scaled as of #836: remaining budget
+    // at turn 1 (10,000, nothing spent yet) exceeds the flat 24,576 ceiling's
+    // ORDINARY_TURN_MIN_MAX_TOKENS floor (8,192), so the remaining-budget
+    // value itself wins — 10,000, not the flat ceiling. See
+    // `turnMaxTokens`'s own doc comment for why (a gap that let a single
+    // ordinary turn overspend a small extra-pass budget several times over).
+    expect(bodies[0].max_tokens).toBe(10_000);
   });
 
   it('bounds the in-loop forced-finish turn to remaining budget (#825 overshoot fix)', async () => {
@@ -209,7 +215,9 @@ describe('OpenAIAgentClient budget handling', () => {
     const result = await client.run('sys', 'init', tools as never, noopTool);
 
     expect(result.stopReason).toBe('completed'); // matches #825: completed, not flagged starved
-    expect(bodies[0].max_tokens).toBe(24_576); // turn 1 (not forced): unaffected, normal ceiling
+    // Turn 1 (not forced) is ALSO budget-scaled as of #836 (see the test
+    // above) — 10,000, not the pre-#836 flat 24,576 ceiling.
+    expect(bodies[0].max_tokens).toBe(10_000);
     expect(bodies[1].max_tokens).toBe(3_000); // forced-finish turn: capped to remaining budget
   });
 
@@ -227,6 +235,11 @@ describe('OpenAIAgentClient budget handling', () => {
 
     await client.run('sys', 'init', tools as never, noopTool);
 
+    // Turn 1 (not forced) is ALSO scaled down here (#836): remaining budget
+    // (7,000) is itself below ORDINARY_TURN_MIN_MAX_TOKENS (8,192), so the
+    // floor wins — a small-extra-pass-budget case where the ordinary-turn
+    // ceiling binds even before any forced-finish turn is ever reached.
+    expect(bodies[0].max_tokens).toBe(8_192);
     expect(bodies[1].max_tokens).toBe(2_048);
   });
 
@@ -261,7 +274,10 @@ describe('OpenAIAgentClient budget handling', () => {
 
     await client.run('sys', 'init', [], noopTool);
 
-    expect(bodies[0].max_tokens).toBe(24_576); // turn 1: unaffected, normal ceiling
+    // Turn 1 (not forced) is ALSO scaled down here (#836): remaining budget
+    // (1,000) is below ORDINARY_TURN_MIN_MAX_TOKENS (8,192), so the floor
+    // wins — not the pre-#836 flat 24,576 ceiling.
+    expect(bodies[0].max_tokens).toBe(8_192);
     expect(bodies[1].max_tokens).toBe(2_048); // the retry: capped to the floor
   }, 15000);
 
@@ -477,6 +493,49 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.neverRan).toBe(false);
     expect(result.turns).toBeGreaterThanOrEqual(1);
   }, 20000);
+});
+
+// ---------------------------------------------------------------------------
+// Ordinary (non-forced-finish) turn max_tokens scaling — issue #836's
+// overspend investigation. Before this fix, only the forced-finish branch
+// scaled max_tokens to remaining budget; an ordinary turn always requested
+// the flat 24,576 ceiling, uncoupled from a SMALL pass's own (much smaller)
+// allocation — the concrete mechanism behind doc-truth's 37,106/11,000 (3.4x)
+// overspend on PR #835. These tests assert the wire-level fix directly,
+// beyond the budget-handling suite's existing bodies[0] assertions above.
+// ---------------------------------------------------------------------------
+describe('OpenAIAgentClient — ordinary-turn max_tokens scaling (#836 overspend fix)', () => {
+  it('scales turn 1 down to the extra-pass-sized allocation itself (11,000), not the flat ceiling', async () => {
+    // The exact shape this fix targets: a small, extra-pass-sized budget
+    // (EXTRA_PASS_MIN_BUDGET_TOKENS) where the OLD flat 24,576 ceiling alone
+    // was already more than double the entire allocation.
+    const { bodies } = mockFetch([toolCallTurn(3_000), stopTurn(CLEAN_JSON, 500)]);
+    const client = makeClient(11_000);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(bodies[0].max_tokens).toBe(11_000);
+  });
+
+  it('leaves a large, main-pass-sized budget unaffected (no regression)', async () => {
+    // remainingBudget (100,000) comfortably exceeds the flat 24,576 ceiling,
+    // so the ceiling itself wins — identical to pre-#836 behavior.
+    const { bodies } = mockFetch([stopTurn(CLEAN_JSON)]);
+    const client = makeClient(100_000);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(bodies[0].max_tokens).toBe(24_576);
+  });
+
+  it('floors an ordinary turn at 8,192 when remaining budget is smaller still', async () => {
+    const { bodies } = mockFetch([stopTurn(CLEAN_JSON)]);
+    const client = makeClient(3_000);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(bodies[0].max_tokens).toBe(8_192);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -8,6 +8,7 @@ import {
   mergeDocTruthFindings,
   mergeDocPassIntoResult,
   docTruthPassBudget,
+  DOC_TRUTH_TOKENS_PER_CLAIM,
   isDocTruthV2Enabled,
   buildClaimWorklist,
   allClaimIds,
@@ -250,31 +251,50 @@ describe('buildDocTruthPassPrompts', () => {
 // ---------------------------------------------------------------------------
 
 describe('docTruthPassBudget', () => {
-  it('is ~40% of the base budget, rounded to an integer, when that clears the floor', () => {
-    expect(docTruthPassBudget(100_000)).toBe(40_000);
-    expect(docTruthPassBudget(50_001)).toBe(20_000); // round(20000.4)
+  /** A context carrying `n` distinct doc claims (mirrors the file's other manyClaimsCtx helpers). */
+  function manyClaimsCtx(n: number): ReviewContext {
+    const entries: Array<[string, string]> = Array.from({ length: n }, (_, i) => [
+      `docs/architecture/doc${i}.md`,
+      `@@ -1,1 +1,2 @@\n # Title\n+This step ${i} requires a fresh checkout.`,
+    ]);
+    return contextWithPatches(entries);
+  }
+
+  it('ignores baseBudget entirely — scaled by this pass own claim count instead (matches every sibling candidate loop)', () => {
+    const ctx = manyClaimsCtx(5);
+    expect(docTruthPassBudget(100_000, ctx)).toBe(docTruthPassBudget(6_000, ctx));
   });
 
-  it('clamps to EXTRA_PASS_MIN_BUDGET_TOKENS for the exact #811 summary-only base (regression)', () => {
-    // PR #811's measured main-pass (summary-only mode) allocation was 6,054 —
-    // 40% of that is 2,422, smaller than a single Kimi turn (5,526-6,564
-    // measured), which is exactly what starved doc-truth on that run.
-    expect(docTruthPassBudget(6_054)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
-    expect(docTruthPassBudget(6_054)).toBeGreaterThanOrEqual(EXTRA_PASS_MIN_BUDGET_TOKENS);
+  it('clamps to EXTRA_PASS_MIN_BUDGET_TOKENS when there are 0 or 1 claims (no claims to scale from)', () => {
+    expect(docTruthPassBudget(100_000, createTestContext())).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+    expect(docTruthPassBudget(100_000, manyClaimsCtx(1))).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
   });
 
-  it("clamps to the floor across summary-only mode's whole 6,000-20,000 base range", () => {
-    // scaleSummaryOnlyBudget's own clamp range (#572) — 40% of the top of
-    // that range (20,000 → 8,000) still sits under the floor.
-    expect(docTruthPassBudget(6_000)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
-    expect(docTruthPassBudget(20_000)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+  it('scales linearly with claim count once above the floor (BASE_OVERHEAD + RATE * n)', () => {
+    // DOC_TRUTH_BASE_OVERHEAD_TOKENS is VERDICT_EMISSION_RESERVE_TOKENS (5,000).
+    expect(docTruthPassBudget(100_000, manyClaimsCtx(2))).toBe(
+      VERDICT_EMISSION_RESERVE_TOKENS + DOC_TRUTH_TOKENS_PER_CLAIM * 2,
+    );
+    expect(docTruthPassBudget(100_000, manyClaimsCtx(5))).toBe(
+      VERDICT_EMISSION_RESERVE_TOKENS + DOC_TRUTH_TOKENS_PER_CLAIM * 5,
+    );
   });
 
-  it('the fraction takes over exactly where it first clears the floor', () => {
-    // 0.4 * 27,500 = 11,000 == the floor exactly; one base-unit higher, the
-    // fraction (rounded) exceeds it.
-    expect(docTruthPassBudget(27_500)).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
-    expect(docTruthPassBudget(27_510)).toBe(11_004); // round(27510 * 0.4)
+  it("reproduces issue #836's PR #835 shape: a full 20-claim worklist gets far more than the old flat floor", () => {
+    // buildClaimWorklist's own static 20-cap (DOC_TRUTH_V2_MAX_CLAIMS) means
+    // claimCount tops out at 20 here — clamped to DOC_TRUTH_MAX_BUDGET
+    // (65,000), nearly 6x the old flat EXTRA_PASS_MIN_BUDGET_TOKENS (11,000)
+    // this exact PR shape used to floor out at regardless of claim count.
+    const budget = docTruthPassBudget(20_000, manyClaimsCtx(55));
+    expect(budget).toBe(65_000);
+    expect(budget).toBeGreaterThan(EXTRA_PASS_MIN_BUDGET_TOKENS * 5);
+  });
+
+  it('clamps to DOC_TRUTH_MAX_BUDGET so a 100-file docs PR cannot run away', () => {
+    // Even far beyond the 20-claim render cap, the result never exceeds the
+    // hard ceiling — capped by buildClaimWorklist's own static cap in
+    // practice, but this asserts the clamp itself, not just that cap.
+    expect(docTruthPassBudget(100_000, manyClaimsCtx(20))).toBe(65_000);
   });
 });
 
@@ -427,7 +447,8 @@ describe('DOC_TRUTH_PASS_SPEC', () => {
     expect(DOC_TRUTH_PASS_SPEC.name).toBe('doc-truth');
     expect(DOC_TRUTH_PASS_SPEC.skipPlugin).toBe('agent-review:doc-truth');
     expect(DOC_TRUTH_PASS_SPEC.maxTurns).toBe(DOC_PASS_MAX_TURNS);
-    expect(DOC_TRUTH_PASS_SPEC.budget(100_000)).toBe(docTruthPassBudget(100_000));
+    const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
+    expect(DOC_TRUTH_PASS_SPEC.budget(100_000, ctx)).toBe(docTruthPassBudget(100_000, ctx));
     expect(DOC_TRUTH_PASS_SPEC.mergeFindings).toBe(mergeDocTruthFindings);
     expect(DOC_TRUTH_PASS_SPEC.mergeResultState).toBe(mergeDocPassIntoResult);
   });
@@ -786,7 +807,7 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
   it('lists only the affordable claims and appends the overflow note when the budget caps the worklist', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const ctx = manyClaimsCtx(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // affords 2 of 6 (500/claim)
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * DOC_TRUTH_TOKENS_PER_CLAIM; // affords 2 of 6 (500/claim)
     const { systemPrompt, initialMessage } = buildDocTruthPassPrompts(ctx, budget);
     expect(systemPrompt).toContain('claim-1');
     expect(systemPrompt).toContain('claim-2');
@@ -798,18 +819,23 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
     expect(initialMessage).toContain('4 additional eligible candidate(s)');
   });
 
-  it('reproduces the Finding-A shape: a ~51-claim worklist at the floor budget still defers most claims', () => {
+  it("reproduces issue #836's PR #835 shape: a full 20-claim worklist now affords most claims, deferring only a few", () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     // 55 distinct claim patches -> 20-id worklist (buildClaimWorklist's own
-    // static cap) at the shared floor budget (11,000 — the common real-PR
-    // case per every sibling pass's own budget-floor tests).
+    // static cap). Post-#836, docTruthPassBudget scales with THIS pass's own
+    // claim count (ignoring baseBudget) rather than flooring at the shared
+    // EXTRA_PASS_MIN_BUDGET_TOKENS regardless of workload — 20 claims clamps
+    // to DOC_TRUTH_MAX_BUDGET (65,000), affording 17 of the 20 (only 3
+    // deferred), a large improvement over the pre-#836 12-of-20 (8 deferred).
     const ctx = manyClaimsCtx(55);
-    const budget = docTruthPassBudget(6_000); // summary-only-sized base -> floors to 11,000
-    expect(budget).toBe(EXTRA_PASS_MIN_BUDGET_TOKENS);
+    const budget = docTruthPassBudget(20_000, ctx);
+    expect(budget).toBe(65_000);
     const { initialMessage } = buildDocTruthPassPrompts(ctx, budget);
     expect(initialMessage).toContain('CANDIDATE OVERFLOW');
+    expect(initialMessage).toContain('3 additional eligible candidate(s)');
     expect(initialMessage).toContain('[claim-1]');
-    expect(initialMessage).not.toContain('[claim-13]'); // ceiling well under 20
+    expect(initialMessage).toContain('[claim-17]'); // ceiling now affords 17
+    expect(initialMessage).not.toContain('[claim-18]'); // beyond the ceiling -> deferred
   });
 
   it('does not append the overflow note when the v1 (non-candidate-loop) path is used, even with a tiny budget', () => {
@@ -827,7 +853,7 @@ describe('buildDocTruthPassPrompts / buildDocTruthPassInitialMessageV2 — v2 co
   it('byte-diff census: the ordinary single-claim real-PR shape is unaffected at the real (100K-base) budget', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const ctx = contextWithPatches([['docs/architecture/worktree.md', DOC_CLAIM_PATCH]]);
-    const realBudget = docTruthPassBudget(100_000);
+    const realBudget = docTruthPassBudget(100_000, ctx);
     expect(buildDocTruthPassPrompts(ctx, realBudget)).toEqual(buildDocTruthPassPrompts(ctx));
   });
 });
@@ -985,7 +1011,7 @@ describe('postProcessDocTruthResult', () => {
   it('stamps candidatesDeferred/deferredCandidateIds when the budget capped the worklist', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const ctx = manyClaimsCtx(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // affords 2 of 6
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * DOC_TRUTH_TOKENS_PER_CLAIM; // affords 2 of 6
     const result = fakeResult([
       verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
       verdictFinding({ claimId: 'claim-2', verdict: 'accurate' }),
@@ -998,7 +1024,7 @@ describe('postProcessDocTruthResult', () => {
   it('a capped-but-complete run (every LISTED claim verdicted) stays incomplete:false — deferral is not incompleteness', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const ctx = manyClaimsCtx(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // affords 2 of 6
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * DOC_TRUTH_TOKENS_PER_CLAIM; // affords 2 of 6
     const result = fakeResult([
       verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
       verdictFinding({ claimId: 'claim-2', verdict: 'accurate' }),
@@ -1012,7 +1038,7 @@ describe('postProcessDocTruthResult', () => {
   it('still requires coverage of every LISTED (kept) claim — omitting one is incomplete_verdict, cap or not', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const ctx = manyClaimsCtx(6);
-    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * 500; // lists claim-1/claim-2 only
+    const budget = VERDICT_EMISSION_RESERVE_TOKENS + 2 * DOC_TRUTH_TOKENS_PER_CLAIM; // lists claim-1/claim-2 only
     const result = fakeResult([verdictFinding({ claimId: 'claim-1', verdict: 'accurate' })]); // claim-2 missing
     const processed = postProcessDocTruthResult(result, ctx, budget);
     expect(processed.incomplete).toBe(true);

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -4,6 +4,7 @@ import {
   runReviewPass,
   appendPassTurns,
   runExtraPasses,
+  unspentMainBudget,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
   OBSERVED_TOKENS_PER_TURN,
   VERDICT_EMISSION_RESERVE_TOKENS,
@@ -96,6 +97,26 @@ describe('EXTRA_PASS_MIN_BUDGET_TOKENS', () => {
     // this outright, since those are both below the measured per-turn cost.
     expect(EXTRA_PASS_MIN_BUDGET_TOKENS).toBeGreaterThanOrEqual(10_000);
     expect(EXTRA_PASS_MIN_BUDGET_TOKENS).toBeLessThanOrEqual(12_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unspentMainBudget — rolling unspent main-pass budget into extra passes
+// (issue #836)
+// ---------------------------------------------------------------------------
+
+describe('unspentMainBudget', () => {
+  it('reproduces PR #835 receipt shape: main allocated 20,000/spent 7,771 -> +12,229', () => {
+    expect(unspentMainBudget(20_000, 7_771)).toBe(12_229);
+  });
+
+  it('floors at 0 when the main pass spent at or beyond its own allocation', () => {
+    expect(unspentMainBudget(10_000, 10_000)).toBe(0);
+    expect(unspentMainBudget(10_000, 15_000)).toBe(0);
+  });
+
+  it('returns the full allocation when the main pass spent nothing', () => {
+    expect(unspentMainBudget(20_000, 0)).toBe(20_000);
   });
 });
 
@@ -268,6 +289,46 @@ describe('runReviewPass', () => {
     expect(result).not.toBeNull();
     expect(result!.findings).toHaveLength(1);
     expect(captured).toEqual({ sys: 'sys', init: 'init', budget: 20_000, maxTurns: 7 });
+  });
+
+  it('adds rolledOverBudget on top of the pass own computed budget (issue #836)', async () => {
+    const ctx = createTestContext();
+    const spec = makeSpec({ budget: base => base * 0.25 });
+    const captured: { budget?: number } = {};
+
+    await runReviewPass(
+      spec,
+      ctx,
+      cfg({ maxTokenBudget: 80_000 }),
+      silentLogger,
+      async (_sys, _init, budget) => {
+        captured.budget = budget;
+        return fakeResult();
+      },
+      12_229, // PR #835's exact receipt shape: 20,000 allocated - 7,771 spent
+    );
+
+    // base 80,000 * 0.25 = 20,000, PLUS the rolled-over surplus.
+    expect(captured.budget).toBe(20_000 + 12_229);
+  });
+
+  it('defaults rolledOverBudget to 0 when omitted (no regression)', async () => {
+    const ctx = createTestContext();
+    const spec = makeSpec({ budget: base => base * 0.25 });
+    const captured: { budget?: number } = {};
+
+    await runReviewPass(
+      spec,
+      ctx,
+      cfg({ maxTokenBudget: 80_000 }),
+      silentLogger,
+      async (_sys, _init, budget) => {
+        captured.budget = budget;
+        return fakeResult();
+      },
+    );
+
+    expect(captured.budget).toBe(20_000);
   });
 
   it('passes context through to budget() so a candidate-count-scaled pass can size itself', async () => {
@@ -562,6 +623,56 @@ describe('runExtraPasses', () => {
         deferredCandidateIds: undefined,
       },
     ]);
+  });
+
+  it('threads rolledOverBudget into every pass own budget AND its reported allocatedTokens (issue #836)', async () => {
+    // PR #835's exact receipt shape: main allocated 20,000, spent 7,771 ->
+    // +12,229 rolled into every extra pass's own budget.
+    const specA = makeSpec({ name: 'pass-a', budget: () => 10_000 });
+    const specB = makeSpec({ name: 'pass-b', budget: () => 5_000 });
+    const ctx = createTestContext();
+    const main = mainResult();
+    const seenBudgets: number[] = [];
+    const runClientFor = () => async (_sys: string, _init: string, budget: number) => {
+      seenBudgets.push(budget);
+      return fakeResult();
+    };
+
+    const { outcomes } = await runExtraPasses(
+      [specA, specB],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+      12_229,
+    );
+
+    // Every pass's own client call actually ran with the bumped budget...
+    expect(seenBudgets).toEqual([10_000 + 12_229, 5_000 + 12_229]);
+    // ...and the attestation-facing allocatedTokens matches that reality,
+    // not the pre-rollover figure (which would understate the real spend
+    // ceiling a pass ran with).
+    expect(outcomes.map(o => o.allocatedTokens)).toEqual([10_000 + 12_229, 5_000 + 12_229]);
+  });
+
+  it('defaults rolledOverBudget to 0 when omitted (no regression)', async () => {
+    const spec = makeSpec({ name: 'pass-a', budget: () => 10_000 });
+    const ctx = createTestContext();
+    const main = mainResult();
+
+    const { outcomes } = await runExtraPasses(
+      [spec],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      () => async () => fakeResult(),
+    );
+
+    expect(outcomes[0].allocatedTokens).toBe(10_000);
   });
 
   it('reads candidatesDeferred/deferredCandidateIds straight off the pass result (candidate-overflow attestation)', async () => {


### PR DESCRIPTION
Fixes #836 — doc-truth starves on docs-heavy PRs, using PR #835's real attestation receipt as the worked example throughout.

## Summary

Four independent, complementary fixes to the extra-pass budget machinery in `packages/review/src/plugins/agent/`. All deterministic, zero LLM spend to verify.

### 1. Roll unspent main-pass budget into the extra-pass pool

`review-pass.ts` gains `unspentMainBudget(mainAllocatedTokens, mainSpentTokens)` (allocated minus spent, floored at 0) and a new optional `rolledOverBudget` parameter on `runReviewPass`/`runExtraPasses`, added on top of whatever each pass's own `budget()` computes (not folded into any one pass's formula — a general executor capability). `index.ts`'s `analyze()`/`analyzeSummaryOnly()` compute this after the main pass completes and thread it through.

**Correction (caught by CodeRabbit)**: my original PR description claimed this mechanism has "no live effect" today because every pass's `budget()` formula ignores its `baseBudget` parameter. That was wrong — it conflated the pass's own formula input with the executor's separate, unconditional addition: `runReviewPass` computes `spec.budget(baseBudget, context) + rolledOverBudget`, applied *after* `budget()` returns, regardless of what that formula used. The rollover DOES change every gated-on pass's final allocation whenever nonzero (confirmed by the existing unit tests, e.g. `captured.budget === base*0.25 + 12_229`), and can push a pass past its own documented ceiling (e.g. doc-truth's `DOC_TRUTH_MAX_BUDGET` = 65,000) — deliberately, since these are tokens the main pass never spent. Fixed the doc comments in `review-pass.ts` and the architecture doc to state this correctly.

### 2. Scale doc-truth's budget per claim (the #823 treatment)

`docTruthPassBudget` now scales with this pass's own claim count (`allClaimIds(buildClaimWorklist(context)).length`), replacing the flat `round(baseBudget × 0.4)` fraction that floored out at `EXTRA_PASS_MIN_BUDGET_TOKENS` (11,000) regardless of workload — exactly what happened on PR #835's 20-claim worklist.

Derivation of `DOC_TRUTH_TOKENS_PER_CLAIM` (3,500): PR #835 is this repo's **only** real production doc-truth receipt with both `spentTokens` and `candidatesDeferred`. Working backward — `affordableCandidateCeiling(11000, 500) = floor((11000-5000)/500) = 12` kept claims, matching the receipt's `candidatesDeferred: 8` on a 20-claim worklist (12+8=20, confirmed via the dogfood replay below). So the real cost was `37106 ÷ 12 kept ≈ 3,092 tokens/claim`, rounded up to 3,500 for margin. This is an **n=1 estimate**, unlike `INCOMPLETE_HANDLING_TOKENS_PER_CANDIDATE`'s 5-PR mean (#823) — documented as such in the code comment, with the reasoning for why a lower rate than incomplete-handling's 12,000 is directionally expected (doc-truth's claims carry pre-fetched evidence — a comparison, not an investigation).

The same constant now also replaces the old 500-token estimate used by the rank-and-cap ceiling (`affordableCandidateCeiling`), closing the mismatch where the ceiling admitted more claims than the budget could actually afford — the root cause of the 3.4x overspend's *magnitude* (see #3).

Floor: `EXTRA_PASS_MIN_BUDGET_TOKENS` (11,000, unchanged). Ceiling: `DOC_TRUTH_MAX_BUDGET = 65,000` (mirrors `incompleteHandlingPassBudget`'s own ceiling) — a 100-file docs PR cannot run away.

### 3. Overspend investigation — verdict: **real gap, not expected lumpiness**

Traced the budget-check/per-turn-spend/forced-finish interaction in `openai-client.ts` (the client path the prod default model, `moonshotai/kimi-k2.7-code`, actually runs on) vs `anthropic-client.ts`.

**Evidence**: `anthropic-client.ts`'s `run()` calls `requestMaxTokens(remainingBudget)` for **every** turn unconditionally (`max_tokens: requestMaxTokens(this.maxTokenBudget - used)`, line 168). `openai-client.ts`'s `turnMaxTokens` (pre-fix) only budget-scaled the **forced-finish** branch (`retryMaxTokens`, PR #825) — an ordinary (non-forced) turn fell through to `chatCompletion`'s flat, budget-blind default (`RETRY_MAX_MAX_TOKENS = 24,576`), regardless of how much smaller the pass's *entire* allocation was. For a small extra-pass budget (11,000), a single ordinary turn's completion ceiling alone (24,576) was already >2x the whole budget — before that turn's (separately uncapped) input tokens are even counted — and the post-response `totalTokens >= maxTokenBudget` check only fires *between* turns, never mid-turn. This is the concrete mechanism behind the observed 37,106/11,000 (3.4x) overspend, not merely "budget checked between candidates, single candidates legitimately expensive."

**Fix**: `turnMaxTokens` now scales *both* branches to remaining budget — ordinary turns get a higher floor (`ORDINARY_TURN_MIN_MAX_TOKENS = 8,192`, roomier than the forced-finish floor since they still need to reason + dispatch tool calls) but are otherwise capped the same way. A large main-pass budget (60K+) is unaffected — remaining budget there always exceeds the flat ceiling until near the end of the run, same as before. Does **not** fully eliminate overshoot (input tokens, i.e. the growing worklist + tool-result history re-sent every turn, aren't bounded by `max_tokens` at all) — a residual, bounded overshoot remains possible on a large-worklist pass's first turn; documented in the code comment as a known, accepted limit given #2 also shrinks how often this ceiling needs to bind.

### 4. Fix the starved-field reporting blind spot

`deriveMainPassAttestation` (`attestation.ts`) keyed its main-pass `stopReason` off *any* `metadata.incomplete === true` finding in the merged findings list — including one caused **solely** by an extra pass. Every extra pass's `mergeResultState` borrows `main.stopReason` from itself when the extra pass is incomplete and main wasn't already (`main.stopReason = passResult.stopReason`), so PR #835's main pass (7,771/20,000 spent, well within budget) inherited doc-truth's own `stopReason: 'budget'` this way, and `passBudget`'s `starved: stopReason === 'budget'` check reported the main pass's own entry as falsely starved.

Fix: key the predicate on `mainPassIncomplete === true` instead — the same SSOT flag `appendIncompleteNotice` (`index.ts`) already sets *only* when the incompleteness is genuinely the main pass's own (mirrors the existing `hasIncompleteMainPass` helper). Verified this pattern holds identically across all five extra passes (stale-duplicate, incomplete-handling, removed-exports, docs-drift, doc-truth), not just doc-truth.

## Dogfood evidence (offline receipt-replay against the real PR #835)

Captured PR #835 as a real harness fixture (`capture-pr.ts 835`) and replayed it through the actual budget/ceiling code (pre- vs post-fix), reproducing the issue's exact numbers and proving the fix's effect:

```
=== Deliverable 2: doc-truth budget scaling ===
claim worklist size (capped at DOC_TRUTH_V2_MAX_CLAIMS=20): 20
OLD formula (flat 0.4x base, floored at 11,000): 11000
NEW formula (claim-count-scaled, issue #836): 65000
OLD ceiling @ 500/claim on 11000 budget: kept 12, deferred 8
NEW ceiling @ 3500/claim on 65000 budget: kept 17, deferred 3

=== Deliverable 1: rollover mechanism (exact #835 receipt numbers) ===
main allocated 20000, spent 7771 -> rolled-over surplus: +12229
extra-pass base budget seen: 20000 + 12229 = 32229
```

The `kept 12, deferred 8` line exactly reproduces PR #835's own `candidatesDeferred: 8` — confirming the derivation is accurate, not just plausible. The `build-prompts.ts` harness script also ran clean (`fires: true` for doc-truth) against the same captured fixture.

Additionally exercised the client-level fix (#3) via wire-level unit tests asserting the exact `max_tokens` request bodies sent (`plugins-agent-budget.test.ts`), and the attestation fix (#4) via the exact PR #835 receipt shape end-to-end (`attestation.test.ts`).

No OpenRouter spend was needed or used — offline evidence was not impossible, so per the task's cost-discipline instruction, none was spent.

## Gates

All clean:
- `npm run format:check` — clean
- `npm run lint` — 0 errors (33 pre-existing warnings, unrelated files)
- `npm run typecheck` — clean
- `npm run build` — clean (all packages)
- `npm test` — **1579/1579** (`@liendev/review`), **860/860** (`@liendev/lien`/cli, excl. e2e), **41/41** (`@liendev/action`), all green
- `lien delta` — exit 0, no new threshold crossings (7 "worsened but still under threshold" + 1 pre-existing-already-over function touched, both allowed per CLAUDE.md; 1 new trivial function `unspentMainBudget` at cyclomatic 1)

## Changeset

None. `@liendev/review` is private/unpublished (`"private": true`), and this repo's established convention — verified empirically across dozens of prior review-only PRs (#799, #807, #822, #823, #825, #827, #834, etc.) — is that changes scoped entirely to `packages/review` don't get a changeset; its version bumps only incidentally via `updateInternalDependencies: "patch"` when `@liendev/core`/`@liendev/parser` (its actual published dependents-of) get their own changesets.

## Review triage

- **Lien Review**: Low Risk, "Stable — 10 pre-existing issues in touched files (none introduced)," zero inline comments. Nothing to fix.
- **CodeRabbit**: 2 actionable findings, both valid, both fixed in a follow-up commit:
  1. `unspentMainBudget`'s doc comment (and the matching architecture-doc paragraph) incorrectly claimed the rollover has "no live effect" today. Real bug in my own reasoning — see the correction above.
  2. The "five passes" summary table's doc-truth row still showed the old `round(base × 0.4)` formula after the "Budget scaling" section below it was rewritten — a stale, self-contradicting table cell. Fixed.

## Harness-evidence gate

This PR does not touch any rule prompt or `packages/review/src/plugins/agent/rules.ts` — it's deterministic budget/attestation plumbing, so no `--calibrate` run was needed or performed. The offline receipt-replay evidence above (real PR #835 fixture, captured via `capture-pr.ts`, replayed through the actual budget/ceiling functions) is the dogfood evidence for this change. Not applying `skip-harness-gate`.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 10 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 3 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 2 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 5 | +3 |
| 🐛 estimated bugs | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR addresses doc-truth budget starvation through four coordinated, deterministic changes: rolling unspent main-pass tokens into extra-pass budgets, scaling doc-truth's allocation per claim with a 3,500 tokens/claim rate capped at 65,000, capping ordinary-turn max_tokens to remaining budget in the OpenAI client, and fixing a starved-field misattribution by keying main-pass attestation on mainPassIncomplete. All changes are internal to the unpublished @liendev/review package, callers of changed functions were updated, and the PR includes regression tests covering the new boundary behaviors.
>
> - docTruthPassBudget now scales with claim count and ignores baseBudget, matching sibling candidate-loop passes
> - OpenAI client ordinary turns now scale max_tokens to remaining budget with an 8,192 floor
> - Unspent main-pass budget rolls over as additive headroom for every extra pass via unspentMainBudget/runExtraPasses
> - deriveMainPassAttestation keys on mainPassIncomplete instead of bare incomplete to fix misattribution

⚠️ The documentation-truthfulness pass did not finish — it hit the token budget limit. Doc-claim verification is partial; code findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2dbc3e5. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extra review passes now account for unused main-pass budget when determining their available allocation.
  * Review token limits now scale more appropriately with remaining budget and document-claim volume.
  * Budget usage is reported more accurately for each review pass.

* **Bug Fixes**
  * Corrected attribution of budget-related stop reasons so extra-pass limitations are not reported as main-pass failures.
  * Improved token ceilings for ordinary investigation turns.

* **Tests**
  * Added regression coverage for budget scaling, rollover handling, and pass-specific status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 392K/365K tokens
<!-- /lien:attestation -->