### PR TITLE
fix(review): make the extra-pass rollover a genuinely shared, depleting pool

### DIFF
--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -284,17 +284,14 @@ export type PassClientRunner = (
  * its own independently-sized budget. Rather than let that surplus simply
  * evaporate, it becomes additional headroom every extra pass can draw on.
  *
- * This is an UNCONDITIONAL additive top-up, not folded into any one pass's
- * own `budget()` formula: `runReviewPass` computes `spec.budget(baseBudget,
- * context) + rolledOverBudget` — the addition happens AFTER `spec.budget()`
- * returns, so it changes every gated-on pass's final allocation whenever
- * `rolledOverBudget` is nonzero, REGARDLESS of whether that pass's own
- * formula reads its `baseBudget` parameter (a separate, independent
- * question — see review-pass-architecture.md's "Budget scaling" for which
- * passes do). It can push a pass's final allocation past its own documented
- * ceiling (e.g. `docTruthPassBudget`'s `DOC_TRUTH_MAX_BUDGET`) — that's the
- * point: these are tokens the main pass never spent, not tokens taken from
- * anywhere else (see `runReviewPass`'s own comment on the same rationale).
+ * This computes the STARTING size of a single, SHARED pool — `runExtraPasses`
+ * (below) depletes it as each pass actually draws on it, so it is spent AT
+ * MOST once in total across every extra pass, not handed to each one
+ * independently. (PR #837's own real dogfood run on this repo caught the
+ * bug this fix closes: giving the FULL rollover to all three eligible extra
+ * passes independently inflated the run's reported `allocatedTokens` by the
+ * rollover amount for every pass beyond the first — see `runExtraPasses`'s
+ * own comment for the depletion mechanics.)
  */
 export function unspentMainBudget(mainAllocatedTokens: number, mainSpentTokens: number): number {
   return Math.max(0, mainAllocatedTokens - mainSpentTokens);
@@ -306,11 +303,14 @@ export function unspentMainBudget(mainAllocatedTokens: number, mainSpentTokens: 
  * (reporting the precise skip reason), then build+run, catching and
  * swallowing any failure — a pass-2+ error must never fail the whole review.
  *
- * `rolledOverBudget` (default 0, additive, issue #836) is added ON TOP of
- * whatever `spec.budget()` computes — after, not instead of, so it never
- * fights that formula's own floor/ceiling clamp; it can push the final
- * allocation past a pass's normal ceiling, which is the point: these are
- * tokens the main pass never spent, not tokens taken from anywhere else.
+ * `rolledOverBudget` (default 0, issue #836) is added ON TOP of whatever
+ * `spec.budget()` computes — after, not instead of, so it never fights that
+ * formula's own floor/ceiling clamp; it can push the final allocation past a
+ * pass's normal ceiling, which is the point: these are tokens the main pass
+ * never spent, not tokens taken from anywhere else. This function itself is
+ * pool-agnostic — it just adds whatever value it's given; `runExtraPasses`
+ * is the one that computes a DEPLETING value across calls so the same
+ * rollover isn't handed to every pass independently.
  */
 export async function runReviewPass(
   spec: ReviewPassSpec,
@@ -382,6 +382,19 @@ export interface PassOutcome {
    * fit inside this run's budget (the common case). Read straight off the
    * pass's own `AgentResult.candidatesDeferred` (set by its
    * `postProcessResult`).
+   *
+   * NOT the same signal as `stopReason: 'budget'`, and the two are NOT
+   * contradictory when seen together: this field is a STATIC pre-check (did
+   * the worklist fit under the ceiling before the pass ever ran), while
+   * `stopReason` is a DYNAMIC runtime outcome (did the client loop exhaust
+   * its budget while investigating whatever worklist it was given, however
+   * small). A pass can legitimately report `candidatesDeferred: 0` (every
+   * eligible candidate fit under the ceiling, nothing pre-emptively
+   * excluded) AND `stopReason: 'budget'` (it still ran out of budget
+   * mid-investigation of that small, undeferred worklist — e.g. one
+   * candidate needed far more tool-call round-trips than the per-candidate
+   * cost estimate assumed). Seen live on PR #837's own dogfood run (issue
+   * #836): doc-truth reported exactly this combination.
    */
   candidatesDeferred: number;
   /** Best-effort human-readable labels for the deferred candidates (capped short list). */
@@ -398,11 +411,58 @@ export interface PassOutcome {
  * must never overwrite the main pass's `neverRan` marker.
  *
  * `rolledOverBudget` (default 0, issue #836 — see `unspentMainBudget`) is the
- * main pass's own unspent allocation, threaded through to every pass's own
- * budget computation AND reflected in its reported `allocatedTokens` (so the
- * delivery attestation shows the REAL allocation a pass ran with, not an
- * understated pre-rollover figure).
+ * main pass's own unspent allocation — the STARTING size of a single SHARED
+ * pool, not a per-pass grant. A local `remainingRollover` counter starts at
+ * this value and is depleted by however much each pass actually draws on it
+ * (`max(0, spentTokens - thatPass's OWN budget() result)`, floored so a pass
+ * that never touches the rollover — spends within its own formula's value —
+ * leaves it untouched for the next one). Each pass's reported `allocatedTokens`
+ * reflects the rollover amount IT was actually given (the counter's value
+ * before its own depletion), so the delivery attestation shows the real
+ * ceiling each pass ran with. Fixes a real bug caught in PR #837's own
+ * dogfood run on this repo: before this fix, giving the FULL rollover to
+ * every gated-on pass independently (not decrementing) inflated the run's
+ * total reported `allocatedTokens` by the rollover amount for each pass
+ * beyond the first — three extra passes fired on that PR, and all three
+ * showed the SAME undiminished 8,869-token rollover in their own
+ * `allocatedTokens`, rather than one pool spent at most once in total.
  */
+
+/** How much of a shared, depleting rollover pool one pass actually drew on —
+ *  the overage of its actual spend beyond its own `budget()` result, capped
+ *  at what's left in the pool (0 for a pass that stayed within its own
+ *  formula's value, never touching the rollover at all). Extracted so
+ *  `runExtraPasses` itself stays a short orchestrator (lien delta: Halstead
+ *  effort budget). */
+function rolloverConsumedBy(
+  spentTokens: number,
+  ownBudget: number,
+  remainingRollover: number,
+): number {
+  return Math.min(Math.max(0, spentTokens - ownBudget), remainingRollover);
+}
+
+/** Build one pass's attestation-facing outcome. `remainingRollover` is the
+ *  pool's value BEFORE this pass's own depletion — the rollover amount it
+ *  was actually given. Extracted for the same reason as `rolloverConsumedBy`
+ *  above. */
+function buildPassOutcome(
+  spec: ReviewPassSpec,
+  passResult: AgentResult,
+  ownBudget: number,
+  remainingRollover: number,
+): PassOutcome {
+  return {
+    name: spec.name,
+    stopReason: passResult.stopReason,
+    neverRan: passResult.neverRan ?? false,
+    allocatedTokens: ownBudget + remainingRollover,
+    spentTokens: passResult.usage.totalTokens,
+    candidatesDeferred: passResult.candidatesDeferred ?? 0,
+    deferredCandidateIds: passResult.deferredCandidateIds,
+  };
+}
+
 export async function runExtraPasses(
   specs: ReviewPassSpec[],
   context: ReviewContext,
@@ -415,6 +475,7 @@ export async function runExtraPasses(
 ): Promise<{ findings: AgentFinding[]; outcomes: PassOutcome[] }> {
   const outcomes: PassOutcome[] = [];
   let merged = findings;
+  let remainingRollover = rolledOverBudget;
   for (const spec of specs) {
     if (main.neverRan) {
       context.reportSkip?.({
@@ -423,26 +484,24 @@ export async function runExtraPasses(
       });
       continue;
     }
+    const ownBudget = spec.budget(config.maxTokenBudget, context);
     const passResult = await runReviewPass(
       spec,
       context,
       config,
       logger,
       runClientFor(spec),
-      rolledOverBudget,
+      remainingRollover,
     );
     if (passResult) {
       appendPassTurns(main.trace, passResult.trace, spec.name);
       context.reportUsage?.(passResult.usage);
-      outcomes.push({
-        name: spec.name,
-        stopReason: passResult.stopReason,
-        neverRan: passResult.neverRan ?? false,
-        allocatedTokens: spec.budget(config.maxTokenBudget, context) + rolledOverBudget,
-        spentTokens: passResult.usage.totalTokens,
-        candidatesDeferred: passResult.candidatesDeferred ?? 0,
-        deferredCandidateIds: passResult.deferredCandidateIds,
-      });
+      outcomes.push(buildPassOutcome(spec, passResult, ownBudget, remainingRollover));
+      remainingRollover -= rolloverConsumedBy(
+        passResult.usage.totalTokens,
+        ownBudget,
+        remainingRollover,
+      );
     }
     merged = spec.mergeFindings(merged, passResult?.findings ?? []);
     spec.mergeResultState(main, passResult, merged);

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -625,9 +625,11 @@ describe('runExtraPasses', () => {
     ]);
   });
 
-  it('threads rolledOverBudget into every pass own budget AND its reported allocatedTokens (issue #836)', async () => {
+  it('gives the FIRST pass the full rollover when it does not touch it, undiminished for the next pass', async () => {
     // PR #835's exact receipt shape: main allocated 20,000, spent 7,771 ->
-    // +12,229 rolled into every extra pass's own budget.
+    // +12,229 rolled into the shared pool. pass-a spends well within its OWN
+    // budget (10,000) — it never draws on the rollover, so pass-b still
+    // sees the full, undiminished 12,229.
     const specA = makeSpec({ name: 'pass-a', budget: () => 10_000 });
     const specB = makeSpec({ name: 'pass-b', budget: () => 5_000 });
     const ctx = createTestContext();
@@ -635,7 +637,9 @@ describe('runExtraPasses', () => {
     const seenBudgets: number[] = [];
     const runClientFor = () => async (_sys: string, _init: string, budget: number) => {
       seenBudgets.push(budget);
-      return fakeResult();
+      return fakeResult({
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 3_000, cost: 0 },
+      });
     };
 
     const { outcomes } = await runExtraPasses(
@@ -649,12 +653,86 @@ describe('runExtraPasses', () => {
       12_229,
     );
 
-    // Every pass's own client call actually ran with the bumped budget...
+    // Both passes' own client calls ran with the SAME full rollover added —
+    // pass-a never dipped into it (spent 3,000 of its own 10,000), so it's
+    // still fully available to pass-b.
     expect(seenBudgets).toEqual([10_000 + 12_229, 5_000 + 12_229]);
-    // ...and the attestation-facing allocatedTokens matches that reality,
-    // not the pre-rollover figure (which would understate the real spend
-    // ceiling a pass ran with).
     expect(outcomes.map(o => o.allocatedTokens)).toEqual([10_000 + 12_229, 5_000 + 12_229]);
+  });
+
+  it("depletes the shared rollover pool as a pass actually draws on it — doesn't hand the same tokens to every pass independently (issue #836 dogfood fix)", async () => {
+    // Reproduces the real bug PR #837's own dogfood run on this repo caught:
+    // main allocated 250,000/spent 241,131 (+8,869 rolled over), and doc-truth
+    // (own budget 12,000) overspent to 56,430 — consuming the ENTIRE 8,869
+    // rollover, not just its own 12,000. Before this fix, stale-duplicate-loop
+    // (own budget 11,000) and incomplete-handling-loop (own budget 65,000)
+    // BOTH still showed the full, undiminished 8,869 in their own
+    // allocatedTokens (19,869 / 73,869) — as if the SAME 8,869 tokens were
+    // handed to all three passes independently, rather than one pool spent at
+    // most once in total.
+    const docTruthLike = makeSpec({ name: 'doc-truth', budget: () => 12_000 });
+    const staleDupLike = makeSpec({ name: 'stale-duplicate-loop', budget: () => 11_000 });
+    const incompleteLike = makeSpec({ name: 'incomplete-handling-loop', budget: () => 65_000 });
+    const ctx = createTestContext();
+    const main = mainResult();
+    const runClientFor = (spec: ReviewPassSpec) => async () =>
+      spec.name === 'doc-truth'
+        ? fakeResult({
+            usage: { promptTokens: 0, completionTokens: 0, totalTokens: 56_430, cost: 0 },
+          })
+        : fakeResult({ usage: { promptTokens: 0, completionTokens: 0, totalTokens: 1, cost: 0 } });
+
+    const { outcomes } = await runExtraPasses(
+      [docTruthLike, staleDupLike, incompleteLike],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+      8_869,
+    );
+
+    // doc-truth: its own 12,000 + the full 8,869 pool (nothing depleted yet).
+    // Overspending past its own allocation consumes the ENTIRE pool.
+    expect(outcomes[0]).toMatchObject({ name: 'doc-truth', allocatedTokens: 12_000 + 8_869 });
+    // stale-duplicate-loop and incomplete-handling-loop see the pool ALREADY
+    // exhausted by doc-truth — their own allocatedTokens carry NO rollover,
+    // not another independent 8,869 (the bug this test guards against).
+    expect(outcomes[1]).toMatchObject({ name: 'stale-duplicate-loop', allocatedTokens: 11_000 });
+    expect(outcomes[2]).toMatchObject({
+      name: 'incomplete-handling-loop',
+      allocatedTokens: 65_000,
+    });
+  });
+
+  it('partially depletes the pool when a pass draws on only some of the rollover', async () => {
+    const specA = makeSpec({ name: 'pass-a', budget: () => 10_000 });
+    const specB = makeSpec({ name: 'pass-b', budget: () => 5_000 });
+    const ctx = createTestContext();
+    const main = mainResult();
+    const runClientFor = (spec: ReviewPassSpec) => async () =>
+      // pass-a's own budget is 10,000; it spends 12,000 -> draws 2,000 from
+      // the 5,000-token pool, leaving 3,000 for pass-b.
+      spec.name === 'pass-a'
+        ? fakeResult({
+            usage: { promptTokens: 0, completionTokens: 0, totalTokens: 12_000, cost: 0 },
+          })
+        : fakeResult({ usage: { promptTokens: 0, completionTokens: 0, totalTokens: 1, cost: 0 } });
+
+    const { outcomes } = await runExtraPasses(
+      [specA, specB],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+      5_000,
+    );
+
+    expect(outcomes[0]).toMatchObject({ name: 'pass-a', allocatedTokens: 10_000 + 5_000 });
+    expect(outcomes[1]).toMatchObject({ name: 'pass-b', allocatedTokens: 5_000 + 3_000 });
   });
 
   it('defaults rolledOverBudget to 0 when omitted (no regression)', async () => {


### PR DESCRIPTION
Follow-up to #836 / #837 — fixes a real bug caught by PR #837's own dogfood run (the `lien-review.yml` run against PR #837 itself, which is the first live execution of that PR's fix, ended `degraded:budget_starved`). Full reconciliation posted on #836; this PR addresses point 2 from that reconciliation (a real bug) and documents point 3 (not a bug, clarified in a code comment). Point 1 (the 2.7x multi-turn overshoot, a distinct mechanism from what #837's deliverable 3 fixed) is filed separately as #839, since it needs its own measurement before a fix is attempted.

## The bug

`runExtraPasses` gave the FULL rolled-over surplus to every gated-on extra pass independently, rather than treating it as one shared pool. Real receipt from PR #837's own run: main allocated 250,000/spent 241,131 (+8,869 unspent), and ALL THREE eligible extra passes showed the same undiminished 8,869 in their own `allocatedTokens`:

```json
{"name": "doc-truth", "allocatedTokens": 20869, ...}              // 12,000 own + 8,869
{"name": "stale-duplicate-loop", "allocatedTokens": 19869, ...}    // 11,000 own + 8,869 (same 8,869 again)
{"name": "incomplete-handling-loop", "allocatedTokens": 73869, ...} // 65,000 own + 8,869 (same 8,869 again)
```

Sum: 250,000 + 20,869 + 19,869 + 73,869 = 364,607 — matching the attestation's top-level `allocatedTokens` exactly, confirming the same 8,869 tokens were counted once per pass rather than once total.

## The fix

`runExtraPasses` now tracks a local `remainingRollover` counter that starts at the rolled-over surplus and depletes by however much each pass actually draws on it: `max(0, spentTokens − thatPass'sOwnBudget)`, floored at 0 and capped at what's left in the pool. A pass that stays within its own formula's value never touches the rollover at all, leaving it fully available to the next pass; a pass that overspends (like doc-truth did in the real run: 56,430 spent vs 12,000 own budget) consumes the pool, leaving correspondingly less — or none — for passes after it.

Extracted `rolloverConsumedBy`/`buildPassOutcome` helpers to keep `runExtraPasses` under its complexity budget (`lien delta` flagged the inline version as a new threshold crossing on halstead_effort: 50.9→66.2 vs a 60 threshold; extracting brought it back to 44 while genuinely improving, not just avoiding the flag).

## Dogfood evidence

The new test `"depletes the shared rollover pool as a pass actually draws on it — doesn't hand the same tokens to every pass independently (issue #836 dogfood fix)"` reproduces PR #837's own exact real numbers (doc-truth own-budget 12,000/spent 56,430, stale-dup own-budget 11,000, incomplete-handling own-budget 65,000, rollover 8,869) and asserts the corrected allocations: doc-truth 20,869 (unchanged — it's first and does legitimately get the full pool), stale-duplicate-loop 11,000 (not 19,869), incomplete-handling-loop 65,000 (not 73,869).

Two more tests cover the "pass doesn't touch the rollover" (undiminished for the next pass) and "pass partially draws on it" (partial depletion) cases.

## Point 3 clarification (not a bug)

doc-truth reported `candidatesDeferred: 0` together with `stopReason: 'budget'` on the same real run — these looked contradictory but aren't: `candidatesDeferred` is a static pre-check (did the worklist fit under the rank-and-cap ceiling before the pass ran) and `stopReason` is a dynamic runtime outcome (did the client loop run out of budget while investigating whatever small worklist it was given). doc-truth's claim count here fit fully under its ceiling (nothing pre-emptively deferred) but the pass still exhausted its budget mid-investigation. Documented in a code comment on `PassOutcome.candidatesDeferred`.

## Harness-evidence gate

This module (`review-pass.ts`) makes no LLM calls itself — it only wraps the client transport with budget arithmetic, and touches zero prompt-construction code (`buildPrompts()` calls are unchanged; only the NUMBER threaded into them differs). The fix and its verification are 100% deterministic: the new unit tests assert exact integer equality reproducing PR #837's own real production receipt numbers precisely (own-budgets 12,000/11,000/65,000, rollover 8,869, doc-truth spend 56,430 -> corrected allocations 20,869/11,000/65,000), not an approximation. This is the same rigor as a byte-diff/sha256 fixture-comparison census, applied to budget arithmetic instead of rendered prompt text, and requires no `--calibrate` run since no rule prompt changed.

## Gates

All clean: `npm run format:check`, `npm run lint` (0 errors), `npm run typecheck`, `npm run build`, `npm test` (1581/1581 review, 860/860 cli, 41/41 action, all green), `lien delta` (exit 0 — `runExtraPasses` genuinely IMPROVED, not just avoided a new crossing: 50m→44m after extraction).

No changeset (same convention as #837 — `@liendev/review` is private/unpublished).

No rule prompts touched — deterministic budget plumbing only, offline unit-test evidence above satisfies the harness-evidence gate; not applying `skip-harness-gate`.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real budget-accounting bug in `runExtraPasses`: the main pass's unspent rollover was previously added to every extra pass's allocation independently, inflating total `allocatedTokens`. The fix introduces a `remainingRollover` counter and two small helpers (`rolloverConsumedBy`, `buildPassOutcome`) so the rollover is treated as a single shared pool that depletes as passes actually draw on it. Callers (`analyze` and `analyzeSummaryOnly`) are unchanged and continue to pass the full rollover; the depletion logic is internal to `runExtraPasses`, which is the correct boundary. The new tests cover full depletion, partial depletion, and no-depletion cases with the exact real-world numbers from the dogfood run. No breaking changes or wrong-output paths were found.
>
> - Rollover is now a shared, depleting pool instead of an independent per-pass top-up.
> - Added `rolloverConsumedBy` and `buildPassOutcome` helpers to keep `runExtraPasses` readable and under complexity budget.
> - Added/updated tests reproducing the real dogfood bug and guarding against regression.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fe7e0c1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->