### PR TITLE
docs(site): publish the first three blog posts

### DIFF
--- a/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
+++ b/packages/site/docs/blog/posts/complexity-nudges-ab-test.md
@@ -4,7 +4,7 @@ description: "We warned an AI coding agent, right before it touched a function, 
 date: 2026-07-23
 author: Alf Henderson
 tags: [evidence, agents, complexity]
-draft: true
+draft: false
 ---
 
 <!-- DRAFT: awaiting owner voice pass -->

--- a/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
+++ b/packages/site/docs/blog/posts/reviewer-that-cant-skip-candidate-loops.md
@@ -4,7 +4,7 @@ description: "A popular open-source database toolkit added six new column types.
 date: 2026-07-24
 author: Alf Henderson
 tags: [evidence, review, architecture]
-draft: true
+draft: false
 ---
 
 <!-- DRAFT: awaiting owner voice pass -->

--- a/packages/site/docs/blog/posts/why-we-built-lien.md
+++ b/packages/site/docs/blog/posts/why-we-built-lien.md
@@ -4,7 +4,7 @@ description: "A tool that gives AI coding assistants a real, structural understa
 date: 2026-07-22
 author: Alf Henderson
 tags: [product, local-first]
-draft: true
+draft: false
 ---
 
 <!-- DRAFT: awaiting owner voice pass -->


### PR DESCRIPTION
Owner-ordered publication flip: `draft: false` on all three seed posts.

Dogfood evidence: local `npm run docs:build` renders `blog/index.html` plus all three post pages in dist (verified by listing dist/blog after the build); with `draft: true` the same build emitted only the index, so the gate works in both directions. Closing lines and staggered dates (07-22/07-23/07-24) landed in #824.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 505 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**
>
> Publishes the first three seed blog posts by flipping `draft: true` to `draft: false` in their front matter. This is a content-publication change only; the build gate has already been verified locally to emit the posts only when `draft` is disabled.
>
> - Set `draft: false` on `why-we-built-lien.md` (dated 2026-07-22)
> - Set `draft: false` on `complexity-nudges-ab-test.md` (dated 2026-07-23)
> - Set `draft: false` on `reviewer-that-cant-skip-candidate-loops.md` (dated 2026-07-24)

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2488a67. Updates automatically on new commits.</sup>
<!-- /lien-stats -->