### PR TITLE
feat(cli,plugin): blast-radius nudge on exported-signature edits

### DIFF
--- a/.changeset/blast-radius-nudge.md
+++ b/.changeset/blast-radius-nudge.md
@@ -1,0 +1,10 @@
+---
+'@liendev/lien': minor
+---
+
+Add the blast-radius nudge — closing the honor-system gap in CLAUDE.md's "run `get_dependents` before changing an exported symbol's signature" rule, the same way `lien delta` already automates the complexity rule.
+
+- New `lien api-delta` command: detects, content-only (`chunkFile`'s existing exported-name and signature metadata, zero index), when a working-tree edit changed or removed the signature of an exported function or class method. `--file <path>` mirrors `lien delta`'s fast path for the edit hook; `--base <ref>` mirrors CI parity. Advisory only — there is no gate, so it always exits 0; the JSON `changes[]` array is what a caller reads.
+- Best-effort enrichment against the structural index (`findDependents` + the shared blast-radius-risk primitive) adds dependent counts and a risk level when an index is available; degrades gracefully (signature-only, no counts) when it isn't, or if the lookup fails for a given symbol — never blocks, never throws.
+- The Claude Code plugin gains an `api-delta-write.sh` hook on `PostToolUse:Edit|Write|MultiEdit` (a sibling of `delta-write.sh` and `test-reminder.sh`) that surfaces a one-line warning via `additionalContext` after an edit that changed/removed an exported signature. Kill switch: `LIEN_BLAST_HOOK=off`.
+- A local, append-only `blast-events.jsonl` ledger (kill switch `LIEN_BLAST_EVENTS=off`) records every edit that changed an exported signature; `lien stats` gains a second "exported-signature nudge" section (7/30-day runs, distinct symbols changed, risk-level breakdown) alongside the existing complexity-delta stats, additive to the existing JSON shape.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -123,6 +123,18 @@ Read this to understand CLAUDE.md's sixth pre-commit gate.
 
 ---
 
+### [Blast-Radius Nudge](./blast-radius-nudge.md)
+`get_dependents` before an exported-signature edit.
+
+Explains the write-time nudge for CLAUDE.md's other honor-system rule:
+- `lien api-delta` CLI: content-based detection of a changed/removed exported function or method signature, best-effort enriched with dependent counts and risk
+- `plugins/claude/hooks/api-delta-write.sh`: the same check as a PostToolUse edit-hook warning
+- `blast-events.jsonl` + `lien stats`'s "Exported-signature nudge" section
+
+Read this to understand the sibling nudge to `lien delta`, and why it's advisory rather than a gate.
+
+---
+
 ### [Claude Code Hook Output Channels](./claude-code-hook-channels.md)
 Which hook output actually reaches the model.
 
@@ -170,6 +182,7 @@ For the history behind these designs, see the [Architectural Decision Records in
 | Complexity analysis (`get_complexity`) | [MCP Server Flow](./mcp-server-flow.md) → Available MCP Tools |
 | Worktree-shared indexing | [Worktree-Aware Indexing](./worktree-aware-indexing.md) |
 | Pre-commit complexity gate (`lien delta`) | [lien delta](./lien-delta.md) |
+| Exported-signature nudge (`lien api-delta`) | [Blast-Radius Nudge](./blast-radius-nudge.md) |
 | Plugin hook design (what reaches the model) | [Claude Code Hook Output Channels](./claude-code-hook-channels.md) |
 | Lien Review's extra LLM passes (doc-truth, candidate loops) | [Agent-Review Pass Architecture](./review-pass-architecture.md) |
 

--- a/docs/architecture/blast-radius-nudge.md
+++ b/docs/architecture/blast-radius-nudge.md
@@ -1,0 +1,275 @@
+# The blast-radius nudge: `get_dependents` before an exported-signature edit
+
+`lien api-delta` detects, at edit time and from content alone, when a working-tree
+change altered or removed the signature of an *exported* symbol — a function or a
+class method that's part of a file's public API surface — and turns that into a
+CLI exit code, a warning from the plugin's post-edit hook, and a local event log
+(`lien stats`) tracking how often it fires. It extends the `lien delta` pattern
+(deterministic core → thin hook → local JSONL ledger) to the other mandatory rule
+in CLAUDE.md that was still honor-system: "run `get_dependents` before changing
+the signature of an exported symbol."
+
+## Motivation
+
+CLAUDE.md has had two "before you touch an exported symbol" rules for a while.
+`lien delta` (see [lien-delta.md](lien-delta.md)) automates the complexity rule —
+an agent gets warned the moment a function crosses a threshold, not after review.
+The `get_dependents` rule had no equivalent: nothing at edit time noticed that a
+signature change would break every caller of the old shape, or that deleting an
+export would break them outright. The gap was pure trust that the agent would
+remember to check.
+
+## What's built
+
+- **The detection primitive** (`packages/cli/src/utils/signature-delta.ts`):
+  computes, from two content strings, which exported functions/methods had their
+  signature changed or their export dropped. See section A.
+- **The `lien api-delta` CLI** (`packages/cli/src/cli/api-delta-cmd.ts`): runs the
+  primitive against `HEAD` or `--base <ref>`, enriches with dependent counts and
+  risk when the index is available, and prints a report. Advisory only — there is
+  no gate, unlike `lien delta`. See section B.
+- **A PostToolUse hook** (`plugins/claude/hooks/api-delta-write.sh`): warns once,
+  right after an `Edit`/`Write`/`MultiEdit`, when that edit changed or removed an
+  exported signature. See section C.
+- **An event log and a `lien stats` section**: a local JSONL log of every edit
+  that changed an exported signature, aggregated into 7- and 30-day windows,
+  additive to `lien stats`'s existing JSON shape. See section D.
+
+Not built (deliberately out of scope for this feature): a `PreToolUse` variant,
+a gate/exit-1 mode, and a CI backstop job. `lien delta`'s CI job
+(`.github/workflows/ci.yml`'s `delta` job) exists because the complexity rule is
+a pass/fail gate; this feature has no such notion — it's an advisory nudge, so
+there is nothing for a CI job to fail on. See "Why advisory, not a gate" below.
+
+## A. The detection primitive (`signature-delta.ts`)
+
+### How it reuses existing machinery
+
+Like `computeComplexityDelta` (`packages/parser/src/insights/complexity-delta.ts`),
+this is pure and content-only: it calls the existing `chunkFile(path, content, {
+useAST: true, astFallback: 'line-based' })` on a "before" and an "after" content
+string and compares per-function metadata. No new parsing, no git plumbing of its
+own — the CLI layer reuses `delta-git.ts`'s existing `collectFileChange` /
+`collectFileChanges` (the same collectors `lien delta` uses).
+
+Per-chunk metadata already carries everything needed:
+
+- `metadata.exports: string[]` — the file's exported-name list, identical on
+  every chunk in that file (it's file-level, not per-symbol).
+- `metadata.signature: string` — the function/method's declaration signature.
+- `metadata.symbolType`, `metadata.symbolName`, `metadata.parentClass`.
+
+**What "exported" means for a chunk:**
+
+- A top-level `function` chunk is exported when its own `symbolName` is in
+  `exports`.
+- A `method` chunk is exported when its **`parentClass`** is in `exports` —
+  methods never appear in `exports` by name; an exported class's public methods
+  are part of the API surface, and breaking their signature breaks callers the
+  same way breaking a top-level exported function does.
+- Hard-private JS methods (`symbolName` starting with `#`) are filtered out
+  before classification ever runs: changing or removing one can never break an
+  external caller, so they are never flagged even on an exported class.
+
+This "exported" rule was verified empirically against the built parser before
+any detection logic was written (a throwaway script asserting `exports`/
+`signature`/`parentClass` population on function, method, and private-method
+chunks) — not assumed from the type declarations alone.
+
+### Matching functions across versions
+
+Identical to `complexity-delta.ts`'s `functionMetadataByKey`: functions are
+matched by the qualified key `` `${parentClass ?? ''}::${symbolName}` ``, with
+same-keyed functions on either side (overloads) paired positionally by ascending
+`startLine`. The same known limitations carry over: a renamed function reads as
+one removed plus one added, and overload pairing is positional, best-effort.
+Reusing the exact matching logic means the two detectors — complexity and
+exported-signature — can never structurally disagree about what counts as "the
+same function across an edit."
+
+### Classification
+
+For each matched (before?, after?) pair:
+
+- **Not exported before** (on either side): silent, always — including a
+  newly-added export (rule: adding an export breaks no existing caller, so there
+  is no signal to surface).
+- **Exported before, not exported after** (deleted, or the `export` keyword was
+  dropped while the function still exists): `removed` — the highest-blast-radius
+  case, since every existing caller will break.
+- **Exported on both sides, signature unchanged**: silent (the common case for
+  most edits — a body-only change).
+- **Exported on both sides, signature changed**: `signature-changed`, carrying
+  both the before and after signature strings.
+
+Changes are sorted worst-first (`removed` before `signature-changed`) so a
+truncated top-N list (the hook shows at most 3) always surfaces the highest-risk
+change first.
+
+```ts
+interface ExportedSymbolChange {
+  symbol: string; // display name, parentClass-qualified: "Foo.bar"
+  symbolName: string; // bare name, for get_dependents / findDependents
+  parentClass?: string;
+  kind: 'signature-changed' | 'removed';
+  beforeSignature?: string; // present only for 'signature-changed'
+  afterSignature?: string; // present only for 'signature-changed'
+}
+```
+
+Pure, content-only, fully unit-testable with two content strings — zero LLM,
+zero index, zero git (see `signature-delta.test.ts`).
+
+## B. The `lien api-delta` CLI command
+
+`packages/cli/src/cli/api-delta-cmd.ts`, registered in `packages/cli/src/cli/index.ts`.
+Parallels `lien delta`'s shape (`--file <path>`, `--base <ref>`, `--format
+text|json`) but drops `--soft` and `--threshold`: there is no gate to soften and
+no numeric threshold to tune.
+
+1. Resolve the repo root (`getRepoRoot`); not a git repo exits 2.
+2. Build the `FileContentChange`(s) via the reused delta-git collectors —
+   `--file` for the hook's single-file fast path, or the whole working tree.
+3. Run `computeExportedSignatureDelta` per file.
+4. **Enrich, best-effort** (section below).
+5. Record one ledger event per file with at least one change (section D).
+6. Print the report; **exit 0 always** — this is advisory, not a gate, so
+   there's no exit-1 concept the way `lien delta` has one.
+
+### Enrichment: dependent counts and risk, best-effort
+
+Only runs when at least one change was found (the rare event, so the common
+edit — no exported-signature change — pays only the cheap content check and
+never touches the index). For each changed symbol, calls the existing
+`findDependents(vectorDB, filepath, log, symbolName, indexVersion)` and composes
+a risk level via the shared `computeBlastRadiusRisk` primitive — the same two
+calls `get_dependents` and `annotate-read.sh` already make. `indexVersion` is
+captured once (`vectorDB.getCurrentVersion()`) so every symbol in one run shares
+`findDependents`'s internal scan cache — only the first symbol in a file pays
+the `scanAll`.
+
+**Graceful degrade**, in two layers:
+
+- **No index at all**: a cheap existence check
+  (`fs.access(<indexDir>/structural.db)`) runs *before* `createVectorDB` — this
+  matters because `createVectorDB(...).initialize()` would otherwise silently
+  create an empty `structural.db` as a side effect of merely running the CLI in
+  an unindexed repo, exactly the failure mode `test-reminder.sh`'s hook already
+  guards against with the same existence check. If no index exists, every
+  change in the batch degrades to signature-only.
+- **`findDependents` throws for one symbol**: only that symbol degrades; the
+  rest of the batch (and other files) still enrich normally.
+
+A degraded change carries `dependentCount: null`, `untestedDependentCount:
+null`, `riskLevel: null`, `enriched: false` — the warning still fires, it just
+can't say how many callers exist.
+
+```jsonc
+// --file mode: a single flat object (what the hook parses)
+{
+  "filepath": "packages/cli/src/cli/delta-cmd.ts",
+  "changes": [
+    {
+      "symbol": "formatDeltaText",
+      "symbolName": "formatDeltaText",
+      "kind": "signature-changed",
+      "beforeSignature": "...",
+      "afterSignature": "...",
+      "dependentCount": 4,
+      "untestedDependentCount": 1,
+      "riskLevel": "medium",
+      "enriched": true
+    }
+  ]
+}
+```
+
+Whole-tree mode (no `--file`) prints a JSON array of these per-file objects
+instead — a secondary, human-facing surface the hook never calls, so its exact
+shape wasn't frozen by any consumer.
+
+## C. The PostToolUse hook (`api-delta-write.sh`)
+
+Mirrors `delta-write.sh` exactly in structure: `command -v jq`, source
+`lien-resolve.sh`, an env kill switch (`LIEN_BLAST_HOOK=off`), read
+`tool_name`/`tool_input.file_path`/`cwd` from stdin, shell out to
+`lien api-delta --file <path> --format json` from the session's `cwd`, and stay
+silent (`exit 0`, no stdout) whenever `changes[]` is empty or the CLI produced no
+output at all (not a git repo, unsupported file, malformed stdin). Registered as
+a 4th `PostToolUse: Edit|Write|MultiEdit` entry in `hooks.json`, alongside
+`delta-write.sh` and `test-reminder.sh` — independent hook entries, same
+matcher.
+
+The warning text depends on `(kind, enriched)`:
+
+```
+⚠ lien: exported signature changed — formatUser (4 dependents, 1 untested, risk medium). Run get_dependents before relying on callers.
+⚠ lien: exported symbol removed — oldHelper (7 dependents, risk high). Callers will break — check get_dependents.
+⚠ lien: exported signature changed — formatDeltaText. Check get_dependents (index unavailable for counts).
+```
+
+The single-change case (by far the common one — most edits touch one exported
+symbol) renders one of these full sentences. Two or three changes fall back to a
+terser combined line (`⚠ lien: N exported-signature changes — item1; item2;
+item3 (+K more). Run get_dependents before relying on callers.`), worst-first,
+matching `computeExportedSignatureDelta`'s own sort.
+
+Output channel: `hookSpecificOutput.additionalContext` — the same channel
+`delta-write.sh` and `test-reminder.sh` use, verified in
+[claude-code-hook-channels.md](claude-code-hook-channels.md) as the one field
+that reaches the model on the next turn.
+
+### Dogfood evidence (real PostToolUse stdin shape)
+
+Verified by piping the real `{session_id, transcript_path, cwd, hook_event_name,
+tool_name, tool_input, tool_response}` payload shape into the hook script
+directly, covering:
+
+- **Enriched, signature-changed**: `⚠ lien: exported signature changed — computeDeltaWindowStats (2 dependents, 0 untested, risk low). Run get_dependents before relying on callers.`
+- **Enriched, removed**: `⚠ lien: exported symbol removed — computeDeltaWindowStats (2 dependents, risk low). Callers will break — check get_dependents.`
+- **Degraded (no index)**: `⚠ lien: exported signature changed — greet. Check get_dependents (index unavailable for counts).` — confirmed only `blast-events.jsonl` was created on disk, never `structural.db`.
+- **Fail-open**: malformed (non-JSON, and valid-JSON-missing-fields) stdin, and a non-git directory — all exit 0 with no `additionalContext` emitted.
+
+## D. Event ledger + `lien stats`
+
+`packages/cli/src/utils/blast-events.ts` is a sibling of `delta-events.ts`, not
+an extension of its `DeltaEvent` shape — a blast-radius event has no exit code,
+mode, or crossing counts, and `lien api-delta` is advisory-only. One line is
+appended to `<indexDir>/blast-events.jsonl` per changed file that had at least
+one exported-signature change — **never for a clean run**, so `lien stats`'s
+"runs" count answers "edits that changed an exported signature," not "edits
+observed." Same 2 MB front-trim, same shape-validation-on-read, same kill switch
+convention (`LIEN_BLAST_EVENTS=off`) as `delta-events.ts`.
+
+`packages/cli/src/utils/blast-stats.ts` is the pure aggregation:
+`computeBlastWindowStats(events, windowDays, now?)` reports, per window, `runs`,
+`distinctSymbolsChanged` (unique `(filepath, symbol)` pairs), and `byRiskLevel`
+(a count per `low|medium|high|critical|unknown` — `unknown` covers degraded,
+no-index changes).
+
+`lien stats` gains a second "Exported-signature nudge" section, printed after
+the existing complexity-delta windows. JSON output nests the new data under a
+`blastRadius` key — additive; the pre-existing top-level `totalEvents`/`windows`
+shape is unchanged for any existing caller.
+
+## Why advisory, not a gate
+
+`lien delta` fails a commit (exit 1) on a new complexity crossing because
+"this function got more complex" has an unambiguous, checkable answer. "Did you
+check `get_dependents`?" doesn't: the agent might already know every caller
+(a self-contained refactor), or the change might be safe by inspection. Blocking
+the edit — or even the commit — on this signal would be enforcing a process step,
+not a correctness property, and CLAUDE.md's own gate liturgy reserves hard
+failures for objectively-verifiable regressions. The nudge exists to make the
+honor-system rule hard to forget, not to replace judgment with a mechanical gate.
+This is also why there is no CI backstop job: a CI job blocking a PR on "an
+exported signature changed" would be a policy no one asked for.
+
+A pre-registered behavioral A/B tested whether the *nudge itself* changes
+agent behavior — a separate question from whether it should ever block. See
+[Behavioral A/B: does the blast-radius warning change what an agent says about
+callers?](../development/blast-radius-nudge-ab.md) for the full protocol and
+an honest null result: the chosen experimental design hit a ceiling effect
+(subagents inherit this repo's own CLAUDE.md, which already states the rule
+the warning reinforces), so it could not isolate the nudge's marginal effect
+— reported as such rather than reframed as inconclusive-therefore-supportive.

--- a/docs/architecture/blast-radius-nudge.md
+++ b/docs/architecture/blast-radius-nudge.md
@@ -1,13 +1,15 @@
 # The blast-radius nudge: `get_dependents` before an exported-signature edit
 
 `lien api-delta` detects, at edit time and from content alone, when a working-tree
-change altered or removed the signature of an *exported* symbol — a function or a
-class method that's part of a file's public API surface — and turns that into a
-CLI exit code, a warning from the plugin's post-edit hook, and a local event log
+change altered or removed the signature of an **exported top-level function or
+exported class method** — the two shapes covered, not "any exported symbol" (see
+"Known limitations" for what's out of scope) — and turns that into a CLI exit
+code, a warning from the plugin's post-edit hook, and a local event log
 (`lien stats`) tracking how often it fires. It extends the `lien delta` pattern
 (deterministic core → thin hook → local JSONL ledger) to the other mandatory rule
 in CLAUDE.md that was still honor-system: "run `get_dependents` before changing
-the signature of an exported symbol."
+the signature of an exported symbol." Within its covered shapes it's a nudge for
+that rule, not a complete enforcement of it.
 
 ## Motivation
 
@@ -80,12 +82,23 @@ chunks) — not assumed from the type declarations alone.
 
 Identical to `complexity-delta.ts`'s `functionMetadataByKey`: functions are
 matched by the qualified key `` `${parentClass ?? ''}::${symbolName}` ``, with
-same-keyed functions on either side (overloads) paired positionally by ascending
-`startLine`. The same known limitations carry over: a renamed function reads as
-one removed plus one added, and overload pairing is positional, best-effort.
+same-keyed functions on either side paired positionally by ascending `startLine`.
 Reusing the exact matching logic means the two detectors — complexity and
 exported-signature — can never structurally disagree about what counts as "the
 same function across an edit."
+
+**The positional-pairing mechanism does not actually engage for TypeScript's
+canonical overload-declaration pattern.** Verified empirically: chunking a
+function with two `declare`-only overload signatures followed by one
+implementation produces a *single* function chunk (the implementation), not
+three — the overload declaration lines (no body) aren't emitted as their own
+`symbolName`-bearing chunks at all, so there is never more than one chunk per
+qualified key for this shape. The positional-pairing code exists (inherited
+unchanged from `complexity-delta.ts`, so the two detectors stay in lockstep for
+whatever cases *do* produce multiple same-keyed chunks) but it has no effect
+here: an edit that changes only an overload declaration's signature, leaving
+the implementation signature untouched, is a **silent miss** — `signature-delta`
+only ever sees the implementation chunk's signature, which didn't change.
 
 ### Classification
 
@@ -251,6 +264,44 @@ no-index changes).
 the existing complexity-delta windows. JSON output nests the new data under a
 `blastRadius` key — additive; the pre-existing top-level `totalEvents`/`windows`
 shape is unchanged for any existing caller.
+
+## Known limitations
+
+All of these are silent misses (safe direction — the nudge under-fires, it
+never fires on something that isn't real), not false positives:
+
+- **Scope: exported top-level functions and exported class methods only.**
+  Verified misses, each confirmed not to produce a chunk `signature-delta` can
+  see:
+  - **Interface method signatures** (e.g. `export interface Foo { bar(x: number): void }`)
+    — an interface's methods aren't `function`/`method`-typed chunks with a
+    `symbolName`, so they're filtered out before classification ever runs.
+  - **Exported type-alias function types** (e.g. `export type Handler = (x: number) => void;`)
+    — same reason: not a function/method chunk.
+  - **Aliased re-exports** (`export { foo as bar }`) — the file's exported-name
+    list carries the alias (`bar`), not the declared function's own name
+    (`foo`); `isExportedChunk` matches on `symbolName`, so a function only
+    exported under an alias is never recognized as exported.
+  - **Reference-form default exports** (`function foo() {...}; export default foo;`)
+    — same alias problem: the export list doesn't necessarily carry `foo`'s own
+    name.
+  - **Anonymous default exports** (`export default function() {...}`) — no
+    `symbolName` at all, filtered out by the "must have a name" guard before
+    the exported check ever runs.
+- **TypeScript overload declarations** — see "Matching functions across
+  versions" above: only the implementation signature is trackable; an
+  overload-declaration-only signature change is a silent miss.
+- **Function-level renames are not tracked** (inherited from
+  `complexity-delta.ts`'s matching): renaming `foo` to `bar` reads as `foo`
+  removed plus `bar` added under a different qualified key, not one function
+  matched across the rename.
+- **Whitespace/formatting-only signature changes are normalized away**
+  (collapsed spacing, added/removed trailing commas, single-to-multi-line
+  param reflow all compare equal — see `normalizeSignature`), but a **positional
+  parameter rename is deliberately still flagged** (`f(a)` → `f(input)`):
+  identifier text is never touched by normalization, and a parameter rename is
+  a real API-surface change in keyword-argument languages (e.g. Python), not
+  noise.
 
 ## Why advisory, not a gate
 

--- a/docs/development/blast-radius-nudge-ab.md
+++ b/docs/development/blast-radius-nudge-ab.md
@@ -1,0 +1,247 @@
+# Behavioral A/B: does the blast-radius warning change what an agent says about callers?
+
+A small, pre-registered experiment testing whether Feature 1's real blast-radius
+warning (as rendered by `plugins/claude/hooks/api-delta-write.sh`) measurably
+changes whether a Sonnet subagent addresses caller/dependent impact when asked
+to change an exported function's signature, relative to an identical prompt
+with no warning.
+
+**Headline result: null, for an identified and explained reason.** Both the
+primary metric and the "does it flag callers beyond the ones the task itself
+requires updating" secondary check came back **8/8 in both conditions** —
+every trial, control and signal alike, spontaneously discussed running
+`get_dependents` / checking dependents before finalizing, several by name and
+several explicitly citing "this project's CLAUDE.md rule" or "this repo's Lien
+workflow." The confound: subagents spawned from a session rooted in this
+Lien repository appear to inherit this repo's own `CLAUDE.md` (which contains
+the exact rule this nudge automates — "run `get_dependents` before renaming,
+removing, or changing the signature of any exported function, class, or
+interface") regardless of whether the injected warning is present or the task
+has anything to do with Lien. This ceiling effect made the chosen protocol
+unable to isolate the nudge's marginal effect. See "Honest read" for what this
+does and doesn't mean.
+
+## Protocol (pre-registered, frozen before any trial ran)
+
+The full pre-registration lives in `.wip/ab-blast/protocol.md` (gitignored per
+this repo's `.wip/` convention; preserved here by reference and reproduced
+below for the record).
+
+> ### Hypothesis
+>
+> Injecting Feature 1's real blast-radius warning (as rendered by
+> `api-delta-write.sh`) into a prompt that asks the agent to change an
+> exported function's signature increases the rate at which the response
+> proactively addresses caller/dependent impact (updates or enumerates call
+> sites, or explicitly says it must check dependents before relying on
+> callers), vs an identical prompt with no warning.
+>
+> Null hypothesis: the warning has no effect (or reduces) caller-impact-addressing.
+>
+> ### Target (frozen, identical in both arms)
+>
+> A small self-contained TypeScript module, `user-utils.ts`, with one exported
+> function `formatUser(user)` and 3 in-file call sites:
+>
+> ```typescript
+> export function formatUser(user) {
+>   return `${user.firstName} ${user.lastName}`;
+> }
+>
+> export function renderUserCard(user) {
+>   return `<div class="user-card">${formatUser(user)}</div>`;
+> }
+>
+> export function renderUserList(users) {
+>   return users.map(u => `<li>${formatUser(u)}</li>`).join('');
+> }
+>
+> export function logUserAction(user, action) {
+>   console.log(`${formatUser(user)} performed action: ${action}`);
+> }
+> ```
+>
+> Task: "change `formatUser` to take `(user, opts)` and thread `opts` through."
+>
+> ### Signal warning block (verbatim from the real hook's rendering)
+>
+> ```
+> ⚠ lien: exported signature changed — formatUser (4 dependents, 1 untested, risk medium). Run get_dependents before relying on callers.
+> ```
+>
+> Injected as a `NOTE — Lien's tooling flagged this edit:` paragraph after the
+> file, before the task. Control: that block is the empty string. This exact
+> template was independently confirmed to match the real hook's output during
+> dogfooding (see the PR body): running `api-delta-write.sh` against a real
+> signature-changed, enriched, single-symbol case produced the identical
+> sentence shape, differing only in symbol name and the actual numbers.
+>
+> ### Conditions, N, and execution
+>
+> Byte-identical prompt across both arms except the warning block. N = 8 per
+> condition, 16 total. Each trial: one fresh `Agent` call, `subagent_type:
+> general-purpose`, `model: sonnet`, no isolation, no repo access (the prompt
+> is fully self-contained; no cwd or Lien context was deliberately supplied).
+> Instructed not to use tools; compliance verified per-trial via the agent's
+> own `tool_uses` metadata (all 16 trials: `tool_uses: 0`).
+>
+> ### Primary metric
+>
+> Binary per trial, against a frozen rubric: does the response (a) update or
+> enumerate the affected call sites, or (b) explicitly state it should check
+> dependents/callers before finalizing? A bare signature change with no
+> caller mention = "no".
+>
+> ### Secondary metrics
+>
+> Literal mention of "dependents"/"callers"/`get_dependents`; whether the
+> injected "1 untested" dependent is specifically acknowledged (signal only,
+> since control never sees that number).
+>
+> ### Exclusion rules
+>
+> Unparseable output, or evidence of tool use. (None triggered — see Results.)
+>
+> ### Analysis plan
+>
+> Report raw rates per condition, no significance testing. A null or reversed
+> result is reported as such.
+
+## Results
+
+### Invalid trials
+
+**0 / 16.** Every trial produced a coherent response; every trial's own
+metadata reported `tool_uses: 0`, confirming the "no tools" instruction was
+honored.
+
+### Primary metric, as literally specified
+
+| Condition | Addressed caller impact (criterion a or b) | Rate |
+|---|---|---|
+| Control (no warning) | 8 / 8 | **100%** |
+| Signal (warning injected) | 8 / 8 | **100%** |
+
+**Null — no observed difference.** Every single trial, in both conditions,
+satisfied the primary metric: all 16 updated the 3 in-file call sites (the
+literal task requirement — "thread `opts` through" mechanically forces this)
+**and** all 16 additionally discussed checking for callers beyond what's
+visible in the file, several by explicit reference to `get_dependents` or
+this repository's own CLAUDE.md.
+
+### Why criterion (a) turned out not to discriminate
+
+Re-reading the rubric against the actual responses surfaced a task-design
+flaw, reported honestly rather than patched after the fact: "thread `opts`
+through" **requires** updating the 3 in-file call sites as the core
+deliverable of the assigned task. Every minimally-competent completion —
+control or signal — therefore satisfies criterion (a) by construction. That
+half of the primary metric was never capable of discriminating between
+conditions; it measures task compliance, not nudge-driven behavior.
+
+### The real (attempted) discriminator: unprompted `get_dependents`/CLAUDE.md reasoning
+
+Set that design flaw aside and look only at criterion (b) — spontaneous
+reasoning about checking dependents/callers *beyond* the visibly-required
+call sites. This is genuinely optional; nothing in the task asks for it.
+
+| Condition | Explicitly discussed checking beyond-file callers/dependents | Rate |
+|---|---|---|
+| Control (no warning) | 8 / 8 | **100%** |
+| Signal (warning injected) | 8 / 8 | **100%** |
+
+Still a dead heat. Every control trial, having received **no warning at all**
+and a task framed as "a hypothetical internal utils module" with no mention
+of Lien, still volunteered language like:
+
+> Control trial 1: "...in the real repo I'd run `get_dependents` on
+> `formatUser`, `renderUserCard`, `renderUserList`, and `logUserAction` before
+> touching their signatures (**per this project's CLAUDE.md rule**)..."
+
+> Control trial 5: "...**In the real Lien repo, CLAUDE.md mandates running
+> `get_dependents`** on each before changing them..."
+
+> Control trial 8: "If this were a real Lien-tracked file, **the project's
+> CLAUDE.md** would require running `get_files_context` and `get_dependents`
+> on `formatUser` before editing..."
+
+Raw trial text: `.wip/ab-blast/trials/control-{1..8}.md`,
+`.wip/ab-blast/trials/signal-{1..8}.md` (gitignored).
+
+### Secondary metric: acknowledging the specific "1 untested" figure
+
+| Condition | Acknowledges the specific "1 untested" dependent | Rate |
+|---|---|---|
+| Control (no warning) | 0 / 8 | 0% (never given the figure — nothing to acknowledge) |
+| Signal (warning injected) | 8 / 8 | 100% |
+
+This is the one clean, unconfounded difference in the dataset — but it's not
+informative about the nudge's *persuasive* effect. Control trials had no way
+to reference a number they were never shown; signal trials could only be
+quoting information handed to them verbatim. It demonstrates the warning's
+*numbers were read and repeated*, not that the warning *changed anything the
+agent wouldn't otherwise have done*.
+
+## Honest read
+
+**This is a null result for the question the experiment set out to answer**,
+and the reason is identifiable rather than mysterious: subagents launched
+from within a session whose working directory is this Lien repository appear
+to inherit this repo's own `CLAUDE.md` — which already states, near-verbatim,
+the exact rule ("run `get_dependents` before ... changing the signature of
+any exported function, class, or interface") that Feature 1's warning exists
+to reinforce. Every trial, control included, had that rule already loaded
+before it ever saw (or didn't see) the injected warning text. That produces a
+ceiling effect: there was no headroom left for the warning to move the needle
+on "does the agent think about checking dependents," because the answer was
+already yes for every trial regardless of condition.
+
+This differs qualitatively from the companion `lien delta` A/B in
+[nudge-behavioral-ab.md](nudge-behavioral-ab.md), which ran under the same
+"no isolation" subagent setup and did **not** hit this confound — that
+experiment's signal was a specific numeric complexity-threshold crossing,
+which doesn't textually overlap with any rule already sitting in this
+repo's CLAUDE.md, so control trials there had no pre-loaded reason to reason
+about it. The blast-radius warning's content, by contrast, restates a rule
+CLAUDE.md already states almost word-for-word, so any subagent that has
+CLAUDE.md loaded will reflexively invoke it once it recognizes "this is an
+exported-signature change" — independent of whether Lien's tooling actually
+told it so.
+
+**What this does not mean:** it is not evidence that the nudge has no real
+effect in production. In real usage, the nudge fires inside the *same* agent
+session that already has CLAUDE.md loaded and is already subject to its
+"honor system" — that's precisely the gap this feature exists to close (an
+agent forgetting to act on a rule it technically knows). This experiment's
+design accidentally re-created "the rule is already known" as the *control*
+condition too, which is a different (and less informative) comparison than
+"does an agent that has forgotten or is about to skip the rule get pulled
+back by seeing the warning." A cleaner test of that specific question would
+need either a target/task pairing whose "exported signature changed" shape is
+harder for the model to pattern-match onto CLAUDE.md from the task alone (so
+control trials don't reflexively cite the rule), or a way to run the
+comparison without CLAUDE.md loaded into either arm — neither of which this
+protocol, once frozen, could be revised to attempt without violating the "no
+post-hoc re-framing" rule the sibling A/B document also holds itself to.
+
+**What the dataset does support:** the warning's numbers were read and acted
+on faithfully. Every signal trial correctly identified that the visible 3
+call sites don't account for the full "4 dependents" the warning claims, and
+7 of 8 explicitly named the "1 untested" dependent as the one needing test
+coverage before merging — the warning's content was legible and its specific
+claims were taken seriously where they appeared. That's a necessary
+precondition for the nudge to work, just not sufficient to demonstrate the
+comparative effect this experiment was designed to isolate.
+
+**Recommendation, not acted on in this PR:** a follow-up A/B, if run, should
+either pick a target/task shape that doesn't pattern-match onto CLAUDE.md's
+already-known rule text, or find a mechanism to exclude project instructions
+from the trial subagents' context — both are design changes to a fresh
+protocol, not a re-run of this one, and are left to the feature owner's
+judgment about whether they're worth the additional trial cost.
+
+## Artifacts
+
+- Protocol: `.wip/ab-blast/protocol.md` (gitignored, referenced above)
+- Raw per-trial outputs: `.wip/ab-blast/trials/{control,signal}-{1..8}.md`
+  (gitignored)

--- a/packages/cli/src/cli/api-delta-cmd.test.ts
+++ b/packages/cli/src/cli/api-delta-cmd.test.ts
@@ -375,10 +375,21 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
 
     const result = lastJsonLog() as {
       filepath: string;
-      changes: Array<{ symbol: string; enriched: boolean; dependentCount: number | null }>;
+      changes: Array<{
+        symbol: string;
+        enriched: boolean;
+        dependentCount: number | null;
+        untestedDependentCount: number | null;
+      }>;
     };
-    expect(result.changes[0].enriched).toBe(true);
-    expect(result.changes[0].dependentCount).toBeGreaterThanOrEqual(0);
+    // The stub index supplies exactly one caller (caller.ts, a non-test file
+    // importing and calling formatUser) — assert the real counts, not just
+    // that enrichment ran at all.
+    expect(result.changes[0]).toMatchObject({
+      enriched: true,
+      dependentCount: 1,
+      untestedDependentCount: 1,
+    });
     expect(errSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/cli/api-delta-cmd.test.ts
+++ b/packages/cli/src/cli/api-delta-cmd.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as coreModule from '@liendev/core';
+import { apiDeltaCommand, formatApiDeltaText, type ApiDeltaOptions } from './api-delta-cmd.js';
+import { readBlastEvents } from '../utils/blast-events.js';
+
+const execFileAsync = promisify(execFile);
+
+const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*m/g, '');
+
+// Only `createVectorDB` is mocked — everything else in this file (git
+// plumbing, chunking) runs for real, mirroring annotate-cmd.test.ts's
+// integration style.
+vi.mock('@liendev/core', async () => {
+  const actual = await vi.importActual<typeof import('@liendev/core')>('@liendev/core');
+  return {
+    ...actual,
+    createVectorDB: vi.fn(actual.createVectorDB),
+  };
+});
+
+describe('formatApiDeltaText', () => {
+  it('reports a clean line when there are no changes', () => {
+    const text = stripAnsi(formatApiDeltaText([], 'HEAD'));
+    expect(text).toContain('no exported-signature changes vs HEAD');
+  });
+
+  it('renders a signature-changed row with dependent counts and risk', () => {
+    const text = stripAnsi(
+      formatApiDeltaText(
+        [
+          {
+            filepath: 'src/foo.ts',
+            changes: [
+              {
+                symbol: 'formatUser',
+                symbolName: 'formatUser',
+                kind: 'signature-changed',
+                beforeSignature: 'a',
+                afterSignature: 'b',
+                dependentCount: 4,
+                untestedDependentCount: 1,
+                riskLevel: 'medium',
+                enriched: true,
+              },
+            ],
+          },
+        ],
+        'HEAD',
+      ),
+    );
+    expect(text).toContain('src/foo.ts');
+    expect(text).toContain('formatUser');
+    expect(text).toContain('4 dependents, 1 untested, risk medium');
+    expect(text).toContain('get_dependents');
+  });
+
+  it('renders a degraded row without counts', () => {
+    const text = stripAnsi(
+      formatApiDeltaText(
+        [
+          {
+            filepath: 'src/foo.ts',
+            changes: [
+              {
+                symbol: 'oldHelper',
+                symbolName: 'oldHelper',
+                kind: 'removed',
+                dependentCount: null,
+                untestedDependentCount: null,
+                riskLevel: null,
+                enriched: false,
+              },
+            ],
+          },
+        ],
+        'HEAD',
+      ),
+    );
+    expect(text).toContain('index unavailable for counts');
+  });
+});
+
+describe('apiDeltaCommand — operational failures exit 2', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 2 on an empty --file (usage error, not silence)', async () => {
+    await expect(apiDeltaCommand({ format: 'text', file: '' })).rejects.toThrow('__exit__:2');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('non-empty path'));
+  });
+
+  it('exits 2 on an empty --base', async () => {
+    await expect(apiDeltaCommand({ format: 'text', base: '' })).rejects.toThrow('__exit__:2');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('non-empty ref'));
+  });
+
+  it('exits 2 on an invalid --format', async () => {
+    await expect(apiDeltaCommand({ format: 'yaml' as unknown as 'text' })).rejects.toThrow(
+      '__exit__:2',
+    );
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --format'));
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('apiDeltaCommand — integration (real git fixtures, no index)', () => {
+  let dir: string;
+  let home: string;
+  let originalCwd: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  async function git(...args: string[]): Promise<void> {
+    await execFileAsync('git', args, { cwd: dir });
+  }
+
+  async function write(rel: string, content: string): Promise<void> {
+    const full = path.join(dir, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, 'utf-8');
+  }
+
+  async function initRepo(): Promise<void> {
+    await git('init', '-q');
+    await git('config', 'user.email', 'test@example.com');
+    await git('config', 'user.name', 'Test');
+    await git('config', 'commit.gpgsign', 'false');
+  }
+
+  async function commitAll(msg: string): Promise<void> {
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', msg);
+  }
+
+  /** Run apiDeltaCommand and resolve to the exit code, instead of throwing the sentinel. */
+  async function runApiDelta(options: ApiDeltaOptions): Promise<number> {
+    try {
+      await apiDeltaCommand(options);
+    } catch (error) {
+      const match = /__exit__:(\d+)/.exec(error instanceof Error ? error.message : String(error));
+      if (match) return Number(match[1]);
+      throw error;
+    }
+    return 0;
+  }
+
+  function lastJsonLog(): Record<string, unknown> {
+    const call = logSpy.mock.calls.at(-1);
+    return JSON.parse(String(call?.[0]));
+  }
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-api-delta-cmd-'));
+    dir = await fs.realpath(dir); // resolve macOS /var -> /private/var
+    originalCwd = process.cwd();
+    process.chdir(dir);
+
+    // Isolate index/ledger recording under a temp LIEN_HOME so these tests
+    // never touch the real developer machine's ~/.lien/indices, and never
+    // find a real structural.db (exercising the degrade-to-signature-only path).
+    originalHome = process.env.LIEN_HOME;
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-api-delta-cmd-home-'));
+    process.env.LIEN_HOME = home;
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.LIEN_HOME;
+    else process.env.LIEN_HOME = originalHome;
+    vi.restoreAllMocks();
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it('exits 2 outside a git repository', async () => {
+    await fs.rm(path.join(dir, '.git'), { recursive: true, force: true }).catch(() => undefined);
+    const exitCode = await runApiDelta({ format: 'text' });
+    expect(exitCode).toBe(2);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('not a git repository'));
+  });
+
+  it('reports the exported-signature change for a single file (--file fast path, degraded — no index)', async () => {
+    await initRepo();
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await commitAll('init');
+    await write('a.ts', 'export function formatUser(user, opts) { return user.name; }');
+
+    const exitCode = await runApiDelta({ format: 'json', file: 'a.ts' });
+    expect(exitCode).toBe(0); // advisory only — always exits 0 once it ran
+
+    const result = lastJsonLog() as {
+      filepath: string;
+      changes: Array<{ symbol: string; kind: string; enriched: boolean }>;
+    };
+    expect(result.filepath).toBe('a.ts');
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toMatchObject({
+      symbol: 'formatUser',
+      kind: 'signature-changed',
+      enriched: false, // no structural.db in this fresh temp home
+      dependentCount: null,
+    });
+  });
+
+  it('prints the clean single-file object when the edit did not change an exported signature', async () => {
+    await initRepo();
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await commitAll('init');
+    await write('a.ts', 'export function formatUser(user) { return user.name.trim(); }');
+
+    const exitCode = await runApiDelta({ format: 'json', file: 'a.ts' });
+    expect(exitCode).toBe(0);
+    expect(lastJsonLog()).toEqual({ filepath: 'a.ts', changes: [] });
+  });
+
+  it('records one ledger event per changed file, readable via readBlastEvents', async () => {
+    await initRepo();
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await commitAll('init');
+    await write('a.ts', 'export function formatUser(user, opts) { return user.name; }');
+
+    await runApiDelta({ format: 'json', file: 'a.ts' });
+
+    const events = await readBlastEvents(dir);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      filepath: 'a.ts',
+      enriched: false,
+      changes: [{ symbol: 'formatUser', kind: 'signature-changed' }],
+    });
+  });
+
+  it('records nothing to the ledger for a clean run (no exported signature change)', async () => {
+    await initRepo();
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await commitAll('init');
+    await write('a.ts', 'export function formatUser(user) { return user.name.trim(); }');
+
+    await runApiDelta({ format: 'json', file: 'a.ts' });
+
+    expect(await readBlastEvents(dir)).toEqual([]);
+  });
+
+  it('text format renders the report for the same single-file change', async () => {
+    await initRepo();
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await commitAll('init');
+    await write('a.ts', 'export function formatUser(user, opts) { return user.name; }');
+
+    await runApiDelta({ format: 'text', file: 'a.ts' });
+
+    const text = stripAnsi(String(logSpy.mock.calls.at(-1)?.[0]));
+    expect(text).toContain('formatUser');
+    expect(text).toContain('index unavailable for counts');
+  });
+});
+
+describe('apiDeltaCommand — enrichment when an index is present', () => {
+  let dir: string;
+  let home: string;
+  let originalCwd: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  async function git(...args: string[]): Promise<void> {
+    await execFileAsync('git', args, { cwd: dir });
+  }
+
+  async function write(rel: string, content: string): Promise<void> {
+    const full = path.join(dir, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, 'utf-8');
+  }
+
+  function lastJsonLog(): Record<string, unknown> {
+    const call = logSpy.mock.calls.at(-1);
+    return JSON.parse(String(call?.[0]));
+  }
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-api-delta-enrich-'));
+    dir = await fs.realpath(dir);
+    originalCwd = process.cwd();
+    process.chdir(dir);
+
+    originalHome = process.env.LIEN_HOME;
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-api-delta-enrich-home-'));
+    process.env.LIEN_HOME = home;
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+
+    await git('init', '-q');
+    await git('config', 'user.email', 'test@example.com');
+    await git('config', 'user.name', 'Test');
+    await git('config', 'commit.gpgsign', 'false');
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.LIEN_HOME;
+    else process.env.LIEN_HOME = originalHome;
+    vi.restoreAllMocks();
+    vi.mocked(coreModule.createVectorDB).mockClear();
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it('reports dependentCount/riskLevel/enriched:true when findDependents succeeds against a stub index', async () => {
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'init');
+    await write('a.ts', 'export function formatUser(user, opts) { return user.name; }');
+
+    // `hasStructuralIndex`'s cheap pre-check only looks for the file's
+    // existence at the real per-repo index dir — its content doesn't matter
+    // since `createVectorDB` itself is mocked below.
+    const { getIndexDir } = await import('@liendev/parser');
+    const realIndexDir = getIndexDir(dir);
+    await fs.mkdir(realIndexDir, { recursive: true });
+    await fs.writeFile(path.join(realIndexDir, 'structural.db'), '', 'utf-8');
+
+    const callerChunk = {
+      content: 'formatUser(x);',
+      metadata: {
+        file: 'caller.ts',
+        startLine: 1,
+        endLine: 1,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'useIt',
+        symbolType: 'function',
+        imports: ['./a'],
+        importedSymbols: { './a': ['formatUser'] },
+        callSites: [{ symbol: 'formatUser', line: 1 }],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getCurrentVersion: vi.fn().mockReturnValue(1),
+      scanAll: vi.fn().mockResolvedValue([callerChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await expect(apiDeltaCommand({ format: 'json', file: 'a.ts' })).rejects.toThrow('__exit__:0');
+
+    const result = lastJsonLog() as {
+      filepath: string;
+      changes: Array<{ symbol: string; enriched: boolean; dependentCount: number | null }>;
+    };
+    expect(result.changes[0].enriched).toBe(true);
+    expect(result.changes[0].dependentCount).toBeGreaterThanOrEqual(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/cli/api-delta-cmd.ts
+++ b/packages/cli/src/cli/api-delta-cmd.ts
@@ -1,0 +1,298 @@
+/**
+ * `lien api-delta` — flag exported-symbol signature changes/removals in the
+ * working tree (FEATURE 1 / the blast-radius nudge). Advisory only: there is
+ * no gate here, unlike `lien delta` — CLAUDE.md's "run get_dependents before
+ * changing an exported symbol" rule has no pass/fail notion, only a nudge to
+ * check impact before relying on callers.
+ */
+
+import chalk from 'chalk';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createVectorDB } from '@liendev/core';
+import { getIndexDir, computeBlastRadiusRisk, type FileContentChange } from '@liendev/parser';
+import { getRepoRoot, collectFileChanges, collectFileChange } from './delta-git.js';
+import {
+  findDependents,
+  type DependencyAnalysisResult,
+} from '../mcp/handlers/dependency-analyzer.js';
+import {
+  computeExportedSignatureDelta,
+  type ExportedSignatureDelta,
+  type ExportedSymbolChange,
+} from '../utils/signature-delta.js';
+import { recordBlastEvent, type BlastEvent } from '../utils/blast-events.js';
+
+export interface ApiDeltaOptions {
+  format: 'text' | 'json';
+  /** Restrict analysis to a single file — the fast path the PostToolUse edit hook uses. */
+  file?: string;
+  /** Compare the working tree against this ref instead of HEAD (e.g. origin/main in CI). */
+  base?: string;
+}
+
+const VALID_FORMATS = ['text', 'json'];
+
+/** Matches get-dependents.ts's local threshold (also duplicated in review's blast-radius.ts) — accepted duplication until a shared helper is worth extracting. */
+const HIGH_COMPLEXITY_THRESHOLD = 15;
+
+export interface EnrichedExportedSymbolChange extends ExportedSymbolChange {
+  /** null when the index was unavailable or enrichment failed (degraded — still fires, just without counts). */
+  dependentCount: number | null;
+  untestedDependentCount: number | null;
+  riskLevel: string | null;
+  enriched: boolean;
+}
+
+export interface EnrichedSignatureDelta {
+  filepath: string;
+  changes: EnrichedExportedSymbolChange[];
+}
+
+function usageFlagError(options: ApiDeltaOptions): string | undefined {
+  if (!VALID_FORMATS.includes(options.format)) {
+    return `Invalid --format "${options.format}". Must be text or json.`;
+  }
+  if (options.file !== undefined && options.file.trim() === '') {
+    return '--file requires a non-empty path.';
+  }
+  if (options.base !== undefined && options.base.trim() === '') {
+    return '--base requires a non-empty ref.';
+  }
+  return undefined;
+}
+
+/** Degraded row: no index, or enrichment failed for this change. Still fires — just without counts. */
+function degradedChange(change: ExportedSymbolChange): EnrichedExportedSymbolChange {
+  return {
+    ...change,
+    dependentCount: null,
+    untestedDependentCount: null,
+    riskLevel: null,
+    enriched: false,
+  };
+}
+
+/**
+ * Mirrors get-dependents.ts's `computeRisk`: production-dependent breadth +
+ * untested-production-dependent count + a high-complexity-and-uncovered
+ * escalation, composed via the shared parser primitive.
+ */
+function computeRisk(analysis: DependencyAnalysisResult): string {
+  const { productionDependentCount, uncoveredProductionDependents, complexityMetrics } = analysis;
+  const maxComplexity = complexityMetrics.maxComplexity;
+  const hasHighComplexityUncovered =
+    uncoveredProductionDependents > 0 && maxComplexity >= HIGH_COMPLEXITY_THRESHOLD;
+  return computeBlastRadiusRisk({
+    dependentCount: productionDependentCount,
+    uncoveredDependents: uncoveredProductionDependents,
+    maxDependentComplexity: maxComplexity > 0 ? maxComplexity : undefined,
+    hasHighComplexityUncovered,
+  }).level;
+}
+
+/** Cheap existence check — avoids `createVectorDB().initialize()`'s side effect of creating an empty structural.db where none exists yet. */
+async function hasStructuralIndex(rootDir: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(getIndexDir(rootDir), 'structural.db'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function enrichOneChange(
+  vectorDB: Awaited<ReturnType<typeof createVectorDB>>,
+  filepath: string,
+  change: ExportedSymbolChange,
+  indexVersion: number,
+): Promise<EnrichedExportedSymbolChange> {
+  try {
+    const log = (): void => undefined;
+    const analysis = await findDependents(vectorDB, filepath, log, change.symbolName, indexVersion);
+    return {
+      ...change,
+      dependentCount: analysis.dependents.length,
+      untestedDependentCount: analysis.uncoveredProductionDependents,
+      riskLevel: computeRisk(analysis),
+      enriched: true,
+    };
+  } catch {
+    return degradedChange(change);
+  }
+}
+
+/**
+ * Enrich every change with dependent counts + risk, best-effort. Only runs
+ * index-touching work when there is at least one change (the rare event) —
+ * the common edit pays only the cheap content-based detection. Degrades to
+ * signature-only (whole batch) when no index exists or the vectorDB itself
+ * fails to open; degrades per-change when `findDependents` throws for that
+ * one symbol. Never throws.
+ */
+async function enrichDeltas(
+  rootDir: string,
+  deltas: ExportedSignatureDelta[],
+): Promise<EnrichedSignatureDelta[]> {
+  if (deltas.length === 0) return [];
+
+  if (!(await hasStructuralIndex(rootDir))) {
+    return deltas.map(d => ({ filepath: d.filepath, changes: d.changes.map(degradedChange) }));
+  }
+
+  try {
+    const vectorDB = await createVectorDB(rootDir);
+    await vectorDB.initialize();
+    // Captured once so every symbol in this run shares the scan cache inside
+    // findDependents — only the first symbol in the batch pays the scanAll.
+    const indexVersion = vectorDB.getCurrentVersion();
+
+    const results: EnrichedSignatureDelta[] = [];
+    for (const delta of deltas) {
+      const changes = await Promise.all(
+        delta.changes.map(c => enrichOneChange(vectorDB, delta.filepath, c, indexVersion)),
+      );
+      results.push({ filepath: delta.filepath, changes });
+    }
+    return results;
+  } catch {
+    // The vectorDB itself failed to open (corrupt store, etc.) — degrade the
+    // whole batch rather than partially enrich and partially throw.
+    return deltas.map(d => ({ filepath: d.filepath, changes: d.changes.map(degradedChange) }));
+  }
+}
+
+function buildBlastEvent(delta: EnrichedSignatureDelta, now: Date): BlastEvent {
+  return {
+    timestamp: now.toISOString(),
+    filepath: delta.filepath,
+    changes: delta.changes.map(c => ({
+      symbol: c.symbol,
+      kind: c.kind,
+      dependentCount: c.dependentCount,
+      untestedDependentCount: c.untestedDependentCount,
+      riskLevel: c.riskLevel,
+    })),
+    enriched: delta.changes.some(c => c.enriched),
+  };
+}
+
+function fmtChange(c: EnrichedExportedSymbolChange): string {
+  const label = c.kind === 'removed' ? chalk.red('✗ removed  ') : chalk.yellow('⚠ changed  ');
+  const detail = c.enriched
+    ? ` — ${c.dependentCount} dependents, ${c.untestedDependentCount} untested, risk ${c.riskLevel}`
+    : chalk.dim(' — index unavailable for counts');
+  return `    ${label}${c.symbol}${detail}`;
+}
+
+/** Render the human-readable report. Pure — no I/O, no process state. */
+export function formatApiDeltaText(deltas: EnrichedSignatureDelta[], baseLabel = 'HEAD'): string {
+  const withChanges = deltas.filter(d => d.changes.length > 0);
+  if (withChanges.length === 0) {
+    return chalk.dim(`lien api-delta — no exported-signature changes vs ${baseLabel}`);
+  }
+
+  const lines: string[] = [
+    chalk.bold(`lien api-delta — exported-signature changes vs ${baseLabel}`),
+    '',
+  ];
+  for (const delta of withChanges) {
+    lines.push(`  ${chalk.cyan(delta.filepath)}`);
+    for (const change of delta.changes) lines.push(fmtChange(change));
+    lines.push('');
+  }
+  lines.push(
+    chalk.dim('  → run get_dependents on any changed/removed symbol before relying on callers.'),
+  );
+  return lines.join('\n');
+}
+
+async function collectChanges(
+  rootDir: string,
+  options: ApiDeltaOptions,
+): Promise<FileContentChange[]> {
+  if (options.file !== undefined) {
+    const single = await collectFileChange(rootDir, options.file, options.base);
+    return single ? [single] : [];
+  }
+  return collectFileChanges(rootDir, options.base);
+}
+
+/**
+ * Resolve the repo root and collect the changed-file content pairs, exiting 2
+ * on any operational failure (not a git repo, a git error). Split out of
+ * `apiDeltaCommand` purely to keep that function short and readable.
+ */
+async function resolveChanges(options: ApiDeltaOptions): Promise<{
+  rootDir: string;
+  changes: FileContentChange[];
+}> {
+  const rootDir = await getRepoRoot(process.cwd());
+  if (!rootDir) {
+    console.error(chalk.red('lien api-delta: not a git repository (or git is not installed)'));
+    process.exit(2);
+  }
+
+  try {
+    return { rootDir, changes: await collectChanges(rootDir, options) };
+  } catch (error) {
+    console.error(
+      chalk.red(
+        `lien api-delta: failed to read git changes: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+    process.exit(2);
+  }
+}
+
+/** Record one ledger event per changed file — never for a clean run (see blast-events.ts). */
+async function recordAllBlastEvents(
+  rootDir: string,
+  enriched: EnrichedSignatureDelta[],
+): Promise<void> {
+  const now = new Date();
+  for (const delta of enriched) {
+    await recordBlastEvent(rootDir, buildBlastEvent(delta, now));
+  }
+}
+
+/** Print the result in the requested format. `--file` mode prints a single flat object (what the hook parses). */
+function printResult(
+  options: ApiDeltaOptions,
+  changes: FileContentChange[],
+  enriched: EnrichedSignatureDelta[],
+): void {
+  if (options.format !== 'json') {
+    console.log(formatApiDeltaText(enriched, options.base ?? 'HEAD'));
+    return;
+  }
+  if (options.file === undefined) {
+    console.log(JSON.stringify(enriched));
+    return;
+  }
+  const fallbackFilepath = changes[0]?.filepath ?? options.file;
+  const primary = enriched.find(d => d.filepath === fallbackFilepath) ?? {
+    filepath: fallbackFilepath,
+    changes: [],
+  };
+  console.log(JSON.stringify(primary));
+}
+
+/** Analyze the working tree's exported-signature delta vs HEAD (or `--base <ref>`). */
+export async function apiDeltaCommand(options: ApiDeltaOptions): Promise<void> {
+  const usageError = usageFlagError(options);
+  if (usageError) {
+    console.error(chalk.red(`lien api-delta: ${usageError}`));
+    process.exit(2);
+  }
+
+  const { rootDir, changes } = await resolveChanges(options);
+
+  const deltas = changes.map(computeExportedSignatureDelta).filter(d => d.changes.length > 0);
+  const enriched = await enrichDeltas(rootDir, deltas);
+  await recordAllBlastEvents(rootDir, enriched);
+  printResult(options, changes, enriched);
+
+  // Advisory only — this is never a gate, so it always exits 0 once it ran.
+  process.exit(0);
+}

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -9,6 +9,7 @@ import { indexCommand } from './index-cmd.js';
 import { serveCommand } from './serve.js';
 import { complexityCommand } from './complexity.js';
 import { deltaCommand } from './delta-cmd.js';
+import { apiDeltaCommand } from './api-delta-cmd.js';
 import { statsCommand } from './stats-cmd.js';
 import { configSetCommand, configGetCommand, configListCommand } from './config.js';
 import { pathCommand } from './path-cmd.js';
@@ -103,6 +104,19 @@ program
     'Compare the working tree against this ref instead of HEAD (e.g. origin/main in CI)',
   )
   .action(deltaCommand);
+
+program
+  .command('api-delta')
+  .description(
+    'Flag exported-symbol signature changes/removals in the working tree (vs HEAD) — advisory, not a gate',
+  )
+  .option('--format <type>', 'Output format: text, json', 'text')
+  .option('--file <path>', 'Analyze only this file vs HEAD (fast path for edit hooks)')
+  .option(
+    '--base <ref>',
+    'Compare the working tree against this ref instead of HEAD (e.g. origin/main in CI)',
+  )
+  .action(apiDeltaCommand);
 
 program
   .command('stats')

--- a/packages/cli/src/cli/stats-cmd.test.ts
+++ b/packages/cli/src/cli/stats-cmd.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { recordDeltaEvent, type DeltaEvent } from '../utils/delta-events.js';
+import { recordBlastEvent, type BlastEvent } from '../utils/blast-events.js';
 import { statsCommand } from './stats-cmd.js';
 
 const execFileAsync = promisify(execFile);
@@ -178,5 +179,144 @@ describe('statsCommand', () => {
     const text = loggedText();
     expect(text).toContain('not proof');
     expect(text).not.toMatch(/warnings heeded/i);
+  });
+});
+
+function blastEvent(overrides: Partial<BlastEvent> = {}): BlastEvent {
+  return {
+    timestamp: new Date().toISOString(),
+    filepath: 'src/foo.ts',
+    changes: [
+      {
+        symbol: 'foo',
+        kind: 'signature-changed',
+        dependentCount: 2,
+        untestedDependentCount: 0,
+        riskLevel: 'low',
+      },
+    ],
+    enriched: true,
+    ...overrides,
+  };
+}
+
+describe('statsCommand — exported-signature nudge (blast-radius) section', () => {
+  let dir: string;
+  let home: string;
+  let originalCwd: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  async function git(...args: string[]): Promise<void> {
+    await execFileAsync('git', args, { cwd: dir });
+  }
+
+  async function initRepo(): Promise<void> {
+    await git('init', '-q');
+    await git('config', 'user.email', 'test@example.com');
+    await git('config', 'user.name', 'Test');
+    await git('config', 'commit.gpgsign', 'false');
+    await fs.writeFile(path.join(dir, 'README.md'), 'x', 'utf-8');
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'init');
+  }
+
+  async function runStats(options: Parameters<typeof statsCommand>[0] = {}): Promise<void> {
+    await statsCommand(options);
+  }
+
+  function lastJsonLog(): Record<string, unknown> {
+    const call = logSpy.mock.calls.at(-1);
+    return JSON.parse(String(call?.[0]));
+  }
+
+  function loggedText(): string {
+    return stripAnsi(logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n'));
+  }
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-stats-blast-cmd-'));
+    dir = await fs.realpath(dir);
+    originalCwd = process.cwd();
+    process.chdir(dir);
+
+    originalHome = process.env.LIEN_HOME;
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-stats-blast-home-'));
+    process.env.LIEN_HOME = home;
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.LIEN_HOME;
+    else process.env.LIEN_HOME = originalHome;
+    vi.restoreAllMocks();
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it('JSON output nests blast-radius stats under `blastRadius`, additive to the pre-existing shape', async () => {
+    await initRepo();
+    await recordBlastEvent(dir, blastEvent());
+    await runStats({ format: 'json' });
+
+    const result = lastJsonLog() as {
+      totalEvents: number;
+      windows: unknown[];
+      blastRadius: { totalEvents: number; windows: Array<{ windowDays: number; runs: number }> };
+    };
+    // Pre-existing top-level shape is untouched.
+    expect(result.totalEvents).toBe(0);
+    expect(result.windows).toHaveLength(2);
+    // New, additive section.
+    expect(result.blastRadius.totalEvents).toBe(1);
+    const win7 = result.blastRadius.windows.find(w => w.windowDays === 7)!;
+    expect(win7.runs).toBe(1);
+  });
+
+  it('text output prints the exported-signature nudge section with distinct symbols and risk buckets', async () => {
+    await initRepo();
+    await recordBlastEvent(dir, blastEvent());
+    await recordBlastEvent(
+      dir,
+      blastEvent({
+        filepath: 'src/bar.ts',
+        changes: [
+          {
+            symbol: 'Widget.render',
+            kind: 'removed',
+            dependentCount: 12,
+            untestedDependentCount: 3,
+            riskLevel: 'high',
+          },
+        ],
+      }),
+    );
+    await runStats({ format: 'text' });
+
+    const text = loggedText();
+    expect(text).toContain('Exported-signature nudge');
+    expect(text).toContain('Distinct symbols changed: 2');
+    expect(text).toContain('high 1');
+  });
+
+  it('still prints the friendly empty state when neither delta nor blast events exist', async () => {
+    await initRepo();
+    await runStats({ format: 'text' });
+    expect(loggedText()).toContain('No lien delta runs recorded yet');
+  });
+
+  it('prints both sections once only a blast event exists (delta log stays empty)', async () => {
+    await initRepo();
+    await recordBlastEvent(dir, blastEvent());
+    await runStats({ format: 'text' });
+
+    const text = loggedText();
+    expect(text).not.toContain('No lien delta runs recorded yet');
+    expect(text).toContain('lien delta — nudge-loop stats');
+    expect(text).toContain('Exported-signature nudge');
   });
 });

--- a/packages/cli/src/cli/stats-cmd.ts
+++ b/packages/cli/src/cli/stats-cmd.ts
@@ -12,8 +12,10 @@
 
 import chalk from 'chalk';
 import { getRepoRoot } from './delta-git.js';
-import { readDeltaEvents } from '../utils/delta-events.js';
+import { readDeltaEvents, type DeltaEvent } from '../utils/delta-events.js';
 import { computeDeltaWindowStats, type DeltaWindowStats } from '../utils/delta-stats.js';
+import { readBlastEvents, type BlastEvent } from '../utils/blast-events.js';
+import { computeBlastWindowStats, type BlastWindowStats } from '../utils/blast-stats.js';
 
 const VALID_FORMATS = ['text', 'json'];
 const WINDOW_DAYS = [7, 30] as const;
@@ -36,6 +38,86 @@ function formatWindow(stats: DeltaWindowStats): string {
   ].join('\n');
 }
 
+/** "exported-signature nudge" section — the FEATURE 1 blast-radius nudge's own local history. */
+function formatBlastWindow(stats: BlastWindowStats): string {
+  const { low, medium, high, critical, unknown } = stats.byRiskLevel;
+  const riskParts = [`low ${low}`, `medium ${medium}`, `high ${high}`, `critical ${critical}`];
+  if (unknown > 0) riskParts.push(`unknown ${unknown}`);
+  return [
+    chalk.bold(`  Last ${stats.windowDays} days`),
+    `    Runs: ${stats.runs}`,
+    `    Distinct symbols changed: ${stats.distinctSymbolsChanged}`,
+    `    By risk level: ${riskParts.join(', ')}`,
+  ].join('\n');
+}
+
+interface StatsData {
+  events: DeltaEvent[];
+  windows: DeltaWindowStats[];
+  blastEvents: BlastEvent[];
+  blastWindows: BlastWindowStats[];
+}
+
+/** Additive: FEATURE 1's own local history nests under `blastRadius`, so the pre-existing top-level shape (totalEvents/windows) never changes for callers. */
+function printJsonStats(data: StatsData): void {
+  console.log(
+    JSON.stringify(
+      {
+        totalEvents: data.events.length,
+        windows: data.windows,
+        blastRadius: { totalEvents: data.blastEvents.length, windows: data.blastWindows },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function printDeltaTextSection(data: StatsData): void {
+  for (const w of data.windows) {
+    console.log(formatWindow(w));
+    console.log('');
+  }
+  console.log(
+    chalk.dim(
+      '"Resolved after flag" means a flagged function was later seen clean — it is not proof\n' +
+        'the warning caused the fix. All data stays on this machine (delta-events.jsonl next to\n' +
+        'the local index); disable recording with LIEN_DELTA_EVENTS=off.',
+    ),
+  );
+}
+
+function printBlastTextSection(data: StatsData): void {
+  console.log('');
+  console.log(chalk.bold('Exported-signature nudge\n'));
+  for (const w of data.blastWindows) {
+    console.log(formatBlastWindow(w));
+    console.log('');
+  }
+  console.log(
+    chalk.dim(
+      "Tracks edits that changed or removed an exported symbol's signature, and the risk level\n" +
+        '(dependents/coverage) at the time. Local-only (blast-events.jsonl next to the local\n' +
+        'index); disable recording with LIEN_BLAST_EVENTS=off.',
+    ),
+  );
+}
+
+function printTextStats(data: StatsData): void {
+  console.log(chalk.bold('lien delta — nudge-loop stats\n'));
+  if (data.events.length === 0 && data.blastEvents.length === 0) {
+    console.log(
+      chalk.dim(
+        'No lien delta runs recorded yet. Run `lien delta`, or edit with the plugin hooks\n' +
+          'installed, to start building local history.',
+      ),
+    );
+    return;
+  }
+  printDeltaTextSection(data);
+  printBlastTextSection(data);
+}
+
 /** Analyze the local `lien delta` event log and report 7/30-day nudge-loop metrics. */
 export async function statsCommand(options: StatsOptions = {}): Promise<void> {
   const format = options.format ?? 'text';
@@ -54,32 +136,13 @@ export async function statsCommand(options: StatsOptions = {}): Promise<void> {
 
   const events = await readDeltaEvents(rootDir);
   const windows = WINDOW_DAYS.map(days => computeDeltaWindowStats(events, days));
+  const blastEvents = await readBlastEvents(rootDir);
+  const blastWindows = WINDOW_DAYS.map(days => computeBlastWindowStats(blastEvents, days));
+  const data: StatsData = { events, windows, blastEvents, blastWindows };
 
   if (format === 'json') {
-    console.log(JSON.stringify({ totalEvents: events.length, windows }, null, 2));
-    return;
+    printJsonStats(data);
+  } else {
+    printTextStats(data);
   }
-
-  console.log(chalk.bold('lien delta — nudge-loop stats\n'));
-  if (events.length === 0) {
-    console.log(
-      chalk.dim(
-        'No lien delta runs recorded yet. Run `lien delta`, or edit with the plugin hooks\n' +
-          'installed, to start building local history.',
-      ),
-    );
-    return;
-  }
-
-  for (const w of windows) {
-    console.log(formatWindow(w));
-    console.log('');
-  }
-  console.log(
-    chalk.dim(
-      '"Resolved after flag" means a flagged function was later seen clean — it is not proof\n' +
-        'the warning caused the fix. All data stays on this machine (delta-events.jsonl next to\n' +
-        'the local index); disable recording with LIEN_DELTA_EVENTS=off.',
-    ),
-  );
 }

--- a/packages/cli/src/utils/blast-events.test.ts
+++ b/packages/cli/src/utils/blast-events.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import {
+  recordBlastEvent,
+  readBlastEvents,
+  blastEventsFilePath,
+  blastEventsEnabled,
+  MAX_BYTES_BEFORE_TRIM,
+  KEEP_LINES_AFTER_TRIM,
+  type BlastEvent,
+} from './blast-events.js';
+
+let originalHome: string | undefined;
+let originalKillSwitch: string | undefined;
+let home: string;
+const rootDir = '/fake/repo/for-blast-events-test';
+
+function sampleEvent(overrides: Partial<BlastEvent> = {}): BlastEvent {
+  return {
+    timestamp: new Date().toISOString(),
+    filepath: 'src/foo.ts',
+    changes: [
+      {
+        symbol: 'foo',
+        kind: 'signature-changed',
+        dependentCount: 2,
+        untestedDependentCount: 0,
+        riskLevel: 'low',
+      },
+    ],
+    enriched: true,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  originalHome = process.env.LIEN_HOME;
+  originalKillSwitch = process.env.LIEN_BLAST_EVENTS;
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-blast-events-test-'));
+  process.env.LIEN_HOME = home;
+  delete process.env.LIEN_BLAST_EVENTS;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.LIEN_HOME;
+  else process.env.LIEN_HOME = originalHome;
+  if (originalKillSwitch === undefined) delete process.env.LIEN_BLAST_EVENTS;
+  else process.env.LIEN_BLAST_EVENTS = originalKillSwitch;
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+describe('blastEventsFilePath', () => {
+  it('lives inside the per-repo index directory', () => {
+    const filePath = blastEventsFilePath(rootDir);
+    expect(filePath).toBe(path.join(getIndexDir(rootDir), 'blast-events.jsonl'));
+  });
+});
+
+describe('blastEventsEnabled', () => {
+  it('is enabled by default', () => {
+    expect(blastEventsEnabled()).toBe(true);
+  });
+
+  it('is disabled when LIEN_BLAST_EVENTS=off', () => {
+    process.env.LIEN_BLAST_EVENTS = 'off';
+    expect(blastEventsEnabled()).toBe(false);
+  });
+
+  it('is enabled for any other value (only the literal "off" disables it)', () => {
+    process.env.LIEN_BLAST_EVENTS = 'false';
+    expect(blastEventsEnabled()).toBe(true);
+  });
+});
+
+describe('recordBlastEvent + readBlastEvents', () => {
+  it('reading before any event is recorded yields an empty array', async () => {
+    expect(await readBlastEvents(rootDir)).toEqual([]);
+  });
+
+  it('appends one event that round-trips through readBlastEvents', async () => {
+    const event = sampleEvent();
+    await recordBlastEvent(rootDir, event);
+
+    const events = await readBlastEvents(rootDir);
+    expect(events).toEqual([event]);
+  });
+
+  it('appends multiple events in order (oldest first)', async () => {
+    const first = sampleEvent({ timestamp: new Date(1000).toISOString() });
+    const second = sampleEvent({ timestamp: new Date(2000).toISOString(), filepath: 'src/bar.ts' });
+    await recordBlastEvent(rootDir, first);
+    await recordBlastEvent(rootDir, second);
+
+    expect(await readBlastEvents(rootDir)).toEqual([first, second]);
+  });
+
+  it('records a degraded (unenriched) event verbatim', async () => {
+    const degraded = sampleEvent({
+      enriched: false,
+      changes: [
+        {
+          symbol: 'foo',
+          kind: 'removed',
+          dependentCount: null,
+          untestedDependentCount: null,
+          riskLevel: null,
+        },
+      ],
+    });
+    await recordBlastEvent(rootDir, degraded);
+
+    const [read] = await readBlastEvents(rootDir);
+    expect(read).toEqual(degraded);
+  });
+
+  it('skips a torn/corrupted line rather than failing the whole read', async () => {
+    const good = sampleEvent();
+    await recordBlastEvent(rootDir, good);
+
+    const filePath = blastEventsFilePath(rootDir);
+    await fs.appendFile(filePath, '{not valid json\n', 'utf-8');
+    await recordBlastEvent(rootDir, sampleEvent({ filepath: 'src/bar.ts' }));
+
+    const events = await readBlastEvents(rootDir);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual(good);
+  });
+
+  it('skips a line that is valid JSON but the wrong shape, instead of crashing', async () => {
+    const good = sampleEvent();
+    await recordBlastEvent(rootDir, good);
+
+    const filePath = blastEventsFilePath(rootDir);
+    // Valid JSON, but changes is empty — a BlastEvent is never recorded with
+    // an empty changes array (see blast-events.ts), so this must not be
+    // trusted even though the JSON itself parses.
+    await fs.appendFile(
+      filePath,
+      `${JSON.stringify({ timestamp: new Date().toISOString(), filepath: 'x.ts', changes: [], enriched: true })}\n`,
+      'utf-8',
+    );
+    await recordBlastEvent(rootDir, sampleEvent({ filepath: 'src/bar.ts' }));
+
+    const events = await readBlastEvents(rootDir);
+    expect(events).toHaveLength(2);
+  });
+
+  it('skips a line whose changes array contains a malformed element', async () => {
+    const good = sampleEvent();
+    await recordBlastEvent(rootDir, good);
+
+    const filePath = blastEventsFilePath(rootDir);
+    const malformed = {
+      timestamp: new Date().toISOString(),
+      filepath: 'x.ts',
+      changes: [{ symbol: 'foo' }], // missing kind/dependentCount/etc.
+      enriched: true,
+    };
+    await fs.appendFile(filePath, `${JSON.stringify(malformed)}\n`, 'utf-8');
+    await recordBlastEvent(rootDir, sampleEvent({ filepath: 'src/bar.ts' }));
+
+    const events = await readBlastEvents(rootDir);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual(good);
+  });
+
+  it('LIEN_BLAST_EVENTS=off disables recording entirely (kill switch)', async () => {
+    process.env.LIEN_BLAST_EVENTS = 'off';
+    await recordBlastEvent(rootDir, sampleEvent());
+
+    expect(await readBlastEvents(rootDir)).toEqual([]);
+    await expect(fs.stat(blastEventsFilePath(rootDir))).rejects.toThrow();
+  });
+
+  it('never throws even if the index directory cannot be created', async () => {
+    const blocker = path.join(home, 'blocker-file');
+    await fs.writeFile(blocker, 'not a directory', 'utf-8');
+    process.env.LIEN_HOME = blocker;
+
+    await expect(recordBlastEvent(rootDir, sampleEvent())).resolves.toBeUndefined();
+  });
+});
+
+describe('truncation-from-front capping', () => {
+  it('trims the oldest lines once the log exceeds the byte cap, keeping the newest', async () => {
+    const filePath = blastEventsFilePath(rootDir);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+    const line = JSON.stringify(sampleEvent({ timestamp: new Date(0).toISOString() }));
+    const lineBytes = Buffer.byteLength(`${line}\n`, 'utf-8');
+    const linesNeeded = Math.ceil(MAX_BYTES_BEFORE_TRIM / lineBytes) + 50;
+
+    const seedLines: string[] = [];
+    for (let i = 0; i < linesNeeded; i++) {
+      seedLines.push(JSON.stringify(sampleEvent({ timestamp: new Date(i).toISOString() })));
+    }
+    await fs.writeFile(filePath, `${seedLines.join('\n')}\n`, 'utf-8');
+
+    const marker = sampleEvent({
+      timestamp: new Date(linesNeeded).toISOString(),
+      filepath: 'marker.ts',
+    });
+    await recordBlastEvent(rootDir, marker);
+
+    const events = await readBlastEvents(rootDir);
+    expect(events.length).toBeLessThanOrEqual(KEEP_LINES_AFTER_TRIM + 1);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.at(-1)).toEqual(marker);
+    expect(events[0].timestamp).not.toBe(new Date(0).toISOString());
+  });
+
+  it('does not trim while under the byte cap', async () => {
+    for (let i = 0; i < 10; i++) {
+      await recordBlastEvent(rootDir, sampleEvent({ timestamp: new Date(i).toISOString() }));
+    }
+    expect(await readBlastEvents(rootDir)).toHaveLength(10);
+  });
+});

--- a/packages/cli/src/utils/blast-events.ts
+++ b/packages/cli/src/utils/blast-events.ts
@@ -1,0 +1,155 @@
+/**
+ * Local, append-only JSONL event log for `lien api-delta` runs that found at
+ * least one exported-signature change — the raw material behind `lien
+ * stats`'s "exported-signature nudge" section. Sibling to `delta-events.ts`,
+ * not sharing its `DeltaEvent` shape: a blast-radius event has no exit code,
+ * mode, or complexity-crossing counts to speak of, and `lien api-delta` is
+ * advisory-only (no gate), so overloading `DeltaEvent` would mean bolting on
+ * fields that don't apply to either concept.
+ *
+ * One line is appended to `<indexDir>/blast-events.jsonl` (the same per-repo
+ * directory `delta-events.jsonl` lives in) per changed file that had at least
+ * one exported-signature change or removal — never for a clean edit, so
+ * `lien stats`'s "runs" count answers "edits that changed an exported
+ * signature", not "edits observed". There is no network call anywhere in this
+ * file, no telemetry, nothing phones home.
+ *
+ * Kill switch: `LIEN_BLAST_EVENTS=off` disables recording entirely (reading
+ * still works, so history already on disk stays visible to `lien stats`).
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import type { ExportedSymbolChangeKind } from './signature-delta.js';
+
+export const BLAST_EVENTS_FILENAME = 'blast-events.jsonl';
+
+/** Trigger: once the log exceeds this many bytes, trim it down. */
+export const MAX_BYTES_BEFORE_TRIM = 2 * 1024 * 1024; // 2 MB
+/** How many of the most recent lines survive a trim (oldest lines are dropped). */
+export const KEEP_LINES_AFTER_TRIM = 2000;
+
+export interface BlastEventChange {
+  symbol: string;
+  kind: ExportedSymbolChangeKind;
+  /** null when the index was unavailable or `findDependents` failed (degraded). */
+  dependentCount: number | null;
+  untestedDependentCount: number | null;
+  riskLevel: string | null;
+}
+
+export interface BlastEvent {
+  /** ISO-8601 timestamp of when the run completed. */
+  timestamp: string;
+  filepath: string;
+  /** Every exported-symbol change detected in this file this run. Never empty. */
+  changes: BlastEventChange[];
+  /** True when at least one change was enriched against the index. */
+  enriched: boolean;
+}
+
+/** `LIEN_BLAST_EVENTS=off` disables recording. Reading is never gated by this. */
+export function blastEventsEnabled(): boolean {
+  return process.env.LIEN_BLAST_EVENTS !== 'off';
+}
+
+/** Absolute path to the JSONL log for `rootDir`'s index directory. */
+export function blastEventsFilePath(rootDir: string): string {
+  return path.join(getIndexDir(rootDir), BLAST_EVENTS_FILENAME);
+}
+
+/**
+ * Append one event, then trim from the front once the log has grown past
+ * `MAX_BYTES_BEFORE_TRIM` — bounded, no silent unbounded growth. Best-effort
+ * throughout: any failure (unwritable disk, a race with a concurrent writer)
+ * is swallowed so recording can never break `lien api-delta` itself.
+ */
+export async function recordBlastEvent(rootDir: string, event: BlastEvent): Promise<void> {
+  if (!blastEventsEnabled()) return;
+  try {
+    const filePath = blastEventsFilePath(rootDir);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.appendFile(filePath, `${JSON.stringify(event)}\n`, 'utf-8');
+    await trimIfOversized(filePath);
+  } catch {
+    // Best-effort: recording must never break `lien api-delta` itself.
+  }
+}
+
+function byteSizeOf(lines: string[]): number {
+  return Buffer.byteLength(`${lines.join('\n')}\n`, 'utf-8');
+}
+
+/** Truncate-from-front once the log exceeds the byte cap — see delta-events.ts's twin for the full rationale. */
+async function trimIfOversized(filePath: string): Promise<void> {
+  const stats = await fs.stat(filePath).catch(() => null);
+  if (!stats || stats.size <= MAX_BYTES_BEFORE_TRIM) return;
+
+  const content = await fs.readFile(filePath, 'utf-8');
+  const lines = content.split('\n').filter(line => line.length > 0);
+
+  let kept = lines.length > KEEP_LINES_AFTER_TRIM ? lines.slice(-KEEP_LINES_AFTER_TRIM) : lines;
+  while (kept.length > 1 && byteSizeOf(kept) > MAX_BYTES_BEFORE_TRIM) {
+    kept = kept.slice(1);
+  }
+
+  if (kept.length === lines.length) return; // nothing to trim
+  await fs.writeFile(filePath, `${kept.join('\n')}\n`, 'utf-8');
+}
+
+function isValidBlastEventChange(value: unknown): value is BlastEventChange {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  if (typeof c.symbol !== 'string') return false;
+  if (c.kind !== 'signature-changed' && c.kind !== 'removed') return false;
+  if (typeof c.dependentCount !== 'number' && c.dependentCount !== null) return false;
+  if (typeof c.untestedDependentCount !== 'number' && c.untestedDependentCount !== null) {
+    return false;
+  }
+  if (typeof c.riskLevel !== 'string' && c.riskLevel !== null) return false;
+  return true;
+}
+
+/**
+ * Shape-validate a parsed JSONL line before trusting it as a `BlastEvent` — a
+ * torn write or hand-edited line must not crash a downstream consumer
+ * (`computeBlastWindowStats`'s per-change iteration). Skipped like a
+ * JSON.parse failure, not thrown.
+ */
+function isValidBlastEvent(value: unknown): value is BlastEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.timestamp !== 'string') return false;
+  if (typeof v.filepath !== 'string') return false;
+  if (typeof v.enriched !== 'boolean') return false;
+  return (
+    Array.isArray(v.changes) && v.changes.length > 0 && v.changes.every(isValidBlastEventChange)
+  );
+}
+
+/**
+ * Read every recorded event for `rootDir`, oldest first. A missing log (never
+ * ran `lien api-delta` here, or the kill switch has always been on) yields an
+ * empty array. A malformed line is skipped rather than failing the whole read.
+ */
+export async function readBlastEvents(rootDir: string): Promise<BlastEvent[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(blastEventsFilePath(rootDir), 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const events: BlastEvent[] = [];
+  for (const line of content.split('\n')) {
+    if (line.trim().length === 0) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isValidBlastEvent(parsed)) events.push(parsed);
+    } catch {
+      // Skip a torn/corrupted line rather than failing the whole read.
+    }
+  }
+  return events;
+}

--- a/packages/cli/src/utils/blast-stats.test.ts
+++ b/packages/cli/src/utils/blast-stats.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { computeBlastWindowStats } from './blast-stats.js';
+import type { BlastEvent } from './blast-events.js';
+
+const NOW = new Date('2026-07-15T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(n: number): string {
+  return new Date(NOW.getTime() - n * DAY_MS).toISOString();
+}
+
+function event(overrides: Partial<BlastEvent> = {}): BlastEvent {
+  return {
+    timestamp: daysAgo(0),
+    filepath: 'src/foo.ts',
+    changes: [
+      {
+        symbol: 'foo',
+        kind: 'signature-changed',
+        dependentCount: 2,
+        untestedDependentCount: 0,
+        riskLevel: 'low',
+      },
+    ],
+    enriched: true,
+    ...overrides,
+  };
+}
+
+describe('computeBlastWindowStats — windowing', () => {
+  it('counts zero runs when there are no events', () => {
+    const stats = computeBlastWindowStats([], 7, NOW);
+    expect(stats).toMatchObject({ windowDays: 7, runs: 0, distinctSymbolsChanged: 0 });
+  });
+
+  it('excludes events older than the window', () => {
+    const events = [event({ timestamp: daysAgo(1) }), event({ timestamp: daysAgo(8) })];
+    expect(computeBlastWindowStats(events, 7, NOW).runs).toBe(1);
+    expect(computeBlastWindowStats(events, 30, NOW).runs).toBe(2);
+  });
+
+  it('includes an event exactly at the window boundary', () => {
+    const events = [event({ timestamp: daysAgo(7) })];
+    expect(computeBlastWindowStats(events, 7, NOW).runs).toBe(1);
+  });
+
+  it('drops events with an unparsable timestamp instead of crashing', () => {
+    const events = [event({ timestamp: 'not-a-date' }), event({ timestamp: daysAgo(1) })];
+    expect(computeBlastWindowStats(events, 7, NOW).runs).toBe(1);
+  });
+});
+
+describe('computeBlastWindowStats — distinctSymbolsChanged', () => {
+  it('dedupes the same (filepath, symbol) across runs', () => {
+    const events = [
+      event({
+        filepath: 'a.ts',
+        changes: [
+          {
+            symbol: 'foo',
+            kind: 'signature-changed',
+            dependentCount: 1,
+            untestedDependentCount: 0,
+            riskLevel: 'low',
+          },
+        ],
+      }),
+      event({
+        filepath: 'a.ts',
+        changes: [
+          {
+            symbol: 'foo',
+            kind: 'removed',
+            dependentCount: 1,
+            untestedDependentCount: 0,
+            riskLevel: 'low',
+          },
+        ],
+      }),
+      event({
+        filepath: 'b.ts',
+        changes: [
+          {
+            symbol: 'foo',
+            kind: 'signature-changed',
+            dependentCount: 1,
+            untestedDependentCount: 0,
+            riskLevel: 'low',
+          },
+        ],
+      }),
+    ];
+    // Same symbol name in two different files counts as two distinct symbols.
+    expect(computeBlastWindowStats(events, 7, NOW).distinctSymbolsChanged).toBe(2);
+  });
+
+  it('counts multiple symbols changed within a single event', () => {
+    const events = [
+      event({
+        changes: [
+          {
+            symbol: 'foo',
+            kind: 'signature-changed',
+            dependentCount: 1,
+            untestedDependentCount: 0,
+            riskLevel: 'low',
+          },
+          {
+            symbol: 'Widget.render',
+            kind: 'removed',
+            dependentCount: 3,
+            untestedDependentCount: 1,
+            riskLevel: 'high',
+          },
+        ],
+      }),
+    ];
+    expect(computeBlastWindowStats(events, 7, NOW).distinctSymbolsChanged).toBe(2);
+  });
+});
+
+describe('computeBlastWindowStats — byRiskLevel', () => {
+  it('buckets each change by its riskLevel', () => {
+    const events = [
+      event({
+        changes: [
+          {
+            symbol: 'a',
+            kind: 'signature-changed',
+            dependentCount: 1,
+            untestedDependentCount: 0,
+            riskLevel: 'low',
+          },
+          {
+            symbol: 'b',
+            kind: 'removed',
+            dependentCount: 10,
+            untestedDependentCount: 2,
+            riskLevel: 'high',
+          },
+        ],
+      }),
+      event({
+        filepath: 'c.ts',
+        changes: [
+          {
+            symbol: 'c',
+            kind: 'signature-changed',
+            dependentCount: 60,
+            untestedDependentCount: 5,
+            riskLevel: 'critical',
+          },
+        ],
+      }),
+    ];
+    expect(computeBlastWindowStats(events, 7, NOW).byRiskLevel).toEqual({
+      low: 1,
+      medium: 0,
+      high: 1,
+      critical: 1,
+      unknown: 0,
+    });
+  });
+
+  it('buckets a degraded (null riskLevel) change as unknown', () => {
+    const events = [
+      event({
+        enriched: false,
+        changes: [
+          {
+            symbol: 'a',
+            kind: 'signature-changed',
+            dependentCount: null,
+            untestedDependentCount: null,
+            riskLevel: null,
+          },
+        ],
+      }),
+    ];
+    expect(computeBlastWindowStats(events, 7, NOW).byRiskLevel.unknown).toBe(1);
+  });
+});

--- a/packages/cli/src/utils/blast-stats.ts
+++ b/packages/cli/src/utils/blast-stats.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure aggregation over recorded `lien api-delta` events (see
+ * `blast-events.ts`) — the numbers behind `lien stats`'s "exported-signature
+ * nudge" section. No I/O: takes an in-memory event array, so it's trivially
+ * unit-testable with synthetic event sequences.
+ */
+
+import type { BlastEvent } from './blast-events.js';
+
+export type BlastRiskBucket = 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+
+const RISK_BUCKETS: readonly BlastRiskBucket[] = ['low', 'medium', 'high', 'critical', 'unknown'];
+
+export interface BlastWindowStats {
+  windowDays: number;
+  /** Edits in the window that changed or removed an exported symbol's signature. */
+  runs: number;
+  /** Distinct (filepath, symbol) pairs changed at least once in the window. */
+  distinctSymbolsChanged: number;
+  /** Count of individual changes in the window, bucketed by risk level ('unknown' = degraded, no index). */
+  byRiskLevel: Record<BlastRiskBucket, number>;
+}
+
+function eventTimeMs(event: BlastEvent): number {
+  return Date.parse(event.timestamp);
+}
+
+/** Events within the last `windowDays` days of `now`. Unparsable timestamps are dropped. */
+function eventsInWindow(events: BlastEvent[], windowDays: number, now: Date): BlastEvent[] {
+  const cutoffMs = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+  return events.filter(e => {
+    const t = eventTimeMs(e);
+    return Number.isFinite(t) && t >= cutoffMs;
+  });
+}
+
+function emptyRiskBuckets(): Record<BlastRiskBucket, number> {
+  return { low: 0, medium: 0, high: 0, critical: 0, unknown: 0 };
+}
+
+function riskBucket(riskLevel: string | null): BlastRiskBucket {
+  return riskLevel !== null && (RISK_BUCKETS as readonly string[]).includes(riskLevel)
+    ? (riskLevel as BlastRiskBucket)
+    : 'unknown';
+}
+
+/**
+ * Compute stats over the events whose timestamp falls within the last
+ * `windowDays` days of `now` (default: real current time).
+ */
+export function computeBlastWindowStats(
+  events: BlastEvent[],
+  windowDays: number,
+  now: Date = new Date(),
+): BlastWindowStats {
+  const inWindow = eventsInWindow(events, windowDays, now);
+  const symbolKeys = new Set<string>();
+  const byRiskLevel = emptyRiskBuckets();
+
+  for (const event of inWindow) {
+    for (const change of event.changes) {
+      symbolKeys.add(`${event.filepath} ${change.symbol}`);
+      byRiskLevel[riskBucket(change.riskLevel)]++;
+    }
+  }
+
+  return {
+    windowDays,
+    runs: inWindow.length,
+    distinctSymbolsChanged: symbolKeys.size,
+    byRiskLevel,
+  };
+}

--- a/packages/cli/src/utils/signature-delta.test.ts
+++ b/packages/cli/src/utils/signature-delta.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { computeExportedSignatureDelta } from './signature-delta.js';
+
+describe('computeExportedSignatureDelta — signature-changed', () => {
+  it('flags an exported top-level function whose signature changed', () => {
+    const before = 'export function formatUser(user) { return user.name; }';
+    const after = 'export function formatUser(user, opts) { return user.name; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+
+    expect(result.filepath).toBe('a.ts');
+    expect(result.changes).toEqual([
+      expect.objectContaining({
+        symbol: 'formatUser',
+        symbolName: 'formatUser',
+        kind: 'signature-changed',
+        beforeSignature: expect.stringContaining('formatUser(user)'),
+        afterSignature: expect.stringContaining('formatUser(user, opts)'),
+      }),
+    ]);
+  });
+
+  it('flags an exported class method whose signature changed, qualified by parentClass', () => {
+    const before = 'export class Widget { render(x) { return x; } }';
+    const after = 'export class Widget { render(x, y) { return x; } }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({
+        symbol: 'Widget.render',
+        symbolName: 'render',
+        parentClass: 'Widget',
+        kind: 'signature-changed',
+      }),
+    ]);
+  });
+
+  it('does not flag a body-only edit that leaves the signature unchanged', () => {
+    const before = 'export function formatUser(user) { return user.name; }';
+    const after = 'export function formatUser(user) { return user.name.trim(); }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('does not flag a non-exported function whose signature changed', () => {
+    const before = 'function helper(x) { return x; }';
+    const after = 'function helper(x, y) { return x; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('does not flag a newly-exported function (adding an export breaks no existing caller)', () => {
+    const before = 'function helper(x) { return x; }';
+    const after = 'export function helper(x) { return x; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+});
+
+describe('computeExportedSignatureDelta — removed', () => {
+  it('flags an exported function whose export was dropped, even though it still exists', () => {
+    const before = 'export function formatUser(user) { return user.name; }';
+    const after = 'function formatUser(user) { return user.name; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+
+    expect(result.changes).toEqual([
+      { symbol: 'formatUser', symbolName: 'formatUser', parentClass: undefined, kind: 'removed' },
+    ]);
+  });
+
+  it('flags an exported function that was deleted entirely', () => {
+    const before = 'export function formatUser(user) { return user.name; } function other() {}';
+    const after = 'function other() {}';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'formatUser', kind: 'removed' }),
+    ]);
+  });
+
+  it('flags every previously-exported symbol as removed when the whole file is deleted', () => {
+    const before =
+      'export function formatUser(user) { return user.name; } export class Widget { render() {} }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after: null });
+
+    const symbols = result.changes.map(c => c.symbol).sort();
+    expect(symbols).toEqual(['Widget.render', 'formatUser']);
+    expect(result.changes.every(c => c.kind === 'removed')).toBe(true);
+  });
+
+  it('flags a class method as removed when the class itself loses its export', () => {
+    const before = 'export class Widget { render(x) { return x; } }';
+    const after = 'class Widget { render(x) { return x; } }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'Widget.render', kind: 'removed' }),
+    ]);
+  });
+});
+
+describe('computeExportedSignatureDelta — hard-private methods are never flagged', () => {
+  it('ignores a #-prefixed private method even though its class is exported', () => {
+    const before = 'export class Widget { #helper(x) { return x; } }';
+    const after = 'export class Widget { #helper(x, y) { return x; } }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('does not flag a private method even when removed', () => {
+    const before = 'export class Widget { #helper(x) { return x; } }';
+    const after = 'export class Widget { }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+});
+
+describe('computeExportedSignatureDelta — brand new file', () => {
+  it('never flags anything for a newly-added file (nothing to compare against)', () => {
+    const after = 'export function formatUser(user) { return user.name; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before: null, after });
+    expect(result.changes).toEqual([]);
+  });
+});
+
+describe('computeExportedSignatureDelta — sort order (worst-first)', () => {
+  it('sorts removed before signature-changed', () => {
+    const before = [
+      'export function alpha(x) { return x; }',
+      'export function zeta(x) { return x; }',
+    ].join('\n');
+    const after = [
+      'export function alpha(x, y) { return x; }', // signature-changed
+      'function zeta(x) { return x; }', // removed
+    ].join('\n');
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+
+    expect(result.changes.map(c => c.symbol)).toEqual(['zeta', 'alpha']);
+    expect(result.changes[0].kind).toBe('removed');
+    expect(result.changes[1].kind).toBe('signature-changed');
+  });
+});

--- a/packages/cli/src/utils/signature-delta.test.ts
+++ b/packages/cli/src/utils/signature-delta.test.ts
@@ -41,6 +41,38 @@ describe('computeExportedSignatureDelta — signature-changed', () => {
     expect(result.changes).toEqual([]);
   });
 
+  it('does not flag a single-to-multi-line param reflow with a trailing comma (whitespace/format-only)', () => {
+    const before = 'export function foo(a, b) { return a + b; }';
+    const after = ['export function foo(', '  a,', '  b,', ') {', '  return a + b;', '}'].join(
+      '\n',
+    );
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('does not flag a trailing-comma-only addition (whitespace/format-only)', () => {
+    const before = 'export function foo(a, b) { return a + b; }';
+    const after = 'export function foo(a, b,) { return a + b; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('does not flag a comma-spacing change, f(a,b) -> f(a, b) (whitespace/format-only)', () => {
+    const before = 'export function foo(a,b) { return a + b; }';
+    const after = 'export function foo(a, b) { return a + b; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('still flags a positional parameter rename, f(a) -> f(input) (a real API-surface change, not noise)', () => {
+    const before = 'export function foo(a) { return a; }';
+    const after = 'export function foo(input) { return input; }';
+    const result = computeExportedSignatureDelta({ filepath: 'a.ts', before, after });
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'foo', kind: 'signature-changed' }),
+    ]);
+  });
+
   it('does not flag a non-exported function whose signature changed', () => {
     const before = 'function helper(x) { return x; }';
     const after = 'function helper(x, y) { return x; }';

--- a/packages/cli/src/utils/signature-delta.ts
+++ b/packages/cli/src/utils/signature-delta.ts
@@ -9,9 +9,13 @@
  * the deterministic half of the nudge; enrichment (dependent counts, risk)
  * happens separately, best-effort, against the index (see `api-delta-cmd.ts`).
  *
- * Reuses `complexity-delta.ts`'s exact machinery and known limitations
- * (qualified-name matching, positional overload pairing, renames not
- * tracked) — see docs/architecture/blast-radius-nudge.md.
+ * Reuses `complexity-delta.ts`'s exact qualified-name matching (function-level
+ * renames are not tracked, same as there). Covers exported top-level functions
+ * and exported class methods only — interface method signatures, exported
+ * type-alias function types, aliased re-exports, default exports, and
+ * TypeScript overload-declaration-only changes are known, safe-direction
+ * (silent) misses — see docs/architecture/blast-radius-nudge.md's "Known
+ * limitations".
  */
 
 import { chunkFile } from '@liendev/parser';
@@ -94,6 +98,26 @@ function functionMetadataByKey(
   return byKey;
 }
 
+/**
+ * Normalize a signature string for equality comparison only (display still
+ * uses the raw `before.signature`/`after.signature`). Collapses whitespace
+ * runs (including newlines) to nothing around structural punctuation, so a
+ * pure reflow — wrapping params onto multiple lines, adding/removing a
+ * trailing comma, or changing comma spacing (`f(a,b)` vs `f(a, b)`) — is
+ * invisible to the comparison. Deliberately does NOT touch identifier text:
+ * a positional parameter rename (`f(a)` -> `f(input)`) still produces a
+ * different normalized string and still fires — that's a real API-surface
+ * change in keyword-argument languages (e.g. Python), not noise. See the
+ * "Known limitations" section of docs/architecture/blast-radius-nudge.md.
+ */
+function normalizeSignature(signature: string): string {
+  return signature
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([(),])\s*/g, '$1')
+    .replace(/,\)/g, ')')
+    .trim();
+}
+
 /** Build the display name / bare name / parentClass triple for a matched pair's anchor. */
 function symbolIdentity(
   anchor: ChunkMetadata,
@@ -127,7 +151,9 @@ function classifyPair(
     return { ...symbolIdentity(before), kind: 'removed' };
   }
 
-  if (before.signature !== after.signature) {
+  const beforeSig = before.signature ?? '';
+  const afterSig = after.signature ?? '';
+  if (normalizeSignature(beforeSig) !== normalizeSignature(afterSig)) {
     return {
       ...symbolIdentity(after),
       kind: 'signature-changed',

--- a/packages/cli/src/utils/signature-delta.ts
+++ b/packages/cli/src/utils/signature-delta.ts
@@ -1,0 +1,174 @@
+/**
+ * Exported-symbol signature-delta primitive — the content-based, zero-index
+ * detector behind `lien api-delta` (FEATURE 1 / the blast-radius nudge).
+ *
+ * CLAUDE.md mandates running `get_dependents` before changing or removing the
+ * signature of an exported symbol, but nothing enforced it at edit time. This
+ * module answers, from two content strings alone, whether an edit changed or
+ * removed the signature of a symbol that was part of the file's public API —
+ * the deterministic half of the nudge; enrichment (dependent counts, risk)
+ * happens separately, best-effort, against the index (see `api-delta-cmd.ts`).
+ *
+ * Reuses `complexity-delta.ts`'s exact machinery and known limitations
+ * (qualified-name matching, positional overload pairing, renames not
+ * tracked) — see docs/architecture/blast-radius-nudge.md.
+ */
+
+import { chunkFile } from '@liendev/parser';
+import type { ChunkMetadata, FileContentChange } from '@liendev/parser';
+
+export type ExportedSymbolChangeKind = 'signature-changed' | 'removed';
+
+export interface ExportedSymbolChange {
+  /** Display name, parentClass-qualified when present: "Foo.bar" or "bar". */
+  symbol: string;
+  /** Bare name, for get_dependents / findDependents symbol tracking. */
+  symbolName: string;
+  parentClass?: string;
+  kind: ExportedSymbolChangeKind;
+  /** Present only for 'signature-changed'. */
+  beforeSignature?: string;
+  /** Present only for 'signature-changed'. */
+  afterSignature?: string;
+}
+
+export interface ExportedSignatureDelta {
+  filepath: string;
+  /** Empty => stay silent; caller (api-delta-cmd) treats this as "nothing to nudge". */
+  changes: ExportedSymbolChange[];
+}
+
+/** Qualified match key — identical to complexity-delta's `functionKey`. */
+function functionKey(meta: ChunkMetadata): string {
+  return `${meta.parentClass ?? ''}::${meta.symbolName ?? ''}`;
+}
+
+/**
+ * Whether a chunk is part of the file's exported API surface. Top-level
+ * functions are exported when their own name is in the file's exported-name
+ * list; methods are exported when their *class* is (methods don't appear in
+ * `exports` by name — see the premise verification in the PR description).
+ * Hard-private JS methods (`#foo`) are never external API surface even on an
+ * exported class, and are filtered out before this is ever called (see
+ * `functionMetadataByKey` below), so this never needs to special-case them.
+ */
+function isExportedChunk(meta: ChunkMetadata): boolean {
+  if (meta.symbolType === 'function') {
+    return !!meta.symbolName && (meta.exports?.includes(meta.symbolName) ?? false);
+  }
+  if (meta.symbolType === 'method') {
+    return !!meta.parentClass && (meta.exports?.includes(meta.parentClass) ?? false);
+  }
+  return false;
+}
+
+/**
+ * Chunk content into function/method metadata, grouped by qualified key and
+ * sorted by startLine so same-keyed functions (overloads) pair positionally —
+ * mirrors complexity-delta.ts's `functionMetadataByKey` exactly, so the two
+ * detectors can never structurally disagree on what counts as "the same
+ * function across versions". Hard-private methods (`#foo`) are dropped here:
+ * they can never break an external caller, so they should never surface as
+ * either a removal or a signature change.
+ */
+function functionMetadataByKey(
+  filepath: string,
+  content: string | null,
+): Map<string, ChunkMetadata[]> {
+  const byKey = new Map<string, ChunkMetadata[]>();
+  if (content === null) return byKey;
+
+  const chunks = chunkFile(filepath, content, { useAST: true, astFallback: 'line-based' });
+  for (const { metadata } of chunks) {
+    if (metadata.symbolType !== 'function' && metadata.symbolType !== 'method') continue;
+    if (!metadata.symbolName) continue;
+    if (metadata.symbolName.startsWith('#')) continue;
+    const key = functionKey(metadata);
+    const list = byKey.get(key) ?? [];
+    list.push(metadata);
+    byKey.set(key, list);
+  }
+  for (const list of byKey.values()) {
+    list.sort((a, b) => a.startLine - b.startLine);
+  }
+  return byKey;
+}
+
+/** Build the display name / bare name / parentClass triple for a matched pair's anchor. */
+function symbolIdentity(
+  anchor: ChunkMetadata,
+): Pick<ExportedSymbolChange, 'symbol' | 'symbolName' | 'parentClass'> {
+  const symbolName = anchor.symbolName ?? '';
+  const parentClass = anchor.parentClass;
+  return {
+    symbol: parentClass ? `${parentClass}.${symbolName}` : symbolName,
+    symbolName,
+    parentClass,
+  };
+}
+
+/**
+ * Classify one matched (before?, after?) pair. Returns null when there is
+ * nothing to report: never exported (on either side — a newly-added export
+ * breaks no existing caller, so it is deliberately not flagged either), or
+ * exported on both sides with an unchanged signature.
+ */
+function classifyPair(
+  before: ChunkMetadata | undefined,
+  after: ChunkMetadata | undefined,
+): ExportedSymbolChange | null {
+  const wasExported = before !== undefined && isExportedChunk(before);
+  if (!wasExported) return null;
+
+  const isExportedNow = after !== undefined && isExportedChunk(after);
+  if (!isExportedNow) {
+    // Deleted, or the export was dropped while the function still exists —
+    // either way, existing callers will break. The highest-blast-radius case.
+    return { ...symbolIdentity(before), kind: 'removed' };
+  }
+
+  if (before.signature !== after.signature) {
+    return {
+      ...symbolIdentity(after),
+      kind: 'signature-changed',
+      beforeSignature: before.signature,
+      afterSignature: after.signature,
+    };
+  }
+
+  return null; // exported on both sides, signature unchanged — silent
+}
+
+/** Worse (higher blast radius) first; deterministic tie-break by symbol name. */
+function compareChanges(a: ExportedSymbolChange, b: ExportedSymbolChange): number {
+  if (a.kind !== b.kind) return a.kind === 'removed' ? -1 : 1;
+  return a.symbol.localeCompare(b.symbol);
+}
+
+/**
+ * Compute the exported-signature delta for a single file's before/after
+ * content. Pure, content-only — zero LLM, zero index, zero git — so it is
+ * fully unit-testable with two content strings.
+ */
+export function computeExportedSignatureDelta(change: FileContentChange): ExportedSignatureDelta {
+  const beforePath = change.oldPath ?? change.filepath;
+  const beforeByKey = functionMetadataByKey(beforePath, change.before);
+  const afterByKey = functionMetadataByKey(change.filepath, change.after);
+
+  const allKeys = new Set<string>([...beforeByKey.keys(), ...afterByKey.keys()]);
+  const changes: ExportedSymbolChange[] = [];
+
+  for (const key of allKeys) {
+    const beforeList = beforeByKey.get(key) ?? [];
+    const afterList = afterByKey.get(key) ?? [];
+    const pairs = Math.max(beforeList.length, afterList.length);
+    for (let i = 0; i < pairs; i++) {
+      const result = classifyPair(beforeList[i], afterList[i]);
+      if (result) changes.push(result);
+    }
+  }
+
+  changes.sort(compareChanges);
+
+  return { filepath: change.filepath, changes };
+}

--- a/plugins/claude/hooks/api-delta-write.sh
+++ b/plugins/claude/hooks/api-delta-write.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Edit|Write|MultiEdit: warn, once, when an edit changed or
+# removed the signature of an EXPORTED function/method. This automates
+# CLAUDE.md's "run get_dependents before changing an exported symbol's
+# signature" rule the same way delta-write.sh already automates the
+# complexity-crossing rule — until now this one was honor-system only.
+#
+# Drives the same FEATURE-1 primitive as `lien api-delta`, through the
+# single-file fast path `lien api-delta --file <path> --format json`, so the
+# hook's warning and the CLI's own JSON can never diverge.
+#
+# Advisory only — there is no gate here (unlike `lien delta`), so the JSON's
+# `changes[]` array is the only thing that matters; exit code is ignored.
+#
+# Best-effort throughout — never fails the user's edit. Disable via
+# LIEN_BLAST_HOOK=off.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+. "$(dirname "${BASH_SOURCE[0]}")/lien-resolve.sh" || exit 0
+
+# Env kill switch.
+if [ "${LIEN_BLAST_HOOK:-}" = "off" ]; then
+  exit 0
+fi
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+case "$tool_name" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+[ -n "$file_path" ] || exit 0
+
+# Run the single-file check as JSON, from the session's cwd so the git root
+# and project root resolve against the right repo (multi-repo safe). Any
+# failure (not a git repo, unsupported file, git error -> exit 2) yields
+# empty/non-JSON output and we stay silent.
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  json="$(cd "$cwd" && "${LIEN_CMD[@]}" api-delta --file "$file_path" --format json 2>/dev/null)"
+else
+  json="$("${LIEN_CMD[@]}" api-delta --file "$file_path" --format json 2>/dev/null)"
+fi
+[ -n "$json" ] || exit 0
+
+# Build the warning from changes[] (already sorted worst-first by the
+# primitive: 'removed' before 'signature-changed'). The single-change case
+# (by far the common one) renders a full, self-contained sentence per kind/
+# enrichment state; 2-3 changes fall back to a terser combined line. Empty
+# array -> jq emits nothing -> stay silent.
+msg="$(printf '%s' "$json" | jq -r '
+  (.changes // []) as $c
+  | ($c | length) as $n
+  | if $n == 0 then empty
+    elif $n == 1 then
+      ($c[0]) as $x
+      | if $x.kind == "removed" then
+          if $x.enriched then
+            "⚠ lien: exported symbol removed — " + $x.symbol
+              + " (" + ($x.dependentCount|tostring) + " dependents, risk " + $x.riskLevel + ")."
+              + " Callers will break — check get_dependents."
+          else
+            "⚠ lien: exported symbol removed — " + $x.symbol + "."
+              + " Check get_dependents (index unavailable for counts)."
+          end
+        else
+          if $x.enriched then
+            "⚠ lien: exported signature changed — " + $x.symbol
+              + " (" + ($x.dependentCount|tostring) + " dependents, "
+              + ($x.untestedDependentCount|tostring) + " untested, risk " + $x.riskLevel + ")."
+              + " Run get_dependents before relying on callers."
+          else
+            "⚠ lien: exported signature changed — " + $x.symbol + "."
+              + " Check get_dependents (index unavailable for counts)."
+          end
+        end
+    else
+      ( [ $c[0:3][]
+          | if .kind == "removed" then
+              "removed " + .symbol
+                + (if .enriched then " (" + (.dependentCount|tostring) + " dependents, risk " + .riskLevel + ")" else " (index unavailable for counts)" end)
+            else
+              .symbol
+                + (if .enriched then " (" + (.dependentCount|tostring) + " dependents, " + (.untestedDependentCount|tostring) + " untested, risk " + .riskLevel + ")" else " (index unavailable for counts)" end)
+            end
+        ] | join("; ") ) as $joined
+      | "⚠ lien: " + ($n|tostring) + " exported-signature changes — " + $joined
+          + (if $n > 3 then " (+\($n - 3) more)" else "" end)
+          + ". Run get_dependents before relying on callers."
+    end
+')"
+[ -n "$msg" ] || exit 0
+
+# additionalContext is the only field that reaches the model on the next turn
+# (verified in CC 2.1.142; matches delta-write.sh / test-reminder.sh).
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' \
+  "$(printf '%s' "$msg" | jq -Rs .)"
+
+exit 0

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Plus write-time hooks: a delta warning (a function whose complexity newly crossed a threshold) and a test-association reminder (which tests to run). Suppresses repeats per session for 5 minutes.",
+  "description": "Lien Read-time impact annotator: surfaces dependents/coverage/complexity as a system reminder when the model reads an indexed file. Plus write-time hooks: a delta warning (a function whose complexity newly crossed a threshold), a blast-radius warning (an exported symbol's signature changed or was removed), and a test-association reminder (which tests to run). Suppresses repeats per session for 5 minutes.",
   "hooks": {
     "PreToolUse": [
       {
@@ -40,6 +40,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/test-reminder.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/api-delta-write.sh",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
## Summary

Adds a nudge for CLAUDE.md's other honor-system rule — "run `get_dependents` before changing the signature of an exported symbol" — the same way `lien delta` already nudges toward the complexity-threshold rule. **Scope: exported top-level functions and exported class methods only** — it does not cover interface method signatures, exported type-alias function types, aliased re-exports (`export { foo as bar }`), default exports, or a TypeScript overload-declaration-only signature change (all confirmed silent misses, safe direction — never a false positive). See `docs/architecture/blast-radius-nudge.md`'s "Known limitations" for the full list. Design doc: `.wip/nudge-design.md` (FEATURE 1 section), gitignored per this repo's `.wip/` convention; the durable design is promoted into `docs/architecture/blast-radius-nudge.md`.

- **`lien api-delta` CLI** (`packages/cli/src/cli/api-delta-cmd.ts`): content-based detection via a new pure primitive, `packages/cli/src/utils/signature-delta.ts`, reusing `chunkFile`'s existing `exports`/`signature` metadata (zero index touched for the common case). `--file`/`--base` mirror `lien delta`'s hook fast path and CI parity. **Advisory only — always exits 0**, no gate.
- **Best-effort enrichment**: `findDependents` + the shared `computeBlastRadiusRisk` primitive add dependent counts and a risk level when the index is available. Degrades to signature-only when no index exists (checked via a cheap `fs.access` on `structural.db` *before* `createVectorDB().initialize()`, so running the CLI never side-effects an empty index into existence) or when a lookup fails for one symbol.
- **`api-delta-write.sh`** hook (`plugins/claude/hooks/`): a sibling PostToolUse hook to `delta-write.sh`/`test-reminder.sh`, warning once per edit via `additionalContext`. Kill switch `LIEN_BLAST_HOOK=off`.
- **`blast-events.jsonl` ledger** + a second "Exported-signature nudge" section in `lien stats`, additive to its existing JSON shape (`blastRadius` key; pre-existing `totalEvents`/`windows` unchanged).
- Changeset (`@liendev/lien` minor).

## Premise verification (Step Zero)

The design doc's premise — that `chunkFile` populates `metadata.exports` (file-level exported names) and `metadata.signature` for functions/methods, and that for methods `exports` carries the *parent class* name, not the method name — was claimed but never actually verified before this PR (the prior attempt's environment was destroyed). Re-verified here against the **built** parser with a throwaway script:

```js
import { chunkFile } from '.../packages/parser/dist/chunker.js';
const chunks = chunkFile('test.ts', source, { useAST: true, astFallback: 'error' });
```//,
run against a fixture with an exported function, an exported class with a public and a `#private` method, and a non-exported class. Output confirmed:
- `exports` is file-level and identical across every chunk in the file (e.g. `["formatUser","Widget"]`).
- `signature` is populated for every function/method chunk.
- For `Widget.render` (method, `parentClass: "Widget"`), `exports` contains `"Widget"`, not `"render"` — confirming the class-name convention.
- `#privateHelper` is present in chunks but never itself in `exports` — confirming private methods need explicit filtering (which `signature-delta.ts` does).

Premise holds. Proceeded with the implementation as designed.

## Dogfood evidence (real PostToolUse stdin shape)

The global `lien` symlink on this machine points to a different parallel worktree, so a `PATH` shim resolving to this worktree's own `dist/index.js` was used for the hook dogfood (no `npm link` was run, to avoid mutating shared global state other concurrent agents may depend on).

**Enriched, signature-changed** (temporarily dropped a param from a real committed function, `computeDeltaWindowStats`, then reverted):
```
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"⚠ lien: exported signature changed — computeDeltaWindowStats (2 dependents, 0 untested, risk low). Run get_dependents before relying on callers."}}
```

**Enriched, removed** (same function, dropped its `export` keyword):
```
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"⚠ lien: exported symbol removed — computeDeltaWindowStats (2 dependents, risk low). Callers will break — check get_dependents."}}
```

**Degraded, no index** (fresh scratch git repo, never indexed):
```
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"⚠ lien: exported signature changed — greet. Check get_dependents (index unavailable for counts)."}}
```
Verified only `blast-events.jsonl` was created on disk for that scratch repo — never `structural.db` — confirming the pre-check avoids the side effect.

**Fail-open** (all exit 0, no `additionalContext`):
- Malformed stdin (non-JSON, and valid-JSON-missing-fields)
- Non-git directory

## A/B #1 (frozen protocol, N=8/arm, free CC subagents, zero OpenRouter spend)

Full write-up: `docs/development/blast-radius-nudge-ab.md`. **Honest null result**, reported as such: both conditions (with and without the injected warning) came back 8/8 on the primary metric. Root cause identified — subagents spawned from a session rooted in this repo appear to inherit this repo's own CLAUDE.md, which already states near-verbatim the rule the warning reinforces ("run `get_dependents` before ... changing the signature of any exported function..."), producing a ceiling effect: every control trial spontaneously cited `get_dependents`/CLAUDE.md unprompted, several by name ("per this project's CLAUDE.md rule", "In the real Lien repo, CLAUDE.md mandates..."). This differs from the companion `lien delta` A/B (`docs/development/nudge-behavioral-ab.md`), whose numeric-threshold signal doesn't textually overlap with any pre-loaded rule, so it didn't hit this confound. Raw per-trial transcripts in `.wip/ab-blast/` (gitignored). Not re-run or reframed post-hoc — the protocol was frozen before any trial launched, and the null is reported plainly per that freeze.

## Review fixes (applied in a follow-up commit, same PR)

1. **Whitespace/format-only signature reformats were false-firing.** `classifyPair` compared raw `metadata.signature` strings; a pure reflow (multi-line param wrapping, a trailing comma, comma-spacing) produced a different string and fired a spurious `signature-changed`. Fixed via a new `normalizeSignature` helper (collapses whitespace around structural punctuation, drops a trailing comma before the closing paren) used only for the equality check — `beforeSignature`/`afterSignature` in the output still carry the raw values. Deliberately does **not** suppress a positional parameter rename (`f(a)` → `f(input)`) — that's a real API-surface change in keyword-argument languages, not noise. Added 4 tests: multi-line reflow + trailing comma, trailing-comma-only, comma-spacing-only (all now silent), and the rename case (still fires).
2. **Scope-accuracy**: softened this PR's own framing (see Summary above) and added a "Known limitations" section to `docs/architecture/blast-radius-nudge.md` naming the 5 verified-missed shapes (interface methods, type-alias function types, aliased re-exports, default exports — reference-form and anonymous).
3. **Doc-accuracy**: corrected the "overload pairing" claim — verified empirically (via the built parser) that TS overload-declaration lines are never emitted as their own chunks, so the inherited positional-pairing mechanism never actually engages for that canonical case; an overload-declaration-only signature change is a silent miss. Doc now states this plainly instead of describing pairing as if it covers overloads.
4. **Test quality**: `api-delta-cmd.test.ts`'s enrichment test asserted `dependentCount >= 0` (vacuous). Tightened to the real expected values from the stub index (`dependentCount: 1`, `untestedDependentCount: 1`).

## Gate chain

`format:check`, `lint` (0 errors, pre-existing-pattern warnings only), `typecheck` (full monorepo), `build` (full monorepo), `npm test` (full monorepo: parser-native/parser/core/review/cli/action, all green), and `node packages/cli/dist/index.js delta` (exit 0, no new crossings — all new functions land under threshold). Re-ran in full after the review-fix commit.

## Test plan

- [x] Unit tests: `signature-delta.test.ts` (17 tests, pure two-content-string style, incl. the 4 new normalization cases), `blast-events.test.ts` (15), `blast-stats.test.ts` (8), `api-delta-cmd.test.ts` (13, JSON shape + real git fixtures + a mocked-index enrichment case with tightened assertions), `stats-cmd.test.ts` additions (4 new tests for the additive `blastRadius` JSON section + text rendering)
- [x] Full gate chain green (see above), re-run after the review-fix commit
- [x] Hook dogfooded with the real PostToolUse stdin shape (enriched × 2 kinds, degraded, 2 fail-open cases)
- [x] A/B #1 run per the frozen protocol; null result reported honestly with root-cause diagnosis

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds an advisory blast-radius nudge for exported-signature edits: a new `lien api-delta` CLI command, a PostToolUse hook, a local JSONL event ledger, and a `lien stats` section. The implementation is intentionally fail-open throughout — operational errors degrade to signature-only output, recording errors are swallowed, and the CLI exits 0 on successful runs. The detection primitive correctly handles exported top-level functions, exported-class methods, and hard-private methods; enrichment reuses existing `findDependents` + `computeBlastRadiusRisk` primitives. All changed logic is covered by unit and integration tests, and the docs accurately describe the advisory behavior and graceful-degradation paths.
>
> - Added `lien api-delta` CLI and `signature-delta.ts` content-based detection for exported-signature changes/removals
> - Added `blast-events.jsonl` ledger and `blast-stats.ts` aggregation, surfaced in `lien stats` under an additive `blastRadius` key
> - Added `plugins/claude/hooks/api-delta-write.sh` PostToolUse hook with kill switch `LIEN_BLAST_HOOK=off

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 84e2eb1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lien api-delta` to detect changes or removals to exported API signatures.
  * Added advisory blast-radius warnings after supported file edits, including dependent counts and risk when available.
  * Added optional local event tracking with configurable kill switches.
  * Extended `lien stats` with exported-signature activity, distinct symbols changed, and risk-level breakdowns.

* **Documentation**
  * Documented the blast-radius nudge, CLI behavior, warnings, reporting, limitations, and experiment results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->