### PR TITLE
docs(development): context-neutral re-runs of the blast-radius and test-verification nudge A/Bs

### DIFF
--- a/docs/development/blast-radius-nudge-ab.md
+++ b/docs/development/blast-radius-nudge-ab.md
@@ -379,18 +379,22 @@ and it is reported as a null rather than reframed as inconclusive-therefore-
 supportive, per this document's own standing rule against post-hoc
 reframing.
 
-**Validity caveat.** A synthetic, zero-context environment (no CLAUDE.md, no
-enabled plugins, no prior conversation, single forced generation turn) is a
-ceiling on how large a nudge's measured effect can be in the other
-direction too: it removes not only the contamination that produced the
-original's false ceiling, but also every ordinary source of context a real
-coding session carries (a real project's own conventions, prior turns,
-accumulated task framing). A real repository usually does carry some
-instructions, just not, usually, the specific ones under test here. So this
-number should be read as a lower bound on what a genuinely naive agent does
-by default, not as a forecast of the nudge's effect inside an actual, more
-richly contextualized coding session. Zero context is a floor for isolating
-the mechanism, not a simulation of production use.
+**Validity caveat.** This is not a literally zero-context environment: the
+user's ambient `~/.claude/rules/context7.md` rule remained active throughout
+(see above), unrelated to either nudged behavior but present nonetheless.
+What was actually achieved is an environment free of repository context,
+CLAUDE.md, and the Lien plugin (no enabled plugins, no prior conversation,
+single forced generation turn), which is a ceiling on how large a nudge's
+measured effect can be in the other direction too: it removes not only the
+contamination that produced the original's false ceiling, but also every
+ordinary source of context a real coding session carries (a real project's
+own conventions, prior turns, accumulated task framing). A real repository
+usually does carry some instructions, just not, usually, the specific ones
+under test here. So this number should be read as a lower bound on what a
+genuinely naive agent does by default, not as a forecast of the nudge's
+effect inside an actual, more richly contextualized coding session. An
+environment free of repository, CLAUDE.md, and Lien-plugin context is a
+floor for isolating the mechanism, not a simulation of production use.
 
 ### Artifacts (this section)
 

--- a/docs/development/blast-radius-nudge-ab.md
+++ b/docs/development/blast-radius-nudge-ab.md
@@ -245,3 +245,157 @@ judgment about whether they're worth the additional trial cost.
 - Protocol: `.wip/ab-blast/protocol.md` (gitignored, referenced above)
 - Raw per-trial outputs: `.wip/ab-blast/trials/{control,signal}-{1..8}.md`
   (gitignored)
+
+---
+
+## 2026-07-24: A/B #1b, context-neutral re-run
+
+The null result above was diagnosed as a ceiling effect caused by trial
+subagents inheriting this repo's own CLAUDE.md (they were launched via the
+`Agent` tool from a session rooted in this Lien repository). This section
+re-runs the same experiment with prompts, target file, warning block,
+rubric, exclusion rules, and N identical to the frozen protocol above (see
+`.wip/ab-neutral/protocol-1b.md`, gitignored, for the full pre-registration).
+The only change is the execution environment: each trial ran headlessly via
+`claude -p --model sonnet`, from a synthetic directory outside any git
+repository and outside any directory carrying a CLAUDE.md, instead of via
+the `Agent` tool from within this repo.
+
+### Mandatory contamination probe (run before any trial)
+
+Before pre-registering, a probe was run against the planned invocation from
+a confirmed-clean directory (no git repo, no CLAUDE.md anywhere up to `/`).
+The probe asked the model to quote, verbatim, any project instructions or
+repo-specific rules present in its context.
+
+Result: contaminated. The response's own system-reminder block listed
+`plugin:lien:lien` among "MCP servers ... still connecting," even though the
+directory had no git repo and no CLAUDE.md. Root cause: the Lien plugin is
+enabled at user level in `~/.claude/settings.json` (`enabledPlugins`), not
+per repo, so its MCP instructions (which state, verbatim, "REQUIRED before
+renaming, removing, or changing the signature of any exported symbol:
+get_dependents(...)") auto-attach to every `claude` session on this machine
+regardless of directory. This is a second, independent contamination
+channel from the one originally diagnosed (repo CLAUDE.md inheritance): the
+confound was two-layered all along. The original A/B #1 trials, launched
+from a session with this same plugin enabled, carried both layers at once,
+which strengthens rather than weakens the original ceiling-effect
+interpretation.
+
+Fix, verified before any trial ran: adding `--strict-mcp-config
+--mcp-config <empty mcpServers file>` to the invocation (identical for both
+arms) produced a re-probe with zero mention of lien, get_dependents,
+complexity, or test-association content. The only remaining ambient item in
+context was the user's global `~/.claude/rules/context7.md` rule (fetch
+current docs via Context7 MCP for library/framework questions), present
+identically in every trial regardless of condition; it is orthogonal to
+caller-impact checking and cannot produce a control vs. signal difference,
+recorded here honestly rather than scrubbed. Raw probe outputs (both the
+contaminated run and the verified-clean run) are archived at
+`.wip/ab-neutral/probes/probe-contaminated.txt` and
+`.wip/ab-neutral/probes/probe-clean.txt`.
+
+### Results
+
+32 headless trials for this document's experiment plus its #2b sibling ran
+without error (0 invalid, matching the original's 0/16). Zero control
+trials, across either experiment, mention Lien, CLAUDE.md, get_dependents,
+or any repo-specific rule, confirming the fix held at trial time, not just
+at probe time (checked by grepping all 32 raw outputs for those terms).
+
+**Primary metric, as literally specified (criterion a or b):**
+
+| Condition | Addressed caller impact | Rate |
+|---|---|---|
+| Control (no warning) | 8 / 8 | 100% |
+| Signal (warning injected) | 8 / 8 | 100% |
+
+Same non-discrimination as the original, and for the same reason: "thread
+`opts` through" mechanically forces every competent completion to update the
+3 in-file call sites (criterion a), so this half of the metric still cannot
+discriminate between conditions. Not new information; reproduced here for
+completeness.
+
+**The real discriminator: spontaneous reasoning about callers beyond the 3
+visible in-file call sites (criterion b alone):**
+
+| Condition | Explicitly discussed beyond-file callers/dependents | Rate |
+|---|---|---|
+| Control (no warning) | 7 / 8 | 87.5% |
+| Signal (warning injected) | 8 / 8 | 100% |
+
+This is a small, directional difference (one trial), not the 8/8 vs. 8/8
+dead heat the original (contaminated) run produced. Every signal trial
+explicitly flagged that the file's 3 visible call sites don't account for
+the warning's claimed "4 dependents" and recommended locating the 4th (five
+of eight named `get_dependents` specifically, echoing the warning's own
+wording, which is expected since the tool name is literally in the injected
+text). Seven of eight control trials, despite never seeing any dependent
+count or tool name, independently raised the general risk that "any code
+outside this file" or "external callers" of the four exported functions
+would need auditing, in generic language with no mention of Lien or any
+specific tool. One control trial (control-8) did not raise this at all.
+
+With N=8 per arm, a 7/8 vs. 8/8 split is not a result that supports a lift
+claim: it could easily reverse on a re-roll. It is reported plainly, not
+inflated. What it does establish, cleanly, is that in a genuinely
+context-free environment, most naive agents (not just contaminated ones)
+already reason about beyond-file caller impact when asked to change an
+exported function's signature, control or signal alike. That is a different
+and more interesting finding than the original's ceiling effect: it
+suggests this specific caller-impact instinct is close to a baseline
+property of the model on this kind of task, not solely an artifact of
+repo-specific instructions or of Lien's plugin. The signal condition's 8/8
+sits at the same ceiling as control's 7/8, so this run still cannot cleanly
+isolate the warning's marginal lift over that baseline; it only narrows how
+much headroom there was to move.
+
+**Secondary metric: acknowledging the specific "1 untested" dependent
+(signal only, unchanged rubric):**
+
+| Condition | Acknowledges "1 untested" specifically | Rate |
+|---|---|---|
+| Control (no warning) | 0 / 8 | 0% (never shown the figure) |
+| Signal (warning injected) | 8 / 8 | 100% |
+
+Identical to the original: every signal trial read and repeated the
+warning's specific numbers faithfully. As before, this shows the warning's
+content is legible, not that it changed behavior the agent wouldn't
+otherwise have reached.
+
+### Honest read
+
+This re-run removed the two identified contamination channels (repo
+CLAUDE.md and the user-level Lien plugin) and still could not produce a
+clean control vs. signal separation on the primary metric: both remain at
+100%, because the task itself forces criterion (a). On the sharper
+criterion (b) measure, the gap narrowed from 8/8 vs. 8/8 (original,
+contaminated) to 7/8 vs. 8/8 (this run, verified clean), a one-trial
+difference that is directionally consistent with the warning having some
+effect but is far too small, at N=8, to call a result. Read plainly: this is
+a second null for the question this protocol was designed to answer,
+arrived at with a materially cleaner environment than the first attempt,
+and it is reported as a null rather than reframed as inconclusive-therefore-
+supportive, per this document's own standing rule against post-hoc
+reframing.
+
+**Validity caveat.** A synthetic, zero-context environment (no CLAUDE.md, no
+enabled plugins, no prior conversation, single forced generation turn) is a
+ceiling on how large a nudge's measured effect can be in the other
+direction too: it removes not only the contamination that produced the
+original's false ceiling, but also every ordinary source of context a real
+coding session carries (a real project's own conventions, prior turns,
+accumulated task framing). A real repository usually does carry some
+instructions, just not, usually, the specific ones under test here. So this
+number should be read as a lower bound on what a genuinely naive agent does
+by default, not as a forecast of the nudge's effect inside an actual, more
+richly contextualized coding session. Zero context is a floor for isolating
+the mechanism, not a simulation of production use.
+
+### Artifacts (this section)
+
+- Pre-registration: `.wip/ab-neutral/protocol-1b.md` (gitignored)
+- Probe outputs: `.wip/ab-neutral/probes/probe-contaminated.txt`,
+  `.wip/ab-neutral/probes/probe-clean.txt` (gitignored)
+- Raw per-trial outputs: `.wip/ab-neutral/trials/blast/{control,signal}-{1..8}.md`
+  (gitignored)

--- a/docs/development/test-verification-nudge-ab.md
+++ b/docs/development/test-verification-nudge-ab.md
@@ -347,16 +347,20 @@ lean on but its own training, already tests before finishing at this task's
 scale. A null from naive agents is real information, not a failed
 experiment, and it is reported as such rather than downplayed.
 
-**Validity caveat.** As with the sibling re-run, a synthetic, zero-context
-environment is a ceiling on how large an effect can be measured in either
-direction: it removes the contamination that inflated the original's
-control condition, but it also removes every ordinary source of context a
-real session carries. A real repository usually does carry some
-instructions, just not, usually, the specific ones under test here. This
-number is a lower bound on what a genuinely naive agent does by default,
-not a forecast of the advisory's effect inside an actual, more richly
-contextualized coding session where an agent may be under time or context
-pressure the single-turn setup here cannot reproduce.
+**Validity caveat.** As with the sibling re-run, this is not a literally
+zero-context environment: the user's ambient `~/.claude/rules/context7.md`
+rule remained active throughout, unrelated to the test-verification
+behavior but present nonetheless. What was actually achieved, an
+environment free of repository context, CLAUDE.md, and the Lien plugin, is
+a ceiling on how large an effect can be measured in either direction: it
+removes the contamination that inflated the original's control condition,
+but it also removes every ordinary source of context a real session
+carries. A real repository usually does carry some instructions, just not,
+usually, the specific ones under test here. This number is a lower bound on
+what a genuinely naive agent does by default, not a forecast of the
+advisory's effect inside an actual, more richly contextualized coding
+session where an agent may be under time or context pressure the
+single-turn setup here cannot reproduce.
 
 ### Artifacts (this section)
 

--- a/docs/development/test-verification-nudge-ab.md
+++ b/docs/development/test-verification-nudge-ab.md
@@ -222,3 +222,146 @@ document's and its sibling's standing "no post-hoc re-framing" rule.
 
 - Protocol: `.wip/ab-testverify/protocol.md` (gitignored, reproduced above)
 - Raw per-trial outputs: `.wip/ab-testverify/trials/results.md` (gitignored)
+
+---
+
+## 2026-07-24: A/B #2b, context-neutral re-run
+
+The null result above was diagnosed as the same class of confound as the
+sibling blast-radius A/B: trial subagents inheriting this repo's own
+CLAUDE.md (they were launched via the `Agent` tool from a session rooted in
+this Lien repository). This section re-runs the same experiment with
+prompt template, advisory text, rubric, exclusion rules, and N identical to
+the frozen protocol above (see `.wip/ab-neutral/protocol-2b.md`, gitignored,
+for the full pre-registration, which shares the same environment amendment
+as A/B #1b's). The only change is the execution environment: each trial ran
+headlessly via `claude -p --model sonnet`, from a synthetic directory
+outside any git repository and outside any directory carrying a CLAUDE.md,
+instead of via the `Agent` tool from within this repo.
+
+### Mandatory contamination probe (shared with A/B #1b, run once before any trial)
+
+The same probe covers both re-runs, since both use the identical execution
+environment. Result: contaminated as run. A confirmed-clean directory (no
+git repo, no CLAUDE.md anywhere up to `/`) still produced a response whose
+system-reminder block listed `plugin:lien:lien` among "MCP servers ... still
+connecting." Root cause: the Lien plugin is enabled at user level in
+`~/.claude/settings.json` (`enabledPlugins`), not per repo, so its MCP
+instructions auto-attach to every `claude` session on this machine
+regardless of directory. For this specific experiment, the fit is
+especially direct: those same MCP instructions state, verbatim, "Always
+check testAssociations and run those tests after changes" as part of the
+mandatory `get_files_context` guidance, which is close to word for word the
+behavior this advisory exists to nudge. That is a concrete, previously
+unidentified channel the original write-up's control-7 bleed-through
+(fabricating "the hook flagged these tests as unrun") could have traveled
+through, in addition to CLAUDE.md text. The confound was two-layered all
+along, which strengthens rather than weakens the original ceiling-effect
+interpretation.
+
+Fix, verified before any trial ran: adding `--strict-mcp-config
+--mcp-config <empty mcpServers file>` to the invocation (identical for both
+arms) produced a re-probe with zero mention of lien, get_dependents,
+complexity, or test-association content. The only remaining ambient item in
+context was the user's global `~/.claude/rules/context7.md` rule, present
+identically in every trial regardless of condition; it is orthogonal to
+running associated tests and cannot produce a control vs. signal
+difference, recorded here honestly rather than scrubbed. Raw probe outputs
+are archived at `.wip/ab-neutral/probes/probe-contaminated.txt` and
+`.wip/ab-neutral/probes/probe-clean.txt` (shared with A/B #1b).
+
+### Results
+
+32 headless trials for this document's experiment plus its #1b sibling ran
+without error (0 invalid, matching the original's 0/16). Zero control
+trials, across either experiment, mention Lien, "the hook," CLAUDE.md, or
+any repo-specific rule, confirming the fix held at trial time, not just at
+probe time (checked by grepping all 32 raw outputs for those terms). Unlike
+the original run, no control trial in this re-run fabricated a mechanism it
+was never told about.
+
+**Primary metric (unchanged rubric):**
+
+| Condition | Ran at least one named test | Rate |
+|---|---|---|
+| Control (no advisory) | 8 / 8 | 100% |
+| Signal (advisory injected) | 8 / 8 | 100% |
+
+Null, identically to the original, and to the sibling blast-radius re-run's
+primary metric. Every response, both conditions, was a next action that ran
+tests.
+
+**Secondary metric: both tests vs. one:**
+
+| Condition | Ran BOTH named tests | Rate |
+|---|---|---|
+| Control | 8 / 8 | 100% |
+| Signal | 8 / 8 | 100% |
+
+Every trial, both conditions, named both `foo.test.ts` and `bar.test.ts`,
+either via `npx jest <path> <path>` or `npm test -- <path> <path>`.
+
+**Secondary metric: scoped vs. broad:**
+
+16 / 16 scoped. Every response named the specific file path(s); none
+reached for a bare, whole-suite command.
+
+**Secondary metric: explicit reference to the advisory (signal only):**
+
+2 / 8. Six of eight signal trials returned only the bare command with no
+accompanying prose (matching the original's observation that a terse
+"just the command" answer under-counts this metric by construction, not
+evidence the advisory was ignored). Of the two that added prose,
+signal-6 wrote "since the ledger indicates they haven't executed yet this
+session" (echoing the advisory's own distinctive "this ledger can't see"
+phrasing) and signal-7 wrote "since edits were made but no test execution
+was observed" (echoing the advisory's "I did not observe running in a Bash
+command"). Both paraphrase the advisory's specific language rather than
+just generic "run your tests" reasoning, so both count as explicit
+references under the original rubric's intent.
+
+### Honest read
+
+This re-run removed the two identified contamination channels (repo
+CLAUDE.md and the user-level Lien plugin, the latter newly identified via
+this re-run's own probe) and the result did not move: 8/8 vs. 8/8 on the
+primary metric, exactly as in the original contaminated run. Unlike the
+sibling blast-radius re-run, there is no secondary "beyond what's strictly
+required" measure available here to look for a smaller, directional
+difference: "run the two tests you just touched" is a single binary
+decision with no equivalent second tier, so this experiment's null is
+uniform across every metric checked, primary and secondary alike. Read
+plainly: this is a second, cleaner null for the same question, not
+reframed as inconclusive-therefore-supportive, per this document's own
+standing rule against post-hoc reframing.
+
+This is, if anything, a more informative null than the blast-radius
+sibling's. It suggests "run the tests associated with the files you just
+edited before ending your turn" is close to a default behavior a current
+Sonnet model reaches for on its own, in a single forced-generation turn,
+with no CLAUDE.md, no enabled plugins, no prior conversation, and no
+mention of Lien, a hook, or any repo convention anywhere in its prompt or
+its context. That is a genuinely useful, if humbling, pre-launch finding
+about this specific nudge: even a maximally naive agent, with nothing to
+lean on but its own training, already tests before finishing at this task's
+scale. A null from naive agents is real information, not a failed
+experiment, and it is reported as such rather than downplayed.
+
+**Validity caveat.** As with the sibling re-run, a synthetic, zero-context
+environment is a ceiling on how large an effect can be measured in either
+direction: it removes the contamination that inflated the original's
+control condition, but it also removes every ordinary source of context a
+real session carries. A real repository usually does carry some
+instructions, just not, usually, the specific ones under test here. This
+number is a lower bound on what a genuinely naive agent does by default,
+not a forecast of the advisory's effect inside an actual, more richly
+contextualized coding session where an agent may be under time or context
+pressure the single-turn setup here cannot reproduce.
+
+### Artifacts (this section)
+
+- Pre-registration: `.wip/ab-neutral/protocol-2b.md` (gitignored)
+- Probe outputs: `.wip/ab-neutral/probes/probe-contaminated.txt`,
+  `.wip/ab-neutral/probes/probe-clean.txt` (gitignored, shared with A/B #1b)
+- Raw per-trial outputs:
+  `.wip/ab-neutral/trials/testverify/{control,signal}-{1..8}.md` (gitignored)


### PR DESCRIPTION
## Summary

- Re-runs A/B #1 (blast-radius, `docs/development/blast-radius-nudge-ab.md`, from #841) and A/B #2 (test-verification, `docs/development/test-verification-nudge-ab.md`, from #843) with the identical frozen prompts, targets, and rubrics, changing only the execution environment: headless `claude -p --model sonnet` from a synthetic directory outside any git repo and outside any CLAUDE.md, instead of the `Agent` tool from within this repo.
- The mandatory pre-trial contamination probe found a second, independent confound beyond the one the originals diagnosed: the Lien plugin is enabled at **user level** in `~/.claude/settings.json` (`enabledPlugins`), so its MCP instructions (which state the `get_dependents` / test-association rules near verbatim) attach to every `claude` session on this machine regardless of directory, git status, or CLAUDE.md presence. Confirmed with a raw probe (`plugin:lien:lien` appears mid-connect even from a clean, git-free directory).
- Fixed with `--strict-mcp-config` plus an empty `--mcp-config`, re-verified clean (zero mention of lien/get_dependents/complexity/test-association), then ran all 32 trials (8 control + 8 signal per experiment).
- Both docs get a new dated section with raw rates, effect direction, the probe output, and an explicit validity caveat. No lift claims beyond what the numbers show.

## Results

**A/B #1b (blast-radius):**
- Primary metric (task-forced criterion a or b): 8/8 control vs 8/8 signal (still non-discriminating, same structural reason as the original).
- The real discriminator (spontaneous beyond-file-caller reasoning, criterion b alone): 7/8 control vs 8/8 signal. A one-trial, directional difference at N=8 — reported plainly, not claimed as a result.
- Zero contamination confirmed: 0/8 control trials mention Lien, CLAUDE.md, or get_dependents (checked by grep across all 32 raw outputs).

**A/B #2b (test-verification):**
- Primary metric: 8/8 control vs 8/8 signal, unchanged from the original's null.
- No secondary "beyond what's required" measure exists for this task shape, so the null is uniform across every metric checked.
- Zero contamination confirmed the same way.

Both write-ups note the ambient `~/.claude/rules/context7.md` rule as the one remaining constant (present identically in every trial, unrelated to either nudged behavior) and the validity caveat that a zero-context environment bounds effect size from above in both directions — a real repo usually carries *some* instructions, just not, usually, these specific ones.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (56 test files / 1033 + 41 tests passed, after bootstrapping with `npm ci` and `npm run build:native -w @liendev/parser-native` in this fresh worktree)
- [x] `node packages/cli/dist/index.js delta` — no complexity-affecting changes vs HEAD
- [x] `node .github/scripts/docs-truth.mjs` — 84 files checked, no violations
- [x] Dogfood: docs-only change; both new sections were produced by actually running all 32 headless trials end-to-end (not simulated) and reading the raw outputs before judging them against the frozen rubrics. Raw trial outputs, the pre-registrations, and both probe outputs are archived under `.wip/ab-neutral/` (gitignored, not part of this diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added context-neutral follow-up sections for two A/B experiments.
  * Documented contamination probes, mitigation steps, rerun procedures, and validation results.
  * Reported that primary outcomes remained unchanged, with a small directional difference in one secondary measure.
  * Added validity caveats and links to preregistration, probe, and raw trial artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 12 high-risk file(s) with 523 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |

> [!WARNING]
> **1 issue found** · Low Risk
>
> Adds dated re-run sections to two development-experiment write-ups (blast-radius and test-verification A/Bs) documenting a second, cleaner trial run headlessly from a synthetic, git-free directory. The new sections report a pre-trial contamination probe that discovered the user-level Lien plugin as an independent confound, the `--strict-mcp-config` mitigation, the 32 trial results, and an explicit validity caveat. No code or behavior changes.
>
> - docs/development/blast-radius-nudge-ab.md: added 2026-07-24 A/B #1b section with probe details, primary/secondary metrics, honest read, validity caveat, and artifact pointers
> - docs/development/test-verification-nudge-ab.md: added 2026-07-24 A/B #2b section with shared probe explanation, results, and validity caveat
> - Both sections report zero contamination after the MCP-config fix and frame the small directional differences as not lift claims at N=8

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ddb20d5. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

