### PR TITLE
feat(cli,parser,plugin): docRefs — shift docs-drift detection onto the blast-radius nudge

### DIFF
--- a/.changeset/docs-refs-nudge.md
+++ b/.changeset/docs-refs-nudge.md
@@ -1,0 +1,11 @@
+---
+'@liendev/lien': minor
+'@liendev/parser': minor
+---
+
+Shift docs-drift detection left onto the blast-radius nudge: when `lien api-delta` detects a REMOVED exported symbol, it now also reports how many indexed documentation chunks still reference it.
+
+- `@liendev/parser` gains `wordBoundaryRe` and `isDistinctiveToken`, lifted out of the review engine's docs-drift pass (`packages/review/src/docs-drift-signals.ts`, now a thin consumer of these instead of duplicating them) so the CLI can reuse the exact same word-boundary + distinctiveness matching precision.
+- `lien api-delta`'s enrichment gains `docRefCount`/`docRefPaths` on every `removed` change (`null`/`[]` for `signature-changed`, or when the index is unavailable): a zero-LLM, fail-open lookup over the indexed `type: 'doc'` chunks for the removed symbol's name.
+- The `api-delta-write.sh` PostToolUse hook appends a short sentence to its existing warning — `"N docs reference X: path1, path2, path3 (+K more)."` — when a removed symbol still has doc references; silent otherwise.
+- The `blast-events.jsonl` ledger gains an additive, optional `docRefCount` field per change.

--- a/docs/architecture/blast-radius-nudge.md
+++ b/docs/architecture/blast-radius-nudge.md
@@ -265,6 +265,130 @@ the existing complexity-delta windows. JSON output nests the new data under a
 `blastRadius` key — additive; the pre-existing top-level `totalEvents`/`windows`
 shape is unchanged for any existing caller.
 
+## E. docRefs: shifting docs-drift left onto a REMOVED change
+
+The PR-review engine's docs-drift pass (`packages/review/src/docs-drift-signals.ts`,
+dark by default) already catches "an untouched doc still names a symbol this PR
+removed" — but only at PR time. This extends the same fact one step earlier: when
+`enrichOneChange` classifies a change as `kind: 'removed'`, it also looks up which
+indexed documentation chunks still reference that symbol, and appends the count
+and up to 3 paths to the same warning. No LLM anywhere — the agent reading the
+warning is the judge of what to do about it.
+
+### Precondition, verified empirically before any of this was built
+
+Markdown gets heading-chunked (`type: 'doc'`) and indexed by default — no flag,
+no opt-in. Confirmed two ways: reading the code path (`DEFAULT_INDEX_INCLUDE_PATTERNS`
+in `packages/parser/src/constants.ts` includes `**/*.md`/`**/*.mdx`/`**/*.markdown`
+unconditionally; `chunkFile` in `packages/parser/src/chunker.ts` routes any such
+path to `chunkMarkdownFile` with no feature flag), and by querying this repo's own
+live index directly: `sqlite3 <indexDir>/structural.db "SELECT COUNT(*) FROM chunks
+WHERE type='doc'"` returned 1,078 real doc chunks, including CLAUDE.md broken into
+per-heading sections. Had this been flag-gated or unbuilt, this feature would not
+have been buildable as scoped — see the original brief's step-zero gate.
+
+### Matching primitives: lifted, not duplicated
+
+The review pass's word-boundary regex (negative-lookaround `wordBoundaryRe`,
+guarding against matching a token as a substring of a longer identifier/path) and
+its corpus-driven distinctiveness gate (originally `isDistinctiveBareDirectory`,
+scoped to bare top-level directory names) are the exact precision machinery this
+feature needs too — a removed symbol named `index` or `config` must not spam the
+warning with incidental prose hits. Both moved into `@liendev/parser`'s new
+`doc-reference-matching.ts` (generalized from "bare directory" to "any token"),
+and `docs-drift-signals.ts` now imports them instead of defining its own copies —
+`isDistinctiveBareDirectory` survives as a one-line delegating export (its own
+test suite imports it by that name) so the lift is behavior-identical: review's
+full 39-test `docs-drift-signals.test.ts` suite, and its full 1581-test package
+suite, pass unchanged after the refactor.
+
+**A real bug was found and fixed during this lift's dogfooding, not assumed
+away**: the distinctiveness gate's original neighbor-character check (a `/` or
+backtick directly adjacent to the match) only recognizes *inline* code spans. It
+does not recognize a multi-line fenced code block — and `createVectorDB`, used as
+the first real-world dogfood symbol, is genuinely referenced in CLAUDE.md's own
+fenced package-structure tree and in `packages/core/README.md`'s fenced usage
+examples, neither of which have a backtick or `/` touching the token itself. The
+gate mis-classified all of those as "not distinctive" and suppressed a real,
+correct 9-file doc reference down to zero. Fixed by tracking per-line fence state
+(mirrors `docs-drift-signals.ts`'s own `isInsideFence`) and treating any line
+inside a fence as code context outright, regardless of neighbor characters. This
+also benefits `isDistinctiveBareDirectory`'s existing bare-directory case (a
+latent gap inherited from the original code, not introduced here) — it simply
+never had a fixture that exercised a fenced-block reference.
+
+### Query path
+
+`packages/cli/src/utils/doc-references.ts`'s `findDocReferences(vectorDB,
+symbolName)`: `vectorDB.scanAll()` (the full unscoped read — no `type` filter
+exists on `VectorDBInterface`, and this already matches the cost class
+`findDependents` pays for the same event), filtered to `metadata.type === 'doc'`,
+then to genuine `wordBoundaryRe` matches, then gated by `isDistinctiveToken`. The
+surviving distinct file paths are sorted and capped at
+`MAX_DOC_REF_PATHS` (3), with the true total count preserved separately so the
+warning can say "(+N more)". Runs *only* when a removal was already classified —
+never on the common edit, and never for a `signature-changed` row (the symbol
+still exists, so "docs reference it" isn't a drift signal there).
+
+Fail-open throughout: `findDocReferences` catches internally and returns `null`
+on any error (closed db, corrupt store), which the caller treats identically to
+"zero references" — omit the line, never block, never throw.
+
+### Surface
+
+Additive fields only:
+
+- `EnrichedExportedSymbolChange` gains `docRefCount: number | null` and
+  `docRefPaths: string[]` — `null`/`[]` for every `signature-changed` row and for
+  a degraded `removed` row (no index, or the lookup failed).
+- `api-delta-write.sh`'s warning gains one sentence for the single-change
+  `removed` case: `" N docs reference X: path1, path2, path3 (+K more)."` The
+  2-3-change fallback branch stays terse — just `", N docs"` per removed item,
+  to avoid ballooning an already-combined line.
+- `BlastEventChange` gains `docRefCount?: number | null` — optional (not just
+  nullable) because events recorded before this field existed have no such key
+  at all; `isValidBlastEventChange`'s reader treats absent, `null`, and a real
+  number as the three legitimate states, and rejects anything else (e.g. a
+  string). `lien stats` is untouched — no natural aggregation was worth adding
+  for this pass.
+
+```jsonc
+// single 'removed' change, enriched, with doc references
+{
+  "symbol": "createVectorDB",
+  "kind": "removed",
+  "dependentCount": 7,
+  "riskLevel": "low",
+  "enriched": true,
+  "docRefCount": 9,
+  "docRefPaths": ["CLAUDE.md", "docs/architecture/blast-radius-nudge.md", "docs/architecture/decisions/0010-retire-qdrant-backend.md"]
+}
+```
+
+### Dogfood evidence (real PostToolUse stdin shape, this repo's own index)
+
+All four cases piped through the real hook script with the genuine
+`{session_id, transcript_path, cwd, hook_event_name, tool_name, tool_input,
+tool_response}` payload shape, against this repo's own live overlay index (not a
+synthetic fixture):
+
+- **Removed symbol with real doc references** (`createVectorDB`, temporarily
+  de-exported in the working tree only, reverted immediately after capture):
+  `⚠ lien: exported symbol removed — createVectorDB (7 dependents, risk low).
+  Callers will break — check get_dependents. 9 docs reference createVectorDB:
+  CLAUDE.md, docs/architecture/blast-radius-nudge.md,
+  docs/architecture/decisions/0010-retire-qdrant-backend.md (+6 more).`
+- **Removed symbol with zero doc references** (`detectFileType`): `⚠ lien:
+  exported symbol removed — detectFileType (4 dependents, risk low). Callers
+  will break — check get_dependents.` — the docRefs sentence is correctly
+  absent, not "0 docs reference…".
+- **Degraded (no index)**, a fresh scratch repo: `⚠ lien: exported symbol
+  removed — greet. Check get_dependents (index unavailable for counts).` —
+  confirmed only `blast-events.jsonl` was created on disk (`docRefCount: null`
+  in the ledger), never `structural.db`.
+- **Fail-open**: malformed (non-JSON, and valid-JSON-missing-fields) stdin, and
+  a non-git directory — all exit 0 with no `additionalContext` emitted.
+
 ## Known limitations
 
 All of these are silent misses (safe direction — the nudge under-fires, it
@@ -302,6 +426,25 @@ never fires on something that isn't real), not false positives:
   identifier text is never touched by normalization, and a parameter rename is
   a real API-surface change in keyword-argument languages (e.g. Python), not
   noise.
+- **docRefs (section E) only fires for `removed`, never `signature-changed`** —
+  a symbol that merely changed shape still exists, so "docs reference it" isn't
+  a drift signal by itself.
+- **docRefs has no suppression tiers.** Unlike the review pass it borrows its
+  matching primitives from, this feature does not exclude changelog/changeset
+  entries, fenced-code samples that are stale on purpose, or past-tense
+  ("formerly", "was removed") prose — a CHANGELOG.md mention counts exactly the
+  same as a live guide. This is a deliberate scope cut (the agent reading the
+  warning is the judge), not an oversight; the review pass's dedicated
+  `isSuppressed`/`classifyPositionTier` machinery was left there rather than
+  duplicated here.
+- **An extra, uncached full `scanAll()` per removed symbol.** `findDocReferences`
+  does not share `findDependents`'s internal scan cache (a private module-level
+  cache in `dependency-analyzer.ts`) — accepted because this only runs on the
+  rare already-detected-removal event, the same event `findDependents` itself
+  already pays a full scan for.
+- **Recall is capped at `MAX_DOC_REF_PATHS` (3) displayed paths**, though the
+  true count is preserved and shown via "(+N more)" — never silently truncated
+  to a smaller number without saying so.
 
 ## Why advisory, not a gate
 

--- a/docs/architecture/blast-radius-nudge.md
+++ b/docs/architecture/blast-radius-nudge.md
@@ -287,7 +287,7 @@ WHERE type='doc'"` returned 1,078 real doc chunks, including CLAUDE.md broken in
 per-heading sections. Had this been flag-gated or unbuilt, this feature would not
 have been buildable as scoped — see the original brief's step-zero gate.
 
-### Matching primitives: lifted, not duplicated
+### Matching primitives: lifted, not duplicated — then genuinely improved, twice, both disclosed
 
 The review pass's word-boundary regex (negative-lookaround `wordBoundaryRe`,
 guarding against matching a token as a substring of a longer identifier/path) and
@@ -298,24 +298,61 @@ warning with incidental prose hits. Both moved into `@liendev/parser`'s new
 `doc-reference-matching.ts` (generalized from "bare directory" to "any token"),
 and `docs-drift-signals.ts` now imports them instead of defining its own copies —
 `isDistinctiveBareDirectory` survives as a one-line delegating export (its own
-test suite imports it by that name) so the lift is behavior-identical: review's
-full 39-test `docs-drift-signals.test.ts` suite, and its full 1581-test package
-suite, pass unchanged after the refactor.
+test suite imports it by that name). **The code-motion step itself was proven
+behavior-identical** before anything else changed: review's full 39-test
+`docs-drift-signals.test.ts` suite, and its full 1581-test package suite, passed
+unchanged immediately after the pure lift, with no logic altered yet.
 
-**A real bug was found and fixed during this lift's dogfooding, not assumed
-away**: the distinctiveness gate's original neighbor-character check (a `/` or
-backtick directly adjacent to the match) only recognizes *inline* code spans. It
-does not recognize a multi-line fenced code block — and `createVectorDB`, used as
-the first real-world dogfood symbol, is genuinely referenced in CLAUDE.md's own
-fenced package-structure tree and in `packages/core/README.md`'s fenced usage
-examples, neither of which have a backtick or `/` touching the token itself. The
-gate mis-classified all of those as "not distinctive" and suppressed a real,
-correct 9-file doc reference down to zero. Fixed by tracking per-line fence state
-(mirrors `docs-drift-signals.ts`'s own `isInsideFence`) and treating any line
-inside a fence as code context outright, regardless of neighbor characters. This
-also benefits `isDistinctiveBareDirectory`'s existing bare-directory case (a
-latent gap inherited from the original code, not introduced here) — it simply
-never had a fixture that exercised a fenced-block reference.
+Two real behavior changes followed, both found by dogfooding this feature (not
+assumed away), both disclosed here rather than folded silently into "the lift":
+
+**1. Fence-awareness (a fix).** The distinctiveness gate's original
+neighbor-character check (a `/` or backtick directly adjacent to the match) only
+recognizes *inline* code spans. It does not recognize a multi-line fenced code
+block — and `createVectorDB`, used as the first real-world dogfood symbol, is
+genuinely referenced in CLAUDE.md's own fenced package-structure tree and in
+`packages/core/README.md`'s fenced usage examples, neither of which have a
+backtick or `/` touching the token itself. The gate mis-classified all of those
+as "not distinctive" and suppressed a real, correct doc reference down to zero.
+Fixed by tracking per-line fence state (mirrors `docs-drift-signals.ts`'s own
+`isInsideFence`) and treating any line inside a fence as code context outright,
+regardless of neighbor characters.
+
+**This is a genuine behavior change for `isDistinctiveBareDirectory`, not an
+identical refactor** — a bare directory name referenced ONLY inside a fenced
+code block previously read as "not distinctive" (silently suppressed) and now
+reads as "distinctive" (correctly flagged). No pre-existing review fixture
+exercised that shape, so no existing test result changed, but the *logic* now
+answers a question it didn't used to get right. This is a deliberate,
+disclosed improvement that aligns the shared gate with `docs-drift-signals.ts`'s
+own `isInsideFence` sweep path — not a "no behavior changed" claim. A new
+review-side regression fixture pins the new behavior explicitly (see
+`docs-drift-signals.test.ts`'s "fenced bare-directory reference" case).
+
+**2. Identifier-shape exemption (a fix, found because the flagship claim
+stopped reproducing).** The distinctiveness gate's rule is "a single prose hit
+ANYWHERE in the corpus suppresses the whole token" — and once this very
+architecture-doc section was written and indexed, it itself contained plain,
+un-backticked prose mentions of `createVectorDB` (e.g. "9 docs reference
+createVectorDB:" in the dogfood-evidence prose below). Under the pre-fix gate,
+that alone made `createVectorDB` "not distinctive," suppressing the flagship
+9-file claim back down to zero — a real over-suppression bug, not a fencing
+edge case. The fix: a token containing an uppercase letter or an underscore
+anywhere (`createVectorDB`, `authToken`, `MyClass`, a single Capitalized class
+name like `Widget`) is exempt from the corpus-wide prose gate entirely — no
+ordinary lowercase English word has that shape, so no amount of plain-prose
+surrounding text can make it ambiguous. A bare all-lowercase token (`index`,
+`config`, `platform`) is unaffected and still goes through the exact same
+strict, corpus-driven check as before.
+
+**This exemption cannot change `isDistinctiveBareDirectory`'s existing
+behavior** — review's bare-top-level-directory referands are always lowercase
+by this repo's own directory-naming convention (verified: every existing
+fixture and this repo's real directories), so the exemption never engages for
+that call site. Proven, not just argued: review's full suite (1581 tests)
+passes unchanged, plus the same new fenced-bare-directory fixture above also
+covers a lowercase token, so it exercises the fence fix without ever touching
+the exemption path.
 
 ### Query path
 
@@ -367,27 +404,65 @@ Additive fields only:
 
 ### Dogfood evidence (real PostToolUse stdin shape, this repo's own index)
 
-All four cases piped through the real hook script with the genuine
-`{session_id, transcript_path, cwd, hook_event_name, tool_name, tool_input,
-tool_response}` payload shape, against this repo's own live overlay index (not a
-synthetic fixture):
+All cases piped through the real hook script with the genuine `{session_id,
+transcript_path, cwd, hook_event_name, tool_name, tool_input, tool_response}`
+payload shape, against this repo's own live overlay index (not a synthetic
+fixture) — **re-captured after the identifier-shape exemption and fence fixes**,
+against the rebuilt CLI, so every claim below reproduces against this PR's own
+final code, not an earlier draft of it:
 
-- **Removed symbol with real doc references** (`createVectorDB`, temporarily
-  de-exported in the working tree only, reverted immediately after capture):
-  `⚠ lien: exported symbol removed — createVectorDB (7 dependents, risk low).
-  Callers will break — check get_dependents. 9 docs reference createVectorDB:
-  CLAUDE.md, docs/architecture/blast-radius-nudge.md,
-  docs/architecture/decisions/0010-retire-qdrant-backend.md (+6 more).`
-- **Removed symbol with zero doc references** (`detectFileType`): `⚠ lien:
-  exported symbol removed — detectFileType (4 dependents, risk low). Callers
-  will break — check get_dependents.` — the docRefs sentence is correctly
-  absent, not "0 docs reference…".
-- **Degraded (no index)**, a fresh scratch repo: `⚠ lien: exported symbol
-  removed — greet. Check get_dependents (index unavailable for counts).` —
-  confirmed only `blast-events.jsonl` was created on disk (`docRefCount: null`
-  in the ledger), never `structural.db`.
-- **Fail-open**: malformed (non-JSON, and valid-JSON-missing-fields) stdin, and
-  a non-git directory — all exit 0 with no `additionalContext` emitted.
+**Removed symbol with real doc references** (`createVectorDB`, temporarily
+de-exported in the working tree only, reverted immediately after capture):
+
+```
+⚠ lien: exported symbol removed — createVectorDB (7 dependents, risk low). Callers will break — check get_dependents. 9 docs reference createVectorDB: CLAUDE.md, docs/architecture/blast-radius-nudge.md, docs/architecture/decisions/0010-retire-qdrant-backend.md (+6 more).
+```
+
+Unchanged from the pre-fix capture (still 9 files) — expected: this doc's own
+prose additions landed inside a file (`blast-radius-nudge.md`) that was already
+one of the 9, so the *distinct-file* count didn't move, only the exemption's
+correctness did (see the two fixes above for what actually changed and why).
+
+**Removed symbol with zero doc references.** Deliberately NOT `detectFileType`
+— an earlier draft of this doc used that as the example and named it directly
+in this same prose, which itself became a doc reference the moment this file
+was indexed, silently invalidating a "zero references" claim about to be
+committed. Demonstrated instead with a synthetic, disposable exported symbol
+(`zzzUnreferencedNudgeDemoHelper`, added and removed via a temporary commit,
+squashed away immediately after capture — never part of this PR's real history)
+specifically so naming it here can never turn it into a real reference:
+
+```
+⚠ lien: exported symbol removed — zzzUnreferencedNudgeDemoHelper (0 dependents, risk low). Callers will break — check get_dependents.
+```
+
+The docRefs sentence is correctly absent — not "0 docs reference…".
+
+**Degraded (no index)**, a fresh scratch repo:
+
+```
+⚠ lien: exported symbol removed — greet. Check get_dependents (index unavailable for counts).
+```
+
+Confirmed only `blast-events.jsonl` was created on disk (`docRefCount: null` in
+the ledger), never `structural.db`.
+
+**Fail-open**: malformed (non-JSON, and valid-JSON-missing-fields) stdin, and a
+non-git directory — all exit 0 with no `additionalContext` emitted.
+
+**Robustness: a hostile/malformed enrichment (`docRefCount: 5, docRefPaths:
+null`).** Before the null-guard fix, piping this shape into the hook script's
+`docRefsClause` crashed jq outright (`Cannot iterate over null (null)`, exit
+5) — silently dropping the ENTIRE warning, including the base "symbol removed"
+sentence that has nothing to do with docRefs. After the fix
+(`(.docRefPaths // [])`), the same input degrades gracefully instead:
+
+```
+⚠ lien: exported symbol removed — x (1 dependents, risk low). Callers will break — check get_dependents. 5 docs reference x:  (+5 more).
+```
+
+The path list renders empty but the count and the base warning both survive —
+never a silent total loss over one malformed field.
 
 ## Known limitations
 
@@ -445,6 +520,14 @@ never fires on something that isn't real), not false positives:
 - **Recall is capped at `MAX_DOC_REF_PATHS` (3) displayed paths**, though the
   true count is preserved and shown via "(+N more)" — never silently truncated
   to a smaller number without saying so.
+- **Fence detection covers ` ``` `/`~~~` only, not a 4-space-indented code
+  block** (the other Markdown convention for a literal code sample). This is
+  consistent with the chunker's own `FENCE_RE` (`markdown-chunker.ts`), which
+  has the same gap — an indented block was never a first-class construct here.
+  A token referenced only inside an indented block, with no other doc mention,
+  still reads as ordinary prose and can be wrongly suppressed by the
+  distinctiveness gate unless it also happens to have an unambiguous
+  identifier shape (section E's exemption).
 
 ## Why advisory, not a gate
 

--- a/docs/architecture/blast-radius-nudge.md
+++ b/docs/architecture/blast-radius-nudge.md
@@ -308,7 +308,7 @@ assumed away), both disclosed here rather than folded silently into "the lift":
 
 **1. Fence-awareness (a fix).** The distinctiveness gate's original
 neighbor-character check (a `/` or backtick directly adjacent to the match) only
-recognizes *inline* code spans. It does not recognize a multi-line fenced code
+recognized *inline* code spans. It did not recognize a multi-line fenced code
 block — and `createVectorDB`, used as the first real-world dogfood symbol, is
 genuinely referenced in CLAUDE.md's own fenced package-structure tree and in
 `packages/core/README.md`'s fenced usage examples, neither of which have a

--- a/packages/cli/src/cli/api-delta-cmd.test.ts
+++ b/packages/cli/src/cli/api-delta-cmd.test.ts
@@ -46,6 +46,8 @@ describe('formatApiDeltaText', () => {
                 untestedDependentCount: 1,
                 riskLevel: 'medium',
                 enriched: true,
+                docRefCount: null,
+                docRefPaths: [],
               },
             ],
           },
@@ -57,6 +59,7 @@ describe('formatApiDeltaText', () => {
     expect(text).toContain('formatUser');
     expect(text).toContain('4 dependents, 1 untested, risk medium');
     expect(text).toContain('get_dependents');
+    expect(text).not.toContain('docs reference');
   });
 
   it('renders a degraded row without counts', () => {
@@ -74,6 +77,8 @@ describe('formatApiDeltaText', () => {
                 untestedDependentCount: null,
                 riskLevel: null,
                 enriched: false,
+                docRefCount: null,
+                docRefPaths: [],
               },
             ],
           },
@@ -82,6 +87,62 @@ describe('formatApiDeltaText', () => {
       ),
     );
     expect(text).toContain('index unavailable for counts');
+  });
+
+  it('renders a removed row with docRefs, showing the capped path list and a "+N more" tail', () => {
+    const text = stripAnsi(
+      formatApiDeltaText(
+        [
+          {
+            filepath: 'src/factory.ts',
+            changes: [
+              {
+                symbol: 'createVectorDB',
+                symbolName: 'createVectorDB',
+                kind: 'removed',
+                dependentCount: 26,
+                untestedDependentCount: 2,
+                riskLevel: 'critical',
+                enriched: true,
+                docRefCount: 5,
+                docRefPaths: ['CLAUDE.md', 'docs/architecture/README.md', 'docs/guide.md'],
+              },
+            ],
+          },
+        ],
+        'HEAD',
+      ),
+    );
+    expect(text).toContain(
+      '5 docs reference createVectorDB: CLAUDE.md, docs/architecture/README.md, docs/guide.md (+2 more)',
+    );
+  });
+
+  it('omits the docRefs clause when docRefCount is zero', () => {
+    const text = stripAnsi(
+      formatApiDeltaText(
+        [
+          {
+            filepath: 'src/foo.ts',
+            changes: [
+              {
+                symbol: 'unusedHelper',
+                symbolName: 'unusedHelper',
+                kind: 'removed',
+                dependentCount: 0,
+                untestedDependentCount: 0,
+                riskLevel: 'low',
+                enriched: true,
+                docRefCount: 0,
+                docRefPaths: [],
+              },
+            ],
+          },
+        ],
+        'HEAD',
+      ),
+    );
+    expect(text).not.toContain('docs reference');
   });
 });
 
@@ -391,5 +452,77 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
       untestedDependentCount: 1,
     });
     expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports docRefCount/docRefPaths for a REMOVED symbol referenced by doc chunks in the stub index', async () => {
+    await write('a.ts', 'export function oldHelper() { return 1; }');
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'init');
+    await write('a.ts', '// oldHelper removed\n');
+
+    const { getIndexDir } = await import('@liendev/parser');
+    const realIndexDir = getIndexDir(dir);
+    await fs.mkdir(realIndexDir, { recursive: true });
+    await fs.writeFile(path.join(realIndexDir, 'structural.db'), '', 'utf-8');
+
+    const docChunk = {
+      content: 'The `oldHelper` function is documented here.',
+      metadata: { file: 'CLAUDE.md', startLine: 1, endLine: 1, type: 'doc', language: 'markdown' },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getCurrentVersion: vi.fn().mockReturnValue(1),
+      scanAll: vi.fn().mockResolvedValue([docChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await expect(apiDeltaCommand({ format: 'json', file: 'a.ts' })).rejects.toThrow('__exit__:0');
+
+    const result = lastJsonLog() as {
+      changes: Array<{
+        kind: string;
+        docRefCount: number | null;
+        docRefPaths: string[];
+      }>;
+    };
+    expect(result.changes[0]).toMatchObject({
+      kind: 'removed',
+      docRefCount: 1,
+      docRefPaths: ['CLAUDE.md'],
+    });
+
+    const events = await readBlastEvents(dir);
+    expect(events).toHaveLength(1);
+    expect(events[0].changes[0]).toMatchObject({ symbol: 'oldHelper', docRefCount: 1 });
+  });
+
+  it('leaves docRefCount null for a signature-changed symbol (docRefs only applies to removals)', async () => {
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'init');
+    await write('a.ts', 'export function formatUser(user, opts) { return user.name; }');
+
+    const { getIndexDir } = await import('@liendev/parser');
+    const realIndexDir = getIndexDir(dir);
+    await fs.mkdir(realIndexDir, { recursive: true });
+    await fs.writeFile(path.join(realIndexDir, 'structural.db'), '', 'utf-8');
+
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getCurrentVersion: vi.fn().mockReturnValue(1),
+      scanAll: vi.fn().mockResolvedValue([]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await expect(apiDeltaCommand({ format: 'json', file: 'a.ts' })).rejects.toThrow('__exit__:0');
+
+    const result = lastJsonLog() as {
+      changes: Array<{ kind: string; docRefCount: number | null; docRefPaths: string[] }>;
+    };
+    expect(result.changes[0]).toMatchObject({
+      kind: 'signature-changed',
+      docRefCount: null,
+      docRefPaths: [],
+    });
   });
 });

--- a/packages/cli/src/cli/api-delta-cmd.ts
+++ b/packages/cli/src/cli/api-delta-cmd.ts
@@ -22,6 +22,7 @@ import {
   type ExportedSymbolChange,
 } from '../utils/signature-delta.js';
 import { recordBlastEvent, type BlastEvent } from '../utils/blast-events.js';
+import { findDocReferences } from '../utils/doc-references.js';
 
 export interface ApiDeltaOptions {
   format: 'text' | 'json';
@@ -42,6 +43,16 @@ export interface EnrichedExportedSymbolChange extends ExportedSymbolChange {
   untestedDependentCount: number | null;
   riskLevel: string | null;
   enriched: boolean;
+  /**
+   * Distinct doc chunks that reference this symbol (see
+   * docs/architecture/blast-radius-nudge.md's docRefs section). Only
+   * computed for `kind === 'removed'` changes — null for `signature-changed`
+   * (not applicable: the symbol still exists, so "docs reference it" isn't a
+   * drift signal) and for a degraded (no index / lookup failed) change.
+   */
+  docRefCount: number | null;
+  /** Up to `MAX_DOC_REF_PATHS` file paths backing `docRefCount`. Empty when `docRefCount` is null or 0. */
+  docRefPaths: string[];
 }
 
 export interface EnrichedSignatureDelta {
@@ -70,6 +81,8 @@ function degradedChange(change: ExportedSymbolChange): EnrichedExportedSymbolCha
     untestedDependentCount: null,
     riskLevel: null,
     enriched: false,
+    docRefCount: null,
+    docRefPaths: [],
   };
 }
 
@@ -101,6 +114,24 @@ async function hasStructuralIndex(rootDir: string): Promise<boolean> {
   }
 }
 
+/**
+ * Doc-chunk references for a REMOVED symbol only — a `signature-changed`
+ * symbol still exists, so "docs reference it" isn't a drift signal. Fails
+ * open to `{ docRefCount: null, docRefPaths: [] }`, matching
+ * `findDocReferences`'s own fail-open contract (see doc-references.ts).
+ */
+async function resolveDocRefs(
+  vectorDB: Awaited<ReturnType<typeof createVectorDB>>,
+  change: ExportedSymbolChange,
+): Promise<Pick<EnrichedExportedSymbolChange, 'docRefCount' | 'docRefPaths'>> {
+  if (change.kind !== 'removed') return { docRefCount: null, docRefPaths: [] };
+
+  const docRefs = await findDocReferences(vectorDB, change.symbolName);
+  return docRefs
+    ? { docRefCount: docRefs.count, docRefPaths: docRefs.paths }
+    : { docRefCount: null, docRefPaths: [] };
+}
+
 async function enrichOneChange(
   vectorDB: Awaited<ReturnType<typeof createVectorDB>>,
   filepath: string,
@@ -110,12 +141,14 @@ async function enrichOneChange(
   try {
     const log = (): void => undefined;
     const analysis = await findDependents(vectorDB, filepath, log, change.symbolName, indexVersion);
+    const docRefs = await resolveDocRefs(vectorDB, change);
     return {
       ...change,
       dependentCount: analysis.dependents.length,
       untestedDependentCount: analysis.uncoveredProductionDependents,
       riskLevel: computeRisk(analysis),
       enriched: true,
+      ...docRefs,
     };
   } catch {
     return degradedChange(change);
@@ -172,9 +205,19 @@ function buildBlastEvent(delta: EnrichedSignatureDelta, now: Date): BlastEvent {
       dependentCount: c.dependentCount,
       untestedDependentCount: c.untestedDependentCount,
       riskLevel: c.riskLevel,
+      docRefCount: c.docRefCount,
     })),
     enriched: delta.changes.some(c => c.enriched),
   };
+}
+
+/** " — N docs reference X: path1, path2 (+K more)" when the removed symbol has doc references, else "". */
+function fmtDocRefs(c: EnrichedExportedSymbolChange): string {
+  if (!c.docRefCount) return '';
+  const shown = c.docRefPaths.join(', ');
+  const more =
+    c.docRefCount > c.docRefPaths.length ? ` (+${c.docRefCount - c.docRefPaths.length} more)` : '';
+  return chalk.dim(` — ${c.docRefCount} docs reference ${c.symbol}: ${shown}${more}`);
 }
 
 function fmtChange(c: EnrichedExportedSymbolChange): string {
@@ -182,7 +225,7 @@ function fmtChange(c: EnrichedExportedSymbolChange): string {
   const detail = c.enriched
     ? ` — ${c.dependentCount} dependents, ${c.untestedDependentCount} untested, risk ${c.riskLevel}`
     : chalk.dim(' — index unavailable for counts');
-  return `    ${label}${c.symbol}${detail}`;
+  return `    ${label}${c.symbol}${detail}${fmtDocRefs(c)}`;
 }
 
 /** Render the human-readable report. Pure — no I/O, no process state. */

--- a/packages/cli/src/utils/blast-events.test.ts
+++ b/packages/cli/src/utils/blast-events.test.ts
@@ -167,6 +167,96 @@ describe('recordBlastEvent + readBlastEvents', () => {
     expect(events[0]).toEqual(good);
   });
 
+  it('round-trips a removed event carrying a populated docRefCount', async () => {
+    const event = sampleEvent({
+      changes: [
+        {
+          symbol: 'oldHelper',
+          kind: 'removed',
+          dependentCount: 3,
+          untestedDependentCount: 1,
+          riskLevel: 'high',
+          docRefCount: 2,
+        },
+      ],
+    });
+    await recordBlastEvent(rootDir, event);
+
+    expect(await readBlastEvents(rootDir)).toEqual([event]);
+  });
+
+  it('round-trips docRefCount: null (checked, no index / lookup failed) distinctly from absent', async () => {
+    const event = sampleEvent({
+      changes: [
+        {
+          symbol: 'oldHelper',
+          kind: 'removed',
+          dependentCount: null,
+          untestedDependentCount: null,
+          riskLevel: null,
+          docRefCount: null,
+        },
+      ],
+    });
+    await recordBlastEvent(rootDir, event);
+
+    const [read] = await readBlastEvents(rootDir);
+    expect(read).toEqual(event);
+    expect(read.changes[0].docRefCount).toBeNull();
+  });
+
+  it('accepts an older event recorded before docRefCount existed (field absent, not just null)', async () => {
+    const filePath = blastEventsFilePath(rootDir);
+    const preExisting = {
+      timestamp: new Date().toISOString(),
+      filepath: 'src/legacy.ts',
+      changes: [
+        {
+          symbol: 'legacyFn',
+          kind: 'removed',
+          dependentCount: 1,
+          untestedDependentCount: 0,
+          riskLevel: 'low',
+        },
+      ],
+      enriched: true,
+    };
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.appendFile(filePath, `${JSON.stringify(preExisting)}\n`, 'utf-8');
+
+    const events = await readBlastEvents(rootDir);
+    expect(events).toHaveLength(1);
+    expect(events[0].changes[0].docRefCount).toBeUndefined();
+  });
+
+  it('skips a line whose docRefCount is the wrong type', async () => {
+    const good = sampleEvent();
+    await recordBlastEvent(rootDir, good);
+
+    const filePath = blastEventsFilePath(rootDir);
+    const malformed = {
+      timestamp: new Date().toISOString(),
+      filepath: 'x.ts',
+      changes: [
+        {
+          symbol: 'foo',
+          kind: 'removed',
+          dependentCount: 1,
+          untestedDependentCount: 0,
+          riskLevel: 'low',
+          docRefCount: 'two', // wrong type — must be number | null | undefined
+        },
+      ],
+      enriched: true,
+    };
+    await fs.appendFile(filePath, `${JSON.stringify(malformed)}\n`, 'utf-8');
+    await recordBlastEvent(rootDir, sampleEvent({ filepath: 'src/bar.ts' }));
+
+    const events = await readBlastEvents(rootDir);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual(good);
+  });
+
   it('LIEN_BLAST_EVENTS=off disables recording entirely (kill switch)', async () => {
     process.env.LIEN_BLAST_EVENTS = 'off';
     await recordBlastEvent(rootDir, sampleEvent());

--- a/packages/cli/src/utils/blast-events.ts
+++ b/packages/cli/src/utils/blast-events.ts
@@ -37,6 +37,14 @@ export interface BlastEventChange {
   dependentCount: number | null;
   untestedDependentCount: number | null;
   riskLevel: string | null;
+  /**
+   * Distinct doc chunks referencing this symbol (see
+   * docs/architecture/blast-radius-nudge.md's docRefs section) — only
+   * meaningful for a `removed` change. `undefined` on any event recorded
+   * before this field existed; readers must treat that the same as `null`
+   * (unknown/not computed), never as "zero references".
+   */
+  docRefCount?: number | null;
 }
 
 export interface BlastEvent {
@@ -98,16 +106,26 @@ async function trimIfOversized(filePath: string): Promise<void> {
   await fs.writeFile(filePath, `${kept.join('\n')}\n`, 'utf-8');
 }
 
+/** A recorded count field: a real number, or `null` for "checked, unknown/degraded". */
+function isValidNumberOrNull(value: unknown): boolean {
+  return typeof value === 'number' || value === null;
+}
+
+/** Same as `isValidNumberOrNull`, plus `undefined` — for a field added after some
+ *  events were already on disk, where an older line simply won't have the key. */
+function isValidOptionalNumber(value: unknown): boolean {
+  return value === undefined || isValidNumberOrNull(value);
+}
+
 function isValidBlastEventChange(value: unknown): value is BlastEventChange {
   if (typeof value !== 'object' || value === null) return false;
   const c = value as Record<string, unknown>;
   if (typeof c.symbol !== 'string') return false;
   if (c.kind !== 'signature-changed' && c.kind !== 'removed') return false;
-  if (typeof c.dependentCount !== 'number' && c.dependentCount !== null) return false;
-  if (typeof c.untestedDependentCount !== 'number' && c.untestedDependentCount !== null) {
-    return false;
-  }
+  if (!isValidNumberOrNull(c.dependentCount)) return false;
+  if (!isValidNumberOrNull(c.untestedDependentCount)) return false;
   if (typeof c.riskLevel !== 'string' && c.riskLevel !== null) return false;
+  if (!isValidOptionalNumber(c.docRefCount)) return false;
   return true;
 }
 

--- a/packages/cli/src/utils/doc-references.test.ts
+++ b/packages/cli/src/utils/doc-references.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { VectorDBInterface, SearchResult } from '@liendev/core';
+import { findDocReferences } from './doc-references.js';
+
+function docChunk(file: string, content: string): SearchResult {
+  return {
+    content,
+    metadata: { file, startLine: 1, endLine: 1, type: 'doc', language: 'markdown' },
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
+
+function codeChunk(file: string, content: string): SearchResult {
+  return {
+    content,
+    metadata: { file, startLine: 1, endLine: 1, type: 'function', language: 'typescript' },
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
+
+function stubVectorDB(chunks: SearchResult[]): VectorDBInterface {
+  return {
+    scanAll: vi.fn().mockResolvedValue(chunks),
+  } as unknown as VectorDBInterface;
+}
+
+describe('findDocReferences', () => {
+  it('reports distinct doc files genuinely referencing the symbol', async () => {
+    const vectorDB = stubVectorDB([
+      docChunk('CLAUDE.md', 'The `createVectorDB` factory resolves worktree mode.'),
+      docChunk('docs/guide.md', 'See `createVectorDB(projectRoot)` for the entry point.'),
+      codeChunk('src/factory.ts', 'export async function createVectorDB() {}'),
+    ]);
+
+    const result = await findDocReferences(vectorDB, 'createVectorDB');
+
+    expect(result).toEqual({ count: 2, paths: ['CLAUDE.md', 'docs/guide.md'] });
+  });
+
+  it('excludes non-doc chunk types even when they contain the symbol', async () => {
+    const vectorDB = stubVectorDB([
+      codeChunk('src/factory.ts', 'export async function createVectorDB() {}'),
+    ]);
+
+    const result = await findDocReferences(vectorDB, 'createVectorDB');
+
+    expect(result).toEqual({ count: 0, paths: [] });
+  });
+
+  it('does not match a substring occurrence (word-boundary precision)', async () => {
+    const vectorDB = stubVectorDB([
+      docChunk('docs/guide.md', 'See `createVectorDBOverlay` for the worktree variant.'),
+    ]);
+
+    const result = await findDocReferences(vectorDB, 'createVectorDB');
+
+    expect(result).toEqual({ count: 0, paths: [] });
+  });
+
+  it('suppresses a generic symbol name that also reads as ordinary prose (index/config spam case)', async () => {
+    const vectorDB = stubVectorDB([
+      docChunk('CLAUDE.md', 'The `index` function builds the search index.'),
+      docChunk('docs/guide.md', 'See the index below for a full list of commands.'),
+    ]);
+
+    const result = await findDocReferences(vectorDB, 'index');
+
+    expect(result).toEqual({ count: 0, paths: [] });
+  });
+
+  it('caps displayed paths at MAX_DOC_REF_PATHS while reporting the true total count', async () => {
+    const vectorDB = stubVectorDB([
+      docChunk('docs/a.md', '`helper()` is documented here.'),
+      docChunk('docs/b.md', '`helper()` is documented here too.'),
+      docChunk('docs/c.md', '`helper()` shows up here as well.'),
+      docChunk('docs/d.md', '`helper()` shows up here too.'),
+    ]);
+
+    const result = await findDocReferences(vectorDB, 'helper');
+
+    expect(result?.count).toBe(4);
+    expect(result?.paths).toEqual(['docs/a.md', 'docs/b.md', 'docs/c.md']);
+  });
+
+  it('dedupes multiple matches within the same file to one path entry', async () => {
+    const vectorDB = stubVectorDB([
+      docChunk('CLAUDE.md', 'First mention of `helper()`.'),
+      docChunk('CLAUDE.md', 'Second mention of `helper()` later in the same file.'),
+    ]);
+
+    const result = await findDocReferences(vectorDB, 'helper');
+
+    expect(result).toEqual({ count: 1, paths: ['CLAUDE.md'] });
+  });
+
+  it('returns zero when the symbol appears nowhere in the doc corpus', async () => {
+    const vectorDB = stubVectorDB([docChunk('CLAUDE.md', 'Nothing relevant here.')]);
+
+    const result = await findDocReferences(vectorDB, 'neverMentioned');
+
+    expect(result).toEqual({ count: 0, paths: [] });
+  });
+
+  it('fails open (returns null) when the scan itself throws', async () => {
+    const vectorDB = {
+      scanAll: vi.fn().mockRejectedValue(new Error('db closed')),
+    } as unknown as VectorDBInterface;
+
+    const result = await findDocReferences(vectorDB, 'anything');
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cli/src/utils/doc-references.ts
+++ b/packages/cli/src/utils/doc-references.ts
@@ -1,0 +1,72 @@
+/**
+ * Doc-reference lookup for a removed exported symbol — the deterministic
+ * "shift docs-drift left" half of the blast-radius nudge (see
+ * docs/architecture/blast-radius-nudge.md's docRefs section). When `lien
+ * api-delta` detects a REMOVED export, this looks up which indexed
+ * documentation ('doc'-type) chunks still name it, so the same warning can
+ * say "N docs reference X: path1, path2, path3" without a second, separate
+ * pass.
+ *
+ * Zero LLM: an index scan narrowed by the same word-boundary +
+ * distinctiveness matching primitives the review pass's docs-drift-signals.ts
+ * uses (`@liendev/parser`'s `doc-reference-matching.ts` — shared, not
+ * duplicated) so a generic symbol name (`index`, `config`) can't spam the
+ * warning with incidental prose hits.
+ */
+
+import type { VectorDBInterface, SearchResult } from '@liendev/core';
+import { wordBoundaryRe, isDistinctiveToken, type CodeChunk } from '@liendev/parser';
+
+/** Distinct doc file paths shown inline before falling back to "+N more". */
+export const MAX_DOC_REF_PATHS = 3;
+
+export interface DocReferenceResult {
+  /** Distinct doc files that genuinely reference the symbol (post word-boundary + distinctiveness filtering). */
+  count: number;
+  /** Up to `MAX_DOC_REF_PATHS` file paths, sorted. */
+  paths: string[];
+}
+
+const EMPTY_RESULT: DocReferenceResult = { count: 0, paths: [] };
+
+function toDocChunk(result: SearchResult): CodeChunk {
+  return { content: result.content, metadata: result.metadata } as CodeChunk;
+}
+
+/** Doc-type chunks whose content contains a genuine word-boundary occurrence of `symbolName`. */
+function collectMatchingDocChunks(allChunks: SearchResult[], symbolName: string): CodeChunk[] {
+  const re = wordBoundaryRe(symbolName);
+  return allChunks
+    .filter(r => r.metadata.type === 'doc' && r.content.includes(symbolName))
+    .map(toDocChunk)
+    .filter(c => re.test(c.content));
+}
+
+/**
+ * Best-effort, fail-open lookup: any thrown error (closed db, corrupt store,
+ * etc.) yields `null` — callers treat that identically to "zero references
+ * found" (omit the docRefs line). This runs only on an already-detected
+ * removal (the rare event `lien api-delta` already pays a full index scan
+ * for via `findDependents`), so an independent scan here is an accepted,
+ * bounded extra cost, not a hot-path concern.
+ */
+export async function findDocReferences(
+  vectorDB: VectorDBInterface,
+  symbolName: string,
+): Promise<DocReferenceResult | null> {
+  try {
+    const allChunks = await vectorDB.scanAll();
+    const docChunks = collectMatchingDocChunks(allChunks, symbolName);
+    if (docChunks.length === 0) return EMPTY_RESULT;
+
+    // A generic symbol name (e.g. `index`, `config`) that also reads as ordinary prose
+    // elsewhere in the corpus must not spam the warning — suppress entirely rather than
+    // report a misleading "N docs reference X" for an incidental word match.
+    if (!isDistinctiveToken(symbolName, docChunks)) return EMPTY_RESULT;
+
+    const files = [...new Set(docChunks.map(c => c.metadata.file))].sort();
+    return { count: files.length, paths: files.slice(0, MAX_DOC_REF_PATHS) };
+  } catch {
+    return null;
+  }
+}

--- a/packages/parser/src/doc-reference-matching.test.ts
+++ b/packages/parser/src/doc-reference-matching.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from './types.js';
+import { wordBoundaryRe, isDistinctiveToken } from './doc-reference-matching.js';
+
+function makeChunk(file: string, content: string): CodeChunk {
+  return {
+    content,
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: content.split('\n').length,
+      type: 'doc',
+      language: 'markdown',
+    },
+  } as CodeChunk;
+}
+
+// ---------------------------------------------------------------------------
+// wordBoundaryRe
+// ---------------------------------------------------------------------------
+
+describe('wordBoundaryRe', () => {
+  it('does not match a token as a prefix of a hyphen-suffixed longer identifier', () => {
+    expect(wordBoundaryRe('runner').test('packages/runner-hosted')).toBe(false);
+  });
+
+  it('does not match a token as a suffix of a hyphen-prefixed longer identifier', () => {
+    expect(wordBoundaryRe('packages/runner').test('sub-packages/runner')).toBe(false);
+  });
+
+  it('matches when followed by / (a legitimate sub-path reference)', () => {
+    expect(wordBoundaryRe('packages/runner').test('packages/runner/README.md')).toBe(true);
+  });
+
+  it('does not match adjacent to a hyphen (a different identifier)', () => {
+    expect(wordBoundaryRe('fetchUser').test('the my-fetchUser helper')).toBe(false);
+  });
+
+  it('does not match adjacent to a period (a different identifier)', () => {
+    expect(wordBoundaryRe('fetchUser').test('the fetchUser.old helper')).toBe(false);
+  });
+
+  it('matches the exact token surrounded by plain prose/punctuation', () => {
+    expect(wordBoundaryRe('fetchUser').test('the `fetchUser` helper requires a config')).toBe(true);
+  });
+
+  it('escapes regex-special characters in the token', () => {
+    expect(wordBoundaryRe('a.b(c)').test('call a.b(c) here')).toBe(true);
+    expect(wordBoundaryRe('a.b(c)').test('no match here')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDistinctiveToken
+// ---------------------------------------------------------------------------
+
+describe('isDistinctiveToken', () => {
+  it('is false when the token also reads as ordinary prose elsewhere in the corpus (#593 platform case)', () => {
+    const docChunks = [
+      makeChunk(
+        'CLAUDE.md',
+        '- `platform/` and `packages/runner` — hosted-platform remnants (see ' +
+          '[ADR-012](docs/architecture/decisions/0012-self-hostable-review-action.md)); safe to ignore.',
+      ),
+      makeChunk(
+        'STYLE_GUIDE.md',
+        'Design identity for all Lien properties (documentation site, platform app).',
+      ),
+    ];
+    expect(isDistinctiveToken('platform', docChunks)).toBe(false);
+  });
+
+  it('is false on a single prose hit even when every OTHER occurrence is path/code-context', () => {
+    const docChunks = [
+      makeChunk('CLAUDE.md', '- `platform/` — hosted-platform remnants; safe to ignore.'),
+      makeChunk(
+        'packages/review/test/harness/README.md',
+        '# One-time setup (or use the existing platform .env)',
+      ),
+    ];
+    expect(isDistinctiveToken('platform', docChunks)).toBe(false);
+  });
+
+  it('is false for a common short symbol name used as ordinary prose (index/config spam case)', () => {
+    const docChunks = [
+      makeChunk('CLAUDE.md', 'The `index` function builds the search index.'),
+      makeChunk('docs/guide.md', 'See the index below for a full list of commands.'),
+    ];
+    expect(isDistinctiveToken('index', docChunks)).toBe(false);
+  });
+
+  it('is true (distinctive counter-example) when every occurrence sits in code/path context', () => {
+    const docChunks = [
+      makeChunk('CLAUDE.md', '- `zznovelplatform/` — internal tooling, safe to ignore.'),
+      makeChunk('docs/guide.md', 'See `zznovelplatform/README.md` for the deprecation notice.'),
+    ];
+    expect(isDistinctiveToken('zznovelplatform', docChunks)).toBe(true);
+  });
+
+  it('is true for a distinctive symbol name backtick-quoted every time it appears', () => {
+    const docChunks = [
+      makeChunk('CLAUDE.md', 'The `createVectorDB` factory resolves worktree mode.'),
+      makeChunk('docs/guide.md', 'See `createVectorDB(projectRoot)` for the entry point.'),
+    ];
+    expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(true);
+  });
+
+  it('treats an occurrence inside a fenced code block as code context even without an adjacent backtick/slash (real false negative found dogfooding: createVectorDB in a README usage example)', () => {
+    const docChunks = [
+      makeChunk(
+        'packages/core/README.md',
+        [
+          '## Usage',
+          '',
+          '```typescript',
+          "import { createVectorDB } from '@liendev/core';",
+          '',
+          "const db = await createVectorDB('./my-project');",
+          '```',
+        ].join('\n'),
+      ),
+    ];
+    expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(true);
+  });
+
+  it('still suppresses a prose hit that sits OUTSIDE any fence, even alongside fenced code elsewhere', () => {
+    const docChunks = [
+      makeChunk(
+        'docs/guide.md',
+        [
+          'The createVectorDB helper is handy.',
+          '```typescript',
+          "const db = await createVectorDB('./my-project');",
+          '```',
+        ].join('\n'),
+      ),
+    ];
+    expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(false);
+  });
+
+  it('is true (vacuously) when the token never appears in the corpus at all', () => {
+    expect(isDistinctiveToken('somewordneverpresent', [])).toBe(true);
+  });
+
+  it('accepts a pre-narrowed corpus (chunks not containing the token trivially pass)', () => {
+    const onlyMatching = [
+      makeChunk('CLAUDE.md', '- `zznovelplatform/` — internal tooling, safe to ignore.'),
+    ];
+    const withUnrelatedChunk = [
+      ...onlyMatching,
+      makeChunk('docs/other.md', 'Nothing to do with the token at all.'),
+    ];
+    expect(isDistinctiveToken('zznovelplatform', onlyMatching)).toBe(
+      isDistinctiveToken('zznovelplatform', withUnrelatedChunk),
+    );
+  });
+});

--- a/packages/parser/src/doc-reference-matching.test.ts
+++ b/packages/parser/src/doc-reference-matching.test.ts
@@ -169,7 +169,7 @@ describe('isDistinctiveToken', () => {
 // ---------------------------------------------------------------------------
 
 describe('isUnambiguousIdentifierShape', () => {
-  it('is true for camelCase (internal capital)', () => {
+  it('is true for camelCase (internal lowercase->uppercase transition)', () => {
     expect(isUnambiguousIdentifierShape('createVectorDB')).toBe(true);
     expect(isUnambiguousIdentifierShape('authToken')).toBe(true);
   });
@@ -182,14 +182,34 @@ describe('isUnambiguousIdentifierShape', () => {
     expect(isUnambiguousIdentifierShape('Widget')).toBe(true);
   });
 
-  it('is true for a token containing an underscore', () => {
+  it('is true for a token containing an INTERNAL underscore', () => {
     expect(isUnambiguousIdentifierShape('my_helper')).toBe(true);
+    expect(isUnambiguousIdentifierShape('foo_bar')).toBe(true);
   });
 
   it('is false for a bare all-lowercase word', () => {
     expect(isUnambiguousIdentifierShape('index')).toBe(false);
     expect(isUnambiguousIdentifierShape('config')).toBe(false);
     expect(isUnambiguousIdentifierShape('platform')).toBe(false);
+  });
+
+  it('is false for a bare ALL-CAPS acronym (no lowercase letter to transition from/to)', () => {
+    expect(isUnambiguousIdentifierShape('API')).toBe(false);
+    expect(isUnambiguousIdentifierShape('ID')).toBe(false);
+    expect(isUnambiguousIdentifierShape('URL')).toBe(false);
+    expect(isUnambiguousIdentifierShape('DB')).toBe(false);
+    expect(isUnambiguousIdentifierShape('UI')).toBe(false);
+    expect(isUnambiguousIdentifierShape('HTTP')).toBe(false);
+    expect(isUnambiguousIdentifierShape('TODO')).toBe(false);
+  });
+
+  it('is false for a single letter (no adjacent pair to transition across)', () => {
+    expect(isUnambiguousIdentifierShape('T')).toBe(false);
+  });
+
+  it('is false for a purely leading/trailing underscore (not an internal separator)', () => {
+    expect(isUnambiguousIdentifierShape('foo_')).toBe(false);
+    expect(isUnambiguousIdentifierShape('_prefix')).toBe(false);
   });
 });
 
@@ -241,5 +261,22 @@ describe('isDistinctiveToken — identifier-shape exemption (reviewer repros)', 
     expect(isDistinctiveToken('index', indexDocs)).toBe(false);
     expect(isDistinctiveToken('config', configDocs)).toBe(false);
     expect(isDistinctiveToken('platform', platformDocs)).toBe(false);
+  });
+
+  it('a bare ALL-CAPS acronym (API/ID/URL) in ordinary prose is still suppressed, NOT granted the exemption', () => {
+    // The whole point of tightening the exemption to require a case TRANSITION: a removed export
+    // literally named `API`, `ID`, or `URL` must not false-fire against every mundane mention of
+    // that acronym elsewhere in the corpus — a false-fire is this nudge's worst failure mode.
+    const apiDocs = [makeChunk('docs/guide.md', 'Call the API to fetch data.')];
+    const idDocs = [makeChunk('docs/guide.md', 'Each user has an ID assigned at signup.')];
+    const urlDocs = [makeChunk('docs/guide.md', 'Check the URL before sharing it.')];
+    expect(isDistinctiveToken('API', apiDocs)).toBe(false);
+    expect(isDistinctiveToken('ID', idDocs)).toBe(false);
+    expect(isDistinctiveToken('URL', urlDocs)).toBe(false);
+  });
+
+  it('foo_bar (an internal underscore) fires despite plain prose mentions, same as a camelCase token', () => {
+    const docChunks = [makeChunk('docs/guide.md', 'The foo_bar helper is used throughout.')];
+    expect(isDistinctiveToken('foo_bar', docChunks)).toBe(true);
   });
 });

--- a/packages/parser/src/doc-reference-matching.test.ts
+++ b/packages/parser/src/doc-reference-matching.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { CodeChunk } from './types.js';
-import { wordBoundaryRe, isDistinctiveToken } from './doc-reference-matching.js';
+import {
+  wordBoundaryRe,
+  isDistinctiveToken,
+  isUnambiguousIdentifierShape,
+} from './doc-reference-matching.js';
 
 function makeChunk(file: string, content: string): CodeChunk {
   return {
@@ -105,7 +109,7 @@ describe('isDistinctiveToken', () => {
     expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(true);
   });
 
-  it('treats an occurrence inside a fenced code block as code context even without an adjacent backtick/slash (real false negative found dogfooding: createVectorDB in a README usage example)', () => {
+  it('treats an occurrence inside a fenced code block as code context even without an adjacent backtick/slash (real false negative found dogfooding: a bare lowercase token in a README usage example)', () => {
     const docChunks = [
       makeChunk(
         'packages/core/README.md',
@@ -113,29 +117,33 @@ describe('isDistinctiveToken', () => {
           '## Usage',
           '',
           '```typescript',
-          "import { createVectorDB } from '@liendev/core';",
+          "import { zznovelfence } from '@liendev/core';",
           '',
-          "const db = await createVectorDB('./my-project');",
+          "const db = await zznovelfence('./my-project');",
           '```',
         ].join('\n'),
       ),
     ];
-    expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(true);
+    // A bare lowercase token (no uppercase/underscore) still goes through the
+    // strict corpus-driven gate — this isolates the FENCE fix specifically,
+    // independent of the identifier-shape exemption tested below.
+    expect(isUnambiguousIdentifierShape('zznovelfence')).toBe(false);
+    expect(isDistinctiveToken('zznovelfence', docChunks)).toBe(true);
   });
 
-  it('still suppresses a prose hit that sits OUTSIDE any fence, even alongside fenced code elsewhere', () => {
+  it('still suppresses a bare lowercase token on a prose hit OUTSIDE any fence, even alongside fenced code elsewhere', () => {
     const docChunks = [
       makeChunk(
         'docs/guide.md',
         [
-          'The createVectorDB helper is handy.',
+          'The zznovelfence helper is handy.',
           '```typescript',
-          "const db = await createVectorDB('./my-project');",
+          "const db = await zznovelfence('./my-project');",
           '```',
         ].join('\n'),
       ),
     ];
-    expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(false);
+    expect(isDistinctiveToken('zznovelfence', docChunks)).toBe(false);
   });
 
   it('is true (vacuously) when the token never appears in the corpus at all', () => {
@@ -153,5 +161,85 @@ describe('isDistinctiveToken', () => {
     expect(isDistinctiveToken('zznovelplatform', onlyMatching)).toBe(
       isDistinctiveToken('zznovelplatform', withUnrelatedChunk),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isUnambiguousIdentifierShape + the exemption it grants in isDistinctiveToken
+// ---------------------------------------------------------------------------
+
+describe('isUnambiguousIdentifierShape', () => {
+  it('is true for camelCase (internal capital)', () => {
+    expect(isUnambiguousIdentifierShape('createVectorDB')).toBe(true);
+    expect(isUnambiguousIdentifierShape('authToken')).toBe(true);
+  });
+
+  it('is true for PascalCase', () => {
+    expect(isUnambiguousIdentifierShape('MyClass')).toBe(true);
+  });
+
+  it('is true for a single Capitalized word (a proper-noun-style class/type name)', () => {
+    expect(isUnambiguousIdentifierShape('Widget')).toBe(true);
+  });
+
+  it('is true for a token containing an underscore', () => {
+    expect(isUnambiguousIdentifierShape('my_helper')).toBe(true);
+  });
+
+  it('is false for a bare all-lowercase word', () => {
+    expect(isUnambiguousIdentifierShape('index')).toBe(false);
+    expect(isUnambiguousIdentifierShape('config')).toBe(false);
+    expect(isUnambiguousIdentifierShape('platform')).toBe(false);
+  });
+});
+
+describe('isDistinctiveToken — identifier-shape exemption (reviewer repros)', () => {
+  it('createVectorDB fires even with plain, un-backticked prose mentions present (the flagship dogfood case)', () => {
+    const docChunks = [
+      makeChunk(
+        'docs/architecture/blast-radius-nudge.md',
+        'Callers will break — check get_dependents. 9 docs reference createVectorDB: CLAUDE.md, docs/guide.md.',
+      ),
+      makeChunk(
+        'CLAUDE.md',
+        'This module also mentions createVectorDB in passing, with no backticks at all.',
+      ),
+    ];
+    expect(isDistinctiveToken('createVectorDB', docChunks)).toBe(true);
+  });
+
+  it("Widget's possessive in plain prose still fires (a Capitalized class name, not a common English word)", () => {
+    const docChunks = [
+      makeChunk('docs/guide.md', "The Widget's constructor accepts an options object."),
+    ];
+    expect(isDistinctiveToken('Widget', docChunks)).toBe(true);
+  });
+
+  it('authToken in YAML front-matter prose still fires', () => {
+    const docChunks = [
+      makeChunk(
+        'docs/guide.md',
+        ['---', 'summary: explains how authToken is issued and rotated', '---', '# Auth'].join(
+          '\n',
+        ),
+      ),
+    ];
+    expect(isDistinctiveToken('authToken', docChunks)).toBe(true);
+  });
+
+  it('MyClass named in a heading (not backticked) still fires', () => {
+    const docChunks = [makeChunk('docs/guide.md', '## MyClass overview')];
+    expect(isDistinctiveToken('MyClass', docChunks)).toBe(true);
+  });
+
+  it('a bare lowercase common word (index/config/platform) in prose is still suppressed', () => {
+    const indexDocs = [makeChunk('docs/guide.md', 'See the index below for a full list.')];
+    const configDocs = [makeChunk('docs/guide.md', 'Edit the config to change defaults.')];
+    const platformDocs = [
+      makeChunk('docs/guide.md', 'Design identity for all Lien properties (platform app).'),
+    ];
+    expect(isDistinctiveToken('index', indexDocs)).toBe(false);
+    expect(isDistinctiveToken('config', configDocs)).toBe(false);
+    expect(isDistinctiveToken('platform', platformDocs)).toBe(false);
   });
 });

--- a/packages/parser/src/doc-reference-matching.ts
+++ b/packages/parser/src/doc-reference-matching.ts
@@ -1,0 +1,127 @@
+import type { CodeChunk } from './types.js';
+
+/**
+ * Shared matching primitives for "does an untouched doc chunk still reference
+ * this token" — the piece two independent consumers need identically:
+ *
+ * - `packages/review/src/docs-drift-signals.ts` (a PR-review-time pass: which
+ *   untouched docs still name a symbol/path this PR removed/renamed/deleted).
+ * - `packages/cli/src/utils/doc-references.ts` (an edit-time nudge: which
+ *   indexed doc chunks reference a symbol `lien api-delta` just found
+ *   removed — see docs/architecture/blast-radius-nudge.md's docRefs section).
+ *
+ * Lifted here (rather than duplicated) so the two stay behavior-identical:
+ * `packages/review` depends on `@liendev/parser` only (not `@liendev/core`),
+ * so this is the one package both call sites can share.
+ */
+
+/**
+ * The characters that would extend a matched token into a DIFFERENT, longer
+ * identifier or path segment — used as a negative lookaround so a token match
+ * doesn't spuriously fire inside a larger token it's merely a substring of
+ * (e.g. `packages/runner` inside `packages/runner-hosted`; `fetchUser` inside
+ * `my-fetchUser` or `fetchUser.old`). Plain `\b` alone is insufficient: `-`
+ * and `.` are non-word characters, so `\b` treats them as legitimate
+ * boundaries even though identifier/path conventions use them to continue
+ * the same token. `/` is deliberately NOT in this set — a leading/trailing
+ * `/` is a legitimate path continuation (`packages/runner/README.md` still
+ * names the same directory).
+ */
+const CONTINUATION_CHARS = '[A-Za-z0-9_.-]';
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * A word/path-boundary regex for `token` — see `CONTINUATION_CHARS` for why
+ * this is stricter than plain `\b`. Pass `flags: 'g'` for a reusable
+ * global-match regex (`matchAll`).
+ */
+export function wordBoundaryRe(token: string, flags = ''): RegExp {
+  const escaped = escapeForRegex(token);
+  return new RegExp(`(?<!${CONTINUATION_CHARS})${escaped}(?!${CONTINUATION_CHARS})`, flags);
+}
+
+/**
+ * A neighbor character that marks a `token` occurrence as CODE/PATH context
+ * (a directory/file listing, or an inline code span) rather than ordinary
+ * prose: a path separator, or the backtick markdown convention uses for a
+ * bare identifier/path (e.g. `` `platform/` `` or `` `createVectorDB` ``).
+ */
+const CODE_CONTEXT_NEIGHBOR_RE = /[/`]/;
+
+/** Fence delimiter: up to 3 leading spaces, then 3+ backticks or 3+ tildes (mirrors
+ *  markdown-chunker.ts's own `FENCE_RE`). */
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * Per-line "entering this line, are we inside a fenced code block" state —
+ * toggles on every fence delimiter strictly before the line (mirrors
+ * `docs-drift-signals.ts`'s own `isInsideFence`, computed once per chunk
+ * instead of once per query line). A multi-line fenced usage example (a
+ * triple-backtick ```typescript block, or an ASCII directory-tree diagram) is
+ * unambiguously code, even though no single occurrence inside it sits
+ * directly against a `/` or a backtick — without this, a genuinely
+ * distinctive symbol referenced only inside such a fence (its normal,
+ * expected form) would wrongly read as "not distinctive" (verified against a
+ * real false negative: `createVectorDB`'s own README usage examples and
+ * CLAUDE.md's fenced package-structure tree).
+ */
+function computeFenceState(lines: string[]): boolean[] {
+  const state: boolean[] = [];
+  let inFence = false;
+  for (const line of lines) {
+    state.push(inFence);
+    if (FENCE_RE.test(line.trim())) inFence = !inFence;
+  }
+  return state;
+}
+
+/** True iff the `tokenLength`-long occurrence starting at `index` in `line`
+ *  sits directly against a `/` or a backtick on either side — i.e. reads as
+ *  a path/identifier, not a word in a sentence. */
+function isCodeContextOccurrence(line: string, index: number, tokenLength: number): boolean {
+  const before = index > 0 ? line[index - 1] : '';
+  const after = line[index + tokenLength] ?? '';
+  return CODE_CONTEXT_NEIGHBOR_RE.test(before) || CODE_CONTEXT_NEIGHBOR_RE.test(after);
+}
+
+/** True iff every occurrence of `re` across `chunk`'s lines sits in
+ *  code/path-context: either the whole line is inside a fenced code block
+ *  (see `computeFenceState`), or the occurrence itself sits in inline
+ *  code/path-context (see `isCodeContextOccurrence`). */
+function everyLineIsCodeContextOnly(chunk: CodeChunk, re: RegExp, tokenLength: number): boolean {
+  const lines = chunk.content.split('\n');
+  const fenceState = computeFenceState(lines);
+  return lines.every(
+    (line, i) =>
+      fenceState[i] ||
+      [...line.matchAll(re)].every(
+        m => m.index === undefined || isCodeContextOccurrence(line, m.index, tokenLength),
+      ),
+  );
+}
+
+/**
+ * True iff EVERY word-boundary occurrence of `token` across `docChunks` reads
+ * as code/path context — never as ordinary prose describing something
+ * unrelated (e.g. a bare directory named `platform` inside "supports every
+ * platform", or a bare symbol named `index`/`config` inside "the index is
+ * built here"). A single prose hit disqualifies the token: when in doubt,
+ * suppress.
+ *
+ * Corpus-driven rather than a hardcoded stopword list: a fixed word list
+ * needs constant upkeep across languages/domains and still misses whatever
+ * wasn't anticipated. Checking what the corpus actually does with the word
+ * is self-maintaining. Chunks that don't even contain `token` trivially pass
+ * (nothing to disqualify), so callers may pass either the full doc corpus or
+ * an already-narrowed "chunks containing this token" set — both produce the
+ * same result.
+ */
+export function isDistinctiveToken(token: string, docChunks: CodeChunk[]): boolean {
+  const re = wordBoundaryRe(token, 'g');
+  return docChunks.every(
+    chunk => !chunk.content.includes(token) || everyLineIsCodeContextOnly(chunk, re, token.length),
+  );
+}

--- a/packages/parser/src/doc-reference-matching.ts
+++ b/packages/parser/src/doc-reference-matching.ts
@@ -103,20 +103,42 @@ function everyLineIsCodeContextOnly(chunk: CodeChunk, re: RegExp, tokenLength: n
   );
 }
 
+/** A lowercase letter immediately followed by an uppercase one, or vice versa
+ *  (`eV` in `createVectorDB`, `hT` in `authToken`, `yC` in `MyClass`, `Wi` in
+ *  `Widget`) — the case TRANSITION that marks camelCase, PascalCase, or a
+ *  single Capitalized word, as opposed to a bare ALL-CAPS acronym (`API`,
+ *  `ID`, `URL`, `DB`, `UI`, `HTTP`, `TODO`), which has no lowercase letter
+ *  anywhere to transition from/to. */
+const CASE_TRANSITION_RE = /[a-z][A-Z]|[A-Z][a-z]/;
+
+/** An underscore with a word character on BOTH sides (`o_b` in `foo_bar`) —
+ *  an internal separator, as opposed to a purely decorative leading/trailing
+ *  underscore (`_prefix`, `foo_`), which doesn't make an ordinary word any
+ *  less ambiguous. */
+const INTERNAL_UNDERSCORE_RE = /\w_\w/;
+
 /**
- * True iff `token` contains an uppercase letter or an underscore anywhere —
- * the shape no ordinary lowercase English word has (`index`, `config`,
- * `platform`), so it CANNOT be mistaken for one no matter how many plain-
- * prose occurrences turn up in the corpus. Deliberately not restricted to a
- * "camelCase/PascalCase boundary strictly after position 0": a single
- * Capitalized proper-noun-style token (a class name referenced in prose
- * without markdown code-formatting, e.g. "the Widget's constructor") is
- * exactly as unambiguous as `createVectorDB` or `authToken` — English
- * common nouns are lowercase mid-sentence, so any capital letter, anywhere,
- * is already a strong enough signal. Exposed for testing.
+ * True iff `token` has an internal camelCase/PascalCase case transition or an
+ * internal underscore — the shape no ordinary lowercase English word has
+ * (`index`, `config`, `platform`), so it CANNOT be mistaken for one no matter
+ * how many plain-prose occurrences turn up in the corpus.
+ *
+ * Deliberately NARROWER than "contains any uppercase letter or underscore
+ * anywhere": a bare ALL-CAPS acronym (`API`, `ID`, `URL`, `DB`, `UI`, `HTTP`,
+ * `TODO`) is exactly the kind of ordinary, high-frequency word this gate
+ * exists to catch — "call the API", "check the ID" are completely mundane
+ * prose, and a removed export literally named `ID` or `API` would otherwise
+ * false-fire against nearly every doc in a real corpus. A single trailing or
+ * leading underscore (`foo_`, `_prefix`) is excluded for the same reason: it
+ * doesn't turn an otherwise-ordinary word into an identifier the way an
+ * INTERNAL separator does. False-fires are this nudge's worst failure mode
+ * (an incorrect "N docs reference X" is actively misleading, whereas a missed
+ * reference is merely silent) — this is why the requirement is a genuine
+ * shape signal, not merely "has a capital letter somewhere." Exposed for
+ * testing.
  */
 export function isUnambiguousIdentifierShape(token: string): boolean {
-  return /[A-Z_]/.test(token);
+  return CASE_TRANSITION_RE.test(token) || INTERNAL_UNDERSCORE_RE.test(token);
 }
 
 /**

--- a/packages/parser/src/doc-reference-matching.ts
+++ b/packages/parser/src/doc-reference-matching.ts
@@ -104,12 +104,39 @@ function everyLineIsCodeContextOnly(chunk: CodeChunk, re: RegExp, tokenLength: n
 }
 
 /**
+ * True iff `token` contains an uppercase letter or an underscore anywhere —
+ * the shape no ordinary lowercase English word has (`index`, `config`,
+ * `platform`), so it CANNOT be mistaken for one no matter how many plain-
+ * prose occurrences turn up in the corpus. Deliberately not restricted to a
+ * "camelCase/PascalCase boundary strictly after position 0": a single
+ * Capitalized proper-noun-style token (a class name referenced in prose
+ * without markdown code-formatting, e.g. "the Widget's constructor") is
+ * exactly as unambiguous as `createVectorDB` or `authToken` — English
+ * common nouns are lowercase mid-sentence, so any capital letter, anywhere,
+ * is already a strong enough signal. Exposed for testing.
+ */
+export function isUnambiguousIdentifierShape(token: string): boolean {
+  return /[A-Z_]/.test(token);
+}
+
+/**
  * True iff EVERY word-boundary occurrence of `token` across `docChunks` reads
  * as code/path context — never as ordinary prose describing something
  * unrelated (e.g. a bare directory named `platform` inside "supports every
  * platform", or a bare symbol named `index`/`config` inside "the index is
  * built here"). A single prose hit disqualifies the token: when in doubt,
  * suppress.
+ *
+ * Skipped entirely for a token with `isUnambiguousIdentifierShape` — a
+ * camelCase/PascalCase identifier or an underscored name reads as code no
+ * matter what surrounds it in prose, so gating it the same way a bare
+ * lowercase word needs to be gated would only produce false suppressions
+ * (found dogfooding: this feature's own architecture-doc writeup mentions
+ * `createVectorDB` inline, un-backticked, in running prose — a real doc
+ * reference that must not be thrown away). The strict corpus-driven check
+ * below remains exactly as it was for a bare lowercase word (the review
+ * pass's bare-top-level-directory case, `platform`/`runner`, is unaffected
+ * by construction: directory names here are always lowercase).
  *
  * Corpus-driven rather than a hardcoded stopword list: a fixed word list
  * needs constant upkeep across languages/domains and still misses whatever
@@ -120,6 +147,8 @@ function everyLineIsCodeContextOnly(chunk: CodeChunk, re: RegExp, tokenLength: n
  * same result.
  */
 export function isDistinctiveToken(token: string, docChunks: CodeChunk[]): boolean {
+  if (isUnambiguousIdentifierShape(token)) return true;
+
   const re = wordBoundaryRe(token, 'g');
   return docChunks.every(
     chunk => !chunk.content.includes(token) || everyLineIsCodeContextOnly(chunk, re, token.length),

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -191,3 +191,10 @@ export type { ChunkOnlyOptions, ChunkOnlyResult } from './chunk-only-index.js';
 
 export { computeBlastRadiusRisk } from './risk/blast-radius-risk.js';
 export type { BlastRadiusRiskInput, BlastRadiusRisk } from './risk/blast-radius-risk.js';
+
+// =============================================================================
+// DOC REFERENCE MATCHING (shared by the review docs-drift pass and the CLI's
+// edit-time docRefs lookup — see doc-reference-matching.ts's own docstring)
+// =============================================================================
+
+export { wordBoundaryRe, isDistinctiveToken } from './doc-reference-matching.js';

--- a/packages/review/src/docs-drift-signals.ts
+++ b/packages/review/src/docs-drift-signals.ts
@@ -52,6 +52,7 @@
  */
 
 import type { CodeChunk } from '@liendev/parser';
+import { wordBoundaryRe, isDistinctiveToken } from '@liendev/parser';
 import type { ReviewContext } from './plugin-types.js';
 import { extractRemovedExports } from './removed-export-signals.js';
 import { detectRenameSweeps } from './rename-sweep-signals.js';
@@ -205,21 +206,6 @@ function directoryIsGone(dir: string, repoChunks: CodeChunk[] | undefined): bool
 }
 
 /**
- * A neighbor character that marks a `token` occurrence as PATH-context (a directory/file listing)
- * rather than ordinary prose: a path separator, or the backtick this repo's own docs use to mark a
- * bare directory/file token (e.g. CLAUDE.md's own `` `packages/` `` / `` `platform/` `` bullets).
- */
-const PATH_CONTEXT_NEIGHBOR_RE = /[/`]/;
-
-/** True iff the `token`-length occurrence starting at `index` in `line` sits directly against a
- *  `/` or a backtick on either side — i.e. reads as a path/identifier, not a word in a sentence. */
-function isPathContextOccurrence(line: string, index: number, tokenLength: number): boolean {
-  const before = index > 0 ? line[index - 1] : '';
-  const after = line[index + tokenLength] ?? '';
-  return PATH_CONTEXT_NEIGHBOR_RE.test(before) || PATH_CONTEXT_NEIGHBOR_RE.test(after);
-}
-
-/**
  * True iff EVERY word-boundary occurrence of a BARE top-level directory referand (e.g. `platform`,
  * no `packages/` prefix) across the repo's doc/config corpus reads as a path/identifier — never as
  * ordinary prose describing something unrelated (e.g. "supports every platform", "the existing
@@ -231,34 +217,17 @@ function isPathContextOccurrence(line: string, index: number, tokenLength: numbe
  * individual file path never carries (both always contain a `/`, so neither can spuriously match a
  * plain English word in the middle of a sentence).
  *
- * Corpus-driven rather than a hardcoded stopword list: a fixed word list needs constant upkeep and
- * still misses whatever wasn't anticipated — this repo's own `platform`/`runner` (see #593's real
- * deletion, the motivating case) are generic SOFTWARE nouns, not classic linguistic stopwords, so an
- * off-the-shelf English stopword list would miss them entirely. Checking what THIS repo's own docs
- * actually do with the word is self-maintaining and needs no list to keep up to date — verified
- * against this repo's own corpus, `platform` reads as ordinary prose in both `STYLE_GUIDE.md`
- * ("...documentation site, platform app...") and this package's own harness `README.md` ("...the
- * existing platform .env...") — exactly the false-positive risk this gate exists to close. Exposed
- * for testing.
+ * Delegates to `@liendev/parser`'s `isDistinctiveToken` — the exact same corpus-driven "does every
+ * occurrence read as code/path context" check, shared with the CLI's edit-time docRefs lookup (see
+ * `doc-reference-matching.ts`'s docstring). Kept as a named export here, rather than inlining the
+ * import at call sites, because this module's own test suite exercises it directly under this name.
+ * Verified against this repo's own corpus, `platform` reads as ordinary prose in both
+ * `STYLE_GUIDE.md` ("...documentation site, platform app...") and this package's own harness
+ * `README.md` ("...the existing platform .env...") — exactly the false-positive risk this gate
+ * exists to close. Exposed for testing.
  */
 export function isDistinctiveBareDirectory(token: string, docChunks: CodeChunk[]): boolean {
-  const re = wordBoundaryRe(token, 'g');
-  return docChunks.every(
-    chunk => !chunk.content.includes(token) || everyLineIsPathContextOnly(chunk, re, token.length),
-  );
-}
-
-/** True iff every occurrence of `re` across `chunk`'s lines sits in path-context (see
- *  `isPathContextOccurrence`). Split out of `isDistinctiveBareDirectory` to keep that function's
- *  own nesting shallow (mirrors `collectMatchesInChunk`'s split out of `sweepReferand`). */
-function everyLineIsPathContextOnly(chunk: CodeChunk, re: RegExp, tokenLength: number): boolean {
-  return chunk.content
-    .split('\n')
-    .every(line =>
-      [...line.matchAll(re)].every(
-        m => m.index === undefined || isPathContextOccurrence(line, m.index, tokenLength),
-      ),
-    );
+  return isDistinctiveToken(token, docChunks);
 }
 
 /**
@@ -344,30 +313,10 @@ function collectUntouchedDocChunks(chunks: CodeChunk[], changed: Set<string>): C
 // ---------------------------------------------------------------------------
 // Word-boundary sweep
 // ---------------------------------------------------------------------------
-
-function escapeForRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * The characters that would extend a matched token into a DIFFERENT, longer identifier or path
- * segment — used as a negative lookaround so a referand match doesn't spuriously fire inside a
- * larger token it's merely a substring of (e.g. `packages/runner` inside `packages/runner-hosted`
- * or `sub-packages/runner`; `fetchUser` inside `my-fetchUser` or `fetchUser.old`). Plain `\b` alone
- * is insufficient: `-` and `.` are non-word characters, so `\b` treats them as legitimate
- * boundaries even though this codebase's identifier/path conventions use them to continue the same
- * token. `/` is deliberately NOT in this set — a leading/trailing `/` is a legitimate path
- * continuation (`packages/runner/README.md` still names the same now-deleted directory), and this
- * repo's own paths are `/`-delimited. (Adversarial review finding — packages/review/src/... #427.)
- */
-const CONTINUATION_CHARS = '[A-Za-z0-9_.-]';
-
-/** A word/path-boundary regex for `token` — see `CONTINUATION_CHARS` for why this is stricter than
- *  plain `\b`. Pass `flags: 'g'` for a reusable global-match regex (`matchAll`). */
-function wordBoundaryRe(token: string, flags = ''): RegExp {
-  const escaped = escapeForRegex(token);
-  return new RegExp(`(?<!${CONTINUATION_CHARS})${escaped}(?!${CONTINUATION_CHARS})`, flags);
-}
+//
+// `wordBoundaryRe` is imported from `@liendev/parser` (`doc-reference-matching.ts`) — shared with
+// the CLI's edit-time docRefs lookup so the two matching behaviors can never drift apart. See that
+// module's docstring for the full "why a negative lookaround, not plain `\b`" rationale.
 
 /** Cheap pre-check before the per-line regex: does `chunk`'s raw content contain the referand's
  *  token at all? (fast reject, mirrors `removed-export-signals.ts`'s own). */

--- a/packages/review/test/docs-drift-signals.test.ts
+++ b/packages/review/test/docs-drift-signals.test.ts
@@ -233,15 +233,21 @@ describe('isDistinctiveBareDirectory', () => {
 
   it(
     'is true when every occurrence sits inside a fenced code block, even without an adjacent ' +
-      'backtick/slash (pins a deliberate behavior CHANGE from the shared @liendev/parser fix: ' +
-      'previously this shape read as "not distinctive" — a fence was never recognized as code ' +
-      'context, only an inline backtick/slash was — and got silently suppressed)',
+      'backtick/slash touching the token itself (pins a deliberate behavior CHANGE from the ' +
+      'shared @liendev/parser fix: previously this shape read as "not distinctive" — a fence was ' +
+      'never recognized as code context, only an inline backtick/slash was — and got silently ' +
+      'suppressed). The fenced line deliberately has NO `/` or backtick adjacent to the token ' +
+      '(no trailing slash, no directory-listing punctuation) — otherwise the PRE-EXISTING ' +
+      'neighbor-character check alone would satisfy this fixture regardless of whether the fence ' +
+      'fix exists at all, making it pass even with the fence fix reverted (verified: it does).',
     () => {
       const docChunks = [
         makeChunk(
           'docs/guide.md',
           20,
-          ['## Directory layout', '', '```', 'zznovelfencedir/', '  src/', '```'].join('\n'),
+          ['## Directory layout', '', '```', 'the zznovelfencedir module lives here', '```'].join(
+            '\n',
+          ),
         ),
       ];
       expect(isDistinctiveBareDirectory('zznovelfencedir', docChunks)).toBe(true);
@@ -253,7 +259,12 @@ describe('isDistinctiveBareDirectory', () => {
       makeChunk(
         'docs/guide.md',
         1,
-        ['The zznovelfencedir helper is handy.', '```', 'zznovelfencedir/', '```'].join('\n'),
+        [
+          'The zznovelfencedir helper is handy.',
+          '```',
+          'the zznovelfencedir module lives here',
+          '```',
+        ].join('\n'),
       ),
     ];
     expect(isDistinctiveBareDirectory('zznovelfencedir', docChunks)).toBe(false);

--- a/packages/review/test/docs-drift-signals.test.ts
+++ b/packages/review/test/docs-drift-signals.test.ts
@@ -230,6 +230,34 @@ describe('isDistinctiveBareDirectory', () => {
   it('is true (vacuously) when the token never appears in the corpus at all', () => {
     expect(isDistinctiveBareDirectory('somewordneverpresent', [])).toBe(true);
   });
+
+  it(
+    'is true when every occurrence sits inside a fenced code block, even without an adjacent ' +
+      'backtick/slash (pins a deliberate behavior CHANGE from the shared @liendev/parser fix: ' +
+      'previously this shape read as "not distinctive" — a fence was never recognized as code ' +
+      'context, only an inline backtick/slash was — and got silently suppressed)',
+    () => {
+      const docChunks = [
+        makeChunk(
+          'docs/guide.md',
+          20,
+          ['## Directory layout', '', '```', 'zznovelfencedir/', '  src/', '```'].join('\n'),
+        ),
+      ];
+      expect(isDistinctiveBareDirectory('zznovelfencedir', docChunks)).toBe(true);
+    },
+  );
+
+  it('still suppresses a bare-directory prose hit OUTSIDE any fence, even alongside fenced code elsewhere', () => {
+    const docChunks = [
+      makeChunk(
+        'docs/guide.md',
+        1,
+        ['The zznovelfencedir helper is handy.', '```', 'zznovelfencedir/', '```'].join('\n'),
+      ),
+    ];
+    expect(isDistinctiveBareDirectory('zznovelfencedir', docChunks)).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/claude/hooks/api-delta-write.sh
+++ b/plugins/claude/hooks/api-delta-write.sh
@@ -53,21 +53,34 @@ fi
 # (by far the common one) renders a full, self-contained sentence per kind/
 # enrichment state; 2-3 changes fall back to a terser combined line. Empty
 # array -> jq emits nothing -> stay silent.
+#
+# docRefsClause (single-change only; docRefCount is always null/absent for a
+# signature-changed row, so this is a no-op there) appends the docs-drift-
+# shifted-left signal: which indexed doc chunks still name a symbol this edit
+# just removed. See docs/architecture/blast-radius-nudge.md's docRefs section.
 msg="$(printf '%s' "$json" | jq -r '
+  def docRefsClause:
+    if (.docRefCount // 0) > 0 then
+      " " + (.docRefCount|tostring) + " docs reference " + .symbol + ": "
+        + (.docRefPaths[0:3] | join(", "))
+        + (if .docRefCount > (.docRefPaths|length)
+           then " (+\(.docRefCount - (.docRefPaths|length)) more)" else "" end)
+        + "."
+    else "" end;
   (.changes // []) as $c
   | ($c | length) as $n
   | if $n == 0 then empty
     elif $n == 1 then
       ($c[0]) as $x
       | if $x.kind == "removed" then
-          if $x.enriched then
+          (if $x.enriched then
             "⚠ lien: exported symbol removed — " + $x.symbol
               + " (" + ($x.dependentCount|tostring) + " dependents, risk " + $x.riskLevel + ")."
               + " Callers will break — check get_dependents."
           else
             "⚠ lien: exported symbol removed — " + $x.symbol + "."
               + " Check get_dependents (index unavailable for counts)."
-          end
+          end) + ($x | docRefsClause)
         else
           if $x.enriched then
             "⚠ lien: exported signature changed — " + $x.symbol
@@ -84,6 +97,7 @@ msg="$(printf '%s' "$json" | jq -r '
           | if .kind == "removed" then
               "removed " + .symbol
                 + (if .enriched then " (" + (.dependentCount|tostring) + " dependents, risk " + .riskLevel + ")" else " (index unavailable for counts)" end)
+                + (if (.docRefCount // 0) > 0 then ", " + (.docRefCount|tostring) + " docs" else "" end)
             else
               .symbol
                 + (if .enriched then " (" + (.dependentCount|tostring) + " dependents, " + (.untestedDependentCount|tostring) + " untested, risk " + .riskLevel + ")" else " (index unavailable for counts)" end)

--- a/plugins/claude/hooks/api-delta-write.sh
+++ b/plugins/claude/hooks/api-delta-write.sh
@@ -63,7 +63,7 @@ msg="$(printf '%s' "$json" | jq -r '
     if (.docRefCount // 0) > 0 then
       (.docRefPaths // []) as $paths
       | " " + (.docRefCount|tostring) + " docs reference " + .symbol + ": "
-        + ($paths[0:3] | join(", "))
+        + ($paths | join(", "))
         + (if .docRefCount > ($paths|length)
            then " (+\(.docRefCount - ($paths|length)) more)" else "" end)
         + "."

--- a/plugins/claude/hooks/api-delta-write.sh
+++ b/plugins/claude/hooks/api-delta-write.sh
@@ -61,10 +61,11 @@ fi
 msg="$(printf '%s' "$json" | jq -r '
   def docRefsClause:
     if (.docRefCount // 0) > 0 then
-      " " + (.docRefCount|tostring) + " docs reference " + .symbol + ": "
-        + (.docRefPaths[0:3] | join(", "))
-        + (if .docRefCount > (.docRefPaths|length)
-           then " (+\(.docRefCount - (.docRefPaths|length)) more)" else "" end)
+      (.docRefPaths // []) as $paths
+      | " " + (.docRefCount|tostring) + " docs reference " + .symbol + ": "
+        + ($paths[0:3] | join(", "))
+        + (if .docRefCount > ($paths|length)
+           then " (+\(.docRefCount - ($paths|length)) more)" else "" end)
         + "."
     else "" end;
   (.changes // []) as $c


### PR DESCRIPTION
## Summary

Roadmap idea 3 (docs-drift shifted left). When `lien api-delta` detects a **REMOVED** exported symbol, it now also looks up which indexed documentation chunks still reference it, appending the count and up to 3 paths to the same warning — the deterministic half of the review engine's docs-drift pass, moved to edit time. No LLM anywhere; the agent reading the warning is the judge.

**Update:** this PR went through one round of adversarial review (see below) that found a real over-suppression bug and two honesty gaps in the first commit. All four findings are fixed in the second commit, with the dogfood evidence fully re-captured against the rebuilt CLI.

- **Step-zero precondition verified empirically before any design/code** (per the brief): markdown is heading-chunked (`type: 'doc'`) and indexed **by default**, no flag. Confirmed both by reading the code path (`DEFAULT_INDEX_INCLUDE_PATTERNS` includes `**/*.md` unconditionally) and by querying this repo's own live index directly (`SELECT COUNT(*) FROM chunks WHERE type='doc'` → 1,078 real chunks).
- **Matching primitives lifted, not duplicated**: `wordBoundaryRe` (word-boundary regex w/ negative lookaround) and `isDistinctiveToken` (generalized from `isDistinctiveBareDirectory`) moved into `@liendev/parser`'s new `doc-reference-matching.ts`. `packages/review/src/docs-drift-signals.ts` now imports them instead of defining its own copies. The pure code-motion step was proven behavior-identical (review's suite passed unchanged immediately after the lift, before any logic changed) — see below for the two real behavior changes that followed, both disclosed rather than folded into "the lift."
- **Query path**: `packages/cli/src/utils/doc-references.ts`'s `findDocReferences(vectorDB, symbolName)` — `vectorDB.scanAll()` (no `type` filter exists on `VectorDBInterface`; same cost class `findDependents` already pays for the same removal event), filtered to `type: 'doc'`, word-boundary matched, distinctiveness-gated, capped at 3 displayed paths with a true total count for "(+N more)". Fail-open throughout.
- **Surface, all additive**: `EnrichedExportedSymbolChange` gains `docRefCount`/`docRefPaths` (only for `kind: 'removed'`); `api-delta-write.sh`'s warning gains one sentence for the single-change case, a terser `", N docs"` for the 2-3-change fallback; `BlastEventChange` gains an optional `docRefCount` (optional, not just nullable, for backward compat with events recorded before this field existed). `lien stats` is untouched.
- Design + full dogfood evidence written into `docs/architecture/blast-radius-nudge.md`'s new "E. docRefs" section.

## Adversarial review findings — all fixed in the second commit

1. **[MEDIUM, design] Over-suppression bug.** The distinctiveness gate suppressed a token on a single plain-prose hit ANYWHERE in the corpus, with no exemption for identifier-shaped tokens — and once this feature's own architecture-doc writeup was indexed, its own plain-prose mentions of `createVectorDB` made the flagship dogfood claim stop reproducing. Fixed: a token containing an uppercase letter or underscore (`createVectorDB`, `authToken`, `MyClass`, a Capitalized class name like `Widget`) is exempt from the corpus-wide prose gate entirely — no ordinary lowercase English word has that shape. A bare lowercase word (`index`, `config`, `platform` — the review pass's bare-directory case) is unaffected, proven by review's full suite passing unchanged plus a new fixture isolating the lowercase path.
2. **[Honesty] "Behavior-identical" was overclaimed.** The fence-context fix from the first commit is a genuine, disclosed behavior CHANGE for `isDistinctiveBareDirectory` — a bare directory referenced only inside a fenced code block now correctly fires instead of being silently suppressed. Reworded throughout the architecture doc to separate "the code-motion lift was proven identical" from "two real, deliberate improvements followed." Added a review-side regression fixture (`docs-drift-signals.test.ts`) pinning the new fenced-bare-directory behavior.
3. **[Robustness] `api-delta-write.sh` hardened.** A malformed `docRefCount: 5, docRefPaths: null` event previously crashed jq outright (`Cannot iterate over null (null)`), silently dropping the ENTIRE warning — including the base "symbol removed" sentence that has nothing to do with docRefs. Fixed with `(.docRefPaths // [])`; verified before/after through the real hook script, not just the extracted jq snippet.
4. **[Docs]** Added the 4-space-indented-code-block fence-detection gap to Known Limitations (consistent with the chunker's own `FENCE_RE`, which has the same gap).

**Re-captured dogfood evidence** against the rebuilt CLI (see the doc's "Dogfood evidence" section for full detail): the flagship `createVectorDB` claim reproduces unchanged (still 9 files — expected, since this doc's prose additions landed inside a file already counted). The "zero references" example was switched from a named real symbol (`detectFileType`, which the doc's own prose had turned into a doc reference once indexed — caught during re-verification) to a synthetic, disposable symbol added and removed via a temporary commit that was squashed away immediately after capture, so naming it in the doc can never turn it into a real reference. The hostile-input robustness fix was verified end-to-end through the actual hook script, both before (crash) and after (graceful degrade).

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (35 pre-existing warnings, unrelated files)
- [x] `npm run typecheck` — clean across parser/core/cli/review/action
- [x] `npm run build` — clean across all packages
- [x] `npm test` — 4,181 tests passed across all packages, 0 failures
- [x] `lien delta` — exit 0, no new complexity-threshold crossings
- [x] Review's full suite (1583 tests, incl. the new fenced-bare-directory fixture) passes
- [x] New unit tests: `doc-reference-matching.test.ts` (26, incl. the exemption-rule reviewer repros and the fence-bug regression), `doc-references.test.ts` (8), extended `api-delta-cmd.test.ts` (+4) and `blast-events.test.ts` (+4)
- [x] Real hook dogfood against this repo's own live overlay index, re-captured against the rebuilt CLI (see above)
- [x] Changeset added (`@liendev/lien` minor, `@liendev/parser` minor — linked group, `@liendev/core` follows automatically)

**Addendum (third commit):** two final residuals from re-verification, both fixed — the identifier-shape exemption was tightened to require a genuine case transition or internal underscore (not merely "any uppercase/underscore anywhere"), so a bare ALL-CAPS acronym like `API`/`ID`/`URL` no longer gets a free pass and false-fires against ordinary prose; and the review-side fenced-bare-directory fixture had `/` immediately after the token, which made it pass via the pre-existing slash-neighbor check regardless of the fence fix — reworded to remove that artifact and re-verified (via a local, reverted-and-restored fence check) that it now genuinely goes red without the fence fix and green with it.

Still draft — merge owned by the reviewer; the `review` CI check's red state is the OpenRouter daily quota cap (unrelated to this code), to be re-run separately after reset.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR shifts docs-drift detection left by enriching `lien api-delta` REMOVED-symbol warnings with indexed doc references. The implementation is largely careful and fail-open: shared parser primitives provide word-boundary + distinctiveness matching, the CLI lookup returns null on any error, and the blast-events ledger handles backward compatibility with absent `docRefCount`. The only concrete defect is a fence-state edge case in the new shared `doc-reference-matching.ts` where trimming a line before the fence-delimiter regex causes 4-space-indented backtick lines to be misclassified as fence openers.
>
> - New `@liendev/parser` module `doc-reference-matching.ts` shares `wordBoundaryRe` and `isDistinctiveToken` between review and CLI.
> - `lien api-delta` appends `docRefCount`/`docRefPaths` to REMOVED changes and renders them in text/JSON output.
> - `blast-events.jsonl` gains an additive optional `docRefCount` field with validation for absent/null/number states.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 64157b4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `lien api-delta` now identifies indexed documentation that references removed exported symbols.
  * Reports reference counts and up to three documentation paths in CLI output and warnings.
  * Blast-radius event records preserve documentation reference counts.

* **Bug Fixes**
  * Documentation matching now avoids substring and generic-prose false positives.
  * Missing or unavailable documentation indexes fail safely without interrupting reporting.

* **Documentation**
  * Added guidance on documentation references, limits, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->