### PR TITLE
fix(lint): cover packages/*/test/ in the root lint glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "docs:preview": "npm run docs:preview -w packages/site",
     "test": "npm run test -w @liendev/parser-native && npm run test -w @liendev/parser && npm run test -w @liendev/core && npm run test -w @liendev/review && npm run test -w packages/cli && npm run test -w @liendev/action",
     "test:coverage": "npm run test:coverage -w @liendev/core",
-    "lint": "eslint --no-error-on-unmatched-pattern packages/*/src/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs",
-    "lint:fix": "eslint --fix --no-error-on-unmatched-pattern packages/*/src/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs",
+    "lint": "eslint --no-error-on-unmatched-pattern packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs",
+    "lint:fix": "eslint --fix --no-error-on-unmatched-pattern packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs",
     "format": "prettier --write packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs",
     "format:check": "prettier --check packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs",
     "check": "npm run format:check && npm run lint && npm run typecheck",
-    "fix": "eslint --fix --no-error-on-unmatched-pattern packages/*/src/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs && prettier --write packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs"
+    "fix": "eslint --fix --no-error-on-unmatched-pattern packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs && prettier --write packages/*/src/ packages/*/test/ packages/parser-native/index.js packages/parser-native/index.d.ts packages/parser-native/scripts/*.mjs"
   },
   "keywords": [
     "mcp",

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -435,7 +435,7 @@ describe('E2E: Real Open Source Projects', () => {
               encoding: 'utf-8',
             });
             console.error(`   Python files found:\n${findPyFiles}`);
-          } catch (e) {
+          } catch (_e) {
             console.error(`   Could not find Python files`);
           }
         }

--- a/packages/review/test/analysis.test.ts
+++ b/packages/review/test/analysis.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { filterAnalyzableFiles, runComplexityAnalysis } from '../src/analysis.js';
 import { silentLogger } from '../src/test-helpers.js';
 

--- a/packages/review/test/engine-present.test.ts
+++ b/packages/review/test/engine-present.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ReviewEngine } from '../src/engine.js';
-import { createTestContext, createTestReport, silentLogger } from '../src/test-helpers.js';
+import { createTestReport, silentLogger } from '../src/test-helpers.js';
 import type {
   ReviewPlugin,
   ReviewFinding,


### PR DESCRIPTION
## Summary
- Root `lint`/`lint:fix`/`fix` scripts only globbed `packages/*/src/`, so ESLint never saw `packages/*/test/**` (including `packages/review/test/harness/fixtures/**`) — violations there escaped the gate chain and only surfaced via external review (#825's unused `h` param, caught by CodeRabbit, not `npm run lint`).
- Extended the three scripts' eslint globs to add `packages/*/test/`, matching the pattern the `format`/`format:check` scripts already use.
- Fixed the (trivial, mechanical) pre-existing unused-var/import errors the wider glob surfaced in `packages/cli/test/e2e/real-projects.test.ts`, `packages/review/test/analysis.test.ts`, and `packages/review/test/engine-present.test.ts`. Left 6 pre-existing `consistent-type-imports`/no-console warnings alone (warnings don't fail the gate — same as pre-existing warnings elsewhere in `src/`; fixing them is a separate, judgment-shaped cleanup, out of scope here).

Closes #830.

## Dogfood evidence

Ran the actual gate-chain commands against this repo after the change:

```
$ npm run lint
...
✖ 38 problems (0 errors, 38 warnings)
$ echo $?
0
```

Confirmed the specific fixture file named in #830 is now covered and clean:
```
$ npx eslint packages/review/test/harness/fixtures/docs-drift/pr799-two-pass-boundary.assertions.ts
(no output -- 0 problems)
```

Full gate chain, all green:
- `npm run format:check` -> pass
- `npm run lint` -> 0 errors, 38 warnings, exit 0
- `npm run typecheck` -> pass
- `npm run build` -> pass
- `npm test` -> 55+57+5 files, 1583+1049+41 tests passed
- `node packages/cli/dist/index.js delta` -> `no complexity changes across 3 file(s) vs HEAD`

No changeset: this only touches root dev-tooling scripts and internal test files, not published-package behavior.

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `node packages/cli/dist/index.js delta`

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR widens the root ESLint globs to include `packages/*/test/` and fixes the resulting unused-variable/import lint errors in three test files. There are no runtime behavior changes — only dev-tooling script updates and mechanical test-file cleanups — so the risk of breaking callers or producing wrong output is minimal.
>
> - Extended root `lint`, `lint:fix`, and `fix` npm scripts to lint `packages/*/test/` in addition to `packages/*/src/`.
> - Fixed unused `vi` import in `packages/review/test/analysis.test.ts`.
> - Fixed unused `createTestContext` import in `packages/review/test/engine-present.test.ts`.
> - Prefixed unused catch binding with underscore in `packages/cli/test/e2e/real-projects.test.ts`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d26184a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->