### PR TITLE
refactor(review): collapse build-prompts.ts main()'s per-pass blocks into a loop

### DIFF
--- a/packages/review/test/harness/build-prompts.ts
+++ b/packages/review/test/harness/build-prompts.ts
@@ -59,18 +59,68 @@ import {
   docsDriftPassBudget,
 } from '../../src/plugins/agent/docs-drift-pass.js';
 import type { AgentConfig } from '../../src/plugins/agent/types.js';
+import type { ReviewContext } from '../../src/plugin-types.js';
 
 import { loadFixture } from './fixture-loader.js';
 
 /** One extra pass's `{fires, ...prompts}` output shape (see `main`'s output object). Extracted
  *  so `main` itself stays a short orchestrator (lien delta: Halstead effort budget) instead of
- *  repeating the same fires-ternary-plus-spread four times. */
+ *  repeating the same fires-ternary-plus-spread per pass. */
 function passOutput(
   fires: boolean,
   build: () => { systemPrompt: string; initialMessage: string },
 ): { fires: true; systemPrompt: string; initialMessage: string } | { fires: false } {
   return fires ? { fires: true, ...build() } : { fires: false };
 }
+
+/** Descriptor for one extra pass — `{ shouldRun, buildPrompts, budget }` from
+ *  the pass's own module, keyed by the output field name `main` emits it
+ *  under. Iterating this array (instead of repeating a `passOutput(...)`
+ *  block per pass) is what keeps adding a 6th pass a one-line data change;
+ *  see #831. All 5 passes share this exact shape today — if a future pass
+ *  doesn't, give it its own inline block instead of forcing the shape. */
+interface PassDescriptor {
+  key: string;
+  shouldRun: (context: ReviewContext, config?: AgentConfig) => boolean;
+  buildPrompts: (
+    context: ReviewContext,
+    budget?: number,
+  ) => { systemPrompt: string; initialMessage: string };
+  budget: (baseBudget: number, context: ReviewContext) => number;
+}
+
+const PASS_DESCRIPTORS: PassDescriptor[] = [
+  {
+    key: 'docTruthPass',
+    shouldRun: shouldRunDocTruthPass,
+    buildPrompts: buildDocTruthPassPrompts,
+    budget: docTruthPassBudget,
+  },
+  {
+    key: 'staleDuplicatePass',
+    shouldRun: shouldRunStaleDuplicatePass,
+    buildPrompts: buildStaleDuplicatePassPrompts,
+    budget: staleDuplicatePassBudget,
+  },
+  {
+    key: 'incompleteHandlingPass',
+    shouldRun: shouldRunIncompleteHandlingPass,
+    buildPrompts: buildIncompleteHandlingPassPrompts,
+    budget: incompleteHandlingPassBudget,
+  },
+  {
+    key: 'removedExportsPass',
+    shouldRun: shouldRunRemovedExportsPass,
+    buildPrompts: buildRemovedExportsPassPrompts,
+    budget: removedExportsPassBudget,
+  },
+  {
+    key: 'docsDriftPass',
+    shouldRun: shouldRunDocsDriftPass,
+    buildPrompts: buildDocsDriftPassPrompts,
+    budget: docsDriftPassBudget,
+  },
+];
 
 async function main(): Promise<void> {
   const fixtureArg = process.argv[2];
@@ -96,20 +146,13 @@ async function main(): Promise<void> {
   // as production would apply it, not an always-uncapped worklist.
   const baseBudget = config?.maxTokenBudget ?? 100_000;
 
-  const docTruthPass = passOutput(shouldRunDocTruthPass(ctx, config), () =>
-    buildDocTruthPassPrompts(ctx, docTruthPassBudget(baseBudget, ctx)),
-  );
-  const staleDuplicatePass = passOutput(shouldRunStaleDuplicatePass(ctx, config), () =>
-    buildStaleDuplicatePassPrompts(ctx, staleDuplicatePassBudget(baseBudget, ctx)),
-  );
-  const incompleteHandlingPass = passOutput(shouldRunIncompleteHandlingPass(ctx, config), () =>
-    buildIncompleteHandlingPassPrompts(ctx, incompleteHandlingPassBudget(baseBudget, ctx)),
-  );
-  const removedExportsPass = passOutput(shouldRunRemovedExportsPass(ctx, config), () =>
-    buildRemovedExportsPassPrompts(ctx, removedExportsPassBudget(baseBudget, ctx)),
-  );
-  const docsDriftPass = passOutput(shouldRunDocsDriftPass(ctx, config), () =>
-    buildDocsDriftPassPrompts(ctx, docsDriftPassBudget(baseBudget, ctx)),
+  const extraPasses = Object.fromEntries(
+    PASS_DESCRIPTORS.map(pass => [
+      pass.key,
+      passOutput(pass.shouldRun(ctx, config), () =>
+        pass.buildPrompts(ctx, pass.budget(baseBudget, ctx)),
+      ),
+    ]),
   );
 
   const output = {
@@ -118,11 +161,7 @@ async function main(): Promise<void> {
     skippedRules: rules.skipped,
     systemPrompt,
     initialMessage,
-    docTruthPass,
-    staleDuplicatePass,
-    incompleteHandlingPass,
-    removedExportsPass,
-    docsDriftPass,
+    ...extraPasses,
   };
 
   process.stdout.write(JSON.stringify(output, null, 2) + '\n');


### PR DESCRIPTION
## Summary
- `packages/review/test/harness/build-prompts.ts`'s `main()` repeated a near-identical `passOutput(...)` block per extra pass (now 5: doc-truth, stale-duplicate, incomplete-handling, removed-exports, docs-drift), tripping `lien delta`'s advisory Halstead-effort warning on `main()` each time a pass was added.
- Replaced the 5 blocks with a `PASS_DESCRIPTORS: PassDescriptor[]` array (`{ key, shouldRun, buildPrompts, budget }`) and a single loop building `extraPasses` via `Object.fromEntries`, spread into the same output shape in the same key order. Adding a 6th pass is now a one-line data addition to the array instead of a new block in `main()`.
- No behavior change: all 5 passes already shared the exact same `(shouldRun, buildPrompts, budget)` signature shape, so this is a mechanical collapse, not a redesign.

Closes #831.

## Dogfood evidence

Captured `build-prompts.ts` output against the 3 checked-in fixtures (the only ones committed -- most fixtures are gitignored per the harness convention) **before** the refactor, then diffed against the **after** output:

```
$ npx tsx packages/review/test/harness/build-prompts.ts <fixture> > before.json   # pre-refactor
$ npx tsx packages/review/test/harness/build-prompts.ts <fixture> > after.json    # post-refactor
$ diff before.json after.json && echo BYTE-IDENTICAL

accurate-doc.fixture.json         -> BYTE-IDENTICAL   (docTruthPass fires:true, others fires:false)
renamed-stale-claim.fixture.json  -> BYTE-IDENTICAL   (docTruthPass fires:true, others fires:false)
placeholder.fixture.json          -> BYTE-IDENTICAL   (all 5 passes fires:false)
```

This exercises both branches of the `passOutput` ternary (the doc-truth fixtures hit `fires:true`, the placeholder hits `fires:false` for all 5) across the refactor.

`lien delta` confirms the fix actually relieves the flagged pressure:
```
$ node packages/cli/dist/index.js delta
packages/review/test/harness/build-prompts.ts
  ✓ improved  main   time 48m → 33m
```

Full gate chain, all green:
- `npm run format:check` -> pass
- `npm run lint` -> 0 errors, 38 warnings (unchanged, all pre-existing elsewhere), exit 0
- `npm run typecheck` -> pass
- `npm run build` -> pass
- `npm run test -w @liendev/review` -> 55 files / 1583 tests passed (fast inner loop on the touched package)
- `npm test` (full suite) -> parser-native/parser/core/review/cli/action all green
- `node packages/cli/dist/index.js delta` -> 1 file improved, 0 violations

No changeset: `@liendev/review` is a private/unpublished package (per CLAUDE.md) and this only touches its offline test harness, not published-package behavior.

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `node packages/cli/dist/index.js delta`
- [x] Byte-diff of `build-prompts.ts` output pre/post refactor on 3 fixtures

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This is a mechanical refactor of a test-harness orchestrator: five near-identical pass-output blocks are collapsed into a single loop over a `PASS_DESCRIPTORS` array, with the same `(shouldRun, buildPrompts, budget)` call shape preserved for each pass. The resulting object is built via `Object.fromEntries` and spread into the output in the same key order. No runtime behavior change is expected, and the PR provides byte-identical output evidence across three fixtures.
>
> - Replaced 5 repeated `passOutput(...)` blocks with a `PASS_DESCRIPTORS` array and a single loop producing `extraPasses` via `Object.fromEntries`.
> - Added a `PassDescriptor` interface and imported `ReviewContext` to type the descriptor array.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 38b75a0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->