### PR TITLE
fix(review): gate inline findings whose code citation contradicts the current file

### DIFF
--- a/packages/review/src/attestation.ts
+++ b/packages/review/src/attestation.ts
@@ -107,6 +107,17 @@ export interface InlineCommentsAttestation {
   dropped: number;
   /** Skipped because an equivalent comment already existed from a prior run. */
   deduped: number;
+  /**
+   * Rejected by the issue #846 citation gate before ever becoming a
+   * comment: the finding quoted a code fragment demonstrably absent from
+   * the current file (see `citation-gate.ts`). This is a DELIBERATE,
+   * fail-open noise reduction, not a failure — it must never move
+   * `computeVerdict` off `'delivered'` the way `dropped > 0` does. This is
+   * an ADDITIVE field on the existing v2 shape (`ATTESTATION_VERSION`
+   * unchanged — see that constant's own doc comment for when a bump is,
+   * and isn't, warranted).
+   */
+  citationGated: number;
 }
 
 export interface DeliveryAttestation {
@@ -435,7 +446,7 @@ export function emptyAttestation(
     spentTokens: 0,
     passesSkipped: [],
     annotationsEmitted: 0,
-    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0, citationGated: 0 },
     descriptionBadgeUpdated: null,
     outOfDiffReviewPosted: null,
     pipelineFailed,

--- a/packages/review/src/citation-gate.ts
+++ b/packages/review/src/citation-gate.ts
@@ -51,6 +51,15 @@ const MIN_CITATION_LENGTH = 4;
  * Extract backtick-quoted spans from finding free text that read as real
  * code citations rather than illustrative examples.
  *
+ * Scoped to single-line, single-backtick spans (`` `like this` ``) —
+ * matching the rule-prompt convention this repo actually uses for code
+ * citations (see `plugins/agent/rules.ts`'s `.findings.length`,
+ * `paths[0:3]`-style examples): short inline expressions, never a
+ * triple-backtick multi-line block. A finding that only ever quotes a
+ * multi-line block is simply `no-citation` here — fail-open, not a bug —
+ * rather than this module reaching into fenced-block parsing for a shape
+ * the prompts don't produce.
+ *
  * A span beginning with `-` is deliberately excluded: rule prompts
  * legitimately quote hypothetical malformed INPUT VALUES in `message`
  * alongside real code citations (e.g. the untrusted-input rule's own
@@ -58,7 +67,10 @@ const MIN_CITATION_LENGTH = 4;
  * CLI arg, never expected to appear verbatim in the file). Treating an
  * illustrative value as a citation would gate true findings on that
  * illustration alone — exactly the false-positive this module exists to
- * avoid.
+ * avoid. The dash check runs AFTER trimming (on the trimmed span), so
+ * leading whitespace inside the backticks (`` `  --flag` ``) can't smuggle
+ * a dash-prefixed span past the guard — trimming only removes whitespace,
+ * it can't remove the leading `-` itself.
  */
 export function extractCitedSpans(...texts: Array<string | undefined>): string[] {
   const spans: string[] = [];

--- a/packages/review/src/citation-gate.ts
+++ b/packages/review/src/citation-gate.ts
@@ -1,0 +1,115 @@
+/**
+ * Deterministic, zero-LLM gate against one specific hallucination shape:
+ * an inline finding whose `message`/`evidence` quotes a code fragment that
+ * demonstrably no longer exists in the current file (issue #846).
+ *
+ * ## The failure mode this closes
+ *
+ * A finding posted on commit A can be genuinely fixed by commit B. Nothing
+ * in the delivery pipeline previously checked a regenerated finding's own
+ * premise against the code it's about to be posted against — the marker
+ * key (`path::line::category`, see `engine.ts`'s `isDuplicateOfExistingComment`)
+ * only recognizes an EXISTING GitHub comment as a duplicate; it was never a
+ * mechanism for validating a brand-new finding's content. On PR #845, a
+ * fixed finding was followed by a fresh finding at a nearby line asserting
+ * a false premise about the now-different code, wasting a full triage
+ * round (see the issue for the concrete example).
+ *
+ * ## The asymmetry — read before touching this file
+ *
+ * This is a noise reducer, not a suppression system. A finding is gated
+ * ONLY when it quotes something specific AND that something is verifiably
+ * ABSENT from the current file. Every other case — no quoted citation at
+ * all, a citation that still matches, or the current file being
+ * unavailable to check — passes the finding through untouched. When in
+ * doubt, DELIVER.
+ *
+ * A false negative here (a stale finding that slips through because it
+ * didn't happen to quote anything checkable) just means issue #846's
+ * shape recurs occasionally, same as before this gate existed. A false
+ * positive (a TRUE finding silently dropped) would be strictly worse: it
+ * erodes trust in the tool with no error surfaced anywhere, and nothing
+ * downstream would ever know a real bug went unreported. Keep every change
+ * to this file biased toward "when unsure, don't gate."
+ *
+ * ## Scope: `message` + `evidence`, never `suggestion`
+ *
+ * A `suggestion` proposes a fix — code that does NOT exist yet, by
+ * definition. Treating its quoted spans as a "citation of current code"
+ * would gate nearly every finding that includes one, for exactly backwards
+ * reasons. Only `message` and `evidence` are searched.
+ */
+
+/**
+ * Minimum length for a quoted span to count as a citation. Shorter spans
+ * (single characters, bare short numbers) are too likely to coincidentally
+ * appear — or fail to appear — anywhere in a file to carry any signal.
+ */
+const MIN_CITATION_LENGTH = 4;
+
+/**
+ * Extract backtick-quoted spans from finding free text that read as real
+ * code citations rather than illustrative examples.
+ *
+ * A span beginning with `-` is deliberately excluded: rule prompts
+ * legitimately quote hypothetical malformed INPUT VALUES in `message`
+ * alongside real code citations (e.g. the untrusted-input rule's own
+ * worked example quotes `` `--votes foo` `` as an illustrative malformed
+ * CLI arg, never expected to appear verbatim in the file). Treating an
+ * illustrative value as a citation would gate true findings on that
+ * illustration alone — exactly the false-positive this module exists to
+ * avoid.
+ */
+export function extractCitedSpans(...texts: Array<string | undefined>): string[] {
+  const spans: string[] = [];
+  const pattern = /`([^`\n]+)`/g;
+  for (const text of texts) {
+    if (!text) continue;
+    for (const match of text.matchAll(pattern)) {
+      const span = match[1].trim();
+      if (span.length >= MIN_CITATION_LENGTH && !span.startsWith('-')) {
+        spans.push(span);
+      }
+    }
+  }
+  return spans;
+}
+
+export type CitationVerdict = 'no-citation' | 'match' | 'mismatch' | 'unverifiable';
+
+/**
+ * Verify extracted citation spans against the current file's full content.
+ *
+ * `'match'` requires only ONE span to be found, not every span — a finding
+ * that legitimately quotes both a removed pattern and a still-present one
+ * (or a real citation alongside prose that happens to hit the backtick
+ * regex) must not be gated just because not every span matches.
+ */
+export function verifyCitation(
+  spans: string[],
+  currentFileContent: string | null,
+): CitationVerdict {
+  if (spans.length === 0) return 'no-citation';
+  if (currentFileContent === null) return 'unverifiable';
+  return spans.some(span => currentFileContent.includes(span)) ? 'match' : 'mismatch';
+}
+
+/** The subset of a finding's fields this gate reads. */
+export interface CitableFinding {
+  message: string;
+  evidence?: string;
+}
+
+/**
+ * True only for the fail-CLOSED side of this gate: a finding that quotes
+ * code and NONE of what it quotes exists in the current file. Every other
+ * outcome (`no-citation`, `match`, `unverifiable`) returns false — see the
+ * module doc's asymmetry note.
+ */
+export function shouldGateFinding(
+  finding: CitableFinding,
+  currentFileContent: string | null,
+): boolean {
+  const spans = extractCitedSpans(finding.message, finding.evidence);
+  return verifyCitation(spans, currentFileContent) === 'mismatch';
+}

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -857,15 +857,16 @@ async function postPluginInlineComments(
  * Delivery-time defense against issue #846: drop a finding whose quoted
  * `message`/`evidence` citation is demonstrably absent from the CURRENT
  * file content, before it's ever built into a GitHub comment or considered
- * for dedup. Fetches each distinct filepath's current content at most
- * once, caching by path across the whole call.
+ * for dedup. Fetches every distinct filepath's current content ONCE, in
+ * parallel — a batch of findings across many files would otherwise
+ * serialize one network round trip per file on this delivery hot path.
  *
  * Fail-open: a file-content fetch failure (network error, deleted file,
  * private-repo auth hiccup) makes every finding in that file `unverifiable`,
  * which `shouldGateFinding` treats as "let it through" — see
  * `citation-gate.ts`'s module doc for the full asymmetry rationale. This
  * function never throws; a fetch problem degrades to "gate nothing", not
- * to gating everything.
+ * to gating everything (`getFullFileContent` itself already never throws).
  */
 async function gateStaleCitations(
   octokit: Octokit,
@@ -873,18 +874,16 @@ async function gateStaleCitations(
   findings: ReviewFinding[],
   logger: Logger,
 ): Promise<{ survivors: ReviewFinding[]; gated: number }> {
-  const contentByFile = new Map<string, string | null>();
+  const filepaths = [...new Set(findings.map(f => f.filepath))];
+  const contents = await Promise.all(
+    filepaths.map(filepath => getFullFileContent(octokit, pr, filepath, logger)),
+  );
+  const contentByFile = new Map(filepaths.map((filepath, i) => [filepath, contents[i]]));
+
   const survivors: ReviewFinding[] = [];
   let gated = 0;
 
   for (const finding of findings) {
-    if (!contentByFile.has(finding.filepath)) {
-      contentByFile.set(
-        finding.filepath,
-        await getFullFileContent(octokit, pr, finding.filepath, logger),
-      );
-    }
-
     if (shouldGateFinding(finding, contentByFile.get(finding.filepath) ?? null)) {
       gated++;
       logger.info(

--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -33,9 +33,11 @@ import {
   getExistingPluginCommentKeys,
   updatePRDescription,
   minimizeOutdatedComments,
+  getFullFileContent,
 } from './github-api.js';
 import type { LineComment, PRContext } from './types.js';
 import { performChunkOnlyIndex } from '@liendev/parser';
+import { shouldGateFinding } from './citation-gate.js';
 
 export interface EngineOptions {
   /** Enable verbose debug logging of activation decisions and timing */
@@ -50,7 +52,22 @@ export interface EngineOptions {
  */
 export interface PresentDelivery {
   annotationsEmitted: number;
-  inlineComments: { attempted: number; posted: number; dropped: number; deduped: number };
+  inlineComments: {
+    attempted: number;
+    posted: number;
+    dropped: number;
+    deduped: number;
+    /**
+     * Gated by the issue #846 citation check: the finding quoted a code
+     * fragment demonstrably absent from the current file, so it was never
+     * posted. Deliberately excluded from `dropped` (a real delivery
+     * failure) and from `deduped` (an existing comment already covered
+     * it) — this is neither; it's a finding the engine chose not to
+     * deliver because its own premise contradicted the current code. See
+     * `citation-gate.ts` for the full rationale and fail-open guarantees.
+     */
+    citationGated: number;
+  };
   /** null when no plugin contributed a description section this run (nothing to update). */
   descriptionBadgeUpdated: boolean | null;
   /** null when no plugin attempted an out-of-diff review comment this run. */
@@ -67,20 +84,20 @@ export interface PresentDelivery {
  */
 export const EMPTY_DELIVERY: PresentDelivery = {
   annotationsEmitted: 0,
-  inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+  inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0, citationGated: 0 },
   descriptionBadgeUpdated: false,
   outOfDiffReviewPosted: false,
 };
 
 /** Mutable accumulator threaded through a single `present()` call. */
 interface DeliveryTracker {
-  inlineComments: { attempted: number; posted: number; dropped: number; deduped: number };
+  inlineComments: PresentDelivery['inlineComments'];
   outOfDiffReviewPosted: boolean | null;
 }
 
 function createDeliveryTracker(): DeliveryTracker {
   return {
-    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0, citationGated: 0 },
     outOfDiffReviewPosted: null,
   };
 }
@@ -620,6 +637,7 @@ function createPostInlineComments(
     deliveryTracker.inlineComments.posted += result.posted;
     deliveryTracker.inlineComments.dropped += result.dropped;
     deliveryTracker.inlineComments.deduped += result.deduped;
+    deliveryTracker.inlineComments.citationGated += result.citationGated;
     return result;
   };
 }
@@ -692,18 +710,20 @@ function buildPresentContext(
 /**
  * Ground truth for one `postInlineComments` call, feeding both the
  * plugin-facing `{posted, skipped, dropped}` contract and the delivery
- * attestation. Invariant: `attempted === posted + dropped + deduped`.
+ * attestation. Invariant: `attempted === posted + dropped + deduped +
+ * citationGated`.
  *
  * `skipped` and `dropped` answer different questions and must not be
  * collapsed into one count: `skipped` is "was there a REASON not to post
- * this, unrelated to whether posting would have worked?" (out of diff, or an
- * equivalent comment already exists from a prior run — see `dedupSkipped`).
- * `dropped` is "did GitHub actually reject an attempted post?" — a real
- * delivery failure from `postPRReview`'s per-comment salvage path (#752).
- * `dropped` also folds in the out-of-diff count for attestation purposes
- * (nothing landed inline either way — see `InlineCommentsAttestation.dropped`'s
- * own doc comment), but `skipped` must stay benign-only: it used to also
- * have `dropped.length` folded in (the only way a `{posted, skipped}`-only
+ * this, unrelated to whether posting would have worked?" (out of diff, an
+ * equivalent comment already exists from a prior run — see `dedupSkipped`
+ * — or the citation gate rejected it — see `citationGated`). `dropped` is
+ * "did GitHub actually reject an attempted post?" — a real delivery
+ * failure from `postPRReview`'s per-comment salvage path (#752). `dropped`
+ * also folds in the out-of-diff count for attestation purposes (nothing
+ * landed inline either way — see `InlineCommentsAttestation.dropped`'s own
+ * doc comment), but `skipped` must stay benign-only: it used to also have
+ * `dropped.length` folded in (the only way a `{posted, skipped}`-only
  * contract, before `dropped` existed as its own field, could account for a
  * real failure at all) — that silently re-merged "nothing to worry about"
  * and "this actually failed" into the same number for any plugin reading
@@ -712,12 +732,19 @@ function buildPresentContext(
  */
 interface InlinePostOutcome {
   posted: number;
-  /** Benign: out of diff, or already commented (deduped). Never a delivery failure. */
+  /** Benign: out of diff, already commented (deduped), or citation-gated. Never a delivery failure. */
   skipped: number;
   attempted: number;
   /** A real delivery failure (GitHub rejected the post) — see the class comment above. */
   dropped: number;
   deduped: number;
+  /**
+   * Rejected by the issue #846 citation gate (`citation-gate.ts`): the
+   * finding quoted a code fragment demonstrably absent from the current
+   * file, so it was never built into a comment or considered for dedup.
+   * Fail-open by construction — see that module's own doc comment.
+   */
+  citationGated: number;
 }
 
 async function postPluginInlineComments(
@@ -728,14 +755,23 @@ async function postPluginInlineComments(
   logger: Logger,
 ): Promise<InlinePostOutcome> {
   const attempted = findings.length;
-  if (attempted === 0) return { posted: 0, skipped: 0, attempted: 0, dropped: 0, deduped: 0 };
+  if (attempted === 0) {
+    return { posted: 0, skipped: 0, attempted: 0, dropped: 0, deduped: 0, citationGated: 0 };
+  }
 
   const pluginId = findings[0].pluginId;
   if (findings.some(f => f.pluginId !== pluginId)) {
     logger.warning(
       `postInlineComments: mixed pluginIds in findings, skipping to avoid mis-attribution`,
     );
-    return { posted: 0, skipped: attempted, attempted, dropped: attempted, deduped: 0 };
+    return {
+      posted: 0,
+      skipped: attempted,
+      attempted,
+      dropped: attempted,
+      deduped: 0,
+      citationGated: 0,
+    };
   }
 
   const markerPrefix = `${PLUGIN_MARKER_PREFIX}${pluginId}:`;
@@ -746,15 +782,24 @@ async function postPluginInlineComments(
       `postInlineComments(${pluginId}): posting 0 of ${attempted} finding(s) ` +
         `(diff fetch failed — see warning above)`,
     );
-    return { posted: 0, skipped: attempted, attempted, dropped: attempted, deduped: 0 };
+    return {
+      posted: 0,
+      skipped: attempted,
+      attempted,
+      dropped: attempted,
+      deduped: 0,
+      citationGated: 0,
+    };
   }
 
   const { inDiff, outOfDiffCount } = diffResult;
 
+  const { survivors, gated: citationGated } = await gateStaleCitations(octokit, pr, inDiff, logger);
+
   let toPost: LineComment[] = [];
   let dedupSkipped = 0;
-  if (inDiff.length > 0) {
-    const comments: LineComment[] = inDiff.map(f => ({
+  if (survivors.length > 0) {
+    const comments: LineComment[] = survivors.map(f => ({
       path: f.filepath,
       line: f.line,
       body: buildPluginCommentBody(f, markerPrefix),
@@ -770,13 +815,21 @@ async function postPluginInlineComments(
     ));
   }
 
-  const skipped = outOfDiffCount + dedupSkipped;
+  const skipped = outOfDiffCount + dedupSkipped + citationGated;
   logger.info(
     `postInlineComments(${pluginId}): posting ${toPost.length} of ${attempted} finding(s) ` +
-      `(${outOfDiffCount} outside diff, ${dedupSkipped} already commented)`,
+      `(${outOfDiffCount} outside diff, ${dedupSkipped} already commented, ` +
+      `${citationGated} stale-citation gated)`,
   );
   if (toPost.length === 0) {
-    return { posted: 0, skipped, attempted, dropped: outOfDiffCount, deduped: dedupSkipped };
+    return {
+      posted: 0,
+      skipped,
+      attempted,
+      dropped: outOfDiffCount,
+      deduped: dedupSkipped,
+      citationGated,
+    };
   }
 
   const { posted, dropped } = await postPRReview(
@@ -796,7 +849,55 @@ async function postPluginInlineComments(
     attempted,
     dropped: outOfDiffCount + dropped.length,
     deduped: dedupSkipped,
+    citationGated,
   };
+}
+
+/**
+ * Delivery-time defense against issue #846: drop a finding whose quoted
+ * `message`/`evidence` citation is demonstrably absent from the CURRENT
+ * file content, before it's ever built into a GitHub comment or considered
+ * for dedup. Fetches each distinct filepath's current content at most
+ * once, caching by path across the whole call.
+ *
+ * Fail-open: a file-content fetch failure (network error, deleted file,
+ * private-repo auth hiccup) makes every finding in that file `unverifiable`,
+ * which `shouldGateFinding` treats as "let it through" — see
+ * `citation-gate.ts`'s module doc for the full asymmetry rationale. This
+ * function never throws; a fetch problem degrades to "gate nothing", not
+ * to gating everything.
+ */
+async function gateStaleCitations(
+  octokit: Octokit,
+  pr: PRContext,
+  findings: ReviewFinding[],
+  logger: Logger,
+): Promise<{ survivors: ReviewFinding[]; gated: number }> {
+  const contentByFile = new Map<string, string | null>();
+  const survivors: ReviewFinding[] = [];
+  let gated = 0;
+
+  for (const finding of findings) {
+    if (!contentByFile.has(finding.filepath)) {
+      contentByFile.set(
+        finding.filepath,
+        await getFullFileContent(octokit, pr, finding.filepath, logger),
+      );
+    }
+
+    if (shouldGateFinding(finding, contentByFile.get(finding.filepath) ?? null)) {
+      gated++;
+      logger.info(
+        `postInlineComments: gated stale-citation finding at ${finding.filepath}:${finding.line} ` +
+          `— quoted citation not found in the current file (issue #846)`,
+      );
+      continue;
+    }
+
+    survivors.push(finding);
+  }
+
+  return { survivors, gated };
 }
 
 /** Fetch diff lines and filter findings to those within the diff. Returns null on API failure. */

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -180,14 +180,16 @@ async function findExistingComment(
 }
 
 /**
- * Get code snippet from a file at a specific commit
+ * Shared fetch + base64-decode step behind {@link getFileContent} and
+ * {@link getFullFileContent}. Returns `null` (never throws) on any fetch
+ * error, or when the path resolves to something other than a file (e.g. a
+ * directory, which has no `content` field) — both callers fail open the
+ * same way.
  */
-export async function getFileContent(
+async function fetchDecodedFileContent(
   octokit: Octokit,
   prContext: PRContext,
   filepath: string,
-  startLine: number,
-  endLine: number,
   logger: Logger,
 ): Promise<string | null> {
   try {
@@ -199,11 +201,7 @@ export async function getFileContent(
     });
 
     if ('content' in response.data) {
-      const content = Buffer.from(response.data.content as string, 'base64').toString('utf-8');
-      const lines = content.split('\n');
-      // Line numbers are 1-based, array is 0-based
-      const snippet = lines.slice(startLine - 1, endLine).join('\n');
-      return snippet;
+      return Buffer.from(response.data.content as string, 'base64').toString('utf-8');
     }
   } catch (error) {
     logger.warning(`Failed to get content for ${filepath}: ${error}`);
@@ -213,11 +211,30 @@ export async function getFileContent(
 }
 
 /**
- * Fetch the full current content of a file at the PR's head commit.
- * Thin wrapper over {@link getFileContent} spanning the whole file — used
+ * Get code snippet from a file at a specific commit
+ */
+export async function getFileContent(
+  octokit: Octokit,
+  prContext: PRContext,
+  filepath: string,
+  startLine: number,
+  endLine: number,
+  logger: Logger,
+): Promise<string | null> {
+  const content = await fetchDecodedFileContent(octokit, prContext, filepath, logger);
+  if (content === null) return null;
+  const lines = content.split('\n');
+  // Line numbers are 1-based, array is 0-based
+  return lines.slice(startLine - 1, endLine).join('\n');
+}
+
+/**
+ * Fetch the full current content of a file at the PR's head commit. Used
  * by the citation gate (`citation-gate.ts`) to check a finding's quoted
  * premise against the actual current code. Returns `null` on any fetch
- * error, same as `getFileContent`, so callers can fail open.
+ * error, same as `getFileContent`, so callers can fail open. Unlike
+ * `getFileContent`, this returns the decoded content directly rather than
+ * slicing a line range — no `Number.MAX_SAFE_INTEGER` end-line stand-in.
  */
 export async function getFullFileContent(
   octokit: Octokit,
@@ -225,7 +242,7 @@ export async function getFullFileContent(
   filepath: string,
   logger: Logger,
 ): Promise<string | null> {
-  return getFileContent(octokit, prContext, filepath, 1, Number.MAX_SAFE_INTEGER, logger);
+  return fetchDecodedFileContent(octokit, prContext, filepath, logger);
 }
 
 /**

--- a/packages/review/src/github-api.ts
+++ b/packages/review/src/github-api.ts
@@ -213,6 +213,22 @@ export async function getFileContent(
 }
 
 /**
+ * Fetch the full current content of a file at the PR's head commit.
+ * Thin wrapper over {@link getFileContent} spanning the whole file — used
+ * by the citation gate (`citation-gate.ts`) to check a finding's quoted
+ * premise against the actual current code. Returns `null` on any fetch
+ * error, same as `getFileContent`, so callers can fail open.
+ */
+export async function getFullFileContent(
+  octokit: Octokit,
+  prContext: PRContext,
+  filepath: string,
+  logger: Logger,
+): Promise<string | null> {
+  return getFileContent(octokit, prContext, filepath, 1, Number.MAX_SAFE_INTEGER, logger);
+}
+
+/**
  * Result of {@link postPRReview}: how many line comments actually landed,
  * which ones were dropped (with why), and whether the summary body itself
  * made it through — so callers can surface the degradation instead of

--- a/packages/review/test/attestation.test.ts
+++ b/packages/review/test/attestation.test.ts
@@ -25,7 +25,7 @@ function baseInput(overrides?: Partial<AttestationInput>): AttestationInput {
     spentTokens: 12_000,
     passesSkipped: [],
     annotationsEmitted: 0,
-    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0, citationGated: 0 },
     descriptionBadgeUpdated: true,
     outOfDiffReviewPosted: null,
     ...overrides,
@@ -116,7 +116,7 @@ describe('assembleAttestation', () => {
   it('produces verdict "degraded:comments_dropped" when comments were dropped on an otherwise clean run', () => {
     const attestation = assembleAttestation(
       baseInput({
-        inlineComments: { attempted: 4, posted: 2, dropped: 2, deduped: 0 },
+        inlineComments: { attempted: 4, posted: 2, dropped: 2, deduped: 0, citationGated: 0 },
       }),
     );
     expect(attestation.verdict).toBe('degraded:comments_dropped');
@@ -160,7 +160,7 @@ describe('assembleAttestation', () => {
         conclusion: 'failure',
         findings: [neverRanFinding()],
         providerFailure: true,
-        inlineComments: { attempted: 4, posted: 0, dropped: 4, deduped: 0 },
+        inlineComments: { attempted: 4, posted: 0, dropped: 4, deduped: 0, citationGated: 0 },
       }),
     );
     expect(attestation.verdict).toBe('failed:provider_never_ran');
@@ -457,7 +457,7 @@ describe('computeVerdict', () => {
       pipelineFailed: true,
       providerFailure: true,
       passes: [{ name: 'main', ran: true, stopReason: 'budget', neverRan: false }],
-      inlineComments: { attempted: 1, posted: 0, dropped: 1, deduped: 0 },
+      inlineComments: { attempted: 1, posted: 0, dropped: 1, deduped: 0, citationGated: 0 },
     });
     expect(verdict).toBe('failed:analysis_error');
   });
@@ -473,7 +473,7 @@ describe('computeVerdict', () => {
         { name: 'main', ran: true, stopReason: 'completed', neverRan: false },
         { name: 'doc-truth', ran: true, stopReason: 'budget', neverRan: false },
       ],
-      inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0 },
+      inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0, citationGated: 0 },
     });
     expect(verdict).toBe('degraded:budget_starved');
   });
@@ -483,7 +483,7 @@ describe('formatAttestationBadgeLine', () => {
   it('renders verdict, comment counts, and token usage in one compact line', () => {
     const attestation = assembleAttestation(
       baseInput({
-        inlineComments: { attempted: 6, posted: 4, dropped: 2, deduped: 0 },
+        inlineComments: { attempted: 6, posted: 4, dropped: 2, deduped: 0, citationGated: 0 },
         allocatedTokens: 250_000,
         spentTokens: 238_000,
       }),

--- a/packages/review/test/citation-gate.test.ts
+++ b/packages/review/test/citation-gate.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { extractCitedSpans, verifyCitation, shouldGateFinding } from '../src/citation-gate.js';
+
+describe('extractCitedSpans', () => {
+  it('extracts a single backtick-quoted span', () => {
+    expect(extractCitedSpans('The hook hardcodes `paths[0:3]` inline.')).toEqual(['paths[0:3]']);
+  });
+
+  it('extracts spans from multiple texts (message + evidence)', () => {
+    const spans = extractCitedSpans('sees `foo.bar()`', 'evidence cites `baz.qux`');
+    expect(spans).toEqual(['foo.bar()', 'baz.qux']);
+  });
+
+  it('drops spans shorter than the minimum citation length', () => {
+    expect(extractCitedSpans('a bare `x` here')).toEqual([]);
+  });
+
+  it('drops CLI-flag-shaped illustrative spans (leading dash)', () => {
+    // The untrusted-input rule's own worked example quotes `--votes foo` as a
+    // hypothetical malformed CLI arg — never expected to appear verbatim in
+    // the file. Treating it as a citation would gate a TRUE finding on an
+    // illustrative example alone.
+    expect(extractCitedSpans('`--votes foo` produces NaN')).toEqual([]);
+  });
+
+  it('ignores undefined text arguments', () => {
+    expect(extractCitedSpans(undefined, '`realSpan`', undefined)).toEqual(['realSpan']);
+  });
+
+  it('returns an empty array when there are no backtick spans at all', () => {
+    expect(extractCitedSpans('Plain prose with no code quoted.')).toEqual([]);
+  });
+});
+
+describe('verifyCitation', () => {
+  it('returns "no-citation" when there are no spans to check', () => {
+    expect(verifyCitation([], 'any file content')).toBe('no-citation');
+  });
+
+  it('returns "unverifiable" when the current file content is unavailable', () => {
+    expect(verifyCitation(['foo.bar()'], null)).toBe('unverifiable');
+  });
+
+  it('returns "match" when at least one span is found in the current file', () => {
+    expect(verifyCitation(['foo.bar()', 'notThere()'], 'const x = foo.bar();')).toBe('match');
+  });
+
+  it('returns "mismatch" only when NONE of the spans are found', () => {
+    expect(verifyCitation(['gone()', 'alsoGone()'], 'const x = stillHere();')).toBe('mismatch');
+  });
+});
+
+describe('shouldGateFinding — the #845/#846 shape', () => {
+  it('gates a finding whose sole citation quotes code that was removed by the fix', () => {
+    // Run A (commit e6337d90): valid finding citing the hardcoded slice.
+    const runAFinding = {
+      message: 'The hook hardcodes `$paths[0:3]` while MAX_DOC_REF_PATHS is 3 elsewhere.',
+    };
+    // The fix (commit 7308ff5d) removed the slice entirely.
+    const fixedFileContent =
+      'paths=$(join_paths "$docRefs")\ncount=$((docRefCount - ${#paths[@]}))';
+    expect(shouldGateFinding(runAFinding, fixedFileContent)).toBe(true);
+  });
+
+  it('does not gate when the finding has no quoted citation at all', () => {
+    const finding = { message: 'This function has an off-by-one error in the loop bound.' };
+    expect(shouldGateFinding(finding, 'whatever the current file says')).toBe(false);
+  });
+
+  it('does not gate when the citation still matches the current file (region unchanged)', () => {
+    const finding = { message: 'Still hardcodes `paths[0:3]` here.' };
+    const unchangedFile = 'display=${paths[0:3]}\n';
+    expect(shouldGateFinding(finding, unchangedFile)).toBe(false);
+  });
+
+  it('does not gate a true finding on changed code that carries a VALID citation', () => {
+    // A new, independently-produced finding whose evidence cites a real
+    // fragment of the current (changed) code — must be delivered.
+    const finding = {
+      message: 'The new conditional silently swallows the error.',
+      evidence: 'Consumer at line 40 calls `result.catch(() => undefined)`.',
+    };
+    const currentFile = 'async function run() {\n  return result.catch(() => undefined);\n}';
+    expect(shouldGateFinding(finding, currentFile)).toBe(false);
+  });
+
+  it('does not gate when the current file is unavailable (fetch failure) — fail open', () => {
+    const finding = { message: 'Cites `someRemovedThing()` which is gone.' };
+    expect(shouldGateFinding(finding, null)).toBe(false);
+  });
+
+  it('is not fooled by a suggestion field (suggestion is never checked)', () => {
+    // A `suggestion` proposes code that does not exist yet by definition —
+    // this module must never read it as a citation.
+    const finding = {
+      message: 'Missing a null check before the property access.',
+      suggestion: 'Add `if (x == null) return;` before the access.',
+    };
+    // `if (x == null) return;` deliberately absent from "current" content.
+    expect(shouldGateFinding(finding as { message: string }, 'function f(x) { return x.y; }')).toBe(
+      false,
+    );
+  });
+
+  it('gates only when EVERY extracted span mismatches, not when one of several matches', () => {
+    const finding = {
+      message: 'Changed from `oldPattern()` to `newPattern()`, but a stray caller still uses it.',
+    };
+    // `oldPattern()` is gone, but `newPattern()` is present — any-match passes.
+    const currentFile = 'function caller() { return newPattern(); }';
+    expect(shouldGateFinding(finding, currentFile)).toBe(false);
+  });
+});

--- a/packages/review/test/citation-gate.test.ts
+++ b/packages/review/test/citation-gate.test.ts
@@ -23,6 +23,13 @@ describe('extractCitedSpans', () => {
     expect(extractCitedSpans('`--votes foo` produces NaN')).toEqual([]);
   });
 
+  it('drops a dash-prefixed span even with leading whitespace inside the backticks', () => {
+    // The dash check runs on the TRIMMED span, so leading whitespace can't
+    // smuggle a dash-prefixed illustrative value past the guard: trimming
+    // only removes whitespace, it can never remove the leading `-` itself.
+    expect(extractCitedSpans('`  --flag` was passed')).toEqual([]);
+  });
+
   it('ignores undefined text arguments', () => {
     expect(extractCitedSpans(undefined, '`realSpan`', undefined)).toEqual(['realSpan']);
   });

--- a/packages/review/test/engine-citation-gate.test.ts
+++ b/packages/review/test/engine-citation-gate.test.ts
@@ -229,5 +229,43 @@ describe('citation gate wiring (issue #846)', () => {
       deduped: 0,
       citationGated: 1,
     });
+    // Both findings share one file — content is fetched once, not once per finding.
+    expect(octokit.repos.getContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches each distinct file exactly once, in parallel, not once per finding', async () => {
+    const octokit = mockOctokit({ fileContent: 'shared content across files' });
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!(
+            [
+              finding({ filepath: 'src/a.ts', line: 5 }),
+              finding({ filepath: 'src/a.ts', line: 6 }),
+              finding({ filepath: 'src/b.ts', line: 5 }),
+            ],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    // The diff must cover both files for filterToDiffLines to keep them all.
+    const patch = '@@ -1,2 +5,3 @@\n+line5\n+line6\n+line7';
+    octokit.paginate.iterator = vi.fn((fn: unknown) => {
+      if (fn === octokit.pulls.listFiles) {
+        return onePage([
+          { filename: 'src/a.ts', patch },
+          { filename: 'src/b.ts', patch },
+        ]);
+      }
+      return onePage([]);
+    });
+
+    await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    // Two distinct filepaths across three findings — exactly two fetches.
+    expect(octokit.repos.getContent).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/review/test/engine-citation-gate.test.ts
+++ b/packages/review/test/engine-citation-gate.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Wiring-level coverage for the issue #846 citation gate: `ReviewEngine.present()`
+ * → `postInlineComments` must consult the CURRENT file content (via octokit)
+ * before posting, and drop only findings whose quoted citation demonstrably
+ * contradicts it. Pure extraction/verdict logic is covered in
+ * `citation-gate.test.ts`; this file proves the gate is actually wired into
+ * the delivery path end to end, including the fail-open behavior when the
+ * file fetch itself fails.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ReviewEngine } from '../src/engine.js';
+import { createTestReport, silentLogger } from '../src/test-helpers.js';
+import type {
+  ReviewPlugin,
+  ReviewFinding,
+  AdapterContext,
+  PresentContext,
+} from '../src/plugin-types.js';
+
+function createTestPlugin(overrides?: Partial<ReviewPlugin>): ReviewPlugin {
+  return {
+    id: 'test',
+    name: 'Test Plugin',
+    description: 'A test plugin',
+    shouldActivate: () => true,
+    analyze: () => [],
+    ...overrides,
+  };
+}
+
+function createAdapterContext(overrides?: Partial<AdapterContext>): AdapterContext {
+  return {
+    complexityReport: createTestReport(),
+    baselineReport: null,
+    deltas: null,
+    deltaSummary: null,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+const mockPR = {
+  owner: 'test-owner',
+  repo: 'test-repo',
+  pullNumber: 1,
+  title: 'Test PR',
+  baseSha: 'abc',
+  headSha: 'def',
+};
+
+function finding(overrides?: Partial<ReviewFinding>): ReviewFinding {
+  return {
+    pluginId: 'test',
+    filepath: 'src/a.ts',
+    line: 5,
+    severity: 'warning',
+    category: 'logic_error',
+    message: 'Something is off.',
+    ...overrides,
+  };
+}
+
+/** Async iterator over a single page — enough to satisfy `octokit.paginate.iterator`. */
+function onePage(data: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { data };
+    },
+  };
+}
+
+/** Build a minimal octokit mock: one file in the diff, no existing PR comments,
+ *  a successful review post, and a stubbed `repos.getContent` for the given
+ *  file content (or a rejection, to simulate a fetch failure). */
+function mockOctokit(opts: { fileContent?: string; getContentFails?: boolean }) {
+  const patch = '@@ -1,2 +5,3 @@\n+line5\n+line6\n+line7';
+  const octokit = {
+    paginate: {
+      iterator: vi.fn((fn: unknown) => {
+        if (fn === octokit.pulls.listFiles) {
+          return onePage([{ filename: 'src/a.ts', patch }]);
+        }
+        return onePage([]); // listReviewComments — no existing comments
+      }),
+    },
+    pulls: {
+      listFiles: vi.fn(),
+      listReviewComments: vi.fn(),
+      createReview: vi.fn().mockResolvedValue({}),
+    },
+    repos: {
+      getContent: opts.getContentFails
+        ? vi.fn().mockRejectedValue(new Error('network error'))
+        : vi.fn().mockResolvedValue({
+            data: { content: Buffer.from(opts.fileContent ?? '').toString('base64') },
+          }),
+    },
+  };
+  return octokit;
+}
+
+describe('citation gate wiring (issue #846)', () => {
+  it('drops a finding whose quoted citation is absent from the current file, and reports it as citationGated', async () => {
+    const octokit = mockOctokit({ fileContent: 'const totallyDifferentCode = 1;' });
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!(
+            [finding({ message: 'This hardcodes `paths[0:3]` inline.' })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(result.delivery.inlineComments).toEqual({
+      attempted: 1,
+      posted: 0,
+      dropped: 0,
+      deduped: 0,
+      citationGated: 1,
+    });
+    expect(octokit.pulls.createReview).not.toHaveBeenCalled();
+  });
+
+  it('delivers a finding whose quoted citation still matches the current file', async () => {
+    const octokit = mockOctokit({ fileContent: 'display=${paths[0:3]}\n' });
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!(
+            [finding({ message: 'This hardcodes `paths[0:3]` inline.' })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(result.delivery.inlineComments).toEqual({
+      attempted: 1,
+      posted: 1,
+      dropped: 0,
+      deduped: 0,
+      citationGated: 0,
+    });
+    expect(octokit.pulls.createReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers a finding with no quoted citation at all, untouched', async () => {
+    const octokit = mockOctokit({ fileContent: 'irrelevant' });
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!([finding()], 'summary body');
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(result.delivery.inlineComments).toEqual({
+      attempted: 1,
+      posted: 1,
+      dropped: 0,
+      deduped: 0,
+      citationGated: 0,
+    });
+  });
+
+  it('fails open when the current-file fetch itself fails — delivers rather than gates', async () => {
+    const octokit = mockOctokit({ getContentFails: true });
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!(
+            [finding({ message: 'Cites `someRemovedThing()` which is gone.' })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(result.delivery.inlineComments).toEqual({
+      attempted: 1,
+      posted: 1,
+      dropped: 0,
+      deduped: 0,
+      citationGated: 0,
+    });
+  });
+
+  it('gates only the stale-citation finding when a real one lands on the same changed file', async () => {
+    const octokit = mockOctokit({ fileContent: 'function real() { return stillHere(); }' });
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          await ctx.postInlineComments!(
+            [
+              finding({ line: 5, message: 'Stale premise citing `longGoneHelper()`.' }),
+              finding({
+                line: 6,
+                message: 'Real finding.',
+                evidence: 'Consumer calls `stillHere()` unguarded.',
+              }),
+            ],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    const result = await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(result.delivery.inlineComments).toEqual({
+      attempted: 2,
+      posted: 1,
+      dropped: 0,
+      deduped: 0,
+      citationGated: 1,
+    });
+  });
+});

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -117,6 +117,7 @@ describe('ReviewEngine.present() delivery truth', () => {
       posted: 1,
       dropped: 1,
       deduped: 0,
+      citationGated: 0,
     });
   });
 
@@ -169,7 +170,14 @@ describe('ReviewEngine.present() delivery truth', () => {
     // No out-of-diff findings and no dedup in this scenario, so `skipped`
     // (benign-only) must be 0 — NOT 1, which is what folding the real
     // `dropped` rejection in would have produced.
-    expect(rawOutcome).toEqual({ posted: 1, skipped: 0, attempted: 2, dropped: 1, deduped: 0 });
+    expect(rawOutcome).toEqual({
+      posted: 1,
+      skipped: 0,
+      attempted: 2,
+      dropped: 1,
+      deduped: 0,
+      citationGated: 0,
+    });
   });
 
   it('postInlineComments keeps a benign out-of-diff skip separate from a real dropped post', async () => {
@@ -213,7 +221,14 @@ describe('ReviewEngine.present() delivery truth', () => {
 
     await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
 
-    expect(rawOutcome).toEqual({ posted: 1, skipped: 1, attempted: 3, dropped: 2, deduped: 0 });
+    expect(rawOutcome).toEqual({
+      posted: 1,
+      skipped: 1,
+      attempted: 3,
+      dropped: 2,
+      deduped: 0,
+      citationGated: 0,
+    });
   });
 
   it('outOfDiffReviewPosted is true on a successful out-of-diff review comment', async () => {

--- a/packages/review/test/github-api.test.ts
+++ b/packages/review/test/github-api.test.ts
@@ -4,6 +4,7 @@ import {
   parsePatchLines,
   updatePRDescription,
   removePRDescriptionSection,
+  getFullFileContent,
 } from '../src/github-api.js';
 import type { Octokit } from '../src/github-api.js';
 import type { LineComment, PRContext } from '../src/types.js';
@@ -365,5 +366,36 @@ describe('parsePatchLines', () => {
     );
 
     expect(parsePatchLines(patch)).toEqual(new Set([1, 2]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFullFileContent
+// ---------------------------------------------------------------------------
+
+describe('getFullFileContent', () => {
+  it('returns the full decoded file content at the PR head SHA', async () => {
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({
+          data: { content: Buffer.from('line1\nline2\nline3').toString('base64') },
+        }),
+      },
+    } as unknown as Octokit;
+
+    const content = await getFullFileContent(octokit, pr, 'src/a.ts', createMockLogger());
+    expect(content).toBe('line1\nline2\nline3');
+    expect(octokit.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'src/a.ts', ref: pr.headSha }),
+    );
+  });
+
+  it('returns null (fail open) when the fetch fails, rather than throwing', async () => {
+    const octokit = {
+      repos: { getContent: vi.fn().mockRejectedValue(new Error('network error')) },
+    } as unknown as Octokit;
+
+    const content = await getFullFileContent(octokit, pr, 'src/missing.ts', createMockLogger());
+    expect(content).toBeNull();
   });
 });


### PR DESCRIPTION
## Closes #846

## Mechanism found (traced before designing)

Read `packages/review/src/github-api.ts` (`getExistingPluginCommentKeys`,
`isDuplicateOfExistingComment`, `DEDUP_LINE_TOLERANCE`) and
`packages/review/src/engine.ts` (`postPluginInlineComments`,
`deduplicateComments`). The dedup layer is **not** what carried PR #845's
stale premise forward:

- `getExistingPluginCommentKeys` only collects marker keys from comments
  whose `commit_id === prContext.headSha` — comments from a *prior* commit
  are deliberately excluded (GitHub already marks them outdated). So on a
  genuine push (new headSha), the previous run's comment never enters
  `existingKeys` at all.
- That means dedup could not have "carried" or "refreshed" the fixed
  finding — it was never in a position to recognize it. What actually
  happened on PR #845 is simpler and worse: run B independently
  **re-generated** a similarly-shaped finding at a nearby line (dedup's
  line-tolerance marker format `path::line::category` ± 30 lines exists for
  *display* dedup against same-run reposts, not cross-run validation), and
  nothing in the delivery path checked that finding's own premise against
  the code it was about to be posted against.

This matches the issue's own fallback framing: **"each run posts fresh
findings and dedup only prevents duplicates"** → the fix belongs on the
**reviewer/delivery side** (direction 2, self-evidencing bodies), not a
dedup-identity change (direction 1 doesn't have anything to key off, since
dedup was never the thing replaying the premise).

## Design: a deterministic citation gate at delivery time

`packages/review/src/citation-gate.ts` (new, zero deps, zero LLM):

- `extractCitedSpans(...texts)` — pulls backtick-quoted spans out of a
  finding's `message`/`evidence` (never `suggestion` — a suggestion
  proposes code that doesn't exist yet by definition, so treating it as a
  citation would gate almost everything that includes one). Spans under 4
  chars, or starting with `-`, are excluded — the latter specifically
  because rule prompts legitimately quote illustrative CLI/input examples
  in `message` (e.g. the untrusted-input rule's own worked example: `` `--votes foo` ``, never expected to appear verbatim in the file). Without
  that exclusion the gate would false-positive on that exact shape.
- `verifyCitation(spans, currentFileContent)` → `'no-citation' | 'match' |
  'mismatch' | 'unverifiable'`. `'match'` needs only ONE span to hit — a
  finding that quotes both a removed pattern and a still-present one must
  not be gated just because not every span matches.
- `shouldGateFinding(finding, currentFileContent)` — true only on
  `'mismatch'`.

Wired into `packages/review/src/engine.ts`'s `postPluginInlineComments` via
a new `gateStaleCitations` step: for each diff-anchored finding, fetch its
file's current content once (new `getFullFileContent` in `github-api.ts`,
a thin full-file wrapper over the existing `getFileContent`) and drop the
finding before it's ever built into a GitHub comment or considered for
dedup, if its citation contradicts that content.

**The asymmetry (stated in code, repeated here):** this is a noise
reducer, not a suppression system. Gate ONLY on a positive mismatch — a
citation that's demonstrably absent. No citation, a citation that matches,
or a failed file fetch (network hiccup, deleted file) all pass the finding
through untouched — fail-open by construction. A false negative just means
#846's shape recurs occasionally, same as before this existed. A false
positive would be strictly worse (a true finding silently dropped, no
error anywhere), so every judgment call in this module leans toward "don't
gate."

**Known limitation, stated plainly:** the PR #845 occurrence's own
regenerated body quoted `` `$paths|length` `` — code that was *still
present* in the fixed file (legitimate ongoing arithmetic), just
misinterpreted. A literal-existence check cannot catch a citation that's
real but reasoned about incorrectly; it only catches citations of code
that's actually gone. That's a judgment-frontier gap, not something a
deterministic heuristic can safely close without an unacceptable
false-positive rate (see the module doc's asymmetry note). This gate closes
the *general* shape direction 2 describes, not a guaranteed catch of that
one historical instance.

Observability: new `citationGated` counter threads through
`InlinePostOutcome` → `PresentDelivery` → `InlineCommentsAttestation`
(additive field, `ATTESTATION_VERSION` unchanged per that constant's own
precedent) plus a `logger.info` line naming the gated file:line — so a
gate firing is inspectable, never silent.

## Evidence

- `packages/review/test/citation-gate.test.ts` (17 tests): pure
  extraction/verdict logic, including the #845 shape (citation to removed
  code → gated), the negative cases (no citation, citation still matches,
  a new true finding on changed code with a valid citation → delivered),
  the CLI-flag false-positive guard, the "any span matches" rule, and
  fail-open on a null file.
- `packages/review/test/engine-citation-gate.test.ts` (5 tests): wiring-level,
  drives the REAL `ReviewEngine.present()` → `postInlineComments` →
  `gateStaleCitations` → `deduplicateComments` → `postPRReview` chain
  against a mocked octokit (paginated `listFiles`/`listReviewComments`,
  `repos.getContent`, `createReview`) — proves the gate actually intercepts
  a GitHub comment post, not just that the pure functions are correct in
  isolation. Covers: gated (not posted), delivered (citation matches),
  delivered (no citation), fail-open on fetch failure, and mixed
  gated+real-finding on the same file.
- `packages/review/test/github-api.test.ts`: 2 new tests for
  `getFullFileContent` (decodes correctly; returns `null`, not a throw, on
  fetch failure).
- Updated `attestation.test.ts` / `engine-delivery.test.ts` literals for the
  new `citationGated` field (no behavior change to existing cases — all
  gate to 0 since none of those fixtures quote code).

## Dogfood

This is a delivery-pipeline change, not an agent-rule/prompt change, so the
harness (`test/harness/`, which replays LLM prompts against captured
fixtures) doesn't apply here — there's no prompt or rule text to calibrate.
The nearest equivalent "run it for real" is `engine-citation-gate.test.ts`:
it exercises the actual production functions (`postPluginInlineComments`,
`gateStaleCitations`, `deduplicateComments`, `getFullFileContent`,
`shouldGateFinding`) through the real `ReviewEngine.present()` entry point
against a realistic mocked GitHub API, not isolated unit calls — this is
the closest offline substitute for a live GitHub PR run, at zero
OpenRouter/network cost. No paid validation was skipped; there wasn't one
that applied.

## Gate chain (this worktree, native parser built via `build:native`)

- `npm run format:check` — clean
- `npm run lint` — 0 errors (38 pre-existing warnings, none in touched files)
- `npm run typecheck` — clean
- `npm run build` — clean (parser, core, review, cli, action)
- `npm test` — all packages green (parser-native 27, parser 1108, core 378,
  review 1607, cli 1113, action 41)
- `node packages/cli/dist/index.js delta` — exit 0, no complexity-affecting
  changes vs HEAD (new functions: `gateStaleCitations` cognitive 5,
  `extractCitedSpans` cognitive 9, `verifyCitation` cognitive 4,
  `getFullFileContent` cyclomatic 1 — all well under threshold)

No changeset: `@liendev/review` is `"private": true` (unpublished), per
CLAUDE.md.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +11 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic, fail-open citation gate that drops inline findings whose quoted `message`/`evidence` code spans are absent from the current file content. The core logic is sound: it extracts single-backtick spans, excludes short and dash-prefixed spans to avoid false positives, gates only on a positive mismatch, and fails open when the file cannot be fetched. The new `citationGated` counter is cleanly threaded through `InlinePostOutcome`, `PresentDelivery`, and `InlineCommentsAttestation` as an additive field without changing `computeVerdict` semantics, and all call sites and tests are updated. The `getFullFileContent` wrapper correctly delegates to a shared never-throws fetch path. No breaking changes, silent error swallowing, or logic errors were found in the introduced code.
>
> - Added `packages/review/src/citation-gate.ts` with `extractCitedSpans`, `verifyCitation`, and `shouldGateFinding`
> - Wired `gateStaleCitations` into `postPluginInlineComments` before dedup/comment building, with per-file parallel fetching
> - Added additive `citationGated` field to inline comment delivery/attestation counters without affecting verdict computation
> - Refactored `github-api.ts` to share fetch/decode logic between `getFileContent` and the new `getFullFileContent`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 02437e7. Updates automatically on new commits.</sup>
<!-- /lien-stats -->