### PR TITLE
fix(review): enforce the per-pass token budget at every turn boundary

### DIFF
--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -229,18 +229,31 @@ export class AnthropicAgentClient {
       turnTraces.push(turnTrace);
       if (this.logAgentTurns) logTurn(this.logger, turnTrace);
 
-      // Done: model finished naturally
-      if (response.stop_reason === 'end_turn') {
-        stopReason = 'completed';
-        break;
-      }
-
-      // Hard budget exceeded — stop immediately
+      // Hard budget exceeded — checked at THIS turn boundary BEFORE the
+      // natural-stop check below (issue #839, parity with the OpenAI client).
+      // Conversation history grows every turn and is never bounded by
+      // max_tokens (only a turn's OUTPUT is), so any turn — not only a
+      // forced-finish one — can push cumulative spend past the allocation on
+      // its own INPUT cost alone. Checking budget first means a turn that
+      // both finishes naturally (stop_reason:'end_turn') AND blows the budget
+      // is never misreported as a clean 'completed': the between-turn check
+      // now fires at every turn boundary unconditionally, bounding overshoot
+      // to at most that one turn's own spend by construction, regardless of
+      // what caused the context to grow. This is a reporting/classification
+      // fix (a turn already happened by the time its cost is known) — it
+      // does not, and is not intended to, change what any turn actually
+      // costs; see `requestMaxTokens` for the complementary output-side bound.
       if (totalTokens >= this.maxTokenBudget) {
         this.logger.warning(
           `[agent] Token budget exceeded (${totalTokens}/${this.maxTokenBudget}), stopping`,
         );
         stopReason = 'budget';
+        break;
+      }
+
+      // Done: model finished naturally, within budget
+      if (response.stop_reason === 'end_turn') {
+        stopReason = 'completed';
         break;
       }
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -450,18 +450,32 @@ export class OpenAIAgentClient {
       turnTraces.push(turnTrace);
       if (this.logAgentTurns) logTurn(this.logger, turnTrace);
 
-      // Done: model finished naturally
-      if (choice.finish_reason === 'stop') {
-        stopReason = 'completed';
-        break;
-      }
-
-      // Budget exceeded
+      // Budget exceeded — checked at THIS turn boundary BEFORE the natural-
+      // stop check below (issue #839). Multi-turn conversation history grows
+      // every turn and is never bounded by max_tokens (only a turn's OUTPUT
+      // is), so any turn — not only a forced-finish one — can push cumulative
+      // spend past the allocation on its own INPUT cost alone. Checking budget
+      // first means a turn that both finishes naturally (finish_reason:'stop')
+      // AND blows the budget is never misreported as a clean 'completed': the
+      // between-turn check now fires at every turn boundary unconditionally,
+      // bounding overshoot to at most that one turn's own spend by
+      // construction, regardless of what caused the context to grow. This is
+      // a reporting/classification fix (a turn already happened by the time
+      // its cost is known) — it does not, and is not intended to, change what
+      // any turn actually costs; see `turnMaxTokens` for the complementary
+      // output-side bound and this pass's own `budget()` formula for sizing
+      // the allocation itself.
       if (totalTokens >= this.maxTokenBudget) {
         this.logger.warning(
           `[agent] Token budget exceeded (${totalTokens}/${this.maxTokenBudget}), stopping`,
         );
         stopReason = 'budget';
+        break;
+      }
+
+      // Done: model finished naturally, within budget
+      if (choice.finish_reason === 'stop') {
+        stopReason = 'completed';
         break;
       }
 

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -152,6 +152,61 @@ describe('AnthropicAgentClient extended thinking + retry forcing', () => {
     expect(mixed).toBeDefined();
   }, 15000);
 
+  it('stops with stopReason=budget (not completed) when a naturally-finishing turn already meets the allocation (issue #839 between-turn check)', async () => {
+    // Parity with the OpenAI client's same fix: `stop_reason:'end_turn'` was
+    // checked BEFORE the cumulative-budget check, so a turn that both
+    // finished naturally AND blew the budget was misreported as a clean
+    // 'completed'. One turn alone (6,000 input tokens) already exceeds the
+    // 5,000-token budget.
+    const verdict =
+      '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"ok","keyChanges":[]}}\n```';
+    createMock.mockResolvedValueOnce(msg([textBlock(verdict)], 6_000, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(5_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(false);
+    expect(result.summary).toBeDefined();
+    expect(result.turns).toBe(1);
+  });
+
+  it('bounds a multi-turn context-accumulation overshoot to the turn that crossed the line (issue #839)', async () => {
+    // Mirrors the shape of the OpenAI client's same test: two ordinary
+    // tool_use turns stay under budget, crossing the 0.6 wrap-up threshold on
+    // turn 2 (forcing turn 3 to drop tools) — then the forced turn's own
+    // (unbounded) input cost is what actually blows the budget.
+    const verdict =
+      '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"ok","keyChanges":[]}}\n```';
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 9_000, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('still investigating'), toolUseBlock], 4_000, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(verdict)], 40_000, 0, 'end_turn'));
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(20_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(false);
+    expect(result.turns).toBe(3);
+    // Bounded to the third turn's own cost — no fourth request attempted.
+    expect(createMock).toHaveBeenCalledTimes(3);
+  });
+
   it('forces the retry with tool_choice:none + thinking (parity with the loop)', async () => {
     createMock
       .mockResolvedValueOnce(

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -243,6 +243,60 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(bodies[1].max_tokens).toBe(2_048);
   });
 
+  it('stops with stopReason=budget (not completed) when a naturally-finishing turn already meets the allocation (issue #839 between-turn check)', async () => {
+    // Before this fix, `finish_reason:'stop'` was checked BEFORE the
+    // cumulative-budget check, so a turn that both finished naturally AND
+    // blew the budget was misreported as a clean 'completed' — a silent
+    // overshoot never flagged as budget-starved (the same gap #825's own PR
+    // body diagnosed but only partially closed, since it only bounded that
+    // turn's OUTPUT, not this classification bug). One turn alone (6,000
+    // tokens, all input — e.g. a large pre-fetched worklist) already exceeds
+    // the 5,000-token budget; the between-turn check must catch this at this
+    // turn's own boundary, not let the natural 'stop' branch hide it.
+    mockFetch([stopTurn(CLEAN_JSON, 6_000)]);
+    const client = makeClient(5_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.stopReason).toBe('budget');
+    // Accounting for whether a verdict was actually produced stays
+    // independent of stopReason: the turn's JSON parsed cleanly, so this
+    // run is NOT incomplete even though it's flagged budget-starved for
+    // attestation purposes — the same coexistence already covered by
+    // "recovers a verdict via the json-forced summary-retry" below.
+    expect(result.incomplete).toBe(false);
+    expect(result.summary).toBeDefined();
+    expect(result.turns).toBe(1);
+  });
+
+  it('bounds a multi-turn context-accumulation overshoot to the turn that crossed the line — no further turn is attempted (issue #839)', async () => {
+    // Mirrors the real doc-truth receipt from issue #839's census (20,869
+    // allocated / 56,430 spent, ~2.7x): two ordinary tool-calling turns stay
+    // comfortably under budget, crossing the 0.6 wrap-up threshold on turn 2
+    // (forcing turn 3 to drop tools and emit its verdict) — then the forced
+    // turn's OWN input cost (the now much larger accumulated conversation
+    // history, unbounded by max_tokens) is what actually blows the budget,
+    // ending the run in a single, naturally-completing turn.
+    const { bodies } = mockFetch([
+      toolCallTurn(9_000),
+      toolCallTurn(4_000), // cumulative 13,000 >= 0.6*20,000 — forces turn 3
+      stopTurn(CLEAN_JSON, 40_000), // cumulative 53,000 — 2.65x the 20,000 budget
+    ]);
+    const client = makeClient(20_000);
+    const tools = [
+      { type: 'function', function: { name: 'read_file', description: 'd', parameters: {} } },
+    ];
+
+    const result = await client.run('sys', 'init', tools as never, noopTool);
+
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(false); // the forced turn's verdict still parsed cleanly
+    expect(result.turns).toBe(3);
+    // The overshoot is bounded to what the THIRD turn alone cost — no fourth
+    // request is ever attempted once that turn's own boundary check fires.
+    expect(bodies).toHaveLength(3);
+  });
+
   it('recovers a verdict via the json-forced summary-retry after a bail', async () => {
     // Loop bails on budget with no verdict; the retry returns raw JSON (as
     // response_format:json_object would) and must be parsed into a summary.


### PR DESCRIPTION
## Scope

Partial fix for #839, deliberately **narrower** than the issue. Per #839's
2026-07-24 census comment, the same multi-turn-context-accumulation
overshoot signature (2.3-3.5x over allocation) hits both doc-truth AND
stale-duplicate-loop, and #838's shared rollover pool masks rather than
fixes it. Per the issue's own instruction, this PR does **not** guess-fix
the accumulation mechanism (unbounded conversation-history growth). It
enforces the budget contract at the executor level instead: a between-turn
check that fires at **every** turn boundary, unconditionally, in both
`OpenAIAgentClient.run()` and `AnthropicAgentClient.run()`.

**This does not close #839** — the accumulation mechanism (why context grows
the way it does, whether the `nearBudget` threshold or turn caps should be
retuned per-pass) stays open. Noted in a comment on #839.

## What was actually broken

Both clients' turn loops already had a post-response
`totalTokens >= maxTokenBudget` check — but it ran **after** the
natural-completion check (`finish_reason === 'stop'` / `stop_reason ===
'end_turn'`):

```js
// before
if (choice.finish_reason === 'stop') { stopReason = 'completed'; break; }
if (totalTokens >= this.maxTokenBudget) { stopReason = 'budget'; break; }
```

Conversation history (system prompt + every prior turn's response + every
tool result) is re-sent in full on every request and is **not** bounded by
`max_tokens` at all — only a turn's OUTPUT is capped (PR #825/#827's fix).
So a turn whose growing INPUT alone pushes cumulative spend past the
allocation, but which also happens to finish naturally (the forced-finish
turn's own shape, or any ordinary turn that emits its verdict directly),
exited the loop as `stopReason: 'completed'` — never `'budget'` — before the
budget check ever ran. That's a real, silent overshoot never flagged as
`degraded:budget_starved` in the delivery attestation, on top of whatever
overshoot the "at least it gets reported" tool-calling path already surfaced.

## The fix

Reorder the check in both clients so budget is evaluated **first**, at
every turn boundary, before the natural-stop branch:

```js
// after
if (totalTokens >= this.maxTokenBudget) { stopReason = 'budget'; break; }
if (choice.finish_reason === 'stop') { stopReason = 'completed'; break; }
```

This makes "stop as soon as cumulative spent meets/exceeds allocation" true
at **every** turn boundary unconditionally, not only the ones that don't
also happen to finish naturally — bounding overshoot to at most one turn's
own spend by construction, regardless of what caused the context to grow
(many small turns, or one big natural-stop turn with a huge accumulated
input). It's a reporting/classification fix: a turn's actual cost is only
knowable after the response comes back, so this can't reduce what any single
turn costs — it ensures the executor never lets that cost go unflagged, and
never lets an already-over-budget state proceed to a further turn (which,
for the natural-stop path, already couldn't happen anyway — the loop breaks
either way; the previous code just mislabeled *why*).

**Scope discipline (per the issue's own guardrail):** no change to prompt
construction, no context trimming, no change to per-candidate budgeting
(`affordableCandidateCeiling`, each pass's own `budget()` formula). `incomplete`
accounting is unaffected — it's governed by verdict/summary presence
(`incomplete = !parsed.summary`), not `stopReason`; the existing, already-
tested coexistence of `stopReason: 'budget'` + `incomplete: false` (a
starved-but-recovered verdict, see "recovers a verdict via the json-forced
summary-retry after a bail") is unchanged and still passes.  `candidatesDeferred`
is a static pre-check (rank-and-cap sizing) independent of `stopReason`, also
unaffected. Attestation field *shapes* are unchanged — only the `stopReason`
*value* a turn can produce is now consistently correct.

## Tests

Four new unit tests (two per client), added next to the existing #825/#836
budget tests:

- **`stops with stopReason=budget (not completed) when a naturally-finishing
  turn already meets the allocation`** — a single turn whose own cost (6,000
  tokens) already exceeds a 5,000-token budget and ends `finish_reason:'stop'`/
  `'end_turn'`. Before this fix: `stopReason: 'completed'`. After: `'budget'`,
  with `incomplete: false` (a valid verdict still parsed) — proving the two
  are independently governed.
- **`bounds a multi-turn context-accumulation overshoot to the turn that
  crossed the line`** — reproduces the shape of #839's own census numbers
  (a real doc-truth receipt: 20,869 allocated / 56,430 spent, ~2.7x): two
  ordinary tool-calling turns cross the 0.6 wrap-up threshold, forcing a
  third (forced-finish) turn whose own accumulated-context input cost (not
  its capped output) is what actually blows the budget 2.65x over on a
  20,000 token budget. Asserts `stopReason: 'budget'`, `turns: 3`, and
  exactly 3 requests made — no 4th turn attempted, i.e. overshoot bounded to
  that one turn's own spend.

All pre-existing tests in both files pass unmodified, including the #825
test whose asserted numbers stay genuinely under budget (8,000 < 10,000) and
so are unaffected by the reorder, and the retry-recovery test that
intentionally keeps `stopReason: 'budget'` + `incomplete: false` reachable
via the post-loop summary-retry path (#813's "do not skip the retry"
decision — untouched).

## Dogfood evidence (offline; zero OpenRouter spend, per this repo's
deterministic-code convention — same as #827/#838)

This touches `openai-client.ts`/`anthropic-client.ts` (the turn-loop
transport), not any rule/prompt. Confirmed `build-prompts.ts` — the
harness's own prompt-assembly entrypoint — imports only `rules.js`,
`system-prompt.js`, and the per-pass prompt builders; it never imports
`openai-client.js`/`anthropic-client.js`, so this change cannot affect
anything a `--calibrate` harness run measures:

```
$ grep '^import' packages/review/test/harness/build-prompts.ts
... rules.js, system-prompt.js, per-pass prompt builders, fixture-loader.js
(no openai-client.js / anthropic-client.js)
```

The real dogfood evidence is the new unit tests themselves: they exercise
the actual `OpenAIAgentClient.run()` / `AnthropicAgentClient.run()` turn
loops end-to-end (system prompt → user message → tool dispatch → forced
wrap-up → verdict extraction), with only the network/SDK boundary faked —
the same fake-client harness pattern `plugins-agent-budget.test.ts` and
`plugins-agent-anthropic.test.ts` already use for every other budget-boundary
fix in this file (#811, #813, #825, #836). Given the fix is deterministic
executor logic with no LLM call of its own to replay, this is the
appropriate level of "real dogfood" rather than a paid live-model run.

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors, 38 pre-existing warnings
- `npm run typecheck` — clean (full monorepo)
- `npm run build` — clean (parser, core, review, cli, action)
- `npm test` — all 6 workspaces green: root 27, core 1108, parser 378,
  review 1613 (incl. the 4 new tests), cli 1113, action 41
- `node packages/cli/dist/index.js delta` — exit 0, "no complexity-affecting
  changes vs HEAD" (the reorder swaps two existing if-blocks; same branch
  count, zero complexity delta)

No changeset — `@liendev/review` is private/unpublished (same convention as
#837/#838).

## Follow-up

Filed as a comment on #839: this bounds the symptom (accurate,
non-silent attestation of any turn that overshoots, regardless of cause) but
does not close it — the accumulation mechanism itself (why a pass's context
grows the way it does; whether `nearBudget`'s 0.6 threshold or per-pass turn
caps need retuning) is still open, per the issue's own scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token-budget handling for AI review runs.
  * Runs that exceed their token budget at the end of a turn are now correctly reported as budget-limited instead of completed.
  * Prevented unnecessary follow-up requests after the budget is exceeded.
  * Preserved generated verdicts and summaries when budget limits are reached.

* **Tests**
  * Added coverage for single- and multi-turn budget-overrun scenarios across supported AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +0 |
| 🧠 mental load | 3 | +0 |
| ⏱️ time to understand | 3 | +0 |
| 🐛 estimated bugs | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR is a narrow, intentional reporting fix: it reorders the cumulative-token budget check before the natural-stop check in both OpenAI and Anthropic agent turn loops. The change ensures that a turn whose accumulated input cost pushes total spend past `maxTokenBudget` is reported as `stopReason: 'budget'` even when the model also happens to finish naturally (`finish_reason: 'stop'` / `stop_reason: 'end_turn'`). The new behavior is covered by four unit tests that exercise the exact divergence scenario, and `incomplete` accounting remains independent of `stopReason` as before. No callers break: downstream consumers already handle `stopReason: 'budget'`.
>
> - Budget check now runs before natural-stop check in both `OpenAIAgentClient.run()` and `AnthropicAgentClient.run()`
> - Four new unit tests verify the boundary behavior for both clients
> - No change to prompt construction, per-turn output caps, summary-retry logic, or attestation field shapes

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1a39aab. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 347K/322K tokens
<!-- /lien:attestation -->