### PR TITLE
ci(review): enable removed-exports candidate loop for this repo's reviews

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -93,3 +93,12 @@ jobs:
           # unit tests independent of that score; this opt-in is itself the
           # real-PR evidence-gathering step, not a claim of a passed bar.
           LIEN_DOCS_DRIFT_PASS: 'on'
+          # removed-exports-pass.ts — same dark/opt-in mechanism as the
+          # three above; this repo opts in as of 2026-07-25 to dogfood it on
+          # its own PRs. Still dark/off for every other @liendev/review /
+          # @liendev/action consumer. This loop has zero real-PR firing data
+          # anywhere (see docs/architecture/review-pass-architecture.md's
+          # status line) — this opt-in exists to start accumulating that
+          # data ahead of any consumer default-on decision, not to claim a
+          # passed calibration bar.
+          LIEN_REMOVED_EXPORTS_PASS: 'on'

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -5,9 +5,9 @@ in PR #799. Five passes plug into it: doc-truth (production-on by default,
 including its v2 per-claim-verdict contract) and four candidate loops,
 stale-duplicate, incomplete-handling, removed-exports, and docs-drift, all
 dark (default off) for `@liendev/review`/`@liendev/action` consumers. This
-repo's own `.github/workflows/lien-review.yml` opts three of the four dark
-loops into its own PR reviews (stale-duplicate, incomplete-handling,
-docs-drift); removed-exports is not yet opted in. See "Which passes are
+repo's own `.github/workflows/lien-review.yml` opts all four dark loops
+into its own PR reviews (stale-duplicate, incomplete-handling, docs-drift,
+and, as of 2026-07-25, removed-exports). See "Which passes are
 live today" below for exact flags and per-pass status, and
 [ADR-014](decisions/0014-per-rule-candidate-loop-passes.md) for the
 decision this doc implements, its rejected alternatives, and its evidence
@@ -138,7 +138,7 @@ not tokens taken from anywhere else.
 | doc-truth | `doc-truth-pass.ts` | `docTruthPass !== false` AND `LIEN_REVIEW_DOC_PASS` not disabling AND ≥1 doc claim | `clamp(RESERVE + 3_500×claimCount, 11_000, 65_000)` | full 6-tool set (same as main pass) | v2 (default as of 2026-07-23): `accurate \| contradicted \| unverifiable` per claim id. v1 (opt-out via `config.docTruthV2: false` or `LIEN_DOC_TRUTH_V2=off`): open findings list | **Production-on** (both the pass and its v2 contract default true) |
 | stale-duplicate loop | `stale-duplicate-pass.ts` | `config.staleDuplicatePass` or `LIEN_STALE_DUP_PASS=on` AND ≥1 high-confidence, same-file candidate | `clamp(2000 + 800×min(n,8), 4000, 30000)` | `read_file`, `grep_codebase` only | `stale \| intentional-reuse \| unverifiable` | **Dark** (default false) |
 | incomplete-handling loop | `incomplete-handling-pass.ts` | `config.incompleteHandlingPass` or `LIEN_INCOMPLETE_PASS=on` AND ≥1 candidate (any of 3 shapes) | `clamp(2500 + 900×min(n,20), 5000, 35000)` | `read_file`, `get_files_context`, `grep_codebase` | `incomplete \| handled \| intentional \| unverifiable` | **Dark** (default false) |
-| removed-exports loop | `removed-exports-pass.ts` | `config.removedExportsPass` or `LIEN_REMOVED_EXPORTS_PASS=on` AND ≥1 removed public export | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `breaking \| intentional \| internal-only \| unverifiable` | **Dark** (default false) |
+| removed-exports loop | `removed-exports-pass.ts` | `config.removedExportsPass` or `LIEN_REMOVED_EXPORTS_PASS=on` AND ≥1 removed public export | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `breaking \| intentional \| internal-only \| unverifiable` | **Dark for consumers; this repo opts in as of 2026-07-25** |
 | docs-drift loop | `docs-drift-pass.ts` | `config.docsDriftPass` or `LIEN_DOCS_DRIFT_PASS=on` AND ≥1 untouched-doc reference to a removed/renamed/deleted referand | `clamp(2000 + 800×min(n,15), 11000, 30000)` | `read_file`, `grep_codebase` only | `drifted \| historical \| intentional \| unverifiable` | **Dark for consumers; this repo opts in as of 2026-07-23** |
 
 Every pass keeps its rule's prompt fragment and signal block in the shared
@@ -525,23 +525,27 @@ fires exactly once per pass that ran.
   config key or `LIEN_INCOMPLETE_PASS=on`. Same non-exposure via
   `action.yml`. This repo's own CI has opted in since 2026-07-17
   (`LIEN_INCOMPLETE_PASS=on`).
-- **removed-exports loop**: merged but dark: `config.removedExportsPass`
-  defaults `false`; opt in via that config key or
-  `LIEN_REMOVED_EXPORTS_PASS=on`. Same non-exposure via `action.yml`.
-  Unlike the other two, has no `*_MAIN=off` opt-out override (see its
-  own table row above): `<removed_exports>` cannot be stripped from the
-  main pass by design, not just "not yet run." This repo has not opted
-  it into its own CI, unlike the other three loops.
+- **removed-exports loop**: merged but dark for `@liendev/review`/
+  `@liendev/action` consumers: `config.removedExportsPass` defaults
+  `false`; opt in via that config key or `LIEN_REMOVED_EXPORTS_PASS=on`.
+  Same non-exposure via `action.yml`. Unlike the other two candidate-loop
+  siblings, has no `*_MAIN=off` opt-out override (see its own table row
+  above): `<removed_exports>` cannot be stripped from the main pass by
+  design, not just "not yet run." This repo's own
+  `.github/workflows/lien-review.yml` sets `LIEN_REMOVED_EXPORTS_PASS: 'on'`
+  as of 2026-07-25, so this repo's own PR reviews run it — this loop has
+  zero real-PR firing data anywhere, and this opt-in exists to start
+  accumulating that data ahead of any consumer default-on decision (held).
 - **docs-drift loop**: merged but dark for `@liendev/review`/
   `@liendev/action` consumers: `config.docsDriftPass` defaults `false`;
   opt in via that config key or `LIEN_DOCS_DRIFT_PASS=on`. Same
   non-exposure via `action.yml`. This repo's own
   `.github/workflows/lien-review.yml` sets `LIEN_DOCS_DRIFT_PASS: 'on'`
   as of 2026-07-23, so this repo's own PR reviews run it; together with
-  stale-duplicate and incomplete-handling, three of the four dark loops
-  are opted into this repo's own CI. No `*_MAIN=off` override exists
-  (docs-drift has no main-pass presence to strip in the first place; see
-  its own subsection above).
+  stale-duplicate, incomplete-handling, and (as of 2026-07-25)
+  removed-exports, all four dark loops are now opted into this repo's own
+  CI. No `*_MAIN=off` override exists (docs-drift has no main-pass
+  presence to strip in the first place; see its own subsection above).
 
 All four dark passes have proven mechanism (gate/prompt/budget/merge/
 attestation wiring, verified via unit tests and byte-diff-neutrality-when-off


### PR DESCRIPTION
## Summary

Sets `LIEN_REMOVED_EXPORTS_PASS: 'on'` on the Lien Review workflow's own review step, opting this repo's PR reviews into the removed-exports candidate loop (`packages/review/src/plugins/agent/removed-exports-pass.ts`) — judges surviving cross-file references to a public export a PR's diff removes, verdicting each `breaking | intentional | internal-only | unverifiable`.

- Verified the env var name and accepted values directly against `removed-exports-pass.ts` (not issue lore): `REMOVED_EXPORTS_PASS_ENV = 'LIEN_REMOVED_EXPORTS_PASS'`, and `envEnabled()` accepts `'1' | 'true' | 'on'` (trimmed, case-insensitive). Used the quoted `'on'` form, matching the existing `LIEN_STALE_DUP_PASS`/`LIEN_INCOMPLETE_PASS`/`LIEN_DOCS_DRIFT_PASS` entries already in this file (YAML 1.1 barewords are a known footgun here).
- Mirrors PR #833's docs-drift flip exactly: same env-var-only workflow change (read directly via `process.env` in the pass's own gate function — no `action.yml` input plumbing), plus keeping `docs/architecture/review-pass-architecture.md`'s status references accurate (this repo now opts in all four dark candidate loops, not three).
- Package/action defaults for external `@liendev/review`/`@liendev/action` consumers are **unchanged** — still dark/opt-in. This is dogfooding only.
- **Census context:** this loop has zero real-PR firing data anywhere (only a synthetic/canary-fixture regression smoke test exists per the architecture doc). This flip exists purely to start accumulating that data ahead of any consumer default-on decision, which is HELD.

## Dogfood evidence

Ran the full gate chain locally against this change (YAML/docs only, so no complexity impact expected — confirmed):

```
$ node packages/cli/dist/index.js delta
lien delta — no complexity-affecting changes vs HEAD (30 ms)
```

`npm run format:check`, `npm run lint` (0 errors), `npm run typecheck`, `npm run build`, and `npm test` (1113 + 41 tests) all pass.

Per the repo's dogfood-before-shipping rule, the real proof is this PR's own Lien Review run picking up the new pass. This PR's own `review` job (run [30129919029](https://github.com/getlien/lien/actions/runs/30129919029/job/89601936108)) ran with the flip live, and its Attestation JSON line shows the transition:

**Before the flip** (PR #833's baseline shape, the constant skip reason every prior PR got):
```
{"plugin":"agent-review:removed-exports-loop","reason":"disabled (opt-in; set config.removedExportsPass or LIEN_REMOVED_EXPORTS_PASS=on to enable)"}
```

**After the flip, this PR's own run** — the pass is now gated on live eligibility, not the opt-in flag, and reports a real (not-disabled) skip reason because this diff is YAML/docs-only and removes no public export:
```
{"plugin":"agent-review:removed-exports-loop","reason":"no removed public export found in this PR’s diff"}
```

Full attestation line from the run log, verbatim:
```json
Attestation: {"attestationVersion":2,"run":{"conclusion":"success","filesAnalyzed":0},"provider":{"passes":[{"name":"main","ran":true,"stopReason":"completed","neverRan":false,"candidatesDeferred":0},{"name":"stale-duplicate-loop","ran":true,"stopReason":"completed","neverRan":false,"candidatesDeferred":0}]},"budget":{"allocatedTokens":22545,"spentTokens":23441,"starved":false,"passes":[{"name":"main","allocatedTokens":8302,"spentTokens":5059,"starved":false},{"name":"stale-duplicate-loop","allocatedTokens":14243,"spentTokens":18382,"starved":false}]},"passesSkipped":[{"plugin":"agent-review:doc-truth","reason":"not a doc-touching PR (no doc claims)"},{"plugin":"agent-review:incomplete-handling-loop","reason":"no variant-sweep, sibling-surface, or unread-field candidate found"},{"plugin":"agent-review:removed-exports-loop","reason":"no removed public export found in this PR’s diff"},{"plugin":"agent-review:docs-drift-loop","reason":"no untouched-doc reference to a removed/renamed/deleted referand in this PR"}],"delivery":{"annotationsEmitted":0,"inlineComments":{"attempted":0,"posted":0,"dropped":0,"deduped":0,"citationGated":0},"descriptionBadge":{"updated":true},"outOfDiffReviewPosted":null},"scope":{"eligibilityPath":"summary_only_diff","filesAnalyzed":0},"verdict":"delivered"}
```

That's the proof the flip is live: the removed-exports-loop's skip reason changed shape from the constant "disabled (opt-in; ...)" string to `removedExportsSkipReason`'s eligibility-based branch (`hasEligibleCandidate` returned false for this PR's own diff, correctly, since it removes no exports). The other three already-enabled loops (stale-duplicate ran; incomplete-handling and docs-drift report their own live eligibility-based skips) confirm this is the same live mechanism, not a fluke.

Lien Review itself came back clean on this PR: 0 findings, "Stable — 92 pre-existing issues repo-wide (none introduced)," Low Risk. CodeRabbit was rate-limited (no review produced) — nothing to triage there.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `node packages/cli/dist/index.js delta`
- [x] Pull this PR's own Lien Review run's Attestation JSON line and paste the removed-exports entry (skip reason transition from "disabled (opt-in; ...)" to a live outcome) — done, see Dogfood evidence above

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 13 high-risk file(s) with 535 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**
>
> Enables the removed-exports candidate loop for this repository's own Lien Review workflow by setting `LIEN_REMOVED_EXPORTS_PASS: 'on'` in `.github/workflows/lien-review.yml`, and updates the architecture documentation to reflect that all four dark loops are now opted into this repo's CI. External `@liendev/review`/`@liendev/action` consumers remain dark/opt-in by default, so this is purely dogfooding with no breaking changes.
>
> - Added `LIEN_REMOVED_EXPORTS_PASS: 'on'` to the lien-review workflow, matching the existing quoted env-var pattern for other dark loops
> - Updated `review-pass-architecture.md` to state all four dark loops (stale-duplicate, incomplete-handling, docs-drift, removed-exports) are now opted into this repo's own reviews

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d0d6b07. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
