### PR TITLE
feat(review): thread pass provenance into the finding-marker dedup key

### DIFF
--- a/packages/review/src/engine.ts
+++ b/packages/review/src/engine.ts
@@ -1156,9 +1156,23 @@ export function createDefaultEngine(opts?: EngineOptions): ReviewEngine {
 /**
  * Build a generic inline comment body for a finding.
  * Embeds a dedup marker so re-runs don't re-post the same comment.
+ *
+ * The marker's dedup key is `filepath::line::category`, plus an ADDITIVE 4th
+ * segment (`::pass`) when the finding carries `metadata.sourcePass` (issue
+ * #839 census follow-up — agent-review findings only; see
+ * `plugins/agent/review-pass.ts`'s `tagSourcePass`). A finding with no
+ * `sourcePass` (every non-agent-review plugin, e.g. `complexity`) keeps the
+ * exact pre-existing 3-segment format — this is a strictly additive format
+ * change scoped to the one plugin that has pass identity to report.
+ * `parsePluginCommentKey` below parses both formats, and back-compat with
+ * OLD-format markers already posted on an existing PR thread is the reason
+ * that function exists at all — see its own doc comment.
  */
-function buildPluginCommentBody(f: ReviewFinding, markerPrefix: string): string {
-  const key = `${f.filepath}::${f.line}::${f.category}`;
+export function buildPluginCommentBody(f: ReviewFinding, markerPrefix: string): string {
+  const pass = (f.metadata as { sourcePass?: string } | undefined)?.sourcePass;
+  const key = pass
+    ? `${f.filepath}::${f.line}::${f.category}::${pass}`
+    : `${f.filepath}::${f.line}::${f.category}`;
   const marker = `${markerPrefix}${key} -->`;
   const severityEmoji = f.severity === 'error' ? '🔴' : f.severity === 'warning' ? '🟡' : 'ℹ️';
   const symbolRef = f.symbolName ? ` in \`${f.symbolName}\`` : '';
@@ -1195,17 +1209,62 @@ interface PluginCommentKey {
   filepath: string;
   line: number;
   category: string;
+  /**
+   * Which pass produced the finding (issue #839 census follow-up), absent for
+   * an OLD-format (pre-provenance) 3-segment key. Deliberately NOT read by
+   * `isDuplicateOfExistingComment`'s equality check below — matching stays
+   * scoped to filepath/category/line so an old-format existing marker and a
+   * new-format candidate (or vice versa) still dedup against each other; see
+   * that function's own doc comment.
+   */
+  pass?: string;
 }
 
-/** Parse a `filepath::line::category` dedup key. Null if malformed. */
+/**
+ * Parse a plugin comment dedup key, accepting BOTH the original 3-segment
+ * `filepath::line::category` format and the newer 4-segment
+ * `filepath::line::category::pass` format (issue #839 census follow-up).
+ * Format is detected positionally, not by total segment count, because a
+ * filepath may itself contain `::` (rare, but the original 3-segment parser
+ * already had to handle it via the same `slice(0, -N)` reassembly used here):
+ *
+ * - Try OLD format first: is the second-to-last segment a valid integer? If
+ *   so, treat it as `line` and the last segment as `category`.
+ * - Otherwise try NEW format: is the THIRD-to-last segment a valid integer?
+ *   If so, treat it as `line`, second-to-last as `category`, and last as
+ *   `pass`.
+ *
+ * Checking OLD format first is deliberate and safe, not merely convenient: by
+ * construction, every key this codebase has ever produced has a `category`
+ * value that is never a bare integer (a fixed, enum-like rule/category
+ * string — `'complexity'`, `'error_handling'`, etc.) and a `line` that always
+ * is one (`String(f.line)`). So the OLD-format check — "is the second-to-last
+ * segment numeric" — is true for every genuine OLD-format key and false for
+ * every genuine NEW-format key's analogous position (which holds `category`,
+ * never numeric), with no realistic ambiguity between the two.
+ *
+ * Returns null for a key that matches neither shape (e.g. too few segments,
+ * a non-integer line, or an empty filepath/category/pass).
+ */
 export function parsePluginCommentKey(key: string): PluginCommentKey | null {
   const parts = key.split('::');
   if (parts.length < 3) return null;
-  const category = parts[parts.length - 1];
-  const line = Number(parts[parts.length - 2]);
-  const filepath = parts.slice(0, -2).join('::');
-  if (!filepath || !category || !Number.isInteger(line)) return null;
-  return { filepath, line, category };
+
+  const oldLine = Number(parts[parts.length - 2]);
+  if (Number.isInteger(oldLine)) {
+    const category = parts[parts.length - 1];
+    const filepath = parts.slice(0, -2).join('::');
+    if (!filepath || !category) return null;
+    return { filepath, line: oldLine, category };
+  }
+
+  if (parts.length < 4) return null;
+  const line = Number(parts[parts.length - 3]);
+  const category = parts[parts.length - 2];
+  const pass = parts[parts.length - 1];
+  const filepath = parts.slice(0, -3).join('::');
+  if (!filepath || !category || !pass || !Number.isInteger(line)) return null;
+  return { filepath, line, category, pass };
 }
 
 /**

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -774,6 +774,15 @@ export function clampText(text: string | undefined): string | undefined {
 }
 
 function mapToReviewFinding(f: AgentFinding, pluginId: string): ReviewFinding {
+  // Fold both optional provenance fields into one `metadata` object (rather
+  // than two independent conditional spreads) so a finding carrying only one
+  // of the two doesn't end up with a spurious `undefined` key for the other.
+  const metadata: Record<string, unknown> = {};
+  if (f.ruleId) metadata.ruleId = f.ruleId;
+  // sourcePass (issue #839 census follow-up): which pass produced this
+  // finding — threaded through to the GitHub inline-comment dedup marker's
+  // 4th segment via `buildPluginCommentBody` (engine.ts).
+  if (f.sourcePass) metadata.sourcePass = f.sourcePass;
   return {
     pluginId,
     filepath: f.filepath,
@@ -785,7 +794,7 @@ function mapToReviewFinding(f: AgentFinding, pluginId: string): ReviewFinding {
     message: clampText(f.message) ?? f.message,
     suggestion: clampText(f.suggestion),
     evidence: clampText(f.evidence),
-    ...(f.ruleId ? { metadata: { ruleId: f.ruleId } } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   };
 }
 

--- a/packages/review/src/plugins/agent/review-pass.ts
+++ b/packages/review/src/plugins/agent/review-pass.ts
@@ -463,6 +463,29 @@ function buildPassOutcome(
   };
 }
 
+/**
+ * Name stamped on the primary investigation's own findings by `runExtraPasses`
+ * below — matches the literal `'main'` `attestation.ts` already uses for the
+ * main pass's own `ProviderPassAttestation`/`PassBudgetAttestation` entries
+ * (no shared constant there either; same convention, applied here to finding
+ * provenance instead of attestation naming).
+ */
+const MAIN_PASS_NAME = 'main';
+
+/**
+ * Stamp every finding in `findings` with `sourcePass` (issue #839 census
+ * follow-up: per-pass finding attribution wasn't machine-recoverable from the
+ * merged findings list or the GitHub inline-comment dedup marker). Returns a
+ * new array; inputs are not mutated. Every `ReviewPassSpec.mergeFindings`
+ * implementation already spreads its input findings (`{ ...f, ruleId: ... }`)
+ * rather than reconstructing them field-by-field, so a tag applied here
+ * survives every pass's own merge step for free — no changes needed to any
+ * of the five `mergeFindings` functions themselves.
+ */
+export function tagSourcePass(findings: AgentFinding[], pass: string): AgentFinding[] {
+  return findings.map(f => ({ ...f, sourcePass: pass }));
+}
+
 export async function runExtraPasses(
   specs: ReviewPassSpec[],
   context: ReviewContext,
@@ -474,7 +497,11 @@ export async function runExtraPasses(
   rolledOverBudget = 0,
 ): Promise<{ findings: AgentFinding[]; outcomes: PassOutcome[] }> {
   const outcomes: PassOutcome[] = [];
-  let merged = findings;
+  // `findings` is always the main pass's own output at every real call site
+  // (`index.ts`'s `analyze()`/`analyzeSummaryOnly()` both pass `result.findings`
+  // straight through) — tag it here, once, rather than at each call site, so
+  // this module stays the single place pass provenance is stamped.
+  let merged = tagSourcePass(findings, MAIN_PASS_NAME);
   let remainingRollover = rolledOverBudget;
   for (const spec of specs) {
     if (main.neverRan) {
@@ -503,7 +530,7 @@ export async function runExtraPasses(
         remainingRollover,
       );
     }
-    merged = spec.mergeFindings(merged, passResult?.findings ?? []);
+    merged = spec.mergeFindings(merged, tagSourcePass(passResult?.findings ?? [], spec.name));
     spec.mergeResultState(main, passResult, merged);
   }
   return { findings: merged, outcomes };

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -113,6 +113,19 @@ export interface AgentFinding {
   evidence?: string;
   /** Rule that triggered this finding, if identifiable. */
   ruleId?: string;
+  /**
+   * Which pass produced this finding: `'main'` for the primary investigation,
+   * or a `ReviewPassSpec.name` (e.g. `'doc-truth'`, `'stale-duplicate-loop'`)
+   * for an extra pass (see `review-pass.ts`). Set by `runExtraPasses` right
+   * before each pass's own findings fold into the merged list — never by a
+   * pass itself — so every `mergeFindings` implementation's existing spread
+   * (`{ ...f, ruleId: ... }`) carries it through for free. Threaded into the
+   * GitHub inline-comment dedup marker's 4th segment (issue #839 census
+   * follow-up: per-pass attribution wasn't machine-recoverable) via
+   * `mapToReviewFinding` → `ReviewFinding.metadata.sourcePass` →
+   * `buildPluginCommentBody` (`engine.ts`).
+   */
+  sourcePass?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/engine-comment-dedup.test.ts
+++ b/packages/review/test/engine-comment-dedup.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   parsePluginCommentKey,
   isDuplicateOfExistingComment,
+  buildPluginCommentBody,
   DEDUP_LINE_TOLERANCE,
 } from '../src/engine.js';
+import type { ReviewFinding } from '../src/plugin-types.js';
 
 describe('parsePluginCommentKey', () => {
   it('parses a well-formed key', () => {
@@ -26,6 +28,94 @@ describe('parsePluginCommentKey', () => {
   it('returns null for an empty filepath or category', () => {
     expect(parsePluginCommentKey('::12::logic_error')).toBeNull();
     expect(parsePluginCommentKey('file.ts::12::')).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // NEW format: filepath::line::category::pass (issue #839 census follow-up —
+  // per-pass finding attribution wasn't machine-recoverable from the marker)
+  // -------------------------------------------------------------------------
+
+  it('parses a well-formed NEW-format key (with pass provenance)', () => {
+    expect(
+      parsePluginCommentKey('packages/review/src/engine.ts::42::error_handling::doc-truth'),
+    ).toEqual({
+      filepath: 'packages/review/src/engine.ts',
+      line: 42,
+      category: 'error_handling',
+      pass: 'doc-truth',
+    });
+  });
+
+  it('parses a NEW-format key whose pass name itself contains a hyphen', () => {
+    expect(parsePluginCommentKey('a.ts::1::bug::stale-duplicate-loop')).toEqual({
+      filepath: 'a.ts',
+      line: 1,
+      category: 'bug',
+      pass: 'stale-duplicate-loop',
+    });
+  });
+
+  it('returns null for a NEW-format-shaped key with an empty pass segment', () => {
+    expect(parsePluginCommentKey('a.ts::1::bug::')).toBeNull();
+  });
+
+  it('reassembles a filepath containing embedded "::" for both formats', () => {
+    // Same defensive reassembly the original 3-segment parser already had
+    // (`slice(0, -2)`), extended to `slice(0, -3)` for the 4-segment format.
+    expect(parsePluginCommentKey('weird::path.ts::12::logic_error')).toEqual({
+      filepath: 'weird::path.ts',
+      line: 12,
+      category: 'logic_error',
+    });
+    expect(parsePluginCommentKey('weird::path.ts::12::logic_error::main')).toEqual({
+      filepath: 'weird::path.ts',
+      line: 12,
+      category: 'logic_error',
+      pass: 'main',
+    });
+  });
+});
+
+describe('buildPluginCommentBody', () => {
+  function baseFinding(overrides: Partial<ReviewFinding> = {}): ReviewFinding {
+    return {
+      pluginId: 'agent-review',
+      filepath: 'src/foo.ts',
+      line: 10,
+      severity: 'warning',
+      category: 'error_handling',
+      message: 'msg',
+      ...overrides,
+    };
+  }
+
+  it('keeps the original 3-segment marker when the finding carries no sourcePass', () => {
+    const body = buildPluginCommentBody(baseFinding(), '<!-- lien-plugin:agent-review:');
+    expect(body).toContain('<!-- lien-plugin:agent-review:src/foo.ts::10::error_handling -->');
+  });
+
+  it('appends a 4th segment when metadata.sourcePass is present (issue #839)', () => {
+    const body = buildPluginCommentBody(
+      baseFinding({ metadata: { sourcePass: 'stale-duplicate-loop' } }),
+      '<!-- lien-plugin:agent-review:',
+    );
+    expect(body).toContain(
+      '<!-- lien-plugin:agent-review:src/foo.ts::10::error_handling::stale-duplicate-loop -->',
+    );
+  });
+
+  it('round-trips through parsePluginCommentKey', () => {
+    const body = buildPluginCommentBody(
+      baseFinding({ metadata: { sourcePass: 'doc-truth' } }),
+      '<!-- lien-plugin:agent-review:',
+    );
+    const key = body.match(/<!-- lien-plugin:agent-review:(.+?) -->/)?.[1];
+    expect(parsePluginCommentKey(key!)).toEqual({
+      filepath: 'src/foo.ts',
+      line: 10,
+      category: 'error_handling',
+      pass: 'doc-truth',
+    });
   });
 });
 
@@ -83,5 +173,60 @@ describe('isDuplicateOfExistingComment', () => {
     const existing = new Set([key('src/a.ts', 10)]);
     expect(isDuplicateOfExistingComment(key('src/a.ts', 15), existing, 4)).toBe(false);
     expect(isDuplicateOfExistingComment(key('src/a.ts', 15), existing, 5)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed old/new marker format (issue #839 census follow-up): the CRITICAL
+  // back-compat requirement — an OLD-format marker already posted on an
+  // existing PR thread must still be recognized as a duplicate of its
+  // NEW-format equivalent (and vice versa), or the format change alone would
+  // cause a double-post on every already-reviewed open PR the day this ships.
+  // -------------------------------------------------------------------------
+
+  const newKey = (file: string, line: number, category = 'logic_error', pass = 'main') =>
+    `${file}::${line}::${category}::${pass}`;
+
+  it('matches a NEW-format candidate against an OLD-format existing marker (same file/line/category)', () => {
+    const existing = new Set([key('src/a.ts', 10)]); // OLD format, no pass
+    expect(
+      isDuplicateOfExistingComment(newKey('src/a.ts', 10, 'logic_error', 'doc-truth'), existing),
+    ).toBe(true);
+  });
+
+  it('matches an OLD-format candidate against a NEW-format existing marker', () => {
+    const existing = new Set([newKey('src/a.ts', 10, 'logic_error', 'stale-duplicate-loop')]);
+    expect(isDuplicateOfExistingComment(key('src/a.ts', 10), existing)).toBe(true);
+  });
+
+  it('matches across formats within the line-drift tolerance, not just exactly', () => {
+    const existing = new Set([key('src/a.ts', 10)]); // OLD format
+    expect(
+      isDuplicateOfExistingComment(
+        newKey('src/a.ts', 10 + DEDUP_LINE_TOLERANCE, 'logic_error', 'doc-truth'),
+        existing,
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT match across formats when the pass differs but file/category/line also differ', () => {
+    const existing = new Set([newKey('src/a.ts', 10, 'logic_error', 'main')]);
+    // Different file — must not match regardless of format or pass name.
+    expect(
+      isDuplicateOfExistingComment(newKey('src/b.ts', 10, 'logic_error', 'main'), existing),
+    ).toBe(false);
+  });
+
+  it('never double-posts across a mixed set of both old- and new-format existing markers', () => {
+    const existing = new Set([
+      key('src/a.ts', 10), // old format, from before this format change shipped
+      newKey('src/c.ts', 20, 'bug', 'incomplete-handling-loop'), // new format, from after
+    ]);
+    expect(
+      isDuplicateOfExistingComment(newKey('src/a.ts', 11, 'logic_error', 'doc-truth'), existing),
+    ).toBe(true);
+    expect(isDuplicateOfExistingComment(key('src/c.ts', 20, 'bug'), existing)).toBe(true);
+    expect(isDuplicateOfExistingComment(newKey('src/d.ts', 1, 'bug', 'main'), existing)).toBe(
+      false,
+    );
   });
 });

--- a/packages/review/test/engine-delivery.test.ts
+++ b/packages/review/test/engine-delivery.test.ts
@@ -231,6 +231,71 @@ describe('ReviewEngine.present() delivery truth', () => {
     });
   });
 
+  // Issue #839 census follow-up: the inline-comment dedup marker gained a 4th
+  // `::pass` segment for provenance. The critical back-compat requirement is
+  // that a PR thread with an OLD-format marker from a run BEFORE this change
+  // never gets double-posted once a run AFTER this change starts emitting
+  // NEW-format markers for the same finding — exercised here through the
+  // real `postInlineComments` → dedup → GitHub-post pipeline, not just the
+  // pure `parsePluginCommentKey`/`isDuplicateOfExistingComment` unit tests in
+  // `engine-comment-dedup.test.ts`.
+  it('does not double-post a finding whose OLD-format marker already exists on the PR thread', async () => {
+    const patch = '@@ -1,2 +5,3 @@\n+line5\n+line6\n+line7';
+    // A prior run posted this exact finding under the pre-#839 3-segment
+    // marker format, on the CURRENT head commit (so it's dedup-eligible).
+    const existingComment = {
+      body: '<!-- lien-plugin:test:src/a.ts::5::logic_error -->\nOld finding body',
+      commit_id: mockPR.headSha,
+      html_url: 'https://github.com/x/y/pull/1#comment-1',
+    };
+    const octokit = {
+      paginate: {
+        iterator: vi.fn((fn: unknown) => {
+          if (fn === octokit.pulls.listFiles) return onePage([{ filename: 'src/a.ts', patch }]);
+          return onePage([existingComment]); // listReviewComments
+        }),
+      },
+      pulls: {
+        listFiles: vi.fn(),
+        listReviewComments: vi.fn(),
+        createReview: vi.fn(),
+        createReviewComment: vi.fn(),
+      },
+    };
+
+    let rawOutcome:
+      | { posted: number; skipped: number; attempted: number; dropped: number; deduped: number }
+      | undefined;
+    const engine = new ReviewEngine();
+    engine.register(
+      createTestPlugin({
+        present: async (_findings, ctx: PresentContext) => {
+          // This run's own finding carries pass provenance — its own marker
+          // would be the NEW 4-segment format if actually posted.
+          rawOutcome = await ctx.postInlineComments!(
+            [finding({ line: 5, metadata: { sourcePass: 'stale-duplicate-loop' } })],
+            'summary body',
+          );
+        },
+      }),
+    );
+
+    await engine.present([], createAdapterContext({ octokit, pr: mockPR }));
+
+    expect(rawOutcome).toEqual({
+      posted: 0,
+      skipped: 1,
+      attempted: 1,
+      dropped: 0,
+      deduped: 1,
+      citationGated: 0,
+    });
+    // Never actually attempted a post — the format change alone must not
+    // cause a double-post of an already-delivered finding.
+    expect(octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(octokit.pulls.createReviewComment).not.toHaveBeenCalled();
+  });
+
   it('outOfDiffReviewPosted is true on a successful out-of-diff review comment', async () => {
     const octokit = {
       pulls: { createReview: vi.fn().mockResolvedValue({}) },

--- a/packages/review/test/plugins-agent-review-pass.test.ts
+++ b/packages/review/test/plugins-agent-review-pass.test.ts
@@ -5,6 +5,7 @@ import {
   appendPassTurns,
   runExtraPasses,
   unspentMainBudget,
+  tagSourcePass,
   EXTRA_PASS_MIN_BUDGET_TOKENS,
   OBSERVED_TOKENS_PER_TURN,
   VERDICT_EMISSION_RESERVE_TOKENS,
@@ -104,6 +105,37 @@ describe('EXTRA_PASS_MIN_BUDGET_TOKENS', () => {
 // unspentMainBudget — rolling unspent main-pass budget into extra passes
 // (issue #836)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// tagSourcePass — finding-marker pass provenance (issue #839 census follow-up)
+// ---------------------------------------------------------------------------
+
+describe('tagSourcePass', () => {
+  it('stamps sourcePass onto every finding', () => {
+    const findings = [finding({ message: 'a' }), finding({ message: 'b' })];
+    expect(tagSourcePass(findings, 'doc-truth')).toEqual([
+      { ...findings[0], sourcePass: 'doc-truth' },
+      { ...findings[1], sourcePass: 'doc-truth' },
+    ]);
+  });
+
+  it('overwrites any pre-existing sourcePass rather than leaving a stale value', () => {
+    const findings = [finding({ sourcePass: 'stale' })];
+    expect(tagSourcePass(findings, 'fresh')[0].sourcePass).toBe('fresh');
+  });
+
+  it('is a pure function — does not mutate the input array or its elements', () => {
+    const findings = [finding()];
+    const result = tagSourcePass(findings, 'main');
+    expect(result).not.toBe(findings);
+    expect(result[0]).not.toBe(findings[0]);
+    expect(findings[0].sourcePass).toBeUndefined();
+  });
+
+  it('returns [] for an empty input', () => {
+    expect(tagSourcePass([], 'main')).toEqual([]);
+  });
+});
 
 describe('unspentMainBudget', () => {
   it('reproduces PR #835 receipt shape: main allocated 20,000/spent 7,771 -> +12,229', () => {
@@ -520,6 +552,69 @@ describe('runExtraPasses', () => {
     expect(findings.map(f => f.message)).toEqual(['main finding', 'finding-1', 'finding-2']);
   });
 
+  it('tags every finding with its originating pass — main vs each extra pass (issue #839 census follow-up)', async () => {
+    const specA = makeSpec({ name: 'stale-duplicate-loop' });
+    const specB = makeSpec({ name: 'incomplete-handling-loop' });
+    const ctx = createTestContext();
+    const main = mainResult();
+    let call = 0;
+    const runClientFor = (spec: ReviewPassSpec) => async () => {
+      call += 1;
+      return fakeResult({ findings: [finding({ message: `${spec.name}-finding-${call}` })] });
+    };
+
+    const { findings } = await runExtraPasses(
+      [specA, specB],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      main.findings,
+      runClientFor,
+    );
+
+    expect(findings.map(f => ({ message: f.message, sourcePass: f.sourcePass }))).toEqual([
+      { message: 'main finding', sourcePass: 'main' },
+      { message: 'stale-duplicate-loop-finding-1', sourcePass: 'stale-duplicate-loop' },
+      { message: 'incomplete-handling-loop-finding-2', sourcePass: 'incomplete-handling-loop' },
+    ]);
+  });
+
+  it('preserves sourcePass through a real mergeFindings shape that overrides ruleId via spread (the pattern all five real passes use)', async () => {
+    // Mirrors mergeStaleDuplicateFindings/mergeIncompleteHandlingFindings/etc:
+    // `loopFindings.map(f => ({ ...f, ruleId: SOME_RULE_ID }))`. Proves
+    // tagSourcePass's stamp survives that spread, so no change was needed to
+    // any of the five real merge functions themselves.
+    const spec = makeSpec({
+      name: 'stale-duplicate-loop',
+      mergeFindings: (merged, passFindings) => [
+        ...merged,
+        ...passFindings.map(f => ({ ...f, ruleId: 'stale-duplicate' })),
+      ],
+    });
+    const ctx = createTestContext();
+    const main = mainResult({ findings: [] });
+    const runClientFor = () => async () => fakeResult({ findings: [finding({ message: 'loop' })] });
+
+    const { findings } = await runExtraPasses(
+      [spec],
+      ctx,
+      cfg(),
+      silentLogger,
+      main,
+      [],
+      runClientFor,
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        message: 'loop',
+        ruleId: 'stale-duplicate',
+        sourcePass: 'stale-duplicate-loop',
+      }),
+    ]);
+  });
+
   it('skips a pass that declines eligibility, recording the reason via reportSkip (feeds passesSkipped)', async () => {
     const reportSkip = vi.fn();
     const ctx = { ...createTestContext(), reportSkip };
@@ -816,7 +911,9 @@ describe('runExtraPasses', () => {
     );
 
     expect(outcomes).toEqual([]);
-    // The main-pass findings survive untouched — a pass-2+ error never fails the review.
-    expect(findings).toEqual(main.findings);
+    // The main-pass findings survive untouched (content-wise) — a pass-2+
+    // error never fails the review. They're still tagged sourcePass:'main'
+    // (every finding runExtraPasses returns is, regardless of outcome).
+    expect(findings).toEqual(tagSourcePass(main.findings, 'main'));
   });
 });


### PR DESCRIPTION
## Scope

Issue #839's 2026-07-24 census comment flagged a measurement gap while
diagnosing the multi-turn budget overshoot: per-pass finding attribution
isn't machine-recoverable. The inline-comment dedup marker
(`<!-- lien-plugin:agent-review:<path>::<line>::<type> -->`) carries no pass
name, so a doc-truth finding and a stale-duplicate-loop finding landing at
the same file/line/category are indistinguishable once `runExtraPasses`
folds every pass's findings into one merged list.

This PR adds a 4th marker segment (`::<pass>`) threaded from an explicit
`AgentFinding.sourcePass` field. It's a small, additive change — I checked
first whether finding objects carry pass identity at delivery time (they
don't, today) and whether threading it through was invasive before building
anything; it wasn't (see "Why this wasn't invasive" below), so I built it
per the assignment rather than stopping to report a scoping assessment.

## Harness evidence (deterministic byte-diff census — no rule/prompt touched)

This PR touches files under `packages/review/src/plugins/agent/**`
(`types.ts`, `review-pass.ts`, `index.ts`), which trips this repo's
harness-evidence CI gate, but changes no rule text and no prompt-assembly
code path. `build-prompts.ts` — the harness's own prompt-assembly
entrypoint — imports only `rules.js`, `system-prompt.js`, each pass's own
gate/prompt-builder/budget functions, `AgentConfig` (type-only) from
`types.js`, and `ReviewContext` from `plugin-types.js`:

```
$ grep '^import' packages/review/test/harness/build-prompts.ts
... rules.js, system-prompt.js, per-pass gate/prompt/budget functions,
    AgentConfig (type-only) from types.js, ReviewContext, fixture-loader.js
(no engine.js, no review-pass.js, no index.js)
```

Everything this PR actually changes is either not imported by
`build-prompts.ts` at all (`review-pass.ts`'s `tagSourcePass`/
`runExtraPasses`, `index.ts`'s `mapToReviewFinding`, `engine.ts`'s
`buildPluginCommentBody`/`parsePluginCommentKey`), or is a NEW optional field
on `AgentFinding` (`sourcePass`) that `AgentConfig` — the only thing
`build-prompts.ts` imports from `types.ts` — doesn't reference at all.

Deterministic byte-diff census, run via `build-prompts.ts` against two
on-disk fixtures, comparing this branch (commit `24ffcee2`) to its base on
`main` (`67958ddd`) in a clean sibling worktree (native parser built via
`npm run build:native -w @liendev/parser-native` + `npm run build -w
@liendev/parser` first, per `docs/development/worktree-development.md`):

```
$ npx tsx test/harness/build-prompts.ts test/harness/fixtures/doc-truth/accurate-doc.fixture.json
# sha256 of output, excluding the run-environment's absolute `fixturePath` line:
before (67958ddd): 6e06f08d66deabc6bd42a7cf74fdd531f05737b7bd6bae36ed9df3d1612fe67f
after  (24ffcee2): 6e06f08d66deabc6bd42a7cf74fdd531f05737b7bd6bae36ed9df3d1612fe67f   <- byte-identical

$ npx tsx test/harness/build-prompts.ts test/harness/fixtures/boundary-change/placeholder.fixture.json
before (67958ddd): a5d1d33c9d64813c5dc48b0b28de88216e29262134a8e18e009837a80756d04b
after  (24ffcee2): a5d1d33c9d64813c5dc48b0b28de88216e29262134a8e18e009837a80756d04b   <- byte-identical
```

Both fixtures' prompt-assembly output is byte-identical before/after (the
only literal diff in the raw stdout is the absolute `fixturePath`, an
environment artifact, not prompt content). No `--calibrate` run needed:
there is no rule/prompt surface for one to calibrate — this is GitHub
delivery/dedup-marker plumbing, not agent-facing prompt content.


## Where provenance gets stamped and threaded

1. **`review-pass.ts`, new `tagSourcePass(findings, pass)`** — a pure
   `.map()` that stamps `sourcePass` onto every finding in an array.
   `runExtraPasses` calls it twice: once on the main pass's own `findings`
   (tagged `'main'`, matching the literal string `attestation.ts` already
   uses for the main pass's own attestation entries), and once on each extra
   pass's own `passResult.findings` (tagged with that `ReviewPassSpec.name` —
   `'doc-truth'`, `'stale-duplicate-loop'`, etc.) *before* handing them to
   `spec.mergeFindings`.
2. **Why this didn't require touching any of the five `mergeFindings`
   functions** (`mergeDocTruthFindings`, `mergeStaleDuplicateFindings`,
   `mergeIncompleteHandlingFindings`, `mergeRemovedExportsFindings`,
   `mergeDocsDriftFindings`): every one of them already copies findings via
   spread (`{ ...f, ruleId: SOME_RULE_ID }`) rather than reconstructing them
   field-by-field. A `sourcePass` stamped before the merge call survives
   automatically. Verified directly by reading all five and with a
   dedicated test using the exact real spread shape.
3. **`index.ts`'s `mapToReviewFinding`** — threads `f.sourcePass` into
   `ReviewFinding.metadata.sourcePass` (same conditional-inclusion pattern
   already used for `ruleId`; a finding lacking `sourcePass` gets no
   metadata key added).
4. **`engine.ts`'s `buildPluginCommentBody`** (now exported for direct
   testing) — appends the 4th segment only when
   `metadata.sourcePass` is present. A finding with no `sourcePass` (every
   non-agent-review plugin, e.g. `complexity`) keeps the exact pre-existing
   3-segment format untouched.

## Why this wasn't invasive

The one path I was worried about going in — whether `ruleId` alone could be
mistaken for pass identity — turned out not to be a shortcut: a candidate-
loop's `mergeXFindings` forces `ruleId` onto BOTH the loop's own findings
*and* any surviving main-pass finding of the same rule that didn't collide,
so `ruleId` post-merge doesn't reliably tell you which pass a finding
actually came from. That's exactly the gap the census called out. Fixing it
required exactly one new field + one tagging call site (`runExtraPasses`),
not a redesign — the merge functions' existing spread pattern did the rest
for free.

## Critical back-compat: old-format markers must still dedup

`parsePluginCommentKey` now accepts BOTH the original 3-segment
`filepath::line::category` format and the new 4-segment
`filepath::line::category::pass` format, detected **positionally**, not by
segment count (a filepath can itself contain `::`, same edge case the
original 3-segment parser already had to reassemble around via
`slice(0, -2)`):

- Try OLD format first: is the second-to-last segment a valid integer? If
  so, that's `line` and the last segment is `category`.
- Otherwise try NEW format: is the *third*-to-last segment a valid integer?
  If so, that's `line`, second-to-last is `category`, last is `pass`.

Checking OLD format first is safe by construction, not just convenient: a
`category` value is always a fixed, enum-like rule/category string (never a
bare integer) and `line` always is one (`String(f.line)`). So "is the
second-to-last segment numeric" is true for every real OLD-format key and
false for every real NEW-format key's analogous position — no realistic
ambiguity between the two shapes.

`isDuplicateOfExistingComment`'s equality check was **not** changed — it
already only compares `filepath`/`category`/`line` (with the existing
line-drift tolerance), never `pass`. So an OLD-format existing marker and a
NEW-format candidate (or vice versa) still match on identity, and the
format change alone can never cause a double-post.

## Tests

- `packages/review/test/plugins-agent-review-pass.test.ts`: `tagSourcePass`
  unit tests (stamps every finding, overwrites stale values, pure/no
  mutation, empty input) + two `runExtraPasses` integration tests — one
  confirming main vs. each extra pass gets the right tag in the merged
  output, one reproducing the real `{ ...f, ruleId: ... }` spread shape all
  five real merge functions use, confirming `sourcePass` survives it.
  Updated one pre-existing test whose exact-equality assertion needed to
  account for the new (expected) `sourcePass: 'main'` tag.
- `packages/review/test/engine-comment-dedup.test.ts`: new-format parsing
  (well-formed, hyphenated pass name, empty pass segment, embedded-`::`
  filepath reassembly for both formats), `buildPluginCommentBody` marker
  construction (3-segment when no `sourcePass`, 4-segment when present,
  round-trip through `parsePluginCommentKey`), and the **critical mixed-
  format dedup matrix**: NEW candidate vs. OLD existing, OLD candidate vs.
  NEW existing, cross-format matching within the line-drift tolerance, a
  mixed set of both formats never causing a false match on an unrelated
  finding.
- `packages/review/test/engine-delivery.test.ts`: an end-to-end test through
  the REAL `postInlineComments` → dedup → GitHub-post pipeline (mocked
  Octokit) — a PR thread with an OLD-format marker already posted, a new run
  producing a finding with `sourcePass` set (which would render a NEW-format
  marker), asserts `deduped: 1, posted: 0` and that `createReview`/
  `createReviewComment` are never called. This is the genuine "does the real
  code path avoid double-posting" proof, not just the pure-function unit
  tests.

All new/updated tests pass; full suite green (see Gates).

## Dogfood evidence

Same reasoning as #852 (zero OpenRouter spend — this is deterministic
delivery/marker logic, not a rule/prompt change): the `engine-delivery.test.ts`
addition above exercises the actual `ReviewEngine.present()` →
`postInlineComments` → `deduplicateComments` → `getExistingPluginCommentKeys`
→ `isDuplicateOfExistingComment` chain end-to-end with a mocked Octokit,
which is the closest thing to "run it for real" available without live PR
traffic or an LLM call. A live PR re-review (an already-reviewed open PR
picking up this change) would be the natural post-merge confirmation, but
isn't reproducible pre-merge without spending real review runs on this
repo's own PRs.

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors, 38 pre-existing warnings
- `npm run typecheck` — clean (full monorepo)
- `npm run build` — clean (parser, core, review, cli, action)
- `npm test` — all 6 workspaces green: root 27, core 1108, parser 378,
  review 1632 (+19 net new tests), cli 1113, action 41
- `node packages/cli/dist/index.js delta` — exit 0. Four functions show
  `worsened` (advisory, not a threshold crossing): `buildPluginCommentBody`
  cognitive 4→5, `parsePluginCommentKey` cognitive 3→8, `mapToReviewFinding`
  cognitive 1→3 (all far under the 15 threshold), and `runExtraPasses`'
  `time` metric (not a gated metric); one new function `tagSourcePass`
  (cyclomatic 1, trivially simple).

No changeset — `@liendev/review` is private/unpublished (same convention as
#837/#838/#852).

## Base

Branched off `main` after #852 (deliverable 1 of this same issue) merged, so
this only diffs the pass-provenance work.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 5 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 5 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds optional pass-provenance tracking to agent-review findings by threading a new `sourcePass` field into the inline-comment dedup marker as an additive 4th segment. The change is narrowly scoped: non-agent plugins keep the existing 3-segment marker, the parser accepts both formats positionally, and the dedup equality check deliberately ignores `pass` so old-format markers still dedup against new-format candidates. The implementation is well-covered by unit tests for parsing, marker construction, mixed-format dedup, and an end-to-end delivery test proving no double-post occurs when an old-format marker already exists on a PR thread.
>
> - Added `sourcePass` to `AgentFinding` and mapped it to `ReviewFinding.metadata.sourcePass` in `mapToReviewFinding`.
> - Added `tagSourcePass` and stamped main/extra-pass findings before merging in `runExtraPasses`.
> - Extended `buildPluginCommentBody` to emit a 4-segment marker when `metadata.sourcePass` is present.
> - Updated `parsePluginCommentKey` to parse both 3-segment and 4-segment keys while preserving filepath-contains-`::` reassembly.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fba3d02. Updates automatically on new commits.</sup>
<!-- /lien-stats -->