### PR TITLE
feat(review): env override for the main pass's token budget (#855)

### DIFF
--- a/.github/workflows/lien-review.yml
+++ b/.github/workflows/lien-review.yml
@@ -102,3 +102,27 @@ jobs:
           # data ahead of any consumer default-on decision, not to claim a
           # passed calibration bar.
           LIEN_REMOVED_EXPORTS_PASS: 'on'
+          # LIEN_REVIEW_TOKEN_BUDGET — an absolute override for the main
+          # pass's final token budget (see docs/architecture/review-pass-
+          # architecture.md's budget section and applyReviewTokenBudgetOverride's
+          # own doc comment, packages/review/src/defaults.ts). Motivating case
+          # (PR #855): the review check failed 3 of 4 runs on a genuinely
+          # large feature diff, the main pass exhausting its allocation.
+          # Attestation receipts across those runs: 161,588 allocated to the
+          # main pass (277,588 total across main + extra passes), yet the
+          # deepest-investigation variant spent up to 475,055 tokens before
+          # dying incomplete; only a shallower-investigation variant finished,
+          # and only because it stayed inside the original allocation by
+          # exploring less. 555,176 is ~2x that 277,588 prior effective total
+          # (555,176 = 277,588 * 2), comfortably clearing the observed 475,055
+          # floor with headroom for the deep path to actually finish. Quoted:
+          # an unquoted six-digit scalar is still worth avoiding on principle
+          # here (env values are always strings; see the 'on' quoting above
+          # for the same footgun class). Raises this repo's own worst-case
+          # per-run OpenRouter cost on large diffs — the owner explicitly
+          # approved that trade 2026-07-25. No action.yml input either (same
+          # env-only, undocumented-by-design mechanism as the flags above);
+          # every other @liendev/review / @liendev/action consumer is
+          # unaffected (unset there, so the diff-scaled/blast-radius-scaled
+          # formula runs exactly as before).
+          LIEN_REVIEW_TOKEN_BUDGET: '555176'

--- a/docs/architecture/review-pass-architecture.md
+++ b/docs/architecture/review-pass-architecture.md
@@ -503,6 +503,55 @@ fires exactly once per pass that ran.
   documented above), which dominates for every real-PR candidate count
   this loop has measured so far (a 1-2 candidate run is the common case).
 
+### The main pass's own budget, and the `LIEN_REVIEW_TOKEN_BUDGET` override
+
+Every formula above scales off "the main pass's base budget"
+(`config.maxTokenBudget`), but that number is itself established upstream,
+in two steps, before any extra pass ever sees it:
+
+1. `scaleAgentBudget` (`review-pr.ts`) estimates a diff-proportional base
+   (content tokens + a per-turn tool-call allowance), scales it by
+   `reviewTokenBudgetMultiplier` (2.0× for the prod default model), and
+   clamps the result to `[60_000, MAX_REVIEW_TOKEN_BUDGET]` (250,000).
+2. `scaleBudgetForBlastRadius` (`plugins/agent/index.ts`) then upscales that
+   number again for a critical/high blast radius (1.5×/1.25×), reclamping to
+   the same `MAX_REVIEW_TOKEN_BUDGET` ceiling — this second clamp, not the
+   first, is the REAL ceiling a run is held to (the pre-blast-radius value
+   computed in step 1 is provisional; see that call site's own comment).
+
+Both steps run unconditionally and unchanged — nothing above was touched.
+`LIEN_REVIEW_TOKEN_BUDGET` (an env-only knob, `applyReviewTokenBudgetOverride`
+in `defaults.ts`) is a THIRD step layered on top, applied at the exact point
+`plugins/agent/index.ts`'s `analyze()`/`analyzeSummaryOnly()` call
+`context.reportBudget` — i.e. at the moment the final number is established
+and handed to the delivery attestation, so `allocatedTokens` always reflects
+whichever value (computed or overridden) the run actually used. Unset (the
+default for every `@liendev/review`/`@liendev/action` consumer), it's a
+byte-identical no-op: `applyReviewTokenBudgetOverride` returns its input
+unchanged. Set to a valid positive integer, it REPLACES that final number
+wholesale (not another multiplier on top), clamped to
+`[MIN_REVIEW_TOKEN_BUDGET_OVERRIDE, MAX_REVIEW_TOKEN_BUDGET_OVERRIDE]`
+(60,000, matching step 1's own floor, and 5× `MAX_REVIEW_TOKEN_BUDGET` =
+1,250,000) — a non-numeric, non-integer, zero, or negative value is ignored
+and the computed value is used instead (fail-open, never a crash). Everything
+downstream of this point — the client's own budget enforcement, the
+extra-pass rollover pool (`unspentMainBudget`) — reads whatever
+`maxTokenBudget` ends up being with no changes of its own; only this one
+substitution point exists.
+
+Motivating case (PR #855, 2026-07-25): the review check failed 3 of 4 runs on
+a genuinely large feature diff, the main pass exhausting its allocation.
+Attestation receipts across those runs: 161,588 allocated to the main pass
+(277,588 total across main + extra passes — already comfortably under the
+existing 250,000 per-pass ceiling), yet the deepest-investigation variant
+spent up to 475,055 tokens before dying incomplete; the one run that finished
+did so only because that particular investigation was shallower, not because
+161,588 was actually enough. This repo's own `.github/workflows/lien-review.yml`
+sets `LIEN_REVIEW_TOKEN_BUDGET: '555176'` (~2× that 277,588 prior effective
+total), comfortably clearing the observed 475,055 floor — see that workflow's
+own comment for the full sizing rationale. Every other `@liendev/review`/
+`@liendev/action` consumer leaves it unset and is unaffected.
+
 ## Which passes are live today
 
 - **doc-truth**: production-on, has been since PR #733. Kill-switches:

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -122,7 +122,7 @@ Reference them from a later step via the step `id`:
 
 ## Advanced configuration
 
-Beyond the inputs above, one behavior is tunable only via an environment
+Beyond the inputs above, a few behaviors are tunable only via an environment
 variable on the action step, not a formal input:
 
 ```yaml
@@ -130,6 +130,7 @@ variable on the action step, not a formal input:
   env:
     LIEN_REVIEW_DOC_PASS: '0' # disable the doc-truth second pass
     LIEN_DOC_TRUTH_V2: 'off' # opt back into the pass's older open-findings-list behavior
+    LIEN_REVIEW_TOKEN_BUDGET: '400000' # raise the main pass's token budget for large diffs
   with:
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
@@ -143,6 +144,17 @@ variable on the action step, not a formal input:
   [Agent-Review Pass Architecture](https://github.com/getlien/lien/blob/main/docs/architecture/review-pass-architecture.md)
   for what v2 changes. Only takes effect when the doc-truth pass itself is
   enabled (i.e., not overridden by `LIEN_REVIEW_DOC_PASS` above).
+- **`LIEN_REVIEW_TOKEN_BUDGET=<int>`**: an absolute override for the main
+  pass's final token budget, for repos whose PRs reproducibly starve the
+  diff-scaled/blast-radius-scaled formula on large diffs (see
+  [Agent-Review Pass Architecture](https://github.com/getlien/lien/blob/main/docs/architecture/review-pass-architecture.md)'s
+  budget section for exactly where this applies). Unset by default — every
+  consumer gets the same diff-scaled budget as before. A non-numeric,
+  non-integer, zero, or negative value is ignored (fails open to the
+  computed budget, never crashes the run); a valid value is clamped to
+  [60,000, 1,250,000] (5× the existing 250,000 ceiling). Raising this raises
+  the run's worst-case per-PR OpenRouter cost — set it deliberately, not
+  speculatively.
 
 There is currently no `model` input. The OpenRouter path pins the calibrated
 default deliberately, since the calibration evidence backing this review

--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -80,3 +80,73 @@ export const REVIEW_TOKEN_BUDGET_MULTIPLIERS: Record<string, number> = {
 export function reviewTokenBudgetMultiplier(model: string): number {
   return REVIEW_TOKEN_BUDGET_MULTIPLIERS[model] ?? 1;
 }
+
+/**
+ * Env var: an absolute override for the main pass's FINAL token budget (after
+ * diff-scaling AND blast-radius scaling — see `applyReviewTokenBudgetOverride`
+ * below for exactly where it applies). Read directly via `process.env`, the
+ * same "no `action.yml` input plumbing" mechanism the candidate-loop passes'
+ * own on/off flags use (`LIEN_STALE_DUP_PASS` etc., see
+ * `.github/workflows/lien-review.yml`).
+ */
+export const REVIEW_TOKEN_BUDGET_OVERRIDE_ENV = 'LIEN_REVIEW_TOKEN_BUDGET';
+
+/**
+ * Floor for `LIEN_REVIEW_TOKEN_BUDGET` — matches the existing floor
+ * `scaleAgentBudget` (`review-pr.ts`) already clamps every diff-scaled budget
+ * to (its inline `60_000`): below this a run can't afford even one real
+ * investigative tool round-trip.
+ */
+export const MIN_REVIEW_TOKEN_BUDGET_OVERRIDE = 60_000;
+
+/**
+ * Ceiling for `LIEN_REVIEW_TOKEN_BUDGET` — 5x `MAX_REVIEW_TOKEN_BUDGET`, the
+ * existing hard ceiling every diff-scaled/blast-radius-scaled budget is
+ * already clamped to. PR #855 is the sizing evidence: its main pass, already
+ * comfortably under that existing 250,000 ceiling at 161,588 allocated, still
+ * spent up to 475,055 tokens on its deepest-investigation variant before
+ * dying incomplete. 5x gives an operator room to size well past that observed
+ * cost while still bounding the worst case a fat-fingered env value (an extra
+ * zero) could rack up.
+ */
+export const MAX_REVIEW_TOKEN_BUDGET_OVERRIDE = MAX_REVIEW_TOKEN_BUDGET * 5;
+
+/**
+ * Apply the `LIEN_REVIEW_TOKEN_BUDGET` env override to a computed main-pass
+ * token budget.
+ *
+ * An operator-facing escape hatch, not a replacement for the diff-scaled/
+ * blast-radius-scaled formulas (`scaleAgentBudget`, `scaleBudgetForBlastRadius`
+ * in `plugins/agent/index.ts`) — those still run exactly as before and
+ * compute `computed`; this only decides whether to keep that value or replace
+ * it wholesale with an absolute operator-supplied one. Motivating case (PR
+ * #855): a genuinely large feature diff's main pass can need far more room
+ * than either formula estimates for — see `MAX_REVIEW_TOKEN_BUDGET_OVERRIDE`'s
+ * own doc comment for that PR's receipt.
+ *
+ * Fails open: an absent, non-numeric, non-integer, zero, or negative value
+ * leaves `computed` untouched — a typo'd env value must never crash a review
+ * run. A valid value is clamped to [`MIN_REVIEW_TOKEN_BUDGET_OVERRIDE`,
+ * `MAX_REVIEW_TOKEN_BUDGET_OVERRIDE`], so a well-intentioned extra zero can't
+ * blow past a sane worst-case cost either.
+ *
+ * Callers apply this at the same point they call `context.reportBudget`
+ * (`plugins/agent/index.ts`'s `analyze()`/`analyzeSummaryOnly()`) — the point
+ * the FINAL main-pass budget is established — so the delivery attestation's
+ * `allocatedTokens` always reflects whichever value, computed or overridden,
+ * the run was actually held to, and every existing downstream consumer of
+ * that final number (the client's own budget enforcement, the extra-pass
+ * rollover pool) sees it unchanged, with no formula of its own to update.
+ */
+export function applyReviewTokenBudgetOverride(computed: number): number {
+  const raw = process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV];
+  if (!raw) return computed;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return computed;
+  }
+  return Math.min(
+    Math.max(parsed, MIN_REVIEW_TOKEN_BUDGET_OVERRIDE),
+    MAX_REVIEW_TOKEN_BUDGET_OVERRIDE,
+  );
+}

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -51,6 +51,8 @@ import {
   DEFAULT_REVIEW_MODEL,
   DEFAULT_OPENROUTER_BASE_URL,
   MAX_REVIEW_TOKEN_BUDGET,
+  REVIEW_TOKEN_BUDGET_OVERRIDE_ENV,
+  applyReviewTokenBudgetOverride,
 } from '../../defaults.js';
 
 /**
@@ -258,19 +260,30 @@ export class AgentReviewPlugin implements ReviewPlugin {
 
     // High-impact PRs need more room to investigate; a too-tight budget is the
     // common cause of the agent bailing before producing a verdict.
-    const maxTokenBudget = scaleBudgetForBlastRadius(
+    const blastRadiusScaledBudget = scaleBudgetForBlastRadius(
       config.maxTokenBudget,
       blastRadius?.globalRisk.level,
     );
-    if (maxTokenBudget !== config.maxTokenBudget) {
+    if (blastRadiusScaledBudget !== config.maxTokenBudget) {
       logger.info(
-        `[${this.id}] Token budget scaled ${config.maxTokenBudget} → ${maxTokenBudget} for ${blastRadius?.globalRisk.level} blast radius`,
+        `[${this.id}] Token budget scaled ${config.maxTokenBudget} → ${blastRadiusScaledBudget} for ${blastRadius?.globalRisk.level} blast radius`,
       );
     }
-    // Report the FINAL allocated ceiling (post blast-radius scaling) for the
-    // delivery attestation's budget.allocatedTokens — the pre-scaling value
-    // computed upstream in review-pr.ts's scaleAgentBudget() isn't the real
-    // ceiling this run was held to.
+    // LIEN_REVIEW_TOKEN_BUDGET (PR #855): an operator-facing escape hatch for
+    // when the diff-scaled/blast-radius-scaled estimate above still isn't
+    // enough room for a genuinely large diff's investigation — see
+    // `applyReviewTokenBudgetOverride`'s own doc comment. A no-op (returns
+    // the same value) unless the env var is set to a valid positive integer.
+    const maxTokenBudget = applyReviewTokenBudgetOverride(blastRadiusScaledBudget);
+    if (maxTokenBudget !== blastRadiusScaledBudget) {
+      logger.info(
+        `[${this.id}] Token budget overridden ${blastRadiusScaledBudget} → ${maxTokenBudget} via ${REVIEW_TOKEN_BUDGET_OVERRIDE_ENV}`,
+      );
+    }
+    // Report the FINAL allocated ceiling (post blast-radius scaling AND any
+    // env override) for the delivery attestation's budget.allocatedTokens —
+    // the pre-scaling value computed upstream in review-pr.ts's
+    // scaleAgentBudget() isn't the real ceiling this run was held to.
     context.reportBudget?.(maxTokenBudget);
 
     const systemPrompt = buildSystemPrompt(rules);
@@ -358,8 +371,10 @@ export class AgentReviewPlugin implements ReviewPlugin {
     // The final budget was already scaled diff-proportionally by
     // `scaleSummaryOnlyBudget` upstream (review-pr.ts's buildPluginConfigs) —
     // unlike the normal path, there's no blast-radius upscale to layer on top
-    // (no chunks means no blast radius is computed).
-    const maxTokenBudget = config.maxTokenBudget;
+    // (no chunks means no blast radius is computed). LIEN_REVIEW_TOKEN_BUDGET
+    // (PR #855) can still raise it — same override, same mechanism as the
+    // normal path's `analyze()` above.
+    const maxTokenBudget = applyReviewTokenBudgetOverride(config.maxTokenBudget);
     context.reportBudget?.(maxTokenBudget);
 
     const result = await runAgentClient(

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -18,10 +18,14 @@ import {
   DEFAULT_REVIEW_MODEL,
   MAX_REVIEW_TOKEN_BUDGET,
   REVIEW_TOKEN_BUDGET_MULTIPLIERS,
+  REVIEW_TOKEN_BUDGET_OVERRIDE_ENV,
+  MIN_REVIEW_TOKEN_BUDGET_OVERRIDE,
+  MAX_REVIEW_TOKEN_BUDGET_OVERRIDE,
+  applyReviewTokenBudgetOverride,
 } from '../src/defaults.js';
-import { silentLogger } from '../src/test-helpers.js';
+import { silentLogger, createTestContext } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
-import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
+import type { PresentContext, ReviewFinding, ReviewContext } from '../src/plugin-types.js';
 import type { AgentResult } from '../src/plugins/agent/types.js';
 import type { PRContext } from '../src/types.js';
 
@@ -1025,6 +1029,198 @@ describe('scaleAgentBudget — model-aware multiplier', () => {
       ...scaleAgentBudget(5, [{ content: 'x'.repeat(40_002) }], DEFAULT_REVIEW_MODEL),
     };
     expect(() => plugin.configSchema.parse(cfg)).not.toThrow();
+  });
+});
+
+describe('applyReviewTokenBudgetOverride — LIEN_REVIEW_TOKEN_BUDGET (PR #855)', () => {
+  afterEach(() => {
+    delete process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV];
+  });
+
+  it('is a byte-identical no-op when unset — the computed value passes through', () => {
+    delete process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV];
+    expect(applyReviewTokenBudgetOverride(161_588)).toBe(161_588);
+  });
+
+  it('is a no-op for an empty-string value (unset in practice)', () => {
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = '';
+    expect(applyReviewTokenBudgetOverride(161_588)).toBe(161_588);
+  });
+
+  it('applies a valid value inside the clamp range, replacing the computed budget', () => {
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = '400000';
+    expect(applyReviewTokenBudgetOverride(161_588)).toBe(400_000);
+  });
+
+  it.each([
+    ['non-numeric garbage', 'not-a-number'],
+    ['a fractional value', '100000.5'],
+    ['zero', '0'],
+    ['a negative value', '-50000'],
+    ['NaN itself', 'NaN'],
+    ['Infinity', 'Infinity'],
+  ])('fails open to the computed value on %s', (_label, raw) => {
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = raw;
+    expect(applyReviewTokenBudgetOverride(161_588)).toBe(161_588);
+  });
+
+  it('clamps a below-floor value up to MIN_REVIEW_TOKEN_BUDGET_OVERRIDE', () => {
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = '1000';
+    expect(applyReviewTokenBudgetOverride(161_588)).toBe(MIN_REVIEW_TOKEN_BUDGET_OVERRIDE);
+  });
+
+  it('clamps an above-ceiling value down to MAX_REVIEW_TOKEN_BUDGET_OVERRIDE (5x the default)', () => {
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = '999999999';
+    expect(applyReviewTokenBudgetOverride(161_588)).toBe(MAX_REVIEW_TOKEN_BUDGET_OVERRIDE);
+    expect(MAX_REVIEW_TOKEN_BUDGET_OVERRIDE).toBe(MAX_REVIEW_TOKEN_BUDGET * 5);
+  });
+
+  it('passes an in-range value through unchanged at the exact floor/ceiling boundaries', () => {
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = String(MIN_REVIEW_TOKEN_BUDGET_OVERRIDE);
+    expect(applyReviewTokenBudgetOverride(1)).toBe(MIN_REVIEW_TOKEN_BUDGET_OVERRIDE);
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = String(MAX_REVIEW_TOKEN_BUDGET_OVERRIDE);
+    expect(applyReviewTokenBudgetOverride(1)).toBe(MAX_REVIEW_TOKEN_BUDGET_OVERRIDE);
+  });
+});
+
+describe('AgentReviewPlugin.analyze — LIEN_REVIEW_TOKEN_BUDGET reaches the attestation (PR #855)', () => {
+  afterEach(() => {
+    delete process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV];
+  });
+
+  const CLEAN_JSON_LOCAL =
+    '```json\n' +
+    JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: 'fine', keyChanges: [] },
+    }) +
+    '\n```';
+
+  function stopTurnLocal(content: string) {
+    return {
+      choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+    };
+  }
+
+  function mockFetchLocal() {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const resp = stopTurnLocal(CLEAN_JSON_LOCAL);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => resp,
+          text: async () => JSON.stringify(resp),
+        };
+      }),
+    );
+  }
+
+  it('reports the overridden value (not the computed one) via context.reportBudget on the normal path', async () => {
+    mockFetchLocal();
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = '400000';
+    const reportBudget = vi.fn();
+    const plugin = new AgentReviewPlugin();
+    const context: ReviewContext = createTestContext({
+      chunks: [
+        {
+          content: 'export function add(a, b) { return a + b; }',
+          metadata: { file: 'src/math.ts', language: 'typescript', symbolType: 'function' },
+        } as ReviewContext['chunks'][number],
+      ],
+      changedFiles: ['src/math.ts'],
+      repoChunks: [],
+      repoRootDir: '/tmp/does-not-matter',
+      reportBudget,
+      config: {
+        apiKey: 'k',
+        provider: 'openai',
+        model: 'test-model',
+        baseUrl: 'http://mock.local',
+        maxTurns: 8,
+        maxTokenBudget: 60_000,
+        summaryEnabled: false,
+        docTruthPass: false,
+      },
+      pr: {
+        title: 'feat: big diff',
+        patches: new Map([['src/math.ts', '@@ diff @@']]),
+      } as ReviewContext['pr'],
+    });
+
+    await plugin.analyze(context);
+
+    expect(reportBudget).toHaveBeenCalledWith(400_000);
+  });
+
+  it('leaves context.reportBudget unaffected on the normal path when unset (default byte-identical)', async () => {
+    mockFetchLocal();
+    delete process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV];
+    const reportBudget = vi.fn();
+    const plugin = new AgentReviewPlugin();
+    const context: ReviewContext = createTestContext({
+      chunks: [
+        {
+          content: 'export function add(a, b) { return a + b; }',
+          metadata: { file: 'src/math.ts', language: 'typescript', symbolType: 'function' },
+        } as ReviewContext['chunks'][number],
+      ],
+      changedFiles: ['src/math.ts'],
+      repoChunks: [],
+      repoRootDir: '/tmp/does-not-matter',
+      reportBudget,
+      config: {
+        apiKey: 'k',
+        provider: 'openai',
+        model: 'test-model',
+        baseUrl: 'http://mock.local',
+        maxTurns: 8,
+        maxTokenBudget: 60_000,
+        summaryEnabled: false,
+        docTruthPass: false,
+      },
+      pr: {
+        title: 'fix: small change',
+        patches: new Map([['src/math.ts', '@@ diff @@']]),
+      } as ReviewContext['pr'],
+    });
+
+    await plugin.analyze(context);
+
+    expect(reportBudget).toHaveBeenCalledWith(60_000);
+  });
+
+  it('reports the overridden value on the summary-only path too', async () => {
+    mockFetchLocal();
+    process.env[REVIEW_TOKEN_BUDGET_OVERRIDE_ENV] = '500000';
+    const reportBudget = vi.fn();
+    const plugin = new AgentReviewPlugin();
+    const context: ReviewContext = createTestContext({
+      chunks: [],
+      allChangedFiles: ['CLAUDE.md'],
+      reportBudget,
+      config: {
+        apiKey: 'k',
+        provider: 'openai',
+        model: 'test-model',
+        baseUrl: 'http://mock.local',
+        maxTurns: 8,
+        maxTokenBudget: 20_000,
+        summaryEnabled: true,
+        docTruthPass: false,
+      },
+      pr: {
+        title: 'docs: remove stale line',
+        patches: new Map([['CLAUDE.md', '@@ -1,2 +1,1 @@\n-stale\n context']]),
+      } as ReviewContext['pr'],
+      repoRootDir: '/tmp/does-not-matter',
+    });
+
+    await plugin.analyze(context);
+
+    expect(reportBudget).toHaveBeenCalledWith(500_000);
   });
 });
 


### PR DESCRIPTION
## Summary

Large feature diffs can reproducibly starve the main agent-review pass.
PR #855's review check failed 3 of 4 runs: attestation receipts show 161,588
tokens allocated to the main pass (277,588 total across main + extra passes),
yet the deepest-investigation variant spent up to 475,055 tokens before dying
incomplete; the one run that finished did so only because that particular
investigation was shallower, not because 161,588 was actually enough.

This adds `LIEN_REVIEW_TOKEN_BUDGET`, an env-only absolute override for the
main pass's final token budget, and sizes it for this repo's own CI.

## The formula (ground-first)

The main pass's real ceiling is established in two steps, both in
`packages/review/src`:

1. `scaleAgentBudget` (`review-pr.ts`): `baseBudget = 4_000 + estimatedContentTokens (diff chars / 4) + maxTurns*6_000 + 2_000`, scaled by `reviewTokenBudgetMultiplier(model)` (2.0x for the prod default, `moonshotai/kimi-k2.7-code`), then clamped to `[60_000, MAX_REVIEW_TOKEN_BUDGET]` (250,000).
2. `scaleBudgetForBlastRadius` (`plugins/agent/index.ts`): upscales that again for critical/high blast radius (1.5x/1.25x), **re-clamping to the same 250,000 ceiling** — this second clamp, not the first, is the real ceiling a run is held to (see that call site's own comment: "the pre-scaling value computed upstream ... isn't the real ceiling").

277,588-shaped totals arise because the delivery attestation's top-level `allocatedTokens` sums the main pass's own number with every extra pass's own independently-computed allocation (doc-truth/stale-duplicate/incomplete-handling/removed-exports/docs-drift — this repo opts into all five). None of those five passes' own budget formulas read the main pass's base budget parameter at all (each is scaled by its own candidate/claim count), so raising the main pass's number doesn't perturb them.

Critically: PR #855's main pass was allocated 161,588 — already comfortably *under* the existing 250,000 ceiling — so the ceiling itself wasn't binding. The diff-scaled formula simply estimated too little for what a genuinely deep investigation of a large diff actually costs. Any override that only replaces the *pre-multiplier* estimate inside `scaleAgentBudget` would still get re-clamped to 250,000 by `scaleBudgetForBlastRadius` downstream — nowhere near the observed 475,055-token need. The override has to act at (or after) that second, real clamp to matter at all.

## The knob (absolute override, not a multiplier)

`applyReviewTokenBudgetOverride` (`packages/review/src/defaults.ts`) is called at the exact point both `analyze()` and `analyzeSummaryOnly()` (`plugins/agent/index.ts`) call `context.reportBudget` — i.e., where the FINAL main-pass budget is established and handed to the delivery attestation:

```ts
const maxTokenBudget = applyReviewTokenBudgetOverride(blastRadiusScaledBudget);
context.reportBudget?.(maxTokenBudget);
```

- **Unset** (every existing `@liendev/review`/`@liendev/action` consumer): byte-identical no-op — returns the input unchanged.
- **Set to a valid positive integer**: replaces the computed value wholesale, clamped to `[60_000 (MIN_REVIEW_TOKEN_BUDGET_OVERRIDE, matching scaleAgentBudget's own existing floor), 1_250_000 (MAX_REVIEW_TOKEN_BUDGET_OVERRIDE = 5x the existing 250,000 ceiling)]`.
- **Anything else** (non-numeric, fractional, zero, negative): fails open to the computed value — never crashes a run over a typo'd env value.
- Everything downstream (the client's own budget enforcement, the extra-pass rollover pool `unspentMainBudget`) reads whatever `maxTokenBudget` ends up being with zero changes of its own — no per-pass formula, no floor, no rollover math was touched.

Chose an absolute override over a multiplier because the real lever is a *final, already-doubly-clamped* number (see above), not a multiplicand on top of a formula that itself has no room left to give — a multiplier on `scaleAgentBudget`'s pre-multiplier estimate would still die at the `scaleBudgetForBlastRadius` re-clamp.

No `action.yml` input — read directly via `process.env`, the same "undocumented-by-design" mechanism the four dark candidate-loop flags (`LIEN_STALE_DUP_PASS` etc.) already use.

## Workflow value + sizing

`.github/workflows/lien-review.yml` now sets `LIEN_REVIEW_TOKEN_BUDGET: '555176'` (quoted — matches the existing `'on'`-quoting convention for the same YAML-bareword-footgun reason, even though a six-digit integer isn't ambiguous the way `on`/`off` are).

Math: `555,176 = 277,588 × 2` — 2x PR #855's own prior effective total (161,588 main + ~116,000 across extra passes). This comfortably clears the observed 475,055-token floor (the deepest-investigation variant's actual spend) with headroom, while staying well inside the override's own 1,250,000 ceiling.

**This raises this repo's own worst-case per-run OpenRouter cost on large diffs.** The owner explicitly approved that trade this morning (2026-07-25). Every other `@liendev/review`/`@liendev/action` consumer is unaffected (unset there).

## Evidence

- **Unit tests** (`packages/review/test/plugins-agent-budget.test.ts`): `applyReviewTokenBudgetOverride` — unset is a no-op, a valid value replaces the computed budget, six garbage-value shapes (non-numeric, fractional, zero, negative, `NaN`, `Infinity`) all fail open, floor/ceiling clamping (incl. exact-boundary values), and `MAX_REVIEW_TOKEN_BUDGET_OVERRIDE === MAX_REVIEW_TOKEN_BUDGET * 5`. Plus three `AgentReviewPlugin.analyze()`-level integration tests proving `context.reportBudget` (the attestation's direct input) receives the overridden value on both the normal and summary-only paths, and stays byte-identical when unset.
- **Dogfood (verbatim, against the actual built `packages/review/dist/index.js`, not just the vitest transform)** — a standalone script drove the real `AgentReviewPlugin.analyze()` with a mocked `fetch` and read `context.reportBudget`'s actual argument:
  ```
  default (unset): LIEN_REVIEW_TOKEN_BUDGET=(unset) -> context.reportBudget(60000)
  workflow value (this repo): LIEN_REVIEW_TOKEN_BUDGET=555176 -> context.reportBudget(555176)
  garbage value (fail-open): LIEN_REVIEW_TOKEN_BUDGET=not-a-number -> context.reportBudget(60000)
  below floor (clamped up): LIEN_REVIEW_TOKEN_BUDGET=1000 -> context.reportBudget(60000)
  above ceiling (clamped down, 5x default): LIEN_REVIEW_TOKEN_BUDGET=999999999 -> context.reportBudget(1250000)
  floor clamp (computed base is 200,000, override asks for 1,000): computed=200000, LIEN_REVIEW_TOKEN_BUDGET=1000 -> context.reportBudget(60000)
  ```
  (The last line isolates the clamp from the coincidental case above it: with a 200,000 computed base and a 1,000 override, the result floors at 60,000 — neither the computed value nor the raw override.)
- **Deterministic byte-diff census**: `build-prompts.ts` is untouched by this PR — `sha256(packages/review/test/harness/build-prompts.ts)` = `e93da6bf723cc180399638db56e2e1abff4f3cc15e305a1946ef6da1ac14e1b3`, byte-identical before and after.
- **Full gate chain**, all green: `npm run format:check`, `npm run lint` (0 errors, only pre-existing unrelated warnings), `npm run typecheck`, `npm run build`, `npm test` (parser+core+review: 57 files/1647 tests; cli: 60 files/1113 tests; action: 5 files/41 tests — all passed), `node packages/cli/dist/index.js delta` (exit 0 — one new function `applyReviewTokenBudgetOverride` at cognitive complexity 3, one pre-existing-and-untouched-threshold "worsened" time-estimate note on `analyzeSummaryOnly`, no new-over-threshold or crossed function).

## Changeset

None. `packages/review` and `packages/action` are both `"private": true` (unpublished); this also touches only workflow config, docs, and tests — matches `.changeset/config.json`'s existing convention (no changesets exist for private-package-only or workflow-only changes elsewhere in this repo's history).

## Test plan

- [x] Unit tests for `applyReviewTokenBudgetOverride` (unset/valid/garbage/clamped) and `AgentReviewPlugin.analyze()`/`analyzeSummaryOnly()` attestation wiring
- [x] Dogfood run against the built `dist/index.js` (see verbatim output above)
- [x] Full gate chain (format/lint/typecheck/build/test/delta) green
- [x] YAML parses `LIEN_REVIEW_TOKEN_BUDGET` as a string (verified via `python3 -c "import yaml..."`)

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +12 |


> [!NOTE]
> **Low Risk**
>
> This PR adds `LIEN_REVIEW_TOKEN_BUDGET`, an env-only absolute override for the main pass's final token budget. The implementation is straightforward and defensive: `applyReviewTokenBudgetOverride` validates the env value with `Number.isFinite` + `Number.isInteger` + `parsed > 0`, clamps valid values to `[60_000, 1_250_000]`, and fails open to the computed budget for any malformed input. It is wired at the correct point — immediately before `context.reportBudget` in both `analyze()` and `analyzeSummaryOnly()` — so the attestation and downstream budget enforcement see the final value. Comprehensive unit tests cover unset, valid, garbage, boundary, and clamping cases, plus integration tests for both code paths. No breaking changes or caller malfunctions were found.
>
> - Added `applyReviewTokenBudgetOverride` in `packages/review/src/defaults.ts` with fail-open validation and clamping
> - Applied the override before `context.reportBudget` in both `AgentReviewPlugin.analyze()` and `analyzeSummaryOnly()`
> - Added unit and integration tests covering valid, invalid, boundary, and clamped inputs
> - Updated workflow and documentation to describe the env-only knob and its sizing rationale

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8425813. Updates automatically on new commits.</sup>
<!-- /lien-stats -->