### PR TITLE
fix(cli): gate the recap's blocked-marker write on LIEN_RECAP everywhere

### DIFF
--- a/.changeset/legacy-report-blocked-gating.md
+++ b/.changeset/legacy-report-blocked-gating.md
@@ -1,0 +1,5 @@
+---
+'@liendev/lien': patch
+---
+
+Fix the session-recap `blocked` loop-prevention marker so its write obeys one consistent switch, `LIEN_RECAP`, everywhere. `recordBlocked` is exempt from `LIEN_TEST_VERIFY=off` by design (it's the recap's loop-prevention, not test-verify recording), but the legacy `lien verify-tests report` path (`runReport`) previously gated it by neither switch — so a user with the recap disabled still wrote a suppressing marker. `runReport` now gates the write on `recapEnabled()`, matching the recap hook path, via a single shared `recapEnabled()` helper in `test-ledger.ts`.

--- a/packages/cli/src/cli/recap-cmd.ts
+++ b/packages/cli/src/cli/recap-cmd.ts
@@ -31,7 +31,12 @@ import {
   wasRecentlyBlocked,
   formatVerifyTestsAdvisory,
 } from './verify-tests-cmd.js';
-import { readSession, recordBlocked, type TestLedgerEvent } from '../utils/test-ledger.js';
+import {
+  readSession,
+  recordBlocked,
+  recapEnabled,
+  type TestLedgerEvent,
+} from '../utils/test-ledger.js';
 import { computeUnverifiedFiles } from '../utils/test-run-matcher.js';
 import { readNudgeEvents, recordNudgeShown, type NudgeEvent } from '../utils/nudge-events.js';
 import {
@@ -50,11 +55,6 @@ export interface RecapOptions {
 }
 
 const VALID_FORMATS = ['text', 'json'];
-
-/** `LIEN_RECAP=off` disables the whole Stop recap surface (reading, computing, and blocking). */
-function recapEnabled(): boolean {
-  return process.env.LIEN_RECAP !== 'off';
-}
 
 function resolveRootDir(): string {
   return resolveProjectRoot(toAbsolutePath(process.cwd()));

--- a/packages/cli/src/cli/verify-tests-cmd.test.ts
+++ b/packages/cli/src/cli/verify-tests-cmd.test.ts
@@ -327,6 +327,34 @@ describe('verify-tests-cmd — integration', () => {
       expect(events.some(e => e.kind === 'blocked')).toBe(true);
     });
 
+    it('does NOT write a blocked marker when LIEN_RECAP=off — the kill switch is honored on the legacy report path (still prints the advisory)', async () => {
+      const rootDir = String((await import('./project-root.js')).resolveProjectRoot());
+      await recordEdit(rootDir, session, 'packages/cli/src/foo.ts', ['foo.test.ts']);
+      process.env.LIEN_RECAP = 'off';
+      try {
+        await reportCommand({ session });
+      } finally {
+        delete process.env.LIEN_RECAP;
+      }
+      // Only the loop-prevention WRITE is gated — the report still prints.
+      const events = await readSession(rootDir, session);
+      expect(events.some(e => e.kind === 'blocked')).toBe(false);
+      expect(logSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes a blocked marker when LIEN_RECAP is explicitly on (parity with the default/unset case above)', async () => {
+      const rootDir = String((await import('./project-root.js')).resolveProjectRoot());
+      await recordEdit(rootDir, session, 'packages/cli/src/foo.ts', ['foo.test.ts']);
+      process.env.LIEN_RECAP = 'on';
+      try {
+        await reportCommand({ session });
+      } finally {
+        delete process.env.LIEN_RECAP;
+      }
+      const events = await readSession(rootDir, session);
+      expect(events.some(e => e.kind === 'blocked')).toBe(true);
+    });
+
     it('suppresses a second block within the 10-minute window (belt-and-braces loop prevention)', async () => {
       const rootDir = String((await import('./project-root.js')).resolveProjectRoot());
       await recordEdit(rootDir, session, 'packages/cli/src/foo.ts', ['foo.test.ts']);

--- a/packages/cli/src/cli/verify-tests-cmd.ts
+++ b/packages/cli/src/cli/verify-tests-cmd.ts
@@ -18,6 +18,7 @@ import {
   recordRun,
   recordBlocked,
   readSession,
+  recapEnabled,
   type TestLedgerEvent,
 } from '../utils/test-ledger.js';
 import {
@@ -190,7 +191,11 @@ async function runReport(options: ReportOptions): Promise<void> {
   // there something to nudge about right now."
   if (unverified.length > 0 && wasRecentlyBlocked(events)) {
     unverified = [];
-  } else if (unverified.length > 0) {
+  } else if (unverified.length > 0 && recapEnabled()) {
+    // Gate the `blocked` loop-prevention write on `LIEN_RECAP`, matching the
+    // recap hook path (`recap-cmd.ts` returns early when the recap is off). The
+    // marker is governed by exactly one switch everywhere, so this legacy path
+    // no longer writes a suppressing marker when the recap surface is disabled.
     await recordBlocked(rootDir, options.session);
   }
 

--- a/packages/cli/src/utils/test-ledger.test.ts
+++ b/packages/cli/src/utils/test-ledger.test.ts
@@ -11,11 +11,13 @@ import {
   clearSession,
   testSessionFilePath,
   testVerifyEnabled,
+  recapEnabled,
   TEST_SESSIONS_DIRNAME,
 } from './test-ledger.js';
 
 let originalHome: string | undefined;
 let originalKillSwitch: string | undefined;
+let originalRecapSwitch: string | undefined;
 let home: string;
 const rootDir = '/fake/repo/for-test-ledger-test';
 const sessionId = 'session-abc-123';
@@ -23,9 +25,11 @@ const sessionId = 'session-abc-123';
 beforeEach(async () => {
   originalHome = process.env.LIEN_HOME;
   originalKillSwitch = process.env.LIEN_TEST_VERIFY;
+  originalRecapSwitch = process.env.LIEN_RECAP;
   home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-ledger-test-'));
   process.env.LIEN_HOME = home;
   delete process.env.LIEN_TEST_VERIFY;
+  delete process.env.LIEN_RECAP;
 });
 
 afterEach(async () => {
@@ -33,6 +37,8 @@ afterEach(async () => {
   else process.env.LIEN_HOME = originalHome;
   if (originalKillSwitch === undefined) delete process.env.LIEN_TEST_VERIFY;
   else process.env.LIEN_TEST_VERIFY = originalKillSwitch;
+  if (originalRecapSwitch === undefined) delete process.env.LIEN_RECAP;
+  else process.env.LIEN_RECAP = originalRecapSwitch;
   await fs.rm(home, { recursive: true, force: true });
 });
 
@@ -69,6 +75,22 @@ describe('testVerifyEnabled', () => {
   it('is enabled for any other value (only the literal "off" disables it)', () => {
     process.env.LIEN_TEST_VERIFY = 'false';
     expect(testVerifyEnabled()).toBe(true);
+  });
+});
+
+describe('recapEnabled (the single switch governing the blocked-marker write)', () => {
+  it('is enabled by default', () => {
+    expect(recapEnabled()).toBe(true);
+  });
+
+  it('is disabled when LIEN_RECAP=off', () => {
+    process.env.LIEN_RECAP = 'off';
+    expect(recapEnabled()).toBe(false);
+  });
+
+  it('is enabled for any other value (only the literal "off" disables it)', () => {
+    process.env.LIEN_RECAP = 'false';
+    expect(recapEnabled()).toBe(true);
   });
 });
 

--- a/packages/cli/src/utils/test-ledger.ts
+++ b/packages/cli/src/utils/test-ledger.ts
@@ -15,10 +15,12 @@
  * report on.
  *
  * Kill switch: `LIEN_TEST_VERIFY=off` disables edit/run recording only; the
- * recap's loop-prevention `blocked` marker (`recordBlocked`) is written
- * regardless, governed by `LIEN_RECAP` at the call site instead. Reading
- * (`readSession`) is never gated by either, so a report requested after the
- * switch was flipped mid-session still sees whatever was recorded before.
+ * recap's loop-prevention `blocked` marker (`recordBlocked`) is exempt from it
+ * and governed by `LIEN_RECAP` instead — the single switch every caller gates
+ * on (both `recap-cmd.ts` and the legacy `verify-tests report`; see
+ * `recapEnabled`). Reading (`readSession`) is never gated by either, so a report
+ * requested after the switch was flipped mid-session still sees whatever was
+ * recorded before.
  */
 
 import fs from 'fs/promises';
@@ -41,6 +43,17 @@ const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
 /** `LIEN_TEST_VERIFY=off` disables edit/run recording only (recordBlocked is exempt — see its note). Reading is never gated by this. */
 export function testVerifyEnabled(): boolean {
   return process.env.LIEN_TEST_VERIFY !== 'off';
+}
+
+/**
+ * `LIEN_RECAP=off` disables the Stop recap surface entirely — the single switch
+ * governing whether the loop-prevention `blocked` marker is written. Both the
+ * recap hook path (`recap-cmd.ts`) and the legacy `verify-tests report`
+ * (`verify-tests-cmd.ts`) gate their `recordBlocked` call on it, so the marker
+ * obeys one consistent rule everywhere. Reading is never gated by this.
+ */
+export function recapEnabled(): boolean {
+  return process.env.LIEN_RECAP !== 'off';
 }
 
 function testSessionsDir(rootDir: string): string {
@@ -119,11 +132,13 @@ export async function recordRun(
  */
 export async function recordBlocked(rootDir: string, sessionId: string): Promise<void> {
   // Deliberately NOT gated by `LIEN_TEST_VERIFY`: the `blocked` event is the
-  // Stop-recap loop-prevention marker (see `wasRecentlyBlocked`/`runReport` in
-  // verify-tests-cmd.ts and the recap command in recap-cmd.ts). The Stop recap
-  // has its own master kill switch, `LIEN_RECAP=off`, checked at the call site;
-  // recording the marker must survive `LIEN_TEST_VERIFY=off` so a delta/blast-only
-  // recap still suppresses its own re-nag on the next Stop.
+  // Stop-recap loop-prevention marker (see `wasRecentlyBlocked` and the recap
+  // command in recap-cmd.ts). Its master switch is `LIEN_RECAP=off`, which every
+  // caller gates on via `recapEnabled()` — the recap hook path (`recap-cmd.ts`)
+  // and the legacy `verify-tests report` (`runReport` in verify-tests-cmd.ts)
+  // both check it before calling this, so the marker obeys one consistent rule.
+  // Being exempt from `LIEN_TEST_VERIFY` lets a delta/blast-only recap still
+  // suppress its own re-nag on the next Stop.
   await writeEvent(rootDir, sessionId, { kind: 'blocked', timestamp: new Date().toISOString() });
 }
 


### PR DESCRIPTION
## What

Fixes the Lien Review finding on #855 (`test-ledger.ts`, `breaking_change`): the session-recap's `blocked` loop-prevention marker was written inconsistently across its two callers.

`recordBlocked` is **exempt from `LIEN_TEST_VERIFY=off` by design** — it's the recap's loop-prevention, not test-verify recording (a delta/blast-only recap must still suppress its own re-nag). But the legacy `lien verify-tests report` path (`runReport`) gated the write by **neither** switch, so a user with the recap disabled (`LIEN_RECAP=off`, or with `LIEN_TEST_VERIFY=off`) still wrote a suppressing marker — a switch that lies on that path.

## Fix — one consistent rule everywhere, governed by `LIEN_RECAP`

- **New shared `recapEnabled()` in `test-ledger.ts`** — single source of truth for the `LIEN_RECAP` gate. `recap-cmd.ts`'s local copy is replaced by it.
- **`runReport` now gates its `recordBlocked` call on `recapEnabled()`**, matching the recap hook path (`recap-cmd.ts` early-returns when the recap is off). Only the marker **write** is gated — the legacy report itself still prints its advisory.
- **Docs** (`test-ledger.ts` header + `recordBlocked` comment) updated: the marker is governed by `LIEN_RECAP` at **every** call site, not "the call site" singular.

The recap hook path is unchanged (it already early-returned on `!recapEnabled()`; now it shares the same helper).

## Tests
- Legacy `report` with `LIEN_RECAP=off` → **no** `blocked` write, and the advisory **still prints** (only the write is gated).
- Legacy `report` with `LIEN_RECAP=on` → writes the marker.
- `recapEnabled()` unit cases (default on / `off` / any-other-value).
- Existing "records a blocked event the first time it actually blocks" (default/unset = on) covers the on-case for parity.

## Gates (full chain, all green)
`format:check` ✓ · `docs-truth` ✓ (86 files, no violations) · `lint` ✓ (0 errors) · `typecheck` ✓ · `build` ✓ · full `test` ✓ (all packages; CLI 1143, +5) · `lien delta` ✓ (exit 0)

Fixes the finding on #855. `@liendev/lien` patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked session markers are now consistently controlled by the `LIEN_RECAP` setting.
  * Disabling recaps prevents blocked markers from being recorded, including through the legacy test-reporting flow.
  * Recap behavior is now consistent across supported command paths.

* **Documentation**
  * Clarified how `LIEN_RECAP` and `LIEN_TEST_VERIFY` affect recap and blocked-marker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes an inconsistency in how the session-recap `blocked` loop-prevention marker is written: the legacy `lien verify-tests report` path now gates `recordBlocked` on the shared `recapEnabled()` helper (reading `LIEN_RECAP`), matching the recap hook path. The change is narrow, well-tested, and the documentation/comments accurately describe the new behavior. No callers are broken: `recordBlocked` remains exempt from `LIEN_TEST_VERIFY`, the legacy report still prints its advisory when recap is disabled, and the recap hook still early-returns entirely when recap is off.
>
> - Centralized `recapEnabled()` in `test-ledger.ts` and removed the duplicate local copy in `recap-cmd.ts`
> - Gated `runReport`'s `recordBlocked` call on `recapEnabled()` so `LIEN_RECAP=off` no longer writes a suppressing marker
> - Added unit and integration tests covering the `LIEN_RECAP=off`, `=on`, and default cases

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8eec49f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->