### PR TITLE
fix(parser): return clean module paths from Python extractImportPath

### DIFF
--- a/.changeset/python-import-paths.md
+++ b/.changeset/python-import-paths.md
@@ -1,0 +1,16 @@
+---
+"@liendev/parser": patch
+---
+
+Fix Python test-association discovery being silently broken for every import
+form: `PythonImportExtractor.extractImportPath()` was returning the raw,
+unparsed statement text (e.g. `"from starlette.responses import FileResponse, ..."`)
+instead of a clean dotted module path, so `chunk.metadata.imports` never
+contained anything `matchesPythonModule()` could match. It now returns the
+clean module path (e.g. `"starlette.responses"`, `"os"`, `".foo"` for
+relative imports) by delegating to the same symbol-processing logic already
+used to build `importedSymbols` — the two can no longer disagree. Also fixes
+a related latent bug in that shared logic where relative from-imports
+(`from . import x`, `from .foo import x`) silently dropped their imported
+symbols entirely, because the module-path lookup didn't account for the
+`relative_import` wrapper node.

--- a/.changeset/python-import-paths.md
+++ b/.changeset/python-import-paths.md
@@ -10,7 +10,12 @@ contained anything `matchesPythonModule()` could match. It now returns the
 clean module path (e.g. `"starlette.responses"`, `"os"`, `".foo"` for
 relative imports) by delegating to the same symbol-processing logic already
 used to build `importedSymbols` — the two can no longer disagree. Also fixes
-a related latent bug in that shared logic where relative from-imports
+two related latent bugs in that shared logic: relative from-imports
 (`from . import x`, `from .foo import x`) silently dropped their imported
 symbols entirely, because the module-path lookup didn't account for the
-`relative_import` wrapper node.
+`relative_import` wrapper node; and wildcard from-imports (`from x.y import
+*`) were dropped in their entirety (module path included), because the
+symbol collector didn't recognize `wildcard_import` nodes and treated the
+resulting empty symbol list as "no import here" — it now records a `'*'`
+placeholder symbol, mirroring `RustImportExtractor`'s existing convention for
+`use crate::models::*;`.

--- a/packages/parser/src/ast/languages/python.test.ts
+++ b/packages/parser/src/ast/languages/python.test.ts
@@ -341,6 +341,33 @@ describe('Python Language', () => {
       const node = root.namedChild(0)!;
       expect(importExtractor.processImportSymbols(node)).toBeNull();
     });
+
+    it('should process an absolute wildcard from-import with a "*" symbol (regression: was silently dropped)', () => {
+      const code = 'from django.http import *\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      const result = importExtractor.processImportSymbols(importNode);
+      expect(result).not.toBeNull();
+      expect(result!.importPath).toBe('django.http');
+      expect(result!.symbols).toEqual(['*']);
+    });
+
+    it('should process a relative wildcard from-import with a "*" symbol', () => {
+      const code = 'from .foo import *\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      const result = importExtractor.processImportSymbols(importNode);
+      expect(result).not.toBeNull();
+      expect(result!.importPath).toBe('.foo');
+      expect(result!.symbols).toEqual(['*']);
+    });
+
+    it('should extract the module path for a wildcard from-import via extractImportPath', () => {
+      const code = 'from django.http import *\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('django.http');
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/python.test.ts
+++ b/packages/parser/src/ast/languages/python.test.ts
@@ -203,12 +203,68 @@ describe('Python Language', () => {
       expect(importExtractor.importNodeTypes).toContain('import_from_statement');
     });
 
-    it('should extract a simple import path', () => {
+    it('should extract a clean simple import path (not raw statement text)', () => {
       const code = 'import os\n';
       const root = mustParse(code, 'python');
       const importNode = root.namedChild(0)!;
       const path = importExtractor.extractImportPath(importNode);
-      expect(path).toBe('import os');
+      expect(path).toBe('os');
+    });
+
+    it('should extract the module (not the alias) for a simple aliased import', () => {
+      const code = 'import os as system\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('os');
+    });
+
+    it('should extract a dotted import path', () => {
+      const code = 'import x.y\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('x.y');
+    });
+
+    it('should extract the dotted module path for a dotted aliased import', () => {
+      const code = 'import x.y as z\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('x.y');
+    });
+
+    it('should extract a clean dotted module path for a from-import', () => {
+      const code = 'from utils.validate import validateEmail, validatePhone\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('utils.validate');
+    });
+
+    it('should extract the module path (not the alias) for a from-import alias', () => {
+      const code = 'from typing import Optional as Opt\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('typing');
+    });
+
+    it('should extract "." for a bare relative from-import', () => {
+      const code = 'from . import x\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('.');
+    });
+
+    it('should extract ".foo" for a single-dot relative from-import', () => {
+      const code = 'from .foo import x\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('.foo');
+    });
+
+    it('should extract "..pkg" for a two-dot relative from-import', () => {
+      const code = 'from ..pkg import y\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('..pkg');
     });
 
     it('should process a simple import into a symbol', () => {
@@ -247,6 +303,36 @@ describe('Python Language', () => {
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).not.toBeNull();
       expect(result!.symbols).toEqual(['Opt']);
+    });
+
+    it('should process a bare relative from-import (regression: symbols were silently dropped)', () => {
+      const code = 'from . import x, y\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      const result = importExtractor.processImportSymbols(importNode);
+      expect(result).not.toBeNull();
+      expect(result!.importPath).toBe('.');
+      expect(result!.symbols).toEqual(['x', 'y']);
+    });
+
+    it('should process a single-dot relative from-import (regression: module path was misread as the symbol)', () => {
+      const code = 'from .foo import x\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      const result = importExtractor.processImportSymbols(importNode);
+      expect(result).not.toBeNull();
+      expect(result!.importPath).toBe('.foo');
+      expect(result!.symbols).toEqual(['x']);
+    });
+
+    it('should process a two-dot relative from-import', () => {
+      const code = 'from ..pkg import y\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      const result = importExtractor.processImportSymbols(importNode);
+      expect(result).not.toBeNull();
+      expect(result!.importPath).toBe('..pkg');
+      expect(result!.symbols).toEqual(['y']);
     });
 
     it('should return null for an unrecognized node type', () => {

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -36,6 +36,30 @@ function extractAliasedSymbolName(node: SyntaxNode): string | null {
   return dottedName?.text ?? null;
 }
 
+/**
+ * Locate the module-path node within a Python `import_from_statement`'s
+ * named children.
+ *
+ * Two grammar shapes:
+ * - Absolute (`from utils.validate import X`): the module path is a
+ *   top-level `dotted_name` (e.g. "utils.validate").
+ * - Relative (`from . import X`, `from .foo import X`, `from ..pkg import Y`):
+ *   the leading dots — and any dotted sub-path after them — are wrapped in a
+ *   single `relative_import` node (e.g. ".", ".foo", "..pkg"). The module's
+ *   own `dotted_name`, if any, is nested *inside* that node, not a sibling
+ *   of it, so it must not be matched directly here.
+ *
+ * Whichever shape applies, the module-path node is always the first named
+ * child — imported symbol names (`dotted_name`/`aliased_import`/
+ * `wildcard_import`) always come after it — so a single `findIndex` checking
+ * both node types is sufficient and always correct.
+ */
+function findModulePathIndex(node: SyntaxNode): number {
+  return node.namedChildren.findIndex(
+    child => child.type === 'relative_import' || child.type === 'dotted_name',
+  );
+}
+
 // =============================================================================
 // TRAVERSER
 // =============================================================================
@@ -179,14 +203,8 @@ export class PythonExportExtractor implements LanguageExportExtractor {
     return exports;
   }
 
-  private findModulePathIndex(node: SyntaxNode): number {
-    return node.namedChildren.findIndex(
-      child => child.type === 'relative_import' || child.type === 'dotted_name',
-    );
-  }
-
   private extractReExportNames(node: SyntaxNode, addExport: (name: string) => void): void {
-    const startIndex = this.findModulePathIndex(node);
+    const startIndex = findModulePathIndex(node);
     if (startIndex === -1) return;
 
     node.namedChildren.slice(startIndex + 1).forEach(child => {
@@ -216,9 +234,31 @@ export class PythonExportExtractor implements LanguageExportExtractor {
 export class PythonImportExtractor implements LanguageImportExtractor {
   readonly importNodeTypes = ['import_statement', 'import_from_statement'];
 
+  /**
+   * Extract the clean dotted module path for the `imports` list (used by
+   * test-association discovery and dependency analysis) — never the raw
+   * statement text. Delegates to `processImportSymbols()` so the `imports`
+   * list and the `importedSymbols` map are always derived from the same
+   * computation and can never disagree.
+   *
+   * Shapes:
+   * - `import os` -> "os"; `import os as system` -> "os" (module, not alias)
+   * - `import x.y` / `import x.y as z` -> "x.y"
+   * - `from utils.validate import X` -> "utils.validate"
+   * - Relative: `from . import X` -> "."; `from .foo import X` -> ".foo";
+   *   `from ..pkg import Y` -> "..pkg" (dots preserved — there's no file
+   *   context available here to resolve them against the importer's own
+   *   path, so the clean-but-unresolved dotted form is the best available
+   *   "path"; see `resolveRelativeImport()` in `../../utils/path-matching.js`
+   *   for why Python relative imports, unlike JS's `./`/`../`, pass through
+   *   that resolution step unchanged today).
+   *
+   * A statement with multiple comma-separated modules (`import a, b.c`)
+   * yields only the first (`"a"`) — a pre-existing limitation of
+   * `processPythonImport()`, not a new one introduced here.
+   */
   extractImportPath(node: SyntaxNode): string | null {
-    // Return the raw text for Python imports (used in the imports list)
-    return node.text.split('\n')[0];
+    return this.processImportSymbols(node)?.importPath ?? null;
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
@@ -269,7 +309,7 @@ export class PythonImportExtractor implements LanguageImportExtractor {
   }
 
   private findModulePath(node: SyntaxNode): { path: string; startIndex: number } | null {
-    const index = node.namedChildren.findIndex(child => child.type === 'dotted_name');
+    const index = findModulePathIndex(node);
     if (index === -1) return null;
     return { path: node.namedChildren[index].text, startIndex: index };
   }

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -256,6 +256,11 @@ export class PythonImportExtractor implements LanguageImportExtractor {
    * A statement with multiple comma-separated modules (`import a, b.c`)
    * yields only the first (`"a"`) — a pre-existing limitation of
    * `processPythonImport()`, not a new one introduced here.
+   *
+   * Wildcard from-imports (`from x.y import *`) still yield the module path
+   * (`"x.y"`) — `collectImportedSymbols()` records a `'*'` placeholder symbol
+   * (mirroring `RustImportExtractor.processUseWildcard()`) so the statement
+   * isn't dropped entirely just because it names no specific symbols.
    */
   extractImportPath(node: SyntaxNode): string | null {
     return this.processImportSymbols(node)?.importPath ?? null;
@@ -322,6 +327,14 @@ export class PythonImportExtractor implements LanguageImportExtractor {
       } else if (child.type === 'aliased_import') {
         const symbolName = extractAliasedSymbolName(child);
         if (symbolName) symbols.push(symbolName);
+      } else if (child.type === 'wildcard_import') {
+        // `from x.y import *` — mirrors RustImportExtractor.processUseWildcard's
+        // `symbols: ['*']` convention. Without this, a wildcard from-import has
+        // zero named children after the module path, so collectImportedSymbols
+        // would return [] and processPythonFromImport would drop the whole
+        // statement (including its otherwise-known importPath) via the
+        // `symbols.length === 0` guard below.
+        symbols.push('*');
       }
     });
     return symbols;

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -626,7 +626,7 @@ use Illuminate\\Http\\Request;
       expect(imports).toContain('Illuminate\\Http\\Request');
     });
 
-    it('should extract Python import statements', () => {
+    it('should extract clean Python module paths (not raw statement text)', () => {
       const content = `
 from utils.validate import validateEmail
 import os
@@ -636,9 +636,9 @@ from typing import Optional
       const parseResult = parseAST(content, 'python');
       const imports = extractImports(parseResult.tree!.rootNode, 'python');
 
-      expect(imports).toContain('from utils.validate import validateEmail');
-      expect(imports).toContain('import os');
-      expect(imports).toContain('from typing import Optional');
+      expect(imports).toContain('utils.validate');
+      expect(imports).toContain('os');
+      expect(imports).toContain('typing');
     });
   });
 


### PR DESCRIPTION
## Summary

`PythonImportExtractor.extractImportPath()` (`packages/parser/src/ast/languages/python.ts`) returned the raw, unparsed statement text (e.g. `"from starlette.responses import FileResponse, JSONResponse, ..."`) instead of a clean dotted module path — the only language extractor that did this (every other language pulls just the specifier via AST field access, e.g. JS's `childForFieldName('source')`, Rust's `argument` field + `convertRustModulePath`).

`test-associations.ts`'s `findTestAssociationsFromChunks` only ever reads `chunk.metadata.imports`, and `matchesPythonModule()` in `utils/path-matching.ts` requires that string to be purely dotted identifiers (`/^[A-Za-z_]\w*(\.[A-Za-z_]\w*)+$/`). A raw statement like `"from starlette.responses import FileResponse, ..."` never matches — spaces, commas, and the literal words `from`/`import` disqualify it. Every Python test-association lookup silently came back empty.

- `extractImportPath()` now delegates to the same `processImportSymbols()` logic already used to build `importedSymbols`, so the two can never disagree again.
- Also fixed a related latent bug in that shared logic: relative from-imports (`from . import x`, `from .foo import x`, `from ..pkg import y`) silently dropped their imported symbols entirely — `findModulePath`'s search for a top-level `dotted_name` missed the `relative_import` wrapper node those forms use, so `processPythonFromImport` returned `null` for every relative import. Promoted the already-correct index-finding logic from `PythonExportExtractor`'s re-export handling (`findModulePathIndex`, which already checked `relative_import` first) into a shared helper used by both extractors, instead of two parallel (one buggy) implementations.

Path shape chosen (documented in the extractImportPath docstring): the clean dotted module path — `"os"`, `"x.y"`, `"utils.validate"` for absolute imports; the aliased *module*, not the alias, for `import x as z`/`from x import y as z`; and the relative-import node's own text (`"."`, `".foo"`, `"..pkg"`) for relative imports, since there's no importer-file context available inside `extractImportPath()` to resolve dots against a path (same reason `resolveRelativeImport()` already special-cases that it only handles JS-style `./`/`../`, passing Python's dotted relative forms through unchanged).

Closes #859

## Root cause confirmation

Confirmed empirically via a real starlette shallow clone (see Dogfood evidence below) — reproduces the issue's exact repro numbers before the fix, and shows correct resolution after.

## Evidence

**Unit tests** (`packages/parser/src/ast/languages/python.test.ts`, `packages/parser/src/ast/symbols.test.ts`): added/updated cases for `import os`, `import os as system`, `import x.y`, `import x.y as z`, `from utils.validate import ...`, `from typing import Optional as Opt`, and relative forms `from . import x`, `from .foo import x`, `from ..pkg import y` — both for `extractImportPath()`'s output and for `processImportSymbols()`'s previously-broken symbol extraction on relative imports.

**Real starlette dogfood** — shallow-cloned `encode/starlette` to `/tmp`, indexed with the CLI, ran the issue's exact `verify-tests note-edit` repro against the same 7 files, then reverted the fix (`git stash`), rebuilt, and re-ran against a fresh index to capture "before" — cleaned up both clone and index afterward.

Before (stashed fix, matches the issue's repro exactly):
```
$ lien verify-tests note-edit --session repro --file starlette/responses.py --format json
{"filepath":"starlette/responses.py","tests":[]}
# same empty result for routing.py, applications.py, staticfiles.py, websockets.py, schemas.py, middleware/cors.py
```

After (fix restored):
```
$ lien verify-tests note-edit --session repro --file starlette/responses.py --format json
{"filepath":"starlette/responses.py","tests":["tests/test_templates.py","tests/test_testclient.py","tests/test_websockets.py","tests/test_schemas.py","tests/test_routing.py","tests/test_staticfiles.py","tests/test_responses.py","tests/test_requests.py","tests/test_formparsers.py","tests/test_exceptions.py","tests/test_endpoints.py","tests/test_convertors.py","tests/test_concurrency.py","tests/test_background.py","tests/test_authentication.py","tests/test_applications.py","tests/middleware/test_trusted_host.py","tests/middleware/test_session.py","tests/middleware/test_https_redirect.py","tests/middleware/test_gzip.py","tests/middleware/test_errors.py","tests/middleware/test_cors.py","tests/middleware/test_base.py"]}
```
All 7 files from the issue's repro (`responses.py`, `routing.py`, `applications.py`, `staticfiles.py`, `websockets.py`, `schemas.py`, `middleware/cors.py`) now resolve to their correct `tests/test_*.py` — including each file's own directly-corresponding test (e.g. `staticfiles.py` -> `tests/test_staticfiles.py`).

**`npm run test:e2e:python -w packages/cli`**: passed (14/14 relevant tests; Requests project).

**Full gate chain**: `format:check` clean, `lint` 0 errors (pre-existing warnings only), `typecheck` clean, `build` clean, `npm test` — 6/6 workspaces green (parser 1119, core 378, review 1647, cli 1143, action 41 — all passed), `node packages/cli/dist/index.js delta` exit 0 (no new-over-threshold crossings; one function shows a negligible "worsened" time-metric wobble at 0m -> 0m, well under threshold).

## Changeset

`@liendev/parser` patch (bug fix). Linked group (`@liendev/parser-native`, `@liendev/core`, `@liendev/lien`) carries the version bump per `.changeset/config.json`.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes Python import-path extraction so `extractImportPath()` returns clean dotted module paths instead of raw statement text, and unifies it with `processImportSymbols()` so `chunk.metadata.imports` and `importedSymbols` stay consistent. It also promotes `findModulePathIndex` to a shared helper that correctly handles `relative_import` wrapper nodes, and adds `wildcard_import` handling with a `'*'` placeholder. The change is well-scoped, thoroughly tested for absolute, aliased, dotted, relative, and wildcard forms, and has no external callers that depend on the old raw-text behavior.
>
> - `extractImportPath()` now delegates to `processImportSymbols()`, producing clean module paths like `"os"`, `"x.y"`, `"utils.validate"`, `".foo"`, `"..pkg"`
> - Shared `findModulePathIndex()` helper correctly handles `relative_import` wrapper nodes for both import and re-export extraction
> - `collectImportedSymbols()` now recognizes `wildcard_import` nodes and records a `'*'` placeholder, preventing wildcard from-imports from being silently dropped

<sup>Reviewed by [Lien Review](https://lien.dev) for commit caeb8bc. Updates automatically on new commits.</sup>
<!-- /lien-stats -->