### PR TITLE
fix(cli): recognize rake, vendored phpunit, composer test, swift test, and gradlew in RUNNER_PATTERNS

### DIFF
--- a/.changeset/runner-patterns-additions.md
+++ b/.changeset/runner-patterns-additions.md
@@ -9,7 +9,8 @@ form: Ruby's Rake/Minitest convention (`rake test`, `rake test:core`,
 PHP's vendored/wrapped phpunit
 (`vendor/bin/phpunit`, `./vendor/bin/phpunit`) and Composer script alias
 (`composer test`), Swift's SwiftPM invocation (`swift test`, `swift test
---filter X`), and the Gradle wrapper script (`./gradlew test`, `./gradlew
+--filter X`), and the Gradle wrapper script, including common multi-task
+invocations (`./gradlew test`, `./gradlew clean test`, `./gradlew
 :module:test`, `gradlew test`). Previously these commands silently failed to
 register as a test run, so the nudge kept nagging even after the correct
 tests had genuinely been run. Purely additive recognition — `isCoveredByScope`

--- a/.changeset/runner-patterns-additions.md
+++ b/.changeset/runner-patterns-additions.md
@@ -12,4 +12,6 @@ form: Ruby's Rake/Minitest convention (`rake test`, `rake test:core`,
 :module:test`, `gradlew test`). Previously these commands silently failed to
 register as a test run, so the nudge kept nagging even after the correct
 tests had genuinely been run. Purely additive recognition — `isCoveredByScope`
-and every existing pattern are unchanged, so no prior classification moves.
+is untouched, and the only existing pattern modification is folding the bare
+`phpunit` pattern into a strict superset that also matches vendored paths;
+every other existing pattern is unchanged, so no prior classification moves.

--- a/.changeset/runner-patterns-additions.md
+++ b/.changeset/runner-patterns-additions.md
@@ -1,0 +1,15 @@
+---
+"@liendev/lien": patch
+---
+
+`RUNNER_PATTERNS` in the did-you-run-the-tests nudge (`lien verify-tests
+note-run`) now recognizes each swept ecosystem's own standard test-invocation
+form: Ruby's Rake/Minitest convention (`rake test`, `rake test:core`,
+`bundle exec rake test[:sub]`), PHP's vendored/wrapped phpunit
+(`vendor/bin/phpunit`, `./vendor/bin/phpunit`) and Composer script alias
+(`composer test`), Swift's SwiftPM invocation (`swift test`, `swift test
+--filter X`), and the Gradle wrapper script (`./gradlew test`, `./gradlew
+:module:test`, `gradlew test`). Previously these commands silently failed to
+register as a test run, so the nudge kept nagging even after the correct
+tests had genuinely been run. Purely additive recognition — `isCoveredByScope`
+and every existing pattern are unchanged, so no prior classification moves.

--- a/.changeset/runner-patterns-additions.md
+++ b/.changeset/runner-patterns-additions.md
@@ -5,7 +5,8 @@
 `RUNNER_PATTERNS` in the did-you-run-the-tests nudge (`lien verify-tests
 note-run`) now recognizes each swept ecosystem's own standard test-invocation
 form: Ruby's Rake/Minitest convention (`rake test`, `rake test:core`,
-`bundle exec rake test[:sub]`), PHP's vendored/wrapped phpunit
+`bundle exec rake test:core`, or any other `test:<namespaced-task>` form),
+PHP's vendored/wrapped phpunit
 (`vendor/bin/phpunit`, `./vendor/bin/phpunit`) and Composer script alias
 (`composer test`), Swift's SwiftPM invocation (`swift test`, `swift test
 --filter X`), and the Gradle wrapper script (`./gradlew test`, `./gradlew

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -68,6 +68,16 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['rake db:migrate', false, false, []],
     ['./gradlew build', false, false, []],
     ['./gradlew clean', false, false, []],
+    // Lien Review finding on PR #873 (Medium Risk): `-x test` / `--exclude-task
+    // test` EXCLUDE the test task rather than running it — the opposite of
+    // "tests ran" — so these must stay unrecognized even though the literal
+    // substring "test" is present.
+    ['./gradlew -x test', false, false, []],
+    ['./gradlew build -x test', false, false, []],
+    ['./gradlew --exclude-task test', false, false, []],
+    // But if `test` genuinely runs earlier in the same command, excluding a
+    // *different* task afterward must not defeat recognition.
+    ['./gradlew test -x integrationTest', true, true, []],
     // Not test runs at all.
     ['ls -la', false, false, []],
     ['git status', false, false, []],

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -33,6 +33,28 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['deno test', true, true, []],
     ['gradle test', true, true, []],
     ['mvn test', true, true, []],
+    // #870: Ruby (Rake/Minitest), PHP (vendored phpunit / composer script),
+    // Swift (SwiftPM), and Gradle-wrapper forms — each ecosystem's own
+    // standard/idiomatic test-invocation command.
+    ['bundle exec rake test:core', true, true, []],
+    ['rake test', true, true, []],
+    ['./rake test', true, true, []],
+    [
+      'vendor/bin/phpunit tests/Cookie/SetCookieTest.php',
+      true,
+      false,
+      ['tests/Cookie/SetCookieTest.php'],
+    ],
+    ['./vendor/bin/phpunit', true, true, []],
+    ['composer test', true, true, []],
+    ['swift test', true, true, []],
+    ['swift test --filter HTTPHeadersTests', true, true, []],
+    ['./gradlew test', true, true, []],
+    ['./gradlew :exposed-core:test', true, true, []],
+    ['gradlew test', true, true, []],
+    // Negative guard: a non-test Rake task must not be swallowed by the
+    // broad `rake test(:sub)?` recognition above.
+    ['rake db:migrate', false, false, []],
     // Not test runs at all.
     ['ls -la', false, false, []],
     ['git status', false, false, []],

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -52,9 +52,18 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['./gradlew test', true, true, []],
     ['./gradlew :exposed-core:test', true, true, []],
     ['gradlew test', true, true, []],
-    // Negative guard: a non-test Rake task must not be swallowed by the
-    // broad `rake test(:sub)?` recognition above.
+    // CodeRabbit review finding on PR #873: a real, common Gradle
+    // multi-task invocation (`clean test`) was previously unrecognized
+    // because the pattern required `test` immediately after `gradlew`.
+    ['./gradlew clean test', true, true, []],
+    ['gradlew build test', true, true, []],
+    ['./gradlew clean :exposed-core:test', true, true, []],
+    // Negative guards: a non-test Rake task must not be swallowed by the
+    // broad `rake test(:sub)?` recognition above, and a Gradle invocation
+    // with no `test` task at all must stay unrecognized.
     ['rake db:migrate', false, false, []],
+    ['./gradlew build', false, false, []],
+    ['./gradlew clean', false, false, []],
     // Not test runs at all.
     ['ls -la', false, false, []],
     ['git status', false, false, []],

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -58,6 +58,10 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['./gradlew clean test', true, true, []],
     ['gradlew build test', true, true, []],
     ['./gradlew clean :exposed-core:test', true, true, []],
+    // CodeRabbit review follow-up: common Gradle flags before the test task.
+    ['./gradlew --no-daemon test', true, true, []],
+    ['./gradlew -q test', true, true, []],
+    ['./gradlew -PmyProp=value test', true, true, []],
     // Negative guards: a non-test Rake task must not be swallowed by the
     // broad `rake test(:sub)?` recognition above, and a Gradle invocation
     // with no `test` task at all must stay unrecognized.

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -78,6 +78,11 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     // But if `test` genuinely runs earlier in the same command, excluding a
     // *different* task afterward must not defeat recognition.
     ['./gradlew test -x integrationTest', true, true, []],
+    // Lien Review follow-up: excluding a *different* task before test also
+    // must not defeat recognition — only `test` itself being the excluded
+    // argument should be rejected.
+    ['./gradlew -x integrationTest test', true, true, []],
+    ['./gradlew --exclude-task integrationTest test', true, true, []],
     // Not test runs at all.
     ['ls -la', false, false, []],
     ['git status', false, false, []],

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -116,10 +116,16 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^swift\s+test(?=\s|$)/,
   /^gradle\s+test(?=\s|$)/,
   // Gradle wrapper script (the near-universal per-project convention,
-  // distinct from a globally-installed `gradle`). `(\S*:)?` absorbs a Gradle
-  // task path like `:exposed-core:test` into the match itself so it is never
-  // mistaken for a scope-narrowing file token (it names no file).
-  /^(\.\/)?gradlew\s+(\S*:)?test(?=\s|$)/,
+  // distinct from a globally-installed `gradle`). Gradle invocations commonly
+  // chain multiple task names before the one that matters (`clean test`,
+  // `build test`), so `(?:[\w.:-]+\s+)*` absorbs any number of leading
+  // bare/colon-namespaced task tokens — deliberately excluding `/` so a real
+  // scope-narrowing file argument is never swallowed as a "task". `(\S*:)?`
+  // then absorbs a Gradle task path like `:exposed-core:test` into the match
+  // itself so it is never mistaken for a scope-narrowing file token (it
+  // names no file). Requires the literal `test` task to actually be present
+  // (a bare `./gradlew clean` with no test task stays unrecognized).
+  /^(\.\/)?gradlew\s+(?:[\w.:-]+\s+)*(\S*:)?test(?=\s|$)/,
   /^mvn\s+test(?=\s|$)/,
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
 ];

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -96,10 +96,30 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^cargo\s+test(?=\s|$)/,
   /^bundle\s+exec\s+rspec(?=\s|$)/,
   /^rspec(?=\s|$)/,
-  /^phpunit(?=\s|$)/,
+  // Ruby's Rake/Minitest convention: the task name is a namespaced suffix
+  // (`test`, `test:core`), never a file/path, so `(:\S*)?` mirrors the
+  // npm-run-script form above rather than being scanned as a scope token.
+  /^bundle\s+exec\s+rake\s+test(:\S*)?(?=\s|$)/,
+  /^(\.\/)?rake\s+test(:\S*)?(?=\s|$)/,
+  // PHP: phpunit is typically vendored per-project (`vendor/bin/phpunit`,
+  // `./vendor/bin/phpunit`), not installed globally; the bare form is kept
+  // as a subset of this pattern rather than a separate one.
+  /^(\.\/)?(vendor\/bin\/)?phpunit(?=\s|$)/,
+  // PHP: `composer test` is a common composer.json `scripts` alias, same
+  // class as `npm test`.
+  /^composer\s+test(?=\s|$)/,
   /^dotnet\s+test(?=\s|$)/,
   /^deno\s+test(?=\s|$)/,
+  // Swift/SwiftPM's one canonical test-invocation form. `--filter X` names a
+  // suite, not a path; `--filter` is already a workspace-scope flag above so
+  // it and its value are skipped, leaving this broad.
+  /^swift\s+test(?=\s|$)/,
   /^gradle\s+test(?=\s|$)/,
+  // Gradle wrapper script (the near-universal per-project convention,
+  // distinct from a globally-installed `gradle`). `(\S*:)?` absorbs a Gradle
+  // task path like `:exposed-core:test` into the match itself so it is never
+  // mistaken for a scope-narrowing file token (it names no file).
+  /^(\.\/)?gradlew\s+(\S*:)?test(?=\s|$)/,
   /^mvn\s+test(?=\s|$)/,
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
 ];

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -122,19 +122,21 @@ const RUNNER_PATTERNS: RegExp[] = [
   // `(?:[\w.:=-]+\s+)*` absorbs any number of leading bare/colon-namespaced
   // task tokens and `-P`-style property flags — deliberately excluding `/`
   // so a real scope-narrowing file argument is never swallowed as a "task".
-  // The negative lookahead guards `-x`/`--exclude-task`: those flags EXCLUDE
-  // their argument task rather than running it, so `-x test` must not be
-  // absorbed as an ordinary leading token feeding into the required `test`
-  // match below (that would falsely read "exclude test" as "ran test" — the
-  // opposite of what happened). If `test` genuinely runs earlier in the
-  // same command (`test -x someOtherTask`), backtracking still finds it;
-  // the guard only blocks `-x`/`--exclude-task` from ever being the thing
-  // that satisfies the match. `(\S*:)?` then absorbs a Gradle task path like
-  // `:exposed-core:test` into the match itself so it is never mistaken for a
-  // scope-narrowing file token (it names no file). Requires the literal
+  // The negative lookbehind guards specifically the `test` this pattern is
+  // about to accept as satisfying the match: `-x`/`--exclude-task` EXCLUDE
+  // their single following argument rather than running it, so a `test`
+  // immediately preceded by one of those flags (`-x test`, `--exclude-task
+  // test`) must not count as "ran test" — the opposite of what happened.
+  // Checking only immediately before the candidate `test` (rather than
+  // blanket-blocking `-x`/`--exclude-task` from ever appearing earlier in
+  // the command) correctly still recognizes `-x someOtherTask test` and
+  // `test -x someOtherTask`, where a *different* task is excluded and
+  // `test` genuinely runs. `(\S*:)?` absorbs a Gradle task path like
+  // `:exposed-core:test` into the match itself so it is never mistaken for
+  // a scope-narrowing file token (it names no file). Requires the literal
   // `test` task to actually be present and not excluded (a bare `./gradlew
   // clean` or `./gradlew -x test` stays unrecognized).
-  /^(\.\/)?gradlew\s+(?:(?!(?:-x|--exclude-task)(?:\s|$))[\w.:=-]+\s+)*(\S*:)?test(?=\s|$)/,
+  /^(\.\/)?gradlew\s+(?:[\w.:=-]+\s+)*(?<!(?:-x|--exclude-task)\s)(\S*:)?test(?=\s|$)/,
   /^mvn\s+test(?=\s|$)/,
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
 ];

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -117,15 +117,17 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^gradle\s+test(?=\s|$)/,
   // Gradle wrapper script (the near-universal per-project convention,
   // distinct from a globally-installed `gradle`). Gradle invocations commonly
-  // chain multiple task names before the one that matters (`clean test`,
-  // `build test`), so `(?:[\w.:-]+\s+)*` absorbs any number of leading
-  // bare/colon-namespaced task tokens — deliberately excluding `/` so a real
-  // scope-narrowing file argument is never swallowed as a "task". `(\S*:)?`
-  // then absorbs a Gradle task path like `:exposed-core:test` into the match
-  // itself so it is never mistaken for a scope-narrowing file token (it
-  // names no file). Requires the literal `test` task to actually be present
-  // (a bare `./gradlew clean` with no test task stays unrecognized).
-  /^(\.\/)?gradlew\s+(?:[\w.:-]+\s+)*(\S*:)?test(?=\s|$)/,
+  // chain multiple task names and flags before the one that matters
+  // (`clean test`, `--no-daemon test`, `-PmyProp=value test`), so
+  // `(?:[\w.:=-]+\s+)*` absorbs any number of leading bare/colon-namespaced
+  // task tokens and `-P`-style property flags — deliberately excluding `/`
+  // so a real scope-narrowing file argument is never swallowed as a "task".
+  // `(\S*:)?` then absorbs a Gradle task path like `:exposed-core:test` into
+  // the match itself so it is never mistaken for a scope-narrowing file
+  // token (it names no file). Requires the literal `test` task to actually
+  // be present (a bare `./gradlew clean` with no test task stays
+  // unrecognized).
+  /^(\.\/)?gradlew\s+(?:[\w.:=-]+\s+)*(\S*:)?test(?=\s|$)/,
   /^mvn\s+test(?=\s|$)/,
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
 ];

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -122,12 +122,19 @@ const RUNNER_PATTERNS: RegExp[] = [
   // `(?:[\w.:=-]+\s+)*` absorbs any number of leading bare/colon-namespaced
   // task tokens and `-P`-style property flags — deliberately excluding `/`
   // so a real scope-narrowing file argument is never swallowed as a "task".
-  // `(\S*:)?` then absorbs a Gradle task path like `:exposed-core:test` into
-  // the match itself so it is never mistaken for a scope-narrowing file
-  // token (it names no file). Requires the literal `test` task to actually
-  // be present (a bare `./gradlew clean` with no test task stays
-  // unrecognized).
-  /^(\.\/)?gradlew\s+(?:[\w.:=-]+\s+)*(\S*:)?test(?=\s|$)/,
+  // The negative lookahead guards `-x`/`--exclude-task`: those flags EXCLUDE
+  // their argument task rather than running it, so `-x test` must not be
+  // absorbed as an ordinary leading token feeding into the required `test`
+  // match below (that would falsely read "exclude test" as "ran test" — the
+  // opposite of what happened). If `test` genuinely runs earlier in the
+  // same command (`test -x someOtherTask`), backtracking still finds it;
+  // the guard only blocks `-x`/`--exclude-task` from ever being the thing
+  // that satisfies the match. `(\S*:)?` then absorbs a Gradle task path like
+  // `:exposed-core:test` into the match itself so it is never mistaken for a
+  // scope-narrowing file token (it names no file). Requires the literal
+  // `test` task to actually be present and not excluded (a bare `./gradlew
+  // clean` or `./gradlew -x test` stays unrecognized).
+  /^(\.\/)?gradlew\s+(?:(?!(?:-x|--exclude-task)(?:\s|$))[\w.:=-]+\s+)*(\S*:)?test(?=\s|$)/,
   /^mvn\s+test(?=\s|$)/,
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
 ];


### PR DESCRIPTION
## Summary

Closes #870

`RUNNER_PATTERNS` in `packages/cli/src/utils/test-run-matcher.ts` (the allow-list behind the did-you-run-the-tests nudge) missed the standard, idiomatic test-invocation form for 4 of 6 languages checked in a real-repo dogfood sweep:

- Ruby (Rake/Minitest): `rake test`, `rake test:core` (any `test:<namespaced-task>` form), `bundle exec rake test:core`
- PHP: `vendor/bin/phpunit`, `./vendor/bin/phpunit` (vendored/project-local convention), `composer test` (script alias)
- Swift (SwiftPM): `swift test`, `swift test --filter X`
- Gradle wrapper: `./gradlew test`, `./gradlew :module:test`, `gradlew test`

Each of these silently failed to classify as a test run, so `verify-tests report`/`recap` kept nagging even after the correct tests had genuinely been run — independent of whether test-association itself is correct.

Purely additive recognition per the module's documented design intent ("recognizing more commands as test runs only ever reduces false nags"). `isCoveredByScope` is untouched.

## Changes

- Added 7 new patterns to `RUNNER_PATTERNS`, folding the pre-existing bare `phpunit` pattern into the new path-qualified one (still matches the bare form — a strict superset).
- `--filter` on `swift test` is already in `WORKSPACE_SCOPE_FLAGS` (added for pnpm), so it's skipped for free and the run stays broad.
- `(\S*:)?` on the gradlew pattern absorbs a Gradle task path (`:exposed-core:test`) into the match itself so it's never mistaken for a scope-narrowing file token.

## Tests

- 18 new classification-table rows in `test-run-matcher.test.ts`, including a negative guard: `rake db:migrate` stays `false` (non-test Rake tasks aren't swallowed).
- Full suite: 72/72 in this file, 1155/1155 in `@liendev/lien`, all workspaces green.

## Dogfood evidence (verbatim)

Synthetic session replaying the sinatra-style command from the issue's repro, against both the pre-fix and post-fix build:

```
$ node packages/cli/dist/index.js verify-tests note-edit --session dogfood --file packages/cli/src/utils/test-run-matcher.ts
Lien: you changed packages/cli/src/utils/test-run-matcher.ts — associated tests: packages/cli/src/utils/test-run-matcher.test.ts. Run them before completing.

$ node packages/cli/dist/index.js verify-tests report --session dogfood
Before finishing: these files you edited this session have associated tests I
did not observe running in a Bash command:
  • packages/cli/src/utils/test-run-matcher.ts → packages/cli/src/utils/test-run-matcher.test.ts
...

$ node packages/cli/dist/index.js verify-tests note-run --session dogfood --command "bundle exec rake test:core"

$ node packages/cli/dist/index.js verify-tests report --session dogfood
(empty — nag cleared)
```

A/B against the pre-fix build (temporarily stashing the matcher change, rebuilding, replaying the identical session): the report **still nagged** after the same `bundle exec rake test:core` run, confirming the bug and the fix.

## Gate chain

`format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`, `build`, full `npm test` (all workspaces green), `lien delta` (0 complexity changes) — all pass.

## Review triage

- CodeRabbit flagged the changeset's initial `test[:sub]` wording as ambiguous with Rake's real bracketed task-argument syntax — fixed by rewording to the actual supported form (`test`, `test:core`), no code/test change needed since the implementation and tests never used bracket syntax.
- Lien Review flagged an overclaim ("every existing pattern unchanged") given the bare-phpunit-pattern fold — fixed by rewording precisely.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR expands RUNNER_PATTERNS to recognize standard test-invocation forms for Ruby/Rake, vendored PHP/phpunit, Composer scripts, SwiftPM, and the Gradle wrapper. The changes are purely additive: the folded phpunit pattern is a strict superset, no other existing patterns are modified, and callers of classifyTestCommand/computeUnverifiedFiles will only see fewer false nags. The Gradle-wrapper regex correctly handles multi-task invocations and uses a negative lookbehind to reject only cases where `test` is the argument immediately following `-x`/`--exclude-task`, while still recognizing `-x otherTask test` and `test -x otherTask`. Test coverage is comprehensive, including negative guards for non-test Rake tasks and Gradle exclusions.
>
> - Added rake, vendored phpunit, composer test, swift test, and gradlew patterns to RUNNER_PATTERNS
> - Folding bare phpunit into a strict-superset path-qualified pattern
> - Gradle-wrapper regex handles chained tasks/flags and excludes `-x test`/`--exclude-task test` while preserving `-x otherTask test`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit c509fd8. Updates automatically on new commits.</sup>
<!-- /lien-stats -->