### PR TITLE
fix(parser): recognize .NET Tests-suffix convention in isTestFile

### DIFF
--- a/.changeset/istestfile-dotnet-convention.md
+++ b/.changeset/istestfile-dotnet-convention.md
@@ -1,0 +1,23 @@
+---
+"@liendev/parser": patch
+---
+
+Fix `isTestFile()` in path-matching.ts to recognize the dominant .NET
+xUnit/NUnit/MSTest test-naming convention: a `Tests` suffix glued onto a
+longer identifier (`UnitTests/`, `IntegrationTests/`, `AutoMapper.DI.Tests/`
+directories) rather than a delimited `test`/`spec` path segment, and
+filenames ending in `Test.cs`/`Tests.cs` (`ScopeTests.cs`,
+`ConfigurationFeatureTest.cs`).
+
+`isTestFile()` is the pre-filter gating all test-association discovery
+(`findTestAssociationsFromChunks`), so this was a 100% test-association
+failure for C# projects using the standard .NET project-template layout
+(confirmed on `AutoMapper/AutoMapper`, where none of its 364 test files
+under `src/UnitTests/`, `src/IntegrationTests/`, or
+`src/AutoMapper.DI.Tests/` ever cleared the gate). Scoped to `.cs` paths and
+case-sensitive (`Tests`/`Test`, capital T) so `Latest.cs`/`Contest.cs` and a
+`latest/`-style directory are not misclassified, and no other language's
+behavior moves, mirroring how the existing Swift branch is scoped to
+`.swift`.
+
+Fixes #866.

--- a/.changeset/istestfile-dotnet-convention.md
+++ b/.changeset/istestfile-dotnet-convention.md
@@ -14,10 +14,11 @@ filenames ending in `Test.cs`/`Tests.cs` (`ScopeTests.cs`,
 failure for C# projects using the standard .NET project-template layout
 (confirmed on `AutoMapper/AutoMapper`, where none of its 364 test files
 under `src/UnitTests/`, `src/IntegrationTests/`, or
-`src/AutoMapper.DI.Tests/` ever cleared the gate). Scoped to `.cs` paths and
-case-sensitive (`Tests`/`Test`, capital T) so `Latest.cs`/`Contest.cs` and a
-`latest/`-style directory are not misclassified, and no other language's
-behavior moves, mirroring how the existing Swift branch is scoped to
-`.swift`.
+`src/AutoMapper.DI.Tests/` ever cleared the gate). Scoped to `.cs` paths;
+both the directory-segment and filename regexes require a literal
+capital-T `Tests`/`Test` suffix (no case-insensitive flag), so
+`Latest.cs`/`Contest.cs` and a `latest/`-style directory are not
+misclassified, and no other language's behavior moves, mirroring how the
+existing Swift branch is scoped to `.swift`.
 
 Fixes #866.

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -394,6 +394,42 @@ describe('isTestFile - Precise Test Detection', () => {
       expect(isTestFile('src\\auth.test.ts')).toBe(true);
     });
   });
+
+  describe('.NET conventions (glued Tests suffix, .cs-scoped)', () => {
+    it('should match a directory segment ending in Tests', () => {
+      expect(isTestFile('src/UnitTests/ConfigurationFeatureTest.cs')).toBe(true);
+      expect(isTestFile('src/IntegrationTests/SomeFeature.cs')).toBe(true);
+      expect(isTestFile('src/AutoMapper.DI.Tests/ContainerTests.cs')).toBe(true);
+    });
+
+    it('should match a filename ending in Test.cs or Tests.cs', () => {
+      expect(isTestFile('src/UnitTests/ScopeTests.cs')).toBe(true);
+      expect(isTestFile('src/UnitTests/ConfigurationFeatureTest.cs')).toBe(true);
+      expect(isTestFile('FooTest.cs')).toBe(true);
+      expect(isTestFile('FooTests.cs')).toBe(true);
+    });
+
+    it('should handle Windows paths for the directory convention', () => {
+      expect(isTestFile('src\\UnitTests\\ConfigurationFeatureTest.cs')).toBe(true);
+    });
+
+    it('should NOT match lowercase test/contest lookalikes (case-sensitive guard)', () => {
+      expect(isTestFile('src/AutoMapper/Latest.cs')).toBe(false);
+      expect(isTestFile('src/AutoMapper/Contest.cs')).toBe(false);
+      expect(isTestFile('latest/Config.cs')).toBe(false);
+      expect(isTestFile('contest/Config.cs')).toBe(false);
+    });
+
+    it('should NOT affect non-.cs files with a glued Tests suffix', () => {
+      expect(isTestFile('FooTests.ts')).toBe(false);
+      expect(isTestFile('src/UnitTests/Helper.ts')).toBe(false);
+    });
+
+    it('should NOT match regular .cs source files', () => {
+      expect(isTestFile('src/AutoMapper/Mapper.cs')).toBe(false);
+      expect(isTestFile('src/AutoMapper/TypeMap.cs')).toBe(false);
+    });
+  });
 });
 
 describe('resolveRelativeImport', () => {

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -343,6 +343,14 @@ export function getCanonicalPath(filepath: string, workspaceRoot: string): strin
  * Swift Package Manager `Tests/` directory). Those checks are scoped to
  * `.swift` paths so behavior for other languages is unchanged.
  *
+ * .NET/xUnit/NUnit/MSTest use a `Tests` suffix glued onto a longer
+ * identifier rather than a delimited `test`/`spec` segment: project
+ * directories like `UnitTests/`, `IntegrationTests/`, `AutoMapper.DI.Tests/`
+ * and files like `ScopeTests.cs`, `ConfigurationFeatureTest.cs`. Those checks
+ * are scoped to `.cs` paths and are case-sensitive (`Tests`/`Test`, capital
+ * T) so `Latest.cs`/`Contest.cs` and a `latest/`-style directory are not
+ * misclassified, and no other language's behavior moves.
+ *
  * @param filepath - The file path to check
  * @returns True if the file is a test file
  */
@@ -352,6 +360,8 @@ export function isTestFile(filepath: string): boolean {
     /_(test|spec)\.[^/]+$/.test(filepath) ||
     /(^|[/\\])(test|tests|spec|specs|__tests__)[/\\]/.test(filepath) ||
     (/\.swift$/.test(filepath) &&
-      (/Tests?\.swift$/.test(filepath) || /(^|[/\\])Tests?[/\\]/.test(filepath)))
+      (/Tests?\.swift$/.test(filepath) || /(^|[/\\])Tests?[/\\]/.test(filepath))) ||
+    (/\.cs$/.test(filepath) &&
+      (/Tests?\.cs$/.test(filepath) || /(^|[/\\])[^/\\]*Tests[/\\]/.test(filepath)))
   );
 }


### PR DESCRIPTION
Closes #866

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds .NET test-file detection to `isTestFile()` in `packages/parser/src/utils/path-matching.ts`. The new branch is scoped to `.cs` paths and uses case-sensitive `Tests`/`Test` suffix matching for directory segments and filenames, mirroring the existing Swift branch. Callers consume `isTestFile()` as a boolean pre-filter, so the change is additive and backward-compatible for non-C# paths. The implementation aligns with the docstring and changeset claims, and the added test coverage exercises positive cases, negative lookalikes, case sensitivity, Windows-path handling, and non-.cs isolation.
>
> - Added .NET-specific `Tests`/`Test` suffix detection for `.cs` files and directories
> - Scoped the new branch to `.cs` paths to avoid changing behavior for other languages
> - Added test cases covering directory suffixes, filename suffixes, case sensitivity, and non-.cs isolation

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 730c372. Updates automatically on new commits.</sup>
<!-- /lien-stats -->