### PR TITLE
fix(parser): resolve manifest-declared import roots for PHP PSR-4 and Go modules

### DIFF
--- a/.changeset/manifest-root-mapping.md
+++ b/.changeset/manifest-root-mapping.md
@@ -1,0 +1,50 @@
+---
+'@liendev/parser': minor
+---
+
+Fix a 100% test-association failure on standard PHP (Composer PSR-4) and Go
+(module-path) project layouts (#867). `matchesFile()`'s namespace/module
+matching in `path-matching.ts` guesses a project's source layout by aligning
+literal directory-name segments, but neither ecosystem's dominant convention
+is guessable that way: Composer's PSR-4 autoloading maps a namespace prefix
+to a directory declared in `composer.json` (e.g. `"GuzzleHttp\\": "src/"`),
+and Go imports are always full module paths (`github.com/org/repo/pkg`)
+whose root segment never equals the literal checkout directory name. Neither
+manifest was ever read, so `GuzzleHttp\Cookie\SetCookie` and
+`github.com/gin-gonic/gin/binding` could never match their real files —
+confirmed on real OSS repos as 67/67 PHP files (guzzle/guzzle) and 59/59 Go
+files (gin-gonic/gin) silently reporting "No test coverage" despite complete,
+passing test suites.
+
+Two small manifest readers, mirroring `workspace-packages.ts`'s existing
+pattern exactly (parse once per workspace root, cache, no-op when the
+manifest is absent): `php-psr4.ts` parses `composer.json`'s `autoload.psr-4`
+/ `autoload-dev.psr-4` maps; `go-module.ts` parses `go.mod`'s `module` line.
+Both are wired in as a third specifier-resolution step (`ManifestRoots`, in
+`ast/symbols.ts`'s `resolveImportSpecifier`), built once per file in
+`ast/chunker.ts`'s `prepareASTContext` from the existing `workspaceRoot`
+option — no new public option was needed. `extractImports`/
+`extractImportedSymbols` gained a new optional trailing parameter to thread
+it through; existing callers that don't pass it are unaffected.
+
+PHP's PSR-4 resolution runs on the raw backslash-separated specifier
+(`GuzzleHttp\Cookie\SetCookie`), matching the longest registered namespace
+prefix and converting the remainder to `/`-separated form — this
+deliberately happens *before* `path-matching.ts`'s `normalizePath` would
+otherwise convert `\` to `/`, since the prefix lookup needs the native PHP
+separator. Go's resolution is exact string-prefix stripping once the module
+line is known, no guessing required.
+
+Verified against a live shallow clone of guzzle/guzzle: 58 of 67 `src/*.php`
+files now resolve real test coverage (up from 0), including the issue's
+named target (`src/Cookie/SetCookie.php` → `tests/Cookie/SetCookieTest.php`).
+The remaining 9 are a separate, pre-existing gap (test files that exercise
+the class through a factory or FQCN reference rather than a `use` import of
+it directly — nothing to resolve from import data alone) and are out of
+scope for this fix. Gin's Go re-sweep is deferred to #868 (a separate
+`matchesAtBoundary` false-positive that still causes a bare tail-segment
+collision after prefix stripping), so Go acceptance is not claimed here.
+
+Scope: only `autoload.psr-4`/`autoload-dev.psr-4` (not `classmap`/`files`,
+not PSR-0) and the single `go.mod` `module` line, matching the issue's
+explicit "no general manifest framework" constraint.

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -4,6 +4,8 @@ import os from 'os';
 import path from 'path';
 import { chunkByAST, shouldUseAST } from './chunker.js';
 import { clearWorkspacePackageCache } from '../workspace-packages.js';
+import { clearPsr4Cache } from '../php-psr4.js';
+import { clearGoModuleCache } from '../go-module.js';
 
 describe('AST Chunker', () => {
   describe('shouldUseAST', () => {
@@ -307,6 +309,144 @@ function run() {
         const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
 
         expect(funcChunk?.metadata.imports).toContain('@liendev/parser');
+      });
+    });
+
+    describe('manifest-root mapping (PHP PSR-4, Go module) — #867', () => {
+      let testDir: string;
+
+      beforeEach(async () => {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-chunker-manifest-roots-'));
+      });
+
+      afterEach(async () => {
+        clearPsr4Cache();
+        clearGoModuleCache();
+        await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+      });
+
+      async function writeJson(relPath: string, data: unknown): Promise<void> {
+        const abs = path.join(testDir, relPath);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, JSON.stringify(data, null, 2));
+      }
+
+      async function writeFile(relPath: string, content: string): Promise<void> {
+        const abs = path.join(testDir, relPath);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+
+      it('resolves a PHP PSR-4 namespaced import to its real source path (guzzle repro)', async () => {
+        await writeJson('composer.json', {
+          name: 'guzzlehttp/guzzle',
+          autoload: { 'psr-4': { 'GuzzleHttp\\': 'src/' } },
+        });
+
+        const content = `<?php
+use GuzzleHttp\\Cookie\\SetCookie;
+use PHPUnit\\Framework\\TestCase;
+
+class SetCookieTest {
+  public function testFoo() {
+    return new SetCookie();
+  }
+}
+?>`;
+
+        const chunks = chunkByAST('tests/Cookie/SetCookieTest.php', content, {
+          workspaceRoot: testDir,
+        });
+        const methodChunk = chunks.find(c => c.metadata.symbolName === 'testFoo');
+
+        expect(methodChunk?.metadata.imports).toContain('src/Cookie/SetCookie');
+        // No registered PSR-4 prefix for PHPUnit → passes through unresolved.
+        expect(methodChunk?.metadata.imports).toContain('PHPUnit\\Framework\\TestCase');
+      });
+
+      it('leaves PHP imports unresolved when there is no composer.json (zero behavior change)', () => {
+        const content = `<?php
+use GuzzleHttp\\Cookie\\SetCookie;
+
+class SetCookieTest {
+  public function testFoo() {
+    return new SetCookie();
+  }
+}
+?>`;
+
+        const chunks = chunkByAST('tests/Cookie/SetCookieTest.php', content, {
+          workspaceRoot: testDir,
+        });
+        const methodChunk = chunks.find(c => c.metadata.symbolName === 'testFoo');
+
+        expect(methodChunk?.metadata.imports).toContain('GuzzleHttp\\Cookie\\SetCookie');
+      });
+
+      it('resolves a Go module-prefixed import to its repo-relative path (gin repro)', async () => {
+        await writeFile('go.mod', 'module github.com/gin-gonic/gin\n\ngo 1.21\n');
+
+        const content = `package binding_test
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin/binding"
+)
+
+func TestMode(t *testing.T) {
+	binding.Validator = nil
+}
+`;
+
+        const chunks = chunkByAST('mode_test.go', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'TestMode');
+
+        expect(funcChunk?.metadata.imports).toContain('binding');
+        expect(funcChunk?.metadata.imports).not.toContain('github.com/gin-gonic/gin/binding');
+      });
+
+      it('leaves Go imports unresolved when there is no go.mod (zero behavior change)', () => {
+        const content = `package binding_test
+
+import "github.com/gin-gonic/gin/binding"
+
+func TestMode(t *testing.T) {
+	binding.Validator = nil
+}
+`;
+
+        const chunks = chunkByAST('mode_test.go', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'TestMode');
+
+        expect(funcChunk?.metadata.imports).toContain('github.com/gin-gonic/gin/binding');
+      });
+
+      it('is a no-op for PHP/Go when workspaceRoot is omitted (existing callers unaffected)', () => {
+        const phpContent = `<?php
+use GuzzleHttp\\Cookie\\SetCookie;
+
+class SetCookieTest {
+  public function testFoo() {
+    return new SetCookie();
+  }
+}
+?>`;
+        const phpChunks = chunkByAST('tests/Cookie/SetCookieTest.php', phpContent);
+        const phpMethodChunk = phpChunks.find(c => c.metadata.symbolName === 'testFoo');
+        expect(phpMethodChunk?.metadata.imports).toContain('GuzzleHttp\\Cookie\\SetCookie');
+
+        const goContent = `package binding_test
+
+import "github.com/gin-gonic/gin/binding"
+
+func TestMode(t *testing.T) {
+	binding.Validator = nil
+}
+`;
+        const goChunks = chunkByAST('mode_test.go', goContent);
+        const goFuncChunk = goChunks.find(c => c.metadata.symbolName === 'TestMode');
+        expect(goFuncChunk?.metadata.imports).toContain('github.com/gin-gonic/gin/binding');
       });
     });
 

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -6,10 +6,13 @@ import {
   extractImportedSymbols,
   extractExports,
   extractCallSites,
+  type ManifestRoots,
 } from './symbols.js';
 import { calculateCognitiveComplexity, calculateHalstead } from './complexity/index.js';
 import { getTraverser } from './traversers/index.js';
 import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
+import { resolvePsr4Map } from '../php-psr4.js';
+import { resolveGoModulePrefix } from '../go-module.js';
 
 export interface ASTChunkOptions {
   minChunkSize?: number;
@@ -73,6 +76,34 @@ const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
 ]);
 
 /**
+ * Build the manifest-declared import-root mapping for a file's language, when
+ * `workspaceRoot` is available. PHP resolves `composer.json`'s PSR-4 map; Go
+ * resolves `go.mod`'s module prefix; every other language gets `undefined`
+ * (a no-op — see `ManifestRoots` in `./symbols.ts`). Returns `undefined`
+ * (rather than an object with empty/absent fields) when the manifest itself
+ * declares nothing, so `resolveImportSpecifier`'s manifest-root step is
+ * skipped entirely for non-PHP/Go-module projects.
+ */
+function buildManifestRoots(
+  language: SupportedLanguage,
+  workspaceRoot: string | undefined,
+): ManifestRoots | undefined {
+  if (!workspaceRoot) return undefined;
+
+  if (language === 'php') {
+    const psr4Map = resolvePsr4Map(workspaceRoot);
+    return psr4Map.size > 0 ? { psr4Map } : undefined;
+  }
+
+  if (language === 'go') {
+    const goModulePrefix = resolveGoModulePrefix(workspaceRoot);
+    return goModulePrefix ? { goModulePrefix } : undefined;
+  }
+
+  return undefined;
+}
+
+/**
  * Prepare AST context by extracting imports, exports, and symbols.
  *
  * For JS/TS, `filepath` is threaded into the import extractors so that relative
@@ -87,6 +118,11 @@ const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
  * import resolution: npm workspaces is a JS-ecosystem mechanism, and other
  * languages' import syntax could otherwise coincidentally collide with a
  * workspace package name.
+ *
+ * Independently, when `workspaceRoot` is provided and the file is PHP or Go,
+ * `buildManifestRoots` resolves that project's manifest-declared import root
+ * (composer.json PSR-4 / go.mod module prefix — see #867) so namespace- or
+ * module-qualified imports resolve to real workspace-relative paths too.
  */
 function prepareASTContext(
   content: string,
@@ -99,10 +135,23 @@ function prepareASTContext(
   const resolutionPath = resolvesImports ? filepath : undefined;
   const workspacePackages =
     resolvesImports && workspaceRoot ? resolveWorkspacePackageEntries(workspaceRoot) : undefined;
+  const manifestRoots = buildManifestRoots(language, workspaceRoot);
   return {
     lines: content.split('\n'),
-    fileImports: extractImports(rootNode, language, resolutionPath, workspacePackages),
-    importedSymbols: extractImportedSymbols(rootNode, language, resolutionPath, workspacePackages),
+    fileImports: extractImports(
+      rootNode,
+      language,
+      resolutionPath,
+      workspacePackages,
+      manifestRoots,
+    ),
+    importedSymbols: extractImportedSymbols(
+      rootNode,
+      language,
+      resolutionPath,
+      workspacePackages,
+      manifestRoots,
+    ),
     fileExports: extractExports(rootNode, language),
     traverser: getTraverser(language),
   };

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -4,6 +4,25 @@ import { getExtractor, getImportExtractor, getSymbolExtractor } from './extracto
 import { getLanguage } from './languages/registry.js';
 
 import { resolveRelativeImport, resolveWorkspaceImport } from '../utils/path-matching.js';
+import { resolvePsr4Import } from '../php-psr4.js';
+import { resolveGoModuleImport } from '../go-module.js';
+
+/**
+ * Per-project manifest-declared import-root mappings, threaded through as a
+ * third specifier-resolution step (after relative-import and workspace-
+ * package resolution) in `resolveImportSpecifier`. Built once per workspace
+ * root in `ast/chunker.ts`'s `prepareASTContext` — see `../php-psr4.ts` and
+ * `../go-module.ts` for how each map is read. At most one field is ever
+ * populated for a given file (the language determines which manifest, if
+ * any, applies), and both are optional so this is a no-op for every language
+ * without a manifest reader.
+ */
+export interface ManifestRoots {
+  /** PHP Composer PSR-4 namespace-prefix -> source-directory map. */
+  psr4Map?: ReadonlyMap<string, string>;
+  /** Go module's declared import-path prefix (`go.mod`'s `module` line). */
+  goModulePrefix?: string;
+}
 
 /**
  * Extract symbol information from an AST node using language-specific extractors.
@@ -54,18 +73,34 @@ function collectImportNodes(rootNode: SyntaxNode, nodeTypeSet: Set<string>): Syn
 }
 
 /**
- * Resolve a single raw import specifier: relative specifiers first (against
- * the importer's directory), then workspace package specifiers (against the
- * `workspacePackages` map). Both steps are no-ops when their respective
- * input isn't provided, so behavior for existing callers is unchanged.
+ * Resolve a single raw import specifier in three steps, each a no-op when its
+ * respective input isn't provided, so behavior for existing callers is
+ * unchanged:
+ * 1. Relative specifiers (`./foo`, `../bar`) against the importer's directory.
+ * 2. Workspace package specifiers (`@scope/pkg`) against the `workspacePackages` map.
+ * 3. Manifest-declared import roots (PHP PSR-4, Go module prefix) against `manifestRoots`.
  */
 function resolveImportSpecifier(
   specifier: string,
   filepath: string | undefined,
   workspacePackages: ReadonlyMap<string, string> | undefined,
+  manifestRoots: ManifestRoots | undefined,
 ): string {
   const relResolved = filepath ? resolveRelativeImport(filepath, specifier) : specifier;
-  return workspacePackages ? resolveWorkspaceImport(relResolved, workspacePackages) : relResolved;
+  const wsResolved = workspacePackages
+    ? resolveWorkspaceImport(relResolved, workspacePackages)
+    : relResolved;
+  return resolveManifestRoot(wsResolved, manifestRoots);
+}
+
+/** Apply step 3 (manifest-root resolution) of `resolveImportSpecifier`. */
+function resolveManifestRoot(specifier: string, manifestRoots: ManifestRoots | undefined): string {
+  if (!manifestRoots) return specifier;
+  if (manifestRoots.psr4Map) return resolvePsr4Import(specifier, manifestRoots.psr4Map);
+  if (manifestRoots.goModulePrefix) {
+    return resolveGoModuleImport(specifier, manifestRoots.goModulePrefix);
+  }
+  return specifier;
 }
 
 /**
@@ -84,6 +119,7 @@ function extractImportPaths(
   importExtractor: ReturnType<typeof getImportExtractor>,
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
+  manifestRoots?: ManifestRoots,
 ): string[] {
   if (!importExtractor) return [];
 
@@ -92,7 +128,9 @@ function extractImportPaths(
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
     const result = importExtractor.extractImportPath(node);
-    if (result) imports.push(resolveImportSpecifier(result, filepath, workspacePackages));
+    if (result) {
+      imports.push(resolveImportSpecifier(result, filepath, workspacePackages, manifestRoots));
+    }
   }
 
   return imports;
@@ -110,15 +148,24 @@ function extractImportPaths(
  * @param workspacePackages - Optional map of workspace package name -> source
  *   entry file (see `resolveWorkspacePackageEntries`). Enables resolution of
  *   bare `@scope/pkg` specifiers that reference sibling workspace packages.
+ * @param manifestRoots - Optional manifest-declared import-root mappings
+ *   (PHP PSR-4, Go module prefix). See `ManifestRoots`.
  */
 export function extractImports(
   rootNode: SyntaxNode,
   language?: SupportedLanguage,
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
+  manifestRoots?: ManifestRoots,
 ): string[] {
   if (!language) return [];
-  return extractImportPaths(rootNode, getImportExtractor(language), filepath, workspacePackages);
+  return extractImportPaths(
+    rootNode,
+    getImportExtractor(language),
+    filepath,
+    workspacePackages,
+    manifestRoots,
+  );
 }
 
 /**
@@ -150,6 +197,7 @@ function extractSymbolsWithExtractor(
   importExtractor: ReturnType<typeof getImportExtractor>,
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
+  manifestRoots?: ManifestRoots,
 ): Record<string, string[]> {
   if (!importExtractor) return {};
 
@@ -159,7 +207,12 @@ function extractSymbolsWithExtractor(
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
     const result = importExtractor.processImportSymbols(node);
     if (result) {
-      const key = resolveImportSpecifier(result.importPath, filepath, workspacePackages);
+      const key = resolveImportSpecifier(
+        result.importPath,
+        filepath,
+        workspacePackages,
+        manifestRoots,
+      );
       addSymbolsToMap(importedSymbols, key, result.symbols);
     }
   }
@@ -178,12 +231,15 @@ function extractSymbolsWithExtractor(
  *   of `./` / `../` specifiers into workspace-relative keys.
  * @param workspacePackages - Optional map of workspace package name -> source
  *   entry file. Enables resolution of bare `@scope/pkg` keys.
+ * @param manifestRoots - Optional manifest-declared import-root mappings
+ *   (PHP PSR-4, Go module prefix). See `ManifestRoots`.
  */
 export function extractImportedSymbols(
   rootNode: SyntaxNode,
   language?: SupportedLanguage,
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
+  manifestRoots?: ManifestRoots,
 ): Record<string, string[]> {
   if (!language) return {};
   return extractSymbolsWithExtractor(
@@ -191,6 +247,7 @@ export function extractImportedSymbols(
     getImportExtractor(language),
     filepath,
     workspacePackages,
+    manifestRoots,
   );
 }
 

--- a/packages/parser/src/go-module.test.ts
+++ b/packages/parser/src/go-module.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { resolveGoModulePrefix, resolveGoModuleImport, clearGoModuleCache } from './go-module.js';
+
+describe('resolveGoModulePrefix', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-go-module-'));
+  });
+
+  afterEach(async () => {
+    clearGoModuleCache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it('returns undefined when there is no go.mod at all', () => {
+    expect(resolveGoModulePrefix(testDir)).toBeUndefined();
+  });
+
+  it('parses the module prefix (gin shape)', async () => {
+    await writeFile('go.mod', 'module github.com/gin-gonic/gin\n\ngo 1.21\n');
+    expect(resolveGoModulePrefix(testDir)).toBe('github.com/gin-gonic/gin');
+  });
+
+  it('parses the module line regardless of leading/trailing whitespace and later directives', async () => {
+    await writeFile(
+      'go.mod',
+      '  module   github.com/foo/bar  \n\nrequire (\n\tgithub.com/x/y v1.0.0\n)\n',
+    );
+    expect(resolveGoModulePrefix(testDir)).toBe('github.com/foo/bar');
+  });
+
+  it('returns undefined when go.mod has no parseable module line', async () => {
+    await writeFile('go.mod', 'go 1.21\n');
+    expect(resolveGoModulePrefix(testDir)).toBeUndefined();
+  });
+
+  it('caches the prefix per workspace root', async () => {
+    await writeFile('go.mod', 'module github.com/gin-gonic/gin\n');
+    const first = resolveGoModulePrefix(testDir);
+    await writeFile('go.mod', 'module github.com/other/repo\n');
+    const second = resolveGoModulePrefix(testDir);
+
+    expect(second).toBe(first);
+    expect(second).toBe('github.com/gin-gonic/gin');
+  });
+});
+
+describe('resolveGoModuleImport', () => {
+  it('is a no-op when modulePrefix is undefined', () => {
+    expect(resolveGoModuleImport('github.com/gin-gonic/gin/binding', undefined)).toBe(
+      'github.com/gin-gonic/gin/binding',
+    );
+  });
+
+  it('strips the module prefix from a cross-package import (gin repro from #867)', () => {
+    expect(
+      resolveGoModuleImport('github.com/gin-gonic/gin/binding', 'github.com/gin-gonic/gin'),
+    ).toBe('binding');
+  });
+
+  it('leaves an import unchanged when it does not start with the module prefix (external dependency)', () => {
+    expect(
+      resolveGoModuleImport('github.com/stretchr/testify/assert', 'github.com/gin-gonic/gin'),
+    ).toBe('github.com/stretchr/testify/assert');
+  });
+
+  it('does not false-positive strip a prefix that merely shares a string prefix without a path boundary', () => {
+    // "github.com/gin-gonic/ginext" must not be treated as inside "github.com/gin-gonic/gin".
+    expect(
+      resolveGoModuleImport('github.com/gin-gonic/ginext/foo', 'github.com/gin-gonic/gin'),
+    ).toBe('github.com/gin-gonic/ginext/foo');
+  });
+
+  it('leaves a bare same-module-root import (no further path segment) unchanged', () => {
+    expect(resolveGoModuleImport('github.com/gin-gonic/gin', 'github.com/gin-gonic/gin')).toBe(
+      'github.com/gin-gonic/gin',
+    );
+  });
+});

--- a/packages/parser/src/go-module.ts
+++ b/packages/parser/src/go-module.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Resolves a Go module's declared import-path prefix from `go.mod`'s single
+ * `module` directive, and strips that prefix from a raw Go import path.
+ *
+ * This closes the Go test-association blind spot (#867): Go imports are
+ * always full module paths (e.g. `github.com/gin-gonic/gin/binding`), never
+ * relative, and the module's own root segment (`github.com/gin-gonic/gin`)
+ * never corresponds to a literal directory in a real checkout — the repo is
+ * cloned to whatever local directory name the user chose, never literally
+ * `github.com/gin-gonic/gin`. `go.mod`'s `module` line is the one place the
+ * project declares its own import-path prefix, so once it's known, stripping
+ * it is exact string-prefix removal — no guessing needed. Mirrors
+ * `workspace-packages.ts`'s pattern: parse once per workspace root, cache the
+ * result, no-op when the manifest is absent.
+ */
+
+/** Per-workspace-root cache so repeated calls during a single index run are O(1). */
+const goModulePrefixCache = new Map<string, string | undefined>();
+
+/** Clears the cached module prefixes. Exported for test isolation. */
+export function clearGoModuleCache(): void {
+  goModulePrefixCache.clear();
+}
+
+/** Parse the `module <path>` directive from a go.mod file's contents. */
+function parseModuleLine(content: string): string | undefined {
+  const match = content.match(/^\s*module\s+(\S+)/m);
+  return match?.[1];
+}
+
+function readModuleLine(filePath: string): string | undefined {
+  try {
+    return parseModuleLine(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build (or retrieve from cache) the Go module import-path prefix for a
+ * workspace root.
+ *
+ * Returns `undefined` when there is no `go.mod`, or it has no parseable
+ * `module` line — callers can treat that as "no resolution" with zero
+ * behavior change.
+ *
+ * @param workspaceRoot - Absolute path to the project root.
+ */
+export function resolveGoModulePrefix(workspaceRoot: string): string | undefined {
+  const normalizedRoot = workspaceRoot.replace(/\\/g, '/').replace(/\/$/, '');
+
+  if (goModulePrefixCache.has(normalizedRoot)) {
+    return goModulePrefixCache.get(normalizedRoot);
+  }
+
+  const modulePrefix = readModuleLine(path.join(normalizedRoot, 'go.mod'));
+  goModulePrefixCache.set(normalizedRoot, modulePrefix);
+  return modulePrefix;
+}
+
+/**
+ * Resolve a raw Go import path (e.g. `github.com/gin-gonic/gin/binding`) to a
+ * repo-relative path (e.g. `binding`), by stripping the project's own module
+ * prefix as declared in `go.mod`.
+ *
+ * No-op (returns `specifier` unchanged) when `modulePrefix` is undefined, or
+ * the specifier doesn't start with `<modulePrefix>/` — imports of other
+ * modules (real external dependencies) and non-Go-module projects see zero
+ * behavior change. Same-package imports (a bare import equal to the module
+ * prefix itself, with no further path segment) are left unchanged too: Go's
+ * own same-package test convention needs no import statement at all, so this
+ * case doesn't arise for the cross-package test-association gap #867 targets.
+ *
+ * @param specifier - The raw Go import path.
+ * @param modulePrefix - The project's `go.mod` `module` value, or `undefined`.
+ */
+export function resolveGoModuleImport(specifier: string, modulePrefix: string | undefined): string {
+  if (!modulePrefix) return specifier;
+  const withSlash = `${modulePrefix}/`;
+  return specifier.startsWith(withSlash) ? specifier.slice(withSlash.length) : specifier;
+}

--- a/packages/parser/src/php-psr4.test.ts
+++ b/packages/parser/src/php-psr4.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { resolvePsr4Map, resolvePsr4Import, clearPsr4Cache } from './php-psr4.js';
+
+describe('resolvePsr4Map', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-php-psr4-'));
+  });
+
+  afterEach(async () => {
+    clearPsr4Cache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeJson(relPath: string, data: unknown): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, JSON.stringify(data, null, 2));
+  }
+
+  it('returns an empty map when there is no composer.json at all', () => {
+    const map = resolvePsr4Map(testDir);
+    expect(map.size).toBe(0);
+  });
+
+  it('returns an empty map when composer.json declares no autoload.psr-4', async () => {
+    await writeJson('composer.json', { name: 'guzzlehttp/guzzle' });
+    const map = resolvePsr4Map(testDir);
+    expect(map.size).toBe(0);
+  });
+
+  it('parses a standard single-namespace PSR-4 map (guzzle shape)', async () => {
+    await writeJson('composer.json', {
+      name: 'guzzlehttp/guzzle',
+      autoload: { 'psr-4': { 'GuzzleHttp\\': 'src/' } },
+    });
+
+    const map = resolvePsr4Map(testDir);
+
+    expect(map.get('GuzzleHttp\\')).toBe('src/');
+  });
+
+  it('normalizes a namespace prefix missing its trailing backslash and a dir missing its trailing slash', async () => {
+    await writeJson('composer.json', {
+      autoload: { 'psr-4': { GuzzleHttp: 'src' } },
+    });
+
+    const map = resolvePsr4Map(testDir);
+
+    expect(map.get('GuzzleHttp\\')).toBe('src/');
+  });
+
+  it('merges autoload and autoload-dev sections', async () => {
+    await writeJson('composer.json', {
+      autoload: { 'psr-4': { 'GuzzleHttp\\': 'src/' } },
+      'autoload-dev': { 'psr-4': { 'GuzzleHttp\\Tests\\': 'tests/' } },
+    });
+
+    const map = resolvePsr4Map(testDir);
+
+    expect(map.get('GuzzleHttp\\')).toBe('src/');
+    expect(map.get('GuzzleHttp\\Tests\\')).toBe('tests/');
+  });
+
+  it('takes the first directory when a PSR-4 prefix maps to a fallback-dir array', async () => {
+    await writeJson('composer.json', {
+      autoload: { 'psr-4': { 'App\\': ['src/', 'lib/'] } },
+    });
+
+    const map = resolvePsr4Map(testDir);
+
+    expect(map.get('App\\')).toBe('src/');
+  });
+
+  it('caches the map per workspace root', async () => {
+    await writeJson('composer.json', {
+      autoload: { 'psr-4': { 'GuzzleHttp\\': 'src/' } },
+    });
+
+    const first = resolvePsr4Map(testDir);
+    // Mutate composer.json after the first read; the cached map must not change.
+    await writeJson('composer.json', { autoload: { 'psr-4': { 'Other\\': 'lib/' } } });
+    const second = resolvePsr4Map(testDir);
+
+    expect(second).toBe(first);
+    expect(second.get('GuzzleHttp\\')).toBe('src/');
+  });
+});
+
+describe('resolvePsr4Import', () => {
+  it('is a no-op for an empty map', () => {
+    const map = new Map<string, string>();
+    expect(resolvePsr4Import('GuzzleHttp\\Cookie\\SetCookie', map)).toBe(
+      'GuzzleHttp\\Cookie\\SetCookie',
+    );
+  });
+
+  it('resolves a namespaced specifier to its real source path (guzzle repro from #867)', () => {
+    const map = new Map([['GuzzleHttp\\', 'src/']]);
+    expect(resolvePsr4Import('GuzzleHttp\\Cookie\\SetCookie', map)).toBe('src/Cookie/SetCookie');
+  });
+
+  it('leaves a specifier unchanged when no registered prefix matches', () => {
+    const map = new Map([['GuzzleHttp\\', 'src/']]);
+    expect(resolvePsr4Import('PHPUnit\\Framework\\TestCase', map)).toBe(
+      'PHPUnit\\Framework\\TestCase',
+    );
+  });
+
+  it('matches the longest registered prefix when multiple are registered', () => {
+    const map = new Map([
+      ['GuzzleHttp\\', 'src/'],
+      ['GuzzleHttp\\Tests\\', 'tests/'],
+    ]);
+
+    expect(resolvePsr4Import('GuzzleHttp\\Tests\\Cookie\\SetCookieTest', map)).toBe(
+      'tests/Cookie/SetCookieTest',
+    );
+    expect(resolvePsr4Import('GuzzleHttp\\Cookie\\SetCookie', map)).toBe('src/Cookie/SetCookie');
+  });
+
+  it('resolves a bare-prefix specifier with no remaining path segment', () => {
+    const map = new Map([['App\\', 'src/']]);
+    expect(resolvePsr4Import('App\\Kernel', map)).toBe('src/Kernel');
+  });
+});

--- a/packages/parser/src/php-psr4.ts
+++ b/packages/parser/src/php-psr4.ts
@@ -1,0 +1,145 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Resolves PHP Composer PSR-4 autoload mappings (`composer.json`'s
+ * `autoload.psr-4` / `autoload-dev.psr-4`) to a `Map<namespacePrefix, dir>`,
+ * and resolves a raw PHP import specifier against that map.
+ *
+ * This closes the PHP test-association blind spot (#867): the PHP import
+ * extractor emits fully namespace-qualified specifiers (e.g.
+ * `GuzzleHttp\Cookie\SetCookie`), but `composer.json` is the only place that
+ * declares the real mapping from a namespace prefix to a source directory
+ * (`"GuzzleHttp\\": "src/"`) — the namespace root essentially never equals a
+ * literal directory name, so `matchesPHPNamespace`'s directory-alignment
+ * guess in `path-matching.ts` fails for the standard, non-Laravel PSR-4
+ * layout. Mirrors `workspace-packages.ts`'s pattern exactly: parse the
+ * manifest once per workspace root, cache the result, and treat "no manifest"
+ * / "no match" as a no-op so every non-PHP or non-Composer project sees zero
+ * behavior change.
+ *
+ * v1 scope (deliberately KISS/YAGNI, per #867's plan): only `autoload.psr-4`
+ * and `autoload-dev.psr-4` are read. `classmap`/`files` autoloading, and
+ * PSR-0, are out of scope — add if/when a real repo needs them.
+ */
+
+/** A minimal shape for the fields of composer.json this module reads. */
+interface ComposerJsonShape {
+  autoload?: { 'psr-4'?: unknown };
+  'autoload-dev'?: { 'psr-4'?: unknown };
+}
+
+/** Per-workspace-root cache so repeated calls during a single index run are O(1) map lookups. */
+const psr4MapCache = new Map<string, Map<string, string>>();
+
+/** Clears the cached PSR-4 maps. Exported for test isolation. */
+export function clearPsr4Cache(): void {
+  psr4MapCache.clear();
+}
+
+function readComposerJson(filePath: string): ComposerJsonShape | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as ComposerJsonShape) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Ensure a PSR-4 namespace prefix ends in exactly one trailing `\`. */
+function normalizeNamespacePrefix(prefix: string): string {
+  return prefix.endsWith('\\') ? prefix : `${prefix}\\`;
+}
+
+/** Ensure a PSR-4 source directory has no leading `./` and exactly one trailing `/`. */
+function normalizeSourceDir(dir: string): string {
+  const cleaned = dir.replace(/^\.\//, '');
+  return cleaned.endsWith('/') ? cleaned : `${cleaned}/`;
+}
+
+/**
+ * Merge one `autoload`/`autoload-dev` PSR-4 section into `map`. Composer
+ * allows a prefix to map to either a single directory string or an array of
+ * fallback directories — the first entry is the common case and the only one
+ * handled here (a fallback dir is, by definition, a secondary location).
+ */
+function collectPsr4Entries(section: unknown, map: Map<string, string>): void {
+  if (!section || typeof section !== 'object') return;
+
+  for (const [prefix, value] of Object.entries(section as Record<string, unknown>)) {
+    const dir = Array.isArray(value)
+      ? value.find((v): v is string => typeof v === 'string')
+      : value;
+    if (typeof dir !== 'string' || dir.length === 0) continue;
+    map.set(normalizeNamespacePrefix(prefix), normalizeSourceDir(dir));
+  }
+}
+
+/**
+ * Build (or retrieve from cache) the PSR-4 namespace-prefix -> source-dir map
+ * for a workspace root.
+ *
+ * Returns an empty map when there is no `composer.json`, or it declares no
+ * `autoload.psr-4`/`autoload-dev.psr-4` map — callers can pass the result
+ * straight through with zero behavior change.
+ *
+ * @param workspaceRoot - Absolute path to the project root.
+ */
+export function resolvePsr4Map(workspaceRoot: string): Map<string, string> {
+  const normalizedRoot = workspaceRoot.replace(/\\/g, '/').replace(/\/$/, '');
+
+  const cached = psr4MapCache.get(normalizedRoot);
+  if (cached) return cached;
+
+  const map = new Map<string, string>();
+  const composerJson = readComposerJson(path.join(normalizedRoot, 'composer.json'));
+  if (composerJson) {
+    collectPsr4Entries(composerJson.autoload?.['psr-4'], map);
+    collectPsr4Entries(composerJson['autoload-dev']?.['psr-4'], map);
+  }
+
+  psr4MapCache.set(normalizedRoot, map);
+  return map;
+}
+
+/**
+ * Resolve a raw PHP import specifier (e.g. `GuzzleHttp\Cookie\SetCookie`) to
+ * a workspace-relative path (e.g. `src/Cookie/SetCookie`), using a PSR-4 map
+ * built by `resolvePsr4Map`.
+ *
+ * Runs on the RAW backslash-separated specifier as emitted by
+ * `PHPImportExtractor` — this resolution step happens in
+ * `resolveImportSpecifier` (`ast/symbols.ts`) *before* `path-matching.ts`'s
+ * `normalizePath` converts `\` to `/`, so the prefix lookup below is
+ * deliberately backslash-aware rather than operating on an already-slashed
+ * form.
+ *
+ * Matches the LONGEST registered namespace prefix (a project can declare
+ * several via `autoload` + `autoload-dev`, and a more specific prefix like
+ * `Foo\Bar\` must win over a broader `Foo\` if both are registered), replaces
+ * it with the mapped directory, and converts the remaining namespace
+ * separators to `/`.
+ *
+ * No-op (returns `specifier` unchanged) when the map is empty or no prefix
+ * matches — non-PSR-4 specifiers and non-Composer projects see zero behavior
+ * change.
+ *
+ * @param specifier - The raw (pre-`normalizePath`) PHP import specifier.
+ * @param psr4Map - Map of namespace prefix (trailing `\`) -> source dir (trailing `/`).
+ */
+export function resolvePsr4Import(specifier: string, psr4Map: ReadonlyMap<string, string>): string {
+  if (psr4Map.size === 0) return specifier;
+
+  let bestPrefix: string | undefined;
+  for (const prefix of psr4Map.keys()) {
+    if (specifier.startsWith(prefix) && (!bestPrefix || prefix.length > bestPrefix.length)) {
+      bestPrefix = prefix;
+    }
+  }
+  if (!bestPrefix) return specifier;
+
+  const dir = psr4Map.get(bestPrefix) as string;
+  const rest = specifier.slice(bestPrefix.length).replace(/\\/g, '/');
+  return `${dir}${rest}`;
+}


### PR DESCRIPTION
## Summary

Closes #867. `matchesFile()`'s namespace/module matching in `path-matching.ts` guesses a project's source layout by aligning literal directory-name segments (`matchesPHPNamespace`). Neither PHP's nor Go's dominant, mainstream project convention is guessable that way:

- **PHP**: Composer's `composer.json` declares the real mapping (`"autoload": {"psr-4": {"GuzzleHttp\\": "src/"}}`) — the namespace root essentially never equals a literal directory name for a non-Laravel-style project.
- **Go**: imports are always full module paths (`github.com/gin-gonic/gin/binding`); the module's root segment never corresponds to a literal directory in a real checkout (the repo is cloned to whatever local name the user chose).

Neither manifest was ever read, so this was a **100% test-association failure** on both ecosystems' standard layouts (see #867 for the original repro: guzzle 67/67 `src/*.php` files, gin 59/59 `.go` files reporting "No test coverage" despite complete, passing test suites).

## Fix

Two small, hardcoded manifest readers — deliberately **not** a general build-system-manifest framework, per the issue's explicit scope constraint — mirroring `workspace-packages.ts`'s existing pattern exactly (parse once per workspace root, cache the result, no-op when the manifest is absent):

- `packages/parser/src/php-psr4.ts` — parses `composer.json`'s `autoload.psr-4` / `autoload-dev.psr-4` maps into `Map<namespacePrefix, dir>`; resolves an import by longest-matching prefix.
- `packages/parser/src/go-module.ts` — parses `go.mod`'s single `module` line; strips that exact prefix from any import that starts with it.

Both are wired in as a **third resolution step** (`ManifestRoots`, a new exported interface in `ast/symbols.ts`) inside `resolveImportSpecifier`, after the existing relative-import and workspace-package steps. `ast/chunker.ts`'s `prepareASTContext` builds the map once per file from the *existing* `workspaceRoot` option (no new public option needed) and threads it through. `extractImports`/`extractImportedSymbols` gained a new optional trailing parameter to carry it — existing callers that don't pass it see zero behavior change.

**Builder detail worth flagging** (left open in the plan): PHP's PSR-4 resolution runs on the **raw backslash-separated specifier** (`GuzzleHttp\Cookie\SetCookie`), not the `/`-normalized form — this resolution step runs *before* `path-matching.ts`'s `normalizePath` converts `\` to `/`, so `resolvePsr4Import` matches namespace prefixes in their native backslash form and converts only the *resolved* remainder to `/`. Documented inline in `php-psr4.ts`.

## Evidence

**Unit tests** (all new, all green):
- `packages/parser/src/php-psr4.test.ts` (12 tests) — `resolvePsr4Map` (composer.json parsing: standard shape, missing trailing slash/backslash normalization, `autoload`+`autoload-dev` merge, fallback-dir arrays, caching) and `resolvePsr4Import` (guzzle repro, no-match passthrough, longest-prefix-wins).
- `packages/parser/src/go-module.test.ts` (10 tests) — `resolveGoModulePrefix` (go.mod parsing, whitespace/directive robustness, caching) and `resolveGoModuleImport` (gin repro, external-dependency passthrough, no false-positive on a shared string prefix without a path boundary).
- `packages/parser/src/ast/chunker.test.ts` — new `describe('manifest-root mapping (PHP PSR-4, Go module) — #867')` block (5 tests): end-to-end `chunkByAST` resolution for both languages, no-manifest no-op, and `workspaceRoot`-omitted no-op (existing callers unaffected).

**Full gate chain**, all green: `format:check`, `lint` (0 errors), `typecheck`, `build`, `npm test` (parser 1161, core, review 1647, cli 1143, action 41 — all passed), `lien delta` (exit 0; only Halstead "time"-metric deltas on touched functions, no new/crossed cognitive or cyclomatic threshold — see full output below).

```
lien delta — complexity vs HEAD
  packages/parser/src/ast/chunker.ts
    ⚠ worsened  prepareASTContext        time 7m → 9m
    · new       buildManifestRoots       cognitive – → 5
  packages/parser/src/ast/symbols.ts
    ⚠ worsened  resolveImportSpecifier   time 3m → 4m
    ⚠ worsened  extractImportPaths       time 12m → 12m
    ⚠ worsened  extractImports           time 3m → 3m
    ⚠ worsened  extractSymbolsWithExtractor time 14m → 15m
    ⚠ worsened  extractImportedSymbols   time 3m → 4m
    · new       resolveManifestRoot      cognitive – → 3
  packages/parser/src/go-module.ts        (all new, max cognitive 2)
  packages/parser/src/php-psr4.ts         (all new, max cognitive 8)
  ⚠ 6 worsened · 7 files · 72 ms   [exit 0]
```

**Dogfood: live spot-check on a shallow clone of guzzle/guzzle** (built locally, native Rust parser compiled, indexed fresh, cleaned up after — clone, index directory, and `lien serve` processes all removed post-check):

```
$ lien annotate src/Cookie/SetCookie.php
Lien impact for src/Cookie/SetCookie.php:
  • 5 files import this — tests/MiddlewareTest.php, tests/Cookie/SetCookieTest.php, ...
  • Test coverage: tests/MiddlewareTest.php, tests/Cookie/SetCookieTest.php (+3 more).
```

The plan's named target flips exactly as specified. Ran `lien annotate` across all 67 `src/*.php` files: **58/67 now resolve real test coverage** (up from 0/67 on `main`). The remaining 9 (`ClientInterface.php`, `ClientTrait.php`, `CookieJarInterface.php`, `PrepareBodyMiddleware.php`, `RetryMiddleware.php`, `DigestChallenge.php`, `Env.php`, `NonSerializableTrait.php`, `ProxySelection.php`) are a **separate, pre-existing gap**: their test files exercise the class through a factory (`Middleware::prepareBody()`/`::retry()`) or an FQCN reference rather than a `use` import of the class directly, so there is no import statement for this fix (or any import-based matcher) to resolve. Confirmed by inspection — e.g. `tests/RetryMiddlewareTest.php` and `tests/PrepareBodyMiddlewareTest.php` genuinely exist and cover these files, they just don't `use GuzzleHttp\RetryMiddleware;`. Out of scope for #867.

**Go acceptance is explicitly NOT claimed in this PR.** Per the wave plan: `resolveGoModuleImport` correctly strips the `github.com/gin-gonic/gin/` prefix (unit-tested against the exact gin repro from #867), but the plan documents that `matchesFile('internal/fs', 'fs')` still tail-matches the top-level `fs.go` after prefix stripping — a separate `matchesAtBoundary` false-positive tracked as **#868**. Gin's real-repo re-sweep is deferred until #868 lands; this PR only claims the PHP dogfood result above.

## Scope (per the wave plan's "no general manifest framework" constraint)

- PHP: only `autoload.psr-4` / `autoload-dev.psr-4`. No `classmap`/`files` autoloading, no PSR-0.
- Go: only the single `go.mod` `module` line. No `replace`/`require` parsing.
- No `pnpm-workspace.yaml`, no Gradle, no Cargo, no `package.json#exports` — unchanged from existing scope.

## Changeset

`@liendev/parser`: **minor** (new public `ManifestRoots` interface, two new modules with exported functions, widened `extractImports`/`extractImportedSymbols` signatures — matching the semver level used for the identically-shaped `workspace-packages.ts` precedent, PR #681).

## Merge gating

Per the wave plan, this is **not** a clean merge-on-green: it moves `get_dependents` dependent counts and risk levels (PSR-4/Go resolution raises real dependent counts), so the orchestrator should triage the PHP re-sweep evidence above (and CI review findings) before merging. Do not treat CI-green alone as sufficient.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> The PR adds manifest-based import resolution for PHP PSR-4 and Go modules, implemented as optional trailing parameters and a new `ManifestRoots` interface. The changes are additive and well-isolated: existing callers that omit `workspaceRoot` or process non-PHP/Go languages see no behavior change. New unit tests cover the manifest parsers and end-to-end chunker resolution, and the implementation mirrors the existing `workspace-packages.ts` caching pattern.
>
> - Adds `php-psr4.ts` and `go-module.ts` manifest readers with per-workspace-root caching
> - Wires manifest roots into `resolveImportSpecifier` as an optional third resolution step
> - Extends `extractImports`/`extractImportedSymbols` with an optional trailing `manifestRoots` parameter

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e35081a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->