### PR TITLE
fix(parser): chunk C# properties as symbols (#871)

### DIFF
--- a/.changeset/csharp-property-chunks.md
+++ b/.changeset/csharp-property-chunks.md
@@ -1,0 +1,19 @@
+---
+'@liendev/parser': minor
+---
+
+Fix C# properties being invisible to symbol tooling (#871): `property_declaration` and `indexer_declaration` are now chunked as their own symbols, so `api-delta`, `get_dependents`, and `list_functions` can see a property being removed or changing type — properties are C#'s dominant public-API idiom (auto-properties, expression-bodied properties, DTO/POCO surfaces), and previously not one of them was chunked as a symbol.
+
+Chunked as `symbolType: 'method'` (Route A), reusing the existing type rather than adding a new `'property'` value to the `symbolType` union — no language emits `'property'` today, and `signature-delta.ts`'s `functionMetadataByKey`/`isExportedChunk` already treat `'method'`-typed chunks as part of a class's exported surface when the class itself is exported, so this requires zero changes outside `csharp.ts`.
+
+Covered forms:
+
+- Accessor-list properties (`public string Name { get; set; }`), including a getter-only shape and `init` accessors.
+- Expression-bodied properties (`public int Count => …`) — the signature captures the contract (type + normalized accessor shape, `{ get; }`) and deliberately excludes the getter's expression, mirroring how a method's body is excluded from its own signature: editing the expression is not a signature change, but changing the property's type or accessor shape is.
+- Static properties.
+- Interface properties.
+- Indexers (`public int this[int index] { get; set; }`), named `this` (indexers have no `name` field in the grammar).
+
+Deliberately not covered: record primary-constructor properties (`record Person(string Name)`) — the grammar represents them as plain `parameter` nodes inside the record's `parameter_list`, a different node shape than `property_declaration`, out of scope for this fix.
+
+Honest cost: chunking every property means a DTO/POCO-heavy C# codebase's index grows. Measured on a shallow clone of AutoMapper/AutoMapper (560 files, 512 `.cs`): chunk count went from 11,175 to 12,411 (+1,236, +11.1%; +1,053 of those are the new `method`-typed property/indexer chunks), and `structural.db` grew from ~23.4 MiB to ~24.4 MiB (+~1.08 MiB, +~4.6%). No other language's chunking changed.

--- a/packages/cli/src/utils/signature-delta.test.ts
+++ b/packages/cli/src/utils/signature-delta.test.ts
@@ -154,6 +154,105 @@ describe('computeExportedSignatureDelta — brand new file', () => {
   });
 });
 
+describe('computeExportedSignatureDelta — C# properties (#871)', () => {
+  it('flags a removed expression-bodied C# property as removed (AutoMapper-like Features.Count)', () => {
+    const before = `public class Features {
+    private readonly System.Collections.Generic.List<string> _features;
+    public int Count => _features?.Count ?? 0;
+}`;
+    const after = `public class Features {
+    private readonly System.Collections.Generic.List<string> _features;
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Features.cs', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'Features.Count', symbolName: 'Count', kind: 'removed' }),
+    ]);
+  });
+
+  it('flags a C# property type change as signature-changed', () => {
+    const before = `public class Features {
+    public int Count => _features?.Count ?? 0;
+}`;
+    const after = `public class Features {
+    public long Count => _features?.Count ?? 0;
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Features.cs', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({
+        symbol: 'Features.Count',
+        symbolName: 'Count',
+        kind: 'signature-changed',
+      }),
+    ]);
+  });
+
+  it('does not flag an expression-bodied property whose expression changed but type did not', () => {
+    const before = `public class Features {
+    public int Count => _features?.Count ?? 0;
+}`;
+    const after = `public class Features {
+    public int Count => _features?.Count ?? 1;
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Features.cs', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('flags a removed accessor-list C# property (auto-property) as removed', () => {
+    const before = `public class Person {
+    public string Name { get; set; }
+}`;
+    const after = `public class Person {
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Person.cs', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'Person.Name', kind: 'removed' }),
+    ]);
+  });
+
+  it('flags an accessor-list C# property that lost its setter as signature-changed', () => {
+    const before = `public class Person {
+    public string Name { get; set; }
+}`;
+    const after = `public class Person {
+    public string Name { get; }
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Person.cs', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'Person.Name', kind: 'signature-changed' }),
+    ]);
+  });
+
+  it('does not flag a C# property on a non-exported (internal) class', () => {
+    const before = `internal class Internal {
+    public int Count => 0;
+}`;
+    const after = `internal class Internal {
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Internal.cs', before, after });
+    expect(result.changes).toEqual([]);
+  });
+
+  it('still flags a C# method signature change alongside an untouched property (methods keep working)', () => {
+    const before = `public class Mapper {
+    public string Name { get; set; }
+    public void Map(int x) { }
+}`;
+    const after = `public class Mapper {
+    public string Name { get; set; }
+    public void Map(int x, int y) { }
+}`;
+    const result = computeExportedSignatureDelta({ filepath: 'Mapper.cs', before, after });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({ symbol: 'Mapper.Map', kind: 'signature-changed' }),
+    ]);
+  });
+});
+
 describe('computeExportedSignatureDelta — sort order (worst-first)', () => {
   it('sorts removed before signature-changed', () => {
     const before = [

--- a/packages/parser/src/ast/languages/csharp.test.ts
+++ b/packages/parser/src/ast/languages/csharp.test.ts
@@ -21,6 +21,11 @@ describe('C# Language', () => {
       expect(traverser.targetNodeTypes).toContain('constructor_declaration');
     });
 
+    it('should identify property_declaration and indexer_declaration as target nodes (#871)', () => {
+      expect(traverser.targetNodeTypes).toContain('property_declaration');
+      expect(traverser.targetNodeTypes).toContain('indexer_declaration');
+    });
+
     it('should identify class/interface/struct/record/enum as container types', () => {
       expect(traverser.containerTypes).toContain('class_declaration');
       expect(traverser.containerTypes).toContain('interface_declaration');
@@ -463,6 +468,126 @@ describe('C# Language', () => {
     });
   });
 
+  describe('Property/Indexer Extraction (#871)', () => {
+    it('should extract an accessor-list property ({ get; set; }) as a method-typed symbol', () => {
+      const code = `public class Person {
+    public string Name { get; set; }
+}`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(propNode, code, 'Person');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('Name');
+      expect(symbol!.type).toBe('method');
+      expect(symbol!.parentClass).toBe('Person');
+      expect(symbol!.signature).toContain('string Name');
+      expect(symbol!.signature).toContain('get;');
+      expect(symbol!.signature).toContain('set;');
+    });
+
+    it('should extract an expression-bodied property (=> …) as a method-typed symbol, contract-only', () => {
+      const code = `public class Features {
+    public int Count => _features?.Count ?? 0;
+}`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(propNode, code, 'Features');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('Count');
+      expect(symbol!.type).toBe('method');
+      expect(symbol!.signature).toContain('int Count');
+      expect(symbol!.signature).toContain('get;');
+      // Contract-only: the getter's expression is excluded, same principle as a
+      // method body being excluded from its signature.
+      expect(symbol!.signature).not.toContain('_features');
+    });
+
+    it('should extract a static property as a method-typed symbol', () => {
+      const code = `public class Config {
+    public static string StaticProp { get; set; }
+}`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(propNode, code, 'Config');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('StaticProp');
+      expect(symbol!.type).toBe('method');
+      expect(symbol!.signature).toContain('static string StaticProp');
+    });
+
+    it('should extract an interface property as a method-typed symbol', () => {
+      const code = `public interface IRepository {
+    string Name { get; set; }
+}`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(propNode, code, 'IRepository');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('Name');
+      expect(symbol!.type).toBe('method');
+      expect(symbol!.parentClass).toBe('IRepository');
+    });
+
+    it('should extract a get-only property as a method-typed symbol', () => {
+      const code = `public class InitOnly {
+    public int InitProp { get; init; }
+}`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(propNode, code, 'InitOnly');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.signature).toContain('get;');
+      expect(symbol!.signature).toContain('init;');
+    });
+
+    it('should extract a multi-line accessor-list property as a method-typed symbol', () => {
+      const code = `public class Wide {
+    public int Multi
+    {
+        get { return _x; }
+        set { _x = value; }
+    }
+}`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(propNode, code, 'Wide');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('Multi');
+      expect(symbol!.signature).toContain('int Multi');
+      expect(symbol!.signature).toContain('get;');
+      expect(symbol!.signature).toContain('set;');
+      // Contract-only: accessor bodies are excluded.
+      expect(symbol!.signature).not.toContain('_x');
+    });
+
+    it('should extract an indexer as a method-typed symbol named "this"', () => {
+      const code = `public class Container {
+    public int this[int index] { get { return 0; } set { } }
+}`;
+      const root = mustParse(code, 'csharp');
+      const indexerNode = findNode(root, 'indexer_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(indexerNode, code, 'Container');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('this');
+      expect(symbol!.type).toBe('method');
+      expect(symbol!.parentClass).toBe('Container');
+      expect(symbol!.signature).toContain('this[int index]');
+      expect(symbol!.signature).toContain('get;');
+      expect(symbol!.signature).toContain('set;');
+    });
+
+    it('should not treat record primary-constructor properties as property_declaration nodes', () => {
+      // Documents a deliberate non-coverage boundary: record positional
+      // properties (`record Person(string Name)`) are `parameter` nodes
+      // inside the record's `parameter_list`, not `property_declaration` —
+      // a different grammar shape, out of scope for #871.
+      const code = `public record Person(string Name, int Age);`;
+      const root = mustParse(code, 'csharp');
+      const propNode = findNode(root, 'property_declaration');
+      expect(propNode).toBeNull();
+    });
+  });
+
   describe('AST Chunking Integration', () => {
     it('should chunk C# methods with parentClass', () => {
       const content = `public class Calculator {
@@ -676,6 +801,72 @@ public class App {
       const executeChunk = chunks.find(c => c.metadata.symbolName === 'Execute');
       expect(executeChunk).toBeDefined();
       expect(executeChunk?.metadata.parentClass).toBe('Service');
+    });
+
+    it('should chunk a property as a method-typed symbol, distinct from the class chunk (#871)', () => {
+      const content = `public class Person {
+    public string Name { get; set; }
+    public int Age { get; set; }
+}`;
+
+      const chunks = chunkByAST('Person.cs', content);
+      // class + 2 properties, each its own chunk.
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+
+      const nameChunk = chunks.find(c => c.metadata.symbolName === 'Name');
+      expect(nameChunk).toBeDefined();
+      expect(nameChunk?.metadata.symbolType).toBe('method');
+      expect(nameChunk?.metadata.parentClass).toBe('Person');
+
+      const ageChunk = chunks.find(c => c.metadata.symbolName === 'Age');
+      expect(ageChunk).toBeDefined();
+      expect(ageChunk?.metadata.symbolType).toBe('method');
+    });
+
+    it('should chunk an expression-bodied property distinctly from an accessor-list one (#871)', () => {
+      const content = `public class Features {
+    private readonly List<string> _features;
+
+    public int Count => _features?.Count ?? 0;
+}`;
+
+      const chunks = chunkByAST('Features.cs', content);
+      const countChunk = chunks.find(c => c.metadata.symbolName === 'Count');
+      expect(countChunk).toBeDefined();
+      expect(countChunk?.metadata.symbolType).toBe('method');
+      expect(countChunk?.metadata.parentClass).toBe('Features');
+    });
+
+    it('should chunk an indexer as a method-typed symbol (#871)', () => {
+      const content = `public class Container {
+    public int this[int index] { get { return 0; } set { } }
+}`;
+
+      const chunks = chunkByAST('Container.cs', content);
+      const indexerChunk = chunks.find(
+        c => c.metadata.symbolName === 'this' && c.metadata.symbolType === 'method',
+      );
+      expect(indexerChunk).toBeDefined();
+      expect(indexerChunk?.metadata.parentClass).toBe('Container');
+    });
+
+    it('should NOT chunk record primary-constructor properties as separate symbols (#871, deliberate)', () => {
+      const content = `public record Point(int X, int Y) {
+    public double Distance() {
+        return Math.Sqrt(X * X + Y * Y);
+    }
+}`;
+
+      const chunks = chunkByAST('Point.cs', content);
+      // Only the record itself and its one real method are chunked; X/Y have
+      // no property_declaration chunk of their own (see the "should not treat
+      // record primary-constructor properties..." symbol-extraction test).
+      const propertyLikeChunks = chunks.filter(
+        c =>
+          c.metadata.symbolType === 'method' &&
+          (c.metadata.symbolName === 'X' || c.metadata.symbolName === 'Y'),
+      );
+      expect(propertyLikeChunks).toEqual([]);
     });
   });
 });

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -6,7 +6,11 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
+import {
+  extractSignature,
+  extractParameters,
+  clampSignatureLength,
+} from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -23,9 +27,28 @@ import { calculateComplexity } from '../complexity/index.js';
  *
  * Lambda expressions can appear in variable declarations:
  *   Action a = () => { ... };
+ *
+ * `property_declaration` and `indexer_declaration` are target nodes too
+ * (issue #871): properties are C#'s dominant public-API idiom (auto-props,
+ * expression-bodied props, DTO/POCO surfaces), and without a dedicated chunk
+ * per property, `api-delta`/`get_dependents`/`list_functions` are structurally
+ * blind to a property being removed or changing type. Chunked as
+ * `symbolType: 'method'` (see `extractPropertyInfo`) rather than a new
+ * `'property'` symbolType — no language emits `'property'` today, and adding
+ * one would ripple into `signature-delta.ts`, `complexity-delta.ts`, risk
+ * scoring, and formatters for a single language's gap. Record primary-
+ * constructor properties (`record Person(string Name)`) are NOT covered:
+ * the grammar represents them as plain `parameter` nodes inside the record's
+ * `parameter_list`, not `property_declaration` — a different, out-of-scope
+ * node shape.
  */
 export class CSharpTraverser implements LanguageTraverser {
-  targetNodeTypes = ['method_declaration', 'constructor_declaration'];
+  targetNodeTypes = [
+    'method_declaration',
+    'constructor_declaration',
+    'property_declaration',
+    'indexer_declaration',
+  ];
 
   containerTypes = [
     'class_declaration',
@@ -296,6 +319,8 @@ export class CSharpImportExtractor implements LanguageImportExtractor {
  * - struct_declaration (struct MyStruct {})
  * - record_declaration (record MyRecord(int X) {})
  * - enum_declaration (enum MyEnum {})
+ * - property_declaration (public string Name { get; set; } / public int Count => …)
+ * - indexer_declaration (public int this[int index] { get; set; })
  *
  * Call sites: invocation_expression (direct calls and obj.Method() calls)
  */
@@ -308,6 +333,8 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
     'struct_declaration',
     'record_declaration',
     'enum_declaration',
+    'property_declaration',
+    'indexer_declaration',
   ];
 
   extractSymbol(node: SyntaxNode, content: string, parentClass?: string): SymbolInfo | null {
@@ -326,6 +353,9 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
         return this.extractRecordInfo(node);
       case 'enum_declaration':
         return this.extractEnumInfo(node);
+      case 'property_declaration':
+      case 'indexer_declaration':
+        return this.extractPropertyInfo(node, content, parentClass);
       default:
         return null;
     }
@@ -392,6 +422,42 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       parentClass,
       signature: extractSignature(node, content),
       parameters: extractParameters(node, content),
+      complexity: calculateComplexity(node),
+    };
+  }
+
+  /**
+   * Extract a property or indexer as a `method`-typed symbol (Route A,
+   * issue #871 — see the rationale on `CSharpTraverser`). An indexer has no
+   * `name` field in the grammar (it's accessed via `this[...]`), so it is
+   * named literally `this`; C# forbids more than one indexer sharing a
+   * parameter signature, so this can't collide the way an overload-set
+   * already doesn't (same positional-pairing behavior as method overloads).
+   *
+   * The signature is built (not reused from `extractSignature`, which
+   * bounds itself on a `body` field that property/indexer nodes don't have)
+   * from the declaration head plus a normalized accessor shape, so a type
+   * change or accessor added/removed is a real signature change, but editing
+   * an expression-bodied getter's expression is not — mirroring how a
+   * method's body is excluded from its own signature.
+   */
+  private extractPropertyInfo(
+    node: SyntaxNode,
+    content: string,
+    parentClass?: string,
+  ): SymbolInfo | null {
+    const isIndexer = node.type === 'indexer_declaration';
+    const name = isIndexer ? 'this' : node.childForFieldName('name')?.text;
+    if (!name) return null;
+
+    return {
+      name,
+      type: 'method',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: extractPropertySignature(node, content),
+      parameters: isIndexer ? extractParameters(node, content) : undefined,
       complexity: calculateComplexity(node),
     };
   }
@@ -494,6 +560,50 @@ function extractCSharpReturnType(node: SyntaxNode): string | undefined {
   const typeNode = node.childForFieldName('returns');
   if (!typeNode) return undefined;
   return typeNode.text;
+}
+
+/**
+ * The declaration "head" of a property/indexer: everything up to whichever
+ * of its `accessors` (`{ get; set; }`) or `value` (`=> expr`) field comes
+ * first — e.g. "public int Count" for `public int Count => …` or
+ * "public int this[int index]" for an indexer. Neither node type has a
+ * `body` field, so `extractSignature`'s body-boundary trick doesn't apply
+ * directly; this is its property/indexer equivalent.
+ */
+function propertyHead(node: SyntaxNode, content: string): string {
+  const boundaries = [node.childForFieldName('accessors'), node.childForFieldName('value')].filter(
+    (n): n is SyntaxNode => n !== null,
+  );
+  const end =
+    boundaries.length > 0 ? Math.min(...boundaries.map(n => n.startIndex)) : node.endIndex;
+  return content.slice(node.startIndex, end).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Accessor kinds (`get`/`set`/`init`/`add`/`remove`) present on a property or
+ * indexer, normalized so an expression-bodied property (`=> expr`, no
+ * `accessor_list`) reads as its semantic equivalent: get-only. This keeps
+ * the accessor *contract* in the signature while excluding the getter's
+ * actual expression, the same principle as excluding a method's body.
+ */
+function accessorKinds(node: SyntaxNode): string[] {
+  const accessorList = node.childForFieldName('accessors');
+  if (accessorList) {
+    return accessorList.namedChildren
+      .filter(child => child.type === 'accessor_declaration')
+      .map(child => child.childForFieldName('name')?.text)
+      .filter((kind): kind is string => !!kind);
+  }
+  return node.childForFieldName('value') ? ['get'] : [];
+}
+
+/** Full property/indexer signature: declaration head + normalized accessor shape. */
+function extractPropertySignature(node: SyntaxNode, content: string): string {
+  const head = propertyHead(node, content);
+  const kinds = accessorKinds(node);
+  const signature =
+    kinds.length > 0 ? `${head} { ${kinds.map(kind => `${kind};`).join(' ')} }` : head;
+  return clampSignatureLength(signature);
 }
 
 /**


### PR DESCRIPTION
Closes #871

## What

`property_declaration` and `indexer_declaration` were never chunked as
individual symbols in the C# parser, so a property being removed or
changing type was invisible to `api-delta`, `get_dependents`, and
`list_functions` -- a real gap since properties are C#'s dominant
public-API idiom (auto-properties, expression-bodied properties,
DTO/POCO surfaces). The coarser file-level export list already
surfaced property *names*, but there was no per-symbol chunk to diff.

Route A only, per the approved plan: chunk properties/indexers as
`symbolType: 'method'`, reusing the existing type instead of widening
the `symbolType` union. No language currently emits a `'property'`
type, and `signature-delta.ts`'s `functionMetadataByKey`/
`isExportedChunk` already treat `'method'`-typed chunks as part of a
class's exported surface when the class itself is exported -- so this
required zero changes to `signature-delta.ts`, `complexity-delta.ts`,
the `symbolType` union, risk scoring, or formatters. The entire change
is contained to `packages/parser/src/ast/languages/csharp.ts`.

## Forms covered

- Accessor-list properties (`public string Name { get; set; }`),
  including getter-only and `init` accessors.
- Expression-bodied properties (`public int Count => …`) -- the
  signature captures the *contract* (type + normalized accessor shape,
  `{ get; }`) and deliberately excludes the getter's expression body,
  mirroring how a method's body is excluded from its own signature:
  editing the expression is not a signature change, but changing the
  property's type or accessor shape is.
- Static properties.
- Interface properties.
- Indexers (`public int this[int index] { get; set; }`), named
  `this` (indexers have no `name` field in the grammar).

**Deliberately not covered:** record primary-constructor properties
(`record Person(string Name)`) -- confirmed via AST inspection that
the grammar represents these as plain `parameter` nodes inside the
record's `parameter_list`, a different node shape than
`property_declaration`, out of scope for this fix. Documented in a
csharp.test.ts regression test.

## Evidence

### 1. Unit tests

- `packages/parser/src/ast/languages/csharp.test.ts`: 13 new tests
  covering the traverser's target-node registration, direct
  `extractSymbol` calls for each form above (accessor-list,
  expression-bodied contract-only signature, static, interface,
  get-only, multi-line accessor list, indexer), the record
  non-coverage boundary, and `chunkByAST` integration tests confirming
  properties/indexers chunk distinctly from their containing class.
  All 72 tests in the file pass (59 pre-existing + 13 new).
- `packages/cli/src/utils/signature-delta.test.ts`: 7 new tests
  against the plan's literal acceptance criteria --
  removing an AutoMapper-style `public int Count => _features?.Count ?? 0;`
  yields `kind: 'removed'`; changing its type (`int` -> `long`) yields
  `kind: 'signature-changed'`; changing only the expression (not the
  type) yields no change (contract-only signature verified); an
  accessor-list property losing its setter yields
  `signature-changed`; a property on a non-exported class is never
  flagged; and an untouched property doesn't interfere with an
  unrelated method's signature-changed detection. All 24 tests in the
  file pass (17 pre-existing + 7 new).

### 2. Bloat measurement (honest cost)

Indexed a shallow clone of `AutoMapper/AutoMapper` (560 files, 512
`.cs`) before and after this change, using isolated `LIEN_HOME`s and
querying `structural.db` directly:

| | Before | After | Delta |
|---|---|---|---|
| Total chunks | 11,175 | 12,411 | **+1,236 (+11.1%)** |
| C# chunks | 10,938 | 12,174 | +1,236 (+11.3%) |
| C# `method`-typed chunks | 3,680 | 4,733 | +1,053 |
| `structural.db` size | 24,489,984 B (~23.4 MiB) | 25,620,480 B (~24.4 MiB) | **+1,130,496 B (~+1.08 MiB, +4.6%)** |
| Index dir total | 24,568 KB | 25,808 KB | +1,240 KB |

~2.4 new property/indexer chunks per C# file on this repo, for a
~4.6% index-size increase. Both clones and both index directories were
removed after measurement.

### 3. Cross-language e2e

`npm run test:e2e:csharp -w packages/cli` -- clones and indexes a real
repo (MediatR) fresh. All 14 non-skipped assertions pass (indexing,
complexity analysis, symbol queries, file-context retrieval, search,
find_similar, reindexing) with no errors.

### 4. Full gate chain

- `npm run format:check` -- pass
- `npm run lint` -- 0 errors (38 pre-existing warnings, none in touched files)
- `npm run typecheck` -- pass
- `npm run build` -- pass
- `npm test` (all packages, excluding cli e2e) -- 1147 + 1150 + 41 tests pass across parser/core/review, cli, action
- `node packages/cli/dist/index.js delta` -- exit 0. One informational `⚠ worsened` (the `extractSymbol` switch's cyclomatic complexity 9 -> 11, from adding two more case labels) and four `new` low-complexity helpers (cognitive 2-5) -- no threshold crossing, no gate failure.

## Changeset

`@liendev/parser` minor (new chunking behavior).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds C# property and indexer chunking to the parser, emitting them as `symbolType: 'method'` chunks so signature-delta, get_dependents, and list_functions can detect property/indexer removals and type/accessor changes. The implementation is contained to `csharp.ts`, reuses existing downstream logic for method-typed chunks, and is accompanied by thorough unit and integration tests. No correctness bugs or breaking changes were identified: the signature construction correctly excludes expression bodies, indexers are handled via the parent-class export rule, and the doc-truth and stale-literal pre-computed candidates all resolve as unrelated or accurate.
>
> - C# `property_declaration` and `indexer_declaration` are now target/symbol node types, chunked as `method`-typed symbols
> - Property/indexer signatures capture only the contract (type + normalized accessor shape), excluding expression bodies
> - Indexers are named `this` and paired positionally like method overloads; public ones are surfaced via the exported-parent-class rule

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3dd8368. Updates automatically on new commits.</sup>
<!-- /lien-stats -->