### PR TITLE
fix(parser,cli): honest not-determinable signal for whole-module-import languages

### DIFF
--- a/.changeset/swift-assoc-honesty.md
+++ b/.changeset/swift-assoc-honesty.md
@@ -1,0 +1,16 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Honesty-only fix for #869: for whole-module-import languages (Swift's
+`import Alamofire` / `@testable import Alamofire` gives import-based
+matching no per-file signal to work with — a structural gap, not a
+matching bug), `lien annotate`'s test-coverage line no longer claims `No
+test coverage.` on files that may in fact be heavily tested. It now reports
+`Test coverage not determinable from imports (whole-module import).`
+instead, for any language whose `LanguageDefinition.wholeModuleImports` flag
+is set (only Swift today, checked via the new `hasWholeModuleImports()`
+export). No heuristic recovery (no `Package.swift` parsing, no
+name-proximity matching) — every other language's wording and behavior is
+unchanged.

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -2,6 +2,32 @@
 
 This document describes Lien's two-pass test detection system that links test files to their source files.
 
+> [!WARNING]
+> **Staleness note:** the two-pass system (convention detection + import
+> analysis) described below predates the current implementation and does not
+> match it. The shipped code runs a single import-based pass
+> (`findTestAssociationsFromChunks` in `packages/parser/src/test-associations.ts`)
+> uniformly across all registered languages — there is no separate
+> convention-matching pass, no per-tier language split, and no framework
+> detection. Swift is also absent from the language support matrix below
+> (added after this doc was last accurate). Treat the diagrams and accuracy
+> figures on this page as aspirational, not the current contract; this is
+> flagged for a dedicated doc-truth rewrite, not fixed here.
+>
+> **Whole-module-import languages (Swift): an honest limitation, not a
+> matching bug.** Swift test files import their subject as a whole module
+> (`import Alamofire`, `@testable import Alamofire`) rather than a specific
+> file or symbol path, so `chunk.metadata.imports` carries no per-file signal
+> the import-based matcher can resolve to a specific source file — this is a
+> structural gap ([#869](https://github.com/getlien/lien/issues/869)), not a
+> fixable false negative. Rather than reporting the misleading `No test
+> coverage.` on files that may in fact be heavily tested, `lien annotate`
+> reports `Test coverage not determinable from imports (whole-module
+> import).` for any language whose `LanguageDefinition.wholeModuleImports`
+> flag is set (checked via `hasWholeModuleImports()` in the language
+> registry). Only Swift sets this flag today; no other language's wording or
+> behavior changes.
+
 ## Overview
 
 Test association links each source file to the tests that cover it, so an AI assistant (or a developer) knows which tests to run after changing a given file.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -189,6 +189,30 @@ describe('formatTests', () => {
       'Test coverage: a.test.ts, b.test.ts (+2 more).',
     );
   });
+
+  // #869: whole-module-import languages (Swift confirmed) get an honest
+  // "not determinable" signal instead of the misleading "No test coverage."
+  // — import-based matching structurally cannot see per-file coverage for
+  // these languages, so an empty array does not mean untested.
+  it('reports not-determinable (not "no coverage") for an empty array on a Swift file', () => {
+    expect(formatTests([], 'Sources/Alamofire/Session.swift')).toBe(
+      'Test coverage not determinable from imports (whole-module import).',
+    );
+  });
+
+  it('still reports "No test coverage." for an empty array on a non-whole-module-import language', () => {
+    expect(formatTests([], 'src/user.ts')).toBe('No test coverage.');
+  });
+
+  it('still reports "No test coverage." for an empty array with no filepath given', () => {
+    expect(formatTests([])).toBe('No test coverage.');
+  });
+
+  it('a non-empty array on a Swift file still lists the real tests, unaffected by the honesty branch', () => {
+    expect(formatTests(['Tests/SessionTests.swift'], 'Sources/Alamofire/Session.swift')).toBe(
+      'Test coverage: Tests/SessionTests.swift.',
+    );
+  });
 });
 
 describe('formatTestReminder', () => {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -4,6 +4,8 @@ import { createVectorDB, ComplexityAnalyzer } from '@liendev/core';
 import {
   findTestAssociationsFromChunks,
   computeBlastRadiusRisk,
+  detectLanguage,
+  hasWholeModuleImports,
   type BlastRadiusRisk,
   type CodeChunk,
 } from '@liendev/parser';
@@ -351,7 +353,7 @@ function emitAnnotation(
   if (dependents.length > 0) {
     lines.push(`  • ${formatDependents(dependents, risk.level, risk.reasoning)}`);
   }
-  lines.push(`  • ${formatTests(tests)}`);
+  lines.push(`  • ${formatTests(tests, filepath)}`);
   if (complexity.warningCount > 0) {
     lines.push(`  • ${formatComplexity(complexity)}`);
   }
@@ -419,8 +421,23 @@ export function formatDependents(
   return `${count} ${noun} this — ${shown.join(', ')}${extra}; risk: ${level}${reason}.`;
 }
 
-export function formatTests(tests: string[]): string {
-  if (tests.length === 0) return 'No test coverage.';
+/**
+ * `filepath` is optional only for callers that genuinely have no file
+ * context (none exist today; kept optional so this stays a narrow,
+ * additive signature change). When present and its language is a
+ * whole-module-import language (Swift — see `LanguageDefinition.
+ * wholeModuleImports`), an empty `tests` array is reported as honestly
+ * undeterminable rather than as an absence of coverage: the file may be
+ * heavily tested, but import-based matching structurally cannot tell (#869).
+ */
+export function formatTests(tests: string[], filepath?: string): string {
+  if (tests.length === 0) {
+    const language = filepath ? detectLanguage(filepath) : null;
+    if (language && hasWholeModuleImports(language)) {
+      return 'Test coverage not determinable from imports (whole-module import).';
+    }
+    return 'No test coverage.';
+  }
   const shown = tests.slice(0, MAX_TESTS_LISTED).join(', ');
   const extra =
     tests.length > MAX_TESTS_LISTED ? ` (+${tests.length - MAX_TESTS_LISTED} more)` : '';

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { detectLanguage, getLanguage, languageExists, getAllLanguages } from './registry.js';
+import {
+  detectLanguage,
+  getLanguage,
+  languageExists,
+  getAllLanguages,
+  hasWholeModuleImports,
+} from './registry.js';
 import type { SupportedLanguage } from './registry.js';
 
 describe('Language Registry', () => {
@@ -139,6 +145,22 @@ describe('Language Registry', () => {
       const extensions = all.flatMap(d => d.extensions);
       expect(new Set(ids).size).toBe(ids.length);
       expect(new Set(extensions).size).toBe(extensions.length);
+    });
+  });
+
+  describe('hasWholeModuleImports', () => {
+    it('is true for Swift (#869: confirmed whole-module import convention)', () => {
+      expect(hasWholeModuleImports('swift')).toBe(true);
+    });
+
+    it('is false for every other registered language', () => {
+      const others = getAllLanguages()
+        .map(d => d.id)
+        .filter(id => id !== 'swift');
+      expect(others.length).toBeGreaterThan(0);
+      others.forEach(id => {
+        expect(hasWholeModuleImports(id)).toBe(false);
+      });
     });
   });
 });

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -114,6 +114,19 @@ export function languageExists(language: string): boolean {
 }
 
 /**
+ * True when `language`'s typical test files import their subject as a whole
+ * module rather than a specific file/symbol path (see
+ * `LanguageDefinition.wholeModuleImports`), so import-based test-association
+ * matching can never resolve a test file to the specific source file(s) it
+ * covers — a structural gap (#869), not a fixable matching bug. Callers use
+ * this to give an honest "not determinable" signal instead of a misleading
+ * "no coverage" one. Only Swift sets this today.
+ */
+export function hasWholeModuleImports(language: SupportedLanguage): boolean {
+  return getLanguage(language).wholeModuleImports === true;
+}
+
+/**
  * Get all registered language definitions.
  */
 export function getAllLanguages(): readonly LanguageDefinition[] {

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -446,6 +446,11 @@ export const swiftDefinition: LanguageDefinition = {
   exportExtractor: new SwiftExportExtractor(),
   importExtractor: new SwiftImportExtractor(),
   symbolExtractor: new SwiftSymbolExtractor(),
+  // Confirmed against real code (#869): `SwiftImportExtractor` extracts only
+  // the bare module path (`import Alamofire` -> `"Alamofire"`), never a
+  // per-file specifier, so import-based test-association can structurally
+  // never resolve a Swift test file to the specific source file it covers.
+  wholeModuleImports: true,
 
   complexity: {
     decisionPoints: [

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -61,4 +61,19 @@ export interface LanguageDefinition {
     /** AST node types representing function/method calls */
     callExpressionTypes: string[];
   };
+
+  /**
+   * True when this language's typical test files import their subject as a
+   * whole module (e.g. Swift's `import Alamofire` / `@testable import
+   * Alamofire`) rather than a specific per-file/per-symbol path, so
+   * `chunk.metadata.imports` carries no per-file signal an import-based
+   * test-association matcher (`matchesFile`) can ever resolve to a specific
+   * source file. This is a structural gap, not a matching bug (#869) — no
+   * heuristic recovers it here. Absent/false (the default for every
+   * language except Swift) means the existing per-file import matching
+   * applies as before; unset is NOT the same as "confirmed false", it's just
+   * unconfirmed, so only set this where the whole-module convention has
+   * been verified against real code.
+   */
+  wholeModuleImports?: boolean;
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -68,6 +68,7 @@ export {
   getLanguage,
   getAllLanguages,
   languageExists,
+  hasWholeModuleImports,
 } from './ast/languages/registry.js';
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Partial fix, #869 stays open (owner decided honesty-only; the issue also tracks the structural gap itself, which remains genuinely unrecoverable from import data alone — no per-file signal exists to reconstruct).

For whole-module-import languages, Swift being the confirmed case (`import Alamofire` / `@testable import Alamofire` gives import-based test-association matching no per-file signal — every test file in the module carries the identical bare-module import string, so `matchesFile` can structurally never resolve which specific source file a test covers), `lien annotate`'s test-coverage line previously reported the misleading `No test coverage.` on files that may in fact be heavily tested. It now reports:

```
Test coverage not determinable from imports (whole-module import).
```

This is the owner-decided "honesty-only" fix (Option 3 from the wave plan) — explicitly **not** name-proximity matching and **not** `Package.swift` parsing, both of which were declined.

## Grounding (why this stayed a small, single-site fix)

Traced before writing any code:
- The literal string is produced at exactly one site: `formatTests()` in `packages/cli/src/cli/annotate-cmd.ts`, called from exactly one place (`emitAnnotation`).
- `filepath` is already in scope one frame up from that call — no cross-layer plumbing needed.
- `detectLanguage(filepath)` is already exported from `@liendev/parser`.
- There was no existing "whole-module-import" concept on `LanguageDefinition`, so this needed one small additive field.

## Changes

- `packages/parser/src/ast/languages/types.ts`: new optional `wholeModuleImports?: boolean` field on `LanguageDefinition` (absent/false everywhere except Swift — no behavior change for any other language).
- `packages/parser/src/ast/languages/swift.ts`: sets `wholeModuleImports: true`.
- `packages/parser/src/ast/languages/registry.ts` (+ barrel export in `index.ts`): new `hasWholeModuleImports(language)` predicate.
- `packages/cli/src/cli/annotate-cmd.ts`: `formatTests(tests, filepath?)` now branches on `hasWholeModuleImports(detectLanguage(filepath))` when `tests` is empty.
- `docs/architecture/test-association.md`: a narrow, targeted callout documenting the real behavior and flagging (not fixing) the doc's pre-existing broader staleness (a fictional two-pass system) — a full rewrite is out of scope for this fix per the wave plan.

## Tests

- `registry.test.ts`: `hasWholeModuleImports('swift')` is `true`; every other registered language is `false`.
- `annotate-cmd.test.ts`: empty-tests + Swift filepath → not-determinable wording; empty-tests + non-Swift filepath → unchanged `No test coverage.`; empty-tests + no filepath → unchanged; non-empty tests on a Swift file → unaffected (still lists real tests).
- Full suite: all workspaces green (`@liendev/parser` 1136/1136, `@liendev/lien` 1147/1147, etc).

## Dogfood evidence (verbatim, shallow Alamofire clone)

```
$ node dist/index.js annotate Source/Core/Session.swift
Lien impact for Source/Core/Session.swift:
  • Test coverage not determinable from imports (whole-module import).

$ node dist/index.js annotate Source/Core/HTTPHeaders.swift
Lien impact for Source/Core/HTTPHeaders.swift:
  • Test coverage not determinable from imports (whole-module import).

$ node dist/index.js annotate Source/Core/AFError.swift
Lien impact for Source/Core/AFError.swift:
  • Test coverage not determinable from imports (whole-module import).
```

These are exactly the issue's own repro files (previously all reporting `No test coverage.` despite heavy real XCTest coverage). `Source/Alamofire.swift` (the false-hub file from #868) is unaffected by this PR — it still shows a (separately tracked, #868) matched coverage line, which is expected since this fix only changes the empty-array branch.

**A/B against the pre-fix build** (stashing the fix, rebuilding, replaying the identical clone): `Session.swift` and `HTTPHeaders.swift` both reverted to `No test coverage.`, confirming the fix is real and not a fixture artifact.

Cleanup: shallow clone and its Lien index (`~/.lien/indices/lien-dogfood-alamofire-*`) both removed after verification.

## Gate chain

`format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`, `build`, full `npm test` (all workspaces green), `lien delta` (0 threshold crossings — `formatTests` cognitive complexity moved 2→6, well under any threshold, exit 0) — all pass.

## Scope

Per the plan's explicit "what NOT to do": no `Package.swift` parsing, no name-proximity matching, no changes to any other language's wording or behavior. `docs/architecture/test-association.md`'s broader two-pass-system staleness is flagged, not fixed, in this PR — that's a separate doc-truth pass.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR is a narrow, honest-only fix for Swift whole-module imports in `lien annotate`. It adds a `wholeModuleImports` flag to `LanguageDefinition` (set only for Swift), exports a `hasWholeModuleImports()` predicate, and updates `formatTests()` to report 'Test coverage not determinable from imports (whole-module import).' instead of the misleading 'No test coverage.' when a Swift file has no matched tests. The change is additive, well-scoped, and covered by unit tests for both the registry predicate and the annotate formatting branch. No other language behavior changes, and the new export is consumed only by the intended caller.
>
> - Added `LanguageDefinition.wholeModuleImports` optional flag, set only in Swift
> - Added and exported `hasWholeModuleImports()` from the language registry
> - Updated `formatTests()` to branch on whole-module-import languages when tests array is empty
> - Added targeted tests for Swift and non-Swift empty-array cases

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 008f70e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->