### PR TITLE
fix(parser): widen LanguageImportExtractor so Go grouped imports keep every target

### DIFF
--- a/.changeset/go-grouped-imports.md
+++ b/.changeset/go-grouped-imports.md
@@ -1,0 +1,44 @@
+---
+'@liendev/parser': minor
+---
+
+Fix Go grouped `import (...)` blocks silently dropping every target but the
+first from `chunk.metadata.imports` (#863). A single `import (...)` block
+commonly groups 2+ non-stdlib packages (e.g. `import ( "fmt";
+"github.com/foo/utils"; "github.com/foo/models" )`), and each is a distinct
+target — but `GoImportExtractor.extractImportPath()`'s one-string-per-node
+contract could only ever report one, so `findTestAssociationsFromChunks`
+(which reads only `chunk.metadata.imports`) was structurally blind to any
+test file that imported a later package in the group. Confirmed on a real
+shallow clone of gin-gonic/gin: `gin.go`'s own grouped import (6 non-stdlib
+targets across `internal/bytesconv`, `internal/fs`, `render`, and three
+external packages) previously recorded only the first
+(`["internal/bytesconv"]`); it now records all six.
+
+Widens the shared `LanguageImportExtractor` interface with a new
+`extractImportPaths(node): string[]` method (returning every target in
+source order) alongside the existing singular `extractImportPath` (kept
+as-is — still used directly by ~60 existing per-language regression tests,
+and by `extractImportPaths`'s own default implementation). Every language
+extractor now implements it: nine languages (JS/TS, PHP, Python, Kotlin,
+C#, Ruby, Swift, Java, Rust) get the default shape — `extractImportPath`'s
+single result wrapped in an array via the new `toImportPathsArray` helper,
+zero behavior change — and only `GoImportExtractor` overrides it with real
+multi-target extraction; `extractImportPath` itself becomes a thin
+`extractImportPaths(node)[0] ?? null` delegate so the two can never
+disagree. `ast/symbols.ts`'s internal `extractImportPaths` (the function
+that builds `chunk.metadata.imports`) now iterates every path an import
+node yields instead of taking at most one.
+
+Deliberately scoped to Go only, per the #859 audit's existing "first wins"
+mitigation for PHP's grouped `use Ns\{A, B};` and Rust's bare-root
+`use crate::{a::X, b::Y};` groups (both already fixed to keep at least the
+first target instead of losing the whole declaration) — those two are
+pinned by regression tests added in that audit and are intentionally NOT
+widened to capture every target here; only Go's genuinely common,
+previously-total-loss case is fixed in this PR.
+
+Does not touch `processImportSymbols` (the `importedSymbols` map, used for
+symbol-usage tracking, not test-association) — Go's existing first-wins
+behavior there is unchanged; `findTestAssociationsFromChunks` reads only
+`imports`, so that was the entire blast radius for #863.

--- a/packages/parser/src/ast/extractors/types.ts
+++ b/packages/parser/src/ast/extractors/types.ts
@@ -91,10 +91,33 @@ export interface LanguageImportExtractor {
   /**
    * Extract the import path from an import node for the imports list.
    *
+   * For a declaration that groups multiple distinct targets (e.g. Go's
+   * `import ( "a"; "b" )`), this returns only the FIRST one — see
+   * `extractImportPaths` for the complete, order-preserving form. Kept
+   * as-is (not derived from `extractImportPaths`'s result in the
+   * interface contract itself) because most languages have exactly one
+   * target per declaration and existing per-language tests pin this
+   * exact "first" behavior.
+   *
    * @param node - AST node matching one of importNodeTypes
    * @returns The import path string, or null to skip
    */
   extractImportPath(node: SyntaxNode): string | null;
+
+  /**
+   * Extract ALL import targets from a single import declaration node.
+   *
+   * Most languages have exactly one target per declaration, so the
+   * default shape is `extractImportPath(node)` wrapped in an array (see
+   * `toImportPathsArray`). Go's grouped `import (...)` blocks can name
+   * several distinct external packages from one declaration node — its
+   * implementation overrides this to return every target instead of
+   * silently dropping all but the first (see #863).
+   *
+   * @param node - AST node matching one of importNodeTypes
+   * @returns Every import path declared by this node, in source order (empty if none)
+   */
+  extractImportPaths(node: SyntaxNode): string[];
 
   /**
    * Extract imported symbols mapped to their source path.
@@ -103,4 +126,14 @@ export interface LanguageImportExtractor {
    * @returns Object with importPath and symbols, or null to skip
    */
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null;
+}
+
+/**
+ * Default `extractImportPaths` shape for every language extractor that has
+ * exactly one import target per declaration node: wrap `extractImportPath`'s
+ * single result in an array (empty when it returns `null`). See
+ * `LanguageImportExtractor.extractImportPaths`.
+ */
+export function toImportPathsArray(path: string | null): string[] {
+  return path ? [path] : [];
 }

--- a/packages/parser/src/ast/languages/csharp.test.ts
+++ b/packages/parser/src/ast/languages/csharp.test.ts
@@ -322,6 +322,18 @@ describe('C# Language', () => {
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).toBeNull();
     });
+
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const code = 'using Newtonsoft.Json;';
+      const root = mustParse(code, 'csharp');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(importNode)).toEqual(['Newtonsoft.Json']);
+
+      const stdlibCode = 'using System;';
+      const stdlibRoot = mustParse(stdlibCode, 'csharp');
+      const stdlibNode = stdlibRoot.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(stdlibNode)).toEqual([]);
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -11,6 +11,7 @@ import {
   extractParameters,
   clampSignatureLength,
 } from '../extractors/symbol-helpers.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -273,6 +274,10 @@ export class CSharpImportExtractor implements LanguageImportExtractor {
     const path = this.getImportPath(node);
     if (!path || isCSharpStdLib(path)) return null;
     return path;
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/go.test.ts
+++ b/packages/parser/src/ast/languages/go.test.ts
@@ -276,6 +276,72 @@ import (
       expect(result!.importPath).toBe('github.com/lib/pq');
       expect(result!.symbols).toEqual(['pq']);
     });
+
+    describe('extractImportPaths (plural, #863)', () => {
+      it('should extract ALL external paths from a grouped import, not just the first', () => {
+        // Reproduces #863: a grouped import block naming two distinct
+        // non-stdlib targets used to silently drop the second.
+        const code = `package main
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"github.com/foo/models"
+)`;
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const paths = importExtractor.extractImportPaths(importNode);
+
+        expect(paths).toEqual(['github.com/foo/utils', 'github.com/foo/models']);
+      });
+
+      it('should return a single-element array for a single (non-grouped) import', () => {
+        const code = 'package main\nimport "github.com/gin-gonic/gin"';
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const paths = importExtractor.extractImportPaths(importNode);
+
+        expect(paths).toEqual(['github.com/gin-gonic/gin']);
+      });
+
+      it('should return an empty array for a stdlib-only grouped import', () => {
+        const code = 'package main\nimport (\n  "fmt"\n  "net/http"\n)';
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const paths = importExtractor.extractImportPaths(importNode);
+
+        expect(paths).toEqual([]);
+      });
+
+      it('should skip stdlib entries within a mixed group, preserving source order', () => {
+        const code = `package main
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"net/http"
+	"github.com/foo/models"
+)`;
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const paths = importExtractor.extractImportPaths(importNode);
+
+        expect(paths).toEqual(['github.com/foo/utils', 'github.com/foo/models']);
+      });
+
+      it('keeps extractImportPath (singular) returning only the first path, in agreement with extractImportPaths', () => {
+        const code = `package main
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"github.com/foo/models"
+)`;
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+
+        expect(importExtractor.extractImportPath(importNode)).toBe(
+          importExtractor.extractImportPaths(importNode)[0],
+        );
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -188,12 +188,33 @@ function isStdLibImport(importPath: string): boolean {
 export class GoImportExtractor implements LanguageImportExtractor {
   readonly importNodeTypes = ['import_declaration'];
 
+  /**
+   * Returns only the FIRST non-stdlib path from a grouped `import (...)`
+   * block — kept for existing callers/tests that want a single result.
+   * Delegates to `extractImportPaths` so the two can never disagree; see
+   * that method for why a grouped import can legitimately declare several
+   * distinct targets (#863).
+   */
   extractImportPath(node: SyntaxNode): string | null {
+    return this.extractImportPaths(node)[0] ?? null;
+  }
+
+  /**
+   * Returns EVERY non-stdlib path declared by this import node, in source
+   * order. A single `import (...)` block commonly groups 2+ external
+   * packages (e.g. `import ( "fmt"; "github.com/foo/utils"; "github.com/foo/models" )`),
+   * and each is a genuinely distinct target — silently keeping only the
+   * first (the pre-#863 behavior) dropped every subsequent target from
+   * `chunk.metadata.imports`, hiding any test file that only imports a
+   * later package in the group from `findTestAssociationsFromChunks`.
+   */
+  extractImportPaths(node: SyntaxNode): string[] {
+    const paths: string[] = [];
     for (const spec of this.collectImportSpecs(node)) {
       const path = this.extractSpecPath(spec);
-      if (path) return path;
+      if (path) paths.push(path);
     }
-    return null;
+    return paths;
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/java.test.ts
+++ b/packages/parser/src/ast/languages/java.test.ts
@@ -272,6 +272,20 @@ describe('Java Language', () => {
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).toBeNull();
     });
+
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const code = 'import com.google.common.collect.ImmutableList;';
+      const root = mustParse(code, 'java');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(importNode)).toEqual([
+        'com.google.common.collect.ImmutableList',
+      ]);
+
+      const stdlibCode = 'import java.util.List;';
+      const stdlibRoot = mustParse(stdlibCode, 'java');
+      const stdlibNode = stdlibRoot.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(stdlibNode)).toEqual([]);
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -227,6 +228,10 @@ export class JavaImportExtractor implements LanguageImportExtractor {
     const path = this.getImportPath(node);
     if (!path || isJavaStdLib(path)) return null;
     return stripWildcardSuffix(path);
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/javascript.test.ts
+++ b/packages/parser/src/ast/languages/javascript.test.ts
@@ -313,6 +313,18 @@ exports.bar = 42;`;
       expect(result).toBeNull();
     });
 
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const code = "import { foo } from './module';";
+      const root = mustParse(code, 'javascript');
+      const node = root.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(node)).toEqual(['./module']);
+
+      const noSourceCode = 'const x = 42;';
+      const noSourceRoot = mustParse(noSourceCode, 'javascript');
+      const noSourceNode = noSourceRoot.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(noSourceNode)).toEqual([]);
+    });
+
     it('should return null for dynamic require()', () => {
       const code = 'const mod = require(dynamicPath);';
       const root = mustParse(code, 'javascript');

--- a/packages/parser/src/ast/languages/javascript.ts
+++ b/packages/parser/src/ast/languages/javascript.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -332,6 +333,10 @@ export class JavaScriptImportExtractor implements LanguageImportExtractor {
     }
 
     return this.extractRequirePath(node);
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -162,6 +162,14 @@ describe('Kotlin Language', () => {
       expect(result?.importPath).toBe('com.example.Service');
       expect(result?.symbols).toContain('Service');
     });
+
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const [imp] = importHeaders('import com.example.Service\n');
+      expect(importExtractor.extractImportPaths(imp)).toEqual(['com.example.Service']);
+
+      const [stdlib] = importHeaders('import kotlin.collections.List\n');
+      expect(importExtractor.extractImportPaths(stdlib)).toEqual([]);
+    });
   });
 
   // ===========================================================================

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -318,6 +319,10 @@ export class KotlinImportExtractor implements LanguageImportExtractor {
     const path = this.getImportPath(node);
     if (!path || isKotlinStdLib(path)) return null;
     return stripWildcardSuffix(path);
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/php.test.ts
+++ b/packages/parser/src/ast/languages/php.test.ts
@@ -253,6 +253,13 @@ class User {
       expect(result!.importPath).toBe('App\\Models\\User');
       expect(result!.symbols).toEqual(['UserModel']);
     });
+
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const code = '<?php\nuse App\\Models\\User;';
+      const root = mustParse(code, 'php');
+      const useNode = root.namedChild(1)!;
+      expect(importExtractor.extractImportPaths(useNode)).toEqual(['App\\Models\\User']);
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -168,6 +169,10 @@ export class PHPImportExtractor implements LanguageImportExtractor {
 
   extractImportPath(node: SyntaxNode): string | null {
     return this.extractPHPUseDeclarationPath(node);
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/python.test.ts
+++ b/packages/parser/src/ast/languages/python.test.ts
@@ -253,6 +253,13 @@ describe('Python Language', () => {
       expect(importExtractor.extractImportPath(importNode)).toBe('.');
     });
 
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const code = 'import os\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(importNode)).toEqual(['os']);
+    });
+
     it('should extract ".foo" for a single-dot relative from-import', () => {
       const code = 'from .foo import x\n';
       const root = mustParse(code, 'python');

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -264,6 +265,10 @@ export class PythonImportExtractor implements LanguageImportExtractor {
    */
   extractImportPath(node: SyntaxNode): string | null {
     return this.processImportSymbols(node)?.importPath ?? null;
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/ruby.test.ts
+++ b/packages/parser/src/ast/languages/ruby.test.ts
@@ -169,6 +169,11 @@ describe('Ruby Language', () => {
     it('should declare call as the import node type', () => {
       expect(importExtractor.importNodeTypes).toEqual(['call']);
     });
+
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      expect(importExtractor.extractImportPaths(firstCall("require 'json'"))).toEqual(['json']);
+      expect(importExtractor.extractImportPaths(firstCall("puts 'hello'"))).toEqual([]);
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/ruby.ts
+++ b/packages/parser/src/ast/languages/ruby.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -186,6 +187,10 @@ export class RubyImportExtractor implements LanguageImportExtractor {
 
   extractImportPath(node: SyntaxNode): string | null {
     return extractRequirePath(node);
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -238,6 +238,18 @@ pub static COUNTER: i32 = 0;`;
       expect(result).toBeNull();
     });
 
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const code = 'use crate::auth::AuthService;';
+      const root = mustParse(code, 'rust');
+      const useNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(useNode)).toEqual(['auth/AuthService']);
+
+      const stdlibCode = 'use std::io::Read;';
+      const stdlibRoot = mustParse(stdlibCode, 'rust');
+      const stdlibNode = stdlibRoot.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(stdlibNode)).toEqual([]);
+    });
+
     // `use crate::config;` (a single segment directly off a BARE crate/self/
     // super root, no further `::`) previously resolved a correct path via
     // extractImportPath (which converts the whole node's text) but returned

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -321,6 +322,10 @@ export class RustImportExtractor implements LanguageImportExtractor {
 
     const fullPath = this.resolveFullPath(argument);
     return fullPath ? convertRustModulePath(fullPath) : null;
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -152,6 +152,14 @@ describe('Swift Language', () => {
       expect(result?.importPath).toBe('Combine.Just');
       expect(result?.symbols).toContain('Just');
     });
+
+    it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
+      const [imp] = imports('import Foundation\n');
+      expect(importExtractor.extractImportPaths(imp)).toEqual(['Foundation']);
+
+      const [stdlib] = imports('import Swift\n');
+      expect(importExtractor.extractImportPaths(stdlib)).toEqual([]);
+    });
   });
 
   // ===========================================================================

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -6,6 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
+import { toImportPathsArray } from '../extractors/types.js';
 import { extractSignature, extractReturnType } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -287,6 +288,10 @@ export class SwiftImportExtractor implements LanguageImportExtractor {
     const path = this.getImportPath(node);
     if (!path || isSwiftStdLib(path)) return null;
     return path;
+  }
+
+  extractImportPaths(node: SyntaxNode): string[] {
+    return toImportPathsArray(this.extractImportPath(node));
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -642,6 +642,35 @@ from typing import Optional
     });
   });
 
+  describe('extractImports - Go grouped imports (#863)', () => {
+    it('should extract ALL non-stdlib targets from a grouped import, not just the first', () => {
+      // Reproduces #863: a test file that only imports the SECOND grouped
+      // target used to be invisible to findTestAssociationsFromChunks,
+      // because chunk.metadata.imports silently dropped everything but the
+      // first non-stdlib path in the group.
+      const content = `
+package main
+
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"github.com/foo/models"
+)
+
+func run() {
+	fmt.Println(utils.Format(models.Load()))
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'go');
+      const imports = extractImports(parseResult.tree!.rootNode, 'go');
+
+      expect(imports).toContain('github.com/foo/utils');
+      expect(imports).toContain('github.com/foo/models');
+      expect(imports).not.toContain('fmt');
+    });
+  });
+
   describe('extractImportedSymbols - PHP', () => {
     it('should extract PHP use statement symbols', () => {
       const content = `<?php

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -127,8 +127,7 @@ function extractImportPaths(
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
-    const result = importExtractor.extractImportPath(node);
-    if (result) {
+    for (const result of importExtractor.extractImportPaths(node)) {
       imports.push(resolveImportSpecifier(result, filepath, workspacePackages, manifestRoots));
     }
   }


### PR DESCRIPTION
## Summary

Closes #863. `GoImportExtractor.extractImportPath()`'s one-string-per-node contract could only ever report the FIRST non-stdlib path found in a grouped `import (...)` block, silently dropping every subsequent target from `chunk.metadata.imports`. Since `findTestAssociationsFromChunks` (`packages/parser/src/test-associations.ts`) reads only `chunk.metadata.imports`, any test file that imports a later (non-first) package in a grouped import was structurally invisible to test-association, `verify-tests`/`recap`, and `get_files_context`'s `testAssociations` — a common-case gap, since real Go files very commonly group 2+ non-stdlib imports in one block (unlike the narrower PHP/Rust cases the #859 audit already handled with a "first wins" mitigation).

Branched off updated `main` (`f730ac18`, after #877/#867 merged), per the wave plan's sequencing — #867 and #863 share `go.ts`/`symbols.ts`.

## Fix

Per the wave plan's design: widen the shared `LanguageImportExtractor` interface (`packages/parser/src/ast/extractors/types.ts`) with a new required method:

```ts
extractImportPaths(node: SyntaxNode): string[];
```

- **Kept `extractImportPath(node): string | null` unchanged** — it's still called directly by ~60 existing per-language regression tests (added by the #859/#865 audits) that pin its exact "first" behavior, so nothing about it moves.
- **9 of 10 languages** (JS/TS, PHP, Python, Kotlin, C#, Ruby, Swift, Java, Rust) get the default shape via a new one-line shared helper, `toImportPathsArray(path)`: wrap `extractImportPath`'s single result in an array (empty when `null`). Zero behavior change for any of them.
- **`GoImportExtractor` is the only override**: `extractImportPaths` now collects every non-stdlib path from `collectImportSpecs`, not just the first. `extractImportPath` becomes a thin delegate — `this.extractImportPaths(node)[0] ?? null` — so the two can never disagree, and the existing pinned test ("should extract first external path from grouped imports") stays green unchanged.
- `ast/symbols.ts`'s internal `extractImportPaths` function (the one that actually builds `chunk.metadata.imports`) now loops over every path `importExtractor.extractImportPaths(node)` yields, instead of pushing at most one.

**Deliberate scope boundary** (per the plan): PHP's grouped `use Ns\{A, B};` and Rust's bare-root `use crate::{a::X, b::Y};` groups keep their existing "first wins" mitigation from the #859 audit — they are **not** widened to capture every target in this PR, since the plan's design sketch names Go specifically and existing regression tests for PHP/Rust must stay pinned. `processImportSymbols` (the `importedSymbols` map, used for symbol-usage tracking, not test-association) is also untouched — `findTestAssociationsFromChunks` reads only `imports`, so that was the entire blast radius.

## Evidence

**Unit tests** (all new, all green):
- `go.test.ts` — new `describe('extractImportPaths (plural, #863)')` block (5 tests): captures all targets from a grouped import (the exact repro shape), single-import wraps to one element, stdlib-only group returns `[]`, stdlib entries are skipped mid-group while preserving source order, and `extractImportPath`/`extractImportPaths()[0]` agree.
- One `extractImportPaths` sanity test added to each of the other 9 language test files (rust, javascript, php, python, kotlin, csharp, ruby, swift, java) — confirms the default wrap-in-array shape and the empty-array case.
- `symbols.test.ts` — new `describe('extractImports - Go grouped imports (#863)')`: an end-to-end `extractImports` test using the issue's own repro shape (`import ( "fmt"; "github.com/foo/utils"; "github.com/foo/models" )`), asserting both non-stdlib targets land in the result and `fmt` doesn't.

**Full gate chain**, all green: `format:check`, `lint` (0 errors), `typecheck`, `build`, `npm test` (parser 1176 — up from 1161 pre-PR, +15 new; core, review 1647, cli 1143, action 41 all still green), `lien delta` (exit 0 — every new method is 1-3 cyclomatic/cognitive; `GoImportExtractor.extractImportPath` actually *improved*, 3→0, now that it delegates instead of looping itself).

```
lien delta — complexity vs HEAD
  ...9 language files: each `extractImportPaths` new, cyclomatic 1
  packages/parser/src/ast/languages/go.ts
    · new       GoImportExtractor.extractImportPaths  cognitive – → 3
    ✓ improved  GoImportExtractor.extractImportPath    cognitive 3 → 0
  packages/parser/src/ast/symbols.ts
    ⚠ worsened  extractImportPaths  time 12m → 13m
  ⚠ 1 worsened · ✓ 1 improved · 23 files   [exit 0]
```

**Dogfood: real before/after comparison on gin-gonic/gin**, per the coordinator's methodology note (raw `chunks.imports` primitive, not `lien annotate`, which suppresses trivial-impact output). Built two CLI binaries — one from `origin/main` at `f730ac18` (post-#867, pre-#863, via a throwaway `git worktree`) and one from this branch — and indexed the SAME shallow gin clone with each, querying the same file:

`gin.go`'s own top-level grouped import block:
```go
import (
	"fmt"
	"html/template"
	// ...stdlib...
	"github.com/gin-gonic/gin/internal/bytesconv"
	filesystem "github.com/gin-gonic/gin/internal/fs"
	"github.com/gin-gonic/gin/render"
	"github.com/quic-go/quic-go/http3"
	"golang.org/x/net/http2"
	"golang.org/x/net/http2/h2c"
)
```

```
$ sqlite3 structural.db "SELECT DISTINCT imports FROM chunks WHERE file = 'gin.go';"

BEFORE (main @ f730ac18):
["internal/bytesconv"]

AFTER (this branch):
["internal/bytesconv","internal/fs","render","github.com/quic-go/quic-go/http3","golang.org/x/net/http2","golang.org/x/net/http2/h2c"]
```

All 6 non-stdlib targets now recorded, up from 1. (The `internal/*`/`render` entries are already module-prefix-stripped thanks to #867, landed in the same build.) Cleaned up fully afterward: the throwaway `git worktree`, the gin clone, and its index directory (`gin-e1d0583b`) were all removed; no `lien serve` process was started.

**Match-level acceptance is explicitly NOT claimed here.** #863 fixes import-path *extraction* completeness (getting every target into `chunk.metadata.imports` in the first place); whether those newly-captured `internal/fs`/`render`-style targets then correctly *match* a real dependent file is the shared matcher's job (`matchesFile`/`matchesAtBoundary`), which is #868's territory per the wave plan. The joint Go re-sweep waits for #868, as the plan specifies.

## Changeset

`@liendev/parser`: **minor** — matches the level used for #867 (PR #877) and for the original `workspace-packages.ts` precedent (PR #681): a widened internal capability/interface, not exported from the package's public `index.ts` surface, but changing observable indexing behavior.

## Merge gating

Per the wave plan, this is merge-on-green **with an orchestrator triage**, not auto-merge — it's a shared-interface change (`LanguageImportExtractor` touches all 10 language extractors) and the joint Go re-sweep with #868 is still pending. Not merging this myself.

## Update: rebased onto main (#879, #881, #883 landed after this branch's original point)

The first merge attempt hit conflicts: #879 (C# property chunking) and #883 (matcher bare-identifier guard) both landed on `main` after this branch's original base, and this PR touches all ten language files. Rebased `fix/go-grouped-imports` onto current `main` (`git rebase origin/main`):

- **One real conflict**, in `csharp.ts`'s import block: `main` added a `clampSignatureLength` import (for #879's property-signature clamping) on the same lines this branch added a `toImportPathsArray` import. Resolved by keeping both imports side by side — no logic conflict, since #879 touches the traverser/symbol-extractor and this PR only touches the import extractor. `csharp.test.ts` and `swift.ts` (also touched by #883) auto-merged cleanly with both branches' changes intact (verified via `git diff origin/main` post-rebase — the diff against current `main` is exactly this PR's original 24-file changeset, nothing more, nothing lost).
- Re-ran the full gate chain against the rebased tree: `format:check`, `lint` (0 errors), `typecheck`, `build` all clean; `npm test` green end-to-end (parser now 1204 tests including #879's and #883's own new tests plus this PR's 15 — `csharp.test.ts` 73 tests confirms both the property-chunking tests and this PR's `extractImportPaths` sanity test survived the merge; `path-matching.test.ts` 85 tests reflects #883's new guard tests); core/review/cli/action all still green; `lien delta` exit 0.
- Re-verified the gin.go before/after dogfood on the rebased build: fresh clone, fresh index, same raw `chunks.imports` query — still returns all 6 targets (`internal/bytesconv`, `internal/fs`, `render`, plus the 3 external packages), identical to the pre-rebase result. Cleaned up (clone + index dir removed) immediately after.
- Force-pushed (`--force-with-lease`) since this is a single-author feature branch with no other consumers — the PR now shows one clean commit (`db87db9d`) whose diff against current `main` is exactly this PR's changes.

Merge still not attempted by me — flagging back to the coordinator for the re-merge.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR widens the internal `LanguageImportExtractor` interface with a new `extractImportPaths` method and uses it in `symbols.ts` to populate `chunk.metadata.imports`. For 9 of 10 languages the new method is a trivial wrapper around the existing singular `extractImportPath`, so behavior is unchanged. Go is the only override: it now collects every non-stdlib path from a grouped `import (...)` block instead of returning just the first. The change is well-scoped, covered by new unit and end-to-end tests, and the singular `extractImportPath` contract is preserved (Go delegates to the plural method and takes `[0]`) so existing regression tests remain valid. No external callers of the interface were found, and the touched doc claims match the code.
>
> - Added `extractImportPaths(node): string[]` to `LanguageImportExtractor` with a default `toImportPathsArray` helper.
> - Go's `extractImportPaths` now returns all non-stdlib paths from grouped imports; `extractImportPath` delegates to preserve first-path behavior.
> - `symbols.ts` iterates every path from `extractImportPaths` when building `chunk.metadata.imports`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit db87db9. Updates automatically on new commits.</sup>
<!-- /lien-stats -->