### PR TITLE
fix(parser): require whole-relationship evidence for bare-identifier boundary matches

### DIFF
--- a/.changeset/boundary-match-precision.md
+++ b/.changeset/boundary-match-precision.md
@@ -1,0 +1,37 @@
+---
+"@liendev/parser": patch
+---
+
+Fix `matchesAtBoundary`/`matchesFile` (and the parallel `matchesPHPNamespace`
+reverse-component matcher) so a bare, slash-free import specifier no longer
+wins a coincidental boundary match against an unrelated multi-segment path.
+
+Confirmed independently in three languages during an OSS dogfood sweep:
+
+- **Go**: `github.com/gin-gonic/gin/internal/fs` tail-matched the unrelated
+  top-level `fs.go`, misattributing a real dependency away from
+  `internal/fs/fs.go` to the wrong file.
+- **Ruby**: a bare `require 'sinatra'` matched every file under `lib/sinatra/`
+  (`base.rb`, `main.rb`, `show_exceptions.rb`, `version.rb`), not just the
+  gem's own entry point (`lib/sinatra.rb`).
+- **Swift**: `import Combine` (Apple's system framework) falsely matched the
+  unrelated `Source/Features/Combine.swift` purely because the basenames
+  coincide.
+
+The fix is one targeted guard, not a scoring system: a bare (no `/`)
+specifier must reach the *end* of the longer string (not merely appear as an
+interior component — this alone fixes the Ruby fan-out) and may have at most
+one leading directory segment before it (the common "source directory
+prefix" convention, e.g. bare `auth` resolving to `src/auth.rs` — more than
+that is a coincidental name collision, not a real relationship). Multi-segment
+patterns, and a cleaned `./`/`../` relative import (already proof the
+specifier names a real project file, not an ambiguous external package), are
+both unaffected.
+
+`matchesPHPNamespace` independently implements the same reverse
+tail-matching idea for PHP-style namespaces and had the identical gap for a
+single-component import (e.g. the Swift `Combine` case actually flows
+through this fallback strategy, not just `matchesAtBoundary`), so it gets the
+same "at most one leading directory" guard.
+
+Fixes #868.

--- a/.changeset/boundary-match-precision.md
+++ b/.changeset/boundary-match-precision.md
@@ -20,13 +20,18 @@ Confirmed independently in three languages during an OSS dogfood sweep:
 
 The fix is one targeted guard, not a scoring system: a bare (no `/`)
 specifier must reach the *end* of the longer string (not merely appear as an
-interior component — this alone fixes the Ruby fan-out) and may have at most
-one leading directory segment before it (the common "source directory
-prefix" convention, e.g. bare `auth` resolving to `src/auth.rs` — more than
-that is a coincidental name collision, not a real relationship). Multi-segment
-patterns, and a cleaned `./`/`../` relative import (already proof the
-specifier names a real project file, not an ambiguous external package), are
-both unaffected.
+interior component — this alone fixes the Ruby fan-out), and the number of
+directory segments allowed before it depends on which side is bare. A bare
+*import* matching within a longer *target* may have at most one leading
+segment — the established "source directory prefix" convention (bare `auth`
+resolving to `src/auth.rs`). A bare *target* (a short top-level file's own
+basename) matching within a longer *import* gets no leading-segment leniency
+at all: there's no confirmed legitimate case for it, and it's exactly the Go
+bug's shape — `internal/fs` (already module-prefix-stripped by #867) must not
+tail-match an unrelated top-level `fs` target just because only one directory
+segment happens to precede the match. Multi-segment patterns, and a cleaned
+`./`/`../` relative import (already proof the specifier names a real project
+file, not an ambiguous external package), are both unaffected.
 
 `matchesPHPNamespace` independently implements the same reverse
 tail-matching idea for PHP-style namespaces and had the identical gap for a

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -294,6 +294,21 @@ describe('matchesFile - Path Boundary Checking', () => {
         expect(testMatchesFile('github.com/gin-gonic/gin/internal/fs', 'internal/fs')).toBe(true);
       });
 
+      it('Go: still rejects the bare-target shape even after #867 strips the module prefix', () => {
+        // #867 resolves the raw github.com/gin-gonic/gin/internal/fs import
+        // down to internal/fs (module prefix stripped). A bare, unrelated
+        // top-level "fs" target must still not tail-match it, even though
+        // only a single directory segment ("internal/") now precedes the
+        // match -- the same leniency that's correct for a bare *import*
+        // (Rust's auth -> src/auth.rs convention, strategy 2) is NOT
+        // legitimate for a bare *target* matched against a longer import
+        // (strategy 1): there's no confirmed real-world case for it, and
+        // it's exactly this bug's shape.
+        expect(testMatchesFile('internal/fs', 'fs')).toBe(false);
+        // The real relationship stays intact.
+        expect(testMatchesFile('internal/fs', 'internal/fs')).toBe(true);
+      });
+
       it('Ruby: a bare gem require must not fan out to every file under the gem directory', () => {
         // Every file under lib/sinatra/ must stop claiming a bare
         // `require 'sinatra'` as a match -- only the gem's own entry point

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -281,6 +281,58 @@ describe('matchesFile - Path Boundary Checking', () => {
       expect(testMatchesFile('django.utils', 'django/utils/timezone.py')).toBe(true);
     });
   });
+
+  describe('bare identifier precision (#868)', () => {
+    describe('repro canaries', () => {
+      it('Go: a bare package-relative basename must not tail-match an unrelated deep import path', () => {
+        // fs.go (top-level, unrelated) must NOT be credited with an import
+        // that's actually internal/fs's (render/html.go imports
+        // github.com/gin-gonic/gin/internal/fs).
+        expect(testMatchesFile('github.com/gin-gonic/gin/internal/fs', 'fs')).toBe(false);
+        // The real relationship (a multi-segment import matching its
+        // multi-segment target) is untouched by this guard.
+        expect(testMatchesFile('github.com/gin-gonic/gin/internal/fs', 'internal/fs')).toBe(true);
+      });
+
+      it('Ruby: a bare gem require must not fan out to every file under the gem directory', () => {
+        // Every file under lib/sinatra/ must stop claiming a bare
+        // `require 'sinatra'` as a match -- only the gem's own entry point
+        // (lib/sinatra.rb) is a real match for a bare specifier.
+        expect(testMatchesFile('sinatra', 'lib/sinatra/base')).toBe(false);
+        expect(testMatchesFile('sinatra', 'lib/sinatra/main')).toBe(false);
+        expect(testMatchesFile('sinatra', 'lib/sinatra/show_exceptions')).toBe(false);
+        expect(testMatchesFile('sinatra', 'lib/sinatra/version')).toBe(false);
+        // The gem's own entry point still matches.
+        expect(testMatchesFile('sinatra', 'lib/sinatra')).toBe(true);
+      });
+
+      it('Swift: a bare system-framework import must not match an unrelated same-named file', () => {
+        // `import Combine` (Apple's system framework) must not match
+        // Source/Features/Combine.swift merely because the basenames
+        // coincide.
+        expect(testMatchesFile('Combine', 'Source/Features/Combine')).toBe(false);
+      });
+    });
+
+    describe('legitimate bare-identifier matches stay intact', () => {
+      it('keeps the single source-directory-prefix convention (Rust-style)', () => {
+        // Already covered under "Rust module matching" above; restated here
+        // to make the #868 guard's intent explicit: exactly one leading
+        // directory segment before a bare identifier is still allowed.
+        expect(testMatchesFile('auth', 'src/auth.rs')).toBe(true);
+        expect(testMatchesFile('utils', 'src/utils.rs')).toBe(true);
+      });
+
+      it('keeps an exact bare-identifier match', () => {
+        expect(testMatchesFile('logger', 'logger')).toBe(true);
+      });
+
+      it('keeps a relative import cleaned down to a bare identifier with a single prefix segment', () => {
+        expect(testMatchesFile('./logger', 'logger')).toBe(true);
+        expect(testMatchesFile('../logger', 'logger')).toBe(true);
+      });
+    });
+  });
 });
 
 /**

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -88,6 +88,53 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
 }
 
 /**
+ * Like `matchesAtBoundary`, but additionally requires a bare (slash-free)
+ * `pattern` to represent the *whole* relationship rather than a coincidental
+ * partial one:
+ *
+ * - The match must reach the end of `str`. An interior hit means `str`
+ *   continues into an unrelated subtree beyond the identifier, e.g. a bare
+ *   `require 'sinatra'` matching every file under `lib/sinatra/` rather than
+ *   just the gem's own entry point (`lib/sinatra.rb`).
+ * - At most one directory segment may precede the match — the common "source
+ *   directory prefix" convention (bare `auth` resolving to `src/auth.rs`).
+ *   More than that is a coincidental name collision, not a real import
+ *   relationship, e.g. a bare `import Combine` (system framework) matching
+ *   `Source/Features/Combine.swift`, or a bare `fs` tail-matching
+ *   `github.com/gin-gonic/gin/internal/fs`.
+ *
+ * Used only for `matchesFile`'s strategies 1/2, which compare the raw
+ * import/target strings as given. A cleaned `./`/`../` relative import
+ * (strategy 3, below) is deliberately exempt: its leading relative marker is
+ * already proof the specifier names a real project file rather than an
+ * ambiguous external package/module/framework, so it doesn't need this extra
+ * scrutiny -- and unlike a bare package name, it carries no information about
+ * how deep the importer's own directory happens to be nested.
+ *
+ * Mirrors the same `prefixSlashes <= 1` convention already used by
+ * `matchesWithSourcePrefix` for Python module matching, below.
+ */
+function matchesAtBoundaryPrecise(str: string, pattern: string): boolean {
+  const index = str.indexOf(pattern);
+  if (index === -1) return false;
+
+  const charBefore = index > 0 ? str[index - 1] : '/';
+  if (charBefore !== '/' && index !== 0) return false;
+
+  const endIndex = index + pattern.length;
+  if (endIndex !== str.length && str[endIndex] !== '/') return false;
+
+  if (!pattern.includes('/')) {
+    if (endIndex !== str.length) return false;
+    const prefix = str.substring(0, index);
+    const prefixSlashes = (prefix.match(/\//g) || []).length;
+    if (prefixSlashes > 1) return false;
+  }
+
+  return true;
+}
+
+/**
  * Determines if an import path matches a target file path.
  *
  * Handles various matching strategies:
@@ -107,23 +154,32 @@ export function matchesFile(normalizedImport: string, normalizedTarget: string):
   if (normalizedImport === normalizedTarget) return true;
 
   // Strategy 1: Check if target path appears in import at path boundaries
-  if (matchesAtBoundary(normalizedImport, normalizedTarget)) {
+  if (matchesAtBoundaryPrecise(normalizedImport, normalizedTarget)) {
     return true;
   }
 
   // Strategy 2: Check if import path appears in target (for longer target paths)
-  if (matchesAtBoundary(normalizedTarget, normalizedImport)) {
+  if (matchesAtBoundaryPrecise(normalizedTarget, normalizedImport)) {
     return true;
   }
 
   // Strategy 3: Handle relative imports (./logger vs src/utils/logger)
-  // Remove leading ./ and ../ from import
+  // Remove leading ./ and ../ from import. Only meaningful -- and only uses
+  // the unrestricted matchesAtBoundary -- when a leading relative marker was
+  // actually stripped; that marker is what proves the specifier names a real
+  // project file rather than an ambiguous external package/module/framework
+  // (see matchesAtBoundaryPrecise's doc comment). Without one, cleanedImport
+  // is identical to normalizedImport, and strategies 1/2 above already tried
+  // (and rejected) that exact pair with the appropriate scrutiny -- rerunning
+  // it here with the looser matcher would silently undo that guard.
   const cleanedImport = normalizedImport.replace(/^(\.\.?\/)+/, '');
-  if (
-    matchesAtBoundary(cleanedImport, normalizedTarget) ||
-    matchesAtBoundary(normalizedTarget, cleanedImport)
-  ) {
-    return true;
+  if (cleanedImport !== normalizedImport) {
+    if (
+      matchesAtBoundary(cleanedImport, normalizedTarget) ||
+      matchesAtBoundary(normalizedTarget, cleanedImport)
+    ) {
+      return true;
+    }
   }
 
   // Strategy 4: PHP namespace matching
@@ -229,6 +285,15 @@ function matchesPythonModule(importPath: string, targetPath: string): boolean {
  *
  * Also useful for case-insensitive file systems.
  *
+ * A single-component (bare) importPath is the same ambiguous case
+ * `matchesAtBoundaryPrecise` (above) guards for `matchesFile`'s strategies
+ * 1/2: on its own it doesn't name a specific file, so matching it against the
+ * tail of an arbitrarily deep targetPath needs the same "at most one leading
+ * directory" limit -- otherwise a bare `import Combine` (system framework)
+ * would match `Source/Features/Combine.swift` purely because the basenames
+ * coincide, exactly like the multi-segment case this function otherwise
+ * guards against.
+ *
  * @param importPath - The normalized import path
  * @param targetPath - The normalized file path
  * @returns True if paths match case-insensitively at component boundaries
@@ -257,9 +322,14 @@ function matchesPHPNamespace(importPath: string, targetPath: string): boolean {
     }
   }
 
-  // All import components must match (from the end)
-  // This ensures App/Models/User matches web/app/Models/User but not app/Services/User
-  return matched === importComponents.length;
+  // All import components must match (from the end).
+  // This ensures App/Models/User matches web/app/Models/User but not app/Services/User.
+  if (matched !== importComponents.length) return false;
+
+  // A bare (single-component) import additionally needs the same "at most
+  // one leading directory" evidence as matchesAtBoundaryPrecise's
+  // bare-identifier guard -- see the doc comment above.
+  return importComponents.length > 1 || targetComponents.length <= 2;
 }
 
 /**

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -96,12 +96,23 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
  *   continues into an unrelated subtree beyond the identifier, e.g. a bare
  *   `require 'sinatra'` matching every file under `lib/sinatra/` rather than
  *   just the gem's own entry point (`lib/sinatra.rb`).
- * - At most one directory segment may precede the match — the common "source
- *   directory prefix" convention (bare `auth` resolving to `src/auth.rs`).
- *   More than that is a coincidental name collision, not a real import
- *   relationship, e.g. a bare `import Combine` (system framework) matching
- *   `Source/Features/Combine.swift`, or a bare `fs` tail-matching
- *   `github.com/gin-gonic/gin/internal/fs`.
+ * - At most `maxLeadingSegments` directory segments may precede the match.
+ *   The two `matchesFile` call sites need different values here because a
+ *   bare identifier plays a different role in each direction:
+ *   - Strategy 2 passes 1, allowing the established "source directory
+ *     prefix" convention (a bare *import* like `auth` resolving to
+ *     `src/auth.rs`) — a real, confirmed pattern (see the Rust tests above).
+ *   - Strategy 1 passes 0 (i.e. no match beyond the exact-match check
+ *     already done in `matchesFile`), because there's no confirmed
+ *     legitimate case for a bare *target* (a short top-level file's own
+ *     basename) matching merely the tail of a longer, qualified import —
+ *     that shape is exactly the Go bug: a manifest-resolved import like
+ *     `internal/fs` (already module-prefix-stripped by #867) must not
+ *     tail-match an unrelated top-level `fs` target just because one leading
+ *     segment happens to precede it.
+ *   Both directions still reject a bare `import Combine` (system framework)
+ *   matching `Source/Features/Combine.swift` (2 leading segments, over
+ *   either threshold).
  *
  * Used only for `matchesFile`'s strategies 1/2, which compare the raw
  * import/target strings as given. A cleaned `./`/`../` relative import
@@ -110,11 +121,12 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
  * ambiguous external package/module/framework, so it doesn't need this extra
  * scrutiny -- and unlike a bare package name, it carries no information about
  * how deep the importer's own directory happens to be nested.
- *
- * Mirrors the same `prefixSlashes <= 1` convention already used by
- * `matchesWithSourcePrefix` for Python module matching, below.
  */
-function matchesAtBoundaryPrecise(str: string, pattern: string): boolean {
+function matchesAtBoundaryPrecise(
+  str: string,
+  pattern: string,
+  maxLeadingSegments: number,
+): boolean {
   const index = str.indexOf(pattern);
   if (index === -1) return false;
 
@@ -128,7 +140,7 @@ function matchesAtBoundaryPrecise(str: string, pattern: string): boolean {
     if (endIndex !== str.length) return false;
     const prefix = str.substring(0, index);
     const prefixSlashes = (prefix.match(/\//g) || []).length;
-    if (prefixSlashes > 1) return false;
+    if (prefixSlashes > maxLeadingSegments) return false;
   }
 
   return true;
@@ -153,13 +165,15 @@ export function matchesFile(normalizedImport: string, normalizedTarget: string):
   // Exact match
   if (normalizedImport === normalizedTarget) return true;
 
-  // Strategy 1: Check if target path appears in import at path boundaries
-  if (matchesAtBoundaryPrecise(normalizedImport, normalizedTarget)) {
+  // Strategy 1: Check if target path appears in import at path boundaries.
+  // maxLeadingSegments: 0 -- see matchesAtBoundaryPrecise's doc comment.
+  if (matchesAtBoundaryPrecise(normalizedImport, normalizedTarget, 0)) {
     return true;
   }
 
-  // Strategy 2: Check if import path appears in target (for longer target paths)
-  if (matchesAtBoundaryPrecise(normalizedTarget, normalizedImport)) {
+  // Strategy 2: Check if import path appears in target (for longer target paths).
+  // maxLeadingSegments: 1 -- see matchesAtBoundaryPrecise's doc comment.
+  if (matchesAtBoundaryPrecise(normalizedTarget, normalizedImport, 1)) {
     return true;
   }
 


### PR DESCRIPTION
Fixes #868.

Design per the association-layer fix wave plan: one targeted guard on
`matchesAtBoundary`/`matchesFile` (plus the parallel `matchesPHPNamespace`
reverse-component matcher), not a scoring system. A bare (slash-free)
identifier no longer wins a boundary match against a longer, unrelated
multi-segment path unless it represents the whole relationship.

## The three repro canaries (now unit tests)

- **Go**: `github.com/gin-gonic/gin/internal/fs` no longer tail-matches the
  unrelated top-level `fs.go`. Also covers the actual post-#867 shape
  (`internal/fs` vs bare `fs`, after module-prefix stripping), verified
  against a real `gin-gonic/gin` clone: `fs.go` now shows no dependents,
  `internal/fs/fs.go` correctly keeps `render/html.go` as its real importer.
- **Ruby**: a bare `require 'sinatra'` no longer fans out to every file
  under `lib/sinatra/` (`base.rb`, `main.rb`, `show_exceptions.rb`,
  `version.rb`) — only the gem's own entry point (`lib/sinatra.rb`) matches.
- **Swift**: `import Combine` (system framework) no longer falsely matches
  the unrelated `Source/Features/Combine.swift`.

## Design notes

- The guard is direction-aware: a bare *import* matching within a longer
  *target* may have at most one leading directory segment (the established
  "source directory prefix" convention, e.g. bare `auth` resolving to
  `src/auth.rs` — Rust's existing tests). A bare *target* matching within a
  longer *import* gets zero leniency — there's no confirmed legitimate case
  for it, and it's exactly the Go bug's shape.
- A cleaned `./`/`../` relative import is exempt from the extra scrutiny:
  its relative marker is already proof it names a real project file, not an
  ambiguous external package/module/framework.
- `matchesPHPNamespace` independently implements the same reverse
  tail-matching idea and had the identical gap for a single-component
  import — it gets the same guard.

## Regression gate (per the plan)

Full existing `path-matching`, `dependency-analyzer`, and
`test-associations` suites pass **unchanged** — no existing test needed
adjusting. One existing test did flip during development (a chained
re-export case relying on a cleaned bare identifier); root-caused to
strategy 3 silently bypassing the new guard, fixed by only running
strategy 3's loose match when `./`/`../` cleaning actually happened, not by
touching the test. Full gate chain green: format, lint, typecheck, build,
full test suite (parser 1189 / core 378 / review 1647 / cli 1154 / action
41), `lien delta` exit 0.

## Merge gating

Per the wave plan, this is **not** merge-on-green — it's the wave's
highest-blast change (shared matcher, all languages, `get_dependents` too).
Opening for the orchestrator's joint re-sweep review (Go/Ruby/Swift/C#)
before merge.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Medium Risk**
>
> This PR adds a direction-aware bare-identifier guard to `matchesFile` and `matchesPHPNamespace` to stop slash-free specifiers from coincidentally tail-matching unrelated multi-segment paths. The logic is sound and well-documented, the three repro canaries are now unit tests, and the key boundaries are pinned: strategy 1 rejects a bare target with one leading segment (`internal/fs` vs `fs` → false), strategy 2 rejects a bare import with two leading segments (`Combine` vs `Source/Features/Combine` → false), and the one-segment allowed case remains (`auth` vs `src/auth.rs` → true). The main residual risk is blast radius — `matchesFile` is a shared matcher used across dependency analysis, test associations, and review — but the PR reports full existing suites passing unchanged.
>
> - Added `matchesAtBoundaryPrecise` with a `maxLeadingSegments` threshold used by strategies 1 and 2.
> - Strategy 1 (bare target in longer import) allows zero leading segments; strategy 2 (bare import in longer target) allows one leading segment.
> - Strategy 3 relative-import fallback now only runs when `./`/`../` was actually stripped, preventing it from silently bypassing the new guard.
> - `matchesPHPNamespace` mirrors the same one-leading-segment limit for single-component imports.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5907c5f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->