### PR TITLE
fix(parser,cli): suppress coincidental basename hub for whole-module imports

### DIFF
--- a/.changeset/whole-module-basename-hub.md
+++ b/.changeset/whole-module-basename-hub.md
@@ -18,14 +18,17 @@ can ever win a `matchesFile` comparison is this coincidental basename
 match — never a real per-file relationship. New
 `isUnresolvableWholeModuleImport(importSpecifier, importerFile)` in
 `@liendev/parser` lets callers skip a bare whole-module import before it
-ever reaches `matchesFile`, wired into all four callers that independently
-implement import matching: `findTestAssociationsFromChunks` and
-`analyzeDependencies`/`buildImportIndex` in `@liendev/parser` (test
-coverage and dependents for `ComplexityAnalyzer`/`get_complexity`), and the
-CLI's own `get_dependents` import index and `get_files_context`'s
-`findTestAssociations` (the "N files import this" dependents count, `lien
-annotate`'s dependents line, and the `testAssociations` field every
-pre-edit `get_files_context` call returns). `Source/Alamofire.swift` now
+ever reaches `matchesFile`, wired into all six callers that independently
+implement import matching: `findTestAssociationsFromChunks`,
+`analyzeDependencies`/`buildImportIndex`, and the exported
+`chunkImportsFrom` primitive in `@liendev/parser` (test coverage and
+dependents for `ComplexityAnalyzer`/`get_complexity`, and the public
+per-chunk import check), and the CLI's own `get_dependents` import index,
+`get_files_context`'s `findTestAssociations`, and `get_dependents`'s
+symbol-level `fileImportsSymbolFromAny` (the "N files import this"
+dependents count, `lien annotate`'s dependents line, the
+`testAssociations` field every pre-edit `get_files_context` call returns,
+and symbol-level `get_dependents` queries). `Source/Alamofire.swift` now
 correctly falls back to #869's "not determinable from imports" signal (or
 an empty dependents/test-associations result) everywhere instead of
 reporting a false hub.

--- a/.changeset/whole-module-basename-hub.md
+++ b/.changeset/whole-module-basename-hub.md
@@ -1,0 +1,31 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Fix #884: a source file whose basename coincidentally equals its own
+module's name (Swift's `Source/Alamofire.swift` in the `Alamofire` module)
+sat inside #868/#883's deliberate one-leading-segment leniency window (the
+same window that legitimately allows Rust's bare `auth` -> `src/auth.rs`)
+and falsely hubbed every whole-module test file (`import Alamofire`) onto
+that one file — reported as ~38 test associations and ~43 dependents on a
+43-line file.
+
+Extends #869's honesty treatment rather than touching the shared matcher:
+for a `wholeModuleImports` language (Swift), `SwiftImportExtractor` never
+emits anything but the bare module name, so the *only* way such an import
+can ever win a `matchesFile` comparison is this coincidental basename
+match — never a real per-file relationship. New
+`isUnresolvableWholeModuleImport(importSpecifier, importerFile)` in
+`@liendev/parser` lets callers skip a bare whole-module import before it
+ever reaches `matchesFile`, wired into both halves of the association
+pipeline: `findTestAssociationsFromChunks` (test coverage) and
+`get_dependents`'s import index (the "N files import this" dependents
+count and `lien annotate`'s dependents line). `Source/Alamofire.swift` now
+correctly falls back to #869's "not determinable from imports" signal on
+both lines instead of reporting a false hub.
+
+`matchesAtBoundaryPrecise`'s general one-leading-segment guard is
+untouched — Rust's `auth` -> `src/auth.rs` and every other non-whole-module
+language keep matching exactly as before; the fix is scoped entirely to the
+caller layer for `wholeModuleImports` languages.

--- a/.changeset/whole-module-basename-hub.md
+++ b/.changeset/whole-module-basename-hub.md
@@ -18,12 +18,17 @@ can ever win a `matchesFile` comparison is this coincidental basename
 match — never a real per-file relationship. New
 `isUnresolvableWholeModuleImport(importSpecifier, importerFile)` in
 `@liendev/parser` lets callers skip a bare whole-module import before it
-ever reaches `matchesFile`, wired into both halves of the association
-pipeline: `findTestAssociationsFromChunks` (test coverage) and
-`get_dependents`'s import index (the "N files import this" dependents
-count and `lien annotate`'s dependents line). `Source/Alamofire.swift` now
-correctly falls back to #869's "not determinable from imports" signal on
-both lines instead of reporting a false hub.
+ever reaches `matchesFile`, wired into all four callers that independently
+implement import matching: `findTestAssociationsFromChunks` and
+`analyzeDependencies`/`buildImportIndex` in `@liendev/parser` (test
+coverage and dependents for `ComplexityAnalyzer`/`get_complexity`), and the
+CLI's own `get_dependents` import index and `get_files_context`'s
+`findTestAssociations` (the "N files import this" dependents count, `lien
+annotate`'s dependents line, and the `testAssociations` field every
+pre-edit `get_files_context` call returns). `Source/Alamofire.swift` now
+correctly falls back to #869's "not determinable from imports" signal (or
+an empty dependents/test-associations result) everywhere instead of
+reporting a false hub.
 
 `matchesAtBoundaryPrecise`'s general one-leading-segment guard is
 untouched — Rust's `auth` -> `src/auth.rs` and every other non-whole-module

--- a/.changeset/whole-module-basename-hub.md
+++ b/.changeset/whole-module-basename-hub.md
@@ -18,19 +18,20 @@ can ever win a `matchesFile` comparison is this coincidental basename
 match — never a real per-file relationship. New
 `isUnresolvableWholeModuleImport(importSpecifier, importerFile)` in
 `@liendev/parser` lets callers skip a bare whole-module import before it
-ever reaches `matchesFile`, wired into all six callers that independently
-implement import matching: `findTestAssociationsFromChunks`,
-`analyzeDependencies`/`buildImportIndex`, and the exported
-`chunkImportsFrom` primitive in `@liendev/parser` (test coverage and
-dependents for `ComplexityAnalyzer`/`get_complexity`, and the public
-per-chunk import check), and the CLI's own `get_dependents` import index,
+ever reaches `matchesFile`, wired into all seven callers that
+independently implement import matching: `findTestAssociationsFromChunks`,
+`analyzeDependencies`/`buildImportIndex`, the exported `chunkImportsFrom`
+primitive, and `collectImportedSymbolsFromSource` (the shared re-export
+symbol collector behind `findReExportedSymbolsForFile`) in
+`@liendev/parser` — plus the CLI's own `get_dependents` import index,
 `get_files_context`'s `findTestAssociations`, and `get_dependents`'s
-symbol-level `fileImportsSymbolFromAny` (the "N files import this"
+symbol-level `fileImportsSymbolFromAny`. Covers the "N files import this"
 dependents count, `lien annotate`'s dependents line, the
 `testAssociations` field every pre-edit `get_files_context` call returns,
-and symbol-level `get_dependents` queries). `Source/Alamofire.swift` now
-correctly falls back to #869's "not determinable from imports" signal (or
-an empty dependents/test-associations result) everywhere instead of
+symbol-level `get_dependents` queries, re-export/barrel-file tracking, and
+`get_complexity`'s dependents. `Source/Alamofire.swift` now correctly
+falls back to #869's "not determinable from imports" signal (or an empty
+dependents/test-associations/re-export result) everywhere instead of
 reporting a false hub.
 
 `matchesAtBoundaryPrecise`'s general one-leading-segment guard is

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -765,6 +765,31 @@ describe('findDependents', () => {
 
       expect(result.dependents.map(d => d.filepath)).toEqual(['Tests/SessionTests.swift']);
     });
+
+    it('does not resolve a symbol-level query through fileImportsSymbolFromAny via the same basename coincidence', async () => {
+      // SwiftImportExtractor.processImportSymbols records a bare `import
+      // Alamofire` as importedSymbols: { Alamofire: ['Alamofire'] } (the
+      // "symbol" is just the module's own name). A symbol-level query for
+      // that exact name must not resolve through the coincidental basename
+      // match either.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Source/Alamofire.swift', { exports: ['AF', 'AFInfo'] }),
+        createChunk('Tests/SessionTests.swift', {
+          imports: ['Alamofire'],
+          importedSymbols: { Alamofire: ['Alamofire'] },
+          callSites: [{ symbol: 'Alamofire', line: 3 }],
+        }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'Source/Alamofire.swift',
+        mockLog,
+        'Alamofire',
+      );
+
+      expect(result.dependents).toHaveLength(0);
+    });
   });
 
   describe('import index caching', () => {

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -721,6 +721,52 @@ describe('findDependents', () => {
     });
   });
 
+  describe('whole-module-import basename hub (#884)', () => {
+    // The Alamofire shape: Source/Alamofire.swift's basename coincidentally
+    // equals the module name every test file bare-imports (`import
+    // Alamofire`, whole-module). Before #884 this fell inside #868/#883's
+    // deliberate one-leading-segment leniency (the same window that
+    // legitimately allows Rust's `auth` -> `src/auth.rs`) and falsely hubbed
+    // every whole-module test file onto this file.
+    it('does not count Swift whole-module test imports as dependents of a same-basename file', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Source/Alamofire.swift'),
+        createChunk('Tests/SessionTests.swift', { imports: ['Alamofire'] }),
+        createChunk('Tests/ValidationTests.swift', { imports: ['Alamofire'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Source/Alamofire.swift', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+    });
+
+    it('still counts a real dependent via the identical one-leading-segment shape for a non-whole-module language', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/auth.rs'),
+        createChunk('tests/auth_test.rs', { imports: ['auth'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/auth.rs', mockLog);
+
+      expect(result.dependents.map(d => d.filepath)).toEqual(['tests/auth_test.rs']);
+    });
+
+    it('leaves other Swift files alone when their imports are not bare whole-module hits', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Source/Networking/Session.swift'),
+        createChunk('Tests/SessionTests.swift', { imports: ['./Networking/Session'] }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'Source/Networking/Session.swift',
+        mockLog,
+      );
+
+      expect(result.dependents.map(d => d.filepath)).toEqual(['Tests/SessionTests.swift']);
+    });
+  });
+
   describe('import index caching', () => {
     it('should cache scan results and reuse on same indexVersion', async () => {
       const chunks = [

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -6,6 +6,7 @@ import {
   matchesFile,
   getCanonicalPath,
   isTestFile,
+  isUnresolvableWholeModuleImport,
   COMPLEXITY_THRESHOLDS,
 } from '@liendev/parser';
 
@@ -174,6 +175,28 @@ function fileImportsSymbolFromAny(
 }
 
 /**
+ * Index one (importPath, chunk) pair, unless it's a bare whole-module import
+ * (#884): for a `wholeModuleImports` language (Swift), a bare import can only
+ * ever match a target through basename coincidence, not a real per-file
+ * dependency — see `isUnresolvableWholeModuleImport`'s doc comment. Indexing
+ * it anyway would let it win both the direct-lookup and fuzzy-match branches
+ * of `findDependentChunks` below purely by coincidence.
+ */
+function indexImportEntry(
+  importPath: string,
+  chunk: SearchResult,
+  normalizePathCached: (path: string) => string,
+  importIndex: Map<string, SearchResult[]>,
+): void {
+  if (isUnresolvableWholeModuleImport(importPath, chunk.metadata.file)) return;
+  const normalizedImport = normalizePathCached(importPath);
+  if (!importIndex.has(normalizedImport)) {
+    importIndex.set(normalizedImport, []);
+  }
+  importIndex.get(normalizedImport)!.push(chunk);
+}
+
+/**
  * Add a chunk to the import index.
  */
 function addChunkToImportIndex(
@@ -183,21 +206,13 @@ function addChunkToImportIndex(
 ): void {
   const imports = chunk.metadata.imports || [];
   for (const imp of imports) {
-    const normalizedImport = normalizePathCached(imp);
-    if (!importIndex.has(normalizedImport)) {
-      importIndex.set(normalizedImport, []);
-    }
-    importIndex.get(normalizedImport)!.push(chunk);
+    indexImportEntry(imp, chunk, normalizePathCached, importIndex);
   }
 
   const importedSymbols = chunk.metadata.importedSymbols;
   if (importedSymbols && typeof importedSymbols === 'object') {
     for (const modulePath of Object.keys(importedSymbols)) {
-      const normalizedImport = normalizePathCached(modulePath);
-      if (!importIndex.has(normalizedImport)) {
-        importIndex.set(normalizedImport, []);
-      }
-      importIndex.get(normalizedImport)!.push(chunk);
+      indexImportEntry(modulePath, chunk, normalizePathCached, importIndex);
     }
   }
 }

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -151,6 +151,11 @@ function buildReExportGraph(
 /**
  * Check if any chunk in the file imports the target symbol from any of the
  * given paths (direct target or re-exporter paths).
+ *
+ * Skips bare whole-module imports (#884): for a `wholeModuleImports`
+ * language (Swift), a bare import can only ever match a target through
+ * basename coincidence, not a real per-file dependency — see
+ * `isUnresolvableWholeModuleImport`'s doc comment.
  */
 function fileImportsSymbolFromAny(
   chunks: SearchResult[],
@@ -162,15 +167,14 @@ function fileImportsSymbolFromAny(
     const importedSymbols = chunk.metadata.importedSymbols;
     if (!importedSymbols) return false;
 
-    for (const [importPath, symbols] of Object.entries(importedSymbols)) {
+    return Object.entries(importedSymbols).some(([importPath, symbols]) => {
+      if (isUnresolvableWholeModuleImport(importPath, chunk.metadata.file)) return false;
       const normalizedImport = normalizePathCached(importPath);
       const matchesAny = targetPaths.some(tp => matchesFile(normalizedImport, tp));
-      if (matchesAny) {
-        if (symbols.includes(targetSymbol)) return true;
-        if (symbols.some(s => s.startsWith('* as '))) return true;
-      }
-    }
-    return false;
+      return (
+        matchesAny && (symbols.includes(targetSymbol) || symbols.some(s => s.startsWith('* as ')))
+      );
+    });
   });
 }
 

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -258,6 +258,42 @@ describe('handleGetFilesContext - test-association scan (scanAll fast path + cac
     expect(parsed.testAssociations).toEqual(['src/__tests__/auth.test.ts']);
   });
 
+  describe('whole-module-import basename hub (#884)', () => {
+    it('does not associate a Swift file whose basename equals the module name with every whole-module test', async () => {
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([
+          makeChunk('Source/Alamofire.swift'),
+          makeChunk('Tests/SessionTests.swift', ['Alamofire']),
+          makeChunk('Tests/ValidationTests.swift', ['Alamofire']),
+        ]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'Source/Alamofire.swift', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual([]);
+    });
+
+    it('still associates a real Rust file via the identical one-leading-segment shape', async () => {
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([makeChunk('src/auth.rs'), makeChunk('tests/auth_test.rs', ['auth'])]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'src/auth.rs', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual(['tests/auth_test.rs']);
+    });
+  });
+
   it('caches the scan across calls with the same indexVersion (no re-scan)', async () => {
     const scanAll = vi.fn().mockResolvedValue([]);
     const ctx = makeCtx({ scanAll, indexVersion: 42 });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -7,6 +7,7 @@ import {
   matchesFile,
   getCanonicalPath,
   isTestFile,
+  isUnresolvableWholeModuleImport,
   MAX_CHUNKS_PER_FILE,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
 } from '@liendev/parser';
@@ -232,6 +233,14 @@ export function createPathCache(workspaceRoot: string): {
  * Scans all indexed chunks to find test files that have import
  * statements matching the target files.
  *
+ * Skips bare whole-module imports (#884): for a `wholeModuleImports`
+ * language (Swift), a bare import can only ever match a target through
+ * basename coincidence, not a real per-file association — see
+ * `isUnresolvableWholeModuleImport`'s doc comment. This mirrors the same
+ * guard in `@liendev/parser`'s `findTestAssociationsFromChunks`; this
+ * function is `get_files_context`'s own separate implementation, so it
+ * needs the identical treatment.
+ *
  * @param filepaths - Array of source file paths
  * @param allChunks - All chunks from the vector database
  * @param ctx - Handler context
@@ -258,6 +267,7 @@ export function findTestAssociations(
       // Check if this test file imports the target
       const imports = chunk.metadata.imports || [];
       for (const imp of imports) {
+        if (isUnresolvableWholeModuleImport(imp, chunk.metadata.file)) continue;
         const normalizedImport = normalize(imp);
         if (matchesFile(normalizedImport, normalizedTarget)) {
           testFiles.add(chunkFile);

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -595,6 +595,34 @@ describe('findReExportedSymbolsForFile', () => {
     ];
     expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual(['ns']);
   });
+
+  describe('whole-module-import basename hub (#884)', () => {
+    it('does not falsely credit a Swift whole-module bare import as re-exporting from a same-basename source', () => {
+      // SwiftImportExtractor.processImportSymbols records a bare `import
+      // Alamofire` as importedSymbols: { Alamofire: ['Alamofire'] }. Without
+      // the guard, collectImportedSymbolsFromSource would match "Alamofire"
+      // against sourcePath "Source/Alamofire" via basename coincidence, and
+      // if the file also happens to export a symbol literally named
+      // "Alamofire", it would be falsely reported as re-exporting it.
+      const chunks = [
+        chunk('Source/Core/Session.swift', {
+          importedSymbols: { Alamofire: ['Alamofire'] },
+          exports: ['Alamofire'],
+        }),
+      ];
+      expect(findReExportedSymbolsForFile(chunks, 'Source/Alamofire', identity)).toEqual([]);
+    });
+
+    it('still finds a real re-export via the identical one-leading-segment shape for a non-whole-module language', () => {
+      const chunks = [
+        chunk('src/reexport.rs', {
+          importedSymbols: { auth: ['auth'] },
+          exports: ['auth'],
+        }),
+      ];
+      expect(findReExportedSymbolsForFile(chunks, 'src/auth', identity)).toEqual(['auth']);
+    });
+  });
 });
 
 describe('chunkImportsFrom', () => {

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   analyzeDependencies,
   findReExportedSymbolsForFile,
+  chunkImportsFrom,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';
 import type { CodeChunk, ChunkMetadata } from './types.js';
@@ -593,5 +594,51 @@ describe('findReExportedSymbolsForFile', () => {
       }),
     ];
     expect(findReExportedSymbolsForFile(chunks, 'src/a.ts', identity)).toEqual(['ns']);
+  });
+});
+
+describe('chunkImportsFrom', () => {
+  const identity = (path: string): string => path;
+
+  function makeChunk(
+    file: string,
+    options: { imports?: string[]; importedSymbols?: Record<string, string[]> } = {},
+  ): CodeChunk {
+    return {
+      content: '',
+      metadata: {
+        file,
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        language: 'typescript',
+        imports: options.imports,
+        importedSymbols: options.importedSymbols,
+      } as ChunkMetadata,
+    };
+  }
+
+  describe('whole-module-import basename hub (#884)', () => {
+    it('does not report a Swift whole-module bare import as importing a same-basename target (raw imports array)', () => {
+      const chunk = makeChunk('Tests/SessionTests.swift', { imports: ['Alamofire'] });
+      expect(chunkImportsFrom(chunk, 'Source/Alamofire', identity)).toBe(false);
+    });
+
+    it('does not report a Swift whole-module bare import as importing a same-basename target (importedSymbols keys)', () => {
+      const chunk = makeChunk('Tests/SessionTests.swift', {
+        importedSymbols: { Alamofire: ['Alamofire'] },
+      });
+      expect(chunkImportsFrom(chunk, 'Source/Alamofire', identity)).toBe(false);
+    });
+
+    it('still reports the identical shape for a non-whole-module language (Rust auth -> src/auth.rs)', () => {
+      const chunk = makeChunk('tests/auth_test.rs', { imports: ['auth'] });
+      expect(chunkImportsFrom(chunk, 'src/auth', identity)).toBe(true);
+    });
+
+    it('still reports a real import from a Swift file when it is not the bare whole-module case', () => {
+      const chunk = makeChunk('Tests/SessionTests.swift', { imports: ['./Networking/Session'] });
+      expect(chunkImportsFrom(chunk, 'Source/Networking/Session', identity)).toBe(true);
+    });
   });
 });

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -493,6 +493,32 @@ describe('analyzeDependencies', () => {
       expect(result.dependents[0].filepath).toBe('src/app.ts');
     });
   });
+
+  describe('whole-module-import basename hub (#884)', () => {
+    it('does not count Swift whole-module test imports as dependents of a same-basename file', () => {
+      const chunks: CodeChunk[] = [
+        createChunk('Source/Alamofire.swift', []),
+        createChunk('Tests/SessionTests.swift', ['Alamofire']),
+        createChunk('Tests/ValidationTests.swift', ['Alamofire']),
+      ];
+
+      const result = analyzeDependencies('Source/Alamofire.swift', chunks, workspaceRoot);
+
+      expect(result.dependentCount).toBe(0);
+    });
+
+    it('still counts a real dependent via the identical one-leading-segment shape for a non-whole-module language', () => {
+      const chunks: CodeChunk[] = [
+        createChunk('src/auth.rs', []),
+        createChunk('tests/auth_test.rs', ['auth']),
+      ];
+
+      const result = analyzeDependencies('src/auth.rs', chunks, workspaceRoot);
+
+      expect(result.dependentCount).toBe(1);
+      expect(result.dependents[0].filepath).toBe('tests/auth_test.rs');
+    });
+  });
 });
 
 // Direct unit coverage for the shared re-export intersection algorithm,

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -316,6 +316,11 @@ const MAX_REEXPORT_DEPTH = 3;
 /**
  * Check if a single chunk imports from the given source path.
  * Checks both `importedSymbols` keys and raw `imports` array.
+ *
+ * Skips bare whole-module imports (#884): for a `wholeModuleImports`
+ * language (Swift), a bare import can only ever match a target through
+ * basename coincidence, not a real per-file dependency — see
+ * `isUnresolvableWholeModuleImport`'s doc comment.
  */
 export function chunkImportsFrom(
   chunk: CodeChunk,
@@ -323,18 +328,15 @@ export function chunkImportsFrom(
   normalizePathCached: (path: string) => string,
 ): boolean {
   const importedSymbols = chunk.metadata.importedSymbols;
-  if (importedSymbols && typeof importedSymbols === 'object') {
-    for (const importPath of Object.keys(importedSymbols)) {
-      if (matchesFile(normalizePathCached(importPath), sourcePath)) return true;
-    }
-  }
+  const importedSymbolPaths =
+    importedSymbols && typeof importedSymbols === 'object' ? Object.keys(importedSymbols) : [];
+  const allImportPaths = [...importedSymbolPaths, ...(chunk.metadata.imports || [])];
 
-  const imports = chunk.metadata.imports || [];
-  for (const imp of imports) {
-    if (matchesFile(normalizePathCached(imp), sourcePath)) return true;
-  }
-
-  return false;
+  return allImportPaths.some(
+    imp =>
+      !isUnresolvableWholeModuleImport(imp, chunk.metadata.file) &&
+      matchesFile(normalizePathCached(imp), sourcePath),
+  );
 }
 
 /**

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -1,6 +1,12 @@
 import type { CodeChunk } from './types.js';
 import type { RiskLevel } from './insights/types.js';
-import { normalizePath, getCanonicalPath, matchesFile, isTestFile } from './utils/path-matching.js';
+import {
+  normalizePath,
+  getCanonicalPath,
+  matchesFile,
+  isTestFile,
+  isUnresolvableWholeModuleImport,
+} from './utils/path-matching.js';
 import { RISK_ORDER } from './insights/types.js';
 
 /**
@@ -76,6 +82,15 @@ function createPathNormalizer(workspaceRoot: string): (path: string) => string {
  * Builds an index mapping normalized import paths to chunks that import them.
  * Enables O(1) lookup instead of O(n*m) iteration.
  *
+ * Skips bare whole-module imports (#884): for a `wholeModuleImports`
+ * language (Swift), a bare import can only ever match a target through
+ * basename coincidence, not a real per-file dependency — see
+ * `isUnresolvableWholeModuleImport`'s doc comment. This is the same guard
+ * applied in the CLI's `get_dependents` handler
+ * (`packages/cli/src/mcp/handlers/dependency-analyzer.ts`); this file feeds
+ * `analyzeDependencies`, consumed by `ComplexityAnalyzer` for complexity
+ * reports and `get_complexity`, so it needs the identical treatment.
+ *
  * @param chunks - All chunks from the vector database
  * @param normalizePathCached - Cached path normalization function
  * @returns Map of normalized import paths to chunks that import them
@@ -89,6 +104,7 @@ function buildImportIndex(
   for (const chunk of chunks) {
     const imports = chunk.metadata.imports || [];
     for (const imp of imports) {
+      if (isUnresolvableWholeModuleImport(imp, chunk.metadata.file)) continue;
       const normalizedImport = normalizePathCached(imp);
       let chunkList = importIndex.get(normalizedImport);
       if (!chunkList) {

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -366,6 +366,11 @@ export function groupChunksByNormalizedPath(
  * Deliberately ignores the raw `imports` array — a raw-only match means the
  * file imports for side effect or does `export * from`, neither of which
  * should qualify it as a re-exporter on its own (#526).
+ *
+ * Skips bare whole-module imports (#884): for a `wholeModuleImports`
+ * language (Swift), a bare import can only ever match a source path through
+ * basename coincidence, not a real re-export relationship — see
+ * `isUnresolvableWholeModuleImport`'s doc comment.
  */
 function collectImportedSymbolsFromSource(
   chunks: CodeChunk[],
@@ -376,11 +381,13 @@ function collectImportedSymbolsFromSource(
   for (const chunk of chunks) {
     const importedSymbols = chunk.metadata.importedSymbols;
     if (!importedSymbols || typeof importedSymbols !== 'object') continue;
-    for (const [importPath, syms] of Object.entries(importedSymbols)) {
-      if (matchesFile(normalizePathCached(importPath), sourcePath)) {
-        for (const sym of syms) symbols.add(sym);
-      }
-    }
+    Object.entries(importedSymbols)
+      .filter(
+        ([importPath]) =>
+          !isUnresolvableWholeModuleImport(importPath, chunk.metadata.file) &&
+          matchesFile(normalizePathCached(importPath), sourcePath),
+      )
+      .forEach(([, syms]) => syms.forEach(sym => symbols.add(sym)));
   }
   return symbols;
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -35,7 +35,13 @@ export {
 // UTILITIES
 // =============================================================================
 
-export { normalizePath, matchesFile, getCanonicalPath, isTestFile } from './utils/path-matching.js';
+export {
+  normalizePath,
+  matchesFile,
+  getCanonicalPath,
+  isTestFile,
+  isUnresolvableWholeModuleImport,
+} from './utils/path-matching.js';
 
 export { extractRepoId } from './utils/repo-id.js';
 

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -88,4 +88,51 @@ describe('findTestAssociationsFromChunks', () => {
 
     expect(result.get('src/auth.ts')).toEqual(['src/__tests__/auth.test.ts']);
   });
+
+  describe('whole-module-import basename hub (#884)', () => {
+    it('does not associate a Swift file whose basename equals the module name with every whole-module test', () => {
+      // The Alamofire shape: every test file does a bare `import Alamofire`
+      // (whole-module), and Source/Alamofire.swift's own basename happens to
+      // equal the module name. Before #884 this fell inside #868/#883's
+      // deliberate one-leading-segment leniency and falsely hubbed every
+      // test file onto this 43-line stub.
+      const chunks: CodeChunk[] = [
+        makeChunk('Source/Alamofire.swift'),
+        makeChunk('Tests/SessionTests.swift', ['Alamofire']),
+        makeChunk('Tests/ValidationTests.swift', ['Alamofire']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['Source/Alamofire.swift'], chunks);
+
+      expect(result.has('Source/Alamofire.swift')).toBe(false);
+    });
+
+    it('still associates a real Rust file via the identical one-leading-segment shape', () => {
+      // Same shape (bare import, one leading directory, basename match) but
+      // Rust is not a wholeModuleImports language, so the legitimate
+      // source-directory-prefix convention must keep working.
+      const chunks: CodeChunk[] = [
+        makeChunk('src/auth.rs'),
+        makeChunk('tests/auth_test.rs', ['auth']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/auth.rs'], chunks);
+
+      expect(result.get('src/auth.rs')).toEqual(['tests/auth_test.rs']);
+    });
+
+    it('leaves other Swift files alone when their imports are not bare whole-module hits', () => {
+      // A qualified/path-like import from a Swift test file is not the bare
+      // whole-module case the #884 guard targets, so normal matching still
+      // applies.
+      const chunks: CodeChunk[] = [
+        makeChunk('Source/Networking/Session.swift'),
+        makeChunk('Tests/SessionTests.swift', ['./Networking/Session']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['Source/Networking/Session.swift'], chunks);
+
+      expect(result.get('Source/Networking/Session.swift')).toEqual(['Tests/SessionTests.swift']);
+    });
+  });
 });

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -3,7 +3,12 @@
  * Finds test files that import given source files by analyzing chunk metadata.
  */
 
-import { isTestFile, normalizePath, matchesFile } from './utils/path-matching.js';
+import {
+  isTestFile,
+  normalizePath,
+  matchesFile,
+  isUnresolvableWholeModuleImport,
+} from './utils/path-matching.js';
 import type { CodeChunk } from './types.js';
 
 /**
@@ -40,7 +45,17 @@ export function findTestAssociationsFromChunks(
 
     for (const chunk of testChunks) {
       const imports = chunk.metadata.imports || [];
-      if (imports.some(imp => matchesFile(normalize(imp), normalizedTarget))) {
+      // Skip bare whole-module imports (#884): for a wholeModuleImports
+      // language (Swift), a bare import can only ever match a target through
+      // basename coincidence, not a real per-file association -- see
+      // isUnresolvableWholeModuleImport's doc comment.
+      if (
+        imports.some(
+          imp =>
+            !isUnresolvableWholeModuleImport(imp, chunk.metadata.file) &&
+            matchesFile(normalize(imp), normalizedTarget),
+        )
+      ) {
         testFiles.add(chunk.metadata.file);
       }
     }

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -5,6 +5,7 @@ import {
   isTestFile,
   resolveRelativeImport,
   resolveWorkspaceImport,
+  isUnresolvableWholeModuleImport,
 } from './path-matching.js';
 
 /**
@@ -346,7 +347,66 @@ describe('matchesFile - Path Boundary Checking', () => {
         expect(testMatchesFile('./logger', 'logger')).toBe(true);
         expect(testMatchesFile('../logger', 'logger')).toBe(true);
       });
+
+      it('#884: matchesFile itself is deliberately left unchanged for the Alamofire shape', () => {
+        // `import Alamofire` vs. `Source/Alamofire.swift` sits inside the
+        // exact same one-leading-segment window as the legitimate Rust
+        // `auth` -> `src/auth.rs` case above -- matchesFile cannot tell them
+        // apart, and #884's fix deliberately doesn't ask it to. The real fix
+        // lives at the caller layer (isUnresolvableWholeModuleImport, tested
+        // below), which stops wholeModuleImports-language callers from ever
+        // handing this bare import to matchesFile in the first place.
+        expect(testMatchesFile('Alamofire', 'Source/Alamofire')).toBe(true);
+      });
     });
+  });
+});
+
+/**
+ * Test cases for the #884 caller-layer guard: bare whole-module imports
+ * (Swift's `import ModuleName`) must never be handed to `matchesFile` by a
+ * wholeModuleImports-language caller, because the only way such a bare
+ * import can ever match a target is coincidental basename equality (the
+ * Alamofire false-hub shape) -- see `isUnresolvableWholeModuleImport`'s own
+ * doc comment for the full reasoning.
+ */
+describe('isUnresolvableWholeModuleImport (#884)', () => {
+  it('suppresses the Alamofire shape: bare import == module name == target basename, 1 leading segment', () => {
+    expect(isUnresolvableWholeModuleImport('Alamofire', 'Source/Alamofire.swift')).toBe(true);
+    // Also true with zero leading segments (module file at the repo root).
+    expect(isUnresolvableWholeModuleImport('Alamofire', 'Alamofire.swift')).toBe(true);
+  });
+
+  it('leaves the identical shape alone for a non-whole-module language (Rust auth -> src/auth.rs)', () => {
+    // Same "bare identifier, one leading segment, basename match" shape as
+    // Alamofire, but Rust doesn't set wholeModuleImports, so matchesFile's
+    // legitimate source-directory-prefix convention must keep working --
+    // this predicate must not suppress it.
+    expect(isUnresolvableWholeModuleImport('auth', 'src/auth.rs')).toBe(false);
+  });
+
+  it('leaves other Swift bare imports alone that do not share the target basename', () => {
+    // `import Combine` (system framework) is still a bare Swift import, but
+    // the caller only ever asks this predicate about the (import, importer)
+    // pair -- it doesn't take a target at all, since a wholeModuleImports
+    // language's bare import is unusable for *any* target, not just a
+    // basename-coincidental one (see the doc comment: matchesFile can only
+    // ever win via the coincidental path for these imports, full stop).
+    expect(isUnresolvableWholeModuleImport('Combine', 'Source/Features/Combine.swift')).toBe(true);
+  });
+
+  it('does not suppress a qualified/dotted or path-like Swift import', () => {
+    // The guard is scoped to genuinely bare (slash-free) specifiers only --
+    // a hypothetical qualified import (e.g. a submodule path containing a
+    // separator) is left alone, matching #868/#883's own "only the bare-
+    // identifier path" scope discipline.
+    expect(isUnresolvableWholeModuleImport('Alamofire/Session', 'Source/Alamofire.swift')).toBe(
+      false,
+    );
+  });
+
+  it('does not suppress bare imports from non-Swift, non-whole-module files', () => {
+    expect(isUnresolvableWholeModuleImport('logger', 'src/logger.ts')).toBe(false);
   });
 });
 

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -7,7 +7,11 @@
 
 import * as path from 'node:path';
 
-import { getSupportedExtensions } from '../ast/languages/registry.js';
+import {
+  getSupportedExtensions,
+  detectLanguage,
+  hasWholeModuleImports,
+} from '../ast/languages/registry.js';
 
 /**
  * Escape special regex characters in a string.
@@ -144,6 +148,43 @@ function matchesAtBoundaryPrecise(
   }
 
   return true;
+}
+
+/**
+ * True when `importSpecifier` is a bare (slash-free) import from a file whose
+ * language sets `LanguageDefinition.wholeModuleImports` (Swift today — see
+ * `hasWholeModuleImports`'s doc comment for #869's structural background).
+ *
+ * `matchesFile` is deliberately language-agnostic: it only ever sees raw
+ * import/target strings, never a language tag. But for a whole-module-import
+ * language, every extracted import IS the bare module name (`SwiftImport
+ * Extractor` never emits a per-file specifier), so the *only* way such an
+ * import can ever "win" a `matchesFile` comparison is through strategy 2's
+ * one-leading-segment leniency (`auth` -> `src/auth.rs`) firing purely
+ * because a target file's basename happens to coincide with the module's own
+ * name (`Source/Alamofire.swift` vs. `import Alamofire`) -- the exact #884
+ * false-hub shape, one leading segment inside the window #868/#883
+ * deliberately preserve for the legitimate Rust-style convention.
+ *
+ * Callers that discover imports per-chunk (`findTestAssociationsFromChunks`,
+ * `get_dependents`'s import index) should call this *before* handing a
+ * candidate import to `matchesFile`, and skip it entirely when true -- the
+ * honest outcome is #869's "not determinable" signal, never a match. This is
+ * intentionally the only place that combines path-matching with language
+ * data; `matchesAtBoundaryPrecise`'s general guard stays untouched and keeps
+ * serving every non-whole-module language (Rust, Go, Ruby, ...) exactly as
+ * before.
+ *
+ * @param importSpecifier - The raw (pre-normalization) import specifier
+ * @param importerFile - File path of the chunk doing the importing
+ */
+export function isUnresolvableWholeModuleImport(
+  importSpecifier: string,
+  importerFile: string,
+): boolean {
+  if (importSpecifier.includes('/')) return false;
+  const language = detectLanguage(importerFile);
+  return language !== null && hasWholeModuleImports(language);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the one named acceptance target that survived the association fix
wave (2026-07-25 resweep, `.wip/resweep-acceptance-2026-07-25.md`, Swift
section): `Source/Alamofire.swift` (a 43-line stub whose basename
coincidentally equals its own module's name) still falsely hubbed every
whole-module `import Alamofire` test file — ~38 test associations, ~43
dependents — because that shape sits inside #868/#883's deliberate
one-leading-segment leniency window, the same window that legitimately
allows Rust's bare `auth` -> `src/auth.rs`.

Implements the issue's option 1 (owner-ordered), extending the #869
honesty treatment using the existing `wholeModuleImports` /
`hasWholeModuleImports()` plumbing from #881, at the **caller layer**:

- `matchesFile`/`matchesAtBoundaryPrecise` (`packages/parser/src/utils/path-matching.ts`)
  are language-agnostic and are **not touched** — the general one-leading-segment
  guard keeps serving every non-whole-module language exactly as before.
- New `isUnresolvableWholeModuleImport(importSpecifier, importerFile)`: for a
  `wholeModuleImports` language (Swift), `SwiftImportExtractor` never emits
  anything but the bare module name, so the *only* way such an import can
  ever win a `matchesFile` comparison is the coincidental-basename shape —
  never a real per-file relationship.
- Grounding — and then Lien Review's own first pass on this PR — showed the
  bug's shape is duplicated across **four independent import-matching
  implementations**, not two. All four now carry the guard:
  - `findTestAssociationsFromChunks` (`packages/parser/src/test-associations.ts`)
    — the test-coverage line, used by `lien annotate` and `@liendev/review`'s
    blast-radius.
  - `get_dependents`'s import index, `addChunkToImportIndex` /
    `indexImportEntry` (`packages/cli/src/mcp/handlers/dependency-analyzer.ts`)
    — the "N files import this" dependents line, also used by `lien annotate`
    and the `get_dependents` MCP tool.
  - `analyzeDependencies` / `buildImportIndex`
    (`packages/parser/src/dependency-analyzer.ts`) — a separate
    implementation consumed by `ComplexityAnalyzer` for `get_complexity` /
    `lien complexity`.
  - `findTestAssociations` (`packages/cli/src/mcp/handlers/get-files-context.ts`)
    — `get_files_context`'s own separate test-association implementation,
    i.e. the `testAssociations` field every MANDATORY pre-edit
    `get_files_context` call returns.

## Evidence

**Unit tests** (`path-matching.test.ts`, `test-associations.test.ts`,
`dependency-analyzer.test.ts` in both parser and cli,
`get-files-context.test.ts`):
- Alamofire shape (bare import == module name == target basename, 1 leading
  segment) suppressed for a `wholeModuleImports` language, at the predicate
  level and all four callers.
- Identical shape still matches for a non-whole-module language (Rust
  `auth` -> `src/auth.rs` pinned, at `matchesFile`, the predicate, and all
  four callers).
- Swift files with qualified/path-like imports (not the bare whole-module
  case) unaffected.
- `matchesFile('Alamofire', 'Source/Alamofire')` pinned as still `true` —
  documents that the general matcher is deliberately untouched; the fix is
  entirely at the caller layer.

**Real-repo before/after** (shallow clone of `Alamofire/Alamofire`, fresh
index each side):

`lien annotate` — "before" built from `origin/main` at `6e653216`, "after"
from this branch:
```
# Before
Lien impact for Source/Alamofire.swift:
  • 43 files import this — watchOS Example/watchOS Example WatchKit Extension/Networking.swift, watchOS Example/watchOS Example WatchKit Extension/ContentView.swift, Example/Source/MasterViewController.swift, Example/Source/DetailViewController.swift, +39 more; risk: critical (43 callers, 4 untested, max complexity 13, untested high-complexity dependent).
  • Test coverage: Tests/WebSocketTests.swift, Tests/ValidationTests.swift (+37 more).

# After
Lien impact for Source/Alamofire.swift:
  • Test coverage not determinable from imports (whole-module import).
```

`Source/Core/Session.swift`, `Source/Core/HTTPHeaders.swift`,
`Source/Core/AFError.swift`, and `Source/Features/Combine.swift` all keep
their #881 "not determinable from imports (whole-module import)" output
identically before and after — no regression on the already-correct cases.

For the two additional call paths (found by Lien Review's own first-pass
review of this PR, see the triage comment below) — "before" built from this
branch's first commit (3638a1be), "after" from the current commit:

`analyzeDependencies('Source/Alamofire.swift', ...)` (parser's own,
feeding `get_complexity`): `dependentCount` **43 (critical) → 0 (low)**.

A live MCP `get_files_context` call (via `@modelcontextprotocol/sdk`'s
stdio client against a real `lien serve`, not just unit tests):
`testAssociations` went from all 38 test files to `[]`.

All clones, worktrees, and index directories were removed after each pass;
no stray `lien serve` process was left running.

**Full suites**: parser (1215 tests), cli (1185 tests, excl. e2e), review,
and action suites all green, unchanged elsewhere — including the #883
canaries (Go `fs.go`, Ruby `sinatra` fan-out, Swift `Combine` collision).

**Gate chain**: `format:check`, `lint` (0 errors, pre-existing warnings
only), `typecheck`, `build`, `test` (root), and
`node packages/cli/dist/index.js delta` (exit 0 both commits — advisory-only
worsenings well under threshold: `findTestAssociationsFromChunks` 11→12,
`findTestAssociations` 9→12, `buildImportIndex` (parser) 7→10; the CLI's
`indexImportEntry` extraction *improved* `addChunkToImportIndex` 11→6).

Changeset: `@liendev/parser` + `@liendev/lien` patch.

Closes #884

## Test plan

- [x] Unit tests for the Alamofire shape, the Rust pin, and the
      qualified-import carve-out, at the predicate level and all four
      caller layers
- [x] Real-repo before/after on a shallow Alamofire clone, incl. a live MCP
      stdio call for `get_files_context` (verbatim above)
- [x] Full parser + cli + review + action suites green
- [x] `lien delta` exit 0
- [x] Lien Review + CodeRabbit findings triaged (see comment below)

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |

> [!NOTE]
> **Low Risk**
>
> This PR adds a caller-layer guard (`isUnresolvableWholeModuleImport`) to stop Swift whole-module bare imports from falsely hubbing onto source files whose basename coincidentally matches the module name. The guard is correctly scoped to slash-free imports in languages marked `wholeModuleImports` (only Swift today) and is wired into every import-matching path the changeset claims: parser test associations, parser dependency analysis (buildImportIndex, chunkImportsFrom, collectImportedSymbolsFromSource), CLI get_dependents import index, CLI get_dependents symbol-level matching, and CLI get_files_context test associations. Existing tests pin that non-whole-module languages (Rust `auth` → `src/auth.rs`) and Swift qualified/path-like imports continue to match, while the Alamofire basename-coincidence shape is suppressed. No contradictions between the changeset's claims and the code were found, and the residual unguarded `collectImportedSymbolsFromSource` concern raised in the PR's own earlier review has been addressed in the current diff.
>
> - New `isUnresolvableWholeModuleImport` predicate in `@liendev/parser` path-matching utilities, exported publicly.
> - Guard applied before `matchesFile` in all parser and CLI import-matching implementations that handle Swift whole-module imports.
> - Comprehensive unit tests plus real-repo before/after validation on Alamofire; non-Swift languages and qualified Swift imports remain unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d601436. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

