### PR TITLE
docs: document the stale-sibling node_modules resolution trap in worktrees

### DIFF
--- a/docs/development/worktree-development.md
+++ b/docs/development/worktree-development.md
@@ -23,6 +23,10 @@ touching the Rust crate itself, see its README for the `cargo build`
 toolchain requirement; that's a `parser-native`-specific concern, not a
 worktree one.
 
+## A fresh worktree with no `node_modules` fails quietly, not loudly
+
+A worktree that hasn't had `npm ci` run in it yet does not error out and tell you so. Node's module resolution walks up the directory tree looking for `node_modules`, and a worktree under `.claude/worktrees/<name>` sits two directories below the main checkout, so resolution silently falls through to the main checkout's `node_modules` instead of the (missing) one in the worktree. If that main checkout's `node_modules` happens to be stale, for example missing the `@liendev/parser-native` symlink, the result is confusing `tsc` module-resolution errors that reference the main checkout's own paths, not an obvious prompt to run `npm ci`. Diagnose it with `ls node_modules` in the worktree itself: if it's missing or empty, that's the cause. The remedy is the same as above: run `npm ci` in the worktree (about 7 seconds) and `npm run build`, adding `npm run build:native -w @liendev/parser-native` if you're touching the AST/parser layer.
+
 ## Historical note
 
 Before Phase 4-B, this doc documented a per-entry `node_modules` symlink


### PR DESCRIPTION
Closes #876

## Summary

`docs/development/worktree-development.md` covers the native-build story for worktrees (npm ci just works since ADR-013 Phase 4-B) but not this fall-through: a fresh linked worktree with zero `node_modules` doesn't fail loudly. Node's module resolution walks up the directory tree, and a worktree under `.claude/worktrees/<name>` sits two directories below the main checkout, so it silently finds the main checkout's `node_modules` instead of the (missing) one in the worktree. If that main checkout's install is stale, for example missing the `@liendev/parser-native` symlink, the result is confusing `tsc` module-resolution errors that reference the main checkout's own paths, not an obvious "run npm ci" message.

Added one paragraph covering symptom, diagnosis (`ls node_modules` in the worktree), and remedy (`npm ci` in-worktree, ~7s, plus `build:native` if touching AST), right after the existing "just works now" section and before the historical note.

## Dogfood evidence (verbatim)

The module-resolution fall-through claim, verified directly rather than assumed:

```
$ mkdir -p /tmp/worktree-resolution-check/.claude/worktrees/fake-worktree
$ cd /tmp/worktree-resolution-check && npm init -y >/dev/null
$ mkdir -p node_modules/.bin && echo '{"marker":"main-checkout-node-modules"}' > node_modules/marker.json
$ cd .claude/worktrees/fake-worktree
$ node -e "console.log(require.resolve('marker.json'))"
/private/tmp/worktree-resolution-check/node_modules/marker.json
```

Confirms exactly the described behavior: from a nested worktree directory with no local `node_modules`, resolution walks up two levels and silently finds the main checkout's copy.

**docs-truth** (clean):
```
$ node .github/scripts/docs-truth.mjs
docs-truth: 85 files checked, no violations.
```

**docs:build**: passes, with the same caveat as the companion PR (#889) for this doc's sibling: `docs/development/worktree-development.md` lives in the repo-root `docs/` tree, not the VitePress-built public site (`packages/site/docs`). I confirmed via the build's `dist/` output that no page for this file exists there, so there's no rendered HTML for this specific change to read. `npm run docs:build` does pass (`build complete in 5.21s`), confirming the site build itself is unaffected.

## Gates (all green)

```
npm run format:check   pass
npm run lint            0 errors (38 pre-existing warnings, unrelated to this change)
npm run typecheck       pass
npm run build           pass
npm test                1186 passed (cli), 41 passed (action), full suite green
node packages/cli/dist/index.js delta   "no complexity-affecting changes vs HEAD" (exit 0)
node .github/scripts/docs-truth.mjs     "85 files checked, no violations"
npm run docs:build      "build complete in 5.21s"
```

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 11 high-risk file(s) with 540 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**
>
> Adds documentation to docs/development/worktree-development.md explaining a quiet Node module-resolution pitfall in fresh git worktrees: when a worktree under .claude/worktrees/<name> has no node_modules, Node walks up the directory tree and silently resolves packages from the main checkout's node_modules, which can produce confusing tsc errors if that install is stale. The new section covers symptoms, diagnosis (ls node_modules in the worktree), and remedy (npm ci plus native build if needed). No code or behavior changes.
>
> - Added a new 'A fresh worktree with no node_modules fails quietly, not loudly' section to worktree-development.md
> - Documents the root cause (Node module-resolution walk-up), symptom (stale main-checkout packages used), diagnosis, and fix

<sup>Reviewed by [Lien Review](https://lien.dev) for commit df49557. Updates automatically on new commits.</sup>
<!-- /lien-stats -->