### PR TITLE
fix(parser,cli): honest not-determinable signal for C# enclosing-namespace access

### DIFF
--- a/.changeset/csharp-enclosing-namespace-honesty.md
+++ b/.changeset/csharp-enclosing-namespace-honesty.md
@@ -1,0 +1,26 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Honesty-only fix for #875: C# lets a nested namespace body reference an
+*enclosing* namespace's members unqualified, with no `using` directive at
+all (`namespace AutoMapper.UnitTests { ... }` can reference
+`AutoMapper.TypeMap` purely via ordinary C# name resolution). Confirmed
+against AutoMapper/AutoMapper: 355/364 `UnitTests/` files rely on exactly
+this and carry no relevant `using`, so import-based test-association has no
+per-file signal for them — a structural gap, not a matching bug. `lien
+annotate`'s test-coverage line no longer claims `No test coverage.` on
+these files; it now reports `Test coverage not determinable from imports
+(enclosing-namespace access).` instead, for any language whose new
+`LanguageDefinition.enclosingNamespaceAccess` flag is set (only C# today,
+checked via the new `hasEnclosingNamespaceAccess()` export).
+
+This is deliberately a separate flag from `wholeModuleImports`: C#'s
+*explicit* dotted `using AutoMapper.X;` still resolves real per-file
+associations correctly (the other 9/364 files, #866/#868) — folding this
+into `wholeModuleImports` would make `isUnresolvableWholeModuleImport`
+discard those working usings too (C# usings are dotted, never slashed, so
+every one of them is "bare" by that check) and regress them. No heuristic
+recovery (no name-proximity matching) — every other language's wording and
+behavior is unchanged.

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -27,6 +27,23 @@ This document describes Lien's two-pass test detection system that links test fi
 > flag is set (checked via `hasWholeModuleImports()` in the language
 > registry). Only Swift sets this flag today; no other language's wording or
 > behavior changes.
+>
+> **C# enclosing-namespace resolution: the same honesty gap, a different
+> cause ([#875](https://github.com/getlien/lien/issues/875)).** A C#
+> namespace body gets implicit, unqualified access to every *enclosing*
+> namespace's public members — `namespace AutoMapper.UnitTests { ... }` can
+> reference `AutoMapper.TypeMap` with no `using` directive at all, per
+> ordinary C# name resolution. Confirmed against AutoMapper/AutoMapper:
+> 355/364 `UnitTests/` files rely on exactly this and carry no relevant
+> `using`, so they're structurally invisible to import-based matching. This
+> is distinct from Swift's `wholeModuleImports` gap: C#'s *explicit* dotted
+> `using AutoMapper.X;` still resolves real per-file associations normally
+> (the other 9/364 files, and the reason `wholeModuleImports` is not set for
+> C# — that flag would discard those working usings too). `lien annotate`
+> reports `Test coverage not determinable from imports (enclosing-namespace
+> access).` for any language whose `LanguageDefinition.enclosingNamespaceAccess`
+> flag is set (checked via `hasEnclosingNamespaceAccess()`). Only C# sets
+> this flag today.
 
 ## Overview
 

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -213,6 +213,23 @@ describe('formatTests', () => {
       'Test coverage: Tests/SessionTests.swift.',
     );
   });
+
+  // #875: C# lets a nested namespace body reach an *enclosing* namespace's
+  // members with zero `using` directive (AutoMapper.UnitTests -> AutoMapper),
+  // so import-based matching has no per-file signal for a test that only
+  // reaches its subject this way. Same honesty treatment as #869's Swift
+  // case, via the separate `enclosingNamespaceAccess` flag.
+  it('reports not-determinable (not "no coverage") for an empty array on a C# file', () => {
+    expect(formatTests([], 'src/AutoMapper/TypeMap.cs')).toBe(
+      'Test coverage not determinable from imports (enclosing-namespace access).',
+    );
+  });
+
+  it('a non-empty array on a C# file still lists the real tests, unaffected by the honesty branch', () => {
+    expect(formatTests(['src/UnitTests/Features.cs'], 'src/AutoMapper/TypeMap.cs')).toBe(
+      'Test coverage: src/UnitTests/Features.cs.',
+    );
+  });
 });
 
 describe('formatTestReminder', () => {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -6,6 +6,7 @@ import {
   computeBlastRadiusRisk,
   detectLanguage,
   hasWholeModuleImports,
+  hasEnclosingNamespaceAccess,
   type BlastRadiusRisk,
   type CodeChunk,
 } from '@liendev/parser';
@@ -429,12 +430,23 @@ export function formatDependents(
  * wholeModuleImports`), an empty `tests` array is reported as honestly
  * undeterminable rather than as an absence of coverage: the file may be
  * heavily tested, but import-based matching structurally cannot tell (#869).
+ *
+ * Same honesty treatment for a language with `enclosingNamespaceAccess` set
+ * (C# — see that field's doc comment): a test file that only reaches this
+ * one via implicit enclosing-namespace access carries no relevant `using`,
+ * so it's structurally invisible to import-based matching too (#875) — even
+ * though C#'s *explicit* dotted usings still resolve normally (#866/#868),
+ * which is why this is a separate flag checked only as this empty-array
+ * fallback, not folded into `wholeModuleImports`.
  */
 export function formatTests(tests: string[], filepath?: string): string {
   if (tests.length === 0) {
     const language = filepath ? detectLanguage(filepath) : null;
     if (language && hasWholeModuleImports(language)) {
       return 'Test coverage not determinable from imports (whole-module import).';
+    }
+    if (language && hasEnclosingNamespaceAccess(language)) {
+      return 'Test coverage not determinable from imports (enclosing-namespace access).';
     }
     return 'No test coverage.';
   }

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -634,6 +634,20 @@ export const csharpDefinition: LanguageDefinition = {
   exportExtractor: new CSharpExportExtractor(),
   importExtractor: new CSharpImportExtractor(),
   symbolExtractor: new CSharpSymbolExtractor(),
+  // Confirmed against real code (#875, AutoMapper/AutoMapper): a C# namespace
+  // body gets implicit, unqualified access to every *enclosing* namespace's
+  // public members (`namespace AutoMapper.UnitTests { ... }` can reference
+  // `AutoMapper.TypeMap` with zero `using` directive — standard C# simple-
+  // name resolution, not a convention). 355/364 of AutoMapper's UnitTests
+  // files rely on exactly this, carrying no relevant `using` at all, so
+  // import-based test-association has no per-file signal for them. This is
+  // NOT `wholeModuleImports`: the 9/364 files with a real dotted
+  // `using AutoMapper.X;` resolve correctly today via ordinary per-file
+  // matching (#866/#868). C# usings are dotted, not slashed, so EVERY C#
+  // import (including those real, working dotted ones) is "bare" by
+  // `isUnresolvableWholeModuleImport`'s slash check — setting
+  // `wholeModuleImports` here would discard all of them and regress #866.
+  enclosingNamespaceAccess: true,
 
   complexity: {
     decisionPoints: [

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -5,6 +5,7 @@ import {
   languageExists,
   getAllLanguages,
   hasWholeModuleImports,
+  hasEnclosingNamespaceAccess,
 } from './registry.js';
 import type { SupportedLanguage } from './registry.js';
 
@@ -161,6 +162,27 @@ describe('Language Registry', () => {
       others.forEach(id => {
         expect(hasWholeModuleImports(id)).toBe(false);
       });
+    });
+  });
+
+  describe('hasEnclosingNamespaceAccess', () => {
+    it('is true for C# (#875: confirmed enclosing-namespace resolution against AutoMapper)', () => {
+      expect(hasEnclosingNamespaceAccess('csharp')).toBe(true);
+    });
+
+    it('is false for every other registered language', () => {
+      const others = getAllLanguages()
+        .map(d => d.id)
+        .filter(id => id !== 'csharp');
+      expect(others.length).toBeGreaterThan(0);
+      others.forEach(id => {
+        expect(hasEnclosingNamespaceAccess(id)).toBe(false);
+      });
+    });
+
+    it('is independent of hasWholeModuleImports (C# is not a whole-module-import language)', () => {
+      expect(hasWholeModuleImports('csharp')).toBe(false);
+      expect(hasEnclosingNamespaceAccess('swift')).toBe(false);
     });
   });
 });

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -127,6 +127,20 @@ export function hasWholeModuleImports(language: SupportedLanguage): boolean {
 }
 
 /**
+ * True when `language` lets a nested namespace body reference an *enclosing*
+ * namespace's members unqualified, with no `using`/`import` directive at all
+ * (see `LanguageDefinition.enclosingNamespaceAccess`). C# confirmed (#875):
+ * import-based test-association has no per-file signal for a test file that
+ * only reaches its subject this way. Distinct from `hasWholeModuleImports` —
+ * a language can have working per-file import matching for its *explicit*
+ * imports (C# does, #866/#868) while still having this gap for the implicit
+ * case, so callers must not conflate the two. Only C# sets this today.
+ */
+export function hasEnclosingNamespaceAccess(language: SupportedLanguage): boolean {
+  return getLanguage(language).enclosingNamespaceAccess === true;
+}
+
+/**
  * Get all registered language definitions.
  */
 export function getAllLanguages(): readonly LanguageDefinition[] {

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -76,4 +76,21 @@ export interface LanguageDefinition {
    * been verified against real code.
    */
   wholeModuleImports?: boolean;
+
+  /**
+   * True when this language lets a nested namespace body reference an
+   * *enclosing* namespace's members unqualified, with no `using`/`import`
+   * directive at all (C# confirmed — see ECMA-334 simple-name resolution:
+   * `namespace AutoMapper.UnitTests { ... }` gets implicit access to
+   * `AutoMapper`'s public members purely because it's a dotted-nested
+   * namespace, never emitting an import for it). Unlike `wholeModuleImports`,
+   * this does NOT mean per-file import matching is universally useless for
+   * the language — C#'s dotted `using X.Y;` still resolves real per-file
+   * associations correctly (#866/#868) — so this must stay a *separate* flag
+   * a caller only consults as a last-resort, empty-associations fallback
+   * (see `hasEnclosingNamespaceAccess` and its one call site in
+   * `annotate-cmd.ts`'s `formatTests`), never folded into
+   * `wholeModuleImports` or `isUnresolvableWholeModuleImport` (#875).
+   */
+  enclosingNamespaceAccess?: boolean;
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -75,6 +75,7 @@ export {
   getAllLanguages,
   languageExists,
   hasWholeModuleImports,
+  hasEnclosingNamespaceAccess,
 } from './ast/languages/registry.js';
 
 // =============================================================================


### PR DESCRIPTION
Partial fix for #875, #875 stays open — same owner precedent as #869/#881: this is a structural gap with no per-file signal to reconstruct from imports alone, so the honest fix is a "not determinable" label, not a heuristic.

## The gap

A C# namespace body gets implicit, unqualified access to every *enclosing* namespace's public members — `namespace AutoMapper.UnitTests { ... }` can reference `AutoMapper.TypeMap` with **zero** `using` directive at all, per ordinary C# name resolution (not a convention, not a build-system trick). Confirmed against a real clone of AutoMapper/AutoMapper: 355/364 `src/UnitTests/` files rely on exactly this and carry no relevant `using`, so import-based test-association has no per-file signal for them at all. The remaining 9/364 have a real dotted `using AutoMapper.X;` and already resolve correctly via #866/#868.

This is the same *class* of gap as #869 (Swift whole-module imports): the relationship is real, but there's no per-file signal in the data Lien has to reconstruct which specific test covers which specific source file. Per the explicit owner decision on #869 (declined for Swift), this is **not** fixed with a name-proximity heuristic — false positives are worse than silence (see #868's bare-name-collision cautionary tale, and #883's guards that this change composes with untouched).

## The fix

Mirrors #881's `wholeModuleImports` mechanism exactly, but as a **separate** flag:

- New `LanguageDefinition.enclosingNamespaceAccess` flag (set for C# only) + `hasEnclosingNamespaceAccess()` registry predicate.
- `lien annotate`'s `formatTests()` now reports `Test coverage not determinable from imports (enclosing-namespace access).` instead of the misleading `No test coverage.` when this flag is set and no associations were found.

Why a separate flag rather than reusing `wholeModuleImports`: C#'s *explicit* dotted usings still resolve real per-file associations correctly (#866/#868). C# usings are dotted, never slashed, so every one of them looks "bare" to `isUnresolvableWholeModuleImport`'s slash check — setting `wholeModuleImports` on C# would make that function discard all of them, silently regressing #866. Zero changes to `matchesFile`, `isTestFile`, or any matching logic — this is purely a `lien annotate` display-layer honesty fix, same blast radius as #881.

## Diff

9 files, purely additive (140 insertions, 0 deletions):
- `packages/parser/src/ast/languages/types.ts` — new `enclosingNamespaceAccess?: boolean` field
- `packages/parser/src/ast/languages/csharp.ts` — sets the flag, documents why (not `wholeModuleImports`)
- `packages/parser/src/ast/languages/registry.ts` + `registry.test.ts` — `hasEnclosingNamespaceAccess()` + tests
- `packages/parser/src/index.ts` — barrel export
- `packages/cli/src/cli/annotate-cmd.ts` + `annotate-cmd.test.ts` — the new branch in `formatTests`
- `docs/architecture/test-association.md` — narrow callout mirroring the existing Swift one
- `.changeset/csharp-enclosing-namespace-honesty.md`

## Gates (all green)

`format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`, `build`, full test suite (parser 45 files / core 36 / review 57 / cli 61 / action 5 — all passed, 0 failures), `npm run test:e2e:csharp -w packages/cli` (MediatR clone, 14 passed), `node packages/cli/dist/index.js delta` → exit 0 (only a benign cognitive 6→9 bump in `formatTests`, well under threshold, plus one new trivial-complexity function).

## Dogfood evidence (verbatim, real AutoMapper/AutoMapper clone, outside the worktree)

Built this branch's CLI, `init --legacy` + `index` against a shallow clone of AutoMapper/AutoMapper (560 files). Compared `lien annotate` output before (parent commit, `deffceec`) vs after (this branch), same index, only the CLI binary swapped:

**Named acceptance targets from the issue (Mapper.cs / TypeMap.cs) — the message flips:**

```
BEFORE: Lien impact for src/AutoMapper/Mapper.cs:
          • No test coverage.
AFTER:  Lien impact for src/AutoMapper/Mapper.cs:
          • Test coverage not determinable from imports (enclosing-namespace access).

BEFORE: Lien impact for src/AutoMapper/TypeMap.cs:
          • No test coverage.
AFTER:  Lien impact for src/AutoMapper/TypeMap.cs:
          • Test coverage not determinable from imports (enclosing-namespace access).
```

**Regression check — the #866 working case (Features.cs) is byte-identical before/after:**

```
Lien impact for src/AutoMapper/Features.cs:
  • 9 files import this — ...; risk: medium (9 callers, 2 untested, max complexity 10).
  • Test coverage: src/UnitTests/MappingExpressionFeatureWithoutReverseTest.cs, src/UnitTests/MappingExpressionFeatureWithReverseTest.cs (+1 more).
```

**Corpus-wide quantification** (looped `lien annotate` over all 85 files under `src/AutoMapper/**/*.cs`, before vs after, same index):

| | Before | After |
|---|---|---|
| `No test coverage.` | 47 | **0** |
| `Test coverage not determinable ... (enclosing-namespace access)` | 0 | **47** |
| Real `Test coverage: ...` (untouched) | 26 | 26 |

Zero new file-to-file associations are created by design (honesty-only, per precedent) — this fix relabels exactly the 47 previously-misleading files and touches nothing else.

**False-positive spot-check** (confirming the untouched, real association mechanism is genuinely correct, not a false positive):
- `src/AutoMapper/Features.cs` declares `namespace AutoMapper.Features;`.
- `src/UnitTests/MappingExpressionFeatureWithoutReverseTest.cs` has `using AutoMapper.Features;` and its body genuinely exercises `Features<TFeature>` (`typeMap.Features.Count.ShouldBe(...)`, `.SetFeature(...)`) — a real, correct match.

**Root-cause confirmation** (grounding the fix's premise):
- `src/AutoMapper/Mapper.cs` and `TypeMap.cs` both declare `namespace AutoMapper;`.
- `src/UnitTests/AutoMapperSpecBase.cs` declares `namespace AutoMapper.UnitTests;` and references `TypeMap` with **no `using` line in the file at all** — the exact enclosing-namespace-access gap #875 describes, confirmed against real code.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds an honest 'not determinable' signal for C# test coverage by introducing a separate `enclosingNamespaceAccess` language flag, mirroring the existing `wholeModuleImports` mechanism for Swift. The change is narrowly scoped to `lien annotate`'s display layer: C# files with no import-based test associations now report 'Test coverage not determinable from imports (enclosing-namespace access).' instead of the misleading 'No test coverage.', while explicit dotted `using` associations continue to resolve normally. The new predicate is properly exported from `@liendev/parser`, consumed only by `formatTests`, and covered by unit tests.
>
> - Added `LanguageDefinition.enclosingNamespaceAccess?: boolean` and `hasEnclosingNamespaceAccess()` registry predicate, exported from `@liendev/parser`.
> - Set `enclosingNamespaceAccess: true` on the C# language definition with a detailed comment explaining why it is not folded into `wholeModuleImports`.
> - Updated `formatTests()` to emit the new not-determinable message for C# files when no test associations are found, preserving existing behavior for all other languages.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 106a98b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->