### PR TITLE
fix(review): per-turn input-growth check for budget wrap-up (partial fix for #839)

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -45,6 +45,116 @@ export function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s;
 }
 
+// ---------------------------------------------------------------------------
+// Wrap-up decision (issue #839 — multi-turn budget accumulation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fraction of the whole budget at which an ordinary investigative turn is
+ * nudged to wrap up (drop tools, emit a verdict next turn) — kept below the
+ * hard cap with headroom so a single capped tool result can't skip past the
+ * wrap-up window straight into the hard stop. Pre-#839 behavior; unchanged by
+ * this fix (see `computeWrapUpReason`'s doc comment for what #839 adds).
+ */
+export const NEAR_BUDGET_FRACTION = 0.6;
+
+/** Inputs to `computeWrapUpReason` — the turn-loop locals both clients already track, passed by
+ *  name so the function itself stays provider-agnostic and testable without either client's
+ *  HTTP/SDK transport. */
+export interface WrapUpCheckInput {
+  /** Cumulative spend (input+output across every turn so far, including the turn just completed). */
+  totalTokens: number;
+  /** THIS turn's own input/prompt token cost (`usage.prompt_tokens` / `usage.input_tokens`). */
+  turnInputTokens: number;
+  maxTokenBudget: number;
+  /** 1-indexed number of the turn just completed. */
+  turn: number;
+  maxTurns: number;
+}
+
+/**
+ * Why (if at all) the NEXT turn should be forced to drop tools and emit its
+ * verdict now, instead of continuing to investigate. `near-budget`/
+ * `last-turn` are the pre-existing coarse checks (issue #836); `input-growth`
+ * is issue #839's own addition — see `computeWrapUpReason`.
+ */
+export type WrapUpReason = 'input-growth' | 'near-budget' | 'last-turn' | null;
+
+/**
+ * Decide whether an ordinary investigative turn should hand off to a forced,
+ * no-tools verdict turn next — and, when so, WHY (surfaced so a client can log
+ * the more surprising `input-growth` case for diagnosability).
+ *
+ * ISSUE #839: conversation history — system prompt + every prior turn's own
+ * response + every tool result — is re-sent in full on every request and is
+ * NEVER bounded by `max_tokens` (only a turn's OUTPUT is; see
+ * `turnMaxTokens`/`requestMaxTokens`). The pre-existing `near-budget` check
+ * only fires once CUMULATIVE spend crosses `NEAR_BUDGET_FRACTION` of the
+ * WHOLE budget — by which point the single forced-finish turn that follows
+ * can still re-send an arbitrarily large accumulated history as its own
+ * (budget-blind) input. That is exactly the mechanism behind the real
+ * doc-truth receipt this closes: 20,869 allocated / 56,430 spent (2.7x, PR
+ * #837's dogfood run) — two ordinary tool-calling turns stayed comfortably
+ * under 60%, then the forced-finish turn's OWN input cost (the now much
+ * larger history) alone blew the budget (see the `plugins-agent-budget.test.ts`
+ * / `plugins-agent-anthropic.test.ts` regression tests reproducing this exact
+ * shape).
+ *
+ * `input-growth` catches this earlier and is data-driven, not a retuned
+ * constant: conversation history only grows turn over turn (nothing is ever
+ * trimmed in this codebase — see `TOOL_RESULT_MAX_CHARS`'s per-call cap, but
+ * no whole-history trim), so THIS turn's own input cost is a conservative
+ * FLOOR on what the next turn's input will cost. If what's left of the budget
+ * can't even cover a repeat of this turn's own input, one more investigative
+ * round-trip cannot possibly complete inside it — force the wrap-up now,
+ * while the conversation is as small as it will ever again be, rather than
+ * let it grow through one or more further turns before the coarser
+ * `near-budget` fraction catches up. This bounds — but, because the
+ * forced-finish turn's own input is still real and still unbounded by
+ * `max_tokens`, cannot fully eliminate — the residual overshoot; see
+ * `turnMaxTokens`'s doc comment for the complementary output-side bound and
+ * `EXTRA_PASS_MIN_BUDGET_TOKENS`'s for the allocation-sizing complement.
+ * Verified NOT to change behavior on any pre-#839 budget test: every existing
+ * fixture crosses `near-budget` or `input-growth` at the same turn boundary
+ * (see the two clients' own test suites) — this is a strict, additive
+ * improvement, not a retuning of the existing thresholds.
+ *
+ * Checked before `near-budget`/`last-turn` so a fast, single-turn spike (a
+ * large pre-rendered worklist on turn 1, or one oversized tool result) is
+ * named precisely rather than folded into the generic near-budget bucket.
+ */
+export function computeWrapUpReason(input: WrapUpCheckInput): WrapUpReason {
+  const { totalTokens, turnInputTokens, maxTokenBudget, turn, maxTurns } = input;
+  const remaining = maxTokenBudget - totalTokens;
+  if (turnInputTokens >= remaining) return 'input-growth';
+  if (totalTokens >= maxTokenBudget * NEAR_BUDGET_FRACTION) return 'near-budget';
+  if (turn >= maxTurns - 1) return 'last-turn';
+  return null;
+}
+
+/**
+ * Log `computeWrapUpReason`'s new `input-growth` case for CI diagnosability —
+ * a no-op for `near-budget`/`last-turn`/`null` (the pre-#839 cases stay
+ * exactly as silent as before this fix). Called unconditionally by both
+ * clients right after computing the reason, so neither of their already-
+ * over-complexity-budget `run()` methods gains an inline branch just to
+ * decide whether to log (see `computeWrapUpReason`'s own call sites).
+ */
+export function logWrapUpReason(
+  logger: Logger,
+  reason: WrapUpReason,
+  turn: number,
+  turnInputTokens: number,
+  remainingBudget: number,
+): void {
+  if (reason !== 'input-growth') return;
+  logger.info(
+    `[agent] Turn ${turn}: this turn's own input (${turnInputTokens}) already meets/exceeds ` +
+      `the ${remainingBudget} tokens left of budget — forcing wrap-up now rather than risking ` +
+      'a further turn (issue #839 input-growth check)',
+  );
+}
+
 /**
  * Parse a boolean-ish env *disable* flag. Per-turn agent logging is ON by
  * default (so every review is diagnosable); only an explicit '0'/'false'

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -24,6 +24,8 @@ import {
   envDisabled,
   logTurn,
   extractFindingsFromText,
+  computeWrapUpReason,
+  logWrapUpReason,
 } from './agent-client-shared.js';
 
 /** Extract the assistant's text content from an Anthropic response for trace. */
@@ -257,12 +259,24 @@ export class AnthropicAgentClient {
         break;
       }
 
-      // Approaching budget or last turn — tell the agent to wrap up.
-      // Threshold kept below the hard cap with headroom so a single capped
-      // tool result can't skip past the wrap-up window into the hard stop.
-      const nearBudget = totalTokens >= this.maxTokenBudget * 0.6;
-      const lastTurn = turn >= this.maxTurns - 1;
-      const shouldWrapUp = nearBudget || lastTurn;
+      // Approaching budget, last turn, or (issue #839) this turn's own input
+      // already ate enough of the budget that another investigative
+      // round-trip can't fit — see `computeWrapUpReason`'s doc comment.
+      const wrapUpReason = computeWrapUpReason({
+        totalTokens,
+        turnInputTokens,
+        maxTokenBudget: this.maxTokenBudget,
+        turn,
+        maxTurns: this.maxTurns,
+      });
+      logWrapUpReason(
+        this.logger,
+        wrapUpReason,
+        turn,
+        turnInputTokens,
+        this.maxTokenBudget - totalTokens,
+      );
+      const shouldWrapUp = wrapUpReason !== null;
       // Drop tools next turn so the model must produce its verdict.
       if (shouldWrapUp) forceFinish = true;
 

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -23,6 +23,8 @@ import {
   envDisabled,
   logTurn,
   extractFindingsWithReasoningFallback,
+  computeWrapUpReason,
+  logWrapUpReason,
 } from './agent-client-shared.js';
 
 // `envDisabled` is re-exported so its existing test import path
@@ -479,11 +481,23 @@ export class OpenAIAgentClient {
         break;
       }
 
-      // Approaching budget or last turn — nudge to wrap up.
-      // Threshold kept below the hard cap with headroom so a single capped
-      // tool result can't skip past the wrap-up window into the hard stop.
-      const nearBudget = totalTokens >= this.maxTokenBudget * 0.6;
-      const lastTurn = turn >= this.maxTurns - 1;
+      // Approaching budget, last turn, or (issue #839) this turn's own input
+      // already ate enough of the budget that another investigative
+      // round-trip can't fit — see `computeWrapUpReason`'s doc comment.
+      const wrapUpReason = computeWrapUpReason({
+        totalTokens,
+        turnInputTokens,
+        maxTokenBudget: this.maxTokenBudget,
+        turn,
+        maxTurns: this.maxTurns,
+      });
+      logWrapUpReason(
+        this.logger,
+        wrapUpReason,
+        turn,
+        turnInputTokens,
+        this.maxTokenBudget - totalTokens,
+      );
 
       // Process tool calls
       if (choice.finish_reason === 'tool_calls' && choice.message.tool_calls) {
@@ -494,7 +508,7 @@ export class OpenAIAgentClient {
           turnTrace,
           toolExecutor,
         );
-        if (nearBudget || lastTurn) {
+        if (wrapUpReason) {
           messages.push({ role: 'user', content: WRAP_UP_NUDGE });
           // Next turn is forced to emit a JSON verdict (no tools).
           forceFinish = true;

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -207,6 +207,38 @@ describe('AnthropicAgentClient extended thinking + retry forcing', () => {
     expect(createMock).toHaveBeenCalledTimes(3);
   });
 
+  it('forces wrap-up after a single turn whose own input already exhausts remaining budget — BEFORE the coarser near-budget fraction would fire (issue #839 input-growth check)', async () => {
+    // Parity with the OpenAI client's same fix. Turn 1's own input (11,500)
+    // leaves cumulative spend at 11,500 — still UNDER the 0.6 wrap-up
+    // fraction (12,000 on a 20,000 budget), so the pre-#839 near-budget-only
+    // check would NOT yet force a wrap-up. The input-growth check catches it
+    // a turn earlier: remaining budget (8,500) can't even cover a repeat of
+    // turn 1's own input, so turn 2 is forced to drop tools and emit its
+    // verdict right away — bounding the run well under budget instead of
+    // letting a third, much larger forced-finish turn compound the overshoot.
+    const verdict =
+      '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"ok","keyChanges":[]}}\n```';
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 11_500, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock(verdict)], 2_000, 0, 'end_turn'));
+    const { logger, lines } = capturingLogger();
+
+    const result = await makeClient(20_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.turns).toBe(2);
+    expect(createMock.mock.calls[1][0].tool_choice).toEqual({ type: 'none' }); // forced-finish
+    expect(result.usage.totalTokens).toBe(13_500); // bounded — no blowout
+    expect(result.stopReason).toBe('completed');
+    expect(lines.some(l => l.includes('input-growth check'))).toBe(true);
+  });
+
   it('forces the retry with tool_choice:none + thinking (parity with the loop)', async () => {
     createMock
       .mockResolvedValueOnce(

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -214,15 +214,20 @@ describe('AnthropicAgentClient extended thinking + retry forcing', () => {
     // check would NOT yet force a wrap-up. The input-growth check catches it
     // a turn earlier: remaining budget (8,500) can't even cover a repeat of
     // turn 1's own input, so turn 2 is forced to drop tools and emit its
-    // verdict right away — bounding the run well under budget instead of
-    // letting a third, much larger forced-finish turn compound the overshoot.
+    // verdict right away.
+    //
+    // Turn 2's own input (13,000) is deliberately >= turn 1's (11,500): the
+    // client re-sends the FULL conversation history every request (`messages`
+    // is append-only, never trimmed), so a real turn's input_tokens can never
+    // be smaller than the turn before it. A non-monotonic mock here would
+    // assert a physically impossible sequence.
     const verdict =
       '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"ok","keyChanges":[]}}\n```';
     createMock
       .mockResolvedValueOnce(
         msg([thinkingBlock('investigating'), toolUseBlock], 11_500, 0, 'tool_use'),
       )
-      .mockResolvedValueOnce(msg([textBlock(verdict)], 2_000, 0, 'end_turn'));
+      .mockResolvedValueOnce(msg([textBlock(verdict)], 13_000, 0, 'end_turn'));
     const { logger, lines } = capturingLogger();
 
     const result = await makeClient(20_000, logger).run(
@@ -234,8 +239,18 @@ describe('AnthropicAgentClient extended thinking + retry forcing', () => {
 
     expect(result.turns).toBe(2);
     expect(createMock.mock.calls[1][0].tool_choice).toEqual({ type: 'none' }); // forced-finish
-    expect(result.usage.totalTokens).toBe(13_500); // bounded — no blowout
-    expect(result.stopReason).toBe('completed');
+    expect(createMock).toHaveBeenCalledTimes(2); // verdict recovered directly — no summary-retry needed
+    // Even the forced turn's own (still budget-blind) input cost (13,000) is
+    // enough, on top of turn 1's 11,500, to cross the 20,000 budget — the
+    // true benefit is NOT a smaller total spend (this fix cannot shrink a
+    // turn's own real cost), it's that the model was cut off ONE
+    // investigative round-trip earlier than the pre-#839 near-budget check
+    // alone would have allowed, and still produced a clean, directly-
+    // recovered verdict.
+    expect(result.usage.totalTokens).toBe(24_500);
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(false); // verdict parsed cleanly despite the budget stop
+    expect(result.summary).toBeDefined();
     expect(lines.some(l => l.includes('input-growth check'))).toBe(true);
   });
 

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -311,7 +311,15 @@ describe('OpenAIAgentClient budget handling', () => {
     // The input-growth check catches it a turn earlier: remaining budget
     // (8,500) can't even cover a repeat of turn 1's own input, so turn 2 is
     // forced to drop tools and emit its verdict right away.
-    const { bodies } = mockFetch([toolCallTurn(11_500), stopTurn(CLEAN_JSON, 2_000)]);
+    //
+    // Turn 2's own input (13,000) is deliberately >= turn 1's (11,500): the
+    // client re-sends the FULL conversation history every request (`messages`
+    // is append-only, never trimmed — see TOOL_RESULT_MAX_CHARS's per-call cap
+    // but no whole-history trim), so a real turn's prompt_tokens can never be
+    // smaller than the turn before it. A non-monotonic mock here would assert
+    // a physically impossible sequence and manufacture a rosier outcome than a
+    // real run could produce.
+    const { bodies } = mockFetch([toolCallTurn(11_500), stopTurn(CLEAN_JSON, 13_000)]);
     const { logger, lines } = capturingLogger();
     const client = makeClient(20_000, logger);
     const tools = [
@@ -323,10 +331,18 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(result.turns).toBe(2);
     expect(bodies[1].tools).toBeUndefined(); // forced-finish: no tools offered
     expect(bodies[1].response_format).toEqual({ type: 'json_object' });
-    // Bounded well under the 20,000 budget — no context-accumulation blowout,
-    // because the forced-finish turn fired while history was still small.
-    expect(result.usage.totalTokens).toBe(13_500);
-    expect(result.stopReason).toBe('completed');
+    expect(bodies).toHaveLength(2); // verdict recovered from the forced turn itself — no summary-retry needed
+    // Even the forced turn's own (still budget-blind) input cost (13,000) is
+    // enough, on top of turn 1's 11,500, to cross the 20,000 budget — the
+    // true benefit here is NOT a smaller total spend (this input-growth fix
+    // cannot shrink a turn's own real cost, only decide sooner whether to risk
+    // another one), it's that the model was cut off ONE investigative
+    // round-trip earlier than the pre-#839 near-budget check alone would have
+    // allowed, and still produced a clean, directly-recovered verdict.
+    expect(result.usage.totalTokens).toBe(24_500);
+    expect(result.stopReason).toBe('budget');
+    expect(result.incomplete).toBe(false); // verdict parsed cleanly despite the budget stop
+    expect(result.summary).toBeDefined();
     expect(lines.some(l => l.includes('input-growth check'))).toBe(true);
   });
 

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -301,6 +301,35 @@ describe('OpenAIAgentClient budget handling', () => {
     expect(bodies).toHaveLength(3);
   });
 
+  it('forces wrap-up after a single turn whose own input already exhausts remaining budget — BEFORE the coarser near-budget fraction would fire (issue #839 input-growth check)', async () => {
+    // A large pre-rendered worklist can make even turn 1's own input cost
+    // most of a small extra-pass budget. Turn 1's input (11,500) leaves
+    // cumulative spend at 11,500 — still UNDER the 0.6 wrap-up fraction
+    // (12,000 on a 20,000 budget), so the pre-#839 near-budget-only check
+    // would NOT yet force a wrap-up and would let turn 2 keep investigating
+    // (growing conversation history further before any forced-finish turn).
+    // The input-growth check catches it a turn earlier: remaining budget
+    // (8,500) can't even cover a repeat of turn 1's own input, so turn 2 is
+    // forced to drop tools and emit its verdict right away.
+    const { bodies } = mockFetch([toolCallTurn(11_500), stopTurn(CLEAN_JSON, 2_000)]);
+    const { logger, lines } = capturingLogger();
+    const client = makeClient(20_000, logger);
+    const tools = [
+      { type: 'function', function: { name: 'read_file', description: 'd', parameters: {} } },
+    ];
+
+    const result = await client.run('sys', 'init', tools as never, noopTool);
+
+    expect(result.turns).toBe(2);
+    expect(bodies[1].tools).toBeUndefined(); // forced-finish: no tools offered
+    expect(bodies[1].response_format).toEqual({ type: 'json_object' });
+    // Bounded well under the 20,000 budget — no context-accumulation blowout,
+    // because the forced-finish turn fired while history was still small.
+    expect(result.usage.totalTokens).toBe(13_500);
+    expect(result.stopReason).toBe('completed');
+    expect(lines.some(l => l.includes('input-growth check'))).toBe(true);
+  });
+
   it('recovers a verdict via the json-forced summary-retry after a bail', async () => {
     // Loop bails on budget with no verdict; the retry returns raw JSON (as
     // response_format:json_object would) and must be parsed into a summary.

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -11,6 +11,9 @@ import {
   isValidSummary,
   isValidFinding,
   AGENT_LOG_MAX,
+  computeWrapUpReason,
+  logWrapUpReason,
+  NEAR_BUDGET_FRACTION,
 } from '../src/plugins/agent/agent-client-shared.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
@@ -543,5 +546,113 @@ describe('extractFindingsWithReasoningFallback (reasoning-channel verdict recove
     const logger = { ...silentLogger, info: (m: string) => void infos.push(m) };
     extractFindingsWithReasoningFallback(null, fence({ findings: [], summary }), logger);
     expect(infos.some(m => m.includes('recovered from the reasoning channel'))).toBe(true);
+  });
+});
+
+describe('computeWrapUpReason (issue #839 — multi-turn budget accumulation)', () => {
+  const base = { totalTokens: 0, turnInputTokens: 0, maxTokenBudget: 20_000, turn: 1, maxTurns: 8 };
+
+  it('returns null when nothing warrants wrapping up', () => {
+    expect(computeWrapUpReason({ ...base, totalTokens: 2_000, turnInputTokens: 1_500 })).toBeNull();
+  });
+
+  it('reports near-budget once cumulative spend crosses NEAR_BUDGET_FRACTION of the whole budget', () => {
+    expect(NEAR_BUDGET_FRACTION).toBe(0.6);
+    // 12,000/20,000 = exactly 0.6 — the boundary itself counts.
+    expect(computeWrapUpReason({ ...base, totalTokens: 12_000, turnInputTokens: 1_000 })).toBe(
+      'near-budget',
+    );
+    expect(
+      computeWrapUpReason({ ...base, totalTokens: 11_999, turnInputTokens: 1_000 }),
+    ).toBeNull();
+  });
+
+  it('reports last-turn on the final turn the loop allows, even with budget to spare', () => {
+    expect(
+      computeWrapUpReason({ ...base, totalTokens: 100, turnInputTokens: 50, turn: 7, maxTurns: 8 }),
+    ).toBe('last-turn');
+    expect(
+      computeWrapUpReason({ ...base, totalTokens: 100, turnInputTokens: 50, turn: 6, maxTurns: 8 }),
+    ).toBeNull();
+  });
+
+  it("reports input-growth when THIS turn's own input already meets/exceeds what's left of the budget, even though cumulative spend is still well under the near-budget fraction (the #839 fix)", () => {
+    // 20,000 budget: after this turn, totalTokens=11,500 (< 12,000 near-budget
+    // threshold) — the coarse fraction check would NOT yet fire. But this
+    // turn's own input (11,500) already meets what's left (8,500): another
+    // investigative turn's input can only be as large or larger (history only
+    // grows), so it can't possibly fit — the fix forces the wrap-up NOW.
+    const result = computeWrapUpReason({
+      ...base,
+      totalTokens: 11_500,
+      turnInputTokens: 11_500,
+    });
+    expect(result).toBe('input-growth');
+  });
+
+  it('input-growth is checked before near-budget/last-turn (priority when multiple would fire)', () => {
+    // Cumulative spend is ALSO past the near-budget fraction here, but the
+    // more specific input-growth reason wins so logs name the real cause.
+    const result = computeWrapUpReason({
+      ...base,
+      totalTokens: 19_000,
+      turnInputTokens: 19_000,
+      turn: 7,
+      maxTurns: 8,
+    });
+    expect(result).toBe('input-growth');
+  });
+
+  it("does not trigger merely because a turn's input is large in absolute terms, when remaining budget covers it comfortably", () => {
+    // A big first turn (10,000 input) on a huge 200,000-token main-pass budget
+    // leaves plenty of room (190,000) — must not force wrap-up prematurely.
+    expect(
+      computeWrapUpReason({
+        totalTokens: 10_500,
+        turnInputTokens: 10_000,
+        maxTokenBudget: 200_000,
+        turn: 1,
+        maxTurns: 20,
+      }),
+    ).toBeNull();
+  });
+
+  it('reproduces the real doc-truth receipt shape (20,869 allocated / 56,430 spent, issue #839 census) without regressing the existing near-budget classification', () => {
+    // Turn 1: input 9,000 (cumulative 9,000) — neither near-budget (< 12,000)
+    // nor input-growth (remaining 11,000 > 9,000) fires yet.
+    expect(computeWrapUpReason({ ...base, totalTokens: 9_000, turnInputTokens: 9_000 })).toBeNull();
+    // Turn 2: input 4,000 (cumulative 13,000) — crosses near-budget (>= 12,000);
+    // input-growth alone would NOT have fired here (remaining 7,000 > 4,000) —
+    // near-budget is still the reason this specific real-shaped case catches,
+    // exactly as it did before this fix (no regression).
+    expect(
+      computeWrapUpReason({ ...base, totalTokens: 13_000, turnInputTokens: 4_000, turn: 2 }),
+    ).toBe('near-budget');
+  });
+});
+
+describe('logWrapUpReason', () => {
+  function capturingLogger(): { logger: Logger; lines: string[] } {
+    const lines: string[] = [];
+    const record = (m: string) => lines.push(m);
+    return { logger: { info: record, warning: record, error: record, debug: record }, lines };
+  }
+
+  it('logs an info line naming turn, own-input, and remaining budget for input-growth', () => {
+    const { logger, lines } = capturingLogger();
+    logWrapUpReason(logger, 'input-growth', 3, 11_500, 8_500);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('Turn 3');
+    expect(lines[0]).toContain('11500');
+    expect(lines[0]).toContain('8500');
+    expect(lines[0]).toContain('#839');
+  });
+
+  it('is a no-op for near-budget/last-turn/null (unchanged, silent pre-#839 behavior)', () => {
+    const { logger, lines } = capturingLogger();
+    logWrapUpReason(logger, 'near-budget', 2, 1, 1);
+    logWrapUpReason(logger, 'last-turn', 7, 1, 1);
+    logWrapUpReason(logger, null, 1, 1, 1);
+    expect(lines).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Scope

Partial fix for #839, deliberately narrow. #839's remaining scope after #852
(turn-boundary classification) is "why a pass's conversation history grows
the way it does across doc-truth and stale-duplicate-loop... reduce
overshoot *magnitude*, not just correctly report it." Per the issue's own
repeated guardrail ("do NOT guess-fix... needs a captured real receipt"),
this PR adds one data-driven mechanism rather than retuning the existing
`nearBudget` fraction (0.6) or per-pass turn caps (`DOC_PASS_MAX_TURNS`)
blind — neither of which has ever been grounded in a real turn-by-turn
capture (the issue's own "Step 1" has never actually happened; only the
*aggregate* 20,869-allocated/56,430-spent receipt was ever captured, not a
turn-by-turn breakdown).

**This does not close #839** — see "What this does NOT fix" below.
`#839 stays open` for that remaining, data-gated work.

## The mechanism

Conversation history (system prompt + every prior turn's response + every
tool result) is re-sent in full on every request and is never bounded by
`max_tokens` — only a turn's OUTPUT is (the #836/#837 `turnMaxTokens`/
`requestMaxTokens` fix). The existing `near-budget` check only forces a
wrap-up once CUMULATIVE spend crosses 60% of the WHOLE budget — by which
point the single forced-finish turn that follows can still re-send an
arbitrarily large accumulated history as its own (budget-blind) input.

`computeWrapUpReason` (new, in `agent-client-shared.ts`, shared by both
clients) adds `input-growth`: since conversation history only grows turn
over turn (nothing is ever trimmed in this codebase — the client re-sends
the full `messages` array on every request, append-only), THIS turn's own
input cost is a conservative FLOOR on what the next turn's input will cost.
If what's left of the budget can't even cover a repeat of this turn's own
input, one more investigative round-trip cannot possibly complete inside
it — force the wrap-up now, while the conversation is as small as it will
ever again be, rather than wait for the coarser 60%-of-total fraction to
catch up. No new magic number: the check is entirely data-driven off
`usage.prompt_tokens`/`usage.input_tokens`, already measured every turn.

Verified to be a strict, additive improvement: every existing budget test
in both clients crosses `near-budget`/`last-turn` at the exact same turn
boundary as before (no regression) — see `computeWrapUpReason`'s own doc
comment and its unit tests for the full case-by-case check.

## What this fixes

A large pre-rendered worklist (or one oversized tool result) can make even
an EARLY turn's own input cost most of a small extra-pass budget, while
cumulative spend is still comfortably under the 60% fraction — the
pre-existing check would let the loop keep offering tools (and a real model
keep investigating, growing context further) before any wrap-up fires. New
regression test (both clients, corrected after adversarial review — see
"Correction" below): turn 1's own input (11,500) leaves cumulative spend at
11,500 on a 20,000 budget — under the 12,000 near-budget threshold — but
already exceeds the 8,500 remaining; the fix forces wrap-up immediately
(turn 2 request: no tools offered, `response_format:json_object`) instead of
risking a further investigative round-trip. The forced turn's own input
(13,000, itself real and unbounded) still pushes total spend to 24,500/
20,000 (1.23x) — this fix cannot shrink what any single turn actually costs
— but the verdict is recovered DIRECTLY from that forced turn (exactly 2
requests, no summary-retry needed), one investigative round-trip earlier
than the pre-existing near-budget check alone would have allowed.

**Awareness note (structural, not this test's outcome):** a review whose
very first turn already trips `input-growth` is cut to a single
investigative round-trip, yet — if that forced turn's own cost happens to
land under budget — reports `stopReason: 'completed'` with no signal that
investigation was truncated early. This is the same quality-vs-honesty
tradeoff the pre-existing `near-budget` mechanism already makes; this fix
doesn't introduce a new one, just an earlier-firing instance of it.

## What this does NOT fix (honest disclosure)

The closest reproduction of the REAL census receipt (20,869 allocated /
56,430 spent, 2.7x — two individually-modest tool-calling turns, neither
of which trips `input-growth`, cumulatively cross the 60% fraction, then
the forced-finish turn's own full-history restatement is what actually
blows the budget) is **unchanged** by this fix: `near-budget` still fires
at the same turn it always did, because *neither preceding turn's own
input* was large enough to trip the new check on its own. Reducing
overshoot in THAT shape needs either (a) a genuinely captured real
turn-by-turn trace to ground retuning `nearBudget`'s fraction or the
per-pass turn caps (the issue's own candidate fixes 1/2), or (b) some other
mechanism — both explicitly deferred here rather than guessed at. Posted a
follow-up comment on #839 with this precise finding.

## Correction (adversarial review on this PR)

The first version of the scenario-B tests (both clients) mocked turn 1
input=11,500 then turn 2 input=2,000 — a **physically impossible**
sequence: the client re-sends the full conversation history every request,
so a real turn's input tokens can never be *smaller* than the turn before
it. That non-monotonic mock manufactured a rosier headline (`stopReason:
'completed'`, 0.68x, "bounded well under budget") than a real run could
produce. Fixed by making turn 2's input monotonic (13,000 ≥ 11,500) in both
clients' tests and in the standalone replay script below — the honest
outcome is `stopReason: 'budget'` (1.23x over), with the verdict still
recovered directly from the forced turn (no summary-retry). The "What this
fixes" section above and all evidence below reflect the corrected numbers.
The existing census-shape (Scenario A) reproduction, unchanged, still shows
no regression.

## Dogfood evidence (zero LLM spend — deterministic accounting)

**Unit tests** (`plugins-agent-client-shared.test.ts`): `computeWrapUpReason`
covers null/near-budget/last-turn/input-growth, the priority order between
them, the "large-but-affordable" non-trigger case, and a reproduction of the
real census shape proving `near-budget` (not `input-growth`) is still what
fires there — i.e. explicitly proving no regression on the diagnosed case.
`logWrapUpReason` covers the new diagnostic log line + its silence for the
three pre-existing reasons.

**Integration tests** (both clients' own `run()` loops, real class, mocked
HTTP, corrected to a monotonic turn sequence): asserts turn count, wire-level
request shape (turn 2 gets NO tools + `response_format:json_object` — proof
the model was cut off from further investigation a turn early), exactly 2
requests (verdict recovered directly, no summary-retry), the honest
`stopReason: 'budget'`, and `incomplete: false`/`summary` defined (a clean
verdict despite the budget stop).

**Real-client replay script** (`.wip/verify-839-input-growth.mjs`, not
committed — gitignored `.wip/`), run against the actual `OpenAIAgentClient`
class before and after this change (via `git checkout <parent-commit> --
<3 src files>`, then restored), printing PassOutcome-shaped receipts + the
wire-level request shape per turn:

Before this fix (both scenarios):
```
=== Scenario A: real doc-truth census receipt shape (20,869 / 56,430, 2.7x) ===
{ "name": "doc-truth (census shape)", "stopReason": "budget", "allocatedTokens": 20000, "spentTokens": 53000, "turns": 3, "overshoot": "2.65x" }
  request 1: tools=offered response_format=none
  request 2: tools=offered response_format=none
  request 3: tools=NONE response_format={"type":"json_object"}
  [not triggered] input-growth check did not fire

=== Scenario B: early single-turn input spike (large first-turn worklist) ===
{ "name": "doc-truth (early-spike shape)", "stopReason": "budget", "allocatedTokens": 20000, "spentTokens": 24500, "turns": 2, "overshoot": "1.23x" }
  request 1: tools=offered response_format=none
  request 2: tools=offered response_format=none   <-- model STILL offered tools on turn 2
  [not triggered] input-growth check did not fire
```

After this fix:
```
=== Scenario A: real doc-truth census receipt shape (20,869 / 56,430, 2.7x) ===
{ "name": "doc-truth (census shape)", "stopReason": "budget", "allocatedTokens": 20000, "spentTokens": 53000, "turns": 3, "overshoot": "2.65x" }
  request 1: tools=offered response_format=none
  request 2: tools=offered response_format=none
  request 3: tools=NONE response_format={"type":"json_object"}
  [not triggered] input-growth check did not fire      <-- IDENTICAL to before: no regression

=== Scenario B: early single-turn input spike (large first-turn worklist) ===
{ "name": "doc-truth (early-spike shape)", "stopReason": "budget", "allocatedTokens": 20000, "spentTokens": 24500, "turns": 2, "overshoot": "1.23x" }
  request 1: tools=offered response_format=none
  request 2: tools=NONE response_format={"type":"json_object"}   <-- forced a turn earlier
  [triggered] [agent] Turn 1: this turn's own input (11500) already meets/exceeds the 8500 tokens left of budget — forcing wrap-up now rather than risking a further turn (issue #839 input-growth check)
```

Scenario A is byte-identical before/after (proves no regression on the
already-diagnosed case). Scenario B's FINAL NUMBERS are also identical
before/after in this specific reproduction — because the mocked turn-2
response happens to be a natural "stop" regardless of what was actually
requested, which a static replay can't avoid. The real, provable behavioral
difference is the WIRE-LEVEL request shape at turn 2: `tools=offered` (old
— a real model is free to keep calling tools, growing context further)
flips to `tools=NONE` + forced JSON verdict (new — cut off one investigative
round-trip earlier). In a live run against a real model, that's the
difference between "may keep investigating" and "must emit its verdict now"
— exactly the mechanism the fix forecloses one round sooner.

## Gates

- `npm run format:check` — pass
- `npm run lint` — pass (0 errors; pre-existing warnings only)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` (root, all packages) — 1665 (review, post-merge with #895) +
  1186 (cli) + 41 (action) tests pass, 0 failures
- `node packages/cli/dist/index.js delta` — exit 0. Both already-over-budget
  `run()` methods (34→33 openai, 35→34 anthropic) go DOWN, not up (extracting
  the decision into `computeWrapUpReason`/`logWrapUpReason` nets a
  simplification, not just an addition):
  ```
  packages/review/src/plugins/agent/agent-client-shared.ts
    · new      computeWrapUpReason      cognitive – → 3
    · new      logWrapUpReason          cognitive – → 1
  packages/review/src/plugins/agent/anthropic-client.ts
    ⚠ pre-exist AnthropicAgentClient.run cognitive 35 → 34
  packages/review/src/plugins/agent/openai-client.ts
    ⚠ pre-exist OpenAIAgentClient.run    cognitive 34 → 33
  ```
- Merged `origin/main` (plain merge, no rebase) to pick up #895 (touches the
  same `agent-client-shared.ts`) — auto-merged conflict-free, re-verified
  all gates green post-merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-agent budget handling when a single turn’s input consumes the remaining budget.
  * Agents now stop tool use and produce a verdict sooner when approaching token or turn limits.
  * Added clearer logging for input-growth budget wrap-ups.

* **Tests**
  * Added coverage for budget exhaustion, forced verdict generation, token accounting, and wrap-up reason prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | -2 |
| 🧠 mental load | 3 | -2 |
| ⏱️ time to understand | 3 | +44 |
| 🐛 estimated bugs | 2 | +0.137 |


> [!NOTE]
> **Low Risk**
>
> This PR extracts the wrap-up decision from both agent clients into a shared `computeWrapUpReason` helper and adds a new `input-growth` trigger that forces an early no-tools verdict when the current turn's own input cost already meets or exceeds the remaining budget. The existing `near-budget` (60%) and `last-turn` checks are preserved with identical semantics, and both OpenAI and Anthropic clients invoke the shared function consistently. The logic is straightforward, provider-agnostic, and covered by unit and integration tests that exercise the boundary values, priority ordering, and the no-regression census receipt shape. No breaking changes or silent wrong-output paths were identified.
>
> - New shared `computeWrapUpReason`/`logWrapUpReason` in `agent-client-shared.ts` with `input-growth`, `near-budget`, and `last-turn` checks.
> - Both `OpenAIAgentClient.run` and `AnthropicAgentClient.run` now use the shared helper instead of inline threshold logic.
> - Added regression tests in both client test suites for the early input-spike scenario and unit tests for the shared decision function.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 062a239. Updates automatically on new commits.</sup>
<!-- /lien-stats -->