### PR TITLE
fix(parser): resolve Java static-member import path ambiguity (#864)

### DIFF
--- a/.changeset/java-static-member-import-path.md
+++ b/.changeset/java-static-member-import-path.md
@@ -1,0 +1,42 @@
+---
+'@liendev/parser': patch
+---
+
+Fix Java `import static a.b.ClassName.member;` (a specific, non-wildcard
+static-member import) never resolving to a test association or dependent for
+its defining class file (#864). `extractImportPath` was already returning a
+syntactically-correct path, but one segment deeper than the class's own file
+— `com.example.Utils.method` where the file is `com/example/Utils.java`, not
+`com/example/Utils/method` — so `matchesFile`/`matchesPythonModule` could
+never match it.
+
+`JavaImportExtractor.extractImportPaths` now returns the class's derived FQN
+(the raw path with its trailing segment dropped) as a second candidate
+alongside the original, unchanged single path from `extractImportPath`. This
+is safe rather than a guess: Java requires every top-level type to live in a
+file named after it, and nested types/members always live inside their
+enclosing top-level type's file, so dropping the trailing segment always
+yields that type's correct FQN — whether the segment names a static member
+(the common case) or a nested class (`import static a.B.Inner;`, correct by
+the same rule). A static import reaching two-plus levels into nested classes
+under-matches silently (the same behavior as before the fix) rather than
+mismatching. Wildcard static imports and ordinary (non-static) imports are
+unaffected.
+
+Confirmed on a real clone of google/gson: `JsonReaderTest.java` statically
+imports 8 specific members of `JsonToken` (`STRING`, `NUMBER`, `BEGIN_ARRAY`,
+...) and was invisible to `lien annotate`'s test-coverage line for
+`JsonToken.java` despite directly testing `JsonReader.peek()`'s `JsonToken`
+return values; it now appears. A full before/after diff of every file's
+test-association set across gson's 264 Java files shows exactly one changed
+entry — this addition — confirming no new false positives elsewhere.
+
+Kotlin's narrower analogous shape (`import a.b.myFunction` for a top-level
+function/property defined in an arbitrarily-named file) is deliberately left
+as an honest, undetermined gap rather than a guess: unlike Java, there is no
+syntactic marker (no `static`-equivalent keyword) distinguishing a top-level
+declaration from a class/object-member access in this grammar — both parse
+to an identical flat `identifier` of `simple_identifier` segments — so
+guessing risks the false-positive fan-out #868 warned against. This is
+documented in `KotlinImportExtractor`'s class doc comment and pinned by a
+regression test; #864 stays open for the Kotlin side.

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -53,11 +53,15 @@ for any file whose language sets `LanguageDefinition.wholeModuleImports` (checke
 
 A related guard, `isUnresolvableWholeModuleImport`, additionally excludes the one case a whole-module import can otherwise "win" a match: a coincidental basename, where a source file's name happens to equal its own module's name (`Source/Alamofire.swift` inside a module also named Alamofire). Without it, that file would falsely appear to be imported by every test in the module. The guard is applied at each of the four independent places that match imports against files: `findTestAssociationsFromChunks` (this document), `get_dependents`'s import index, and the two callers above that share `path-matching.ts`.
 
+## Java static-member imports: a derived second candidate
+
+`import static pkg.Class.member;` (a specific, non-wildcard static-member import) extracts a path one segment deeper than the file that defines it — `com.example.Utils.method`, when the file is `com/example/Utils.java` — so it could never match via `matchesFile` on its own. `JavaImportExtractor.extractImportPaths` (`packages/parser/src/ast/languages/java.ts`) now returns the class's derived FQN (the path with its trailing segment dropped) as a second candidate alongside the unchanged original. This is safe rather than a guess: Java requires every top-level type to live in a file named after it, and nested types/members always live inside their enclosing top-level type's file, so dropping the trailing segment always yields that type's correct FQN — whether the segment names a static member or a nested class (`import static a.B.Inner;`, correct by the same rule). A static import reaching two-plus levels into nested classes under-matches silently, the same as before this fix, rather than mismatching. Wildcard static imports and ordinary (non-static) imports are unaffected. Verified on a real clone of google/gson: `JsonReaderTest.java`'s static imports of `JsonToken.STRING`/`NUMBER`/etc. now associate it with `JsonToken.java`, with zero other test-association changes across the repo's 264 Java files.
+
 ## Known gaps
 
 These are structural: no import-level signal exists for the case, so the honest answer is a gap, not a bug to fix in the matcher. Each is tracked as an open issue; check its current state before treating this list as final.
 
-- **Java static member imports and Kotlin top-level function/property imports** ([#864](https://github.com/getlien/lien/issues/864)): `import static pkg.Class.member;` (and the Kotlin equivalent for a top-level function or property) extracts a path one segment deeper than the file that defines it, so it does not match via `matchesFile`. Ordinary class-level imports in both languages are unaffected.
+- **Kotlin top-level function/property imports** ([#864](https://github.com/getlien/lien/issues/864)): `import a.b.myFunction`, for a top-level function or property defined in an arbitrarily-named file within the package, extracts a path that never matches its defining file. Java's analogous static-member shape is fixed (above) because the `static` keyword is itself proof the trailing segment is a class member or nested type; Kotlin's grammar has no equivalent marker — a top-level declaration and a class/object-member access (`import a.b.MyObject.method`) parse to the identical flat `identifier` of `simple_identifier` segments — so guessing which applies risks the false-positive fan-out #868 warned against. Ordinary Kotlin class imports are unaffected. Confirmed unchanged on a real clone of JetBrains/Exposed: zero test-association changes across 755 Kotlin files.
 - **C# enclosing-namespace references** ([#875](https://github.com/getlien/lien/issues/875)): a file in a sub-namespace can reference an enclosing namespace's members with no `using` statement at all, leaving no import signal. Only the dotted `using X.Y;` form resolves.
 - **PHP factory/FQCN usage** ([#878](https://github.com/getlien/lien/issues/878)): a test that reaches production code through a factory method or a fully-qualified class name at the call site, rather than a `use` import, leaves no import signal to match on.
 
@@ -77,8 +81,8 @@ These are structural: no import-level signal exists for the case, so the honest 
 | Go | generic patterns | yes | go.mod module path |
 | Ruby | generic patterns | yes | none needed |
 | C# | `Tests`/`Test` suffix convention | yes | none (see known gaps) |
-| Java | generic patterns | yes | none (see known gaps for static member imports) |
-| Kotlin | generic patterns | yes | none (see known gaps for top-level imports) |
+| Java | generic patterns | yes (incl. static-member imports, derived class-path candidate) | none |
+| Kotlin | generic patterns | yes | none (see known gaps for top-level function/property imports) |
 | Rust | generic patterns | yes | none needed |
 | Swift | `Tests`/`Test` convention | not determinable (whole-module imports) | none |
 

--- a/packages/parser/src/ast/languages/java.test.ts
+++ b/packages/parser/src/ast/languages/java.test.ts
@@ -286,6 +286,75 @@ describe('Java Language', () => {
       const stdlibNode = stdlibRoot.namedChild(0)!;
       expect(importExtractor.extractImportPaths(stdlibNode)).toEqual([]);
     });
+
+    describe('static-member class-path fallback (#864)', () => {
+      it('extractImportPaths adds the class FQN as a second candidate for a specific static-member import', () => {
+        const code = 'import static com.google.common.base.Preconditions.checkNotNull;';
+        const root = mustParse(code, 'java');
+        const importNode = root.namedChild(0)!;
+
+        // extractImportPath (singular) stays exactly as-is — pinned by the test above.
+        expect(importExtractor.extractImportPath(importNode)).toBe(
+          'com.google.common.base.Preconditions.checkNotNull',
+        );
+
+        // extractImportPaths (plural) adds the class's own FQN so matching
+        // against Preconditions.java's file path can succeed.
+        expect(importExtractor.extractImportPaths(importNode)).toEqual([
+          'com.google.common.base.Preconditions.checkNotNull',
+          'com.google.common.base.Preconditions',
+        ]);
+      });
+
+      it('resolves a nested static class import to its enclosing type by the same rule (coincidentally correct)', () => {
+        const code = 'import static com.example.Outer.Inner;';
+        const root = mustParse(code, 'java');
+        const importNode = root.namedChild(0)!;
+
+        expect(importExtractor.extractImportPaths(importNode)).toEqual([
+          'com.example.Outer.Inner',
+          'com.example.Outer',
+        ]);
+      });
+
+      it('only drops one segment for multi-level nested static imports — an honest partial result, not a wrong guess', () => {
+        const code = 'import static com.example.Outer.Middle.member;';
+        const root = mustParse(code, 'java');
+        const importNode = root.namedChild(0)!;
+
+        // Dropping one segment gives 'com.example.Outer.Middle', which still
+        // isn't Outer.java's real path — this candidate simply won't match
+        // anything, same as before the fix (no false positive, no crash).
+        expect(importExtractor.extractImportPaths(importNode)).toEqual([
+          'com.example.Outer.Middle.member',
+          'com.example.Outer.Middle',
+        ]);
+      });
+
+      it('does not add a class-path candidate for static wildcard imports (already resolved to the class FQN)', () => {
+        const code = 'import static com.example.Utils.*;';
+        const root = mustParse(code, 'java');
+        const importNode = root.namedChild(0)!;
+
+        expect(importExtractor.extractImportPaths(importNode)).toEqual(['com.example.Utils']);
+      });
+
+      it('does not add a class-path candidate for ordinary (non-static) imports', () => {
+        const code = 'import com.example.MyClass;';
+        const root = mustParse(code, 'java');
+        const importNode = root.namedChild(0)!;
+
+        expect(importExtractor.extractImportPaths(importNode)).toEqual(['com.example.MyClass']);
+      });
+
+      it('returns [] for a static stdlib member import (filtered before the fallback runs)', () => {
+        const code = 'import static java.lang.Math.PI;';
+        const root = mustParse(code, 'java');
+        const importNode = root.namedChild(0)!;
+
+        expect(importExtractor.extractImportPaths(importNode)).toEqual([]);
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -211,6 +211,47 @@ function stripWildcardSuffix(path: string): string {
 }
 
 /**
+ * For `import static a.b.ClassName.member;` (specific, non-wildcard), the
+ * path `extractImportPath` returns is one segment deeper than the file that
+ * defines it — the file is named after `ClassName`, not the trailing
+ * `member` (#864). Java requires every top-level type to live in a file
+ * named after it, and nested types/members always live inside their
+ * enclosing top-level type's file, so dropping the trailing segment always
+ * yields that type's correct FQN — whether the trailing segment names a
+ * static member (the common case) or a nested class
+ * (`import static a.B.Inner;`, where `Inner` is itself a type — dropping
+ * still resolves to `a.B`'s file, correct by the same rule). This can only
+ * under-match silently (a static import reaching two-plus levels into
+ * nested classes, e.g. `a.Outer.Middle.member`, where dropping one segment
+ * gives `a.Outer.Middle` — still not a real file, so it simply won't match
+ * anything, same as today) — it can never mismatch. So it's returned as an
+ * ADDITIONAL candidate path from `extractImportPaths`, never a replacement:
+ * `extractImportPath`'s pinned single-path return stays exactly as-is.
+ *
+ * Wildcard static imports (`import static a.B.*;`) are excluded: their
+ * `extractImportPath` result is already the class's FQN (the trailing `.*`
+ * is stripped above), so dropping another segment there would walk past the
+ * class into its package — wrong, not merely imprecise.
+ *
+ * Regular (non-static) imports don't get this treatment either — the whole
+ * path already IS the class's FQN there, so dropping a segment would be a
+ * real regression, not a safe extra candidate.
+ *
+ * Kotlin has an analogous-looking shape (`import a.b.Foo.member` /
+ * `import a.b.topLevelFn`) but no equivalent fix: its grammar gives both a
+ * flat `identifier` of `simple_identifier` segments with no marker
+ * distinguishing "class member access" from "bare top-level declaration" —
+ * unlike Java, there's no `static` keyword (or anything else) to hang this
+ * logic on, so guessing would risk the false-positive shape #868 warned
+ * against. Left as an honest gap per the #864/#869 precedent.
+ */
+function staticMemberClassPath(node: SyntaxNode, path: string): string | null {
+  if (!hasChildOfType(node, 'static') || hasChildOfType(node, 'asterisk')) return null;
+  const lastDot = path.lastIndexOf('.');
+  return lastDot > 0 ? path.slice(0, lastDot) : null;
+}
+
+/**
  * Java import extractor
  *
  * Handles all Java import patterns:
@@ -231,7 +272,10 @@ export class JavaImportExtractor implements LanguageImportExtractor {
   }
 
   extractImportPaths(node: SyntaxNode): string[] {
-    return toImportPathsArray(this.extractImportPath(node));
+    const path = this.extractImportPath(node);
+    if (!path) return [];
+    const classPath = staticMemberClassPath(node, path);
+    return classPath ? [path, classPath] : toImportPathsArray(path);
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -170,6 +170,18 @@ describe('Kotlin Language', () => {
       const [stdlib] = importHeaders('import kotlin.collections.List\n');
       expect(importExtractor.extractImportPaths(stdlib)).toEqual([]);
     });
+
+    it('honestly leaves a top-level function/property import as a single, one-segment-too-deep path (#864, no analogous fix — see class doc comment)', () => {
+      // `import a.b.topLevelFn` and `import a.b.MyObject.method` parse to the
+      // identical flat identifier shape in this grammar — there is no
+      // syntactic marker (unlike Java's `static` keyword) distinguishing
+      // "class/object member" from "genuine top-level declaration in an
+      // arbitrarily-named file". Guessing which one applies risks the
+      // false-positive fan-out #868 warned against, so no fallback candidate
+      // is added here; this pins that (documented, deliberate) behavior.
+      const [imp] = importHeaders('import a.b.topLevelFn\n');
+      expect(importExtractor.extractImportPaths(imp)).toEqual(['a.b.topLevelFn']);
+    });
   });
 
   // ===========================================================================

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -311,6 +311,21 @@ function stripWildcardSuffix(path: string): string {
  * `import_list`; the engine's import scan descends one level to reach them
  * (see `collectImportNodes` in ast/symbols.ts). Standard-library imports
  * (kotlin.*, kotlinx.*, java.*, javax.*) are filtered out.
+ *
+ * `extractImportPaths` has no analogue of Java's `staticMemberClassPath`
+ * fallback (#864): a top-level function/property import (`import
+ * a.b.myFunction`, defined in an arbitrarily-named file within package
+ * `a.b`) and a class/object-member import (`import a.b.MyObject.method`)
+ * parse to the identical shape — a flat `identifier` of `simple_identifier`
+ * segments with no distinguishing marker (verified empirically: no
+ * `static`-equivalent keyword, no different node type). Java's fix works
+ * because the `static` keyword's presence is itself the syntactic proof that
+ * the trailing segment is a class member/nested type, not a package
+ * component. Without an equivalent marker here, dropping the trailing
+ * segment can't be told apart from truncating a genuine top-level
+ * declaration down to a bare package directory (a many-files fan-out, the
+ * same false-positive shape #868 warned against) — so this stays an honest,
+ * undetermined gap rather than a guess.
  */
 export class KotlinImportExtractor implements LanguageImportExtractor {
   readonly importNodeTypes = ['import_header'];

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -6,6 +6,7 @@ import {
   extractExports,
   extractCallSites,
 } from './symbols.js';
+import { matchesFile, normalizePath } from '../utils/path-matching.js';
 
 describe('Symbol Extraction', () => {
   describe('extractImportedSymbols', () => {
@@ -668,6 +669,47 @@ func run() {
       expect(imports).toContain('github.com/foo/utils');
       expect(imports).toContain('github.com/foo/models');
       expect(imports).not.toContain('fmt');
+    });
+  });
+
+  describe('extractImports - Java static-member class-path fallback (#864)', () => {
+    it('a specific static-member import now matches its defining class file end-to-end', () => {
+      // Reproduces #864: `import static a.B.member;` extracted only the raw,
+      // one-segment-too-deep path, which could never match the class's own
+      // file via matchesFile/matchesPythonModule. extractImports now also
+      // captures the class's FQN, so a test file doing this static import
+      // is discoverable as covering Preconditions.java.
+      const content = `
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class Foo {
+  void bar() { checkNotNull(this); }
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'java');
+      const imports = extractImports(parseResult.tree!.rootNode, 'java');
+
+      expect(imports).toContain('com.google.common.base.Preconditions.checkNotNull');
+      expect(imports).toContain('com.google.common.base.Preconditions');
+
+      const target = normalizePath('com/google/common/base/Preconditions.java', '');
+      // Before the fix, none of `imports` would satisfy matchesFile against
+      // the class's own file — this is the concrete before/after behavior.
+      expect(imports.some(imp => matchesFile(normalizePath(imp, ''), target))).toBe(true);
+    });
+
+    it('an ordinary (non-static) import is unaffected — still exactly one path', () => {
+      const content = `
+import com.example.MyClass;
+
+class Foo {}
+      `.trim();
+
+      const parseResult = parseAST(content, 'java');
+      const imports = extractImports(parseResult.tree!.rootNode, 'java');
+
+      expect(imports).toEqual(['com.example.MyClass']);
     });
   });
 


### PR DESCRIPTION
## Summary

Partial fix for #864, #864 stays open (Kotlin side).

Follow-up from the #859/#865 import-extractor audit: `import static
pkg.Class.member;` (a specific, non-wildcard static-member import)
extracted a syntactically-correct path that's one segment deeper than
the file that defines it — `com.example.Utils.method` where the file
is `com/example/Utils.java` — so `matchesFile`/`matchesPythonModule`
in `packages/parser/src/utils/path-matching.ts` could never match it.

## Fix

Builds on #882's plural `extractImportPaths(node): string[]` extension
point. `JavaImportExtractor.extractImportPaths`
(`packages/parser/src/ast/languages/java.ts`) now returns a second
candidate — the class's derived FQN (the raw path with its trailing
segment dropped) — alongside the unchanged original from
`extractImportPath` (kept exactly as pinned by existing tests).

This is safe rather than a guess: Java requires every top-level type
to live in a file named after it, and nested types/members always live
inside their enclosing top-level type's file, so dropping the trailing
segment always yields that type's correct FQN — whether the segment
names a static member (the common case) or a nested class (`import
static a.B.Inner;`, correct by the same rule). A static import
reaching two-plus levels into nested classes under-matches silently
(same as before the fix) rather than mismatching. Wildcard static
imports and ordinary (non-static) imports are unaffected.

## Kotlin: honest gap, not fixed here

Kotlin has a narrower analogous shape (`import a.b.myFunction` for a
top-level function/property defined in an arbitrarily-named file
within the package). Verified empirically (parsed both shapes against
the real grammar): a top-level function/property import and a
class/object-member-access import (`import a.b.MyObject.method`)
produce the **identical** flat `identifier` of `simple_identifier`
segments — there is no `static`-equivalent keyword or any other
syntactic marker to hang a fix on. Guessing which shape applies risks
the false-positive fan-out #868 warned against, so per the #864/#869/#881
precedent this stays an honest, undetermined gap — documented in
`KotlinImportExtractor`'s class doc comment and pinned by a regression
test that locks in the current (unchanged) single-path behavior.

## Docs

`docs/architecture/test-association.md` was rewritten on `main` in
#889 while this branch was in flight (merged via fast-forward, no
conflicts). Updated the doc's `#864` passage: added a "Java
static-member imports: a derived second candidate" section describing
the fix, narrowed the "Known gaps" bullet to Kotlin only, and updated
the language-support table's Java/Kotlin rows.

## Tests

- `java.test.ts`: new `describe('static-member class-path fallback
  (#864)')` — specific static-member import gets the class-FQN
  candidate added; nested static-class import resolves correctly
  (coincidentally, by the same rule); multi-level nested static import
  only drops one segment (honest partial result, not a wrong guess);
  static wildcard and ordinary imports are unaffected; stdlib static
  import still returns `[]`.
- `kotlin.test.ts`: new test pinning the deliberate no-fix behavior for
  a top-level function import (`extractImportPaths` still returns the
  single, one-segment-too-deep path).
- `symbols.test.ts`: end-to-end `extractImports` test proving
  `matchesFile` now succeeds against the class's own file for the
  static-member shape, plus a control test showing an ordinary import
  is unaffected.

## Gates

```
npm run format:check   PASS
npm run lint           PASS (0 errors; pre-existing warnings only, none in touched files)
npm run typecheck      PASS
npm run build          PASS
npm test               PASS — parser 1230, core 378, review 1647, cli 1186, action 41 (all green)
node packages/cli/dist/index.js delta   PASS (exit 0 — 1 "worsened" cognitive-complexity
                                          note, no threshold crossing)
npm run test:e2e:java -w packages/cli     PASS (JavaPoet)
npm run test:e2e:kotlin -w packages/cli   PASS (Klaxon)
```

`lien delta` detail (informational only, no threshold crossings):
```
packages/parser/src/ast/languages/java.ts
  ⚠ worsened  JavaImportExtractor.extractImportPaths  cognitive 0 → 2
  · new       staticMemberClassPath                   cognitive – → 3
```

## Dogfood (mandatory, verbatim evidence)

Built two CLI binaries from a scratch dir outside this worktree
(`mktemp -d`) — one from `origin/main` (`deffceec`, via a throwaway
`git worktree add`), one from this branch — and indexed real clones of
`google/gson` (Java) and `JetBrains/Exposed` (Kotlin) with each,
separate `LIEN_HOME`s so the two indexes never collide.

### Java: google/gson, real `lien annotate` before/after

`JsonReaderTest.java` statically imports 8 specific members of
`JsonToken` (`STRING`, `NUMBER`, `BEGIN_ARRAY`, ... — confirmed real,
direct correctness relationship by reading the test file: it asserts
`reader.peek()` against these exact `JsonToken` values, e.g.
`assertThat(reader.peek()).isEqualTo(BEGIN_ARRAY)`).

```
$ node <before>/dist/index.js annotate gson/src/main/java/com/google/gson/stream/JsonToken.java
Lien impact for gson/src/main/java/com/google/gson/stream/JsonToken.java:
  • 24 files import this — ...; risk: critical (24 callers, 12 untested, ...).
  • Test coverage: gson/src/test/java/com/google/gson/functional/NumberLimitsTest.java,
    gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java (+1 more).

$ node <after>/dist/index.js annotate gson/src/main/java/com/google/gson/stream/JsonToken.java
Lien impact for gson/src/main/java/com/google/gson/stream/JsonToken.java:
  • 25 files import this — ...; risk: critical (25 callers, 12 untested, ...).
  • Test coverage: gson/src/test/java/com/google/gson/stream/JsonReaderTest.java,
    gson/src/test/java/com/google/gson/functional/NumberLimitsTest.java (+2 more).
```

`JsonReaderTest.java` is now included — the exact, expected addition.

**No new false positives**: an exhaustive before/after diff of
`findTestAssociationsFromChunks` across **all 264 Java files** in gson
(not just the one file above) shows exactly **one** changed
association in the whole repo, and it's an addition, not a removal:

```
total java files scanned: 264
files with a changed test-association set: 1
total added associations: 1  total removed associations: 0
[{ file: "gson/src/main/java/com/google/gson/stream/JsonToken.java",
   added: ["gson/src/test/java/com/google/gson/stream/JsonReaderTest.java"],
   removed: [] }]
```

### Kotlin: JetBrains/Exposed — confirmed honest no-op

Exposed's real code makes heavy use of top-level function imports
(e.g. `import org.jetbrains.exposed.v1.core.alias`, `.and`, `.avg`,
`.between`, ...). Raw `chunk.metadata.imports` for a real consumer
file is byte-identical before and after:

```
["org.example.tables.StarWarsFilmsTable","org.jetbrains.exposed.v1.core.JoinType",
 "org.jetbrains.exposed.v1.core.alias","org.jetbrains.exposed.v1.jdbc.select",
 "org.jetbrains.exposed.v1.jdbc.selectAll"]
```
(identical in both the before- and after-build indexes)

Exhaustive before/after diff across **all 755 Kotlin files**:

```
total kotlin files scanned: 755
files with a changed test-association set: 0
total added associations: 0  total removed associations: 0
```

Zero behavior change, confirming the deliberate honest-gap decision
holds in practice, not just in the unit tests.

All scratch clones, throwaway builds, and `LIEN_HOME` index dirs were
outside this worktree (`/tmp`) and are not part of this diff.

## Changeset

`@liendev/parser` patch (`.changeset/java-static-member-import-path.md`).

## Scope note

Per the brief, kept this diff scoped to `java.ts`/`kotlin.ts`/their
tests, `symbols.test.ts` (a new end-to-end test, additive), and the
doc. No changes to shared matching code (`path-matching.ts`) or the
extractor interface itself — the plural `extractImportPaths` extension
point from #882 was sufficient. Did not rebase onto sibling branches
(#875 C#, #878 PHP) per instructions.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a safe, additive fallback for Java static-member imports: `JavaImportExtractor.extractImportPaths` now returns both the original member path and the enclosing class FQN for `import static pkg.Class.member;`, allowing downstream file matching to associate the importing test with the defining class file. Wildcard static imports and ordinary imports are correctly excluded, and Kotlin deliberately does not receive an analogous fix because its grammar lacks a `static`-equivalent marker. The change is well-scoped, thoroughly tested, and backed by real-repo validation on google/gson showing exactly one expected association addition and no false positives.
>
> - Java static-member imports now emit a second candidate path (class FQN) in `extractImportPaths`, fixing under-association without replacing the original path
> - Kotlin's analogous top-level function/property import gap is documented and left unfixed to avoid false-positive fan-out
> - New unit and end-to-end tests pin the behavior for Java, Kotlin, and `extractImports`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0c9d0b3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->