### PR TITLE
fix(review): harden verdict recovery against JSON-dense-diff derailment

### DIFF
--- a/packages/review/src/defaults.ts
+++ b/packages/review/src/defaults.ts
@@ -26,10 +26,26 @@ export const DEFAULT_OPENROUTER_OUTPUT_COST_PER_MTOK = 3.5;
  * (the direct lever against those timeouts); `allow_fallbacks` keeps the run
  * resilient if that endpoint fails. Overridable via the `providerRouting`
  * config (e.g. add `ignore`/`order` once logs name a flaky provider).
+ *
+ * `require_parameters: true` (issue #829) restricts routing to providers that
+ * actually support every parameter on the request — per OpenRouter's own
+ * "Filter Providers by Parameter Support" guidance, without it a provider can
+ * silently ignore an unsupported parameter instead of honoring or rejecting
+ * it. The forced-verdict retry (`attemptVerdictCompletion`) depends on
+ * `response_format: { type: 'json_object' }` to structurally guarantee JSON
+ * back — a provider that ignores that field would return ordinary prose
+ * instead, which is indistinguishable from the model itself derailing. Two
+ * real incidents (PR #845, runs 30113956762/30114812093) show exactly that
+ * shape: the main pass's forced-finish turn AND both bounded summary-retry
+ * attempts (all three `response_format:'json_object'` requests) came back
+ * unparseable on a JSON-dense diff. `sort`/`allow_fallbacks` are unaffected —
+ * `require_parameters` only prunes the candidate set each request is routed
+ * within, it doesn't change the sort or fallback behavior itself.
  */
 export const DEFAULT_PROVIDER_ROUTING: Record<string, unknown> = {
   sort: 'throughput',
   allow_fallbacks: true,
+  require_parameters: true,
 };
 
 /**

--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -89,16 +89,25 @@ export function logTurn(logger: Logger, turn: TurnTrace | undefined, label?: str
  *  1. each ```json fence, LAST first — the model emits its verdict last, so a
  *     few-shot/example fence earlier in the prose must not win;
  *  2. the raw body (a response_format:json_object / forced-verdict turn);
- *  3. the first balanced JSON object in the text (brace-depth scan — recovers
- *     a complete, valid verdict followed by trailing prose, e.g. "Wait, I need
- *     to double-check…" appended after the closing brace, #792's
- *     incomplete-handling canary);
+ *  3. every top-level balanced JSON object in the text, in the order they
+ *     appear (brace-depth scan — recovers a complete, valid verdict followed
+ *     by trailing prose, e.g. "Wait, I need to double-check…" appended after
+ *     the closing brace, #792's incomplete-handling canary; also recovers a
+ *     verdict that isn't the first such object, e.g. an incidental
+ *     JSON-shaped fragment quoted earlier while investigating a JSON-dense
+ *     diff, #829);
  *  4. a naive first-open-to-last-close slice of the whole text (model ignored
  *     json_object and wrapped the verdict in prose with no other braces).
  *
  * Prefer a candidate carrying a `summary` (the verdict marker) so an
  * `{"findings": [...]}`-only example can't beat the real verdict; fall back to
- * the first findings-only candidate if nothing carries a summary.
+ * the first findings-only candidate if nothing carries a summary. This holds
+ * both ACROSS strategies (a fence beats a balanced object) and WITHIN the
+ * balanced-object strategy (the first object carrying `summary` wins over a
+ * later one) — see `allBalancedJsonObjects`'s doc comment for why that keeps
+ * #792's "trust the original verdict, not a later self-revision" behavior
+ * unchanged while still recovering a verdict an earlier non-verdict object
+ * previously hid.
  */
 export function extractFindingsFromText(
   text: string,
@@ -114,10 +123,10 @@ export function extractFindingsFromText(
   const candidates: Array<{ value: string | undefined; recovered?: string }> = [
     ...fences.map(value => ({ value })),
     { value: text.trim() },
-    {
-      value: firstBalancedJsonObject(text),
+    ...allBalancedJsonObjects(text).map(value => ({
+      value,
       recovered: 'balanced-object extraction (trailing content after the closing brace)',
-    },
+    })),
     { value: embeddedJsonObject(text) },
   ];
 
@@ -263,26 +272,32 @@ export function embeddedJsonObject(content: string): string | undefined {
   return start !== -1 && end > start ? content.slice(start, end + 1) : undefined;
 }
 
-/**
- * Scan from the first `{` and track brace depth — respecting string literals
- * and escapes — to find the first *complete, balanced* JSON object, stopping
- * as soon as depth returns to zero and ignoring everything after.
- *
- * Recovers a verdict that is otherwise valid but has trailing content
- * appended after its closing brace — observed on the incomplete-handling
- * canary post-#787 (#792 3-vote screen): the model emits a complete, correct
- * verdict, then appends "Wait, I need to double-check…" prose (which itself
- * contains further `{`/`}` characters). `embeddedJsonObject`'s naive
- * first-open/last-close slice overshoots into that trailing content and
- * produces unparseable JSON; this stops at the first balanced close instead.
- * Returns undefined if the text has no `{` or never balances (e.g. a
- * genuinely truncated response) — never guesses at an unbalanced slice.
- */
 /** Matches a double-quoted JSON string literal, escapes included. */
 const JSON_STRING_LITERAL = /"(?:\\.|[^"\\])*"/g;
 
-export function firstBalancedJsonObject(text: string): string | undefined {
-  const start = text.indexOf('{');
+/**
+ * Safety valve on `allBalancedJsonObjects`' scan: each object found re-masks
+ * the remaining text, so a pathological "{}{}{}…" essay could otherwise cost
+ * O(n²). A genuine verdict is always among the first few objects in real
+ * model output; this bounds worst-case work on adversarial/degenerate input
+ * without affecting any real recovery.
+ */
+const MAX_BALANCED_OBJECTS_SCANNED = 25;
+
+/**
+ * Find the single balanced JSON object starting at `text`'s first `{` at or
+ * after `searchFrom`, tracking brace depth (respecting string literals and
+ * escapes) until it returns to zero. Returns its `[start, end]` (inclusive)
+ * indices, or `undefined` if there's no more `{` or it never balances (e.g. a
+ * genuinely truncated response) — never guesses at an unbalanced slice.
+ * Pulled out of `allBalancedJsonObjects` so that function's own loop stays
+ * under the complexity budget.
+ */
+function nextBalancedObjectRange(
+  text: string,
+  searchFrom: number,
+): { start: number; end: number } | undefined {
+  const start = text.indexOf('{', searchFrom);
   if (start === -1) return undefined;
 
   // Mask string contents with same-length `"` filler so quotes/escapes never
@@ -294,9 +309,57 @@ export function firstBalancedJsonObject(text: string): string | undefined {
   let depth = 0;
   for (let i = 0; i < masked.length; i++) {
     if (masked[i] === '{') depth++;
-    else if (masked[i] === '}' && --depth === 0) return text.slice(start, start + i + 1);
+    else if (masked[i] === '}' && --depth === 0) return { start, end: start + i };
   }
   return undefined; // never balanced — no complete object found
+}
+
+/**
+ * Scan the whole text for every top-level *complete, balanced* JSON object,
+ * in the order they appear, resuming right after each one's closing brace to
+ * look for the next. Stops (without emitting a partial entry) the moment a
+ * `{` never balances, since a genuinely truncated response can't be guessed
+ * at.
+ *
+ * Recovers, in one pass:
+ *  - a verdict that is otherwise valid but has trailing content appended
+ *    after its closing brace — observed on the incomplete-handling canary
+ *    post-#787 (#792's 3-vote screen): the model emits a complete, correct
+ *    verdict, then appends "Wait, I need to double-check…" prose (which
+ *    itself contains further `{`/`}` characters). `embeddedJsonObject`'s
+ *    naive first-open/last-close slice overshoots into that trailing
+ *    content and produces unparseable JSON; stopping at each balanced close
+ *    instead means the first object is recovered cleanly and any later ones
+ *    are visible as separate candidates rather than corrupting the slice.
+ *  - a verdict that isn't the FIRST top-level object in the text — e.g. an
+ *    incidental JSON-shaped fragment the model quoted while investigating a
+ *    JSON-dense diff (issue #829) sits before the real, later verdict.
+ *    `extractFindingsFromText` tries every object this returns and still
+ *    prefers the first one carrying `summary`, so a genuine verdict
+ *    followed by the model second-guessing itself into a "revised" verdict
+ *    (also #792) is unaffected — only a real verdict that was previously
+ *    invisible because an earlier, non-verdict object ate the single-object
+ *    scan's only attempt is newly recovered.
+ */
+export function allBalancedJsonObjects(text: string): string[] {
+  const objects: string[] = [];
+  let searchFrom = 0;
+  while (objects.length < MAX_BALANCED_OBJECTS_SCANNED) {
+    const range = nextBalancedObjectRange(text, searchFrom);
+    if (!range) break;
+    objects.push(text.slice(range.start, range.end + 1));
+    searchFrom = range.end + 1;
+  }
+  return objects;
+}
+
+/**
+ * The first top-level balanced JSON object in the text — see
+ * `allBalancedJsonObjects` for the full scan this delegates to and why a
+ * caller may prefer the complete list instead.
+ */
+export function firstBalancedJsonObject(text: string): string | undefined {
+  return allBalancedJsonObjects(text)[0];
 }
 
 /** Type guard to validate a summary object. */

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -192,6 +192,27 @@ OPENROUTER_API_KEY=… ./packages/review/test/harness/sweep.sh
 OPENROUTER_API_KEY=… ./packages/review/test/harness/sweep.sh anthropic/claude-haiku-4.5 deepseek/deepseek-chat-v3.1
 ```
 
+## Reliability fixtures (main-pass completion, not a rule finding)
+
+These pin a run-COMPLETION regression rather than a specific finding — the
+`expect` closure is a minimal Tier-1 sanity check (the run engaged the diff
+at all), and the fixture's real signal is the harness's own pass/fail rate
+across `--votes`/`--calibrate` and the per-vote `--trace` output. Always
+tagged `characterization` (a model-reliability frontier, not a rule to push
+to 9/10 by prompt iteration).
+
+| Fixture | PR | Why |
+|---|---|---|
+| `incomplete-handling/pr845-json-dense-verdict-derailment` | #845 | Issue #829: on this JSON-dense diff, the main pass's own final turn (and both bounded summary-retry attempts) can emit prose instead of the required findings/summary JSON — reported honestly as `incomplete`, never a silent clean review. Real GH Actions incidents (runs 30113956762, 30114812093) reproduced 2026-07-25 in the harness itself: 1 of 3 fresh votes pre-fix derailed the same way (`finishReason:'length'` on both retries — truncated, not merely mis-parsed), 0 of 3 post-fix (`DEFAULT_PROVIDER_ROUTING.require_parameters`, `defaults.ts`). `config: { docTruthPass: false }` is baked into the captured fixture so a vote only pays for the main pass. |
+
+Regenerate:
+
+```bash
+npx tsx packages/review/test/harness/capture-pr.ts 845 \
+  packages/review/test/harness/fixtures/incomplete-handling/pr845-json-dense-verdict-derailment.fixture.json
+# then re-apply config: { docTruthPass: false } to the captured JSON (capture-pr.ts doesn't take a --config flag)
+```
+
 ## Captured fixtures aren't committed (size)
 
 Snapshot-captured fixtures are typically 10MB+ (a full repo's `repoChunks`).

--- a/packages/review/test/harness/fixtures/incomplete-handling/pr845-json-dense-verdict-derailment.assertions.ts
+++ b/packages/review/test/harness/fixtures/incomplete-handling/pr845-json-dense-verdict-derailment.assertions.ts
@@ -1,0 +1,62 @@
+/**
+ * PR #845 (feat/nudge-docs-refs) — regression fixture for issue #829: the
+ * review engine's verdict-derailment flake.
+ *
+ * This is NOT a rule-finding fixture. It pins a RELIABILITY shape: on this
+ * PR's real diff, the main pass's own final ("finish_reason:'stop'") turn
+ * repeatedly emitted a long prose investigation instead of the required
+ * findings/summary JSON, and BOTH bounded summary-retry attempts (also
+ * `response_format:'json_object'`) came back unparseable too — reported
+ * honestly as `stopReason:'completed'` + `incomplete:true` (see
+ * `describeIncompleteStop` in `agent-client-shared.ts`'s caller,
+ * `index.ts`'s `appendIncompleteNotice`: "ended without emitting a
+ * parseable JSON verdict while investigating").
+ *
+ * Real incidents (verbatim, free — GH Actions logs, no LLM spend to
+ * reproduce): PR #845 run 30113956762 attempt 2 and run 30114812093
+ * attempt 1, both prod Kimi (`moonshotai/kimi-k2.7-code`), both derailed
+ * the same way — a ~227K-262K-token Turn 5 of dense "Issue 1: … Issue 21: …"
+ * self-review prose, no parseable JSON anywhere in either attempt or its
+ * two retries. Neither incident's captured text contains a genuine verdict
+ * object anywhere (confirmed by inspecting the untruncated turn output), so
+ * a parsing-side fix alone cannot recover THOSE specific runs — the fix
+ * that ships with this fixture (`DEFAULT_PROVIDER_ROUTING.require_parameters:
+ * true`, `defaults.ts`) targets the mechanism that made even the *forced*
+ * JSON retries unreliable: without it, OpenRouter can route
+ * `response_format:'json_object'` to a provider that silently ignores the
+ * field instead of honoring or rejecting it (OpenRouter's own "Filter
+ * Providers by Parameter Support" guidance). The complementary
+ * `allBalancedJsonObjects` extractor change (same PR) closes a real but
+ * narrower gap: a genuine verdict that isn't the FIRST balanced JSON object
+ * in unfenced text is no longer invisible to the scanner.
+ *
+ * Tagged `characterization`, not `canary`: this is a known model-reliability
+ * frontier (the prod model occasionally derails on JSON/regex-dense diffs),
+ * not a rule this fixture can force to a 9/10 bar by prompt iteration alone.
+ * `config: { docTruthPass: false }` is baked into the captured fixture so a
+ * `--votes`/`--calibrate` run only pays for the main pass (the pass this
+ * fixture is about), not doc-truth's separate pass on the same diff — same
+ * pattern as `crossrepo/pr4172-columndatatype-gel-gap`'s baked-in config.
+ *
+ * The assertion below is a minimal Tier-1 sanity check (the run engaged the
+ * diff at all) — this fixture's real signal is read from the harness's own
+ * pass/fail rate across N votes/calibration runs and the per-vote trace
+ * files (`--trace <dir>`), not a single finding's content. A rising
+ * derailment rate here over time is the regression this fixture exists to
+ * catch; a single red vote is expected some fraction of the time and is not
+ * itself a regression.
+ */
+import type { FixtureAssertions } from '../../assertions.js';
+
+const assertions: FixtureAssertions = {
+  description:
+    'PR #845 — JSON-dense docRefs diff; regression pin for the #829 verdict-derailment flake (main pass reliability, not a single finding)',
+  rule: 'incomplete-handling',
+  expect: (result, h) => {
+    h.expectToolCalled('get_files_context', result);
+  },
+  votes: 3,
+  tags: ['characterization'],
+};
+
+export default assertions;

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -8,6 +8,7 @@ import {
   readVerdict,
   embeddedJsonObject,
   firstBalancedJsonObject,
+  allBalancedJsonObjects,
   isValidSummary,
   isValidFinding,
   AGENT_LOG_MAX,
@@ -237,6 +238,37 @@ describe('firstBalancedJsonObject', () => {
   });
 });
 
+describe('allBalancedJsonObjects', () => {
+  it('returns a single-element list for one object (matches firstBalancedJsonObject)', () => {
+    expect(allBalancedJsonObjects('{"a":1}')).toEqual(['{"a":1}']);
+  });
+
+  it('returns an empty list when there is no opening brace', () => {
+    expect(allBalancedJsonObjects('no braces here')).toEqual([]);
+  });
+
+  it('returns an empty list when the (only) braces never balance', () => {
+    expect(allBalancedJsonObjects('{"a": {"b": 1')).toEqual([]);
+  });
+
+  it('finds every top-level object in sequence, resuming after each close', () => {
+    const text = '{"a":1} between {"b":2} and {"c":3}';
+    expect(allBalancedJsonObjects(text)).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+  });
+
+  it('stops scanning once a later `{` never balances, keeping the earlier complete ones', () => {
+    const text = '{"a":1} then {"b": unbalanced';
+    expect(allBalancedJsonObjects(text)).toEqual(['{"a":1}']);
+  });
+
+  it('bounds the scan against a pathological run of tiny objects (no hang, no crash)', () => {
+    const text = '{}'.repeat(1000);
+    const objects = allBalancedJsonObjects(text);
+    expect(objects.length).toBeLessThanOrEqual(25);
+    expect(objects.every(o => o === '{}')).toBe(true);
+  });
+});
+
 describe('readVerdict', () => {
   it('reads a {findings, summary} object', () => {
     const { findings, summary: s } = readVerdict({ findings: [finding], summary });
@@ -454,6 +486,30 @@ describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
     expect(out.findings).toHaveLength(1);
   });
 
+  // Issue #829: on a JSON-dense diff, the model's own investigative prose can
+  // quote an incidental JSON-shaped fragment (e.g. discussing a literal from
+  // the diff) BEFORE its real verdict, unfenced. The single-object scan used
+  // to stop at that first (non-verdict) object and never look further;
+  // `allBalancedJsonObjects` now tries every one in order, so the real
+  // verdict — still the first candidate that carries `summary` — is
+  // recovered instead of being shadowed by the earlier fragment.
+  it('#829: recovers a verdict that is not the first balanced object in unfenced text', () => {
+    const verdict = JSON.stringify({ findings: [finding], summary });
+    const text =
+      'Issue 7: JSON.stringify({x: NaN}) produces `{"x":null}`. Not a real verdict.\n' +
+      `Here is my actual verdict:\n${verdict}`;
+    const out = extractFindingsFromText(text);
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(1);
+  });
+
+  // The mirror-image case is a genuine, stated limitation, not a regression:
+  // if the EARLIER object also fully mimics the verdict shape (a leaked
+  // `<output_format>` contract example carrying its own dummy summary), a
+  // purely positional/shape-based scan cannot tell it apart from a real
+  // verdict without risking shape A's "trust the original, not a
+  // self-revision" behavior above. First-with-summary-wins is the documented
+  // trade-off (see `allBalancedJsonObjects`'s doc comment).
   it('shape B (#792 stale-duplicate): a wholesale-corrupted stop-turn stays unrecovered', () => {
     // Verbatim 28-char corrupted payload from both stale-duplicate screen
     // runs. It happens to be syntactically valid JSON (all the punctuation

--- a/packages/review/test/plugins-agent-provider-routing.test.ts
+++ b/packages/review/test/plugins-agent-provider-routing.test.ts
@@ -122,7 +122,11 @@ describe('OpenAIAgentClient provider routing', () => {
     const { bodies } = mockFetch([stopTurn()]);
     await makeClient().run('sys', 'init', [], noopTool);
     expect(bodies[0].provider).toEqual(DEFAULT_PROVIDER_ROUTING);
-    expect(bodies[0].provider).toEqual({ sort: 'throughput', allow_fallbacks: true });
+    expect(bodies[0].provider).toEqual({
+      sort: 'throughput',
+      allow_fallbacks: true,
+      require_parameters: true,
+    });
   });
 
   it('omits the default block for a non-OpenRouter endpoint (Gemini/DeepSeek reject unknown fields)', async () => {


### PR DESCRIPTION
## Summary

partial fix for #829, #829 stays open — see "What this does not guarantee" below.

On JSON-dense diffs, the review agent's main pass can derail: its final
turn (and both bounded summary-retry attempts) emit prose instead of the
required findings/summary JSON, reported honestly as `incomplete` rather
than a silent clean review (never a false-positive "no issues found").

## Diagnosis (from existing data — zero LLM spend)

Read the two real incidents named on the issue via `gh api
.../actions/runs/<id>/attempts/<n>` (both derailed attempts, not the
final successful re-run gh normally shows):

- PR #845 run `30113956762` attempt 2, run `30114812093` attempt 1 — both
  prod Kimi (`moonshotai/kimi-k2.7-code`). In both, the main pass's Turn 5
  (`finish_reason:'stop'`) emitted ~227K-262K tokens of "Issue 1: … Issue
  21: …" self-review prose, no parseable JSON anywhere. `[agent] No JSON
  output — requesting summary...` fired, then `Retry verdict was
  unparseable — attempting one more bounded retry`, then both bounded
  retries (`response_format:{type:'json_object'}`, tools dropped) *also*
  came back as prose, not JSON — despite the request structurally
  requiring JSON. Neither captured trace contains a genuine verdict object
  anywhere, so a parsing-side fix alone cannot recover those two specific
  runs.
- That "forced JSON mode still returns prose" shape pointed at
  `DEFAULT_PROVIDER_ROUTING` (`packages/review/src/defaults.ts`): it sets
  `sort:'throughput'` + `allow_fallbacks:true` but not
  `require_parameters:true`. Per OpenRouter's own "Filter Providers by
  Parameter Support" docs, without `require_parameters:true` a provider can
  silently ignore `response_format:json_object` instead of honoring or
  rejecting it — exactly indistinguishable from the model itself derailing.
- Separately, per PR #723's precedent (recovering findings under a
  corrupted key) and the maintainer's own 2026-07-25 triage note, `readVerdict`
  had no last-object preference in `extractFindingsFromText`'s raw
  (unfenced) balanced-JSON-object candidate: it only ever looked at the
  FIRST complete `{...}` in the text, so a genuine verdict positioned after
  an earlier, incidental JSON-shaped fragment (plausible on a diff this
  dense with jq/JSON literals) was invisible to the scanner.

## Fix (deterministic, no prompt/rule change)

1. **`DEFAULT_PROVIDER_ROUTING.require_parameters = true`**
   (`packages/review/src/defaults.ts`) — routes only to providers that
   actually support every parameter on the request, closing the gap that
   let both forced-JSON retries above silently return prose.
2. **`allBalancedJsonObjects`** (`agent-client-shared.ts`, replacing
   `firstBalancedJsonObject`'s internals — `firstBalancedJsonObject` itself
   stays exported, now `allBalancedJsonObjects(text)[0]`) scans *every*
   top-level balanced JSON object in the text, not just the first.
   `extractFindingsFromText` tries each in order and still prefers the
   first one carrying `summary` — so PR #792's "trust the original
   verdict, not the model's later self-revision" regression test is
   unaffected, while a real verdict an earlier non-verdict object
   previously hid is now recovered. New `MAX_BALANCED_OBJECTS_SCANNED`
   bounds the scan against a pathological run of tiny objects (this
   function processes untrusted LLM output).

Neither change touches `system-prompt.ts`/`rules.ts` — no rule/prompt
surface exists for `--calibrate` to measure, same precedent as PR #827's
byte-diff census for the same file. This is client-transport-config +
parsing robustness.

## What this does NOT guarantee

`require_parameters:true` fixes the *confirmed* mechanism behind both
real incidents (a non-compliant provider silently ignoring forced JSON
mode) and reproduced cleanly in a fresh live A/B (below). It does not
mathematically guarantee zero derailment — a compliant provider can, in
principle, still truncate a forced-JSON completion before it contains a
complete object (`finishReason:'length'`, observed in the "before" vote
below). That residual truncation-under-token-cap risk is a separate,
harder problem (shrinking the retry's own conversation context) not
addressed here. Hence: partial fix, issue stays open.

## Dogfood evidence (live A/B against the harness, real OpenRouter spend)

Captured PR #845's diff as a harness fixture (`capture-pr.ts`, free,
deterministic) with `config:{docTruthPass:false}` baked in so a vote only
pays for the main pass:
`packages/review/test/harness/fixtures/incomplete-handling/pr845-json-dense-verdict-derailment.{fixture.json (gitignored),assertions.ts}`.

**Before** (`git stash` back to pre-fix code, 3 live votes, prod model, $0.1804):

```
~ incomplete-handling/pr845-json-dense-verdict-derailment — measured 2/3 (non-gating, see fixture header) · $0.1804
```

Vote 3 reproduced the exact incident shape fresh: `passed:false`,
`findings:0`, 5 trace turns (3 main + 2 bounded retries), turns 4 and 5
both `finishReason:'length'` with plain prose content — e.g. turn 4 ends
mid-sentence discussing `isValidNumberOrNull`/jq output, turn 5 mid-sentence
discussing fence-detection — despite both being
`response_format:json_object` forced-verdict requests.

**After** (this branch, `git stash pop`, same fixture, 3 live votes, $0.1489):

```
~ incomplete-handling/pr845-json-dense-verdict-derailment — measured 3/3 (non-gating, see fixture header) · $0.1489
```

All 3 votes: `passed:true`, `findings:1`, exactly 3 trace turns each (no
retry needed at all) — Turn 3 (`finish_reason:'stop'`) directly produced a
parseable verdict.

Total OpenRouter spend: **$0.3293** (well under the ~$3 cap; no
`--calibrate 10` run — no rule/prompt surface to calibrate, see above).

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors (38 pre-existing warnings, none in touched files)
- `npm run typecheck` — clean across parser/core/cli/review/action
- `npm run build` — clean across all packages
- `npm test` — all packages green (parser, core, cli, review 1654, action)
- `node packages/cli/dist/index.js delta` — exit 0; `firstBalancedJsonObject`
  improved (cognitive 9→0, now a one-line delegate), `extractFindingsFromText`
  shows a "worsened" time-to-understand note (54m→58m, still under threshold,
  never `--soft`), two new small functions well under threshold
  (`allBalancedJsonObjects` cognitive 3, `nextBalancedObjectRange` cognitive 9)

No changeset: `@liendev/review` is `"private": true` (unpublished), per
CLAUDE.md.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR hardens verdict recovery on JSON-dense diffs by adding `require_parameters: true` to OpenRouter provider routing and replacing the single-object balanced-JSON scan with a bounded multi-object scan. Both changes are defensive and well-scoped: the routing change prevents providers from silently ignoring forced JSON mode, and the parser change recovers verdicts that are not the first balanced JSON object in unfenced text while preserving the existing preference for the first object carrying a `summary`. The touched logic is covered by updated unit tests, including a regression test for issue #829 and a boundary test for the 25-object scan limit. No callers are broken and no behavioral regressions were found.
>
> - Added `require_parameters: true` to `DEFAULT_PROVIDER_ROUTING` so OpenRouter only routes to providers that support every request parameter, including `response_format: 'json_object'`.
> - Introduced `allBalancedJsonObjects` with a `MAX_BALANCED_OBJECTS_SCANNED` cap of 25, and made `extractFindingsFromText` try every top-level balanced JSON object as a candidate verdict.
> - Updated `firstBalancedJsonObject` to delegate to `allBalancedJsonObjects(text)[0]`, preserving its existing contract.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ed79c11. Updates automatically on new commits.</sup>
<!-- /lien-stats -->