### PR TITLE
fix(parser): resolve PHP fully-qualified class-name references with no use import

### DIFF
--- a/.changeset/php-fqcn-references.md
+++ b/.changeset/php-fqcn-references.md
@@ -1,0 +1,40 @@
+---
+'@liendev/parser': minor
+---
+
+Closes part of #878: after #877's PSR-4 manifest mapping, 58/67 guzzle
+`src/*.php` files resolved real test coverage via declaration-based (`use
+...;`) import extraction. The remaining 9 files are referenced by their
+tests only through a fully-qualified class name or a factory — `new
+\GuzzleHttp\RetryMiddleware(...)`, `\GuzzleHttp\Exception\ClientException::class`
+— with no corresponding `use` import anywhere in the file, since PHP
+resolves a leading-`\` name absolutely regardless of what's imported.
+Declaration-based extraction (`namespace_use_declaration` nodes only) is
+structurally blind to this.
+
+`PHPImportExtractor` gains a new optional `extractReferencedFQCNs` method
+(added to the `LanguageImportExtractor` interface as an optional member —
+every other language simply omits it, zero behavior change) that
+recursively scans a whole PHP file for three unambiguous expression shapes
+whose class-name part is a fully-qualified (leading-`\`) `qualified_name`
+node: `new \Foo\Bar\Baz(...)`, `\Foo\Bar\Baz::class` (or any other static
+constant access), and `\Foo\Bar\Baz::method()`. A "qualified but not fully
+qualified" name (`Foo\Bar`, no leading `\`) is deliberately excluded — PHP
+resolves it relative to the current namespace or a `use`-imported alias,
+which is genuinely ambiguous without cross-referencing the file's own
+`use` imports, and is exactly the false-positive shape #868/#883 guard
+against. A fully-qualified single-segment name (`\DateTime`, `\Exception`)
+is also excluded: it can only ever name a PHP built-in or global-namespace
+class, never a Composer-autoloaded project file. `ast/symbols.ts`'s
+`extractImportPaths` merges these reference specifiers in through the
+exact same resolution pipeline (including PSR-4) as declaration-based
+imports, deduplicated, so `path-matching.ts`'s matcher needs no changes at
+all.
+
+Honest remainder, per #869/#881's precedent: the dominant shape among
+guzzle's 9 remaining files — `Middleware::retry()` internally `new`-ing
+`RetryMiddleware` from a *different* file (`Middleware.php`), with zero
+textual mention of `RetryMiddleware` anywhere in the test itself — needs
+transitive reasoning across files that a single-file structural scan
+cannot provide. That case is not resolved here and stays an honest "no
+signal" rather than a guess; #878 stays open to track it.

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -39,6 +39,14 @@ Both readers are intentionally narrow: parsed once per workspace root, cached, a
 
 Verified directly: a `composer.json` with `"GuzzleHttp\\": "src/"` correctly associates a test under `tests/` that imports `GuzzleHttp\Cookie\SetCookie` with `src/Cookie/SetCookie.php`, and a `go.mod` declaring `module example.com/gadget` correctly associates a test importing `example.com/gadget/internal/foo` with `internal/foo/foo.go`.
 
+## PHP fully-qualified class-name references
+
+PHP resolves a leading-`\` name absolutely, regardless of what's `use`-imported in scope — so a test can genuinely reference a class through `new \Foo\Bar\Baz(...)`, `\Foo\Bar\Baz::class`, or `\Foo\Bar\Baz::method()` with no corresponding `use` statement anywhere in the file, invisible to the declaration-based extraction above. `PHPImportExtractor.extractReferencedFQCNs` (`packages/parser/src/ast/languages/php.ts`) recursively scans a whole file for exactly those three expression shapes, requiring the class-name part to be a `qualified_name` node whose own text starts with `\` — genuinely unambiguous, unlike a "qualified but not fully-qualified" name (`Foo\Bar`, no leading `\`), which resolves relative to the current namespace or a `use` alias and is excluded as ambiguous. A fully-qualified single-segment name (`\DateTime`, `\Exception`) is also excluded, since it can only ever be a PHP built-in, never a Composer-autoloaded project file. The results are resolved through the exact same PSR-4 pipeline as a normal `use` import and merged in, deduplicated.
+
+Verified on a live guzzle/guzzle clone: `tests/ClientTest.php` references `\GuzzleHttp\Exception\ClientException::class` with no `use` import for it (it already imports `GuzzleHttp\Client`, not the exception), and now correctly appears in `src/Exception/ClientException.php`'s test-coverage list alongside the file's other, already-`use`-resolved test associations.
+
+This does not resolve the more common factory-indirection shape in the same codebase (see Known gaps below): a test that calls a factory method (`Middleware::retry()`) whose *internal implementation* — in a different file — is what actually names the concrete class (`RetryMiddleware`). No FQCN or `use` reference to that class exists anywhere in the test file itself for a single-file scan to find.
+
 ## Whole-module-import languages: an honest limitation
 
 Swift test files import their subject as a whole module (`import Alamofire`, `@testable import Alamofire`) rather than a specific file or symbol path, so there is no per-file signal for the matcher to resolve. This is a structural gap, not a fixable false negative: every test file in a module carries the identical bare-module import string.
@@ -59,7 +67,7 @@ These are structural: no import-level signal exists for the case, so the honest 
 
 - **Java static member imports and Kotlin top-level function/property imports** ([#864](https://github.com/getlien/lien/issues/864)): `import static pkg.Class.member;` (and the Kotlin equivalent for a top-level function or property) extracts a path one segment deeper than the file that defines it, so it does not match via `matchesFile`. Ordinary class-level imports in both languages are unaffected.
 - **C# enclosing-namespace references** ([#875](https://github.com/getlien/lien/issues/875)): a file in a sub-namespace can reference an enclosing namespace's members with no `using` statement at all, leaving no import signal. Only the dotted `using X.Y;` form resolves.
-- **PHP factory/FQCN usage** ([#878](https://github.com/getlien/lien/issues/878)): a test that reaches production code through a factory method or a fully-qualified class name at the call site, rather than a `use` import, leaves no import signal to match on.
+- **PHP factory-indirection usage** ([#878](https://github.com/getlien/lien/issues/878), partial): a direct fully-qualified class-name reference (`\Foo\Bar\Baz::class`, `new \Foo\Bar\Baz(...)`) is resolved (see above). What's left is a test that only ever names a *factory* (`Middleware::retry()`), where the factory's own implementation — in a different file — is what actually instantiates the concrete class. That needs reasoning across files, not just within one; still an honest no-signal gap.
 
 ## Where associations surface
 

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -450,6 +450,65 @@ func TestMode(t *testing.T) {
       });
     });
 
+    describe('PHP FQCN-reference scanning composed with PSR-4 (#878)', () => {
+      let testDir: string;
+
+      beforeEach(async () => {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-chunker-fqcn-refs-'));
+      });
+
+      afterEach(async () => {
+        clearPsr4Cache();
+        await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+      });
+
+      it('resolves a fully-qualified reference through the PSR-4 map, with no `use` import present', async () => {
+        await fs.mkdir(testDir, { recursive: true });
+        await fs.writeFile(
+          path.join(testDir, 'composer.json'),
+          JSON.stringify({ autoload: { 'psr-4': { 'GuzzleHttp\\': 'src/' } } }, null, 2),
+        );
+
+        // Deliberately no `use GuzzleHttp\RetryMiddleware;` -- the whole point
+        // of #878 is that this reference has none.
+        const content = `<?php
+use PHPUnit\\Framework\\TestCase;
+
+class RetryMiddlewareTest extends TestCase {
+  public function testRetry() {
+    $x = new \\GuzzleHttp\\RetryMiddleware($decider, $handler);
+  }
+}
+?>`;
+
+        const chunks = chunkByAST('tests/RetryMiddlewareTest.php', content, {
+          workspaceRoot: testDir,
+        });
+        const methodChunk = chunks.find(c => c.metadata.symbolName === 'testRetry');
+
+        expect(methodChunk?.metadata.imports).toContain('src/RetryMiddleware');
+      });
+
+      it('is a no-op for a plain bare `use`-only file (zero behavior change)', () => {
+        const content = `<?php
+use GuzzleHttp\\Cookie\\SetCookie;
+
+class SetCookieTest {
+  public function testFoo() {
+    return new SetCookie();
+  }
+}
+?>`;
+
+        const chunks = chunkByAST('tests/Cookie/SetCookieTest.php', content, {
+          workspaceRoot: testDir,
+        });
+        const methodChunk = chunks.find(c => c.metadata.symbolName === 'testFoo');
+
+        expect(methodChunk?.metadata.imports).toEqual(['GuzzleHttp\\Cookie\\SetCookie']);
+      });
+    });
+
     it('should calculate cyclomatic complexity', () => {
       const content = `
 function complexFunction(x: number): string {

--- a/packages/parser/src/ast/extractors/types.ts
+++ b/packages/parser/src/ast/extractors/types.ts
@@ -126,6 +126,36 @@ export interface LanguageImportExtractor {
    * @returns Object with importPath and symbols, or null to skip
    */
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null;
+
+  /**
+   * Extract additional "reference" import-like specifiers that name another
+   * file's symbol WITHOUT going through this language's own import-
+   * declaration syntax at all — so declaration-based extraction (the
+   * `importNodeTypes` walk above) is structurally blind to them.
+   *
+   * PHP's motivating case (#878): a fully-qualified class name (`new
+   * \Foo\Bar\Baz(...)`, `\Foo\Bar\Baz::class`, `\Foo\Bar\Baz::method()`)
+   * never requires a `use` statement — PHP resolves a leading-`\` name as
+   * absolute regardless of what's imported — so a test file can genuinely
+   * reference a source class with zero corresponding
+   * `namespace_use_declaration` node anywhere in the file.
+   *
+   * Optional: most languages have no such construct and simply omit this
+   * method. Callers (`extractImportPaths` in `ast/symbols.ts`) treat a
+   * missing implementation as "no additional references" — a no-op, so
+   * every existing language and caller sees zero behavior change.
+   *
+   * @param rootNode - AST root node for the whole file. Unlike the
+   *   declaration-based walk (which only looks at the top one-or-two levels
+   *   from the root), implementations of this method are expected to scan
+   *   the entire file recursively, since these references can appear
+   *   anywhere in a function/method body.
+   * @returns Extra raw specifiers, in the same pre-resolution form
+   *   `extractImportPaths` returns — subject to the same downstream
+   *   resolution pipeline (relative-import / workspace-package /
+   *   manifest-root resolution).
+   */
+  extractReferencedFQCNs?(rootNode: SyntaxNode): string[];
 }
 
 /**

--- a/packages/parser/src/ast/languages/php.test.ts
+++ b/packages/parser/src/ast/languages/php.test.ts
@@ -260,6 +260,126 @@ class User {
       const useNode = root.namedChild(1)!;
       expect(importExtractor.extractImportPaths(useNode)).toEqual(['App\\Models\\User']);
     });
+
+    // FQCN-reference scanning (#878): a test file can genuinely exercise a
+    // source class via a fully-qualified reference with no corresponding
+    // `use` import for declaration-based extraction to find. Guzzle's real
+    // remainder from #877's dogfood (`RetryMiddleware.php`, referenced only
+    // via `Middleware::retry()`) stays unresolved by design -- see the
+    // last test in this block.
+    describe('extractReferencedFQCNs (fully-qualified class-name references, #878)', () => {
+      it('extracts a fully-qualified `new` instantiation', () => {
+        const code = `<?php
+class FooTest {
+  public function testFoo() {
+    $x = new \\GuzzleHttp\\RetryMiddleware($a, $b);
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([
+          'GuzzleHttp\\RetryMiddleware',
+        ]);
+      });
+
+      it('extracts a fully-qualified `::class` reference', () => {
+        const code = `<?php
+class FooTest {
+  public function testFoo() {
+    $this->expectException(\\GuzzleHttp\\Exception\\ClientException::class);
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([
+          'GuzzleHttp\\Exception\\ClientException',
+        ]);
+      });
+
+      it('extracts a fully-qualified static method call', () => {
+        const code = `<?php
+class FooTest {
+  public function testFoo() {
+    $y = \\GuzzleHttp\\Middleware::retry();
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual(['GuzzleHttp\\Middleware']);
+      });
+
+      it('deduplicates repeated references to the same class', () => {
+        const code = `<?php
+class FooTest {
+  public function testFoo() {
+    $a = new \\GuzzleHttp\\RetryMiddleware();
+    $b = new \\GuzzleHttp\\RetryMiddleware();
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([
+          'GuzzleHttp\\RetryMiddleware',
+        ]);
+      });
+
+      it('ignores a "qualified" (not fully-qualified) name -- no leading backslash', () => {
+        // Inside namespace Tests, `GuzzleHttp\Middleware` (no leading \) resolves
+        // relative to the current namespace or a `use`-imported alias -- genuinely
+        // ambiguous without cross-referencing the file's own use imports, and
+        // exactly the shape #868/#883 guard against elsewhere. Real PHP code
+        // always uses either a leading-\ FQCN or a bare `use`-imported name for
+        // this; this input is deliberately the untrusted middle case.
+        const code = `<?php
+namespace Tests;
+class FooTest {
+  public function testFoo() {
+    $y = GuzzleHttp\\Middleware::retry();
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([]);
+      });
+
+      it('ignores a bare name already reachable via a `use` import', () => {
+        const code = `<?php
+use GuzzleHttp\\Exception\\ClientException;
+class FooTest {
+  public function testFoo() {
+    self::assertInstanceOf(ClientException::class, $e);
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([]);
+      });
+
+      it('ignores a fully-qualified single-segment (global-namespace) reference', () => {
+        // \DateTime, \Exception, etc. are PHP built-ins or global-namespace
+        // classes -- never a Composer-autoloaded project file under a PSR-4
+        // vendor prefix, so there is no source file this could ever match.
+        const code = `<?php
+class FooTest {
+  public function testFoo() {
+    $x = \\DateTime::class;
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([]);
+      });
+
+      it('does not resolve the transitive factory-indirection shape (honest remainder, #878)', () => {
+        // The real guzzle case: RetryMiddlewareTest.php calls Middleware::retry()
+        // and never mentions RetryMiddleware anywhere in its own text -- the
+        // factory (a DIFFERENT file, Middleware.php) is what internally `new`s
+        // RetryMiddleware. A single-file structural scan has no way to see that;
+        // this is the honest, documented remainder of #878.
+        const code = `<?php
+use GuzzleHttp\\Middleware;
+class RetryMiddlewareTest {
+  public function testRetry() {
+    $middleware = Middleware::retry(fn() => true);
+  }
+}`;
+        const root = mustParse(code, 'php');
+        expect(importExtractor.extractReferencedFQCNs(root)).toEqual([]);
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -199,6 +199,95 @@ export class PHPImportExtractor implements LanguageImportExtractor {
     return grouped ? { importPath: grouped.importPath, symbols: [grouped.alias] } : null;
   }
 
+  /**
+   * Scan the WHOLE file (recursively — unlike declaration-based extraction,
+   * which only looks at top-level `namespace_use_declaration` nodes) for
+   * fully-qualified class-name references that never go through a `use`
+   * statement at all. Closes the structural gap in #878: a test can
+   * genuinely exercise a source class via a factory (`Middleware::retry()`
+   * internally `new`-ing `RetryMiddleware`) or a direct FQCN (`new
+   * \GuzzleHttp\RetryMiddleware()`, `\GuzzleHttp\RetryMiddleware::class`)
+   * with zero corresponding import declaration for `use`-based extraction to
+   * find.
+   *
+   * Only three PHP expression shapes are considered, and only when their
+   * class-name part is a `qualified_name` node whose own text starts with a
+   * leading `\` (i.e. genuinely fully-qualified, resolved absolutely
+   * regardless of any `use` imports in scope — see
+   * `isFullyQualifiedReference`'s doc comment for why this is the
+   * unambiguous case, unlike a bare or merely-"qualified" name):
+   * - `new \Foo\Bar\Baz(...)` (`object_creation_expression`)
+   * - `\Foo\Bar\Baz::class` / `\Foo\Bar\Baz::SOME_CONST` (`class_constant_access_expression`)
+   * - `\Foo\Bar\Baz::method()` (`scoped_call_expression`)
+   *
+   * Deliberately does NOT attempt the transitive "factory hides the FQCN in
+   * a different file" shape (e.g. `Middleware::retry()` from a *test* file,
+   * where `RetryMiddleware` is only named inside `Middleware.php`, never in
+   * the test itself) — that needs graph-level reasoning across files, well
+   * beyond a single-file structural scan. That case has no signal available
+   * at this layer and is the honest, documented remainder of #878.
+   */
+  extractReferencedFQCNs(rootNode: SyntaxNode): string[] {
+    const refs: string[] = [];
+    const seen = new Set<string>();
+
+    const visit = (node: SyntaxNode): void => {
+      const fqcn = this.extractFQCNReference(node);
+      if (fqcn && !seen.has(fqcn)) {
+        seen.add(fqcn);
+        refs.push(fqcn);
+      }
+      node.namedChildren.forEach(visit);
+    };
+    visit(rootNode);
+
+    return refs;
+  }
+
+  private static readonly FQCN_REFERENCE_NODE_TYPES = new Set([
+    'object_creation_expression',
+    'class_constant_access_expression',
+    'scoped_call_expression',
+  ]);
+
+  private extractFQCNReference(node: SyntaxNode): string | null {
+    if (!PHPImportExtractor.FQCN_REFERENCE_NODE_TYPES.has(node.type)) return null;
+
+    const classPart = node.namedChildren.find(child => child.type === 'qualified_name');
+    if (!classPart || !this.isFullyQualifiedReference(classPart)) return null;
+
+    const parts = this.extractQualifiedNameParts(classPart);
+    // Require an actual namespace segment (>= 2 parts). A fully-qualified
+    // SINGLE-segment name (`\DateTime`, `\Exception`) always names a PHP
+    // built-in or global-namespace class, never a Composer-autoloaded
+    // project file under a PSR-4 vendor prefix -- so it can't correspond to
+    // a real source file and would only ever risk exercising the bare-
+    // identifier ambiguity #868/#883 guard against, for zero possible gain.
+    return parts.length > 1 ? parts.join('\\') : null;
+  }
+
+  /**
+   * True when `qualifiedName` (a `qualified_name` node) is FULLY qualified —
+   * its own source text starts with a leading `\`. PHP resolves such a name
+   * absolutely, ignoring any `use` imports in scope, so it is unambiguous
+   * proof the file names that exact class.
+   *
+   * A `qualified_name` WITHOUT the leading `\` (e.g. `Foo\Bar` inside `use
+   * Foo\Bar::method()`) is merely "qualified": PHP resolves it relative to
+   * the current namespace, or via an imported alias for its first segment —
+   * genuinely ambiguous without cross-referencing the file's own namespace
+   * and `use` imports. Treating it as a reference here would risk exactly
+   * the false-positive shape #868/#883 guard against, so it's excluded.
+   *
+   * `qualified_name`'s own child structure (`namespace_name` + `name`) is
+   * IDENTICAL whether or not the leading `\` is present — the marker exists
+   * only in the node's own text span, not as a separate child — so this
+   * checks `.text` directly rather than inspecting children.
+   */
+  private isFullyQualifiedReference(qualifiedName: SyntaxNode): boolean {
+    return qualifiedName.text.startsWith('\\');
+  }
+
   private extractPHPUseDeclarationPath(node: SyntaxNode): string | null {
     const clause = node.namedChildren.find(child => child.type === 'namespace_use_clause');
     if (clause) return this.extractPHPQualifiedName(clause);

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -203,9 +203,9 @@ export class PHPImportExtractor implements LanguageImportExtractor {
    * Scan the WHOLE file (recursively — unlike declaration-based extraction,
    * which only looks at top-level `namespace_use_declaration` nodes) for
    * fully-qualified class-name references that never go through a `use`
-   * statement at all. Closes the structural gap in #878: a test can
-   * genuinely exercise a source class via a factory (`Middleware::retry()`
-   * internally `new`-ing `RetryMiddleware`) or a direct FQCN (`new
+   * statement at all. Partially addresses #878 — direct fully-qualified
+   * references only (see below for what's still open): a test can
+   * genuinely exercise a source class via a direct FQCN (`new
    * \GuzzleHttp\RetryMiddleware()`, `\GuzzleHttp\RetryMiddleware::class`)
    * with zero corresponding import declaration for `use`-based extraction to
    * find.
@@ -224,8 +224,10 @@ export class PHPImportExtractor implements LanguageImportExtractor {
    * a different file" shape (e.g. `Middleware::retry()` from a *test* file,
    * where `RetryMiddleware` is only named inside `Middleware.php`, never in
    * the test itself) — that needs graph-level reasoning across files, well
-   * beyond a single-file structural scan. That case has no signal available
-   * at this layer and is the honest, documented remainder of #878.
+   * beyond a single-file structural scan. That factory-indirection case has
+   * no signal available at this layer and is unresolvable here; it stays an
+   * honest, documented, still-open remainder of #878, not something this
+   * method claims to handle.
    */
   extractReferencedFQCNs(rootNode: SyntaxNode): string[] {
     const refs: string[] = [];

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -104,6 +104,34 @@ function resolveManifestRoot(specifier: string, manifestRoots: ManifestRoots | u
 }
 
 /**
+ * Append `extractReferencedFQCNs`'s results (PHP only, today — see that
+ * method's doc comment for #878's background) to `imports` IN PLACE, each
+ * resolved through the same pipeline as a declaration-based import and
+ * deduplicated against what's already present. A no-op when the extractor
+ * doesn't implement the optional method, so every other language's
+ * `extractImportPaths` behavior is unaffected.
+ */
+function appendReferencedFQCNs(
+  imports: string[],
+  importExtractor: ReturnType<typeof getImportExtractor>,
+  rootNode: SyntaxNode,
+  filepath: string | undefined,
+  workspacePackages: ReadonlyMap<string, string> | undefined,
+  manifestRoots: ManifestRoots | undefined,
+): void {
+  if (!importExtractor?.extractReferencedFQCNs) return;
+
+  const seen = new Set(imports);
+  for (const result of importExtractor.extractReferencedFQCNs(rootNode)) {
+    const resolved = resolveImportSpecifier(result, filepath, workspacePackages, manifestRoots);
+    if (!seen.has(resolved)) {
+      seen.add(resolved);
+      imports.push(resolved);
+    }
+  }
+}
+
+/**
  * Extract import paths using the language-specific extractor.
  *
  * When `filepath` is provided, relative specifiers (`./foo`, `../bar`) are
@@ -113,6 +141,9 @@ function resolveManifestRoot(specifier: string, manifestRoots: ManifestRoots | u
  * resolve to that package's source entry file, enabling cross-package
  * dependency analysis in monorepos. Everything else passes through
  * unchanged.
+ *
+ * Also merges in `appendReferencedFQCNs`'s results (#878) — see its doc
+ * comment.
  */
 function extractImportPaths(
   rootNode: SyntaxNode,
@@ -131,6 +162,15 @@ function extractImportPaths(
       imports.push(resolveImportSpecifier(result, filepath, workspacePackages, manifestRoots));
     }
   }
+
+  appendReferencedFQCNs(
+    imports,
+    importExtractor,
+    rootNode,
+    filepath,
+    workspacePackages,
+    manifestRoots,
+  );
 
   return imports;
 }

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -135,4 +135,40 @@ describe('findTestAssociationsFromChunks', () => {
       expect(result.get('Source/Networking/Session.swift')).toEqual(['Tests/SessionTests.swift']);
     });
   });
+
+  describe('PHP FQCN-reference association (#878)', () => {
+    // These chunks model the shape `PHPImportExtractor.extractReferencedFQCNs`
+    // (ast/languages/php.ts) plus PSR-4 resolution (php-psr4.ts) actually
+    // produce -- a workspace-relative path merged into `imports` alongside
+    // any real `use`-based imports, with no per-node distinction left by the
+    // time it reaches this layer. See ast/chunker.test.ts and
+    // ast/languages/php.test.ts for coverage of the extraction step itself.
+    it('associates a test file that references the class only via a fully-qualified `new`, no `use` import at all', () => {
+      const chunks: CodeChunk[] = [
+        makeChunk('src/RetryMiddleware.php'),
+        makeChunk('tests/RetryMiddlewareTest.php', ['src/RetryMiddleware']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/RetryMiddleware.php'], chunks);
+
+      expect(result.get('src/RetryMiddleware.php')).toEqual(['tests/RetryMiddlewareTest.php']);
+    });
+
+    it('honestly finds no association for the factory-indirection remainder (no signal in either file)', () => {
+      // The real, unresolved guzzle shape: the test only ever names the
+      // factory (`Middleware`), never `RetryMiddleware` itself -- that name
+      // lives exclusively inside Middleware.php, a different file. No
+      // extraction change can manufacture a signal that isn't textually
+      // present anywhere in the test file; this is #878's honest remainder.
+      const chunks: CodeChunk[] = [
+        makeChunk('src/RetryMiddleware.php'),
+        makeChunk('src/Middleware.php'),
+        makeChunk('tests/RetryMiddlewareTest.php', ['src/Middleware']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/RetryMiddleware.php'], chunks);
+
+      expect(result.has('src/RetryMiddleware.php')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

partial fix for #878, #878 stays open.

After #877's PSR-4 manifest mapping, PHP test-association matching is
still blind to a class that a test references only through a
**fully-qualified class name**, with no corresponding `use` import
anywhere in the file — PHP resolves a leading-`\` name absolutely,
regardless of what's imported, so no `use` statement is required or
present for `new \Foo\Bar\Baz(...)`, `\Foo\Bar\Baz::class`, or
`\Foo\Bar\Baz::method()`.

This PR resolves exactly that resolvable subset and ships an honest
no-signal outcome for the rest, per the #869/#881 precedent.

## What's fixed

`PHPImportExtractor` gains a new optional `extractReferencedFQCNs` method
(`packages/parser/src/ast/languages/php.ts`) that recursively scans a
whole PHP file (not just top-level `namespace_use_declaration` nodes) for
three expression shapes whose class-name part is a fully-qualified
(leading-`\`) `qualified_name` node:

- `new \Foo\Bar\Baz(...)` (`object_creation_expression`)
- `\Foo\Bar\Baz::class` / `\Foo\Bar\Baz::SOME_CONST` (`class_constant_access_expression`)
- `\Foo\Bar\Baz::method()` (`scoped_call_expression`)

`extractReferencedFQCNs` is a new **optional** member on the
`LanguageImportExtractor` interface (`ast/extractors/types.ts`) — every
other language simply omits it, zero behavior change. `ast/symbols.ts`'s
`extractImportPaths` merges these reference specifiers through the exact
same resolution pipeline as declaration-based imports (including PSR-4),
deduplicated, so `path-matching.ts`'s matcher needed no changes at all —
the new specifiers arrive in the identical raw form a normal `use` import
would produce.

**Deliberately excluded** (composes with #883's guards rather than
weakening them):
- A "qualified but not fully-qualified" name (`Foo\Bar`, no leading `\`)
  — PHP resolves it relative to the current namespace or a `use` alias,
  genuinely ambiguous without cross-referencing the file's own imports,
  and exactly the false-positive shape #868/#883 guard against.
- A fully-qualified **single-segment** name (`\DateTime`, `\Exception`)
  — can only ever be a PHP built-in or global-namespace class, never a
  Composer-autoloaded project file, so there's no real source file it
  could match.

## What's still open (the honest remainder)

The dominant shape among #878's originally-named 9 guzzle files (and, per
a fresh full-repo dogfood sweep, several more that have appeared since
that issue was filed) is **factory indirection**: a test calls
`Middleware::retry()`, and `Middleware::retry()`'s own implementation —
in a *different* file, `Middleware.php` — is what actually `new`s
`RetryMiddleware`. There is zero textual mention of `RetryMiddleware`
anywhere in the test file itself. A single-file structural scan
(everything this PR does) cannot manufacture a signal that isn't present
anywhere in the file being scanned; recovering this needs transitive
reasoning across files, which is out of scope here. #878 stays open to
track it, and I verified by direct inspection that this genuinely is a
zero-textual-trace case (not a shape my scan happens to miss).

## Dogfood evidence (verbatim, live guzzle/guzzle clone)

Cloned `guzzle/guzzle` fresh into a scratch dir outside the worktree,
built this branch's CLI, indexed, and ran `lien annotate` across all 67
`src/*.php` files — twice, on the identical clone/index, once at the
commit right before this PR's first commit (`deffceec`) and once on this
branch — to isolate exactly what this PR changes, independent of any
repo drift since #877's original snapshot.

**Aggregate**: 54/67 files resolve real test coverage both before and
after (guzzle's upstream `main` has grown 4 more genuinely-untested-by-
import-signal files since #877's original 58/67 snapshot — unrelated to
this PR; confirmed identical 13-file uncovered set before and after).

**The one real, verified win** — full before/after diff across all 67
files' `annotate` output showed exactly one substantive change:

```
BEFORE:
Lien impact for src/Exception/ClientException.php:
  • 4 files import this — tests/PoolTest.php, tests/MiddlewareTest.php,
    tests/Exception/RequestExceptionTest.php, tests/Exception/ClientExceptionTest.php
  • Test coverage: tests/PoolTest.php, tests/MiddlewareTest.php (+2 more).

AFTER:
Lien impact for src/Exception/ClientException.php:
  • 5 files import this — tests/PoolTest.php, tests/MiddlewareTest.php,
    tests/ClientTest.php, tests/Exception/RequestExceptionTest.php, +1 more
  • Test coverage: tests/PoolTest.php, tests/MiddlewareTest.php (+3 more).
```

`tests/ClientTest.php` newly appears. Root cause, verified by inspection:
line 1693 has `$this->expectException(\GuzzleHttp\Exception\ClientException::class);`
— a bare backslash-prefixed FQCN reference, no `use` import for it
anywhere in the file (`ClientTest.php` only `use`s `GuzzleHttp\Client`).
**Spot-checked the new association is correct**: the surrounding test,
`testThrowsHttpErrorsByDefault`, mocks a 404 response and asserts a
`ClientException` is thrown — a genuine, meaningful test of
`ClientException.php`'s behavior, previously invisible to test-association
with zero signal.

A broader grep across the entire `tests/` tree for this exact FQCN
pattern (leading-backslash, multi-segment, outside of string literals)
turned up exactly one occurrence in the whole repo — this one. Every
other backslash-qualified-looking string I found was inside an
`expectExceptionMessage('...')` string literal (not real PHP code), and
correctly does *not* match, since extraction is AST-based (real
`class_constant_access_expression`/`object_creation_expression`/
`scoped_call_expression` nodes), not a text/regex scan.

None of #878's originally-named 9 remainder files changed — confirmed by
direct inspection that each is the pure factory-indirection shape (zero
textual trace of the target class name anywhere in its test file), the
documented honest remainder above.

## Tests

- `packages/parser/src/ast/languages/php.test.ts` — 8 new unit tests for
  `extractReferencedFQCNs` directly: all three expression shapes, dedup,
  and every exclusion case (qualified-but-not-fully-qualified, bare
  `use`-resolvable name, single-segment global name, the factory
  remainder itself).
- `packages/parser/src/ast/chunker.test.ts` — end-to-end: a fully-
  qualified reference with no `use` import resolves through the PSR-4 map
  to the real workspace-relative path; a plain `use`-only file is
  unaffected (zero behavior change).
- `packages/parser/src/test-associations.test.ts` — `findTestAssociationsFromChunks`
  associates the FQCN-only case, and honestly finds no association for
  the factory-indirection remainder.

Full suite green: parser 1233, core 378, review 1647, cli 1186, action 41
(`npm test`, all workspaces). `format:check` / `lint` (0 errors) /
`typecheck` / `build` all pass. `lien delta` exit 0 — three new small
functions (max cognitive 4), one pre-existing function's cognitive
complexity untouched after a small extraction (`appendReferencedFQCNs`)
to keep `extractImportPaths` simple; only a Halstead "time" delta remains
on it, no threshold crossed.

## Scope

Diff is scoped to PHP extraction (`ast/languages/php.ts`), the shared
optional-interface plumbing it needs (`ast/extractors/types.ts`,
`ast/symbols.ts`), and tests/docs. No changes to `path-matching.ts`,
`csharp.ts`, `java.ts`, or `kotlin.ts` (concurrent sibling work).

## Changeset

`@liendev/parser`: minor (new optional interface member + new public
method, matching #877's precedent for a similarly-shaped additive
change).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds an optional `extractReferencedFQCNs` method to `LanguageImportExtractor` and implements it for PHP to capture fully-qualified class-name references (`new \Foo\Bar`, `\Foo\Bar::class`, `\Foo\Bar::method()`) that have no corresponding `use` import. The new specifiers flow through the existing PSR-4 resolution pipeline in `symbols.ts` with deduplication, leaving other languages unaffected. The implementation correctly excludes ambiguous qualified-but-not-fully-qualified names, single-segment global names, and factory-indirection cases as documented. Tests cover the three expression shapes, deduplication, exclusions, and end-to-end PSR-4 resolution.
>
> - Added optional `extractReferencedFQCNs` to `LanguageImportExtractor` interface
> - Implemented PHP FQCN reference scanning for `object_creation_expression`, `class_constant_access_expression`, and `scoped_call_expression`
> - Merged FQCN references into `extractImportPaths` via `appendReferencedFQCNs` with deduplication and existing resolution pipeline

⚠️ The incomplete-handling pass did not finish — it stopped unexpectedly. That pass's findings are partial; the main review's findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit c886701. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

---

<!-- lien:attestation -->
Attested: degraded:provider_partial · 223K/1857K tokens
<!-- /lien:attestation -->