### PR TITLE
Nudge A/B v2: task-decoupled protocol + instrument for the blast & test-verify nudges (frozen, not yet run)

### DIFF
--- a/docs/development/blast-radius-nudge-ab.md
+++ b/docs/development/blast-radius-nudge-ab.md
@@ -447,10 +447,22 @@ tool exists), scoped `acceptEdits` + explicit allowlist. 0 invalid, 0 logged-out
 timed-out, **0 tool denials** (symmetric). Recap held off in both arms, so the edit-time
 warning is the *only* blast delivery.
 
-**Contamination:** 0/20 OFF trials on a word-boundary re-scan. (The runner's raw scan
-reported 20/20 "leaks" — all the substring `lien` inside the ambient skill name
-`…client…` the default config dir exposes; symmetric across arms, outside the primary
-metric. Reported raw-and-corrected per the honesty rule.) The user's ambient
+**Contamination:** 0/10 OFF trials in this experiment on a word-boundary re-scan (0/20
+across both experiments). The runner's raw substring scan flagged all 10/10 — every hit
+the substring `lien` inside the ambient skill name `…client…` the default config dir
+exposes; symmetric across arms, outside the primary metric. Reported raw-and-corrected
+per the honesty rule.
+
+**Validity audit (post-review).** A review flagged that the runner hardcoded OFF-arm
+validity to `true`, asymmetric with the signal arm's edit-completed gate — so a control
+*no-op* would have scored as a MISS rather than INVALID. Re-scoring every blast trial in
+**both** arms under a symmetric rule — did the agent's edit actually change
+`applyDiscount`'s signature (the same `api-delta` oracle the signal arm used)? — confirms
+**all 20 trials completed the task edit, 0 no-ops in either arm**, so the counts are
+unchanged. An offline re-run of the *corrected* scoring pipeline over the archived
+transcripts reproduces the published counts exactly (10/10 vs 3/10, p = 0.001548 — the
+0.0015 above was 4-dp rounding). The runner has been fixed to gate both arms
+symmetrically. Evidence is in the PR transparency note. The user's ambient
 `~/.claude/rules/context7.md` and other non-Lien plugins' skill lists are present
 identically in both arms (unrelated to caller-checking).
 

--- a/docs/development/blast-radius-nudge-ab.md
+++ b/docs/development/blast-radius-nudge-ab.md
@@ -403,3 +403,63 @@ floor for isolating the mechanism, not a simulation of production use.
   `.wip/ab-neutral/probes/probe-clean.txt` (gitignored)
 - Raw per-trial outputs: `.wip/ab-neutral/trials/blast/{control,signal}-{1..8}.md`
   (gitignored)
+
+---
+
+## 2026-07-26: A/B v2 (task-decoupled) — the discriminating re-run **separates**
+
+Both prior sections returned nulls diagnosed as **task-forcing**: the target's callers
+were visible in-file and the task ("thread `opts` through") *required* touching them, so
+caller-checking *was* the task and the warning had no headroom. The v2 protocol —
+frozen pre-registration in
+[nudge-ab-v2-protocol.md](nudge-ab-v2-protocol.md) — removes that confound. The changed
+symbol's dependents live in **other directories** (`src/checkout/cart.ts`,
+`src/reports/invoice.ts`) with nothing in the edited file hinting at them; the task is a
+plain feature request ("add an optional minimum-price floor to `applyDiscount`") that
+never mentions callers or risk; and the primary metric is raised from *sentiment* to
+**concrete action** — the agent must actually search for / open / name a specific
+out-of-directory dependent. Generic "other callers may need updating" hedging (the prior
+run's 7/8 ceiling) explicitly does **not** count.
+
+**Result: the blast warning separates.**
+
+| Condition | Concrete beyond-file caller action | Rate |
+|---|---|---|
+| Signal (`LIEN_BLAST_HOOK` on) | 10 / 10 | **100%** |
+| Control (`LIEN_BLAST_HOOK` off) | 3 / 10 | **30%** |
+
+One-sided Fisher exact **p = 0.0015** — the pre-registered separation threshold
+(p < 0.05) is met, so this document's standing launch rule now **permits a lift claim**
+for this nudge. Every signal trial grepped for `applyDiscount` and named the specific
+out-of-directory dependents; the 3 control hits are the real, non-zero baseline (some
+agents check callers unprompted), but 7 of 10 do not when the task doesn't demand it and
+the dependents aren't visible in the edited file. This is the first clean separation in
+the series, and it confirms the prior nulls were the task-forcing artifact, not evidence
+the warning is inert.
+
+**Environment (mechanism b', see protocol §3).** 20 headless `claude -p --model sonnet`
+trials (10/arm, seeded interleave), from fixture sandboxes with no `CLAUDE.md`; the
+**default** config dir (Keychain auth) with the ambient `lien@lien` plugin disabled
+per-invocation via a `--settings enabledPlugins` override (saved settings byte-identical
+before/after), `--strict-mcp-config` (so `get_dependents` itself isn't available — the
+signal agents grepped instead, making this rate a **lower bound** vs production where the
+tool exists), scoped `acceptEdits` + explicit allowlist. 0 invalid, 0 logged-out, 0
+timed-out, **0 tool denials** (symmetric). Recap held off in both arms, so the edit-time
+warning is the *only* blast delivery.
+
+**Contamination:** 0/20 OFF trials on a word-boundary re-scan. (The runner's raw scan
+reported 20/20 "leaks" — all the substring `lien` inside the ambient skill name
+`…client…` the default config dir exposes; symmetric across arms, outside the primary
+metric. Reported raw-and-corrected per the honesty rule.) The user's ambient
+`~/.claude/rules/context7.md` and other non-Lien plugins' skill lists are present
+identically in both arms (unrelated to caller-checking).
+
+**Validity caveat (unchanged from #844).** This is a lower-bound environment — no
+CLAUDE.md, no Lien plugin, single-repo sandbox — a floor for isolating the mechanism,
+not a forecast of the effect inside a richly-contextualized production session. A clean
+separation here is strong evidence the nudge moves behavior; it does not by itself
+quantify the production lift.
+
+Artifacts: pre-registration `docs/development/nudge-ab-v2-protocol.md`; runner
+`scripts/experiments/nudge-ab-v2/`; raw per-trial transcripts + verdicts + summary under
+`.wip/nudge-ab-v2/blast/` (gitignored).

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -111,10 +111,34 @@ silent. `recap-stop.sh` wraps that report text as `{"decision":"block","reason":
 
 ## 3. Execution environment (frozen)
 
-Each trial is one headless, agentic `claude -p` run **with tools enabled** (Edit,
-Write, Read, Bash, Grep, Glob), from inside the trial's scenario dir. This is the
-core departure from v1, whose trials were tool-free single-turn generations: the v2
-metrics are about what the agent *does* in a repo, so it must be able to act.
+Each trial is one headless, agentic `claude -p` run **with a scoped, explicit tool
+allowlist**, from inside the trial's scenario dir. This is the core departure from v1,
+whose trials were tool-free single-turn generations: the v2 metrics are about what the
+agent *does* in a repo, so it must be able to act.
+
+**Permissions (frozen, identical in both arms).** Trials run with
+`--permission-mode acceptEdits` (auto-accepts file edits inside the throwaway sandbox)
+plus an **explicit `--allowedTools` allowlist** — *not* `bypassPermissions`. The
+allowlist is `Read, Grep, Glob, Edit, Write, MultiEdit` plus a curated set of scoped
+`Bash(<prefix>:*)` rules covering exactly a trial's legitimate actions: read-only
+inspection/search (`grep`, `rg`, `git grep`, `cat`, `ls`, `find`, `sed`, …) — the
+blast metric's measured behavior — and the fixture's test runner (`npx vitest`,
+`vitest`, `npm test`/`npm run test`, `node --test`, `tsc`) — the verify metric's
+measured behavior. It excludes arbitrary shell (no `rm`/`curl`/`wget`/`install`/
+network). Because the allowlist is byte-identical across arms, any denial is a
+constant that differences out; in headless `-p` a non-allowlisted call is
+denied-and-continues (never an interactive stall), and **every denial is logged per
+arm** (`detect.mjs` `collectDenials`) so arm-symmetry is verifiable in the summary.
+The exact list lives in `run.mjs` (`ALLOWED_TOOLS`). The scoped config's viability was
+confirmed before the counted run via `run.mjs smoke` (one real tool-using ON trial per
+experiment; no fatal denial of a measured behavior).
+
+The verify fixture's `vitest` devDep is provisioned once into a cache and symlinked
+into each verify trial dir **after indexing** (so the index never walks
+`node_modules`), so a trial's `npx vitest run <path>` resolves locally and runs
+offline rather than stalling on a network fetch. The test command is recorded by
+`test-run-note.sh` whether or not vitest exits zero, so the verify metric fires on the
+command being *issued and executed*, independent of the test's result.
 
 Clean context is enforced by three independent controls, all identical across arms:
 
@@ -347,7 +371,11 @@ node scripts/experiments/nudge-ab-v2/run.mjs check
 # 2. mandatory contamination + plumbing probe (1 claude call) — must pass
 node scripts/experiments/nudge-ab-v2/run.mjs probe
 
-# 3. the arms (gated on the probe marker)
+# 3. scoped-permission viability smoke (2 uncounted claude calls) — confirm
+#    trials complete under acceptEdits + the allowlist, no fatal denials
+node scripts/experiments/nudge-ab-v2/run.mjs smoke
+
+# 4. the arms (gated on the probe marker)
 node scripts/experiments/nudge-ab-v2/run.mjs run blast
 node scripts/experiments/nudge-ab-v2/run.mjs run verify
 ```

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -369,11 +369,13 @@ The run aborts (no result claimed) if any holds:
 
 ## 8. Validity caveats (carried forward, stated before running)
 
-- **Lower-bound environment.** Like PR #844, this removes not just the contamination
-  but *every* ambient instruction (no CLAUDE.md, no plugin, no user rules, no prior
-  turns). It is a floor for isolating the mechanism, not a forecast of the effect in a
-  real, richly-contextualized session under time pressure — the exact gap these nudges
-  exist to close. A separation here is strong evidence; a null here does **not** prove
+- **Lower-bound environment.** Like PR #844, this removes nearly every ambient
+  instruction (no CLAUDE.md, no Lien plugin, no repo rules, no prior turns) — the one
+  documented exception is the user's global `~/.claude/rules/context7.md`, which remains
+  present identically in both arms (unrelated to caller-checking or test-running, so it
+  cannot produce an arm difference; see §3a). It is a floor for isolating the mechanism,
+  not a forecast of the effect in a real, richly-contextualized session under time
+  pressure — the exact gap these nudges exist to close. A separation here is strong evidence; a null here does **not** prove
   the nudge is useless in production, only that a maximally-naive agent doesn't need it
   at this task scale.
 - **Blast tool absence.** With MCP stripped, the ON agent cannot literally call

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -140,25 +140,49 @@ offline rather than stalling on a network fetch. The test command is recorded by
 `test-run-note.sh` whether or not vitest exits zero, so the verify metric fires on the
 command being *issued and executed*, independent of the test's result.
 
-Clean context is enforced by three independent controls, all identical across arms:
+Clean context is enforced by three independent controls, all identical across arms.
+The chosen mechanism (call it **b'**) is empirically validated by `run.mjs probe-b1`;
+two rejected alternatives and why they failed are recorded in §3c.
 
-1. **Isolated config dir.** `CLAUDE_CONFIG_DIR` points at a throwaway `mktemp -d` dir
-   (outside the repo) with a minimal `settings.json` and **no `enabledPlugins` and no
-   user `rules/`**. This is what disables the ambient, user-level `lien@lien` plugin —
-   both its MCP *instructions* (the confound PR #844 discovered) and its *hooks* — for
-   the run. A fresh config dir otherwise reports **"Not logged in"** (CC reads the
-   account/OAuth linkage from `.claude.json`, which the fresh dir lacks), so the runner
-   seeds an **account-only** `.claude.json` — `userID` + `oauthAccount` **only**, read
-   from the real `~/.claude.json` at runtime, with **no `mcpServers`, no `projects`, no
-   `enabledPlugins`** — restoring auth while staying plugin- and MCP-free (the probe
-   proves the context stays clean). Those personal fields live only in the throwaway
-   dir, are deleted in cleanup, are redacted from every on-disk artifact, and never
-   enter the repo, `.wip/`, or any committed output.
-2. **Stripped MCP.** `--strict-mcp-config --mcp-config <{"mcpServers":{}}>` — belt and
-   braces; zero MCP servers, no Lien tool instructions.
-3. **Explicit hooks only.** The nudge under test is wired by absolute path via
-   `--settings` (see §4), so the experiment exercises **this checkout's** hook
-   scripts, not a commit-pinned plugin snapshot.
+1. **Default config dir + per-invocation plugin disable.** Trials run with the
+   **default** `CLAUDE_CONFIG_DIR` (unchanged), because macOS auth lives in the
+   **Keychain**, not in `.claude.json` — an *isolated* config dir reports "Not logged
+   in" no matter what account metadata is seeded (see §3c). The ambient user-level
+   `lien@lien` plugin is disabled **for the spawned process only** via a
+   per-invocation `--settings` override, `enabledPlugins: {"lien@lien": false}`. This
+   does **not** mutate the saved `~/.claude/settings.json` (the probe diffs it byte-for-
+   byte before/after). Disabling the plugin is what stops its **hooks** from firing —
+   critically `annotate-read`, which has no env kill switch and whose output literally
+   **names the out-of-file dependents** (`Lien impact for … src/checkout/cart.ts,
+   src/reports/invoice.ts`); if it fired it would hand both arms the exact fact the
+   blast nudge is meant to reveal.
+2. **Stripped MCP.** `--strict-mcp-config --mcp-config <{"mcpServers":{}}>` — zero MCP
+   servers, no Lien tool *instructions* (the confound PR #844 diagnosed).
+3. **Explicit hooks by absolute path.** The nudge under test is wired via `--settings`
+   to **this checkout's** hook scripts (not a commit-pinned plugin snapshot), and
+   `probe-b1` confirms these `--settings` hooks *do* fire in headless `-p` (nudge-events
+   ledger records the `blast` shown-event) while the disabled plugin's `annotate` does
+   not.
+
+Trials run inside fixture sandboxes under `mktemp` (outside the repo), and the runner
+asserts no `CLAUDE.md` exists in the cwd or any ancestor — so no repo instructions
+load. The one remaining ambient item is the user's `~/.claude/rules/context7.md`
+(unrelated to either nudged behavior, identical across arms — acceptable per the v1
+precedent). All on-disk artifacts are redacted of account fields (email/org UUIDs) read
+from `~/.claude.json` at runtime.
+
+### 3c. Rejected context mechanisms (for the record)
+
+- **(a) Isolated `CLAUDE_CONFIG_DIR` + account-only `.claude.json` seed** — *failed*.
+  A fresh config dir reports "Not logged in": the OAuth **token** is in the macOS
+  Keychain, and `oauthAccount` in `.claude.json` is only metadata, so seeding it does
+  not authenticate. (Copying the Keychain credential itself was ruled out as an
+  out-of-scope live-credential copy.)
+- **(b'') Default config dir + `--strict-mcp-config` alone** — *failed (contaminated)*.
+  `--strict-mcp-config` removes the plugin's MCP instructions, but its **hooks** still
+  fire in headless: `probe-default` showed the agent reporting "the hooks flagged …
+  invoice.ts and cart.ts, both untested," i.e. `annotate-read` injected the named
+  dependents into the context. Hence the plugin must be disabled outright (b').
 
 The hooks shell out to the bare `lien` binary; the runner puts a `lien` shim on
 `PATH` that resolves to this checkout's build (`packages/cli/dist/index.js`), so the
@@ -166,23 +190,27 @@ CLI under test is unambiguous.
 
 ### 3a. Mandatory contamination + plumbing probe (hard precondition)
 
-Before **any** arm runs, `run.mjs probe` executes one `claude -p` with the exact arm
-invocation (isolated config dir, stripped MCP, `--settings {hooks:{}}`) from a
-git-free, `CLAUDE.md`-free directory, asking the model to quote verbatim every project
-instruction / repo rule / tool-usage policy in its context (`prompts/probe.txt`,
-"…if there are none, reply NONE"). It **passes only if**:
+Before **any** arm runs, `run.mjs probe-b1` executes one `claude -p` with the **exact
+arm invocation** (default config dir, plugin disabled via `--settings`, stripped MCP,
+this checkout's blast hook wired) inside an indexed fixture sandbox. The prompt has the
+model list its context instructions verbatim, then Read and Edit `discount.ts` — so the
+ambient plugin's Read/Edit hooks would fire *if* the disable didn't take. It **passes
+only if** (all via `verdictB1`):
 
-- the output is non-empty (proves auth + the isolated-config plumbing work), **and**
-- the output contains **none** of: `get_dependents`, `get_files_context`,
-  `search_code`, `claude.md`, `lien`, `blast radius`, `complexity threshold`,
-  `test association` (the frozen `contaminationScan` list), **and**
-- programmatically: no `CLAUDE.md` in the scenario dir or any ancestor up to `/`, and
-  the mcp-config is empty.
+- **auth works** — not "Not logged in"; **and**
+- **the plugin is off** — the nudge-events ledger has **no `annotate` event** and the
+  transcript shows no `Lien impact` / `hooks flagged` text; **and**
+- **our hooks fire** — the ledger **has the `blast` shown-event** (proves `--settings`
+  hooks fire in headless); **and**
+- **saved settings untouched** — `~/.claude/settings.json` is byte-identical
+  before/after; **and**
+- the model's answer contains none of the `contaminationScan` Lien terms.
 
-The runner writes a `.probe-passed` marker only on success and **refuses to run any
-arm without it**. The probe output is archived to `.wip/nudge-ab-v2/probe.jsonl`.
-(The user's ambient `~/.claude/rules/context7.md` is removed by control #1 above, so
-unlike PR #844 it is *not* present in this environment — a strictly cleaner context.)
+The runner writes `.probe-passed` + `.auth-mode = default+plugindisable+strict-mcp` only
+on success, and `cmdRun` **refuses to run any arm** unless that exact auth-mode marker is
+present. The probe transcript is archived (redacted) to `.wip/nudge-ab-v2/probe-b1.jsonl`.
+The ambient `~/.claude/rules/context7.md` remains present (identical across arms —
+acceptable per the v1 precedent).
 
 ### 3b. Hook-liveness precondition (zero-LLM)
 
@@ -374,14 +402,11 @@ npm ci && npm run build && npm run build:native -w @liendev/parser-native
 # 1. zero-LLM instrument check (free) — must pass
 node scripts/experiments/nudge-ab-v2/run.mjs check
 
-# 2. mandatory contamination + plumbing probe (1 claude call) — must pass
-node scripts/experiments/nudge-ab-v2/run.mjs probe
+# 2. mandatory contamination + plumbing probe (1 claude call, the b' mechanism)
+#    — must pass (writes .auth-mode=default+plugindisable+strict-mcp)
+node scripts/experiments/nudge-ab-v2/run.mjs probe-b1
 
-# 3. scoped-permission viability smoke (2 uncounted claude calls) — confirm
-#    trials complete under acceptEdits + the allowlist, no fatal denials
-node scripts/experiments/nudge-ab-v2/run.mjs smoke
-
-# 4. the arms (gated on the probe marker)
+# 3. the arms (gated on the b' auth-mode marker; §7 re-draw to N=10 valid)
 node scripts/experiments/nudge-ab-v2/run.mjs run blast
 node scripts/experiments/nudge-ab-v2/run.mjs run verify
 ```

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -261,7 +261,7 @@ by `scripts/experiments/nudge-ab-v2/hooks/silent-note-edit.sh` — the same
 adds nothing the model can see; it only holds ledger population constant so the *only*
 variable is the Stop advisory. This isolates the Stop hook (PR #843's target) rather
 than bundling it with the edit-time reminder. The fidelity trade-off is stated in
-[§8](#8-validity-caveats).
+[§8](#8-validity-caveats-carried-forward-stated-before-running).
 
 ---
 
@@ -351,10 +351,17 @@ The run aborts (no result claimed) if any holds:
 
 1. **Contamination probe fails** (§3a) — non-empty-and-clean not satisfied.
 2. **Hook-liveness check fails** (§3b) — a fixture no longer triggers its nudge.
-3. **> 20% invalid trials** in either arm of an experiment (agent never edited the
-   target, transcript unparseable, ON-arm nudge never fired). Invalid trials up to that
-   cap are re-drawn with fresh session ids; beyond it, the experiment is declared an
-   instrument failure, not a measured null.
+3. **> 20% invalid trials** in either arm of an experiment (agent never completed the
+   task edit, transcript unparseable, timed out, or came back logged-out). Validity is
+   now **symmetric across arms** — both require the task edit to have actually landed
+   (blast: `api-delta` shows `applyDiscount`'s signature changed; verify: the target was
+   edited), not the old asymmetric "control is always valid." Invalid trials up to the
+   cap (`ceil(0.2·N)` = 2 per arm at N=10) are **re-drawn with fresh session ids**, so a
+   fully-invalid-free run is exactly `2·N` counted trials while a worst-case within-cap
+   run adds up to `2·2` extra invocations per experiment (budget note: the §9 estimate
+   is the invalid-free floor; re-draws can add a handful more). Beyond the cap the
+   experiment is declared an instrument failure, not a measured null. **The 2026-07-26
+   run needed 0 re-draws (0 invalid across all 40 trials).**
 4. **Any OFF-arm contamination leak** that cannot be isolated to specific re-drawable
    trials.
 

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -1,0 +1,371 @@
+# Nudge A/B v2 — the task-decoupled, discriminating protocol (FROZEN pre-registration)
+
+This document is the **pre-registration** for a second-generation A/B test of two
+Lien nudges that the first-generation experiments could only measure as nulls:
+
+- **Blast-radius warning** — `plugins/claude/hooks/api-delta-write.sh` (PR #841).
+- **Did-you-run-the-tests advisory** — the Stop hook `recap-stop.sh`'s unrun-tests
+  section (`lien recap`, the successor to PR #843's `test-verify-stop.sh`).
+
+It is frozen before the first trial runs. Once any arm has executed, nothing below
+changes: no metric is added, redefined, or reinterpreted post hoc; a null is
+reported as a null. The runner that executes it is
+`scripts/experiments/nudge-ab-v2/run.mjs`; this document and that runner are the
+whole instrument, and running it later requires **zero further design decisions**.
+
+> **Status: designed and frozen. NOT YET RUN.** The arms cost real OpenRouter/API
+> budget (see [Cost](#cost-estimate)); they run only after the owner approves the
+> spend. The runner refuses to start an arm until the contamination probe has
+> passed in the same invocation.
+
+---
+
+## 1. The problem this design exists to defeat: task-forcing
+
+Both first-generation A/Bs
+([blast-radius-nudge-ab.md](blast-radius-nudge-ab.md),
+[test-verification-nudge-ab.md](test-verification-nudge-ab.md)) returned an honest
+**8/8 vs 8/8 null on the primary metric**, and the context-neutral re-runs (PR #844)
+reproduced the null in a verified-clean environment (7/8 vs 8/8 on the sharper blast
+sub-metric; 8/8 vs 8/8 on test-verification). The diagnosis was **not** "the nudge
+does nothing." It was that the frozen scenarios were **task-forced**: the scenario
+text made the nudged behavior derivable from the task itself, so any competent model
+did it with or without the nudge, leaving no headroom to measure a difference.
+
+- Blast: the target file showed all its call sites in-file, and the task
+  ("thread `opts` through") *required* updating them. Checking callers was the task.
+- Test-verification: the associated tests were **named in the prompt**, and "run the
+  tests you just touched" is close to a current model's default on any edit.
+
+v2 removes the task-forcing on both axes. The nudged behavior must **not** be
+derivable from the task or the edited file:
+
+1. **Out-of-file dependents.** The changed symbol's callers live in *other
+   directories*; nothing in the edited file names or hints at them. Finding them
+   requires a search the task never asks for.
+2. **A test not named after its source.** The associated test is linked to the
+   source only by an `import`, never by filename, so "which test covers this?" has
+   **no lexical answer** — you either already know (the nudge tells you) or you go
+   and run the import-graph query.
+3. **Plain feature/fix tasks.** Each prompt is a normal feature request. It never
+   mentions callers, dependents, tests, risk, coverage, or Lien.
+
+The two nudges are also each **isolated**: every *other* nudge is held off in both
+arms, so exactly one signal varies per experiment (see [§4](#4-arms-the-real-kill-switches)).
+
+---
+
+## 2. Scenario fixtures (frozen)
+
+Pristine trees live under `scripts/experiments/nudge-ab-v2/fixtures/`. The runner
+copies one to a fresh temp dir per trial, `git init`s + commits it, and
+`lien index`es it, so each trial is independent. They are plain JS/TS projects
+outside `packages/`, so the repo's build/lint/typecheck/test/format tooling never
+touches them.
+
+### 2a. Blast fixture (`fixtures/blast/`, project `pricing-app`)
+
+```
+src/pricing/discount.ts     export applyDiscount(price, rate)   ← the edited file
+src/checkout/cart.ts        imports + calls applyDiscount        ← out-of-dir dependent #1
+src/reports/invoice.ts      imports + calls applyDiscount        ← out-of-dir dependent #2
+```
+
+`discount.ts` is self-contained on its face — nothing in it names `cart.ts` or
+`invoice.ts`. **Task** (`prompts/blast.task.txt`): add an *optional* minimum-price
+floor to `applyDiscount`. The natural implementation adds a parameter, which changes
+an exported signature → `api-delta` fires. Because the new parameter is optional,
+the two dependents still compile and behave correctly, so **the only thing that
+surfaces their existence is the blast warning** — nothing about the task forces the
+agent to go look for them.
+
+Verified (zero-LLM, `run.mjs check`): after the edit, `lien api-delta` reports
+`applyDiscount signature-changed, dependentCount 2, untestedDependentCount 2,
+riskLevel medium, enriched`, and `api-delta-write.sh` renders:
+
+```
+⚠ lien: exported signature changed — applyDiscount (2 dependents, 2 untested, risk medium). Run get_dependents before relying on callers.
+```
+
+### 2b. Verify fixture (`fixtures/verify/`, project `orders-app`)
+
+```
+src/order-status.ts             export formatStatus(order)        ← the edited file
+test/regression-suite.test.ts   imports formatStatus (vitest)     ← associated by IMPORT, not name
+```
+
+**Task** (`prompts/verify.task.txt`): include the customer's name in the formatted
+status string — a tiny, low-stakes edit that does not read as "test me." There is
+**no `test` script** in `package.json`, so running the suite is a deliberate,
+discovery-requiring act (`npx vitest run <path>`), not a reflex. The test's filename
+(`regression-suite`) shares no stem with its source (`order-status`), so a naive scan
+of source names gives no path to it.
+
+Verified (zero-LLM, `run.mjs check`): `lien verify-tests note-edit` associates
+`src/order-status.ts → test/regression-suite.test.ts` (import-based, via
+`findTestAssociationsFromChunks`); `lien verify-tests report` raises it as unrun; and
+after a covering `npx vitest run test/regression-suite.test.ts` the report goes
+silent. `recap-stop.sh` wraps that report text as `{"decision":"block","reason":…}`.
+
+---
+
+## 3. Execution environment (frozen)
+
+Each trial is one headless, agentic `claude -p` run **with tools enabled** (Edit,
+Write, Read, Bash, Grep, Glob), from inside the trial's scenario dir. This is the
+core departure from v1, whose trials were tool-free single-turn generations: the v2
+metrics are about what the agent *does* in a repo, so it must be able to act.
+
+Clean context is enforced by three independent controls, all identical across arms:
+
+1. **Isolated config dir.** `CLAUDE_CONFIG_DIR` points at a runner-generated dir with
+   a minimal `settings.json` and **no `enabledPlugins` and no user `rules/`**. This is
+   what disables the ambient, user-level `lien@lien` plugin — both its MCP
+   *instructions* (the confound PR #844 discovered) and its *hooks* — for the run.
+   macOS auth lives in the Keychain, not this dir, so headless `claude` still
+   authenticates.
+2. **Stripped MCP.** `--strict-mcp-config --mcp-config <{"mcpServers":{}}>` — belt and
+   braces; zero MCP servers, no Lien tool instructions.
+3. **Explicit hooks only.** The nudge under test is wired by absolute path via
+   `--settings` (see §4), so the experiment exercises **this checkout's** hook
+   scripts, not a commit-pinned plugin snapshot.
+
+The hooks shell out to the bare `lien` binary; the runner puts a `lien` shim on
+`PATH` that resolves to this checkout's build (`packages/cli/dist/index.js`), so the
+CLI under test is unambiguous.
+
+### 3a. Mandatory contamination + plumbing probe (hard precondition)
+
+Before **any** arm runs, `run.mjs probe` executes one `claude -p` with the exact arm
+invocation (isolated config dir, stripped MCP, `--settings {hooks:{}}`) from a
+git-free, `CLAUDE.md`-free directory, asking the model to quote verbatim every project
+instruction / repo rule / tool-usage policy in its context (`prompts/probe.txt`,
+"…if there are none, reply NONE"). It **passes only if**:
+
+- the output is non-empty (proves auth + the isolated-config plumbing work), **and**
+- the output contains **none** of: `get_dependents`, `get_files_context`,
+  `search_code`, `claude.md`, `lien`, `blast radius`, `complexity threshold`,
+  `test association` (the frozen `contaminationScan` list), **and**
+- programmatically: no `CLAUDE.md` in the scenario dir or any ancestor up to `/`, and
+  the mcp-config is empty.
+
+The runner writes a `.probe-passed` marker only on success and **refuses to run any
+arm without it**. The probe output is archived to `.wip/nudge-ab-v2/probe.jsonl`.
+(The user's ambient `~/.claude/rules/context7.md` is removed by control #1 above, so
+unlike PR #844 it is *not* present in this environment — a strictly cleaner context.)
+
+### 3b. Hook-liveness precondition (zero-LLM)
+
+`run.mjs check` materializes both fixtures and asserts the real hooks render the
+intended nudges against them (the exact output quoted in §2). It runs with no LLM and
+must pass; a fixture that no longer triggers its nudge is an instrument failure, not a
+result. **This check has been run and passes on the frozen fixtures** (it is part of
+this PR's dogfooding evidence).
+
+---
+
+## 4. Arms: the real kill switches
+
+Arms differ **only** by the real env kill switch of the nudge under test. Everything
+else — prompt, fixture, model, tools, config — is byte-identical. The base env
+(`LIEN_DELTA_HOOK=off`, `LIEN_ANNOTATE_GUARD=off`) plus each experiment's `baseEnv`
+neutralizes every other nudge in both arms.
+
+| Experiment | Signal (ON) | Control (OFF) | Held off in BOTH arms |
+|---|---|---|---|
+| **blast** | `LIEN_BLAST_HOOK` unset (on) | `LIEN_BLAST_HOOK=off` | `LIEN_RECAP=off`, `LIEN_TEST_REMINDER=off`, `LIEN_DELTA_HOOK=off` |
+| **verify** | `LIEN_RECAP` unset (on) | `LIEN_RECAP=off` | `LIEN_BLAST_HOOK=off`, `LIEN_TEST_REMINDER=off`, `LIEN_DELTA_HOOK=off` |
+
+Wiring (`--settings`, absolute paths):
+
+- **blast** — one hook: `PostToolUse Edit|Write|MultiEdit → api-delta-write.sh`. Recap
+  is off in both arms, so the edit-time warning is the *only* delivery of the blast
+  signal; the OFF arm gets nothing.
+- **verify** — three hooks: `PostToolUse Edit|Write|MultiEdit → silent-note-edit.sh`
+  (scaffolding), `PostToolUse Bash → test-run-note.sh` (real, records observed runs),
+  `Stop → recap-stop.sh` (real, the nudge under test).
+
+### 4a. Why the `silent-note-edit.sh` scaffolding is legitimate, not a cheat
+
+The Stop advisory can only fire if the session ledger records that the target file was
+edited and has an associated test. In production, the *edit-time* reminder
+(`test-reminder.sh`) does that recording — **but it also prints the associated test's
+name**, which would hand the agent the very fact this experiment withholds, collapsing
+the discriminator. So `test-reminder.sh` is held off in both arms
+(`LIEN_TEST_REMINDER=off`), and the ledger recording it would do is provided instead
+by `scripts/experiments/nudge-ab-v2/hooks/silent-note-edit.sh` — the same
+`lien verify-tests note-edit` call, output discarded, **identical in both arms**. It
+adds nothing the model can see; it only holds ledger population constant so the *only*
+variable is the Stop advisory. This isolates the Stop hook (PR #843's target) rather
+than bundling it with the edit-time reminder. The fidelity trade-off is stated in
+[§8](#8-validity-caveats).
+
+---
+
+## 5. Sample size, randomization, N
+
+- **N = 10 per arm**, 20 per experiment, **40 arm trials total**. This deviates from
+  v1's N = 8, deliberately: v1 was confirming an expected null and needed no power;
+  v2 is built to *detect* a real difference and to survive a single-trial flip. At
+  N = 10, an 8/10-vs-2/10 or 9/10-vs-3/10 split clears one-sided Fisher p < 0.05 with
+  margin, where the same effect at N = 8 would sit on the significance boundary. 10
+  also matches the repo's established `--calibrate 10` convention.
+- **Interleaving.** Arms run in a single fixed, seeded Fisher-Yates order
+  (`INTERLEAVE_SEED = 20260725`) mixing all 20 `on`/`off` labels, so neither arm
+  clusters in time. The order is reproducible from the seed.
+- **Each trial is independent**: fresh temp repo, fresh index, fresh `--session-id`.
+
+---
+
+## 6. Primary metrics and exact detection rules (frozen)
+
+Detection is deterministic and offline, over the captured `stream-json` transcript
+plus the FEATURE-2 ledger. All rules are implemented in
+`scripts/experiments/nudge-ab-v2/detect.mjs`; the prose here and that code are the
+same specification.
+
+### 6a. Blast — concrete beyond-file caller action
+
+**Positive iff the agent, anywhere in the trial, takes a concrete action to identify
+callers of `applyDiscount` beyond the edited file** — ANY of:
+
+- a `Grep` (or `Bash` grep/rg/git-grep) whose pattern is the symbol `applyDiscount`;
+- a `Grep`/`Read`/`Glob`/`Bash` that targets a specific out-of-directory dependent
+  (`cart.ts`, `cartTotal`, `invoice.ts`, `invoiceLine`, `checkout/`, `reports/`);
+- a final answer that **names** a specific dependent by one of those identifiers.
+
+**Explicitly NOT counted:** generic hedging ("other callers may need updating",
+"external usages could break") that neither searches for nor names a specific
+dependent. That sentiment is exactly the ceiling v1 hit (7/8 in clean control), so the
+v2 discriminator is raised to *observable action*. The generic-sentiment rate is still
+recorded, as a **secondary/context** signal only, never the primary.
+
+- **Hypothesis:** signal (ON) positive-rate > control (OFF).
+- **Validity of an ON trial:** the blast warning actually fired (a `blast` note-shown
+  event for the session in `nudge-events.jsonl`). An ON trial where the agent made no
+  qualifying signature change (no warning) is **invalid** and re-drawn.
+
+> Note: MCP is stripped, so the literal `get_dependents` tool does not exist in-trial;
+> a nudged agent acts via grep/read instead. The metric counts that. This makes the
+> blast number a *lower bound* on the warning's pull relative to production, where the
+> named tool is present (see §8).
+
+### 6b. Verify — ran the associated test
+
+**Positive iff the associated test (`test/regression-suite.test.ts`) was observed run**
+this session. The **authoritative oracle** is the FEATURE-2 ledger, queried post-run
+by `lien verify-tests report --session <id>` from the trial dir (reuses the shipped
+`classifyTestCommand`/coverage logic, so no detection drift): empty report ⇒ the test
+was covered (positive); the file still listed ⇒ not run (negative). This captures
+*any* covering run — scoped-by-path or whole-suite — including runs the agent makes in
+the extra turn the Stop `block` grants. The transcript's test commands are recorded as
+a cross-check but the ledger is authoritative.
+
+- **Hypothesis:** signal (ON, advisory present) positive-rate > control (OFF).
+- **Mechanism note (context, not a separate primary):** in the ON arm the Stop
+  advisory only fires when the agent has *not* already run the test; the comparison of
+  final run-rates therefore measures exactly the advisory's rescue of the
+  otherwise-non-testers. If current models test-by-default even here, both arms sit
+  high and the null is real information (v1 already suggested this is likely) — it is
+  reported as such.
+
+### 6c. Decision rule (frozen)
+
+For each experiment: report raw rates `hits/N` per arm. **Primary separation is
+declared iff one-sided Fisher's exact p < 0.05 in the hypothesized direction (ON >
+OFF).** Per the standing launch rule, **no lift claim** is made for either nudge unless
+its pre-registered primary metric separates by that test. A non-separating result is a
+null, reported as a null — not reframed as "inconclusive, therefore supportive."
+
+Contamination guard: any OFF-arm transcript containing a `contaminationScan` term is
+flagged as a leak in the summary; leaks invalidate the affected trials.
+
+---
+
+## 7. Abort criteria (frozen)
+
+The run aborts (no result claimed) if any holds:
+
+1. **Contamination probe fails** (§3a) — non-empty-and-clean not satisfied.
+2. **Hook-liveness check fails** (§3b) — a fixture no longer triggers its nudge.
+3. **> 20% invalid trials** in either arm of an experiment (agent never edited the
+   target, transcript unparseable, ON-arm nudge never fired). Invalid trials up to that
+   cap are re-drawn with fresh session ids; beyond it, the experiment is declared an
+   instrument failure, not a measured null.
+4. **Any OFF-arm contamination leak** that cannot be isolated to specific re-drawable
+   trials.
+
+---
+
+## 8. Validity caveats (carried forward, stated before running)
+
+- **Lower-bound environment.** Like PR #844, this removes not just the contamination
+  but *every* ambient instruction (no CLAUDE.md, no plugin, no user rules, no prior
+  turns). It is a floor for isolating the mechanism, not a forecast of the effect in a
+  real, richly-contextualized session under time pressure — the exact gap these nudges
+  exist to close. A separation here is strong evidence; a null here does **not** prove
+  the nudge is useless in production, only that a maximally-naive agent doesn't need it
+  at this task scale.
+- **Blast tool absence.** With MCP stripped, the ON agent cannot literally call
+  `get_dependents`; it greps instead. The blast rate is thus a lower bound vs
+  production where the tool exists.
+- **Verify isolates the Stop hook.** By holding the edit-time reminder off in both
+  arms, this measures the Stop advisory *alone*, not the full test-verification feature
+  (edit-time reminder + Stop) a user actually enables. A positive result is
+  attributable to the Stop hook specifically; the bundled feature could be stronger.
+- **N = 10.** Real but modest power. A 7/10-vs-9/10-type flicker is not a result and is
+  reported as a null, exactly as v1's 7/8-vs-8/8 was.
+
+---
+
+## 9. Cost estimate
+
+- **41 headless `claude -p` invocations**: 40 arm trials (10 × 2 arms × 2 experiments)
+  + 1 contamination probe. The zero-LLM instrument check and all ledger/`api-delta`
+  oracles are free.
+- Each arm trial is **agentic** (reads a few files, greps, edits, sometimes runs a
+  test, 1–2 Stop cycles) on `--model sonnet`. Rough order: tens of thousands of
+  (largely cache-eligible) input tokens + a few thousand output tokens per trial ⇒
+  **≈ $0.10–0.30 per trial**.
+- **Total ≈ $5–12**, comparable to one harness `--calibrate 10` sweep (~$5–8). Dropping
+  to N = 8 (v1 parity) would cut ~20% (32 trials).
+
+These are estimates; actual spend is metered by the provider. The run is gated on
+owner approval of this budget.
+
+---
+
+## 10. How to run (after approval)
+
+```bash
+# 0. one-time: build this checkout so the lien shim resolves to it
+npm ci && npm run build && npm run build:native -w @liendev/parser-native
+
+# 1. zero-LLM instrument check (free) — must pass
+node scripts/experiments/nudge-ab-v2/run.mjs check
+
+# 2. mandatory contamination + plumbing probe (1 claude call) — must pass
+node scripts/experiments/nudge-ab-v2/run.mjs probe
+
+# 3. the arms (gated on the probe marker)
+node scripts/experiments/nudge-ab-v2/run.mjs run blast
+node scripts/experiments/nudge-ab-v2/run.mjs run verify
+```
+
+Raw transcripts, per-trial verdicts, the probe output, and the `*-summary.json`
+(rates + Fisher p + separation decision) are written under `.wip/nudge-ab-v2/`
+(gitignored). Results get a dated section appended to
+[blast-radius-nudge-ab.md](blast-radius-nudge-ab.md) and
+[test-verification-nudge-ab.md](test-verification-nudge-ab.md), reported as whatever
+they are.
+
+---
+
+## 11. Artifacts (this PR)
+
+- Pre-registration: this document (frozen).
+- Fixtures: `scripts/experiments/nudge-ab-v2/fixtures/{blast,verify}/`.
+- Prompts: `scripts/experiments/nudge-ab-v2/prompts/`.
+- Scaffolding hook: `scripts/experiments/nudge-ab-v2/hooks/silent-note-edit.sh`.
+- Runner + detection: `scripts/experiments/nudge-ab-v2/run.mjs`, `detect.mjs`.
+- Kit overview: `scripts/experiments/nudge-ab-v2/README.md`.

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -142,12 +142,18 @@ command being *issued and executed*, independent of the test's result.
 
 Clean context is enforced by three independent controls, all identical across arms:
 
-1. **Isolated config dir.** `CLAUDE_CONFIG_DIR` points at a runner-generated dir with
-   a minimal `settings.json` and **no `enabledPlugins` and no user `rules/`**. This is
-   what disables the ambient, user-level `lien@lien` plugin — both its MCP
-   *instructions* (the confound PR #844 discovered) and its *hooks* — for the run.
-   macOS auth lives in the Keychain, not this dir, so headless `claude` still
-   authenticates.
+1. **Isolated config dir.** `CLAUDE_CONFIG_DIR` points at a throwaway `mktemp -d` dir
+   (outside the repo) with a minimal `settings.json` and **no `enabledPlugins` and no
+   user `rules/`**. This is what disables the ambient, user-level `lien@lien` plugin —
+   both its MCP *instructions* (the confound PR #844 discovered) and its *hooks* — for
+   the run. A fresh config dir otherwise reports **"Not logged in"** (CC reads the
+   account/OAuth linkage from `.claude.json`, which the fresh dir lacks), so the runner
+   seeds an **account-only** `.claude.json` — `userID` + `oauthAccount` **only**, read
+   from the real `~/.claude.json` at runtime, with **no `mcpServers`, no `projects`, no
+   `enabledPlugins`** — restoring auth while staying plugin- and MCP-free (the probe
+   proves the context stays clean). Those personal fields live only in the throwaway
+   dir, are deleted in cleanup, are redacted from every on-disk artifact, and never
+   enter the repo, `.wip/`, or any committed output.
 2. **Stripped MCP.** `--strict-mcp-config --mcp-config <{"mcpServers":{}}>` — belt and
    braces; zero MCP servers, no Lien tool instructions.
 3. **Explicit hooks only.** The nudge under test is wired by absolute path via

--- a/docs/development/nudge-ab-v2-protocol.md
+++ b/docs/development/nudge-ab-v2-protocol.md
@@ -13,10 +13,15 @@ reported as a null. The runner that executes it is
 `scripts/experiments/nudge-ab-v2/run.mjs`; this document and that runner are the
 whole instrument, and running it later requires **zero further design decisions**.
 
-> **Status: designed and frozen. NOT YET RUN.** The arms cost real OpenRouter/API
-> budget (see [Cost](#cost-estimate)); they run only after the owner approves the
-> spend. The runner refuses to start an arm until the contamination probe has
-> passed in the same invocation.
+> **Status: RUN 2026-07-26 — both nudges separated.** Blast **10/10 vs 3/10**
+> (Fisher one-sided p = 0.0015); test-verification **10/10 vs 0/10** (p ≈ 5.4e-6).
+> 40/40 valid, 0 logged-out, 0 timed-out, 0 tool denials, 0 real contamination
+> (word-boundary corrected). Results are written up in
+> [blast-radius-nudge-ab.md](blast-radius-nudge-ab.md) and
+> [test-verification-nudge-ab.md](test-verification-nudge-ab.md); raw artifacts under
+> `.wip/nudge-ab-v2/`. The context mechanism that actually ran was **b'** (§3): the
+> default config dir with the ambient plugin disabled per-invocation — the isolated-dir
+> and strict-mcp-only alternatives failed (§3c).
 
 ---
 

--- a/docs/development/test-verification-nudge-ab.md
+++ b/docs/development/test-verification-nudge-ab.md
@@ -424,10 +424,19 @@ trials (10/arm, seeded interleave), fixture sandboxes with no `CLAUDE.md`; defau
 dir with the ambient `lien@lien` plugin disabled per-invocation (saved settings
 untouched), `--strict-mcp-config`, scoped `acceptEdits` + allowlist; blast + edit-time
 reminder held off in both arms, `vitest` provisioned so the test command runs locally. 0
-invalid, 0 logged-out, 0 timed-out, **0 tool denials** (symmetric). Contamination: 0/20
-OFF trials on a word-boundary re-scan (the raw 20/20 "leaks" were the substring `lien` in
-the ambient `…client…` skill name — symmetric, outside the metric; reported
-raw-and-corrected).
+invalid, 0 logged-out, 0 timed-out, **0 tool denials** (symmetric). Contamination: 0/10
+OFF trials in this experiment on a word-boundary re-scan (0/20 across both experiments);
+the raw substring scan flagged all 10/10 on `lien` inside the ambient `…client…` skill
+name — symmetric, outside the metric; reported raw-and-corrected.
+
+**Validity audit (post-review).** This experiment already gated validity on the target
+being edited (symmetric across arms), so the OFF-arm asymmetry the review found in the
+blast scorer did not apply here. An offline re-run of the corrected scoring pipeline over
+the archived transcripts reproduces the published counts exactly (10/10 vs 0/10), and the
+precise Fisher p is **5.413 × 10⁻⁶** (the summary JSON's `0` was a `toFixed(4)`
+serialization bug, now fixed to preserve small p-values); the independent transcript
+cross-check agrees with the ledger oracle on all 20 trials. Evidence in the PR
+transparency note.
 
 **Validity caveats.** (1) Lower-bound environment (no CLAUDE.md/plugin/prior turns) — a
 floor for the mechanism, not a production forecast. (2) This isolates the **Stop

--- a/docs/development/test-verification-nudge-ab.md
+++ b/docs/development/test-verification-nudge-ab.md
@@ -382,3 +382,59 @@ single-turn setup here cannot reproduce.
   `.wip/ab-neutral/probes/probe-clean.txt` (gitignored, shared with A/B #1b)
 - Raw per-trial outputs:
   `.wip/ab-neutral/trials/testverify/{control,signal}-{1..8}.md` (gitignored)
+
+---
+
+## 2026-07-26: A/B v2 (task-decoupled) — the Stop advisory **separates decisively**
+
+Both prior sections returned 8/8-vs-8/8 nulls, read as "run the tests you just touched
+is close to a current model's default." But those scenarios **named the tests in the
+prompt** — task-forcing. The v2 protocol
+([nudge-ab-v2-protocol.md](nudge-ab-v2-protocol.md), frozen pre-registration) removes it:
+the associated test is linked to its source **only by an `import`**
+(`test/regression-suite.test.ts` imports `src/order-status.ts`), never by filename, so
+"which test covers this?" has **no lexical answer**; the task is a tiny feature edit
+("include the customer's name in the formatted status") that doesn't read as "test me";
+and there is no `test` script, so running the suite is a deliberate, discovery-requiring
+act. The edit-time reminder is held off in both arms (its ledger recording provided by a
+silent scaffold), so this isolates the **Stop advisory** (`recap-stop.sh` / `LIEN_RECAP`)
+alone. Primary metric: did the agent run that specific unnamed test, via the shipped
+`verify-tests` ledger oracle.
+
+**Result: the Stop advisory separates — the cleanest result in the series.**
+
+| Condition | Ran the (non-lexically-named) associated test | Rate |
+|---|---|---|
+| Signal (`LIEN_RECAP` on) | 10 / 10 | **100%** |
+| Control (`LIEN_RECAP` off) | 0 / 10 | **0%** |
+
+One-sided Fisher exact **p ≈ 5.4 × 10⁻⁶** (= 1 / C(20,10)) — far past the pre-registered
+threshold, so the launch rule **permits a lift claim**. Every signal trial, prompted by
+the Stop advisory naming the exact test file, ran
+`npx vitest run test/regression-suite.test.ts`; **not one** control trial found or ran it.
+This directly **overturns the prior "agents test by default" reading**: once the test is
+made non-obvious (not named after its source, no `test` script), a naive agent does *not*
+run it on its own — the advisory is what gets it run. The earlier nulls measured "will an
+agent run a test whose name it was handed," which the advisory can't move because the
+answer is already yes; this measures "will it run a test it has to go find," where the
+advisory is the whole difference.
+
+**Environment (mechanism b', see protocol §3).** 20 headless `claude -p --model sonnet`
+trials (10/arm, seeded interleave), fixture sandboxes with no `CLAUDE.md`; default config
+dir with the ambient `lien@lien` plugin disabled per-invocation (saved settings
+untouched), `--strict-mcp-config`, scoped `acceptEdits` + allowlist; blast + edit-time
+reminder held off in both arms, `vitest` provisioned so the test command runs locally. 0
+invalid, 0 logged-out, 0 timed-out, **0 tool denials** (symmetric). Contamination: 0/20
+OFF trials on a word-boundary re-scan (the raw 20/20 "leaks" were the substring `lien` in
+the ambient `…client…` skill name — symmetric, outside the metric; reported
+raw-and-corrected).
+
+**Validity caveats.** (1) Lower-bound environment (no CLAUDE.md/plugin/prior turns) — a
+floor for the mechanism, not a production forecast. (2) This isolates the **Stop
+advisory**; the full shipped feature also fires an edit-time reminder, so the deployed
+feature is at least this effective. A separation this large in a floor environment is
+strong evidence the advisory changes behavior.
+
+Artifacts: pre-registration `docs/development/nudge-ab-v2-protocol.md`; runner
+`scripts/experiments/nudge-ab-v2/`; raw transcripts + verdicts + summary under
+`.wip/nudge-ab-v2/verify/` (gitignored).

--- a/scripts/experiments/nudge-ab-v2/README.md
+++ b/scripts/experiments/nudge-ab-v2/README.md
@@ -1,0 +1,52 @@
+# nudge-ab-v2 experiment kit
+
+The runnable instrument for the **task-decoupled** A/B re-test of two Lien nudges
+(blast-radius warning, did-you-run-the-tests Stop advisory). The **frozen
+pre-registration** — hypotheses, scenario rationale, arms, metrics, abort criteria,
+cost — is the authority and lives at
+[`docs/development/nudge-ab-v2-protocol.md`](../../../docs/development/nudge-ab-v2-protocol.md).
+Read it first. This README only covers how to drive the kit.
+
+## Why v2 exists
+
+The v1 A/Bs came back null because the scenarios were **task-forced**: the nudged
+behavior was derivable from the task, so both arms did it and there was no headroom.
+v2 decouples them — out-of-file dependents with no in-file hint, a test associated to
+its source only by `import` (never by filename), and plain feature prompts that never
+mention callers/tests/risk. See the protocol doc's §1–§2.
+
+## Layout
+
+```
+run.mjs         orchestrator: check | probe | run <blast|verify>
+detect.mjs      frozen, deterministic metric detection (pure functions)
+hooks/          silent-note-edit.sh — experiment scaffolding (NOT a shipped hook)
+fixtures/       pristine scenario repos (blast, verify), materialized per trial
+prompts/        the frozen task + probe prompts
+```
+
+The real nudges under test are the shipped `plugins/claude/hooks/api-delta-write.sh`
+(blast) and `recap-stop.sh` (verify); the runner wires them by absolute path via
+`--settings` and toggles them with their real env kill switches
+(`LIEN_BLAST_HOOK`, `LIEN_RECAP`).
+
+## Commands
+
+```bash
+node run.mjs check   # zero-LLM: asserts the fixtures still trigger their nudges. FREE.
+node run.mjs probe   # mandatory clean-context + plumbing precondition (1 claude call).
+node run.mjs run blast    # 20 arm trials (gated on the probe having passed)
+node run.mjs run verify   # 20 arm trials
+```
+
+`check` requires only a built CLI (`npm run build` + `build:native`). `probe`/`run`
+additionally require the `claude` CLI and API budget — **run only after owner
+approval of the cost** (protocol §9). The runner refuses to start an arm until the
+probe has passed in the same invocation. Outputs land in `.wip/nudge-ab-v2/`
+(gitignored).
+
+## Do not
+
+- Do not add or redefine a metric after an arm has run — the pre-registration is
+  frozen (protocol §6).
+- Do not "fix" a null into a lift claim — a null is a null (protocol §6c, §8).

--- a/scripts/experiments/nudge-ab-v2/README.md
+++ b/scripts/experiments/nudge-ab-v2/README.md
@@ -1,5 +1,12 @@
 # nudge-ab-v2 experiment kit
 
+> This file is **tool-usage documentation co-located with the runnable script it
+> describes** (how to invoke `run.mjs`), not permanent project documentation — the
+> authoritative, tracked write-up is the protocol doc and the two A/B docs under
+> `docs/development/`. It lives next to the code it documents on purpose; the repo's
+> "permanent docs live in `docs/`" rule is satisfied by the protocol doc, which this
+> README defers to.
+
 The runnable instrument for the **task-decoupled** A/B re-test of two Lien nudges
 (blast-radius warning, did-you-run-the-tests Stop advisory). The **frozen
 pre-registration** — hypotheses, scenario rationale, arms, metrics, abort criteria,

--- a/scripts/experiments/nudge-ab-v2/README.md
+++ b/scripts/experiments/nudge-ab-v2/README.md
@@ -49,8 +49,7 @@ node run.mjs run verify   # 20 arm trials
 `check` requires only a built CLI (`npm run build` + `build:native`). `probe`/`run`
 additionally require the `claude` CLI and API budget — **run only after owner
 approval of the cost** (protocol §9). The runner refuses to start an arm until the
-probe has passed in the same invocation. Outputs land in `.wip/nudge-ab-v2/`
-(gitignored).
+probe has passed. Outputs land in `.wip/nudge-ab-v2/` (gitignored).
 
 ## Do not
 

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -141,10 +141,12 @@ export function verifyTranscriptRanTest(toolUses) {
   for (const tu of toolUses) {
     if (tu.name.toLowerCase() !== 'bash') continue;
     const cmd = String(tu.input?.command || '');
-    // Each alternative is a real test-runner invocation; bare `pnpm` (which
-    // matched `pnpm install`) is narrowed to `pnpm ... test`.
+    // The runner keyword must START a command segment (^, &&, ||, |, ;), after
+    // optional `cd … &&` and leading `VAR=val` env assignments — so `pnpm test`
+    // matches but `pnpm install test` (the literal word `test` mid-command) does
+    // not. Mirrors classifyTestCommand's segment-anchored approach.
     const looksLikeRunner =
-      /\b(vitest|npm\s+(run\s+)?test|npm\s+t\b|jest|mocha|pnpm\s+(run\s+)?test|yarn\s+test)\b/.test(
+      /(?:^|&&|\|\||[|;])\s*(?:cd\s+\S+\s*&&\s*)?(?:[A-Za-z_]\w*=\S+\s+)*(vitest|npx\s+vitest|npm\s+(?:run\s+)?test|npm\s+t\b|jest|npx\s+jest|mocha|pnpm\s+(?:run\s+)?test|yarn\s+test)\b/.test(
         cmd,
       );
     if (!looksLikeRunner) continue;

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -171,9 +171,16 @@ const CONTAMINATION_TERMS = [
   'test association',
   'testassociation',
 ];
+// Word-boundary matching: the short term `lien` must not match inside `client`
+// / `salient` / `alien` (the ambient skill name "…client…" the default config
+// dir exposes was the sole source of the 2026-07-26 run's raw "leaks"). Applied
+// uniformly; the counted run was re-scored offline with this same rule.
 export function contaminationScan(text) {
   const t = text.toLowerCase();
-  return CONTAMINATION_TERMS.filter(term => t.includes(term));
+  return CONTAMINATION_TERMS.filter(term => {
+    const re = new RegExp('\\b' + term.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&') + '\\b', 'i');
+    return re.test(t);
+  });
 }
 
 // A trial (or probe/warm) call that came back unauthenticated — the first call

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -1,0 +1,173 @@
+// Deterministic, pre-registered metric detection for nudge-ab-v2.
+// FROZEN: these rules are the pre-registration. No post-hoc edits once trials
+// have run. Pure functions over a captured stream-json transcript — no LLM,
+// no network, unit-inspectable.
+
+// --- transcript parsing ---------------------------------------------------
+
+// stream-json (with --verbose) is newline-delimited JSON. Assistant tool calls
+// live in message.content[] blocks of type 'tool_use'; assistant prose lives in
+// type 'text' blocks; the terminal {type:'result'} line carries `result`
+// (final text) and `session_id`.
+function parseLines(text) {
+  const objs = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      objs.push(JSON.parse(trimmed));
+    } catch {
+      /* skip non-JSON lines */
+    }
+  }
+  return objs;
+}
+
+function collectBlocks(obj, toolUses, textBlocks) {
+  const content = obj?.message?.content;
+  if (!Array.isArray(content)) return;
+  for (const block of content) {
+    if (block?.type === 'tool_use') {
+      toolUses.push({ name: block.name || '', input: block.input || {} });
+    } else if (block?.type === 'text' && typeof block.text === 'string') {
+      textBlocks.push(block.text);
+    }
+  }
+}
+
+export function parseTranscript(text) {
+  const toolUses = [];
+  const textBlocks = [];
+  let resultText = '';
+  let sessionId = '';
+  for (const obj of parseLines(text)) {
+    if (obj.type === 'result' && typeof obj.result === 'string') resultText += '\n' + obj.result;
+    if (obj.session_id && !sessionId) sessionId = obj.session_id;
+    collectBlocks(obj, toolUses, textBlocks);
+  }
+  const finalText = (textBlocks.join('\n') + '\n' + resultText).trim();
+  return { toolUses, finalText, sessionId };
+}
+
+// --- BLAST primary metric -------------------------------------------------
+// FROZEN. Positive iff the agent takes a CONCRETE action to identify callers of
+// the changed symbol BEYOND the edited file — a search for the symbol, or
+// opening/naming a specific out-of-directory dependent. Generic hedging
+// ("other callers may need updating") that neither searches for nor names a
+// specific dependent does NOT count: that sentiment is the ceiling the prior
+// A/B hit, so the discriminator is deliberately raised to observable action.
+
+const SYMBOL = 'applyDiscount';
+const DEPENDENT_HINTS = [
+  'cart.ts',
+  'cartTotal',
+  'invoice.ts',
+  'invoiceLine',
+  'checkout/',
+  'reports/',
+];
+const SEARCH_TOOLS = ['grep', 'rg', 'ripgrep', 'ag ', 'git grep', 'findstr'];
+
+function bashIsSymbolSearch(command) {
+  if (!command.includes(SYMBOL)) return false;
+  return SEARCH_TOOLS.some(t => command.includes(t));
+}
+
+const str = v => String(v ?? '');
+const hasHint = s => DEPENDENT_HINTS.some(h => s.includes(h));
+
+function grepReasons(input) {
+  const reasons = [];
+  if (str(input.pattern).includes(SYMBOL)) reasons.push(`grep pattern for ${SYMBOL}`);
+  if (hasHint(str(input.path) + ' ' + str(input.glob)))
+    reasons.push('grep scoped to dependent path');
+  return reasons;
+}
+
+function bashReasons(input) {
+  const cmd = str(input.command);
+  const reasons = [];
+  if (bashIsSymbolSearch(cmd)) reasons.push('bash search for symbol');
+  if (hasHint(cmd)) reasons.push('bash referenced a dependent path');
+  return reasons;
+}
+
+// Reasons a single tool_use counts as concrete beyond-file caller action.
+function blastReasonsForTool(tu) {
+  const name = str(tu.name).toLowerCase();
+  const input = tu.input || {};
+  if (name === 'grep') return grepReasons(input);
+  if (name === 'bash') return bashReasons(input);
+  if (name === 'read') return hasHint(str(input.file_path)) ? ['read dependent file'] : [];
+  if (name === 'glob') return hasHint(str(input.pattern)) ? ['glob for dependent path'] : [];
+  return [];
+}
+
+export function blastMetric(toolUses, finalText) {
+  const reasons = toolUses.flatMap(blastReasonsForTool);
+  // (B3) final answer names a specific dependent by identifier/file
+  const named = DEPENDENT_HINTS.filter(h => finalText.includes(h));
+  if (named.length > 0) reasons.push(`named specific dependent(s): ${named.join(', ')}`);
+  return { hit: reasons.length > 0, reasons };
+}
+
+// A weaker, prior-art-style sentiment signal, recorded for context only — NOT
+// the primary metric. True when the agent hedges about callers/dependents
+// without any concrete action or specific naming.
+const GENERIC_CALLER_WORDS = [
+  'caller',
+  'callers',
+  'dependent',
+  'depends on',
+  'depend on',
+  'usage',
+  'used elsewhere',
+];
+export function blastGenericSentiment(finalText, primaryHit) {
+  if (primaryHit) return false;
+  const t = finalText.toLowerCase();
+  return GENERIC_CALLER_WORDS.some(w => t.includes(w));
+}
+
+// --- VERIFY: transcript cross-check ---------------------------------------
+// The authoritative oracle for "did the agent run the associated test" is the
+// FEATURE-2 ledger, queried post-run by the runner via
+// `lien verify-tests report` (reuses the shipped classifyTestCommand, no drift).
+// This transcript scan is a recorded cross-check only. FROZEN.
+
+const TEST_TOKENS = ['regression-suite.test.ts', 'order-status'];
+export function verifyTranscriptRanTest(toolUses) {
+  const reasons = [];
+  for (const tu of toolUses) {
+    if (tu.name.toLowerCase() !== 'bash') continue;
+    const cmd = String(tu.input?.command || '');
+    const looksLikeRunner =
+      /\b(vitest|npm\s+(run\s+)?test|npm\s+t|jest|mocha|pnpm|yarn\s+test)\b/.test(cmd);
+    if (!looksLikeRunner) continue;
+    const scoped = TEST_TOKENS.some(t => cmd.includes(t));
+    const broad = !/\.(test|spec)\.[tj]sx?/.test(cmd) && !cmd.includes('/');
+    if (scoped) reasons.push(`scoped run: ${cmd}`);
+    else if (broad) reasons.push(`broad run: ${cmd}`);
+  }
+  return { hit: reasons.length > 0, reasons };
+}
+
+// --- contamination scan (both arms; hard-fail if hit in an OFF arm) --------
+// FROZEN. Any of these surfacing in a transcript means the clean-context
+// guarantee leaked (repo CLAUDE.md, Lien plugin MCP instructions, etc.).
+const CONTAMINATION_TERMS = [
+  'get_dependents',
+  'get_files_context',
+  'search_code',
+  'claude.md',
+  'lien',
+  'blast radius',
+  'blast-radius',
+  'complexity threshold',
+  'test association',
+  'testassociation',
+];
+export function contaminationScan(text) {
+  const t = text.toLowerCase();
+  return CONTAMINATION_TERMS.filter(term => t.includes(term));
+}

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -155,11 +155,15 @@ export function verifyTranscriptRanTest(toolUses) {
 // --- contamination scan (both arms; hard-fail if hit in an OFF arm) --------
 // FROZEN. Any of these surfacing in a transcript means the clean-context
 // guarantee leaked (repo CLAUDE.md, Lien plugin MCP instructions, etc.).
+// NOTE: 'claude.md' is deliberately NOT a term. The repo-CLAUDE.md channel is
+// closed structurally (trials/probes run in fixture sandboxes with no CLAUDE.md
+// ancestor — asserted separately), and the substring false-positives on a model
+// merely *stating* "no CLAUDE.md is present." These are the Lien-plugin's own
+// rule/tool vocabulary, which is the actual instruction-contamination signal.
 const CONTAMINATION_TERMS = [
   'get_dependents',
   'get_files_context',
   'search_code',
-  'claude.md',
   'lien',
   'blast radius',
   'blast-radius',

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -172,6 +172,15 @@ export function contaminationScan(text) {
   return CONTAMINATION_TERMS.filter(term => t.includes(term));
 }
 
+// A trial (or probe/warm) call that came back unauthenticated — the first call
+// against a brand-new CLAUDE_CONFIG_DIR can race on auth. Such a trial is
+// invalid (never a measured negative) and re-drawn.
+const LOGGED_OUT_RE =
+  /not logged in|please run \/login|invalid api key|authentication_error|oauth token .*expired/i;
+export function looksLoggedOut(text) {
+  return LOGGED_OUT_RE.test(text || '');
+}
+
 // --- tool-permission denials (logged per arm; must difference out) --------
 // The allowlist is identical in both arms, so any denial is a constant, not a
 // confound. We record them so arm-symmetry can be verified after the run.

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -171,3 +171,51 @@ export function contaminationScan(text) {
   const t = text.toLowerCase();
   return CONTAMINATION_TERMS.filter(term => t.includes(term));
 }
+
+// --- tool-permission denials (logged per arm; must difference out) --------
+// The allowlist is identical in both arms, so any denial is a constant, not a
+// confound. We record them so arm-symmetry can be verified after the run.
+const DENIAL_RE =
+  /permission|haven't granted|not allowed|requested permission|denied|isn't allowed/i;
+
+function denialText(content) {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content))
+    return content.map(c => (typeof c?.text === 'string' ? c.text : '')).join(' ');
+  return '';
+}
+
+function summarizeToolInput(tu) {
+  const i = tu.input || {};
+  return String(i.command || i.file_path || i.pattern || i.path || '').slice(0, 120);
+}
+
+function indexToolUseIds(objs) {
+  const map = new Map();
+  for (const obj of objs) {
+    const content = obj?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const b of content)
+      if (b?.type === 'tool_use') map.set(b.id, { name: b.name, input: b.input });
+  }
+  return map;
+}
+
+function isDeniedResult(b) {
+  return b?.type === 'tool_result' && b.is_error && DENIAL_RE.test(denialText(b.content));
+}
+
+function denialsInObj(obj, idToTool) {
+  const content = obj?.message?.content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(isDeniedResult).map(b => {
+    const tu = idToTool.get(b.tool_use_id) || {};
+    return { tool: tu.name || 'unknown', detail: summarizeToolInput(tu) };
+  });
+}
+
+export function collectDenials(text) {
+  const objs = parseLines(text);
+  const idToTool = indexToolUseIds(objs);
+  return objs.flatMap(obj => denialsInObj(obj, idToTool));
+}

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -181,6 +181,19 @@ export function looksLoggedOut(text) {
   return LOGGED_OUT_RE.test(text || '');
 }
 
+// Did the agent actually edit the target file? Guards the verify oracle: an
+// EMPTY `verify-tests report` means "test observed run" ONLY if the file was
+// really edited — a no-op/logged-out trial also produces an empty report and
+// must NOT be scored as a run (it is invalid instead).
+export function editedTarget(toolUses, targetPath) {
+  const base = targetPath.split('/').pop();
+  return toolUses.some(
+    tu =>
+      /^(edit|write|multiedit)$/i.test(tu.name || '') &&
+      String(tu.input?.file_path || '').includes(base),
+  );
+}
+
 // --- tool-permission denials (logged per arm; must difference out) --------
 // The allowlist is identical in both arms, so any denial is a constant, not a
 // confound. We record them so arm-symmetry can be verified after the run.

--- a/scripts/experiments/nudge-ab-v2/detect.mjs
+++ b/scripts/experiments/nudge-ab-v2/detect.mjs
@@ -141,8 +141,12 @@ export function verifyTranscriptRanTest(toolUses) {
   for (const tu of toolUses) {
     if (tu.name.toLowerCase() !== 'bash') continue;
     const cmd = String(tu.input?.command || '');
+    // Each alternative is a real test-runner invocation; bare `pnpm` (which
+    // matched `pnpm install`) is narrowed to `pnpm ... test`.
     const looksLikeRunner =
-      /\b(vitest|npm\s+(run\s+)?test|npm\s+t|jest|mocha|pnpm|yarn\s+test)\b/.test(cmd);
+      /\b(vitest|npm\s+(run\s+)?test|npm\s+t\b|jest|mocha|pnpm\s+(run\s+)?test|yarn\s+test)\b/.test(
+        cmd,
+      );
     if (!looksLikeRunner) continue;
     const scoped = TEST_TOKENS.some(t => cmd.includes(t));
     const broad = !/\.(test|spec)\.[tj]sx?/.test(cmd) && !cmd.includes('/');
@@ -251,4 +255,37 @@ export function collectDenials(text) {
   const objs = parseLines(text);
   const idToTool = indexToolUseIds(objs);
   return objs.flatMap(obj => denialsInObj(obj, idToTool));
+}
+
+// --- statistics -----------------------------------------------------------
+// One-sided Fisher exact (P(X >= observed a) under the null), via the
+// hypergeometric tail. Small N, so direct log-factorials are fine. Shared by
+// the runner and the offline re-scorer so both use identical math.
+function logFact(n) {
+  let s = 0;
+  for (let i = 2; i <= n; i++) s += Math.log(i);
+  return s;
+}
+function logHyper(k, n1, n2, t) {
+  return (
+    logFact(n1) +
+    logFact(n2) +
+    logFact(t) +
+    logFact(n1 + n2 - t) -
+    logFact(n1 + n2) -
+    logFact(k) -
+    logFact(n1 - k) -
+    logFact(t - k) -
+    logFact(n2 - (t - k))
+  );
+}
+export function fisherOneSided(a, n1, c, n2) {
+  const t = a + c;
+  if (n1 === 0 || n2 === 0) return 1;
+  let p = 0;
+  for (let k = a; k <= Math.min(n1, t); k++) {
+    if (t - k < 0 || t - k > n2) continue;
+    p += Math.exp(logHyper(k, n1, n2, t));
+  }
+  return Math.min(1, p);
 }

--- a/scripts/experiments/nudge-ab-v2/fixtures/blast/package.json
+++ b/scripts/experiments/nudge-ab-v2/fixtures/blast/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pricing-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/scripts/experiments/nudge-ab-v2/fixtures/blast/src/checkout/cart.ts
+++ b/scripts/experiments/nudge-ab-v2/fixtures/blast/src/checkout/cart.ts
@@ -1,0 +1,11 @@
+import { applyDiscount } from '../pricing/discount.js';
+
+interface LineItem {
+  price: number;
+  rate: number;
+}
+
+// Out-of-directory dependent #1 of applyDiscount. Calls it positionally.
+export function cartTotal(items: LineItem[]): number {
+  return items.reduce((sum, item) => sum + applyDiscount(item.price, item.rate), 0);
+}

--- a/scripts/experiments/nudge-ab-v2/fixtures/blast/src/pricing/discount.ts
+++ b/scripts/experiments/nudge-ab-v2/fixtures/blast/src/pricing/discount.ts
@@ -1,0 +1,5 @@
+// The edited file. Self-contained on its face: nothing here names or hints at
+// the modules that call applyDiscount (they live in other directories).
+export function applyDiscount(price: number, rate: number): number {
+  return price - price * rate;
+}

--- a/scripts/experiments/nudge-ab-v2/fixtures/blast/src/reports/invoice.ts
+++ b/scripts/experiments/nudge-ab-v2/fixtures/blast/src/reports/invoice.ts
@@ -1,0 +1,6 @@
+import { applyDiscount } from '../pricing/discount.js';
+
+// Out-of-directory dependent #2 of applyDiscount. Calls it positionally.
+export function invoiceLine(label: string, price: number, rate: number): string {
+  return `${label}: ${applyDiscount(price, rate).toFixed(2)}`;
+}

--- a/scripts/experiments/nudge-ab-v2/fixtures/verify/package.json
+++ b/scripts/experiments/nudge-ab-v2/fixtures/verify/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "orders-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "vitest": "^2.0.0"
+  }
+}

--- a/scripts/experiments/nudge-ab-v2/fixtures/verify/package.json
+++ b/scripts/experiments/nudge-ab-v2/fixtures/verify/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "vitest": "^2.0.0"
+    "vitest": "2.1.9"
   }
 }

--- a/scripts/experiments/nudge-ab-v2/fixtures/verify/src/order-status.ts
+++ b/scripts/experiments/nudge-ab-v2/fixtures/verify/src/order-status.ts
@@ -1,0 +1,9 @@
+export interface Order {
+  id: string;
+  state: string;
+  customerName: string;
+}
+
+export function formatStatus(order: Order): string {
+  return `Order ${order.id}: ${order.state}`;
+}

--- a/scripts/experiments/nudge-ab-v2/fixtures/verify/test/regression-suite.test.ts
+++ b/scripts/experiments/nudge-ab-v2/fixtures/verify/test/regression-suite.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { formatStatus } from '../src/order-status.js';
+
+// Associated with src/order-status.ts by IMPORT, not by filename — a naive
+// scan of source-file names gives no lexical path to "regression-suite".
+describe('formatStatus', () => {
+  it('includes the order id', () => {
+    expect(formatStatus({ id: 'A1', state: 'shipped', customerName: 'Dana' })).toContain('A1');
+  });
+
+  it('includes the order state', () => {
+    expect(formatStatus({ id: 'A1', state: 'shipped', customerName: 'Dana' })).toContain('shipped');
+  });
+});

--- a/scripts/experiments/nudge-ab-v2/hooks/silent-note-edit.sh
+++ b/scripts/experiments/nudge-ab-v2/hooks/silent-note-edit.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# EXPERIMENT SCAFFOLDING (nudge-ab-v2) — NOT a shipped plugin hook.
+#
+# Populates FEATURE-2's session test-ledger with the edit the agent just made,
+# WITHOUT emitting any model-visible reminder text. It exists so ledger
+# population is held CONSTANT across both arms of the verify-tests A/B, leaving
+# the real Stop advisory (recap-stop.sh, toggled by LIEN_RECAP) as the only
+# thing that varies between arms.
+#
+# Why not just use the shipped test-reminder.sh to populate the ledger? Because
+# test-reminder.sh couples the recording with an edit-time reminder that NAMES
+# the associated test file. That naming would hand the agent the very
+# information this experiment withholds (the test is deliberately not named
+# after its source), collapsing the discriminator. So test-reminder.sh is held
+# off in both arms (LIEN_TEST_REMINDER=off) and the recording it would
+# otherwise do is provided here, silently and identically in both arms.
+#
+# Mirrors the defensive shape of the real hooks (jq guard, session_id
+# hardening, cwd resolution, best-effort). Emits nothing on any path.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v lien >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+case "$tool_name" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+
+[ -n "$file_path" ] || exit 0
+[ -n "$session_id" ] || exit 0
+case "$session_id" in
+  *[!A-Za-z0-9_-]*) exit 0 ;;
+esac
+
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  (cd "$cwd" && lien verify-tests note-edit --session "$session_id" --file "$file_path" >/dev/null 2>&1) || true
+else
+  lien verify-tests note-edit --session "$session_id" --file "$file_path" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/scripts/experiments/nudge-ab-v2/prompts/blast.task.txt
+++ b/scripts/experiments/nudge-ab-v2/prompts/blast.task.txt
@@ -1,0 +1,1 @@
+In src/pricing/discount.ts, add an optional minimum-price floor to applyDiscount so that applying a discount can never reduce a price below the floor. When a floor is provided, clamp the result so it is at least the floor; when it is omitted, applyDiscount must behave exactly as it does today.

--- a/scripts/experiments/nudge-ab-v2/prompts/probe.txt
+++ b/scripts/experiments/nudge-ab-v2/prompts/probe.txt
@@ -1,0 +1,1 @@
+Before doing anything else: list, verbatim, every project instruction, repository rule, coding-workflow mandate, or tool-usage policy that is currently present in your context (from any system prompt, project file, plugin, MCP server, or settings). Quote each one. If there are none of these at all, reply with exactly the single word NONE and nothing else. Do not use any tools.

--- a/scripts/experiments/nudge-ab-v2/prompts/verify.task.txt
+++ b/scripts/experiments/nudge-ab-v2/prompts/verify.task.txt
@@ -1,0 +1,1 @@
+In src/order-status.ts, include the customer's name in the formatted status string so it reads like "Order A1 (Dana): shipped".

--- a/scripts/experiments/nudge-ab-v2/rescore.mjs
+++ b/scripts/experiments/nudge-ab-v2/rescore.mjs
@@ -33,6 +33,21 @@ const OUT = path.join(REPO, '.wip/nudge-ab-v2');
 const BLAST_TARGET = 'src/pricing/discount.ts';
 const VERIFY_TARGET = 'src/order-status.ts';
 
+// Guarded JSON read: a corrupt/empty archived file (partial write, manual edit)
+// reports the offending path and forces a non-zero exit rather than aborting the
+// whole audit with a bare SyntaxError.
+function readJson(file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error(`CORRUPT/UNREADABLE archive file: ${file} — ${e.message}`);
+    process.exitCode = 1;
+    return null;
+  }
+}
+
 // Edit/Write ops targeting the file, from parseTranscript's already-decoded
 // tool_use blocks (no re-parsing of the raw JSONL).
 function opsFromTool(tu) {
@@ -87,7 +102,7 @@ function blastEditCompleted(replay, ops) {
 }
 
 function scoreRow(exp, dir, idx, replay) {
-  const saved = JSON.parse(fs.readFileSync(path.join(dir, `${idx}.json`), 'utf8'));
+  const saved = readJson(path.join(dir, `${idx}.json`)) || {};
   const transcript = fs.readFileSync(path.join(dir, `${idx}.jsonl`), 'utf8');
   const parsed = parseTranscript(transcript);
   const usable = !looksLoggedOut(transcript) && !saved.timedOut && !saved.failed;
@@ -135,7 +150,7 @@ function rescore(exp) {
 
 for (const exp of ['blast', 'verify']) {
   const re = rescore(exp);
-  const pub = JSON.parse(fs.readFileSync(path.join(OUT, `${exp}-summary.json`), 'utf8'));
+  const pub = readJson(path.join(OUT, `${exp}-summary.json`)) || {};
   const countsMatch = re.on === pub.on && re.off === pub.off;
   console.log(`=== ${exp} ===`);
   console.log(`  published summary : on=${pub.on}  off=${pub.off}  p=${pub.fisherOneSidedP}`);

--- a/scripts/experiments/nudge-ab-v2/rescore.mjs
+++ b/scripts/experiments/nudge-ab-v2/rescore.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Offline CORRECTED-pipeline re-score over the archived raw trials under
+// .wip/nudge-ab-v2/. Zero LLM, no trial re-runs — the raw data stands. It
+// re-derives per-arm counts and Fisher p using the SAME corrected scoring logic
+// run.mjs now uses, to confirm the corrected instrument reproduces the published
+// numbers (closing the loop beyond the manual audit).
+//
+//   blast : hit = blastMetric(transcript); valid = symmetric api-delta replay
+//           (did the agent's edit change applyDiscount's signature?) — the same
+//           `blastEditCompleted` oracle, applied identically to BOTH arms.
+//   verify: hit = the ledger result saved at run time (the per-trial store dir
+//           was cleaned up, so the ledger can't be re-queried offline); valid =
+//           editedTarget(transcript). The transcript cross-check
+//           (verifyTranscriptRanTest) is reported as an independent agreement.
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseTranscript,
+  blastMetric,
+  editedTarget,
+  looksLoggedOut,
+  verifyTranscriptRanTest,
+  fisherOneSided,
+} from './detect.mjs';
+
+const KIT = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(KIT, '..', '..', '..');
+const CLI = path.join(REPO, 'packages/cli/dist/index.js');
+const OUT = path.join(REPO, '.wip/nudge-ab-v2');
+const BLAST_TARGET = 'src/pricing/discount.ts';
+const VERIFY_TARGET = 'src/order-status.ts';
+
+// Edit/Write ops targeting the file, from parseTranscript's already-decoded
+// tool_use blocks (no re-parsing of the raw JSONL).
+function opsFromTool(tu) {
+  const i = tu.input || {};
+  if (tu.name === 'Edit') return [{ kind: 'edit', old: i.old_string, neu: i.new_string }];
+  if (tu.name === 'Write') return [{ kind: 'write', content: i.content }];
+  if (tu.name === 'MultiEdit')
+    return (i.edits || []).map(e => ({ kind: 'edit', old: e.old_string, neu: e.new_string }));
+  return [];
+}
+
+function editsForTarget(toolUses, targetBase) {
+  return toolUses
+    .filter(tu => String(tu.input?.file_path || '').endsWith(targetBase))
+    .flatMap(opsFromTool);
+}
+
+function applyOps(content, ops) {
+  let cur = content;
+  for (const op of ops) {
+    if (op.kind === 'write') cur = op.content;
+    else if (op.old != null && cur.includes(op.old)) cur = cur.replace(op.old, op.neu);
+  }
+  return cur;
+}
+
+function makeBlastReplay() {
+  const W = fs.mkdtempSync(path.join(os.tmpdir(), 'rescore-blast-'));
+  fs.cpSync(path.join(KIT, 'fixtures/blast'), W, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: W });
+  execFileSync('git', ['add', '-A'], { cwd: W });
+  execFileSync('git', ['-c', 'user.email=a@b.c', '-c', 'user.name=a', 'commit', '-qm', 'i'], {
+    cwd: W,
+  });
+  return { W, pristine: fs.readFileSync(path.join(W, BLAST_TARGET), 'utf8') };
+}
+
+function blastEditCompleted(replay, ops) {
+  execFileSync('git', ['checkout', '--', '.'], { cwd: replay.W });
+  fs.writeFileSync(path.join(replay.W, BLAST_TARGET), applyOps(replay.pristine, ops));
+  const r = spawnSync('node', [CLI, 'api-delta', '--file', BLAST_TARGET, '--format', 'json'], {
+    cwd: replay.W,
+    encoding: 'utf8',
+  });
+  let d;
+  try {
+    d = JSON.parse(r.stdout);
+  } catch {
+    return false;
+  }
+  return (d.changes || []).some(c => c.kind === 'signature-changed' || c.kind === 'removed');
+}
+
+function scoreRow(exp, dir, idx, replay) {
+  const saved = JSON.parse(fs.readFileSync(path.join(dir, `${idx}.json`), 'utf8'));
+  const transcript = fs.readFileSync(path.join(dir, `${idx}.jsonl`), 'utf8');
+  const parsed = parseTranscript(transcript);
+  const usable = !looksLoggedOut(transcript) && !saved.timedOut && !saved.failed;
+  if (exp === 'blast') {
+    const ops = editsForTarget(parsed.toolUses, 'discount.ts');
+    return {
+      hit: blastMetric(parsed.toolUses, parsed.finalText).hit,
+      valid: usable && blastEditCompleted(replay, ops),
+    };
+  }
+  const crosscheck = verifyTranscriptRanTest(parsed.toolUses).hit;
+  return {
+    hit: saved.hit,
+    valid: usable && editedTarget(parsed.toolUses, VERIFY_TARGET),
+    crosscheck,
+  };
+}
+
+function rescore(exp) {
+  const replay = exp === 'blast' ? makeBlastReplay() : null;
+  const arms = { on: [], off: [] };
+  for (const arm of ['on', 'off']) {
+    const dir = path.join(OUT, exp, arm);
+    for (const f of fs
+      .readdirSync(dir)
+      .filter(x => x.endsWith('.json'))
+      .sort()) {
+      arms[arm].push(scoreRow(exp, dir, f.replace('.json', ''), replay));
+    }
+  }
+  if (replay) fs.rmSync(replay.W, { recursive: true, force: true });
+  const tally = rows => {
+    const v = rows.filter(r => r.valid);
+    return { n: v.length, hits: v.filter(r => r.hit).length };
+  };
+  const on = tally(arms.on);
+  const off = tally(arms.off);
+  return {
+    on: `${on.hits}/${on.n}`,
+    off: `${off.hits}/${off.n}`,
+    fisherOneSidedP: Number(fisherOneSided(on.hits, on.n, off.hits, off.n).toExponential(3)),
+    arms,
+  };
+}
+
+for (const exp of ['blast', 'verify']) {
+  const re = rescore(exp);
+  const pub = JSON.parse(fs.readFileSync(path.join(OUT, `${exp}-summary.json`), 'utf8'));
+  const countsMatch = re.on === pub.on && re.off === pub.off;
+  console.log(`=== ${exp} ===`);
+  console.log(`  published summary : on=${pub.on}  off=${pub.off}  p=${pub.fisherOneSidedP}`);
+  console.log(`  corrected re-score: on=${re.on}  off=${re.off}  p=${re.fisherOneSidedP}`);
+  console.log(`  counts reproduce EXACTLY: ${countsMatch ? 'YES' : 'NO'}`);
+  if (exp === 'verify') {
+    const agree = re.arms.on.concat(re.arms.off).every(r => r.crosscheck === r.hit);
+    console.log(`  verify transcript cross-check agrees with ledger hit: ${agree ? 'YES' : 'NO'}`);
+  }
+  fs.writeFileSync(
+    path.join(OUT, `${exp}-summary-rescored.json`),
+    JSON.stringify({ on: re.on, off: re.off, fisherOneSidedP: re.fisherOneSidedP }, null, 2),
+  );
+}

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -310,6 +310,19 @@ function cmdCheck() {
 // off-switch) from injecting "Lien impact for … <named dependents>" into both
 // arms. cfg.dir === null tells runClaude not to override CLAUDE_CONFIG_DIR.
 const PLUGIN_DISABLE = { 'lien@lien': false };
+// Lien plugin MCP tool/rule vocabulary that the blast NUDGE never contains — so
+// its appearance in the probe's instruction self-report means plugin
+// instructions leaked (they must not, under --strict-mcp-config + plugin disable).
+const PLUGIN_INSTRUCTION_TERMS = [
+  'get_files_context',
+  'search_code',
+  'list_functions',
+  'find_similar',
+  'get_complexity',
+  'testassociations',
+  'test association',
+  'complexityheadroom',
+];
 function runConfig(tmp) {
   const emptyMcp = path.join(tmp, 'empty-mcp.json');
   fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
@@ -496,9 +509,16 @@ function cmdProbeB1() {
       loggedOut: looksLoggedOut(transcript),
       myHooksFire: nudgeShown(dest, 'blast', sid),
       annotateFired: nudgeShown(dest, 'annotate', sid),
-      modelSawAnnotate: /Lien impact|hooks flagged/i.test(parsed.finalText),
+      sawAnnotateOutput: /lien impact|files import this/i.test(parsed.finalText),
       savedSettingsUntouched: before === after,
-      instructionContamination: contaminationScan(parsed.finalText),
+      // Instruction-leak = the Lien PLUGIN's own MCP tool/rule vocabulary that the
+      // blast NUDGE does NOT contain. (The nudge says "get_dependents"/"lien", so
+      // those are excluded — the model referencing the nudge is not contamination;
+      // it even reported get_dependents "doesn't exist in my toolset", confirming
+      // --strict-mcp-config worked.)
+      mcpInstructionLeak: PLUGIN_INSTRUCTION_TERMS.filter(t =>
+        parsed.finalText.toLowerCase().includes(t),
+      ),
     };
     console.log(redactAccount(JSON.stringify(result, null, 2)));
     verdictB1(result);
@@ -514,7 +534,7 @@ function verdictB1(r) {
   if (!r.savedSettingsUntouched)
     throw new Error("PROBE(b') FAILED: saved ~/.claude/settings.json CHANGED — abort");
   if (!r.myHooksFire) throw new Error("PROBE(b') FAILED: my explicit hooks did NOT fire — STOP");
-  const clean = !r.annotateFired && !r.modelSawAnnotate && r.instructionContamination.length === 0;
+  const clean = !r.annotateFired && !r.sawAnnotateOutput && r.mcpInstructionLeak.length === 0;
   if (!clean) {
     console.log(
       "PROBE(b') CONTAMINATED — plugin-disable override not honored. Both b'' and b' failed; STOP and report.",

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+// nudge-ab-v2 runner — the operational realization of the FROZEN pre-registration
+// in docs/development/nudge-ab-v2-protocol.md. Running the experiment later
+// requires ZERO design decisions: every knob below is fixed by that document.
+//
+// Subcommands:
+//   check   Zero-LLM instrument verification. Materializes both fixtures,
+//           indexes them, and asserts the real hooks render the intended
+//           nudges (blast warning + unrun-tests recap). No `claude` calls.
+//   probe   The mandatory contamination + plumbing precondition (1 `claude`
+//           call, no tools). MUST pass before any arm runs.
+//   run     The gated experiment arms. Refuses to start unless `probe` passed
+//           in this invocation first.
+//
+// Nothing here runs experiment arms unless explicitly invoked with `run`.
+import { execFileSync, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseTranscript,
+  blastMetric,
+  blastGenericSentiment,
+  verifyTranscriptRanTest,
+  contaminationScan,
+} from './detect.mjs';
+
+// ---- FROZEN CONFIG -------------------------------------------------------
+const N_PER_ARM = 10; // justified in the protocol doc (detection-oriented power)
+const MODEL = 'sonnet';
+const INTERLEAVE_SEED = 20260725; // fixed; drives the arm order
+const ALLOWED_TOOLS = 'Edit,Write,Read,Bash,Grep,Glob';
+
+const KIT = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(KIT, '..', '..', '..');
+const PLUGIN_HOOKS = path.join(REPO, 'plugins', 'claude', 'hooks');
+const KIT_HOOKS = path.join(KIT, 'hooks');
+const CLI_ENTRY = path.join(REPO, 'packages', 'cli', 'dist', 'index.js');
+const OUT_ROOT = path.join(REPO, '.wip', 'nudge-ab-v2');
+
+// Env deltas per arm. Anything unset here inherits the process env; the base
+// env (applied to BOTH arms of BOTH experiments) neutralizes every OTHER nudge
+// so exactly one signal varies per experiment.
+const BASE_ENV = { LIEN_DELTA_HOOK: 'off', LIEN_ANNOTATE_GUARD: 'off' };
+const EXPERIMENTS = {
+  blast: {
+    fixture: 'blast',
+    task: 'prompts/blast.task.txt',
+    target: 'src/pricing/discount.ts',
+    // recap held OFF in both arms so the ONLY delivery of the blast signal is
+    // the edit-time api-delta warning (isolates PR #841's hook).
+    baseEnv: { LIEN_RECAP: 'off', LIEN_TEST_REMINDER: 'off' },
+    armEnv: { on: {}, off: { LIEN_BLAST_HOOK: 'off' } },
+    settings: () => ({
+      hooks: {
+        PostToolUse: [
+          postTool('Edit|Write|MultiEdit', hookCmd(PLUGIN_HOOKS, 'api-delta-write.sh')),
+        ],
+      },
+    }),
+  },
+  verify: {
+    fixture: 'verify',
+    task: 'prompts/verify.task.txt',
+    target: 'src/order-status.ts',
+    // blast + edit-time reminder held OFF in both arms; the edit-time reminder
+    // would name the test and defeat the "unnamed test" discriminator, so its
+    // ledger recording is provided by the silent scaffolding hook instead.
+    baseEnv: { LIEN_BLAST_HOOK: 'off', LIEN_TEST_REMINDER: 'off' },
+    armEnv: { on: {}, off: { LIEN_RECAP: 'off' } },
+    settings: () => ({
+      hooks: {
+        PostToolUse: [
+          postTool('Edit|Write|MultiEdit', hookCmd(KIT_HOOKS, 'silent-note-edit.sh')),
+          postTool('Bash', hookCmd(PLUGIN_HOOKS, 'test-run-note.sh')),
+        ],
+        Stop: [{ hooks: [{ type: 'command', command: hookCmd(PLUGIN_HOOKS, 'recap-stop.sh') }] }],
+      },
+    }),
+  },
+};
+
+const hookCmd = (dir, name) => `bash ${path.join(dir, name)}`;
+const postTool = (matcher, command) => ({ matcher, hooks: [{ type: 'command', command }] });
+
+// ---- small utilities -----------------------------------------------------
+function lien(args, cwd, env) {
+  return spawnSync('node', [CLI_ENTRY, ...args], {
+    cwd,
+    env: env || process.env,
+    encoding: 'utf8',
+  });
+}
+
+// A `lien` shim on PATH so the plugin hooks (which call the bare `lien`
+// binary) resolve to THIS build, not whatever is globally installed.
+function makeLienShim(tmp) {
+  const bin = path.join(tmp, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  const shim = path.join(bin, 'lien');
+  fs.writeFileSync(shim, `#!/usr/bin/env bash\nexec node ${JSON.stringify(CLI_ENTRY)} "$@"\n`);
+  fs.chmodSync(shim, 0o755);
+  return bin;
+}
+
+// Deterministic Fisher-Yates using a tiny seeded LCG (interleave order is part
+// of the frozen protocol, so it must be reproducible).
+function seededOrder(labels, seed) {
+  const a = labels.slice();
+  let s = seed >>> 0;
+  const next = () => (s = (s * 1103515245 + 12345) & 0x7fffffff);
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = next() % (i + 1);
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// ---- materialization -----------------------------------------------------
+function materialize(fixtureName, dest, shimBin) {
+  const src = path.join(KIT, 'fixtures', fixtureName);
+  fs.cpSync(src, dest, { recursive: true });
+  const env = { ...process.env, PATH: `${shimBin}:${process.env.PATH}` };
+  execFileSync('git', ['init', '-q'], { cwd: dest });
+  execFileSync('git', ['add', '-A'], { cwd: dest });
+  execFileSync(
+    'git',
+    ['-c', 'user.email=ab@lien.dev', '-c', 'user.name=ab', 'commit', '-qm', 'init'],
+    {
+      cwd: dest,
+    },
+  );
+  const r = lien(['index'], dest, env);
+  if (r.status !== 0) throw new Error(`index failed in ${dest}: ${r.stderr}`);
+  return env;
+}
+
+// ---- check (zero-LLM instrument verification) ----------------------------
+function assert(cond, msg) {
+  if (!cond) throw new Error(`CHECK FAILED: ${msg}`);
+  console.log(`  ok: ${msg}`);
+}
+
+function checkBlast(tmp, shimBin) {
+  console.log('[check] blast fixture');
+  const dest = path.join(tmp, 'blast');
+  const env = materialize('blast', dest, shimBin);
+  const before = lien(
+    ['api-delta', '--file', 'src/pricing/discount.ts', '--format', 'json'],
+    dest,
+    env,
+  );
+  assert(JSON.parse(before.stdout).changes.length === 0, 'no api-delta before the edit');
+  // apply the same signature change the task induces
+  const edited =
+    'export function applyDiscount(price: number, rate: number, floor?: number): number {\n' +
+    '  const discounted = price - price * rate;\n' +
+    '  return floor !== undefined ? Math.max(discounted, floor) : discounted;\n}\n';
+  fs.writeFileSync(path.join(dest, 'src/pricing/discount.ts'), edited);
+  const stdin = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/pricing/discount.ts' },
+    cwd: dest,
+    session_id: 'checkblast01',
+  });
+  const hook = spawnSync('bash', [path.join(PLUGIN_HOOKS, 'api-delta-write.sh')], {
+    input: stdin,
+    env,
+    encoding: 'utf8',
+  });
+  const ctx = JSON.parse(hook.stdout).hookSpecificOutput.additionalContext;
+  console.log(`  blast nudge: ${ctx}`);
+  assert(
+    ctx.includes('applyDiscount') && ctx.includes('dependents'),
+    'blast hook rendered the enriched warning',
+  );
+  assert(ctx.includes('get_dependents'), 'blast warning asks to check dependents');
+}
+
+function checkVerify(tmp, shimBin) {
+  console.log('[check] verify fixture');
+  const dest = path.join(tmp, 'verify');
+  const env = materialize('verify', dest, shimBin);
+  const sid = 'checkverify01';
+  const note = lien(
+    ['verify-tests', 'note-edit', '--session', sid, '--file', 'src/order-status.ts'],
+    dest,
+    env,
+  );
+  console.log(`  note-edit: ${note.stdout.trim()}`);
+  assert(
+    note.stdout.includes('regression-suite.test.ts'),
+    'associates the non-lexically-named test by import',
+  );
+  const recap = lien(['verify-tests', 'report', '--session', sid], dest, env);
+  assert(
+    recap.stdout.includes('src/order-status.ts'),
+    'recap/report raises the unrun associated test',
+  );
+  lien(
+    [
+      'verify-tests',
+      'note-run',
+      '--session',
+      sid,
+      '--command',
+      'npx vitest run test/regression-suite.test.ts',
+    ],
+    dest,
+    env,
+  );
+  const after = lien(['verify-tests', 'report', '--session', sid], dest, env);
+  assert(after.stdout.trim() === '', 'report goes silent after a covering test run');
+}
+
+function cmdCheck() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-check-'));
+  const shimBin = makeLienShim(tmp);
+  try {
+    checkBlast(tmp, shimBin);
+    checkVerify(tmp, shimBin);
+    console.log('\nINSTRUMENT CHECK PASSED');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ---- isolated clean config dir + empty mcp -------------------------------
+// No enabledPlugins, no user rules → the ambient Lien plugin (hooks + MCP) and
+// the global ~/.claude/rules do NOT load. Auth on macOS lives in the Keychain,
+// not this dir, so a headless `claude` still authenticates.
+function isolatedConfig(tmp) {
+  const dir = path.join(tmp, 'cc-config');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'settings.json'),
+    JSON.stringify({ model: MODEL, includeCoAuthoredBy: false }, null, 2),
+  );
+  const emptyMcp = path.join(tmp, 'empty-mcp.json');
+  fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
+  return { dir, emptyMcp };
+}
+
+function claudeArgs(prompt, sessionId, settingsFile, emptyMcp) {
+  return [
+    '-p',
+    prompt,
+    '--model',
+    MODEL,
+    '--session-id',
+    sessionId,
+    '--settings',
+    settingsFile,
+    '--strict-mcp-config',
+    '--mcp-config',
+    emptyMcp,
+    '--permission-mode',
+    'bypassPermissions',
+    '--allowedTools',
+    ALLOWED_TOOLS,
+    '--output-format',
+    'stream-json',
+    '--verbose',
+  ];
+}
+
+function runClaude(prompt, sessionId, cwd, settingsFile, cfg, extraEnv, shimBin) {
+  const env = {
+    ...process.env,
+    ...BASE_ENV,
+    ...extraEnv,
+    PATH: `${shimBin}:${process.env.PATH}`,
+    CLAUDE_CONFIG_DIR: cfg.dir,
+  };
+  const res = spawnSync('claude', claudeArgs(prompt, sessionId, settingsFile, cfg.emptyMcp), {
+    cwd,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return res.stdout || '';
+}
+
+// ---- probe (mandatory precondition) --------------------------------------
+function cmdProbe() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probe-'));
+  const shimBin = makeLienShim(tmp);
+  const cfg = isolatedConfig(tmp);
+  // clean, git-free, CLAUDE.md-free directory
+  const cwd = path.join(tmp, 'clean');
+  fs.mkdirSync(cwd, { recursive: true });
+  assertNoAncestorClaudeMd(cwd);
+  const settingsFile = path.join(tmp, 'probe-settings.json');
+  fs.writeFileSync(settingsFile, JSON.stringify({ hooks: {} }));
+  const prompt = fs.readFileSync(path.join(KIT, 'prompts', 'probe.txt'), 'utf8');
+  const out = runClaude(prompt, randomUUID(), cwd, settingsFile, cfg, {}, shimBin);
+  fs.mkdirSync(OUT_ROOT, { recursive: true });
+  fs.writeFileSync(path.join(OUT_ROOT, 'probe.jsonl'), out);
+  const hits = contaminationScan(out);
+  if (out.trim() === '')
+    throw new Error('PROBE FAILED: empty output (auth/plumbing problem with isolated config dir)');
+  if (hits.length > 0) throw new Error(`PROBE FAILED (contaminated): ${hits.join(', ')}`);
+  fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
+  console.log('PROBE PASSED — context clean, plumbing live. Arms may run.');
+}
+
+function assertNoAncestorClaudeMd(dir) {
+  let d = dir;
+  for (;;) {
+    if (fs.existsSync(path.join(d, 'CLAUDE.md'))) throw new Error(`CLAUDE.md present at ${d}`);
+    const parent = path.dirname(d);
+    if (parent === d) return;
+    d = parent;
+  }
+}
+
+// ---- run (gated arms) ----------------------------------------------------
+function verifyRanOracle(dest, sid, env) {
+  const report = lien(['verify-tests', 'report', '--session', sid], dest, env);
+  return report.stdout.trim() === ''; // empty ⇒ the associated test was observed run
+}
+
+function blastFired(dest, sid) {
+  const store = lien(['path', '--store'], dest).stdout.trim();
+  const events = path.join(store, 'nudge-events.jsonl');
+  if (!fs.existsSync(events)) return false;
+  const body = fs.readFileSync(events, 'utf8');
+  return body.includes('"nudge":"blast"') && body.includes(sid);
+}
+
+function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
+  const exp = EXPERIMENTS[expName];
+  const dest = path.join(tmp, `${expName}-${arm}-${idx}`);
+  const env = materialize(exp.fixture, dest, shimBin);
+  const settingsFile = path.join(dest, '.ab-settings.json');
+  fs.writeFileSync(settingsFile, JSON.stringify(exp.settings()));
+  const sid = randomUUID();
+  const task = fs.readFileSync(path.join(KIT, exp.task), 'utf8');
+  const armEnv = { ...exp.baseEnv, ...exp.armEnv[arm] };
+  const transcript = runClaude(task, sid, dest, settingsFile, cfg, armEnv, shimBin);
+  const parsed = parseTranscript(transcript);
+  const result = scoreTrial(expName, arm, dest, sid, env, parsed, transcript);
+  saveTrial(expName, arm, idx, transcript, result);
+  fs.rmSync(dest, { recursive: true, force: true });
+  return result;
+}
+
+function scoreTrial(expName, arm, dest, sid, env, parsed, transcript) {
+  const contamination = arm === 'off' ? contaminationScan(transcript) : [];
+  if (expName === 'blast') {
+    const m = blastMetric(parsed.toolUses, parsed.finalText);
+    return {
+      hit: m.hit,
+      reasons: m.reasons,
+      generic: blastGenericSentiment(parsed.finalText, m.hit),
+      valid: arm === 'off' ? true : blastFired(dest, sid),
+      contamination,
+    };
+  }
+  const ran = verifyRanOracle(dest, sid, env);
+  return {
+    hit: ran,
+    reasons: verifyTranscriptRanTest(parsed.toolUses).reasons,
+    valid: true,
+    contamination,
+  };
+}
+
+function saveTrial(expName, arm, idx, transcript, result) {
+  const dir = path.join(OUT_ROOT, expName, arm);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${idx}.jsonl`), transcript);
+  fs.writeFileSync(path.join(dir, `${idx}.json`), JSON.stringify(result, null, 2));
+}
+
+function cmdRun(expName) {
+  if (!fs.existsSync(path.join(OUT_ROOT, '.probe-passed'))) {
+    throw new Error(
+      'Refusing to run: contamination probe has not passed. Run `node run.mjs probe` first.',
+    );
+  }
+  if (!EXPERIMENTS[expName]) throw new Error(`unknown experiment: ${expName}`);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `nudge-ab-${expName}-`));
+  const shimBin = makeLienShim(tmp);
+  const cfg = isolatedConfig(tmp);
+  const labels = seededOrder(
+    Array.from({ length: N_PER_ARM }, (_, i) => [`on:${i}`, `off:${i}`]).flat(),
+    INTERLEAVE_SEED,
+  );
+  const results = { on: [], off: [] };
+  for (const label of labels) {
+    const [arm, i] = label.split(':');
+    console.log(`[run] ${expName} ${arm} #${i}`);
+    results[arm].push(runTrial(expName, arm, i, tmp, shimBin, cfg));
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+  report(expName, results);
+}
+
+// ---- reporting -----------------------------------------------------------
+function tally(rows) {
+  const valid = rows.filter(r => r.valid);
+  return {
+    n: valid.length,
+    hits: valid.filter(r => r.hit).length,
+    invalid: rows.length - valid.length,
+  };
+}
+
+function report(expName, results) {
+  const on = tally(results.on);
+  const off = tally(results.off);
+  const leaks = [...results.on, ...results.off].filter(r => r.contamination.length > 0).length;
+  const p = fisherOneSided(on.hits, on.n, off.hits, off.n);
+  const separated = p < 0.05 && on.hits / Math.max(on.n, 1) > off.hits / Math.max(off.n, 1);
+  const summary = {
+    experiment: expName,
+    on: `${on.hits}/${on.n}`,
+    off: `${off.hits}/${off.n}`,
+    invalid: { on: on.invalid, off: off.invalid },
+    contaminationLeaks: leaks,
+    fisherOneSidedP: Number(p.toFixed(4)),
+    primarySeparated: separated,
+    launchClaimPermitted: separated,
+  };
+  fs.writeFileSync(
+    path.join(OUT_ROOT, `${expName}-summary.json`),
+    JSON.stringify(summary, null, 2),
+  );
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+// One-sided Fisher exact (P(X >= observed on-hits) under the null), via the
+// hypergeometric tail. Small N, so direct factorials are fine.
+function logFact(n) {
+  let s = 0;
+  for (let i = 2; i <= n; i++) s += Math.log(i);
+  return s;
+}
+function logHyper(k, n1, n2, t) {
+  return (
+    logFact(n1) +
+    logFact(n2) +
+    logFact(t) +
+    logFact(n1 + n2 - t) -
+    logFact(n1 + n2) -
+    logFact(k) -
+    logFact(n1 - k) -
+    logFact(t - k) -
+    logFact(n2 - (t - k))
+  );
+}
+function fisherOneSided(a, n1, c, n2) {
+  const t = a + c;
+  if (n1 === 0 || n2 === 0) return 1;
+  let p = 0;
+  for (let k = a; k <= Math.min(n1, t); k++) {
+    if (t - k < 0 || t - k > n2) continue;
+    p += Math.exp(logHyper(k, n1, n2, t));
+  }
+  return Math.min(1, p);
+}
+
+// ---- entry ---------------------------------------------------------------
+function main() {
+  const [, , cmd, ...rest] = process.argv;
+  if (cmd === 'check') return cmdCheck();
+  if (cmd === 'probe') return cmdProbe();
+  if (cmd === 'run') {
+    const exp = rest[0];
+    if (!exp) throw new Error('usage: run.mjs run <blast|verify>');
+    return cmdRun(exp);
+  }
+  console.log('usage: run.mjs <check|probe|run <blast|verify>>');
+  process.exit(cmd ? 1 : 0);
+}
+main();

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -28,6 +28,7 @@ import {
   collectDenials,
   looksLoggedOut,
   editedTarget,
+  fisherOneSided,
 } from './detect.mjs';
 
 // ---- FROZEN CONFIG -------------------------------------------------------
@@ -372,7 +373,14 @@ function runClaude(prompt, sessionId, cwd, settingsFile, cfg, extraEnv, shimBin)
     killSignal: 'SIGKILL',
   });
   const timedOut = Boolean(res.error && res.error.code === 'ETIMEDOUT');
-  return { stdout: res.stdout || '', timedOut };
+  // Surface every OTHER spawn failure (ENOENT, buffer overflow, signal) and any
+  // non-zero exit so the trial is marked invalid rather than silently scored as
+  // a miss on empty output. status is null when killed by signal/timeout.
+  const spawnError =
+    res.error && res.error.code !== 'ETIMEDOUT' ? String(res.error.code || res.error.message) : '';
+  const nonZeroExit = !timedOut && res.status != null && res.status !== 0 ? res.status : null;
+  const failed = Boolean(spawnError) || nonZeroExit != null;
+  return { stdout: res.stdout || '', timedOut, failed, spawnError, exitStatus: res.status };
 }
 
 // Redaction: the seed's personal fields (email/org/account UUIDs) must never
@@ -382,8 +390,14 @@ function runClaude(prompt, sessionId, cwd, settingsFile, cfg, extraEnv, shimBin)
 let _redactTerms = null;
 function redactionTerms() {
   if (_redactTerms) return _redactTerms;
-  const oa =
-    JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude.json'), 'utf8')).oauthAccount || {};
+  let oa = {};
+  try {
+    oa =
+      JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude.json'), 'utf8')).oauthAccount ||
+      {};
+  } catch {
+    oa = {}; // no ~/.claude.json (or unreadable) → nothing to redact
+  }
   _redactTerms = [
     oa.emailAddress,
     oa.accountUuid,
@@ -472,17 +486,19 @@ function cmdProbeDefault() {
 // hooks still fire (nudge-events has "blast"), (c) the saved ~/.claude settings
 // on disk are byte-identical before/after. Detection is via the nudge-events
 // ledger, not transcript grep.
+const readSaved = p => (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null);
+
 function cmdProbeB1() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probeb1-'));
   const savedSettings = path.join(os.homedir(), '.claude', 'settings.json');
-  const before = fs.readFileSync(savedSettings, 'utf8');
+  const before = readSaved(savedSettings);
   try {
     const shimBin = makeLienShim(tmp);
     const emptyMcp = path.join(tmp, 'empty-mcp.json');
     fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
     const cfg = { dir: null, emptyMcp }; // DEFAULT config dir
     const dest = path.join(tmp, 'blast');
-    materialize('blast', dest, shimBin, false);
+    const env = materialize('blast', dest, shimBin, false);
     const settingsFile = path.join(dest, '.ab-settings.json');
     const s = EXPERIMENTS.blast.settings();
     s.enabledPlugins = { 'lien@lien': false }; // disable ambient plugin, this process only
@@ -504,11 +520,11 @@ function cmdProbeB1() {
     fs.mkdirSync(OUT_ROOT, { recursive: true });
     writeArtifact(path.join(OUT_ROOT, 'probe-b1.jsonl'), transcript);
     const parsed = parseTranscript(transcript);
-    const after = fs.readFileSync(savedSettings, 'utf8');
+    const after = readSaved(savedSettings);
     const result = {
       loggedOut: looksLoggedOut(transcript),
-      myHooksFire: nudgeShown(dest, 'blast', sid),
-      annotateFired: nudgeShown(dest, 'annotate', sid),
+      myHooksFire: nudgeShown(dest, 'blast', sid, env),
+      annotateFired: nudgeShown(dest, 'annotate', sid, env),
       sawAnnotateOutput: /lien impact|files import this/i.test(parsed.finalText),
       savedSettingsUntouched: before === after,
       // Instruction-leak = the Lien PLUGIN's own MCP tool/rule vocabulary that the
@@ -525,7 +541,8 @@ function cmdProbeB1() {
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
     // Belt-and-braces: restore the saved settings if anything touched them.
-    if (fs.readFileSync(savedSettings, 'utf8') !== before) fs.writeFileSync(savedSettings, before);
+    if (before !== null && readSaved(savedSettings) !== before)
+      fs.writeFileSync(savedSettings, before);
   }
 }
 
@@ -567,9 +584,10 @@ function verifyRanOracle(dest, sid, env) {
 // Reliable, deterministic oracle for "did hook <nudgeType> fire this session":
 // the nudge-events ledger, NOT transcript grep (a hook's additionalContext does
 // not appear grep-ably in the stream-json transcript — only the model's
-// paraphrase of it does, which is unreliable).
-function nudgeShown(dest, nudgeType, sid) {
-  const store = lien(['path', '--store'], dest).stdout.trim();
+// paraphrase of it does, which is unreliable). env is threaded so `lien path
+// --store` resolves the SAME store the trial's hooks wrote to.
+function nudgeShown(dest, nudgeType, sid, env) {
+  const store = lien(['path', '--store'], dest, env).stdout.trim();
   if (!store) return false;
   const events = path.join(store, 'nudge-events.jsonl');
   if (!fs.existsSync(events)) return false;
@@ -577,8 +595,20 @@ function nudgeShown(dest, nudgeType, sid) {
   return body.includes(`"nudge":"${nudgeType}"`) && body.includes(sid);
 }
 
-function blastFired(dest, sid) {
-  return nudgeShown(dest, 'blast', sid);
+// SYMMETRIC blast validity oracle for BOTH arms: did the agent's edit actually
+// change the exported signature (the task)? `lien api-delta` runs regardless of
+// LIEN_BLAST_HOOK, so control and signal are gated identically — unlike the old
+// `fired = arm==='off' ? true : blastFired(...)`, under which a control no-op
+// scored as a MISS while a signal no-op scored as INVALID.
+function blastEditCompleted(dest, env) {
+  const r = lien(['api-delta', '--file', EXPERIMENTS.blast.target, '--format', 'json'], dest, env);
+  let d;
+  try {
+    d = JSON.parse(r.stdout);
+  } catch {
+    return false;
+  }
+  return (d.changes || []).some(c => c.kind === 'signature-changed' || c.kind === 'removed');
 }
 
 function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
@@ -595,60 +625,92 @@ function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
   const sid = randomUUID();
   const task = fs.readFileSync(path.join(KIT, exp.task), 'utf8');
   const armEnv = { ...exp.baseEnv, ...exp.armEnv[arm] };
-  const { stdout: transcript, timedOut } = runClaude(
-    task,
-    sid,
-    dest,
-    settingsFile,
-    cfg,
-    armEnv,
-    shimBin,
-  );
+  const {
+    stdout: transcript,
+    timedOut,
+    failed,
+    spawnError,
+    exitStatus,
+  } = runClaude(task, sid, dest, settingsFile, cfg, armEnv, shimBin);
   const parsed = parseTranscript(transcript);
-  const result = scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut });
+  const result = scoreTrial({
+    expName,
+    arm,
+    dest,
+    sid,
+    env,
+    parsed,
+    transcript,
+    timedOut,
+    failed,
+    spawnError,
+    exitStatus,
+  });
   saveTrial(expName, arm, idx, transcript, result);
   fs.rmSync(dest, { recursive: true, force: true });
   return result;
 }
 
-function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut }) {
+function scoreTrial({
+  expName,
+  arm,
+  dest,
+  sid,
+  env,
+  parsed,
+  transcript,
+  timedOut,
+  failed,
+  spawnError,
+  exitStatus,
+}) {
   const contamination = arm === 'off' ? contaminationScan(transcript) : [];
   const denials = collectDenials(transcript);
   const loggedOut = looksLoggedOut(transcript);
-  const usable = !timedOut && !loggedOut;
+  const usable = !timedOut && !loggedOut && !failed;
+  const base = {
+    timedOut,
+    loggedOut,
+    failed,
+    spawnError: spawnError || '',
+    exitStatus,
+    contamination,
+    denials,
+  };
   if (expName === 'blast') {
     const m = blastMetric(parsed.toolUses, parsed.finalText);
-    const fired = arm === 'off' ? true : blastFired(dest, sid);
+    // SYMMETRIC: both arms require the task edit (signature change) to be valid.
+    const editCompleted = blastEditCompleted(dest, env);
     return {
       hit: m.hit,
       reasons: m.reasons,
       generic: blastGenericSentiment(parsed.finalText, m.hit),
-      valid: usable && fired,
-      timedOut,
-      loggedOut,
-      contamination,
-      denials,
+      valid: usable && editCompleted,
+      editCompleted,
+      ...base,
     };
   }
   // Verify: an empty `verify-tests report` only means "test ran" if the target
   // was actually edited — otherwise a no-op/logged-out trial reads as a false
-  // positive. Require the edit for validity.
+  // positive. Require the edit for validity (symmetric with blast's rule).
   const edited = editedTarget(parsed.toolUses, EXPERIMENTS.verify.target);
   const ran = verifyRanOracle(dest, sid, env);
   return {
     hit: ran,
     reasons: verifyTranscriptRanTest(parsed.toolUses).reasons,
     valid: usable && edited,
-    timedOut,
-    loggedOut,
     edited,
-    contamination,
-    denials,
+    ...base,
   };
 }
 
 function saveTrial(expName, arm, idx, transcript, result) {
-  const dir = path.join(OUT_ROOT, expName, arm);
+  // Route uncounted smoke trials to a separate _smoke/ tree so they never mix
+  // with the counted 0..N trial directories the report/audit read from.
+  const isSmoke = String(idx).startsWith('smoke');
+  const dir = isSmoke
+    ? path.join(OUT_ROOT, '_smoke', `${expName}-${arm}`)
+    : path.join(OUT_ROOT, expName, arm);
   fs.mkdirSync(dir, { recursive: true });
   writeArtifact(path.join(dir, `${idx}.jsonl`), transcript);
   writeArtifact(path.join(dir, `${idx}.json`), JSON.stringify(result, null, 2));
@@ -729,6 +791,7 @@ function invalidReasons(rows) {
   return {
     timedOut: rows.filter(r => r.timedOut).length,
     loggedOut: rows.filter(r => r.loggedOut).length,
+    failed: rows.filter(r => r.failed).length,
   };
 }
 
@@ -745,45 +808,15 @@ function report(expName, results) {
     off: `${off.hits}/${off.n}`,
     invalid: { on: on.invalid, off: off.invalid },
     invalidReasons: { on: invalidReasons(results.on), off: invalidReasons(results.off) },
-    contaminationLeaks: leaks,
+    contamination: { offTrialsScanned: results.off.length, flagged: leaks },
     denials: { on: denialSummary(results.on), off: denialSummary(results.off) },
-    fisherOneSidedP: Number(p.toFixed(4)),
+    // toExponential(3) preserves small p-values (toFixed(4) turned 5.4e-6 into 0).
+    fisherOneSidedP: Number(p.toExponential(3)),
     primarySeparated: separated,
     launchClaimPermitted: separated,
   };
   writeArtifact(path.join(OUT_ROOT, `${expName}-summary.json`), JSON.stringify(summary, null, 2));
   console.log(redactAccount(JSON.stringify(summary, null, 2)));
-}
-
-// One-sided Fisher exact (P(X >= observed on-hits) under the null), via the
-// hypergeometric tail. Small N, so direct factorials are fine.
-function logFact(n) {
-  let s = 0;
-  for (let i = 2; i <= n; i++) s += Math.log(i);
-  return s;
-}
-function logHyper(k, n1, n2, t) {
-  return (
-    logFact(n1) +
-    logFact(n2) +
-    logFact(t) +
-    logFact(n1 + n2 - t) -
-    logFact(n1 + n2) -
-    logFact(k) -
-    logFact(n1 - k) -
-    logFact(t - k) -
-    logFact(n2 - (t - k))
-  );
-}
-function fisherOneSided(a, n1, c, n2) {
-  const t = a + c;
-  if (n1 === 0 || n2 === 0) return 1;
-  let p = 0;
-  for (let k = a; k <= Math.min(n1, t); k++) {
-    if (t - k < 0 || t - k > n2) continue;
-    p += Math.exp(logHyper(k, n1, n2, t));
-  }
-  return Math.min(1, p);
 }
 
 // ---- smoke (scoped-mode viability, uncounted) ----------------------------

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -471,7 +471,11 @@ function cmdProbeDefault() {
         "PROBE(b'') PASSED — default config + --strict-mcp-config is clean AND hooks fire.",
       );
     } else {
-      console.log("PROBE(b'') CONTAMINATED — ambient plugin leaks in headless. Fall back to b'.");
+      // Throw (like the sibling checks) so a contaminated b'' probe exits non-zero,
+      // matching how §3c records b'' as failed.
+      throw new Error(
+        "PROBE(b'') CONTAMINATED — ambient plugin leaks in headless. Fall back to b'.",
+      );
     }
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -299,35 +299,21 @@ function cmdCheck() {
   }
 }
 
-// ---- isolated clean config dir + empty mcp -------------------------------
-// A throwaway config dir INSIDE the caller's mktemp `tmp` (outside the repo, never
-// committed). settings.json carries NO enabledPlugins and NO user rules, so the
-// ambient `lien@lien` plugin (hooks + MCP) does not load. Auth is restored by
-// seeding an ACCOUNT-ONLY .claude.json (userID + oauthAccount only) read from the
-// real ~/.claude.json at runtime — CC otherwise reports "not logged in" because a
-// fresh config dir lacks the account linkage. No mcpServers / projects /
-// enabledPlugins are copied, so the seed stays plugin- and MCP-free (the probe
-// proves it). The personal fields live only in this tmp dir and are deleted in
-// cleanup; they never enter the repo, .wip/, or any committed artifact.
-function seedAccountOnly(dir) {
-  const real = path.join(os.homedir(), '.claude.json');
-  const src = JSON.parse(fs.readFileSync(real, 'utf8'));
-  if (!src.oauthAccount) throw new Error('SEED FAILED: no oauthAccount in ~/.claude.json');
-  const seed = { userID: src.userID, oauthAccount: src.oauthAccount };
-  fs.writeFileSync(path.join(dir, '.claude.json'), JSON.stringify(seed));
-}
-
-function isolatedConfig(tmp) {
-  const dir = path.join(tmp, 'cc-config');
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(
-    path.join(dir, 'settings.json'),
-    JSON.stringify({ model: MODEL, includeCoAuthoredBy: false }, null, 2),
-  );
-  seedAccountOnly(dir);
+// ---- run/context config (the b' mechanism) -------------------------------
+// Clean context = the DEFAULT config dir (so macOS Keychain auth works — an
+// isolated CLAUDE_CONFIG_DIR reports "not logged in" because the OAuth token is
+// in the Keychain, not .claude.json) with the ambient `lien@lien` plugin
+// disabled FOR THE SPAWNED PROCESS ONLY via a per-invocation --settings
+// `enabledPlugins` override (leaves saved settings untouched — verified by
+// probe-b1), plus `--strict-mcp-config`, plus this checkout's explicit hooks.
+// Disabling the plugin is what stops the ambient annotate-read hook (no
+// off-switch) from injecting "Lien impact for … <named dependents>" into both
+// arms. cfg.dir === null tells runClaude not to override CLAUDE_CONFIG_DIR.
+const PLUGIN_DISABLE = { 'lien@lien': false };
+function runConfig(tmp) {
   const emptyMcp = path.join(tmp, 'empty-mcp.json');
   fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
-  return { dir, emptyMcp };
+  return { dir: null, emptyMcp };
 }
 
 function claudeArgs(prompt, sessionId, settingsFile, emptyMcp) {
@@ -399,38 +385,6 @@ function redactAccount(text) {
 }
 function writeArtifact(file, text) {
   fs.writeFileSync(file, redactAccount(text));
-}
-
-// ---- probe (mandatory precondition) --------------------------------------
-function cmdProbe() {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probe-'));
-  try {
-    const shimBin = makeLienShim(tmp);
-    const cfg = isolatedConfig(tmp);
-    const cwd = path.join(tmp, 'clean'); // clean, git-free, CLAUDE.md-free directory
-    fs.mkdirSync(cwd, { recursive: true });
-    assertNoAncestorClaudeMd(cwd);
-    const settingsFile = path.join(tmp, 'probe-settings.json');
-    fs.writeFileSync(settingsFile, JSON.stringify({ hooks: {} }));
-    const prompt = fs.readFileSync(path.join(KIT, 'prompts', 'probe.txt'), 'utf8');
-    const { stdout: out } = runClaude(prompt, randomUUID(), cwd, settingsFile, cfg, {}, shimBin);
-    fs.mkdirSync(OUT_ROOT, { recursive: true });
-    writeArtifact(path.join(OUT_ROOT, 'probe.jsonl'), out);
-    const hits = contaminationScan(out);
-    if (out.trim() === '')
-      throw new Error(
-        'PROBE FAILED: empty output (auth/plumbing problem with isolated config dir)',
-      );
-    if (looksLoggedOut(out))
-      throw new Error(
-        'PROBE FAILED: not logged in — auth does not survive the isolated config dir',
-      );
-    if (hits.length > 0) throw new Error(`PROBE FAILED (contaminated): ${hits.join(', ')}`);
-    fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
-    console.log('PROBE PASSED — context clean, plumbing live. Arms may run.');
-  } finally {
-    fs.rmSync(tmp, { recursive: true, force: true });
-  }
 }
 
 // ---- b'' probe: DEFAULT config dir + --strict-mcp-config ------------------
@@ -611,8 +565,13 @@ function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
   const exp = EXPERIMENTS[expName];
   const dest = path.join(tmp, `${expName}-${arm}-${idx}`);
   const env = materialize(exp.fixture, dest, shimBin, true);
+  assertNoAncestorClaudeMd(dest); // structural: no repo CLAUDE.md can load in the sandbox
   const settingsFile = path.join(dest, '.ab-settings.json');
-  fs.writeFileSync(settingsFile, JSON.stringify(exp.settings()));
+  // b' mechanism: disable the ambient plugin for this process; wire our hooks.
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify({ ...exp.settings(), enabledPlugins: PLUGIN_DISABLE }),
+  );
   const sid = randomUUID();
   const task = fs.readFileSync(path.join(KIT, exp.task), 'utf8');
   const armEnv = { ...exp.baseEnv, ...exp.armEnv[arm] };
@@ -675,16 +634,20 @@ function saveTrial(expName, arm, idx, transcript, result) {
   writeArtifact(path.join(dir, `${idx}.json`), JSON.stringify(result, null, 2));
 }
 
+const B1_AUTH_MODE = 'default+plugindisable+strict-mcp';
 function cmdRun(expName) {
-  if (!fs.existsSync(path.join(OUT_ROOT, '.probe-passed'))) {
+  const modeFile = path.join(OUT_ROOT, '.auth-mode');
+  const passed = fs.existsSync(path.join(OUT_ROOT, '.probe-passed'));
+  const mode = passed && fs.existsSync(modeFile) ? fs.readFileSync(modeFile, 'utf8').trim() : '';
+  if (mode !== B1_AUTH_MODE) {
     throw new Error(
-      'Refusing to run: contamination probe has not passed. Run `node run.mjs probe` first.',
+      `Refusing to run: probe-b1 has not passed clean. Run \`node run.mjs probe-b1\` first (need auth-mode ${B1_AUTH_MODE}).`,
     );
   }
   if (!EXPERIMENTS[expName]) throw new Error(`unknown experiment: ${expName}`);
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `nudge-ab-${expName}-`));
   const shimBin = makeLienShim(tmp);
-  const cfg = isolatedConfig(tmp);
+  const cfg = runConfig(tmp);
   const labels = seededOrder(
     Array.from({ length: N_PER_ARM }, (_, i) => [`on:${i}`, `off:${i}`]).flat(),
     INTERLEAVE_SEED,
@@ -811,7 +774,7 @@ function fisherOneSided(a, n1, c, n2) {
 function cmdSmoke() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-smoke-'));
   const shimBin = makeLienShim(tmp);
-  const cfg = isolatedConfig(tmp);
+  const cfg = runConfig(tmp);
   for (const expName of ['blast', 'verify']) {
     const r = runTrial(expName, 'on', 'smoke', tmp, shimBin, cfg);
     console.log(
@@ -831,16 +794,15 @@ function cmdSmoke() {
 function main() {
   const [, , cmd, ...rest] = process.argv;
   if (cmd === 'check') return cmdCheck();
-  if (cmd === 'probe') return cmdProbe();
-  if (cmd === 'probe-default') return cmdProbeDefault();
-  if (cmd === 'probe-b1') return cmdProbeB1();
+  if (cmd === 'probe-default') return cmdProbeDefault(); // b'' diagnostic (contaminated)
+  if (cmd === 'probe' || cmd === 'probe-b1') return cmdProbeB1(); // the run precondition
   if (cmd === 'smoke') return cmdSmoke();
   if (cmd === 'run') {
     const exp = rest[0];
     if (!exp) throw new Error('usage: run.mjs run <blast|verify>');
     return cmdRun(exp);
   }
-  console.log('usage: run.mjs <check|probe|probe-default|probe-b1|smoke|run <blast|verify>>');
+  console.log('usage: run.mjs <check|probe|probe-default|smoke|run <blast|verify>>');
   process.exit(cmd ? 1 : 0);
 }
 main();

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -497,6 +497,83 @@ function cmdProbeDefault() {
   }
 }
 
+// ---- b' probe: default config dir + per-invocation plugin disable ---------
+// Uses the DEFAULT config dir (auth works) but disables the ambient lien plugin
+// FOR THE SPAWNED PROCESS ONLY via a --settings enabledPlugins override, plus
+// --strict-mcp-config, plus my explicit hooks. Verifies (a) the plugin is off
+// (annotate-read did NOT fire — nudge-events has no "annotate"), (b) my explicit
+// hooks still fire (nudge-events has "blast"), (c) the saved ~/.claude settings
+// on disk are byte-identical before/after. Detection is via the nudge-events
+// ledger, not transcript grep.
+function cmdProbeB1() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probeb1-'));
+  const savedSettings = path.join(os.homedir(), '.claude', 'settings.json');
+  const before = fs.readFileSync(savedSettings, 'utf8');
+  try {
+    const shimBin = makeLienShim(tmp);
+    const emptyMcp = path.join(tmp, 'empty-mcp.json');
+    fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
+    const cfg = { dir: null, emptyMcp }; // DEFAULT config dir
+    const dest = path.join(tmp, 'blast');
+    materialize('blast', dest, shimBin, false);
+    const settingsFile = path.join(dest, '.ab-settings.json');
+    const s = EXPERIMENTS.blast.settings();
+    s.enabledPlugins = { 'lien@lien': false }; // disable ambient plugin, this process only
+    fs.writeFileSync(settingsFile, JSON.stringify(s));
+    const sid = randomUUID();
+    const prompt =
+      'First, list verbatim every project instruction, repository rule, or tool-usage policy currently in your context; if there are none, reply NONE. ' +
+      'Then read the file src/pricing/discount.ts. ' +
+      'Then modify applyDiscount to take an optional third parameter floor (number), clamping the result to at least floor when provided. Then stop.';
+    const { stdout: transcript } = runClaude(
+      prompt,
+      sid,
+      dest,
+      settingsFile,
+      cfg,
+      EXPERIMENTS.blast.baseEnv,
+      shimBin,
+    );
+    fs.mkdirSync(OUT_ROOT, { recursive: true });
+    writeArtifact(path.join(OUT_ROOT, 'probe-b1.jsonl'), transcript);
+    const parsed = parseTranscript(transcript);
+    const after = fs.readFileSync(savedSettings, 'utf8');
+    const result = {
+      loggedOut: looksLoggedOut(transcript),
+      myHooksFire: nudgeShown(dest, 'blast', sid),
+      annotateFired: nudgeShown(dest, 'annotate', sid),
+      modelSawAnnotate: /Lien impact|hooks flagged/i.test(parsed.finalText),
+      savedSettingsUntouched: before === after,
+      instructionContamination: contaminationScan(parsed.finalText),
+    };
+    console.log(redactAccount(JSON.stringify(result, null, 2)));
+    verdictB1(result);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    // Belt-and-braces: restore the saved settings if anything touched them.
+    if (fs.readFileSync(savedSettings, 'utf8') !== before) fs.writeFileSync(savedSettings, before);
+  }
+}
+
+function verdictB1(r) {
+  if (r.loggedOut) throw new Error("PROBE(b') FAILED: not logged in from DEFAULT config dir");
+  if (!r.savedSettingsUntouched)
+    throw new Error("PROBE(b') FAILED: saved ~/.claude/settings.json CHANGED — abort");
+  if (!r.myHooksFire) throw new Error("PROBE(b') FAILED: my explicit hooks did NOT fire — STOP");
+  const clean = !r.annotateFired && !r.modelSawAnnotate && r.instructionContamination.length === 0;
+  if (!clean) {
+    console.log(
+      "PROBE(b') CONTAMINATED — plugin-disable override not honored. Both b'' and b' failed; STOP and report.",
+    );
+    return;
+  }
+  fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
+  fs.writeFileSync(path.join(OUT_ROOT, '.auth-mode'), 'default+plugindisable+strict-mcp');
+  console.log(
+    "PROBE(b') PASSED — auth works, ambient plugin off, my hooks fire, saved settings untouched.",
+  );
+}
+
 function assertNoAncestorClaudeMd(dir) {
   let d = dir;
   for (;;) {
@@ -513,12 +590,21 @@ function verifyRanOracle(dest, sid, env) {
   return report.stdout.trim() === ''; // empty ⇒ the associated test was observed run
 }
 
-function blastFired(dest, sid) {
+// Reliable, deterministic oracle for "did hook <nudgeType> fire this session":
+// the nudge-events ledger, NOT transcript grep (a hook's additionalContext does
+// not appear grep-ably in the stream-json transcript — only the model's
+// paraphrase of it does, which is unreliable).
+function nudgeShown(dest, nudgeType, sid) {
   const store = lien(['path', '--store'], dest).stdout.trim();
+  if (!store) return false;
   const events = path.join(store, 'nudge-events.jsonl');
   if (!fs.existsSync(events)) return false;
   const body = fs.readFileSync(events, 'utf8');
-  return body.includes('"nudge":"blast"') && body.includes(sid);
+  return body.includes(`"nudge":"${nudgeType}"`) && body.includes(sid);
+}
+
+function blastFired(dest, sid) {
+  return nudgeShown(dest, 'blast', sid);
 }
 
 function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
@@ -747,13 +833,14 @@ function main() {
   if (cmd === 'check') return cmdCheck();
   if (cmd === 'probe') return cmdProbe();
   if (cmd === 'probe-default') return cmdProbeDefault();
+  if (cmd === 'probe-b1') return cmdProbeB1();
   if (cmd === 'smoke') return cmdSmoke();
   if (cmd === 'run') {
     const exp = rest[0];
     if (!exp) throw new Error('usage: run.mjs run <blast|verify>');
     return cmdRun(exp);
   }
-  console.log('usage: run.mjs <check|probe|probe-default|smoke|run <blast|verify>>');
+  console.log('usage: run.mjs <check|probe|probe-default|probe-b1|smoke|run <blast|verify>>');
   process.exit(cmd ? 1 : 0);
 }
 main();

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -26,6 +26,7 @@ import {
   verifyTranscriptRanTest,
   contaminationScan,
   collectDenials,
+  looksLoggedOut,
 } from './detect.mjs';
 
 // ---- FROZEN CONFIG -------------------------------------------------------
@@ -302,7 +303,9 @@ function cmdCheck() {
 // the global ~/.claude/rules do NOT load. Auth on macOS lives in the Keychain,
 // not this dir, so a headless `claude` still authenticates.
 function isolatedConfig(tmp) {
-  const dir = path.join(tmp, 'cc-config');
+  // Persistent (not per-tmp): warmed once, then reused across probe/smoke/run so
+  // the first-call auth race in a brand-new config dir happens at most once.
+  const dir = path.join(OUT_ROOT, 'cc-config');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(
     path.join(dir, 'settings.json'),
@@ -311,6 +314,34 @@ function isolatedConfig(tmp) {
   const emptyMcp = path.join(tmp, 'empty-mcp.json');
   fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
   return { dir, emptyMcp };
+}
+
+// Establish auth in the isolated config dir before any trial, so the first
+// COUNTED trial isn't the one that races "Not logged in". Idempotent via a
+// marker; a persistent failure is a hard auth stop.
+function warmConfig(cfg, shimBin, tmp) {
+  const marker = path.join(cfg.dir, '.warmed');
+  if (fs.existsSync(marker)) return;
+  const settings = path.join(tmp, 'warm-settings.json');
+  fs.writeFileSync(settings, JSON.stringify({ hooks: {} }));
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const { stdout } = runClaude(
+      'Reply with the single word OK.',
+      randomUUID(),
+      tmp,
+      settings,
+      cfg,
+      {},
+      shimBin,
+    );
+    if (stdout && !looksLoggedOut(stdout)) {
+      fs.writeFileSync(marker, new Date().toISOString());
+      return;
+    }
+  }
+  throw new Error(
+    'WARM FAILED: isolated config dir still reports not-logged-in after 3 attempts — auth problem, STOP and report',
+  );
 }
 
 function claudeArgs(prompt, sessionId, settingsFile, emptyMcp) {
@@ -362,6 +393,7 @@ function cmdProbe() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probe-'));
   const shimBin = makeLienShim(tmp);
   const cfg = isolatedConfig(tmp);
+  warmConfig(cfg, shimBin, tmp);
   // clean, git-free, CLAUDE.md-free directory
   const cwd = path.join(tmp, 'clean');
   fs.mkdirSync(cwd, { recursive: true });
@@ -432,6 +464,8 @@ function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
 function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut }) {
   const contamination = arm === 'off' ? contaminationScan(transcript) : [];
   const denials = collectDenials(transcript);
+  const loggedOut = looksLoggedOut(transcript);
+  const usable = !timedOut && !loggedOut;
   if (expName === 'blast') {
     const m = blastMetric(parsed.toolUses, parsed.finalText);
     const fired = arm === 'off' ? true : blastFired(dest, sid);
@@ -439,8 +473,9 @@ function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut
       hit: m.hit,
       reasons: m.reasons,
       generic: blastGenericSentiment(parsed.finalText, m.hit),
-      valid: !timedOut && fired,
+      valid: usable && fired,
       timedOut,
+      loggedOut,
       contamination,
       denials,
     };
@@ -449,8 +484,9 @@ function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut
   return {
     hit: ran,
     reasons: verifyTranscriptRanTest(parsed.toolUses).reasons,
-    valid: !timedOut,
+    valid: usable,
     timedOut,
+    loggedOut,
     contamination,
     denials,
   };
@@ -473,6 +509,7 @@ function cmdRun(expName) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `nudge-ab-${expName}-`));
   const shimBin = makeLienShim(tmp);
   const cfg = isolatedConfig(tmp);
+  warmConfig(cfg, shimBin, tmp);
   const labels = seededOrder(
     Array.from({ length: N_PER_ARM }, (_, i) => [`on:${i}`, `off:${i}`]).flat(),
     INTERLEAVE_SEED,
@@ -530,6 +567,13 @@ function denialSummary(rows) {
   return { total: all.length, byTool };
 }
 
+function invalidReasons(rows) {
+  return {
+    timedOut: rows.filter(r => r.timedOut).length,
+    loggedOut: rows.filter(r => r.loggedOut).length,
+  };
+}
+
 function report(expName, results) {
   const on = tally(results.on);
   const off = tally(results.off);
@@ -542,6 +586,7 @@ function report(expName, results) {
     on: `${on.hits}/${on.n}`,
     off: `${off.hits}/${off.n}`,
     invalid: { on: on.invalid, off: off.invalid },
+    invalidReasons: { on: invalidReasons(results.on), off: invalidReasons(results.off) },
     contaminationLeaks: leaks,
     denials: { on: denialSummary(results.on), off: denialSummary(results.off) },
     fisherOneSidedP: Number(p.toFixed(4)),
@@ -595,6 +640,7 @@ function cmdSmoke() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-smoke-'));
   const shimBin = makeLienShim(tmp);
   const cfg = isolatedConfig(tmp);
+  warmConfig(cfg, shimBin, tmp);
   for (const expName of ['blast', 'verify']) {
     const r = runTrial(expName, 'on', 'smoke', tmp, shimBin, cfg);
     console.log(

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -360,8 +360,10 @@ function runClaude(prompt, sessionId, cwd, settingsFile, cfg, extraEnv, shimBin)
     ...BASE_ENV,
     ...extraEnv,
     PATH: `${shimBin}:${process.env.PATH}`,
-    CLAUDE_CONFIG_DIR: cfg.dir,
   };
+  // cfg.dir === null ⇒ use the DEFAULT config dir (auth works; ambient plugin
+  // loads — the b'' contamination probe). Otherwise isolate.
+  if (cfg.dir) env.CLAUDE_CONFIG_DIR = cfg.dir;
   const res = spawnSync('claude', claudeArgs(prompt, sessionId, settingsFile, cfg.emptyMcp), {
     cwd,
     env,
@@ -426,6 +428,70 @@ function cmdProbe() {
     if (hits.length > 0) throw new Error(`PROBE FAILED (contaminated): ${hits.join(', ')}`);
     fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
     console.log('PROBE PASSED — context clean, plumbing live. Arms may run.');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ---- b'' probe: DEFAULT config dir + --strict-mcp-config ------------------
+// Tests whether using the default (authenticating) config dir with MCP stripped
+// leaves a clean context. Triggers the ambient plugin's Read/Edit hooks against
+// an indexed fixture and checks for BOTH instruction-level and hook-level leaks;
+// also confirms hooks fire in headless at all (via the blast nudge). The one
+// uncontrolled ambient hook is annotate-read (no off switch), whose output
+// literally names the dependents — signature "Lien impact for".
+function analyzeDefaultProbe(transcript) {
+  const parsed = parseTranscript(transcript);
+  return {
+    loggedOut: looksLoggedOut(transcript),
+    hooksFireInHeadless: /exported signature changed/.test(transcript),
+    annotateContamination: /Lien impact for/.test(transcript),
+    instructionContamination: contaminationScan(parsed.finalText),
+  };
+}
+
+function cmdProbeDefault() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probeb2-'));
+  try {
+    const shimBin = makeLienShim(tmp);
+    const emptyMcp = path.join(tmp, 'empty-mcp.json');
+    fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
+    const cfg = { dir: null, emptyMcp }; // DEFAULT config dir (auth + ambient plugin)
+    const dest = path.join(tmp, 'blast');
+    materialize('blast', dest, shimBin, false);
+    const settingsFile = path.join(dest, '.ab-settings.json');
+    fs.writeFileSync(settingsFile, JSON.stringify(EXPERIMENTS.blast.settings()));
+    const prompt =
+      'First, list verbatim every project instruction, repository rule, or tool-usage policy currently in your context; if there are none, reply NONE. ' +
+      'Then read the file src/pricing/discount.ts. ' +
+      'Then modify applyDiscount to take an optional third parameter floor (number), clamping the result to at least floor when provided. Then stop.';
+    const { stdout: transcript } = runClaude(
+      prompt,
+      randomUUID(),
+      dest,
+      settingsFile,
+      cfg,
+      EXPERIMENTS.blast.baseEnv,
+      shimBin,
+    );
+    fs.mkdirSync(OUT_ROOT, { recursive: true });
+    writeArtifact(path.join(OUT_ROOT, 'probe-default.jsonl'), transcript);
+    const a = analyzeDefaultProbe(transcript);
+    console.log(redactAccount(JSON.stringify(a, null, 2)));
+    if (a.loggedOut) throw new Error("PROBE(b'') FAILED: not logged in from DEFAULT config dir");
+    if (!a.hooksFireInHeadless)
+      throw new Error(
+        "PROBE(b'') FAILED: no hook fired in headless (no blast nudge) — fundamental, STOP",
+      );
+    if (!a.annotateContamination && a.instructionContamination.length === 0) {
+      fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
+      fs.writeFileSync(path.join(OUT_ROOT, '.auth-mode'), 'default+strict-mcp');
+      console.log(
+        "PROBE(b'') PASSED — default config + --strict-mcp-config is clean AND hooks fire.",
+      );
+    } else {
+      console.log("PROBE(b'') CONTAMINATED — ambient plugin leaks in headless. Fall back to b'.");
+    }
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -680,13 +746,14 @@ function main() {
   const [, , cmd, ...rest] = process.argv;
   if (cmd === 'check') return cmdCheck();
   if (cmd === 'probe') return cmdProbe();
+  if (cmd === 'probe-default') return cmdProbeDefault();
   if (cmd === 'smoke') return cmdSmoke();
   if (cmd === 'run') {
     const exp = rest[0];
     if (!exp) throw new Error('usage: run.mjs run <blast|verify>');
     return cmdRun(exp);
   }
-  console.log('usage: run.mjs <check|probe|smoke|run <blast|verify>>');
+  console.log('usage: run.mjs <check|probe|probe-default|smoke|run <blast|verify>>');
   process.exit(cmd ? 1 : 0);
 }
 main();

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -299,49 +299,34 @@ function cmdCheck() {
 }
 
 // ---- isolated clean config dir + empty mcp -------------------------------
-// No enabledPlugins, no user rules → the ambient Lien plugin (hooks + MCP) and
-// the global ~/.claude/rules do NOT load. Auth on macOS lives in the Keychain,
-// not this dir, so a headless `claude` still authenticates.
+// A throwaway config dir INSIDE the caller's mktemp `tmp` (outside the repo, never
+// committed). settings.json carries NO enabledPlugins and NO user rules, so the
+// ambient `lien@lien` plugin (hooks + MCP) does not load. Auth is restored by
+// seeding an ACCOUNT-ONLY .claude.json (userID + oauthAccount only) read from the
+// real ~/.claude.json at runtime — CC otherwise reports "not logged in" because a
+// fresh config dir lacks the account linkage. No mcpServers / projects /
+// enabledPlugins are copied, so the seed stays plugin- and MCP-free (the probe
+// proves it). The personal fields live only in this tmp dir and are deleted in
+// cleanup; they never enter the repo, .wip/, or any committed artifact.
+function seedAccountOnly(dir) {
+  const real = path.join(os.homedir(), '.claude.json');
+  const src = JSON.parse(fs.readFileSync(real, 'utf8'));
+  if (!src.oauthAccount) throw new Error('SEED FAILED: no oauthAccount in ~/.claude.json');
+  const seed = { userID: src.userID, oauthAccount: src.oauthAccount };
+  fs.writeFileSync(path.join(dir, '.claude.json'), JSON.stringify(seed));
+}
+
 function isolatedConfig(tmp) {
-  // Persistent (not per-tmp): warmed once, then reused across probe/smoke/run so
-  // the first-call auth race in a brand-new config dir happens at most once.
-  const dir = path.join(OUT_ROOT, 'cc-config');
+  const dir = path.join(tmp, 'cc-config');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(
     path.join(dir, 'settings.json'),
     JSON.stringify({ model: MODEL, includeCoAuthoredBy: false }, null, 2),
   );
+  seedAccountOnly(dir);
   const emptyMcp = path.join(tmp, 'empty-mcp.json');
   fs.writeFileSync(emptyMcp, JSON.stringify({ mcpServers: {} }));
   return { dir, emptyMcp };
-}
-
-// Establish auth in the isolated config dir before any trial, so the first
-// COUNTED trial isn't the one that races "Not logged in". Idempotent via a
-// marker; a persistent failure is a hard auth stop.
-function warmConfig(cfg, shimBin, tmp) {
-  const marker = path.join(cfg.dir, '.warmed');
-  if (fs.existsSync(marker)) return;
-  const settings = path.join(tmp, 'warm-settings.json');
-  fs.writeFileSync(settings, JSON.stringify({ hooks: {} }));
-  for (let attempt = 0; attempt < 3; attempt++) {
-    const { stdout } = runClaude(
-      'Reply with the single word OK.',
-      randomUUID(),
-      tmp,
-      settings,
-      cfg,
-      {},
-      shimBin,
-    );
-    if (stdout && !looksLoggedOut(stdout)) {
-      fs.writeFileSync(marker, new Date().toISOString());
-      return;
-    }
-  }
-  throw new Error(
-    'WARM FAILED: isolated config dir still reports not-logged-in after 3 attempts — auth problem, STOP and report',
-  );
 }
 
 function claudeArgs(prompt, sessionId, settingsFile, emptyMcp) {
@@ -388,30 +373,61 @@ function runClaude(prompt, sessionId, cwd, settingsFile, cfg, extraEnv, shimBin)
   return { stdout: res.stdout || '', timedOut };
 }
 
+// Redaction: the seed's personal fields (email/org/account UUIDs) must never
+// appear in any on-disk artifact (probe output, transcripts, summaries). Terms
+// are read from the real ~/.claude.json at runtime — never hardcoded — and
+// stripped from everything written under OUT_ROOT.
+let _redactTerms = null;
+function redactionTerms() {
+  if (_redactTerms) return _redactTerms;
+  const oa =
+    JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude.json'), 'utf8')).oauthAccount || {};
+  _redactTerms = [
+    oa.emailAddress,
+    oa.accountUuid,
+    oa.organizationUuid,
+    oa.organizationName,
+    oa.displayName,
+  ].filter(v => typeof v === 'string' && v.length > 2);
+  return _redactTerms;
+}
+function redactAccount(text) {
+  return redactionTerms().reduce((acc, term) => acc.split(term).join('[REDACTED]'), text);
+}
+function writeArtifact(file, text) {
+  fs.writeFileSync(file, redactAccount(text));
+}
+
 // ---- probe (mandatory precondition) --------------------------------------
 function cmdProbe() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-probe-'));
-  const shimBin = makeLienShim(tmp);
-  const cfg = isolatedConfig(tmp);
-  warmConfig(cfg, shimBin, tmp);
-  // clean, git-free, CLAUDE.md-free directory
-  const cwd = path.join(tmp, 'clean');
-  fs.mkdirSync(cwd, { recursive: true });
-  assertNoAncestorClaudeMd(cwd);
-  const settingsFile = path.join(tmp, 'probe-settings.json');
-  fs.writeFileSync(settingsFile, JSON.stringify({ hooks: {} }));
-  const prompt = fs.readFileSync(path.join(KIT, 'prompts', 'probe.txt'), 'utf8');
-  const { stdout: out } = runClaude(prompt, randomUUID(), cwd, settingsFile, cfg, {}, shimBin);
-  fs.mkdirSync(OUT_ROOT, { recursive: true });
-  fs.writeFileSync(path.join(OUT_ROOT, 'probe.jsonl'), out);
-  const hits = contaminationScan(out);
-  if (out.trim() === '')
-    throw new Error('PROBE FAILED: empty output (auth/plumbing problem with isolated config dir)');
-  if (looksLoggedOut(out))
-    throw new Error('PROBE FAILED: not logged in — auth does not survive the isolated config dir');
-  if (hits.length > 0) throw new Error(`PROBE FAILED (contaminated): ${hits.join(', ')}`);
-  fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
-  console.log('PROBE PASSED — context clean, plumbing live. Arms may run.');
+  try {
+    const shimBin = makeLienShim(tmp);
+    const cfg = isolatedConfig(tmp);
+    const cwd = path.join(tmp, 'clean'); // clean, git-free, CLAUDE.md-free directory
+    fs.mkdirSync(cwd, { recursive: true });
+    assertNoAncestorClaudeMd(cwd);
+    const settingsFile = path.join(tmp, 'probe-settings.json');
+    fs.writeFileSync(settingsFile, JSON.stringify({ hooks: {} }));
+    const prompt = fs.readFileSync(path.join(KIT, 'prompts', 'probe.txt'), 'utf8');
+    const { stdout: out } = runClaude(prompt, randomUUID(), cwd, settingsFile, cfg, {}, shimBin);
+    fs.mkdirSync(OUT_ROOT, { recursive: true });
+    writeArtifact(path.join(OUT_ROOT, 'probe.jsonl'), out);
+    const hits = contaminationScan(out);
+    if (out.trim() === '')
+      throw new Error(
+        'PROBE FAILED: empty output (auth/plumbing problem with isolated config dir)',
+      );
+    if (looksLoggedOut(out))
+      throw new Error(
+        'PROBE FAILED: not logged in — auth does not survive the isolated config dir',
+      );
+    if (hits.length > 0) throw new Error(`PROBE FAILED (contaminated): ${hits.join(', ')}`);
+    fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
+    console.log('PROBE PASSED — context clean, plumbing live. Arms may run.');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 }
 
 function assertNoAncestorClaudeMd(dir) {
@@ -497,8 +513,8 @@ function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut
 function saveTrial(expName, arm, idx, transcript, result) {
   const dir = path.join(OUT_ROOT, expName, arm);
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, `${idx}.jsonl`), transcript);
-  fs.writeFileSync(path.join(dir, `${idx}.json`), JSON.stringify(result, null, 2));
+  writeArtifact(path.join(dir, `${idx}.jsonl`), transcript);
+  writeArtifact(path.join(dir, `${idx}.json`), JSON.stringify(result, null, 2));
 }
 
 function cmdRun(expName) {
@@ -511,7 +527,6 @@ function cmdRun(expName) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `nudge-ab-${expName}-`));
   const shimBin = makeLienShim(tmp);
   const cfg = isolatedConfig(tmp);
-  warmConfig(cfg, shimBin, tmp);
   const labels = seededOrder(
     Array.from({ length: N_PER_ARM }, (_, i) => [`on:${i}`, `off:${i}`]).flat(),
     INTERLEAVE_SEED,
@@ -595,11 +610,8 @@ function report(expName, results) {
     primarySeparated: separated,
     launchClaimPermitted: separated,
   };
-  fs.writeFileSync(
-    path.join(OUT_ROOT, `${expName}-summary.json`),
-    JSON.stringify(summary, null, 2),
-  );
-  console.log(JSON.stringify(summary, null, 2));
+  writeArtifact(path.join(OUT_ROOT, `${expName}-summary.json`), JSON.stringify(summary, null, 2));
+  console.log(redactAccount(JSON.stringify(summary, null, 2)));
 }
 
 // One-sided Fisher exact (P(X >= observed on-hits) under the null), via the
@@ -642,14 +654,16 @@ function cmdSmoke() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-smoke-'));
   const shimBin = makeLienShim(tmp);
   const cfg = isolatedConfig(tmp);
-  warmConfig(cfg, shimBin, tmp);
   for (const expName of ['blast', 'verify']) {
     const r = runTrial(expName, 'on', 'smoke', tmp, shimBin, cfg);
     console.log(
-      `[smoke] ${expName} on: hit=${r.hit} valid=${r.valid} timedOut=${r.timedOut} ` +
-        `denials=${r.denials.length} reasons=${JSON.stringify(r.reasons)}`,
+      redactAccount(
+        `[smoke] ${expName} on: hit=${r.hit} valid=${r.valid} timedOut=${r.timedOut} ` +
+          `loggedOut=${r.loggedOut} denials=${r.denials.length} reasons=${JSON.stringify(r.reasons)}`,
+      ),
     );
-    if (r.denials.length) console.log(`         denied: ${JSON.stringify(r.denials)}`);
+    if (r.denials.length)
+      console.log(redactAccount(`         denied: ${JSON.stringify(r.denials)}`));
   }
   fs.rmSync(tmp, { recursive: true, force: true });
   console.log('SMOKE done — inspect validity/denials above before the counted run.');

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -407,6 +407,8 @@ function cmdProbe() {
   const hits = contaminationScan(out);
   if (out.trim() === '')
     throw new Error('PROBE FAILED: empty output (auth/plumbing problem with isolated config dir)');
+  if (looksLoggedOut(out))
+    throw new Error('PROBE FAILED: not logged in — auth does not survive the isolated config dir');
   if (hits.length > 0) throw new Error(`PROBE FAILED (contaminated): ${hits.join(', ')}`);
   fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
   console.log('PROBE PASSED — context clean, plumbing live. Arms may run.');

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -553,10 +553,11 @@ function verdictB1(r) {
   if (!r.myHooksFire) throw new Error("PROBE(b') FAILED: my explicit hooks did NOT fire — STOP");
   const clean = !r.annotateFired && !r.sawAnnotateOutput && r.mcpInstructionLeak.length === 0;
   if (!clean) {
-    console.log(
+    // Throw (like the sibling checks) so a contaminated probe exits non-zero and
+    // automated callers can't mistake it for success; .probe-passed stays unwritten.
+    throw new Error(
       "PROBE(b') CONTAMINATED — plugin-disable override not honored. Both b'' and b' failed; STOP and report.",
     );
-    return;
   }
   fs.writeFileSync(path.join(OUT_ROOT, '.probe-passed'), new Date().toISOString());
   fs.writeFileSync(path.join(OUT_ROOT, '.auth-mode'), 'default+plugindisable+strict-mcp');
@@ -576,9 +577,14 @@ function assertNoAncestorClaudeMd(dir) {
 }
 
 // ---- run (gated arms) ----------------------------------------------------
+// `ran` (empty report ⇒ test observed run) is only meaningful when the CLI
+// itself succeeded. A failed `report` (non-zero exit, stderr, or spawn error)
+// also yields empty stdout, which would otherwise read as a false "ran"; so we
+// return cliOk and the caller marks a failed-CLI trial INVALID, never a hit.
 function verifyRanOracle(dest, sid, env) {
   const report = lien(['verify-tests', 'report', '--session', sid], dest, env);
-  return report.stdout.trim() === ''; // empty ⇒ the associated test was observed run
+  const cliOk = report.status === 0 && !report.error && !(report.stderr || '').trim();
+  return { cliOk, ran: report.stdout.trim() === '' };
 }
 
 // Reliable, deterministic oracle for "did hook <nudgeType> fire this session":
@@ -681,25 +687,30 @@ function scoreTrial({
     const m = blastMetric(parsed.toolUses, parsed.finalText);
     // SYMMETRIC: both arms require the task edit (signature change) to be valid.
     const editCompleted = blastEditCompleted(dest, env);
+    // §6a: an ON trial is valid only if the blast warning actually FIRED (a
+    // `blast` note-shown event). OFF has no warning, so the check is ON-only.
+    const nudgeFired = arm === 'on' ? nudgeShown(dest, 'blast', sid, env) : true;
     return {
       hit: m.hit,
       reasons: m.reasons,
       generic: blastGenericSentiment(parsed.finalText, m.hit),
-      valid: usable && editCompleted,
+      valid: usable && editCompleted && nudgeFired,
       editCompleted,
+      nudgeFired,
       ...base,
     };
   }
   // Verify: an empty `verify-tests report` only means "test ran" if the target
-  // was actually edited — otherwise a no-op/logged-out trial reads as a false
-  // positive. Require the edit for validity (symmetric with blast's rule).
+  // was actually edited AND the report CLI succeeded — otherwise a no-op,
+  // logged-out, or failed-CLI trial reads as a false positive.
   const edited = editedTarget(parsed.toolUses, EXPERIMENTS.verify.target);
-  const ran = verifyRanOracle(dest, sid, env);
+  const oracle = verifyRanOracle(dest, sid, env);
   return {
-    hit: ran,
+    hit: oracle.cliOk && oracle.ran,
     reasons: verifyTranscriptRanTest(parsed.toolUses).reasons,
-    valid: usable && edited,
+    valid: usable && edited && oracle.cliOk,
     edited,
+    cliOk: oracle.cliOk,
     ...base,
   };
 }

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -25,13 +25,60 @@ import {
   blastGenericSentiment,
   verifyTranscriptRanTest,
   contaminationScan,
+  collectDenials,
 } from './detect.mjs';
 
 // ---- FROZEN CONFIG -------------------------------------------------------
 const N_PER_ARM = 10; // justified in the protocol doc (detection-oriented power)
+const TRIAL_TIMEOUT_MS = 240000; // per-trial wall clock; a timeout ⇒ invalid trial (§7)
 const MODEL = 'sonnet';
 const INTERLEAVE_SEED = 20260725; // fixed; drives the arm order
-const ALLOWED_TOOLS = 'Edit,Write,Read,Bash,Grep,Glob';
+
+// Trials run with --permission-mode acceptEdits (auto-accepts file edits in the
+// sandbox) plus this EXPLICIT allowlist — NOT bypassPermissions. The list is
+// identical in both arms, so any denial is a constant that differences out; it
+// covers exactly what a legitimate trial does (read/search/edit + run the
+// fixture's test runner) and nothing else (no rm/curl/network/install). In
+// headless -p a non-allowlisted tool call is denied-and-continues (never an
+// interactive stall); denials are logged per arm for symmetry (see report()).
+const PERMISSION_MODE = 'acceptEdits';
+const ALLOWED_TOOLS = [
+  'Read',
+  'Grep',
+  'Glob',
+  'Edit',
+  'Write',
+  'MultiEdit',
+  // read-only inspection + search — the blast metric's measured behavior
+  'Bash(grep:*)',
+  'Bash(rg:*)',
+  'Bash(git grep:*)',
+  'Bash(git diff:*)',
+  'Bash(git log:*)',
+  'Bash(git status:*)',
+  'Bash(cat:*)',
+  'Bash(head:*)',
+  'Bash(tail:*)',
+  'Bash(ls:*)',
+  'Bash(find:*)',
+  'Bash(sed:*)',
+  'Bash(awk:*)',
+  'Bash(wc:*)',
+  'Bash(pwd:*)',
+  'Bash(echo:*)',
+  // the fixture's test runner + typecheck — the verify metric's measured behavior
+  'Bash(npx vitest:*)',
+  'Bash(vitest:*)',
+  'Bash(npm test:*)',
+  'Bash(npm run test:*)',
+  'Bash(npm t:*)',
+  'Bash(node --test:*)',
+  'Bash(node --check:*)',
+  'Bash(npx tsc:*)',
+  'Bash(tsc:*)',
+  'Bash(pnpm test:*)',
+  'Bash(yarn test:*)',
+];
 
 const KIT = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.resolve(KIT, '..', '..', '..');
@@ -118,8 +165,27 @@ function seededOrder(labels, seed) {
   return a;
 }
 
+// One-time: install the verify fixture's devDeps (vitest) into a cache, so a
+// trial's `npx vitest run <path>` resolves LOCALLY and runs offline rather than
+// stalling on a network fetch. Symlinked into each verify trial dir.
+const VERIFY_NM_CACHE = path.join(OUT_ROOT, 'verify-nm');
+function ensureVerifyDeps() {
+  const nm = path.join(VERIFY_NM_CACHE, 'node_modules');
+  if (fs.existsSync(path.join(nm, 'vitest'))) return nm;
+  fs.mkdirSync(VERIFY_NM_CACHE, { recursive: true });
+  fs.copyFileSync(
+    path.join(KIT, 'fixtures', 'verify', 'package.json'),
+    path.join(VERIFY_NM_CACHE, 'package.json'),
+  );
+  execFileSync('npm', ['install', '--no-audit', '--no-fund', '--silent'], {
+    cwd: VERIFY_NM_CACHE,
+    stdio: 'ignore',
+  });
+  return nm;
+}
+
 // ---- materialization -----------------------------------------------------
-function materialize(fixtureName, dest, shimBin) {
+function materialize(fixtureName, dest, shimBin, provision) {
   const src = path.join(KIT, 'fixtures', fixtureName);
   fs.cpSync(src, dest, { recursive: true });
   const env = { ...process.env, PATH: `${shimBin}:${process.env.PATH}` };
@@ -134,6 +200,10 @@ function materialize(fixtureName, dest, shimBin) {
   );
   const r = lien(['index'], dest, env);
   if (r.status !== 0) throw new Error(`index failed in ${dest}: ${r.stderr}`);
+  // Symlink deps AFTER indexing so the index never walks node_modules.
+  if (provision && fixtureName === 'verify') {
+    fs.symlinkSync(ensureVerifyDeps(), path.join(dest, 'node_modules'), 'dir');
+  }
   return env;
 }
 
@@ -146,7 +216,7 @@ function assert(cond, msg) {
 function checkBlast(tmp, shimBin) {
   console.log('[check] blast fixture');
   const dest = path.join(tmp, 'blast');
-  const env = materialize('blast', dest, shimBin);
+  const env = materialize('blast', dest, shimBin, false);
   const before = lien(
     ['api-delta', '--file', 'src/pricing/discount.ts', '--format', 'json'],
     dest,
@@ -182,7 +252,7 @@ function checkBlast(tmp, shimBin) {
 function checkVerify(tmp, shimBin) {
   console.log('[check] verify fixture');
   const dest = path.join(tmp, 'verify');
-  const env = materialize('verify', dest, shimBin);
+  const env = materialize('verify', dest, shimBin, false);
   const sid = 'checkverify01';
   const note = lien(
     ['verify-tests', 'note-edit', '--session', sid, '--file', 'src/order-status.ts'],
@@ -257,12 +327,13 @@ function claudeArgs(prompt, sessionId, settingsFile, emptyMcp) {
     '--mcp-config',
     emptyMcp,
     '--permission-mode',
-    'bypassPermissions',
-    '--allowedTools',
-    ALLOWED_TOOLS,
+    PERMISSION_MODE,
     '--output-format',
     'stream-json',
     '--verbose',
+    // variadic, kept LAST so it can't consume a following flag
+    '--allowedTools',
+    ...ALLOWED_TOOLS,
   ];
 }
 
@@ -279,8 +350,11 @@ function runClaude(prompt, sessionId, cwd, settingsFile, cfg, extraEnv, shimBin)
     env,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
+    timeout: TRIAL_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
-  return res.stdout || '';
+  const timedOut = Boolean(res.error && res.error.code === 'ETIMEDOUT');
+  return { stdout: res.stdout || '', timedOut };
 }
 
 // ---- probe (mandatory precondition) --------------------------------------
@@ -295,7 +369,7 @@ function cmdProbe() {
   const settingsFile = path.join(tmp, 'probe-settings.json');
   fs.writeFileSync(settingsFile, JSON.stringify({ hooks: {} }));
   const prompt = fs.readFileSync(path.join(KIT, 'prompts', 'probe.txt'), 'utf8');
-  const out = runClaude(prompt, randomUUID(), cwd, settingsFile, cfg, {}, shimBin);
+  const { stdout: out } = runClaude(prompt, randomUUID(), cwd, settingsFile, cfg, {}, shimBin);
   fs.mkdirSync(OUT_ROOT, { recursive: true });
   fs.writeFileSync(path.join(OUT_ROOT, 'probe.jsonl'), out);
   const hits = contaminationScan(out);
@@ -333,38 +407,52 @@ function blastFired(dest, sid) {
 function runTrial(expName, arm, idx, tmp, shimBin, cfg) {
   const exp = EXPERIMENTS[expName];
   const dest = path.join(tmp, `${expName}-${arm}-${idx}`);
-  const env = materialize(exp.fixture, dest, shimBin);
+  const env = materialize(exp.fixture, dest, shimBin, true);
   const settingsFile = path.join(dest, '.ab-settings.json');
   fs.writeFileSync(settingsFile, JSON.stringify(exp.settings()));
   const sid = randomUUID();
   const task = fs.readFileSync(path.join(KIT, exp.task), 'utf8');
   const armEnv = { ...exp.baseEnv, ...exp.armEnv[arm] };
-  const transcript = runClaude(task, sid, dest, settingsFile, cfg, armEnv, shimBin);
+  const { stdout: transcript, timedOut } = runClaude(
+    task,
+    sid,
+    dest,
+    settingsFile,
+    cfg,
+    armEnv,
+    shimBin,
+  );
   const parsed = parseTranscript(transcript);
-  const result = scoreTrial(expName, arm, dest, sid, env, parsed, transcript);
+  const result = scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut });
   saveTrial(expName, arm, idx, transcript, result);
   fs.rmSync(dest, { recursive: true, force: true });
   return result;
 }
 
-function scoreTrial(expName, arm, dest, sid, env, parsed, transcript) {
+function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut }) {
   const contamination = arm === 'off' ? contaminationScan(transcript) : [];
+  const denials = collectDenials(transcript);
   if (expName === 'blast') {
     const m = blastMetric(parsed.toolUses, parsed.finalText);
+    const fired = arm === 'off' ? true : blastFired(dest, sid);
     return {
       hit: m.hit,
       reasons: m.reasons,
       generic: blastGenericSentiment(parsed.finalText, m.hit),
-      valid: arm === 'off' ? true : blastFired(dest, sid),
+      valid: !timedOut && fired,
+      timedOut,
       contamination,
+      denials,
     };
   }
   const ran = verifyRanOracle(dest, sid, env);
   return {
     hit: ran,
     reasons: verifyTranscriptRanTest(parsed.toolUses).reasons,
-    valid: true,
+    valid: !timedOut,
+    timedOut,
     contamination,
+    denials,
   };
 }
 
@@ -395,8 +483,34 @@ function cmdRun(expName) {
     console.log(`[run] ${expName} ${arm} #${i}`);
     results[arm].push(runTrial(expName, arm, i, tmp, shimBin, cfg));
   }
+  redrawInvalids(expName, results, tmp, shimBin, cfg);
   fs.rmSync(tmp, { recursive: true, force: true });
   report(expName, results);
+}
+
+// §7: re-draw invalid trials (with fresh session ids) until each arm has
+// N_PER_ARM VALID trials, aborting if an arm exceeds the 20% invalid cap.
+function redrawInvalids(expName, results, tmp, shimBin, cfg) {
+  const cap = Math.ceil(0.2 * N_PER_ARM);
+  for (const arm of ['on', 'off']) {
+    let invalid = results[arm].filter(r => !r.valid).length;
+    let extra = 0;
+    while (results[arm].filter(r => r.valid).length < N_PER_ARM) {
+      if (invalid > cap) {
+        throw new Error(
+          `ABORT: ${expName} ${arm} exceeded invalid cap (${invalid} > ${cap}) — instrument failure, no result claimed`,
+        );
+      }
+      const id = `${arm}-redraw-${extra++}`;
+      console.log(`[redraw] ${expName} ${id}`);
+      const r = runTrial(expName, arm, id, tmp, shimBin, cfg);
+      results[arm].push(r);
+      if (!r.valid) invalid++;
+    }
+    if (invalid > cap) {
+      throw new Error(`ABORT: ${expName} ${arm} exceeded invalid cap (${invalid} > ${cap})`);
+    }
+  }
 }
 
 // ---- reporting -----------------------------------------------------------
@@ -409,6 +523,13 @@ function tally(rows) {
   };
 }
 
+function denialSummary(rows) {
+  const all = rows.flatMap(r => r.denials || []);
+  const byTool = {};
+  for (const d of all) byTool[d.tool] = (byTool[d.tool] || 0) + 1;
+  return { total: all.length, byTool };
+}
+
 function report(expName, results) {
   const on = tally(results.on);
   const off = tally(results.off);
@@ -417,10 +538,12 @@ function report(expName, results) {
   const separated = p < 0.05 && on.hits / Math.max(on.n, 1) > off.hits / Math.max(off.n, 1);
   const summary = {
     experiment: expName,
+    permissionMode: PERMISSION_MODE,
     on: `${on.hits}/${on.n}`,
     off: `${off.hits}/${off.n}`,
     invalid: { on: on.invalid, off: off.invalid },
     contaminationLeaks: leaks,
+    denials: { on: denialSummary(results.on), off: denialSummary(results.off) },
     fisherOneSidedP: Number(p.toFixed(4)),
     primarySeparated: separated,
     launchClaimPermitted: separated,
@@ -463,17 +586,39 @@ function fisherOneSided(a, n1, c, n2) {
   return Math.min(1, p);
 }
 
+// ---- smoke (scoped-mode viability, uncounted) ----------------------------
+// Runs one real tool-using ON trial per experiment under the exact scoped
+// permission config, so we can confirm trials COMPLETE (edits auto-accepted,
+// search + test-run allowed, no fatal denial of a measured behavior) before
+// spending on the counted arms. Not part of the frozen sample.
+function cmdSmoke() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nudge-ab-smoke-'));
+  const shimBin = makeLienShim(tmp);
+  const cfg = isolatedConfig(tmp);
+  for (const expName of ['blast', 'verify']) {
+    const r = runTrial(expName, 'on', 'smoke', tmp, shimBin, cfg);
+    console.log(
+      `[smoke] ${expName} on: hit=${r.hit} valid=${r.valid} timedOut=${r.timedOut} ` +
+        `denials=${r.denials.length} reasons=${JSON.stringify(r.reasons)}`,
+    );
+    if (r.denials.length) console.log(`         denied: ${JSON.stringify(r.denials)}`);
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+  console.log('SMOKE done — inspect validity/denials above before the counted run.');
+}
+
 // ---- entry ---------------------------------------------------------------
 function main() {
   const [, , cmd, ...rest] = process.argv;
   if (cmd === 'check') return cmdCheck();
   if (cmd === 'probe') return cmdProbe();
+  if (cmd === 'smoke') return cmdSmoke();
   if (cmd === 'run') {
     const exp = rest[0];
     if (!exp) throw new Error('usage: run.mjs run <blast|verify>');
     return cmdRun(exp);
   }
-  console.log('usage: run.mjs <check|probe|run <blast|verify>>');
+  console.log('usage: run.mjs <check|probe|smoke|run <blast|verify>>');
   process.exit(cmd ? 1 : 0);
 }
 main();

--- a/scripts/experiments/nudge-ab-v2/run.mjs
+++ b/scripts/experiments/nudge-ab-v2/run.mjs
@@ -27,6 +27,7 @@ import {
   contaminationScan,
   collectDenials,
   looksLoggedOut,
+  editedTarget,
 } from './detect.mjs';
 
 // ---- FROZEN CONFIG -------------------------------------------------------
@@ -498,13 +499,18 @@ function scoreTrial({ expName, arm, dest, sid, env, parsed, transcript, timedOut
       denials,
     };
   }
+  // Verify: an empty `verify-tests report` only means "test ran" if the target
+  // was actually edited — otherwise a no-op/logged-out trial reads as a false
+  // positive. Require the edit for validity.
+  const edited = editedTarget(parsed.toolUses, EXPERIMENTS.verify.target);
   const ran = verifyRanOracle(dest, sid, env);
   return {
     hit: ran,
     reasons: verifyTranscriptRanTest(parsed.toolUses).reasons,
-    valid: usable,
+    valid: usable && edited,
     timedOut,
     loggedOut,
+    edited,
     contamination,
     denials,
   };


### PR DESCRIPTION
## Summary

A **frozen pre-registration + runnable instrument** for a second-generation A/B
re-test of two Lien nudges that the first-generation experiments could only measure
as nulls:

- the **blast-radius warning** (`plugins/claude/hooks/api-delta-write.sh`, PR #841), and
- the **did-you-run-the-tests advisory** (the Stop hook `recap-stop.sh` / `lien recap`,
  successor to PR #843's `test-verify-stop.sh`).

The protocol doc IS the pre-registration and is complete enough that running it later
requires zero further design decisions. **This PR designs and freezes the experiment
and ships the instrument; it does NOT run the arms.** The arms cost real API budget
(~$5–12, see below) and are gated on owner approval of that spend.

## The problem this design defeats: task-forcing

v1 ([blast-radius-nudge-ab.md](../blob/main/docs/development/blast-radius-nudge-ab.md),
[test-verification-nudge-ab.md](../blob/main/docs/development/test-verification-nudge-ab.md))
and the context-neutral re-runs (PR #844) both returned an honest **8/8 vs 8/8 null**.
The diagnosis was never "the nudge does nothing" — it was that the frozen scenarios were
**task-forced**: the scenario made the nudged behavior derivable from the task itself, so
a competent model did it with or without the nudge, leaving no headroom.

- Blast: all call sites were in-file and the task ("thread `opts` through") *required*
  updating them — checking callers *was* the task.
- Verify: the associated tests were **named in the prompt**, and "run the tests you just
  touched" is a current model's near-default.

v2 removes task-forcing on both axes:

1. **Out-of-file dependents** — the changed symbol's callers live in other directories
   (`src/checkout`, `src/reports`); nothing in the edited file hints at them.
2. **A test not named after its source** — `test/regression-suite.test.ts` is linked to
   `src/order-status.ts` only by `import`, so "which test covers this?" has no lexical
   answer.
3. **Plain feature prompts** — never mention callers, tests, risk, coverage, or Lien.

The primary metrics are correspondingly sharpened to **observable action**, not
sentiment: the blast metric counts a concrete search-for / open-of / naming-of a
specific out-of-directory dependent, and explicitly does **not** count the generic "other
callers may need updating" hedging that was v1's 7/8 ceiling.

## Design highlights

- **Real kill switches, one signal per experiment.** Arms differ only by the nudge's real
  env switch (`LIEN_BLAST_HOOK` / `LIEN_RECAP`); every other nudge is held off in both arms.
- **Hermetic clean context (all three contamination layers controlled).** Isolated
  `CLAUDE_CONFIG_DIR` with no `enabledPlugins` and no user `rules/` (kills the ambient
  user-level `lien@lien` plugin's hooks *and* MCP instructions — the confound PR #844
  found), plus `--strict-mcp-config --mcp-config {}`, plus explicit hooks wired by
  absolute path to this checkout. macOS auth is in the Keychain, so the isolated config
  dir keeps auth. A **mandatory contamination probe** (baked into the runner as a hard
  precondition — the runner refuses to start an arm without a `.probe-passed` marker)
  verifies the context is clean before any arm.
- **`silent-note-edit.sh` scaffolding** holds FEATURE-2 ledger population constant across
  the verify arms without leaking the test name, so the *only* variable is the Stop
  advisory (isolates PR #843's Stop hook rather than bundling it with the edit-time
  reminder). Rationale + fidelity caveat in the protocol doc §4a/§8.
- **N = 10/arm** (deviates from v1's 8, justified: v2 is detection-oriented and needs
  power to survive a one-trial flip; matches the repo's `--calibrate 10` convention),
  seeded interleave, one-sided **Fisher exact p < 0.05** as the frozen separation rule.
  Launch rule stands: **no lift claim unless the primary separates.** Abort criteria,
  honesty rules (nulls reported as nulls, no post-hoc metric changes), and validity
  caveats are all frozen in the doc.

## Dogfooding evidence (this PR)

Per the dogfood-before-shipping mandate, the instrument was exercised end-to-end at
**zero LLM cost** against the frozen fixtures (`node scripts/experiments/nudge-ab-v2/run.mjs check`):

```
[check] blast fixture
  blast nudge: ⚠ lien: exported signature changed — applyDiscount (2 dependents, 2 untested, risk medium). Run get_dependents before relying on callers.
  ok: blast hook rendered the enriched warning
[check] verify fixture
  note-edit: Lien: you changed src/order-status.ts — associated tests: test/regression-suite.test.ts. Run them before completing.
  ok: associates the non-lexically-named test by import
  ok: recap/report raises the unrun associated test
  ok: report goes silent after a covering test run
INSTRUMENT CHECK PASSED
```

The frozen Fisher decision rule was also verified: 9/10-vs-2/10 → p=0.003 (separation),
8/10-vs-3/10 → p=0.035 (separation), 10/10-vs-9/10 → p=0.5 (a null flicker, correctly not
significant), 8/8-vs-8/8 → p=1.0. The `claude -p` arms themselves are **not** run here
(gated on approval); the headless-hook plumbing (PostToolUse `additionalContext` +
Stop `block` re-prompt firing in `claude -p`) is confirmed against the Claude Code docs
for the installed CLI and validated by the contamination/plumbing probe at run time.

## Cost of the run (for approval)

41 headless `claude -p` invocations (40 agentic arm trials + 1 probe) on `--model
sonnet`, ≈ $0.10–0.30/trial ⇒ **≈ $5–12 total**, comparable to one harness
`--calibrate 10` sweep. Zero-LLM instrument checks and ledger oracles are free.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `node packages/cli/dist/index.js delta` — exit 0, no new complexity crossings
- [x] `node .github/scripts/docs-truth.mjs` — 87 files checked, no violations
- [x] Dogfood: `run.mjs check` passes against the frozen fixtures (output above)

## Files

- `docs/development/nudge-ab-v2-protocol.md` — the frozen pre-registration.
- `scripts/experiments/nudge-ab-v2/` — runner (`run.mjs`), detection (`detect.mjs`),
  fixtures, prompts, scaffolding hook, kit README.

Context/lineage: PR #841 (blast hook), PR #843 (test-verification), PR #844
(context-neutral re-runs that surfaced the contamination layers). Results, once the run
is approved and executed, will be appended as dated sections to the two v1 A/B docs.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR adds a frozen A/B v2 experiment instrument (runner, detector, fixtures, protocol docs) under `scripts/experiments/nudge-ab-v2/` with no production API changes. The code is generally careful: probe gating is persisted-marker-based, validity gating is symmetric across arms, Fisher p-values preserve small values, and contamination scanning uses word boundaries. The main residual issue is in the offline re-scorer, where a corrupt archived per-trial JSON can cause a failed/timed-out trial to be rescored as usable.
>
> - Added frozen pre-registration docs and v2 results appendices for blast-radius and test-verification A/Bs.
> - Added runnable experiment kit: run.mjs orchestrator, detect.mjs deterministic metrics, rescore.mjs audit tool, fixtures, prompts, and silent scaffolding hook.
> - Implemented symmetric validity gating and contamination probe for the b' context mechanism.

⚠️ The stale-duplicate pass did not finish — it hit the token budget limit. That pass's findings are partial; the main review's findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bf8d4f2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 1/1 comments posted · 775K/733K tokens
<!-- /lien:attestation -->
---

## RESULT (run 2026-07-26): both nudges separate

The task-decoupled protocol defeats the v1 task-forcing nulls.

| Experiment | Signal (nudge on) | Control (nudge off) | Fisher one-sided p | Separated? |
|---|---|---|---|---|
| **blast** (concrete beyond-file caller action) | **10/10** | **3/10** | **0.0015** | yes |
| **verify** (ran the non-lexically-named test) | **10/10** | **0/10** | **~5.4e-6** | yes |

40/40 valid, 0 logged-out, 0 timed-out, **0 tool denials** (symmetric), **0 real
contamination** (word-boundary corrected; the raw scan's 20/20 OFF "leaks" were the
substring `lien` inside the ambient skill name `…client…` — symmetric, outside the
metric). Per the frozen p<0.05 rule, the launch rule now permits lift claims for both.

**Auth/context mechanism actually used = b'** (protocol §3): the **default** `CLAUDE_CONFIG_DIR`
(macOS Keychain auth) with the ambient `lien@lien` plugin disabled **for the spawned
process only** via a `--settings enabledPlugins:{lien@lien:false}` override (saved
`~/.claude/settings.json` byte-identical before/after) + `--strict-mcp-config` + this
checkout's explicit hooks, scoped `acceptEdits` + allowlist, fixture sandboxes with no
CLAUDE.md. Rejected en route: (a) isolated config + account-seed (OAuth token is in the
Keychain, not `.claude.json` → "not logged in"); (b'') default + strict-mcp alone
(ambient `annotate-read` hook still fires and names the dependents). Full write-ups
appended to both v1 A/B docs; raw artifacts under `.wip/nudge-ab-v2/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a frozen protocol and supporting write-up for the task-decoupled Nudge A/B v2 experiments.
  * Documented experiment setup, isolation controls, validity caveats, execution steps, and expected artifacts.

* **Tests**
  * Added deterministic transcript scoring, contamination checks, test-run verification, and invalid-trial handling.
  * Added isolated fixtures and automated trial execution for blast-radius and test-verification scenarios.

* **Chores**
  * Added a command-line experiment runner with checks, probes, smoke runs, gated experiments, and archived results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

## Transparency note — post-review integrity audit + corrected-pipeline reproduction (HEAD 9ff960fe)

A review raised an OFF-arm validity asymmetry (control no-op would score as a MISS, not INVALID). Audited and fixed. **The numbers did not move.**

**Symmetric re-score (both arms gated on "did the edit change applyDiscount's signature?", via the same api-delta oracle):**

```
blast: ON 10/10 completed the task edit (0 no-ops) | OFF 10/10 completed the task edit (0 no-ops)
       → every OFF miss was a genuine completion that didn't take the caller-action, NOT a no-op.
```

**Offline corrected-pipeline re-score over the archived transcripts (`rescore.mjs`, zero-LLM, no trial re-runs) vs the published summaries:**

```
=== blast ===
  published summary : on=10/10  off=3/10  p=0.0015
  corrected re-score: on=10/10  off=3/10  p=0.001548     counts reproduce EXACTLY: YES
=== verify ===
  published summary : on=10/10  off=0/10  p=0            (p=0 was a toFixed(4) bug)
  corrected re-score: on=10/10  off=0/10  p=0.000005413  counts reproduce EXACTLY: YES
  verify transcript cross-check agrees with ledger hit: YES (all 20)
```

Counts reproduce exactly; the corrected Fisher p is precise (blast 0.001548 = the rounded 0.0015; verify 5.413e-6, recovering the value `toFixed(4)` had flattened to 0). **The launch-rule verdict stands: both nudges separate at p<0.05.** All fixes are in the runner (symmetric `blastEditCompleted`, `res.error`/`res.status` surfaced, env threaded, precise p, smoke artifacts separated, guards, regex) — see per-thread replies.
### Review round 2 — two archive-based confirmations (HEAD 110c9efd)

Two findings needed the archives to decide (no re-runs). Both confirm the numbers stand.

**§6a — did all 10 ON blast trials fire the blast note-shown event?** YES (all 10). Run-time ON validity already required `blastFired`(nudgeShown) — all 10 saved `valid=true`/`usable=true`; and an offline api-delta replay shows all 10 ON edits were signature-changed (the hook's precondition, `LIEN_BLAST_HOOK` on). The code now also gates ON validity on `nudgeShown` per §6a.

```
on/0..9: savedValid=true usable=true runtimeNudgeFired=true sigChangedReplay=true  (×10)  => ALL 10 fired: YES
```

**Verify CLI-status hole — could any counted hit be a failed-CLI empty-stdout false positive?** No. Every ON verify hit is backed by a genuine `npx vitest run test/regression-suite.test.ts` command in the transcript (cross-check 20/20), and OFF hits=0.

```
verify on/0..9: hit=true  crosscheck=true  cmd="npx vitest run test/regression-suite.test.ts …"  (×10)
verify off:     0 hits    (no false positive possible)
```

`verifyRanOracle` now returns `{cliOk, ran}` (a failed CLI ⇒ invalid, never a hit); the re-scorer still reproduces both counts exactly.