### PR TITLE
refactor(parser): consolidate import-matcher call sites behind one guarded primitive

### DIFF
--- a/.changeset/import-matcher-consolidation.md
+++ b/.changeset/import-matcher-consolidation.md
@@ -31,11 +31,26 @@ PR body's golden-proof evidence).
 Also fixes #887: a multi-segment bare `require`/import specifier (e.g. Ruby's
 `require 'rack/protection'`) fanned out to every file nested under its own
 directory (`rack-protection/lib/rack/protection/*`) instead of matching only
-that directory's own entry point. `matchesAtBoundaryPrecise`'s "must reach
-the end of the compared string" anchor previously only applied to
-slash-free (single-segment) patterns like `sinatra`; it now applies to every
-bare, non-relative pattern regardless of how many segments it has. The
-existing single-segment guards (#868/#883), the Rust source-directory-prefix
-convention, and genuine multi-segment-to-multi-segment matches are
-unaffected — see the new `matchesFile` unit tests and the sinatra-clone
-association-level dogfood in the PR body.
+that directory's own entry point. The fix is language-aware, not a blanket
+change to `matchesFile`: Ruby's bare multi-segment `require` names exactly
+one file, but Go's `import "pkg/sub"` (normalized to the bare `pkg/sub` by
+#877's module-prefix stripping) names a *package* — every file in that
+directory is a legitimate member, so the same "must reach the end of the
+compared string" tightening would have wrongly rejected real Go dependents
+if applied unconditionally (an earlier revision of this fix did exactly that
+and was caught in review — see the PR body's Correction section for the
+proof and the fix).
+
+`matchesFile` gains an optional third parameter,
+`requireExactTailForMultiSegment` (default `false`, preserving every
+existing caller's behavior unchanged), and a new `LanguageDefinition`
+flag — `singleFileImports` (set on Ruby only) — drives it via the new
+`hasSingleFileImportSemantics` helper. `importMatchesTarget` derives the
+flag from the importer's language for the five migrated call sites;
+`findDependentChunks`'s fuzzy-match loop (in both `@liendev/parser` and the
+CLI) applies the same derivation per chunk, since its import-index bucket
+can span multiple importer files sharing one normalized specifier. Verified
+against both a real sinatra clone (820 spurious dependent edges removed,
+gem/library entry points unchanged) and a real gin clone (all 67 dependent
+edges preserved, including the `internal/fs` package-directory case) — see
+the PR body.

--- a/.changeset/import-matcher-consolidation.md
+++ b/.changeset/import-matcher-consolidation.md
@@ -1,0 +1,29 @@
+---
+'@liendev/parser': patch
+---
+
+Consolidate the five match-side reverse-dependency call paths
+(`findTestAssociationsFromChunks`, `chunkImportsFrom`,
+`collectImportedSymbolsFromSource`, `fileImportsSymbolFromAny`,
+`findTestAssociations`) behind one guarded primitive, `importMatchesTarget`,
+in `packages/parser/src/utils/path-matching.ts` (#886).
+
+Each of the five used to open-code
+`!isUnresolvableWholeModuleImport(imp, importerFile) && matchesFile(normalize(imp), target)`
+independently — the exact two-line idiom that was forgotten at a new call
+site three times across #885's review rounds (the #884 whole-module guard
+missing from a freshly-added site). `importMatchesTarget(importSpecifier,
+importerFile, normalizedTarget, normalize)` couples the guard to `matchesFile`
+so a match-side caller can no longer invoke one without the other; the two
+build-side sites with no target in scope (`buildImportIndex`,
+`indexImportEntry`/`addChunkToImportIndex`) still call
+`isUnresolvableWholeModuleImport` directly, and `findDependentChunks`'s fuzzy
+loop and `buildReExportGraph` are deliberately left on raw `matchesFile` (see
+the #886 design comment for why those four don't fit the primitive).
+
+No exported signature changes to any of the five migrated functions or to
+`matchesFile`/`isUnresolvableWholeModuleImport` themselves — `importMatchesTarget`
+is a new, additive export. Behavior-preserving by construction: verified via a
+byte-identical before/after diff of `get_dependents`/test-association output
+across this repo and the multi-language `lien-review-testbed` fixture (see the
+PR body's golden-proof evidence).

--- a/.changeset/import-matcher-consolidation.md
+++ b/.changeset/import-matcher-consolidation.md
@@ -27,3 +27,15 @@ is a new, additive export. Behavior-preserving by construction: verified via a
 byte-identical before/after diff of `get_dependents`/test-association output
 across this repo and the multi-language `lien-review-testbed` fixture (see the
 PR body's golden-proof evidence).
+
+Also fixes #887: a multi-segment bare `require`/import specifier (e.g. Ruby's
+`require 'rack/protection'`) fanned out to every file nested under its own
+directory (`rack-protection/lib/rack/protection/*`) instead of matching only
+that directory's own entry point. `matchesAtBoundaryPrecise`'s "must reach
+the end of the compared string" anchor previously only applied to
+slash-free (single-segment) patterns like `sinatra`; it now applies to every
+bare, non-relative pattern regardless of how many segments it has. The
+existing single-segment guards (#868/#883), the Rust source-directory-prefix
+convention, and genuine multi-segment-to-multi-segment matches are
+unaffected — see the new `matchesFile` unit tests and the sinatra-clone
+association-level dogfood in the PR body.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -110,6 +110,80 @@ describe('findDependents', () => {
     });
   });
 
+  describe('#887 language-aware directory-vs-file matching', () => {
+    it('Ruby: a bare multi-segment require does not credit a sibling file under the same directory', async () => {
+      // rack-protection/lib/rack/protection/base.rb bare-requires
+      // 'rack/protection' -- that must resolve to the umbrella
+      // rack-protection/lib/rack/protection.rb, not to an unrelated sibling
+      // module that merely shares the directory (#887).
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('rack-protection/lib/rack/protection/base.rb', {
+          imports: ['rack/protection'],
+        }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'rack-protection/lib/rack/protection/xss_header.rb',
+        mockLog,
+      );
+
+      expect(result.dependents.map(d => d.filepath)).not.toContain(
+        'rack-protection/lib/rack/protection/base.rb',
+      );
+    });
+
+    it('Ruby: the umbrella entry point itself is still a legitimate match', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('rack-protection/lib/rack/protection/base.rb', {
+          imports: ['rack/protection'],
+        }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'rack-protection/lib/rack/protection.rb',
+        mockLog,
+      );
+
+      expect(result.dependents.map(d => d.filepath)).toContain(
+        'rack-protection/lib/rack/protection/base.rb',
+      );
+    });
+
+    it('Go: a package-directory import still credits every file in the directory as a dependent (the caught regression)', async () => {
+      // #877 normalizes `import "mymodule/internal/fs"` down to the bare
+      // `internal/fs`. In Go that names a PACKAGE, so every .go file inside
+      // the directory (e.g. fs.go) is a legitimate dependent -- an earlier
+      // revision of the #887 fix broke this (67 -> 9 dependent edges on a
+      // real gin clone) by applying Ruby's stricter anchor unconditionally.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('render/html.go', { imports: ['internal/fs'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'internal/fs/fs.go', mockLog);
+
+      expect(result.dependents.map(d => d.filepath)).toContain('render/html.go');
+    });
+
+    it('applies the language check per chunk, not once per shared import key', async () => {
+      // Two chunks share the identical normalized import key ('pkg/sub'):
+      // one Go, one Ruby. The fuzzy-match loop iterates the index by key, so
+      // it must not decide "match or no match" once per key -- the Go chunk
+      // is a real dependent, the Ruby chunk is not.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('render/html.go', { imports: ['pkg/sub'] }),
+        createChunk('lib/pkg/consumer.rb', { imports: ['pkg/sub'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'pkg/sub/child.go', mockLog);
+      const filepaths = result.dependents.map(d => d.filepath);
+
+      expect(filepaths).toContain('render/html.go');
+      expect(filepaths).not.toContain('lib/pkg/consumer.rb');
+    });
+  });
+
   describe('re-export chains / barrel files', () => {
     it('should find transitive dependents through barrel file re-exports', async () => {
       // target.ts exports Foo

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -8,6 +8,7 @@ import {
   isTestFile,
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
+  hasSingleFileImportSemantics,
   COMPLEXITY_THRESHOLDS,
 } from '@liendev/parser';
 
@@ -812,6 +813,42 @@ function hasTestImporter(filepath: string, ctx: ScanContext): boolean {
 }
 
 /**
+ * Add the chunks keyed by `normalizedImport` to the dependent set via
+ * `addChunk`, applying the #887 per-chunk language check when the match is
+ * ambiguous.
+ *
+ * A multi-segment specifier that matches `normalizedTarget` ONLY through the
+ * permissive (package-directory) path -- not the strict (single-file) path
+ * -- is #887's ambiguous shape: a Go-shaped importer legitimately means it
+ * (every file in the package directory is a member); a Ruby-shaped importer
+ * doesn't (a sibling file under the same directory is a separate, unrelated
+ * module). `matchesFile` can't disambiguate that without both a target and
+ * an importer's language in scope at once, and this function's `chunks`
+ * bucket can span multiple importer files (and in principle languages)
+ * sharing the same normalized import key, so the language check runs per
+ * chunk rather than once per key -- see `hasSingleFileImportSemantics`'s doc
+ * comment. `importMatchesTarget` (used by every match-side call site that
+ * *does* have a single importer file) makes the same derivation once,
+ * up front.
+ */
+function addFuzzyMatchChunks(
+  normalizedImport: string,
+  normalizedTarget: string,
+  chunks: SearchResult[],
+  addChunk: (chunk: SearchResult) => void,
+): void {
+  if (!matchesFile(normalizedImport, normalizedTarget)) return;
+
+  const ambiguous =
+    normalizedImport.includes('/') && !matchesFile(normalizedImport, normalizedTarget, true);
+
+  for (const chunk of chunks) {
+    if (ambiguous && hasSingleFileImportSemantics(chunk.metadata.file)) continue;
+    addChunk(chunk);
+  }
+}
+
+/**
  * Find dependent chunks using direct lookup and fuzzy matching.
  */
 function findDependentChunks(
@@ -838,10 +875,8 @@ function findDependentChunks(
 
   // Fuzzy match for relative imports and path variations
   for (const [normalizedImport, chunks] of importIndex.entries()) {
-    if (normalizedImport !== normalizedTarget && matchesFile(normalizedImport, normalizedTarget)) {
-      for (const chunk of chunks) {
-        addChunk(chunk);
-      }
+    if (normalizedImport !== normalizedTarget) {
+      addFuzzyMatchChunks(normalizedImport, normalizedTarget, chunks, addChunk);
     }
   }
 

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -7,6 +7,7 @@ import {
   getCanonicalPath,
   isTestFile,
   isUnresolvableWholeModuleImport,
+  importMatchesTarget,
   COMPLEXITY_THRESHOLDS,
 } from '@liendev/parser';
 
@@ -152,10 +153,8 @@ function buildReExportGraph(
  * Check if any chunk in the file imports the target symbol from any of the
  * given paths (direct target or re-exporter paths).
  *
- * Skips bare whole-module imports (#884): for a `wholeModuleImports`
- * language (Swift), a bare import can only ever match a target through
- * basename coincidence, not a real per-file dependency — see
- * `isUnresolvableWholeModuleImport`'s doc comment.
+ * Uses `importMatchesTarget`, which applies the #884 whole-module guard
+ * before `matchesFile` — see its doc comment in path-matching.ts (#886).
  */
 function fileImportsSymbolFromAny(
   chunks: SearchResult[],
@@ -168,11 +167,11 @@ function fileImportsSymbolFromAny(
     if (!importedSymbols) return false;
 
     return Object.entries(importedSymbols).some(([importPath, symbols]) => {
-      if (isUnresolvableWholeModuleImport(importPath, chunk.metadata.file)) return false;
-      const normalizedImport = normalizePathCached(importPath);
-      const matchesAny = targetPaths.some(tp => matchesFile(normalizedImport, tp));
+      const pathMatches = targetPaths.some(tp =>
+        importMatchesTarget(importPath, chunk.metadata.file, tp, normalizePathCached),
+      );
       return (
-        matchesAny && (symbols.includes(targetSymbol) || symbols.some(s => s.startsWith('* as ')))
+        pathMatches && (symbols.includes(targetSymbol) || symbols.some(s => s.startsWith('* as ')))
       );
     });
   });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -4,10 +4,9 @@ import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import {
   normalizePath,
-  matchesFile,
   getCanonicalPath,
   isTestFile,
-  isUnresolvableWholeModuleImport,
+  importMatchesTarget,
   MAX_CHUNKS_PER_FILE,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
 } from '@liendev/parser';
@@ -233,13 +232,11 @@ export function createPathCache(workspaceRoot: string): {
  * Scans all indexed chunks to find test files that have import
  * statements matching the target files.
  *
- * Skips bare whole-module imports (#884): for a `wholeModuleImports`
- * language (Swift), a bare import can only ever match a target through
- * basename coincidence, not a real per-file association — see
- * `isUnresolvableWholeModuleImport`'s doc comment. This mirrors the same
- * guard in `@liendev/parser`'s `findTestAssociationsFromChunks`; this
- * function is `get_files_context`'s own separate implementation, so it
- * needs the identical treatment.
+ * Uses `importMatchesTarget`, which applies the #884 whole-module guard
+ * before `matchesFile` — see its doc comment in path-matching.ts (#886).
+ * This mirrors the same guard in `@liendev/parser`'s
+ * `findTestAssociationsFromChunks`; this function is `get_files_context`'s
+ * own separate implementation, so it needs the identical treatment.
  *
  * @param filepaths - Array of source file paths
  * @param allChunks - All chunks from the vector database
@@ -267,9 +264,7 @@ export function findTestAssociations(
       // Check if this test file imports the target
       const imports = chunk.metadata.imports || [];
       for (const imp of imports) {
-        if (isUnresolvableWholeModuleImport(imp, chunk.metadata.file)) continue;
-        const normalizedImport = normalize(imp);
-        if (matchesFile(normalizedImport, normalizedTarget)) {
+        if (importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize)) {
           testFiles.add(chunkFile);
           break;
         }

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -6,6 +6,7 @@ import {
   getAllLanguages,
   hasWholeModuleImports,
   hasEnclosingNamespaceAccess,
+  hasSingleFileImports,
 } from './registry.js';
 import type { SupportedLanguage } from './registry.js';
 
@@ -183,6 +184,28 @@ describe('Language Registry', () => {
     it('is independent of hasWholeModuleImports (C# is not a whole-module-import language)', () => {
       expect(hasWholeModuleImports('csharp')).toBe(false);
       expect(hasEnclosingNamespaceAccess('swift')).toBe(false);
+    });
+  });
+
+  describe('hasSingleFileImports', () => {
+    it('is true for Ruby (#887: a bare multi-segment require names one file, not a package directory)', () => {
+      expect(hasSingleFileImports('ruby')).toBe(true);
+    });
+
+    it('is false for every other registered language, notably Go (package-directory semantics)', () => {
+      expect(hasSingleFileImports('go')).toBe(false);
+      const others = getAllLanguages()
+        .map(d => d.id)
+        .filter(id => id !== 'ruby');
+      expect(others.length).toBeGreaterThan(0);
+      others.forEach(id => {
+        expect(hasSingleFileImports(id)).toBe(false);
+      });
+    });
+
+    it('is independent of hasWholeModuleImports/hasEnclosingNamespaceAccess', () => {
+      expect(hasWholeModuleImports('ruby')).toBe(false);
+      expect(hasEnclosingNamespaceAccess('ruby')).toBe(false);
     });
   });
 });

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -141,6 +141,18 @@ export function hasEnclosingNamespaceAccess(language: SupportedLanguage): boolea
 }
 
 /**
+ * True when `language`'s bare, potentially multi-segment import specifiers
+ * always name a single file rather than a package directory whose files are
+ * all implicitly members (see `LanguageDefinition.singleFileImports`, #887).
+ * Only Ruby sets this today; every other language (notably Go, whose
+ * `import "pkg/sub"` names a directory) leaves it unset and keeps the
+ * permissive package-directory matching `matchesFile` has always done.
+ */
+export function hasSingleFileImports(language: SupportedLanguage): boolean {
+  return getLanguage(language).singleFileImports === true;
+}
+
+/**
  * Get all registered language definitions.
  */
 export function getAllLanguages(): readonly LanguageDefinition[] {

--- a/packages/parser/src/ast/languages/ruby.ts
+++ b/packages/parser/src/ast/languages/ruby.ts
@@ -296,6 +296,13 @@ export const rubyDefinition: LanguageDefinition = {
   exportExtractor: new RubyExportExtractor(),
   importExtractor: new RubyImportExtractor(),
   symbolExtractor: new RubySymbolExtractor(),
+  // A bare, multi-segment `require` (e.g. `require 'rack/protection'`) loads
+  // exactly one file resolved via $LOAD_PATH -- a sibling file that happens
+  // to share the same directory (`rack/protection/base.rb`) is a distinct,
+  // unrelated module, not an implicit member of the required specifier
+  // (#887). See `LanguageDefinition.singleFileImports`'s doc comment for the
+  // contrast with Go's package-directory semantics.
+  singleFileImports: true,
 
   complexity: {
     // Structural control-flow branch points. NOTE: Ruby's logical operators

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -93,4 +93,34 @@ export interface LanguageDefinition {
    * `wholeModuleImports` or `isUnresolvableWholeModuleImport` (#875).
    */
   enclosingNamespaceAccess?: boolean;
+
+  /**
+   * True when a BARE (non-relative), potentially multi-segment import
+   * specifier in this language always names a single file, never a
+   * directory whose files are all implicitly members of the same unit
+   * (#887).
+   *
+   * Ruby sets this: `require 'rack/protection'` loads exactly one file
+   * (`rack/protection.rb`, resolved via `$LOAD_PATH`) — a sibling file like
+   * `rack/protection/base.rb` is a separate, unrelated module that merely
+   * shares a directory, not an implicit member of the `rack/protection`
+   * specifier. Go is the opposite and deliberately leaves this unset:
+   * `import "mymodule/internal/fs"` normalizes (after #877's module-prefix
+   * stripping) to the bare `internal/fs`, which names a PACKAGE — every
+   * `.go` file inside that directory is a member of the package, so
+   * `internal/fs` legitimately matches `internal/fs/fs.go`,
+   * `internal/fs/utils.go`, etc. Absent/false (the default for every
+   * language except Ruby) preserves that permissive package-directory
+   * matching. Every other currently-supported language is unaffected either
+   * way and leaves this unset too: TypeScript/JavaScript resolve specifiers
+   * to a concrete file before `matchesFile` ever runs, Python/PHP use their
+   * own dedicated matching strategies (`matchesPythonModule`/
+   * `matchesPHPNamespace`), and Rust's multi-segment module paths already
+   * name an exact file — see `matchesFile`'s
+   * `requireExactTailForMultiSegment` parameter for how this flag is
+   * consumed (only `importMatchesTarget` derives it from the importer's
+   * language; the two build-side sites and the two stay-raw `matchesFile`
+   * call sites don't have a specific target to disambiguate against).
+   */
+  singleFileImports?: boolean;
 }

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -520,6 +520,74 @@ describe('analyzeDependencies', () => {
       expect(result.dependents[0].filepath).toBe('tests/auth_test.rs');
     });
   });
+
+  describe('#887 language-aware directory-vs-file matching (findDependentChunks)', () => {
+    it('Ruby: a bare multi-segment require does not credit a sibling file under the same directory', () => {
+      // rack-protection/lib/rack/protection/base.rb bare-requires
+      // 'rack/protection' -- that must resolve to the umbrella
+      // rack-protection/lib/rack/protection.rb, not to an unrelated sibling
+      // module that merely shares the directory (#887).
+      const chunks: CodeChunk[] = [
+        createChunk('rack-protection/lib/rack/protection/base.rb', ['rack/protection']),
+      ];
+
+      const result = analyzeDependencies(
+        'rack-protection/lib/rack/protection/xss_header.rb',
+        chunks,
+        workspaceRoot,
+      );
+
+      expect(result.dependents.map(d => d.filepath)).not.toContain(
+        'rack-protection/lib/rack/protection/base.rb',
+      );
+    });
+
+    it('Ruby: the umbrella entry point itself is still a legitimate match', () => {
+      const chunks: CodeChunk[] = [
+        createChunk('rack-protection/lib/rack/protection/base.rb', ['rack/protection']),
+      ];
+
+      const result = analyzeDependencies(
+        'rack-protection/lib/rack/protection.rb',
+        chunks,
+        workspaceRoot,
+      );
+
+      expect(result.dependents.map(d => d.filepath)).toContain(
+        'rack-protection/lib/rack/protection/base.rb',
+      );
+    });
+
+    it('Go: a package-directory import still credits every file in the directory as a dependent (the caught regression)', () => {
+      // #877 normalizes `import "mymodule/internal/fs"` down to the bare
+      // `internal/fs`. In Go that names a PACKAGE, so every .go file inside
+      // the directory (e.g. fs.go) is a legitimate dependent -- an earlier
+      // revision of the #887 fix broke this (67 -> 9 dependent edges on a
+      // real gin clone) by applying Ruby's stricter anchor unconditionally.
+      const chunks: CodeChunk[] = [createChunk('render/html.go', ['internal/fs'])];
+
+      const result = analyzeDependencies('internal/fs/fs.go', chunks, workspaceRoot);
+
+      expect(result.dependents.map(d => d.filepath)).toContain('render/html.go');
+    });
+
+    it('applies the language check per chunk, not once per shared import key', () => {
+      // Two chunks share the identical normalized import key ('pkg/sub'):
+      // one Go, one Ruby. findDependentChunks's fuzzy loop iterates the
+      // index by key, so it must not decide "match or no match" once per
+      // key -- the Go chunk is a real dependent, the Ruby chunk is not.
+      const chunks: CodeChunk[] = [
+        createChunk('render/html.go', ['pkg/sub']),
+        createChunk('lib/pkg/consumer.rb', ['pkg/sub']),
+      ];
+
+      const result = analyzeDependencies('pkg/sub/child.go', chunks, workspaceRoot);
+      const filepaths = result.dependents.map(d => d.filepath);
+
+      expect(filepaths).toContain('render/html.go');
+      expect(filepaths).not.toContain('lib/pkg/consumer.rb');
+    });
+  });
 });
 
 // Direct unit coverage for the shared re-export intersection algorithm,

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -7,6 +7,7 @@ import {
   isTestFile,
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
+  hasSingleFileImportSemantics,
 } from './utils/path-matching.js';
 import { RISK_ORDER } from './insights/types.js';
 
@@ -120,6 +121,42 @@ function buildImportIndex(
 }
 
 /**
+ * Add the chunks keyed by `normalizedImport` to the dependent set via
+ * `addChunk`, applying the #887 per-chunk language check when the match is
+ * ambiguous.
+ *
+ * A multi-segment specifier that matches `normalizedTarget` ONLY through the
+ * permissive (package-directory) path -- not the strict (single-file) path
+ * -- is #887's ambiguous shape: a Go-shaped importer legitimately means it
+ * (every file in the package directory is a member); a Ruby-shaped importer
+ * doesn't (a sibling file under the same directory is a separate, unrelated
+ * module). `matchesFile` can't disambiguate that without both a target and
+ * an importer's language in scope at once, and this function's `chunks`
+ * bucket can span multiple importer files (and in principle languages)
+ * sharing the same normalized import key, so the language check runs per
+ * chunk rather than once per key -- see `hasSingleFileImportSemantics`'s doc
+ * comment. `importMatchesTarget` (used by every match-side call site that
+ * *does* have a single importer file) makes the same derivation once,
+ * up front.
+ */
+function addFuzzyMatchChunks(
+  normalizedImport: string,
+  normalizedTarget: string,
+  chunks: CodeChunk[],
+  addChunk: (chunk: CodeChunk) => void,
+): void {
+  if (!matchesFile(normalizedImport, normalizedTarget)) return;
+
+  const ambiguous =
+    normalizedImport.includes('/') && !matchesFile(normalizedImport, normalizedTarget, true);
+
+  for (const chunk of chunks) {
+    if (ambiguous && hasSingleFileImportSemantics(chunk.metadata.file)) continue;
+    addChunk(chunk);
+  }
+}
+
+/**
  * Finds all chunks that import the target file using index + fuzzy matching.
  *
  * @param normalizedTarget - The normalized path of the target file
@@ -153,10 +190,8 @@ function findDependentChunks(
   // Note: This is O(M) where M = unique import paths. For large codebases with many
   // violations, consider caching fuzzy match results at a higher level.
   for (const [normalizedImport, chunks] of importIndex.entries()) {
-    if (normalizedImport !== normalizedTarget && matchesFile(normalizedImport, normalizedTarget)) {
-      for (const chunk of chunks) {
-        addChunk(chunk);
-      }
+    if (normalizedImport !== normalizedTarget) {
+      addFuzzyMatchChunks(normalizedImport, normalizedTarget, chunks, addChunk);
     }
   }
 

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -6,6 +6,7 @@ import {
   matchesFile,
   isTestFile,
   isUnresolvableWholeModuleImport,
+  importMatchesTarget,
 } from './utils/path-matching.js';
 import { RISK_ORDER } from './insights/types.js';
 
@@ -317,10 +318,8 @@ const MAX_REEXPORT_DEPTH = 3;
  * Check if a single chunk imports from the given source path.
  * Checks both `importedSymbols` keys and raw `imports` array.
  *
- * Skips bare whole-module imports (#884): for a `wholeModuleImports`
- * language (Swift), a bare import can only ever match a target through
- * basename coincidence, not a real per-file dependency — see
- * `isUnresolvableWholeModuleImport`'s doc comment.
+ * Uses `importMatchesTarget`, which applies the #884 whole-module guard
+ * before `matchesFile` — see its doc comment in path-matching.ts (#886).
  */
 export function chunkImportsFrom(
   chunk: CodeChunk,
@@ -332,10 +331,8 @@ export function chunkImportsFrom(
     importedSymbols && typeof importedSymbols === 'object' ? Object.keys(importedSymbols) : [];
   const allImportPaths = [...importedSymbolPaths, ...(chunk.metadata.imports || [])];
 
-  return allImportPaths.some(
-    imp =>
-      !isUnresolvableWholeModuleImport(imp, chunk.metadata.file) &&
-      matchesFile(normalizePathCached(imp), sourcePath),
+  return allImportPaths.some(imp =>
+    importMatchesTarget(imp, chunk.metadata.file, sourcePath, normalizePathCached),
   );
 }
 
@@ -367,10 +364,8 @@ export function groupChunksByNormalizedPath(
  * file imports for side effect or does `export * from`, neither of which
  * should qualify it as a re-exporter on its own (#526).
  *
- * Skips bare whole-module imports (#884): for a `wholeModuleImports`
- * language (Swift), a bare import can only ever match a source path through
- * basename coincidence, not a real re-export relationship — see
- * `isUnresolvableWholeModuleImport`'s doc comment.
+ * Uses `importMatchesTarget`, which applies the #884 whole-module guard
+ * before `matchesFile` — see its doc comment in path-matching.ts (#886).
  */
 function collectImportedSymbolsFromSource(
   chunks: CodeChunk[],
@@ -382,10 +377,8 @@ function collectImportedSymbolsFromSource(
     const importedSymbols = chunk.metadata.importedSymbols;
     if (!importedSymbols || typeof importedSymbols !== 'object') continue;
     Object.entries(importedSymbols)
-      .filter(
-        ([importPath]) =>
-          !isUnresolvableWholeModuleImport(importPath, chunk.metadata.file) &&
-          matchesFile(normalizePathCached(importPath), sourcePath),
+      .filter(([importPath]) =>
+        importMatchesTarget(importPath, chunk.metadata.file, sourcePath, normalizePathCached),
       )
       .forEach(([, syms]) => syms.forEach(sym => symbols.add(sym)));
   }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -41,6 +41,7 @@ export {
   getCanonicalPath,
   isTestFile,
   isUnresolvableWholeModuleImport,
+  importMatchesTarget,
 } from './utils/path-matching.js';
 
 export { extractRepoId } from './utils/repo-id.js';

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -42,6 +42,7 @@ export {
   isTestFile,
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
+  hasSingleFileImportSemantics,
 } from './utils/path-matching.js';
 
 export { extractRepoId } from './utils/repo-id.js';

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -3,12 +3,7 @@
  * Finds test files that import given source files by analyzing chunk metadata.
  */
 
-import {
-  isTestFile,
-  normalizePath,
-  matchesFile,
-  isUnresolvableWholeModuleImport,
-} from './utils/path-matching.js';
+import { isTestFile, normalizePath, importMatchesTarget } from './utils/path-matching.js';
 import type { CodeChunk } from './types.js';
 
 /**
@@ -45,15 +40,11 @@ export function findTestAssociationsFromChunks(
 
     for (const chunk of testChunks) {
       const imports = chunk.metadata.imports || [];
-      // Skip bare whole-module imports (#884): for a wholeModuleImports
-      // language (Swift), a bare import can only ever match a target through
-      // basename coincidence, not a real per-file association -- see
-      // isUnresolvableWholeModuleImport's doc comment.
+      // importMatchesTarget applies the #884 whole-module guard before
+      // matchesFile -- see its doc comment in path-matching.ts (#886).
       if (
-        imports.some(
-          imp =>
-            !isUnresolvableWholeModuleImport(imp, chunk.metadata.file) &&
-            matchesFile(normalize(imp), normalizedTarget),
+        imports.some(imp =>
+          importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
         )
       ) {
         testFiles.add(chunk.metadata.file);

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -6,6 +6,7 @@ import {
   resolveRelativeImport,
   resolveWorkspaceImport,
   isUnresolvableWholeModuleImport,
+  importMatchesTarget,
 } from './path-matching.js';
 
 /**
@@ -407,6 +408,55 @@ describe('isUnresolvableWholeModuleImport (#884)', () => {
 
   it('does not suppress bare imports from non-Swift, non-whole-module files', () => {
     expect(isUnresolvableWholeModuleImport('logger', 'src/logger.ts')).toBe(false);
+  });
+});
+
+/**
+ * Test cases for the #886 consolidated primitive: `importMatchesTarget`
+ * couples `isUnresolvableWholeModuleImport`'s guard to `matchesFile` so a
+ * match-side caller can never invoke one without the other.
+ */
+describe('importMatchesTarget (#886)', () => {
+  const normalize = (p: string): string => normalizePath(p, '/fake/workspace');
+
+  it('matches like matchesFile would, for a non-whole-module language', () => {
+    expect(importMatchesTarget('./logger', 'src/foo.ts', normalize('src/logger'), normalize)).toBe(
+      true,
+    );
+    expect(
+      importMatchesTarget('src/database.ts', 'src/foo.ts', normalize('src/logger.ts'), normalize),
+    ).toBe(false);
+  });
+
+  it('suppresses the #884 Alamofire whole-module false-hub shape that matchesFile alone would match', () => {
+    // matchesFile itself still matches this pair (#884's own regression pin) --
+    // the guard is what makes the combined primitive reject it.
+    expect(matchesFile(normalize('Alamofire'), normalize('Source/Alamofire.swift'))).toBe(true);
+    expect(
+      importMatchesTarget(
+        'Alamofire',
+        'Source/AlamofireTests.swift',
+        normalize('Source/Alamofire.swift'),
+        normalize,
+      ),
+    ).toBe(false);
+  });
+
+  it('leaves the identical bare-identifier shape alone for a non-whole-module language (Rust)', () => {
+    expect(
+      importMatchesTarget('auth', 'src/consumer.rs', normalize('src/auth.rs'), normalize),
+    ).toBe(true);
+  });
+
+  it('rejects a real per-file relationship guarded by the whole-module language, not the pair', () => {
+    // Swift's SwiftImportExtractor never emits anything but the bare module
+    // name, so even a genuine same-file relationship reads as "not
+    // determinable" rather than a match -- this is the same honest #869
+    // outcome isUnresolvableWholeModuleImport documents, just reached through
+    // the combined primitive instead of the open-coded pattern.
+    expect(
+      importMatchesTarget('Combine', 'Tests/CombineTests.swift', normalize('Combine'), normalize),
+    ).toBe(false);
   });
 });
 

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -361,6 +361,39 @@ describe('matchesFile - Path Boundary Checking', () => {
       });
     });
   });
+
+  describe('two-segment bare require precision (#887)', () => {
+    it('Ruby: a multi-segment bare require must not fan out to every file under its own directory', () => {
+      // sinatra's bundled rack-protection: `require 'rack/protection'` must
+      // match only the gem's own entry point, not every file nested under
+      // rack-protection/lib/rack/protection/ -- the multi-segment shape of
+      // the same #868/#883 single-segment bug (`sinatra` vs. `lib/sinatra/*`).
+      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection/csrf')).toBe(
+        false,
+      );
+      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection/base')).toBe(
+        false,
+      );
+      // The gem's own entry point still matches.
+      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection')).toBe(true);
+    });
+
+    it('regression: the #868 single-segment guard is unaffected', () => {
+      expect(testMatchesFile('sinatra', 'lib/sinatra')).toBe(true);
+      expect(testMatchesFile('sinatra', 'lib/sinatra/base')).toBe(false);
+    });
+
+    it('regression: the Rust one-leading-segment source-prefix convention is unaffected', () => {
+      expect(testMatchesFile('auth', 'src/auth.rs')).toBe(true);
+    });
+
+    it('regression: a genuine multi-segment import still matches its multi-segment target', () => {
+      // Untouched by the #887 end-anchor extension -- these already reached
+      // the end of the compared string before the fix.
+      expect(testMatchesFile('auth/middleware', 'src/auth/middleware.rs')).toBe(true);
+      expect(testMatchesFile('github.com/gin-gonic/gin/internal/fs', 'internal/fs')).toBe(true);
+    });
+  });
 });
 
 /**

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -7,6 +7,7 @@ import {
   resolveWorkspaceImport,
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
+  hasSingleFileImportSemantics,
 } from './path-matching.js';
 
 /**
@@ -24,10 +25,14 @@ describe('matchesFile - Path Boundary Checking', () => {
   // Test helper: normalize paths without workspace root (not needed for unit tests)
   const normalize = (path: string): string => normalizePath(path, '/fake/workspace');
 
-  const testMatchesFile = (importPath: string, targetPath: string): boolean => {
+  const testMatchesFile = (
+    importPath: string,
+    targetPath: string,
+    requireExactTailForMultiSegment = false,
+  ): boolean => {
     const normalizedImport = normalize(importPath);
     const normalizedTarget = normalize(targetPath);
-    return matchesFile(normalizedImport, normalizedTarget);
+    return matchesFile(normalizedImport, normalizedTarget, requireExactTailForMultiSegment);
   };
 
   describe('should match valid imports', () => {
@@ -362,36 +367,64 @@ describe('matchesFile - Path Boundary Checking', () => {
     });
   });
 
-  describe('two-segment bare require precision (#887)', () => {
-    it('Ruby: a multi-segment bare require must not fan out to every file under its own directory', () => {
+  describe('two-segment bare require precision (#887, language-aware)', () => {
+    it('Ruby (strict mode): a multi-segment bare require must not fan out to every file under its own directory', () => {
       // sinatra's bundled rack-protection: `require 'rack/protection'` must
       // match only the gem's own entry point, not every file nested under
       // rack-protection/lib/rack/protection/ -- the multi-segment shape of
       // the same #868/#883 single-segment bug (`sinatra` vs. `lib/sinatra/*`).
-      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection/csrf')).toBe(
-        false,
-      );
-      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection/base')).toBe(
-        false,
-      );
+      // `requireExactTailForMultiSegment: true` is exactly what
+      // `importMatchesTarget` derives for a `.rb` importer via
+      // `hasSingleFileImportSemantics` (see below) -- passed explicitly here
+      // to unit-test the matcher in isolation.
+      expect(
+        testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection/csrf', true),
+      ).toBe(false);
+      expect(
+        testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection/base', true),
+      ).toBe(false);
       // The gem's own entry point still matches.
-      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection')).toBe(true);
+      expect(testMatchesFile('rack/protection', 'rack-protection/lib/rack/protection', true)).toBe(
+        true,
+      );
     });
 
-    it('regression: the #868 single-segment guard is unaffected', () => {
+    it('Go (default/permissive mode): the identical multi-segment shape is a legitimate package-directory member match', () => {
+      // A HIGH-severity regression caught in review: #877 normalizes
+      // `import "mymodule/internal/fs"` down to the bare `internal/fs`
+      // after module-prefix stripping. In Go that names a PACKAGE -- every
+      // `.go` file inside the directory is a member, so `internal/fs` MUST
+      // keep matching `internal/fs/fs.go` (and any other file in that
+      // directory) under the default, non-strict mode real Go callers use.
+      // An earlier version of this fix applied the Ruby-only anchor
+      // unconditionally and broke exactly this case (67 → 9 dependent edges
+      // on a real gin clone) before being caught and reworked.
+      expect(testMatchesFile('internal/fs', 'internal/fs/fs.go')).toBe(true);
+      expect(testMatchesFile('internal/fs', 'internal/fs/utils.go')).toBe(true);
+      // Explicitly confirms the default parameter IS permissive (`false`).
+      expect(testMatchesFile('internal/fs', 'internal/fs/fs.go', false)).toBe(true);
+    });
+
+    it('regression: the #868 single-segment guard is unaffected by the strict flag either way', () => {
       expect(testMatchesFile('sinatra', 'lib/sinatra')).toBe(true);
       expect(testMatchesFile('sinatra', 'lib/sinatra/base')).toBe(false);
+      expect(testMatchesFile('sinatra', 'lib/sinatra', true)).toBe(true);
+      expect(testMatchesFile('sinatra', 'lib/sinatra/base', true)).toBe(false);
     });
 
     it('regression: the Rust one-leading-segment source-prefix convention is unaffected', () => {
       expect(testMatchesFile('auth', 'src/auth.rs')).toBe(true);
     });
 
-    it('regression: a genuine multi-segment import still matches its multi-segment target', () => {
+    it('regression: a genuine multi-segment import still matches its multi-segment target in both modes', () => {
       // Untouched by the #887 end-anchor extension -- these already reached
-      // the end of the compared string before the fix.
+      // the end of the compared string before the fix, in either mode.
       expect(testMatchesFile('auth/middleware', 'src/auth/middleware.rs')).toBe(true);
+      expect(testMatchesFile('auth/middleware', 'src/auth/middleware.rs', true)).toBe(true);
       expect(testMatchesFile('github.com/gin-gonic/gin/internal/fs', 'internal/fs')).toBe(true);
+      expect(testMatchesFile('github.com/gin-gonic/gin/internal/fs', 'internal/fs', true)).toBe(
+        true,
+      );
     });
   });
 });
@@ -490,6 +523,60 @@ describe('importMatchesTarget (#886)', () => {
     expect(
       importMatchesTarget('Combine', 'Tests/CombineTests.swift', normalize('Combine'), normalize),
     ).toBe(false);
+  });
+
+  describe('#887 language-aware routing', () => {
+    it('Ruby importer: rejects the rack/protection child-file fan-out, keeps the entry point', () => {
+      const importerFile = 'rack-protection/spec/spec_helper.rb';
+      expect(
+        importMatchesTarget(
+          'rack/protection',
+          importerFile,
+          normalize('rack-protection/lib/rack/protection/xss_header'),
+          normalize,
+        ),
+      ).toBe(false);
+      expect(
+        importMatchesTarget(
+          'rack/protection',
+          importerFile,
+          normalize('rack-protection/lib/rack/protection'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+
+    it('Go importer: keeps matching every file inside its package directory (the caught regression)', () => {
+      // The reviewer's proven-failing shape at an earlier revision of this
+      // fix: a language-unaware unconditional end-anchor made this return
+      // false, reversing #877 on a real gin clone (67 -> 9 dependent edges).
+      const importerFile = 'render/html.go';
+      expect(
+        importMatchesTarget('internal/fs', importerFile, normalize('internal/fs/fs.go'), normalize),
+      ).toBe(true);
+      expect(
+        importMatchesTarget(
+          'internal/fs',
+          importerFile,
+          normalize('internal/fs/utils.go'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('hasSingleFileImportSemantics (#887)', () => {
+  it('is true for a Ruby importer file', () => {
+    expect(hasSingleFileImportSemantics('rack-protection/lib/rack/protection/base.rb')).toBe(true);
+  });
+
+  it('is false for a Go importer file', () => {
+    expect(hasSingleFileImportSemantics('render/html.go')).toBe(false);
+  });
+
+  it('is false for an importer file in an unrecognized/undetectable language', () => {
+    expect(hasSingleFileImportSemantics('README.md')).toBe(false);
   });
 });
 

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -92,17 +92,23 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
 }
 
 /**
- * Like `matchesAtBoundary`, but additionally requires a bare (slash-free)
+ * Like `matchesAtBoundary`, but additionally requires a bare (non-relative)
  * `pattern` to represent the *whole* relationship rather than a coincidental
  * partial one:
  *
- * - The match must reach the end of `str`. An interior hit means `str`
- *   continues into an unrelated subtree beyond the identifier, e.g. a bare
- *   `require 'sinatra'` matching every file under `lib/sinatra/` rather than
- *   just the gem's own entry point (`lib/sinatra.rb`).
- * - At most `maxLeadingSegments` directory segments may precede the match.
- *   The two `matchesFile` call sites need different values here because a
- *   bare identifier plays a different role in each direction:
+ * - The match must reach the end of `str`, whether `pattern` is a single
+ *   segment or multi-segment. An interior hit means `str` continues into an
+ *   unrelated subtree beyond the pattern, e.g. a bare `require 'sinatra'`
+ *   matching every file under `lib/sinatra/` rather than just the gem's own
+ *   entry point (`lib/sinatra.rb`), or a bare multi-segment `require
+ *   'rack/protection'` matching every file under its own
+ *   `rack-protection/lib/rack/protection/` directory rather than just that
+ *   directory's own entry point (#887) — the single-segment and
+ *   multi-segment shapes of the same bug.
+ * - For a single-segment (slash-free) `pattern` specifically, at most
+ *   `maxLeadingSegments` directory segments may additionally precede the
+ *   match. The two `matchesFile` call sites need different values here
+ *   because a bare identifier plays a different role in each direction:
  *   - Strategy 2 passes 1, allowing the established "source directory
  *     prefix" convention (a bare *import* like `auth` resolving to
  *     `src/auth.rs`) — a real, confirmed pattern (see the Rust tests above).
@@ -116,7 +122,11 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
  *     segment happens to precede it.
  *   Both directions still reject a bare `import Combine` (system framework)
  *   matching `Source/Features/Combine.swift` (2 leading segments, over
- *   either threshold).
+ *   either threshold). This leading-segment restriction does NOT extend to
+ *   multi-segment patterns: a multi-segment specifier already carries its
+ *   own internal structure (e.g. `rack/protection`'s own slash), so it needs
+ *   no additional "how deep is the importer nested" scrutiny beyond the
+ *   end-of-string anchor above.
  *
  * Used only for `matchesFile`'s strategies 1/2, which compare the raw
  * import/target strings as given. A cleaned `./`/`../` relative import
@@ -140,8 +150,14 @@ function matchesAtBoundaryPrecise(
   const endIndex = index + pattern.length;
   if (endIndex !== str.length && str[endIndex] !== '/') return false;
 
+  // The match must reach the end of `str` for every bare pattern reaching
+  // this function -- single- or multi-segment (#887). Previously this only
+  // fired inside the slash-free branch below, so a multi-segment pattern
+  // like `rack/protection` could match anywhere `str` continued afterward
+  // (every file under its own directory), the exact #887 fan-out.
+  if (endIndex !== str.length) return false;
+
   if (!pattern.includes('/')) {
-    if (endIndex !== str.length) return false;
     const prefix = str.substring(0, index);
     const prefixSlashes = (prefix.match(/\//g) || []).length;
     if (prefixSlashes > maxLeadingSegments) return false;

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -11,6 +11,7 @@ import {
   getSupportedExtensions,
   detectLanguage,
   hasWholeModuleImports,
+  hasSingleFileImports,
 } from '../ast/languages/registry.js';
 
 /**
@@ -96,19 +97,14 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
  * `pattern` to represent the *whole* relationship rather than a coincidental
  * partial one:
  *
- * - The match must reach the end of `str`, whether `pattern` is a single
- *   segment or multi-segment. An interior hit means `str` continues into an
- *   unrelated subtree beyond the pattern, e.g. a bare `require 'sinatra'`
+ * - For a single-segment (slash-free) `pattern`, the match must always
+ *   reach the end of `str`. An interior hit means `str` continues into an
+ *   unrelated subtree beyond the identifier, e.g. a bare `require 'sinatra'`
  *   matching every file under `lib/sinatra/` rather than just the gem's own
- *   entry point (`lib/sinatra.rb`), or a bare multi-segment `require
- *   'rack/protection'` matching every file under its own
- *   `rack-protection/lib/rack/protection/` directory rather than just that
- *   directory's own entry point (#887) — the single-segment and
- *   multi-segment shapes of the same bug.
- * - For a single-segment (slash-free) `pattern` specifically, at most
- *   `maxLeadingSegments` directory segments may additionally precede the
- *   match. The two `matchesFile` call sites need different values here
- *   because a bare identifier plays a different role in each direction:
+ *   entry point (`lib/sinatra.rb`). At most `maxLeadingSegments` directory
+ *   segments may additionally precede the match. The two `matchesFile` call
+ *   sites need different values here because a bare identifier plays a
+ *   different role in each direction:
  *   - Strategy 2 passes 1, allowing the established "source directory
  *     prefix" convention (a bare *import* like `auth` resolving to
  *     `src/auth.rs`) — a real, confirmed pattern (see the Rust tests above).
@@ -122,11 +118,26 @@ export function matchesAtBoundary(str: string, pattern: string): boolean {
  *     segment happens to precede it.
  *   Both directions still reject a bare `import Combine` (system framework)
  *   matching `Source/Features/Combine.swift` (2 leading segments, over
- *   either threshold). This leading-segment restriction does NOT extend to
- *   multi-segment patterns: a multi-segment specifier already carries its
- *   own internal structure (e.g. `rack/protection`'s own slash), so it needs
- *   no additional "how deep is the importer nested" scrutiny beyond the
- *   end-of-string anchor above.
+ *   either threshold).
+ * - For a MULTI-segment `pattern`, whether an interior hit (an unrelated
+ *   subtree continuing beyond the match) is rejected depends on
+ *   `requireExactTailForMultiSegment`, because the two currently-supported
+ *   languages that reach this branch disagree about what a multi-segment
+ *   bare specifier names:
+ *   - Ruby: `require 'rack/protection'` loads exactly ONE file
+ *     (`rack/protection.rb`) — a sibling `rack/protection/base.rb` is a
+ *     separate module, not a member (#887). Callers for Ruby-shaped
+ *     importers pass `true`, rejecting the interior-hit ("child file")
+ *     case the same way the single-segment branch always has.
+ *   - Go: `import "mymodule/internal/fs"` (normalized to the bare
+ *     `internal/fs` after #877's module-prefix stripping) names a PACKAGE —
+ *     every `.go` file inside that directory is a legitimate member, so an
+ *     interior hit (`internal/fs/fs.go`) must still match. Callers for
+ *     Go-shaped importers (and the default, permissive value) pass `false`.
+ *   `maxLeadingSegments` is never applied to a multi-segment pattern in
+ *   either case: it already carries its own internal structure (e.g.
+ *   `rack/protection`'s own slash), so it needs no additional "how deep is
+ *   the importer nested" scrutiny.
  *
  * Used only for `matchesFile`'s strategies 1/2, which compare the raw
  * import/target strings as given. A cleaned `./`/`../` relative import
@@ -140,6 +151,7 @@ function matchesAtBoundaryPrecise(
   str: string,
   pattern: string,
   maxLeadingSegments: number,
+  requireExactTailForMultiSegment: boolean,
 ): boolean {
   const index = str.indexOf(pattern);
   if (index === -1) return false;
@@ -148,22 +160,35 @@ function matchesAtBoundaryPrecise(
   if (charBefore !== '/' && index !== 0) return false;
 
   const endIndex = index + pattern.length;
-  if (endIndex !== str.length && str[endIndex] !== '/') return false;
-
-  // The match must reach the end of `str` for every bare pattern reaching
-  // this function -- single- or multi-segment (#887). Previously this only
-  // fired inside the slash-free branch below, so a multi-segment pattern
-  // like `rack/protection` could match anywhere `str` continued afterward
-  // (every file under its own directory), the exact #887 fan-out.
-  if (endIndex !== str.length) return false;
+  const atEnd = endIndex === str.length;
+  if (!atEnd && str[endIndex] !== '/') return false;
 
   if (!pattern.includes('/')) {
-    const prefix = str.substring(0, index);
-    const prefixSlashes = (prefix.match(/\//g) || []).length;
-    if (prefixSlashes > maxLeadingSegments) return false;
+    return matchesSingleSegmentTail(str, index, atEnd, maxLeadingSegments);
   }
+  // Multi-segment: an interior hit (`!atEnd`, e.g. a "child file" under the
+  // pattern's own directory) is only rejected for single-file-import
+  // languages (Ruby) -- see the doc comment above and
+  // `requireExactTailForMultiSegment`'s callers.
+  return atEnd || !requireExactTailForMultiSegment;
+}
 
-  return true;
+/**
+ * Single-segment-only tail of `matchesAtBoundaryPrecise`: the match must
+ * reach the end of `str`, and at most `maxLeadingSegments` directory
+ * segments may precede it. Split out to keep the parent function's
+ * cognitive complexity down.
+ */
+function matchesSingleSegmentTail(
+  str: string,
+  index: number,
+  atEnd: boolean,
+  maxLeadingSegments: number,
+): boolean {
+  if (!atEnd) return false;
+  const prefix = str.substring(0, index);
+  const prefixSlashes = (prefix.match(/\//g) || []).length;
+  return prefixSlashes <= maxLeadingSegments;
 }
 
 /**
@@ -218,23 +243,51 @@ export function isUnresolvableWholeModuleImport(
  * 5. PHP namespace imports (App\Models\User vs app/Models/User.php)
  * 6. Python module imports (django.http → django/http/__init__.py or django/http/*.py)
  *
+ * `matchesFile` itself stays language-agnostic (see `isUnresolvableWholeModuleImport`'s
+ * doc comment) — it never inspects `importerFile` or detects a language. But
+ * strategies 1/2's multi-segment boundary check has one genuine language-
+ * dependent fork (#887): does a bare multi-segment specifier name a single
+ * file (Ruby) or a package directory whose files are all members (Go)? A
+ * language-agnostic caller can't know, so it's threaded in as an explicit
+ * parameter rather than decided here — see `requireExactTailForMultiSegment`
+ * and `importMatchesTarget`, the only caller that derives it from the
+ * importer's language. Every other caller passes the default (`false`,
+ * permissive/Go-safe), preserving this function's pre-#887 behavior exactly.
+ *
  * @param normalizedImport - Normalized import path
  * @param normalizedTarget - Normalized target file path
+ * @param requireExactTailForMultiSegment - When true, a multi-segment bare
+ *   pattern must reach the end of the compared string (Ruby's single-file
+ *   `require` semantics); when false (the default), a multi-segment bare
+ *   pattern may also match a "child" continuing past it (Go's package-
+ *   directory semantics, and the safe default for every other language).
  * @returns True if the import matches the target file
  */
-export function matchesFile(normalizedImport: string, normalizedTarget: string): boolean {
+export function matchesFile(
+  normalizedImport: string,
+  normalizedTarget: string,
+  requireExactTailForMultiSegment = false,
+): boolean {
   // Exact match
   if (normalizedImport === normalizedTarget) return true;
 
   // Strategy 1: Check if target path appears in import at path boundaries.
   // maxLeadingSegments: 0 -- see matchesAtBoundaryPrecise's doc comment.
-  if (matchesAtBoundaryPrecise(normalizedImport, normalizedTarget, 0)) {
+  // `pattern` here is the TARGET (a concrete file reference), never a raw
+  // import specifier -- the "does a bare multi-segment specifier name a
+  // file or a directory" question `requireExactTailForMultiSegment` answers
+  // doesn't apply to this position, so this call always passes `false`
+  // regardless of the caller's language, matching this strategy's
+  // pre-#887 behavior unconditionally.
+  if (matchesAtBoundaryPrecise(normalizedImport, normalizedTarget, 0, false)) {
     return true;
   }
 
   // Strategy 2: Check if import path appears in target (for longer target paths).
   // maxLeadingSegments: 1 -- see matchesAtBoundaryPrecise's doc comment.
-  if (matchesAtBoundaryPrecise(normalizedTarget, normalizedImport, 1)) {
+  if (
+    matchesAtBoundaryPrecise(normalizedTarget, normalizedImport, 1, requireExactTailForMultiSegment)
+  ) {
     return true;
   }
 
@@ -276,23 +329,35 @@ export function matchesFile(normalizedImport: string, normalizedTarget: string):
  * The single guarded import-matching decision: does `importSpecifier` (as
  * written in `importerFile`) resolve to `normalizedTarget`?
  *
- * Couples the #884 whole-module guard to `matchesFile` so the two can never
- * drift apart again. `matchesFile` is language-agnostic -- it only ever sees
- * normalized strings and cannot know the importer's language -- so the guard
- * MUST run on the RAW specifier first. Every match-side reverse-dependency
- * call path that used to open-code
+ * Couples two guards to `matchesFile` so neither can drift apart from a
+ * match-side call site again:
+ * - The #884 whole-module guard (`isUnresolvableWholeModuleImport`) --
+ *   `matchesFile` is language-agnostic and cannot know the importer's
+ *   language, so this MUST run on the RAW specifier first.
+ * - The #887 single-file-vs-package-directory distinction
+ *   (`requireExactTailForMultiSegment`) -- derived from the importer's
+ *   language via `hasSingleFileImports`, since that's the only information
+ *   that can disambiguate a bare multi-segment specifier like `rack/protection`
+ *   (Ruby: names one file) from `internal/fs` (Go: names a package directory
+ *   whose files are all members). This is the ONE call site with both an
+ *   importer file *and* a target to compare against, so it's the only place
+ *   this derivation happens.
+ *
+ * Every match-side reverse-dependency call path that used to open-code
  * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`
  * now goes through here instead (#886); the two build-side sites that index
  * imports with no target in scope (`buildImportIndex`,
  * `indexImportEntry`/`addChunkToImportIndex`) still call
  * `isUnresolvableWholeModuleImport` directly, and `findDependentChunks`'s
  * fuzzy loop and `buildReExportGraph` stay on raw `matchesFile` -- see #886's
- * design comment for why those four are not routed through this primitive.
+ * design comment for why those four are not routed through this primitive,
+ * and `findDependentChunks`'s own doc comment for how it independently
+ * derives the #887 distinction per-chunk (it has no single importer file).
  *
  * @param importSpecifier - The raw (pre-normalization) import specifier, or
  *   an `importedSymbols` key (same shape).
  * @param importerFile - File path of the chunk doing the importing (needed
- *   for the whole-module guard's language detection).
+ *   for both guards' language detection).
  * @param normalizedTarget - The already-normalized target path to compare
  *   against.
  * @param normalize - The caller's own cached `normalizePath` wrapper.
@@ -304,7 +369,22 @@ export function importMatchesTarget(
   normalize: (p: string) => string,
 ): boolean {
   if (isUnresolvableWholeModuleImport(importSpecifier, importerFile)) return false;
-  return matchesFile(normalize(importSpecifier), normalizedTarget);
+  return matchesFile(
+    normalize(importSpecifier),
+    normalizedTarget,
+    hasSingleFileImportSemantics(importerFile),
+  );
+}
+
+/**
+ * True when `importerFile`'s language sets `LanguageDefinition.singleFileImports`
+ * (Ruby today) -- see that flag's doc comment for the Ruby-vs-Go distinction
+ * this drives. Shared by `importMatchesTarget` and `findDependentChunks`'s
+ * per-chunk #887 check so the two can't compute it differently.
+ */
+export function hasSingleFileImportSemantics(importerFile: string): boolean {
+  const language = detectLanguage(importerFile);
+  return language !== null && hasSingleFileImports(language);
 }
 
 /**

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -166,14 +166,18 @@ function matchesAtBoundaryPrecise(
  * false-hub shape, one leading segment inside the window #868/#883
  * deliberately preserve for the legitimate Rust-style convention.
  *
- * Callers that discover imports per-chunk (`findTestAssociationsFromChunks`,
- * `get_dependents`'s import index) should call this *before* handing a
- * candidate import to `matchesFile`, and skip it entirely when true -- the
- * honest outcome is #869's "not determinable" signal, never a match. This is
- * intentionally the only place that combines path-matching with language
- * data; `matchesAtBoundaryPrecise`'s general guard stays untouched and keeps
- * serving every non-whole-module language (Rust, Go, Ruby, ...) exactly as
- * before.
+ * Match-side callers (does this import resolve to this target?) should go
+ * through `importMatchesTarget` below, which applies this guard before
+ * calling `matchesFile` so the two can never drift apart (#886). Build-side
+ * callers with no target in scope (`buildImportIndex`,
+ * `indexImportEntry`/`addChunkToImportIndex`) have nothing for
+ * `importMatchesTarget` to compare against, so they keep calling this
+ * predicate directly to decide whether an (import, chunk) pair is worth
+ * indexing at all -- the honest outcome when it's true is #869's "not
+ * determinable" signal, never a match. This is intentionally the only place
+ * that combines path-matching with language data; `matchesAtBoundaryPrecise`'s
+ * general guard stays untouched and keeps serving every non-whole-module
+ * language (Rust, Go, Ruby, ...) exactly as before.
  *
  * @param importSpecifier - The raw (pre-normalization) import specifier
  * @param importerFile - File path of the chunk doing the importing
@@ -250,6 +254,41 @@ export function matchesFile(normalizedImport: string, normalizedTarget: string):
   }
 
   return false;
+}
+
+/**
+ * The single guarded import-matching decision: does `importSpecifier` (as
+ * written in `importerFile`) resolve to `normalizedTarget`?
+ *
+ * Couples the #884 whole-module guard to `matchesFile` so the two can never
+ * drift apart again. `matchesFile` is language-agnostic -- it only ever sees
+ * normalized strings and cannot know the importer's language -- so the guard
+ * MUST run on the RAW specifier first. Every match-side reverse-dependency
+ * call path that used to open-code
+ * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`
+ * now goes through here instead (#886); the two build-side sites that index
+ * imports with no target in scope (`buildImportIndex`,
+ * `indexImportEntry`/`addChunkToImportIndex`) still call
+ * `isUnresolvableWholeModuleImport` directly, and `findDependentChunks`'s
+ * fuzzy loop and `buildReExportGraph` stay on raw `matchesFile` -- see #886's
+ * design comment for why those four are not routed through this primitive.
+ *
+ * @param importSpecifier - The raw (pre-normalization) import specifier, or
+ *   an `importedSymbols` key (same shape).
+ * @param importerFile - File path of the chunk doing the importing (needed
+ *   for the whole-module guard's language detection).
+ * @param normalizedTarget - The already-normalized target path to compare
+ *   against.
+ * @param normalize - The caller's own cached `normalizePath` wrapper.
+ */
+export function importMatchesTarget(
+  importSpecifier: string,
+  importerFile: string,
+  normalizedTarget: string,
+  normalize: (p: string) => string,
+): boolean {
+  if (isUnresolvableWholeModuleImport(importSpecifier, importerFile)) return false;
+  return matchesFile(normalize(importSpecifier), normalizedTarget);
 }
 
 /**


### PR DESCRIPTION
Design: https://github.com/getlien/lien/issues/886#issuecomment-5080538500 (design pass, anchored against `main@deffceec`). Closes #886 (includes #887's acceptance case per the design's absorbed scope).

## Freshness re-derivation

The design was written against `main@deffceec`. Since then, #891 (C# `enclosingNamespaceAccess` flag), #893 (Java static-member import path), and #896 (PHP FQCN references) merged — all touch `test-associations.ts`'s *consumers* (via new import candidates/flags upstream of extraction) but **none touch `path-matching.ts`, `dependency-analyzer.ts` (parser/cli), or `test-associations.ts` themselves**. Confirmed via `git diff deffceec origin/main -- <those files>` → empty.

Branched off `origin/main@99cf7e59` (post-#896) and re-grepped every `matchesFile(`/`isUnresolvableWholeModuleImport(` call site from scratch (not trusting design-time line numbers). Found exactly the 7 sites the design lists — no new site from #891/#893/#896:
- `enclosingNamespaceAccess` (#891) only feeds `annotate-cmd.ts`'s honesty label, never `matchesFile`.
- PHP's `extractReferencedFQCNs` (#896) feeds the `imports` array *upstream*, at extraction time — every match-side site already iterates that same array, so no new call site.

KISS check: the consolidation still fits the current tree exactly as designed. Proceeded without redesign.

## Re-derived call-site table (current `HEAD`, not design-time numbers)

**Match-side (migrated to `importMatchesTarget`, 5):**

| # | Site | File:line |
|---|---|---|
| 1 | `findTestAssociationsFromChunks` | `packages/parser/src/test-associations.ts:47` |
| 3 | `chunkImportsFrom` | `packages/parser/src/dependency-analyzer.ts:370` |
| 4 | `collectImportedSymbolsFromSource` | `packages/parser/src/dependency-analyzer.ts:416` |
| 6 | `fileImportsSymbolFromAny` | `packages/cli/src/mcp/handlers/dependency-analyzer.ts:172` |
| 7 | `findTestAssociations` | `packages/cli/src/mcp/handlers/get-files-context.ts:267` |

**Build-side (left as-is, 2):**

| # | Site | File:line |
|---|---|---|
| 2 | `buildImportIndex` | `packages/parser/src/dependency-analyzer.ts:109` |
| 5 | `indexImportEntry`/`addChunkToImportIndex` | `packages/cli/src/mcp/handlers/dependency-analyzer.ts:195` |

**Stay-raw `matchesFile` (left as-is, 4 — not part of the 7, confirmed not routed through the primitive):**

| Site | File:line |
|---|---|
| `findDependentChunks` fuzzy loop (parser, via `addFuzzyMatchChunks`) | `packages/parser/src/dependency-analyzer.ts:148` |
| `findDependentChunks` fuzzy loop (cli, via `addFuzzyMatchChunks`) | `packages/cli/src/mcp/handlers/dependency-analyzer.ts:840` |
| `buildReExportGraph` (parser) | `packages/parser/src/dependency-analyzer.ts:504` |
| `buildReExportGraph` (cli) | `packages/cli/src/mcp/handlers/dependency-analyzer.ts:138` |

New primitive: `packages/parser/src/utils/path-matching.ts` (`importMatchesTarget`), exported from the parser barrel (`packages/parser/src/index.ts`). No exported-signature changes to any of the 5 migrated functions; `matchesFile` gained one optional, backward-compatible parameter in the language-aware rework below (Correction section).

## Commit A — pure no-op consolidation (526f65a2)

Extracted `importMatchesTarget(rawImport, importerFile, normalizedTarget, normalize)` and migrated the 5 match-side sites. Added 4 new unit tests for the primitive itself (`path-matching.test.ts`).

`lien delta` on this commit shows every touched function **improving** (guard branch removed), never crossing:

```
packages/cli/src/mcp/handlers/dependency-analyzer.ts
  ✓ improved  fileImportsSymbolFromAny cognitive 4 → 3
packages/cli/src/mcp/handlers/get-files-context.ts
  ✓ improved  findTestAssociations     cognitive 12 → 9
packages/parser/src/dependency-analyzer.ts
  ✓ improved  chunkImportsFrom         cognitive 4 → 3
  ✓ improved  collectImportedSymbolsFromSource cognitive 8 → 7
packages/parser/src/test-associations.ts
  ✓ improved  findTestAssociationsFromChunks cognitive 12 → 11
packages/parser/src/utils/path-matching.ts
  · new       importMatchesTarget      cognitive – → 1
  ✓ 5 improved · 7 files · 121 ms
```

### Golden proof (Commit A vs. parent `99cf7e59`)

Built a scratch dump tool (not committed) that indexes a corpus fresh via the real `indexCodebase`/`createVectorDB`, then calls the real handler functions (`findDependents`, `get_files_context`'s `findTestAssociations`, parser's `findTestAssociationsFromChunks`) directly against the real SQLite index — no mocks. Ran it against a full `git clone` of `origin/main@99cf7e59` (pristine parent, standalone index) and this branch, on multiple corpora (superseded by the final re-run below, which repeats this exact proof against final `HEAD` after the Correction).

## Commit B — #887 two-segment bare-require fix (20c1e383)

`matchesAtBoundaryPrecise`'s "match must reach the end of the compared string" anchor only fired for slash-free (single-segment) patterns. A multi-segment bare specifier like Ruby's `rack/protection` skipped it entirely, so it matched every file nested under its own directory instead of just that directory's entry point. This commit's original fix applied the anchor to *every* bare pattern unconditionally — **this was wrong, see Correction below.**

---

## ⚠️ Correction (caught in adversarial review, fixed in 429e9a41)

Commit B's unconditional end-anchor was proven **HIGH-severity broken** for Go by a second reviewer pass, with a real-repo reproduction:

> After #877's go.mod prefix-stripping, a Go import like `"mod/internal/fs"` is stored as the 2-segment bare specifier `internal/fs` — which in Go names a **directory** (every file in the package), not a single file. The unconditional anchor requires an exact-tail match, so it matches nothing for directory-packages. Real-gin-clone proof: `get_dependents` 67→9 edges (58 genuine edges lost, 0 gained), 10 files drop to zero dependents, the entire `codec/json` package flips to "No test coverage" — reversing #877 on its own reference repo.

I reproduced this myself against a fresh `git clone` of `gin-gonic/gin` before writing the fix (see below) and confirmed it: `render/html.go` and `gin.go` both import `"github.com/gin-gonic/gin/internal/fs"` (normalized to bare `internal/fs`), which must match every file inside `internal/fs/` (`fs.go`, member of `package fs`) — Ruby's `require 'rack/protection'` and Go's `import "pkg/sub"` are the **same textual shape** with opposite semantics (one file vs. one package/directory), and `matchesFile` cannot tell them apart without knowing the importer's language.

**Fix (commit 429e9a41), keeping Commit A untouched:**
- New `LanguageDefinition.singleFileImports` flag (Ruby only) + `hasSingleFileImports` registry helper — same pattern as `wholeModuleImports`/`enclosingNamespaceAccess`.
- `matchesFile(normalizedImport, normalizedTarget, requireExactTailForMultiSegment = false)` — the anchor is now an explicit, opt-in parameter instead of unconditional. Every pre-existing 2-arg caller (all 4 stay-raw `matchesFile` call sites, all existing tests) is byte-for-byte unaffected by the default. Strategy 1 (where the boundary-checked `pattern` is the *target*, not a raw import specifier) always passes `false` — the single-file-vs-package question doesn't apply to that position; only strategy 2 (`pattern` = the import specifier) takes the caller's value.
- `importMatchesTarget` derives the flag from the importer's language via the new `hasSingleFileImportSemantics(importerFile)` helper — all 5 migrated match-side call sites get the fix automatically, zero call-site changes (Commit A's diff is untouched).
- `findDependentChunks` (both `@liendev/parser` and the CLI) — a stay-raw site, per the original design — independently derives the same flag **per chunk**, not once per import-index key, because its fuzzy-match bucket can span multiple importer files/languages sharing one normalized specifier. This is where the real dependent-count impact for both the Ruby fix and the Go regression actually lives (`get_dependents`'s primary discovery path), not the 5 migrated sites, which is why the bug was only caught by dogfooding the real tool rather than unit-testing `importMatchesTarget` in isolation.
- Resolved the dead general-boundary-check line the unconditional anchor had made redundant, by computing `atEnd` once and branching cleanly instead of re-checking it.

**Per-language reasoning (verified, documented in code):**
- **Ruby** — `singleFileImports: true`. `require 'x/y'` loads exactly one file.
- **Go** — unset (permissive/default). `import "x/y"` names a package directory; every file inside is a member.
- **Python** (strategy 5, `matchesPythonModule`), **PHP** (strategy 4, `matchesPHPNamespace`) — separate dedicated matching functions, never reach `matchesAtBoundaryPrecise` at all; unaffected either way.
- **Rust** — multi-segment module paths already name an exact file (`auth/middleware` → `src/auth/middleware.rs`), so `atEnd` is always true for genuine matches regardless of the flag; unaffected either way.
- **TS/JS workspace paths** — bare specifiers are resolved to a concrete file (`resolveWorkspaceImport`/`resolveRelativeImport`) *before* `matchesFile` ever runs; nothing multi-segment-bare reaches this code path.

**New regression coverage** (`path-matching.test.ts`, `registry.test.ts`, `dependency-analyzer.test.ts` ×2, `get-dependents`/`dependency-analyzer.test.ts` in cli): the exact Go canary the reviewer proved failing (`internal/fs` must match `internal/fs/fs.go`) at both the `matchesFile` level and the `importMatchesTarget` level; the Ruby canary retained (`rack/protection` must not match children); a mixed-language "same import key, different importer" test proving the check runs per chunk, not per key; `hasSingleFileImports` registry tests.

### Re-verified golden proof (final `HEAD`, all 3 commits, 4 corpora)

Rebuilt the parent clone at `99cf7e59` (this time also building `parser-native` — a first attempt without it silently produced a near-empty index and nearly gave a false-clean result; caught and fixed before trusting any number below) and re-ran the dump tool for parent vs. final `HEAD`:

**`lien-review-testbed/`** — byte-identical (0-line diff), 425 chunks / 40 files both sides.

**`packages/`** (self-referential) — 36-line diff, **every line** an `avgComplexity`/`averageComplexity`/`maxComplexity`/`highComplexityDependents` field, all *improving* (matches `lien delta`'s reported gains from the extra `atEnd`-once refactor). Zero change to any dependent list, risk level, test association, or symbol usage.

**Real `sinatra` clone** (fresh clone, same corpus as before) — unchanged from the pre-Correction numbers: **820 spurious dependent edges removed** across 40 files; both true entry points (`rack-protection/lib/rack/protection.rb`: 22→22, `sinatra-contrib/lib/sinatra/contrib.rb`: 2→2) unchanged. Spot-checks unchanged from before:
- **Removed edge, genuinely wrong-before:** `rack-protection/lib/rack/protection/base.rb` (`require 'rack/protection'` only — never `require 'rack/protection/xss_header'`) was wrongly listed as `xss_header.rb`'s dependent; gone.
- **Surviving edge, genuinely right:** `lib/sinatra/base.rb`'s `require 'rack/protection'` → `rack-protection/lib/rack/protection.rb`, the real umbrella file that `autoload`s every sibling module — unchanged.

**Real `gin-gonic/gin` clone** (fresh clone, `34dac20`) — **zero-line diff** against parent. `internal/fs`/`render/html.go`/`gin.go` reproduced exactly as the reviewer described, then confirmed fixed:
```
total dependent edges across all files: parent=67  head=67
internal/fs/fs.go  parent deps=['gin.go', 'render/html.go']
internal/fs/fs.go  head   deps=['gin.go', 'render/html.go']
```
Opened the source to confirm both edges are genuine: `render/html.go:11` and `gin.go:18` both import `"github.com/gin-gonic/gin/internal/fs"`; `internal/fs/fs.go` declares `package fs` — the real file that import resolves to, one of two files (`fs.go`, `fs_test.go`) in the package directory.

**Corpus blindness, closed:** the original two corpora (this repo, `lien-review-testbed/`) contain no Go-shaped multi-segment bare imports, so neither the original Commit B golden-proof nor its own unit tests would ever have caught this — only dogfooding against a real Go codebase did. `lien-review-testbed/` is TS/JS/Python/Ruby/Swift/C#/PHP/Rust/Kotlin but has no Go fixture; worth a future addition, not done in this PR (scope discipline).

## Gates (final `HEAD` — 3 commits: 526f65a2, 20c1e383, 429e9a41)

```
npm run format:check   — pass
npm run lint            — 0 errors, 38 pre-existing warnings (unchanged)
npm run typecheck        — pass
npm run build             — pass
npm test                    — all packages green (parser/core/review/cli/action), 0 failed
node packages/cli/dist/index.js delta — exit 0, "no complexity changes vs HEAD"
```

One changeset: `.changeset/import-matcher-consolidation.md` (`@liendev/parser` patch), covering all three commits.
---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR consolidates five match-side import-matching call sites behind a new `importMatchesTarget` primitive and adds language-aware handling for Ruby single-file `require` semantics versus Go package-directory imports. The changes are backward-compatible (`matchesFile`'s new parameter is optional and defaults to the old permissive behavior), no public signatures are broken, and the new `singleFileImports` flag is consumed consistently by both `importMatchesTarget` and the per-chunk `addFuzzyMatchChunks` logic in parser and CLI. Extensive unit tests cover the Ruby/Go boundary cases and the per-chunk mixed-language scenario.
>
> - Introduced `importMatchesTarget` and `hasSingleFileImportSemantics` in `path-matching.ts`, exported from the parser barrel.
> - Migrated five match-side call sites to the consolidated primitive, removing duplicated whole-module guard logic.
> - Added `requireExactTailForMultiSegment` to `matchesFile` and `singleFileImports` to `LanguageDefinition` (Ruby only) to fix #887 without regressing Go package-directory matching.

⚠️ The documentation-truthfulness pass did not finish — it hit the token budget limit. Doc-claim verification is partial; code findings are unaffected.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7ef143f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 823K/793K tokens
<!-- /lien:attestation -->
