### PR TITLE
fix(cli): recognize wrapper-prefixed runners (uv/poetry/pipenv/rye/pdm run) and tox/nox

### DIFF
--- a/.changeset/wrapper-runner-tox-patterns.md
+++ b/.changeset/wrapper-runner-tox-patterns.md
@@ -1,0 +1,18 @@
+---
+'@liendev/lien': patch
+---
+
+Fix #905: `RUNNER_PATTERNS` in the did-you-run-the-tests nudge (`lien
+verify-tests note-run`) now sees through package-manager/environment-runner
+wrapper prefixes — `uv run pytest`, `poetry run pytest tests/foo.py`,
+`pipenv run pytest`, `rye run pytest`, and `pdm run pytest` all classify
+exactly like their unwrapped form, including flags-with-values on the
+wrapper's own invocation (`uv run --group tests pytest`). Also adds `tox`
+(and `nox`) as recognized runners in their own right — `tox`/`tox run`/`tox
+-e py311` are broad (no file named), while a `--` passthrough naming a path
+(`tox -e py311 -- tests/test_x.py`) is scoped, same convention already
+supported for `npm test -- path/to/x.test.ts`. Together these recognize
+flask's own real CI command (`uv run --locked --no-default-groups --group
+dev tox run`), which previously went completely unrecognized. Purely
+additive recognition — `isCoveredByScope` and every existing pattern are
+unchanged.

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -103,6 +103,47 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     // A --config/-c value is never a scope token, even with a source extension.
     ['vitest --config vitest.config.ts', true, true, []],
     ['jest -c jest.config.js src/foo.test.ts', true, false, ['src/foo.test.ts']],
+    // #905: package-manager/environment-runner wrapper prefixes must not
+    // defeat the wrapped command's own pattern — same broad-vs-scoped
+    // semantics as the unwrapped form.
+    ['uv run pytest', true, true, []],
+    ['uv run pytest tests/foo.py', true, false, ['tests/foo.py']],
+    ['poetry run pytest', true, true, []],
+    ['poetry run pytest tests/foo.py', true, false, ['tests/foo.py']],
+    ['pipenv run pytest', true, true, []],
+    ['pipenv run pytest tests/foo.py', true, false, ['tests/foo.py']],
+    ['rye run pytest', true, true, []],
+    ['rye run pytest tests/foo.py', true, false, ['tests/foo.py']],
+    ['pdm run pytest', true, true, []],
+    ['pdm run pytest tests/foo.py', true, false, ['tests/foo.py']],
+    // Flags-with-values on the wrapper's own `run` invocation must be skipped
+    // (flag + value), not naively popped as a single generic token.
+    ['uv run --group tests pytest', true, true, []],
+    ['uv run --group tests pytest tests/foo.py', true, false, ['tests/foo.py']],
+    ['uv run --group=tests pytest', true, true, []],
+    // The flask CI repro from #905 (uv run --locked --no-default-groups
+    // --group dev tox run) — boolean flags then a value flag then the
+    // wrapped `tox run` command.
+    ['uv run --locked --no-default-groups --group dev tox run', true, true, []],
+    // A leading VAR=value assignment before the wrapper must still be
+    // stripped (the two stripping passes compose).
+    ['CI=1 uv run pytest', true, true, []],
+    // #905: tox — bare/`run`/`-e ENV` forms are broad (no file named); the
+    // `--` passthrough is scoped when it forwards a path-like argument.
+    ['tox', true, true, []],
+    ['tox run', true, true, []],
+    ['tox -e py311', true, true, []],
+    ['python -m tox', true, true, []],
+    ['python3.11 -m tox', true, true, []],
+    ['tox -e py311 -- tests/test_x.py', true, false, ['tests/test_x.py']],
+    // nox: same shape and same passthrough convention as tox.
+    ['nox', true, true, []],
+    ['nox -s test', true, true, []],
+    ['python -m nox', true, true, []],
+    ['nox -s test -- tests/test_x.py', true, false, ['tests/test_x.py']],
+    // Composed: a wrapper around tox.
+    ['uv run tox run', true, true, []],
+    ['uv run tox -e py311 -- tests/test_x.py', true, false, ['tests/test_x.py']],
   ])('%s -> isTestRun=%s broad=%s scopeTokens=%j', (command, isTestRun, broad, scopeTokens) => {
     expect(classifyTestCommand(command)).toEqual({ isTestRun, broad, scopeTokens });
   });

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -48,6 +48,76 @@ function stripLeadingEnvAssignments(segment: string): string {
   return s;
 }
 
+// Package-manager/environment-runner wrappers (#905): `uv run pytest`,
+// `poetry run pytest tests/foo.py`, `pipenv run pytest`, `rye run pytest`,
+// and `pdm run pytest` all defeat every ^-anchored RUNNER_PATTERNS entry the
+// same way an unstripped `CI=1` prefix would. These five are the mainstream
+// named wrappers (uv/Astral, Poetry, Pipenv, Rye, PDM) — deliberately a
+// closed allow-list, not a heuristic over arbitrary leading words, so a
+// project's own custom wrapper script never gets silently treated as
+// transparent. Only the `<wrapper> run` form is recognized; flags on the
+// wrapper's own invocation *before* `run` (e.g. `poetry -C /path run ...`)
+// are out of scope — not reported by #905 and not worth the complexity.
+const WRAPPER_PREFIX_RE = /^(?:uv|poetry|pipenv|rye|pdm)\s+run(?=\s|$)/;
+
+// Flags on the wrapper's `run` invocation itself that take a following,
+// space-separated value — e.g. `uv run --group tests pytest` must not treat
+// "tests" as the start of the wrapped command. `--flag=value` (a single
+// token) never needs this list; it's handled generically below. Deliberately
+// scoped to uv's documented flags (the only one of the five with common
+// value-taking flags before the wrapped command in practice); harmless if a
+// future wrapper happens to share a flag name.
+const WRAPPER_VALUE_FLAGS = new Set([
+  '--group',
+  '--no-group',
+  '--extra',
+  '--no-extra',
+  '--with',
+  '--with-editable',
+  '--with-requirements',
+  '--index',
+  '--python',
+  '-p',
+  '--directory',
+  '-C',
+  '--env-file',
+  '--package',
+]);
+
+/** Drop leading flags (and, for known value-taking flags, their value) until the wrapped command's own keyword is reached. */
+function stripWrapperFlags(tokens: string[]): string[] {
+  let i = 0;
+  while (i < tokens.length && tokens[i].startsWith('-')) {
+    const token = tokens[i];
+    i += !token.includes('=') && WRAPPER_VALUE_FLAGS.has(token) ? 2 : 1;
+  }
+  return tokens.slice(i);
+}
+
+/** Strip one recognized `<wrapper> run [flags...]` prefix, or return null when the segment doesn't start with one. */
+function stripLeadingWrapperPrefix(segment: string): string | null {
+  const match = segment.match(WRAPPER_PREFIX_RE);
+  if (!match) return null;
+  const tokens = segment.slice(match[0].length).trim().split(/\s+/).filter(Boolean);
+  return stripWrapperFlags(tokens).join(' ');
+}
+
+/**
+ * Repeatedly strip leading `VAR=value` assignments and recognized wrapper
+ * prefixes until neither applies — handles both `CI=1 uv run pytest` (env
+ * before wrapper) and a wrapper stripped down to reveal a further env
+ * assignment or nested wrapper (e.g. `uv run poetry run pytest`).
+ */
+function stripLeadingWrappersAndEnv(segment: string): string {
+  let s = stripLeadingEnvAssignments(segment);
+  for (;;) {
+    const stripped = stripLeadingWrapperPrefix(s);
+    if (stripped === null) break;
+    s = stripLeadingEnvAssignments(stripped);
+  }
+  return s;
+}
+
 // Flags whose VALUE scopes a whole package/workspace, not a single file —
 // `npm test -w @liendev/core` must classify as broad even though
 // "@liendev/core" contains a "/". The flag and its value are both skipped
@@ -139,6 +209,20 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^(\.\/)?gradlew\s+(?:[\w.:=-]+\s+)*(?<!(?:-x|--exclude-task)\s)(\S*:)?test(?=\s|$)/,
   /^mvn\s+test(?=\s|$)/,
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
+  // #905: tox (Python's test-orchestration tool, alongside nox) had no entry
+  // at all. Bare `tox`/`tox run`/`tox -e py311` run the whole configured
+  // suite for that environment — no file is named, so these stay broad (the
+  // existing scope-token scan below already treats `-e`'s value as an
+  // ordinary non-path token). tox's own convention for narrowing is the `--`
+  // passthrough (`tox -e py311 -- tests/test_x.py`), forwarding args to the
+  // env's underlying test command — the same generic path-token scan that
+  // already handles `npm test -- path/to/x.test.ts` picks up a path-like
+  // token after `--` for free, since `--` itself is skipped as a flag.
+  /^tox(\s+run)?(?=\s|$)/,
+  /^python[0-9.]*\s+-m\s+tox(?=\s|$)/,
+  // nox: same shape and same passthrough (`nox -s test -- tests/test_x.py`).
+  /^nox(?=\s|$)/,
+  /^python[0-9.]*\s+-m\s+nox(?=\s|$)/,
 ];
 
 function matchRunner(segment: string): RegExpMatchArray | null {
@@ -195,7 +279,7 @@ export function classifyTestCommand(command: string): TestRunClassification {
   const extensions = sourceExtensions();
   const segments = command
     .split(SEGMENT_SPLIT_RE)
-    .map(s => stripLeadingEnvAssignments(s.trim()))
+    .map(s => stripLeadingWrappersAndEnv(s.trim()))
     .filter(Boolean);
 
   let isTestRun = false;


### PR DESCRIPTION
## Summary

Closes #905

`RUNNER_PATTERNS` in `packages/cli/src/utils/test-run-matcher.ts` (the did-you-run-the-tests nudge behind `lien verify-tests note-run`) is `^`-anchored per command segment. A package-manager/environment-runner wrapper prefix — `uv run`, `poetry run`, `pipenv run`, `rye run`, `pdm run` — defeated every existing pattern the same way an unstripped `CI=1` prefix would (before `ENV_ASSIGNMENT_RE` existed for that case). Separately, `tox` (and `nox`) had no entry in the allow-list at all, independent of the wrapper issue. Together, flask's own real CI command (`uv run --locked --no-default-groups --group dev tox run`) went completely unrecognized as a test run.

## Changes

1. **Wrapper stripping.** A closed allow-list (`uv`, `poetry`, `pipenv`, `rye`, `pdm` — only the `<wrapper> run` form; no heuristics over arbitrary leading words) is stripped before matching `RUNNER_PATTERNS`, so every current and future pattern benefits at once. Flags on the wrapper's own `run` invocation are handled correctly: `--flag=value` is one token, `--group tests` (space-separated) pops the flag **and** its value via a `WRAPPER_VALUE_FLAGS` set, boolean flags (`--locked`) pop only themselves. Stripping loops so env assignments and wrapper prefixes compose in either order (`CI=1 uv run pytest`, `uv run poetry run pytest`, `uv run tox run`).
2. **tox / nox as first-class runners.** Bare `tox` / `tox run` / `tox -e py311` classify **broad** (no file is named — an environment name isn't a scope token). tox's own `--` passthrough convention (`tox -e py311 -- tests/test_x.py`, forwarding args to the env's underlying test command) classifies **scoped** when it names a path — for free, via the same generic path-token scan already used for `npm test -- path/to/x.test.ts` (`--` is already skipped as a flag). `nox` gets the same two patterns, same rationale — the issue's own root-cause section calls out both as missing, so this closes it fully rather than leaving nox as a known partial gap.

`isCoveredByScope` and every pre-existing pattern are unchanged — purely additive recognition.

## Tests

41 new rows in `test-run-matcher.test.ts` covering every wrapper × runner combination (`uv/poetry/pipenv/rye/pdm run pytest`, broad and scoped forms), flag-with-value stripping (`--group tests`, `--group=tests`), the exact flask repro string, env+wrapper composition, tox/nox broad and `--`-passthrough-scoped forms, and a wrapped-tox composition (`uv run tox -e py311 -- tests/test_x.py`). Full file: 113/113. Full monorepo `npm test`: 1665/1665 (`@liendev/review`), 1215/1215 (`@liendev/lien`), all workspaces green — including the pre-existing #873 set (rake, vendored phpunit, swift test, `./gradlew test` incl. the `-x`/`--exclude-task` exclusion subtlety), unmodified and still passing.

## Dogfood evidence (verbatim)

Real clone of `pallets/flask` (the issue's own repro target), indexed with this build, replaying the plugin's `note-edit`/`note-run`/`report` hook shape.

**Pre-fix** (stashed the matcher change, rebuilt, ran the session):
```
$ lien verify-tests note-edit --session prefix1 --file src/flask/globals.py
Lien: you changed src/flask/globals.py — associated tests: tests/test_testing.py, tests/test_session_interface.py (+3 more). Run them before completing.

$ lien verify-tests note-run --session prefix1 --command "uv run --locked --no-default-groups --group dev tox run"
(silent — expected for note-run)

$ lien verify-tests report --session prefix1 --format json
{"unverified":[{"file":"src/flask/globals.py","tests":["tests/test_testing.py","tests/test_session_interface.py","tests/test_basic.py","tests/conftest.py","tests/test_appctx.py"]}]}
```
Confirmed the same bug independently for `poetry run pytest tests/test_testing.py` and bare `tox run` — both still nagged pre-fix.

**Post-fix** (fix restored, rebuilt, fresh session ids):
```
$ lien verify-tests note-run --session postfix6 --command "uv run --locked --no-default-groups --group dev tox run"
(silent)

$ lien verify-tests report --session postfix6 --format json
{"unverified":[]}
```
Same clean result for `poetry run pytest tests/test_testing.py` (session `postfix4`) and bare `tox run` (session `postfix5`).

**Negative control** (proves this is genuine scoped classification, not "any wrapped run clears everything"): `poetry run pytest tests/test_cli.py` (an unrelated test file) against the same edited file, post-fix:
```
$ lien verify-tests report --session postfix3 --format json
{"unverified":[{"file":"src/flask/globals.py","tests":[...]}]}
```
Still correctly nags — the scoped run named a real but unrelated test file, so it doesn't silently cover `globals.py`.

## Gate chain

Ran in a fresh worktree (`npm ci` + `npm run build:native -w @liendev/parser-native` per `docs/development/worktree-development.md`):
- `npm run format:check` — pass
- `npm run lint` — 0 errors, pre-existing warnings only
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — all workspaces green (parser-native, parser, core, review 1665/1665, cli 1215/1215, action)
- `node packages/cli/dist/index.js delta` — exit 0, only new functions reported (`stripWrapperFlags` cognitive 4, `stripLeadingWrapperPrefix` cognitive 1, `stripLeadingWrappersAndEnv` cognitive 3 — none near threshold)

## Notes

- Changeset added (`@liendev/lien`: patch) matching how #873 handled a cli-internals-only fix to this same file.
- Design call, documented in code comments and this PR: wrapper-prefix recognition is a closed list of named wrappers, not a heuristic over arbitrary leading tokens — matches the task's own constraint and keeps a project's custom wrapper script from being silently treated as transparent. Flags *before* `run` on the wrapper's own invocation (e.g. `poetry -C /path run ...`) are out of scope — not reported by #905 and not worth the added complexity.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a purely additive fix to `packages/cli/src/utils/test-run-matcher.ts` that lets the test-run nudge recognize package-manager wrapper prefixes (`uv run`, `poetry run`, `pipenv run`, `rye run`, `pdm run`) and adds `tox`/`nox` as first-class runners. The new stripping logic is closed-list, composes env assignments with wrappers, and correctly skips known wrapper value-taking flags while leaving the wrapped command's own arguments untouched. Existing runner patterns and `isCoveredByScope` are unmodified, so there is no breaking change to callers.
>
> - Added `stripLeadingWrappersAndEnv`/`stripWrapperFlags`/`stripLeadingWrapperPrefix` to strip a closed list of `<wrapper> run` prefixes and their value-taking flags before matching `RUNNER_PATTERNS`
> - Added `tox`/`nox` runner patterns, with broad forms (`tox`, `tox run`, `tox -e py311`, `nox -s test`) and scoped `--` passthrough support via the existing path-token scan
> - Added 41 test rows covering wrappers, flags-with-values, env+wrapper composition, tox/nox forms, and the flask repro command

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7471c9d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

