### PR TITLE
fix(parser): union git-tracked files into scan/gitignore filter (#899, #900)

### DIFF
--- a/.changeset/gitignore-tracked-file-exemption.md
+++ b/.changeset/gitignore-tracked-file-exemption.md
@@ -1,0 +1,39 @@
+---
+"@liendev/parser": patch
+---
+
+Fix two related bugs where lexical ignore rules silently dropped real,
+committed source from the index (#899, #900), reproduced against a clone of
+`cli/cli`:
+
+- **#899**: the hardcoded `build/**`/`**/build/**` entries in
+  `ALWAYS_IGNORE_PATTERNS` unconditionally swallowed any directory literally
+  named `build`, with no way to distinguish generated output from real
+  source (`internal/build/build.go`, a hand-written Go file defining
+  `Version`/`Date`, was entirely absent from the manifest).
+- **#900**: `.gitignore` was applied lexically to every file with no
+  tracked-file exemption. Real git only ever ignores UNTRACKED files, so a
+  stale bare-name pattern (a root `.gitignore` line `gh`, meant to hide a
+  locally built binary) matched — and silently dropped — the unrelated,
+  fully tracked `cmd/gh/` and `internal/gh/` source trees, including the
+  literal `func main()` entrypoint.
+
+**Fix**: in a git repository, `scanCodebase` and `createGitignoreFilter` now
+union the lexical scan/filter with git's tracked-file list
+(`getGitTrackedFiles`, one `git ls-files -z` call, cached for the life of
+one scan/filter — never a per-file subprocess). A path git tracks is
+rescued from `ALWAYS_IGNORE_PATTERNS`, `.gitignore`, and ecosystem excludes
+regardless, with one exception: `NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS`
+(`.git/**`, `.lien/**`, `node_modules/**`, `.claude/worktrees/**`) is a hard
+carve-out that stays excluded even if git tracks it, since git *can* track
+a committed `node_modules` or a nested `.claude/worktrees` clone and
+indexing either reproduces the 21GB-index blowup `ALWAYS_IGNORE_PATTERNS`
+exists to prevent. Non-git directories are unaffected — the tracked-file
+set is empty and the union is a no-op, preserving today's pure-lexical
+behavior exactly.
+
+New regression coverage in `gitignore.test.ts`/`scanner.test.ts`: tracked
+source at depth inside a `build`-named directory, tracked source shadowed
+by a bare-name `.gitignore` pattern, the tracked-vs-untracked distinction
+(an untracked file under the same paths stays excluded), and the hard
+carve-out (a tracked `node_modules` file is never rescued).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12128,6 +12128,7 @@
         "@liendev/parser-native": "^0.61.0",
         "glob": "^10.5.0",
         "ignore": "5.3.0",
+        "minimatch": "^9.0.4",
         "p-limit": "5.0.0"
       },
       "devDependencies": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -22,6 +22,7 @@
     "@liendev/parser-native": "^0.61.0",
     "glob": "^10.5.0",
     "ignore": "5.3.0",
+    "minimatch": "^9.0.4",
     "p-limit": "5.0.0"
   },
   "devDependencies": {

--- a/packages/parser/src/gitignore.test.ts
+++ b/packages/parser/src/gitignore.test.ts
@@ -2,7 +2,24 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createGitignoreFilter } from './gitignore.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Initialize a git repo with a fixed identity, for tracked-file rescue tests. */
+async function initGitRepo(dir: string): Promise<void> {
+  await execFileAsync('git', ['init', '-q'], { cwd: dir });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+}
+
+/** Stage and commit everything currently on disk. */
+async function gitCommitAll(dir: string, message = 'initial commit'): Promise<void> {
+  await execFileAsync('git', ['add', '-A'], { cwd: dir });
+  await execFileAsync('git', ['commit', '-q', '-m', message], { cwd: dir });
+}
 
 describe('createGitignoreFilter', () => {
   let testDir: string;
@@ -210,6 +227,94 @@ describe('createGitignoreFilter', () => {
       expect(isIgnored('.wip/report.md')).toBe(true);
       expect(isIgnored('cache.tmp')).toBe(true);
       expect(isIgnored('src/index.ts')).toBe(false);
+    });
+  });
+
+  // Regression tests for #899/#900: the watcher path (createGitignoreFilter)
+  // must apply the same git-tracked-file exemption as the full scan
+  // (scanCodebase), or a file present after `lien index -f` could
+  // mysteriously disappear once the watcher reindexes it incrementally.
+  describe('git-tracked-file rescue (#899, #900)', () => {
+    it('rescues a tracked file at depth inside a directory literally named "build" (#899)', async () => {
+      await fs.mkdir(path.join(testDir, 'internal', 'build'), { recursive: true });
+      await fs.writeFile(
+        path.join(testDir, 'internal', 'build', 'build.go'),
+        'package build\n\nvar Version = "dev"\n',
+      );
+
+      await initGitRepo(testDir);
+      await gitCommitAll(testDir);
+
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('internal/build/build.go')).toBe(false);
+      // Sibling ALWAYS_IGNORE_PATTERNS behavior is unaffected
+      expect(isIgnored('dist/bundle.js')).toBe(true);
+    });
+
+    it('rescues tracked files shadowed by a bare-name .gitignore pattern (#900)', async () => {
+      await fs.mkdir(path.join(testDir, 'cmd', 'gh'), { recursive: true });
+      await fs.writeFile(path.join(testDir, 'cmd', 'gh', 'main.go'), 'package main\n');
+      await fs.mkdir(path.join(testDir, 'internal', 'gh'), { recursive: true });
+      await fs.writeFile(path.join(testDir, 'internal', 'gh', 'gh.go'), 'package gh\n');
+
+      await initGitRepo(testDir);
+      // Commit BEFORE the .gitignore line exists -- otherwise `git add`
+      // would itself refuse to stage these paths, which wouldn't exercise
+      // the bug at all. The real-world shape (#900) is a pattern added
+      // *after* the files it now shadows were already tracked.
+      await gitCommitAll(testDir);
+      await fs.writeFile(path.join(testDir, '.gitignore'), 'gh\n');
+      await gitCommitAll(testDir, 'add stale gh ignore pattern');
+
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('cmd/gh/main.go')).toBe(false);
+      expect(isIgnored('internal/gh/gh.go')).toBe(false);
+    });
+
+    it('does not rescue untracked files under a hardcoded-ignored path (tracked-vs-untracked distinction)', async () => {
+      await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+      await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+      await initGitRepo(testDir);
+      await gitCommitAll(testDir);
+
+      // Never added to git -- genuinely untracked generated output.
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('build/output.js')).toBe(true);
+      expect(isIgnored('src/real.ts')).toBe(false);
+    });
+
+    it('does not rescue untracked files shadowed by a bare-name .gitignore pattern', async () => {
+      await fs.writeFile(path.join(testDir, '.gitignore'), 'gh\n');
+      await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+      await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+      await initGitRepo(testDir);
+      await gitCommitAll(testDir);
+
+      // Never added to git -- a genuine local artifact the pattern targets.
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('cmd/gh/main.go')).toBe(true);
+      expect(isIgnored('src/real.ts')).toBe(false);
+    });
+
+    it('never rescues node_modules even if git tracks it (hard non-negotiable carve-out)', async () => {
+      await fs.mkdir(path.join(testDir, 'node_modules', 'leftpad'), { recursive: true });
+      await fs.writeFile(
+        path.join(testDir, 'node_modules', 'leftpad', 'index.js'),
+        'module.exports = () => {};\n',
+      );
+
+      await initGitRepo(testDir);
+      await gitCommitAll(testDir);
+
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('node_modules/leftpad/index.js')).toBe(true);
     });
   });
 });

--- a/packages/parser/src/gitignore.ts
+++ b/packages/parser/src/gitignore.ts
@@ -2,6 +2,10 @@ import ignore, { type Ignore } from 'ignore';
 import fs from 'fs/promises';
 import type fsSync from 'fs';
 import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Patterns that should always be ignored regardless of user configuration.
@@ -36,6 +40,69 @@ export const ALWAYS_IGNORE_PATTERNS = [
 
 /** Directories to skip during .gitignore discovery (no useful .gitignore inside) */
 const SKIP_DIRS = new Set(['node_modules', 'vendor', '.git', '.lien', 'dist', 'build']);
+
+/**
+ * Paths that are never indexed even when git tracks them. Deliberately much
+ * narrower than {@link ALWAYS_IGNORE_PATTERNS}: `dist/**`, `build/**`,
+ * `vendor/**`, and minified assets are intentionally NOT here, because a
+ * tracked file living under one of those is exactly the case the tracked-file
+ * exemption exists to rescue (see #899, #900). What IS here is either Lien's
+ * own bookkeeping (`.git`, `.lien`) or a path that would be actively dangerous
+ * to index regardless of tracked status: git *can* track `node_modules`
+ * (e.g. a vendored/committed dependency tree) or a `.claude/worktrees` nested
+ * clone, and indexing either reproduces the exact 21GB-index blowup
+ * `ALWAYS_IGNORE_PATTERNS` (below) was introduced to prevent.
+ */
+export const NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS = [
+  '.git/**',
+  '**/.git/**',
+  '.lien/**',
+  '**/.lien/**',
+  'node_modules/**',
+  '**/node_modules/**',
+  '.claude/worktrees/**',
+  '**/.claude/worktrees/**',
+];
+
+// git ls-files output can be large for repos with hundreds of thousands of
+// tracked files; keep the buffer generous so large repos never truncate
+// silently rather than raising an error.
+const LS_FILES_MAX_BUFFER = 256 * 1024 * 1024;
+const LS_FILES_TIMEOUT_MS = 30_000;
+
+/**
+ * Returns the set of paths (relative to `rootDir`, forward-slash-normalized)
+ * that git tracks, or an empty set if `rootDir` is not inside a git working
+ * tree, or git itself isn't available. Never throws.
+ *
+ * Real git only ever applies `.gitignore` to UNTRACKED files -- a pattern
+ * added to silence a local build artifact never hides a file that's already
+ * committed. This is the single source of truth for that tracked-file
+ * exemption: a file git reports as tracked is by definition real, committed
+ * source, regardless of what `.gitignore` or {@link ALWAYS_IGNORE_PATTERNS}
+ * say about its path (see #899, #900). One `git ls-files -z` call, cached by
+ * the caller for the lifetime of one scan/filter -- never a per-file
+ * subprocess.
+ */
+export async function getGitTrackedFiles(rootDir: string): Promise<Set<string>> {
+  try {
+    const { stdout } = await execFileAsync('git', ['ls-files', '-z'], {
+      cwd: rootDir,
+      timeout: LS_FILES_TIMEOUT_MS,
+      maxBuffer: LS_FILES_MAX_BUFFER,
+    });
+    return new Set(
+      stdout
+        .split('\0')
+        .filter(Boolean)
+        .map(p => p.replace(/\\/g, '/')),
+    );
+  } catch {
+    // Not a git repo, git not installed, or the command otherwise failed --
+    // fall back to pure lexical behavior (empty set = no rescues applied).
+    return new Set();
+  }
+}
 
 /** Whether a directory entry should be traversed during .gitignore discovery */
 function shouldTraverseDir(entry: fsSync.Dirent): boolean {
@@ -104,11 +171,26 @@ function matchesScopedIgnore(normalized: string, prefix: string, ig: Ignore): bo
 }
 
 /**
+ * Whether a git-tracked path should be exempted from lexical ignore rules.
+ * False for paths under {@link NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS} even if
+ * git tracks them -- see that constant's doc comment for why.
+ */
+function isRescuedByGitTracking(
+  normalized: string,
+  trackedFiles: Set<string>,
+  neverIndexIg: Ignore,
+): boolean {
+  return trackedFiles.has(normalized) && !neverIndexIg.ignores(normalized);
+}
+
+/**
  * Create a filter function that checks if a file path is gitignored.
  * Discovers .gitignore files throughout the directory tree and applies
  * each at its appropriate scope, plus built-in exclusions (node_modules,
  * vendor, .git, .lien, .claude/worktrees, dist, build, minified assets) to
- * match the full scan behavior in scanner.ts.
+ * match the full scan behavior in scanner.ts. In a git repository, a path
+ * git tracks is exempted from all of the above (see {@link getGitTrackedFiles})
+ * except the narrow {@link NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS} carve-out.
  *
  * Limitation: scoped evaluation is OR across .gitignore files, so a nested
  * .gitignore cannot un-ignore a pattern from a parent. Cross-scope negation
@@ -125,8 +207,15 @@ export async function createGitignoreFilter(
   const alwaysIg = ignore();
   alwaysIg.add(ALWAYS_IGNORE_PATTERNS);
 
-  // Discover all .gitignore files and build scoped ignore instances
-  const gitignoreMap = await discoverGitignoreFiles(rootDir);
+  const neverIndexIg = ignore();
+  neverIndexIg.add(NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS);
+
+  // Discover all .gitignore files and the tracked-file set in parallel --
+  // independent I/O, no reason to serialize them.
+  const [gitignoreMap, trackedFiles] = await Promise.all([
+    discoverGitignoreFiles(rootDir),
+    getGitTrackedFiles(rootDir),
+  ]);
   const scopedIgnores: Array<{ prefix: string; ig: Ignore }> = [];
 
   for (const [relDir, content] of gitignoreMap) {
@@ -140,6 +229,7 @@ export async function createGitignoreFilter(
 
   return (relativePath: string) => {
     const normalized = relativePath.replace(/\\/g, '/');
+    if (isRescuedByGitTracking(normalized, trackedFiles, neverIndexIg)) return false;
     if (alwaysIg.ignores(normalized)) return true;
     return scopedIgnores.some(({ prefix, ig }) => matchesScopedIgnore(normalized, prefix, ig));
   };

--- a/packages/parser/src/scanner.test.ts
+++ b/packages/parser/src/scanner.test.ts
@@ -2,7 +2,24 @@ import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { detectFileType, detectLanguage, scanCodebase } from './scanner.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Initialize a git repo with a fixed identity, for tracked-file rescue tests. */
+async function initGitRepo(dir: string): Promise<void> {
+  await execFileAsync('git', ['init', '-q'], { cwd: dir });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+}
+
+/** Stage and commit everything currently on disk. */
+async function gitCommitAll(dir: string, message = 'initial commit'): Promise<void> {
+  await execFileAsync('git', ['add', '-A'], { cwd: dir });
+  await execFileAsync('git', ['commit', '-q', '-m', message], { cwd: dir });
+}
 
 describe('detectFileType', () => {
   it('should export detectLanguage as a backwards-compat alias', () => {
@@ -191,5 +208,158 @@ describe('scanCodebase', () => {
     const relative = files.map(f => path.relative(testDir, f));
 
     expect(relative).toContain(path.join('.github', 'workflows', 'ci.yml'));
+  });
+});
+
+// Regression tests for #899 (hardcoded `build/**` swallows a real, tracked
+// `build`-named source directory) and #900 (a stale bare-name `.gitignore`
+// pattern shadows a real, tracked source subtree). Fix: in a git repository,
+// union the lexical scan with `git ls-files` so tracked files are always
+// indexable -- see `rescueTrackedFiles` / `getGitTrackedFiles`.
+describe('scanCodebase — git-tracked-file rescue (#899, #900)', () => {
+  let testDir: string;
+
+  afterEach(async () => {
+    if (!testDir) return;
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('rescues a tracked file at depth inside a directory literally named "build" (#899)', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-tracked-build-'));
+
+    await fs.mkdir(path.join(testDir, 'internal', 'build'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'internal', 'build', 'build.go'),
+      'package build\n\nvar Version = "dev"\n',
+    );
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+    await initGitRepo(testDir);
+    await gitCommitAll(testDir);
+
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+    expect(relative).toContain('internal/build/build.go');
+    expect(relative).toContain('src/real.ts');
+  });
+
+  it('rescues tracked files shadowed by a bare-name .gitignore pattern (#900)', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-tracked-bare-gh-'));
+
+    await fs.mkdir(path.join(testDir, 'cmd', 'gh'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'cmd', 'gh', 'main.go'),
+      'package main\n\nfunc main() {}\n',
+    );
+    await fs.mkdir(path.join(testDir, 'internal', 'gh'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'internal', 'gh', 'gh.go'),
+      'package gh\n\ntype Config interface{}\n',
+    );
+
+    await initGitRepo(testDir);
+    // Commit BEFORE the .gitignore line exists -- otherwise `git add` would
+    // itself refuse to stage these paths, which wouldn't exercise the bug at
+    // all. The real-world shape (#900) is a bare, slash-free pattern (which
+    // legitimately matches a path component named "gh" at any depth, per
+    // git semantics) added *after* the files it now shadows were tracked.
+    await gitCommitAll(testDir);
+    await fs.writeFile(path.join(testDir, '.gitignore'), 'gh\n');
+    await gitCommitAll(testDir, 'add stale gh ignore pattern');
+
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+    expect(relative).toContain('cmd/gh/main.go');
+    expect(relative).toContain('internal/gh/gh.go');
+  });
+
+  it('does not rescue untracked files under a hardcoded-ignored path (tracked-vs-untracked distinction)', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-untracked-build-'));
+
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+    await initGitRepo(testDir);
+    await gitCommitAll(testDir);
+
+    // Created AFTER the commit -- genuinely untracked generated output,
+    // exactly the case ALWAYS_IGNORE_PATTERNS' build/** exists to exclude.
+    await fs.mkdir(path.join(testDir, 'build'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'build', 'output.js'), 'console.log("generated");\n');
+
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+    expect(relative).toContain('src/real.ts');
+    expect(relative).not.toContain('build/output.js');
+  });
+
+  it('does not rescue untracked files shadowed by a bare-name .gitignore pattern', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-untracked-bare-gh-'));
+
+    await fs.writeFile(path.join(testDir, '.gitignore'), 'gh\n');
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+    await initGitRepo(testDir);
+    await gitCommitAll(testDir);
+
+    // Created AFTER the commit -- a genuine local build artifact the
+    // .gitignore line is meant to hide, never added to git.
+    await fs.mkdir(path.join(testDir, 'cmd', 'gh'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'cmd', 'gh', 'main.go'), 'package main\n');
+
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+    expect(relative).toContain('src/real.ts');
+    expect(relative).not.toContain('cmd/gh/main.go');
+  });
+
+  it('never rescues node_modules even if git tracks it (hard non-negotiable carve-out)', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-tracked-node-modules-'));
+
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+
+    // A misconfigured repo that committed its dependency tree -- git is
+    // perfectly capable of tracking this; Lien must never index it anyway.
+    await fs.mkdir(path.join(testDir, 'node_modules', 'leftpad'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, 'node_modules', 'leftpad', 'index.js'),
+      'module.exports = () => {};\n',
+    );
+
+    await initGitRepo(testDir);
+    await gitCommitAll(testDir);
+
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+    expect(relative).toContain('src/real.ts');
+    expect(relative).not.toContain('node_modules/leftpad/index.js');
+  });
+
+  it('keeps pure lexical behavior for non-git directories (build/** stays excluded)', async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-nongit-build-'));
+
+    await fs.mkdir(path.join(testDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'src', 'real.ts'), 'export const real = true;\n');
+    await fs.mkdir(path.join(testDir, 'build'), { recursive: true });
+    await fs.writeFile(path.join(testDir, 'build', 'output.js'), 'console.log("generated");\n');
+
+    // No git init -- this directory is not a git repo at all.
+    const files = await scanCodebase({ rootDir: testDir });
+    const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+    expect(relative).toContain('src/real.ts');
+    expect(relative).not.toContain('build/output.js');
   });
 });

--- a/packages/parser/src/scanner.ts
+++ b/packages/parser/src/scanner.ts
@@ -1,9 +1,14 @@
 import { glob } from 'glob';
+import { Minimatch } from 'minimatch';
 import ignore from 'ignore';
 import fs from 'fs/promises';
 import path from 'path';
 import type { ScanOptions } from './types.js';
-import { ALWAYS_IGNORE_PATTERNS } from './gitignore.js';
+import {
+  ALWAYS_IGNORE_PATTERNS,
+  NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS,
+  getGitTrackedFiles,
+} from './gitignore.js';
 
 /**
  * Load .gitignore from the given paths (first match wins) and return an ignore instance.
@@ -21,7 +26,51 @@ async function loadGitignore(...dirs: string[]): Promise<ReturnType<typeof ignor
 }
 
 /**
+ * Find git-tracked files that lexical scanning (gitignore rules, hardcoded
+ * `ALWAYS_IGNORE_PATTERNS`, ecosystem excludes) dropped, and rescue them.
+ *
+ * Real git only ever ignores UNTRACKED files -- a hardcoded `build/**`
+ * pattern or a stale `.gitignore` line can't tell a generated-output
+ * directory apart from a real tracked source directory that happens to
+ * share its name (#899, #900). A path git tracks is by definition real,
+ * committed source, so it's added back regardless of what lexical rules say,
+ * with two exceptions: paths under {@link NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS}
+ * (never indexed, tracked or not) and paths that don't match `patterns` at
+ * all (a rescue still respects the caller's include-pattern/extension filter
+ * -- it does not index every tracked file regardless of type).
+ */
+function rescueTrackedFiles(
+  rootDir: string,
+  trackedFiles: Set<string>,
+  lexicalFiles: string[],
+  patterns: string[],
+): string[] {
+  if (trackedFiles.size === 0) return [];
+
+  const neverIndexIg = ignore().add(NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS);
+  const lexicalRelSet = new Set(
+    lexicalFiles.map(file => path.relative(rootDir, file).replace(/\\/g, '/')),
+  );
+  const includeMatchers = patterns.map(pattern => new Minimatch(pattern, { dot: false }));
+
+  const rescued: string[] = [];
+  for (const relPath of trackedFiles) {
+    if (lexicalRelSet.has(relPath)) continue;
+    if (neverIndexIg.ignores(relPath)) continue;
+    if (!includeMatchers.some(matcher => matcher.match(relPath))) continue;
+    rescued.push(path.join(rootDir, relPath));
+  }
+  return rescued;
+}
+
+/**
  * Scan codebase for files matching include/exclude patterns.
+ *
+ * In a git repository, the lexical scan below is unioned with git's
+ * tracked-file list ({@link rescueTrackedFiles}) so tracked source is never
+ * silently dropped by a hardcoded ignore pattern or a stale `.gitignore`
+ * line. Non-git directories are unaffected -- {@link getGitTrackedFiles}
+ * returns an empty set and the union is a no-op.
  */
 export async function scanCodebase(options: ScanOptions): Promise<string[]> {
   const { rootDir, includePatterns = [], excludePatterns = [] } = options;
@@ -62,10 +111,14 @@ export async function scanCodebase(options: ScanOptions): Promise<string[]> {
   const uniqueFiles = Array.from(new Set(allFiles));
 
   // Filter using ignore patterns
-  return uniqueFiles.filter(file => {
+  const lexicalFiles = uniqueFiles.filter(file => {
     const relativePath = path.relative(rootDir, file);
     return !ig.ignores(relativePath);
   });
+
+  const trackedFiles = await getGitTrackedFiles(rootDir);
+  const rescued = rescueTrackedFiles(rootDir, trackedFiles, lexicalFiles, patterns);
+  return [...lexicalFiles, ...rescued];
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes two related bugs in the scanner/gitignore subsystem, both reproduced against a real clone of `cli/cli`:

- **#899**: `ALWAYS_IGNORE_PATTERNS` hardcodes `build/**`/`**/build/**`, unconditionally swallowing any directory literally named `build` at any depth — with no way to tell a generated-output directory apart from real source that happens to share the name. `internal/build/build.go` (hand-written Go defining `Version`/`Date`, used by `gh --version`) was entirely absent from the manifest.
- **#900**: `.gitignore` is applied lexically to every file with no tracked-file exemption. Real git only ever ignores UNTRACKED files — a stale bare-name pattern (`gh`, meant to hide a locally built binary) legitimately matches a path component named `gh` at any depth, but Lien then dropped the whole tracked `cmd/gh/` and `internal/gh/` source trees, including the literal `func main()` entrypoint, even though git itself never ignores them.

## Design

In a git repository, `scanCodebase` (packages/parser/src/scanner.ts) and `createGitignoreFilter` (packages/parser/src/gitignore.ts) now union their lexical result with git's tracked-file list, via a new `getGitTrackedFiles(rootDir)` helper: one `git ls-files -z` call, parsed into a `Set<string>` of forward-slash-normalized, rootDir-relative paths. A path git tracks is rescued from `ALWAYS_IGNORE_PATTERNS`, the repo's own `.gitignore`, and ecosystem excludes regardless — a tracked file is by definition real, committed source. `getGitTrackedFiles` never throws: any failure (not a git repo, git not installed, command error) yields an empty set, so non-git directories are unaffected and keep today's pure-lexical behavior exactly.

**Hard carve-out.** One exception survives even for tracked files: `NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS` = `.git/**`, `.lien/**`, `node_modules/**`, `.claude/worktrees/**`. The first two are Lien's own bookkeeping; the latter two are patterns git *can* legitimately track (a committed `node_modules`, or a `.claude/worktrees` nested full-repo clone) but that would reproduce the exact 21GB-index blowup `ALWAYS_IGNORE_PATTERNS` exists to prevent. Everything else in `ALWAYS_IGNORE_PATTERNS` — `dist/**`, `build/**`, `vendor/**`, minified assets — is deliberately *not* in this carve-out, since a tracked file under any of those is exactly the case #899/#900 exist to rescue.

**scanCodebase specifics.** Because glob's own `ignore` option (not just the post-filter) already excludes `ALWAYS_IGNORE_PATTERNS` paths, glob never even discovers files under a hardcoded-ignored directory like `build/`. So the rescue can't just relax the post-filter — it independently unions `getGitTrackedFiles` output that (a) isn't already in the lexical result, (b) isn't under the hard carve-out, and (c) matches the caller's include patterns (extension filter, via `minimatch` — already an indirect dependency through `glob`, now declared directly). That include-pattern check matters: a rescue still respects "index only source-like files," it doesn't index every tracked file regardless of type.

**Watcher path (`createGitignoreFilter`).** Traced its call sites: it's lazily created *once* per watch session (`packages/cli/src/mcp/file-change-handler.ts`) and only invalidated when a `.gitignore` file itself changes — never called per file-change event. So adding one `getGitTrackedFiles` call at filter-creation time (run in parallel with the existing `discoverGitignoreFiles` tree walk via `Promise.all`) costs nothing extra per event; it's the same cadence as the .gitignore-discovery walk that already happens there. Given that, I gave it the *same* exemption as `scanCodebase`, for consistency — without it, a file present after `lien index -f` could mysteriously vanish the moment the watcher incrementally reindexed it. The known tradeoff: the tracked-file snapshot is only as fresh as the last filter rebuild (same staleness profile the existing `.gitignore`-content cache already has), so a file `git add`ed mid-session won't be rescued until the next `.gitignore` change or restart. Acceptable — solving live git-index staleness is out of scope for this fix.

## Tests

New coverage in `gitignore.test.ts` (createGitignoreFilter) and `scanner.test.ts` (scanCodebase), both files, covering the classes the issues call out:
- Tracked source at depth inside a `build`-named directory is rescued (#899).
- Tracked source shadowed by a bare-name `.gitignore` pattern is rescued (#900) — committed *before* the shadowing pattern existed, matching the real-world shape (a stale pattern added after the fact).
- Tracked-vs-untracked distinction: an untracked file under the same paths stays excluded, both for the hardcoded-pattern case and the bare-gitignore-pattern case.
- Hard carve-out: a tracked `node_modules` file is never rescued.
- Non-git directories: pure lexical behavior unchanged.

All existing tests pass unmodified (the union is purely additive; every prior non-git-repo test fixture continues to see identical results).

## Dogfood evidence (verbatim)

Cloned `cli/cli` into `mktemp -d` outside this worktree, built this branch's CLI, ran `init --editor claude-code --legacy && index -f`:

```
$ tail -8 .gitignore
*~

vendor/
gh

# Test coverage artifacts
coverage.out
lcov.info
$ git ls-files cmd/gh/ | wc -l
       1
$ git ls-files internal/gh/ | wc -l
       5
$ git ls-files internal/build/ | wc -l
       1

$ node <fixed-branch>/packages/cli/dist/index.js init --editor claude-code --legacy
✓ Created .mcp.json
✓ Installed .claude/agents/Explore.md

$ node <fixed-branch>/packages/cli/dist/index.js index -f
✔ Indexing complete (937/937)
  Completed in 3.3s
```

Manifest check — before this fix the issues reported 929 files total, with these files entirely absent. After:

```
Total files in manifest: 937
gh-shadowed files present: 7
  cmd/gh/main.go
  internal/gh/gh.go
  internal/gh/ghtelemetry/telemetry.go
  internal/gh/mock/config.go
  internal/gh/mock/migration.go
  internal/gh/projects.go
  skills/gh/SKILL.md
build-named-dir files present: 1
  internal/build/build.go
```

929 → 937 is exactly +8: the 7 `gh`-shadowed files plus `internal/build/build.go` — precisely the files both issues name.

**Counter-case — untracked build output stays excluded.** In the same clone, added an untracked `build/output.js` (confirmed `??` in `git status`), then re-ran `index -f`:

```
$ git status --short build/
?? build/output.js
$ node <fixed-branch>/packages/cli/dist/index.js index -f
✔ Indexing complete (937/937)
```

Still 937 (not 938) — `build/output.js` absent from the manifest, confirmed via direct manifest inspection (`'build/output.js' present: False`).

**Non-git directory — lexical behavior unchanged.** A fresh, non-git scratch directory with `src/real.ts` and an untracked `build/output.js`:

```
$ node <fixed-branch>/packages/cli/dist/index.js index -f
✔ Indexing complete (1/1)
```

Manifest contains only `src/real.ts` — `build/output.js` stays excluded exactly as before this change, confirming the union is a no-op outside git repositories.

**This repo (lien) before/after.** Since this worktree is a linked git worktree, indexing it goes through `OverlayBackend` (shared base + writable overlay) rather than a full scan — the overlay-delta manifest was identical before/after this fix (277/277 files, byte-identical file list, `diff` exit 0). For a genuine full-scan comparison unconfounded by the overlay, I additionally built a *baseline* CLI from the exact `origin/main` commit this branch forked from (`99cf7e59`) into a plain, non-worktree clone, and ran both the baseline and the fixed CLI against that same clone's content:

```
baseline (origin/main CLI):  ✔ Indexing complete (640/640)
fixed (this branch's CLI):   ✔ Indexing complete (640/640)
$ diff lien-full-before.txt lien-full-after.txt; echo "DIFF EXIT: $?"
DIFF EXIT: 0
```

No change, as expected — nothing tracked is currently over-ignored in this repo itself.

## Gates

All six pre-commit gates green on this branch (native parser binding built via `npm run build:native -w @liendev/parser-native` first, per the worktree doc):

- `npm run format:check` — pass
- `npm run lint` — 0 errors (38 pre-existing warnings, unrelated to this change)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — all packages green: parser 1256/1256, core 378/378, review 1665/1665, cli 1188/1188, action 41/41
- `node packages/cli/dist/index.js delta --base origin/main` — exit 0 (2 pre-existing functions "worsened" but stayed under threshold: `createGitignoreFilter` cognitive 2→3, `scanCodebase` time 21m→27m; new helper functions `getGitTrackedFiles`/`isRescuedByGitTracking`/`rescueTrackedFiles` all land well under threshold)

Changeset: `@liendev/parser` patch (linked group carries `@liendev/core`/`@liendev/lien`/`@liendev/parser-native` along automatically; `packages/core` source itself wasn't touched).

Closes #899, closes #900.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR fixes two real indexing bugs (#899, #900) by unioning lexical ignore rules with git's tracked-file list in both full scans and the watcher filter. The core logic is sound: tracked files are rescued from hardcoded and .gitignore patterns, with a narrow carve-out for paths that must stay excluded (node_modules, .git, .lien, .claude/worktrees). Tests cover the key cases. The main residual risk is the blanket catch in getGitTrackedFiles, which silently degrades to old behavior whenever git fails inside an actual repository.
>
> - scanCodebase now rescues git-tracked files that lexical rules excluded, subject to include patterns and the never-index carve-out
> - createGitignoreFilter applies the same tracked-file exemption so watcher incremental reindexing stays consistent with full scans
> - getGitTrackedFiles runs one `git ls-files -z` call per scan/filter, but swallows all errors into an empty Set

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 046c26e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

