### PR TITLE
fix(parser): resolve Rust Cargo workspace crate names to real source paths

### DIFF
--- a/.changeset/rust-cargo-workspace-crate-map.md
+++ b/.changeset/rust-cargo-workspace-crate-map.md
@@ -1,0 +1,42 @@
+---
+'@liendev/parser': patch
+---
+
+Fixes #903 (the third leg of #867, alongside PHP's PSR-4 map and Go's module
+path): `convertRustModulePath` only recognized `crate::`/`self::`/`super::`
+as internal-path prefixes, so any Cargo workspace member crate's `tests/`
+integration tests — which Cargo always compiles as a SEPARATE crate, and
+which therefore reference the crate under test by its published name (`use
+tokio_util::codec::Framed;`) rather than `crate::` — were indistinguishable
+from a genuinely external crates.io dependency and silently dropped. On
+tokio-rs/tokio, this left 225/231 (97.4%) of the workspace's integration
+test files with empty `imports`, blind to `get_files_context`'s
+`testAssociations`, `verify-tests`/`recap`, and `annotate`'s test-coverage
+line.
+
+Adds `rust-crate-map.ts`, a manifest reader mirroring `php-psr4.ts`/
+`go-module.ts`'s existing pattern: it parses a Cargo workspace root's
+`Cargo.toml` `[workspace] members` (glob-expanded) plus each matched
+member's own `[package] name` (and the root's own `[package]`, for a
+single-crate project or a workspace root that's also a member crate) into a
+`Map<crateName, crateSrcDir>`, normalizing hyphens to underscores to match
+the identifier form Rust `use` paths actually use (`tokio-util` the package
+vs. `tokio_util` the path). Unlike PHP/Go, this map is threaded straight
+into `RustImportExtractor` (a new optional `rustCrateMap` parameter on
+`extractImportPaths`/`processImportSymbols`, widening the
+`LanguageImportExtractor` interface) rather than applied as post-extraction
+string resolution in `ast/symbols.ts` — Rust's extractor has to decide
+"internal vs. external crate" before it ever emits a specifier, which
+happens before `resolveImportSpecifier`'s pipeline ever sees it. Only
+workspace-member crates resolve; a genuinely external crate (`serde`,
+`futures`, ...) is dropped exactly as before this fix, so single-crate
+projects and true external dependencies see zero behavior change.
+
+v1 scope (deliberately KISS/YAGNI, matching #867's PHP/Go precedent): only
+`[workspace] members` and each matched member's `[package] name` are read.
+Module-path resolution mirrors the existing `crate::` transform exactly
+(`<crate>::<rest>` -> `<crateDir>/src/<rest>`), the same "first leg" the
+issue's own suggested-fix section calls out as acceptable — full
+`<mod>.rs`/`<mod>/mod.rs` file resolution is unchanged from the pre-existing
+`crate::`-relative behavior. `[dependencies] path = "..."` entries and
+workspace `exclude` are out of scope.

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -6,6 +6,7 @@ import { chunkByAST, shouldUseAST } from './chunker.js';
 import { clearWorkspacePackageCache } from '../workspace-packages.js';
 import { clearPsr4Cache } from '../php-psr4.js';
 import { clearGoModuleCache } from '../go-module.js';
+import { clearRustCrateMapCache } from '../rust-crate-map.js';
 
 describe('AST Chunker', () => {
   describe('shouldUseAST', () => {
@@ -447,6 +448,116 @@ func TestMode(t *testing.T) {
         const goChunks = chunkByAST('mode_test.go', goContent);
         const goFuncChunk = goChunks.find(c => c.metadata.symbolName === 'TestMode');
         expect(goFuncChunk?.metadata.imports).toContain('github.com/gin-gonic/gin/binding');
+      });
+    });
+
+    describe('manifest-root mapping (Rust Cargo workspace) — #903', () => {
+      let testDir: string;
+
+      beforeEach(async () => {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-chunker-rust-crate-map-'));
+      });
+
+      afterEach(async () => {
+        clearRustCrateMapCache();
+        await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+      });
+
+      async function writeFile(relPath: string, content: string): Promise<void> {
+        const abs = path.join(testDir, relPath);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+
+      async function writeTokioWorkspace(): Promise<void> {
+        await writeFile('Cargo.toml', '[workspace]\nmembers = [\n  "tokio",\n  "tokio-util",\n]\n');
+        await writeFile('tokio/Cargo.toml', '[package]\nname = "tokio"\nversion = "1.0.0"\n');
+        await writeFile(
+          'tokio-util/Cargo.toml',
+          '[package]\nname = "tokio-util"\nversion = "0.7.0"\n',
+        );
+      }
+
+      it('resolves a sibling workspace-crate import from an integration test (tokio-util repro from #903)', async () => {
+        await writeTokioWorkspace();
+
+        const content = `use tokio_util::codec::Framed;
+
+#[test]
+fn framed_codec_roundtrips() {
+    assert!(true);
+}
+`;
+
+        const chunks = chunkByAST('tokio/tests/codec.rs', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'framed_codec_roundtrips');
+
+        expect(funcChunk?.metadata.imports).toContain('tokio-util/src/codec/Framed');
+      });
+
+      it('leaves a genuinely external crate import unresolved even with a workspace crate map present', async () => {
+        await writeTokioWorkspace();
+
+        const content = `use futures::stream::StreamExt;
+
+#[test]
+fn uses_futures() {
+    assert!(true);
+}
+`;
+
+        const chunks = chunkByAST('tokio/tests/stream.rs', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'uses_futures');
+
+        // No workspace member named "futures" — must stay dropped, exactly as
+        // it was before this fix (no guessing, #868 precedent).
+        expect(funcChunk?.metadata.imports).toEqual([]);
+      });
+
+      it('leaves Rust imports dropped when there is no Cargo.toml (zero behavior change)', () => {
+        const content = `use tokio_util::codec::Framed;
+
+#[test]
+fn framed_codec_roundtrips() {
+    assert!(true);
+}
+`;
+
+        const chunks = chunkByAST('tokio/tests/codec.rs', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'framed_codec_roundtrips');
+
+        expect(funcChunk?.metadata.imports).toEqual([]);
+      });
+
+      it('is a no-op for Rust when workspaceRoot is omitted (existing callers unaffected)', () => {
+        const content = `use tokio_util::codec::Framed;
+
+#[test]
+fn framed_codec_roundtrips() {
+    assert!(true);
+}
+`;
+
+        const chunks = chunkByAST('tokio/tests/codec.rs', content);
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'framed_codec_roundtrips');
+
+        expect(funcChunk?.metadata.imports).toEqual([]);
+      });
+
+      it('still resolves plain crate::-relative imports the same way alongside a populated crate map', async () => {
+        await writeTokioWorkspace();
+
+        const content = `use crate::runtime::Handle;
+
+fn get_handle() -> Handle {
+    todo!()
+}
+`;
+
+        const chunks = chunkByAST('tokio/src/lib.rs', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'get_handle');
+
+        expect(funcChunk?.metadata.imports).toContain('runtime/Handle');
       });
     });
 

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -13,6 +13,7 @@ import { getTraverser } from './traversers/index.js';
 import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
 import { resolvePsr4Map } from '../php-psr4.js';
 import { resolveGoModulePrefix } from '../go-module.js';
+import { resolveRustCrateMap } from '../rust-crate-map.js';
 
 export interface ASTChunkOptions {
   minChunkSize?: number;
@@ -78,11 +79,12 @@ const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
 /**
  * Build the manifest-declared import-root mapping for a file's language, when
  * `workspaceRoot` is available. PHP resolves `composer.json`'s PSR-4 map; Go
- * resolves `go.mod`'s module prefix; every other language gets `undefined`
- * (a no-op — see `ManifestRoots` in `./symbols.ts`). Returns `undefined`
- * (rather than an object with empty/absent fields) when the manifest itself
- * declares nothing, so `resolveImportSpecifier`'s manifest-root step is
- * skipped entirely for non-PHP/Go-module projects.
+ * resolves `go.mod`'s module prefix; Rust resolves the Cargo workspace's
+ * member crate names (#903); every other language gets `undefined` (a no-op
+ * — see `ManifestRoots` in `./symbols.ts`). Returns `undefined` (rather than
+ * an object with empty/absent fields) when the manifest itself declares
+ * nothing, so the corresponding resolution step is skipped entirely for
+ * projects without that manifest.
  */
 function buildManifestRoots(
   language: SupportedLanguage,
@@ -98,6 +100,11 @@ function buildManifestRoots(
   if (language === 'go') {
     const goModulePrefix = resolveGoModulePrefix(workspaceRoot);
     return goModulePrefix ? { goModulePrefix } : undefined;
+  }
+
+  if (language === 'rust') {
+    const rustCrateMap = resolveRustCrateMap(workspaceRoot);
+    return rustCrateMap.size > 0 ? { rustCrateMap } : undefined;
   }
 
   return undefined;
@@ -119,10 +126,11 @@ function buildManifestRoots(
  * languages' import syntax could otherwise coincidentally collide with a
  * workspace package name.
  *
- * Independently, when `workspaceRoot` is provided and the file is PHP or Go,
- * `buildManifestRoots` resolves that project's manifest-declared import root
- * (composer.json PSR-4 / go.mod module prefix — see #867) so namespace- or
- * module-qualified imports resolve to real workspace-relative paths too.
+ * Independently, when `workspaceRoot` is provided and the file is PHP, Go, or
+ * Rust, `buildManifestRoots` resolves that project's manifest-declared import
+ * root (composer.json PSR-4 / go.mod module prefix — see #867; Cargo
+ * workspace member crate names — see #903) so namespace-, module-, or
+ * crate-qualified imports resolve to real workspace-relative paths too.
  */
 function prepareASTContext(
   content: string,

--- a/packages/parser/src/ast/extractors/types.ts
+++ b/packages/parser/src/ast/extractors/types.ts
@@ -115,17 +115,28 @@ export interface LanguageImportExtractor {
    * silently dropping all but the first (see #863).
    *
    * @param node - AST node matching one of importNodeTypes
+   * @param rustCrateMap - Rust-only (#903): map of workspace crate name
+   *   (underscore form) -> crate `src/` dir, from `resolveRustCrateMap`.
+   *   Every other language's implementation ignores this parameter — Rust's
+   *   own extractor is the only one that needs to resolve a bare `use` root
+   *   against a workspace crate BEFORE deciding whether the import is
+   *   internal or external, which (unlike PHP/Go) happens inside the
+   *   extractor itself rather than as post-processing in `ast/symbols.ts`.
    * @returns Every import path declared by this node, in source order (empty if none)
    */
-  extractImportPaths(node: SyntaxNode): string[];
+  extractImportPaths(node: SyntaxNode, rustCrateMap?: ReadonlyMap<string, string>): string[];
 
   /**
    * Extract imported symbols mapped to their source path.
    *
    * @param node - AST node matching one of importNodeTypes
+   * @param rustCrateMap - Rust-only (#903) — see `extractImportPaths`.
    * @returns Object with importPath and symbols, or null to skip
    */
-  processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null;
+  processImportSymbols(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): { importPath: string; symbols: string[] } | null;
 
   /**
    * Extract additional "reference" import-like specifiers that name another

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -317,6 +317,77 @@ pub static COUNTER: i32 = 0;`;
       const path = importExtractor.extractImportPath(useNode);
       expect(path).toBe('Foo');
     });
+
+    // #903: a Cargo workspace member's `tests/` integration tests are
+    // compiled as a SEPARATE crate, so they reference the crate under test by
+    // its published name (`use tokio_util::codec::Framed;`), never `crate::`.
+    // Passing a `rustCrateMap` (built by `resolveRustCrateMap`) lets the
+    // extractor tell a workspace-member crate apart from a genuinely
+    // external one, without changing any existing crate/self/super behavior.
+    describe('workspace crate-map resolution (#903)', () => {
+      const rustCrateMap = new Map([
+        ['tokio_util', 'tokio-util/src'],
+        ['tokio_test', 'tokio-test/src'],
+      ]);
+
+      it('resolves a workspace-member crate import (tokio-util repro)', () => {
+        const code = 'use tokio_util::codec::Framed;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBe(
+          'tokio-util/src/codec/Framed',
+        );
+      });
+
+      it('resolves a bare workspace-crate group reference (no module segment before the braces) to the crate dir itself', () => {
+        // `use tokio_test::{assert_ok, assert_err};` (tokio-test's own repro
+        // shape from #903) has no module path between the crate name and the
+        // group -- convertRustModulePath's `rest` is empty, so it resolves to
+        // the crate's src dir itself, same as a bare crate::-relative import
+        // with nothing to strip.
+        const code = 'use tokio_test::{assert_ok, assert_err};';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBe('tokio-test/src');
+
+        const result = importExtractor.processImportSymbols(useNode, rustCrateMap);
+        expect(result).not.toBeNull();
+        expect(result!.importPath).toBe('tokio-test/src');
+        expect(result!.symbols).toContain('assert_ok');
+        expect(result!.symbols).toContain('assert_err');
+      });
+
+      it('still returns null for a genuinely external crate even with a crate map present', () => {
+        const code = 'use futures::stream::StreamExt;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBeNull();
+      });
+
+      it('is a no-op (returns null) for a non-crate/self/super root when no crate map is passed — zero behavior change', () => {
+        const code = 'use tokio_util::codec::Framed;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode)).toBeNull();
+      });
+
+      it('resolves imported symbols for a workspace-member crate the same way', () => {
+        const code = 'use tokio_util::codec::Framed;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        const result = importExtractor.processImportSymbols(useNode, rustCrateMap);
+        expect(result).not.toBeNull();
+        expect(result!.importPath).toBe('tokio-util/src/codec');
+        expect(result!.symbols).toEqual(['Framed']);
+      });
+
+      it('still resolves crate::-relative imports unaffected by a populated crate map', () => {
+        const code = 'use crate::auth::AuthService;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBe('auth/AuthService');
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -13,6 +13,7 @@ import {
   extractReturnType,
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
+import { resolveRustCrateImport } from '../../rust-crate-map.js';
 
 // =============================================================================
 // TRAVERSER
@@ -186,8 +187,25 @@ export class RustExportExtractor implements LanguageExportExtractor {
  * - `self::config` -> `config`
  * - `super::utils` -> `../utils`
  * - `std::io` -> null (external crate, skip)
+ * - `tokio_util::codec::Framed` -> `tokio-util/src/codec/Framed`, but ONLY
+ *   when `rustCrateMap` identifies `tokio_util` as a known workspace member
+ *   crate (#903) — otherwise falls through to the same "external crate,
+ *   skip" outcome as before this fix, so a project with no manifest-declared
+ *   crate map (or a genuinely external crates.io dependency) sees zero
+ *   behavior change. See `../../rust-crate-map.ts` for how the map is built
+ *   and matched.
+ *
+ * @param path - The raw `use` path (never itself a bare `crate`/`self`/`super`
+ *   keyword — see `isBareRootToken`'s callers, which combine that case with
+ *   the following segment before calling this function).
+ * @param rustCrateMap - Map of workspace crate name (underscore form) ->
+ *   crate `src/` dir. Undefined/empty for every project without a resolvable
+ *   Cargo workspace/package manifest.
  */
-function convertRustModulePath(path: string): string | null {
+function convertRustModulePath(
+  path: string,
+  rustCrateMap?: ReadonlyMap<string, string>,
+): string | null {
   // Remove leading `crate::`, `self::`, or `super::`
   if (path.startsWith('crate::')) {
     return path.slice('crate::'.length).replace(/::/g, '/');
@@ -198,8 +216,9 @@ function convertRustModulePath(path: string): string | null {
   if (path.startsWith('super::')) {
     return '../' + path.slice('super::'.length).replace(/::/g, '/');
   }
-  // External crate - skip
-  return null;
+  // Not crate/self/super-relative — resolve against a known workspace crate
+  // (#903), or treat as a genuinely external crate (skip) when it isn't one.
+  return resolveRustCrateImport(path, rustCrateMap);
 }
 
 /**
@@ -316,44 +335,50 @@ function extractUseListSymbols(useList: SyntaxNode): string[] {
 export class RustImportExtractor implements LanguageImportExtractor {
   readonly importNodeTypes = ['use_declaration'];
 
-  extractImportPath(node: SyntaxNode): string | null {
+  extractImportPath(node: SyntaxNode, rustCrateMap?: ReadonlyMap<string, string>): string | null {
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 
     const fullPath = this.resolveFullPath(argument);
-    return fullPath ? convertRustModulePath(fullPath) : null;
+    return fullPath ? convertRustModulePath(fullPath, rustCrateMap) : null;
   }
 
-  extractImportPaths(node: SyntaxNode): string[] {
-    return toImportPathsArray(this.extractImportPath(node));
+  extractImportPaths(node: SyntaxNode, rustCrateMap?: ReadonlyMap<string, string>): string[] {
+    return toImportPathsArray(this.extractImportPath(node, rustCrateMap));
   }
 
-  processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
+  processImportSymbols(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): { importPath: string; symbols: string[] } | null {
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 
-    return this.processUseArgument(argument);
+    return this.processUseArgument(argument, rustCrateMap);
   }
 
-  private processUseArgument(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
+  private processUseArgument(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): { importPath: string; symbols: string[] } | null {
     // Simple: `use crate::auth::AuthService;`
     if (node.type === 'scoped_identifier') {
-      return this.processScopedIdentifier(node);
+      return this.processScopedIdentifier(node, rustCrateMap);
     }
 
     // List: `use crate::auth::{AuthService, AuthError};`
     if (node.type === 'scoped_use_list') {
-      return this.processScopedUseList(node);
+      return this.processScopedUseList(node, rustCrateMap);
     }
 
     // Alias: `use crate::auth::Service as Auth;`
     if (node.type === 'use_as_clause') {
-      return this.processUseAsClause(node);
+      return this.processUseAsClause(node, rustCrateMap);
     }
 
     // Wildcard: `use crate::models::*;`
     if (node.type === 'use_wildcard') {
-      return this.processUseWildcard(node);
+      return this.processUseWildcard(node, rustCrateMap);
     }
 
     // Direct identifier (rare): `use SomeItem;`
@@ -366,6 +391,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
 
   private processScopedIdentifier(
     node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
   ): { importPath: string; symbols: string[] } | null {
     const pathNode = node.childForFieldName('path');
     const nameNode = node.childForFieldName('name');
@@ -379,18 +405,21 @@ export class RustImportExtractor implements LanguageImportExtractor {
     // `resolveFullPath`/`extractImportPath` already derive from the whole
     // node's text for this same statement).
     const modulePath = isBareRootToken(pathNode)
-      ? convertRustModulePath(`${pathNode.text}::${nameNode.text}`)
-      : convertRustModulePath(pathNode.text);
+      ? convertRustModulePath(`${pathNode.text}::${nameNode.text}`, rustCrateMap)
+      : convertRustModulePath(pathNode.text, rustCrateMap);
     if (!modulePath) return null;
 
     return { importPath: modulePath, symbols: [nameNode.text] };
   }
 
-  private processScopedUseList(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
+  private processScopedUseList(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): { importPath: string; symbols: string[] } | null {
     const scopePath = extractScopePath(node);
     if (!scopePath) return null;
 
-    const modulePath = convertRustModulePath(scopePath);
+    const modulePath = convertRustModulePath(scopePath, rustCrateMap);
     if (!modulePath) return null;
 
     const useList = node.namedChildren.find(child => child.type === 'use_list');
@@ -412,7 +441,10 @@ export class RustImportExtractor implements LanguageImportExtractor {
     return symbols.length > 0 ? { importPath: modulePath, symbols } : null;
   }
 
-  private processUseAsClause(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
+  private processUseAsClause(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): { importPath: string; symbols: string[] } | null {
     // `use crate::auth::Service as Auth;`
     // The first child is the path (scoped_identifier), alias field has the alias
     const aliasNode = node.childForFieldName('alias');
@@ -422,7 +454,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const scopePathNode = pathChild.childForFieldName('path');
     if (!scopePathNode) return null;
 
-    const modulePath = convertRustModulePath(scopePathNode.text);
+    const modulePath = convertRustModulePath(scopePathNode.text, rustCrateMap);
     if (!modulePath) return null;
 
     const symbol = aliasNode?.text || pathChild.childForFieldName('name')?.text;
@@ -431,7 +463,10 @@ export class RustImportExtractor implements LanguageImportExtractor {
     return { importPath: modulePath, symbols: [symbol] };
   }
 
-  private processUseWildcard(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
+  private processUseWildcard(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): { importPath: string; symbols: string[] } | null {
     // `use crate::models::*;` -> AST is:
     //   use_wildcard
     //     scoped_identifier (crate::models)
@@ -440,7 +475,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const scopedId = node.namedChildren.find(child => child.type === 'scoped_identifier');
     if (!scopedId) return null;
 
-    const modulePath = convertRustModulePath(scopedId.text);
+    const modulePath = convertRustModulePath(scopedId.text, rustCrateMap);
     if (!modulePath) return null;
     return { importPath: modulePath, symbols: ['*'] };
   }

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -10,18 +10,31 @@ import { resolveGoModuleImport } from '../go-module.js';
 /**
  * Per-project manifest-declared import-root mappings, threaded through as a
  * third specifier-resolution step (after relative-import and workspace-
- * package resolution) in `resolveImportSpecifier`. Built once per workspace
- * root in `ast/chunker.ts`'s `prepareASTContext` — see `../php-psr4.ts` and
- * `../go-module.ts` for how each map is read. At most one field is ever
- * populated for a given file (the language determines which manifest, if
- * any, applies), and both are optional so this is a no-op for every language
- * without a manifest reader.
+ * package resolution) in `resolveImportSpecifier` — EXCEPT for Rust, whose
+ * `rustCrateMap` is threaded straight into the import extractor instead (see
+ * its own doc comment below). Built once per workspace root in
+ * `ast/chunker.ts`'s `prepareASTContext` — see `../php-psr4.ts`,
+ * `../go-module.ts`, and `../rust-crate-map.ts` for how each map is read. At
+ * most one field is ever populated for a given file (the language determines
+ * which manifest, if any, applies), and all are optional so this is a no-op
+ * for every language without a manifest reader.
  */
 export interface ManifestRoots {
   /** PHP Composer PSR-4 namespace-prefix -> source-directory map. */
   psr4Map?: ReadonlyMap<string, string>;
   /** Go module's declared import-path prefix (`go.mod`'s `module` line). */
   goModulePrefix?: string;
+  /**
+   * Rust Cargo workspace crate name (underscore form) -> crate `src/` dir map
+   * (#903). Unlike `psr4Map`/`goModulePrefix`, this is NOT consumed by
+   * `resolveManifestRoot` below — Rust's extractor (`ast/languages/rust.ts`)
+   * must decide "internal vs. external crate" BEFORE it ever emits a
+   * specifier (a `crate::`/`self::`/`super::`-relative path is converted;
+   * anything else is dropped), so the map is passed straight into
+   * `extractImportPaths`/`processImportSymbols` as an extra argument instead
+   * of being applied as post-extraction string resolution.
+   */
+  rustCrateMap?: ReadonlyMap<string, string>;
 }
 
 /**
@@ -158,7 +171,7 @@ function extractImportPaths(
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
-    for (const result of importExtractor.extractImportPaths(node)) {
+    for (const result of importExtractor.extractImportPaths(node, manifestRoots?.rustCrateMap)) {
       imports.push(resolveImportSpecifier(result, filepath, workspacePackages, manifestRoots));
     }
   }
@@ -244,7 +257,7 @@ function extractSymbolsWithExtractor(
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
-    const result = importExtractor.processImportSymbols(node);
+    const result = importExtractor.processImportSymbols(node, manifestRoots?.rustCrateMap);
     if (result) {
       const key = resolveImportSpecifier(
         result.importPath,

--- a/packages/parser/src/rust-crate-map.test.ts
+++ b/packages/parser/src/rust-crate-map.test.ts
@@ -109,6 +109,33 @@ describe('resolveRustCrateMap', () => {
     expect(map.size).toBe(2);
   });
 
+  it('reads the real `members` array, not `default-members`, when default-members is declared first', async () => {
+    // TOML formatters commonly sort keys alphabetically, which places
+    // "default-members" before "members" -- an unanchored `members = [...]`
+    // regex would match the "members = [" tail of "default-members = [" and
+    // extract that array instead, silently dropping the real workspace
+    // members (and picking up bogus/unrelated crate names).
+    await writeFile(
+      'Cargo.toml',
+      [
+        '[workspace]',
+        'default-members = ["tokio"]',
+        'members = [',
+        '  "tokio",',
+        '  "tokio-util",',
+        ']',
+      ].join('\n'),
+    );
+    await writeFile('tokio/Cargo.toml', '[package]\nname = "tokio"\nversion = "1.0.0"\n');
+    await writeFile('tokio-util/Cargo.toml', '[package]\nname = "tokio-util"\nversion = "0.7.0"\n');
+
+    const map = resolveRustCrateMap(testDir);
+
+    expect(map.get('tokio')).toBe('tokio/src');
+    expect(map.get('tokio_util')).toBe('tokio-util/src');
+    expect(map.size).toBe(2);
+  });
+
   it('caches the map per workspace root', async () => {
     await writeFile('Cargo.toml', '[package]\nname = "my-crate"\n');
     const first = resolveRustCrateMap(testDir);

--- a/packages/parser/src/rust-crate-map.test.ts
+++ b/packages/parser/src/rust-crate-map.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  resolveRustCrateMap,
+  resolveRustCrateImport,
+  clearRustCrateMapCache,
+} from './rust-crate-map.js';
+
+describe('resolveRustCrateMap', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-rust-crate-map-'));
+  });
+
+  afterEach(async () => {
+    clearRustCrateMapCache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it('returns an empty map when there is no Cargo.toml at all', () => {
+    expect(resolveRustCrateMap(testDir).size).toBe(0);
+  });
+
+  it('maps a single-crate project (no [workspace]) by its own [package] name', async () => {
+    await writeFile(
+      'Cargo.toml',
+      '[package]\nname = "my-crate"\nversion = "0.1.0"\nedition = "2021"\n',
+    );
+
+    const map = resolveRustCrateMap(testDir);
+    // Hyphens in the package name become underscores in `use` paths (#903).
+    expect(map.get('my_crate')).toBe('src');
+    expect(map.size).toBe(1);
+  });
+
+  it("maps a Cargo workspace's members by each one's own [package] name (tokio shape)", async () => {
+    await writeFile(
+      'Cargo.toml',
+      [
+        '[workspace]',
+        'resolver = "2"',
+        'members = [',
+        '  "tokio",',
+        '  "tokio-test",',
+        '  "tokio-stream",',
+        '  "tokio-util",',
+        '',
+        '  # Internal',
+        '  "benches",',
+        ']',
+        '',
+        '[patch.crates-io]',
+        'tokio = { path = "tokio" }',
+      ].join('\n'),
+    );
+    await writeFile('tokio/Cargo.toml', '[package]\nname = "tokio"\nversion = "1.0.0"\n');
+    await writeFile('tokio-test/Cargo.toml', '[package]\nname = "tokio-test"\nversion = "0.4.0"\n');
+    await writeFile(
+      'tokio-stream/Cargo.toml',
+      '[package]\nname = "tokio-stream"\nversion = "0.1.0"\n',
+    );
+    await writeFile('tokio-util/Cargo.toml', '[package]\nname = "tokio-util"\nversion = "0.7.0"\n');
+    // "benches" is a declared member with no Cargo.toml of its own in this
+    // fixture -- must be skipped gracefully, not throw.
+    await fs.mkdir(path.join(testDir, 'benches'), { recursive: true });
+
+    const map = resolveRustCrateMap(testDir);
+
+    expect(map.get('tokio')).toBe('tokio/src');
+    expect(map.get('tokio_test')).toBe('tokio-test/src');
+    expect(map.get('tokio_stream')).toBe('tokio-stream/src');
+    expect(map.get('tokio_util')).toBe('tokio-util/src');
+    expect(map.has('benches')).toBe(false);
+    expect(map.size).toBe(4);
+  });
+
+  it("also maps the workspace root's own [package] when it is itself a member crate", async () => {
+    await writeFile(
+      'Cargo.toml',
+      '[package]\nname = "root-crate"\nversion = "0.1.0"\n\n[workspace]\nmembers = ["sub"]\n',
+    );
+    await writeFile('sub/Cargo.toml', '[package]\nname = "sub"\nversion = "0.1.0"\n');
+
+    const map = resolveRustCrateMap(testDir);
+
+    expect(map.get('root_crate')).toBe('src');
+    expect(map.get('sub')).toBe('sub/src');
+    expect(map.size).toBe(2);
+  });
+
+  it('resolves glob-pattern workspace members', async () => {
+    await writeFile('Cargo.toml', '[workspace]\nmembers = ["crates/*"]\n');
+    await writeFile('crates/foo/Cargo.toml', '[package]\nname = "foo"\nversion = "0.1.0"\n');
+    await writeFile('crates/bar/Cargo.toml', '[package]\nname = "bar"\nversion = "0.1.0"\n');
+
+    const map = resolveRustCrateMap(testDir);
+
+    expect(map.get('foo')).toBe('crates/foo/src');
+    expect(map.get('bar')).toBe('crates/bar/src');
+    expect(map.size).toBe(2);
+  });
+
+  it('caches the map per workspace root', async () => {
+    await writeFile('Cargo.toml', '[package]\nname = "my-crate"\n');
+    const first = resolveRustCrateMap(testDir);
+    await writeFile('Cargo.toml', '[package]\nname = "renamed-crate"\n');
+    const second = resolveRustCrateMap(testDir);
+
+    expect(second).toBe(first);
+    expect(second.has('my_crate')).toBe(true);
+    expect(second.has('renamed_crate')).toBe(false);
+  });
+});
+
+describe('resolveRustCrateImport', () => {
+  it('is a no-op (returns null) when crateMap is undefined', () => {
+    expect(resolveRustCrateImport('tokio_util::codec::Framed', undefined)).toBeNull();
+  });
+
+  it('is a no-op (returns null) when crateMap is empty', () => {
+    expect(resolveRustCrateImport('tokio_util::codec::Framed', new Map())).toBeNull();
+  });
+
+  it('resolves a workspace crate import to its src dir + module path (tokio-util repro from #903)', () => {
+    const crateMap = new Map([['tokio_util', 'tokio-util/src']]);
+    expect(resolveRustCrateImport('tokio_util::codec::Framed', crateMap)).toBe(
+      'tokio-util/src/codec/Framed',
+    );
+  });
+
+  it('resolves a bare crate-root import (no further path) to the crate dir itself', () => {
+    const crateMap = new Map([['tokio_test', 'tokio-test/src']]);
+    expect(resolveRustCrateImport('tokio_test', crateMap)).toBe('tokio-test/src');
+  });
+
+  it('leaves a genuinely external crate unresolved (returns null) -- no guessing, #868 precedent', () => {
+    const crateMap = new Map([['tokio_util', 'tokio-util/src']]);
+    expect(resolveRustCrateImport('futures::stream::StreamExt', crateMap)).toBeNull();
+    expect(resolveRustCrateImport('serde::Deserialize', crateMap)).toBeNull();
+  });
+
+  it('does not false-positive on a shared string prefix without a path boundary', () => {
+    // "tokio_util_extra" must not be treated as the "tokio_util" crate.
+    const crateMap = new Map([['tokio_util', 'tokio-util/src']]);
+    expect(resolveRustCrateImport('tokio_util_extra::foo', crateMap)).toBeNull();
+  });
+});

--- a/packages/parser/src/rust-crate-map.ts
+++ b/packages/parser/src/rust-crate-map.ts
@@ -81,12 +81,20 @@ function extractPackageName(content: string): string | undefined {
  * (possibly glob) entries, e.g. `"tokio"`, `"crates/*"`. Handles the array
  * spanning multiple lines -- Cargo's own convention once a workspace has more
  * than a couple of members (see tokio-rs/tokio's own root manifest).
+ *
+ * The `members` key is matched anchored to the start of a line (allowing only
+ * leading whitespace) rather than as a bare substring search. Cargo also
+ * supports a distinct `default-members` key in the same `[workspace]` table,
+ * and TOML formatters commonly place it first (alphabetically before
+ * `members`) -- an unanchored `/members\s*=\s*\[/` would match the "members
+ * = [" tail of "default-members = [" and silently extract THAT array
+ * instead, dropping the real workspace members.
  */
 function extractWorkspaceMemberGlobs(content: string): string[] {
   const body = extractTableBody(content, '[workspace]');
   if (!body) return [];
 
-  const arrayMatch = body.match(/members\s*=\s*\[([\s\S]*?)\]/);
+  const arrayMatch = body.match(/^[ \t]*members\s*=\s*\[([\s\S]*?)\]/m);
   if (!arrayMatch) return [];
 
   const quoted = arrayMatch[1].match(/"([^"]+)"/g) ?? [];

--- a/packages/parser/src/rust-crate-map.ts
+++ b/packages/parser/src/rust-crate-map.ts
@@ -1,0 +1,197 @@
+import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
+
+/**
+ * Resolves Rust Cargo workspace member crate names to their source
+ * directories, building a `Map<crateName (underscore form), crateSrcDir>`
+ * from the workspace root's `Cargo.toml` `[workspace] members` list plus each
+ * matched member's own `[package] name` (and the root's own `[package]`, for
+ * a single-crate project or a workspace root that's also a member crate).
+ *
+ * This closes the Rust test-association blind spot (#903 -- the third leg of
+ * #867, alongside PHP's `composer.json` PSR-4 map and Go's `go.mod` module
+ * path): Cargo always compiles a crate's `tests/` directory as a SEPARATE
+ * crate, so an integration test references the crate under test by its
+ * PUBLISHED name (`use tokio_util::codec::Framed;`), never `crate::` --
+ * `convertRustModulePath` (`ast/languages/rust.ts`) has no way to tell that
+ * apart from a genuinely external crates.io dependency, and drops it. Once a
+ * workspace's member crate names are known, resolving `<crate>::<rest>` into
+ * `<crateDir>/src/<rest>` is exact string substitution -- the same shape as
+ * `workspace-packages.ts`'s existing pattern (parse once per workspace root,
+ * cache the result, no-op when the manifest is absent).
+ *
+ * v1 scope (deliberately KISS/YAGNI, matching #867's PHP/Go precedent): only
+ * `[workspace] members` (glob-expanded, mirroring `workspace-packages.ts`'s
+ * `resolveMemberDirs`) and each matched member's own `[package] name` are
+ * read. `[dependencies] path = "..."` entries, workspace `exclude`, and
+ * virtual-manifest edge cases beyond a plain `[workspace]`/`[package]` split
+ * are out of scope -- add if/when a real repo needs them. Only WORKSPACE-
+ * member crates are ever mapped; a crate that merely appears in
+ * `[dependencies]` (with no workspace-membership relationship) stays
+ * external -- no guessing, per #868's precedent.
+ */
+
+/** Per-workspace-root cache so repeated calls during a single index run are O(1) map lookups. */
+const rustCrateMapCache = new Map<string, Map<string, string>>();
+
+/** Clears the cached crate maps. Exported for test isolation. */
+export function clearRustCrateMapCache(): void {
+  rustCrateMapCache.clear();
+}
+
+function readCargoToml(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract a top-level TOML table's body text -- everything between a
+ * `[header]` line and the next line starting with `[` (or end of file).
+ * Deliberately naive line-based scanning: sufficient for the narrow
+ * `[package]`/`[workspace]` shapes this module reads, not a general TOML
+ * parser.
+ */
+function extractTableBody(content: string, header: string): string | null {
+  const lines = content.split('\n');
+  const startIndex = lines.findIndex(line => line.trim() === header);
+  if (startIndex === -1) return null;
+
+  const bodyLines: string[] = [];
+  for (const line of lines.slice(startIndex + 1)) {
+    if (/^\s*\[/.test(line)) break;
+    bodyLines.push(line);
+  }
+  return bodyLines.join('\n');
+}
+
+/** Extract `[package] name = "..."` from a Cargo.toml's contents, if present. */
+function extractPackageName(content: string): string | undefined {
+  const body = extractTableBody(content, '[package]');
+  if (!body) return undefined;
+  const match = body.match(/^\s*name\s*=\s*"([^"]+)"/m);
+  return match?.[1];
+}
+
+/**
+ * Extract `[workspace] members = [...]` from a Cargo.toml's contents, as raw
+ * (possibly glob) entries, e.g. `"tokio"`, `"crates/*"`. Handles the array
+ * spanning multiple lines -- Cargo's own convention once a workspace has more
+ * than a couple of members (see tokio-rs/tokio's own root manifest).
+ */
+function extractWorkspaceMemberGlobs(content: string): string[] {
+  const body = extractTableBody(content, '[workspace]');
+  if (!body) return [];
+
+  const arrayMatch = body.match(/members\s*=\s*\[([\s\S]*?)\]/);
+  if (!arrayMatch) return [];
+
+  const quoted = arrayMatch[1].match(/"([^"]+)"/g) ?? [];
+  return quoted.map(q => q.slice(1, -1));
+}
+
+function isDirectory(absPath: string): boolean {
+  try {
+    return fs.statSync(absPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve workspace member globs to member directories (workspace-relative, POSIX separators). */
+function resolveMemberDirs(workspaceRoot: string, globs: string[]): string[] {
+  const matched = new Set<string>();
+  for (const pattern of globs) {
+    for (const result of globSync(pattern, { cwd: workspaceRoot })) {
+      const relDir = result.replace(/\\/g, '/');
+      if (isDirectory(path.join(workspaceRoot, relDir))) {
+        matched.add(relDir);
+      }
+    }
+  }
+  return Array.from(matched);
+}
+
+/** Normalize a Cargo package name to the identifier form used in `use` paths (hyphens -> underscores). */
+function toRustIdentifier(crateName: string): string {
+  return crateName.replace(/-/g, '_');
+}
+
+/** Add a `crateName -> memberDir/src` entry to `map`, when `content` declares a `[package] name`. */
+function addPackageEntry(
+  map: Map<string, string>,
+  memberDir: string,
+  content: string | null,
+): void {
+  if (!content) return;
+  const name = extractPackageName(content);
+  if (!name) return;
+  map.set(toRustIdentifier(name), path.posix.join(memberDir, 'src'));
+}
+
+/**
+ * Build (or retrieve from cache) the crate-name -> crate-`src/`-dir map for a
+ * Cargo workspace (or a single-crate project's own package).
+ *
+ * Returns an empty map when there is no root `Cargo.toml` -- callers can pass
+ * the result straight through with zero behavior change.
+ *
+ * @param workspaceRoot - Absolute path to the project root.
+ */
+export function resolveRustCrateMap(workspaceRoot: string): Map<string, string> {
+  const normalizedRoot = workspaceRoot.replace(/\\/g, '/').replace(/\/$/, '');
+
+  const cached = rustCrateMapCache.get(normalizedRoot);
+  if (cached) return cached;
+
+  const map = new Map<string, string>();
+  const rootManifest = readCargoToml(path.join(normalizedRoot, 'Cargo.toml'));
+  if (rootManifest) {
+    // The workspace root is sometimes itself a member crate (a `[package]`
+    // and a `[workspace]` both present in the same manifest).
+    addPackageEntry(map, '.', rootManifest);
+
+    const memberGlobs = extractWorkspaceMemberGlobs(rootManifest);
+    for (const memberDir of resolveMemberDirs(normalizedRoot, memberGlobs)) {
+      const memberManifest = readCargoToml(path.join(normalizedRoot, memberDir, 'Cargo.toml'));
+      addPackageEntry(map, memberDir, memberManifest);
+    }
+  }
+
+  rustCrateMapCache.set(normalizedRoot, map);
+  return map;
+}
+
+/**
+ * Resolve a raw Rust module path (e.g. `tokio_util::codec::Framed` --
+ * already confirmed by `convertRustModulePath` NOT to start with
+ * `crate::`/`self::`/`super::`) against a workspace's crate map, by matching
+ * its root segment (the part before the first `::`, or the whole path if
+ * there is none) against a known workspace crate name.
+ *
+ * No-op (returns `null`, i.e. "still looks external") when `crateMap` is
+ * absent/empty or the root segment doesn't match any known crate -- a
+ * genuinely external crates.io dependency (`serde`, `futures`, ...) is never
+ * in the map, so it's dropped exactly as it was before this fix (#868's "no
+ * guessing" precedent: only real workspace members ever resolve).
+ *
+ * @param modulePath - The raw (non-crate/self/super) `use` path.
+ * @param crateMap - Map of crate name (underscore form) -> crate `src/` dir, from `resolveRustCrateMap`.
+ */
+export function resolveRustCrateImport(
+  modulePath: string,
+  crateMap: ReadonlyMap<string, string> | undefined,
+): string | null {
+  if (!crateMap || crateMap.size === 0) return null;
+
+  const sepIndex = modulePath.indexOf('::');
+  const root = sepIndex === -1 ? modulePath : modulePath.slice(0, sepIndex);
+  const crateDir = crateMap.get(root);
+  if (!crateDir) return null;
+
+  const rest = sepIndex === -1 ? '' : modulePath.slice(sepIndex + 2).replace(/::/g, '/');
+  return rest ? `${crateDir}/${rest}` : crateDir;
+}


### PR DESCRIPTION
## Summary

Closes #903 — the third leg of #867, alongside PHP's `composer.json` PSR-4 map and Go's `go.mod` module path (#877).

`convertRustModulePath` (`packages/parser/src/ast/languages/rust.ts`) only recognized `crate::`/`self::`/`super::` as internal-path prefixes; any other root segment was treated as an external crate and dropped. That's correct for genuinely external crates.io dependencies, but a Cargo workspace member's `tests/` directory is always compiled by Cargo as a SEPARATE crate — so its integration tests reference the crate under test by its **published name** (`use tokio_util::codec::Framed;`), never `crate::`. The extractor had no way to tell that apart from a real external dependency, so every such import was silently discarded.

On tokio-rs/tokio, this left **225/231 (97.4%)** of the workspace's integration test files (`tokio/tests/`, `tokio-util/tests/`, `tokio-stream/tests/`) with empty `imports` — blind to `get_files_context`'s `testAssociations`, `verify-tests`/`recap`, and `annotate`'s test-coverage line.

## Fix

Adds `packages/parser/src/rust-crate-map.ts`, a manifest reader mirroring `php-psr4.ts`/`go-module.ts`'s existing pattern (parse once per workspace root, cache, no-op when absent):

- Parses the workspace root's `Cargo.toml` `[workspace] members` (glob-expanded, same approach as `workspace-packages.ts`'s `resolveMemberDirs`) plus each matched member's own `[package] name` — and the root's own `[package]`, for a single-crate project or a workspace root that's also a member crate.
- Builds `Map<crateName, crateSrcDir>`, normalizing hyphens to underscores (`tokio-util` the package -> `tokio_util` the `use`-path identifier).
- `resolveRustCrateImport(modulePath, crateMap)` resolves `<crate>::<rest>` -> `<crateDir>/src/<rest>` — the exact same transform shape `convertRustModulePath` already applies for `crate::`, just with an explicit directory prefix instead of an implicit "current crate" one.

**Plumbing difference from PHP/Go:** PHP/Go's manifest resolution runs as post-extraction string resolution in `ast/symbols.ts`'s `resolveImportSpecifier`, because those extractors always emit the raw specifier unconditionally. Rust's extractor instead decides "internal vs. external" *before* it ever emits anything (returns `null` immediately for a non-crate/self/super root), which happens *before* `resolveImportSpecifier`'s pipeline would ever see it. So the crate map is threaded straight into `RustImportExtractor` instead: a new optional `rustCrateMap` parameter on the `LanguageImportExtractor` interface's `extractImportPaths`/`processImportSymbols` methods (every other language's implementation ignores it — zero behavior change), built once per file in `ast/chunker.ts`'s `buildManifestRoots` and threaded through `ast/symbols.ts`'s two extractor call sites.

Only **workspace-member crates** are ever mapped — a crate that merely appears as a `[dependencies]` entry (no workspace-membership relationship) stays external and is dropped exactly as before this fix (no guessing, per #868's precedent).

## Scope (v1, deliberately KISS/YAGNI)

- Only `[workspace] members` and each matched member's `[package] name` are read. `[dependencies] path = "..."` entries and workspace `exclude` are out of scope.
- Module-path resolution mirrors the pre-existing `crate::` transform exactly (`<crate>::<rest>` -> `<crateDir>/src/<rest>`) — this is the "first leg" the issue's own suggested-fix section calls out as acceptable. Full `<mod>.rs` vs. `<mod>/mod.rs` file resolution beyond that is unchanged from the pre-existing `crate::`-relative behavior (same known limitation, not introduced by this fix).

## Tests

- `packages/parser/src/rust-crate-map.test.ts` (12 new tests): `resolveRustCrateMap` (tokio-shape workspace parsing incl. comments/glob members/root-is-also-member, caching, no-manifest no-op) and `resolveRustCrateImport` (tokio-util repro, bare crate-root reference, external-crate no-op, no false-positive on a shared string prefix).
- `packages/parser/src/ast/languages/rust.test.ts`: new `describe('workspace crate-map resolution (#903)')` block (6 tests) exercising `RustImportExtractor` directly with a crate map.
- `packages/parser/src/ast/chunker.test.ts`: new `describe('manifest-root mapping (Rust Cargo workspace) — #903')` block (5 tests) — end-to-end `chunkByAST` resolution incl. the tokio-util repro, external-crate no-op, no-manifest no-op, `workspaceRoot`-omitted no-op, and `crate::`-relative imports unaffected.

**Full gate chain**, all green: `format:check`, `lint` (0 errors, pre-existing warnings only, none touching my files), `typecheck`, `build`, `npm test` (parser 1268, core+review 1665, cli 1188, action 41 — all passed), `lien delta` (exit 0 — only Halstead "time"-metric/cognitive advisories on touched functions, no new-over-threshold or crossed function; full output below).

```
lien delta — complexity vs HEAD
  packages/parser/src/ast/chunker.ts
    ⚠ worsened  buildManifestRoots       cognitive 5 → 7
  packages/parser/src/ast/languages/rust.ts
    ⚠ worsened  convertRustModulePath    time 10m → 14m
    ⚠ worsened  RustImportExtractor.extractImportPath time 3m → 4m
    ⚠ worsened  RustImportExtractor.extractImportPaths time 0m → 1m
    ⚠ worsened  RustImportExtractor.processImportSymbols time 2m → 4m
    ⚠ worsened  RustImportExtractor.processUseArgument time 7m → 11m
    ⚠ worsened  RustImportExtractor.processScopedIdentifier time 12m → 16m
    ⚠ worsened  RustImportExtractor.processScopedUseList time 25m → 28m
    ⚠ worsened  RustImportExtractor.processUseAsClause time 15m → 20m
    ⚠ worsened  RustImportExtractor.processUseWildcard time 7m → 9m
  packages/parser/src/ast/symbols.ts
    ⚠ worsened  extractImportPaths       time 16m → 17m
    ⚠ worsened  extractSymbolsWithExtractor time 15m → 16m
  packages/parser/src/rust-crate-map.ts  (all new, max cognitive 6)
  ⚠ 12 worsened · 8 files · 123 ms   [exit 0]
```

Also ran `npm run test:e2e:rust -w packages/cli` (Anyhow, a real single-crate project) — passed, 14/14 (140 skipped for other languages).

## Dogfood (verbatim evidence)

Cloned `tokio-rs/tokio` (`--depth 1`) into `mktemp -d` copies **outside this worktree**, twice — once indexed with a CLI built from `origin/main` (the exact commit this branch is based on, `99cf7e5`), once with this branch's built CLI. Both indexed cleanly (826/826 files, ~2.3s).

**Quantified: integration-test files with non-empty `imports`, before vs. after**

| Directory | Before | After |
|---|---|---|
| `tokio/tests/*.rs` | 6/178 | 164/178 |
| `tokio-util/tests/*.rs` | 0/29 | 28/29 |
| `tokio-stream/tests/*.rs` | 0/24 | 23/24 |
| **Combined** | **6/231 (2.6%)** | **215/231 (93.1%)** |

209 files gained non-empty imports net-new; all 6 pre-existing non-empty files are unchanged (no regression). The remaining 16 empty files are honest "no signal" cases on inspection (e.g. `unwindsafe.rs`/`_require_full.rs`/`tests/support/*.rs` only reference `std::`; `macros_rename_test.rs` uses `use std as tokio;` / `use ::tokio as tokio1;`, an absolute-path-prefix rename shape genuinely out of this fix's scope) — not swept under the rug, and not a regression versus the pre-fix baseline (which was empty for these too).

**Test-association coverage gained — 3 concrete wins, via the actual `lien annotate` tool, spot-checked by opening each test file:**

```
$ lien annotate tokio-util/src/codec/mod.rs
BEFORE: No test coverage.
AFTER:  Test coverage: tokio-util/tests/udp.rs, tokio-util/tests/length_delimited.rs (+7 more).

$ lien annotate tokio/src/runtime/mod.rs
BEFORE: No test coverage.
AFTER:  Test coverage: tokio-util/tests/abort_on_drop.rs, tokio/tests/uds_socket.rs (+23 more).

$ lien annotate tokio-stream/src/lib.rs
BEFORE: No test coverage.
AFTER:  Test coverage: tokio-stream/tests/stream_stream_map.rs, tokio-stream/tests/stream_pending.rs (+13 more).
```

Spot-checked `tokio-util/tests/framed.rs`, `tokio-stream/tests/stream_merge.rs`, and the issue's own repro file `tokio/tests/rt_basic.rs` directly — each really does `use tokio_util::...`/`use tokio_stream::...`/`use tokio::...` at the top, confirming these aren't false matches.

**Zero false positives from external crates:** `tokio/tests/task_panic.rs` has `use futures::future;` alongside real internal imports — resolved imports are `["tokio/src/runtime/Builder","tokio/src/task"]`, with no trace of `futures` anywhere. Confirmed workspace-wide: zero rows across all 231 integration test files have `futures` appearing in a resolved `imports` string.

**Single-crate repos unaffected:**
- Real project (`dtolnay/anyhow`, no `[workspace]`): diffed every file's resolved `imports` before vs. after — **zero `src/*.rs` files changed at all**. The only diffs are in `tests/*.rs`, where Anyhow's own integration tests self-reference `use anyhow::...` — this is the same bug pattern at n=1 crate, and now correctly resolves (`[]` -> `["src"]`/`["src/anyhow"]` etc.) instead of silently dropping. Not a regression; the intentional, correct generalization of the fix.
- Fresh `cargo init --lib` fixture with a hand-authored `tests/integration.rs` containing `use tiny_fixture::add;` (self-reference) and `use serde::Serialize;` (genuinely external, not a real dependency): `src/lib.rs`'s imports are **byte-identical** before/after (`[]`/`[]`). `tests/integration.rs` goes from `[]` -> `["src/add"]`, with no trace of `serde` — confirming the external-crate guard holds even in the single-crate case.

All temporary clones, index directories (`~/.lien/indices/tokio-*`, `anyhow-*`, `tiny-fixture-*`), and the `mktemp -d` root were removed after verification.

## Changeset

`@liendev/parser`: patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust import resolution for Cargo workspaces.
  * Workspace member crate imports now resolve to local source paths, including hyphenated crate names.
  * External crate imports continue to be excluded as expected.
  * Preserved existing behavior for relative Rust imports and projects without workspace manifests.
* **Tests**
  * Added coverage for single-crate projects, workspace members, glob patterns, missing manifests, caching, and external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds Rust Cargo workspace crate-name resolution so integration tests in workspace member crates can resolve `use crate_name::...` imports to real source paths instead of being silently dropped as external dependencies. The implementation mirrors the existing PHP/Go manifest-resolution pattern, threads a new optional `rustCrateMap` through the Rust import extractor only, and preserves the prior behavior for `crate::`/`self::`/`super::`-relative paths and genuinely external crates. The change is well-scoped, thoroughly tested, and the touched doc comments accurately describe the code.
>
> - Adds `packages/parser/src/rust-crate-map.ts` to parse root `Cargo.toml` `[workspace] members` and each member's `[package] name` into a `Map<crateName, crateSrcDir>`, normalizing hyphens to underscores.
> - Widens `LanguageImportExtractor.extractImportPaths`/`processImportSymbols` with an optional `rustCrateMap` parameter that only Rust's extractor consumes.
> - Updates `convertRustModulePath` to fall back to workspace-crate resolution for non-crate/self/super roots, while still dropping unknown external crates.
> - Threads the crate map through `ast/chunker.ts` and `ast/symbols.ts` only for Rust files, leaving all other languages unchanged.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3a7ebd3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

