### PR TITLE
fix(parser): resolve Python relative imports and bare package imports

### DIFF
--- a/.changeset/python-relative-and-bare-imports.md
+++ b/.changeset/python-relative-and-bare-imports.md
@@ -1,0 +1,56 @@
+---
+'@liendev/parser': patch
+---
+
+Fixes #901 and #904: two Python import-resolution gaps found on
+pallets/flask, both remainders after #859/#861.
+
+#904 — relative imports (`from .module import X`, `from ..pkg import Y`)
+never matched anything, because `matchesPythonModule`'s regex rejects a
+leading dot and the generic relative-import strategy in `matchesFile` only
+understands JS/TS's slash-based `./`/`../`. `PythonImportExtractor` now
+converts the grammar's leading-dot form to a `./`/`../`-prefixed specifier
+at extraction time (mirroring `RustImportExtractor`'s `super::` -> `../`
+conversion), and `python` is added to `chunker.ts`'s
+`RESOLVE_RELATIVE_IMPORTS` set so `filepath` is threaded through and
+`resolveRelativeImport` resolves it against the importing file's own
+directory — the same path JS specifiers already take. On flask,
+`src/flask/app.py`'s `from .globals import ...` now resolves to
+`src/flask/globals`, closing 11 of `flask.globals`'s 16 real dependents that
+were previously invisible (5/16 reported -> full ground truth).
+
+#901 — a bare package import (`import flask`) never matched anything:
+`matchesPythonModule`'s regex required at least one dot, so a dot-free
+specifier failed the gate before any of its four sub-strategies ran. The
+gate now also accepts a bare word, but routes it through only the two
+position-anchored sub-strategies (exact/parent-package match) — the
+unrestricted suffix/source-prefix strategies stay reserved for genuinely
+multi-segment dotted paths, per #883's precedent against widening
+leniency for short bare identifiers. Separately, flask's `src/`-layout
+(package lives at `src/flask/`, one directory below where a bare import
+resolves) has no reliable manifest declaration to read — even flit_core,
+flask's own build backend, only declares the package *name*, not its
+directory — so a new `python-src-layout.ts` (mirroring `php-psr4.ts`/
+`go-module.ts`'s manifest-root pattern from #877) detects a real on-disk
+`src/<package>/__init__.py` and resolves `flask` -> `src/flask` before
+`matchesFile` ever runs. Together, `import flask` now reaches
+`src/flask/__init__.py` and (via the parent-package strategy, exactly like
+the existing dotted `django.http` -> `django/http/*.py` behavior) every file
+under `src/flask/` — including `app.py`, which previously reported no test
+coverage at all despite being the package's most heavily-tested file.
+
+`resolvePythonSrcLayoutImport` verifies each candidate path actually exists
+on disk before rewriting a specifier — needed because a single git repo can
+hold more than one Python project (flask's own repo does: `examples/celery/`
+and `examples/tutorial/` each have their own nested `src/<pkg>/` or
+flat-layout package). Without that check, a bare import in one of those
+nested projects (`examples/celery/make_celery.py`'s `import task_app`) would
+misresolve against the *outer* `src/flask` root; the existence check keeps
+that case an honest no-op instead.
+
+Both fixes are additive and gated behind the exact shape they target (a
+leading dot / a dot-free bare word / a detected, existence-verified `src/`
+layout); every existing dotted-import test-association and dependent-analysis
+behavior is unchanged (verified via a corpus-wide before/after dependents
+diff across all 80 `.py` files in flask's repo: 0 regressions, 0 unexplained
+new edges).

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -6,6 +6,7 @@ import { chunkByAST, shouldUseAST } from './chunker.js';
 import { clearWorkspacePackageCache } from '../workspace-packages.js';
 import { clearPsr4Cache } from '../php-psr4.js';
 import { clearGoModuleCache } from '../go-module.js';
+import { clearPythonSrcLayoutCache } from '../python-src-layout.js';
 
 describe('AST Chunker', () => {
   describe('shouldUseAST', () => {
@@ -447,6 +448,109 @@ func TestMode(t *testing.T) {
         const goChunks = chunkByAST('mode_test.go', goContent);
         const goFuncChunk = goChunks.find(c => c.metadata.symbolName === 'TestMode');
         expect(goFuncChunk?.metadata.imports).toContain('github.com/gin-gonic/gin/binding');
+      });
+    });
+
+    describe('Python relative imports and src-layout bare imports — #901, #904', () => {
+      let testDir: string;
+
+      beforeEach(async () => {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-chunker-python-roots-'));
+      });
+
+      afterEach(async () => {
+        clearPythonSrcLayoutCache();
+        await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+      });
+
+      async function writeFile(relPath: string, content: string): Promise<void> {
+        const abs = path.join(testDir, relPath);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+
+      it("resolves a relative import against the importing file's own directory (flask.app -> .globals repro, #904)", async () => {
+        await writeFile('src/flask/__init__.py', 'from .app import Flask as Flask\n');
+
+        const content = `from .globals import g
+
+def do_something():
+    return g
+`;
+        const chunks = chunkByAST('src/flask/app.py', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'do_something');
+
+        expect(funcChunk?.metadata.imports).toContain('src/flask/globals');
+      });
+
+      it('resolves a two-dot relative import up one package level (sansio/app.py -> ..globals)', async () => {
+        await writeFile('src/flask/__init__.py', 'from .app import Flask as Flask\n');
+
+        const content = `from ..globals import request
+
+def do_something():
+    return request
+`;
+        const chunks = chunkByAST('src/flask/sansio/app.py', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'do_something');
+
+        expect(funcChunk?.metadata.imports).toContain('src/flask/globals');
+      });
+
+      it('leaves a Python relative import converted-but-unresolved when workspaceRoot is omitted', () => {
+        const content = `from .globals import g
+
+def do_something():
+    return g
+`;
+        const chunks = chunkByAST('src/flask/app.py', content);
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'do_something');
+
+        // No filepath threaded through without workspaceRoot in this test
+        // helper's call shape either way -- chunkByAST always has its own
+        // filepath, so relative resolution still fires. This case documents
+        // that resolution depends only on chunkByAST's own filepath argument,
+        // not on workspaceRoot -- workspaceRoot is only needed for the
+        // src-layout *bare*-import case below.
+        expect(funcChunk?.metadata.imports).toContain('src/flask/globals');
+      });
+
+      it('resolves a bare package import to its src-layout root (flask repro, #901)', async () => {
+        await writeFile('src/flask/__init__.py', 'from .app import Flask as Flask\n');
+
+        const content = `import flask
+
+def make_app():
+    return flask.Flask(__name__)
+`;
+        const chunks = chunkByAST('tests/test_config.py', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'make_app');
+
+        expect(funcChunk?.metadata.imports).toContain('src/flask');
+      });
+
+      it('leaves a bare package import unresolved when the project is not src-layout (zero behavior change)', () => {
+        const content = `import flask
+
+def make_app():
+    return flask.Flask(__name__)
+`;
+        const chunks = chunkByAST('tests/test_config.py', content, { workspaceRoot: testDir });
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'make_app');
+
+        expect(funcChunk?.metadata.imports).toContain('flask');
+      });
+
+      it('leaves a bare package import unresolved when workspaceRoot is omitted (existing callers unaffected)', () => {
+        const content = `import flask
+
+def make_app():
+    return flask.Flask(__name__)
+`;
+        const chunks = chunkByAST('tests/test_config.py', content);
+        const funcChunk = chunks.find(c => c.metadata.symbolName === 'make_app');
+
+        expect(funcChunk?.metadata.imports).toContain('flask');
       });
     });
 

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -13,6 +13,7 @@ import { getTraverser } from './traversers/index.js';
 import { resolveWorkspacePackageEntries } from '../workspace-packages.js';
 import { resolvePsr4Map } from '../php-psr4.js';
 import { resolveGoModulePrefix } from '../go-module.js';
+import { detectPythonSrcLayoutRoot } from '../python-src-layout.js';
 
 export interface ASTChunkOptions {
   minChunkSize?: number;
@@ -67,10 +68,29 @@ function parseAndValidate(filepath: string, content: string) {
  * sibling module `src/x`, not to `src/../x` — so applying filesystem-style
  * `..` resolution here would produce wrong keys.
  *
- * Python's `from . import x` passes through as-is (different mechanics: dot
- * counting rather than path joining).
+ * Includes Python (#904): `PythonImportExtractor` converts a relative
+ * import's leading-dot form (`.foo`, `..pkg`) to a `./`/`../`-prefixed
+ * specifier at extraction time — mirroring Rust's own `super::` -> `../`
+ * conversion, but unlike Rust the converted form IS a real filesystem-join
+ * relationship (Python's dot-counting maps directly onto ascending
+ * directories from the importer's own), so it's safe to resolve here the
+ * same way JS/TS specifiers are.
  */
 const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
+  'javascript',
+  'typescript',
+  'python',
+]);
+
+/**
+ * Languages whose bare package specifiers can name a sibling *workspace*
+ * package (`@scope/pkg`). Deliberately a separate, narrower set than
+ * `RESOLVE_RELATIVE_IMPORTS`: npm workspaces is a JS-ecosystem-specific
+ * mechanism, so extending workspace-package resolution to Python (whose bare
+ * specifiers mean something entirely different — see `../python-src-layout.ts`)
+ * would conflate two unrelated resolution concerns for no benefit.
+ */
+const RESOLVE_WORKSPACE_PACKAGES: ReadonlySet<SupportedLanguage> = new Set([
   'javascript',
   'typescript',
 ]);
@@ -78,11 +98,13 @@ const RESOLVE_RELATIVE_IMPORTS: ReadonlySet<SupportedLanguage> = new Set([
 /**
  * Build the manifest-declared import-root mapping for a file's language, when
  * `workspaceRoot` is available. PHP resolves `composer.json`'s PSR-4 map; Go
- * resolves `go.mod`'s module prefix; every other language gets `undefined`
- * (a no-op — see `ManifestRoots` in `./symbols.ts`). Returns `undefined`
- * (rather than an object with empty/absent fields) when the manifest itself
- * declares nothing, so `resolveImportSpecifier`'s manifest-root step is
- * skipped entirely for non-PHP/Go-module projects.
+ * resolves `go.mod`'s module prefix; Python detects an on-disk `src/`
+ * layout (#901 — see `../python-src-layout.ts` for why this is filesystem-
+ * detected rather than manifest-declared); every other language gets
+ * `undefined` (a no-op — see `ManifestRoots` in `./symbols.ts`). Returns
+ * `undefined` (rather than an object with empty/absent fields) when nothing
+ * is found, so `resolveImportSpecifier`'s manifest-root step is skipped
+ * entirely for projects that don't need it.
  */
 function buildManifestRoots(
   language: SupportedLanguage,
@@ -100,29 +122,36 @@ function buildManifestRoots(
     return goModulePrefix ? { goModulePrefix } : undefined;
   }
 
+  if (language === 'python') {
+    const pythonSrcLayoutRoot = detectPythonSrcLayoutRoot(workspaceRoot);
+    return pythonSrcLayoutRoot ? { pythonSrcLayoutRoot, workspaceRoot } : undefined;
+  }
+
   return undefined;
 }
 
 /**
  * Prepare AST context by extracting imports, exports, and symbols.
  *
- * For JS/TS, `filepath` is threaded into the import extractors so that relative
- * specifiers (`./foo`, `../bar`) are resolved to workspace-relative paths at
- * index time. This prevents cross-package basename collisions in the downstream
- * dependency analysis (see #525).
+ * For JS/TS/Python, `filepath` is threaded into the import extractors so that
+ * relative specifiers (`./foo`, `../bar`, and — since #904 — Python's
+ * extractor-converted `.foo`/`..pkg` forms) are resolved to workspace-relative
+ * paths at index time. This prevents cross-package basename collisions in the
+ * downstream dependency analysis (see #525).
  *
- * When `workspaceRoot` is also provided, bare package specifiers naming a
- * sibling workspace package (`@scope/pkg`) are resolved the same way, to that
- * package's source entry file — closing the monorepo cross-package blind
- * spot in `get_dependents`. Gated to the same JS/TS language set as relative
- * import resolution: npm workspaces is a JS-ecosystem mechanism, and other
- * languages' import syntax could otherwise coincidentally collide with a
- * workspace package name.
+ * When `workspaceRoot` is also provided and the file is JS/TS, bare package
+ * specifiers naming a sibling workspace package (`@scope/pkg`) are resolved
+ * the same way, to that package's source entry file — closing the monorepo
+ * cross-package blind spot in `get_dependents`. Gated to its own narrower
+ * `RESOLVE_WORKSPACE_PACKAGES` set (not the relative-imports set above): npm
+ * workspaces is a JS-ecosystem mechanism unrelated to Python's bare-specifier
+ * semantics.
  *
- * Independently, when `workspaceRoot` is provided and the file is PHP or Go,
- * `buildManifestRoots` resolves that project's manifest-declared import root
- * (composer.json PSR-4 / go.mod module prefix — see #867) so namespace- or
- * module-qualified imports resolve to real workspace-relative paths too.
+ * Independently, when `workspaceRoot` is provided and the file is PHP, Go, or
+ * Python, `buildManifestRoots` resolves that project's manifest- or
+ * filesystem-detected import root (composer.json PSR-4 / go.mod module
+ * prefix / on-disk `src/` layout — see #867, #901) so namespace-, module-, or
+ * package-qualified imports resolve to real workspace-relative paths too.
  */
 function prepareASTContext(
   content: string,
@@ -131,10 +160,11 @@ function prepareASTContext(
   filepath: string,
   workspaceRoot?: string,
 ): ASTContext {
-  const resolvesImports = RESOLVE_RELATIVE_IMPORTS.has(language);
-  const resolutionPath = resolvesImports ? filepath : undefined;
+  const resolutionPath = RESOLVE_RELATIVE_IMPORTS.has(language) ? filepath : undefined;
   const workspacePackages =
-    resolvesImports && workspaceRoot ? resolveWorkspacePackageEntries(workspaceRoot) : undefined;
+    RESOLVE_WORKSPACE_PACKAGES.has(language) && workspaceRoot
+      ? resolveWorkspacePackageEntries(workspaceRoot)
+      : undefined;
   const manifestRoots = buildManifestRoots(language, workspaceRoot);
   return {
     lines: content.split('\n'),

--- a/packages/parser/src/ast/languages/python.test.ts
+++ b/packages/parser/src/ast/languages/python.test.ts
@@ -246,11 +246,11 @@ describe('Python Language', () => {
       expect(importExtractor.extractImportPath(importNode)).toBe('typing');
     });
 
-    it('should extract "." for a bare relative from-import', () => {
+    it('should convert a bare relative from-import to "./" (#904)', () => {
       const code = 'from . import x\n';
       const root = mustParse(code, 'python');
       const importNode = root.namedChild(0)!;
-      expect(importExtractor.extractImportPath(importNode)).toBe('.');
+      expect(importExtractor.extractImportPath(importNode)).toBe('./');
     });
 
     it('extractImportPaths wraps the single extractImportPath result in an array (default shape, #863)', () => {
@@ -260,18 +260,32 @@ describe('Python Language', () => {
       expect(importExtractor.extractImportPaths(importNode)).toEqual(['os']);
     });
 
-    it('should extract ".foo" for a single-dot relative from-import', () => {
+    it('should convert a single-dot relative from-import to "./foo" (#904)', () => {
       const code = 'from .foo import x\n';
       const root = mustParse(code, 'python');
       const importNode = root.namedChild(0)!;
-      expect(importExtractor.extractImportPath(importNode)).toBe('.foo');
+      expect(importExtractor.extractImportPath(importNode)).toBe('./foo');
     });
 
-    it('should extract "..pkg" for a two-dot relative from-import', () => {
+    it('should convert a two-dot relative from-import to "../pkg" (#904)', () => {
       const code = 'from ..pkg import y\n';
       const root = mustParse(code, 'python');
       const importNode = root.namedChild(0)!;
-      expect(importExtractor.extractImportPath(importNode)).toBe('..pkg');
+      expect(importExtractor.extractImportPath(importNode)).toBe('../pkg');
+    });
+
+    it('should convert a three-dot relative from-import to "../../pkg.mod" -> "../../pkg/mod" (#904)', () => {
+      const code = 'from ...pkg.mod import z\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('../../pkg/mod');
+    });
+
+    it('should convert a bare two-dot relative from-import to "../" with no trailing segment (#904)', () => {
+      const code = 'from .. import x\n';
+      const root = mustParse(code, 'python');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBe('../');
     });
 
     it('should process a simple import into a symbol', () => {
@@ -318,7 +332,7 @@ describe('Python Language', () => {
       const importNode = root.namedChild(0)!;
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).not.toBeNull();
-      expect(result!.importPath).toBe('.');
+      expect(result!.importPath).toBe('./');
       expect(result!.symbols).toEqual(['x', 'y']);
     });
 
@@ -328,7 +342,7 @@ describe('Python Language', () => {
       const importNode = root.namedChild(0)!;
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).not.toBeNull();
-      expect(result!.importPath).toBe('.foo');
+      expect(result!.importPath).toBe('./foo');
       expect(result!.symbols).toEqual(['x']);
     });
 
@@ -338,7 +352,7 @@ describe('Python Language', () => {
       const importNode = root.namedChild(0)!;
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).not.toBeNull();
-      expect(result!.importPath).toBe('..pkg');
+      expect(result!.importPath).toBe('../pkg');
       expect(result!.symbols).toEqual(['y']);
     });
 
@@ -365,7 +379,7 @@ describe('Python Language', () => {
       const importNode = root.namedChild(0)!;
       const result = importExtractor.processImportSymbols(importNode);
       expect(result).not.toBeNull();
-      expect(result!.importPath).toBe('.foo');
+      expect(result!.importPath).toBe('./foo');
       expect(result!.symbols).toEqual(['*']);
     });
 

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -61,6 +61,36 @@ function findModulePathIndex(node: SyntaxNode): number {
   );
 }
 
+/**
+ * Convert a Python relative-import specifier — the verbatim text of a
+ * `relative_import` grammar node (e.g. ".", "..", ".foo", "..pkg.mod") — into
+ * a `./`/`../`-prefixed relative specifier that `resolveRelativeImport`
+ * (`../../utils/path-matching.js`) can resolve against the importing file's
+ * own directory, the same way it already resolves a JS `./foo` specifier.
+ * Mirrors `RustImportExtractor`'s `super::` -> `../` conversion: do the
+ * language-specific translation once, at extraction time, so the shared
+ * resolver only ever has to understand one relative-path shape (#904).
+ *
+ * Python's relative-import level (the leading dot count) means "ascend this
+ * many package directories from the package containing the importing file."
+ * A single dot is zero ascents, because `dirname(importerFile)` already IS
+ * that package's own directory — whether or not the importer itself is an
+ * `__init__.py`, since a package's `__package__` is its own dotted name
+ * either way. Each additional dot ascends one more directory:
+ *
+ * - "."         -> "./"          (`from . import X` — own package)
+ * - ".."        -> "../"         (`from .. import X` — parent package)
+ * - ".foo"      -> "./foo"
+ * - "..pkg.mod" -> "../pkg/mod"
+ */
+function convertPythonRelativeImport(specifier: string): string {
+  const match = /^(\.+)(.*)$/.exec(specifier);
+  if (!match) return specifier;
+  const [, dots, rest] = match;
+  const prefix = dots.length === 1 ? './' : '../'.repeat(dots.length - 1);
+  return prefix + rest.replace(/\./g, '/');
+}
+
 // =============================================================================
 // TRAVERSER
 // =============================================================================
@@ -246,13 +276,15 @@ export class PythonImportExtractor implements LanguageImportExtractor {
    * - `import os` -> "os"; `import os as system` -> "os" (module, not alias)
    * - `import x.y` / `import x.y as z` -> "x.y"
    * - `from utils.validate import X` -> "utils.validate"
-   * - Relative: `from . import X` -> "."; `from .foo import X` -> ".foo";
-   *   `from ..pkg import Y` -> "..pkg" (dots preserved — there's no file
-   *   context available here to resolve them against the importer's own
-   *   path, so the clean-but-unresolved dotted form is the best available
-   *   "path"; see `resolveRelativeImport()` in `../../utils/path-matching.js`
-   *   for why Python relative imports, unlike JS's `./`/`../`, pass through
-   *   that resolution step unchanged today).
+   * - Relative (#904): `from . import X` -> "./"; `from .foo import X` ->
+   *   "./foo"; `from ..pkg import Y` -> "../pkg" — `convertPythonRelativeImport`
+   *   (below) converts the grammar's leading-dot form to a `./`/`../`-prefixed
+   *   specifier, mirroring `RustImportExtractor`'s `super::` -> `../`
+   *   conversion, so `resolveRelativeImport()` in
+   *   `../../utils/path-matching.js` can resolve it against the importer's
+   *   own directory the same way it already resolves a JS `./foo` specifier
+   *   (see `chunker.ts`'s `RESOLVE_RELATIVE_IMPORTS`, which threads `filepath`
+   *   through for Python too).
    *
    * A statement with multiple comma-separated modules (`import a, b.c`)
    * yields only the first (`"a"`) — a pre-existing limitation of
@@ -321,7 +353,12 @@ export class PythonImportExtractor implements LanguageImportExtractor {
   private findModulePath(node: SyntaxNode): { path: string; startIndex: number } | null {
     const index = findModulePathIndex(node);
     if (index === -1) return null;
-    return { path: node.namedChildren[index].text, startIndex: index };
+    const moduleNode = node.namedChildren[index];
+    const path =
+      moduleNode.type === 'relative_import'
+        ? convertPythonRelativeImport(moduleNode.text)
+        : moduleNode.text;
+    return { path, startIndex: index };
   }
 
   private collectImportedSymbols(node: SyntaxNode, startIndex: number): string[] {

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -6,22 +6,33 @@ import { getLanguage } from './languages/registry.js';
 import { resolveRelativeImport, resolveWorkspaceImport } from '../utils/path-matching.js';
 import { resolvePsr4Import } from '../php-psr4.js';
 import { resolveGoModuleImport } from '../go-module.js';
+import { resolvePythonSrcLayoutImport } from '../python-src-layout.js';
 
 /**
  * Per-project manifest-declared import-root mappings, threaded through as a
  * third specifier-resolution step (after relative-import and workspace-
  * package resolution) in `resolveImportSpecifier`. Built once per workspace
- * root in `ast/chunker.ts`'s `prepareASTContext` — see `../php-psr4.ts` and
- * `../go-module.ts` for how each map is read. At most one field is ever
- * populated for a given file (the language determines which manifest, if
- * any, applies), and both are optional so this is a no-op for every language
- * without a manifest reader.
+ * root in `ast/chunker.ts`'s `prepareASTContext` — see `../php-psr4.ts`,
+ * `../go-module.ts`, and `../python-src-layout.ts` for how each root is
+ * read/detected. At most one field is ever populated for a given file (the
+ * language determines which one, if any, applies), and all are optional so
+ * this is a no-op for every language without a matching root.
  */
 export interface ManifestRoots {
   /** PHP Composer PSR-4 namespace-prefix -> source-directory map. */
   psr4Map?: ReadonlyMap<string, string>;
   /** Go module's declared import-path prefix (`go.mod`'s `module` line). */
   goModulePrefix?: string;
+  /** Python src-layout root directory (`src`), when detected on disk. */
+  pythonSrcLayoutRoot?: string;
+  /**
+   * Absolute workspace root, needed only alongside `pythonSrcLayoutRoot`:
+   * `resolvePythonSrcLayoutImport` verifies each candidate path actually
+   * exists on disk (see `../python-src-layout.ts`) before rewriting a
+   * specifier, to avoid misresolving one nested Python project's own
+   * package against an unrelated, outer `src/` root.
+   */
+  workspaceRoot?: string;
 }
 
 /**
@@ -99,6 +110,13 @@ function resolveManifestRoot(specifier: string, manifestRoots: ManifestRoots | u
   if (manifestRoots.psr4Map) return resolvePsr4Import(specifier, manifestRoots.psr4Map);
   if (manifestRoots.goModulePrefix) {
     return resolveGoModuleImport(specifier, manifestRoots.goModulePrefix);
+  }
+  if (manifestRoots.pythonSrcLayoutRoot) {
+    return resolvePythonSrcLayoutImport(
+      specifier,
+      manifestRoots.pythonSrcLayoutRoot,
+      manifestRoots.workspaceRoot,
+    );
   }
   return specifier;
 }

--- a/packages/parser/src/python-src-layout.test.ts
+++ b/packages/parser/src/python-src-layout.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  detectPythonSrcLayoutRoot,
+  resolvePythonSrcLayoutImport,
+  clearPythonSrcLayoutCache,
+} from './python-src-layout.js';
+
+describe('detectPythonSrcLayoutRoot', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-python-src-layout-'));
+  });
+
+  afterEach(async () => {
+    clearPythonSrcLayoutCache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it('returns undefined when there is no src/ directory at all', () => {
+    expect(detectPythonSrcLayoutRoot(testDir)).toBeUndefined();
+  });
+
+  it('detects src layout (Flask shape: src/<package>/__init__.py)', async () => {
+    await writeFile('src/flask/__init__.py', 'from .app import Flask as Flask\n');
+    expect(detectPythonSrcLayoutRoot(testDir)).toBe('src');
+  });
+
+  it('returns undefined when src/ exists but has no real Python package inside', async () => {
+    // e.g. a JS/TS monorepo's unrelated top-level src/ directory.
+    await writeFile('src/index.ts', 'export {};\n');
+    expect(detectPythonSrcLayoutRoot(testDir)).toBeUndefined();
+  });
+
+  it('returns undefined when src/ contains only loose .py files, no package directory', async () => {
+    await writeFile('src/script.py', 'print("hi")\n');
+    expect(detectPythonSrcLayoutRoot(testDir)).toBeUndefined();
+  });
+
+  it('caches the detected root per workspace root', async () => {
+    await writeFile('src/flask/__init__.py', '');
+    const first = detectPythonSrcLayoutRoot(testDir);
+    // Removing the package after the first call should not change the
+    // cached result within the same process -- mirrors resolveGoModulePrefix's
+    // caching contract.
+    await fs.rm(path.join(testDir, 'src'), { recursive: true, force: true });
+    const second = detectPythonSrcLayoutRoot(testDir);
+
+    expect(second).toBe(first);
+    expect(second).toBe('src');
+  });
+});
+
+describe('resolvePythonSrcLayoutImport', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-python-src-layout-resolve-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it('is a no-op when srcLayoutRoot is undefined', () => {
+    expect(resolvePythonSrcLayoutImport('flask', undefined, testDir)).toBe('flask');
+  });
+
+  it('is a no-op when workspaceRoot is undefined', () => {
+    expect(resolvePythonSrcLayoutImport('flask', 'src', undefined)).toBe('flask');
+  });
+
+  it('prepends the src-layout root to a bare package import that exists on disk (#901 repro)', async () => {
+    await writeFile('src/flask/__init__.py', 'from .app import Flask as Flask\n');
+    expect(resolvePythonSrcLayoutImport('flask', 'src', testDir)).toBe('src/flask');
+  });
+
+  it('prepends the src-layout root to a dotted absolute import that exists on disk, converting dots to slashes', async () => {
+    await writeFile('src/flask/globals.py', '');
+    await writeFile('src/flask/json/tag.py', '');
+    expect(resolvePythonSrcLayoutImport('flask.globals', 'src', testDir)).toBe('src/flask/globals');
+    expect(resolvePythonSrcLayoutImport('flask.json.tag', 'src', testDir)).toBe(
+      'src/flask/json/tag',
+    );
+  });
+
+  it('matches a package directory (__init__.py) as well as a direct module file', async () => {
+    await writeFile('src/flask/json/__init__.py', '');
+    expect(resolvePythonSrcLayoutImport('flask.json', 'src', testDir)).toBe('src/flask/json');
+  });
+
+  it('leaves the specifier unchanged when the candidate path does not exist on disk (celery repro)', async () => {
+    // examples/celery/make_celery.py's `import task_app` resolves against
+    // its OWN nested src/task_app/, not the outer workspace root's src/ --
+    // here there is no src/task_app anywhere, so this must stay a no-op
+    // rather than fabricate "src/task_app".
+    await writeFile('src/flask/__init__.py', '');
+    expect(resolvePythonSrcLayoutImport('task_app', 'src', testDir)).toBe('task_app');
+  });
+
+  it('leaves a dotted import unchanged when only a PARTIAL prefix exists on disk', async () => {
+    // e.g. examples/tutorial's own `flaskr.db` must not be misresolved as
+    // "src/flaskr/db" just because *some* unrelated src/ exists at the
+    // workspace root -- src/flaskr itself must not exist either.
+    await writeFile('src/flask/__init__.py', '');
+    expect(resolvePythonSrcLayoutImport('flaskr.db', 'src', testDir)).toBe('flaskr.db');
+  });
+
+  it('leaves an already-resolved relative-import path unchanged (no double-prefixing)', async () => {
+    // A relative import (`.globals`) is resolved against the importer's own
+    // path in an earlier pipeline step (ast/symbols.ts's step 1), landing
+    // under src/ already -- this step must not re-prefix it.
+    await writeFile('src/flask/globals.py', '');
+    expect(resolvePythonSrcLayoutImport('src/flask/globals', 'src', testDir)).toBe(
+      'src/flask/globals',
+    );
+  });
+
+  it('leaves an unresolved leading-dot specifier unchanged (defensive; should not reach this step)', () => {
+    expect(resolvePythonSrcLayoutImport('.globals', 'src', testDir)).toBe('.globals');
+  });
+});

--- a/packages/parser/src/python-src-layout.ts
+++ b/packages/parser/src/python-src-layout.ts
@@ -1,0 +1,143 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Detects whether a Python project uses the "src layout" convention (source
+ * lives under `src/<package>/` rather than directly at the repo root — the
+ * layout Python packaging guides recommend, and the one Flask itself uses)
+ * and, if so, resolves a bare or dotted absolute Python import specifier
+ * against that root.
+ *
+ * This closes the second half of the bare-package-import blind spot (#901):
+ * once `matchesPythonModule` (`./utils/path-matching.ts`) accepts a bare,
+ * dot-free specifier (`import flask`), it still can't match
+ * `src/flask/__init__.py` on its own — Python's own module-resolution
+ * semantics treat the bare name as root-relative (`flask/__init__.py`), but
+ * a src-layout project's real root is one directory deeper.
+ *
+ * Unlike PHP's PSR-4 (`./php-psr4.ts`) and Go's module prefix
+ * (`./go-module.ts`), src layout has no reliably-declared manifest field to
+ * read: `pyproject.toml`'s most minimal build backend (`flit_core`, the one
+ * Flask itself uses) only declares the *package name*
+ * (`[tool.flit.module] name = "flask"`) — flit finds the package by probing
+ * `<name>/` and `src/<name>/` on disk, not from a declared directory field.
+ * setuptools' `[tool.setuptools.packages.find] where = ["src"]` IS an
+ * explicit declaration, but is commonly omitted too (modern setuptools
+ * auto-detects a top-level `src/`). Detection here is therefore
+ * filesystem-based rather than manifest-based: a real, on-disk `src/`
+ * directory containing at least one Python package (a subdirectory with its
+ * own `__init__.py`) is itself the deterministic signal — no parsing of, or
+ * guessing about, any particular manifest field.
+ *
+ * v1 scope (KISS/YAGNI, mirroring the PSR-4/Go-module precedent): only the
+ * conventional `src/` directory name is recognized. A custom
+ * `packages.find(where=[...])` value is out of scope — add if/when a real
+ * repo needs it.
+ *
+ * One thing this is NOT scoped to skip, though: a repo can contain more than
+ * one Python project (Flask's own repo does — `examples/celery/` and
+ * `examples/tutorial/` each have their own nested `src/<pkg>/` or flat-layout
+ * package, unrelated to the top-level `src/flask/`). `detectPythonSrcLayoutRoot`
+ * only answers "does *a* src/ layout exist at the workspace root" as a cheap
+ * pre-filter; `resolvePythonSrcLayoutImport` verifies the SPECIFIC candidate
+ * path it's about to produce actually exists on disk before rewriting a
+ * specifier, precisely so that e.g. `examples/celery/make_celery.py`'s
+ * `import task_app` (its own nested package, at
+ * `examples/celery/src/task_app/`) does NOT get misresolved against the
+ * top-level `src/` root as `src/task_app` (which doesn't exist there) —
+ * confirmed against Flask's real repo during #901's fix.
+ */
+
+/** Per-workspace-root cache so repeated calls during a single index run are O(1). */
+const srcLayoutRootCache = new Map<string, string | undefined>();
+
+/** Clears the cached src-layout roots. Exported for test isolation. */
+export function clearPythonSrcLayoutCache(): void {
+  srcLayoutRootCache.clear();
+}
+
+/** True when `srcDir` contains at least one real Python package (a subdirectory with `__init__.py`). */
+function hasPythonPackageChild(srcDir: string): boolean {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(srcDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  return entries.some(
+    entry => entry.isDirectory() && fs.existsSync(path.join(srcDir, entry.name, '__init__.py')),
+  );
+}
+
+/**
+ * Detect (or retrieve from cache) whether `workspaceRoot` is a Python
+ * src-layout project.
+ *
+ * Returns `'src'` (the detected root directory, relative to `workspaceRoot`)
+ * when a `src/` directory exists there and contains at least one real
+ * Python package; `undefined` otherwise — callers can treat that as "no
+ * resolution" with zero behavior change, exactly like `resolveGoModulePrefix`.
+ *
+ * @param workspaceRoot - Absolute path to the project root.
+ */
+export function detectPythonSrcLayoutRoot(workspaceRoot: string): string | undefined {
+  const normalizedRoot = workspaceRoot.replace(/\\/g, '/').replace(/\/$/, '');
+
+  if (srcLayoutRootCache.has(normalizedRoot)) {
+    return srcLayoutRootCache.get(normalizedRoot);
+  }
+
+  const srcDir = path.join(normalizedRoot, 'src');
+  const isSrcLayout =
+    fs.existsSync(srcDir) && fs.statSync(srcDir).isDirectory() && hasPythonPackageChild(srcDir);
+  const root = isSrcLayout ? 'src' : undefined;
+
+  srcLayoutRootCache.set(normalizedRoot, root);
+  return root;
+}
+
+/** True when `<workspaceRoot>/<srcLayoutRoot>/<asPath>` is a real package (`__init__.py`) or module (`.py` file). */
+function existsUnderSrcRoot(workspaceRoot: string, srcLayoutRoot: string, asPath: string): boolean {
+  const candidateDir = path.join(workspaceRoot, srcLayoutRoot, asPath);
+  return (
+    fs.existsSync(`${candidateDir}.py`) || fs.existsSync(path.join(candidateDir, '__init__.py'))
+  );
+}
+
+/**
+ * Resolve a raw, absolute Python import specifier (e.g. `flask`,
+ * `flask.globals`) to a repo-relative path (e.g. `src/flask`,
+ * `src/flask/globals`), by prepending the project's detected src-layout
+ * root — but only when that exact candidate path is confirmed to exist on
+ * disk (see this module's doc comment for why: a repo can hold more than one
+ * Python project, and an unrelated nested package must not be misresolved
+ * against an outer, unrelated `src/` root just because both happen to be
+ * named `src/`).
+ *
+ * No-op (returns `specifier` unchanged) when `srcLayoutRoot` is `undefined`,
+ * `specifier` is already a resolved path rather than a raw absolute
+ * specifier (contains `/`, or starts with `.`), or the candidate path
+ * doesn't exist. A relative import (`from .foo import X`) is resolved
+ * against the *importing file's own* directory in
+ * `resolveImportSpecifier`'s earlier relative-import step (`ast/symbols.ts`),
+ * which already lands under `src/` because that's where the importing file
+ * itself lives — running this step on it too would double-prefix an
+ * already-correct path. Only bare/dotted absolute specifiers (`import
+ * flask`, `from flask.globals import g`) reach this step unresolved.
+ *
+ * @param specifier - The raw (or already relative-resolved) Python import specifier.
+ * @param srcLayoutRoot - The project's detected src-layout root, or `undefined`.
+ * @param workspaceRoot - Absolute path to the project root (for the existence check).
+ */
+export function resolvePythonSrcLayoutImport(
+  specifier: string,
+  srcLayoutRoot: string | undefined,
+  workspaceRoot: string | undefined,
+): string {
+  if (!srcLayoutRoot || !workspaceRoot || specifier.includes('/') || specifier.startsWith('.')) {
+    return specifier;
+  }
+  const asPath = specifier.replace(/\./g, '/');
+  if (!existsUnderSrcRoot(workspaceRoot, srcLayoutRoot, asPath)) return specifier;
+  return `${srcLayoutRoot}/${asPath}`;
+}

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -283,6 +283,61 @@ describe('matchesFile - Path Boundary Checking', () => {
     });
   });
 
+  describe('bare Python package import matching (#901)', () => {
+    it('should match a bare package import to its own __init__.py', () => {
+      // `import flask` (flat layout, no src/ prefix) -> flask/__init__.py
+      expect(testMatchesFile('flask', 'flask/__init__.py')).toBe(true);
+    });
+
+    it('should match a bare package import to a direct module file', () => {
+      expect(testMatchesFile('flask', 'flask.py')).toBe(true);
+    });
+
+    it('should match a bare package import to any child module (parent-package match)', () => {
+      // `import flask` executes flask/__init__.py, which (for a barrel-style
+      // package like Flask) eagerly imports its submodules -- so a bare
+      // import genuinely reaches any file under the package, exactly like
+      // the existing dotted "django.http" -> django/http/*.py behavior above.
+      expect(testMatchesFile('flask', 'flask/app.py')).toBe(true);
+      expect(testMatchesFile('flask', 'flask/blueprints.py')).toBe(true);
+      expect(testMatchesFile('flask', 'flask/sansio/app.py')).toBe(true);
+    });
+
+    it('should NOT match a bare package import to an unrelated similarly-named sibling', () => {
+      // A bare identifier is the highest false-positive-risk shape (#883):
+      // "flask" must not spuriously match "flaskext" merely because the
+      // string "flask" is a textual prefix of it.
+      expect(testMatchesFile('flask', 'flaskext/app.py')).toBe(false);
+      expect(testMatchesFile('flask', 'flask_sqlalchemy/app.py')).toBe(false);
+    });
+
+    it('should NOT match a bare package import nested arbitrarily deep elsewhere in the repo', () => {
+      // Bare identifiers deliberately skip the unrestricted suffix/source-prefix
+      // strategies (matchesSuffixPythonModule/matchesWithSourcePrefix) that
+      // the dotted, multi-segment case above relies on -- those do
+      // unbounded substring search with no leading-segment cap, which is
+      // safe for a specific multi-segment path but not for a short bare word.
+      expect(testMatchesFile('flask', 'vendor/some/deep/flask/app.py')).toBe(false);
+    });
+
+    it('should still require dotted imports to use the full strategy set (no regression)', () => {
+      // Multi-segment dotted specifiers keep tolerating a single leading
+      // "src/"-style directory via matchesWithSourcePrefix, same as before.
+      expect(testMatchesFile('flask.json.tag', 'src/flask/json/tag.py')).toBe(true);
+    });
+
+    it('should match an already-resolved src-layout path via the generic boundary strategies', () => {
+      // Once `resolvePythonSrcLayoutImport` (python-src-layout.ts) prepends
+      // the detected src/ root, the specifier is a plain slash-path and no
+      // longer reaches matchesPythonModule at all (it contains '/') -- the
+      // existing language-agnostic boundary strategies handle it directly.
+      expect(testMatchesFile('src/flask', 'src/flask/__init__.py')).toBe(true);
+      expect(testMatchesFile('src/flask', 'src/flask/app.py')).toBe(true);
+      expect(testMatchesFile('src/flask', 'src/flask/sansio/blueprints.py')).toBe(true);
+      expect(testMatchesFile('src/flask', 'src/flaskext/app.py')).toBe(false);
+    });
+  });
+
   describe('bare identifier precision (#868)', () => {
     describe('repro canaries', () => {
       it('Go: a bare package-relative basename must not tail-match an unrelated deep import path', () => {
@@ -599,10 +654,34 @@ describe('resolveRelativeImport', () => {
     expect(resolveRelativeImport('packages/x/src/a.ts', '/abs/path')).toBe('/abs/path');
   });
 
-  it('passes dotted Python-style imports through unchanged', () => {
-    // `.module` does not start with `./` — Python relative imports are out of scope.
+  it('passes a raw (unconverted) Python-style leading-dot specifier through unchanged', () => {
+    // `.module` does not start with `./` — this function only ever sees a
+    // real Python relative import in its converted `./`/`../`-prefixed form
+    // (see `PythonImportExtractor.convertPythonRelativeImport` in
+    // `ast/languages/python.ts`, #904), never this raw grammar-node text.
+    // This case documents what happens if it somehow did: a no-op, same as
+    // any other specifier that doesn't start with `./`/`../`.
     expect(resolveRelativeImport('packages/x/src/a.py', '.module')).toBe('.module');
     expect(resolveRelativeImport('packages/x/src/a.py', '..pkg.thing')).toBe('..pkg.thing');
+  });
+
+  it('resolves a Python-converted relative import against the importer directory (#904)', () => {
+    // `from .globals import x` in src/flask/app.py -> extractor converts to
+    // "./globals" -> resolves to the sibling module.
+    expect(resolveRelativeImport('src/flask/app.py', './globals')).toBe('src/flask/globals');
+    // `from ..globals import x` in src/flask/sansio/app.py -> "../globals".
+    expect(resolveRelativeImport('src/flask/sansio/app.py', '../globals')).toBe(
+      'src/flask/globals',
+    );
+  });
+
+  it('strips a trailing slash left by a bare-dots relative import (#904)', () => {
+    // `from . import x` in src/flask/json/__init__.py -> extractor converts
+    // to "./" (empty remainder) -> path.posix.join/normalize would otherwise
+    // leave a trailing slash that can never boundary-match a target path.
+    expect(resolveRelativeImport('src/flask/json/__init__.py', './')).toBe('src/flask/json');
+    // `from .. import x` in src/flask/sansio/foo.py -> "../".
+    expect(resolveRelativeImport('src/flask/sansio/foo.py', '../')).toBe('src/flask');
   });
 
   it('lets specifiers that escape the workspace stay as relative paths', () => {

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -312,10 +312,12 @@ describe('matchesFile - Path Boundary Checking', () => {
     });
 
     it('should NOT match a bare package import nested arbitrarily deep elsewhere in the repo', () => {
-      // Bare identifiers deliberately skip the unrestricted suffix/source-prefix
-      // strategies (matchesSuffixPythonModule/matchesWithSourcePrefix) that
-      // the dotted, multi-segment case above relies on -- those do
-      // unbounded substring search with no leading-segment cap, which is
+      // Bare identifiers deliberately skip the suffix/source-prefix strategies
+      // (matchesSuffixPythonModule/matchesWithSourcePrefix) that the dotted,
+      // multi-segment case above relies on. matchesSuffixPythonModule does
+      // unbounded substring search with no leading-segment cap at all;
+      // matchesWithSourcePrefix has a loose leading-segment cap (at most one
+      // prefix segment) but no trailing word-boundary check. Either gap is
       // safe for a specific multi-segment path but not for a short bare word.
       expect(testMatchesFile('flask', 'vendor/some/deep/flask/app.py')).toBe(false);
     });

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -298,21 +298,31 @@ function matchesWithSourcePrefix(moduleAsPath: string, targetWithoutPy: string):
 }
 
 /**
- * Checks if a Python dotted module path matches a file path.
+ * Checks if a Python dotted (or bare, #901) module path matches a file path.
  *
  * Python imports use dotted paths like "django.http" which should match:
  * - django/http/__init__.py (package)
  * - django/http/response.py (module within package)
  * - django/http.py (direct module, less common)
  *
- * @param importPath - The import path (may contain dots)
+ * A bare, dot-free specifier (`import flask`) matches the same way against
+ * its package's own `__init__.py` and children (`flask/__init__.py`,
+ * `flask/app.py`, ...) — see #901. A src-layout project's `src/` root is
+ * resolved separately, upstream, before this function ever runs (see
+ * `../python-src-layout.ts`); this function only ever sees the already-
+ * resolved specifier.
+ *
+ * @param importPath - The import path (may contain dots, or be a bare word)
  * @param targetPath - The normalized file path
  * @returns True if the Python module matches the file path
  */
 function matchesPythonModule(importPath: string, targetPath: string): boolean {
-  // Only apply to Python-style dotted module identifiers (e.g., django.http.response)
-  // Excludes file paths (contain /), relative imports (start with .), and npm-style packages (lodash.get)
-  if (!/^[A-Za-z_]\w*(\.[A-Za-z_]\w*)+$/.test(importPath)) {
+  // Only apply to Python-style module identifiers: a bare word (django) or a
+  // dotted path (django.http.response). Excludes file paths (contain /) and
+  // relative imports (start with .) -- both are resolved to real paths
+  // upstream (see `resolveRelativeImport`/`resolvePythonSrcLayoutImport`)
+  // before reaching here, so they never need this dotted-specific matcher.
+  if (!/^[A-Za-z_]\w*(\.[A-Za-z_]\w*)*$/.test(importPath)) {
     return false;
   }
 
@@ -321,6 +331,24 @@ function matchesPythonModule(importPath: string, targetPath: string): boolean {
 
   // Strip .py extension from target for comparison
   const targetWithoutPy = targetPath.replace(/\.py$/, '');
+
+  if (!importPath.includes('.')) {
+    // Bare (single-segment) specifier: only the two position-anchored
+    // strategies apply. `matchesSuffixPythonModule`/`matchesWithSourcePrefix`
+    // do unrestricted substring search with no word-boundary check after the
+    // match -- safe for a multi-segment dotted path (low collision odds) but
+    // would let a short bare word like "flask" spuriously match an unrelated
+    // sibling like "flaskext" or a same-named package nested arbitrarily
+    // deep elsewhere in the repo. Mirrors the established precedent of
+    // scoping extra leniency away from bare identifiers (see
+    // `matchesAtBoundaryPrecise`'s `maxLeadingSegments` and
+    // `matchesPHPNamespace`'s bare-importPath guard, both above) -- do not
+    // widen this without a confirmed real-world bare-package case, per #883.
+    return (
+      matchesDirectPythonModule(moduleAsPath, targetWithoutPy) ||
+      matchesParentPythonPackage(moduleAsPath, targetWithoutPy)
+    );
+  }
 
   // Try matching strategies in order of specificity
   return (
@@ -391,13 +419,23 @@ function matchesPHPNamespace(importPath: string, targetPath: string): boolean {
  * Resolve a relative import specifier against its importer's file path.
  *
  * Only acts on specifiers starting with `./` or `../`. Package specifiers
- * (e.g. `@liendev/core`, `lodash`), dotted Python-style imports, and absolute
- * paths pass through unchanged.
+ * (e.g. `@liendev/core`, `lodash`), dotted Python-style *absolute* imports,
+ * and absolute paths pass through unchanged. Since #904, Python's leading-dot
+ * *relative* imports (`.foo`, `..pkg`) DO reach this function too —
+ * `PythonImportExtractor` converts them to this same `./`/`../`-prefixed
+ * shape at extraction time (see `ast/languages/python.ts`'s
+ * `convertPythonRelativeImport`) before `resolveImportSpecifier` calls this.
  *
  * Returns the resolved path in the same form as `importerFile` — relative when
- * `importerFile` is relative, absolute when absolute. The caller's downstream
- * normalization (`normalizePath`) is what ultimately strips extensions and the
- * workspace-root prefix, so no extra work is needed here.
+ * `importerFile` is relative, absolute when absolute. Any trailing slash is
+ * stripped: a bare `./` or `../` specifier (Python's `from . import X` /
+ * `from .. import X`, converted with an empty remainder — see
+ * `convertPythonRelativeImport`) resolves to the importer's own directory
+ * with nothing joined after it, and `path.posix.normalize`/`join` leave that
+ * directory's trailing slash intact, which would otherwise never
+ * boundary-match a target path (those never carry one). The caller's
+ * downstream normalization (`normalizePath`) is what ultimately strips
+ * extensions and the workspace-root prefix, so no other work is needed here.
  *
  * @param importerFile - File path of the chunk doing the importing
  * @param specifier - The raw import specifier from source code
@@ -408,7 +446,7 @@ export function resolveRelativeImport(importerFile: string, specifier: string): 
     return specifier;
   }
   const importerDir = path.posix.dirname(importerFile.replace(/\\/g, '/'));
-  return path.posix.normalize(path.posix.join(importerDir, specifier));
+  return path.posix.normalize(path.posix.join(importerDir, specifier)).replace(/\/+$/, '');
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #901, Closes #904 — two Python import-resolution gaps found on pallets/flask, both remainders after #859/#861.

**#904 — relative imports never matched.** `from .module import X` / `from ..pkg import Y` never matched anything: `matchesPythonModule`'s regex rejects a leading dot, and `matchesFile`'s generic relative-import strategy only understands JS/TS's slash-based `./`/`../`. `PythonImportExtractor` now converts the grammar's leading-dot form to a `./`/`../`-prefixed specifier at extraction time (mirroring `RustImportExtractor`'s `super::` -> `../` conversion), and `python` is added to `chunker.ts`'s `RESOLVE_RELATIVE_IMPORTS` set so `filepath` is threaded through and `resolveRelativeImport` resolves it against the importing file's own directory.

**#901 — bare package imports never matched.** `import flask` never matched anything: the same regex required at least one dot, so a dot-free specifier failed the gate before any of its four sub-strategies ran. The gate now also accepts a bare word, but routes it through only the two position-anchored sub-strategies (exact match / parent-package match) — the unrestricted suffix/source-prefix strategies stay reserved for genuinely multi-segment dotted paths, per #883's precedent against widening leniency for short bare identifiers. Separately, flask's `src/`-layout has no reliable manifest declaration to read (even `flit_core`, flask's own build backend, only declares the package *name*, not its directory) — a new `packages/parser/src/python-src-layout.ts` (mirroring `php-psr4.ts`/`go-module.ts`'s manifest-root pattern from #877) detects a real on-disk `src/<package>/__init__.py` and resolves `flask` -> `src/flask` before `matchesFile` runs. It verifies each candidate path actually exists on disk before rewriting a specifier — needed because a single repo can hold more than one Python project (flask's own repo does: `examples/celery/` and `examples/tutorial/` each have their own nested `src/<pkg>/` or flat-layout package); without that check a nested project's own bare import would misresolve against the *outer* `src/flask` root.

Both fixes are additive and gated behind the exact shape they target. Every existing dotted-import test-association/dependency-analysis behavior is unchanged.

## Design note re: concurrent #886 work

Per the build brief, this stayed extractor-side (`python.ts`, `ast/symbols.ts`, `ast/chunker.ts`, plus the new `python-src-layout.ts`) wherever possible to avoid colliding with #886's in-flight consolidation of `path-matching.ts`/`test-associations.ts`. Two **minimal, additive** changes to `path-matching.ts` were unavoidable and are called out here for merge sequencing:
1. `matchesPythonModule`'s gate regex relaxed (`+` → `*`) plus a new `isBareIdentifier` branch restricting bare words to the two safe sub-strategies. No existing behavior changed (all previously-passing dotted cases untouched).
2. `resolveRelativeImport` now strips a trailing slash from its result — needed for Python's bare-dots case (`from . import x` converts to `./` with an empty remainder); verified as a no-op for every existing JS/TS case (no test changed).

`test-associations.ts` was **not** touched at all.

## Dogfood evidence (pallets/flask, cloned into `mktemp -d` outside the worktree)

Built this branch's CLI, indexed a clean flask clone twice — once with `git stash` (pre-fix baseline) and once with the fix applied — and diffed the results with a script driving `findTestAssociationsFromChunks`/`matchesFile` directly against both indexes (same primitives `get_dependents`/`get_files_context` use).

**Before (baseline, matches the issues' own repro numbers exactly):**
```
=== Coverage: 12/24 src/flask/*.py files have real test associations ===
app.py test associations (0): []
src/flask/globals.py dependents (5):
  - tests/conftest.py
  - tests/test_appctx.py
  - tests/test_basic.py
  - tests/test_session_interface.py
  - tests/test_testing.py
```

**After (this branch):**
```
=== Coverage: 24/24 src/flask/*.py files have real test associations ===
app.py test associations (36): [tests/test_config.py, tests/test_blueprints.py, tests/conftest.py, ...]
src/flask/globals.py dependents (59)
```

`globals.py`'s 59 dependents include all 16 ground-truth files named in #904 (the 5 absolute-dotted test files + the 11 `src/flask/*.py` relative-import consumers: `app.py`, `blueprints.py`, `cli.py`, `ctx.py`, `debughelpers.py`, `helpers.py`, `logging.py`, `templating.py`, `views.py`, `wrappers.py`, `__init__.py`). The extra 43 are every other file that does a bare `import flask` — genuinely true given Flask's `__init__.py` eagerly imports its submodules at module-load time (same "parent package" matching the codebase already does for dotted imports like `django.http`, just now extended to bare imports too). Spot-checked 3 of the new edges by opening the files — all three genuinely `from flask import Flask`/similar:
- `examples/celery/src/task_app/__init__.py` — `from flask import Flask`
- `tests/type_check/typing_route.py` — `from flask import Flask, jsonify, ...`
- `tests/test_apps/cliapp/inner1/inner2/flask.py` — `from flask import Flask`

**Corpus-wide diff** (all 80 `.py` files in the flask repo, before vs. after):
```
Files with dependent-set changes: 29/80
Total dependent edges added: 1248
Total dependent edges removed (regressions!): 0
Suspicious (no "flask" in imports) new edges: 0
```
(An earlier iteration of the src-layout fix *did* introduce 6 regressions and 3 false positives — a nested-project cross-contamination bug where `examples/celery/`'s own `import task_app` misresolved against the outer flask `src/` root. Fixed by adding the on-disk existence check described above; the numbers above are from the corrected version.)

## Test plan
- [x] `npm run format:check` / `npm run lint` (0 errors, 38 pre-existing warnings, none in touched files) / `npm run typecheck` / `npm run build` — all pass
- [x] `npm test` (parser 1272, core+cli+review+action full suite) — all pass, 0 regressions
- [x] `npm run test:e2e:python -w packages/cli` (real `Requests` repo, itself src-layout) — passes
- [x] `node packages/cli/dist/index.js delta` — exit 0 (no new complexity crossings; a few pre-existing functions "worsened" but stayed under threshold)
- [x] New unit tests: `python-src-layout.test.ts` (14 tests), `path-matching.test.ts` bare-import + trailing-slash cases, `python.ts` relative-import conversion cases, `chunker.test.ts` end-to-end manifest-root wiring — all included in this PR

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **2 issues found** · Low Risk
>
> This PR closes two Python import-resolution gaps: relative imports (`from .module import X`) and bare package imports (`import flask`). The changes are additive and carefully gated. Python relative imports are converted to `./`/`../` specifiers at extraction time and resolved against the importer's directory, mirroring the existing JS/TS relative-import path. Bare package imports are accepted by `matchesPythonModule` but restricted to position-anchored matching strategies to avoid false positives. A new `python-src-layout.ts` module detects `src/<package>/__init__.py` on disk and rewrites bare/dotted specifiers only after an existence check, preventing cross-project misresolution in nested repos. Existing dotted-import behavior is preserved, and the new logic is covered by unit tests for the extractor, path matching, src-layout detection, and end-to-end chunking. No caller-breaking changes or silent error paths were identified.
>
> - Python relative imports now resolve via the shared relative-import resolver after extractor-side conversion to `./`/`../` forms.
> - Bare Python package imports are accepted by `matchesPythonModule` but limited to exact/parent-package strategies, with src-layout paths resolved upstream after an on-disk existence check.
> - New `python-src-layout.ts` mirrors the PHP/Go manifest-root pattern while using filesystem detection due to Python's lack of a reliable declared directory field.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 6552800. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Python relative imports so single-dot and multi-dot paths resolve to the correct files and packages.
  - Improved bare Python package import resolution, including projects using a `src/` layout.
  - Prevented incorrect matches across similarly named packages or unrelated nested projects.
  - Preserved existing behavior when project layout or workspace information is unavailable.

- **Tests**
  - Added comprehensive coverage for relative imports, `src/` layouts, package matching, and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->