### PR TITLE
docs(parser): correct bare-Python-import matcher risk comments

### DIFF
--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -498,7 +498,7 @@ def do_something():
         expect(funcChunk?.metadata.imports).toContain('src/flask/globals');
       });
 
-      it('leaves a Python relative import converted-but-unresolved when workspaceRoot is omitted', () => {
+      it('still fully resolves a Python relative import when workspaceRoot is omitted (resolution keys off filepath, not workspaceRoot)', () => {
         const content = `from .globals import g
 
 def do_something():

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -314,11 +314,17 @@ describe('matchesFile - Path Boundary Checking', () => {
     it('should NOT match a bare package import nested arbitrarily deep elsewhere in the repo', () => {
       // Bare identifiers deliberately skip the suffix/source-prefix strategies
       // (matchesSuffixPythonModule/matchesWithSourcePrefix) that the dotted,
-      // multi-segment case above relies on. matchesSuffixPythonModule does
-      // unbounded substring search with no leading-segment cap at all;
-      // matchesWithSourcePrefix has a loose leading-segment cap (at most one
-      // prefix segment) but no trailing word-boundary check. Either gap is
-      // safe for a specific multi-segment path but not for a short bare word.
+      // multi-segment case above relies on. matchesSuffixPythonModule IS
+      // properly boundary-checked (its `endsWith('/' + moduleAsPath)` anchors
+      // to a leading `/` and the end of the string) but places no cap at all
+      // on how many directories may precede that match -- this repro's
+      // "flask" nested under vendor/some/deep/ would otherwise match.
+      // matchesWithSourcePrefix is the opposite shape: it caps the leading
+      // side to at most one directory, but never checks what follows the
+      // match, so it would let a bare word like "flask" match purely because
+      // it's a textual prefix of an unrelated sibling like "flaskext" (see
+      // the previous test). Either gap is safe for a specific multi-segment
+      // dotted path but not for a short bare word.
       expect(testMatchesFile('flask', 'vendor/some/deep/flask/app.py')).toBe(false);
     });
 

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -334,14 +334,19 @@ function matchesPythonModule(importPath: string, targetPath: string): boolean {
 
   if (!importPath.includes('.')) {
     // Bare (single-segment) specifier: only the two position-anchored
-    // strategies apply. `matchesSuffixPythonModule`/`matchesWithSourcePrefix`
-    // do unrestricted substring search with no word-boundary check after the
-    // match -- safe for a multi-segment dotted path (low collision odds) but
-    // would let a short bare word like "flask" spuriously match an unrelated
-    // sibling like "flaskext" or a same-named package nested arbitrarily
-    // deep elsewhere in the repo. Mirrors the established precedent of
-    // scoping extra leniency away from bare identifiers (see
-    // `matchesAtBoundaryPrecise`'s `maxLeadingSegments` and
+    // strategies apply. The other two are each risky in their own way for a
+    // short bare word: `matchesSuffixPythonModule` is properly boundary-
+    // checked (its `endsWith('/' + moduleAsPath)` requires a leading `/` and
+    // anchors to the end of the string) but places NO cap on how many
+    // directories may precede that match, so "flask" could match a
+    // same-named package nested arbitrarily deep elsewhere in the repo.
+    // `matchesWithSourcePrefix` caps the leading side (at most one directory)
+    // but never checks what follows the match at all, so it would let
+    // "flask" spuriously match purely because it's a textual prefix of an
+    // unrelated sibling like "flaskext". Both are safe for a multi-segment
+    // dotted path (low collision odds) but not for a bare word. Mirrors the
+    // established precedent of scoping extra leniency away from bare
+    // identifiers (see `matchesAtBoundaryPrecise`'s `maxLeadingSegments` and
     // `matchesPHPNamespace`'s bare-importPath guard, both above) -- do not
     // widen this without a confirmed real-world bare-package case, per #883.
     return (


### PR DESCRIPTION
## Summary

Fast-follow to #911. The final review run on #911 raised 3 comment-accuracy findings after merge (sequencing gap, zero behavior impact at the time). Fixes all three here, comment/title-only:

1. **`packages/parser/src/utils/path-matching.ts`** — the comment in `matchesPythonModule`'s bare-identifier branch claimed both `matchesSuffixPythonModule` and `matchesWithSourcePrefix` "do unrestricted substring search with no word-boundary check after the match." Wrong for `matchesSuffixPythonModule`: its `endsWith('/' + moduleAsPath)` / `endsWith('/' + moduleAsPath + '/__init__')` checks DO anchor to a leading `/` and the end of the string — it's properly boundary-checked, just with no cap on how many directories may precede the match. Reworded to attribute each function's actual gap: `matchesSuffixPythonModule` = unbounded leading depth; `matchesWithSourcePrefix` = capped leading depth (≤1 segment) but no trailing boundary check at all.
2. **`packages/parser/src/utils/path-matching.test.ts`** — same inaccuracy in the test comment, reworded to match, cross-referencing the neighboring "flaskext" test for the `matchesWithSourcePrefix` case.
3. **`packages/parser/src/ast/chunker.test.ts`** — a test titled "leaves a Python relative import converted-but-unresolved when workspaceRoot is omitted" whose own assertion (`expect(...).toContain('src/flask/globals')`) proves the opposite — full resolution, since relative-import resolution keys off `chunkByAST`'s `filepath` argument, not `workspaceRoot`. Retitled to describe the actual behavior.

No code logic changed anywhere — verified against the exact implementations line by line before writing the new wording.

## Test plan
- [x] `npx prettier --check` on the three changed files
- [x] `npm run lint` (0 errors, same 38 pre-existing warnings, none in touched files)
- [x] `npm run typecheck -w @liendev/parser`
- [x] `npx vitest run packages/parser/src/utils/path-matching.test.ts packages/parser/src/ast/chunker.test.ts` — 157/157 passing

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a pure documentation/comment correction with no executable code changes. It fixes three inaccurate comments in parser path-matching and chunker tests to align with the actual implementation: `matchesSuffixPythonModule` is boundary-checked but allows unbounded leading depth, `matchesWithSourcePrefix` caps leading depth but lacks trailing boundary checks, and Python relative import resolution keys off `chunkByAST`'s `filepath` rather than `workspaceRoot`. Because no logic changed, the high blast radius of `path-matching.ts` does not translate into new runtime risk.
>
> - Rewrote `matchesPythonModule` comment in path-matching.ts to accurately describe the distinct risks of `matchesSuffixPythonModule` vs `matchesWithSourcePrefix` for bare Python imports.
> - Updated path-matching.test.ts comment to match, cross-referencing the `flaskext` sibling-prefix test case.
> - Retitled chunker.test.ts test to reflect that relative imports fully resolve even when `workspaceRoot` is omitted.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit acaf749. Updates automatically on new commits.</sup>
<!-- /lien-stats -->