### PR TITLE
fix(parser,cli): recover Go's same-package test-association signal (#902)

### DIFF
--- a/.changeset/go-same-package-test-association.md
+++ b/.changeset/go-same-package-test-association.md
@@ -1,0 +1,38 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Fixes #902: Go's dominant same-package unit-test convention (`foo_test.go`
+in the same directory and `package foo` as `foo.go`, with NO import
+statement at all — Go forbids a package importing itself) left import-based
+test-association matching structurally blind to it. Measured against a real
+`cli/cli` clone: 336/356 (94.4%) of `_test.go` files basename-pair with a
+same-named sibling; applying that pairing to the 457 files the issue
+identified as having a same-directory `_test.go` sibling closes the entire
+previously-dark set.
+
+Two tiers, no AST/package-clause parsing needed (Go's compiler already
+enforces one package per directory, so same-directory is itself reliable
+evidence):
+
+- **Tier 1 — basename pairing** (`foo.go` <-> `foo_test.go`, same
+  directory): folded directly into the existing test-association signal
+  everywhere it's computed (`findTestAssociationsFromChunks`,
+  `get_files_context`'s `testAssociations`), so it flows through to
+  `lien annotate`, the MCP-mandated `get_files_context` tool,
+  `@liendev/review`'s test-coverage signals, and `verify-tests`/`recap`
+  automatically — no signature changes.
+- **Tier 2 — package-level fallback** (every `_test.go` file in the
+  directory, only when tier 1 finds nothing for that specific file): real,
+  same-package signal but coarser, so it gets a distinct, honestly-worded
+  label scoped only to `lien annotate`'s printed text (mirroring the
+  #869/#875 Swift/C# honesty-label precedent) — deliberately not folded
+  into `get_files_context`, `@liendev/review`'s gap detection, or
+  `verify-tests`'s ledger/scope-matching.
+
+New `LanguageDefinition.sameDirectoryTestConvention` flag (Go only) +
+`hasSameDirectoryTestConvention()` registry predicate, and a new
+`go-same-directory-tests.ts` module (`buildGoTestDirIndex`,
+`pairGoBasenameTest`, `findGoPackageLevelTests`) exported from
+`@liendev/parser`.

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -78,7 +78,7 @@ Unlike the whole-module/enclosing-namespace gaps above, this one needs no heuris
 - **Tier 1 (`pairGoBasenameTest`)**: `foo.go` <-> `foo_test.go`, same directory, exact stem match. Folded directly into the same result as a real import match — no hedging — in both `findTestAssociationsFromChunks` (this document) and `get_files_context`'s own separate `findTestAssociations`, gated by `LanguageDefinition.sameDirectoryTestConvention` (checked via `hasSameDirectoryTestConvention()` in the language registry; only Go sets this today). This is why it flows automatically to every consumer listed below with no signature changes.
 - **Tier 2 (`findGoPackageLevelTests`)**: every `_test.go` file in the target's directory, consulted only when tier 1 finds nothing for that specific file. Real, same-package signal, but coarser — a directory's one test file may not literally exercise every sibling (though Go's own per-directory build-tag convention, e.g. platform-specific `embed_linux_amd64.go` variants of a single abstraction, is the common shape here). `lien annotate` reports this distinctly rather than folding it into the same claim as tier 1 or an import match:
 
-  ```
+  ```text
   Test coverage (package-level, no dedicated test file for this specific file): licenses_test.go.
   ```
 

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -69,6 +69,23 @@ This is a deliberately separate flag from `wholeModuleImports`, not a reuse of i
 
 The structural remainder — which specific test covers which specific file within an enclosing namespace — stays genuinely unrecoverable from import data alone, the same as Swift's whole-module gap: there is no heuristic recovery here (no name-proximity matching), per the same false-positives-are-worse-than-silence reasoning as the bare-identifier guard above.
 
+## Go's same-package test convention: a recovered signal, not just an honest label
+
+Go's dominant unit-test shape colocates a `_test.go` file in the same directory and `package` as the file it tests, with **no import statement connecting them at all** — Go forbids a package from importing itself, so `chunk.metadata.imports` carries zero signal for this convention ([#902](https://github.com/getlien/lien/issues/902)). Measured against a real `cli/cli` clone: 336/356 (94.4%) of `_test.go` files basename-pair with a same-named sibling (`foo.go` <-> `foo_test.go`); the remainder are either external `package foo_test` files (still resolved via ordinary import matching, since an external test package must import what it tests) or the rare directory with no sibling source file at all (e.g. a repo-wide acceptance test).
+
+Unlike the whole-module/enclosing-namespace gaps above, this one needs no heuristic and no honesty label for its primary tier — Go's compiler already enforces one package per directory, so "same directory" is itself deterministic evidence, recoverable with pure filepath-string reasoning (`packages/parser/src/go-same-directory-tests.ts`), no AST or `package`-clause parsing required:
+
+- **Tier 1 (`pairGoBasenameTest`)**: `foo.go` <-> `foo_test.go`, same directory, exact stem match. Folded directly into the same result as a real import match — no hedging — in both `findTestAssociationsFromChunks` (this document) and `get_files_context`'s own separate `findTestAssociations`, gated by `LanguageDefinition.sameDirectoryTestConvention` (checked via `hasSameDirectoryTestConvention()` in the language registry; only Go sets this today). This is why it flows automatically to every consumer listed below with no signature changes.
+- **Tier 2 (`findGoPackageLevelTests`)**: every `_test.go` file in the target's directory, consulted only when tier 1 finds nothing for that specific file. Real, same-package signal, but coarser — a directory's one test file may not literally exercise every sibling (though Go's own per-directory build-tag convention, e.g. platform-specific `embed_linux_amd64.go` variants of a single abstraction, is the common shape here). `lien annotate` reports this distinctly rather than folding it into the same claim as tier 1 or an import match:
+
+  ```
+  Test coverage (package-level, no dedicated test file for this specific file): licenses_test.go.
+  ```
+
+  Deliberately scoped to `lien annotate`'s own printed text only (mirroring the whole-module/enclosing-namespace sections' single-site discipline) — **not** threaded into `get_files_context`'s `testAssociations`, `@liendev/review`'s test-coverage gap detection, or `verify-tests`'s ledger/scope-matching. A file with only tier-2 coverage still reads as a gap to those three, which is the conservative, correct call: tier 2's evidence is real but not precise enough to suppress a review finding or clear a verification nudge on its own.
+
+Both tiers are structurally bounded to the same directory (Go's own compiler guarantee) — the worst either can produce is "attributed to the wrong file in the same package," never the cross-directory textual collisions the bare-identifier guard above protects against.
+
 ## Java static-member imports: a derived second candidate
 
 `import static pkg.Class.member;` (a specific, non-wildcard static-member import) extracts a path one segment deeper than the file that defines it — `com.example.Utils.method`, when the file is `com/example/Utils.java` — so it could never match via `matchesFile` on its own. `JavaImportExtractor.extractImportPaths` (`packages/parser/src/ast/languages/java.ts`) now returns the class's derived FQN (the path with its trailing segment dropped) as a second candidate alongside the unchanged original. This is safe rather than a guess: Java requires every top-level type to live in a file named after it, and nested types/members always live inside their enclosing top-level type's file, so dropping the trailing segment always yields that type's correct FQN — whether the segment names a static member or a nested class (`import static a.B.Inner;`, correct by the same rule). A static import reaching two-plus levels into nested classes under-matches silently, the same as before this fix, rather than mismatching. Wildcard static imports and ordinary (non-static) imports are unaffected. Verified on a real clone of google/gson: `JsonReaderTest.java`'s static imports of `JsonToken.STRING`/`NUMBER`/etc. now associate it with `JsonToken.java`, with zero other test-association changes across the repo's 264 Java files.
@@ -90,9 +107,9 @@ These are structural: no import-level signal exists for the case, so the honest 
 
 ## Where associations surface
 
-- `get_files_context`'s `testAssociations` field (MCP tool)
-- `lien annotate` and the post-edit test-association reminder hook (`lien annotate --tests-only`, and its ledger-recording sibling `lien verify-tests note-edit`)
-- `@liendev/review`'s blast-radius rendering (test coverage context for a changed file)
+- `get_files_context`'s `testAssociations` field (MCP tool) — includes Go tier 1 (basename pairing), not tier 2 (package-level fallback)
+- `lien annotate` and the post-edit test-association reminder hook (`lien annotate --tests-only`, and its ledger-recording sibling `lien verify-tests note-edit`) — the only surface that also shows Go's tier 2 fallback, distinctly labeled; `verify-tests`'s ledger/scope-matching itself still only sees tier 1
+- `@liendev/review`'s blast-radius rendering (test coverage context for a changed file) — tier 1 only, same reasoning as `get_files_context`
 
 ## Language support
 
@@ -101,7 +118,7 @@ These are structural: no import-level signal exists for the case, so the honest 
 | TypeScript / JavaScript | generic patterns | yes | workspace packages (monorepo) |
 | Python | generic patterns | yes (dotted modules) | none needed |
 | PHP | generic patterns | yes (incl. fully-qualified class-name references) | composer.json PSR-4 |
-| Go | generic patterns | yes | go.mod module path |
+| Go | generic patterns | yes (imports) + same-directory basename pairing, no import needed (package-level fallback in `lien annotate` only) | go.mod module path |
 | Ruby | generic patterns | yes | none needed |
 | C# | `Tests`/`Test` suffix convention | yes (dotted `using`); not determinable for enclosing-namespace references | none (see honest limitation above) |
 | Java | generic patterns | yes (incl. static-member imports, derived class-path candidate) | none |

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -230,6 +230,47 @@ describe('formatTests', () => {
       'Test coverage: src/UnitTests/Features.cs.',
     );
   });
+
+  // #902 tier 2: Go's same-package convention has real signal even when
+  // `tests` (tier 1's basename pairing / imports) comes back empty --
+  // package-level fallback gets its own distinct wording, never conflated
+  // with a direct match or with Swift/C#'s "not determinable" (this case IS
+  // determinable, just coarser).
+  describe('Go package-level fallback (#902 tier 2)', () => {
+    it('reports the distinct package-level wording when tests is empty but package-level tests exist', () => {
+      expect(
+        formatTests([], 'internal/licenses/embed_linux_amd64.go', [
+          'internal/licenses/licenses_test.go',
+        ]),
+      ).toBe(
+        'Test coverage (package-level, no dedicated test file for this specific file): internal/licenses/licenses_test.go.',
+      );
+    });
+
+    it('truncates package-level fallback tests with a (+N more) suffix', () => {
+      expect(
+        formatTests([], 'pkg/cmd/codespace/root.go', [
+          'pkg/cmd/codespace/create_test.go',
+          'pkg/cmd/codespace/list_test.go',
+          'pkg/cmd/codespace/edit_test.go',
+        ]),
+      ).toBe(
+        'Test coverage (package-level, no dedicated test file for this specific file): pkg/cmd/codespace/create_test.go, pkg/cmd/codespace/list_test.go (+1 more).',
+      );
+    });
+
+    it('still reports "No test coverage." when both tests and package-level tests are empty', () => {
+      expect(formatTests([], 'pkg/cmd/label/untested.go', [])).toBe('No test coverage.');
+    });
+
+    it('ignores package-level tests entirely once a real (tier 1) association exists', () => {
+      expect(
+        formatTests(['pkg/cmd/label/list_test.go'], 'pkg/cmd/label/list.go', [
+          'pkg/cmd/label/should-not-appear_test.go',
+        ]),
+      ).toBe('Test coverage: pkg/cmd/label/list_test.go.');
+    });
+  });
 });
 
 describe('formatTestReminder', () => {
@@ -250,6 +291,28 @@ describe('formatTestReminder', () => {
       formatTestReminder('src/foo.ts', ['a.test.ts', 'b.test.ts', 'c.test.ts', 'd.test.ts']),
     ).toBe(
       'Lien: you changed src/foo.ts — associated tests: a.test.ts, b.test.ts (+2 more). Run them before completing.',
+    );
+  });
+
+  // #902 tier 2: mirrors formatTests's package-level fallback wording, for
+  // the shorter post-edit reminder line.
+  it('reports the package-level fallback wording when tests is empty but package-level tests exist', () => {
+    expect(
+      formatTestReminder(
+        'internal/licenses/embed_linux_amd64.go',
+        [],
+        ['internal/licenses/licenses_test.go'],
+      ),
+    ).toBe(
+      'Lien: you changed internal/licenses/embed_linux_amd64.go — no dedicated test file, but its package has: internal/licenses/licenses_test.go. Consider running them before completing.',
+    );
+  });
+
+  it('prefers the direct-tests wording when both tests and package-level tests are non-empty', () => {
+    expect(
+      formatTestReminder('src/foo.ts', ['src/foo.test.ts'], ['should-not-appear.test.ts']),
+    ).toBe(
+      'Lien: you changed src/foo.ts — associated tests: src/foo.test.ts. Run them before completing.',
     );
   });
 });

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -7,8 +7,14 @@ import {
   detectLanguage,
   hasWholeModuleImports,
   hasEnclosingNamespaceAccess,
+  hasSameDirectoryTestConvention,
+  isTestFile,
+  normalizePath,
+  buildGoTestDirIndex,
+  findGoPackageLevelTests,
   type BlastRadiusRisk,
   type CodeChunk,
+  type GoTestCandidate,
 } from '@liendev/parser';
 import { findDependents, type DependentInfo } from '../mcp/handlers/dependency-analyzer.js';
 import {
@@ -168,6 +174,128 @@ function adaptChunkImports(chunks: DependencyAnalysisChunk[]): CodeChunk[] {
 // signature honest without leaking the SearchResult import here.
 type DependencyAnalysisChunk = Awaited<ReturnType<typeof findDependents>>['allChunks'][number];
 
+/**
+ * #902 tier 2, last resort: when `tests` (the core tier-1/import-based
+ * result) is empty and `filepath`'s language sets
+ * `sameDirectoryTestConvention` (Go), every test file in the same directory
+ * — real, same-package signal, but coarser than tier 1, so it's kept
+ * strictly separate from `tests` rather than merged into it. This is why
+ * `scanTestAssociations`'s `packageLevelTests` field is additive: callers
+ * that record or verify against `.tests` (`lookupTestAssociations` /
+ * `verify-tests`'s ledger and scope-matching) see zero behavior change —
+ * only `lien annotate`'s own printed text (`formatTests`/
+ * `formatTestReminder`) consults this.
+ */
+function computeGoPackageLevelFallback(
+  tests: string[],
+  filepath: string,
+  allChunks: CodeChunk[],
+  rootDir: string,
+): string[] {
+  if (tests.length > 0) return [];
+  const language = detectLanguage(filepath);
+  if (!language || !hasSameDirectoryTestConvention(language)) return [];
+
+  const cache = new Map<string, string>();
+  const normalize = (p: string): string => {
+    if (cache.has(p)) return cache.get(p)!;
+    const normalized = normalizePath(p, rootDir);
+    cache.set(p, normalized);
+    return normalized;
+  };
+
+  const candidates: GoTestCandidate[] = allChunks
+    .filter(chunk => isTestFile(chunk.metadata.file))
+    .filter(chunk => {
+      const chunkLanguage = detectLanguage(chunk.metadata.file);
+      return chunkLanguage !== null && hasSameDirectoryTestConvention(chunkLanguage);
+    })
+    .map(chunk => ({ file: chunk.metadata.file, normalized: normalize(chunk.metadata.file) }));
+
+  return findGoPackageLevelTests(normalize(filepath), buildGoTestDirIndex(candidates));
+}
+
+/** All per-file analysis `run()` needs to decide whether/how to print. */
+interface AnnotationData {
+  allChunks: CodeChunk[];
+  dependents: DependentInfo[];
+  tests: string[];
+  packageLevelTests: string[];
+  complexity: ComplexitySummary;
+  headroom: ComplexityHeadroom;
+  risk: BlastRadiusRisk;
+}
+
+type VectorDB = Awaited<ReturnType<typeof createVectorDB>>;
+
+/**
+ * Gather every analysis input the full (non-`--tests-only`) annotation
+ * needs — dependents, test associations (incl. #902's tier 1/tier 2),
+ * complexity, headroom, and blast-radius risk — in one place, so `run()`
+ * itself stays a thin decide-and-print shell.
+ */
+async function computeAnnotationData(
+  vectorDB: VectorDB,
+  filepath: RelativePath,
+  rootDir: AbsolutePath,
+): Promise<AnnotationData> {
+  const log = () => undefined;
+  // includeAllChunks=true: annotator needs the chunks for test-association
+  // and complexity lookups. The default (false) keeps the MCP path cheap.
+  const result = await findDependents(
+    vectorDB,
+    filepath,
+    log,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    true,
+  );
+  const allChunks = adaptChunkImports(result.allChunks);
+
+  const tests = findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
+  const packageLevelTests = computeGoPackageLevelFallback(tests, filepath, allChunks, rootDir);
+  const complexity = computeComplexitySummary(allChunks, filepath);
+  // Plan-time nudge (mirrors get_files_context's complexityHeadroom): reuses
+  // the exact same computation the MCP tool uses, so a "near budget" verdict
+  // can never disagree between the read-hook annotation and get_files_context.
+  // `allChunks` spans the target file plus its dependents/dependencies, so
+  // filter down to the target file's own chunks first — other files' near-
+  // budget functions must not leak into this file's nudge (mirrors
+  // computeComplexitySummary's own `[filepath]` scoping below).
+  const headroom = computeComplexityHeadroom(allChunks.filter(c => c.metadata.file === filepath));
+  // Strict join: is any high-complexity dependent (per the core's threshold
+  // of 10) actually untested? Avoids the previous proxy that could escalate
+  // risk when uncovered/complex pairs were unrelated. Uses the
+  // core-filtered highComplexityDependents so this code never drifts from
+  // the rest of Lien's risk semantics.
+  const hasHighComplexityUncovered = anyHighComplexityUncovered(
+    result.complexityMetrics.highComplexityDependents,
+    allChunks,
+    rootDir,
+  );
+  const risk = computeBlastRadiusRisk({
+    dependentCount: result.dependents.length,
+    uncoveredDependents: result.uncoveredProductionDependents,
+    // Dependents' max complexity feeds the blast-radius risk score. The
+    // target file's own complexity (`complexity.max`) is reported
+    // separately on the display line below — different signal.
+    maxDependentComplexity: result.complexityMetrics.maxComplexity,
+    hasHighComplexityUncovered,
+  });
+
+  return {
+    allChunks,
+    dependents: result.dependents,
+    tests,
+    packageLevelTests,
+    complexity,
+    headroom,
+    risk,
+  };
+}
+
 async function run(file: string, options?: AnnotateOptions): Promise<void> {
   const paths = resolvePaths(file);
   if (!paths) return;
@@ -193,69 +321,41 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
 
-    const log = () => undefined;
-    // includeAllChunks=true: annotator needs the chunks for test-association
-    // and complexity lookups. The default (false) keeps the MCP path cheap.
-    const result = await findDependents(
-      vectorDB,
-      filepath,
-      log,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
-    const allChunks = adaptChunkImports(result.allChunks);
+    const data = await computeAnnotationData(vectorDB, filepath, rootDir);
 
-    const tests =
-      findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
-    const complexity = computeComplexitySummary(allChunks, filepath);
-    // Plan-time nudge (mirrors get_files_context's complexityHeadroom): reuses
-    // the exact same computation the MCP tool uses, so a "near budget" verdict
-    // can never disagree between the read-hook annotation and get_files_context.
-    // `allChunks` spans the target file plus its dependents/dependencies, so
-    // filter down to the target file's own chunks first — other files' near-
-    // budget functions must not leak into this file's nudge (mirrors
-    // computeComplexitySummary's own `[filepath]` scoping below).
-    const headroom = computeComplexityHeadroom(allChunks.filter(c => c.metadata.file === filepath));
-    const dependentCount = result.dependents.length;
-    const uncovered = result.uncoveredProductionDependents;
-    // Dependents' max complexity feeds the blast-radius risk score. The
-    // target file's own complexity (`complexity.max`) is reported
-    // separately on the display line below — different signal.
-    const maxDependentComplexity = result.complexityMetrics.maxComplexity;
-    // Strict join: is any high-complexity dependent (per the core's
-    // threshold of 10) actually untested? Avoids the previous proxy that
-    // could escalate risk when uncovered/complex pairs were unrelated.
-    // Uses the core-filtered highComplexityDependents so this code never
-    // drifts from the rest of Lien's risk semantics.
-    const hasHighComplexityUncovered = anyHighComplexityUncovered(
-      result.complexityMetrics.highComplexityDependents,
-      allChunks,
-      rootDir,
-    );
-
-    if (isTrivial(dependentCount, complexity.warningCount, tests.length, headroom.entries.length)) {
-      return;
-    }
-
-    const risk = computeBlastRadiusRisk({
-      dependentCount,
-      uncoveredDependents: uncovered,
-      maxDependentComplexity,
-      hasHighComplexityUncovered,
-    });
-
-    // Habituation guard's risk floor (opt-in via --min-risk; the read hook
-    // passes LIEN_ANNOTATE_MIN_RISK). No floor → current always-on behavior.
     if (
-      belowRiskFloor(risk.level, complexity.warningCount, headroom.entries.length, options?.minRisk)
+      isTrivial(
+        data.dependents.length,
+        data.complexity.warningCount,
+        data.tests.length,
+        data.headroom.entries.length,
+      )
     ) {
       return;
     }
 
-    emitAnnotation(filepath, result.dependents, tests, complexity, risk, headroom);
+    // Habituation guard's risk floor (opt-in via --min-risk; the read hook
+    // passes LIEN_ANNOTATE_MIN_RISK). No floor → current always-on behavior.
+    if (
+      belowRiskFloor(
+        data.risk.level,
+        data.complexity.warningCount,
+        data.headroom.entries.length,
+        options?.minRisk,
+      )
+    ) {
+      return;
+    }
+
+    emitAnnotation(
+      filepath,
+      data.dependents,
+      data.tests,
+      data.packageLevelTests,
+      data.complexity,
+      data.risk,
+      data.headroom,
+    );
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
@@ -265,6 +365,15 @@ export interface FileTestAssociations {
   filepath: RelativePath;
   rootDir: AbsolutePath;
   tests: string[];
+  /**
+   * #902 tier 2, last resort: populated only when `tests` is empty and the
+   * file's language sets `sameDirectoryTestConvention` (Go). Deliberately
+   * NOT part of `tests` — `lookupTestAssociations`'s caller
+   * (`verify-tests-cmd.ts`'s ledger/scope-matching) reads only `.tests` and
+   * is unaffected; only the printed reminder (`formatTestReminder`) consults
+   * this field. See `computeGoPackageLevelFallback`.
+   */
+  packageLevelTests: string[];
 }
 
 /**
@@ -288,7 +397,8 @@ async function scanTestAssociations(paths: ResolvedPaths): Promise<FileTestAssoc
     const allChunks = adaptChunkImports(await vectorDB.scanAll());
     const tests =
       findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
-    return { filepath, rootDir, tests };
+    const packageLevelTests = computeGoPackageLevelFallback(tests, filepath, allChunks, rootDir);
+    return { filepath, rootDir, tests, packageLevelTests };
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
@@ -312,20 +422,38 @@ export async function lookupTestAssociations(file: string): Promise<FileTestAsso
  * no associated tests (the signal for the hook to stay silent).
  */
 async function runTestsOnly(paths: ResolvedPaths): Promise<void> {
-  const { filepath, tests } = await scanTestAssociations(paths);
-  if (tests.length === 0) return;
-  console.log(formatTestReminder(filepath, tests));
+  const { filepath, tests, packageLevelTests } = await scanTestAssociations(paths);
+  if (tests.length === 0 && packageLevelTests.length === 0) return;
+  console.log(formatTestReminder(filepath, tests, packageLevelTests));
 }
 
 /**
  * Render the one-line post-edit reminder. Pure and exported so the wording
  * and truncation are unit-testable without indexing a real project.
+ *
+ * `packageLevelTests` (#902 tier 2) is consulted only when `tests` is empty
+ * — the same honest, distinctly-worded fallback `formatTests` uses for the
+ * full annotation, applied to the shorter reminder line.
  */
-export function formatTestReminder(filepath: string, tests: string[]): string {
-  const shown = tests.slice(0, MAX_TESTS_LISTED).join(', ');
+export function formatTestReminder(
+  filepath: string,
+  tests: string[],
+  packageLevelTests: string[] = [],
+): string {
+  if (tests.length === 0 && packageLevelTests.length > 0) {
+    const shown = formatTruncatedList(packageLevelTests);
+    return `Lien: you changed ${filepath} — no dedicated test file, but its package has: ${shown}. Consider running them before completing.`;
+  }
+  const shown = formatTruncatedList(tests);
+  return `Lien: you changed ${filepath} — associated tests: ${shown}. Run them before completing.`;
+}
+
+/** Join the first `MAX_TESTS_LISTED` entries with a "(+N more)" tail. Shared by `formatTests`/`formatTestReminder`. */
+function formatTruncatedList(items: string[]): string {
+  const shown = items.slice(0, MAX_TESTS_LISTED).join(', ');
   const extra =
-    tests.length > MAX_TESTS_LISTED ? ` (+${tests.length - MAX_TESTS_LISTED} more)` : '';
-  return `Lien: you changed ${filepath} — associated tests: ${shown}${extra}. Run them before completing.`;
+    items.length > MAX_TESTS_LISTED ? ` (+${items.length - MAX_TESTS_LISTED} more)` : '';
+  return `${shown}${extra}`;
 }
 
 /** Return type of `computeComplexityHeadroom` — the plan-time nudge data. */
@@ -346,6 +474,7 @@ function emitAnnotation(
   filepath: RelativePath,
   dependents: DependentInfo[],
   tests: string[],
+  packageLevelTests: string[],
   complexity: ComplexitySummary,
   risk: BlastRadiusRisk,
   headroom: ComplexityHeadroom,
@@ -354,7 +483,7 @@ function emitAnnotation(
   if (dependents.length > 0) {
     lines.push(`  • ${formatDependents(dependents, risk.level, risk.reasoning)}`);
   }
-  lines.push(`  • ${formatTests(tests, filepath)}`);
+  lines.push(`  • ${formatTests(tests, filepath, packageLevelTests)}`);
   if (complexity.warningCount > 0) {
     lines.push(`  • ${formatComplexity(complexity)}`);
   }
@@ -438,8 +567,19 @@ export function formatDependents(
  * though C#'s *explicit* dotted usings still resolve normally (#866/#868),
  * which is why this is a separate flag checked only as this empty-array
  * fallback, not folded into `wholeModuleImports`.
+ *
+ * `packageLevelTests` (#902 tier 2) is a THIRD, distinct kind of fallback —
+ * unlike Swift/C#'s "not determinable" (zero signal at all), this case IS
+ * determinable, just coarser than a direct match: real test files exist in
+ * the same directory, but none basename-pairs with this specific file. Only
+ * consulted when `tests` is empty; never merged into `tests` itself (see
+ * `computeGoPackageLevelFallback`).
  */
-export function formatTests(tests: string[], filepath?: string): string {
+export function formatTests(
+  tests: string[],
+  filepath?: string,
+  packageLevelTests: string[] = [],
+): string {
   if (tests.length === 0) {
     const language = filepath ? detectLanguage(filepath) : null;
     if (language && hasWholeModuleImports(language)) {
@@ -448,12 +588,12 @@ export function formatTests(tests: string[], filepath?: string): string {
     if (language && hasEnclosingNamespaceAccess(language)) {
       return 'Test coverage not determinable from imports (enclosing-namespace access).';
     }
+    if (packageLevelTests.length > 0) {
+      return `Test coverage (package-level, no dedicated test file for this specific file): ${formatTruncatedList(packageLevelTests)}.`;
+    }
     return 'No test coverage.';
   }
-  const shown = tests.slice(0, MAX_TESTS_LISTED).join(', ');
-  const extra =
-    tests.length > MAX_TESTS_LISTED ? ` (+${tests.length - MAX_TESTS_LISTED} more)` : '';
-  return `Test coverage: ${shown}${extra}.`;
+  return `Test coverage: ${formatTruncatedList(tests)}.`;
 }
 
 export function formatComplexity(summary: ComplexitySummary): string {

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -294,6 +294,64 @@ describe('handleGetFilesContext - test-association scan (scanAll fast path + cac
     });
   });
 
+  describe('Go same-package test convention, tier 1 basename pairing (#902)', () => {
+    it('associates foo.go with foo_test.go in the same directory, with no import at all', async () => {
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([
+          makeChunk('pkg/cmd/label/list.go'),
+          makeChunk('pkg/cmd/label/list_test.go'),
+        ]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'pkg/cmd/label/list.go', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual(['pkg/cmd/label/list_test.go']);
+    });
+
+    it('does not fan out to every test file in the directory -- only the exact basename pair', async () => {
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([
+          makeChunk('internal/licenses/licenses.go'),
+          makeChunk('internal/licenses/embed_linux_amd64.go'),
+          makeChunk('internal/licenses/licenses_test.go'),
+        ]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'internal/licenses/embed_linux_amd64.go', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual([]);
+    });
+
+    it('reports no association for a genuinely untested Go file', async () => {
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([
+          makeChunk('pkg/cmd/label/list.go'),
+          makeChunk('pkg/cmd/label/list_test.go'),
+          makeChunk('pkg/cmd/label/untested.go'),
+        ]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'pkg/cmd/label/untested.go', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual([]);
+    });
+  });
+
   it('caches the scan across calls with the same indexVersion (no re-scan)', async () => {
     const scanAll = vi.fn().mockResolvedValue([]);
     const ctx = makeCtx({ scanAll, indexVersion: 42 });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -7,8 +7,14 @@ import {
   getCanonicalPath,
   isTestFile,
   importMatchesTarget,
+  detectLanguage,
+  hasSameDirectoryTestConvention,
+  buildGoTestDirIndex,
+  pairGoBasenameTest,
   MAX_CHUNKS_PER_FILE,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
+  type GoTestCandidate,
+  type GoTestDirIndex,
 } from '@liendev/parser';
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 
@@ -226,6 +232,76 @@ export function createPathCache(workspaceRoot: string): {
   return { normalize, cache };
 }
 
+/** Canonical test-file paths among `allChunks` whose imports resolve to `normalizedTarget`. */
+function collectImportMatchedTestFiles(
+  allChunks: Array<{ metadata: { file: string; imports?: string[] } }>,
+  normalizedTarget: string,
+  normalize: (path: string) => string,
+  workspaceRoot: string,
+): string[] {
+  const matched: string[] = [];
+  for (const chunk of allChunks) {
+    const chunkFile = getCanonicalPath(chunk.metadata.file, workspaceRoot);
+    if (!isTestFile(chunkFile)) continue;
+
+    const imports = chunk.metadata.imports || [];
+    if (
+      imports.some(imp =>
+        importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
+      )
+    ) {
+      matched.push(chunkFile);
+    }
+  }
+  return matched;
+}
+
+/**
+ * True when `filepath`'s language sets `sameDirectoryTestConvention` (Go
+ * today, #902) — mirrors `@liendev/parser`'s own
+ * `hasGoSameDirectoryConvention` (test-associations.ts); this handler is
+ * `get_files_context`'s separate implementation, so it needs the identical
+ * per-file check.
+ */
+function hasGoSameDirectoryConvention(filepath: string): boolean {
+  const language = detectLanguage(filepath);
+  return language !== null && hasSameDirectoryTestConvention(language);
+}
+
+/**
+ * #902: directory index of same-directory-test-convention (Go) test chunks,
+ * built once per `findTestAssociations` call and reused for every target
+ * file below — mirrors `@liendev/parser`'s own `findTestAssociationsFromChunks`
+ * (this handler is `get_files_context`'s separate implementation, so it
+ * needs the identical treatment; tier 2's package-level fallback stays
+ * `lien annotate`-only, see annotate-cmd.ts).
+ */
+function buildGoTestDirIndexFromChunks(
+  allChunks: Array<{ metadata: { file: string; imports?: string[] } }>,
+  workspaceRoot: string,
+  normalize: (path: string) => string,
+): GoTestDirIndex {
+  const candidates: GoTestCandidate[] = allChunks
+    .filter(chunk => isTestFile(getCanonicalPath(chunk.metadata.file, workspaceRoot)))
+    .filter(chunk => hasGoSameDirectoryConvention(chunk.metadata.file))
+    .map(chunk => ({
+      file: getCanonicalPath(chunk.metadata.file, workspaceRoot),
+      normalized: normalize(chunk.metadata.file),
+    }));
+  return buildGoTestDirIndex(candidates);
+}
+
+/** #902 tier 1: same-directory basename-paired Go test(s) for `filepath`. */
+function collectGoBasenameTestFiles(
+  filepath: string,
+  normalizedTarget: string,
+  goTestDirIndex: GoTestDirIndex,
+): string[] {
+  return hasGoSameDirectoryConvention(filepath)
+    ? pairGoBasenameTest(normalizedTarget, goTestDirIndex)
+    : [];
+}
+
 /**
  * Find test files that import the given source files.
  *
@@ -237,6 +313,10 @@ export function createPathCache(workspaceRoot: string): {
  * This mirrors the same guard in `@liendev/parser`'s
  * `findTestAssociationsFromChunks`; this function is `get_files_context`'s
  * own separate implementation, so it needs the identical treatment.
+ *
+ * Also folds in #902 tier 1 (Go's same-directory basename-paired test
+ * convention, which carries no import statement at all) — see
+ * `buildGoTestDirIndexFromChunks`/`collectGoBasenameTestFiles` above.
  *
  * @param filepaths - Array of source file paths
  * @param allChunks - All chunks from the vector database
@@ -250,26 +330,14 @@ export function findTestAssociations(
 ): string[][] {
   const { workspaceRoot } = ctx;
   const { normalize } = createPathCache(workspaceRoot);
+  const goTestDirIndex = buildGoTestDirIndexFromChunks(allChunks, workspaceRoot, normalize);
 
   return filepaths.map(filepath => {
     const normalizedTarget = normalize(filepath);
-    const testFiles = new Set<string>();
-
-    for (const chunk of allChunks) {
-      const chunkFile = getCanonicalPath(chunk.metadata.file, workspaceRoot);
-
-      // Skip if not a test file
-      if (!isTestFile(chunkFile)) continue;
-
-      // Check if this test file imports the target
-      const imports = chunk.metadata.imports || [];
-      for (const imp of imports) {
-        if (importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize)) {
-          testFiles.add(chunkFile);
-          break;
-        }
-      }
-    }
+    const testFiles = new Set<string>([
+      ...collectImportMatchedTestFiles(allChunks, normalizedTarget, normalize, workspaceRoot),
+      ...collectGoBasenameTestFiles(filepath, normalizedTarget, goTestDirIndex),
+    ]);
 
     return Array.from(testFiles);
   });

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -597,4 +597,9 @@ export const goDefinition: LanguageDefinition = {
   symbols: {
     callExpressionTypes: ['call_expression'],
   },
+
+  // #902: a _test.go file tests its own directory's package with no import
+  // statement at all -- see LanguageDefinition.sameDirectoryTestConvention's
+  // doc comment for the full rationale.
+  sameDirectoryTestConvention: true,
 };

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -7,6 +7,7 @@ import {
   hasWholeModuleImports,
   hasEnclosingNamespaceAccess,
   hasSingleFileImports,
+  hasSameDirectoryTestConvention,
 } from './registry.js';
 import type { SupportedLanguage } from './registry.js';
 
@@ -206,6 +207,28 @@ describe('Language Registry', () => {
     it('is independent of hasWholeModuleImports/hasEnclosingNamespaceAccess', () => {
       expect(hasWholeModuleImports('ruby')).toBe(false);
       expect(hasEnclosingNamespaceAccess('ruby')).toBe(false);
+    });
+  });
+
+  describe('hasSameDirectoryTestConvention', () => {
+    it('is true for Go (#902: the dominant same-package _test.go convention)', () => {
+      expect(hasSameDirectoryTestConvention('go')).toBe(true);
+    });
+
+    it('is false for every other registered language', () => {
+      const others = getAllLanguages()
+        .map(d => d.id)
+        .filter(id => id !== 'go');
+      expect(others.length).toBeGreaterThan(0);
+      others.forEach(id => {
+        expect(hasSameDirectoryTestConvention(id)).toBe(false);
+      });
+    });
+
+    it('is independent of hasWholeModuleImports/hasEnclosingNamespaceAccess/hasSingleFileImports', () => {
+      expect(hasWholeModuleImports('go')).toBe(false);
+      expect(hasEnclosingNamespaceAccess('go')).toBe(false);
+      expect(hasSingleFileImports('go')).toBe(false);
     });
   });
 });

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -153,6 +153,19 @@ export function hasSingleFileImports(language: SupportedLanguage): boolean {
 }
 
 /**
+ * True when `language`'s dominant test convention colocates a test file in
+ * the same directory as its subject with no import statement at all (see
+ * `LanguageDefinition.sameDirectoryTestConvention`, #902). Only Go sets this
+ * today. Unlike `hasWholeModuleImports`/`hasEnclosingNamespaceAccess`, a
+ * caller consulting this recovers a real association (the directory itself
+ * is reliable evidence), not just an honesty label — see
+ * `go-same-directory-tests.ts`.
+ */
+export function hasSameDirectoryTestConvention(language: SupportedLanguage): boolean {
+  return getLanguage(language).sameDirectoryTestConvention === true;
+}
+
+/**
  * Get all registered language definitions.
  */
 export function getAllLanguages(): readonly LanguageDefinition[] {

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -123,4 +123,26 @@ export interface LanguageDefinition {
    * call sites don't have a specific target to disambiguate against).
    */
   singleFileImports?: boolean;
+
+  /**
+   * True when this language's dominant test convention colocates a test file
+   * in the same directory as its subject with NO import statement connecting
+   * them at all (#902).
+   *
+   * Go confirmed: a `_test.go` file in `package foo` tests `package foo`'s
+   * other files in the same directory purely by Go's own compiler-enforced
+   * one-package-per-directory rule — no `import` is needed or even legal for
+   * a package to import itself, so `chunk.metadata.imports` carries zero
+   * signal for this, the dominant Go unit-test shape (measured at 94.4% of
+   * a real codebase's `_test.go` files basename-pairing with a same-named
+   * sibling; 100% same-directory). This is a structural gap, not a matching
+   * bug, the same category as `wholeModuleImports`/`enclosingNamespaceAccess`
+   * above — except here the directory itself IS reliable, deterministic
+   * evidence (unlike those two), so callers recover a real association from
+   * it (see `go-same-directory-tests.ts`) rather than only an honesty label.
+   * Absent/false (the default for every language except Go) means no
+   * directory-based signal is consulted; only set this where the convention
+   * has been verified against real code.
+   */
+  sameDirectoryTestConvention?: boolean;
 }

--- a/packages/parser/src/go-same-directory-tests.test.ts
+++ b/packages/parser/src/go-same-directory-tests.test.ts
@@ -53,6 +53,20 @@ describe('buildGoTestDirIndex + pairGoBasenameTest (tier 1)', () => {
 
     expect(pairGoBasenameTest('pkg/cmd/label/list', index)).toEqual(['pkg/cmd/label/list_test.go']);
   });
+
+  it('structurally cannot self-match when the query target is itself a _test.go file', () => {
+    // A _test.go target would need a candidate whose basename is the
+    // target's own basename plus a second, literal "_test" suffix
+    // (list_test -> list_test_test) to match -- never the target's own
+    // basename, so no self-match guard is needed here (unlike
+    // findGoPackageLevelTests below, which has no basename discriminator).
+    const index = buildGoTestDirIndex([
+      candidate('pkg/cmd/label/list_test.go'),
+      candidate('pkg/cmd/label/create_test.go'),
+    ]);
+
+    expect(pairGoBasenameTest('pkg/cmd/label/list_test', index)).toEqual([]);
+  });
 });
 
 describe('findGoPackageLevelTests (tier 2, fallback only)', () => {
@@ -94,5 +108,27 @@ describe('findGoPackageLevelTests (tier 2, fallback only)', () => {
     expect(findGoPackageLevelTests('internal/licenses/embed_linux_amd64', index)).toEqual([
       'internal/licenses/licenses_test.go',
     ]);
+  });
+
+  it('excludes the target itself when the query target is a _test.go file in its own directory index', () => {
+    // Calling `lien annotate` directly on a _test.go file (or scanning one
+    // as a target for any other reason) must not report the file as
+    // "covered by itself" -- the target is a candidate in its own
+    // directory's index, same as any other test file there.
+    const index = buildGoTestDirIndex([
+      candidate('pkg/cmd/label/list_test.go'),
+      candidate('pkg/cmd/label/create_test.go'),
+    ]);
+
+    const result = findGoPackageLevelTests('pkg/cmd/label/list_test', index);
+
+    expect(result).not.toContain('pkg/cmd/label/list_test.go');
+    expect(result).toEqual(['pkg/cmd/label/create_test.go']);
+  });
+
+  it('returns an empty array when the only candidate in the directory is the target itself', () => {
+    const index = buildGoTestDirIndex([candidate('pkg/cmd/label/list_test.go')]);
+
+    expect(findGoPackageLevelTests('pkg/cmd/label/list_test', index)).toEqual([]);
   });
 });

--- a/packages/parser/src/go-same-directory-tests.test.ts
+++ b/packages/parser/src/go-same-directory-tests.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildGoTestDirIndex,
+  pairGoBasenameTest,
+  findGoPackageLevelTests,
+  type GoTestCandidate,
+} from './go-same-directory-tests.js';
+
+/** A candidate whose `normalized` form matches the extension-stripped `file`. */
+function candidate(file: string): GoTestCandidate {
+  return { file, normalized: file.replace(/\.go$/, '') };
+}
+
+describe('buildGoTestDirIndex + pairGoBasenameTest (tier 1)', () => {
+  it('pairs a basename-matched test file in the same directory', () => {
+    const index = buildGoTestDirIndex([candidate('pkg/cmd/label/list_test.go')]);
+
+    expect(pairGoBasenameTest('pkg/cmd/label/list', index)).toEqual(['pkg/cmd/label/list_test.go']);
+  });
+
+  it('does not pair across directories even with a matching basename', () => {
+    const index = buildGoTestDirIndex([candidate('pkg/cmd/other/list_test.go')]);
+
+    expect(pairGoBasenameTest('pkg/cmd/label/list', index)).toEqual([]);
+  });
+
+  it('does not pair a test file with a different basename in the same directory', () => {
+    const index = buildGoTestDirIndex([candidate('pkg/cmd/label/create_test.go')]);
+
+    expect(pairGoBasenameTest('pkg/cmd/label/list', index)).toEqual([]);
+  });
+
+  it('returns nothing for a directory with no candidates at all', () => {
+    const index = buildGoTestDirIndex([]);
+
+    expect(pairGoBasenameTest('pkg/cmd/label/list', index)).toEqual([]);
+  });
+
+  it('pairs a top-level (no-directory) file correctly', () => {
+    const index = buildGoTestDirIndex([candidate('main_test.go')]);
+
+    expect(pairGoBasenameTest('main', index)).toEqual(['main_test.go']);
+  });
+
+  it('dedupes when multiple chunks exist for the same physical test file', () => {
+    // A real test file commonly yields more than one chunk (one per
+    // function/block) -- each becomes its own candidate, so the module
+    // itself must not report the same file twice.
+    const index = buildGoTestDirIndex([
+      candidate('pkg/cmd/label/list_test.go'),
+      candidate('pkg/cmd/label/list_test.go'),
+    ]);
+
+    expect(pairGoBasenameTest('pkg/cmd/label/list', index)).toEqual(['pkg/cmd/label/list_test.go']);
+  });
+});
+
+describe('findGoPackageLevelTests (tier 2, fallback only)', () => {
+  it('returns every test file in the target directory regardless of basename', () => {
+    const index = buildGoTestDirIndex([candidate('internal/licenses/licenses_test.go')]);
+
+    expect(findGoPackageLevelTests('internal/licenses/embed_linux_amd64', index)).toEqual([
+      'internal/licenses/licenses_test.go',
+    ]);
+  });
+
+  it('returns all test files when a directory has several', () => {
+    const index = buildGoTestDirIndex([
+      candidate('pkg/cmd/codespace/create_test.go'),
+      candidate('pkg/cmd/codespace/list_test.go'),
+    ]);
+
+    const result = findGoPackageLevelTests('pkg/cmd/codespace/root', index);
+    expect(result).toHaveLength(2);
+    expect(result).toContain('pkg/cmd/codespace/create_test.go');
+    expect(result).toContain('pkg/cmd/codespace/list_test.go');
+  });
+
+  it('returns an empty array for a directory with no test files at all', () => {
+    const index = buildGoTestDirIndex([candidate('pkg/other/foo_test.go')]);
+
+    expect(findGoPackageLevelTests('pkg/untested/bar', index)).toEqual([]);
+  });
+
+  it('dedupes when multiple chunks exist for the same physical test file (real-world internal/licenses shape)', () => {
+    // Regression case found dogfooding against a real cli/cli clone:
+    // licenses_test.go yielded two chunks, and the pre-dedupe
+    // implementation reported it twice in the package-level fallback list.
+    const index = buildGoTestDirIndex([
+      candidate('internal/licenses/licenses_test.go'),
+      candidate('internal/licenses/licenses_test.go'),
+    ]);
+
+    expect(findGoPackageLevelTests('internal/licenses/embed_linux_amd64', index)).toEqual([
+      'internal/licenses/licenses_test.go',
+    ]);
+  });
+});

--- a/packages/parser/src/go-same-directory-tests.ts
+++ b/packages/parser/src/go-same-directory-tests.ts
@@ -95,6 +95,13 @@ function dedupeFiles(files: string[]): string[] {
  * `normalizedTarget` must already be extension-stripped (Go's own
  * `foo_test.go` normalizes to `.../foo_test`, so the expected suffix is a
  * plain `_test`, not `_test.go`).
+ *
+ * No self-match guard is needed here (unlike `findGoPackageLevelTests`
+ * below): the required candidate basename is `normalizedTarget`'s own
+ * basename with a non-empty `_test` literal appended, which can never equal
+ * `normalizedTarget`'s own basename again -- so a target can never satisfy
+ * its own match condition, even when the target is itself a `_test.go` file
+ * (its basename would need to double-suffix to `..._test_test` to match).
  */
 export function pairGoBasenameTest(normalizedTarget: string, dirIndex: GoTestDirIndex): string[] {
   const dir = path.posix.dirname(normalizedTarget);
@@ -110,10 +117,14 @@ export function pairGoBasenameTest(normalizedTarget: string, dirIndex: GoTestDir
 
 /**
  * Tier 2, fallback only: every same-directory-test-convention test file in
- * `normalizedTarget`'s own directory, regardless of basename. Callers must
- * only consult this when tier 1 (`pairGoBasenameTest`) finds nothing for the
- * same target, and must present the result distinctly from a direct match —
- * see `annotate-cmd.ts`'s honesty label for the one place this is wired in.
+ * `normalizedTarget`'s own directory, regardless of basename, EXCLUDING
+ * `normalizedTarget` itself. Without that exclusion, calling this on a
+ * `_test.go` file directly (e.g. `lien annotate some_test.go`) would list
+ * the file as covered by itself, since a `_test.go` target is itself a
+ * candidate in its own directory's index. Callers must only consult this
+ * when tier 1 (`pairGoBasenameTest`) finds nothing for the same target, and
+ * must present the result distinctly from a direct match — see
+ * `annotate-cmd.ts`'s honesty label for the one place this is wired in.
  */
 export function findGoPackageLevelTests(
   normalizedTarget: string,
@@ -121,5 +132,10 @@ export function findGoPackageLevelTests(
 ): string[] {
   const dir = path.posix.dirname(normalizedTarget);
   const candidates = dirIndex.get(dir);
-  return candidates ? dedupeFiles(candidates.map(candidate => candidate.file)) : [];
+  if (!candidates) return [];
+  return dedupeFiles(
+    candidates
+      .filter(candidate => candidate.normalized !== normalizedTarget)
+      .map(candidate => candidate.file),
+  );
 }

--- a/packages/parser/src/go-same-directory-tests.ts
+++ b/packages/parser/src/go-same-directory-tests.ts
@@ -1,0 +1,125 @@
+/**
+ * Go's dominant same-package test convention (#902): a `_test.go` file in
+ * `package foo` tests `package foo`'s other files in the same directory with
+ * NO import statement connecting them at all — Go forbids a package from
+ * importing itself, so `chunk.metadata.imports` carries zero signal for this,
+ * the language's own dominant unit-test shape (measured at 94.4% of a real
+ * codebase's `_test.go` files basename-pairing with a same-named sibling;
+ * 100% same-directory). Import-based matching (`matchesFile`,
+ * `importMatchesTarget`) is structurally blind to it, by construction of the
+ * language — not a matching bug.
+ *
+ * This module needs no AST/package-clause parsing to recover the signal: Go's
+ * compiler already enforces one package per directory (the sole exception —
+ * a `_test.go` file declaring an external `package foo_test` — still sits in
+ * the same directory, so it's covered the same way; see #902's design for why
+ * this needs no disambiguation). "Same directory" is therefore itself
+ * reliable, deterministic evidence — this is pure filepath-string reasoning,
+ * exactly like `isTestFile` already is.
+ *
+ * Two tiers, most to least precise (per #902's design, evidenced against a
+ * real `cli/cli` clone — basename pairing alone recovers 73.5% of the
+ * previously-dark files there, package-level fallback the remaining 26.5%):
+ *
+ *  - Tier 1, `pairGoBasenameTest`: `foo.go` <-> `foo_test.go`, same directory,
+ *    exact stem match. As trustworthy as a real import match — no hedging —
+ *    so callers fold this directly into their existing test-association set
+ *    (see `test-associations.ts` and `get-files-context.ts`).
+ *  - Tier 2, `findGoPackageLevelTests`: every `_test.go` file in the target's
+ *    directory, used ONLY as a last resort when tier 1 finds nothing for that
+ *    specific file. Real, non-fabricated same-package signal, but coarser —
+ *    callers must present it distinctly (see `annotate-cmd.ts`'s honesty
+ *    label), never with tier 1's unqualified confidence.
+ *
+ * Both tiers are bounded to the same directory by construction — the worst
+ * either can produce is "attributed to the wrong file in the same package,"
+ * never the cross-directory textual collisions #868/#883 guard against.
+ */
+
+import * as path from 'node:path';
+
+/**
+ * A candidate Go test file, carrying both the form to add to a result set
+ * (`file`, whatever raw/canonical form the caller's other test-file paths
+ * use) and the form to compare directories/basenames on (`normalized` —
+ * already extension-stripped and workspace-relative, via the caller's own
+ * `normalizePath`/`normalize` cache, so this module never has to know about
+ * normalization itself).
+ */
+export interface GoTestCandidate {
+  /** The path to report back to the caller (e.g. `chunk.metadata.file`). */
+  file: string;
+  /** Extension-stripped, workspace-relative form, for directory/basename comparison. */
+  normalized: string;
+}
+
+/** Directory -> every same-directory-test-convention test candidate in it. */
+export type GoTestDirIndex = ReadonlyMap<string, readonly GoTestCandidate[]>;
+
+/**
+ * Build a directory index from a list of candidate Go test files. Callers
+ * build this once per scan (not per target file) and reuse it — mirrors the
+ * existing `testChunks` pre-filter pattern in `findTestAssociationsFromChunks`.
+ */
+export function buildGoTestDirIndex(candidates: readonly GoTestCandidate[]): GoTestDirIndex {
+  const index = new Map<string, GoTestCandidate[]>();
+  for (const candidate of candidates) {
+    const dir = path.posix.dirname(candidate.normalized);
+    const existing = index.get(dir);
+    if (existing) {
+      existing.push(candidate);
+    } else {
+      index.set(dir, [candidate]);
+    }
+  }
+  return index;
+}
+
+/**
+ * Multiple chunks (functions/blocks) commonly exist for one physical test
+ * file, so a candidate list built straight from chunks can carry the same
+ * `file` several times over. Both tiers below return a deduplicated list
+ * regardless of caller behavior, so a single test file is never reported
+ * twice in one file's association/fallback list.
+ */
+function dedupeFiles(files: string[]): string[] {
+  return Array.from(new Set(files));
+}
+
+/**
+ * Tier 1: the test file(s) in `normalizedTarget`'s own directory whose
+ * basename is exactly `<target-basename>_test` (Go's `foo.go` <->
+ * `foo_test.go` convention). Returns the candidates' `file` form (not
+ * `normalized`), ready to add straight into a caller's test-association set.
+ *
+ * `normalizedTarget` must already be extension-stripped (Go's own
+ * `foo_test.go` normalizes to `.../foo_test`, so the expected suffix is a
+ * plain `_test`, not `_test.go`).
+ */
+export function pairGoBasenameTest(normalizedTarget: string, dirIndex: GoTestDirIndex): string[] {
+  const dir = path.posix.dirname(normalizedTarget);
+  const expectedBasename = `${path.posix.basename(normalizedTarget)}_test`;
+  const candidates = dirIndex.get(dir);
+  if (!candidates) return [];
+  return dedupeFiles(
+    candidates
+      .filter(candidate => path.posix.basename(candidate.normalized) === expectedBasename)
+      .map(candidate => candidate.file),
+  );
+}
+
+/**
+ * Tier 2, fallback only: every same-directory-test-convention test file in
+ * `normalizedTarget`'s own directory, regardless of basename. Callers must
+ * only consult this when tier 1 (`pairGoBasenameTest`) finds nothing for the
+ * same target, and must present the result distinctly from a direct match —
+ * see `annotate-cmd.ts`'s honesty label for the one place this is wired in.
+ */
+export function findGoPackageLevelTests(
+  normalizedTarget: string,
+  dirIndex: GoTestDirIndex,
+): string[] {
+  const dir = path.posix.dirname(normalizedTarget);
+  const candidates = dirIndex.get(dir);
+  return candidates ? dedupeFiles(candidates.map(candidate => candidate.file)) : [];
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -78,6 +78,7 @@ export {
   languageExists,
   hasWholeModuleImports,
   hasEnclosingNamespaceAccess,
+  hasSameDirectoryTestConvention,
 } from './ast/languages/registry.js';
 
 // =============================================================================
@@ -134,6 +135,12 @@ export { computeContentHash, isHashAlgorithmCompatible } from './content-hash.js
 // =============================================================================
 
 export { findTestAssociationsFromChunks } from './test-associations.js';
+export {
+  buildGoTestDirIndex,
+  pairGoBasenameTest,
+  findGoPackageLevelTests,
+} from './go-same-directory-tests.js';
+export type { GoTestCandidate, GoTestDirIndex } from './go-same-directory-tests.js';
 
 // =============================================================================
 // GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -171,4 +171,98 @@ describe('findTestAssociationsFromChunks', () => {
       expect(result.has('src/RetryMiddleware.php')).toBe(false);
     });
   });
+
+  describe('Go same-package test convention, tier 1 basename pairing (#902)', () => {
+    it('associates foo.go with foo_test.go in the same directory, with no import at all', () => {
+      // The dominant Go shape: package foo in both files, zero import
+      // statement -- Go forbids a package importing itself.
+      const chunks: CodeChunk[] = [
+        makeChunk('pkg/cmd/label/list.go'),
+        makeChunk('pkg/cmd/label/list_test.go'),
+      ];
+
+      const result = findTestAssociationsFromChunks(['pkg/cmd/label/list.go'], chunks);
+
+      expect(result.get('pkg/cmd/label/list.go')).toEqual(['pkg/cmd/label/list_test.go']);
+    });
+
+    it('still basename-pairs an external test package file (package foo_test) sharing the directory', () => {
+      // Basename pairing is deliberately package-clause-blind (#902's
+      // design): an external `package foo_test` file still sits in the same
+      // directory, so it pairs the same way -- no double-counting risk
+      // since the result is a Set.
+      const chunks: CodeChunk[] = [
+        makeChunk('internal/prompter/prompter.go'),
+        makeChunk('internal/prompter/prompter_test.go'),
+      ];
+
+      const result = findTestAssociationsFromChunks(['internal/prompter/prompter.go'], chunks);
+
+      expect(result.get('internal/prompter/prompter.go')).toEqual([
+        'internal/prompter/prompter_test.go',
+      ]);
+    });
+
+    it('does not fan out to every test file in a directory -- only the exact basename pair', () => {
+      // internal/licenses shape: several sibling .go files, one test file
+      // named after only ONE of them. The others get nothing from tier 1
+      // (they may get tier 2's package-level fallback -- lien annotate only,
+      // not this function -- see annotate-cmd.test.ts).
+      const chunks: CodeChunk[] = [
+        makeChunk('internal/licenses/licenses.go'),
+        makeChunk('internal/licenses/embed_linux_amd64.go'),
+        makeChunk('internal/licenses/licenses_test.go'),
+      ];
+
+      const result = findTestAssociationsFromChunks(
+        ['internal/licenses/licenses.go', 'internal/licenses/embed_linux_amd64.go'],
+        chunks,
+      );
+
+      expect(result.get('internal/licenses/licenses.go')).toEqual([
+        'internal/licenses/licenses_test.go',
+      ]);
+      expect(result.has('internal/licenses/embed_linux_amd64.go')).toBe(false);
+    });
+
+    it('reports no association for a genuinely untested Go file (no _test.go sibling at all)', () => {
+      const chunks: CodeChunk[] = [
+        makeChunk('pkg/cmd/label/list.go'),
+        makeChunk('pkg/cmd/label/list_test.go'),
+        makeChunk('pkg/cmd/label/untested.go'),
+      ];
+
+      const result = findTestAssociationsFromChunks(['pkg/cmd/label/untested.go'], chunks);
+
+      expect(result.has('pkg/cmd/label/untested.go')).toBe(false);
+    });
+
+    it('composes with a real cross-package import match without duplicating the test file', () => {
+      const chunks: CodeChunk[] = [
+        makeChunk('pkg/cmd/label/list.go'),
+        makeChunk('pkg/cmd/label/list_test.go'),
+        makeChunk('pkg/cmd/other/other_test.go', ['pkg/cmd/label']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['pkg/cmd/label/list.go'], chunks);
+
+      expect(result.get('pkg/cmd/label/list.go')).toHaveLength(2);
+      expect(result.get('pkg/cmd/label/list.go')).toContain('pkg/cmd/label/list_test.go');
+      expect(result.get('pkg/cmd/label/list.go')).toContain('pkg/cmd/other/other_test.go');
+    });
+
+    it('does not apply the same-directory convention to a non-Go language', () => {
+      // A same-named, same-directory pair in a language without
+      // sameDirectoryTestConvention set must not get this treatment --
+      // only real import-based matching applies.
+      const chunks: CodeChunk[] = [
+        makeChunk('src/list.ts'),
+        makeChunk('src/list_test.ts'), // no import -- would only match via Go's convention
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/list.ts'], chunks);
+
+      expect(result.has('src/list.ts')).toBe(false);
+    });
+  });
 });

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -4,7 +4,62 @@
  */
 
 import { isTestFile, normalizePath, importMatchesTarget } from './utils/path-matching.js';
+import { detectLanguage, hasSameDirectoryTestConvention } from './ast/languages/registry.js';
+import {
+  buildGoTestDirIndex,
+  pairGoBasenameTest,
+  type GoTestCandidate,
+  type GoTestDirIndex,
+} from './go-same-directory-tests.js';
 import type { CodeChunk } from './types.js';
+
+/**
+ * True when `filepath`'s language sets `sameDirectoryTestConvention` (Go
+ * today, #902) -- the per-file convenience wrapper `pairGoBasenameTest`'s
+ * callers need, mirroring `isUnresolvableWholeModuleImport`'s
+ * `detectLanguage` + registry-predicate shape in path-matching.ts.
+ */
+function hasGoSameDirectoryConvention(filepath: string): boolean {
+  const language = detectLanguage(filepath);
+  return language !== null && hasSameDirectoryTestConvention(language);
+}
+
+/** Test files among `testChunks` whose imports resolve to `normalizedTarget`. */
+function collectImportMatchedTests(
+  testChunks: CodeChunk[],
+  normalizedTarget: string,
+  normalize: (p: string) => string,
+): string[] {
+  const matched: string[] = [];
+  for (const chunk of testChunks) {
+    const imports = chunk.metadata.imports || [];
+    // importMatchesTarget applies the #884 whole-module guard before
+    // matchesFile -- see its doc comment in path-matching.ts (#886).
+    if (
+      imports.some(imp =>
+        importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
+      )
+    ) {
+      matched.push(chunk.metadata.file);
+    }
+  }
+  return matched;
+}
+
+/**
+ * #902 tier 1: same-directory basename-paired Go test(s) for `filepath`, or
+ * `[]` for any non-Go target (or a Go target with no basename pair). See
+ * `go-same-directory-tests.ts`'s module doc for why this needs no hedging.
+ */
+function collectGoBasenameTests(
+  filepath: string,
+  normalizedTarget: string,
+  goTestDirIndex: GoTestDirIndex,
+): string[] {
+  return hasGoSameDirectoryConvention(filepath)
+    ? pairGoBasenameTest(normalizedTarget, goTestDirIndex)
+    : [];
+}
 
 /**
  * Find test files that import the given source files.
@@ -34,22 +89,23 @@ export function findTestAssociationsFromChunks(
   // Pre-filter to only test chunks for performance
   const testChunks = chunks.filter(chunk => isTestFile(chunk.metadata.file));
 
+  // #902: Go's dominant same-package test convention emits no import
+  // statement at all, so the import-matching loop below is structurally
+  // blind to it. Build a directory index of same-directory-test-convention
+  // (Go) test chunks once, reused for every target file below -- tier 1
+  // only (basename pairing); tier 2 (package-level fallback) is a
+  // `lien annotate`-only honesty fallback, see annotate-cmd.ts.
+  const goTestCandidates: GoTestCandidate[] = testChunks
+    .filter(chunk => hasGoSameDirectoryConvention(chunk.metadata.file))
+    .map(chunk => ({ file: chunk.metadata.file, normalized: normalize(chunk.metadata.file) }));
+  const goTestDirIndex = buildGoTestDirIndex(goTestCandidates);
+
   for (const filepath of filepaths) {
     const normalizedTarget = normalize(filepath);
-    const testFiles = new Set<string>();
-
-    for (const chunk of testChunks) {
-      const imports = chunk.metadata.imports || [];
-      // importMatchesTarget applies the #884 whole-module guard before
-      // matchesFile -- see its doc comment in path-matching.ts (#886).
-      if (
-        imports.some(imp =>
-          importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
-        )
-      ) {
-        testFiles.add(chunk.metadata.file);
-      }
-    }
+    const testFiles = new Set<string>([
+      ...collectImportMatchedTests(testChunks, normalizedTarget, normalize),
+      ...collectGoBasenameTests(filepath, normalizedTarget, goTestDirIndex),
+    ]);
 
     if (testFiles.size > 0) {
       result.set(filepath, Array.from(testFiles));


### PR DESCRIPTION
Closes #902.

## Summary

Go's dominant same-package unit-test convention — a `_test.go` file in `package foo`, same directory as `foo.go`, with **no import statement at all** (Go forbids a package importing itself) — left import-based test-association matching structurally blind to it. Design posted and approved at https://github.com/getlien/lien/issues/902#issuecomment-5080818965; built per that design once #906 (the import-matcher consolidation) merged.

Two tiers, evidenced against a real `cli/cli` clone, no AST/`package`-clause parsing needed (Go's compiler already enforces one package per directory, so same-directory is itself reliable evidence):

- **Tier 1 — basename pairing** (`foo.go` <-> `foo_test.go`, same directory): folded directly into the existing signal in both `findTestAssociationsFromChunks` (parser) and `get_files_context`'s own `findTestAssociations` (cli) — no signature changes, so it flows automatically to `lien annotate`, the MCP-mandated `get_files_context` tool, `@liendev/review`'s test-coverage signals, and `verify-tests`/`recap`.
- **Tier 2 — package-level fallback** (every `_test.go` in the directory, only when tier 1 finds nothing): real but coarser signal, given a distinct, honestly-worded label scoped only to `lien annotate`'s printed text (mirrors the #869/#875 Swift/C# honesty-label precedent). Deliberately **not** threaded into `get_files_context`, review's gap detection, or verify-tests' ledger/scope-matching — a file with only package-level coverage still reads as a gap there, the conservative, correct call.

New `LanguageDefinition.sameDirectoryTestConvention` flag (Go only) + `hasSameDirectoryTestConvention()` registry predicate, and a new `packages/parser/src/go-same-directory-tests.ts` module (`buildGoTestDirIndex`, `pairGoBasenameTest`, `findGoPackageLevelTests`), exported from `@liendev/parser`.

## Design questions resolved (see the issue comment for full detail)

- **False positives**: both tiers are structurally bounded to the same directory (Go's compiler guarantee) — the worst either can produce is "attributed to the wrong file in the same package," never the cross-directory textual collisions #868/#883 fixed.
- **External test packages** (`package foo_test`): basename pairing is package-clause-blind, so these still pair the same way when a basename match exists; composition with real import-based matching is a plain `Set` union — no double-counting.
- **verify-tests scope**: tier 2 stays entirely out of `scanTestAssociations`'s `tests` field (only a new, separate `packageLevelTests` field, consumed only by `formatTests`/`formatTestReminder`), so `verify-tests-cmd.ts`'s ledger/`isCoveredByScope` matching sees zero behavior change.

## Gates (all green)

`format:check`, `lint` (0 errors, 38 pre-existing warnings, none in touched files), `typecheck`, `build`, full `npm test` (parser-native 27/27, parser 1351/1351, core 378/378, review 1665/1665, cli 1228/1228, action 41/41), `npm run test:e2e:go -w packages/cli` (real chi/chi clone, 14/14), `node packages/cli/dist/index.js delta` → **exit 0** (no new-over-threshold crossings; one pre-existing-budget function (`run` in `annotate-cmd.ts`) was refactored via extraction and *improved* 59m→30m Halstead effort while adding the new wiring).

## Dogfood evidence (verbatim, fresh `cli/cli` clone, real index, `--depth 1`)

Quantified the issue's own 457-file denominator (non-test `.go` files with ≥1 same-directory `_test.go` sibling) via a real before/after A/B: built the pre-fix binary (`git stash` back to `db565d21`, rebuild), scanned all 457 files with `lien annotate <file> --tests-only`, restored the fix, rebuilt, rescanned the identical file list against the identical index (no reindex needed — the fix only changes query-time association logic, not what's indexed).

| | Baseline (pre-fix) | This branch |
|---|---|---|
| Dark (no signal at all) | **276/457 (60.4%)** | **0/457 (0%)** |
| Direct association ("associated tests: ...") | 181/457 (39.6%) | 411/457 (89.9%) |
| Package-level fallback (tier 2, honestly labeled) | n/a | 46/457 (10.1%) |

Every one of the 276 previously-dark files now gets real signal: 230 via tier 1 (basename pairing), 46 via tier 2 (package-level) — `230 + 46 = 276`, exact closure of the measured gap.

**Issue's own named examples** (`pkg/cmd/label/list.go`, `pkg/cmd/codespace/list.go`, `context/remote.go`), before (baseline) vs after:
```
$ node dist/index.js annotate pkg/cmd/label/list.go        # BEFORE: No test coverage.
$ node dist/index.js annotate pkg/cmd/label/list.go        # AFTER:
  • Test coverage: pkg/cmd/label/list_test.go.

$ node dist/index.js annotate pkg/cmd/codespace/list.go    # AFTER:
  • Test coverage: pkg/cmd/codespace/list_test.go.

$ node dist/index.js annotate context/remote.go            # AFTER:
  • Test coverage: pkg/cmd/factory/remote_resolver_test.go, pkg/cmd/skills/install/install_test.go (+16 more).
```
(`pkg/cmd/run/run.go`, also named in the issue, is a genuine directory-has-no-test-file case — see below — so it correctly stays "No test coverage." both before and after; not every issue-named file has a sibling test.)

**Tier 1 win, spot-checked by opening both files** — `cmd/gen-docs/main.go` / `cmd/gen-docs/main_test.go`, both `package main`, zero import between them:
```go
// main_test.go
func Test_run(t *testing.T) {
	dir := t.TempDir()
	args := []string{"--man-page", "--website", "--doc-path", dir}
	err := run(args)   // calls main.go's own run() directly, no import
	...
}
```
```
$ node dist/index.js annotate cmd/gen-docs/main.go --tests-only
Lien: you changed cmd/gen-docs/main.go — associated tests: cmd/gen-docs/main_test.go. Run them before completing.
```

**Tier 2 win, spot-checked by opening both files** — `internal/licenses/embed_darwin_amd64.go` (a build-tag-gated platform variant, `package licenses`) / `internal/licenses/licenses_test.go` (the directory's one test file, calling `Content()`, the function these variants implement):
```
$ node dist/index.js annotate internal/licenses/embed_darwin_amd64.go
  • Test coverage (package-level, no dedicated test file for this specific file): internal/licenses/licenses_test.go.
```

**Genuinely-untested file still correctly shows nothing** — `pkg/cmd/run/run.go`'s directory (`ls pkg/cmd/run/`) contains no `_test.go` file at all:
```
$ node dist/index.js annotate pkg/cmd/run/run.go --tests-only
(silent — exit 0, no output)
$ node dist/index.js annotate pkg/cmd/run/run.go
  • No test coverage.
```

**A real bug found and fixed during this dogfood pass**: the first `--tests-only` corpus scan surfaced a duplicate test-file name in several package-level results (e.g. `internal/licenses/licenses_test.go` listed twice for `embed_darwin_amd64.go`) — a real test file commonly yields more than one chunk (one per function), and `findGoPackageLevelTests`/`pairGoBasenameTest` weren't deduping by file. Fixed (`dedupeFiles` in `go-same-directory-tests.ts`), covered by new regression tests using the exact `internal/licenses` shape, and reconfirmed against the same live clone — the corpus-wide scan now shows zero duplicate test names across all 457 files (verified programmatically, not just spot-checked).

Cleanup: the clone and its two `~/.lien/indices/cli-*` entries (baseline + fixed builds) were both removed after verification.

## Scope

Per the approved design, this PR is tier 1 + tier 2 exactly as posted. Not in scope (explicitly, per the design's stated scope decision): threading tier 2 into `get_files_context`/review/verify-tests. A separate, related finding from Phase 1 (`verify-tests`'s `isCoveredByScope` not recognizing Go's own idiomatic `go test ./pkg/x/...` package-scoped run form) was filed as #908 and will be a follow-up PR.

## Test plan

- [x] New unit tests: `go-same-directory-tests.test.ts` (10 tests, incl. the dedup regression), `test-associations.test.ts` (+6 Go cases), `registry.test.ts` (+3 cases), `get-files-context.test.ts` (+3 cases), `annotate-cmd.test.ts` (+6 cases for the tier-2 wording and precedence).
- [x] Full six-gate chain green (see above).
- [x] Real-repo dogfood with a genuine before/after A/B (see above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go test coverage detection for same-package tests that do not use imports.
  * Associates source files with matching `foo_test.go` files in the same directory.
  * Added clearly labeled package-level fallback coverage when no exact test match is available.
  * Extended accurate Go test associations to annotations, context views, review coverage, and test reminders.

* **Documentation**
  * Documented Go’s test-association rules and how coverage appears across features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |

> [!NOTE]
> **Low Risk**
>
> This PR implements Go's same-package test-association recovery (#902) through two tiers: basename pairing (tier 1) folded into core test-association signals, and package-level fallback (tier 2) scoped only to `lien annotate`'s printed text. The implementation is careful, well-tested, and consistent across `@liendev/parser`, `get_files_context`, and `lien annotate`. Tier 2 is deliberately isolated from `get_files_context`, review gap detection, and verify-tests ledger/scope-matching, matching the approved design. No runtime bugs, silent error swallowing, or breaking caller malfunctions were found.
>
> - Added `LanguageDefinition.sameDirectoryTestConvention` flag (Go only) and `hasSameDirectoryTestConvention()` registry predicate
> - Added `go-same-directory-tests.ts` module with directory-indexed basename pairing and package-level fallback
> - Wired tier 1 basename pairing into `findTestAssociationsFromChunks` and `get_files_context`'s `findTestAssociations`
> - Wired tier 1 + tier 2 into `lien annotate`, with tier 2 surfaced only through distinct `formatTests`/`formatTestReminder` wording

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 510918d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

