### PR TITLE
fix(cli): recognize go test directory scopes in isCoveredByScope (#908)

### DIFF
--- a/.changeset/go-scoped-run-directory-coverage.md
+++ b/.changeset/go-scoped-run-directory-coverage.md
@@ -1,0 +1,25 @@
+---
+'@liendev/lien': patch
+---
+
+Fixes #908: `isCoveredByScope` (the did-you-run-the-tests nudge behind
+`lien verify-tests note-run`/`report`/`recap`) now recognizes a
+directory-scoped test run as covering the files inside it, not just an
+exact basename/stem match. Go's own idiomatic `go test` invocation always
+names a package directory, never an individual file — `go test
+./pkg/x/...` (recursive) and `go test ./pkg/x` (that package only, no
+subdirectories) previously matched nothing and left the whole package
+nagging as unverified even after a correctly, narrowly-targeted run.
+
+The new directory-scope check is path-segment-aware, not a string prefix:
+`./pkg/cmd/label` (with or without the recursive `/...` suffix) does not
+cover a different, unrelated package that merely shares a text prefix
+(`./pkg/cmd/labeler`). The check is intentionally not Go-gated — any scope
+token that names a directory rather than a specific file (no recognized
+source extension) gets the same treatment, since `scopeTokens` carry no
+record of which runner produced them and the same directory-scope
+reasoning is valid for any other ecosystem's directory-scoped invocation
+(e.g. `pytest tests/unit/`).
+
+Purely additive: existing basename/stem matching, `classifyTestCommand`,
+and every current `RUNNER_PATTERNS` entry are unchanged.

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -269,4 +269,93 @@ describe('computeUnverifiedFiles', () => {
   it('an empty edits map yields an empty result regardless of runs', () => {
     expect(computeUnverifiedFiles(new Map(), [])).toEqual([]);
   });
+
+  // #908: Go's own idiomatic go test invocation always names a PACKAGE
+  // (directory), never a file -- `go test ./pkg/x/...` (recursive) and
+  // `go test ./pkg/x` (exact package only) previously matched nothing in
+  // isCoveredByScope's basename-only check, nagging even a correctly,
+  // narrowly-targeted run.
+  describe('directory-scoped runs (#908)', () => {
+    it('a recursive directory scope (go test ./pkg/x/...) covers a file directly in that directory', () => {
+      const edits = new Map([['pkg/cmd/label/list.go', ['pkg/cmd/label/list_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/label/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+
+    it('a recursive directory scope covers a file nested in a subdirectory', () => {
+      const edits = new Map([['pkg/cmd/label/sub/deep.go', ['pkg/cmd/label/sub/deep_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/label/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+
+    it('a non-recursive directory scope (go test ./pkg/x, no ...) covers a file directly in that directory', () => {
+      const edits = new Map([['pkg/cmd/label/list.go', ['pkg/cmd/label/list_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/label'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+
+    it('a non-recursive directory scope does NOT cover a file in a subdirectory (Go: each dir is its own package)', () => {
+      const edits = new Map([['pkg/cmd/label/sub/deep.go', ['pkg/cmd/label/sub/deep_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/label'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([
+        { file: 'pkg/cmd/label/sub/deep.go', tests: ['pkg/cmd/label/sub/deep_test.go'] },
+      ]);
+    });
+
+    it('a directory scope for a different package still nags (path-segment-aware, not string-prefix)', () => {
+      // The exact false-clear class this fix must not reopen: "label" is a
+      // text prefix of "labeler", but pkg/cmd/labeler is a real, different,
+      // unrelated package.
+      const edits = new Map([['pkg/cmd/labeler/other.go', ['pkg/cmd/labeler/other_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/label/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([
+        { file: 'pkg/cmd/labeler/other.go', tests: ['pkg/cmd/labeler/other_test.go'] },
+      ]);
+    });
+
+    it('a non-recursive directory scope for a different package (no ...) also still nags', () => {
+      const edits = new Map([['pkg/cmd/labeler/other.go', ['pkg/cmd/labeler/other_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/label'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([
+        { file: 'pkg/cmd/labeler/other.go', tests: ['pkg/cmd/labeler/other_test.go'] },
+      ]);
+    });
+
+    it('a directory scope matches via the associated test file directory too, not just the edited file', () => {
+      // Go's own same-package convention means these are usually identical,
+      // but the check is symmetric with the existing basename/stem checks,
+      // which also look at both the file and its tests.
+      const edits = new Map([['pkg/cmd/label/list.go', ['pkg/cmd/other/list_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/other/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+
+    it('a scope token that names a real file (recognized extension) is NOT treated as a directory scope', () => {
+      // Unusual for `go test` in practice, but must not regress existing
+      // file-scoped matching for any other runner that DOES pass file paths.
+      const edits = new Map([['pkg/cmd/label/list.go', ['pkg/cmd/label/list_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['pkg/cmd/label/list_test.go'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+
+    it('a directory scope one level up does not cover a file two levels down without the recursive suffix', () => {
+      const edits = new Map([['pkg/cmd/label/sub/deep.go', ['pkg/cmd/label/sub/deep_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([
+        { file: 'pkg/cmd/label/sub/deep.go', tests: ['pkg/cmd/label/sub/deep_test.go'] },
+      ]);
+    });
+
+    it('a directory scope one level up DOES cover a file two levels down WITH the recursive suffix', () => {
+      const edits = new Map([['pkg/cmd/label/sub/deep.go', ['pkg/cmd/label/sub/deep_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['./pkg/cmd/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+
+    it('a directory scope token without a leading ./ still matches (go test pkg/x/...)', () => {
+      const edits = new Map([['pkg/cmd/label/list.go', ['pkg/cmd/label/list_test.go']]]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: ['pkg/cmd/label/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+  });
 });

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -326,11 +326,73 @@ function stemKey(p: string): string {
 }
 
 /**
+ * Split a scope token into its directory portion and whether it carries
+ * Go's recursive `/...` suffix (`go test ./pkg/x/...`). A token with no
+ * `/...` suffix is still a directory scope, just non-recursive — matching
+ * Go's own semantics exactly: `go test ./pkg/x` runs only that package,
+ * never its subdirectories (each is a separate package); only the `/...`
+ * form recurses. A trailing slash (with or without the wildcard) is
+ * stripped first so `./pkg/x/` and `./pkg/x` parse identically.
+ */
+function parseDirectoryScope(token: string): { dir: string; recursive: boolean } {
+  const trimmed = token.replace(/\/+$/, '');
+  if (trimmed.endsWith('/...')) {
+    return { dir: trimmed.slice(0, -'/...'.length), recursive: true };
+  }
+  return { dir: trimmed, recursive: false };
+}
+
+/** Strip a leading "./" so `./pkg/x` and `pkg/x` compare equal. */
+function normalizeDirForComparison(dir: string): string {
+  return dir.replace(/^\.\//, '');
+}
+
+/**
+ * True when `token` names a directory rather than a specific file — i.e. it
+ * carries no recognized source extension once a `/...` recursive suffix is
+ * stripped. Go's own `go test` invocation ALWAYS names a package directory,
+ * never an individual file (there is no per-file `go test` form at all), so
+ * this fires for essentially every real Go scope token — but the check
+ * itself is deliberately language-agnostic, not Go-gated: `scopeTokens` are
+ * flattened across every matched run with no record of which runner
+ * produced them (tagging would need a much larger structural change than
+ * this fix warrants), and "this names a directory, not a file" is an
+ * equally valid signal for any other ecosystem's directory-scoped run
+ * (e.g. `pytest tests/unit/`).
+ */
+function isDirectoryScopeToken(token: string, extensions: ReadonlySet<string>): boolean {
+  const { dir } = parseDirectoryScope(token);
+  return ![...extensions].some(ext => dir.endsWith(ext));
+}
+
+/**
+ * Path-segment-aware directory containment: is `fileDir` the scope
+ * token's own directory (always allowed), or nested under it (only when
+ * the token's `/...` recursive suffix was present)?
+ *
+ * Deliberately NOT a string-prefix check — `./pkg/cmd/label` must not
+ * cover `./pkg/cmd/labeler`, a real, different, unrelated package that
+ * merely shares a text prefix. Comparing for exact equality, or a prefix
+ * of `scopeDir + '/'` specifically, anchors the match to a genuine
+ * path-segment boundary instead of a raw substring.
+ */
+function isDirCoveredByScopeToken(fileDir: string, scopeToken: string): boolean {
+  const { dir, recursive } = parseDirectoryScope(scopeToken);
+  const scopeDir = normalizeDirForComparison(dir);
+  const normalizedFileDir = normalizeDirForComparison(fileDir);
+  if (normalizedFileDir === scopeDir) return true;
+  return recursive && normalizedFileDir.startsWith(`${scopeDir}/`);
+}
+
+/**
  * A pending edited file is covered when a scoped run's token EXACTLY matches
  * (case-insensitive) the file's own basename or an associated test's
  * basename, or when their stems match after stripping one extension and one
  * `.test`/`.spec` segment (so a run naming `foo.test.ts` covers an edit to
- * `foo.ts`, and vice versa).
+ * `foo.ts`, and vice versa) — or when the token is a directory scope (#908,
+ * `go test ./pkg/x/...` / `./pkg/x`) whose directory contains the file's own
+ * directory or an associated test's directory (see `isDirCoveredByScopeToken`
+ * for the recursive-vs-exact distinction).
  *
  * Deliberately NOT substring/bidirectional-containment, unlike an earlier
  * version of this function — see the module doc comment and the dated
@@ -338,19 +400,29 @@ function stemKey(p: string): string {
  * matching let e.g. a `oauth.test.ts` run silently "cover" an unrelated
  * `auth.ts` edit (because "auth" is a substring of "oauth"), which is a
  * worse failure mode (a real gap goes unnoticed) than the false nag this
- * feature is otherwise biased to avoid.
+ * feature is otherwise biased to avoid. The directory-scope check above is
+ * exactly as strict, just at the directory level (`isDirCoveredByScopeToken`
+ * anchors on a real path-segment boundary, never a bare string prefix).
  */
-function isCoveredByScope(file: string, tests: string[], scopeTokens: string[]): boolean {
+function isCoveredByScope(
+  file: string,
+  tests: string[],
+  scopeTokens: string[],
+  extensions: ReadonlySet<string>,
+): boolean {
   const fileBase = baseKey(file);
   const fileStem = stemKey(file);
   const testBases = tests.map(baseKey);
   const testStems = tests.map(stemKey);
+  const candidateDirs = [file, ...tests].map(p => path.posix.dirname(p));
 
   return scopeTokens.some(token => {
     const tokenBase = baseKey(token);
     if (tokenBase === fileBase || testBases.includes(tokenBase)) return true;
     const tokenStem = stemKey(token);
-    return tokenStem === fileStem || testStems.includes(tokenStem);
+    if (tokenStem === fileStem || testStems.includes(tokenStem)) return true;
+    if (!isDirectoryScopeToken(token, extensions)) return false;
+    return candidateDirs.some(dir => isDirCoveredByScopeToken(dir, token));
   });
 }
 
@@ -369,10 +441,11 @@ export function computeUnverifiedFiles(
   if (runs.some(r => r.isTestRun && r.broad)) return [];
 
   const scopeTokens = runs.filter(r => r.isTestRun && !r.broad).flatMap(r => r.scopeTokens);
+  const extensions = sourceExtensions();
 
   const unverified: Array<{ file: string; tests: string[] }> = [];
   for (const [file, tests] of edits) {
-    if (!isCoveredByScope(file, tests, scopeTokens)) unverified.push({ file, tests });
+    if (!isCoveredByScope(file, tests, scopeTokens, extensions)) unverified.push({ file, tests });
   }
   return unverified;
 }


### PR DESCRIPTION
Closes #908.

## Summary

Go's own idiomatic `go test` invocation always names a **package directory**, never an individual file — there is no per-file `go test` invocation form at all. Before this fix, `isCoveredByScope` (the did-you-run-the-tests nudge behind `lien verify-tests note-run`/`report`/`recap`) only compared a scope token's basename/stem against a file's own basename/stem, so neither of Go's two real invocation forms — `go test ./pkg/x/...` (recursive) nor `go test ./pkg/x` (that package only) — ever matched anything. A correctly, narrowly-targeted Go test run left the whole package nagging as unverified, and this got materially more consequential once #913 shipped: Go files now have real, associated test names (via tier 1) to fail to match against.

Traced and root-caused in the Phase 1 design for #902; filed as its own issue (#908) since it's a different layer (run-verification, not test-association) than #902 itself.

## Fix

Built on `test-run-matcher.ts`'s post-#907 state (wrapper/tox-runner recognition — untouched by this change). Added a **path-segment-aware directory-scope check** as an additional way a scope token can cover a file — never replacing the existing basename/stem match, only adding to it:

- A scope token with no recognized source extension (once a `/...` recursive suffix is stripped) is treated as a directory scope.
- `<dir>/...` → **recursive**: covers `<dir>` and everything nested under it.
- `<dir>` (bare, no `/...`) → **non-recursive**: covers only files directly in `<dir>`, matching Go's actual semantics exactly (`go test ./pkg/x` runs only that package, never subdirectories — each is its own separate package).
- Matching is **exact-directory or `scopeDir + '/'`-prefixed**, never a raw string prefix — `./pkg/cmd/label` does not cover `./pkg/cmd/labeler`, a different, unrelated package that merely shares a text prefix. This is the exact substring-false-clear class `isCoveredByScope`'s own doc comment already warns about (the `oauth.test.ts`-covers-`auth.ts` precedent) — the new check is exactly as strict, just at the directory level.

**Deliberately not Go-gated.** `scopeTokens` are flattened across every matched run in `computeUnverifiedFiles` with no record of which runner produced them, and gating this to Go specifically would need scope tokens tagged by originating runner — a much larger structural change than this fix needs. "This token names a directory, not a file" is an equally valid, correct signal for any other ecosystem's directory-scoped run (e.g. `pytest tests/unit/`), so the check is general.

## Gates (all green)

`format:check`, `lint` (0 errors, 38 pre-existing warnings, none in touched files), `typecheck`, `build`, full `npm test` (parser-native/parser/core/review/cli 1239/1239/action all green — cli count up from 1228 to 1239, matching the 11 new tests), `node packages/cli/dist/index.js delta` → **exit 0** (only two advisory "worsened" markers, `isCoveredByScope` cognitive 3→5 and `computeUnverifiedFiles` time 24m→25m, nowhere near any threshold).

Changeset: `@liendev/lien` patch only (this is a CLI-side-only fix, `packages/parser` untouched — matches #907's changeset scoping for the same file).

## Dogfood evidence (verbatim, fresh `cli/cli` clone, real index)

Replayed the exact hook shape the plugin uses: `note-edit` → `note-run` → `report`, against `pkg/cmd/label/list.go`, which has a real tier-1 association from #913 (`pkg/cmd/label/list_test.go`):

```
$ node dist/index.js annotate pkg/cmd/label/list.go --tests-only
Lien: you changed pkg/cmd/label/list.go — associated tests: pkg/cmd/label/list_test.go. Run them before completing.
```

**Before this fix (built from `f65df047`, #913 merged but not #908) — reproduces the bug:**
```
$ node dist/index.js verify-tests note-edit --session baseline1 --file pkg/cmd/label/list.go
$ node dist/index.js verify-tests note-run --session baseline1 --command "go test ./pkg/cmd/label/..."
$ node dist/index.js verify-tests report --session baseline1 --format json
{"unverified":[{"file":"pkg/cmd/label/list.go","tests":["pkg/cmd/label/list_test.go"]}]}
```
Wrongly nags — the developer ran exactly the right, idiomatic command and gets no credit for it.

**After this fix, same scenario — clears correctly:**
```
$ node dist/index.js verify-tests note-run --session fixed1 --command "go test ./pkg/cmd/label/..."
$ node dist/index.js verify-tests report --session fixed1 --format json
{"unverified":[]}
```

**Non-recursive form (`go test ./pkg/cmd/label`, no `/...`) also clears correctly:**
```
$ node dist/index.js verify-tests note-run --session fixed2 --command "go test ./pkg/cmd/label"
$ node dist/index.js verify-tests report --session fixed2 --format json
{"unverified":[]}
```

**A run scoped to a genuinely different package still nags, as it must:**
```
$ node dist/index.js verify-tests note-edit --session fixed3 --file pkg/cmd/label/list.go
$ node dist/index.js verify-tests note-run --session fixed3 --command "go test ./pkg/cmd/repo/..."
$ node dist/index.js verify-tests report --session fixed3 --format json
{"unverified":[{"file":"pkg/cmd/label/list.go","tests":["pkg/cmd/label/list_test.go"]}]}
```

The `label`-vs-`labeler` false-clear boundary itself is covered by 2 dedicated unit tests (recursive and non-recursive forms) rather than a real-repo pair, since no such naturally-occurring near-miss exists in `cli/cli`'s current tree — the unit tests exercise it directly and precisely.

Cleanup: the clone and its `~/.lien/indices/cli-*` entry were removed after verification.

## Test plan

- [x] 11 new unit tests in `test-run-matcher.test.ts`: recursive coverage (own dir + nested), non-recursive coverage (own dir only, not nested), the `label`/`labeler` false-clear guard (both recursive and non-recursive forms), directory-scope-via-test-file-directory (symmetry with existing basename/stem checks), a real-file-extension token is NOT treated as a directory scope (no regression for file-scoped runners), and a token without a leading `./`.
- [x] All 113 pre-existing tests in the file still pass unchanged.
- [x] Full six-gate chain green.
- [x] Real-repo dogfood with a genuine before/after A/B, plus the required clear/nag pair (correct scope clears, wrong scope still nags).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a path-segment-aware directory-scope check to `isCoveredByScope` so that Go's idiomatic `go test ./pkg/x/...` and `go test ./pkg/x` invocations correctly cover files in the named package directory. The change is purely additive: existing basename/stem matching and runner recognition are untouched, and the new logic correctly distinguishes recursive (`/...`) from non-recursive directory scopes while guarding against text-prefix false clears (e.g., `label` vs `labeler`). The implementation is well-covered by 11 new unit tests and aligns with the PR's claims.
>
> - Added `parseDirectoryScope`, `normalizeDirForComparison`, `isDirectoryScopeToken`, and `isDirCoveredByScopeToken` helpers to detect and match directory-scoped test runs.
> - Extended `isCoveredByScope` to fall back to directory containment when basename/stem matching fails, using exact-directory or `scopeDir + '/'` prefix checks.
> - Added comprehensive tests for recursive/non-recursive coverage, the `label`/`labeler` false-clear guard, test-file-directory symmetry, and leading `./` normalization.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit db25801. Updates automatically on new commits.</sup>
<!-- /lien-stats -->