### PR TITLE
fix(cli): resolve project root via nearest completed index, not nearest .git (#894)

### DIFF
--- a/.changeset/annotate-project-root-resolution.md
+++ b/.changeset/annotate-project-root-resolution.md
@@ -1,0 +1,31 @@
+---
+'@liendev/lien': patch
+'@liendev/core': patch
+---
+
+Fixes #894: `lien annotate` (and every other read-side command that resolves
+a project root without an explicit `--root`/`--path` — `gc`, `path`,
+`store-paths`, `recap`, `nudge`, `verify-tests`) now prefers the nearest
+ancestor directory that has actually completed a `lien index` build over the
+nearest `.git`. Previously, a directory with no `.git` of its own — a
+monorepo subdirectory indexed as its own project, or a repo nested inside a
+larger checkout — would resolve past its own (real, populated) index to an
+unrelated outer `.git` root that was never indexed, silently reporting
+against the wrong store.
+
+`resolveProjectRoot` (`packages/cli/src/cli/project-root.ts`) is the single
+shared helper behind all of the commands above; the fix lives entirely in
+its resolution algorithm, so every consumer gets it for free. `lien
+index`/`init`/`serve` are deliberately unchanged — they take `process.cwd()`
+(or an explicit override) as the root verbatim, which is how a repo-less
+subdirectory gets indexed as its own project in the first place.
+
+Additionally, `lien annotate` now warns loudly (one line, via stdout — the
+read-hook pipes its stderr to `/dev/null`) instead of silently printing a
+plausible-looking but empty annotation when the resolved root's index has
+never been built, using the same `hasData()` signal the MCP server's
+auto-index gate already relies on.
+
+`@liendev/core` gains one new export, `VERSION_FILE` (the `.lien-index-version`
+marker filename), so the CLI can check for a completed index synchronously
+without pulling in `readVersionFile`'s async read/parse path.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -366,11 +366,16 @@ describe('annotateCommand (integration)', () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
-  it('silently exits when the index is missing (tmpHome has none)', async () => {
+  // #894: this used to be silent (an empty-but-plausible "no dependents/no
+  // test coverage" annotation, or nothing at all) — now it's a loud,
+  // one-line warning via stdout (never stderr — the read-hook pipes lien
+  // annotate's stderr to /dev/null, so stdout is the only channel that
+  // reaches the agent).
+  it('warns loudly instead of silently analyzing an unindexed root (tmpHome has no index)', async () => {
     await annotateCommand('packages/cli/src/cli/index.ts');
-    // VectorDB init against an empty tmp home should fail or return empty;
-    // either way, the command must not throw or print errors.
     expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toContain('Lien: no index found at the resolved project root');
   });
 });
 
@@ -412,6 +417,7 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
     };
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       scanAll: vi.fn().mockResolvedValue([overBudgetChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
@@ -446,6 +452,7 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
     };
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       scanAll: vi.fn().mockResolvedValue([quietChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
@@ -504,6 +511,7 @@ describe('annotateCommand — --tests-only (integration)', () => {
     };
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       scanAll: vi.fn().mockResolvedValue([testChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
@@ -536,6 +544,7 @@ describe('annotateCommand — --tests-only (integration)', () => {
     };
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       scanAll: vi.fn().mockResolvedValue([unrelatedChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -87,8 +87,11 @@ export function belowRiskFloor(
  * post-edit test-association reminder (or nothing, if the file has no
  * associated tests) — see `runTestsOnly`.
  *
- * All errors result in empty stdout and exit 0, so a missing index or
- * unknown file never breaks the hook pipeline.
+ * All THROWN errors result in empty stdout and exit 0, so an unknown/
+ * unreadable file never breaks the hook pipeline. One case is deliberately
+ * NOT silent, though: a resolved project root whose index has never been
+ * built (#894) prints a one-line warning instead of an empty-but-plausible
+ * "no dependents"/"no test coverage" annotation — see `formatNoIndexWarning`.
  */
 export async function annotateCommand(file: string, options?: AnnotateOptions): Promise<void> {
   try {
@@ -321,6 +324,13 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
 
+    // #894: warn loudly instead of silently analyzing an empty store — see
+    // `formatNoIndexWarning`.
+    if (!(await vectorDB.hasData())) {
+      console.log(formatNoIndexWarning(rootDir));
+      return;
+    }
+
     const data = await computeAnnotationData(vectorDB, filepath, rootDir);
 
     if (
@@ -374,6 +384,18 @@ export interface FileTestAssociations {
    * this field. See `computeGoPackageLevelFallback`.
    */
   packageLevelTests: string[];
+  /**
+   * #894: true when `rootDir`'s index has never been built (`hasData()` is
+   * false for both standalone and worktree-overlay backends — see
+   * `formatNoIndexWarning`). An empty `tests`/`packageLevelTests` array is
+   * ambiguous on its own — genuinely no test coverage and "wrong/unindexed
+   * root" look identical — so callers that want to tell them apart (today:
+   * only `runTestsOnly`) check this field. `verify-tests-cmd.ts`'s
+   * `lookupTestAssociations` caller ignores it and keeps its existing
+   * fail-open "no tests" handling — its hook contract is deliberately silent
+   * on any absence of tests, indexed or not.
+   */
+  indexMissing: boolean;
 }
 
 /**
@@ -394,11 +416,18 @@ async function scanTestAssociations(paths: ResolvedPaths): Promise<FileTestAssoc
   try {
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
+    // #894: check before scanning, not after — an empty scan result is
+    // indistinguishable from "no tests" otherwise. `hasData()` is the same
+    // signal the MCP server's auto-index gate uses, and is worktree/overlay-
+    // aware (true when either the base or the overlay has rows).
+    if (!(await vectorDB.hasData())) {
+      return { filepath, rootDir, tests: [], packageLevelTests: [], indexMissing: true };
+    }
     const allChunks = adaptChunkImports(await vectorDB.scanAll());
     const tests =
       findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
     const packageLevelTests = computeGoPackageLevelFallback(tests, filepath, allChunks, rootDir);
-    return { filepath, rootDir, tests, packageLevelTests };
+    return { filepath, rootDir, tests, packageLevelTests, indexMissing: false };
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
@@ -422,9 +451,32 @@ export async function lookupTestAssociations(file: string): Promise<FileTestAsso
  * no associated tests (the signal for the hook to stay silent).
  */
 async function runTestsOnly(paths: ResolvedPaths): Promise<void> {
-  const { filepath, tests, packageLevelTests } = await scanTestAssociations(paths);
+  const { filepath, rootDir, tests, packageLevelTests, indexMissing } =
+    await scanTestAssociations(paths);
+  if (indexMissing) {
+    console.log(formatNoIndexWarning(rootDir));
+    return;
+  }
   if (tests.length === 0 && packageLevelTests.length === 0) return;
   console.log(formatTestReminder(filepath, tests, packageLevelTests));
+}
+
+/**
+ * #894: the resolved project root's index has never been built (see
+ * `hasData()` call sites above). Printing the normal annotation/reminder
+ * here would be actively misleading — an empty dependents list or "No test
+ * coverage" reads as a confident answer, not as "wrong root" or "never
+ * indexed". Loud on purpose, and via `console.log` (not `console.error`):
+ * the PostToolUse read-hook (`annotate-read.sh`) pipes `lien annotate`'s
+ * stderr to `/dev/null` and only stdout reaches the agent as
+ * `additionalContext`.
+ */
+export function formatNoIndexWarning(rootDir: string): string {
+  return (
+    `Lien: no index found at the resolved project root (${rootDir}). ` +
+    `Run 'lien index' there, or check that this is the right root — a ` +
+    `nested git repo or a repo-less subdirectory can resolve to the wrong ancestor.`
+  );
 }
 
 /**

--- a/packages/cli/src/cli/project-root.test.ts
+++ b/packages/cli/src/cli/project-root.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import os from 'os';
 import fs from 'fs/promises';
+import { getIndexDir } from '@liendev/parser';
+import { VERSION_FILE } from '@liendev/core';
 import { resolveProjectRoot } from './project-root.js';
 
 describe('resolveProjectRoot', () => {
@@ -40,5 +42,117 @@ describe('resolveProjectRoot', () => {
     const root = await fs.realpath(tmp);
     await fs.mkdir(path.join(root, '.git'));
     expect(resolveProjectRoot(root)).toBe(root);
+  });
+
+  // #894: git-repo-nested-in-git-tree / monorepo-subdirectory-without-its-
+  // own-.git. `lien index` was run against a subdirectory that has no `.git`
+  // of its own but sits inside an unrelated outer `.git` checkout. A read-side
+  // command (annotate, gc, path, ...) invoked from inside that subdirectory
+  // must resolve back to it — not walk straight past it to the outer `.git`,
+  // which was never indexed.
+  describe('#894: nested-git-repo-in-git-tree / repo-less indexed subdirectory', () => {
+    let originalLienHome: string | undefined;
+    let lienHome: string;
+
+    beforeEach(async () => {
+      originalLienHome = process.env.LIEN_HOME;
+      lienHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-home-'));
+      process.env.LIEN_HOME = lienHome;
+    });
+
+    afterEach(async () => {
+      if (originalLienHome === undefined) delete process.env.LIEN_HOME;
+      else process.env.LIEN_HOME = originalLienHome;
+      await fs.rm(lienHome, { recursive: true, force: true });
+    });
+
+    /** Stand in for a completed `lien index`/overlay build against `projectRoot`. */
+    async function markIndexed(projectRoot: string): Promise<void> {
+      const indexDir = getIndexDir(projectRoot);
+      await fs.mkdir(indexDir, { recursive: true });
+      await fs.writeFile(path.join(indexDir, VERSION_FILE), String(Date.now()));
+    }
+
+    it('prefers a completed index on a repo-less subdirectory over an outer .git', async () => {
+      const outerRoot = await fs.realpath(tmp);
+      await fs.mkdir(path.join(outerRoot, '.git'));
+      const innerProject = path.join(outerRoot, 'vendor', 'assertj-core');
+      await fs.mkdir(innerProject, { recursive: true });
+      await markIndexed(innerProject);
+
+      // Invoked from a subdirectory of the indexed (but git-less) project —
+      // the exact #894 repro shape.
+      const cwd = path.join(innerProject, 'src', 'main');
+      await fs.mkdir(cwd, { recursive: true });
+
+      expect(resolveProjectRoot(cwd)).toBe(innerProject);
+    });
+
+    it('still finds the completed index when invoked from the project root itself', async () => {
+      const outerRoot = await fs.realpath(tmp);
+      await fs.mkdir(path.join(outerRoot, '.git'));
+      const innerProject = path.join(outerRoot, 'vendor', 'assertj-core');
+      await fs.mkdir(innerProject, { recursive: true });
+      await markIndexed(innerProject);
+
+      expect(resolveProjectRoot(innerProject)).toBe(innerProject);
+    });
+
+    it('falls back to the outer .git when nothing has been indexed yet (ambiguous case, unchanged from before)', async () => {
+      const outerRoot = await fs.realpath(tmp);
+      await fs.mkdir(path.join(outerRoot, '.git'));
+      const innerProject = path.join(outerRoot, 'vendor', 'assertj-core');
+      await fs.mkdir(innerProject, { recursive: true });
+      // No markIndexed() call — nothing indexed anywhere yet.
+
+      expect(resolveProjectRoot(innerProject)).toBe(outerRoot);
+    });
+
+    // Dogfooding this very fix surfaced this exact shape: this repo carries a
+    // checked-in, vestigial packages/cli/.lien.config.json (pre-monorepo
+    // history) that isn't an active project root. An earlier version of this
+    // fix used ".lien.config.json presence" as the "initialized project"
+    // signal and that file hijacked resolution away from the real repo root.
+    // A config file alone — with no completed index behind it — must NOT win;
+    // only a real, completed index does.
+    it('does not let a bare .lien.config.json (no completed index) hijack resolution', async () => {
+      const outerRoot = await fs.realpath(tmp);
+      await fs.mkdir(path.join(outerRoot, '.git'));
+      const staleConfigDir = path.join(outerRoot, 'packages', 'cli');
+      await fs.mkdir(staleConfigDir, { recursive: true });
+      await fs.writeFile(path.join(staleConfigDir, '.lien.config.json'), '{}');
+
+      const cwd = path.join(staleConfigDir, 'src');
+      await fs.mkdir(cwd, { recursive: true });
+
+      expect(resolveProjectRoot(cwd)).toBe(outerRoot);
+    });
+
+    // Linked-worktree shape (docs/architecture/worktree-aware-indexing.md):
+    // a Claude Code agent worktree lives on disk *inside* the main checkout
+    // (e.g. `<main>/.claude/worktrees/<name>`), so the main repo's `.git`
+    // directory is a filesystem ancestor of the worktree root — the same
+    // "outer .git" topology #894 is about. A worktree root has its own `.git`
+    // *file* (not dir) and, once its overlay has been built at least once,
+    // its own completed index (`OverlayBackend` keys `dbPath`/`VERSION_FILE`
+    // off the worktree's own path exactly like a standalone `SqliteBackend`
+    // — see the module doc comment). Resolution must stop at the worktree
+    // root, never walk past it to the main checkout.
+    it('resolves to a linked worktree root, not the outer main-checkout .git it sits inside', async () => {
+      const mainCheckout = await fs.realpath(tmp);
+      await fs.mkdir(path.join(mainCheckout, '.git'));
+      const worktreeRoot = path.join(mainCheckout, '.claude', 'worktrees', 'agent-123');
+      await fs.mkdir(worktreeRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(worktreeRoot, '.git'),
+        `gitdir: ${path.join(mainCheckout, '.git', 'worktrees', 'agent-123')}\n`,
+      );
+      await markIndexed(worktreeRoot); // simulates a completed overlay build
+
+      const cwd = path.join(worktreeRoot, 'packages', 'cli', 'src');
+      await fs.mkdir(cwd, { recursive: true });
+
+      expect(resolveProjectRoot(cwd)).toBe(worktreeRoot);
+    });
   });
 });

--- a/packages/cli/src/cli/project-root.ts
+++ b/packages/cli/src/cli/project-root.ts
@@ -1,25 +1,93 @@
 import fs from 'fs';
 import path from 'path';
+import { getIndexDir } from '@liendev/parser';
+import { VERSION_FILE } from '@liendev/core';
 import { type AbsolutePath, toAbsolutePath } from '../types/paths.js';
 
 /**
- * Walk upward from `start` looking for a `.git` marker (file or dir).
- * Falls back to the resolved start path if none is found.
- *
- * Return type is `AbsolutePath` because `path.resolve` always produces an
- * absolute path. Downstream code can rely on this without runtime checks.
+ * Walk upward from `start` (inclusive) looking for a directory that satisfies
+ * `predicate`. Returns the first match, or `null` if none is found by the
+ * time the filesystem root is reached.
  */
-export function resolveProjectRoot(start: string = process.cwd()): AbsolutePath {
-  let dir = path.resolve(start);
+function walkUp(start: string, predicate: (dir: string) => boolean): string | null {
+  let dir = start;
   const fsRoot = path.parse(dir).root;
   // Loop is inclusive of fsRoot — a repo rooted at / (or a drive root) is
-  // rare but valid, and should still be detected before falling back.
+  // rare but valid, and should still be detected before giving up.
   while (true) {
-    if (fs.existsSync(path.join(dir, '.git'))) {
-      return toAbsolutePath(dir);
-    }
-    if (dir === fsRoot) break;
+    if (predicate(dir)) return dir;
+    if (dir === fsRoot) return null;
     dir = path.dirname(dir);
   }
-  return toAbsolutePath(path.resolve(start));
+}
+
+/**
+ * Has `dir` ever completed a real `lien index` (or worktree-overlay) build?
+ * Checks for `VERSION_FILE` inside `dir`'s own index directory (keyed by
+ * `dir`'s absolute path — see `getIndexDir`), which both backends write ONLY
+ * after a build actually completes (`writeVersionFile` — see
+ * `SqliteBackend`/`OverlayBackend`), never as a side effect of merely opening
+ * a store. That distinction matters: opening a store for a bare `initialize()`
+ * DOES `mkdir` the index directory, so a plain "does the directory exist"
+ * check would go stale the first time *anything* — even a misresolved
+ * `annotate` run — opens a store there.
+ *
+ * Checking `.lien.config.json` presence instead (or in addition) was tried
+ * and dropped: this very repo carries a checked-in, vestigial
+ * `packages/cli/.lien.config.json` (pre-monorepo history, PR #42) that isn't
+ * an active project root — running `lien annotate` from inside `packages/cli`
+ * would have hijacked resolution to that subdirectory. A completed index is
+ * ground truth ("did `lien index` actually run here") in a way a config file
+ * is not.
+ */
+function hasCompletedIndex(dir: string): boolean {
+  return fs.existsSync(path.join(getIndexDir(dir), VERSION_FILE));
+}
+
+function hasGitMarker(dir: string): boolean {
+  return fs.existsSync(path.join(dir, '.git'));
+}
+
+/**
+ * Resolve the project root for `start`. Two-pass, nearest match wins each
+ * pass:
+ *
+ * 1. Nearest ancestor (inclusive) that has already completed a real
+ *    `lien index` build (`hasCompletedIndex`). This wins even when a `.git`
+ *    sits closer, farther, or in between — a directory Lien has actually
+ *    indexed is a stronger signal than "some ancestor happens to be a git
+ *    repo."
+ * 2. Nearest ancestor with a `.git` marker (file or dir), the original
+ *    heuristic — used only when no ancestor has a completed index.
+ * 3. The resolved `start` path itself, unchanged.
+ *
+ * This exists to keep read-side commands (`annotate`, `gc`, `path`,
+ * `store-paths`, `recap`, `nudge`, `verify-tests` — every consumer of this
+ * function) from resolving a *different* root than the one `lien index` was
+ * actually run against. The failure mode (#894): a directory with no `.git`
+ * of its own (a monorepo subdirectory indexed as its own project, or a repo
+ * nested inside a larger checkout) sits under an unrelated outer `.git`.
+ * Walking straight to that outer `.git` — the old, single-pass behavior —
+ * silently lands on a root that was never indexed, while the directory the
+ * caller actually meant sits right there with a real index. Pass 1 fixes
+ * that by checking "was this directory actually indexed" before ever
+ * considering `.git` at all.
+ *
+ * `lien index`/`lien init`/`lien serve` deliberately do NOT go through this
+ * function — they take `process.cwd()` (or an explicit `--root`/`--path`) as
+ * the root verbatim, because that's how a repo-less subdirectory gets
+ * indexed as its own project in the first place. Routing them through the
+ * `.git`-preferring fallback here would break exactly that setup on a fresh
+ * (never-yet-indexed) first run.
+ */
+export function resolveProjectRoot(start: string = process.cwd()): AbsolutePath {
+  const resolvedStart = path.resolve(start);
+
+  const indexed = walkUp(resolvedStart, hasCompletedIndex);
+  if (indexed) return toAbsolutePath(indexed);
+
+  const gitRoot = walkUp(resolvedStart, hasGitMarker);
+  if (gitRoot) return toAbsolutePath(gitRoot);
+
+  return toAbsolutePath(resolvedStart);
 }

--- a/packages/cli/src/cli/verify-tests-cmd.test.ts
+++ b/packages/cli/src/cli/verify-tests-cmd.test.ts
@@ -155,6 +155,7 @@ describe('verify-tests-cmd — integration', () => {
     it('records the edit and prints the byte-identical reminder line when the file has associated tests', async () => {
       vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
         initialize: vi.fn().mockResolvedValue(undefined),
+        hasData: vi.fn().mockResolvedValue(true),
         scanAll: vi.fn().mockResolvedValue([testChunkImporting(target)]),
       } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
@@ -180,6 +181,7 @@ describe('verify-tests-cmd — integration', () => {
     it('prints the JSON shape in --format json', async () => {
       vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
         initialize: vi.fn().mockResolvedValue(undefined),
+        hasData: vi.fn().mockResolvedValue(true),
         scanAll: vi.fn().mockResolvedValue([testChunkImporting(target)]),
       } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
@@ -192,6 +194,7 @@ describe('verify-tests-cmd — integration', () => {
     it('prints nothing and records nothing when the file has no associated tests', async () => {
       vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
         initialize: vi.fn().mockResolvedValue(undefined),
+        hasData: vi.fn().mockResolvedValue(true),
         scanAll: vi.fn().mockResolvedValue([testChunkImporting('some/other/file.ts')]),
       } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,7 +72,7 @@ export type { IndexStrategy } from './vectordb/overlay-resolution.js';
 export type { VectorDBInterface, SearchResult } from './vectordb/types.js';
 export { SYMBOL_TYPE_MATCHES } from './vectordb/types.js';
 export type { RelevanceCategory } from './vectordb/relevance.js';
-export { readVersionFile, writeVersionFile } from './vectordb/version.js';
+export { readVersionFile, writeVersionFile, VERSION_FILE } from './vectordb/version.js';
 
 // =============================================================================
 // INDEX GARBAGE COLLECTION

--- a/packages/core/src/vectordb/version.ts
+++ b/packages/core/src/vectordb/version.ts
@@ -1,7 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-const VERSION_FILE = '.lien-index-version';
+// Exported (not just module-private) so callers that only need to know
+// "has a real index build ever completed here" — e.g. project-root
+// resolution (#894) — can check for the file's existence synchronously
+// with `fs.existsSync`, without duplicating the literal or pulling in the
+// async read/parse path `readVersionFile` needs.
+export const VERSION_FILE = '.lien-index-version';
 
 /**
  * Writes a version timestamp file to mark when the index was last updated.


### PR DESCRIPTION
## Summary

`lien annotate` walked up to the nearest `.git` to find the project root. When the actual (indexed) project was a `.git`-less subdirectory of a larger checkout, or a repo nested inside another git tree, this landed on an unrelated outer repo that was never indexed — `lien index` (run earlier directly against the subdirectory) never walks up at all, so the two commands silently disagreed on the root, and `annotate` reported against a store that was never built.

**Fix:** `resolveProjectRoot` (`packages/cli/src/cli/project-root.ts`) — the single helper shared by every read-side command that resolves a root without an explicit override — now does two passes, nearest match wins each:
1. Nearest ancestor (inclusive) that has **actually completed a `lien index` build** (checked via the `.lien-index-version` marker each backend writes only on a real completed build — never as a side effect of merely opening a store).
2. Nearest ancestor with a `.git` marker — the original heuristic, used only when no ancestor has a completed index.
3. The resolved start path itself (unchanged fallback).

**Commands unified** (all consume `resolveProjectRoot`, zero call-site changes needed): `annotate`, `gc`, `path`, `store-paths` (used by hook hooks via `lien path --store`), `recap`, `nudge`, `verify-tests`.

**Deliberately NOT changed:**
- `lien index`/`init`/`serve` — they take `process.cwd()` (or an explicit `--root`/`--path`) as the root verbatim. That's *how* a repo-less subdirectory gets indexed as its own project in the first place; routing them through the `.git`-preferring walk would break that setup on a fresh first run.
- `lien delta`/`api-delta`/`stats` (`getRepoRoot` in `delta-git.ts`) — these need the actual git repository toplevel for `git diff`, a different concern from "which Lien index applies here."
- `verify-tests-cmd.ts`'s consumption of `lookupTestAssociations` — its `note-edit` hook is intentionally fail-open/silent by design (`runFailOpen`); the new `indexMissing` field is available there but not wired in, to keep this fix scoped to the reported command.

**Also:** `lien annotate` now warns loudly (one stdout line — the read-hook pipes its stderr to `/dev/null`, so stdout is the only channel that reaches the agent) instead of silently printing a plausible-looking but empty annotation when the resolved root's index was never built, reusing `hasData()` (the same signal the MCP server's auto-index gate already checks).

**Design note (dogfooding caught a real bug in my first draft):** the first version of this fix used ".lien.config.json presence OR completed index" as the "initialized project" signal, per the issue's suggested shape. Dogfooding it against this very repo found that `packages/cli/.lien.config.json` is a genuine, checked-in vestigial file (pre-monorepo history, PR #42) that isn't an active project root — it would have hijacked resolution for anyone running Lien commands from inside `packages/cli/`. Switched to checking only for a completed index (ground truth: "did `lien index` actually run here"), and added a regression test (`does not let a bare .lien.config.json (no completed index) hijack resolution`) encoding this.

Worktree-aware indexing (`docs/architecture/worktree-aware-indexing.md`) is unaffected: `OverlayBackend` keys its own `dbPath`/version-file off the worktree's own path exactly like a standalone `SqliteBackend`, so a worktree with a completed overlay build is found the same way; a dedicated regression test covers this shape.

Closes #894.

## Dogfood evidence (verbatim)

Reproduced the issue's exact shape: an outer git repo containing an inner project directory with **no `.git` of its own** (`vendor/assertj-core/`), matching the real assertj-core repro in the issue. Built a pre-fix binary from `origin/main` in a separate worktree and a post-fix binary from this branch, both pointed at the same isolated `LIEN_HOME`/on-disk index for an apples-to-apples comparison.

**Pre-fix — `lien index` and `lien path --root`/`annotate` silently disagree:**
```
$ cd vendor/assertj-core && lien(pre-fix) index
✔ Indexing complete (2/2)

$ lien(pre-fix) path --root
/private/tmp/lien-outer-repo.iU97Sl        # WRONG — the outer repo, never indexed

$ lien(pre-fix) path --store
/tmp/.../indices/lien-outer-repo.iU97Sl-20dcfe85   # a different store than the one `index` just wrote to

$ lien(pre-fix) annotate src/main/java/Calculator.java
Lien impact for vendor/assertj-core/src/main/java/Calculator.java:
  • No test coverage.                       # misleading — Calculator.java IS used by CalculatorClient.java;
                                             #   the tool is silently reading the wrong, empty store
```

**Post-fix — same on-disk index, same cwd:**
```
$ lien(post-fix) path --root
/private/tmp/lien-outer-repo.iU97Sl/vendor/assertj-core     # correct — matches where `index` actually ran

$ lien(post-fix) path --store
/tmp/.../indices/assertj-core-e3b8f17d      # the real, populated store `index` wrote to

$ lien(post-fix) status
Index status: ✓ Exists
Index files: 3                              # proves it's reading the real, non-empty store

$ lien(post-fix) annotate src/main/java/Calculator.java
Lien impact for src/main/java/Calculator.java:
  • No test coverage.                       # filepath is now correctly root-relative (no vendor/assertj-core/ prefix)
```

**Post-fix — "warn loudly" when genuinely nothing is indexed** (ran from the outer root, which was never indexed in this scenario):
```
$ lien(post-fix) annotate vendor/assertj-core/src/main/java/Calculator.java
Lien: no index found at the resolved project root (/private/tmp/lien-outer-repo.iU97Sl). Run 'lien index'
there, or check that this is the right root — a nested git repo or a repo-less subdirectory can resolve
to the wrong ancestor.
```
(pre-fix, the identical call prints the same misleading empty "No test coverage." line — no error, no hint anything is wrong.)

**Normal single-repo flow, unchanged** (fresh repo, `index` from root, `annotate` from a subdirectory):
```
$ lien path --root      # from repo root
/private/tmp/lien-simple-repo.LuIVfq
$ cd src && lien path --root      # from a subdirectory — same answer
/private/tmp/lien-simple-repo.LuIVfq
$ lien annotate util.js
Lien impact for src/util.js:
  • 1 file imports this — src/main.js; risk: medium (1 caller, 1 untested).
  • No test coverage.
```

**Linked-worktree flow, unchanged** (`git worktree add`, then indexed from inside the worktree):
```
$ lien path --root      # from inside the linked worktree
/private/tmp/lien-worktree-check.W21PEZ    # correctly the worktree's own root, not the main checkout
$ lien index
✔ Overlay ready: 0 added, 0 modified, 0 deleted, 2 shared with base
$ lien status
Worktree:
Mode: ✓ Overlay (sharing base index from main checkout)
Main checkout: /private/tmp/lien-simple-repo.LuIVfq
Base index: ✓ Found
$ cd src && lien annotate util.js
Lien impact for src/util.js:
  • 1 file imports this — src/main.js; risk: medium (1 caller, 1 untested).
```

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — pass (0 errors, pre-existing warnings only)
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm test` — pass (parser-native, parser, core, review, cli, action — all green; native parser built via `npm run build:native -w @liendev/parser-native` per worktree-development.md)
- [x] `node packages/cli/dist/index.js delta` — exit 0 (3 worsened, all pre-existing functions gaining a few cognitive points from the new checks, none crossing threshold; 1 improved — `resolveProjectRoot` itself dropped from 5 to 2 after the extraction)
- [x] New regression tests in `project-root.test.ts` covering: nested-git/repo-less-subdirectory preference, the stale-`.lien.config.json` false-positive, and the linked-worktree shape
- [x] Manual dogfood above (pre-fix vs post-fix, single-repo, linked-worktree)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real root-resolution bug (#894) by making `resolveProjectRoot` prefer a directory that has actually completed a `lien index` build over the nearest `.git` marker. The change is localized to one shared helper, so all read-side commands (`annotate`, `gc`, `path`, `store-paths`, `recap`, `nudge`, `verify-tests`) pick up the fix without call-site changes. `lien annotate` additionally warns loudly when the resolved root has no index data, using the same `hasData()` signal the MCP server already uses. A new `VERSION_FILE` export from `@liendev/core` lets the CLI check for the completed-index marker synchronously. The added regression tests cover the nested-git, stale-config, and linked-worktree shapes described in the PR.
>
> - `resolveProjectRoot` now does two passes: nearest completed-index directory first, then nearest `.git`, then the start path.
> - `lien annotate` and its `--tests-only` path now warn via stdout when `hasData()` is false instead of emitting a plausible empty result.
> - `@liendev/core` exports `VERSION_FILE` so the CLI can check the completed-index marker without importing the async read/parse path.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2333874. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 651K/965K tokens
<!-- /lien:attestation -->