### PR TITLE
fix(review): slim summary-retry context + raise 25-object verdict-scan cap

### DIFF
--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -386,40 +386,65 @@ export function embeddedJsonObject(content: string): string | undefined {
 const JSON_STRING_LITERAL = /"(?:\\.|[^"\\])*"/g;
 
 /**
- * Safety valve on `allBalancedJsonObjects`' scan: each object found re-masks
- * the remaining text, so a pathological "{}{}{}…" essay could otherwise cost
- * O(n²). A genuine verdict is always among the first few objects in real
- * model output; this bounds worst-case work on adversarial/degenerate input
- * without affecting any real recovery.
+ * Safety valve on `allBalancedJsonObjects`'s scan: a hard ceiling on how many
+ * top-level objects it will ever return, bounding worst-case return size on a
+ * pathological "{}{}{}…" essay (this function processes untrusted LLM
+ * output). Raised from the original 25 — issue #829's residual gap: a
+ * genuine verdict positioned 26th+ in JSON-dense prose was invisible to the
+ * scan (the regression test below pins the 26th-position shape). The
+ * original 25 existed only to bound the OLD per-object re-masking cost
+ * (O(objects × text length) — see `maskStringLiterals`'s doc comment for the
+ * fix); now that masking happens once per scan, a much higher ceiling costs
+ * no extra passes over the text, so 200 is generous headroom past any
+ * observed or plausible real verdict position while still bounding a
+ * genuinely adversarial input. Exported for the boundary test.
  */
-const MAX_BALANCED_OBJECTS_SCANNED = 25;
+export const MAX_BALANCED_OBJECTS_SCANNED = 200;
 
 /**
- * Find the single balanced JSON object starting at `text`'s first `{` at or
- * after `searchFrom`, tracking brace depth (respecting string literals and
- * escapes) until it returns to zero. Returns its `[start, end]` (inclusive)
- * indices, or `undefined` if there's no more `{` or it never balances (e.g. a
- * genuinely truncated response) — never guesses at an unbalanced slice.
- * Pulled out of `allBalancedJsonObjects` so that function's own loop stays
- * under the complexity budget.
+ * Mask every double-quoted string literal in `text` with same-length `"`
+ * filler, ONCE for the whole text, so brace-depth scanning never has to
+ * track quotes/escapes char-by-char — braces inside a string literal (e.g.
+ * prose like "{user, token}") can't skew the depth count, and offsets into
+ * the result line up 1:1 with `text`.
+ *
+ * Pulled out so `allBalancedJsonObjects` computes this exactly once per scan
+ * (O(text length) total) instead of `nextBalancedObjectRange` re-masking its
+ * own remaining suffix on every object it finds — that per-object re-mask
+ * was O(objects × text length) work, which is what forced
+ * `MAX_BALANCED_OBJECTS_SCANNED` down to a stingy 25 in the first place (see
+ * that constant's own doc comment for the #829 gap raising it exposed). The
+ * regex itself is backtracking-safe: the two branches of its alternation
+ * (`\\.` vs `[^"\\]`) are mutually exclusive per character, so there's no
+ * ambiguous path for the engine to backtrack across — a single linear pass,
+ * same guarantee `safeRegex`'s callers rely on elsewhere in this codebase.
+ */
+function maskStringLiterals(text: string): string {
+  return text.replace(JSON_STRING_LITERAL, m => '"'.repeat(m.length));
+}
+
+/**
+ * Find the single balanced JSON object starting at `masked`'s first `{` at or
+ * after `searchFrom`, tracking brace depth until it returns to zero. `masked`
+ * must already have its string literals blanked (see `maskStringLiterals`) —
+ * every call scanning the same text shares that ONE masked copy rather than
+ * each re-masking its own remaining suffix. Returns its `[start, end]`
+ * (inclusive) indices, or `undefined` if there's no more `{` or it never
+ * balances (e.g. a genuinely truncated response) — never guesses at an
+ * unbalanced slice. Pulled out of `allBalancedJsonObjects` so that function's
+ * own loop stays under the complexity budget.
  */
 function nextBalancedObjectRange(
-  text: string,
+  masked: string,
   searchFrom: number,
 ): { start: number; end: number } | undefined {
-  const start = text.indexOf('{', searchFrom);
+  const start = masked.indexOf('{', searchFrom);
   if (start === -1) return undefined;
 
-  // Mask string contents with same-length `"` filler so quotes/escapes never
-  // have to be tracked char-by-char in the scan below — braces inside a
-  // string literal (e.g. prose like "{user, token}") can't skew the depth
-  // count, and offsets into `masked` line up 1:1 with `text.slice(start)`.
-  const masked = text.slice(start).replace(JSON_STRING_LITERAL, m => '"'.repeat(m.length));
-
   let depth = 0;
-  for (let i = 0; i < masked.length; i++) {
+  for (let i = start; i < masked.length; i++) {
     if (masked[i] === '{') depth++;
-    else if (masked[i] === '}' && --depth === 0) return { start, end: start + i };
+    else if (masked[i] === '}' && --depth === 0) return { start, end: i };
   }
   return undefined; // never balanced — no complete object found
 }
@@ -452,10 +477,11 @@ function nextBalancedObjectRange(
  *    scan's only attempt is newly recovered.
  */
 export function allBalancedJsonObjects(text: string): string[] {
+  const masked = maskStringLiterals(text);
   const objects: string[] = [];
   let searchFrom = 0;
   while (objects.length < MAX_BALANCED_OBJECTS_SCANNED) {
-    const range = nextBalancedObjectRange(text, searchFrom);
+    const range = nextBalancedObjectRange(masked, searchFrom);
     if (!range) break;
     objects.push(text.slice(range.start, range.end + 1));
     searchFrom = range.end + 1;
@@ -470,6 +496,69 @@ export function allBalancedJsonObjects(text: string): string[] {
  */
 export function firstBalancedJsonObject(text: string): string | undefined {
   return allBalancedJsonObjects(text)[0];
+}
+
+// ---------------------------------------------------------------------------
+// Summary-retry slim context (issue #829 — truncation-under-token-cap remainder)
+// ---------------------------------------------------------------------------
+
+/**
+ * Bound on how much of the last investigative turn's own text feeds the
+ * summary-retry's slim prompt (`buildSlimRetryPrompt`, below). That text can
+ * itself be enormous — both of #829's real incidents had their derailed turn
+ * emit ~227K-262K tokens of "Issue 1: … Issue 21: …" self-review prose — so
+ * even a "slim" retry built only from it still needs its own bound to stay
+ * meaningfully smaller than replaying the whole tool-calling history. ~20K
+ * chars ≈ 5K tokens: enough room for several concrete findings, small next
+ * to a multi-turn investigation's accumulated tool-call/tool-result history.
+ */
+export const SLIM_RETRY_CONTEXT_MAX_CHARS = 20_000;
+
+/**
+ * Pick the text carrying the model's actual investigative decisions for the
+ * summary-retry: the last loop turn's own response content, falling back to
+ * its reasoning channel when content is empty. Mirrors
+ * `extractFindingsWithReasoningFallback`'s channel preference — applied here
+ * to what the retry SENDS instead of what it reads back.
+ */
+export function lastTurnFindingsText(
+  turn: { responseText?: string; reasoning?: string } | undefined,
+): string {
+  const content = turn?.responseText?.trim();
+  return content ? content : (turn?.reasoning?.trim() ?? '');
+}
+
+/** Labels the replayed findings text so the model knows what it's looking at. */
+const SLIM_RETRY_CONTEXT_PREFIX =
+  'Your own analysis from the investigation so far (the rest of the conversation is omitted to keep this request small):';
+
+/**
+ * Build the summary-retry's SLIM prompt text: the last investigative turn's
+ * own analysis (bounded — see `SLIM_RETRY_CONTEXT_MAX_CHARS`) plus the hard
+ * instruction to emit the verdict now. Falls back to the bare instruction
+ * when there's no findings text to replay (e.g. the loop bailed with a
+ * completely empty last turn).
+ *
+ * ISSUE #829 (truncation remainder, post-#895's `require_parameters` fix):
+ * the pre-fix retry appended its instruction directly onto the FULL
+ * accumulated conversation — system prompt, initial message, and every prior
+ * turn's own tool calls/tool results — and resent that whole history as the
+ * retry's own input. On a JSON-dense diff that history is itself large
+ * enough that even a genuinely `require_parameters:true`-routed, forced-
+ * JSON-compliant provider still truncated the retry's OUTPUT before it
+ * contained a complete verdict object (`finishReason:'length'`, both real
+ * incidents named on the issue). A verdict retry doesn't need the tool-
+ * calling history at all — everything the model needs to decide the verdict
+ * already lives in its own last turn's text (that prose IS the findings,
+ * just not yet JSON) — so both clients now build a FRESH, minimal message
+ * list for the retry instead of appending to the accumulated one (see
+ * `openai-client.ts` / `anthropic-client.ts`'s `runSummaryRetry`), dropping
+ * every earlier tool call/tool result regardless of how large the
+ * investigation's own history grew.
+ */
+export function buildSlimRetryPrompt(findingsText: string, instruction: string): string {
+  const truncated = truncate(findingsText.trim(), SLIM_RETRY_CONTEXT_MAX_CHARS);
+  return truncated ? `${SLIM_RETRY_CONTEXT_PREFIX}\n\n${truncated}\n\n${instruction}` : instruction;
 }
 
 /** Type guard to validate a summary object. */

--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -394,12 +394,16 @@ const JSON_STRING_LITERAL = /"(?:\\.|[^"\\])*"/g;
  * scan (the regression test below pins the 26th-position shape).
  *
  * CORRECTNESS OVER THROUGHPUT (adversarial review of the first cut of this
- * fix): an earlier version of this change hoisted `maskStringLiterals` to
- * run ONCE over the whole text, then had every candidate object's scan share
- * that one masked copy — genuinely O(text length) instead of the per-object
- * O(objects × text length) this comment used to justify a stingy 25. That
- * hoist was NOT behavior-preserving: masking the whole text in one pass lets
- * an odd number of stray/unescaped double-quote characters ANYWHERE earlier
+ * fix — HISTORICAL paragraph below: the design it describes was reverted
+ * and is NOT what the code in this file does today; see
+ * `nextBalancedObjectRange`'s own doc comment for the current, correct
+ * behavior): an earlier, since-reverted version of this change hoisted
+ * `maskStringLiterals` so every candidate object's scan shared ONE
+ * pre-computed masked copy of the whole text — genuinely O(text length)
+ * instead of the per-object O(objects × text length) this comment used to
+ * justify a stingy 25. That hoist was NOT behavior-preserving: sharing that
+ * whole-text mask across every candidate lets an odd number of
+ * stray/unescaped double-quote characters ANYWHERE earlier
  * in the text shift the regex's global quote-pairing, potentially masking
  * over the real verdict's own opening brace and losing it entirely — proven
  * by the reviewer on both a synthetic stray-quote-in-prose case and the
@@ -440,9 +444,10 @@ export const MAX_BALANCED_OBJECTS_SCANNED = 200;
  * char-by-char — braces inside a string literal (e.g. prose like "{user,
  * token}") can't skew the depth count, and offsets into the result line up
  * 1:1 with `text`. Called on each candidate's own remaining SUFFIX (see
- * `nextBalancedObjectRange`), never on the whole text at once — see
- * `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment for why a whole-text mask is
- * NOT safe here (stray-quote parity can shift and hide a real verdict).
+ * `nextBalancedObjectRange`) — every candidate gets its OWN fresh mask; the
+ * whole text is never masked as a single shared unit — see
+ * `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment for why that would be unsafe
+ * (stray-quote parity can shift and hide a real verdict).
  */
 function maskStringLiterals(text: string): string {
   return text.replace(JSON_STRING_LITERAL, m => '"'.repeat(m.length));
@@ -457,14 +462,16 @@ function maskStringLiterals(text: string): string {
  *
  * Re-masks `text.slice(start)` FRESH on every call, rather than sharing one
  * whole-text masked copy across every candidate — deliberately, not an
- * oversight. Masking the whole text once lets an odd number of stray,
+ * oversight (an earlier, since-reverted cut of this fix shared one mask
+ * across the whole text; see `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment
+ * for that history and the adversarial-review proof of why it was wrong).
+ * Sharing a mask across the whole text lets an odd number of stray,
  * unescaped double-quote characters anywhere BEFORE `start` shift the global
  * quote-pairing the regex produces, which can mask straight over THIS
  * candidate's own opening `{` (if it lands between two quotes the regex
- * wrongly paired as a string literal) and make a real verdict invisible —
- * see `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment for the adversarial-review
- * proof. Re-anchoring the mask at each candidate's own `{` makes recovering
- * THAT object immune to whatever quote parity came before it, at the cost of
+ * wrongly paired as a string literal) and make a real verdict invisible.
+ * Re-anchoring the mask at each candidate's own `{` makes recovering THAT
+ * object immune to whatever quote parity came before it, at the cost of
  * re-scanning the remaining suffix per candidate (bounded by
  * `MAX_BALANCED_OBJECTS_SCANNED`). Pulled out of `allBalancedJsonObjects` so
  * that function's own loop stays under the complexity budget.

--- a/packages/review/src/plugins/agent/agent-client-shared.ts
+++ b/packages/review/src/plugins/agent/agent-client-shared.ts
@@ -387,64 +387,100 @@ const JSON_STRING_LITERAL = /"(?:\\.|[^"\\])*"/g;
 
 /**
  * Safety valve on `allBalancedJsonObjects`'s scan: a hard ceiling on how many
- * top-level objects it will ever return, bounding worst-case return size on a
- * pathological "{}{}{}…" essay (this function processes untrusted LLM
+ * top-level objects it will ever return, bounding worst-case work/return size
+ * on a pathological "{}{}{}…" essay (this function processes untrusted LLM
  * output). Raised from the original 25 — issue #829's residual gap: a
  * genuine verdict positioned 26th+ in JSON-dense prose was invisible to the
- * scan (the regression test below pins the 26th-position shape). The
- * original 25 existed only to bound the OLD per-object re-masking cost
- * (O(objects × text length) — see `maskStringLiterals`'s doc comment for the
- * fix); now that masking happens once per scan, a much higher ceiling costs
- * no extra passes over the text, so 200 is generous headroom past any
- * observed or plausible real verdict position while still bounding a
- * genuinely adversarial input. Exported for the boundary test.
+ * scan (the regression test below pins the 26th-position shape).
+ *
+ * CORRECTNESS OVER THROUGHPUT (adversarial review of the first cut of this
+ * fix): an earlier version of this change hoisted `maskStringLiterals` to
+ * run ONCE over the whole text, then had every candidate object's scan share
+ * that one masked copy — genuinely O(text length) instead of the per-object
+ * O(objects × text length) this comment used to justify a stingy 25. That
+ * hoist was NOT behavior-preserving: masking the whole text in one pass lets
+ * an odd number of stray/unescaped double-quote characters ANYWHERE earlier
+ * in the text shift the regex's global quote-pairing, potentially masking
+ * over the real verdict's own opening brace and losing it entirely — proven
+ * by the reviewer on both a synthetic stray-quote-in-prose case and the
+ * #829 26th-object decoy shape with one added stray quote (a 1-of-3
+ * stray-quote parity sweep: odd counts lost the verdict, even counts didn't).
+ * A truncated `finishReason:'length'` turn — the exact shape this whole fix
+ * targets — naturally ends mid-string-literal, i.e. with an odd, unterminated
+ * quote: this is the TARGET failure class, not an edge case. So
+ * `nextBalancedObjectRange` (below) re-masks fresh from each candidate's own
+ * `{`, per the ORIGINAL design — correctness beats the throughput win on
+ * this path. See `nextBalancedObjectRange`'s own doc comment for the
+ * mechanics and the `stray quote` regression tests
+ * (`plugins-agent-client-shared.test.ts`) pinning both failure cases plus a
+ * 0-4 stray-quote parity sweep that must all recover.
+ *
+ * Re-measured with per-object re-masking restored, at the 200 cap:
+ *  - 200 tiny objects spread through ~500K chars of realistic filler: ~26ms.
+ *  - the TRUE worst case for this algorithm — 200 tiny objects clustered up
+ *    front, followed by a huge brace-free tail (every one of the 200 calls
+ *    re-masks nearly that whole tail) — at a ~900K-char tail (roughly the
+ *    size of the largest real derailed-turn text observed on this issue):
+ *    ~70ms. Even doubled to ~2.3M chars: ~160ms.
+ * A single turn's own output text is bounded well under these sizes by the
+ * per-request `max_tokens` ceiling both clients already enforce (at most
+ * `RETRY_MAX_MAX_TOKENS`/`MAX_TOKENS` tokens per completion — see
+ * `openai-client.ts`/`anthropic-client.ts`), so even the TRUE worst-case
+ * shape stays in double-digit milliseconds for any text this function will
+ * realistically ever see. The O(objects × text length) revisit is real, but
+ * at this cap it stays trivial in absolute terms, so 200 stays the cap (not
+ * reverted to 25). See `plugins-agent-client-shared.test.ts`'s perf tests for
+ * the exact benchmarked shapes.
  */
 export const MAX_BALANCED_OBJECTS_SCANNED = 200;
 
 /**
  * Mask every double-quoted string literal in `text` with same-length `"`
- * filler, ONCE for the whole text, so brace-depth scanning never has to
- * track quotes/escapes char-by-char — braces inside a string literal (e.g.
- * prose like "{user, token}") can't skew the depth count, and offsets into
- * the result line up 1:1 with `text`.
- *
- * Pulled out so `allBalancedJsonObjects` computes this exactly once per scan
- * (O(text length) total) instead of `nextBalancedObjectRange` re-masking its
- * own remaining suffix on every object it finds — that per-object re-mask
- * was O(objects × text length) work, which is what forced
- * `MAX_BALANCED_OBJECTS_SCANNED` down to a stingy 25 in the first place (see
- * that constant's own doc comment for the #829 gap raising it exposed). The
- * regex itself is backtracking-safe: the two branches of its alternation
- * (`\\.` vs `[^"\\]`) are mutually exclusive per character, so there's no
- * ambiguous path for the engine to backtrack across — a single linear pass,
- * same guarantee `safeRegex`'s callers rely on elsewhere in this codebase.
+ * filler so brace-depth scanning never has to track quotes/escapes
+ * char-by-char — braces inside a string literal (e.g. prose like "{user,
+ * token}") can't skew the depth count, and offsets into the result line up
+ * 1:1 with `text`. Called on each candidate's own remaining SUFFIX (see
+ * `nextBalancedObjectRange`), never on the whole text at once — see
+ * `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment for why a whole-text mask is
+ * NOT safe here (stray-quote parity can shift and hide a real verdict).
  */
 function maskStringLiterals(text: string): string {
   return text.replace(JSON_STRING_LITERAL, m => '"'.repeat(m.length));
 }
 
 /**
- * Find the single balanced JSON object starting at `masked`'s first `{` at or
- * after `searchFrom`, tracking brace depth until it returns to zero. `masked`
- * must already have its string literals blanked (see `maskStringLiterals`) —
- * every call scanning the same text shares that ONE masked copy rather than
- * each re-masking its own remaining suffix. Returns its `[start, end]`
- * (inclusive) indices, or `undefined` if there's no more `{` or it never
- * balances (e.g. a genuinely truncated response) — never guesses at an
- * unbalanced slice. Pulled out of `allBalancedJsonObjects` so that function's
- * own loop stays under the complexity budget.
+ * Find the single balanced JSON object starting at `text`'s first `{` at or
+ * after `searchFrom`, tracking brace depth (respecting string literals and
+ * escapes) until it returns to zero. Returns its `[start, end]` (inclusive)
+ * indices, or `undefined` if there's no more `{` or it never balances (e.g. a
+ * genuinely truncated response) — never guesses at an unbalanced slice.
+ *
+ * Re-masks `text.slice(start)` FRESH on every call, rather than sharing one
+ * whole-text masked copy across every candidate — deliberately, not an
+ * oversight. Masking the whole text once lets an odd number of stray,
+ * unescaped double-quote characters anywhere BEFORE `start` shift the global
+ * quote-pairing the regex produces, which can mask straight over THIS
+ * candidate's own opening `{` (if it lands between two quotes the regex
+ * wrongly paired as a string literal) and make a real verdict invisible —
+ * see `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment for the adversarial-review
+ * proof. Re-anchoring the mask at each candidate's own `{` makes recovering
+ * THAT object immune to whatever quote parity came before it, at the cost of
+ * re-scanning the remaining suffix per candidate (bounded by
+ * `MAX_BALANCED_OBJECTS_SCANNED`). Pulled out of `allBalancedJsonObjects` so
+ * that function's own loop stays under the complexity budget.
  */
 function nextBalancedObjectRange(
-  masked: string,
+  text: string,
   searchFrom: number,
 ): { start: number; end: number } | undefined {
-  const start = masked.indexOf('{', searchFrom);
+  const start = text.indexOf('{', searchFrom);
   if (start === -1) return undefined;
 
+  const masked = maskStringLiterals(text.slice(start));
   let depth = 0;
-  for (let i = start; i < masked.length; i++) {
+  for (let i = 0; i < masked.length; i++) {
     if (masked[i] === '{') depth++;
-    else if (masked[i] === '}' && --depth === 0) return { start, end: i };
+    else if (masked[i] === '}' && --depth === 0) return { start, end: start + i };
   }
   return undefined; // never balanced — no complete object found
 }
@@ -477,11 +513,10 @@ function nextBalancedObjectRange(
  *    scan's only attempt is newly recovered.
  */
 export function allBalancedJsonObjects(text: string): string[] {
-  const masked = maskStringLiterals(text);
   const objects: string[] = [];
   let searchFrom = 0;
   while (objects.length < MAX_BALANCED_OBJECTS_SCANNED) {
-    const range = nextBalancedObjectRange(masked, searchFrom);
+    const range = nextBalancedObjectRange(text, searchFrom);
     if (!range) break;
     objects.push(text.slice(range.start, range.end + 1));
     searchFrom = range.end + 1;
@@ -516,16 +551,40 @@ export const SLIM_RETRY_CONTEXT_MAX_CHARS = 20_000;
 
 /**
  * Pick the text carrying the model's actual investigative decisions for the
- * summary-retry: the last loop turn's own response content, falling back to
- * its reasoning channel when content is empty. Mirrors
- * `extractFindingsWithReasoningFallback`'s channel preference — applied here
- * to what the retry SENDS instead of what it reads back.
+ * summary-retry. Walks the turn history NEWEST FIRST, taking each turn's own
+ * response content — falling back to its reasoning channel when content is
+ * empty, mirroring `extractFindingsWithReasoningFallback`'s channel
+ * preference (applied here to what the retry SENDS instead of what it reads
+ * back) — and concatenating non-empty turns until
+ * `SLIM_RETRY_CONTEXT_MAX_CHARS` is reached or history is exhausted.
+ *
+ * FLOOR AGAINST FALSE-CLEAN (adversarial-review finding on the first cut of
+ * this fix): the very LAST loop turn alone can be a pure tool_calls turn
+ * with EMPTY content and no reasoning — e.g. the loop hit `max_turns`/budget
+ * right after a turn whose only output was tool calls, with no closing
+ * prose. Reading only that one turn returned `''`, so the retry became a
+ * BARE instruction ("output the verdict now") with zero real context to
+ * summarize. A model asked that with nothing to go on can fabricate a
+ * plausible-looking, entirely synthetic clean/empty verdict instead of
+ * honestly failing — a FALSE-CLEAN result, the worst failure class this
+ * codebase tracks (see `readVerdict`'s corrupted-key recovery for the same
+ * "never guess, but never go silent either" tension). Walking backward for
+ * the most recent turn that actually said something closes that gap without
+ * unbounding the retry's input: `SLIM_RETRY_CONTEXT_MAX_CHARS` still caps the
+ * concatenation as a whole, not per turn.
  */
 export function lastTurnFindingsText(
-  turn: { responseText?: string; reasoning?: string } | undefined,
+  turns: ReadonlyArray<{ responseText?: string; reasoning?: string }>,
 ): string {
-  const content = turn?.responseText?.trim();
-  return content ? content : (turn?.reasoning?.trim() ?? '');
+  const parts: string[] = [];
+  let total = 0;
+  for (let i = turns.length - 1; i >= 0 && total < SLIM_RETRY_CONTEXT_MAX_CHARS; i--) {
+    const text = turns[i].responseText?.trim() || turns[i].reasoning?.trim() || '';
+    if (!text) continue;
+    parts.push(text);
+    total += text.length;
+  }
+  return parts.join('\n\n---\n\n');
 }
 
 /** Labels the replayed findings text so the model knows what it's looking at. */
@@ -533,11 +592,11 @@ const SLIM_RETRY_CONTEXT_PREFIX =
   'Your own analysis from the investigation so far (the rest of the conversation is omitted to keep this request small):';
 
 /**
- * Build the summary-retry's SLIM prompt text: the last investigative turn's
- * own analysis (bounded — see `SLIM_RETRY_CONTEXT_MAX_CHARS`) plus the hard
- * instruction to emit the verdict now. Falls back to the bare instruction
- * when there's no findings text to replay (e.g. the loop bailed with a
- * completely empty last turn).
+ * Build the summary-retry's SLIM prompt text: the recent investigative
+ * turns' own analysis (see `lastTurnFindingsText`, bounded overall — below —
+ * to `SLIM_RETRY_CONTEXT_MAX_CHARS`) plus the hard instruction to emit the
+ * verdict now. Falls back to the bare instruction when there's no findings
+ * text to replay at all (e.g. every turn in history was genuinely empty).
  *
  * ISSUE #829 (truncation remainder, post-#895's `require_parameters` fix):
  * the pre-fix retry appended its instruction directly onto the FULL
@@ -549,12 +608,30 @@ const SLIM_RETRY_CONTEXT_PREFIX =
  * contained a complete verdict object (`finishReason:'length'`, both real
  * incidents named on the issue). A verdict retry doesn't need the tool-
  * calling history at all — everything the model needs to decide the verdict
- * already lives in its own last turn's text (that prose IS the findings,
+ * already lives in its own recent turns' text (that prose IS the findings,
  * just not yet JSON) — so both clients now build a FRESH, minimal message
  * list for the retry instead of appending to the accumulated one (see
  * `openai-client.ts` / `anthropic-client.ts`'s `runSummaryRetry`), dropping
  * every earlier tool call/tool result regardless of how large the
  * investigation's own history grew.
+ *
+ * KNOWN LIMITATION — HEAD-KEEPING TRUNCATION CAN MAKE A RECOVERED VERDICT
+ * PARTIAL (documented per adversarial-review finding, not silently accepted):
+ * `truncate` keeps the HEAD of `findingsText` and drops the tail. On the
+ * exact "Issue 1: … Issue 21: …" enumerated-findings shape this whole fix
+ * targets, that means only the FIRST couple of issues (roughly the first
+ * ~20K chars' worth, often just 1-2 of 21 on a real derailed turn) survive
+ * into the retry — the rest of the enumeration and any trailing "in
+ * conclusion…" synthesis are silently dropped. This is a genuine, real
+ * limitation: the slim retry can recover A verdict instead of none, not
+ * necessarily the FULL set of findings the model had actually found. HEAD is
+ * kept deliberately rather than the TAIL: the early items in an enumerated
+ * list are where the CONCRETE, schema-fillable specifics live (a claimed
+ * file/line/behavior an `AgentFinding` needs `filepath`/`line`/`message`
+ * for), while a trailing wrap-up tends to be generic synthesis prose with
+ * little of that concrete substance — keeping the head trades completeness
+ * for a higher chance the retry can still build at least one valid,
+ * concrete finding rather than none at all.
  */
 export function buildSlimRetryPrompt(findingsText: string, instruction: string): string {
   const truncated = truncate(findingsText.trim(), SLIM_RETRY_CONTEXT_MAX_CHARS);

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -26,6 +26,8 @@ import {
   extractFindingsFromText,
   computeWrapUpReason,
   logWrapUpReason,
+  lastTurnFindingsText,
+  buildSlimRetryPrompt,
 } from './agent-client-shared.js';
 
 /** Extract the assistant's text content from an Anthropic response for trace. */
@@ -312,8 +314,7 @@ export class AnthropicAgentClient {
     if (!parsed.summary && lastResponse) {
       const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
       const retry = await this.runSummaryRetry(
-        messages,
-        lastResponse,
+        lastTurnFindingsText(lastLoopTurn),
         turn,
         tools,
         remainingBudget,
@@ -447,6 +448,9 @@ export class AnthropicAgentClient {
         finishReason: response.stop_reason ?? undefined,
         inputTokens,
         outputTokens,
+        // Every call site of this method is a summary-retry attempt (issue
+        // #829's slim-context fix, see `runSummaryRetry`) — always true here.
+        slimRetry: true,
       };
       const parsed = extractResponse(response.content, this.logger);
       return { parsed, traceTurn, inputTokens, outputTokens };
@@ -473,10 +477,20 @@ export class AnthropicAgentClient {
    * useful move left is asking again, once, before surfacing `incomplete`
    * (never a silent 0-findings-as-if-clean result — see `run()`'s
    * `incomplete = !parsed.summary` computation).
+   *
+   * Builds a FRESH, minimal message list — just the last investigative
+   * turn's own findings text plus the retry instruction (issue #829's
+   * truncation remainder) — instead of appending onto the loop's full
+   * accumulated `messages`. The pre-fix version also had to satisfy any
+   * PENDING tool_use blocks from the last response with dummy tool_result
+   * entries before the API would accept the follow-up turn
+   * (`appendRetryPrompt`); a fresh message list has no pending tool_use to
+   * satisfy, so that bookkeeping is gone along with the accumulated
+   * history. See `buildSlimRetryPrompt`'s doc comment
+   * (`agent-client-shared.ts`) for the full rationale.
    */
   private async runSummaryRetry(
-    messages: Anthropic.Messages.MessageParam[],
-    lastResponse: Anthropic.Messages.Message,
+    findingsText: string,
     turn: number,
     tools: Anthropic.Messages.Tool[],
     remainingBudget: number,
@@ -486,11 +500,20 @@ export class AnthropicAgentClient {
     inputTokens: number;
     outputTokens: number;
   } | null> {
-    this.logger.info('[agent] No JSON output — requesting summary...');
+    this.logger.info(
+      "[agent] No JSON output — requesting summary via a slim retry (last turn's own analysis only, no tool-calling history)",
+    );
     await new Promise(resolve => setTimeout(resolve, 3_000));
-    appendRetryPrompt(messages, lastResponse);
+    const slimMessages: Anthropic.Messages.MessageParam[] = [
+      { role: 'user', content: buildSlimRetryPrompt(findingsText, RETRY_USER_PROMPT) },
+    ];
 
-    const first = await this.attemptVerdictCompletion(messages, tools, remainingBudget, turn + 1);
+    const first = await this.attemptVerdictCompletion(
+      slimMessages,
+      tools,
+      remainingBudget,
+      turn + 1,
+    );
     if (!first) return null;
     if (first.parsed.summary || first.parsed.findings.length > 0) {
       return { ...first, traceTurns: [first.traceTurn] };
@@ -499,7 +522,12 @@ export class AnthropicAgentClient {
     this.logger.warning(
       '[agent] Retry verdict was unparseable — attempting one more bounded retry',
     );
-    const second = await this.attemptVerdictCompletion(messages, tools, remainingBudget, turn + 2);
+    const second = await this.attemptVerdictCompletion(
+      slimMessages,
+      tools,
+      remainingBudget,
+      turn + 2,
+    );
     if (!second) return { ...first, traceTurns: [first.traceTurn] };
     return {
       parsed: second.parsed,
@@ -542,29 +570,6 @@ async function executeOneToolUse(
       content: truncate(result, TOOL_RESULT_MAX_CHARS),
     },
   };
-}
-
-/**
- * Append the dummy tool_results + retry instruction the Anthropic API
- * needs to accept the truncated conversation. If the last response had
- * pending tool_use blocks, we have to satisfy them before the user
- * turn or the API rejects the request.
- */
-function appendRetryPrompt(
-  messages: Anthropic.Messages.MessageParam[],
-  lastResponse: Anthropic.Messages.Message,
-): void {
-  messages.push({ role: 'assistant', content: lastResponse.content });
-  const pendingToolUse = lastResponse.content.filter(
-    (b): b is Anthropic.Messages.ToolUseBlock => b.type === 'tool_use',
-  );
-  const retryContent: Anthropic.Messages.ContentBlockParam[] = pendingToolUse.map(b => ({
-    type: 'tool_result' as const,
-    tool_use_id: b.id,
-    content: '[Budget exceeded — tool not executed]',
-  }));
-  retryContent.push({ type: 'text' as const, text: RETRY_USER_PROMPT });
-  messages.push({ role: 'user', content: retryContent });
 }
 
 const RETRY_SYSTEM_PROMPT =

--- a/packages/review/src/plugins/agent/anthropic-client.ts
+++ b/packages/review/src/plugins/agent/anthropic-client.ts
@@ -314,7 +314,7 @@ export class AnthropicAgentClient {
     if (!parsed.summary && lastResponse) {
       const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
       const retry = await this.runSummaryRetry(
-        lastTurnFindingsText(lastLoopTurn),
+        lastTurnFindingsText(turnTraces),
         turn,
         tools,
         remainingBudget,

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -25,6 +25,8 @@ import {
   extractFindingsWithReasoningFallback,
   computeWrapUpReason,
   logWrapUpReason,
+  lastTurnFindingsText,
+  buildSlimRetryPrompt,
 } from './agent-client-shared.js';
 
 // `envDisabled` is re-exported so its existing test import path
@@ -542,7 +544,12 @@ export class OpenAIAgentClient {
     // conversation to summarize, so skip the doomed retry (and its 3s sleep).
     if (!parsed.summary && completedTurns > 0) {
       const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
-      const retry = await this.runSummaryRetry(messages, turn, remainingBudget);
+      const retry = await this.runSummaryRetry(
+        systemPrompt,
+        lastTurnFindingsText(lastLoopTurn),
+        turn,
+        remainingBudget,
+      );
       if (retry) {
         totalInputTokens += retry.inputTokens;
         totalOutputTokens += retry.outputTokens;
@@ -671,6 +678,9 @@ export class OpenAIAgentClient {
         finishReason: choice?.finish_reason,
         inputTokens,
         outputTokens,
+        // Every call site of this method is a summary-retry attempt (issue
+        // #829's slim-context fix, see `runSummaryRetry`) — always true here.
+        slimRetry: true,
       };
       const parsed = extractResponse(
         choice?.message.content ?? null,
@@ -702,9 +712,19 @@ export class OpenAIAgentClient {
    * useful move left is asking again, once, before surfacing `incomplete`
    * (never a silent 0-findings-as-if-clean result — see `run()`'s
    * `incomplete = !parsed.summary` computation).
+   *
+   * Builds a FRESH, minimal message list — `systemPrompt` + the last
+   * investigative turn's own findings text + the retry instruction — instead
+   * of appending onto the loop's full accumulated `messages` (issue #829's
+   * truncation remainder: replaying every prior turn's tool calls/tool
+   * results made the retry's OWN input large enough that even a compliant,
+   * forced-JSON provider could truncate its output before completing a
+   * verdict object). See `buildSlimRetryPrompt`'s doc comment
+   * (`agent-client-shared.ts`) for the full rationale.
    */
   private async runSummaryRetry(
-    messages: ChatMessage[],
+    systemPrompt: string,
+    findingsText: string,
     turn: number,
     remainingBudget: number,
   ): Promise<{
@@ -713,15 +733,20 @@ export class OpenAIAgentClient {
     inputTokens: number;
     outputTokens: number;
   } | null> {
-    this.logger.info('[agent] No JSON output — requesting summary...');
+    this.logger.info(
+      "[agent] No JSON output — requesting summary via a slim retry (system prompt + last turn's own analysis only, no tool-calling history)",
+    );
     await new Promise(resolve => setTimeout(resolve, 3_000));
-    messages.push({ role: 'user', content: RETRY_NUDGE });
+    const slimMessages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: buildSlimRetryPrompt(findingsText, RETRY_NUDGE) },
+    ];
 
     // Computed once and reused for both attempts (parity with the Anthropic
     // client's `remainingBudget` handling) — a badly-starved pass gets a
     // small, bounded request instead of the flat 24,576-token ceiling.
     const maxTokens = retryMaxTokens(remainingBudget);
-    const first = await this.attemptVerdictCompletion(messages, turn + 1, maxTokens);
+    const first = await this.attemptVerdictCompletion(slimMessages, turn + 1, maxTokens);
     if (!first) return null;
     if (first.parsed.summary || first.parsed.findings.length > 0) {
       return { ...first, traceTurns: [first.traceTurn] };
@@ -730,7 +755,7 @@ export class OpenAIAgentClient {
     this.logger.warning(
       '[agent] Retry verdict was unparseable — attempting one more bounded retry',
     );
-    const second = await this.attemptVerdictCompletion(messages, turn + 2, maxTokens);
+    const second = await this.attemptVerdictCompletion(slimMessages, turn + 2, maxTokens);
     if (!second) return { ...first, traceTurns: [first.traceTurn] };
     return {
       parsed: second.parsed,

--- a/packages/review/src/plugins/agent/openai-client.ts
+++ b/packages/review/src/plugins/agent/openai-client.ts
@@ -546,7 +546,7 @@ export class OpenAIAgentClient {
       const remainingBudget = this.maxTokenBudget - (totalInputTokens + totalOutputTokens);
       const retry = await this.runSummaryRetry(
         systemPrompt,
-        lastTurnFindingsText(lastLoopTurn),
+        lastTurnFindingsText(turnTraces),
         turn,
         remainingBudget,
       );

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -240,6 +240,21 @@ export interface TurnTrace {
   finishReason?: string;
   inputTokens?: number;
   outputTokens?: number;
+  /**
+   * True on a summary-retry turn built from the SLIM context (issue #829's
+   * truncation remainder): the last investigative turn's own text plus the
+   * retry instruction, NOT the full accumulated tool-calling history — see
+   * `buildSlimRetryPrompt` (`agent-client-shared.ts`) and each client's
+   * `runSummaryRetry`. Absent on every ordinary loop turn. This is the
+   * receipt that a slim (not full-context) retry happened, inspectable via
+   * `AgentResult.trace.turns` — the same mechanism the harness's `--trace`
+   * mode already reads (see PR #895's dogfood evidence). Not plumbed into
+   * `attestation.ts`'s `ProviderPassAttestation`: no existing telemetry
+   * channel carries per-pass retry-shape data from `AgentResult` to
+   * `buildRunAttestation` (`review-pr.ts`) today, and adding one is
+   * disproportionate to this fix's scope — the trace is the receipt.
+   */
+  slimRetry?: boolean;
 }
 
 /**

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -544,4 +544,49 @@ describe('AnthropicAgentClient — slim summary-retry context (#829 truncation r
 
     expect(lines.some(l => l.includes('slim retry'))).toBe(true);
   });
+
+  // Adversarial-review finding F3: the LAST loop turn alone can be bare (a
+  // pure tool_use turn with no text and no thinking) when the loop ends
+  // right at max_turns — reading only that turn used to feed the retry zero
+  // real context (false-clean risk). End-to-end proof the fix reaches back
+  // through turn history via the real client loop, not just the shared
+  // helper in isolation.
+  it("falls back to an earlier turn's own text for the retry when the turn right before max_turns is bare (#829 F3)", async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg(
+          [thinkingBlock('Issue 1: a real concern about null handling.'), toolUseBlock],
+          100,
+          0,
+          'tool_use',
+        ),
+      )
+      .mockResolvedValueOnce(msg([toolUseBlock], 100, 0, 'tool_use')) // bare: no text, no thinking
+      .mockResolvedValueOnce(
+        msg(
+          [
+            textBlock(
+              '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"recovered","keyChanges":[]}}\n```',
+            ),
+          ],
+          50,
+          0,
+          'end_turn',
+        ),
+      );
+    const { logger } = capturingLogger();
+    const client = new AnthropicAgentClient({
+      apiKey: 'test',
+      model: 'claude-test',
+      maxTurns: 2,
+      maxTokenBudget: 1_000_000,
+      logger,
+    });
+
+    const result = await client.run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    expect(result.incomplete).toBe(false);
+    const retryArgs = createMock.mock.calls[2][0];
+    expect(retryArgs.messages[0].content).toContain('Issue 1: a real concern about null handling.');
+  });
 });

--- a/packages/review/test/plugins-agent-anthropic.test.ts
+++ b/packages/review/test/plugins-agent-anthropic.test.ts
@@ -406,3 +406,142 @@ describe('AnthropicAgentClient — bounded second retry attempt for corrupted st
     expect(createMock).toHaveBeenCalledTimes(3);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #829's truncation remainder (post-#895's require_parameters fix): the
+// summary-retry must send a SLIM message list — just the last investigative
+// turn's own text + the instruction — not the full accumulated tool_use/
+// tool_result history. See `buildSlimRetryPrompt` (agent-client-shared.ts)
+// for the deterministic construction these pin at the wire level.
+// ---------------------------------------------------------------------------
+describe('AnthropicAgentClient — slim summary-retry context (#829 truncation remainder)', () => {
+  it('sends only a single user message on the retry — not the accumulated tool_use/tool_result history', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('more investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(
+        msg([textBlock('Issue 1: looks suspicious. No JSON yet.')], 50, 0, 'end_turn'),
+      )
+      .mockResolvedValueOnce(
+        msg(
+          [
+            textBlock(
+              '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"recovered","keyChanges":[]}}\n```',
+            ),
+          ],
+          50,
+          0,
+          'end_turn',
+        ),
+      );
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(1_000_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    expect(result.incomplete).toBe(false);
+    const retryArgs = createMock.mock.calls[3][0]; // 3 main-loop turns, retry is call 4
+    const retryMessages = retryArgs.messages as Array<{ role: string; content: unknown }>;
+    expect(retryMessages).toHaveLength(1);
+    expect(retryMessages[0].role).toBe('user');
+    // No dummy tool_result / assistant tool_use replay — the fresh list has
+    // no pending tool_use to satisfy in the first place.
+    expect((retryMessages[0].content as Array<{ type: string }> | string).toString()).not.toContain(
+      'tool_result',
+    );
+  });
+
+  it("carries the last investigative turn's own text into the retry prompt", async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(
+        msg([textBlock('Issue 1: a real concern about null handling.')], 50, 0, 'end_turn'),
+      )
+      .mockResolvedValueOnce(
+        msg(
+          [
+            textBlock(
+              '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"recovered","keyChanges":[]}}\n```',
+            ),
+          ],
+          50,
+          0,
+          'end_turn',
+        ),
+      );
+    const { logger } = capturingLogger();
+
+    await makeClient(1_000_000, logger).run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    const retryArgs = createMock.mock.calls[2][0];
+    expect(retryArgs.messages[0].content).toContain('Issue 1: a real concern about null handling.');
+    expect(retryArgs.messages[0].content).toContain('You ran out of budget');
+  });
+
+  it('marks the retry-produced trace turns with slimRetry: true', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock('no verdict here')], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(
+        msg(
+          [
+            textBlock(
+              '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"recovered","keyChanges":[]}}\n```',
+            ),
+          ],
+          50,
+          0,
+          'end_turn',
+        ),
+      );
+    const { logger } = capturingLogger();
+
+    const result = await makeClient(1_000_000, logger).run(
+      'sys',
+      'init',
+      TOOLS as never,
+      async () => 'ok',
+    );
+
+    const retryTurns = result.trace!.turns.filter(t => t.slimRetry);
+    expect(retryTurns).toHaveLength(1);
+    expect(result.trace!.turns[0].slimRetry).toBeUndefined();
+  });
+
+  it('logs that the retry is slim (diagnosable in CI logs, distinct from the old flat message)', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        msg([thinkingBlock('investigating'), toolUseBlock], 100, 0, 'tool_use'),
+      )
+      .mockResolvedValueOnce(msg([textBlock('no verdict here')], 50, 0, 'end_turn'))
+      .mockResolvedValueOnce(
+        msg(
+          [
+            textBlock(
+              '```json\n{"findings":[],"summary":{"riskLevel":"low","overview":"recovered","keyChanges":[]}}\n```',
+            ),
+          ],
+          50,
+          0,
+          'end_turn',
+        ),
+      );
+    const { logger, lines } = capturingLogger();
+
+    await makeClient(1_000_000, logger).run('sys', 'init', TOOLS as never, async () => 'ok');
+
+    expect(lines.some(l => l.includes('slim retry'))).toBe(true);
+  });
+});

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -739,6 +739,71 @@ describe('OpenAIAgentClient — bounded second retry attempt for corrupted stop-
   }, 15000);
 });
 
+// ---------------------------------------------------------------------------
+// Issue #829's truncation remainder (post-#895's require_parameters fix): the
+// summary-retry must send a SLIM message list — system prompt + the last
+// investigative turn's own text + the instruction — not the full accumulated
+// tool-calling history. See `buildSlimRetryPrompt` (agent-client-shared.ts)
+// for the deterministic construction these pin at the wire level.
+// ---------------------------------------------------------------------------
+describe('OpenAIAgentClient — slim summary-retry context (#829 truncation remainder)', () => {
+  it('sends only [system, user] on the retry — not the accumulated tool-calling history', async () => {
+    const { bodies } = mockFetch([
+      toolCallTurn(100), // turn 1: investigation (would bloat a full-history retry)
+      toolCallTurn(100), // turn 2: more investigation
+      stopTurn('Issue 1: looks suspicious. Issue 2: also suspicious. No JSON yet.'), // turn 3: derails
+      stopTurn(CLEAN_JSON, 50), // retry attempt 1: recovers
+    ]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(false);
+    const retryBody = bodies[3]; // 3 main-loop turns (0-2), retry is bodies[3]
+    const retryMessages = retryBody.messages as Array<{ role: string; content: string }>;
+    expect(retryMessages).toHaveLength(2);
+    expect(retryMessages[0]).toEqual({ role: 'system', content: 'sys' });
+    expect(retryMessages.some(m => m.role === 'tool')).toBe(false);
+  });
+
+  it("carries the last investigative turn's own text into the retry prompt", async () => {
+    const { bodies } = mockFetch([
+      toolCallTurn(100),
+      stopTurn('Issue 1: a real concern about null handling.'),
+      stopTurn(CLEAN_JSON, 50),
+    ]);
+    const client = makeClient(1_000_000);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    const retryMessages = bodies[2].messages as Array<{ role: string; content: string }>;
+    expect(retryMessages[1].content).toContain('Issue 1: a real concern about null handling.');
+    expect(retryMessages[1].content).toContain('Output ONLY the JSON block');
+  });
+
+  it('marks the retry-produced trace turns with slimRetry: true', async () => {
+    mockFetch([toolCallTurn(100), stopTurn('no json here'), stopTurn(CLEAN_JSON, 50)]);
+    const client = makeClient(1_000_000);
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    const retryTurns = result.trace!.turns.filter(t => t.slimRetry);
+    expect(retryTurns).toHaveLength(1);
+    // Ordinary loop turns are untouched by the new field.
+    expect(result.trace!.turns[0].slimRetry).toBeUndefined();
+  });
+
+  it('logs that the retry is slim (diagnosable in CI logs, distinct from the old flat message)', async () => {
+    const { logger, lines } = capturingLogger();
+    mockFetch([toolCallTurn(100), stopTurn('no json here'), stopTurn(CLEAN_JSON, 50)]);
+    const client = makeClient(1_000_000, logger);
+
+    await client.run('sys', 'init', [], noopTool);
+
+    expect(lines.some(l => l.includes('slim retry'))).toBe(true);
+  });
+});
+
 /** Shared by both the `appendIncompleteNotice` and `hasProviderFailure` suites below. */
 function baseResult(overrides: Partial<AgentResult>): AgentResult {
   return {

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -802,6 +802,34 @@ describe('OpenAIAgentClient — slim summary-retry context (#829 truncation rema
 
     expect(lines.some(l => l.includes('slim retry'))).toBe(true);
   });
+
+  // Adversarial-review finding F3: the LAST loop turn alone can be bare (a
+  // pure tool_calls turn with no content and no reasoning) when the loop
+  // ends right at max_turns — reading only that turn used to feed the retry
+  // zero real context (false-clean risk). End-to-end proof the fix reaches
+  // back through turn history via the real client loop, not just the shared
+  // helper in isolation.
+  it("falls back to an earlier turn's reasoning for the retry when the turn right before max_turns is bare (#829 F3)", async () => {
+    const { bodies } = mockFetch([
+      toolCallTurn(100, null, 'Issue 1: a real concern about null handling.'), // turn 1: has reasoning
+      toolCallTurn(100), // turn 2: bare tool_calls (no content, no reasoning) — hits max_turns right after
+      stopTurn(CLEAN_JSON, 50), // retry: recovers
+    ]);
+    const client = new OpenAIAgentClient({
+      apiKey: 'test',
+      baseUrl: 'http://mock.local',
+      model: 'test-model',
+      maxTurns: 2,
+      maxTokenBudget: 1_000_000,
+      logger: silentLogger,
+    });
+
+    const result = await client.run('sys', 'init', [], noopTool);
+
+    expect(result.incomplete).toBe(false);
+    const retryMessages = bodies[2].messages as Array<{ role: string; content: string }>;
+    expect(retryMessages[1].content).toContain('Issue 1: a real concern about null handling.');
+  });
 });
 
 /** Shared by both the `appendIncompleteNotice` and `hasProviderFailure` suites below. */

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -15,6 +15,10 @@ import {
   computeWrapUpReason,
   logWrapUpReason,
   NEAR_BUDGET_FRACTION,
+  MAX_BALANCED_OBJECTS_SCANNED,
+  SLIM_RETRY_CONTEXT_MAX_CHARS,
+  lastTurnFindingsText,
+  buildSlimRetryPrompt,
 } from '../src/plugins/agent/agent-client-shared.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { Logger } from '../src/logger.js';
@@ -265,10 +269,35 @@ describe('allBalancedJsonObjects', () => {
   });
 
   it('bounds the scan against a pathological run of tiny objects (no hang, no crash)', () => {
-    const text = '{}'.repeat(1000);
+    const text = '{}'.repeat(10_000);
     const objects = allBalancedJsonObjects(text);
-    expect(objects.length).toBeLessThanOrEqual(25);
+    expect(objects.length).toBeLessThanOrEqual(MAX_BALANCED_OBJECTS_SCANNED);
     expect(objects.every(o => o === '{}')).toBe(true);
+  });
+
+  // Issue #829's residual 25-object-cap gap: a verdict positioned 26th+ in
+  // JSON-dense prose was invisible to the old cap. Raising the cap (see
+  // MAX_BALANCED_OBJECTS_SCANNED's doc comment for why a higher ceiling is
+  // now safe) must actually recover it.
+  it('recovers a verdict positioned as the 26th top-level object (#829 residual cap gap)', () => {
+    const decoys = Array.from({ length: 25 }, (_, i) => `{"noise":${i}}`).join(' ');
+    const verdict = JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: '26th object', keyChanges: [] },
+    });
+    const text = `${decoys} ${verdict}`;
+    const objects = allBalancedJsonObjects(text);
+    expect(objects).toHaveLength(26);
+    expect(objects[25]).toBe(verdict);
+  });
+
+  it('still respects MAX_BALANCED_OBJECTS_SCANNED as a hard ceiling on a huge decoy run', () => {
+    const decoys = Array.from(
+      { length: MAX_BALANCED_OBJECTS_SCANNED + 50 },
+      (_, i) => `{"n":${i}}`,
+    ).join(' ');
+    const objects = allBalancedJsonObjects(decoys);
+    expect(objects).toHaveLength(MAX_BALANCED_OBJECTS_SCANNED);
   });
 });
 
@@ -506,6 +535,22 @@ describe('extractFindingsFromText (fence-priority verdict recovery)', () => {
     expect(out.findings).toHaveLength(1);
   });
 
+  // #829's residual cap gap, end to end through the full extraction pipeline
+  // (not just `allBalancedJsonObjects` directly, above): a verdict quoted
+  // 26th in a JSON-dense investigation used to be invisible under the old
+  // 25-object cap — `extractFindingsFromText` returned no summary at all.
+  it('#829: recovers a verdict positioned 26th in JSON-dense prose (was invisible under the old 25-object cap)', () => {
+    const decoys = Array.from(
+      { length: 25 },
+      (_, i) => `Issue ${i + 1}: found a JSON-shaped fragment {"n":${i}} while investigating.`,
+    ).join('\n');
+    const verdict = JSON.stringify({ findings: [finding], summary });
+    const text = `${decoys}\nHere is my actual verdict:\n${verdict}`;
+    const out = extractFindingsFromText(text);
+    expect(out.summary).toEqual(summary);
+    expect(out.findings).toHaveLength(1);
+  });
+
   // The mirror-image case is a genuine, stated limitation, not a regression:
   // if the EARLIER object also fully mimics the verdict shape (a leaked
   // `<output_format>` contract example carrying its own dummy summary), a
@@ -710,5 +755,77 @@ describe('logWrapUpReason', () => {
     logWrapUpReason(logger, 'last-turn', 7, 1, 1);
     logWrapUpReason(logger, null, 1, 1, 1);
     expect(lines).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #829's OTHER remainder (post-#895's require_parameters fix): even a
+// compliant, forced-JSON provider can truncate a summary-retry under its own
+// token cap, because the pre-fix retry re-sent the FULL accumulated
+// conversation (system prompt + every prior turn's tool calls/tool results)
+// as its own input. These pin the deterministic, zero-LLM construction of the
+// SLIM replacement — see each client's `runSummaryRetry` for how the wire
+// format is built from these.
+// ---------------------------------------------------------------------------
+describe('lastTurnFindingsText', () => {
+  it('returns undefined turn as an empty string', () => {
+    expect(lastTurnFindingsText(undefined)).toBe('');
+  });
+
+  it('prefers responseText over reasoning when both are present', () => {
+    expect(lastTurnFindingsText({ responseText: 'the content', reasoning: 'the reasoning' })).toBe(
+      'the content',
+    );
+  });
+
+  it('falls back to reasoning when responseText is empty/whitespace-only', () => {
+    expect(lastTurnFindingsText({ responseText: '   ', reasoning: 'the reasoning' })).toBe(
+      'the reasoning',
+    );
+    expect(lastTurnFindingsText({ reasoning: 'the reasoning' })).toBe('the reasoning');
+  });
+
+  it('returns an empty string when neither channel has anything', () => {
+    expect(lastTurnFindingsText({})).toBe('');
+    expect(lastTurnFindingsText({ responseText: '', reasoning: '' })).toBe('');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(lastTurnFindingsText({ responseText: '  padded text  ' })).toBe('padded text');
+  });
+});
+
+describe('buildSlimRetryPrompt', () => {
+  const instruction = 'Output ONLY the JSON verdict now.';
+
+  it('wraps the findings text with a label and the instruction', () => {
+    const prompt = buildSlimRetryPrompt('Issue 1: something looks off.', instruction);
+    expect(prompt).toContain('Issue 1: something looks off.');
+    expect(prompt).toContain(instruction);
+    // The findings text comes before the instruction — the model reads its
+    // own prior analysis, THEN the hard instruction to convert it to JSON.
+    expect(prompt.indexOf('Issue 1:')).toBeLessThan(prompt.indexOf(instruction));
+  });
+
+  it('falls back to the bare instruction when there is no findings text', () => {
+    expect(buildSlimRetryPrompt('', instruction)).toBe(instruction);
+    expect(buildSlimRetryPrompt('   ', instruction)).toBe(instruction);
+  });
+
+  it('bounds the replayed findings text to SLIM_RETRY_CONTEXT_MAX_CHARS', () => {
+    // Mirrors both #829 incidents' own derailed turn: ~227K-262K tokens of
+    // "Issue 1: … Issue 21: …" prose — a slim retry built from it must still
+    // stay small, not just avoid the OLD full-history problem.
+    const huge = 'X'.repeat(SLIM_RETRY_CONTEXT_MAX_CHARS + 5_000);
+    const prompt = buildSlimRetryPrompt(huge, instruction);
+    expect(prompt.length).toBeLessThan(huge.length);
+    expect(prompt).toContain('…[truncated');
+    expect(prompt).toContain(instruction);
+  });
+
+  it('is deterministic (same inputs, same output — no hidden randomness/state)', () => {
+    const a = buildSlimRetryPrompt('some findings', instruction);
+    const b = buildSlimRetryPrompt('some findings', instruction);
+    expect(a).toBe(b);
   });
 });

--- a/packages/review/test/plugins-agent-client-shared.test.ts
+++ b/packages/review/test/plugins-agent-client-shared.test.ts
@@ -299,6 +299,90 @@ describe('allBalancedJsonObjects', () => {
     const objects = allBalancedJsonObjects(decoys);
     expect(objects).toHaveLength(MAX_BALANCED_OBJECTS_SCANNED);
   });
+
+  // ---------------------------------------------------------------------------
+  // Adversarial-review finding F1 on the first cut of this fix: hoisting the
+  // string-literal mask to run ONCE over the whole text (instead of fresh per
+  // candidate object) was NOT behavior-preserving. An odd number of stray,
+  // unescaped double-quote characters ANYWHERE earlier in the text shifts the
+  // regex's global quote-pairing and can mask straight over a later verdict's
+  // own opening brace, losing it entirely. A truncated `finishReason:'length'`
+  // turn naturally ends mid-string-literal — an odd, unterminated quote is
+  // the TARGET failure class this whole fix exists for, not an edge case.
+  // Per-object re-masking (restored — see `nextBalancedObjectRange`'s doc
+  // comment) is immune to this: these must all recover regardless of the
+  // stray-quote count/parity earlier in the text.
+  // ---------------------------------------------------------------------------
+  it('case B: a single stray, unterminated quote in prose before the verdict does not hide it', () => {
+    const verdict = JSON.stringify({ findings: [finding], summary });
+    const text = `The user's config had a "weird value here.\nHere is my actual verdict:\n${verdict}`;
+    expect(allBalancedJsonObjects(text)).toContain(verdict);
+  });
+
+  it('case C: the #829 26th-object decoy shape with an added stray quote still recovers the verdict', () => {
+    const decoys = Array.from({ length: 25 }, (_, i) => `{"noise":${i}}`).join(' ');
+    const verdict = JSON.stringify({
+      findings: [],
+      summary: { riskLevel: 'low', overview: '26th object with stray quote', keyChanges: [] },
+    });
+    const text = `${decoys} some "unterminated prose here ${verdict}`;
+    expect(allBalancedJsonObjects(text)).toContain(verdict);
+  });
+
+  it.each([0, 1, 2, 3, 4])(
+    'stray-quote parity sweep: recovers the verdict with %i stray quote(s) earlier in the text',
+    count => {
+      const verdict = JSON.stringify({
+        findings: [],
+        summary: { riskLevel: 'low', overview: 'ok', keyChanges: [] },
+      });
+      const strayQuotes = '"'.repeat(count);
+      const text = `Some prose with ${strayQuotes} stray quotes in it.\n${verdict}`;
+      expect(allBalancedJsonObjects(text)).toContain(verdict);
+    },
+  );
+});
+
+describe('allBalancedJsonObjects — performance with per-object re-masking restored (#829 F1 correctness fix)', () => {
+  // Correctness (F1) requires re-masking each candidate's own remaining
+  // suffix instead of sharing one whole-text mask — genuinely
+  // O(objects × text length) again. These pin that it stays cheap in
+  // ABSOLUTE terms at the 200 cap, per the adversarial-review decision
+  // (measured locally: ~26ms/~70ms; generous multiples here to avoid CI
+  // flakiness while still catching a real regression) — see
+  // `MAX_BALANCED_OBJECTS_SCANNED`'s doc comment for the full benchmark.
+  it('stays fast on ~500K chars of realistic decoy density (200 objects)', () => {
+    const filler = 'x'.repeat(2000);
+    const text = Array.from(
+      { length: MAX_BALANCED_OBJECTS_SCANNED },
+      (_, i) => `{"n":${i}}${filler}`,
+    ).join(' ');
+
+    const start = performance.now();
+    const objects = allBalancedJsonObjects(text);
+    const elapsed = performance.now() - start;
+
+    expect(objects).toHaveLength(MAX_BALANCED_OBJECTS_SCANNED);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('stays cheap on the TRUE worst case: 200 decoys clustered up front + a huge brace-free tail', () => {
+    const decoysFront = Array.from(
+      { length: MAX_BALANCED_OBJECTS_SCANNED },
+      (_, i) => `{"n":${i}}`,
+    ).join(' ');
+    // ~920K chars, no braces at all — every one of the 200 calls re-masks
+    // nearly this whole tail, the algorithm's genuine worst case.
+    const hugeTail = 'the quick brown fox jumps over the lazy dog. '.repeat(20_000);
+    const text = `${decoysFront} ${hugeTail}`;
+
+    const start = performance.now();
+    const objects = allBalancedJsonObjects(text);
+    const elapsed = performance.now() - start;
+
+    expect(objects).toHaveLength(MAX_BALANCED_OBJECTS_SCANNED);
+    expect(elapsed).toBeLessThan(1000);
+  });
 });
 
 describe('readVerdict', () => {
@@ -768,30 +852,77 @@ describe('logWrapUpReason', () => {
 // format is built from these.
 // ---------------------------------------------------------------------------
 describe('lastTurnFindingsText', () => {
-  it('returns undefined turn as an empty string', () => {
-    expect(lastTurnFindingsText(undefined)).toBe('');
+  it('returns an empty string for an empty turn history', () => {
+    expect(lastTurnFindingsText([])).toBe('');
   });
 
-  it('prefers responseText over reasoning when both are present', () => {
-    expect(lastTurnFindingsText({ responseText: 'the content', reasoning: 'the reasoning' })).toBe(
-      'the content',
-    );
+  it('prefers responseText over reasoning when both are present on the last turn', () => {
+    expect(
+      lastTurnFindingsText([{ responseText: 'the content', reasoning: 'the reasoning' }]),
+    ).toBe('the content');
   });
 
-  it('falls back to reasoning when responseText is empty/whitespace-only', () => {
-    expect(lastTurnFindingsText({ responseText: '   ', reasoning: 'the reasoning' })).toBe(
+  it('falls back to reasoning when the last turn responseText is empty/whitespace-only', () => {
+    expect(lastTurnFindingsText([{ responseText: '   ', reasoning: 'the reasoning' }])).toBe(
       'the reasoning',
     );
-    expect(lastTurnFindingsText({ reasoning: 'the reasoning' })).toBe('the reasoning');
+    expect(lastTurnFindingsText([{ reasoning: 'the reasoning' }])).toBe('the reasoning');
   });
 
-  it('returns an empty string when neither channel has anything', () => {
-    expect(lastTurnFindingsText({})).toBe('');
-    expect(lastTurnFindingsText({ responseText: '', reasoning: '' })).toBe('');
+  it('returns an empty string when every turn has nothing on either channel', () => {
+    expect(lastTurnFindingsText([{}])).toBe('');
+    expect(lastTurnFindingsText([{ responseText: '', reasoning: '' }])).toBe('');
   });
 
   it('trims surrounding whitespace', () => {
-    expect(lastTurnFindingsText({ responseText: '  padded text  ' })).toBe('padded text');
+    expect(lastTurnFindingsText([{ responseText: '  padded text  ' }])).toBe('padded text');
+  });
+
+  // Adversarial-review finding F3 on the first cut of this fix: the LAST turn
+  // alone can be a pure tool_calls turn with empty content AND no reasoning
+  // (a forced-finish/max-turns bail right after tool-calling, no closing
+  // prose) — reading only that one turn returned '', turning the retry into
+  // a bare instruction with zero real context (a false-clean risk: the model
+  // can fabricate a plausible empty verdict when given nothing to summarize).
+  it('falls back to an earlier turn when the LAST turn is empty on both channels (#829 F3 false-clean floor)', () => {
+    const turns = [
+      { responseText: 'Issue 1: a real concern about null handling.' },
+      { responseText: '', toolCalls: [] }, // pure tool_calls turn, no prose
+    ];
+    expect(lastTurnFindingsText(turns)).toContain('Issue 1: a real concern about null handling.');
+  });
+
+  it('walks arbitrarily far back through empty turns to find real content', () => {
+    const turns = [
+      { responseText: 'the real investigative notes' },
+      { responseText: '' },
+      { responseText: '' },
+      { responseText: '', reasoning: '' },
+    ];
+    expect(lastTurnFindingsText(turns)).toBe('the real investigative notes');
+  });
+
+  it('returns an empty string when EVERY turn in history is empty (nothing to fall back to)', () => {
+    const turns = [{ responseText: '' }, { responseText: '', reasoning: '' }, {}];
+    expect(lastTurnFindingsText(turns)).toBe('');
+  });
+
+  it('concatenates multiple recent non-empty turns, newest first, while under budget', () => {
+    const turns = [
+      { responseText: 'older investigative notes' },
+      { responseText: 'newest investigative notes' },
+    ];
+    const result = lastTurnFindingsText(turns);
+    expect(result.indexOf('newest investigative notes')).toBeLessThan(
+      result.indexOf('older investigative notes'),
+    );
+  });
+
+  it('stops accumulating once the newest turn alone already fills the budget', () => {
+    const huge = 'X'.repeat(SLIM_RETRY_CONTEXT_MAX_CHARS + 1);
+    const turns = [{ responseText: 'should not appear' }, { responseText: huge }];
+    const result = lastTurnFindingsText(turns);
+    expect(result).not.toContain('should not appear');
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses both remainders left open by #895 on issue #829 — `#829 stays open`, see "Evidence tiers" below for why this isn't an unqualified close.

1. **Truncation-under-token-cap remainder.** Even a compliant, `require_parameters:true`-routed provider can still truncate a forced-JSON summary-retry (`finishReason:'length'`) because the pre-fix retry appended its instruction directly onto the loop's FULL accumulated conversation — system prompt, initial message, and every prior turn's own tool calls/tool results — and resent that whole history as the retry's own input. Both real incidents named on #895's evidence hit exactly this shape.
2. **25-object cap residual**, flagged in #895's own adversarial review comment: `allBalancedJsonObjects` capped its scan at 25 top-level JSON objects (a safety valve against an O(objects × text length) per-object re-masking cost), so a genuine verdict positioned 26th+ in JSON-dense prose was invisible to the scanner.

## Correction (evidence-honesty)

An earlier commit on this PR claimed hoisting `maskStringLiterals` to run ONCE over the whole text (instead of fresh per candidate object) was "behavior-preserving" and "costs no extra passes, same guarantee." **That claim was false, and an adversarial reviewer proved it**: masking the whole text in one pass lets an odd number of stray, unescaped double-quote characters ANYWHERE earlier in the text shift the regex's global quote-pairing, which can mask straight over a later verdict's own opening brace and lose it entirely. The reviewer demonstrated verdict LOSS on a synthetic stray-quote-in-prose case and on the #829 26th-object decoy shape with one added stray quote, plus a parity sweep (1/3 stray quotes lost the verdict, 0/2/4 recovered it) — and a truncated `finishReason:'length'` turn naturally ends mid-string-literal (an odd, unterminated quote), making this the TARGET failure class this whole fix exists for, not an edge case.

**Fixed** by reverting `nextBalancedObjectRange` to re-mask fresh from each candidate's own `{` (the original, correct design) — correctness over the throughput win. Re-benchmarked with per-object masking restored to confirm the 200 cap (not reverted to 25) still stays cheap: 200 tiny decoy objects across ~500K chars of realistic filler ≈ 26ms; the algorithm's TRUE worst case (200 decoys clustered up front + a huge brace-free tail) at a ~920K-char tail ≈ 70ms, doubled to ~2.3M chars ≈ 160ms — all comfortably inside the per-turn text sizes this function will realistically ever see (bounded by each client's own per-request `max_tokens` ceiling). Added the reviewer's regression tests verbatim in spirit (cases B and C, plus a 0–4 stray-quote parity sweep) and two perf tests pinning the benchmarked shapes — see `plugins-agent-client-shared.test.ts`.

## Fix

1. **Slim summary-retry context** (`agent-client-shared.ts`'s new `buildSlimRetryPrompt` / `lastTurnFindingsText`, consumed by both `openai-client.ts` and `anthropic-client.ts`'s `runSummaryRetry`): the retry now builds a FRESH, minimal message list — system prompt (OpenAI only; Anthropic already used a dedicated concise retry system prompt) + recent investigative turns' own text (bounded to `SLIM_RETRY_CONTEXT_MAX_CHARS` = 20K chars ≈ 5K tokens — that text can itself be huge, both incidents' derailed turns emitted ~227K-262K tokens of "Issue 1: … Issue 21: …" prose) + the retry instruction — instead of appending onto the accumulated history. Drops every earlier tool call/tool result regardless of how large the investigation grew. The Anthropic client's `appendRetryPrompt` (dummy tool_result satisfying for pending `tool_use` blocks) is now dead code and removed — a fresh message list has no pending tool_use to satisfy.

   **False-clean floor (adversarial-review finding F3):** the very LAST loop turn alone can be a pure tool_calls turn with empty content and no reasoning (e.g. the loop hit `max_turns`/budget right after a turn whose only output was tool calls). Reading only that turn returned `''`, turning the retry into a bare "output the verdict now" instruction with zero real context — a model given nothing to summarize can fabricate a plausible-looking, entirely synthetic clean verdict instead of honestly failing (a false-clean result, the worst failure class this codebase tracks). `lastTurnFindingsText` now walks the turn history newest-first, concatenating non-empty turns until the same `SLIM_RETRY_CONTEXT_MAX_CHARS` budget is reached, so the retry always carries real context when any exists anywhere in history. Covered by unit tests plus end-to-end client tests (both providers) proving the real run loop recovers an earlier turn's text when the turn right before `max_turns` is bare.

   **Documented limitation (adversarial-review finding F2, not silently accepted):** `buildSlimRetryPrompt`'s `truncate()` keeps the HEAD of the findings text and drops the tail. On the exact "Issue 1: … Issue 21: …" enumerated shape this fix targets, that means only the first couple of issues (often just 1-2 of 21 on a real derailed turn) survive the 20K-char budget — a recovered verdict can be PARTIAL, not the full set of findings the model actually found. HEAD is kept deliberately over TAIL: early enumerated items carry the concrete, schema-fillable specifics (a claimed file/line/behavior an `AgentFinding` needs `filepath`/`line`/`message` for), while a trailing wrap-up tends to be generic synthesis prose with little of that substance — keeping the head trades completeness for a higher chance of recovering at least one valid, concrete finding instead of none at all. Documented inline on `buildSlimRetryPrompt`.

   **Receipt:** retry-produced `TurnTrace` entries are marked `slimRetry: true`, inspectable via `AgentResult.trace.turns` (the same mechanism the harness's `--trace` mode and #895's own dogfood evidence already read). NOT plumbed into `attestation.ts`'s `ProviderPassAttestation` — no existing telemetry channel carries per-pass retry-shape data from `AgentResult` to `buildRunAttestation`, and adding one is disproportionate to this fix's scope (documented inline in `types.ts`).

2. **Raised the 25-object cap to 200.** See the "Correction" section above for the masking approach this ended up with (per-object re-masking restored for correctness) and the re-benchmarked cost. The masking regex itself stays backtracking-safe (unchanged: `\\.` vs `[^"\\]` are mutually exclusive per character, no ambiguous backtrack path).

## Harness evidence

**Fixture replay — real OpenRouter spend, live votes (not a `--calibrate` run; see "why calibrate doesn't apply" below):**

- Fixture: `packages/review/test/harness/fixtures/incomplete-handling/pr845-json-dense-verdict-derailment.fixture.json` (gitignored per the harness's own convention; recaptured fresh for this PR via `capture-pr.ts` against PR #845 — native parser built first with `npm run build:native -w @liendev/parser-native`, `config: { docTruthPass: false }` re-applied to the captured JSON per the harness README's documented recipe for this fixture).
- Command run: `npx tsx packages/review/test/harness/run.ts --fixture test/harness/fixtures/incomplete-handling/pr845-json-dense-verdict-derailment.fixture.json --votes 3 --trace /tmp/harness-trace-829`.
- Result: **measured 3/3 (non-gating, see fixture header) · $0.2078 total spend.** All 3 votes completed in exactly 3 main-loop turns each (`finishReason:'stop'`), no summary-retry needed on any vote. This matches PR #895's own post-fix baseline for this identical fixture (0/3 derailed) — confirms no regression to the already-good post-#895 behavior. This replay predates the F1/F3 adversarial-review fixes above; since none of the 3 votes exercised the retry path OR hit `allBalancedJsonObjects`'s balanced-object fallback (the model's output parsed via the fence/raw-body path), it is unaffected by — and does not need to be re-run for — either fix.
- Why this doesn't fully close #829: none of the 3 votes happened to derail naturally, so while the replay is real, live harness evidence, it does not itself exercise the new slim-retry code path (the retry only fires when the loop bails without a verdict). The slim-retry construction is instead proven deterministically — see "Unit tests" below.
- **Why no `--calibrate` run**: this PR, like #895 before it, touches only `agent-client-shared.ts` / `openai-client.ts` / `anthropic-client.ts` — no `system-prompt.ts`/`rules.ts` rule/prompt surface exists for `--calibrate` to measure (same precedent #895 itself cited for this exact file). This is client-transport/parsing-robustness work, not a rule/prompt change, so a `--calibrate 10` reliability score isn't the applicable evidence form here; the applicable form is the live fixture-vote replay above plus the deterministic unit tests below (mirroring exactly how #895 evidenced its own change to this same file).

**Unit tests (zero LLM spend) — the primary, most direct evidence for the code-level fixes themselves:**
- 33 new/updated tests across `plugins-agent-client-shared.test.ts`, `plugins-agent-budget.test.ts` (OpenAI), and `plugins-agent-anthropic.test.ts` (Anthropic), including the post-adversarial-review additions:
  - `lastTurnFindingsText` / `buildSlimRetryPrompt`: channel preference, truncation bound, determinism, multi-turn newest-first fallback, and the F3 false-clean-floor shape (last turn bare, falls back to an earlier turn; falls back arbitrarily far; stays empty only when EVERY turn is empty).
  - Both clients: retry sends only `[system, user]` (OpenAI) / a single user message (Anthropic) — asserted directly against the mocked request body, confirming NO tool-call/tool-result history is replayed; retry trace turns carry `slimRetry: true`; the log line names it a "slim retry"; end-to-end (real client loop, not just the shared helper) proof that a bare turn right before `max_turns` falls back to an earlier turn's text.
  - `allBalancedJsonObjects`: a verdict positioned exactly 26th is recovered (both directly and end-to-end via `extractFindingsFromText`); the F1 stray-quote regression suite (cases B and C, plus a 0–4 stray-quote parity sweep) all recover the verdict regardless of quote parity; two perf tests pin the re-benchmarked worst-case timings.
- Full review suite: **1701/1701 passing.**

## Evidence tiers (why `#829 stays open`)

- **25-object cap fix:** fully proven — the exact "verdict as 26th balanced object" failing shape from #895's adversarial review is now a passing regression test, and the F1 masking-correctness bug the first cut introduced is now fixed and covered by its own regression suite.
- **Slim-retry fix:** the construction itself (what gets sent, in what shape, bounded to what size, with the F3 false-clean floor) is fully proven deterministically and matches the fix direction exactly. What is NOT proven is a live "caught a real derailment mid-flight and the slim retry recovered a verdict" moment — #895's own PR had that (a genuine before/after A/B on an actually-derailing case); this PR's 3 votes didn't reproduce one. Given #895 itself said "#829 stays open" with *stronger* live evidence than I have here, closing outright would overclaim. Recommend keeping #829 open until either a live incident recurs post-merge (and the slim retry visibly recovers it via `slimRetry: true` in the trace) or someone spends additional harness budget deliberately forcing a budget-starved bail to exercise the retry live.

## Gates

- `npm run format:check` — clean
- `npm run lint` — 0 errors (38 pre-existing warnings, none in touched files — same count as #895)
- `npm run typecheck` — clean across parser/core/cli/review/action
- `npm run build` — clean across all packages
- `npm test` — all packages green (parser 27, core 1354, cli 378 non-e2e, review 1701, action 41)
- `node packages/cli/dist/index.js delta` — exit 0; no new complexity crossings. `nextBalancedObjectRange` IMPROVED (time-to-understand 25m→22m, still net-positive after the F1 revert); `allBalancedJsonObjects` shows a further "improved" time-to-understand note; `lastTurnFindingsText` shows a "worsened" cognitive-complexity note (1→5, still well under threshold — it now walks turn history instead of reading one turn) from the F3 fix; `maskStringLiterals`/`buildSlimRetryPrompt` stay tiny new functions; `appendRetryPrompt` removed entirely; the two clients' already-over-budget `run()`/`attemptVerdictCompletion` methods show only "worsened"/"pre-exist" time notes from touching pre-existing violations, never a new crossing.

No changeset: `@liendev/review` is `"private": true` (unpublished), confirmed against #895 (merged with the same no-changeset rationale).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 11 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 3 | +0 |
| 🧠 mental load | 3 | +0 |
| ⏱️ time to understand | 3 | +0 |
| 🐛 estimated bugs | 2 | +0.003 |


> [!NOTE]
> **Low Risk**
>
> This PR addresses two residual issues from #895/#829: it replaces the full-context summary retry with a slim retry built only from the last investigative turn's own text plus a fresh instruction, and it raises the balanced-JSON-object scan cap from 25 to 200 while preserving the per-object string-literal re-masking that keeps the scanner correct on stray/unterminated quotes. Both clients (OpenAI and Anthropic) now construct a minimal retry message list, and retry turns are marked with a new `slimRetry` trace flag. The changes are deterministic, well-scoped, and covered by targeted unit tests including the exact 26th-object boundary and stray-quote parity cases.
>
> - Slim summary retry: fresh [system + user] (OpenAI) or single user (Anthropic) message list, no accumulated tool-call/tool-result history replayed
> - Balanced JSON object scan cap raised from 25 to 200 with per-object re-masking retained for correctness on truncated/string-literal-heavy output
> - New `slimRetry` flag on `TurnTrace` and shared helpers `lastTurnFindingsText` / `buildSlimRetryPrompt`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8ac91a7. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 645K/974K tokens
<!-- /lien:attestation -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of valid review verdicts from dense or adversarial JSON responses.
  * Expanded scanning to handle more candidate JSON objects and stray quotation marks.

* **Improvements**
  * Summary retries now use a concise, bounded context from recent findings instead of replaying the full conversation.
  * Added fallback handling when recent findings are unavailable.
  * Retry activity is now clearly marked in review traces and logs.

* **Tests**
  * Added coverage for JSON recovery, context truncation, fallback behavior, and retry trace reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->