### PR TITLE
feat(parser,cli): Swift symbol-usage test-association signal (#869 spike)

### DIFF
--- a/.changeset/swift-symbol-usage-association.md
+++ b/.changeset/swift-symbol-usage-association.md
@@ -1,0 +1,35 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+#869: a measure-gated spike recovering non-import test-association signal
+for Swift/XCTest, where whole-module imports (`import Alamofire`) carry zero
+per-file information (see the existing "not determinable" honesty label).
+
+New deterministic, zero-LLM signal (`packages/parser/src/swift-symbol-usage-signals.ts`,
+mirroring `stale-literal-signals.ts`'s template): a test chunk's own
+`callSites` versus which single source file uniquely defines the referenced
+symbol. Two gates keep this precise:
+
+- A new, stricter `isMultiSegmentIdentifier` helper (>= 2 camelCase/
+  underscore segments) — the shipped `isUnambiguousIdentifierShape` (docRefs'
+  gate) passes every single Capitalized word trivially (`Get`, `Run`,
+  `Session`, `Client`), so it's insufficient as a collision-resistance gate
+  on its own. Both gates apply together; `isUnambiguousIdentifierShape`
+  itself is untouched.
+- `extension <ForeignType>` declarations are excluded from the definition
+  side unless the type also has a real, non-extension declaration
+  in-project — the one false-positive shape measured on Alamofire (a file
+  merely extending a Foundation type like `HTTPURLResponse` otherwise looks
+  like it "defines" that type to every test that references it).
+
+Calibrated on Alamofire/Alamofire plus two additional real Swift repos of
+different shapes; see the #869 PR for the full precision tables.
+
+Surfaced as a DISTINCT third label tier in `lien annotate` — "inferred from
+symbol usage", never merged into the confident import-based association —
+mirroring #902's Go same-directory tier-2 discipline. Deliberately kept out
+of `get_files_context`, `@liendev/review`'s gap detection, and
+`verify-tests`'s ledger/scope-matching, same conservative call as that
+precedent.

--- a/.changeset/swift-symbol-usage-association.md
+++ b/.changeset/swift-symbol-usage-association.md
@@ -10,7 +10,7 @@ per-file information (see the existing "not determinable" honesty label).
 New deterministic, zero-LLM signal (`packages/parser/src/swift-symbol-usage-signals.ts`,
 mirroring `stale-literal-signals.ts`'s template): a test chunk's own
 `callSites` versus which single source file uniquely defines the referenced
-symbol. Two gates keep this precise:
+symbol. Three gates keep this precise:
 
 - A new, stricter `isMultiSegmentIdentifier` helper (>= 2 camelCase/
   underscore segments) — the shipped `isUnambiguousIdentifierShape` (docRefs'
@@ -20,12 +20,25 @@ symbol. Two gates keep this precise:
   itself is untouched.
 - `extension <ForeignType>` declarations are excluded from the definition
   side unless the type also has a real, non-extension declaration
-  in-project — the one false-positive shape measured on Alamofire (a file
+  in-project — one false-positive shape measured on Alamofire (a file
   merely extending a Foundation type like `HTTPURLResponse` otherwise looks
   like it "defines" that type to every test that references it).
+- `isTypeShapedIdentifier`: an edge needs at least one leading-uppercase,
+  multi-segment driving symbol, or it's demoted. Added after adversarial
+  re-verification (opening actual call sites, not just re-confirming
+  declaration uniqueness) found real false positives where a bare method
+  name collided with something the indexer can't see at all — a stdlib
+  protocol witness (`Decoder.singleValueContainer()`), a stdlib type's own
+  extension overload (`TaskGroup.addTask(name:...)`), or an external
+  package's free function (`swift-dependencies`' `withDependencies`). This
+  gate is necessary (one calibration repo failed precision without it) but
+  costly: roughly half of all previously-good edges are lost project-wide,
+  including every edge to Alamofire's `Request.swift` — see the #869 PR for
+  the full before/after precision tables.
 
 Calibrated on Alamofire/Alamofire plus two additional real Swift repos of
-different shapes; see the #869 PR for the full precision tables.
+different shapes (vapor/vapor, pointfreeco/swift-composable-architecture);
+see the #869 PR for the full precision tables.
 
 Surfaced as a DISTINCT third label tier in `lien annotate` — "inferred from
 symbol usage", never merged into the confident import-based association —

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -86,6 +86,26 @@ Unlike the whole-module/enclosing-namespace gaps above, this one needs no heuris
 
 Both tiers are structurally bounded to the same directory (Go's own compiler guarantee) — the worst either can produce is "attributed to the wrong file in the same package," never the cross-directory textual collisions the bare-identifier guard above protects against.
 
+## Swift symbol-usage association: a measure-gated non-import signal
+
+Swift's whole-module-import gap (above) is a genuine structural blind spot — but the SQLite chunk store already carries a DIFFERENT signal that doesn't depend on imports at all: a test chunk's own `callSites` (the AST-extracted symbols it references) versus which single source file uniquely DEFINES that symbol. Measured against a real Alamofire/Alamofire clone ([#869](https://github.com/getlien/lien/issues/869)), this recovers real, spot-checked coverage for exactly the files the whole-module gap above leaves dark — including the named cases that motivated the investigation (`Request.swift`, `HTTPHeaders.swift`).
+
+`packages/parser/src/swift-symbol-usage-signals.ts` implements the rule: test `T` associates with source `S` iff `T`'s `callSites` reference a symbol `X` such that:
+
+1. `X` passes **both** the shipped `isUnambiguousIdentifierShape` (docRefs' gate) **and** this module's own, stricter `isMultiSegmentIdentifier` — at least 2 camelCase/PascalCase/underscore segments. The shipped gate alone is insufficient here: its case-transition check is satisfied by the first two characters of ANY Capitalized word (`Ge` in `Get`, `Se` in `Session`), so it passes `Get`/`Run`/`Map`/`Session`/`Client` just as readily as `TypeMap`/`HTTPHeaders` — fine for its original prose-vs-code job, useless as a collision-resistance gate. `isMultiSegmentIdentifier` is a separate, additional helper; the shipped gate itself is untouched.
+2. `X` is defined in **exactly one** non-test Swift file project-wide.
+3. That defining file is not `T` itself.
+
+The definition side excludes `extension <ForeignType> { ... }` declarations from counting as a definition, unless the type also has a real (non-extension) declaration somewhere in the project. This is the one false-positive shape measured on Alamofire: `extractSwiftClasses` treats `extension HTTPURLResponse { ... }` as *defining* `HTTPURLResponse`, so every test that happens to reference that Foundation type would otherwise falsely hub onto the extending file. Because a Foundation/stdlib type is never actually declared inside the project, "every declaration of X in this corpus is an extension" already IS the foreign-type test — no hardcoded list of framework type names required.
+
+This is a strictly ADDITIVE, lower-confidence THIRD tier, never merged into the confident import-based association above (or Go's tier 2) — mirroring that tier's discipline exactly:
+
+```text
+Test coverage inferred from symbol usage (not import-verified): Tests/HTTPHeadersTests.swift.
+```
+
+for any Swift file whose `tests` (tier 1) came back empty but the symbol-usage signal found a hit; falls through to the existing `Test coverage not determinable from imports (whole-module import).` label when it doesn't. Scoped to `lien annotate`'s printed text only (`computeSwiftSymbolUsageFallback` in `annotate-cmd.ts`) — deliberately **not** threaded into `get_files_context`'s `testAssociations`, `@liendev/review`'s test-coverage gap detection, or `verify-tests`'s ledger/scope-matching, the same conservative call as Go's tier 2.
+
 ## Java static-member imports: a derived second candidate
 
 `import static pkg.Class.member;` (a specific, non-wildcard static-member import) extracts a path one segment deeper than the file that defines it — `com.example.Utils.method`, when the file is `com/example/Utils.java` — so it could never match via `matchesFile` on its own. `JavaImportExtractor.extractImportPaths` (`packages/parser/src/ast/languages/java.ts`) now returns the class's derived FQN (the path with its trailing segment dropped) as a second candidate alongside the unchanged original. This is safe rather than a guess: Java requires every top-level type to live in a file named after it, and nested types/members always live inside their enclosing top-level type's file, so dropping the trailing segment always yields that type's correct FQN — whether the segment names a static member or a nested class (`import static a.B.Inner;`, correct by the same rule). A static import reaching two-plus levels into nested classes under-matches silently, the same as before this fix, rather than mismatching. Wildcard static imports and ordinary (non-static) imports are unaffected. Verified on a real clone of google/gson: `JsonReaderTest.java`'s static imports of `JsonToken.STRING`/`NUMBER`/etc. now associate it with `JsonToken.java`, with zero other test-association changes across the repo's 264 Java files.
@@ -107,8 +127,8 @@ These are structural: no import-level signal exists for the case, so the honest 
 
 ## Where associations surface
 
-- `get_files_context`'s `testAssociations` field (MCP tool) — includes Go tier 1 (basename pairing), not tier 2 (package-level fallback)
-- `lien annotate` and the post-edit test-association reminder hook (`lien annotate --tests-only`, and its ledger-recording sibling `lien verify-tests note-edit`) — the only surface that also shows Go's tier 2 fallback, distinctly labeled; `verify-tests`'s ledger/scope-matching itself still only sees tier 1
+- `get_files_context`'s `testAssociations` field (MCP tool) — includes Go tier 1 (basename pairing), not tier 2 (package-level fallback) or Swift's symbol-usage signal
+- `lien annotate` and the post-edit test-association reminder hook (`lien annotate --tests-only`, and its ledger-recording sibling `lien verify-tests note-edit`) — the only surface that also shows Go's tier 2 fallback and Swift's symbol-usage signal, both distinctly labeled; `verify-tests`'s ledger/scope-matching itself still only sees tier 1
 - `@liendev/review`'s blast-radius rendering (test coverage context for a changed file) — tier 1 only, same reasoning as `get_files_context`
 
 ## Language support
@@ -124,7 +144,7 @@ These are structural: no import-level signal exists for the case, so the honest 
 | Java | generic patterns | yes (incl. static-member imports, derived class-path candidate) | none |
 | Kotlin | generic patterns | yes | none (see known gaps for top-level function/property imports) |
 | Rust | generic patterns | yes | none needed |
-| Swift | `Tests`/`Test` convention | not determinable (whole-module imports) | none |
+| Swift | `Tests`/`Test` convention | not determinable (whole-module imports); measure-gated symbol-usage fallback in `lien annotate` only (see above) | none |
 
 ## History
 

--- a/docs/architecture/test-association.md
+++ b/docs/architecture/test-association.md
@@ -88,15 +88,36 @@ Both tiers are structurally bounded to the same directory (Go's own compiler gua
 
 ## Swift symbol-usage association: a measure-gated non-import signal
 
-Swift's whole-module-import gap (above) is a genuine structural blind spot — but the SQLite chunk store already carries a DIFFERENT signal that doesn't depend on imports at all: a test chunk's own `callSites` (the AST-extracted symbols it references) versus which single source file uniquely DEFINES that symbol. Measured against a real Alamofire/Alamofire clone ([#869](https://github.com/getlien/lien/issues/869)), this recovers real, spot-checked coverage for exactly the files the whole-module gap above leaves dark — including the named cases that motivated the investigation (`Request.swift`, `HTTPHeaders.swift`).
+Swift's whole-module-import gap (above) is a genuine structural blind spot — but the SQLite chunk store already carries a DIFFERENT signal that doesn't depend on imports at all: a test chunk's own `callSites` (the AST-extracted symbols it references) versus which single source file uniquely DEFINES that symbol. Measured against real Alamofire/vapor/swift-composable-architecture clones ([#869](https://github.com/getlien/lien/issues/869)), this recovers real, individually-verified coverage for a subset of the files the whole-module gap above leaves dark.
 
 `packages/parser/src/swift-symbol-usage-signals.ts` implements the rule: test `T` associates with source `S` iff `T`'s `callSites` reference a symbol `X` such that:
 
 1. `X` passes **both** the shipped `isUnambiguousIdentifierShape` (docRefs' gate) **and** this module's own, stricter `isMultiSegmentIdentifier` — at least 2 camelCase/PascalCase/underscore segments. The shipped gate alone is insufficient here: its case-transition check is satisfied by the first two characters of ANY Capitalized word (`Ge` in `Get`, `Se` in `Session`), so it passes `Get`/`Run`/`Map`/`Session`/`Client` just as readily as `TypeMap`/`HTTPHeaders` — fine for its original prose-vs-code job, useless as a collision-resistance gate. `isMultiSegmentIdentifier` is a separate, additional helper; the shipped gate itself is untouched.
 2. `X` is defined in **exactly one** non-test Swift file project-wide.
 3. That defining file is not `T` itself.
+4. The (S, T) edge has at least one driving symbol that also passes `isTypeShapedIdentifier` — see below.
 
-The definition side excludes `extension <ForeignType> { ... }` declarations from counting as a definition, unless the type also has a real (non-extension) declaration somewhere in the project. This is the one false-positive shape measured on Alamofire: `extractSwiftClasses` treats `extension HTTPURLResponse { ... }` as *defining* `HTTPURLResponse`, so every test that happens to reference that Foundation type would otherwise falsely hub onto the extending file. Because a Foundation/stdlib type is never actually declared inside the project, "every declaration of X in this corpus is an extension" already IS the foreign-type test — no hardcoded list of framework type names required.
+The definition side excludes `extension <ForeignType> { ... }` declarations from counting as a definition, unless the type also has a real (non-extension) declaration somewhere in the project. This is one false-positive shape measured on Alamofire: `extractSwiftClasses` treats `extension HTTPURLResponse { ... }` as *defining* `HTTPURLResponse`, so every test that happens to reference that Foundation type would otherwise falsely hub onto the extending file. Because a Foundation/stdlib type is never actually declared inside the project, "every declaration of X in this corpus is an extension" already IS the foreign-type test — no hardcoded list of framework type names required.
+
+### Gate 4: a post-ship hardening after adversarial re-verification found real false positives
+
+The first shipped version of this signal (gates 1-3 only) was calibrated and measured as ~100% precision across all three repos. An adversarial re-check of the raw evidence — opening the actual call sites, not just re-confirming declaration uniqueness — found that gates 1-3 are insufficient: "unique among this project's own indexed files" does not mean "this specific call resolves to that declaration." Swift lets a bare method name collide with something the indexer never sees at all:
+
+- **A stdlib protocol witness.** Alamofire's `Tests/TestHelpers.swift` calls `decoder.singleValueContainer()` inside an `extension HTTPHeaders: Decodable` — the Swift stdlib `Decoder` protocol's own requirement, satisfied by every conforming type in existence, not Alamofire's differently-typed `URLEncodedFormEncoder.singleValueContainer()`.
+- **A stdlib type's own extension overload.** swift-composable-architecture's `Effect.swift` adds a `name:`-taking `TaskGroup.addTask` overload as a backwards-compatible shim; every test call site actually uses the plain, no-`name:` stdlib `TaskGroup.addTask(priority:operation:)`.
+- **An external package's free function.** The same repo's `withDependencies { ... }` call sites all resolve to the separate `swift-dependencies` package's own top-level function, not `TestStore.withDependencies` — the package is a `Package.swift` dependency, never part of the indexed project.
+
+Every confirmed false positive (`singleValueContainer`, `asURL`, `addTask`, `flatMap`, `withDependencies`) shared one trait: the edge's only driving symbol(s) were lowercase method names, with no PascalCase type reference alongside them. `isTypeShapedIdentifier` (leading-uppercase — allowing Swift's `_`-prefixed SPI convention, e.g. `_CancelID` — and multi-segment) requires at least one such driver per edge; a purely method-driven edge is demoted. This is a structural, method-name-agnostic shape check, not a hardcoded list of risky method names.
+
+**The trade-off, measured exhaustively (every edge in all three repos, independently re-verified) after the fix:**
+
+| Repo | Pre-hardening edges | Pre-hardening honest precision | Post-hardening edges | Post-hardening precision |
+|---|---|---|---|---|
+| Alamofire/Alamofire | 46 | 44/46 = 95.7% (2 confirmed FPs) | 26 | 26/26 = 100% |
+| vapor/vapor | 57 | 57/57 = 100% (0 FPs) | 25 | 25/25 = 100% |
+| pointfreeco/swift-composable-architecture | 49 | 41/49 = 83.7% (8 confirmed FPs) | 29 | 29/29 = 100% |
+
+Gate 4 is necessary — without it, swift-composable-architecture fails the ship bar outright — but it is costly: roughly half of all previously-good edges are lost project-wide (62 of 142 confirmed-good pre-hardening edges), including **every** edge to Alamofire's own `Request.swift`, the file that originally motivated this investigation (`Request` is single-segment and can never itself be a type-shaped driver, and none of its distinctively-named methods have a type-shaped symbol alongside them in the tests that call them). vapor loses 32 confirmed-good edges for zero precision benefit (it had none to fix). This is a real, substantial recall cost from a blunt but precision-safe rule — flagged here rather than glossed over.
 
 This is a strictly ADDITIVE, lower-confidence THIRD tier, never merged into the confident import-based association above (or Go's tier 2) — mirroring that tier's discipline exactly:
 

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -271,6 +271,60 @@ describe('formatTests', () => {
       ).toBe('Test coverage: pkg/cmd/label/list_test.go.');
     });
   });
+
+  // #869 measure-gated spike, tier 4 (lowest confidence): Swift's non-import
+  // symbol-usage signal gets its own distinct "inferred" wording — never
+  // conflated with a direct match or with the honest "not determinable"
+  // label (this case has real, if lower-confidence, signal).
+  describe('Swift symbol-usage fallback (#869 measure-gated spike)', () => {
+    it('reports the distinct inferred wording when tests is empty but symbol-usage tests exist', () => {
+      expect(
+        formatTests([], 'Source/Core/HTTPHeaders.swift', [], ['Tests/HTTPHeadersTests.swift']),
+      ).toBe(
+        'Test coverage inferred from symbol usage (not import-verified): Tests/HTTPHeadersTests.swift.',
+      );
+    });
+
+    it('truncates symbol-usage fallback tests with a (+N more) suffix', () => {
+      expect(
+        formatTests(
+          [],
+          'Source/Core/Request.swift',
+          [],
+          [
+            'Tests/RequestTests.swift',
+            'Tests/RequestRetryTests.swift',
+            'Tests/RequestEventMonitorTests.swift',
+          ],
+        ),
+      ).toBe(
+        'Test coverage inferred from symbol usage (not import-verified): Tests/RequestTests.swift, Tests/RequestRetryTests.swift (+1 more).',
+      );
+    });
+
+    it('still reports the honest "not determinable" label when symbol-usage tests are also empty', () => {
+      expect(formatTests([], 'Source/Core/Untested.swift', [], [])).toBe(
+        'Test coverage not determinable from imports (whole-module import).',
+      );
+    });
+
+    it('ignores symbol-usage tests entirely once a real (tier 1) association exists', () => {
+      expect(
+        formatTests(
+          ['Tests/SessionTests.swift'],
+          'Source/Core/Session.swift',
+          [],
+          ['Tests/should-not-appear.swift'],
+        ),
+      ).toBe('Test coverage: Tests/SessionTests.swift.');
+    });
+
+    it('does not apply the Swift fallback wording on a non-whole-module-import language', () => {
+      expect(formatTests([], 'src/user.ts', [], ['src/user-inferred.test.ts'])).toBe(
+        'No test coverage.',
+      );
+    });
+  });
 });
 
 describe('formatTestReminder', () => {
@@ -313,6 +367,43 @@ describe('formatTestReminder', () => {
       formatTestReminder('src/foo.ts', ['src/foo.test.ts'], ['should-not-appear.test.ts']),
     ).toBe(
       'Lien: you changed src/foo.ts — associated tests: src/foo.test.ts. Run them before completing.',
+    );
+  });
+
+  // #869 measure-gated spike, tier 4: mirrors formatTests's inferred wording,
+  // for the shorter post-edit reminder line. Consulted only when BOTH tests
+  // and package-level tests are empty.
+  it('reports the symbol-usage fallback wording when both tests and package-level tests are empty', () => {
+    expect(
+      formatTestReminder('Source/Core/HTTPHeaders.swift', [], [], ['Tests/HTTPHeadersTests.swift']),
+    ).toBe(
+      'Lien: you changed Source/Core/HTTPHeaders.swift — no import-verified test match, but symbol usage suggests: Tests/HTTPHeadersTests.swift (inferred, not import-verified). Consider running them before completing.',
+    );
+  });
+
+  it('prefers the package-level wording over symbol-usage when both are non-empty', () => {
+    expect(
+      formatTestReminder(
+        'internal/licenses/embed_linux_amd64.go',
+        [],
+        ['internal/licenses/licenses_test.go'],
+        ['should-not-appear.swift'],
+      ),
+    ).toBe(
+      'Lien: you changed internal/licenses/embed_linux_amd64.go — no dedicated test file, but its package has: internal/licenses/licenses_test.go. Consider running them before completing.',
+    );
+  });
+
+  it('prefers the direct-tests wording over symbol-usage when both are non-empty', () => {
+    expect(
+      formatTestReminder(
+        'Source/Core/Session.swift',
+        ['Tests/SessionTests.swift'],
+        [],
+        ['should-not-appear.swift'],
+      ),
+    ).toBe(
+      'Lien: you changed Source/Core/Session.swift — associated tests: Tests/SessionTests.swift. Run them before completing.',
     );
   });
 });
@@ -553,5 +644,72 @@ describe('annotateCommand — --tests-only (integration)', () => {
     expect(errSpy).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
     expect(dependencyAnalyzerModule.findDependents).not.toHaveBeenCalled();
+  });
+
+  // #869 measure-gated spike, end-to-end: a Swift source file with no import
+  // signal at all (whole-module imports carry zero per-file information)
+  // still surfaces its non-import symbol-usage fallback through the real
+  // `scanTestAssociations` -> `computeSwiftSymbolUsageFallback` ->
+  // `findSwiftSymbolUsageAssociations` -> `formatTestReminder` pipeline.
+  //
+  // `resolvePaths` requires the target to exist on disk, so this creates (and
+  // cleans up) a throwaway `.swift` fixture under the real repo root rather
+  // than mocking the filesystem — the only integration-safe way to exercise
+  // this specific path with a Swift-detected extension.
+  it('prints the symbol-usage fallback reminder for a Swift file with no import signal', async () => {
+    const fs = await import('fs/promises');
+    const repoRoot = path.resolve(process.cwd(), '..', '..');
+    const fixtureDir = path.join(repoRoot, '__annotate_swift_fixture__');
+    const swiftTarget = '__annotate_swift_fixture__/HTTPHeaders.swift';
+    await fs.mkdir(fixtureDir, { recursive: true });
+    await fs.writeFile(path.join(fixtureDir, 'HTTPHeaders.swift'), 'class HTTPHeaders {}\n');
+
+    const declChunk = {
+      content: '',
+      metadata: {
+        file: swiftTarget,
+        startLine: 1,
+        endLine: 20,
+        type: 'class',
+        language: 'swift',
+        symbolName: 'HTTPHeaders',
+        symbolType: 'class',
+        signature: 'class HTTPHeaders',
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    const swiftTestChunk = {
+      content: '',
+      metadata: {
+        file: 'Tests/HTTPHeadersTests.swift',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        language: 'swift',
+        symbolName: 'testHeaders',
+        symbolType: 'method',
+        callSites: [{ symbol: 'HTTPHeaders', line: 5 }],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
+      scanAll: vi.fn().mockResolvedValue([declChunk, swiftTestChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    try {
+      await annotateCommand(swiftTarget, { testsOnly: true });
+
+      expect(errSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0]).toBe(
+        `Lien: you changed ${swiftTarget} — no import-verified test match, but symbol usage suggests: Tests/HTTPHeadersTests.swift (inferred, not import-verified). Consider running them before completing.`,
+      );
+    } finally {
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { createVectorDB, ComplexityAnalyzer } from '@liendev/core';
 import {
   findTestAssociationsFromChunks,
+  findSwiftSymbolUsageAssociations,
   computeBlastRadiusRisk,
   detectLanguage,
   hasWholeModuleImports,
@@ -218,12 +219,35 @@ function computeGoPackageLevelFallback(
   return findGoPackageLevelTests(normalize(filepath), buildGoTestDirIndex(candidates));
 }
 
+/**
+ * #869 measure-gated spike, tier 3 (lowest confidence), last resort: when
+ * `tests` (tier 1, import-based) is empty and `filepath`'s language sets
+ * `wholeModuleImports` (Swift), fall back to the non-import symbol-usage
+ * signal — see `findSwiftSymbolUsageAssociations`'s module doc for the full
+ * association rule and its measured Alamofire precision. Deliberately NOT
+ * merged into `tests`, mirroring `computeGoPackageLevelFallback`'s
+ * discipline: `lookupTestAssociations`'s caller (`verify-tests-cmd.ts`)
+ * reads only `.tests` and is unaffected; only the printed annotation/
+ * reminder consults this field.
+ */
+function computeSwiftSymbolUsageFallback(
+  tests: string[],
+  filepath: string,
+  allChunks: CodeChunk[],
+): string[] {
+  if (tests.length > 0) return [];
+  const language = detectLanguage(filepath);
+  if (!language || !hasWholeModuleImports(language)) return [];
+  return findSwiftSymbolUsageAssociations([filepath], allChunks).get(filepath) ?? [];
+}
+
 /** All per-file analysis `run()` needs to decide whether/how to print. */
 interface AnnotationData {
   allChunks: CodeChunk[];
   dependents: DependentInfo[];
   tests: string[];
   packageLevelTests: string[];
+  symbolUsageTests: string[];
   complexity: ComplexitySummary;
   headroom: ComplexityHeadroom;
   risk: BlastRadiusRisk;
@@ -259,6 +283,7 @@ async function computeAnnotationData(
 
   const tests = findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
   const packageLevelTests = computeGoPackageLevelFallback(tests, filepath, allChunks, rootDir);
+  const symbolUsageTests = computeSwiftSymbolUsageFallback(tests, filepath, allChunks);
   const complexity = computeComplexitySummary(allChunks, filepath);
   // Plan-time nudge (mirrors get_files_context's complexityHeadroom): reuses
   // the exact same computation the MCP tool uses, so a "near budget" verdict
@@ -293,6 +318,7 @@ async function computeAnnotationData(
     dependents: result.dependents,
     tests,
     packageLevelTests,
+    symbolUsageTests,
     complexity,
     headroom,
     risk,
@@ -362,6 +388,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
       data.dependents,
       data.tests,
       data.packageLevelTests,
+      data.symbolUsageTests,
       data.complexity,
       data.risk,
       data.headroom,
@@ -384,6 +411,18 @@ export interface FileTestAssociations {
    * this field. See `computeGoPackageLevelFallback`.
    */
   packageLevelTests: string[];
+  /**
+   * #869 measure-gated spike, tier 3 (lowest confidence), last resort:
+   * populated only when `tests` is empty and the file's language sets
+   * `wholeModuleImports` (Swift) — see `findSwiftSymbolUsageAssociations`'s
+   * module doc for the association rule. Deliberately NOT part of `tests` —
+   * same discipline as `packageLevelTests` above: `lookupTestAssociations`'s
+   * caller (`verify-tests-cmd.ts`'s ledger/scope-matching) reads only
+   * `.tests` and is unaffected; only the printed reminder
+   * (`formatTestReminder`) consults this field. See
+   * `computeSwiftSymbolUsageFallback`.
+   */
+  symbolUsageTests: string[];
   /**
    * #894: true when `rootDir`'s index has never been built (`hasData()` is
    * false for both standalone and worktree-overlay backends — see
@@ -421,13 +460,21 @@ async function scanTestAssociations(paths: ResolvedPaths): Promise<FileTestAssoc
     // signal the MCP server's auto-index gate uses, and is worktree/overlay-
     // aware (true when either the base or the overlay has rows).
     if (!(await vectorDB.hasData())) {
-      return { filepath, rootDir, tests: [], packageLevelTests: [], indexMissing: true };
+      return {
+        filepath,
+        rootDir,
+        tests: [],
+        packageLevelTests: [],
+        symbolUsageTests: [],
+        indexMissing: true,
+      };
     }
     const allChunks = adaptChunkImports(await vectorDB.scanAll());
     const tests =
       findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
     const packageLevelTests = computeGoPackageLevelFallback(tests, filepath, allChunks, rootDir);
-    return { filepath, rootDir, tests, packageLevelTests, indexMissing: false };
+    const symbolUsageTests = computeSwiftSymbolUsageFallback(tests, filepath, allChunks);
+    return { filepath, rootDir, tests, packageLevelTests, symbolUsageTests, indexMissing: false };
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
@@ -451,14 +498,14 @@ export async function lookupTestAssociations(file: string): Promise<FileTestAsso
  * no associated tests (the signal for the hook to stay silent).
  */
 async function runTestsOnly(paths: ResolvedPaths): Promise<void> {
-  const { filepath, rootDir, tests, packageLevelTests, indexMissing } =
+  const { filepath, rootDir, tests, packageLevelTests, symbolUsageTests, indexMissing } =
     await scanTestAssociations(paths);
   if (indexMissing) {
     console.log(formatNoIndexWarning(rootDir));
     return;
   }
-  if (tests.length === 0 && packageLevelTests.length === 0) return;
-  console.log(formatTestReminder(filepath, tests, packageLevelTests));
+  if (tests.length === 0 && packageLevelTests.length === 0 && symbolUsageTests.length === 0) return;
+  console.log(formatTestReminder(filepath, tests, packageLevelTests, symbolUsageTests));
 }
 
 /**
@@ -485,16 +532,23 @@ export function formatNoIndexWarning(rootDir: string): string {
  *
  * `packageLevelTests` (#902 tier 2) is consulted only when `tests` is empty
  * — the same honest, distinctly-worded fallback `formatTests` uses for the
- * full annotation, applied to the shorter reminder line.
+ * full annotation, applied to the shorter reminder line. `symbolUsageTests`
+ * (#869 tier 3) is consulted only when BOTH `tests` and `packageLevelTests`
+ * are empty — the lowest-confidence fallback, checked last.
  */
 export function formatTestReminder(
   filepath: string,
   tests: string[],
   packageLevelTests: string[] = [],
+  symbolUsageTests: string[] = [],
 ): string {
   if (tests.length === 0 && packageLevelTests.length > 0) {
     const shown = formatTruncatedList(packageLevelTests);
     return `Lien: you changed ${filepath} — no dedicated test file, but its package has: ${shown}. Consider running them before completing.`;
+  }
+  if (tests.length === 0 && packageLevelTests.length === 0 && symbolUsageTests.length > 0) {
+    const shown = formatTruncatedList(symbolUsageTests);
+    return `Lien: you changed ${filepath} — no import-verified test match, but symbol usage suggests: ${shown} (inferred, not import-verified). Consider running them before completing.`;
   }
   const shown = formatTruncatedList(tests);
   return `Lien: you changed ${filepath} — associated tests: ${shown}. Run them before completing.`;
@@ -527,6 +581,7 @@ function emitAnnotation(
   dependents: DependentInfo[],
   tests: string[],
   packageLevelTests: string[],
+  symbolUsageTests: string[],
   complexity: ComplexitySummary,
   risk: BlastRadiusRisk,
   headroom: ComplexityHeadroom,
@@ -535,7 +590,7 @@ function emitAnnotation(
   if (dependents.length > 0) {
     lines.push(`  • ${formatDependents(dependents, risk.level, risk.reasoning)}`);
   }
-  lines.push(`  • ${formatTests(tests, filepath, packageLevelTests)}`);
+  lines.push(`  • ${formatTests(tests, filepath, packageLevelTests, symbolUsageTests)}`);
   if (complexity.warningCount > 0) {
     lines.push(`  • ${formatComplexity(complexity)}`);
   }
@@ -626,15 +681,28 @@ export function formatDependents(
  * the same directory, but none basename-pairs with this specific file. Only
  * consulted when `tests` is empty; never merged into `tests` itself (see
  * `computeGoPackageLevelFallback`).
+ *
+ * `symbolUsageTests` (#869 measure-gated spike, a FOURTH tier — lowest
+ * confidence of all) is consulted only for a `wholeModuleImports` language
+ * (Swift) whose `tests` came back empty: a non-import, symbol-usage-derived
+ * signal (see `findSwiftSymbolUsageAssociations`'s module doc), distinctly
+ * worded as "inferred" rather than either a confident match or the honest
+ * "not determinable" label — real signal, but not import-verified, so it
+ * gets its own label rather than silently upgrading to either of the other
+ * two.
  */
 export function formatTests(
   tests: string[],
   filepath?: string,
   packageLevelTests: string[] = [],
+  symbolUsageTests: string[] = [],
 ): string {
   if (tests.length === 0) {
     const language = filepath ? detectLanguage(filepath) : null;
     if (language && hasWholeModuleImports(language)) {
+      if (symbolUsageTests.length > 0) {
+        return `Test coverage inferred from symbol usage (not import-verified): ${formatTruncatedList(symbolUsageTests)}.`;
+      }
       return 'Test coverage not determinable from imports (whole-module import).';
     }
     if (language && hasEnclosingNamespaceAccess(language)) {

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -142,6 +142,13 @@ export {
 } from './go-same-directory-tests.js';
 export type { GoTestCandidate, GoTestDirIndex } from './go-same-directory-tests.js';
 
+// #869 measure-gated spike: Swift's non-import symbol-usage test-association
+// signal (see swift-symbol-usage-signals.ts's module doc).
+export {
+  findSwiftSymbolUsageAssociations,
+  isMultiSegmentIdentifier,
+} from './swift-symbol-usage-signals.js';
+
 // =============================================================================
 // GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)
 // =============================================================================

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -147,6 +147,7 @@ export type { GoTestCandidate, GoTestDirIndex } from './go-same-directory-tests.
 export {
   findSwiftSymbolUsageAssociations,
   isMultiSegmentIdentifier,
+  isTypeShapedIdentifier,
 } from './swift-symbol-usage-signals.js';
 
 // =============================================================================

--- a/packages/parser/src/swift-symbol-usage-signals.test.ts
+++ b/packages/parser/src/swift-symbol-usage-signals.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findSwiftSymbolUsageAssociations,
+  isMultiSegmentIdentifier,
+} from './swift-symbol-usage-signals.js';
+import type { CodeChunk } from './types.js';
+
+describe('isMultiSegmentIdentifier', () => {
+  it('rejects single Capitalized English words (must NEVER associate)', () => {
+    expect(isMultiSegmentIdentifier('Get')).toBe(false);
+    expect(isMultiSegmentIdentifier('Run')).toBe(false);
+    expect(isMultiSegmentIdentifier('Map')).toBe(false);
+    expect(isMultiSegmentIdentifier('Send')).toBe(false);
+    expect(isMultiSegmentIdentifier('Session')).toBe(false);
+    expect(isMultiSegmentIdentifier('Client')).toBe(false);
+  });
+
+  it('rejects bare lowercase words and bare ALL-CAPS acronyms', () => {
+    expect(isMultiSegmentIdentifier('count')).toBe(false);
+    expect(isMultiSegmentIdentifier('URL')).toBe(false);
+    expect(isMultiSegmentIdentifier('API')).toBe(false);
+  });
+
+  it('accepts real multi-segment PascalCase/camelCase identifiers', () => {
+    expect(isMultiSegmentIdentifier('TypeMap')).toBe(true);
+    expect(isMultiSegmentIdentifier('getStatusCode')).toBe(true);
+    expect(isMultiSegmentIdentifier('RetryMiddleware')).toBe(true);
+    expect(isMultiSegmentIdentifier('prepareForRetry')).toBe(true);
+  });
+
+  it('accepts an acronym-prefixed PascalCase identifier (HTTPHeaders)', () => {
+    expect(isMultiSegmentIdentifier('HTTPHeaders')).toBe(true);
+  });
+
+  it('accepts an internally-underscored identifier', () => {
+    expect(isMultiSegmentIdentifier('get_status_code')).toBe(true);
+  });
+
+  it('rejects a single word with only a decorative leading/trailing underscore', () => {
+    expect(isMultiSegmentIdentifier('_prefix')).toBe(false);
+    expect(isMultiSegmentIdentifier('suffix_')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSwiftSymbolUsageAssociations
+// ---------------------------------------------------------------------------
+
+interface ChunkOptions {
+  file: string;
+  symbolName?: string;
+  symbolType?: 'function' | 'method' | 'class' | 'interface';
+  signature?: string;
+  callSites?: Array<{ symbol: string; line: number }>;
+  language?: string;
+}
+
+function makeChunk(opts: ChunkOptions): CodeChunk {
+  return {
+    content: '',
+    metadata: {
+      file: opts.file,
+      startLine: 1,
+      endLine: 10,
+      type: opts.symbolType === 'class' || opts.symbolType === 'interface' ? 'class' : 'function',
+      language: opts.language ?? 'swift',
+      symbolName: opts.symbolName,
+      symbolType: opts.symbolType,
+      signature: opts.signature,
+      callSites: opts.callSites,
+    },
+  };
+}
+
+/** A real, non-extension class/struct declaration chunk. */
+function declChunk(file: string, symbolName: string): CodeChunk {
+  return makeChunk({
+    file,
+    symbolName,
+    symbolType: 'class',
+    signature: `class ${symbolName}`,
+  });
+}
+
+/** An `extension <symbolName>` declaration chunk. */
+function extensionChunk(file: string, symbolName: string): CodeChunk {
+  return makeChunk({
+    file,
+    symbolName,
+    symbolType: 'class',
+    signature: `extension ${symbolName}`,
+  });
+}
+
+/** A method/function declaration chunk. */
+function methodChunk(file: string, symbolName: string): CodeChunk {
+  return makeChunk({
+    file,
+    symbolName,
+    symbolType: 'method',
+    signature: `func ${symbolName}()`,
+  });
+}
+
+/** A Swift XCTest-shaped test chunk referencing `callSites`. */
+function testChunk(file: string, callSites: string[]): CodeChunk {
+  return makeChunk({
+    file,
+    symbolName: 'testSomething',
+    symbolType: 'method',
+    signature: 'func testSomething()',
+    callSites: callSites.map((symbol, i) => ({ symbol, line: i + 1 })),
+  });
+}
+
+describe('findSwiftSymbolUsageAssociations', () => {
+  it('associates a test referencing a uniquely-defined, multi-segment type', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/HTTPHeaders.swift', 'HTTPHeaders'),
+      testChunk('Tests/HTTPHeadersTests.swift', ['HTTPHeaders']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/HTTPHeaders.swift'], chunks);
+
+    expect(result.get('Source/Core/HTTPHeaders.swift')).toEqual(['Tests/HTTPHeadersTests.swift']);
+  });
+
+  it('associates via a method-level symbol (not just the type name)', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/Request.swift', 'Request'),
+      methodChunk('Source/Core/Request.swift', 'prepareForRetry'),
+      testChunk('Tests/RequestTests.swift', ['prepareForRetry']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/Request.swift'], chunks);
+
+    expect(result.get('Source/Core/Request.swift')).toEqual(['Tests/RequestTests.swift']);
+  });
+
+  it('never associates via a single Capitalized word, even when uniquely defined (must NEVER associate)', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/Session.swift', 'Session'),
+      testChunk('Tests/SessionTests.swift', ['Session']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/Session.swift'], chunks);
+
+    expect(result.get('Source/Core/Session.swift')).toBeUndefined();
+  });
+
+  it('does not associate when the symbol is defined in more than one file (not unique)', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/TypeMap.swift', 'TypeMap'),
+      declChunk('Source/Other/TypeMap.swift', 'TypeMap'), // duplicate definition elsewhere
+      testChunk('Tests/TypeMapTests.swift', ['TypeMap']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/TypeMap.swift'], chunks);
+
+    expect(result.get('Source/Core/TypeMap.swift')).toBeUndefined();
+  });
+
+  it('excludes an extension of a foreign (never really declared) type from the definition side', () => {
+    // HTTPURLResponse is a Foundation type — never has a real (non-extension)
+    // declaration anywhere in the project, only this extension.
+    const chunks: CodeChunk[] = [
+      extensionChunk('Source/Core/HTTPHeaders.swift', 'HTTPURLResponse'),
+      testChunk('Tests/SomeTests.swift', ['HTTPURLResponse']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/HTTPHeaders.swift'], chunks);
+
+    expect(result.get('Source/Core/HTTPHeaders.swift')).toBeUndefined();
+  });
+
+  it('does not exclude an extension of an in-project type that also has a real declaration', () => {
+    // MultipartFormData is genuinely declared in-project; an extension of it
+    // elsewhere is real, in-project structure, not a foreign-type FP shape.
+    // (Two defining files means "not unique" under the conservative
+    // uniqueness gate — this asserts the extension does NOT itself get
+    // silently dropped, only that uniqueness still requires exactly one file.)
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/MultipartFormData.swift', 'MultipartFormData'),
+      extensionChunk('Source/Core/MultipartFormData+Encoding.swift', 'MultipartFormData'),
+      testChunk('Tests/MultipartFormDataTests.swift', ['MultipartFormData']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(
+      ['Source/Core/MultipartFormData.swift', 'Source/Core/MultipartFormData+Encoding.swift'],
+      chunks,
+    );
+
+    // Two real (non-foreign) definitions -> not unique -> no association for either file.
+    expect(result.get('Source/Core/MultipartFormData.swift')).toBeUndefined();
+    expect(result.get('Source/Core/MultipartFormData+Encoding.swift')).toBeUndefined();
+  });
+
+  it('ignores non-Swift chunks entirely (same-language gate)', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({
+        file: 'src/TypeMap.ts',
+        symbolName: 'TypeMap',
+        symbolType: 'class',
+        signature: 'class TypeMap',
+        language: 'typescript',
+      }),
+      testChunk('Tests/TypeMapTests.swift', ['TypeMap']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['src/TypeMap.ts'], chunks);
+
+    expect(result.get('src/TypeMap.ts')).toBeUndefined();
+  });
+
+  it('dedupes multiple test files and multiple call sites into one list', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/RetryPolicy.swift', 'RetryPolicy'),
+      testChunk('Tests/RetryPolicyTests.swift', ['RetryPolicy', 'RetryPolicy']),
+      testChunk('Tests/RetryPolicyMoreTests.swift', ['RetryPolicy']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/RetryPolicy.swift'], chunks);
+
+    expect(result.get('Source/Core/RetryPolicy.swift')).toEqual([
+      'Tests/RetryPolicyTests.swift',
+      'Tests/RetryPolicyMoreTests.swift',
+    ]);
+  });
+
+  it('only reports associations for requested filepaths', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('Source/Core/HTTPHeaders.swift', 'HTTPHeaders'),
+      declChunk('Source/Core/RetryPolicy.swift', 'RetryPolicy'),
+      testChunk('Tests/HTTPHeadersTests.swift', ['HTTPHeaders']),
+      testChunk('Tests/RetryPolicyTests.swift', ['RetryPolicy']),
+    ];
+
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/HTTPHeaders.swift'], chunks);
+
+    expect(result.get('Source/Core/HTTPHeaders.swift')).toEqual(['Tests/HTTPHeadersTests.swift']);
+    expect(result.has('Source/Core/RetryPolicy.swift')).toBe(false);
+  });
+});

--- a/packages/parser/src/swift-symbol-usage-signals.test.ts
+++ b/packages/parser/src/swift-symbol-usage-signals.test.ts
@@ -2,8 +2,35 @@ import { describe, it, expect } from 'vitest';
 import {
   findSwiftSymbolUsageAssociations,
   isMultiSegmentIdentifier,
+  isTypeShapedIdentifier,
 } from './swift-symbol-usage-signals.js';
 import type { CodeChunk } from './types.js';
+
+describe('isTypeShapedIdentifier', () => {
+  it('accepts a multi-segment PascalCase type name', () => {
+    expect(isTypeShapedIdentifier('HTTPHeaders')).toBe(true);
+    expect(isTypeShapedIdentifier('RetryPolicy')).toBe(true);
+  });
+
+  it('accepts an underscore-prefixed SPI/implementation-detail type name', () => {
+    expect(isTypeShapedIdentifier('_CancelID')).toBe(true);
+    expect(isTypeShapedIdentifier('_EffectPublisher')).toBe(true);
+  });
+
+  it('rejects a multi-segment lowercase method name', () => {
+    expect(isTypeShapedIdentifier('prepareForRetry')).toBe(false);
+    expect(isTypeShapedIdentifier('singleValueContainer')).toBe(false);
+    expect(isTypeShapedIdentifier('withDependencies')).toBe(false);
+  });
+
+  it('rejects a single Capitalized word (still gated by isMultiSegmentIdentifier)', () => {
+    expect(isTypeShapedIdentifier('Session')).toBe(false);
+  });
+
+  it('rejects an underscore-prefixed single word', () => {
+    expect(isTypeShapedIdentifier('_prefix')).toBe(false);
+  });
+});
 
 describe('isMultiSegmentIdentifier', () => {
   it('rejects single Capitalized English words (must NEVER associate)', () => {
@@ -125,16 +152,139 @@ describe('findSwiftSymbolUsageAssociations', () => {
     expect(result.get('Source/Core/HTTPHeaders.swift')).toEqual(['Tests/HTTPHeadersTests.swift']);
   });
 
-  it('associates via a method-level symbol (not just the type name)', () => {
+  it('associates via a method-level symbol WHEN the same edge also has a type-shaped driver', () => {
+    // Note: a bare single-segment type name like `Request` itself can never
+    // serve as the type-shaped driver (it fails `isMultiSegmentIdentifier`,
+    // same as `Session`/`Get`/`Run`) — this fixture uses a realistically
+    // multi-segment type name (`RequestBuilder`) so the type-shaped driver
+    // requirement below can actually be satisfied.
     const chunks: CodeChunk[] = [
-      declChunk('Source/Core/Request.swift', 'Request'),
-      methodChunk('Source/Core/Request.swift', 'prepareForRetry'),
-      testChunk('Tests/RequestTests.swift', ['prepareForRetry']),
+      declChunk('Source/Core/RequestBuilder.swift', 'RequestBuilder'),
+      methodChunk('Source/Core/RequestBuilder.swift', 'prepareForRetry'),
+      testChunk('Tests/RequestBuilderTests.swift', ['RequestBuilder', 'prepareForRetry']),
     ];
 
-    const result = findSwiftSymbolUsageAssociations(['Source/Core/Request.swift'], chunks);
+    const result = findSwiftSymbolUsageAssociations(['Source/Core/RequestBuilder.swift'], chunks);
 
-    expect(result.get('Source/Core/Request.swift')).toEqual(['Tests/RequestTests.swift']);
+    expect(result.get('Source/Core/RequestBuilder.swift')).toEqual([
+      'Tests/RequestBuilderTests.swift',
+    ]);
+  });
+
+  // Post-ship adversarial re-verification (#869): a purely method-driven edge
+  // — no type-shaped co-driver at all — is demoted, even when the method
+  // name is uniquely declared in-project. See `isTypeShapedIdentifier`'s doc
+  // for the confirmed real-world false positives this catches.
+  describe('type-shaped-driver requirement (post-ship hardening)', () => {
+    it('demotes an edge whose ONLY driver is a method name, even when uniquely defined', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('Source/Core/Request.swift', 'Request'),
+        methodChunk('Source/Core/Request.swift', 'prepareForRetry'),
+        testChunk('Tests/RequestTests.swift', ['prepareForRetry']), // no type-shaped co-driver
+      ];
+
+      const result = findSwiftSymbolUsageAssociations(['Source/Core/Request.swift'], chunks);
+
+      expect(result.get('Source/Core/Request.swift')).toBeUndefined();
+    });
+
+    // Confirmed real false positive (Alamofire/Alamofire, Tests/TestHelpers.swift:505):
+    // `decoder.singleValueContainer()` inside `extension HTTPHeaders: Decodable`
+    // calls the Swift stdlib `Decoder` protocol's own witness — completely
+    // unrelated to Alamofire's own, differently-typed `singleValueContainer()`
+    // declared on its custom `URLEncodedFormEncoder`. Both happen to be the
+    // only project-indexed declaration of that bare name, so pre-hardening
+    // this associated `URLEncodedFormEncoder.swift` with every test that
+    // merely implements ANY `Decodable` conformance — a foreign-protocol-
+    // witness collision, not a real reference to the encoder at all.
+    it('does not associate a foreign-protocol-witness method call (singleValueContainer regression)', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('Source/Features/URLEncodedFormEncoder.swift', 'URLEncodedFormEncoder'),
+        methodChunk('Source/Features/URLEncodedFormEncoder.swift', 'singleValueContainer'),
+        testChunk('Tests/TestHelpers.swift', ['singleValueContainer']),
+      ];
+
+      const result = findSwiftSymbolUsageAssociations(
+        ['Source/Features/URLEncodedFormEncoder.swift'],
+        chunks,
+      );
+
+      expect(result.get('Source/Features/URLEncodedFormEncoder.swift')).toBeUndefined();
+    });
+
+    // Confirmed real false positive (swift-composable-architecture,
+    // Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift):
+    // `group.addTask { ... }` (no `name:` argument) calls the Swift stdlib
+    // `TaskGroup.addTask(priority:operation:)` directly — TCA's own
+    // `Effect.swift` only adds a DIFFERENT, `name:`-taking overload as a
+    // backwards-compatible shim, never invoked by a call with no `name:`.
+    // Both are the only project-indexed declaration of `addTask`, but the
+    // stdlib's own `TaskGroup` extension is invisible to the indexer.
+    it('does not associate a stdlib-type-extension-overload method call (addTask regression)', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('Source/Effect.swift', 'Effect'),
+        methodChunk('Source/Effect.swift', 'addTask'),
+        testChunk('Tests/ComposableArchitectureTests.swift', ['addTask']),
+      ];
+
+      const result = findSwiftSymbolUsageAssociations(['Source/Effect.swift'], chunks);
+
+      expect(result.get('Source/Effect.swift')).toBeUndefined();
+    });
+
+    // Confirmed real false positive (swift-composable-architecture,
+    // Tests/ComposableArchitectureTests/ViewStoreTests.swift):
+    // `Array(...).flatMap { $0 }` calls the Swift stdlib `Sequence.flatMap`
+    // on a plain `[[Int]]` — unrelated to TCA's own `TaskResult.flatMap`,
+    // a completely different (project-defined) type.
+    it('does not associate a stdlib-Sequence method call (flatMap regression)', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('Source/Deprecations.swift', 'TaskResult'),
+        methodChunk('Source/Deprecations.swift', 'flatMap'),
+        testChunk('Tests/ViewStoreTests.swift', ['flatMap']),
+      ];
+
+      const result = findSwiftSymbolUsageAssociations(['Source/Deprecations.swift'], chunks);
+
+      expect(result.get('Source/Deprecations.swift')).toBeUndefined();
+    });
+
+    // Confirmed real false positive (swift-composable-architecture,
+    // 4 test files): a bare `withDependencies { ... }` call resolves to the
+    // EXTERNAL `swift-dependencies` package's own top-level free function —
+    // a separate Swift package dependency, never indexed — not TCA's own
+    // `TestStore.withDependencies` method, which requires a `store.` receiver.
+    it('does not associate an external-package free-function call (withDependencies regression)', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('Source/TestStore.swift', 'TestStore'),
+        methodChunk('Source/TestStore.swift', 'withDependencies'),
+        testChunk('Tests/EffectCancellationTests.swift', ['withDependencies']),
+      ];
+
+      const result = findSwiftSymbolUsageAssociations(['Source/TestStore.swift'], chunks);
+
+      expect(result.get('Source/TestStore.swift')).toBeUndefined();
+    });
+
+    it('still associates when the same edge ALSO has a type-shaped driver alongside the risky method name', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('Source/Features/URLEncodedFormEncoder.swift', 'URLEncodedFormEncoder'),
+        methodChunk('Source/Features/URLEncodedFormEncoder.swift', 'singleValueContainer'),
+        testChunk('Tests/ParameterEncoderTests.swift', [
+          'URLEncodedFormEncoder',
+          'singleValueContainer',
+        ]),
+      ];
+
+      const result = findSwiftSymbolUsageAssociations(
+        ['Source/Features/URLEncodedFormEncoder.swift'],
+        chunks,
+      );
+
+      expect(result.get('Source/Features/URLEncodedFormEncoder.swift')).toEqual([
+        'Tests/ParameterEncoderTests.swift',
+      ]);
+    });
   });
 
   it('never associates via a single Capitalized word, even when uniquely defined (must NEVER associate)', () => {

--- a/packages/parser/src/swift-symbol-usage-signals.ts
+++ b/packages/parser/src/swift-symbol-usage-signals.ts
@@ -22,12 +22,33 @@
  *      `buildSwiftDefinitionMap`, which also excludes `extension <ForeignType>`
  *      declarations from counting as a definition (see its doc for why).
  *   3. S !== T.
+ *   4. The (S, T) EDGE has at least one driving symbol that also passes
+ *      `isTypeShapedIdentifier` (see its doc) — a purely method-driven edge
+ *      is demoted even if every individual symbol independently passed
+ *      gates 1-3.
  *
- * Measured on a real Alamofire/Alamofire clone (#869 design comment): 52
- * edges, ~88% precision, ~96% after the extension-exclusion filter — all 6
- * residual false positives were extensions of Foundation types
- * (`HTTPURLResponse`, `URLComponents`, `OperationQueue`, `NSNumber`,
- * `JSONDecoder`).
+ * Gate 4 is a post-ship hardening, added after adversarial re-verification
+ * found that gates 1-3 alone are insufficient: "unique in this project's own
+ * indexed files" does not imply "this call resolves to that declaration",
+ * because Swift lets a bare method name collide with something the indexer
+ * never sees at all — a stdlib protocol witness, a stdlib type's own
+ * extension overload, or an external package's free function of the same
+ * name. Confirmed real false positives across Alamofire/vapor/swift-
+ * composable-architecture: `singleValueContainer`, `asURL`, `addTask`,
+ * `flatMap`, `withDependencies` — every one a lowercase-only edge with no
+ * type-shaped co-driver (see `isTypeShapedIdentifier`'s doc, and the
+ * regression tests in `swift-symbol-usage-signals.test.ts`).
+ *
+ * Measured on real clones (see #869's PR thread for the full tables,
+ * including the pre-hardening numbers and the confirmed false positives
+ * above): gate 4 brings measured precision to 100% on all three calibration
+ * repos, at a substantial recall cost — roughly half of the pre-hardening
+ * edges are lost project-wide, including EVERY edge to Alamofire's own
+ * `Request.swift` (the file that originally motivated this investigation):
+ * `Request` itself is single-segment and can never serve as a type-shaped
+ * driver, and none of its distinctively-named methods (`prepareForRetry`,
+ * `cURLDescription`, ...) have a type-shaped symbol alongside them in the
+ * tests that call them.
  *
  * This is a strictly ADDITIVE, lower-confidence THIRD tier — never merged
  * into the confident import-based association
@@ -91,6 +112,41 @@ export function isMultiSegmentIdentifier(token: string): boolean {
 /** Both distinctiveness gates the design requires, ANDed together (see module doc). */
 function isDistinctiveSwiftSymbol(token: string): boolean {
   return isUnambiguousIdentifierShape(token) && isMultiSegmentIdentifier(token);
+}
+
+/**
+ * True iff `token` reads as a TYPE reference — leading-uppercase (allowing
+ * Swift's `_`-prefixed SPI/implementation-detail naming convention, e.g.
+ * `_CancelID`, `_EffectPublisher` — the underscore itself carries no case
+ * information) AND multi-segment — rather than a method/property name.
+ *
+ * Hardening (post-#869-ship, adversarial re-verification): a bare lowercase
+ * METHOD name, even when uniquely DECLARED in-project, is not reliable
+ * evidence a given call site actually resolves to that declaration. Swift
+ * lets many independent, uninexed things share one method name — a stdlib
+ * protocol witness (`Decoder.singleValueContainer()`, satisfied by every
+ * conforming type, including ones outside this project entirely), a stdlib
+ * TYPE extension overload (`TaskGroup.addTask(name:...)` shimming the
+ * built-in `addTask`), or a same-named free function from an external
+ * package dependency (`swift-dependencies`' own top-level
+ * `withDependencies(_:operation:)`) — and the indexer only ever sees this
+ * project's own files, so "unique in this project" silently ignores every
+ * one of those. Measured on real Alamofire/vapor/swift-composable-architecture
+ * clones: every confirmed false positive (`singleValueContainer`, `asURL`,
+ * `addTask`, `flatMap`, `withDependencies`) was a lowercase-only edge with NO
+ * type-shaped co-driver. A PascalCase, multi-segment symbol referenced via a
+ * bare call (`Foo(...)`, Swift's constructor-call spelling) doesn't have this
+ * problem: it names this project's own type directly, and if a same-named
+ * external type existed unqualified in the same file the compiler would
+ * refuse to build over the ambiguity, not silently pick one.
+ *
+ * Deliberately NOT a hardcoded list of risky method names (that would be a
+ * denylist, and a new unindexed collision would always be one method name
+ * away) — this is a structural, method-name-agnostic shape check. Exposed
+ * for testing.
+ */
+export function isTypeShapedIdentifier(token: string): boolean {
+  return /^_*[A-Z]/.test(token) && isMultiSegmentIdentifier(token);
 }
 
 // ---------------------------------------------------------------------------
@@ -169,32 +225,58 @@ function uniqueOwners(defMap: Map<string, Set<string>>): Map<string, string> {
 // Usage side: test callSites -> uniquely-owned distinctive symbols
 // ---------------------------------------------------------------------------
 
-/** Record `testFile` as a match for `owner` in `result`, deduping. */
-function recordUsageMatch(result: Map<string, string[]>, owner: string, testFile: string): void {
-  const tests = result.get(owner) ?? [];
-  if (!tests.includes(testFile)) tests.push(testFile);
-  result.set(owner, tests);
+/** One candidate (source, test) pairing and every distinctive symbol driving it. */
+interface EdgeCandidate {
+  source: string;
+  test: string;
+  symbols: Set<string>;
+}
+
+/** `source test` — a key uniquely identifying one edge candidate. */
+function edgeKey(source: string, test: string): string {
+  return `${source} ${test}`;
 }
 
 /**
- * Match one test chunk's `callSites` against `owners`, recording any
- * distinctive, uniquely-owned, non-self hit into `result`. Split out of
- * `findSwiftSymbolUsageAssociations` so the per-call-site gate checks aren't
- * nested inside that function's own outer chunk loop.
+ * Match one test chunk's `callSites` against `owners`, recording every
+ * distinctive, uniquely-owned, non-self hit's DRIVING SYMBOL into
+ * `candidates` (keyed by source+test pair — a pair may be driven by several
+ * symbols, e.g. `HTTPHeaders`/`HTTPHeader` both matching `HTTPHeaders.swift`
+ * from the same test file). Split out of `collectEdgeCandidates` so the
+ * per-call-site gate checks aren't nested inside its own outer chunk loop.
  */
 function matchTestChunkCallSites(
   chunk: CodeChunk,
   owners: Map<string, string>,
   wanted: Set<string>,
-  result: Map<string, string[]>,
+  candidates: Map<string, EdgeCandidate>,
 ): void {
   const testFile = chunk.metadata.file;
   for (const call of chunk.metadata.callSites ?? []) {
     if (!isDistinctiveSwiftSymbol(call.symbol)) continue;
     const owner = owners.get(call.symbol);
     if (!owner || owner === testFile || !wanted.has(owner)) continue;
-    recordUsageMatch(result, owner, testFile);
+
+    const key = edgeKey(owner, testFile);
+    const candidate = candidates.get(key) ?? { source: owner, test: testFile, symbols: new Set() };
+    candidate.symbols.add(call.symbol);
+    candidates.set(key, candidate);
   }
+}
+
+/** Every (source, test) edge candidate, with the full set of symbols driving each. */
+function collectEdgeCandidates(
+  chunks: CodeChunk[],
+  owners: Map<string, string>,
+  wanted: Set<string>,
+): Map<string, EdgeCandidate> {
+  const candidates = new Map<string, EdgeCandidate>();
+  for (const chunk of chunks) {
+    if (detectLanguage(chunk.metadata.file) === 'swift' && isTestFile(chunk.metadata.file)) {
+      matchTestChunkCallSites(chunk, owners, wanted, candidates);
+    }
+  }
+  return candidates;
 }
 
 /**
@@ -206,6 +288,12 @@ function matchTestChunkCallSites(
  * non-Swift chunks are ignored on both the definition and usage side (the
  * design's explicit "same language" gate).
  *
+ * An edge is kept only when AT LEAST ONE of its driving symbols is
+ * `isTypeShapedIdentifier` — see that function's doc for why a purely
+ * method-driven edge isn't reliable evidence on its own (adversarial
+ * re-verification post-ship found 5 confirmed false positives across
+ * Alamofire/TCA, every one lowercase-method-only).
+ *
  * `chunks` should be the FULL project chunk set — uniqueness is a
  * project-wide property, not scoped to `filepaths`.
  */
@@ -215,12 +303,16 @@ export function findSwiftSymbolUsageAssociations(
 ): Map<string, string[]> {
   const owners = uniqueOwners(buildSwiftDefinitionMap(collectSwiftDeclarations(chunks)));
   const wanted = new Set(filepaths);
+  const candidates = collectEdgeCandidates(chunks, owners, wanted);
 
   const result = new Map<string, string[]>();
-  for (const chunk of chunks) {
-    if (detectLanguage(chunk.metadata.file) === 'swift' && isTestFile(chunk.metadata.file)) {
-      matchTestChunkCallSites(chunk, owners, wanted, result);
-    }
+  for (const { source, test, symbols } of candidates.values()) {
+    const hasTypeShapedDriver = [...symbols].some(isTypeShapedIdentifier);
+    if (!hasTypeShapedDriver) continue; // demote a purely method-driven edge
+
+    const tests = result.get(source) ?? [];
+    tests.push(test);
+    result.set(source, tests);
   }
   return result;
 }

--- a/packages/parser/src/swift-symbol-usage-signals.ts
+++ b/packages/parser/src/swift-symbol-usage-signals.ts
@@ -1,0 +1,226 @@
+/**
+ * #869 measure-gated spike: a deterministic, zero-LLM symbol-usage signal for
+ * Swift/XCTest test association.
+ *
+ * Swift test files import their subject as a whole module (`import
+ * Alamofire`, `@testable import Alamofire`) rather than a specific file or
+ * symbol path (see `LanguageDefinition.wholeModuleImports`), so import-based
+ * matching (`findTestAssociationsFromChunks`) is structurally blind for this
+ * entire language family — every test file in a module carries the identical
+ * bare-module import string. This module recovers a DIFFERENT, non-import
+ * signal already sitting in the indexed chunk store: a test chunk's own
+ * `callSites` (the AST-extracted symbols it references) versus which single
+ * source file uniquely DEFINES that symbol.
+ *
+ * Association rule (test T -> source S): T's chunk references a symbol X via
+ * `callSites` such that:
+ *   1. X passes `isDistinctiveSwiftSymbol` — the shipped `isUnambiguousIdentifierShape`
+ *      gate AND this module's own, stricter `isMultiSegmentIdentifier` gate
+ *      (see that function's doc for why the shipped gate alone passes nearly
+ *      every ordinary English word and is insufficient here).
+ *   2. X is defined in EXACTLY ONE non-test Swift file project-wide (S) — see
+ *      `buildSwiftDefinitionMap`, which also excludes `extension <ForeignType>`
+ *      declarations from counting as a definition (see its doc for why).
+ *   3. S !== T.
+ *
+ * Measured on a real Alamofire/Alamofire clone (#869 design comment): 52
+ * edges, ~88% precision, ~96% after the extension-exclusion filter — all 6
+ * residual false positives were extensions of Foundation types
+ * (`HTTPURLResponse`, `URLComponents`, `OperationQueue`, `NSNumber`,
+ * `JSONDecoder`).
+ *
+ * This is a strictly ADDITIVE, lower-confidence THIRD tier — never merged
+ * into the confident import-based association
+ * (`findTestAssociationsFromChunks`) or Go's same-directory tier 2
+ * (`go-same-directory-tests.ts`). Mirrors that same tier's discipline: kept
+ * out of `get_files_context`, `@liendev/review`'s gap detection, and
+ * `verify-tests`'s ledger/scope-matching — surfaced only via `lien annotate`
+ * (see `annotate-cmd.ts`'s `computeSwiftSymbolUsageFallback`, the sole
+ * caller).
+ */
+
+import type { CodeChunk } from './types.js';
+import { isTestFile } from './utils/path-matching.js';
+import { detectLanguage } from './ast/languages/registry.js';
+import { isUnambiguousIdentifierShape } from './doc-reference-matching.js';
+
+// ---------------------------------------------------------------------------
+// Distinctiveness: multi-segment identifier gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Split `token` into its camelCase/PascalCase/underscore segments. Only the
+ * segment COUNT matters to callers, so case is preserved and digits are left
+ * alone (unlike core's `deriveSymbolTokens`, which this intentionally does
+ * NOT import/share — `@liendev/parser` has zero dependency on `@liendev/core`,
+ * see CLAUDE.md's package dependency chain — so this is a small, independent
+ * duplicate of the same camelCase-boundary regex shape).
+ */
+function splitIdentifierSegments(token: string): string[] {
+  return token
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // fooBar -> foo Bar
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // HTTPServer -> HTTP Server
+    .split(/[_\s]+/)
+    .filter(Boolean);
+}
+
+/**
+ * True iff `token` has AT LEAST 2 camelCase/PascalCase/underscore segments —
+ * the shape that separates a real, collision-resistant identifier
+ * (`TypeMap`, `getStatusCode`, `RetryMiddleware`, `HTTPHeaders`) from a single
+ * ordinary Capitalized English word (`Get`, `Run`, `Map`, `Session`, `Client`).
+ *
+ * Measured necessity (#869 design comment): the shipped
+ * `isUnambiguousIdentifierShape` (docRefs' gate) passes EVERY single
+ * Capitalized word trivially — its case-transition check is satisfied by the
+ * very first two characters of any Capitalized word (`Ge` in `Get`, `Se` in
+ * `Session`), which was never a problem for its original prose-vs-code
+ * distinction but makes it useless as a COLLISION-resistance gate here. A
+ * single Capitalized common word is exactly the shape most likely to also be
+ * a stdlib/Foundation type or an unrelated project symbol — this gate must
+ * reject those outright, never leaving it to the uniqueness check alone.
+ * Deliberately does NOT touch or weaken `isUnambiguousIdentifierShape` itself
+ * (docRefs' prose-vs-code distinction is a different property) — this is an
+ * additional, stricter helper applied only by this signal. Exposed for
+ * testing.
+ */
+export function isMultiSegmentIdentifier(token: string): boolean {
+  return splitIdentifierSegments(token).length >= 2;
+}
+
+/** Both distinctiveness gates the design requires, ANDed together (see module doc). */
+function isDistinctiveSwiftSymbol(token: string): boolean {
+  return isUnambiguousIdentifierShape(token) && isMultiSegmentIdentifier(token);
+}
+
+// ---------------------------------------------------------------------------
+// Definition side: unique ownership, excluding foreign-type extensions
+// ---------------------------------------------------------------------------
+
+/**
+ * True iff `chunk` is a Swift `extension <Type> { ... }` declaration — the
+ * same `class_declaration` node Swift's extractor uses for real class/struct/
+ * actor/enum declarations, distinguished only by its `extension `-prefixed
+ * signature (see `swift.ts`'s `declarationKeyword`/`extractClassInfo`).
+ */
+function isSwiftExtensionDeclaration(chunk: CodeChunk): boolean {
+  return (
+    chunk.metadata.symbolType === 'class' &&
+    (chunk.metadata.signature ?? '').startsWith('extension ')
+  );
+}
+
+interface SwiftDeclaration {
+  file: string;
+  symbol: string;
+  isExtension: boolean;
+}
+
+/** Non-test Swift chunks that carry a definition-worthy symbol name. */
+function collectSwiftDeclarations(chunks: CodeChunk[]): SwiftDeclaration[] {
+  const out: SwiftDeclaration[] = [];
+  for (const chunk of chunks) {
+    const file = chunk.metadata.file;
+    if (detectLanguage(file) !== 'swift' || isTestFile(file)) continue;
+    const symbol = chunk.metadata.symbolName;
+    if (!symbol) continue;
+    out.push({ file, symbol, isExtension: isSwiftExtensionDeclaration(chunk) });
+  }
+  return out;
+}
+
+/**
+ * Build symbol -> defining file(s), excluding `extension <ForeignType>`
+ * declarations — a type extended but never actually DECLARED (as a real
+ * class/struct/actor/enum/protocol) anywhere in the project. This is the one
+ * principled, non-denylist false-positive filter the #869 design comment
+ * requires: a Foundation/stdlib type like `HTTPURLResponse` only ever shows
+ * up in the indexed corpus via an `extension HTTPURLResponse { ... }` chunk
+ * (there is no real declaration to index — it lives outside the project), so
+ * "every declaration of X in this project is an extension" IS the foreign-type
+ * test, with no hardcoded list of framework type names required. An
+ * extension of an IN-PROJECT type (one that also has a real, non-extension
+ * declaration somewhere) is not excluded by this rule.
+ */
+function buildSwiftDefinitionMap(declarations: SwiftDeclaration[]): Map<string, Set<string>> {
+  const realDeclarationSymbols = new Set(
+    declarations.filter(d => !d.isExtension).map(d => d.symbol),
+  );
+  const defMap = new Map<string, Set<string>>();
+  for (const decl of declarations) {
+    if (decl.isExtension && !realDeclarationSymbols.has(decl.symbol)) continue; // foreign-type extension
+    const files = defMap.get(decl.symbol) ?? new Set<string>();
+    files.add(decl.file);
+    defMap.set(decl.symbol, files);
+  }
+  return defMap;
+}
+
+/** Symbols uniquely defined (exactly one file) across `defMap`, mapped to that file. */
+function uniqueOwners(defMap: Map<string, Set<string>>): Map<string, string> {
+  const owners = new Map<string, string>();
+  for (const [symbol, files] of defMap) {
+    if (files.size === 1) owners.set(symbol, [...files][0]);
+  }
+  return owners;
+}
+
+// ---------------------------------------------------------------------------
+// Usage side: test callSites -> uniquely-owned distinctive symbols
+// ---------------------------------------------------------------------------
+
+/** Record `testFile` as a match for `owner` in `result`, deduping. */
+function recordUsageMatch(result: Map<string, string[]>, owner: string, testFile: string): void {
+  const tests = result.get(owner) ?? [];
+  if (!tests.includes(testFile)) tests.push(testFile);
+  result.set(owner, tests);
+}
+
+/**
+ * Match one test chunk's `callSites` against `owners`, recording any
+ * distinctive, uniquely-owned, non-self hit into `result`. Split out of
+ * `findSwiftSymbolUsageAssociations` so the per-call-site gate checks aren't
+ * nested inside that function's own outer chunk loop.
+ */
+function matchTestChunkCallSites(
+  chunk: CodeChunk,
+  owners: Map<string, string>,
+  wanted: Set<string>,
+  result: Map<string, string[]>,
+): void {
+  const testFile = chunk.metadata.file;
+  for (const call of chunk.metadata.callSites ?? []) {
+    if (!isDistinctiveSwiftSymbol(call.symbol)) continue;
+    const owner = owners.get(call.symbol);
+    if (!owner || owner === testFile || !wanted.has(owner)) continue;
+    recordUsageMatch(result, owner, testFile);
+  }
+}
+
+/**
+ * Find Swift test files whose `callSites` reference a distinctive symbol
+ * uniquely owned by one of `filepaths`. Returns `Map<sourceFile, testFile[]>`
+ * — the same shape as `findTestAssociationsFromChunks`, so callers can slot
+ * it in identically (see `computeSwiftSymbolUsageFallback` in
+ * `annotate-cmd.ts` for the sole caller). Only ever meaningful for Swift;
+ * non-Swift chunks are ignored on both the definition and usage side (the
+ * design's explicit "same language" gate).
+ *
+ * `chunks` should be the FULL project chunk set — uniqueness is a
+ * project-wide property, not scoped to `filepaths`.
+ */
+export function findSwiftSymbolUsageAssociations(
+  filepaths: string[],
+  chunks: CodeChunk[],
+): Map<string, string[]> {
+  const owners = uniqueOwners(buildSwiftDefinitionMap(collectSwiftDeclarations(chunks)));
+  const wanted = new Set(filepaths);
+
+  const result = new Map<string, string[]>();
+  for (const chunk of chunks) {
+    if (detectLanguage(chunk.metadata.file) === 'swift' && isTestFile(chunk.metadata.file)) {
+      matchTestChunkCallSites(chunk, owners, wanted, result);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Correction (adversarial re-verification, after initial "ship" claim)

**The original version of this PR claimed 100% precision on all three calibration repos. That claim was wrong and is retracted.** An adversarial reviewer reproduced the exact 46-edge Alamofire set and found a real false positive; re-verifying every edge in all three repos by opening the actual call sites (not just re-confirming declaration uniqueness) found **10 confirmed false positives total**, enough to fail the ship gate outright on `swift-composable-architecture` (41/49 = 83.7%, well under the ~95% bar).

**Root cause of the bad original evidence:** the mechanism verified that a driving symbol's *definition* was unique in-project, but never verified that a test's actual *call site* resolves to that definition. Swift lets a bare method name collide with something the indexer never sees at all:

- **Stdlib protocol witness** — Alamofire's `Tests/TestHelpers.swift:505` calls `decoder.singleValueContainer()` inside `extension HTTPHeaders: Decodable`. That's the Swift stdlib `Decoder` protocol's own requirement, satisfied by every conforming type in existence — not Alamofire's differently-typed `URLEncodedFormEncoder.singleValueContainer()`, which merely happened to be the only *project-indexed* declaration of that bare name.
- **Stdlib type's own extension overload** — `swift-composable-architecture`'s `Effect.swift` adds a `name:`-taking `TaskGroup.addTask` shim; every real test call site (`group.addTask { ... }`, no `name:` argument) resolves to the plain stdlib `TaskGroup.addTask(priority:operation:)` instead.
- **External package's free function** — the same repo's bare `withDependencies { ... }` calls (4 test files) resolve to the separate `swift-dependencies` package's own top-level function — a `Package.swift` dependency, never part of the indexed project — not `TestStore.withDependencies`.
- A second Alamofire edge (`asURL`, `Tests/TestHelpers.swift`) was borderline/incidentally-mixed rather than cleanly correct and is counted as a defect here for the same reason: the mechanism can't distinguish it from the confirmed-bad cases without receiver-type information it doesn't have.

**Fix shipped:** a new `isTypeShapedIdentifier` gate — an edge is kept only when at least one of its driving symbols is leading-uppercase (allowing Swift's `_`-prefixed SPI convention, e.g. `_CancelID`) and multi-segment. This is a structural, method-name-agnostic shape check, not a hardcoded list of risky method names. Verified to eliminate all 10 confirmed false positives.

**Honest precision, before and after the fix (every edge in all three repos, independently re-verified by opening real call sites):**

| Repo | Pre-fix edges | Pre-fix honest precision | Post-fix edges | Post-fix precision |
|---|---|---|---|---|
| Alamofire/Alamofire | 46 | 44/46 = **95.7%** (2 confirmed FPs) | 26 | **26/26 = 100%** |
| vapor/vapor | 57 | 57/57 = **100%** (0 FPs found) | 25 | **25/25 = 100%** |
| pointfreeco/swift-composable-architecture | 49 | 41/49 = **83.7%** (8 confirmed FPs) | 29 | **29/29 = 100%** |

**The cost of the fix, stated plainly:** roughly half of all previously-good edges are lost project-wide (62 of 142 confirmed-good pre-fix edges, 44%). Most notably, **every edge to Alamofire's own `Request.swift` — the file that originally motivated this whole investigation — is now lost.** `Request` is single-segment (fails `isMultiSegmentIdentifier`, same shape as `Session`/`Get`/`Run`) and can never itself be a type-shaped driver, and none of its distinctively-named methods (`prepareForRetry`, `cURLDescription`, `onURLRequestCreation`, ...) have a type-shaped symbol alongside them in the tests that call them. `vapor` loses 32 confirmed-good edges (its `withApp` test-harness hub, `guardMiddleware`, `hexEncodedString`, etc. — all independently verified correct) for **zero** precision benefit, since vapor had no defects to fix in the first place.

The ship gate (per the original #869 design comment) is a precision-only bar, and the fix brings all three repos to a verified, re-checked 100%. But the practical value of the shipped mechanism is now meaningfully smaller than originally presented — this is flagged prominently, not glossed over, so it can be weighed on its merits rather than on the retracted numbers below.

---

## Summary

Implements the measure-gated Swift symbol-usage association spike from #869's design comment: a deterministic, zero-LLM signal that recovers real (if lower-confidence) test-association coverage for Swift/XCTest files, where whole-module imports (`import Alamofire`) carry zero per-file signal today.

- New `packages/parser/src/swift-symbol-usage-signals.ts` (mirrors `stale-literal-signals.ts`'s template): associates test `T` with source `S` iff `T`'s `callSites` reference a symbol `X` that (a) passes **both** the shipped `isUnambiguousIdentifierShape` **and** a new, stricter `isMultiSegmentIdentifier` (≥2 camel/underscore segments — required because the shipped gate alone passes every single Capitalized word like `Get`/`Run`/`Session` trivially), (b) is defined in **exactly one** non-test Swift file project-wide, (c) that file isn't `T` itself, and — added post-correction — (d) the edge has **at least one type-shaped (leading-uppercase, multi-segment) driving symbol** (see the Correction above for why).
- Definition-side exclusion of `extension <ForeignType>` declarations — a type extended but never actually *declared* in-project (Foundation/stdlib types like `HTTPURLResponse`) — unless the type also has a real, non-extension declaration somewhere in the project. No hardcoded denylist: "every declaration of X in this corpus is an extension" already *is* the foreign-type test.
- Surfaced as a **distinct fourth label tier** in `lien annotate` — "inferred from symbol usage" — never merged into the confident import-based `tests` set, mirroring #902's Go same-directory tier-2 discipline exactly. Deliberately kept out of `get_files_context`, `@liendev/review`'s gap detection, and `verify-tests`'s ledger/scope-matching (see "Scope call" below).

## Ship-gate: calibration on 3 real Swift repos of different shapes

See the Correction section above for the full, honest before/after precision tables and methodology (independent re-verification of every edge by opening the actual call sites — exhaustive, since every repo's edge count is under 60 both before and after the fix). All three repos clear the ~95% bar **after** the `isTypeShapedIdentifier` fix; `swift-composable-architecture` did not clear it before.

### Named targets (Alamofire, the repo #869's original investigation used)

- **`Source/Core/HTTPHeaders.swift`** ← `Tests/HTTPHeadersTests.swift`, via `HTTPHeaders`, `HTTPHeader` — the clean 1:1 case, recovered structurally, **still recovers after the fix** (both driving symbols are type-shaped).
- **`Source/Core/Request.swift`** — the file that originally motivated #869's investigation. Recovered pre-fix via `cURLDescription`/`onURLRequestCreation`/`onURLSessionTaskCreation`/`eventMonitor`/`prepareForRetry`/`cacheResponse`; **no longer recovers post-fix** — see the Correction above for why (no type-shaped driver is structurally possible for this file). Reverts to the honest "not determinable" label, same as before this feature shipped.
- **`Source/Core/AFError.swift`** — genuinely has real test coverage (`Tests/AFError+AlamofireTests.swift` exists), but shows the honest "not determinable" label both before and after this PR, and before/after the fix. Known limitation: `AFError`'s failure-reason types are nested inside `extension AFError { enum … }`, so their declaration name is captured as the dotted compound `AFError.MultipartEncodingFailureReason` while a callsite only ever records the bare last segment — the two never match. Conservative miss (recall), not a precision defect.

### `lien annotate` before/after (verbatim, captured against the final, corrected code)

**HTTPHeaders.swift** (Alamofire, the clean 1:1 case — still recovers):
```
# before (main branch build, no symbol-usage signal at all)
Lien impact for Source/Core/HTTPHeaders.swift:
  • Test coverage not determinable from imports (whole-module import).

# after (this branch, post-correction)
Lien impact for Source/Core/HTTPHeaders.swift:
  • Test coverage inferred from symbol usage (not import-verified): Tests/HTTPHeadersTests.swift.
```

**Request.swift** (Alamofire — recovered by the original spike, lost by the correction):
```
# before this PR, AND after the isTypeShapedIdentifier fix (identical — the honest label)
Lien impact for Source/Core/Request.swift:
  • Test coverage not determinable from imports (whole-module import).
  • Max cyclomatic complexity: 15 (1 function over warn threshold).
```

**URLEncodedFormEncoder.swift** (Alamofire — the confirmed `singleValueContainer` false positive, now cleaned up):
```
# after the fix — only the genuine ParameterEncoderTests.swift edge remains;
# the spurious TestHelpers.swift/singleValueContainer edge is gone
Lien impact for Source/Features/URLEncodedFormEncoder.swift:
  • Test coverage inferred from symbol usage (not import-verified): Tests/ParameterEncoderTests.swift.
```

**AFError.swift** (Alamofire, genuinely-untested-by-this-heuristic example — real tests exist, honest label unaffected by anything in this PR):
```
Lien impact for Source/Core/AFError.swift:
  • Test coverage not determinable from imports (whole-module import).
```

**`lien annotate --tests-only` (the real post-edit hook path)**, HTTPHeaders.swift:
```
Lien: you changed Source/Core/HTTPHeaders.swift — no import-verified test match, but symbol usage suggests: Tests/HTTPHeadersTests.swift (inferred, not import-verified). Consider running them before completing.
```

### Known, accepted characteristics (not precision defects — distinct from the false positives above)

- **"Hub" files**: a shared test-harness helper genuinely called by nearly every test file (vapor's `withApp`, TCA's `TestStore`) produces a high-fan-out association. Every one of *these* edges is correct (the test really does call the uniquely-defined, type-independent helper) but low-specificity — reviewer-attack-vector #3 from the design comment, an accepted characteristic. (Several of vapor's `withApp` edges were lost to the `isTypeShapedIdentifier` fix regardless, since `withApp` alone has no type-shaped co-driver.)
- **Protocol-method collisions the design comment specifically flagged as an attack vector** (`singleValueContainer`, `encodeNil`, etc. — reviewer-attack-vector #2) DID materialize as real false positives, contrary to the original PR's claim. This is now corrected above.

## Scope call: `get_files_context`

Per the design's explicit permission to skip if not "trivial": **not wired into `get_files_context`**. That handler (`packages/cli/src/mcp/handlers/get-files-context.ts`) maintains its own fully separate re-implementation of test-association matching against a different chunk shape (`SearchResult`, not `CodeChunk`), and two of its neighboring functions already sit at/over complexity threshold (`computeComplexityHeadroom` cognitive 25/15, `buildMetadata`-adjacent risk in a 4-importer file). Duplicating a second signal computation into that hot path for a spike whose primary deliverable is the `lien annotate` surface isn't trivial, and is deferred to a follow-up if this proves out further. Wired fully into `lien annotate` (both the full annotation and the `--tests-only` post-edit reminder).

## Gates

- `npm run format:check` — pass
- `npm run lint` — 0 errors (38 pre-existing warnings, untouched)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — pass (parser 1387, core+review 378, cli 1253, action 41 — all green)
- `lien delta` — exit 0, no NEW over-threshold crossings

Changeset: `@liendev/parser` + `@liendev/lien` patch (updated to describe the final, corrected shipped behavior — this PR has not been released, so the changeset describes the end state directly rather than layering a second entry).

## Rebase note

Branched from `origin/main` at the time origin/main included #919 (`resolveProjectRoot` via nearest completed index) and #922 (path-matching boundary fix), both landing after this work started. Rebased on top and manually resolved the `FileTestAssociations`/`scanTestAssociations`/`runTestsOnly` three-way conflict with #894's `indexMissing`/`formatNoIndexWarning` work (both features' fields now coexist cleanly) — verified with a full rebuild + test run + `lien delta` post-resolution.

Closes #869.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR adds Swift symbol-usage fallback detection for source changes that lack direct test coverage. It introduces identifier-shape heuristics to recognize type-like symbols, but the implementation mishandles leading-underscore SPI/implementation-detail prefixes, causing `_CancelID`-style identifiers to be rejected despite tests and docs claiming they are accepted. The bug reduces recall for Swift internal types and would fail the newly added test.
>
> - Adds Swift extension and symbol-usage signal detection
> - Adds identifier-shape helpers (`isTypeShapedIdentifier`, `isMultiSegmentIdentifier`)
> - Mishandles `_`-prefixed SPI identifiers in `splitIdentifierSegments`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit cdbe964. Updates automatically on new commits.</sup>
<!-- /lien-stats -->