### PR TITLE
fix(cli): distinguish unindexed paths from empty results in MCP handlers

### DIFF
--- a/packages/cli/src/mcp/handlers/get-complexity.test.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.test.ts
@@ -27,6 +27,16 @@ vi.mock('@liendev/core', async () => {
   };
 });
 
+vi.mock('../utils/unindexed-paths.js', async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...(original as Record<string, unknown>),
+    findUnindexedPaths: vi.fn().mockResolvedValue([]),
+  };
+});
+
+import { findUnindexedPaths } from '../utils/unindexed-paths.js';
+
 describe('handleGetComplexity', () => {
   const mockVectorDB = {
     scanWithFilter: vi.fn(),
@@ -63,6 +73,7 @@ describe('handleGetComplexity', () => {
     if (mockAnalyzeFn) {
       mockAnalyzeFn.mockClear();
     }
+    vi.mocked(findUnindexedPaths).mockResolvedValue([]);
   });
 
   const getMockAnalyze = () => (globalThis as any).__mockAnalyze;
@@ -548,6 +559,69 @@ describe('handleGetComplexity', () => {
         indexVersion: 1234567890,
         indexDate: '2025-12-19',
       });
+    });
+  });
+
+  describe('unindexed path note (files param)', () => {
+    const emptyReport: ComplexityReport = {
+      summary: {
+        filesAnalyzed: 0,
+        avgComplexity: 0,
+        maxComplexity: 0,
+        totalViolations: 0,
+        bySeverity: { error: 0, warning: 0 },
+      },
+      files: {},
+    };
+
+    it('adds an unmissable note when a requested file has no manifest entry', async () => {
+      vi.mocked(findUnindexedPaths).mockResolvedValue(['src/does/not/exist.ts']);
+      getMockAnalyze().mockResolvedValue(emptyReport);
+
+      const result = await handleGetComplexity({ files: ['src/does/not/exist.ts'] }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('"src/does/not/exist.ts"');
+    });
+
+    it('in a mixed batch, names only the unindexed entry — a good path never masks a bad one', async () => {
+      vi.mocked(findUnindexedPaths).mockResolvedValue(['does/not/exist.ts']);
+      getMockAnalyze().mockResolvedValue(emptyReport);
+
+      const result = await handleGetComplexity(
+        { files: ['src/file1.ts', 'does/not/exist.ts'] },
+        mockCtx,
+      );
+
+      expect(findUnindexedPaths).toHaveBeenCalledWith(
+        mockVectorDB,
+        ['src/file1.ts', 'does/not/exist.ts'],
+        expect.any(String),
+      );
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('"does/not/exist.ts"');
+      expect(parsed.note).not.toContain('"src/file1.ts"');
+    });
+
+    it('adds no note when every requested file is indexed', async () => {
+      vi.mocked(findUnindexedPaths).mockResolvedValue([]);
+      getMockAnalyze().mockResolvedValue(emptyReport);
+
+      const result = await handleGetComplexity({ files: ['src/file1.ts'] }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed).not.toHaveProperty('note');
+    });
+
+    it('skips the unindexed-path check entirely for a whole-codebase sweep (no files param)', async () => {
+      getMockAnalyze().mockResolvedValue(emptyReport);
+
+      const result = await handleGetComplexity({ top: 10 }, mockCtx);
+
+      expect(findUnindexedPaths).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed).not.toHaveProperty('note');
     });
   });
 });

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -2,6 +2,7 @@ import collect from 'collect.js';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetComplexitySchema } from '../schemas/index.js';
 import type { GetComplexityInput } from '../schemas/index.js';
+import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
 import { ComplexityAnalyzer } from '@liendev/core';
 import type { ComplexityViolation, FileComplexityData, ComplexityReport } from '@liendev/parser';
 import type { ToolContext, MCPToolResult } from '../types.js';
@@ -97,6 +98,20 @@ export async function handleGetComplexity(args: unknown, ctx: ToolContext): Prom
     log('Analyzing complexity...');
     await checkAndReconnect();
 
+    // When `files` is given, distinguish "path unknown to the index" from
+    // "indexed, zero violations" — filesAnalyzed silently dropping a mistyped
+    // path to 0 (or, in a mixed batch, just quietly excluding it) reads as a
+    // clean bill of health unless called out explicitly.
+    let unindexedNote: string | undefined;
+    if (files && files.length > 0) {
+      const workspaceRoot = process.cwd().replace(/\\/g, '/');
+      const unindexedPaths = await findUnindexedPaths(vectorDB, files, workspaceRoot);
+      unindexedNote = formatUnindexedPathsNote(unindexedPaths);
+      if (unindexedPaths.length > 0) {
+        log(`Path(s) not found in index: ${unindexedPaths.join(', ')}`, 'warning');
+      }
+    }
+
     // Step 1: Run complexity analysis
     const analyzer = new ComplexityAnalyzer(vectorDB);
     const report = await analyzer.analyze(files);
@@ -120,6 +135,7 @@ export async function handleGetComplexity(args: unknown, ctx: ToolContext): Prom
         bySeverity,
       },
       violations: topViolations,
+      ...(unindexedNote && { note: unindexedNote }),
     };
   })(args);
 }

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -14,6 +14,16 @@ vi.mock('./dependency-analyzer.js', async importOriginal => {
 
 import { findDependents } from './dependency-analyzer.js';
 
+vi.mock('../utils/unindexed-paths.js', async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...(original as Record<string, unknown>),
+    findUnindexedPaths: vi.fn().mockResolvedValue([]),
+  };
+});
+
+import { findUnindexedPaths } from '../utils/unindexed-paths.js';
+
 describe('handleGetDependents', () => {
   const mockLog = vi.fn();
   const mockCheckAndReconnect = vi.fn().mockResolvedValue(undefined);
@@ -102,6 +112,7 @@ describe('handleGetDependents', () => {
 
     // Default mock for findDependents
     vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+    vi.mocked(findUnindexedPaths).mockResolvedValue([]);
   });
 
   describe('basic functionality', () => {
@@ -672,6 +683,29 @@ describe('handleGetDependents', () => {
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.error).toBe('Invalid parameters');
+    });
+  });
+
+  describe('unindexed path note', () => {
+    it('adds an unmissable note when the filepath has no manifest entry at all', async () => {
+      vi.mocked(findUnindexedPaths).mockResolvedValue(['src/does/not/exist.ts']);
+
+      const result = await handleGetDependents({ filepath: 'src/does/not/exist.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('"src/does/not/exist.ts"');
+    });
+
+    it('adds no note when the filepath is indexed, regardless of dependentCount', async () => {
+      vi.mocked(findUnindexedPaths).mockResolvedValue([]);
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({ dependents: [] }));
+
+      const result = await handleGetDependents({ filepath: 'src/isolated.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(0);
+      expect(parsed).not.toHaveProperty('note');
     });
   });
 });

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetDependentsSchema } from '../schemas/index.js';
+import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
 import { computeBlastRadiusRisk, type BlastRadiusRisk } from '@liendev/parser';
 import {
@@ -44,6 +45,8 @@ interface DependentsResponse {
   riskReasoning: string[];
   dependents: DependentInfo[];
   complexityMetrics: ComplexityMetrics;
+  /** Set when `filepath` has no entry in the index manifest at all — see unindexed-paths.ts. */
+  note?: string;
 }
 
 /**
@@ -108,6 +111,7 @@ function buildDependentsResponse(
   args: ValidatedArgs,
   risk: BlastRadiusRisk,
   indexInfo: IndexInfo,
+  note?: string,
 ): DependentsResponse {
   const { symbol, filepath, depth } = args;
 
@@ -132,6 +136,9 @@ function buildDependentsResponse(
   }
   if (analysis.totalUsageCount !== undefined) {
     response.totalUsageCount = analysis.totalUsageCount;
+  }
+  if (note) {
+    response.note = note;
   }
 
   return response;
@@ -167,6 +174,16 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
     // Capture index metadata once to avoid inconsistency from concurrent reindex
     const indexInfo = getIndexMetadata();
 
+    // Distinguish "path unknown to the index" from "indexed, zero
+    // dependents" — a bare dependentCount:0/riskLevel:"low" reads as "safe to
+    // edit" unless a mistyped path is called out explicitly.
+    const workspaceRoot = process.cwd().replace(/\\/g, '/');
+    const unindexedPaths = await findUnindexedPaths(vectorDB, [filepath], workspaceRoot);
+    const unindexedNote = formatUnindexedPathsNote(unindexedPaths);
+    if (unindexedPaths.length > 0) {
+      log(`Path not found in index: ${filepath}`, 'warning');
+    }
+
     // Analyze dependencies (pass indexVersion for scan cache)
     const analysis = await findDependents(
       vectorDB,
@@ -185,6 +202,6 @@ export async function handleGetDependents(args: unknown, ctx: ToolContext): Prom
     logRiskAssessment(analysis, risk.level, symbol, log);
 
     // Build and return response
-    return buildDependentsResponse(analysis, validatedArgs, risk, indexInfo);
+    return buildDependentsResponse(analysis, validatedArgs, risk, indexInfo, unindexedNote);
   })(args);
 }

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -10,6 +10,16 @@ import {
 import type { ToolContext } from '../types.js';
 import type { SearchResult } from '@liendev/core';
 
+vi.mock('../utils/unindexed-paths.js', async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...(original as Record<string, unknown>),
+    findUnindexedPaths: vi.fn().mockResolvedValue([]),
+  };
+});
+
+import { findUnindexedPaths } from '../utils/unindexed-paths.js';
+
 /** Build a function/method chunk carrying stored complexity metrics. */
 function makeFnChunk(
   symbolName: string,
@@ -699,5 +709,68 @@ describe('handleGetFilesContext — complexityHeadroom in the response', () => {
     );
     const parsed = JSON.parse(result.content![0].text);
     expect(parsed.files['src/a.ts'].complexityHeadroomWarning).toContain('extractSymbols');
+  });
+});
+describe('handleGetFilesContext — unindexed path note', () => {
+  const mockLog = vi.fn();
+
+  function ctxReturning(chunks: SearchResult[]): ToolContext {
+    return {
+      vectorDB: {
+        scanWithFilter: vi.fn().mockResolvedValue(chunks),
+        scanAll: vi.fn().mockResolvedValue([]),
+        search: vi.fn().mockResolvedValue([]),
+        dbPath: '/fake/index/path',
+      } as any,
+      rootDir: process.cwd(),
+      log: mockLog,
+      checkAndReconnect: vi.fn().mockResolvedValue(undefined),
+      getIndexMetadata: vi.fn(() => ({ indexVersion: 1, indexDate: '2026-07-01' })),
+      getReindexState: vi.fn(() => ({
+        inProgress: false,
+        pendingFiles: [],
+        lastReindexTimestamp: null,
+        lastReindexDurationMs: null,
+      })),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTestAssociationScanCache();
+    vi.mocked(findUnindexedPaths).mockResolvedValue([]);
+  });
+
+  it('adds an unmissable note for a single unindexed filepath, even with zero chunks', async () => {
+    vi.mocked(findUnindexedPaths).mockResolvedValue(['src/does/not/exist.ts']);
+    const ctx = ctxReturning([]);
+    const result = await handleGetFilesContext({ filepaths: 'src/does/not/exist.ts' }, ctx);
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed.chunks).toEqual([]);
+    expect(parsed.testAssociations).toEqual([]);
+    expect(parsed.note).toContain('⚠ Lien:');
+    expect(parsed.note).toContain('"src/does/not/exist.ts"');
+  });
+
+  it('adds no note when the path is indexed, even with genuinely zero chunks', async () => {
+    vi.mocked(findUnindexedPaths).mockResolvedValue([]);
+    const ctx = ctxReturning([]);
+    const result = await handleGetFilesContext({ filepaths: 'src/empty.ts' }, ctx);
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed).not.toHaveProperty('note');
+  });
+
+  it('in a mixed batch, names only the unindexed entry — a good path never masks a bad one', async () => {
+    vi.mocked(findUnindexedPaths).mockResolvedValue(['does/not/exist.ts']);
+    const ctx = ctxReturning([makeFnChunk('tidy', { cognitive: 4, file: 'src/a.ts' })]);
+    const result = await handleGetFilesContext(
+      { filepaths: ['src/a.ts', 'does/not/exist.ts'] },
+      ctx,
+    );
+    const parsed = JSON.parse(result.content![0].text);
+    expect(parsed.note).toContain('"does/not/exist.ts"');
+    expect(parsed.note).not.toContain('"src/a.ts"');
+    expect(parsed.files['src/a.ts'].chunks.length).toBeGreaterThan(0);
+    expect(parsed.files['does/not/exist.ts'].chunks).toEqual([]);
   });
 });

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -1,6 +1,7 @@
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetFilesContextSchema } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
+import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import {
   normalizePath,
@@ -662,6 +663,16 @@ export async function handleGetFilesContext(
       workspaceRoot,
     };
 
+    // Step 0: Distinguish "path unknown to the index" from "indexed, zero
+    // results" — an empty chunks/testAssociations answer reads as "safe to
+    // edit" unless a mistyped path is called out explicitly. See
+    // unindexed-paths.ts for why the manifest (not scanAll) is the right check.
+    const unindexedPaths = await findUnindexedPaths(vectorDB, filepaths, workspaceRoot);
+    const unindexedNote = formatUnindexedPathsNote(unindexedPaths);
+    if (unindexedPaths.length > 0) {
+      log(`Path(s) not found in index: ${unindexedPaths.join(', ')}`, 'warning');
+    }
+
     // Step 1: Search for chunks belonging to each file
     const fileChunksMap = await searchFileChunks(filepaths, handlerCtx);
 
@@ -696,7 +707,7 @@ export async function handleGetFilesContext(
 
     // Step 5: Build and return response
     return isSingleFile
-      ? buildSingleFileResponse(filepaths[0], filesData, indexInfo)
-      : buildMultiFileResponse(filesData, indexInfo);
+      ? buildSingleFileResponse(filepaths[0], filesData, indexInfo, unindexedNote)
+      : buildMultiFileResponse(filesData, indexInfo, unindexedNote);
   })(args);
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -98,6 +98,8 @@ Returns for each file:
 ALWAYS check testAssociations before modifying source code.
 After changes, remind the user to run the associated tests.
 
+If a filepath isn't in the index at all (typo, wrong directory prefix, wrong case), the response says so via \`note\` — empty chunks/testAssociations by themselves do NOT mean "no dependents, safe to edit"; they can also mean the path was never found. Check \`note\` for this before trusting an empty result.
+
 May include complexityHeadroom: functions already at/near their complexity budget (cyclomatic/cognitive) — steer clear of adding to them. When present, complexityHeadroomWarning is a one-line imperative summary of the same data — read it first.
 
 Batch calls are more efficient than multiple single-file calls.`,
@@ -141,7 +143,8 @@ Returns:
 - riskLevel: "low" | "medium" | "high" | "critical"
 - dependents[]: { filepath, isTestFile, usages[]? }
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
-- totalUsageCount?: number (when symbol parameter provided)`,
+- totalUsageCount?: number (when symbol parameter provided)
+- note?: present and explicit when \`filepath\` has no entry in the index at all — a dependentCount of 0 / riskLevel "low" can otherwise look identical whether the file genuinely has no dependents or the path was never indexed`,
   ),
   toMCPToolSchema(
     GetComplexitySchema,
@@ -168,6 +171,7 @@ Returns:
 - summary: { filesAnalyzed, avgComplexity, maxComplexity, violationCount, bySeverity: { error, warning } }
 - violations[]: { filepath, symbolName, symbolType, complexity, metricType, threshold, severity, riskLevel, dependentCount }
 - metricType: "cyclomatic" | "cognitive" | "halstead_effort" | "halstead_bugs"
-- severity: "error" | "warning"`,
+- severity: "error" | "warning"
+- note?: present and explicit when a requested \`files\` entry has no index entry at all — filesAnalyzed silently excludes it otherwise`,
   ),
 ];

--- a/packages/cli/src/mcp/utils/unindexed-paths.test.ts
+++ b/packages/cli/src/mcp/utils/unindexed-paths.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { findUnindexedPaths, formatUnindexedPathsNote } from './unindexed-paths.js';
+import type { VectorDBInterface } from '@liendev/core';
+
+const getIndexedFilesMock = vi.fn<() => Promise<string[]>>();
+
+vi.mock('@liendev/core', async () => {
+  const actual = await vi.importActual('@liendev/core');
+  return {
+    ...actual,
+    ManifestManager: class {
+      getIndexedFiles = getIndexedFilesMock;
+    },
+  };
+});
+
+function makeVectorDB(dbPath = '/fake/index/path'): VectorDBInterface {
+  return { dbPath } as unknown as VectorDBInterface;
+}
+
+describe('findUnindexedPaths', () => {
+  it('returns nothing when every requested path is in the manifest', async () => {
+    getIndexedFilesMock.mockResolvedValue(['Command/Command.php', 'Application.php']);
+    const result = await findUnindexedPaths(makeVectorDB(), ['Command/Command.php'], '/workspace');
+    expect(result).toEqual([]);
+  });
+
+  it('reports a filepath with no manifest entry at all', async () => {
+    getIndexedFilesMock.mockResolvedValue(['Command/Command.php']);
+    const result = await findUnindexedPaths(
+      makeVectorDB(),
+      ['src/Command/Command.php'],
+      '/workspace',
+    );
+    expect(result).toEqual(['src/Command/Command.php']);
+  });
+
+  it('in a mixed batch, reports only the unindexed entries — a good path never masks a bad one', async () => {
+    getIndexedFilesMock.mockResolvedValue(['Command/Command.php']);
+    const result = await findUnindexedPaths(
+      makeVectorDB(),
+      ['Command/Command.php', 'does/not/exist.php'],
+      '/workspace',
+    );
+    expect(result).toEqual(['does/not/exist.php']);
+  });
+
+  it('canonicalizes against the workspace root before comparing', async () => {
+    getIndexedFilesMock.mockResolvedValue(['Command/Command.php']);
+    const result = await findUnindexedPaths(
+      makeVectorDB(),
+      ['/workspace/Command/Command.php'],
+      '/workspace',
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('fails open (reports nothing unindexed) when the manifest read throws', async () => {
+    getIndexedFilesMock.mockRejectedValue(new Error('disk on fire'));
+    const result = await findUnindexedPaths(makeVectorDB(), ['Command/Command.php'], '/workspace');
+    expect(result).toEqual([]);
+  });
+
+  it('fails open when dbPath is missing (e.g. a test mock that never set one)', async () => {
+    // ManifestManager's real constructor throws synchronously on a non-string
+    // indexPath; the mock above doesn't reproduce that, so drive it through
+    // the real class for this one case.
+    vi.doUnmock('@liendev/core');
+    const realModule = (await vi.importActual('./unindexed-paths.js')) as {
+      findUnindexedPaths: typeof findUnindexedPaths;
+    };
+    const realFindUnindexedPaths = realModule.findUnindexedPaths;
+    const result = await realFindUnindexedPaths(
+      makeVectorDB(undefined as unknown as string),
+      ['Command/Command.php'],
+      '/workspace',
+    );
+    expect(result).toEqual([]);
+  });
+});
+
+describe('formatUnindexedPathsNote', () => {
+  it('returns undefined when nothing is unindexed', () => {
+    expect(formatUnindexedPathsNote([])).toBeUndefined();
+  });
+
+  it('names every unindexed path and is unmissable (⚠ Lien: prefix)', () => {
+    const note = formatUnindexedPathsNote(['src/Command/Command.php', 'does/not/exist.php']);
+    expect(note).toContain('⚠ Lien:');
+    expect(note).toContain('"src/Command/Command.php"');
+    expect(note).toContain('"does/not/exist.php"');
+  });
+});

--- a/packages/cli/src/mcp/utils/unindexed-paths.ts
+++ b/packages/cli/src/mcp/utils/unindexed-paths.ts
@@ -1,0 +1,60 @@
+import { ManifestManager } from '@liendev/core';
+import type { VectorDBInterface } from '@liendev/core';
+import { getCanonicalPath } from '@liendev/parser';
+
+/**
+ * Of `filepaths`, the subset with no entry in the index manifest at all.
+ *
+ * `get_files_context`, `get_dependents`, and `get_complexity` all answer
+ * questions about a caller-supplied filepath by querying the chunk/dependency
+ * data for that path — and a path the index has never heard of (a typo'd
+ * directory prefix, wrong case, a file outside the indexed project) produces
+ * exactly the same shape as a real file that legitimately has zero
+ * chunks/dependents/violations: an empty result, reported with full
+ * confidence. That silent conflation is dangerous specifically because these
+ * are the tools an agent is told to trust before editing — an unknown path
+ * masquerading as "this file has no dependents" reads as "safe to edit
+ * carelessly".
+ *
+ * The manifest (`ManifestManager.getIndexedFiles()`) is the cheap way to
+ * break the tie: it's the indexer's own ledger of "these paths are indexed",
+ * independent of how many chunks each one produced, so a lookup here doesn't
+ * require a full `scanAll` and doesn't get confused by a file that is indexed
+ * but genuinely empty.
+ */
+export async function findUnindexedPaths(
+  vectorDB: VectorDBInterface,
+  filepaths: readonly string[],
+  workspaceRoot: string,
+): Promise<string[]> {
+  // Fail open, mirroring ManifestManager.load()'s own policy: this is a
+  // diagnostic add-on, not load-bearing, so a missing/unreadable manifest
+  // must never surface as a false "unindexed" claim or crash the handler.
+  try {
+    const manifest = new ManifestManager(vectorDB.dbPath);
+    const indexedFiles = await manifest.getIndexedFiles();
+    const indexedCanonical = new Set(indexedFiles.map(f => getCanonicalPath(f, workspaceRoot)));
+    return filepaths.filter(fp => !indexedCanonical.has(getCanonicalPath(fp, workspaceRoot)));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Render an unmissable note for filepaths the index has no record of,
+ * mirroring the imperative, `⚠ Lien:`-prefixed tone of
+ * `formatComplexityHeadroomWarning` (get-files-context.ts) — this is the same
+ * "make it unmissable" step, just for a different signal. Returns `undefined`
+ * when every path is known, so callers can spread it in conditionally without
+ * an extra length check.
+ */
+export function formatUnindexedPathsNote(unindexedPaths: readonly string[]): string | undefined {
+  if (unindexedPaths.length === 0) return undefined;
+  const list = unindexedPaths.map(p => `"${p}"`).join(', ');
+  return (
+    `⚠ Lien: not found in the index: ${list}. This is NOT the same as "indexed with ` +
+    `no results" — do not treat it as a low-risk or dependency-free file. Check for a ` +
+    `typo (missing/extra directory prefix, wrong case) before editing; try search_code ` +
+    `or list_functions to find the real path, or run "lien index" if the file was added recently.`
+  );
+}


### PR DESCRIPTION
## Summary

**Headline defect: `get_dependents` on an unindexed path returns `riskLevel: "low"` — the literal "safe to edit" signal.** A path the index has never heard of (typo'd directory prefix, wrong case, a file outside the indexed project) comes back with `dependentCount: 0`, `riskLevel: "low"`, `riskReasoning: []`. That's not merely a missing warning — it's the exact affirmative signal the tool exists to produce when a file genuinely has no dependents, emitted instead for a file that was never found at all. For the one tool whose entire job is to catch "is this safe to change?" before an edit, a wrong risk verdict is a worse defect than an empty context payload.

`get_files_context` and `get_complexity` have the identical root cause and I confirmed both genuinely have it (this is not a speculative sweep): none of the three checks whether a caller-supplied filepath is actually in the index before answering. All three query chunk/dependency data directly, and an unindexed path produces exactly the same shape as a real file that legitimately has zero chunks/dependents/violations — a confident, empty (or falsely-reassuring) success with no way to tell the two cases apart.

`search_code`, `find_similar`, and `list_functions` were checked and correctly excluded: they take a query/pattern rather than a filepath, a 0-results answer to "does anything match this keyword" is a legitimate and different outcome, and all three already document their own 0-results notes for that reason. The defect is specific to the three filepath-taking handlers above.

## Fix

- New `packages/cli/src/mcp/utils/unindexed-paths.ts`: `findUnindexedPaths()` checks requested filepaths against `ManifestManager.getIndexedFiles()` — the indexer's own ledger of what's indexed, independent of chunk count. Reusing the existing manifest rather than adding a new scan is the right call here: it's what distinguishes "not indexed" from "indexed but genuinely empty" without a fresh `scanAll`. `formatUnindexedPathsNote()` renders an unmissable `⚠ Lien:`-prefixed note (same tone as the existing `complexityHeadroomWarning`).
- Wired into all three handlers via the existing `note` response field — the same diagnostic-note convention `search_code`/`find_similar`/`list_functions` already use, not a new shape.
- A mixed batch (some good paths, some bad) reports exactly the unindexed entries by name — one bad path can't hide behind a good one, and the design deliberately never throws: a mixed batch still returns every valid entry's real data, with the invalid one clearly marked instead of failing the whole call.
- **Fails open** on any manifest-read error (missing `dbPath`, unreadable file, etc.) — mirrors `ManifestManager.load()`'s own fail-open policy. This diagnostic addition can never crash a handler or false-flag a path just because the manifest was momentarily unreadable; a reviewer would otherwise reasonably ask what happens there.
- Updated the three tool descriptions in `packages/cli/src/mcp/tools.ts` to document the new `note` behavior.

## How this was found

Found via a foreign-repo dogfood of Lien's own MCP tools, not a fixture or a fuzzer: I hit this by guessing a plausible `src/` prefix against a real clone of `symfony/console`, which doesn't use that layout (the actual path is `Command/Command.php`, no `src/`). That's an easy, ordinary mistake for an agent working an unfamiliar repo — exactly Lien's target usage — which is what makes this reachable in practice rather than only in adversarial testing.

## Dogfood evidence (real symfony/console clone, real MCP surface)

Reproduced via a minimal stdio MCP client issuing real `callTool` requests against the actual built CLI (`node dist/index.js serve`) — not calling the handler functions directly.

**`get_dependents` — the risk-verdict bug, before:**
```json
{
  "filepath": "src/Command/Command.php",
  "dependentCount": 0,
  "productionDependentCount": 0,
  "riskLevel": "low",
  "riskReasoning": [],
  "dependents": []
}
```
No error, no warning — reads as "nothing depends on this, safe to change."

**`get_dependents`, after** — same call, now also carries:
```json
"note": "⚠ Lien: not found in the index: \"src/Command/Command.php\". This is NOT the same as \"indexed with no results\" — do not treat it as a low-risk or dependency-free file. Check for a typo (missing/extra directory prefix, wrong case) before editing; try search_code or list_functions to find the real path, or run \"lien index\" if the file was added recently."
```

**`get_files_context` — before:**
```json
{ "file": "src/Command/Command.php", "chunks": [], "testAssociations": [] }
```
**After:** same `chunks`/`testAssociations`, plus the identical `note` shown above.

**Good path unaffected** (`Command/Command.php`, the real path): 6 real chunks returned for `get_files_context`, `get_dependents` reports its real dependent count — only the pre-existing truncation note present, no unindexed-path note in either case.

**Mixed batch** (`get_files_context` with `["Command/Command.php", "does/not/exist.php"]`):
```
note: ⚠ Lien: not found in the index: "does/not/exist.php". ...
files["Command/Command.php"].chunks.length > 0
files["does/not/exist.php"].chunks == []
```
The bad entry is named explicitly; the good entry's real data is untouched — confirms the no-throw, mixed-batch design works as intended.

**`get_complexity`** with `files: ["src/Command/Command.php"]` — before: `filesAnalyzed: 0`, no note. After: same, plus the note. In a mixed batch (`["Command/Command.php", "src/does/not/exist.php"]`), `filesAnalyzed: 1` with the note naming only the bad entry. A whole-codebase sweep (no `files` param) is untouched — no manifest check runs, no note.

**Secondary finding (separate, pre-existing, out of scope for this PR):** while gathering this evidence, `get_dependents` on the bad path at one point returned the *same* `dependentCount`/`riskLevel` as the real path (93 dependents) rather than 0. This traces to `matchesFile`'s import-path fuzzy matching being permissive enough that a PHP namespace-resolved import specifier coincidentally collided with the guessed path — a real, separate bug in path-matching heuristics, unrelated to this fix (this PR's `note` still correctly flags the path as absent from the manifest regardless of what the dependent-count heuristic returns). Flagging for a follow-up, not fixing here to stay in scope.

## Gates

All six pre-commit gates green in a clean worktree branched from `origin/main` (isolated from unrelated concurrent work in progress elsewhere in the repo):
- `npm run format:check` ✅
- `npm run lint` ✅ (0 errors; 38 pre-existing warnings unrelated to this change)
- `npm run typecheck` ✅
- `npm run build` ✅
- `npm test` ✅ (parser 27, core 1387, review 378, action 41, cli 1270 — all packages, exit 0)
- `lien delta` ✅ (exit 0 — 4 pre-existing functions worsened slightly but none crossed threshold; new code (`findUnindexedPaths`, `formatUnindexedPathsNote`) at cognitive complexity 1)

## Test plan

- [x] Unit tests for `findUnindexedPaths`/`formatUnindexedPathsNote`: manifest hit/miss, mixed batch, workspace-root canonicalization, fail-open on a throwing manifest read, fail-open on a missing `dbPath`
- [x] `get_dependents`: unindexed path note, no note when indexed
- [x] `get_files_context`: unindexed single path, indexed-but-empty path (no false positive), mixed batch
- [x] `get_complexity`: unindexed single file, mixed batch, no note for a whole-codebase sweep (no `files` param)
- [x] Full existing suite re-verified green (no regressions from the new manifest check)

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a diagnostic layer that distinguishes unindexed filepaths from genuinely empty results in three filepath-taking MCP handlers (`get_files_context`, `get_dependents`, `get_complexity`). The core logic in `unindexed-paths.ts` checks requested paths against `ManifestManager.getIndexedFiles()`, fails open on any manifest error, and renders a prominent `note` field. The change is localized, well-tested, and the response-shape additions are optional fields documented in the tool descriptions. No callers are broken: the new `note` parameter is optional in `buildSingleFileResponse`/`buildMultiFileResponse`, and sibling handlers that take queries rather than filepaths correctly do not need the check.
>
> - New `findUnindexedPaths`/`formatUnindexedPathsNote` utilities wired into the three filepath-based MCP handlers
> - Optional `note` field added to handler responses without changing existing field semantics
> - Intentional fail-open behavior on manifest read errors to avoid false-flagging indexed paths

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9f06c3e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->