### PR TITLE
fix(cli,parser): symbol-level dependent attribution false zeros

### DIFF
--- a/.changeset/symbol-level-dependent-attribution.md
+++ b/.changeset/symbol-level-dependent-attribution.md
@@ -1,0 +1,39 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Fix `get_dependents({ filepath, symbol })` reporting `dependentCount: 0` /
+`riskLevel: "low"` for methods, constructors, and package-qualified
+functions that have real callers (e.g. Go's `bytesconv.StringToBytes`, PHP's
+`Cursor::__construct`). CLAUDE.md marks this exact call **REQUIRED** before
+any signature change, so the false zero was a confident "safe to edit"
+verdict on code with many callers.
+
+Two independent causes, both fixed:
+
+- No language's import statement names a class member or (for Go) a
+  package's individual function independently of the class/package itself
+  (`use Ns\Cursor;` records `Cursor`, never `__construct`; `import
+  "app/bytesconv"` records `bytesconv`, never `StringToBytes`). Once a
+  chunk is confirmed to import from the target path at all, `get_dependents`
+  now also accepts a real call site named `symbol` in that same chunk as
+  evidence. When neither a named import nor a call site can confirm usage
+  and `symbol` isn't a top-level export (the structural shape of a
+  method/constructor query), the response degrades to the file-level answer
+  instead of asserting an unverifiable symbol-scoped zero, and sets
+  `symbolAttributionDegraded: true` plus a `symbolAttributionNote` so
+  callers can tell a floor from a verified count.
+- Go's grouped `import (...)` blocks only ever recorded the first non-stdlib
+  spec's symbols, silently dropping every import after it in the same
+  declaration from `chunk.metadata.importedSymbols` (confirmed on real gin
+  source: `render/json.go` groups `codec/json` and `internal/bytesconv`
+  together; only `codec/json` was ever recorded). `processImportSymbols`
+  callers now go through a new `processImportSymbolsList`, mirroring the
+  existing `extractImportPaths`/`toImportPathsArray` pattern for the plural
+  case.
+
+Verifying the PHP case against a real symfony/console checkout also
+surfaced a PSR-4 empty-root resolution bug that made `get_dependents`
+return false zeros even for plain class-name and file-level queries there —
+independently found and fixed by #926, since merged.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -291,6 +291,129 @@ describe('findDependents', () => {
     });
   });
 
+  describe('qualified-access fallback (methods, constructors, package-level functions)', () => {
+    it('Go-style: a package-qualified function call is attributed via callSites even though importedSymbols only records the package alias', async () => {
+      // Go's `import "internal/bytesconv"` records the package alias
+      // ("bytesconv") in importedSymbols, never the individual function
+      // called through it -- the real evidence lives in callSites instead.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('internal/bytesconv/bytesconv.go', { exports: ['StringToBytes'] }),
+        createChunk('auth.go', {
+          imports: ['internal/bytesconv'],
+          importedSymbols: { 'internal/bytesconv': ['bytesconv'] },
+          callSites: [{ symbol: 'StringToBytes', line: 37 }],
+          symbolName: 'basicAuth',
+        }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'internal/bytesconv/bytesconv.go',
+        mockLog,
+        'StringToBytes',
+      );
+
+      expect(result.dependents).toHaveLength(1);
+      expect(result.dependents[0].filepath).toBe('auth.go');
+      expect(result.totalUsageCount).toBe(1);
+      expect(result.symbolAttributionDegraded).toBeUndefined();
+    });
+
+    it('does not attribute a same-named call site from a file that imports a different package', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('internal/bytesconv/bytesconv.go', { exports: ['StringToBytes'] }),
+        createChunk('unrelated.go', {
+          imports: ['internal/other'],
+          importedSymbols: { 'internal/other': ['other'] },
+          callSites: [{ symbol: 'StringToBytes', line: 5 }],
+        }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'internal/bytesconv/bytesconv.go',
+        mockLog,
+        'StringToBytes',
+      );
+
+      expect(result.dependents).toHaveLength(0);
+    });
+
+    it('PHP-style: a method call is attributed via callSites even though importedSymbols only records the class name', async () => {
+      // `use ...\\Cursor;` records the class name in importedSymbols, never
+      // the method invoked on an instance of it.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Cursor.php', { exports: ['Cursor'] }),
+        createChunk('QuestionHelper.php', {
+          imports: ['Cursor'],
+          importedSymbols: { Cursor: ['Cursor'] },
+          callSites: [{ symbol: 'moveUp', line: 265 }],
+          symbolName: 'someMethod',
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Cursor.php', mockLog, 'moveUp');
+
+      expect(result.dependents).toHaveLength(1);
+      expect(result.dependents[0].filepath).toBe('QuestionHelper.php');
+      expect(result.totalUsageCount).toBe(1);
+    });
+
+    it('degrades to file-level dependents when the symbol is not a top-level export and no call site confirms usage (constructor shape)', async () => {
+      // PHP's `new Cursor(...)` isn't tracked as a call site at all (the
+      // parser gap), and `__construct` is never a top-level PHP export --
+      // the structural signature of an unresolvable symbol query. Reporting
+      // the symbol-scoped zero here would read as "no callers, safe to
+      // change" even though QuestionHelper.php genuinely imports Cursor.php.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Cursor.php', { exports: ['Cursor'] }),
+        createChunk('QuestionHelper.php', {
+          imports: ['Cursor'],
+          importedSymbols: { Cursor: ['Cursor'] },
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Cursor.php', mockLog, '__construct');
+
+      expect(result.symbolAttributionDegraded).toBe(true);
+      expect(result.dependents).toHaveLength(1);
+      expect(result.dependents[0].filepath).toBe('QuestionHelper.php');
+      expect(result.totalUsageCount).toBeUndefined();
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("isn't a top-level export"),
+        'warning',
+      );
+    });
+
+    it('does not degrade (stays a real empty result) when there are no file-level dependents at all', async () => {
+      // The structural gap distinct from the one above (see #869): a
+      // whole-module-import language can have zero import edges into a
+      // file at all, so there is no file-level answer to widen to either.
+      // Must not fabricate dependents where none can be found.
+      mockDB.scanAll.mockResolvedValue([createChunk('Session.swift', { exports: ['Session'] })]);
+
+      const result = await findDependents(mockDB as any, 'Session.swift', mockLog, 'validate');
+
+      expect(result.symbolAttributionDegraded).toBeUndefined();
+      expect(result.dependents).toHaveLength(0);
+    });
+
+    it('does not degrade when the symbol IS a top-level export with zero real usages (true negative)', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/target.ts', { exports: ['Foo', 'Bar'] }),
+        createChunk('src/unrelated.ts', {
+          imports: ['src/target.ts'],
+          importedSymbols: { 'src/target': ['Bar'] },
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'Foo');
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.symbolAttributionDegraded).toBeUndefined();
+    });
+  });
+
   describe('complexity metrics', () => {
     it('should calculate correct file and overall complexity metrics', async () => {
       mockDB.scanAll.mockResolvedValue([

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -106,6 +106,15 @@ export interface DependencyAnalysisResult {
   truncated: boolean;
   /** Count of production dependents that are NOT imported by any test file. */
   uncoveredProductionDependents: number;
+  /**
+   * True when `symbol` was requested but couldn't be attributed at the
+   * symbol level (it isn't a top-level export of the target file -- the
+   * signature of a method or constructor, which no import statement in any
+   * language names independently of its class -- see `buildDependentsList`),
+   * so `dependents`/`riskLevel` were widened to the full file-level answer
+   * instead of asserting an unverifiable symbol-scoped count.
+   */
+  symbolAttributionDegraded?: boolean;
 }
 
 /**
@@ -156,6 +165,23 @@ function buildReExportGraph(
  *
  * Uses `importMatchesTarget`, which applies the #884 whole-module guard
  * before `matchesFile` — see its doc comment in path-matching.ts (#886).
+ *
+ * Qualified-access fallback: no language's import statement names a class's
+ * members, or (for Go) a package's individual functions, independently of
+ * the class/package itself -- `use Ns\\Cursor;` records `Cursor`, never
+ * `__construct`; Go's `import "app/bytesconv"` records the package alias
+ * `bytesconv`, never `StringToBytes`. Requiring a literal `targetSymbol`
+ * match inside `importedSymbols` for those cases means the check can never
+ * pass, even though the call site itself (`bytesconv.StringToBytes(...)`,
+ * `$cursor->moveUp()`) is genuine, correctly-attributed evidence -- and a
+ * caller mandated to check this before touching a method/constructor/
+ * package-level function would see a false "0 dependents, low risk"
+ * all-clear on code with real callers. So once a chunk is confirmed to
+ * import from the target path at all, a real call site named
+ * `targetSymbol` in that same chunk is accepted too -- the same category of
+ * trade-off already documented on `findSymbolUsages` below for JS namespace
+ * imports (occasional same-name false positives, far better than a
+ * guaranteed false negative for every member/qualified symbol).
  */
 function fileImportsSymbolFromAny(
   chunks: SearchResult[],
@@ -167,14 +193,19 @@ function fileImportsSymbolFromAny(
     const importedSymbols = chunk.metadata.importedSymbols;
     if (!importedSymbols) return false;
 
-    return Object.entries(importedSymbols).some(([importPath, symbols]) => {
-      const pathMatches = targetPaths.some(tp =>
+    const entriesFromTarget = Object.entries(importedSymbols).filter(([importPath]) =>
+      targetPaths.some(tp =>
         importMatchesTarget(importPath, chunk.metadata.file, tp, normalizePathCached),
-      );
-      return (
-        pathMatches && (symbols.includes(targetSymbol) || symbols.some(s => s.startsWith('* as ')))
-      );
-    });
+      ),
+    );
+    if (entriesFromTarget.length === 0) return false;
+
+    const namedMatch = entriesFromTarget.some(
+      ([, symbols]) => symbols.includes(targetSymbol) || symbols.some(s => s.startsWith('* as ')),
+    );
+    if (namedMatch) return true;
+
+    return (chunk.metadata.callSites ?? []).some(cs => cs.symbol === targetSymbol);
   });
 }
 
@@ -307,6 +338,19 @@ function groupChunksByFile(chunks: SearchResult[]): Map<string, SearchResult[]> 
 
 /**
  * Build the dependents list, either file-level or symbol-level.
+ *
+ * When `symbol` doesn't resolve to any usage AND it isn't one of the target
+ * file's own top-level exports, that combination is the structural
+ * signature of a method or constructor query (#928-adjacent) -- no
+ * language's import statement names a class member independently of its
+ * class, so neither the named-import check nor its call-site fallback in
+ * `fileImportsSymbolFromAny` had anything to key off. Asserting the
+ * symbol-scoped zero in that case would read as "no callers, safe to
+ * change" on a file that may have real file-level dependents, so this
+ * degrades to the file-level answer instead (`symbolAttributionDegraded`
+ * tells the caller the count is a widened floor, not a verified
+ * per-symbol count) -- getting the failure mode right beats asserting a
+ * precise count we can't actually back up.
  */
 function buildDependentsList(
   chunksByFile: Map<string, SearchResult[]>,
@@ -317,22 +361,40 @@ function buildDependentsList(
   filepath: string,
   log: (message: string, level?: 'warning') => void,
   reExporterPaths: string[] = [],
-): { dependents: DependentInfo[]; totalUsageCount?: number } {
+): { dependents: DependentInfo[]; totalUsageCount?: number; symbolAttributionDegraded?: boolean } {
   if (symbol) {
-    // Validate that the target file exports this symbol
-    validateSymbolExport(targetFileChunks, symbol, filepath, log);
+    const exportsSymbol = validateSymbolExport(targetFileChunks, symbol, filepath, log);
 
     // Symbol-level analysis — check imports from target AND re-exporter paths
-    return findSymbolUsages(
+    const symbolResult = findSymbolUsages(
       chunksByFile,
       symbol,
       normalizedTarget,
       normalizePathCached,
       reExporterPaths,
     );
+
+    if (!exportsSymbol && symbolResult.dependents.length === 0 && chunksByFile.size > 0) {
+      log(
+        `Note: "${symbol}" isn't a top-level export of ${filepath} (likely a method or ` +
+          `constructor) — symbol-level usage could not be confirmed. Falling back to ` +
+          `file-level dependents.`,
+        'warning',
+      );
+      return { ...buildFileLevelDependents(chunksByFile), symbolAttributionDegraded: true };
+    }
+
+    return symbolResult;
   }
 
-  // File-level analysis
+  return buildFileLevelDependents(chunksByFile);
+}
+
+/** File-level dependents: every file in `chunksByFile`, regardless of symbol. */
+function buildFileLevelDependents(chunksByFile: Map<string, SearchResult[]>): {
+  dependents: DependentInfo[];
+  totalUsageCount?: number;
+} {
   const dependents = Array.from(chunksByFile.keys()).map(fp => ({
     filepath: fp,
     isTestFile: isTestFile(fp),
@@ -345,26 +407,30 @@ function buildDependentsList(
  * Validate that the target file exports the requested symbol.
  *
  * Design decision: This function only logs a warning and does NOT throw an error
- * or return false to stop execution. This is intentional because:
+ * or stop execution on a miss. This is intentional because:
  *
  * 1. The export might be dynamic or conditional (not captured by static analysis)
  * 2. False positives are better than false negatives (we want to show potential matches)
  * 3. The user can see the warning and interpret results accordingly
  *
- * The function continues to search for usages even if the symbol isn't found in exports,
- * which may reveal re-exports, dynamic exports, or help diagnose indexing issues.
+ * The caller continues to search for usages even when this returns false, which may
+ * reveal re-exports, dynamic exports, or help diagnose indexing issues. The boolean
+ * return additionally lets `buildDependentsList` distinguish "genuinely zero callers"
+ * from "not a top-level export at all" (methods/constructors) — see its doc comment.
  */
 function validateSymbolExport(
   targetFileChunks: SearchResult[],
   symbol: string,
   filepath: string,
   log: (message: string, level?: 'warning') => void,
-): void {
+): boolean {
   const exportsSymbol = targetFileChunks.some(chunk => chunk.metadata.exports?.includes(symbol));
 
   if (!exportsSymbol) {
     log(`Warning: Symbol "${symbol}" not found in exports of ${filepath}`, 'warning');
   }
+
+  return exportsSymbol;
 }
 
 /**
@@ -533,7 +599,7 @@ export async function findDependents(
   });
 
   const targetFileChunks = symbol ? (allChunksByFile.get(normalizedTarget) ?? []) : [];
-  const { dependents, totalUsageCount } = buildDependentsList(
+  const { dependents, totalUsageCount, symbolAttributionDegraded } = buildDependentsList(
     chunksByFile,
     symbol,
     normalizedTarget,
@@ -579,6 +645,7 @@ export async function findDependents(
     totalUsageCount,
     truncated,
     uncoveredProductionDependents,
+    symbolAttributionDegraded,
   };
 }
 

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -62,6 +62,7 @@ describe('handleGetDependents', () => {
       totalUsageCount?: number;
       truncated?: boolean;
       uncoveredProductionDependents?: number;
+      symbolAttributionDegraded?: boolean;
     } = {},
   ) {
     const dependents = overrides.dependents ?? [{ filepath: 'src/consumer.ts', isTestFile: false }];
@@ -86,6 +87,7 @@ describe('handleGetDependents', () => {
       totalUsageCount: overrides.totalUsageCount,
       truncated: overrides.truncated ?? false,
       uncoveredProductionDependents: overrides.uncoveredProductionDependents ?? 0,
+      symbolAttributionDegraded: overrides.symbolAttributionDegraded,
     };
   }
 
@@ -590,6 +592,46 @@ describe('handleGetDependents', () => {
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.symbol).toBeUndefined();
       expect(parsed.totalUsageCount).toBeUndefined();
+    });
+  });
+
+  describe('symbolAttributionDegraded (method/constructor symbols)', () => {
+    it('surfaces symbolAttributionDegraded and a note when the analyzer degrades to file-level', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({
+          dependents: [{ filepath: 'src/QuestionHelper.php', isTestFile: false }],
+          symbolAttributionDegraded: true,
+        }),
+        totalUsageCount: undefined,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'src/Cursor.php', symbol: '__construct' },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.symbolAttributionDegraded).toBe(true);
+      expect(parsed.symbolAttributionNote).toContain('__construct');
+      expect(parsed.symbolAttributionNote).toContain('top-level exports');
+      expect(parsed.dependentCount).toBe(1);
+      expect(parsed.totalUsageCount).toBeUndefined();
+    });
+
+    it('omits symbolAttributionDegraded and the note for a normal, non-degraded symbol query', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({ dependents: [{ filepath: 'src/a.ts', isTestFile: false }] }),
+        totalUsageCount: 1,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'src/utils/validate.ts', symbol: 'validateEmail' },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.symbolAttributionDegraded).toBeUndefined();
+      expect(parsed.symbolAttributionNote).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -47,6 +47,17 @@ interface DependentsResponse {
   complexityMetrics: ComplexityMetrics;
   /** Set when `filepath` has no entry in the index manifest at all — see unindexed-paths.ts. */
   note?: string;
+  /**
+   * True when `symbol` couldn't be attributed at the symbol level (it's not
+   * a top-level export of `filepath` -- the shape of a method or
+   * constructor) and the response was widened to file-level dependents
+   * instead of asserting an unverifiable symbol-scoped count. When set,
+   * treat `dependentCount`/`riskLevel` as a floor over ALL of this file's
+   * dependents, not a confirmed count of callers of `symbol` specifically.
+   */
+  symbolAttributionDegraded?: boolean;
+  /** Human-readable explanation, present only when `symbolAttributionDegraded` is true. */
+  symbolAttributionNote?: string;
 }
 
 /**
@@ -60,6 +71,14 @@ function logRiskAssessment(
 ): void {
   const prodTest = `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test)`;
   const truncatedSuffix = analysis.truncated ? ' [truncated]' : '';
+
+  if (symbol && analysis.symbolAttributionDegraded) {
+    log(
+      `Symbol-level attribution degraded for "${symbol}" — falling back to ` +
+        `${analysis.dependents.length} file-level dependents ${prodTest} - risk: ${riskLevel}${truncatedSuffix}`,
+    );
+    return;
+  }
 
   if (symbol && analysis.totalUsageCount !== undefined) {
     if (analysis.totalUsageCount > 0) {
@@ -139,6 +158,15 @@ function buildDependentsResponse(
   }
   if (note) {
     response.note = note;
+  }
+  if (analysis.symbolAttributionDegraded) {
+    response.symbolAttributionDegraded = true;
+    response.symbolAttributionNote =
+      `"${symbol}" doesn't appear in ${filepath}'s tracked top-level exports (likely a ` +
+      `method or constructor — no import statement names one of those independently of ` +
+      `its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, ` +
+      `riskLevel, and dependents below are the file-level answer (every file that imports ` +
+      `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`;
   }
 
   return response;

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -37,7 +37,12 @@ export const GetDependentsSchema = z.object({
       'Optional: specific exported symbol to find usages of.\n\n' +
         'When provided, returns call sites instead of just importing files.\n\n' +
         "Example: 'validateEmail' to find where validateEmail() is called.\n\n" +
-        "Response includes 'usages' array showing which functions call this symbol.",
+        "Response includes 'usages' array showing which functions call this symbol.\n\n" +
+        "Also accepts a method or constructor name (e.g. '__construct', 'moveUp').\n" +
+        "Those aren't top-level exports, so when call sites for one can't be " +
+        'confirmed, the response sets symbolAttributionDegraded: true and widens ' +
+        'dependentCount/riskLevel to the file-level answer rather than asserting an ' +
+        'unverifiable symbol-scoped count — check that flag before trusting a low count.',
     ),
 
   depth: z

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -144,7 +144,11 @@ Returns:
 - dependents[]: { filepath, isTestFile, usages[]? }
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
 - totalUsageCount?: number (when symbol parameter provided)
-- note?: present and explicit when \`filepath\` has no entry in the index at all — a dependentCount of 0 / riskLevel "low" can otherwise look identical whether the file genuinely has no dependents or the path was never indexed`,
+- note?: present and explicit when \`filepath\` has no entry in the index at all — a dependentCount of 0 / riskLevel "low" can otherwise look identical whether the file genuinely has no dependents or the path was never indexed
+- symbolAttributionDegraded?: boolean + symbolAttributionNote?: string — set when
+  symbol names a method or constructor (not a top-level export) and call sites
+  couldn't be confirmed; dependentCount/riskLevel are then the file-level answer
+  (every importer of filepath), not a verified count of callers of symbol itself`,
   ),
   toMCPToolSchema(
     GetComplexitySchema,

--- a/packages/parser/src/ast/extractors/types.ts
+++ b/packages/parser/src/ast/extractors/types.ts
@@ -139,6 +139,32 @@ export interface LanguageImportExtractor {
   ): { importPath: string; symbols: string[] } | null;
 
   /**
+   * Extract ALL imported-symbol mappings from a single import declaration node.
+   *
+   * Most languages have exactly one importPath per declaration, so the
+   * default shape is `processImportSymbols(node)` wrapped in an array (see
+   * `toImportSymbolsArray`). Go's grouped `import (...)` blocks can name
+   * several distinct external packages from one declaration node -- the
+   * same multi-target shape `extractImportPaths` already handles for the
+   * plain-path list (#863) -- so its implementation overrides this to
+   * return every target's symbols instead of silently dropping all but the
+   * first non-stdlib spec, which otherwise leaves `chunk.metadata.
+   * importedSymbols` missing an entry for every import after the first in
+   * the same declaration (confirmed on real gin source: `render/json.go`'s
+   * grouped import names both `codec/json` and `internal/bytesconv`, but
+   * the pre-fix singular `processImportSymbols` only ever recorded
+   * `codec/json`).
+   *
+   * @param node - AST node matching one of importNodeTypes
+   * @param rustCrateMap - Rust-only (#903) -- see `extractImportPaths`.
+   * @returns Every {importPath, symbols} pair declared by this node, in source order (empty if none)
+   */
+  processImportSymbolsList(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): Array<{ importPath: string; symbols: string[] }>;
+
+  /**
    * Extract additional "reference" import-like specifiers that name another
    * file's symbol WITHOUT going through this language's own import-
    * declaration syntax at all — so declaration-based extraction (the
@@ -177,4 +203,16 @@ export interface LanguageImportExtractor {
  */
 export function toImportPathsArray(path: string | null): string[] {
   return path ? [path] : [];
+}
+
+/**
+ * Default `processImportSymbolsList` shape for every language extractor that
+ * has exactly one importPath per declaration node: wrap `processImportSymbols`'s
+ * single result in an array (empty when it returns `null`). See
+ * `LanguageImportExtractor.processImportSymbolsList`.
+ */
+export function toImportSymbolsArray(
+  result: { importPath: string; symbols: string[] } | null,
+): Array<{ importPath: string; symbols: string[] }> {
+  return result ? [result] : [];
 }

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -11,7 +11,7 @@ import {
   extractParameters,
   clampSignatureLength,
 } from '../extractors/symbol-helpers.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -294,6 +294,10 @@ export class CSharpImportExtractor implements LanguageImportExtractor {
     const parts = path.split('.');
     const lastPart = parts[parts.length - 1];
     return { importPath: path, symbols: [lastPart] };
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   private getImportPath(node: SyntaxNode): string | null {

--- a/packages/parser/src/ast/languages/go.test.ts
+++ b/packages/parser/src/ast/languages/go.test.ts
@@ -342,6 +342,82 @@ import (
         );
       });
     });
+
+    describe('processImportSymbolsList (plural)', () => {
+      it('should record EVERY non-stdlib spec from a grouped import, not just the first', () => {
+        // The processImportSymbols analog of #863: a grouped import block
+        // naming two distinct non-stdlib targets used to silently drop the
+        // second from chunk.metadata.importedSymbols entirely -- confirmed
+        // on real gin source (render/json.go groups `codec/json` and
+        // `internal/bytesconv`; only the first ever made it into
+        // importedSymbols, which hid every StringToBytes caller in that file
+        // from symbol-level get_dependents queries).
+        const code = `package main
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"github.com/foo/models"
+)`;
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const results = importExtractor.processImportSymbolsList(importNode);
+
+        expect(results).toEqual([
+          { importPath: 'github.com/foo/utils', symbols: ['utils'] },
+          { importPath: 'github.com/foo/models', symbols: ['models'] },
+        ]);
+      });
+
+      it('should return a single-element array for a single (non-grouped) import', () => {
+        const code = 'package main\nimport "github.com/gin-gonic/gin"';
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const results = importExtractor.processImportSymbolsList(importNode);
+
+        expect(results).toEqual([{ importPath: 'github.com/gin-gonic/gin', symbols: ['gin'] }]);
+      });
+
+      it('should return an empty array for a stdlib-only grouped import', () => {
+        const code = 'package main\nimport (\n  "fmt"\n  "net/http"\n)';
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const results = importExtractor.processImportSymbolsList(importNode);
+
+        expect(results).toEqual([]);
+      });
+
+      it('preserves per-spec aliases across a grouped import', () => {
+        const code = `package main
+import (
+	"fmt"
+	router "github.com/gin-gonic/gin"
+	"github.com/foo/models"
+)`;
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+        const results = importExtractor.processImportSymbolsList(importNode);
+
+        expect(results).toEqual([
+          { importPath: 'github.com/gin-gonic/gin', symbols: ['router'] },
+          { importPath: 'github.com/foo/models', symbols: ['models'] },
+        ]);
+      });
+
+      it('keeps processImportSymbols (singular) agreeing with the first entry of the list', () => {
+        const code = `package main
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"github.com/foo/models"
+)`;
+        const root = mustParse(code, 'go');
+        const importNode = root.namedChild(1)!;
+
+        expect(importExtractor.processImportSymbols(importNode)).toEqual(
+          importExtractor.processImportSymbolsList(importNode)[0],
+        );
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -218,11 +218,27 @@ export class GoImportExtractor implements LanguageImportExtractor {
   }
 
   processImportSymbols(node: SyntaxNode): { importPath: string; symbols: string[] } | null {
-    // Collect all import specs from the declaration
-    const specs = this.collectImportSpecs(node);
+    return this.processImportSymbolsList(node)[0] ?? null;
+  }
 
-    // Process each spec, filtering out stdlib imports
-    for (const spec of specs) {
+  /**
+   * Returns EVERY non-stdlib spec's {importPath, symbols} from this
+   * declaration, not just the first -- the same multi-target gap
+   * `extractImportPaths` already closed for the plain path list (#863).
+   * `import (...)` blocks commonly group 2+ external packages (confirmed on
+   * real gin source: `render/json.go`'s single grouped import names both
+   * `codec/json` and `internal/bytesconv`), and the pre-fix singular-return
+   * `processImportSymbols` silently dropped every one after the first,
+   * leaving `chunk.metadata.importedSymbols` missing an entry for the
+   * dropped path entirely -- not just imprecise, but ABSENT, which made
+   * every downstream symbol-level consumer (e.g. MCP's `get_dependents`)
+   * blind to real dependents whose only recorded import happened to land on
+   * a later spec in the same block.
+   */
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    const results: Array<{ importPath: string; symbols: string[] }> = [];
+
+    for (const spec of this.collectImportSpecs(node)) {
       const path = this.getSpecRawPath(spec);
       if (!path || isStdLibImport(path)) continue;
 
@@ -232,10 +248,10 @@ export class GoImportExtractor implements LanguageImportExtractor {
       const defaultSymbol = parts[parts.length - 1];
       const symbol = alias || defaultSymbol;
 
-      return { importPath: path, symbols: [symbol] };
+      results.push({ importPath: path, symbols: [symbol] });
     }
 
-    return null;
+    return results;
   }
 
   private collectImportSpecs(node: SyntaxNode): SyntaxNode[] {

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -293,6 +293,10 @@ export class JavaImportExtractor implements LanguageImportExtractor {
     }
 
     return { importPath: path, symbols: [lastPart] };
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   private getImportPath(node: SyntaxNode): string | null {

--- a/packages/parser/src/ast/languages/javascript.ts
+++ b/packages/parser/src/ast/languages/javascript.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -353,6 +353,10 @@ export class JavaScriptImportExtractor implements LanguageImportExtractor {
       return this.processBareRequire(node);
     }
     return null;
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   private processImportStatement(

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -358,6 +358,10 @@ export class KotlinImportExtractor implements LanguageImportExtractor {
     const alias = childByType(node, 'import_alias');
     const aliasName = alias ? childByType(alias, 'type_identifier')?.text : undefined;
     return { importPath: path, symbols: [aliasName ?? lastPart] };
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   private getImportPath(node: SyntaxNode): string | null {

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -197,6 +197,10 @@ export class PHPImportExtractor implements LanguageImportExtractor {
 
     const grouped = this.firstGroupedTarget(node);
     return grouped ? { importPath: grouped.importPath, symbols: [grouped.alias] } : null;
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   /**

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -311,6 +311,10 @@ export class PythonImportExtractor implements LanguageImportExtractor {
       return this.processPythonFromImport(node);
     }
     return null;
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   private processSimpleImport(child: SyntaxNode): { importPath: string; symbols: string[] } {

--- a/packages/parser/src/ast/languages/ruby.ts
+++ b/packages/parser/src/ast/languages/ruby.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -197,6 +197,10 @@ export class RubyImportExtractor implements LanguageImportExtractor {
     const importPath = extractRequirePath(node);
     if (!importPath) return null;
     return { importPath, symbols: [moduleBasename(importPath)] };
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 }
 

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import {
   extractSignature,
   extractParameters,
@@ -355,6 +355,13 @@ export class RustImportExtractor implements LanguageImportExtractor {
     if (!argument) return null;
 
     return this.processUseArgument(argument, rustCrateMap);
+  }
+
+  processImportSymbolsList(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+  ): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node, rustCrateMap));
   }
 
   private processUseArgument(

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -6,7 +6,7 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { toImportPathsArray } from '../extractors/types.js';
+import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import { extractSignature, extractReturnType } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -301,6 +301,10 @@ export class SwiftImportExtractor implements LanguageImportExtractor {
     const parts = path.split('.');
     const lastPart = parts[parts.length - 1];
     return { importPath: path, symbols: [lastPart] };
+  }
+
+  processImportSymbolsList(node: SyntaxNode): Array<{ importPath: string; symbols: string[] }> {
+    return toImportSymbolsArray(this.processImportSymbols(node));
   }
 
   private getImportPath(node: SyntaxNode): string | null {

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -672,6 +672,38 @@ func run() {
     });
   });
 
+  describe('extractImportedSymbols - Go grouped imports', () => {
+    it('should record EVERY non-stdlib target from a grouped import, not just the first', () => {
+      // The extractImportedSymbols analog of #863: a grouped import naming
+      // two distinct non-stdlib packages used to leave chunk.metadata.
+      // importedSymbols missing an entry for every one after the first --
+      // confirmed on real gin source (render/json.go groups `codec/json`
+      // and `internal/bytesconv`; only `codec/json` made it into
+      // importedSymbols, hiding every bytesconv.StringToBytes call site in
+      // that file from symbol-level get_dependents queries).
+      const content = `
+package main
+
+import (
+	"fmt"
+	"github.com/foo/utils"
+	"github.com/foo/models"
+)
+
+func run() {
+	fmt.Println(utils.Format(models.Load()))
+}
+      `.trim();
+
+      const parseResult = parseAST(content, 'go');
+      const importedSymbols = extractImportedSymbols(parseResult.tree!.rootNode, 'go');
+
+      expect(importedSymbols['github.com/foo/utils']).toEqual(['utils']);
+      expect(importedSymbols['github.com/foo/models']).toEqual(['models']);
+      expect(importedSymbols['fmt']).toBeUndefined();
+    });
+  });
+
   describe('extractImports - Java static-member class-path fallback (#864)', () => {
     it('a specific static-member import now matches its defining class file end-to-end', () => {
       // Reproduces #864: `import static a.B.member;` extracted only the raw,

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -276,8 +276,8 @@ function extractSymbolsWithExtractor(
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
-    const result = importExtractor.processImportSymbols(node, manifestRoots?.rustCrateMap);
-    if (result) {
+    const results = importExtractor.processImportSymbolsList(node, manifestRoots?.rustCrateMap);
+    for (const result of results) {
       const key = resolveImportSpecifier(
         result.importPath,
         filepath,

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -326,6 +326,8 @@ Is it safe to change this file?
 
 When `symbol` is provided, the response also includes `totalUsageCount` (number of tracked call sites across all files) and each dependent may include a `usages` array with `callerSymbol`, `line`, and `snippet` fields.
 
+`symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`) — those aren't top-level exports, so when call sites for one can't be confirmed, the response sets `symbolAttributionDegraded: true` plus a `symbolAttributionNote` and widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count. Check that flag before treating a low count as verified.
+
 ### Risk Levels
 
 | Level | Dependent Count | Meaning |


### PR DESCRIPTION
## ✅ Rebased onto `main` — duplicate dropped, both new conflicts resolved

Update: `main` had #926 (older PSR-4 duplicate PR, now merged) **and** #927
(a separate "distinguish unindexed paths from empty results" fix that landed
concurrently and also touched `get-dependents.ts`/`tools.ts`) merged onto it
by the time I rebased. Both handled:

1. `git rebase origin/main`, dropping the duplicate PSR-4 commit
   (`84c56b6b`) — it conflicted (not a clean empty-apply) against #926's
   version of the same hunk, so I replaced `php-psr4.ts`/`php-psr4.test.ts`
   with `main`'s exact content and kept only the changeset addition, trimmed
   to no longer claim the PSR-4 fix as this PR's own (that credit belongs to
   #926 now).
2. A **second, unrelated conflict** against #927 in the same two files
   (`get-dependents.ts`, `tools.ts`) — #927 adds a `note?`/`findUnindexedPaths`
   field to the same response interface and response-builder function this
   PR extends with `symbolAttributionDegraded?`/`symbolAttributionNote?`.
   Both additions are independent (different response fields, different
   `if` blocks) so the resolution was additive — kept both, in both the
   interface and `buildDependentsResponse`. Re-verified end to end below
   (including a direct check that #927's own unindexed-path note still
   fires correctly post-rebase).

Final history: `83e010a0` (changeset-only, was `84c56b6b`) → `0566781f`
(the `a671e84e` symbol-attribution work, unchanged) → `f05b9e88` (#927,
merged) → `c7046a3d` (#926, merged) → ... `main`. Force-pushed with
`--force-with-lease`. All six gates re-run from scratch on this final tree
(not carried over from either intermediate state) — see below.

**One thing surfaced by the rebase that I want to flag rather than paper
over, per your instruction:** `riskLevel` for both `console` cases changed
from `"high"` (my last report) to `"low"` post-rebase. `dependentCount: 6`
and `symbolAttributionDegraded: true` are unchanged — exactly what you asked
me to confirm still holds. The `riskLevel` drop is a *correct* second-order
effect of #926's own fix reaching this surface: `Tests/CursorTest.php` and
`Tests/Command/InvokableCommandTest.php` are now properly recognized as
test files (`productionDependentCount: 4`, `testDependentCount: 2` — the
4/2 split you asked me to check, confirmed below), so the 4 real production
dependents are no longer misclassified as "untested" — they're actually
covered by the now-correctly-recognized test files, so the honest risk
reads lower. `complexityRiskBoost` in `complexityMetrics` is still
`"critical"` (the underlying complexity of `QuestionHelper.php`/
`ArgumentResolver.php` didn't change); it's specifically the untested-boost
component of the risk formula that no longer fires. I did not touch
anything risk-related — this is `main`'s own #926 code behaving correctly
against data this PR's fix newly exposes.

## Summary

`get_dependents({ filepath, symbol })` returned `dependentCount: 0` /
`riskLevel: "low"` for exported symbols with real callers whenever `symbol`
named a method, constructor, or Go package-level function reached only
through a qualified access (`bytesconv.StringToBytes(...)`,
`$cursor->moveUp()`) — because no language's import statement names a class
member (or, for Go, an individual function) independently of its
class/package. CLAUDE.md marks this exact call **REQUIRED** before any
signature change, so the false zero was a confident "safe to edit" verdict
on code with many callers. This is what PR #917's dogfood report flagged.

This picks up a WIP commit (`a671e84e`, now `0566781f` after rebase) left by
an agent that hit the org spend limit mid-`npm test`, judges it, finishes
verification, and originally fixed one more bug discovered along the way
(the PSR-4 duplicate of #926 — see the rebase note above; that fix now
comes from `main` instead).
## Summary

`get_dependents({ filepath, symbol })` returned `dependentCount: 0` /
`riskLevel: "low"` for exported symbols with real callers whenever `symbol`
named a method, constructor, or Go package-level function reached only
through a qualified access (`bytesconv.StringToBytes(...)`,
`$cursor->moveUp()`) — because no language's import statement names a class
member (or, for Go, an individual function) independently of its
class/package. CLAUDE.md marks this exact call **REQUIRED** before any
signature change, so the false zero was a confident "safe to edit" verdict
on code with many callers. This is what PR #917's dogfood report flagged.

This picks up a WIP commit (`a671e84e`) left by an agent that hit the org
spend limit mid-`npm test`, judges it, finishes verification, and fixes one
more bug discovered along the way (`84c56b6b` — see the coordination note
above).

## Was the inherited diff scope creep?

The brief asked for a diff scoped to `dependency-analyzer.ts`/`get-dependents.ts`.
What's there instead also touches parser-level symbol extraction across all
ten languages. **I checked this against the real corpus rather than taking
it on faith, and it is not scope creep:**

- **The core fix** (`dependency-analyzer.ts`): once a chunk is confirmed to
  import from the target path at all, a real call site named `symbol` in
  that chunk is now accepted as evidence too (previously only a literal
  match inside `importedSymbols` counted). When neither a named import nor a
  call site can confirm usage and `symbol` isn't a top-level export (the
  structural shape of a method/constructor query), the response degrades to
  the file-level answer instead of asserting an unverifiable symbol-scoped
  zero, and sets `symbolAttributionDegraded: true` + `symbolAttributionNote`.
- **The Go grouped-import fix is load-bearing, not incidental.** I grep-verified
  gin's real source: `render/json.go` and `binding/form_mapping.go` (8 of the
  11 real `StringToBytes` call sites) both group `codec/json` before
  `internal/bytesconv` in one `import (...)` block. The pre-fix
  `processImportSymbols` returned on the *first* non-stdlib spec, so
  `bytesconv` was silently absent from those two files'
  `importedSymbols` entirely — the call-site fallback above can never fire
  without an import-path match first. Without this fix, the acceptance
  criterion below tops out at 3 dependents (`auth.go`, `render/text.go`),
  not 11.
- **The other 8 languages are 4-line mechanical boilerplate** implementing
  a new required interface member (`processImportSymbolsList`) via the
  existing `toImportSymbolsArray` helper — this exactly mirrors the
  already-established `extractImportPaths`/`toImportPathsArray` pattern
  already required on every language file (from #863's path-side fix), not
  a new design invented for this change.

So I kept it as-is rather than trying to shrink it further.

## A second bug found during verification (not scope creep either — it blocked the acceptance test)

Verifying the PHP acceptance case (`Cursor.php` / `__construct`) against a
real `symfony/console` checkout returned `0/"low"` — including the
**already-working baseline** (`{filepath:"Cursor.php",symbol:"Cursor"}` →
expected `6/"high"`), which meant this wasn't my fix's fault. Root cause:
`packages/parser/src/php-psr4.ts`'s `collectPsr4Entries` treated a
composer.json `autoload.psr-4` directory of `""` as *absent* (same as no
mapping), and `normalizeSourceDir` separately turned `""` into `"/"` — so
even once collected, resolution produced a leading-slash path (`"/Cursor"`)
that `path-matching.ts` can never match. An empty-string dir is Composer's
own convention for "this namespace prefix **is** the repo root" (symfony/console's
own `composer.json`: `"Symfony\\Component\\Console\\": ""`) — not a rare
edge case, and unrelated to both #928 (bare-module matching) and #930 (C#
`global using`). I fixed this too, independently, before realizing #926 had
already fixed the exact same thing — see the rebase note at the top: that
duplicate commit is now dropped, and the fix comes from `main` (#926).

## Gate chain (all six, run in full after every change, including the PSR-4 fix)

```
npm run format:check   ✅ 0 issues
npm run lint            ✅ 0 errors (38 pre-existing warnings, none in touched files)
npm run typecheck       ✅ 0 errors
npm run build           ✅ all 5 packages
npm test                ✅ 1+50+36+57+62+5 = 211 files / 4842 tests, 0 failures
                            (parser 27, action-bucket 1417, core 378, review 1701,
                             cli 1278, action 41)
node packages/cli/dist/index.js delta --base origin/main   ✅ exit 0, no new-over-threshold
                                             crossings (6 worsened / 2 improved, all
                                             pre-existing functions gaining bounded
                                             complexity from the new call-site-fallback
                                             branch, all well under threshold)
```

**Verified split:** the previous agent reported typecheck/build green before
dying mid-`npm test`; the full suite and `lien delta` had never completed. I
re-ran all six gates from scratch after entering the worktree (independently
re-confirming, not assuming, the previous agent's typecheck/build claim),
then again after my own PSR-4 fix, then a third time on the final tree after
rebasing onto `main` (past both #926 and #927) — a rebase is a new tree, so
the earlier green runs don't carry over.

## Acceptance criteria — verbatim, real corpus (`gin` @ 34dac209, `symfony/console` @ 535e18a1), re-measured on the final rebased tree

| Case | Before | After (pre-rebase) | After (rebased onto main, final) |
|---|---|---|---|
| `gin`: `internal/bytesconv/bytesconv.go` / `StringToBytes` | `dependentCount: 0`, `riskLevel: "low"` | `dependentCount: 4`, `totalUsageCount: 11`, `riskLevel: "high"` | unchanged: `dependentCount: 4`, `totalUsageCount: 11` (exactly the 11 grep-verified non-test call sites across `auth.go`, `render/text.go`, `render/json.go`, `binding/form_mapping.go`), `riskLevel: "high"` |
| `console`: `Cursor.php` / `__construct` | `dependentCount: 0`, `riskLevel: "low"` | `dependentCount: 6`, `riskLevel: "high"`, `symbolAttributionDegraded: true` | `dependentCount: 6` (unchanged), `productionDependentCount: 4`, `testDependentCount: 2`, `symbolAttributionDegraded: true` (unchanged) — **`riskLevel` is now `"low"`, down from `"high"`; see the rebase note at the top for why that's a correct effect of #926's own fix, not a regression.** Note text unchanged: `"__construct" doesn't appear in Cursor.php's tracked top-level exports (likely a method or constructor...) ... dependentCount, riskLevel, and dependents below are the file-level answer ... rather than a verified count of callers of "__construct" specifically.` |
| `console`: unresolvable symbol (`totallyMadeUpMethodNameXyz`) | — | degrades to file-level (`6/"high"`) | still degrades to file-level rather than a confident `0/"low"` (now `6/"low"`, same reasoning as the row above) — the required failure mode holds |
| Regression — `console`: `Cursor.php` / `Cursor` (class-name) | working baseline: `6/"high"` | unchanged: `6/"high"` | `dependentCount: 6` unchanged; `riskLevel` now `"low"` (same #926-driven reason); `productionDependentCount: 4` / `testDependentCount: 2` |
| Regression — `console`: `Cursor.php` (file-level, no symbol) | working baseline | unchanged | `dependentCount: 6` unchanged, same risk-level note as above |
| Bonus — `console`: unindexed path (`TotallyBogusPath.php`, from #927) | — | — | `note` fires correctly: `⚠ Lien: not found in the index... do not treat it as a low-risk or dependency-free file...` — confirms my manual resolution of the #927 merge conflict in `get-dependents.ts` didn't just compile, it works end to end |

**On the `6` for `__construct` — is that a true per-symbol count or a floor?**
It's a **deliberate floor, not a verified `__construct` call-site count**,
and `symbolAttributionDegraded: true` is exactly the signal that says so —
readers shouldn't have to infer it from the boolean alone, so here's the
breakdown I grep-verified against the 6 actual dependent files:

| File | Actually calls `new Cursor(...)`? |
|---|---|
| `Helper/QuestionHelper.php` | ✅ yes (1 of the 3 grep-verified production sites) |
| `Helper/ProgressBar.php` | ✅ yes (1 of 3) |
| `Command/InvokableCommand.php` | ✅ yes (1 of 3) |
| `Tests/CursorTest.php` | ✅ yes, 5×, but it's a **test file** |
| `ArgumentResolver/ArgumentResolver.php` | ❌ no — references `Cursor::class` (a class-constant, for type-based argument resolution), never instantiates it |
| `Tests/Command/InvokableCommandTest.php` | ❌ no — `Cursor $cursor` is a type-hinted parameter, never instantiated there |

So only 3 of the 6 file-level dependents genuinely construct `Cursor`
(matching the `≥3` acceptance bar exactly); the other 3 import `Cursor.php`
for unrelated reasons (a class-constant reference, a type hint, and a test
file). **Post-rebase, the two `Tests/` files are now correctly classified**
(`productionDependentCount: 4`, `testDependentCount: 2` — confirmed on the
rebased tree, exactly the split predicted) instead of the pre-rebase
`productionDependentCount: 6`, `testDependentCount: 0` misclassification —
that reclassification is what dropped `riskLevel` from `"high"` to `"low"`
above (the two production dependents that looked "untested" are, correctly,
covered by these now-recognized tests).

This over-inclusion is the intended, conservative behavior for the degraded
path: `buildDependentsList` widens to *every* file-level importer once
symbol-level attribution can't be confirmed, on the reasoning that an
inflated-but-labeled count is far safer than a confident false zero before
a risky edit — CLAUDE.md's mandate is "check `get_dependents` before
touching an exported symbol," and a caller who sees `symbolAttributionDegraded`
is expected to go look at the listed dependents themselves (as I just did
above) rather than trust the raw number as a precise call-site count.

## Nudge text — real hook, real stdin, before/after (the thing that actually reaches a model)

Reproduced by editing `gin`'s real `bytesconv.go` to change `StringToBytes`'s
signature and piping the real Claude Code `PostToolUse` stdin shape into
`plugins/claude/hooks/api-delta-write.sh`, with a `lien` PATH shim pointed at
each build (a temporary `ecf89ae3` worktree for "before", this branch for
"after"; both reindexed the corpus with their own build first):

**Before** (pre-fix, commit `ecf89ae3`, matches PR #917's dogfood report exactly):
```
⚠ lien: exported signature changed — StringToBytes (0 dependents, 0 untested, risk low). Run get_dependents before relying on callers.
```

**After** (this branch):
```
⚠ lien: exported signature changed — StringToBytes (4 dependents, 1 untested, risk high). Run get_dependents before relying on callers.
```

The corpus indices were left re-indexed with this branch's (fixed) build.

## Out of scope (untouched, filed separately)

- #928 — fabricated graphs via bare-module matching
- #930 — C# `global using`

## Files

- `packages/cli/src/mcp/handlers/dependency-analyzer.ts` / `get-dependents.ts` (+ schema/tools docs) — the core fix
- `packages/parser/src/ast/languages/go.ts` (+ `symbols.ts`, `extractors/types.ts`) — grouped-import fix, load-bearing per above
- `packages/parser/src/ast/languages/{csharp,java,javascript,kotlin,php,python,ruby,rust,swift}.ts` — mechanical interface boilerplate
- `packages/parser/src/php-psr4.ts` — the newly found empty-root PSR-4 fix (**duplicates #926 — see coordination note**)
- `packages/site/docs/guide/mcp-tools.md` — docs for the new `symbolAttributionDegraded`/`symbolAttributionNote` fields
- `.changeset/symbol-level-dependent-attribution.md` — added (the inherited diff shipped without one)

---
<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes two independent false-zero bugs in symbol-level dependency attribution and one PHP PSR-4 root-mapping bug. The core change lets `get_dependents` accept a real call site named `symbol` as evidence once the importing chunk is confirmed to import from the target path, and degrades method/constructor queries to the file-level answer with `symbolAttributionDegraded` when symbol-level attribution cannot be confirmed. A Go parser fix records every non-stdlib spec from grouped `import (...)` blocks instead of only the first, and a PHP PSR-4 fix correctly handles empty-string source directories. All three fixes are well-scoped, thoroughly tested, and the new response fields are properly threaded through the MCP response without breaking existing callers.
>
> - Symbol-level `get_dependents` now uses call-site evidence and degrades to file-level attribution for methods/constructors instead of reporting false zeros.
> - Go grouped imports now record all non-stdlib specs, fixing missing `importedSymbols` entries for later specs in the same block.
> - PHP PSR-4 resolution now accepts empty-string source directories (package-root mappings) instead of treating them as absent.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 84c56b6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependent analysis for methods, constructors, and package-qualified functions.
  * Prevented false zero dependent counts and low-risk results when callers exist.
  * Corrected grouped Go import processing to include all imported packages.
  * Fixed PHP PSR-4 resolution for namespaces mapped to the repository root.

* **New Features**
  * Added attribution status and explanatory notes when symbol-level results fall back to file-level results.

* **Documentation**
  * Clarified `get_dependents` response behavior and how to interpret degraded attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes two independent false-zero bugs in symbol-level dependency attribution and one PHP PSR-4 root-mapping bug. The core change lets `get_dependents` accept a real call site named `symbol` as evidence once the importing chunk is confirmed to import from the target path, and degrades method/constructor queries to the file-level answer with `symbolAttributionDegraded` when symbol-level attribution cannot be confirmed. A Go parser fix records every non-stdlib spec from grouped `import (...)` blocks instead of only the first, and a PHP PSR-4 fix correctly handles empty-string source directories. All three fixes are well-scoped, thoroughly tested, and the new response fields are properly threaded through the MCP response without breaking existing callers.
>
> - Symbol-level `get_dependents` now uses call-site evidence and degrades to file-level attribution for methods/constructors instead of reporting false zeros.
> - Go grouped imports now record all non-stdlib specs, fixing missing `importedSymbols` entries for later specs in the same block.
> - PHP PSR-4 resolution now accepts empty-string source directories (package-root mappings) instead of treating them as absent.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 84c56b6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependent analysis for methods, constructors, and package-qualified functions.
  * Prevented false zero dependent counts and low-risk results when callers exist.
  * Corrected grouped Go import processing to include all imported packages.
  * Fixed PHP PSR-4 resolution for namespaces mapped to the repository root.

* **New Features**
  * Added attribution status and explanatory notes when symbol-level results fall back to file-level results.

* **Documentation**
  * Clarified `get_dependents` response behavior and how to interpret degraded attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
