### PR TITLE
fix(parser): stop treating C# global using as a file-to-file import edge

### DIFF
--- a/.changeset/csharp-global-using-import-edges.md
+++ b/.changeset/csharp-global-using-import-edges.md
@@ -1,0 +1,29 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+#930: `global using Namespace;` was resolved as a file-to-file import of
+every file in that namespace, so a boilerplate `GlobalUsings.cs` (no code,
+just a list of `global using` directives) became a false "dependent" of,
+and false "test coverage" for, every file in every namespace it lists —
+while the file's own `dependentCount`/`riskLevel`/`riskReasoning` were
+computed entirely from that boilerplate. Confirmed on a real 254-file C#
+corpus (serilog/serilog): 13 of 25 sampled files' "confident" test-coverage
+line was driven 100% by `GlobalUsings.cs` pollution; after this fix, zero
+files anywhere in the corpus list a `GlobalUsings.cs` as an importer or as
+test coverage.
+
+Fixed in `CSharpImportExtractor` (`packages/parser/src/ast/languages/csharp.ts`):
+a `using_directive` node with a leading, unnamed `global` token now
+contributes no import path, since a global using's effect is project-wide,
+not scoped to the file that declares it — that file has no real dependency
+relationship with the namespaces it lists.
+
+This does not recover the *true* dependents/test-coverage that a global
+using makes invisible (C# needs no per-file `using` once a global using
+exists for a namespace, so the import graph has no signal for those real
+usages) — that requires a type-reference-based resolution mechanism this
+codebase doesn't have today (unlike the directory-based same-package/
+same-directory heuristics `test-associations.ts` already has for Go/Java),
+and is tracked separately. This change only removes the false edges.

--- a/packages/parser/src/ast/languages/csharp.test.ts
+++ b/packages/parser/src/ast/languages/csharp.test.ts
@@ -334,6 +334,49 @@ describe('C# Language', () => {
       const stdlibNode = stdlibRoot.namedChild(0)!;
       expect(importExtractor.extractImportPaths(stdlibNode)).toEqual([]);
     });
+
+    // A `global using` applies project-wide, not to the file that declares
+    // it — its declaring file has no real dependency on the namespaces it
+    // lists (issue #930). This is the same shape as GlobalUsings.cs in
+    // real-world .NET 6+ projects (e.g. serilog/serilog).
+    it('should return null for a global using (#930)', () => {
+      const code = 'global using Serilog.Parsing;';
+      const root = mustParse(code, 'csharp');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBeNull();
+    });
+
+    it('should return an empty array from extractImportPaths for a global using (#930)', () => {
+      const code = 'global using Serilog.Parsing;';
+      const root = mustParse(code, 'csharp');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPaths(importNode)).toEqual([]);
+    });
+
+    it('should return null from processImportSymbols for a global using (#930)', () => {
+      const code = 'global using Serilog.Parsing;';
+      const root = mustParse(code, 'csharp');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.processImportSymbols(importNode)).toBeNull();
+    });
+
+    it('should return null for a global static using of a non-stdlib namespace (#930)', () => {
+      const code = 'global using static MyLib.Utils;';
+      const root = mustParse(code, 'csharp');
+      const importNode = root.namedChild(0)!;
+      expect(importExtractor.extractImportPath(importNode)).toBeNull();
+    });
+
+    it('should still extract a regular using in the same file as a global using (#930)', () => {
+      const code = `global using Serilog.Parsing;
+using Newtonsoft.Json;
+`;
+      const root = mustParse(code, 'csharp');
+      const globalNode = root.namedChild(0)!;
+      const regularNode = root.namedChild(1)!;
+      expect(importExtractor.extractImportPath(globalNode)).toBeNull();
+      expect(importExtractor.extractImportPath(regularNode)).toBe('Newtonsoft.Json');
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -258,12 +258,36 @@ function isCSharpStdLib(importPath: string): boolean {
 }
 
 /**
+ * Check whether a `using_directive` node is a `global using` (issue #930).
+ * The grammar represents `global` as an unnamed leading token sibling of
+ * `using`, not a field, so it has to be found by scanning `.children`
+ * (which includes unnamed tokens) rather than `.namedChildren` or
+ * `childForFieldName`.
+ *
+ * A global using's effect isn't scoped to the file that declares it — it
+ * applies project-wide, which is the entire point of the keyword — so the
+ * declaring file (conventionally `GlobalUsings.cs`, itself typically just a
+ * list of these directives with no other code) has no real dependency
+ * relationship with the namespaces it lists. Every consumer downstream of
+ * this extractor resolves a namespace-shaped import path against every file
+ * physically under that namespace's path (see `path-matching.ts`'s
+ * `matchesPythonModule`, which C#'s dotted paths also satisfy), so without
+ * this check the declaring file becomes a spurious "importer" of, and a
+ * spurious "test coverage" association for, every file in every namespace
+ * it lists.
+ */
+function isGlobalUsingDirective(node: SyntaxNode): boolean {
+  return node.children.some(child => !child.isNamed && child.type === 'global');
+}
+
+/**
  * C# import extractor
  *
  * Handles all C# using patterns:
  * - using Newtonsoft.Json;             (regular using)
  * - using static MyLib.Utils;          (static using)
  * - using Json = Newtonsoft.Json;      (alias using)
+ * - global using Newtonsoft.Json;      (global using — see isGlobalUsingDirective)
  *
  * Standard library usings (System.*, Microsoft.*) are filtered out.
  */
@@ -297,6 +321,10 @@ export class CSharpImportExtractor implements LanguageImportExtractor {
   }
 
   private getImportPath(node: SyntaxNode): string | null {
+    // A global using has no file-scoped dependency relationship — see
+    // isGlobalUsingDirective — so it never contributes an import path.
+    if (isGlobalUsingDirective(node)) return null;
+
     // qualified_name is always the import path when present
     const qualifiedName = node.namedChildren.find(c => c.type === 'qualified_name');
     if (qualifiedName) return qualifiedName.text;


### PR DESCRIPTION
## Summary

`global using Namespace;` was resolved by `CSharpImportExtractor` exactly like
a regular `using`, so it got matched against every file physically under
that namespace's path (`path-matching.ts`'s `matchesPythonModule`, which
C#'s dotted namespaces satisfy too). A boilerplate `GlobalUsings.cs` (25
lines, just `global using` directives, no code) became a false "importer"
of, and false "test coverage" for, every file in every namespace it lists —
while that file's own `dependentCount`/`riskLevel`/`riskReasoning` were
derived entirely from the same boilerplate. This is issue #930, found by
the foreign-repo dogfood on serilog/serilog, and is the same root cause as
the C# half of #929 (GlobalUsings.cs polluting the test-coverage list).

**Fix (part 1 of the issue's two-part suggestion — see "not done" below):**
`CSharpImportExtractor.getImportPath` (`packages/parser/src/ast/languages/csharp.ts`)
now recognizes a `using_directive`'s leading, unnamed `global` token (the
grammar has no field for it — confirmed by dumping the AST) and returns
`null` for it, so it contributes no import path to `chunk.metadata.imports`/
`importedSymbols`. A global using's effect is project-wide, not scoped to
the file that declares it, so that file has no real dependency relationship
with the namespaces it lists.

I traced the pipeline before writing this (via a research subagent) to
confirm a single-point fix was sufficient: both the general dependents graph
(`dependency-analyzer.ts`) and the test-association scan
(`test-associations.ts`) are pure downstream consumers of the same
`chunk.metadata.imports`/`importedSymbols` fields that `ast/symbols.ts`
bakes in from this one extractor — there is no separate C#-specific code
path for either. Fixing the extractor closes both holes at once.

## Verbatim before/after (serilog/serilog, real 254-file C# corpus)

Reindexed the same corpus with the pre-fix build, then with this branch's
build, using the exact CLI/commands a consuming agent would run.

**Before** (pre-fix build, matches the issue exactly):
```
$ node <cli> annotate src/Serilog/Parsing/Alignment.cs
Lien impact for src/Serilog/Parsing/Alignment.cs:
  • 3 files import this — src/Serilog/GlobalUsings.cs, test/Serilog.Tests/GlobalUsings.cs,
    test/Serilog.PerformanceTests/GlobalUsings.cs; risk: medium (3 callers, 1 untested).
  • Test coverage: test/Serilog.Tests/GlobalUsings.cs, test/Serilog.PerformanceTests/GlobalUsings.cs.
```

**After** (this branch):
```
$ node <cli> annotate src/Serilog/Parsing/Alignment.cs
Lien impact for src/Serilog/Parsing/Alignment.cs:
  • Test coverage not determinable from imports (enclosing-namespace access).
```

**Corpus-wide sweep** (all 246 non-boilerplate `.cs` files, `annotate` on
each): 0 files anywhere in the corpus still list a `GlobalUsings.cs` as an
importer or as test coverage. The only 14 hits for `GlobalUsings` in any
`annotate` output are each file's own self-referential header line (e.g.
`Lien impact for src/Serilog/GlobalUsings.cs:` when annotating that file
itself) — not a dependent listing.

**M6 sampler** (`associationCoverage` from `scripts/experiments/dogfood-oss/provision.mjs`,
reused as-is against the same 25-file deterministic sample, before vs after,
same corpus):

| | sampled | confident coverage | of which GlobalUsings.cs-polluted |
|---|---|---|---|
| Before (pre-fix build) | 25 | 12/25 (48%) | **12/12 — 100%** |
| After (this branch) | 25 | 0/25 (0%) | 0/12 |

Every single "confident" hit in the pre-fix sample was driven entirely by
the bug. The drop to 0/25 is the bug being fixed, not new breakage — I
verified this isn't a regression in the underlying computation by checking
`get_dependents` directly (unaffected by the CLI's `annotate`-only
low-impact "stay quiet" triviality rule): e.g. `PropertyToken.cs` still
correctly shows `testDependentCount: 1` for its one real, non-boilerplate
test dependent (`MessageTemplateParserTests.cs`) — `annotate` prints
nothing for it only because that specific file trips the pre-existing,
unrelated `isTrivial()` silence rule (1 dependent, real test coverage, no
complexity/headroom flags), not because of anything this fix touches.

This change is scoped to `packages/parser/src/ast/languages/csharp.ts` only,
so it cannot affect the other corpus languages (hono, gin, tokio, etc.).

## What this does NOT fix (stated honestly, per the issue's own framing)

The 5 real production dependents of `Alignment.cs` from the issue
(`MessageTemplateTextFormatter.cs`, `MessageTemplateRenderer.cs`,
`Padding.cs`, `PropertyToken.cs`, `MessageTemplateParser.cs`) are **still
not found** — `get_dependents` now reports `dependentCount: 0` for
`Alignment.cs` rather than 3 wrong ones. Part 1 removes the false edges;
it does not recover the true ones (part 2 of the issue).

I looked into part 2 before deciding to ship part 1 alone. The Go/Java
same-package pattern cited in the issue (`go-same-directory-tests.ts`,
`java-same-package-tests.ts`) is a **test-association-only** heuristic: it
plugs into `test-associations.ts` via a single `LanguageDefinition` flag
(`sameDirectoryTestConvention`) read by `registry.ts` and consulted directly
in `findTestAssociationsFromChunks` — a small, already-paved extension
point for that one consumer. No equivalent hook exists for the *general*
`get_dependents`/`annotate` path: `dependency-analyzer.ts`/`path-matching.ts`
expose only generic string-matching flags, none of which is a "call this
language's extra-signal function to recover real edges" hook. Recovering
C#'s true dependents there would need new plumbing in
`dependency-analyzer.ts` itself (a genuinely new interface member, wired in
analogously) — a bigger, separate change, and out of scope for this fix per
the issue's own "ship part 1 alone" fallback. Filed as a follow-up rather
than attempted here.

Also note: PR #926 (Java same-package test-association, merged as
`c7046a3d` after this branch was created — rebased onto it) already covers
the *test-association* half of "part 2" for Go/Java. A C# analog of that
narrower heuristic (`csharp-same-namespace-tests.ts`, using the same
`sameDirectoryTestConvention`-style flag) is a much smaller, separately
worthwhile follow-up from the general `get_dependents` plumbing gap above —
not attempted here to keep this PR's diff to the minimal, verifiable fix.

## Gate chain (all six)

```
npm run format:check   ✅ 0 issues
npm run lint            ✅ 0 errors (38 pre-existing warnings, none in touched files)
npm run typecheck       ✅ 0 errors
npm run build           ✅ all 5 packages
npm test                ✅ 209 files / parser 50, core 36, review 57, cli 62, action 5, parser-native 1 — 0 failures
node packages/cli/dist/index.js delta --base origin/main
                         ✅ exit 0 — 1 advisory "worsened" (getImportPath cognitive 2→3,
                            well under threshold; new isGlobalUsingDirective at 1),
                            no new-over-threshold crossing
```

Rebased onto `origin/main` after #926/#927 merged mid-session; diff vs
`origin/main` is exactly 3 files (csharp.ts, csharp.test.ts, changeset).

## Files

- `packages/parser/src/ast/languages/csharp.ts` — the fix (`isGlobalUsingDirective` + one guard in `getImportPath`)
- `packages/parser/src/ast/languages/csharp.test.ts` — 5 new tests covering global/global-static using, mixed-file regression
- `.changeset/csharp-global-using-import-edges.md`

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a targeted fix for C# global using directives being incorrectly treated as file-scoped imports. It adds a single helper `isGlobalUsingDirective` that detects the unnamed `global` token in a `using_directive` node and causes `getImportPath` to return null, preventing `GlobalUsings.cs` from becoming a false dependent of every namespace it lists. The change is isolated to `packages/parser/src/ast/languages/csharp.ts` and is covered by five new tests covering global using, global static using, and mixed-file regression. Downstream consumers of `chunk.metadata.imports`/`importedSymbols` will simply see no entry for global usings, which matches the intended behavior.
>
> - Added `isGlobalUsingDirective` to detect leading unnamed `global` token in C# `using_directive` nodes
> - Guarded `getImportPath` to return null for global usings so they do not create spurious import edges
> - Added regression tests for global using, global static using, and mixed global + regular using files

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d873155. Updates automatically on new commits.</sup>
<!-- /lien-stats -->