### PR TITLE
fix(parser,cli): stop Python bare-module matching from fabricating cross-language test-coverage hubs

### DIFF
--- a/.changeset/fix-python-bare-module-false-hub.md
+++ b/.changeset/fix-python-bare-module-false-hub.md
@@ -1,0 +1,36 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+#929: a direct-importing test file could be omitted from `lien annotate`'s
+"Test coverage" line and from `get_files_context`'s `testAssociations`,
+crowded out by unrelated files that matched only through a false hub.
+
+Root cause: `matchesFile`'s Strategy 5 (`matchesPythonModule`) applies
+Python's "a bare package import covers every file nested under it" semantic
+unconditionally, regardless of the importer's actual language. A resolved
+bare specifier from any other language can coincidentally look exactly like
+a Python identifier -- confirmed on a real TypeScript repo (hono), where a
+test's own package-root barrel import (`import { Hono } from '../..'`,
+resolved to the bare specifier `src`) matched every single file under `src/`,
+and on a real Go repo (gin), where an ordinary whole-package import
+(`"github.com/gin-gonic/gin/binding"`, resolved to the bare `binding` after
+module-prefix stripping) matched every file in that package directory. Both
+shapes fabricated "this test covers everything" for files with no real
+relationship to the target, sometimes displacing the file's own genuine
+direct importer once the result list was truncated for display.
+
+Fix: `matchesFile` gains an `allowPythonModuleMatching` parameter (default
+`true`, preserving this function's own behavior for direct callers);
+`importMatchesTarget` -- the shared choke point behind `get_dependents`,
+`get_files_context`, and `lien annotate`'s test-association matching --
+now derives it from the importer's actual language via the new
+`hasPythonModuleSemantics`, mirroring the existing `hasSingleFileImportSemantics`
+(#887) guard. Genuine Python bare-package matching is unaffected (verified:
+zero result changes across a 25-file Python corpus sample).
+
+Additionally, `collectImportMatchedTests`/`collectImportMatchedTestFiles` now
+rank an exact, literal direct import ahead of any fuzzier match, so a real
+direct importer can no longer sort behind other real matches and be
+truncated out of the displayed list purely due to chunk-scan order.

--- a/.changeset/fix-python-bare-module-false-hub.md
+++ b/.changeset/fix-python-bare-module-false-hub.md
@@ -33,4 +33,8 @@ zero result changes across a 25-file Python corpus sample).
 Additionally, `collectImportMatchedTests`/`collectImportMatchedTestFiles` now
 rank an exact, literal direct import ahead of any fuzzier match, so a real
 direct importer can no longer sort behind other real matches and be
-truncated out of the displayed list purely due to chunk-scan order.
+truncated out of the displayed list purely due to chunk-scan order. That
+exact-match check applies the same #884 whole-module guard as the fuzzy
+path, so a Swift bare `import Module` can't jump the queue into the exact
+bucket just because the target file's basename happens to equal the module
+name.

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -352,6 +352,32 @@ describe('handleGetFilesContext - test-association scan (scanAll fast path + cac
     });
   });
 
+  describe('direct-importer ranking (#929)', () => {
+    // Mirrors @liendev/parser's own test-associations.test.ts coverage --
+    // this handler is get_files_context's separate implementation (see
+    // collectImportMatchedTestFiles's doc comment), so it needs the
+    // identical ranking guarantee: a test whose own import resolves to
+    // exactly the target must not sort behind a fuzzier match.
+    it('ranks an exact direct importer ahead of a fuzzy match, even when the fuzzy match is scanned first', async () => {
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([
+          makeChunk('src/auth.rs'),
+          makeChunk('tests/other_test.rs', ['auth']),
+          makeChunk('tests/auth_direct_test.rs', ['src/auth']),
+        ]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'src/auth.rs', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual(['tests/auth_direct_test.rs', 'tests/other_test.rs']);
+    });
+  });
+
   it('caches the scan across calls with the same indexVersion (no re-scan)', async () => {
     const scanAll = vi.fn().mockResolvedValue([]);
     const ctx = makeCtx({ scanAll, indexVersion: 42 });

--- a/packages/cli/src/mcp/handlers/get-files-context.test.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.test.ts
@@ -376,6 +376,31 @@ describe('handleGetFilesContext - test-association scan (scanAll fast path + cac
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.testAssociations).toEqual(['tests/auth_direct_test.rs', 'tests/other_test.rs']);
     });
+
+    it('does not let a Swift whole-module bare import jump the exact-match queue ahead of a real direct importer', async () => {
+      // Mirrors test-associations.test.ts's identical regression pin: a
+      // top-level Swift file whose basename equals its own module name
+      // means a bare `import Alamofire` (whole-module) normalizes to
+      // literally the same string as the target itself -- the #884
+      // Alamofire shape, reintroduced one layer up via the exact-match
+      // bucket unless the whole-module guard is applied there too.
+      const scanAll = vi
+        .fn()
+        .mockResolvedValue([
+          makeChunk('Alamofire.swift'),
+          makeChunk('OtherTests.swift', ['Alamofire']),
+          makeChunk('AlamofireTests.swift', ['./Alamofire']),
+        ]);
+      const ctx = makeCtx({ scanAll, indexVersion: 1 });
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'Alamofire.swift', includeRelated: false },
+        ctx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.testAssociations).toEqual(['AlamofireTests.swift']);
+    });
   });
 
   it('caches the scan across calls with the same indexVersion (no re-scan)', async () => {

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -238,28 +238,39 @@ export function createPathCache(workspaceRoot: string): {
   return { normalize, cache };
 }
 
-/** Canonical test-file paths among `allChunks` whose imports resolve to `normalizedTarget`. */
+/**
+ * Canonical test-file paths among `allChunks` whose imports resolve to
+ * `normalizedTarget`, exact literal matches first (#929) -- mirrors
+ * `@liendev/parser`'s own `collectImportMatchedTests` (test-associations.ts;
+ * this handler is `get_files_context`'s separate implementation, so it needs
+ * the identical treatment). See that function's doc comment for why an exact
+ * direct importer must not be left to sort behind a fuzzier match once a
+ * caller truncates the list for display.
+ */
 function collectImportMatchedTestFiles(
   allChunks: Array<{ metadata: { file: string; imports?: string[] } }>,
   normalizedTarget: string,
   normalize: (path: string) => string,
   workspaceRoot: string,
 ): string[] {
-  const matched: string[] = [];
+  const exact: string[] = [];
+  const fuzzy: string[] = [];
   for (const chunk of allChunks) {
     const chunkFile = getCanonicalPath(chunk.metadata.file, workspaceRoot);
     if (!isTestFile(chunkFile)) continue;
 
     const imports = chunk.metadata.imports || [];
-    if (
-      imports.some(imp =>
-        importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
-      )
-    ) {
-      matched.push(chunkFile);
+    const isExactMatch = imports.some(imp => normalize(imp) === normalizedTarget);
+    const isFuzzyMatch = imports.some(imp =>
+      importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
+    );
+    if (isExactMatch) {
+      exact.push(chunkFile);
+    } else if (isFuzzyMatch) {
+      fuzzy.push(chunkFile);
     }
   }
-  return matched;
+  return [...exact, ...fuzzy];
 }
 
 /**

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -7,6 +7,7 @@ import {
   getCanonicalPath,
   isTestFile,
   importMatchesTarget,
+  isUnresolvableWholeModuleImport,
   detectLanguage,
   hasSameDirectoryTestConvention,
   buildGoTestDirIndex,
@@ -239,6 +240,27 @@ export function createPathCache(workspaceRoot: string): {
 }
 
 /**
+ * True when `imp` (as written in `importerFile`) is a literal, exact
+ * reference to `normalizedTarget` -- the #929 direct-importer signal -- and
+ * is not merely a whole-module-import language's bare module name that
+ * happens to coincide with it. The #884 whole-module guard has to be
+ * applied here directly: this check never calls `matchesFile`/
+ * `importMatchesTarget`, so nothing else would catch a Swift `import
+ * Alamofire` against a target file named `Alamofire.swift` (the classic
+ * #884 false-hub shape) before it jumped the queue into the trusted exact
+ * bucket below. Extracted so `collectImportMatchedTestFiles`'s own loop
+ * body doesn't grow another nested condition per guard.
+ */
+function isExactDirectImport(
+  imp: string,
+  importerFile: string,
+  normalizedTarget: string,
+  normalize: (path: string) => string,
+): boolean {
+  return !isUnresolvableWholeModuleImport(imp, importerFile) && normalize(imp) === normalizedTarget;
+}
+
+/**
  * Canonical test-file paths among `allChunks` whose imports resolve to
  * `normalizedTarget`, exact literal matches first (#929) -- mirrors
  * `@liendev/parser`'s own `collectImportMatchedTests` (test-associations.ts;
@@ -260,7 +282,9 @@ function collectImportMatchedTestFiles(
     if (!isTestFile(chunkFile)) continue;
 
     const imports = chunk.metadata.imports || [];
-    const isExactMatch = imports.some(imp => normalize(imp) === normalizedTarget);
+    const isExactMatch = imports.some(imp =>
+      isExactDirectImport(imp, chunk.metadata.file, normalizedTarget, normalize),
+    );
     const isFuzzyMatch = imports.some(imp =>
       importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
     );

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -43,6 +43,7 @@ export {
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
   hasSingleFileImportSemantics,
+  hasPythonModuleSemantics,
 } from './utils/path-matching.js';
 
 export { extractRepoId } from './utils/repo-id.js';

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -265,4 +265,44 @@ describe('findTestAssociationsFromChunks', () => {
       expect(result.has('src/list.ts')).toBe(false);
     });
   });
+
+  describe('direct-importer ranking (#929)', () => {
+    // The real hono repro: `src/utils/jwt/jwt.test.ts` imports `./jws`
+    // directly (an exact, unambiguous reference), but scan order alone
+    // decided display order, so this genuine direct importer sorted behind
+    // several other real-but-fuzzier matches and was truncated out of
+    // `lien annotate`'s "Test coverage" line entirely. A direct importer
+    // must be included AND ranked ahead of a fuzzy match, not merely
+    // present somewhere in the result.
+    it('ranks an exact direct importer ahead of a fuzzy match, even when the fuzzy match is scanned first', () => {
+      const chunks: CodeChunk[] = [
+        makeChunk('src/auth.rs'),
+        // Scanned FIRST: only matches via Strategy 2's bare "source
+        // directory prefix" leniency (a real match, but not a direct
+        // reference to the target's own resolved path).
+        makeChunk('tests/other_test.rs', ['auth']),
+        // Scanned SECOND: its own import resolves to exactly the target's
+        // normalized path -- the direct, unambiguous reference.
+        makeChunk('tests/auth_direct_test.rs', ['src/auth']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/auth.rs'], chunks);
+
+      expect(result.get('src/auth.rs')).toEqual([
+        'tests/auth_direct_test.rs',
+        'tests/other_test.rs',
+      ]);
+    });
+
+    it('still finds only the fuzzy match when no exact importer exists', () => {
+      const chunks: CodeChunk[] = [
+        makeChunk('src/auth.rs'),
+        makeChunk('tests/other_test.rs', ['auth']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/auth.rs'], chunks);
+
+      expect(result.get('src/auth.rs')).toEqual(['tests/other_test.rs']);
+    });
+  });
 });

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -304,5 +304,34 @@ describe('findTestAssociationsFromChunks', () => {
 
       expect(result.get('src/auth.rs')).toEqual(['tests/other_test.rs']);
     });
+
+    it('does not let a Swift whole-module bare import jump the exact-match queue ahead of a real direct importer', () => {
+      // The #884 Alamofire shape, reintroduced one layer up: a top-level
+      // Swift file whose basename equals its own module name means a bare
+      // `import Alamofire` (whole-module -- Swift's SwiftImportExtractor
+      // never emits a per-file specifier) normalizes to literally the same
+      // string as the target itself. Without the whole-module guard on the
+      // exact-match check, this satisfies `normalize(imp) ===
+      // normalizedTarget` and gets promoted straight into the trusted
+      // `exact` bucket ahead of `AlamofireTests.swift`'s genuine, qualified
+      // direct import. The guard rejects the bare whole-module "match"
+      // entirely (mirroring the existing #884 test above), not merely
+      // de-prioritizes it -- `importMatchesTarget`'s own #884 guard excludes
+      // it from the fuzzy bucket too, so it must not appear in the result
+      // at all.
+      const chunks: CodeChunk[] = [
+        makeChunk('Alamofire.swift'),
+        // Scanned FIRST: bare whole-module import, coincidentally identical
+        // to the target's own normalized path -- must NOT count as exact,
+        // and (like every other whole-module import) is rejected outright.
+        makeChunk('OtherTests.swift', ['Alamofire']),
+        // Scanned SECOND: a real, qualified direct import.
+        makeChunk('AlamofireTests.swift', ['./Alamofire']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['Alamofire.swift'], chunks);
+
+      expect(result.get('Alamofire.swift')).toEqual(['AlamofireTests.swift']);
+    });
   });
 });

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -3,7 +3,12 @@
  * Finds test files that import given source files by analyzing chunk metadata.
  */
 
-import { isTestFile, normalizePath, importMatchesTarget } from './utils/path-matching.js';
+import {
+  isTestFile,
+  normalizePath,
+  importMatchesTarget,
+  isUnresolvableWholeModuleImport,
+} from './utils/path-matching.js';
 import {
   detectLanguage,
   hasSameDirectoryTestConvention,
@@ -60,7 +65,35 @@ function hasJavaSamePackageConvention(filepath: string): boolean {
  * re-deriving which `matchesFile` strategy fired, which would mean
  * threading a new return shape through `importMatchesTarget`) keeps this
  * change local to the one function that assembles the display order.
+ *
+ * The "exact" bucket still needs the #884 whole-module guard applied
+ * directly (it never calls `matchesFile`/`importMatchesTarget`, so nothing
+ * else applies it): a whole-module-import language (Swift) only ever emits
+ * the bare module name as its "import", so a target file whose basename
+ * happens to equal that name -- the classic #884 Alamofire shape -- would
+ * otherwise satisfy the literal `normalize(imp) === normalizedTarget` check
+ * and jump the queue into the trusted `exact` bucket, ahead of a real
+ * direct importer. See `isUnresolvableWholeModuleImport`'s doc comment.
  */
+/**
+ * True when `imp` (as written in `importerFile`) is a literal, exact
+ * reference to `normalizedTarget` -- the #929 direct-importer signal -- and
+ * is not merely a whole-module-import language's bare module name that
+ * happens to coincide with it (the #884 Alamofire shape). This check never
+ * calls `matchesFile`/`importMatchesTarget`, so the #884 whole-module guard
+ * has to be applied here directly, independently of the fuzzy path below.
+ * Extracted so `collectImportMatchedTests`'s own loop body doesn't grow
+ * another nested condition per guard.
+ */
+function isExactDirectImport(
+  imp: string,
+  importerFile: string,
+  normalizedTarget: string,
+  normalize: (p: string) => string,
+): boolean {
+  return !isUnresolvableWholeModuleImport(imp, importerFile) && normalize(imp) === normalizedTarget;
+}
+
 function collectImportMatchedTests(
   testChunks: CodeChunk[],
   normalizedTarget: string,
@@ -70,7 +103,9 @@ function collectImportMatchedTests(
   const fuzzy: string[] = [];
   for (const chunk of testChunks) {
     const imports = chunk.metadata.imports || [];
-    const isExactMatch = imports.some(imp => normalize(imp) === normalizedTarget);
+    const isExactMatch = imports.some(imp =>
+      isExactDirectImport(imp, chunk.metadata.file, normalizedTarget, normalize),
+    );
     // importMatchesTarget applies the #884 whole-module guard before
     // matchesFile -- see its doc comment in path-matching.ts (#886).
     const isFuzzyMatch = imports.some(imp =>

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -44,26 +44,45 @@ function hasJavaSamePackageConvention(filepath: string): boolean {
   return language !== null && hasSamePackageTestConvention(language);
 }
 
-/** Test files among `testChunks` whose imports resolve to `normalizedTarget`. */
+/**
+ * Test files among `testChunks` whose imports resolve to `normalizedTarget`,
+ * exact literal matches first (#929). A test whose own import specifier
+ * resolves to exactly `normalizedTarget` -- a genuine, unambiguous direct
+ * reference -- is strictly better evidence than one that only matched via
+ * `matchesFile`'s fuzzier boundary/PHP/Python strategies, but both used to
+ * come back in the same undifferentiated bag, ordered only by chunk-scan
+ * order. Downstream display (`lien annotate`'s `formatTests`) truncates to
+ * the first `MAX_TESTS_LISTED` entries, so an exact direct importer that
+ * happened to sort last was silently dropped from what an agent actually
+ * reads -- the real hono/jws.ts repro (#929) had `jwt.test.ts`'s own direct
+ * `./jws` import buried behind several other real, but less specific,
+ * matches purely due to scan order. Partitioning first (rather than
+ * re-deriving which `matchesFile` strategy fired, which would mean
+ * threading a new return shape through `importMatchesTarget`) keeps this
+ * change local to the one function that assembles the display order.
+ */
 function collectImportMatchedTests(
   testChunks: CodeChunk[],
   normalizedTarget: string,
   normalize: (p: string) => string,
 ): string[] {
-  const matched: string[] = [];
+  const exact: string[] = [];
+  const fuzzy: string[] = [];
   for (const chunk of testChunks) {
     const imports = chunk.metadata.imports || [];
+    const isExactMatch = imports.some(imp => normalize(imp) === normalizedTarget);
     // importMatchesTarget applies the #884 whole-module guard before
     // matchesFile -- see its doc comment in path-matching.ts (#886).
-    if (
-      imports.some(imp =>
-        importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
-      )
-    ) {
-      matched.push(chunk.metadata.file);
+    const isFuzzyMatch = imports.some(imp =>
+      importMatchesTarget(imp, chunk.metadata.file, normalizedTarget, normalize),
+    );
+    if (isExactMatch) {
+      exact.push(chunk.metadata.file);
+    } else if (isFuzzyMatch) {
+      fuzzy.push(chunk.metadata.file);
     }
   }
-  return matched;
+  return [...exact, ...fuzzy];
 }
 
 /**

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -8,6 +8,7 @@ import {
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
   hasSingleFileImportSemantics,
+  hasPythonModuleSemantics,
 } from './path-matching.js';
 
 /**
@@ -669,6 +670,53 @@ describe('importMatchesTarget (#886)', () => {
         ),
       ).toBe(true);
     });
+  });
+
+  describe('#929 Python-bare-module guard', () => {
+    // The real hono/TypeScript repro: `src/utils/jwt/jwt.test.ts` directly
+    // imports `./jws`, but `annotate`'s "Test coverage" line omitted it and
+    // instead listed several unrelated test files -- every one of which
+    // imports the package's own root barrel (`import { Hono } from '../..'`,
+    // which resolves to the bare specifier `src`). `matchesFile`'s Strategy 5
+    // (`matchesPythonModule`) treated that bare `src` as a Python package
+    // import covering every file nested under `src/`, fabricating a match
+    // against `src/utils/jwt/jws` for a test with no real relationship to it.
+    const normalizedJws = normalize('src/utils/jwt/jws.ts');
+
+    it('matchesFile alone still matches the bare-barrel pair (this function stays permissive by default)', () => {
+      expect(matchesFile('src', normalizedJws)).toBe(true);
+    });
+
+    it('suppresses the bare-barrel false hub for a non-Python (TypeScript) importer', () => {
+      expect(
+        importMatchesTarget('src', 'src/adapter/deno/websocket.test.ts', normalizedJws, normalize),
+      ).toBe(false);
+    });
+
+    it('leaves genuine Python bare-package matching alone for an actual Python importer', () => {
+      expect(
+        importMatchesTarget(
+          'flask',
+          'flask/tests/test_app.py',
+          normalize('flask/app.py'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('hasPythonModuleSemantics (#929)', () => {
+  it('is true for a Python importer file', () => {
+    expect(hasPythonModuleSemantics('flask/tests/test_app.py')).toBe(true);
+  });
+
+  it('is false for a TypeScript importer file', () => {
+    expect(hasPythonModuleSemantics('src/adapter/deno/websocket.test.ts')).toBe(false);
+  });
+
+  it('is false for an importer file in an unrecognized/undetectable language', () => {
+    expect(hasPythonModuleSemantics('README.md')).toBe(false);
   });
 });
 

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -254,6 +254,27 @@ export function isUnresolvableWholeModuleImport(
  * importer's language. Every other caller passes the default (`false`,
  * permissive/Go-safe), preserving this function's pre-#887 behavior exactly.
  *
+ * Strategy 5 has its own, narrower language fork (#929): `matchesPythonModule`'s
+ * bare-specifier branch treats a resolved single-segment specifier as a
+ * Python package import, matching every file nested anywhere underneath it
+ * (`matchesParentPythonPackage`'s unbounded `startsWith`, no depth cap at
+ * all -- unlike every other strategy here, which anchors both edges of the
+ * match). That is a real Python semantic, but `matchesFile` used to run it
+ * unconditionally for every language, and a resolved bare specifier can
+ * coincidentally look exactly like a Python identifier in any language --
+ * confirmed on a real TypeScript repo (hono), where a test's own package-root
+ * barrel import (`import { Hono } from '../..'`, resolved to the bare
+ * specifier `src`) satisfied `matchesParentPythonPackage('src', 'src/utils/
+ * jwt/jws')` for every single file under `src/`, fabricating "this test
+ * covers everything" for a bare barrel import with no real relationship to
+ * the target. See `allowPythonModuleMatching` and `importMatchesTarget`,
+ * the only caller that derives it from the importer's language. Every other
+ * caller passes the default (`true`), preserving this function's pre-#929
+ * behavior exactly -- this is deliberately scoped to `importMatchesTarget`'s
+ * match-side callers, mirroring #887's precedent, not to `matchesFile`'s
+ * direct callers (existing Python fixtures, `findDependentChunks`'s fuzzy
+ * loop, `buildReExportGraph`).
+ *
  * @param normalizedImport - Normalized import path
  * @param normalizedTarget - Normalized target file path
  * @param requireExactTailForMultiSegment - When true, a multi-segment bare
@@ -261,12 +282,17 @@ export function isUnresolvableWholeModuleImport(
  *   `require` semantics); when false (the default), a multi-segment bare
  *   pattern may also match a "child" continuing past it (Go's package-
  *   directory semantics, and the safe default for every other language).
+ * @param allowPythonModuleMatching - When false, Strategy 5 (Python module
+ *   matching) is skipped entirely. Defaults to `true` (this function's
+ *   pre-#929 behavior); `importMatchesTarget` passes `false` for any
+ *   non-Python importer -- see the doc comment above.
  * @returns True if the import matches the target file
  */
 export function matchesFile(
   normalizedImport: string,
   normalizedTarget: string,
   requireExactTailForMultiSegment = false,
+  allowPythonModuleMatching = true,
 ): boolean {
   // Exact match
   if (normalizedImport === normalizedTarget) return true;
@@ -318,7 +344,7 @@ export function matchesFile(
 
   // Strategy 5: Python module matching
   // Python imports use dotted paths like "django.http" which should match "django/http/response.py"
-  if (matchesPythonModule(normalizedImport, normalizedTarget)) {
+  if (allowPythonModuleMatching && matchesPythonModule(normalizedImport, normalizedTarget)) {
     return true;
   }
 
@@ -329,7 +355,7 @@ export function matchesFile(
  * The single guarded import-matching decision: does `importSpecifier` (as
  * written in `importerFile`) resolve to `normalizedTarget`?
  *
- * Couples two guards to `matchesFile` so neither can drift apart from a
+ * Couples three guards to `matchesFile` so neither can drift apart from a
  * match-side call site again:
  * - The #884 whole-module guard (`isUnresolvableWholeModuleImport`) --
  *   `matchesFile` is language-agnostic and cannot know the importer's
@@ -342,6 +368,12 @@ export function matchesFile(
  *   whose files are all members). This is the ONE call site with both an
  *   importer file *and* a target to compare against, so it's the only place
  *   this derivation happens.
+ * - The #929 Python-bare-module guard (`allowPythonModuleMatching`) --
+ *   `matchesFile`'s Strategy 5 is a real Python semantic, but a false hub for
+ *   any other language whose resolved bare specifier coincidentally matches
+ *   a Python identifier shape (see `matchesFile`'s doc comment for the real
+ *   hono/TypeScript repro). Derived from the importer's language the same
+ *   way as the #887 guard, at this same call site.
  *
  * Every match-side reverse-dependency call path that used to open-code
  * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`
@@ -357,7 +389,7 @@ export function matchesFile(
  * @param importSpecifier - The raw (pre-normalization) import specifier, or
  *   an `importedSymbols` key (same shape).
  * @param importerFile - File path of the chunk doing the importing (needed
- *   for both guards' language detection).
+ *   for all three guards' language detection).
  * @param normalizedTarget - The already-normalized target path to compare
  *   against.
  * @param normalize - The caller's own cached `normalizePath` wrapper.
@@ -373,6 +405,7 @@ export function importMatchesTarget(
     normalize(importSpecifier),
     normalizedTarget,
     hasSingleFileImportSemantics(importerFile),
+    hasPythonModuleSemantics(importerFile),
   );
 }
 
@@ -385,6 +418,22 @@ export function importMatchesTarget(
 export function hasSingleFileImportSemantics(importerFile: string): boolean {
   const language = detectLanguage(importerFile);
   return language !== null && hasSingleFileImports(language);
+}
+
+/**
+ * True when `importerFile`'s language is Python -- the only language
+ * `matchesFile`'s Strategy 5 (`matchesPythonModule`) is a confirmed real
+ * semantic for (#929). Unlike `hasSingleFileImportSemantics` above, this
+ * isn't backed by a `LanguageDefinition` flag: `matchesPythonModule` is
+ * Python-specific by construction (dotted-module parsing, `__init__.py`
+ * handling), not a generic per-language toggle other languages could
+ * legitimately opt into, so a direct language-identity check is the honest
+ * representation. Shared by `importMatchesTarget`'s `allowPythonModuleMatching`
+ * argument -- see `matchesFile`'s doc comment for the false-hub this guards
+ * against.
+ */
+export function hasPythonModuleSemantics(importerFile: string): boolean {
+  return detectLanguage(importerFile) === 'python';
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #929 — a foreign-repo dogfood finding: `src/utils/jwt/jws.ts` in
honojs/hono showed 7 "Test coverage" entries and omitted
`src/utils/jwt/jwt.test.ts`, a test that directly imports the file and
exercises it 39 times.

## Root cause

`matchesFile`'s Strategy 5 (`matchesPythonModule`) applies Python's "a bare
package import covers every file nested under it" semantic **unconditionally,
regardless of the importer's actual language** (`matchesFile` is otherwise
deliberately language-agnostic). A resolved bare specifier from any other
language can coincidentally look exactly like a Python identifier:

- **TypeScript (hono):** every test that does `import { Hono } from '../..'`
  resolves that specifier down to the bare string `src` — which then
  satisfies `matchesParentPythonPackage('src', 'src/utils/jwt/jws')` for
  **every single file under `src/`**, fabricating "this test covers
  everything" for tests with zero real relationship to the target.
- **Go (gin):** an ordinary whole-package import like
  `"github.com/gin-gonic/gin/binding"` resolves to the bare `binding` after
  module-prefix stripping, and the same unbounded `startsWith` matches every
  file inside `binding/`.

Traced with targeted debug instrumentation against the real hono index —
`jwt.test.ts`'s own direct `./jws` import genuinely matched (it was never
filtered out), it just sorted **last** among 7 matches because the other 6
were bogus `src`-barrel hits, and `lien annotate`'s display cap
(`MAX_TESTS_LISTED = 2`) never got far enough to show it.

## Fix

- `matchesFile` gains an `allowPythonModuleMatching` parameter (default
  `true` — every direct caller of `matchesFile`, including the existing
  Python test fixtures, is unaffected).
- `importMatchesTarget` — the single choke point behind `get_dependents`,
  `get_files_context`, and `lien annotate`'s test-association matching —
  now derives it from the importer's actual language via a new
  `hasPythonModuleSemantics`, mirroring the existing `hasSingleFileImportSemantics`
  (#887) guard exactly.
- `collectImportMatchedTests` (parser) / `collectImportMatchedTestFiles`
  (cli) now additionally rank an **exact literal** import match ahead of any
  fuzzier match, so a genuine direct importer can never again be crowded out
  by scan order alone, independent of the Strategy-5 fix above.

## Dogfood evidence (verbatim, against the existing indexed hono corpus — not re-cloned/re-indexed)

Before:
```
$ node <cli> annotate src/utils/jwt/jws.ts
  • Test coverage: runtime-tests/node/index.test.ts, src/middleware/jwk/index.test.ts (+5 more).
$ node <cli> annotate src/utils/jwt/jws.ts | grep -c "jwt.test.ts"
0
```

After (this fix):
```
$ node <cli> annotate src/utils/jwt/jws.ts
Lien impact for src/utils/jwt/jws.ts:
  • 14 files import this — src/utils/jwt/types.ts, src/utils/jwt/jwt.ts, src/middleware/jwt/jwt.ts, src/middleware/jwk/jwk.ts, +10 more; risk: high (14 callers, max complexity 36, untested high-complexity dependent).
  • Test coverage: src/middleware/jwk/index.test.ts, src/utils/jwt/jwt.test.ts.
  • Max cyclomatic complexity: 15 (1 function over warn threshold).
$ node <cli> annotate src/utils/jwt/jws.ts | grep -c "jwt.test.ts"
1
```

Both remaining entries are genuine direct importers (both literally import
`.../utils/jwt/jws` in their own `imports` list) — the 5 bogus matches are
gone, and `jwt.test.ts` is no longer truncated out.

## Corpus re-measurement (25-file sampler, same method as #926/#929's own baselines)

| Repo | Lang | Baseline (confident) | Pre-fix (this run) | Post-fix (this run) |
|---|---|---|---|---|
| honojs/hono | TS | 22/25 | 21/25 | 13/25 |
| gin-gonic/gin | Go | 16/25 | 16/25 | 8/25 |
| tokio-rs/tokio | Rust | 15/25 | 15/25 | 15/25 |
| serilog/serilog | C# | 13/25 | 1/25 | 0/25 |
| pallets/flask (Python sanity check, not in original scope) | Python | — | 9/25 | 9/25 (**0 flips**) |

**The hono/gin drops are the fix working as intended, not a regression** — I
diffed every flipped file's raw annotate output before/after and manually
verified each one:
- Every hono flip's pre-fix "match" was the **identical** bogus signature
  (`runtime-tests/node/index.test.ts, src/helper/css/index.test.tsx (+3
  more)` — the universal `src`-barrel false hub), for files with no real
  per-file test at all.
- Every gin flip (e.g. `binding/header.go`, `render/html.go`) previously
  "matched" root-package files (`mode_test.go`, `deprecated_test.go`) via
  the bare-`binding`/bare-`render` false hub; post-fix they correctly fall
  through to Go's own honest tier-2 "package-level fallback" message citing
  their **real** same-directory siblings — strictly more correct, just not
  credited by this sampler's narrow `/Test coverage:/i` regex (which,
  per #926's own comment, doesn't count the honest inferred/package-level
  tiers as "confident" either).
- tokio: zero flips — Rust's own Strategy-2 leniency already covered its
  legitimate bare-import cases without ever needing Strategy 5.
- flask: zero flips at all (verified explicitly) — confirms genuine Python
  matching is fully preserved.
- serilog: pre-fix **on this specific indexed corpus** measured 1/25, not
  the cited 13/25 baseline — this mismatch exists independently of this fix
  (reproduced with the unmodified code) and looks like a corpus-state/
  measurement discrepancy unrelated to #929; flagging rather than
  investigating further since re-indexing was out of scope for this task.

### Side finding (not fixed here, out of scope for #929)

A few hono files (e.g. `src/middleware/jsx-renderer/index.ts`) had their
*only* prior "confident" match come from the bogus `src`-barrel hub, masking
a **separate, pre-existing** gap: a bare self-referencing import specifier
(`import { x } from '.'`) is stored literally as `"."` and never resolved to
a real path by the extractor, so it never matches anything even though the
test genuinely imports its own sibling `index.ts`. Worth its own follow-up
issue; not touched here.

## Test plan

- [x] New unit tests: `hasPythonModuleSemantics` + `#929 Python-bare-module
      guard` regression pins in `path-matching.test.ts`, mirroring #884/#887's
      existing test shape (matchesFile alone still permissive by default;
      importMatchesTarget suppresses the cross-language false hub; genuine
      Python matching preserved).
- [x] New unit tests: "direct-importer ranking (#929)" in both
      `test-associations.test.ts` and `get-files-context.test.ts` — an exact
      direct importer scanned *after* a fuzzy match still sorts first in the
      result.
- [x] `npm run format:check` / `npm run lint` (0 errors) / `npm run
      typecheck` / `npm run build` (all packages) / `npm test` (all
      packages: parser 1419, cli 1254, core 27, review 378, site 1701,
      action 41 — all green) / `node packages/cli/dist/index.js delta`
      (exit 0; 4 "worsened but under threshold" cognitive-complexity deltas
      from the added ranking logic, no new-over-threshold crossings)
- [x] Verbatim dogfood re-measurement against the real, already-indexed
      corpus (table above) — no re-clone, no re-index.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a cross-language false-hub bug by gating Python bare-module matching on the importer's actual language and by ranking exact direct-importer matches ahead of fuzzy matches in test-association collection. The core change is sound: `matchesFile` keeps its previous default behavior via the new `allowPythonModuleMatching` parameter, while `importMatchesTarget` correctly derives it from `hasPythonModuleSemantics`. The exact-match partitions in both parser and CLI correctly apply the existing `isUnresolvableWholeModuleImport` guard, so Swift whole-module imports cannot jump into the trusted exact bucket. No correctness issues or breaking changes were found.
>
> - `matchesFile` gains `allowPythonModuleMatching` (default `true`); `importMatchesTarget` derives it from the importer language via `hasPythonModuleSemantics`.
> - `collectImportMatchedTests` and `collectImportMatchedTestFiles` now partition exact literal direct imports before fuzzier matches, with the #884 whole-module guard applied to both buckets.
> - New regression tests cover the TypeScript/Go false-hub suppression, preserved Python matching, and exact-importer ranking behavior.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2afb178. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 651K/802K tokens
<!-- /lien:attestation -->