### PR TITLE
fix(cli): honest dependentAttributionIncomplete for C# zero-dependent get_dependents scans

### DIFF
--- a/.changeset/csharp-dependent-attribution-incomplete.md
+++ b/.changeset/csharp-dependent-attribution-incomplete.md
@@ -1,0 +1,23 @@
+---
+"@liendev/lien": patch
+---
+
+Follow-up to #930 (`global using` no longer producing false import edges,
+shipped in #932): removing those false edges alone left `get_dependents`
+reporting a confidently-empty `dependentCount: 0` / `riskLevel: "low"` for a
+C# file with real callers Lien simply has no signal for — a false-all-clear
+that's arguably worse than the fabrication it replaced, since C#'s
+enclosing-namespace access means a real caller needs no per-file `using` at
+all once a `global using` exists for a namespace.
+
+`get_dependents` now sets `dependentAttributionIncomplete: true` plus a
+`dependentAttributionNote` for exactly that shape (a file-level query with
+zero dependents found, in a language where `hasEnclosingNamespaceAccess` is
+set) — mirroring the `symbolAttributionDegraded` pattern already shipped for
+symbol-level queries (#928). `dependentCount: 0` in that case now reads as
+"the import graph found nothing," not a verified "nothing depends on this
+file."
+
+This does not recover the true dependents (that needs type-reference-based
+resolution the codebase doesn't have today — tracked separately); it makes
+the failure mode honest instead of silently misleading.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -414,6 +414,54 @@ describe('findDependents', () => {
     });
   });
 
+  describe('dependentAttributionIncomplete (C# enclosing-namespace-access floor, #930)', () => {
+    it('flags a file-level query with zero dependents for a C# file', async () => {
+      // Once a `global using` exists for a namespace, a real C# caller needs
+      // no per-file `using` at all -- the import graph has no signal for
+      // that usage, so a zero-dependent result here is "nothing found," not
+      // a verified "nothing depends on this file."
+      mockDB.scanAll.mockResolvedValue([createChunk('Alignment.cs', { exports: ['Alignment'] })]);
+
+      const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.dependentAttributionIncomplete).toBe(true);
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining('enclosing-namespace access'),
+        'warning',
+      );
+    });
+
+    it('does not flag a C# file that has real file-level dependents', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Alignment.cs', { exports: ['Alignment'] }),
+        createChunk('Consumer.cs', { imports: ['Alignment.cs'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog);
+
+      expect(result.dependents).toHaveLength(1);
+      expect(result.dependentAttributionIncomplete).toBeUndefined();
+    });
+
+    it('does not flag a zero-dependent TypeScript file (no enclosing-namespace access)', async () => {
+      mockDB.scanAll.mockResolvedValue([createChunk('src/target.ts', { exports: ['doStuff'] })]);
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.dependentAttributionIncomplete).toBeUndefined();
+    });
+
+    it('does not flag a zero-dependent C# SYMBOL query (that is symbolAttributionDegraded/real-empty territory instead)', async () => {
+      mockDB.scanAll.mockResolvedValue([createChunk('Alignment.cs', { exports: ['Alignment'] })]);
+
+      const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog, 'Alignment');
+
+      expect(result.dependentAttributionIncomplete).toBeUndefined();
+    });
+  });
+
   describe('complexity metrics', () => {
     it('should calculate correct file and overall complexity metrics', async () => {
       mockDB.scanAll.mockResolvedValue([

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -9,6 +9,8 @@ import {
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
   hasSingleFileImportSemantics,
+  detectLanguage,
+  hasEnclosingNamespaceAccess,
   COMPLEXITY_THRESHOLDS,
 } from '@liendev/parser';
 
@@ -115,6 +117,20 @@ export interface DependencyAnalysisResult {
    * instead of asserting an unverifiable symbol-scoped count.
    */
   symbolAttributionDegraded?: boolean;
+  /**
+   * True for a FILE-level query (no `symbol` requested) that came back with
+   * zero dependents for a language where `hasEnclosingNamespaceAccess` is
+   * set (currently only C# -- see that flag's doc comment). Those languages
+   * let a real caller use `filepath`'s types with no per-file import
+   * statement naming it at all (C#'s `global using` / implicit
+   * enclosing-namespace member access -- #930), so the import-graph scan
+   * this function runs has no signal for that usage shape. `dependentCount:
+   * 0` / `riskLevel: "low"` in this case means "the import graph found
+   * nothing," not "nothing depends on this file" -- the same false-all-clear
+   * risk `symbolAttributionDegraded` guards against for symbol queries, just
+   * for the file-level answer instead.
+   */
+  dependentAttributionIncomplete?: boolean;
 }
 
 /**
@@ -633,6 +649,13 @@ export async function findDependents(
   // call.
   const allChunks = includeAllChunks ? Array.from(allChunksByFile.values()).flat() : [];
 
+  const dependentAttributionIncomplete = checkDependentAttributionIncomplete(
+    filepath,
+    symbol,
+    dependents.length,
+    log,
+  );
+
   return {
     dependents,
     productionDependentCount,
@@ -646,7 +669,36 @@ export async function findDependents(
     truncated,
     uncoveredProductionDependents,
     symbolAttributionDegraded,
+    dependentAttributionIncomplete,
   };
+}
+
+/**
+ * True for a file-level query (no `symbol` -- that case has its own
+ * `symbolAttributionDegraded` handling above) that found zero dependents in
+ * a language where the import graph structurally cannot see every real
+ * usage (see `DependencyAnalysisResult.dependentAttributionIncomplete`'s
+ * doc comment). Logs a warning when it fires, matching the logging
+ * `buildDependentsList` already does for its own degradation case.
+ */
+function checkDependentAttributionIncomplete(
+  filepath: string,
+  symbol: string | undefined,
+  dependentCount: number,
+  log: (message: string, level?: 'warning') => void,
+): true | undefined {
+  if (symbol || dependentCount !== 0) return undefined;
+
+  const targetLanguage = detectLanguage(filepath);
+  if (targetLanguage === null || !hasEnclosingNamespaceAccess(targetLanguage)) return undefined;
+
+  log(
+    `No import-based dependents found for ${filepath} -- ${targetLanguage} has enclosing-` +
+      `namespace access, so this scan has no signal for a real caller that reaches it ` +
+      `without a per-file import (#930)`,
+    'warning',
+  );
+  return true;
 }
 
 /** Depth-1 seed: direct importers plus barrel re-exporters. */

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -63,6 +63,7 @@ describe('handleGetDependents', () => {
       truncated?: boolean;
       uncoveredProductionDependents?: number;
       symbolAttributionDegraded?: boolean;
+      dependentAttributionIncomplete?: boolean;
     } = {},
   ) {
     const dependents = overrides.dependents ?? [{ filepath: 'src/consumer.ts', isTestFile: false }];
@@ -88,6 +89,7 @@ describe('handleGetDependents', () => {
       truncated: overrides.truncated ?? false,
       uncoveredProductionDependents: overrides.uncoveredProductionDependents ?? 0,
       symbolAttributionDegraded: overrides.symbolAttributionDegraded,
+      dependentAttributionIncomplete: overrides.dependentAttributionIncomplete,
     };
   }
 
@@ -632,6 +634,35 @@ describe('handleGetDependents', () => {
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.symbolAttributionDegraded).toBeUndefined();
       expect(parsed.symbolAttributionNote).toBeUndefined();
+    });
+  });
+
+  describe('dependentAttributionIncomplete (C# enclosing-namespace-access floor, #930)', () => {
+    it('surfaces dependentAttributionIncomplete and a note for a zero-dependent file-level query', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({ dependents: [], dependentAttributionIncomplete: true }),
+      );
+
+      const result = await handleGetDependents(
+        { filepath: 'src/Serilog/Parsing/Alignment.cs' },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(0);
+      expect(parsed.dependentAttributionIncomplete).toBe(true);
+      expect(parsed.dependentAttributionNote).toContain('Alignment.cs');
+      expect(parsed.dependentAttributionNote).toContain('the scan found nothing');
+    });
+
+    it('omits dependentAttributionIncomplete and the note for a normal query', async () => {
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents({ filepath: 'src/utils/validate.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentAttributionIncomplete).toBeUndefined();
+      expect(parsed.dependentAttributionNote).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -58,6 +58,16 @@ interface DependentsResponse {
   symbolAttributionDegraded?: boolean;
   /** Human-readable explanation, present only when `symbolAttributionDegraded` is true. */
   symbolAttributionNote?: string;
+  /**
+   * True for a file-level query (no `symbol`) that found zero dependents in
+   * a language where the import graph structurally can't see every real
+   * usage (see `DependencyAnalysisResult.dependentAttributionIncomplete`).
+   * When set, `dependentCount: 0` / `riskLevel: "low"` means "nothing found,"
+   * not "nothing depends on this file" — don't treat it as a verified clear.
+   */
+  dependentAttributionIncomplete?: boolean;
+  /** Human-readable explanation, present only when `dependentAttributionIncomplete` is true. */
+  dependentAttributionNote?: string;
 }
 
 /**
@@ -67,7 +77,7 @@ function logRiskAssessment(
   analysis: DependencyAnalysisResult,
   riskLevel: string,
   symbol: string | undefined,
-  log: (msg: string) => void,
+  log: (msg: string, level?: 'warning') => void,
 ): void {
   const prodTest = `(${analysis.productionDependentCount} prod, ${analysis.testDependentCount} test)`;
   const truncatedSuffix = analysis.truncated ? ' [truncated]' : '';
@@ -77,6 +87,12 @@ function logRiskAssessment(
       `Symbol-level attribution degraded for "${symbol}" — falling back to ` +
         `${analysis.dependents.length} file-level dependents ${prodTest} - risk: ${riskLevel}${truncatedSuffix}`,
     );
+    return;
+  }
+
+  if (analysis.dependentAttributionIncomplete) {
+    // findDependents already logged the underlying warning (dependency-analyzer.ts);
+    // just skip the generic "Found 0 dependents" log below rather than duplicate it.
     return;
   }
 
@@ -167,6 +183,15 @@ function buildDependentsResponse(
       `its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, ` +
       `riskLevel, and dependents below are the file-level answer (every file that imports ` +
       `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`;
+  }
+  if (analysis.dependentAttributionIncomplete) {
+    response.dependentAttributionIncomplete = true;
+    response.dependentAttributionNote =
+      `No import-based dependents were found for ${filepath}, but its language lets real ` +
+      `callers use its exports with no per-file import naming it at all (C#'s "global using" ` +
+      `/ implicit enclosing-namespace member access). The import graph has no signal for ` +
+      `that usage shape, so dependentCount: 0 and riskLevel: "low" here mean "the scan found ` +
+      `nothing," not "nothing depends on this file" — don't treat this as a verified clear.`;
   }
 
   return response;

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -29,6 +29,10 @@ symbol:
   'truncated: true' means the BFS stopped at 'maxNodes' (default 500).
   Symbol-level queries stay at depth 1 — pass depth only for file-level.
 
+  If a result carries dependentAttributionIncomplete, a dependentCount of 0 and a
+  riskLevel of "low" mean Lien could not SEE the callers, not that there are none —
+  grep before concluding the symbol is unused. riskLevel is not adjusted for it.
+
 For discovery ("where is X?", "how does Y work?"), call search_code FIRST.
 It runs full-text BM25 keyword search over code, docstrings, and camelCase-split
 identifiers. Query with concrete KEYWORDS, identifiers, and domain terms

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -148,7 +148,14 @@ Returns:
 - symbolAttributionDegraded?: boolean + symbolAttributionNote?: string — set when
   symbol names a method or constructor (not a top-level export) and call sites
   couldn't be confirmed; dependentCount/riskLevel are then the file-level answer
-  (every importer of filepath), not a verified count of callers of symbol itself`,
+  (every importer of filepath), not a verified count of callers of symbol itself
+- dependentAttributionIncomplete?: boolean + dependentAttributionNote?: string — set
+  when a file-level query returns ZERO dependents in a language whose callers need no
+  per-file import (C# today: enclosing-namespace access under a \`global using\`). When
+  this is true, treat dependentCount 0 and riskLevel "low" as a FLOOR, not a finding —
+  it means Lien could not see callers, not that none exist. Verify with grep before
+  concluding a symbol is unused. riskLevel is not adjusted for this and may still read
+  "low"; the flag is the authoritative signal.`,
   ),
   toMCPToolSchema(
     GetComplexitySchema,

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -328,6 +328,8 @@ When `symbol` is provided, the response also includes `totalUsageCount` (number 
 
 `symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`) — those aren't top-level exports, so when call sites for one can't be confirmed, the response sets `symbolAttributionDegraded: true` plus a `symbolAttributionNote` and widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count. Check that flag before treating a low count as verified.
 
+A file-level query (no `symbol`) that finds zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930) — sets `dependentAttributionIncomplete: true` plus a `dependentAttributionNote`. `dependentCount: 0` / `riskLevel: "low"` in that case means "the import graph found nothing," not "nothing depends on this file" — check that flag too before treating a zero count as a verified all-clear.
+
 ### Risk Levels
 
 | Level | Dependent Count | Meaning |


### PR DESCRIPTION
## Summary

Follow-up to #930. The false-edge fix (`global using` no longer resolving
to a file-to-file import) already shipped in #932 — **that part is on
`main`**, not this PR. This PR addresses the concern raised on #932 after
merge: removing the false edges alone leaves `get_dependents` reporting a
confidently-empty `dependentCount: 0` / `riskLevel: "low"` for a C# file
with real callers the import graph structurally can't see (C#'s enclosing-
namespace access means a real caller needs no per-file `using` at all once
a `global using` exists for that namespace). A silent, confident zero is
arguably worse than the fabrication it replaced — it reads as "safe to
change" on a file that may have real callers Lien simply never saw.

**Fix:** `get_dependents` now sets `dependentAttributionIncomplete: true`
plus a `dependentAttributionNote` whenever a file-level query (no `symbol`)
comes back with zero dependents for a language where
`hasEnclosingNamespaceAccess` is set (only C# today). This mirrors the
`symbolAttributionDegraded` pattern already shipped for symbol-level
queries (#928) — same idea, applied to the file-level "zero" case instead
of the symbol-level "unresolvable" case.

```json
{
  "dependentCount": 0,
  "riskLevel": "low",
  "dependents": [],
  "dependentAttributionIncomplete": true,
  "dependentAttributionNote": "No import-based dependents were found for src/Serilog/Parsing/Alignment.cs, but its language lets real callers use its exports with no per-file import naming it at all (C#'s \"global using\" / implicit enclosing-namespace member access). The import graph has no signal for that usage shape, so dependentCount: 0 and riskLevel: \"low\" here mean \"the scan found nothing,\" not \"nothing depends on this file\" — don't treat this as a verified clear."
}
```

The flag only fires for the specific shape the concern was about: a
file-level query, genuinely zero dependents, in an enclosing-namespace-
access language. It does NOT fire when:
- a `symbol` was requested (that's `symbolAttributionDegraded`'s territory, unaffected),
- the file has any real dependents at all (even 1),
- the language doesn't have `hasEnclosingNamespaceAccess` set (every other language, unaffected).

## What this does NOT do

It does not recover the true dependents. That needs type-reference-based
resolution the codebase doesn't have today for the general
`get_dependents`/`annotate` path — see the "Part 2" discussion on #930/#932
for why that's a separate, larger effort (no existing extension point,
unlike the directory-based same-package/same-directory heuristics
`test-associations.ts` already has for Go/Java test-association matching).
This PR makes the failure mode honest instead of silently misleading, which
is the smaller, well-scoped alternative explicitly called out as acceptable
when full type-reference resolution is out of scope.

## Verbatim dogfood (serilog/serilog, real 254-file C# corpus, reindexed with this branch's build)

```
$ node <cli> serve   # via MCP get_dependents
get_dependents({"filepath":"src/Serilog/Parsing/Alignment.cs"})
```
```json
{
  "dependentCount": 0,
  "productionDependentCount": 0,
  "testDependentCount": 0,
  "riskLevel": "low",
  "riskReasoning": [],
  "dependents": [],
  "dependentAttributionIncomplete": true,
  "dependentAttributionNote": "No import-based dependents were found for src/Serilog/Parsing/Alignment.cs, but its language lets real callers use its exports with no per-file import naming it at all (C#'s \"global using\" / implicit enclosing-namespace member access). The import graph has no signal for that usage shape, so dependentCount: 0 and riskLevel: \"low\" here mean \"the scan found nothing,\" not \"nothing depends on this file\" — don't treat this as a verified clear."
}
```

Regression-checked the same corpus:
- `PropertyToken.cs` (1 real test dependent found): `dependentAttributionIncomplete` correctly **absent** — the flag doesn't fire when real dependents exist.
- A `symbol`-scoped query on a C# file with zero dependents: `dependentAttributionIncomplete` correctly **absent** — that's `symbolAttributionDegraded`'s territory, unaffected.
- A TypeScript file with zero dependents (hono corpus, no `enclosingNamespaceAccess`): flag correctly never fires for non-C# languages (guaranteed by `hasEnclosingNamespaceAccess` only being set for C# — covered by existing tests, not language-specific to this PR).

## Gate chain (all six)

```
npm run format:check   ✅ 0 issues
npm run lint            ✅ 0 errors (38 pre-existing warnings, none in touched files)
npm run typecheck       ✅ 0 errors
npm run build           ✅ all 5 packages
npm test                ✅ 211 files, 0 failures (parser 50, core 36, review 57, cli 62, action 5, parser-native 1)
npm run docs:build      ✅ + read the rendered mcp-tools.html output (renders cleanly)
node packages/cli/dist/index.js delta --base origin/main
                         ✅ exit 0 — 3 advisory "worsened" only (findDependents Halstead-time
                            metric 49m→54m after extracting the new logic into its own
                            `checkDependentAttributionIncomplete` helper to keep it under the
                            60m threshold it briefly crossed pre-extraction; logRiskAssessment
                            9→10, buildDependentsResponse 4→5 — all well under their limits),
                            no new-over-threshold crossing
```

Diff vs `origin/main` is exactly 6 files: the two handler files + their
tests, the docs update, and a new changeset (kept separate from #932's
already-shipped, not-yet-released changeset rather than reopening it).

## Files

- `packages/cli/src/mcp/handlers/dependency-analyzer.ts` — `checkDependentAttributionIncomplete` + wiring into `findDependents`'s return
- `packages/cli/src/mcp/handlers/get-dependents.ts` — response fields + `buildDependentsResponse`/`logRiskAssessment` wiring
- `packages/cli/src/mcp/handlers/dependency-analyzer.test.ts`, `get-dependents.test.ts` — new tests mirroring the `symbolAttributionDegraded` test pattern
- `packages/site/docs/guide/mcp-tools.md` — response-field documentation
- `.changeset/csharp-dependent-attribution-incomplete.md`

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds an honesty flag (`dependentAttributionIncomplete` + `dependentAttributionNote`) to file-level `get_dependents` queries that return zero dependents for C# files, where enclosing-namespace access and `global using` mean real callers may exist without any per-file import edge. The change is narrowly scoped: it only fires when there is no `symbol`, zero dependents, and the language has `hasEnclosingNamespaceAccess` set (currently only C#). The implementation correctly checks all three conditions, surfaces the flag through the MCP response, and avoids duplicate logging. Tests cover the trigger case and the three exclusion cases (symbol query, non-zero dependents, non-C# language). Documentation and guidance claims match the code behavior. No breaking changes or wrong-output paths were found.
>
> - Added `checkDependentAttributionIncomplete` helper that sets `dependentAttributionIncomplete` only for file-level, zero-dependent C# queries
> - Surfaced `dependentAttributionIncomplete` and `dependentAttributionNote` in the `get_dependents` MCP response via `buildDependentsResponse`
> - Updated `logRiskAssessment` to accept the optional warning level parameter and skip generic logging when the flag is set
> - Added tests and updated MCP tool docs/instructions

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bd49c69. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `get_dependents` now flags cases where import-based analysis may not identify all file dependents.
  - Responses include an explanatory note when zero dependents cannot be treated as a confirmed absence of usage.
  - Risk reporting avoids presenting these cases as definitively low risk.

- **Documentation**
  - Clarified how to interpret `dependentAttributionIncomplete`, zero dependent counts, and low-risk results for file-level queries.

- **Tests**
  - Added coverage for C#, TypeScript, symbol-level, and normal dependent queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 632K/892K tokens
<!-- /lien:attestation -->