### PR TITLE
fix(parser,cli): stop get_dependents from fabricating dependency graphs

### DIFF
--- a/.changeset/fix-fabricated-dependency-graphs.md
+++ b/.changeset/fix-fabricated-dependency-graphs.md
@@ -44,3 +44,8 @@ Also reconciles the reported `dependentCount`/`riskReasoning` mismatch (e.g.
 production-only callers by design (test callers shouldn't weigh into risk
 the same way), just without saying so — now labeled "N production callers"
 explicitly.
+
+`targetIndexed`'s `note` defers to #927's manifest-based `note` whenever both
+would fire for the same target (the overwhelming common case — a
+nonexistent path is both "not in the manifest" and "has no chunks"): only
+one note is ever shown, never two competing explanations of the same zero.

--- a/.changeset/fix-fabricated-dependency-graphs.md
+++ b/.changeset/fix-fabricated-dependency-graphs.md
@@ -1,0 +1,46 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+#928: `get_dependents` fabricated dependency graphs via language-blind
+bare-module matching — a confident wrong answer, not a degraded one, since
+the tool exists specifically to catch "is this safe to change?" before an
+edit.
+
+Two independent shapes, found via the foreign-repo dogfood (#917):
+
+- **Rust `self::`/`super::` collapsed to a directory-less string.**
+  `RustImportExtractor` stripped these keywords down to a bare or merely
+  `../`-prefixed specifier with no knowledge of the importer's real location,
+  which `matchesFile`'s generic bare-identifier leniency (designed for the
+  legitimate `crate::auth` -> `src/auth.rs` convention) then had to guess at
+  match time — and could coincidentally match an unrelated same-named file
+  elsewhere with a single leading directory. Reproduced on tokio-rs/tokio:
+  `benches/copy.rs` (a leaf benchmark nothing can import) fuzzy-matched
+  `tokio/src/fs/mod.rs`'s `self::copy` and
+  `tokio/src/io/util/copy_bidirectional.rs`'s `super::copy`, fabricating 80
+  dependents. Fixed by resolving `self::`/`super::` precisely against the
+  importer's own file-to-module-aware location (`resolveRustRelativeModulePath`
+  in `ast/languages/rust.ts`) instead of the old lossy string convention —
+  this also makes real Rust cross-file dependency tracking MORE accurate
+  (the 79 real callers of `tokio::fs::copy` are now correctly attributed to
+  `tokio/src/fs/copy.rs`, not to the unrelated benchmark).
+- **No existence check before the fuzzy search.** A nonexistent path that
+  collides on a namespace/directory suffix with a real file silently
+  inherited that file's entire graph — `src/Command/Command.php` (guessed,
+  doesn't exist) returned the same 93 dependents as the real
+  `Command/Command.php`, because `matchesFile`'s multi-segment boundary
+  strategy has no cap on extra leading target directories (deliberately, to
+  support e.g. PHP PSR-4 vendor prefixes) — there is no purely textual way to
+  tell a real deep path from a fabricated one with the same suffix. Fixed by
+  checking the target actually has chunks in the index before running the
+  fuzzy search at all (`get_dependents`'s new `targetIndexed` result field);
+  an unresolvable target now always comes back with zero dependents and an
+  explicit `note`, never someone else's graph.
+
+Also reconciles the reported `dependentCount`/`riskReasoning` mismatch (e.g.
+`dependentCount: 80` next to `"14 callers"`): the reasoning already counted
+production-only callers by design (test callers shouldn't weigh into risk
+the same way), just without saying so — now labeled "N production callers"
+explicitly.

--- a/packages/cli/src/cli/api-delta-cmd.test.ts
+++ b/packages/cli/src/cli/api-delta-cmd.test.ts
@@ -409,6 +409,28 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
     await fs.mkdir(realIndexDir, { recursive: true });
     await fs.writeFile(path.join(realIndexDir, 'structural.db'), '', 'utf-8');
 
+    // The target file itself must have a chunk in the stub index (#928) --
+    // get_dependents/findDependents now requires the requested target to be
+    // indexed at all before running its fuzzy dependent search, to stop an
+    // unresolvable path from silently inheriting an unrelated file's graph.
+    // A real index always has at least one chunk for a.ts itself; this stub
+    // must model that too, or the target reads as "not indexed" and
+    // dependentCount comes back 0 regardless of caller.ts below.
+    const targetChunk = {
+      content: 'export function formatUser(user) { return user.name; }',
+      metadata: {
+        file: 'a.ts',
+        startLine: 1,
+        endLine: 1,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'formatUser',
+        symbolType: 'function',
+        exports: ['formatUser'],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
     const callerChunk = {
       content: 'formatUser(x);',
       metadata: {
@@ -429,7 +451,7 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
       getCurrentVersion: vi.fn().mockReturnValue(1),
-      scanAll: vi.fn().mockResolvedValue([callerChunk]),
+      scanAll: vi.fn().mockResolvedValue([targetChunk, callerChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
     await expect(apiDeltaCommand({ format: 'json', file: 'a.ts' })).rejects.toThrow('__exit__:0');

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -120,6 +120,11 @@ describe('findDependents', () => {
         createChunk('rack-protection/lib/rack/protection/base.rb', {
           imports: ['rack/protection'],
         }),
+        // The requested target must itself be indexed (#928) -- otherwise
+        // this test would pass vacuously (empty dependents for an
+        // unresolved target) rather than actually exercising the anti-fan-
+        // out guard it's named for.
+        createChunk('rack-protection/lib/rack/protection/xss_header.rb'),
       ]);
 
       const result = await findDependents(
@@ -138,6 +143,10 @@ describe('findDependents', () => {
         createChunk('rack-protection/lib/rack/protection/base.rb', {
           imports: ['rack/protection'],
         }),
+        // The requested target must itself be indexed (#928) for the fuzzy
+        // dependent search to run at all -- a real umbrella entry point is
+        // always its own chunk in a real index.
+        createChunk('rack-protection/lib/rack/protection.rb'),
       ]);
 
       const result = await findDependents(
@@ -159,6 +168,8 @@ describe('findDependents', () => {
       // real gin clone) by applying Ruby's stricter anchor unconditionally.
       mockDB.scanAll.mockResolvedValue([
         createChunk('render/html.go', { imports: ['internal/fs'] }),
+        // The requested target must itself be indexed (#928).
+        createChunk('internal/fs/fs.go'),
       ]);
 
       const result = await findDependents(mockDB as any, 'internal/fs/fs.go', mockLog);
@@ -174,6 +185,8 @@ describe('findDependents', () => {
       mockDB.scanAll.mockResolvedValue([
         createChunk('render/html.go', { imports: ['pkg/sub'] }),
         createChunk('lib/pkg/consumer.rb', { imports: ['pkg/sub'] }),
+        // The requested target must itself be indexed (#928).
+        createChunk('pkg/sub/child.go'),
       ]);
 
       const result = await findDependents(mockDB as any, 'pkg/sub/child.go', mockLog);
@@ -638,6 +651,71 @@ describe('findDependents', () => {
       expect(result.productionDependentCount).toBe(0);
       expect(result.testDependentCount).toBe(0);
       expect(result.complexityMetrics.complexityRiskBoost).toBe('low');
+    });
+  });
+
+  describe("#928: an unresolvable target must not inherit an unrelated file's dependent graph", () => {
+    it('a completely nonexistent path (no chunks anywhere) returns zero dependents with targetIndexed: false', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/real.ts', { exports: ['thing'] }),
+        createChunk('src/consumer.ts', { imports: ['src/real.ts'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/totally/made/up/File.ts', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.targetIndexed).toBe(false);
+      expect(result.complexityMetrics.complexityRiskBoost).toBe('low');
+    });
+
+    it('a real file with genuinely zero dependents is still targetIndexed: true', async () => {
+      // Distinguishes "confirmed zero dependents" (a real, indexed, isolated
+      // file) from "unresolved target" (the case above) -- both return an
+      // empty `dependents` array, but only `targetIndexed` tells them apart.
+      mockDB.scanAll.mockResolvedValue([createChunk('src/isolated.ts', { exports: ['foo'] })]);
+
+      const result = await findDependents(mockDB as any, 'src/isolated.ts', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.targetIndexed).toBe(true);
+    });
+
+    it('a nonexistent path that would otherwise basename/suffix-collide with a real file does not inherit its graph (the PHP Command/Command.php repro)', async () => {
+      // Command/Command.php is a real, indexed file with a real dependent.
+      // matchesFile's generic multi-segment boundary strategy (Strategy 2)
+      // has no cap on how many extra leading directories the TARGET may
+      // carry beyond an already-resolved import specifier -- deliberately,
+      // to support e.g. PHP PSR-4 vendor prefixes ("Domain/Services/Auth"
+      // legitimately matching "web/Domain/Services/Auth"). That means a
+      // caller guessing a plausible-but-wrong "src/" prefix
+      // ("src/Command/Command.php") would, without an existence check,
+      // silently inherit the real file's entire graph purely because
+      // "Command/Command" is a suffix of "src/Command/Command" -- there is
+      // no purely textual way to tell the two shapes apart, so the existence
+      // check is load-bearing here, not merely defense in depth.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Application.php', { imports: ['Command/Command'] }),
+        createChunk('Command/Command.php', { exports: ['Command'] }),
+      ]);
+
+      const real = await findDependents(mockDB as any, 'Command/Command.php', mockLog);
+      expect(real.dependents.map(d => d.filepath)).toContain('Application.php');
+      expect(real.targetIndexed).toBe(true);
+
+      const fake = await findDependents(mockDB as any, 'src/Command/Command.php', mockLog);
+      expect(fake.dependents).toHaveLength(0);
+      expect(fake.targetIndexed).toBe(false);
+    });
+
+    it('logs a warning when the target is not found in the index', async () => {
+      mockDB.scanAll.mockResolvedValue([createChunk('src/real.ts')]);
+
+      await findDependents(mockDB as any, 'src/nope.ts', mockLog);
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining('Target not found in index'),
+        'warning',
+      );
     });
   });
 

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -131,6 +131,23 @@ export interface DependencyAnalysisResult {
    * for the file-level answer instead.
    */
   dependentAttributionIncomplete?: boolean;
+  /**
+   * False when the requested target has zero chunks anywhere in the scanned
+   * index (#928) — i.e. it isn't a real file the indexer has seen, whether
+   * because it was never indexed, is misspelled, or genuinely has no
+   * extractable content. `matchesFile`'s fuzzy-matching strategies are tuned
+   * to resolve real ambiguous specifiers (relative imports, namespace
+   * prefixes, bare crate-root modules); they were never meant to stand in
+   * for an existence check, and running them against a target with no
+   * chunks of its own risks matching on textual coincidence alone (a
+   * fabricated path silently inheriting an unrelated real file's entire
+   * dependent graph — see the PHP `Command/Command.php` basename-collision
+   * repro in #928). When `false`, `dependents`/`symbolAttributionDegraded`/
+   * `dependentAttributionIncomplete` above are moot -- `dependents` is
+   * deliberately left empty rather than fuzzy-matched, and callers should
+   * treat the whole result as "unresolved", not "confirmed zero dependents".
+   */
+  targetIndexed: boolean;
 }
 
 /**
@@ -599,7 +616,11 @@ export async function findDependents(
   );
   const ctx: ScanContext = { importIndex, allChunksByFile, normalizePathCached, log };
 
-  const { chunksByFile, reExporterPaths } = seedDepth1Dependents(ctx, normalizedTarget);
+  const { targetIndexed, chunksByFile, reExporterPaths } = seedIfTargetIndexed(
+    ctx,
+    normalizedTarget,
+    filepath,
+  );
 
   // Stamp depth-1 files, then BFS outward if requested.
   const hopsByFile = new Map<string, number>();
@@ -653,6 +674,7 @@ export async function findDependents(
     filepath,
     symbol,
     dependents.length,
+    targetIndexed,
     log,
   );
 
@@ -670,6 +692,7 @@ export async function findDependents(
     uncoveredProductionDependents,
     symbolAttributionDegraded,
     dependentAttributionIncomplete,
+    targetIndexed,
   };
 }
 
@@ -680,14 +703,22 @@ export async function findDependents(
  * usage (see `DependencyAnalysisResult.dependentAttributionIncomplete`'s
  * doc comment). Logs a warning when it fires, matching the logging
  * `buildDependentsList` already does for its own degradation case.
+ *
+ * Skipped when `targetIndexed` is false (#928): an unresolved target's zero
+ * dependents already carries its own, more fundamental "unresolved" signal
+ * (see `seedIfTargetIndexed`) -- layering the C#-specific reasoning on top
+ * would produce two notes competing to explain the same zero, one of them
+ * describing a language nuance that's moot when the file was never found
+ * in the index at all.
  */
 function checkDependentAttributionIncomplete(
   filepath: string,
   symbol: string | undefined,
   dependentCount: number,
+  targetIndexed: boolean,
   log: (message: string, level?: 'warning') => void,
 ): true | undefined {
-  if (symbol || dependentCount !== 0) return undefined;
+  if (symbol || dependentCount !== 0 || !targetIndexed) return undefined;
 
   const targetLanguage = detectLanguage(filepath);
   if (targetLanguage === null || !hasEnclosingNamespaceAccess(targetLanguage)) return undefined;
@@ -699,6 +730,39 @@ function checkDependentAttributionIncomplete(
     'warning',
   );
   return true;
+}
+
+/**
+ * #928: only run the fuzzy dependent search against a target that's actually
+ * indexed. `allChunksByFile` is keyed by the same `normalizePathCached` used
+ * for `normalizedTarget`, so this check is free (no extra I/O) and precise
+ * for "does the index have any chunks for this file at all". Skipping the
+ * fuzzy search entirely for an unresolvable target — rather than letting it
+ * run and possibly latch onto an unrelated real file's import graph through
+ * textual coincidence — trades a possible false negative (a real but oddly-
+ * shaped match we don't find) for a guaranteed non-fabrication: an
+ * unresolvable target always comes back with zero dependents, never someone
+ * else's.
+ */
+function seedIfTargetIndexed(
+  ctx: ScanContext,
+  normalizedTarget: string,
+  filepath: string,
+): {
+  targetIndexed: boolean;
+  chunksByFile: Map<string, SearchResult[]>;
+  reExporterPaths: string[];
+} {
+  const targetIndexed = ctx.allChunksByFile.has(normalizedTarget);
+  if (!targetIndexed) {
+    ctx.log(
+      `Target not found in index: ${filepath} — returning zero dependents rather than a fuzzy-matched guess`,
+      'warning',
+    );
+    return { targetIndexed, chunksByFile: new Map(), reExporterPaths: [] };
+  }
+  const { chunksByFile, reExporterPaths } = seedDepth1Dependents(ctx, normalizedTarget);
+  return { targetIndexed, chunksByFile, reExporterPaths };
 }
 
 /** Depth-1 seed: direct importers plus barrel re-exporters. */

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -64,6 +64,7 @@ describe('handleGetDependents', () => {
       uncoveredProductionDependents?: number;
       symbolAttributionDegraded?: boolean;
       dependentAttributionIncomplete?: boolean;
+      targetIndexed?: boolean;
     } = {},
   ) {
     const dependents = overrides.dependents ?? [{ filepath: 'src/consumer.ts', isTestFile: false }];
@@ -90,6 +91,7 @@ describe('handleGetDependents', () => {
       uncoveredProductionDependents: overrides.uncoveredProductionDependents ?? 0,
       symbolAttributionDegraded: overrides.symbolAttributionDegraded,
       dependentAttributionIncomplete: overrides.dependentAttributionIncomplete,
+      targetIndexed: overrides.targetIndexed ?? true,
     };
   }
 
@@ -737,8 +739,12 @@ describe('handleGetDependents', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.riskLevel).toBe('medium');
+      // "production callers", not bare "callers" (#928) -- risk scoring feeds
+      // productionDependentCount in, which can differ from the response's
+      // wider top-level dependentCount (production + test); the label makes
+      // that scoping explicit instead of leaving two unexplained numbers.
       expect(parsed.riskReasoning).toEqual(
-        expect.arrayContaining(['8 callers', '3 untested', 'max complexity 12']),
+        expect.arrayContaining(['8 production callers', '3 untested', 'max complexity 12']),
       );
     });
 
@@ -759,7 +765,7 @@ describe('handleGetDependents', () => {
     });
   });
 
-  describe('unindexed path note', () => {
+  describe('unindexed path note (#927)', () => {
     it('adds an unmissable note when the filepath has no manifest entry at all', async () => {
       vi.mocked(findUnindexedPaths).mockResolvedValue(['src/does/not/exist.ts']);
 
@@ -772,13 +778,66 @@ describe('handleGetDependents', () => {
 
     it('adds no note when the filepath is indexed, regardless of dependentCount', async () => {
       vi.mocked(findUnindexedPaths).mockResolvedValue([]);
-      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis({ dependents: [] }));
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({ dependents: [], targetIndexed: true }),
+      );
 
       const result = await handleGetDependents({ filepath: 'src/isolated.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.dependentCount).toBe(0);
       expect(parsed).not.toHaveProperty('note');
+    });
+  });
+
+  describe('#928: unresolved-target note (chunk-based fallback)', () => {
+    it('adds an unmissable note when the target has no chunks in the index at all', async () => {
+      // findUnindexedPaths defaults to [] in beforeEach (manifest has no
+      // opinion here) -- this exercises the #928 chunk-based note on its own.
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({ dependents: [], targetIndexed: false }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'src/does/not/exist.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(0);
+      expect(parsed.riskLevel).toBe('low');
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('"src/does/not/exist.ts"');
+    });
+
+    it('adds no note when the target is indexed, regardless of dependentCount', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({ dependents: [], targetIndexed: true }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'src/isolated.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(0);
+      expect(parsed).not.toHaveProperty('note');
+    });
+
+    it('does not duplicate or contradict the #927 manifest note when both mechanisms would fire', async () => {
+      // A genuinely nonexistent path is BOTH "not in the manifest" (#927)
+      // AND "has no chunks in this scan" (#928) -- the overwhelming common
+      // case. Only the manifest note (the more authoritative "is this path
+      // even part of the indexed project" signal) should appear; the #928
+      // note must not also append or overwrite it with a second, redundant
+      // explanation of the same zero.
+      vi.mocked(findUnindexedPaths).mockResolvedValue(['src/does/not/exist.ts']);
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({ dependents: [], targetIndexed: false }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'src/does/not/exist.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('⚠ Lien:');
+      // Exactly one note field, sourced from #927 (its wording, not #928's).
+      expect(parsed.note).toContain('not found in the index');
+      expect(parsed.note).not.toContain('has no chunks anywhere in the index');
     });
   });
 });

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -45,7 +45,15 @@ interface DependentsResponse {
   riskReasoning: string[];
   dependents: DependentInfo[];
   complexityMetrics: ComplexityMetrics;
-  /** Set when `filepath` has no entry in the index manifest at all — see unindexed-paths.ts. */
+  /**
+   * Set either when `filepath` has no entry in the index manifest at all
+   * (see unindexed-paths.ts), or — when the manifest check doesn't already
+   * explain it — when `filepath` has zero chunks anywhere in the current
+   * scan (#928). Either way, every count above is then a deliberate `0`, not
+   * a fuzzy-matched answer: read this before trusting `dependentCount: 0` /
+   * `riskLevel: "low"` as "safe to edit". See `buildDependentsResponse` for
+   * the precedence between the two sources.
+   */
   note?: string;
   /**
    * True when `symbol` couldn't be attributed at the symbol level (it's not
@@ -130,12 +138,33 @@ function computeRisk(analysis: DependencyAnalysisResult): BlastRadiusRisk {
   // Any high-complexity dependent that is also untested escalates risk.
   const hasHighComplexityUncovered =
     uncoveredProductionDependents > 0 && maxComplexity >= HIGH_COMPLEXITY_THRESHOLD;
-  return computeBlastRadiusRisk({
+  const risk = computeBlastRadiusRisk({
     dependentCount: productionDependentCount,
     uncoveredDependents: uncoveredProductionDependents,
     maxDependentComplexity: maxComplexity > 0 ? maxComplexity : undefined,
     hasHighComplexityUncovered,
   });
+  return { ...risk, reasoning: clarifyCallerReasoning(risk.reasoning) };
+}
+
+/**
+ * Relabel the shared primitive's generic "N callers"/"N caller" reasoning
+ * entry to make explicit that it counts PRODUCTION dependents only (#928).
+ * `computeRisk` above deliberately feeds `productionDependentCount` in — a
+ * test file calling the target shouldn't weigh into risk the same way a
+ * production caller does — but the response's own top-level `dependentCount`
+ * field is the WIDER total (production + test). Left unrelabeled, a reader
+ * sees two different numbers answering what looks like the same question
+ * ("14 callers" next to `dependentCount: 80`) with nothing to indicate
+ * they're deliberately scoped differently; this makes the scoping explicit
+ * instead of changing either number. Scoped to this handler's own response
+ * rather than the shared `blast-radius-risk.ts` primitive, which the review-
+ * side blast-radius injection also consumes with its own (unrelated) scoping.
+ */
+function clarifyCallerReasoning(reasoning: string[]): string[] {
+  return reasoning.map(entry =>
+    /^\d+ callers?$/.test(entry) ? entry.replace(/ callers?$/, m => ` production${m}`) : entry,
+  );
 }
 
 /**
@@ -172,8 +201,25 @@ function buildDependentsResponse(
   if (analysis.totalUsageCount !== undefined) {
     response.totalUsageCount = analysis.totalUsageCount;
   }
+  // #927's manifest-based note takes precedence: it's the more authoritative
+  // "is this path even part of the indexed project" signal (independent of
+  // chunk count), and in the overwhelming common case (a typo'd/nonexistent
+  // path) both it and the #928 chunk-based check below would fire for the
+  // same reason -- setting both would just be two notes saying the same
+  // thing. The #928 check still adds real value on its own for the narrower
+  // gap the manifest can't see: a path the manifest lists as indexed but
+  // that produced zero chunks in this scan (e.g. a genuinely empty file).
   if (note) {
     response.note = note;
+  } else if (!analysis.targetIndexed) {
+    response.note =
+      `⚠ Lien: "${filepath}" has no chunks anywhere in the index — every count above ` +
+      'is a deliberate 0, not a confirmed empty dependency graph. This can mean the ' +
+      'path was never indexed, is misspelled (wrong directory prefix, wrong case), or ' +
+      'genuinely has no extractable content. Do not treat this as a low-risk or ' +
+      'dependency-free file; check for a typo before editing, try search_code or ' +
+      'list_functions to find the real path, or run "lien index" if the file was added ' +
+      'recently.';
   }
   if (analysis.symbolAttributionDegraded) {
     response.symbolAttributionDegraded = true;

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -178,11 +178,17 @@ function test() {
       });
     });
 
-    it('should NOT resolve relative-looking specifiers for non-JS/TS languages (#525 scope)', () => {
-      // Rust's extractor rewrites `super::utils::helper` as `../utils/helper`
-      // as an internal storage convention, not as a filesystem path. Resolving
-      // that against the chunk's directory would produce incorrect keys, so
-      // the gate in prepareASTContext must keep Rust imports untouched.
+    it('does NOT resolve Rust self::/super:: via the generic JS/TS-style relative-import join (#525 scope)', () => {
+      // Rust is deliberately excluded from `RESOLVE_RELATIVE_IMPORTS` (see
+      // that set's doc comment in ast/chunker.ts) because a naive filesystem-
+      // style ".." join of the extractor's `../utils/helper` storage
+      // convention would ascend past the importer's own directory when the
+      // importer is a "leaf" file (crates/app/src/foo.rs isn't a mod.rs, so
+      // its own directory already IS its parent module's location — see
+      // `resolveRustRelativeModulePath`'s doc comment). Rust instead resolves
+      // self::/super:: via its OWN module-aware mechanism (#928, threaded
+      // through `rustImporterFile`), which for this exact leaf-file shape
+      // correctly stays in the SAME directory rather than ascending.
       const rustContent = `
 use super::utils::helper;
 
@@ -195,10 +201,28 @@ pub fn run() {
       const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
 
       expect(funcChunk?.metadata.imports).toBeDefined();
-      // The Rust extractor's normalized form stays exactly as-is.
-      expect(funcChunk?.metadata.imports).toContain('../utils/helper');
-      // Explicitly NOT resolved against crates/app/src/foo.rs.
+      // Resolved precisely to the real sibling path (#928) -- NOT the old
+      // directory-less "../utils/helper" storage convention, and NOT the
+      // naive (wrong, ascends one level too far) generic join a JS/TS-style
+      // resolver would have produced.
+      expect(funcChunk?.metadata.imports).toContain('crates/app/src/utils/helper');
+      expect(funcChunk?.metadata.imports).not.toContain('../utils/helper');
       expect(funcChunk?.metadata.imports).not.toContain('crates/app/utils/helper');
+    });
+
+    it('resolves Rust self:: from a mod.rs to a sibling in the SAME directory (#928)', () => {
+      const rustContent = `
+pub use self::copy::copy;
+
+pub fn run() {
+    copy();
+}
+      `.trim();
+
+      const chunks = chunkByAST('tokio/src/fs/mod.rs', rustContent);
+      const funcChunk = chunks.find(c => c.metadata.symbolName === 'run');
+
+      expect(funcChunk?.metadata.imports).toContain('tokio/src/fs/copy/copy');
     });
 
     describe('cross-package workspace imports', () => {

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -63,11 +63,17 @@ function parseAndValidate(filepath: string, content: string) {
  * resolving relative imports against the importer's path produces the correct
  * workspace-relative target.
  *
- * Deliberately excludes Rust: its extractor emits `../x` as an internal
- * storage convention for `super::x`, but that string does not describe the
- * actual filesystem target. `super::x` from `src/foo.rs` resolves to the
- * sibling module `src/x`, not to `src/../x` — so applying filesystem-style
- * `..` resolution here would produce wrong keys.
+ * Deliberately excludes Rust: `super::x` from a "leaf" file `src/foo.rs`
+ * resolves to the SIBLING module `src/x`, not to `src/../x` — Rust's
+ * `self::`/`super::` traverse the MODULE tree, which only sometimes lines up
+ * with a filesystem `..` (it depends on whether the importer is itself a
+ * `mod.rs`/`lib.rs`/`main.rs` — see `RustImportExtractor`'s doc comments), so
+ * this generic filesystem-style join would produce wrong keys for it. Rust
+ * resolves `self::`/`super::` precisely via its OWN extractor-internal
+ * mechanism instead (#928, `resolveRustRelativeModulePath` in
+ * `ast/languages/rust.ts`, threaded through via `ManifestRoots.rustCrateMap`'s
+ * sibling `importerFile` argument) — this set staying Rust-free is about
+ * which MECHANISM resolves it, not whether it's resolved at all.
  *
  * Includes Python (#904): `PythonImportExtractor` converts a relative
  * import's leading-dot form (`.foo`, `..pkg`) to a `./`/`../`-prefixed
@@ -174,6 +180,12 @@ function prepareASTContext(
       ? resolveWorkspacePackageEntries(workspaceRoot)
       : undefined;
   const manifestRoots = buildManifestRoots(language, workspaceRoot);
+  // Rust's self::/super:: resolution (#928) needs the file's real path
+  // UNCONDITIONALLY, unlike `resolutionPath` above (which is deliberately
+  // gated to skip Rust — see `RESOLVE_RELATIVE_IMPORTS`'s doc comment).
+  // `rustImporterFile` is the dedicated, ungated channel for that; every
+  // other language's extractor ignores it.
+  const rustImporterFile = language === 'rust' ? filepath : undefined;
   return {
     lines: content.split('\n'),
     fileImports: extractImports(
@@ -182,6 +194,7 @@ function prepareASTContext(
       resolutionPath,
       workspacePackages,
       manifestRoots,
+      rustImporterFile,
     ),
     importedSymbols: extractImportedSymbols(
       rootNode,
@@ -189,6 +202,7 @@ function prepareASTContext(
       resolutionPath,
       workspacePackages,
       manifestRoots,
+      rustImporterFile,
     ),
     fileExports: extractExports(rootNode, language),
     traverser: getTraverser(language),

--- a/packages/parser/src/ast/extractors/types.ts
+++ b/packages/parser/src/ast/extractors/types.ts
@@ -122,20 +122,36 @@ export interface LanguageImportExtractor {
    *   against a workspace crate BEFORE deciding whether the import is
    *   internal or external, which (unlike PHP/Go) happens inside the
    *   extractor itself rather than as post-processing in `ast/symbols.ts`.
+   * @param importerFile - Rust-only (#928): workspace-relative path of the
+   *   file containing this `use` declaration. Rust's `self::`/`super::`
+   *   resolve relative to the IMPORTER's own location, but which directory
+   *   that means depends on Rust's file-to-module convention (a `mod.rs`
+   *   represents its own containing directory; any other file represents a
+   *   module nested one level inside it) — this can't be decided by the
+   *   generic `./`/`../` relative-import resolution every other language
+   *   uses (see `ast/chunker.ts`'s `RESOLVE_RELATIVE_IMPORTS` doc comment),
+   *   so Rust's own extractor resolves it directly instead. Every other
+   *   language's implementation ignores this parameter.
    * @returns Every import path declared by this node, in source order (empty if none)
    */
-  extractImportPaths(node: SyntaxNode, rustCrateMap?: ReadonlyMap<string, string>): string[];
+  extractImportPaths(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
+  ): string[];
 
   /**
    * Extract imported symbols mapped to their source path.
    *
    * @param node - AST node matching one of importNodeTypes
    * @param rustCrateMap - Rust-only (#903) — see `extractImportPaths`.
+   * @param importerFile - Rust-only (#928) — see `extractImportPaths`.
    * @returns Object with importPath and symbols, or null to skip
    */
   processImportSymbols(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null;
 
   /**
@@ -157,11 +173,13 @@ export interface LanguageImportExtractor {
    *
    * @param node - AST node matching one of importNodeTypes
    * @param rustCrateMap - Rust-only (#903) -- see `extractImportPaths`.
+   * @param importerFile - Rust-only (#928) -- see `extractImportPaths`.
    * @returns Every {importPath, symbols} pair declared by this node, in source order (empty if none)
    */
   processImportSymbolsList(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): Array<{ importPath: string; symbols: string[] }>;
 
   /**

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -388,6 +388,131 @@ pub static COUNTER: i32 = 0;`;
         expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBe('auth/AuthService');
       });
     });
+
+    // #928: without `importerFile`, `self::`/`super::` fell back to a
+    // directory-less (or merely `../`-prefixed) string with no knowledge of
+    // the importer's real location. `matchesFile`'s generic bare-identifier
+    // leniency (designed for the legitimate `crate::auth` -> `src/auth.rs`
+    // convention) then had to guess at match time, and could coincidentally
+    // match an unrelated same-named file elsewhere in the repo through a
+    // single leading directory — the exact tokio-rs/tokio repro from #928:
+    // `benches/copy.rs` (a leaf Rust benchmark nothing can import) fuzzy-
+    // matched `tokio/src/fs/mod.rs`'s `self::copy` and
+    // `tokio/src/io/util/copy_bidirectional.rs`'s `super::copy`, fabricating
+    // 80 dependents. Passing `importerFile` resolves both keywords to the
+    // REAL workspace-relative path up front, so the generic matcher never
+    // sees an ambiguous bare word for these two keywords at all.
+    describe('self::/super:: importer-relative resolution (#928)', () => {
+      it('resolves self:: from a module-root file (mod.rs) to a sibling in the SAME directory', () => {
+        // The tokio/src/fs/mod.rs repro: `pub use self::copy::copy;` must
+        // resolve to tokio/src/fs/copy/copy (extractImportPath returns the
+        // FULL path including the imported item name — see
+        // processImportSymbols below for the module-only form), not the
+        // directory-less bare "copy" that used to fuzzy-match an unrelated
+        // benches/copy.rs.
+        const code = 'use self::copy::copy;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, undefined, 'tokio/src/fs/mod.rs')).toBe(
+          'tokio/src/fs/copy/copy',
+        );
+      });
+
+      it('resolves super:: from a LEAF file to a sibling in the SAME directory (no traversal)', () => {
+        // The tokio/src/io/util/copy_bidirectional.rs repro: `use
+        // super::copy::CopyBuffer;` must resolve to
+        // tokio/src/io/util/copy/CopyBuffer, not tokio/src/io/copy/CopyBuffer
+        // (a naive filesystem-style ".." join would incorrectly ascend past
+        // io/util/ since a leaf file's own directory already IS its parent
+        // module's location).
+        const code = 'use super::copy::CopyBuffer;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(
+          importExtractor.extractImportPath(
+            useNode,
+            undefined,
+            'tokio/src/io/util/copy_bidirectional.rs',
+          ),
+        ).toBe('tokio/src/io/util/copy/CopyBuffer');
+      });
+
+      it('resolves super:: from a module-root file (mod.rs) to the PARENT directory', () => {
+        // Asymmetric with the leaf case above: a mod.rs IS its directory's
+        // own module, so super:: from it genuinely ascends one level.
+        const code = 'use super::helper;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, undefined, 'tokio/src/io/mod.rs')).toBe(
+          'tokio/src/helper',
+        );
+      });
+
+      it('recognizes lib.rs and main.rs as module-root files too', () => {
+        const code = 'use super::helper;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, undefined, 'tokio/src/lib.rs')).toBe(
+          'tokio/helper',
+        );
+        expect(importExtractor.extractImportPath(useNode, undefined, 'tokio/src/main.rs')).toBe(
+          'tokio/helper',
+        );
+      });
+
+      it('self:: from a repo-root module-root file resolves with no leading slash', () => {
+        const code = 'use self::helper;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(useNode, undefined, 'mod.rs')).toBe('helper');
+      });
+
+      it('processImportSymbols resolves self::/super:: the same way as extractImportPath', () => {
+        const code = 'use self::copy::copy;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        const result = importExtractor.processImportSymbols(
+          useNode,
+          undefined,
+          'tokio/src/fs/mod.rs',
+        );
+        expect(result).not.toBeNull();
+        expect(result!.importPath).toBe('tokio/src/fs/copy');
+        expect(result!.symbols).toEqual(['copy']);
+      });
+
+      it('extractImportPaths threads importerFile through to extractImportPath', () => {
+        const code = 'use super::copy::CopyBuffer;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(
+          importExtractor.extractImportPaths(
+            useNode,
+            undefined,
+            'tokio/src/io/util/copy_bidirectional.rs',
+          ),
+        ).toEqual(['tokio/src/io/util/copy/CopyBuffer']);
+      });
+
+      it('crate::-relative imports are unaffected by importerFile (absolute from the crate root already)', () => {
+        const code = 'use crate::auth::AuthService;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+        expect(
+          importExtractor.extractImportPath(useNode, undefined, 'tokio/src/io/util/deep/mod.rs'),
+        ).toBe('auth/AuthService');
+      });
+
+      it('is a strict no-op (identical to the pre-#928 behavior) when importerFile is omitted', () => {
+        const selfCode = 'use self::config::Settings;';
+        const selfRoot = mustParse(selfCode, 'rust');
+        expect(importExtractor.extractImportPath(selfRoot.namedChild(0)!)).toBe('config/Settings');
+
+        const superCode = 'use super::utils::helper;';
+        const superRoot = mustParse(superCode, 'rust');
+        expect(importExtractor.extractImportPath(superRoot.namedChild(0)!)).toBe('../utils/helper');
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -181,11 +181,97 @@ export class RustExportExtractor implements LanguageExportExtractor {
 // =============================================================================
 
 /**
+ * Whether `importerFile`'s basename identifies it as a Rust module-root file
+ * (`mod.rs`, or the crate-root files `lib.rs`/`main.rs`) rather than a "leaf"
+ * file. Rust's file-to-module convention gives these two shapes DIFFERENT
+ * containing-directory semantics — see `resolveRustRelativeModulePath`'s doc
+ * comment for why that distinction matters for `self::`/`super::`.
+ */
+function isRustModuleRootFile(importerFile: string): boolean {
+  const base = importerFile.slice(importerFile.lastIndexOf('/') + 1);
+  return base === 'mod.rs' || base === 'lib.rs' || base === 'main.rs';
+}
+
+/**
+ * Directory portion of a forward-slash path. A tiny hand-rolled stand-in for
+ * `path.posix.dirname` — importing `node:path` here would collide with this
+ * file's own frequently-used `path` parameter name (the raw `use` path
+ * string), so a one-line local helper is clearer than an aliased import.
+ */
+function dirnameOf(p: string): string {
+  const idx = p.lastIndexOf('/');
+  return idx === -1 ? '' : p.slice(0, idx);
+}
+
+/** Join a directory (possibly empty, meaning repo root) with a path segment. */
+function joinFromDir(dir: string, rest: string): string {
+  return dir ? `${dir}/${rest}` : rest;
+}
+
+/**
+ * Resolve a `self::`/`super::`-relative Rust module path against the
+ * importing file's own location (#928).
+ *
+ * Before this, `self::`/`super::` were stripped down to a directory-less (or
+ * merely `../`-prefixed) string with no knowledge of the importer's real
+ * location — `matchesFile`'s generic bare-identifier leniency (designed for
+ * the legitimate `crate::auth` -> `src/auth.rs` convention) then had to guess,
+ * and could coincidentally match a same-named file anywhere else with a
+ * single leading directory (e.g. a Rust benchmark `benches/copy.rs` fuzzy-
+ * matching an unrelated sibling module reached via `self::copy`). Resolving
+ * to the real path up front means the generic matcher never sees an
+ * ambiguous bare word for these two keywords at all.
+ *
+ * Rust's file-to-module mapping means `self::`/`super::` resolve differently
+ * depending on whether `importerFile` is itself a module-root file
+ * (`mod.rs`/`lib.rs`/`main.rs`, representing its OWN containing directory) or
+ * a "leaf" file (e.g. `copy_bidirectional.rs`, representing a module nested
+ * one level INSIDE its containing directory):
+ *
+ * - `self::X` from a module-root file -> `<its directory>/X` (a sibling
+ *   inside the same directory the mod.rs/lib.rs/main.rs itself lives in).
+ * - `super::X` from a module-root file -> `<parent of its directory>/X` —
+ *   its enclosing module lives one directory up.
+ * - `super::X` from a leaf file -> `<its directory>/X` — a leaf file's own
+ *   containing directory already IS its parent module's location (exactly
+ *   what `self::` from THAT parent's own mod.rs would resolve to), so no
+ *   directory traversal is needed.
+ * - `self::X` from a leaf file names a genuine CHILD of the leaf file's own
+ *   module, which on disk lives one directory *deeper* (a subdirectory named
+ *   after the leaf file, Rust's 2018+-edition file-plus-sibling-directory
+ *   split) — a real but rare shape this function does not model precisely;
+ *   it falls back to the same directory as an approximation. That's still
+ *   strictly more precise (same-directory scope) than the pre-#928 behavior
+ *   (any matching bare word anywhere in the repo), so this is a safe
+ *   approximation even when it isn't exact.
+ *
+ * @param importerFile - Workspace-relative path of the file containing the
+ *   `use` declaration.
+ * @param keyword - Which relative keyword produced `rest`.
+ * @param rest - The path following `self::`/`super::`, already `::`-to-`/`
+ *   converted (e.g. `copy` or `copy/CopyBuffer`).
+ */
+function resolveRustRelativeModulePath(
+  importerFile: string,
+  keyword: 'self' | 'super',
+  rest: string,
+): string {
+  const normalizedImporter = importerFile.replace(/\\/g, '/');
+  const importerDir = dirnameOf(normalizedImporter);
+  const moduleDir =
+    keyword === 'super' && isRustModuleRootFile(normalizedImporter)
+      ? dirnameOf(importerDir)
+      : importerDir;
+  return joinFromDir(moduleDir, rest);
+}
+
+/**
  * Convert a Rust module path to a relative file path.
  *
  * - `crate::auth::middleware` -> `auth/middleware`
- * - `self::config` -> `config`
- * - `super::utils` -> `../utils`
+ * - `self::config` -> `config` (or, with `importerFile`, resolved precisely
+ *   against the importer's own directory — see `resolveRustRelativeModulePath`)
+ * - `super::utils` -> `../utils` (ditto)
  * - `std::io` -> null (external crate, skip)
  * - `tokio_util::codec::Framed` -> `tokio-util/src/codec/Framed`, but ONLY
  *   when `rustCrateMap` identifies `tokio_util` as a known workspace member
@@ -201,20 +287,28 @@ export class RustExportExtractor implements LanguageExportExtractor {
  * @param rustCrateMap - Map of workspace crate name (underscore form) ->
  *   crate `src/` dir. Undefined/empty for every project without a resolvable
  *   Cargo workspace/package manifest.
+ * @param importerFile - Workspace-relative path of the file containing this
+ *   `use` declaration (#928). When provided, `self::`/`super::` resolve
+ *   precisely via `resolveRustRelativeModulePath` instead of the old
+ *   directory-less/pseudo-relative string. Omitted callers (and any caller
+ *   predating #928) keep the exact previous behavior.
  */
 function convertRustModulePath(
   path: string,
   rustCrateMap?: ReadonlyMap<string, string>,
+  importerFile?: string,
 ): string | null {
   // Remove leading `crate::`, `self::`, or `super::`
   if (path.startsWith('crate::')) {
     return path.slice('crate::'.length).replace(/::/g, '/');
   }
   if (path.startsWith('self::')) {
-    return path.slice('self::'.length).replace(/::/g, '/');
+    const rest = path.slice('self::'.length).replace(/::/g, '/');
+    return importerFile ? resolveRustRelativeModulePath(importerFile, 'self', rest) : rest;
   }
   if (path.startsWith('super::')) {
-    return '../' + path.slice('super::'.length).replace(/::/g, '/');
+    const rest = path.slice('super::'.length).replace(/::/g, '/');
+    return importerFile ? resolveRustRelativeModulePath(importerFile, 'super', rest) : '../' + rest;
   }
   // Not crate/self/super-relative — resolve against a known workspace crate
   // (#903), or treat as a genuinely external crate (skip) when it isn't one.
@@ -335,57 +429,68 @@ function extractUseListSymbols(useList: SyntaxNode): string[] {
 export class RustImportExtractor implements LanguageImportExtractor {
   readonly importNodeTypes = ['use_declaration'];
 
-  extractImportPath(node: SyntaxNode, rustCrateMap?: ReadonlyMap<string, string>): string | null {
+  extractImportPath(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
+  ): string | null {
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 
     const fullPath = this.resolveFullPath(argument);
-    return fullPath ? convertRustModulePath(fullPath, rustCrateMap) : null;
+    return fullPath ? convertRustModulePath(fullPath, rustCrateMap, importerFile) : null;
   }
 
-  extractImportPaths(node: SyntaxNode, rustCrateMap?: ReadonlyMap<string, string>): string[] {
-    return toImportPathsArray(this.extractImportPath(node, rustCrateMap));
+  extractImportPaths(
+    node: SyntaxNode,
+    rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
+  ): string[] {
+    return toImportPathsArray(this.extractImportPath(node, rustCrateMap, importerFile));
   }
 
   processImportSymbols(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 
-    return this.processUseArgument(argument, rustCrateMap);
+    return this.processUseArgument(argument, rustCrateMap, importerFile);
   }
 
   processImportSymbolsList(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): Array<{ importPath: string; symbols: string[] }> {
-    return toImportSymbolsArray(this.processImportSymbols(node, rustCrateMap));
+    return toImportSymbolsArray(this.processImportSymbols(node, rustCrateMap, importerFile));
   }
 
   private processUseArgument(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     // Simple: `use crate::auth::AuthService;`
     if (node.type === 'scoped_identifier') {
-      return this.processScopedIdentifier(node, rustCrateMap);
+      return this.processScopedIdentifier(node, rustCrateMap, importerFile);
     }
 
     // List: `use crate::auth::{AuthService, AuthError};`
     if (node.type === 'scoped_use_list') {
-      return this.processScopedUseList(node, rustCrateMap);
+      return this.processScopedUseList(node, rustCrateMap, importerFile);
     }
 
     // Alias: `use crate::auth::Service as Auth;`
     if (node.type === 'use_as_clause') {
-      return this.processUseAsClause(node, rustCrateMap);
+      return this.processUseAsClause(node, rustCrateMap, importerFile);
     }
 
     // Wildcard: `use crate::models::*;`
     if (node.type === 'use_wildcard') {
-      return this.processUseWildcard(node, rustCrateMap);
+      return this.processUseWildcard(node, rustCrateMap, importerFile);
     }
 
     // Direct identifier (rare): `use SomeItem;`
@@ -399,6 +504,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
   private processScopedIdentifier(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     const pathNode = node.childForFieldName('path');
     const nameNode = node.childForFieldName('name');
@@ -412,8 +518,8 @@ export class RustImportExtractor implements LanguageImportExtractor {
     // `resolveFullPath`/`extractImportPath` already derive from the whole
     // node's text for this same statement).
     const modulePath = isBareRootToken(pathNode)
-      ? convertRustModulePath(`${pathNode.text}::${nameNode.text}`, rustCrateMap)
-      : convertRustModulePath(pathNode.text, rustCrateMap);
+      ? convertRustModulePath(`${pathNode.text}::${nameNode.text}`, rustCrateMap, importerFile)
+      : convertRustModulePath(pathNode.text, rustCrateMap, importerFile);
     if (!modulePath) return null;
 
     return { importPath: modulePath, symbols: [nameNode.text] };
@@ -422,11 +528,12 @@ export class RustImportExtractor implements LanguageImportExtractor {
   private processScopedUseList(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     const scopePath = extractScopePath(node);
     if (!scopePath) return null;
 
-    const modulePath = convertRustModulePath(scopePath, rustCrateMap);
+    const modulePath = convertRustModulePath(scopePath, rustCrateMap, importerFile);
     if (!modulePath) return null;
 
     const useList = node.namedChildren.find(child => child.type === 'use_list');
@@ -451,6 +558,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
   private processUseAsClause(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     // `use crate::auth::Service as Auth;`
     // The first child is the path (scoped_identifier), alias field has the alias
@@ -461,7 +569,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const scopePathNode = pathChild.childForFieldName('path');
     if (!scopePathNode) return null;
 
-    const modulePath = convertRustModulePath(scopePathNode.text, rustCrateMap);
+    const modulePath = convertRustModulePath(scopePathNode.text, rustCrateMap, importerFile);
     if (!modulePath) return null;
 
     const symbol = aliasNode?.text || pathChild.childForFieldName('name')?.text;
@@ -473,6 +581,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
   private processUseWildcard(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
+    importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     // `use crate::models::*;` -> AST is:
     //   use_wildcard
@@ -482,7 +591,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const scopedId = node.namedChildren.find(child => child.type === 'scoped_identifier');
     if (!scopedId) return null;
 
-    const modulePath = convertRustModulePath(scopedId.text, rustCrateMap);
+    const modulePath = convertRustModulePath(scopedId.text, rustCrateMap, importerFile);
     if (!modulePath) return null;
     return { importPath: modulePath, symbols: ['*'] };
   }

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -183,6 +183,7 @@ function extractImportPaths(
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
   manifestRoots?: ManifestRoots,
+  rustImporterFile?: string,
 ): string[] {
   if (!importExtractor) return [];
 
@@ -190,7 +191,11 @@ function extractImportPaths(
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
-    for (const result of importExtractor.extractImportPaths(node, manifestRoots?.rustCrateMap)) {
+    for (const result of importExtractor.extractImportPaths(
+      node,
+      manifestRoots?.rustCrateMap,
+      rustImporterFile,
+    )) {
       imports.push(resolveImportSpecifier(result, filepath, workspacePackages, manifestRoots));
     }
   }
@@ -215,12 +220,23 @@ function extractImportPaths(
  *
  * @param filepath - Optional path of the file being chunked. Enables resolution
  *   of `./` / `../` specifiers so they store workspace-relative paths instead
- *   of bare basenames.
+ *   of bare basenames. Deliberately gated per-language by the caller (see
+ *   `ast/chunker.ts`'s `RESOLVE_RELATIVE_IMPORTS`) — Rust is excluded here
+ *   because filesystem-style `..` resolution would misresolve `self::`/
+ *   `super::` (see `rustImporterFile` below for how Rust resolves them
+ *   instead).
  * @param workspacePackages - Optional map of workspace package name -> source
  *   entry file (see `resolveWorkspacePackageEntries`). Enables resolution of
  *   bare `@scope/pkg` specifiers that reference sibling workspace packages.
  * @param manifestRoots - Optional manifest-declared import-root mappings
  *   (PHP PSR-4, Go module prefix). See `ManifestRoots`.
+ * @param rustImporterFile - Rust-only (#928): the file's real workspace-
+ *   relative path, passed UNCONDITIONALLY (never gated by
+ *   `RESOLVE_RELATIVE_IMPORTS`, unlike `filepath` above) so
+ *   `RustImportExtractor` can resolve `self::`/`super::` against the
+ *   importer's own location via its own file-to-module-aware logic — see
+ *   `ast/languages/rust.ts`'s `resolveRustRelativeModulePath`. Every other
+ *   language's extractor ignores this parameter.
  */
 export function extractImports(
   rootNode: SyntaxNode,
@@ -228,6 +244,7 @@ export function extractImports(
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
   manifestRoots?: ManifestRoots,
+  rustImporterFile?: string,
 ): string[] {
   if (!language) return [];
   return extractImportPaths(
@@ -236,6 +253,7 @@ export function extractImports(
     filepath,
     workspacePackages,
     manifestRoots,
+    rustImporterFile,
   );
 }
 
@@ -269,6 +287,7 @@ function extractSymbolsWithExtractor(
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
   manifestRoots?: ManifestRoots,
+  rustImporterFile?: string,
 ): Record<string, string[]> {
   if (!importExtractor) return {};
 
@@ -276,7 +295,11 @@ function extractSymbolsWithExtractor(
   const nodeTypeSet = new Set(importExtractor.importNodeTypes);
 
   for (const node of collectImportNodes(rootNode, nodeTypeSet)) {
-    const results = importExtractor.processImportSymbolsList(node, manifestRoots?.rustCrateMap);
+    const results = importExtractor.processImportSymbolsList(
+      node,
+      manifestRoots?.rustCrateMap,
+      rustImporterFile,
+    );
     for (const result of results) {
       const key = resolveImportSpecifier(
         result.importPath,
@@ -299,11 +322,14 @@ function extractSymbolsWithExtractor(
  * legacy callers that don't pass it.
  *
  * @param filepath - Optional path of the file being chunked. Enables resolution
- *   of `./` / `../` specifiers into workspace-relative keys.
+ *   of `./` / `../` specifiers into workspace-relative keys. Gated per-language
+ *   by the caller — see `extractImports`'s doc comment for why Rust is
+ *   excluded and uses `rustImporterFile` instead.
  * @param workspacePackages - Optional map of workspace package name -> source
  *   entry file. Enables resolution of bare `@scope/pkg` keys.
  * @param manifestRoots - Optional manifest-declared import-root mappings
  *   (PHP PSR-4, Go module prefix). See `ManifestRoots`.
+ * @param rustImporterFile - Rust-only (#928) — see `extractImports`.
  */
 export function extractImportedSymbols(
   rootNode: SyntaxNode,
@@ -311,6 +337,7 @@ export function extractImportedSymbols(
   filepath?: string,
   workspacePackages?: ReadonlyMap<string, string>,
   manifestRoots?: ManifestRoots,
+  rustImporterFile?: string,
 ): Record<string, string[]> {
   if (!language) return {};
   return extractSymbolsWithExtractor(
@@ -319,6 +346,7 @@ export function extractImportedSymbols(
     filepath,
     workspacePackages,
     manifestRoots,
+    rustImporterFile,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #928: `matchesFile`'s fuzzy-match strategies are language-blind and can fabricate an entire dependency graph for a file — a confident wrong `get_dependents` answer, not a degraded one, since this is the tool the MCP server instructions require callers to check before changing any exported symbol.

Two independent root causes, both found via the foreign-repo dogfood (#917):

1. **Rust `self::`/`super::` collapsed to a directory-less string at extraction time.** `RustImportExtractor`/`convertRustModulePath` stripped `self::`/`super::` down to a bare (or merely `../`-prefixed) specifier with zero knowledge of the importing file's real location. That ambiguous string then had to be resolved by `matchesFile`'s generic bare-identifier leniency — the same leniency that legitimately supports Rust's `crate::auth` -> `src/auth.rs` convention — which has no way to tell "this bare word came from a real crate-root reference" apart from "this bare word came from a same-directory sibling reference that happens to collide with an unrelated top-level directory." On tokio-rs/tokio, `tokio/src/fs/mod.rs`'s `self::copy` and `tokio/src/io/util/copy_bidirectional.rs`'s `super::copy` both fuzzy-matched the completely unrelated `benches/copy.rs` (a leaf benchmark — nothing can import a bench), and the (otherwise correct) re-export/transitive-dependent graph walk then pulled in every real consumer of the real `tokio::fs::copy`/`tokio::io::util::copy` functions, fabricating 80 dependents for the bench.

   **Fix:** teach the Rust extractor to resolve `self::`/`super::` precisely against the importing file's own location, using Rust's actual file-to-module convention (a `mod.rs`/`lib.rs`/`main.rs` represents its own containing directory; any other file represents a module nested one level inside it — so `super::` from a "leaf" file stays in the same directory, it does not ascend). This is threaded through as a new, Rust-only, ungated `rustImporterFile` parameter (mirroring the existing `rustCrateMap` precedent) — every other language's extractor ignores it, and Rust keeps its exact prior behavior when the parameter is omitted. See `resolveRustRelativeModulePath`'s doc comment in `packages/parser/src/ast/languages/rust.ts` for the full four-shape derivation.

2. **No existence check before the fuzzy search.** `get_dependents` never checked whether the requested `filepath` was actually present in the index before running the fuzzy dependent search — it only cared whether some import specifier textually resolved to the target string, never whether the target itself was real. `matchesFile`'s multi-segment boundary strategy (Strategy 2) deliberately has no cap on how many extra leading directories the *target* may carry beyond an already-resolved import specifier (this is required — it's exactly how a real PHP PSR-4 vendor prefix like `Domain/Services/Auth` legitimately matches `web/Domain/Services/Auth`), which means a nonexistent path that shares a real file's trailing path segments is *textually indistinguishable* from a legitimate deep-prefixed match. On symfony/console, a guessed `src/Command/Command.php` (doesn't exist — the repo has no `src/`) returned the identical 93-dependent, `critical`-risk graph as the real `Command/Command.php`, purely because `Command/Command` is a suffix of `src/Command/Command`.

   **Fix:** `findDependents` now checks `allChunksByFile.has(normalizedTarget)` (free — it's the same map already built from the existing scan, keyed by the same normalizer) before running the fuzzy search at all. When the target has no chunks anywhere in the index, the search is skipped entirely: `dependents` comes back empty, a new `targetIndexed: false` field is set on `DependencyAnalysisResult`, and `get_dependents` surfaces an explicit `⚠ Lien:` `note` so a `dependentCount: 0`/`riskLevel: "low"` reads as "unresolved," not "confirmed safe." This is a self-contained, in-memory check (no new I/O, no dependency on the not-yet-merged #927) — when #927 lands, its manifest-based `note` and this one will agree rather than contradict.

Also addresses the reported `dependentCount`/`riskReasoning` inconsistency (`dependentCount: 80` next to `"14 callers"` in the original repro): the reasoning was already computed from `productionDependentCount` by design (a test file calling the target shouldn't weigh into risk the same way a production caller does), just without saying so. Now labeled `"N production callers"` explicitly, so the two numbers are visibly, deliberately different rather than looking like a bug in themselves.

## Acceptance criteria

- [x] tokio `benches/copy.rs` -> not 80 fabricated dependents. **0**, and `targetIndexed: true`/no note (it's a real, indexed file — this is a confirmed-zero answer, not an "unresolved" one).
- [x] `src/Command/Command.php` (nonexistent) does **not** return the real file's 93-dependent graph. Now **0**, `targetIndexed: false`, explicit note.
- [x] `Command/Command.php` (real) still returns its correct graph. Still **93**, `critical`, unchanged.
- [x] `dependentCount` and `riskReasoning`'s caller count agree or the difference is explained. Explained: `riskReasoning` now says `"N production callers"`.
- [x] No regression on file-level lookups that currently work — full test suite green (below), plus real cross-file Rust dependents are now *more* accurate, not just fewer (see dogfood evidence).

## Dogfood evidence (real corpora, real built CLI, real MCP tool calls)

Per CLAUDE.md's mandatory dogfood policy, all four cases were re-run against **copies** of the actual corpora from the original repro (`/tmp/lien-dogfood-460173c9`, not re-cloned, not re-indexed in place — the team's shared corpus indices were left untouched; I copied `tokio/` and `console/` to a scratch location, indexed the copies via `lien serve`'s on-connect auto-index using this branch's own freshly built CLI, and queried through a real MCP `stdio` client (`@modelcontextprotocol/sdk`), not by calling handler functions directly).

**1. tokio `benches/copy.rs` — before:**
```json
{
  "dependentCount": 80,
  "productionDependentCount": 14,
  "testDependentCount": 66,
  "riskLevel": "medium",
  "riskReasoning": ["14 callers", "8 untested", "max complexity 6"],
  "dependents": [
    { "filepath": "tokio/src/fs/mod.rs" },
    { "filepath": "tokio/src/io/util/copy_bidirectional.rs" },
    { "filepath": "examples/udp-codec.rs" },
    { "filepath": "benches/time_timeout.rs" },
    "...76 more, mostly tokio/tests/fs_*.rs and benches/*.rs"
  ]
}
```

**after:**
```json
{
  "dependentCount": 0,
  "productionDependentCount": 0,
  "testDependentCount": 0,
  "riskLevel": "low",
  "riskReasoning": [],
  "dependents": []
}
```
(no `note` field — the file is real and indexed; this is a confirmed-zero answer)

**Accuracy check — the 79 real callers previously misattributed to the bench are now correctly attributed to the real file that defines the function:**
```
get_dependents({filepath: "tokio/src/fs/copy.rs"})
  -> dependentCount: 79, first: tokio/src/fs/mod.rs, examples/udp-codec.rs, benches/time_timeout.rs, ...
get_dependents({filepath: "tokio/src/io/util/copy.rs"})
  -> dependentCount: 155, first: tokio/src/io/util/copy_bidirectional.rs, examples/udp-codec.rs, ...
get_dependents({filepath: "tokio/src/io/util/copy_bidirectional.rs"})
  -> dependentCount: 154, first: examples/udp-codec.rs, benches/time_timeout.rs, ...
```

**2. PHP `src/Command/Command.php` (nonexistent) — before:**
```json
{ "dependentCount": 93, "riskLevel": "critical",
  "riskReasoning": ["93 callers", "93 untested", "max complexity 28", "untested high-complexity dependent"] }
```
**after:**
```json
{
  "dependentCount": 0,
  "riskLevel": "low",
  "riskReasoning": [],
  "note": "⚠ Lien: \"src/Command/Command.php\" has no chunks anywhere in the index — every count above is a deliberate 0, not a confirmed empty dependency graph. This can mean the path was never indexed, is misspelled (wrong directory prefix, wrong case), or genuinely has no extractable content. Do not treat this as a low-risk or dependency-free file; check for a typo before editing, try search_code or list_functions to find the real path, or run \"lien index\" if the file was added recently."
}
```

**3. PHP `Command/Command.php` (real) — before and after (unchanged, confirming no regression):**
```json
{
  "dependentCount": 93,
  "riskLevel": "critical",
  "riskReasoning": ["93 production callers", "93 untested", "max complexity 28", "untested high-complexity dependent"],
  "dependents": [{ "filepath": "SingleCommandApplication.php" }, { "filepath": "ConsoleBundle.php" }, { "filepath": "Application.php" }, "...90 more"]
}
```
(`"93 callers"` -> `"93 production callers"` is the only change — the label clarification described above; the count and every dependent are identical)

**4. PHP `src/Cursor.php` (nonexistent) — before:** `dependentCount: 6, riskLevel: "high"`. **after:**
```json
{ "dependentCount": 0, "riskLevel": "low", "note": "⚠ Lien: \"src/Cursor.php\" has no chunks anywhere in the index — ..." }
```

**5. PHP `totally/made/up/File.php` (no collision, for completeness) — before:** `dependentCount: 0, riskLevel: "low"`, no distinguishing signal from a real isolated file. **after:** same `dependentCount: 0`, now with the same `note`, honestly flagging it as unresolved rather than looking identical to a confirmed-empty real file.

## Gates

All six pre-commit gates green in this worktree (branched from `origin/main`):
- `npm run format:check` — pass
- `npm run lint` — 0 errors, 38 pre-existing warnings (unrelated to this change, same count as reported on a recent sibling PR)
- `npm run typecheck` — pass across all packages
- `npm run build` — pass
- `npm test` (all packages) — parser 1397, core 378, review 1701, action 41, cli 1259 — all green
- `lien delta` — exit 0. No new-over-threshold crossings. One pre-existing-but-under-threshold function (`findDependents`) worsened from 49m to 50m "time to understand" after extracting the new existence-check into its own named helper (`seedIfTargetIndexed`) specifically to keep it from crossing; several Rust extractor functions show minor "worsened" time-to-understand from the added `importerFile` parameter threading, none crossing their thresholds.

## Constraints followed

- Own worktree branched from `origin/main` (not `worktree-fix-symbol-dependents`, which is reserved for the separate symbol-attribution false-zero bug).
- Did not touch `packages/parser/src/utils/path-matching.ts`'s `matchesFile`/`matchesAtBoundaryPrecise`/PHP-namespace logic at all — I traced the PHP repro down to that file's deliberately-uncapped multi-segment leading-directory leniency (needed for real PSR-4 vendor prefixes) and confirmed a purely textual fix there is impossible without also breaking legitimate matches of the identical shape; the existence check in `dependency-analyzer.ts` is the sound fix instead. This keeps this PR's diff clear of the file PR #926 is concurrently modifying.
- Did not touch `dependency-analyzer.ts`'s symbol-level attribution path (the false-zero bug on `worktree-fix-symbol-dependents`) — my change to that file is additive (a new existence-check gate ahead of the existing fuzzy search) and should rebase cleanly.


---

## Update: rebased onto main (2026-07-29)

Main moved several times since this PR was opened (#931 symbol attribution, #932 C# global using, #934 Python bare-module, #917 dogfood docs, #927 unindexed-path notes, #936 C# dependentAttributionIncomplete). Rebased and resolved real conflicts in `dependency-analyzer.ts`, `get-dependents.ts`/`.test.ts`, and `symbols.ts` (the last from #931's `processImportSymbolsList` API change, which needed the same `importerFile` threading as the method it superseded).

**Re-verified after rebase, with a fresh `lien index --force` on newly-copied corpora and this branch's own freshly rebuilt CLI (not a stale/other-worktree binary):**
- tokio `benches/copy.rs` → still `dependentCount: 0`, no `note` (`targetIndexed: true` — a real, indexed file, confirmed-zero, not unresolved).
- `src/Command/Command.php` (nonexistent) → still `dependentCount: 0`, with a `note`.
- `Command/Command.php` (real) → still `dependentCount: 93` (unchanged — no dependents lost). The `riskReasoning` count itself now reads `"29 production callers"` rather than `"93"`: unrelated to this PR, #926 (merged since) improved PHP test-file detection (capitalized `Tests/`), so 64 of the 93 are now correctly recognized as test files that were previously miscounted as production. The label mechanism this PR adds is doing exactly what it's supposed to — reporting whatever the (now more accurate) production count actually is.

**Checked #934 doesn't subsume any of this PR's fix, independently (not just by reading its PR body):** built #934's branch (`fix/929-direct-importer-test-priority`) in isolation, force-reindexed a fresh tokio copy, and confirmed `benches/copy.rs` still returns 80 fabricated dependents against #934's build alone — it fixes a different `matchesFile` strategy (Strategy 5, Python bare-module matching applied cross-language) than the one this PR's tokio case goes through (Strategy 2, bare-single-segment leniency, fed by Rust's `self::`/`super::` collapsing to an ambiguous string). Zero file-level overlap between the two PRs either.

**Checked this PR's `targetIndexed`-based `note` against #927's manifest-based `note`, now that both are live on `main` and testable together (not just asserted):** added a test (`does not duplicate or contradict the #927 manifest note when both mechanisms would fire`) covering the common case where a nonexistent path is both "not in the manifest" and "has no chunks" — confirmed only #927's note appears (the more authoritative "is this path even part of the indexed project" signal), never a second, redundant explanation. `buildDependentsResponse` now checks the manifest note first and only falls back to this PR's chunk-based note for the narrower case the manifest doesn't cover (a path the manifest lists as indexed that produced zero chunks in the current scan). Reproduced live against real corpora post-rebase: the fake PHP path's `note` reads with #927's exact wording ("not found in the index: ..."), not this PR's ("has no chunks anywhere in the index").

All six gates re-verified green on the rebased tree: format, lint (0 errors), typecheck, build, full test suite (parser 1441, core 378, review 1701, action 41, cli 1293 — all green), `lien delta` (exit 0, no crossings).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes two root causes of fabricated dependency graphs in `get_dependents`: (1) Rust `self::`/`super::` imports are now resolved against the importer's actual file-to-module location rather than collapsing to ambiguous bare strings, and (2) `findDependents` now verifies the target file exists in the index before running fuzzy matching, returning `targetIndexed: false` and an explicit note for unresolvable paths. It also clarifies risk reasoning by relabeling "N callers" to "N production callers". The changes are well-scoped, backward-compatible when the new `importerFile` parameter is omitted, and covered by targeted tests for the exact boundary cases (unindexed target, real isolated file, basename-collision nonexistent path, and Rust leaf/mod.rs resolution shapes).
>
> - Rust `self::`/`super::` resolution now uses importer-aware module semantics via `resolveRustRelativeModulePath`
> - `findDependents` gates fuzzy search on `allChunksByFile.has(normalizedTarget)` and surfaces `targetIndexed`
> - Risk reasoning relabeled to "N production callers" to explain the deliberate production-only scope

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2129a3c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 657K/814K tokens
<!-- /lien:attestation -->