### PR TITLE
fix(cli): surface dependentAttributionIncomplete in annotate too

### DIFF
--- a/.changeset/annotate-dependents-incomplete.md
+++ b/.changeset/annotate-dependents-incomplete.md
@@ -1,0 +1,13 @@
+---
+"@liendev/lien": patch
+---
+
+Follow-up to #930/#936: `annotate` (and the read-hook nudge it powers) now
+prints `"Dependents not determinable from imports (enclosing-namespace
+access)."` whenever a C# file's dependents can't be determined from imports
+— the same `dependentAttributionIncomplete` signal `get_dependents` already
+carries, now surfaced in `annotate` too. Previously the annotation stayed
+silent about dependents in exactly this case (a zero-dependent result was
+never printed at all), and could even suppress the whole annotation via the
+low-impact "stay quiet" rule despite dependents being genuinely
+indeterminate rather than genuinely zero.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -70,6 +70,14 @@ describe('isTrivial', () => {
   it('is trivial when headroomCount is explicitly 0', () => {
     expect(isTrivial(0, 0, 1, 0)).toBe(true);
   });
+
+  it('is never trivial when dependentAttributionIncomplete is true, even with test coverage present (#930/#936)', () => {
+    expect(isTrivial(0, 0, 1, 0, true)).toBe(false);
+  });
+
+  it('defaults dependentAttributionIncomplete to false — pre-existing 4-arg callers are unaffected', () => {
+    expect(isTrivial(0, 0, 1, 0)).toBe(true);
+  });
 });
 
 describe('belowRiskFloor (habituation guard)', () => {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -300,6 +300,14 @@ function computeSwiftSymbolUsageFallback(
 interface AnnotationData {
   allChunks: CodeChunk[];
   dependents: DependentInfo[];
+  /**
+   * True when `dependents` came back empty for a language where the import
+   * graph structurally cannot see every real usage (C#'s enclosing-
+   * namespace access -- #930/#936). A zero-dependent result in that case
+   * means "the scan found nothing," not "nothing depends on this file" --
+   * see `formatDependents`'s counterpart honesty label in `formatTests`.
+   */
+  dependentAttributionIncomplete?: boolean;
   tests: string[];
   packageLevelTests: string[];
   symbolUsageTests: string[];
@@ -371,6 +379,7 @@ async function computeAnnotationData(
   return {
     allChunks,
     dependents: result.dependents,
+    dependentAttributionIncomplete: result.dependentAttributionIncomplete,
     tests,
     packageLevelTests,
     symbolUsageTests,
@@ -420,6 +429,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
         data.complexity.warningCount,
         data.tests.length,
         data.headroom.entries.length,
+        data.dependentAttributionIncomplete,
       )
     ) {
       return;
@@ -441,6 +451,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
     emitAnnotation(
       filepath,
       data.dependents,
+      data.dependentAttributionIncomplete,
       data.tests,
       data.packageLevelTests,
       data.symbolUsageTests,
@@ -636,6 +647,7 @@ export function withHeadroomWarning(lines: string[], headroom: ComplexityHeadroo
 function emitAnnotation(
   filepath: RelativePath,
   dependents: DependentInfo[],
+  dependentAttributionIncomplete: boolean | undefined,
   tests: string[],
   packageLevelTests: string[],
   symbolUsageTests: string[],
@@ -646,6 +658,9 @@ function emitAnnotation(
   const lines: string[] = [`Lien impact for ${filepath}:`];
   if (dependents.length > 0) {
     lines.push(`  • ${formatDependents(dependents, risk.level, risk.reasoning)}`);
+  } else if (dependentAttributionIncomplete) {
+    // Mirrors formatTests's "not determinable" honesty label -- see #930/#936.
+    lines.push(`  • Dependents not determinable from imports (enclosing-namespace access).`);
   }
   lines.push(`  • ${formatTests(tests, filepath, packageLevelTests, symbolUsageTests)}`);
   if (complexity.warningCount > 0) {
@@ -660,7 +675,12 @@ export function isTrivial(
   complexityWarnings: number,
   testCount: number,
   headroomCount = 0,
+  dependentAttributionIncomplete = false,
 ): boolean {
+  // An incomplete-attribution zero is exactly the false-all-clear shape
+  // this annotation exists to warn about -- never let it go silent, the
+  // same way a complexity/headroom concern always clears the floor below.
+  if (dependentAttributionIncomplete) return false;
   return dependentCount <= 1 && complexityWarnings === 0 && testCount > 0 && headroomCount === 0;
 }
 


### PR DESCRIPTION
## Summary

Third piece of #930's follow-up chain:
- #932 — the false-edge fix (merged)
- #936 — `dependentAttributionIncomplete` surfaced in `get_dependents`, `tools.ts`, and `instructions.ts` where the model actually reads it (merged)
- This PR — the same signal, surfaced in `annotate` too

Team-lead's Gap review on #936 asked: *"annotate currently surfaces #932's 'Test coverage not determinable...' but says nothing about dependents being indeterminate. If annotate is a consumer of this too, it should say so."* It is: `annotate-cmd.ts` calls `findDependents` directly (the same function `get_dependents` calls), so `dependentAttributionIncomplete` was already computed and available on `computeAnnotationData`'s result — it just wasn't threaded through to the printed line, and worse, `isTrivial` could suppress the whole annotation whenever real test coverage happened to be found despite dependents being genuinely indeterminate.

## Fix

- `AnnotationData` now carries `dependentAttributionIncomplete` (from `findDependents`'s existing result).
- `emitAnnotation` prints `"Dependents not determinable from imports (enclosing-namespace access)."` when `dependents.length === 0` and the flag is set — mirroring `formatTests`'s existing honesty label for test coverage word-for-word in structure.
- `isTrivial` gained an optional 5th parameter (`dependentAttributionIncomplete`, defaults `false` — every existing call site is unaffected) and now never silences an annotation when it's set, the same way an active complexity/headroom concern already always clears the floor.

## Verbatim dogfood (serilog/serilog, reindexed with this branch's build)

**Before this PR** (main + #936, i.e. the flag exists in `get_dependents` but `annotate` doesn't know about it):
```
$ node <cli> annotate src/Serilog/Parsing/Alignment.cs
Lien impact for src/Serilog/Parsing/Alignment.cs:
  • Test coverage not determinable from imports (enclosing-namespace access).
```
(No line about dependents at all — dependentCount is 0, so the pre-existing `if (dependents.length > 0)` guard skips it silently.)

**After this PR:**
```
$ node <cli> annotate src/Serilog/Parsing/Alignment.cs
Lien impact for src/Serilog/Parsing/Alignment.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).
```

Regression-checked: `PropertyToken.cs` (1 real test dependent, `dependentAttributionIncomplete` false) still correctly prints **nothing** — `isTrivial`'s existing silence rule is untouched for the case where attribution is NOT incomplete.

## Gate chain (all six)

```
npm run format:check   ✅ 0 issues
npm run lint            ✅ 0 errors (38 pre-existing warnings, none in touched files)
npm run typecheck       ✅ 0 errors
npm run build           ✅ all 5 packages
npm test                ✅ 211 files, 0 failures
node packages/cli/dist/index.js delta --base origin/main
                         ✅ exit 0 — 4 advisory "worsened" only (Halstead-time and cognitive
                            metrics on the touched functions, all well under threshold),
                            no new-over-threshold crossing
```

Diff vs `origin/main` (which already includes #936) is exactly 3 files:
`annotate-cmd.ts` + `annotate-cmd.test.ts` + a new changeset.

## Files

- `packages/cli/src/cli/annotate-cmd.ts` — `AnnotationData` field, `computeAnnotationData` wiring, `isTrivial`'s new parameter, `emitAnnotation`'s new line
- `packages/cli/src/cli/annotate-cmd.test.ts` — new `isTrivial` tests for the parameter's default and override behavior
- `.changeset/annotate-dependents-incomplete.md`

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR threads the `dependentAttributionIncomplete` signal from `findDependents` through `annotate`'s `AnnotationData`, prints an honesty label when zero dependents are indeterminate, and prevents `isTrivial` from suppressing such annotations. The change is narrow and well-tested for the `isTrivial` path. The only gap is that `belowRiskFloor`'s habituation guard does not also clear the floor for `dependentAttributionIncomplete`, so `--min-risk` can still silence the annotation in exactly the case the PR aims to surface.
>
> - `AnnotationData` carries `dependentAttributionIncomplete` from `findDependents`
> - `emitAnnotation` prints a 'Dependents not determinable...' line for incomplete-attribution zeros
> - `isTrivial` gains a defaulted 5th parameter and never suppresses when the flag is true

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e623068. Updates automatically on new commits.</sup>
<!-- /lien-stats -->