### PR TITLE
docs(cli): document get_dependents' unindexed-target note at model-facing surfaces

### DIFF
--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -33,6 +33,11 @@ symbol:
   riskLevel of "low" mean Lien could not SEE the callers, not that there are none —
   grep before concluding the symbol is unused. riskLevel is not adjusted for it.
 
+  If a result carries a note, filepath is not resolvable in the index at all
+  (never indexed, misspelled, or a typo'd directory prefix) — dependentCount: 0
+  and riskLevel: "low" then mean "unresolved", not "confirmed safe to change".
+  Fix the path (try search_code or list_functions) before trusting the result.
+
 For discovery ("where is X?", "how does Y work?"), call search_code FIRST.
 It runs full-text BM25 keyword search over code, docstrings, and camelCase-split
 identifiers. Query with concrete KEYWORDS, identifiers, and domain terms

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -144,7 +144,7 @@ Returns:
 - dependents[]: { filepath, isTestFile, usages[]? }
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
 - totalUsageCount?: number (when symbol parameter provided)
-- note?: present and explicit when \`filepath\` has no entry in the index at all — a dependentCount of 0 / riskLevel "low" can otherwise look identical whether the file genuinely has no dependents or the path was never indexed
+- note?: present and explicit when \`filepath\` isn't resolvable in the index at all — a dependentCount of 0 / riskLevel "low" can otherwise look identical whether the file genuinely has no dependents or the path was never found. Two independent checks can produce it (not in the index manifest; or indexed with zero chunks for this exact path), but only ONE note is ever returned — never two competing explanations of the same zero.
 - symbolAttributionDegraded?: boolean + symbolAttributionNote?: string — set when
   symbol names a method or constructor (not a top-level export) and call sites
   couldn't be confirmed; dependentCount/riskLevel are then the file-level answer

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -330,6 +330,8 @@ When `symbol` is provided, the response also includes `totalUsageCount` (number 
 
 A file-level query (no `symbol`) that finds zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930) — sets `dependentAttributionIncomplete: true` plus a `dependentAttributionNote`. `dependentCount: 0` / `riskLevel: "low"` in that case means "the import graph found nothing," not "nothing depends on this file" — check that flag too before treating a zero count as a verified all-clear.
 
+When `filepath` isn't resolvable in the index at all — never indexed, misspelled, or a typo'd directory prefix — the response instead carries a `note` explaining that. `dependentCount: 0` / `riskLevel: "low"` in that case means "the path is unresolved," not "confirmed zero dependents"; the two can look identical unless you check for `note`. Two independent checks can produce it (the index manifest has no entry for the path at all; or the path resolves in the manifest but has zero chunks in the current scan), but only one `note` is ever returned for a given call — never two competing explanations of the same zero.
+
 ### Risk Levels
 
 | Level | Dependent Count | Meaning |


### PR DESCRIPTION
## Summary

Small follow-up to #937, which merged before this doc pass landed on top of it.

`get_dependents`'s `note` field (existing since #927, extended by #937 with a second, chunk-based fallback source — see #937's PR body for the full precedence rationale) was documented at the *human*-facing surface (`packages/site/docs/guide/mcp-tools.md`) but not at either surface a model actually reads:

- `SERVER_INSTRUCTIONS` (`packages/cli/src/mcp/instructions.ts`) — sent on every MCP connection. Already documented `dependentAttributionIncomplete` (#936) but said nothing about `note`.
- The `get_dependents` tool description (`packages/cli/src/mcp/tools.ts`) — already documented `note`'s existence, but not that it can come from either of two checks (manifest lookup or chunk presence) and is deliberately never doubled.

This closes that gap, and expands the site docs paragraph to match.

## Why this is worth its own PR

#937 merged (as #937/8c3b2ce9) before this commit was added on top of it in the same branch — by the time the doc work was ready, the branch had already been merged and deleted. Re-based this commit onto current `origin/main` directly; it's the exact same change, no logic touched.

## Gates

- `npm run format:check` / `npm run lint` (0 errors) / `npm run typecheck` / `npm run build` / `npm test` (cli 1295, all green) / `lien delta` (exit 0, no complexity-affecting changes — text-only)
- `packages/cli/src/mcp/tools.test.ts` and `packages/cli/src/mcp/instructions.claude-md-sync.test.ts` (the two tests that would catch a doc/schema mismatch) explicitly re-run and green.

Docs-only change; no dogfood beyond the gates above applies (nothing in the tool's actual behavior changed, only what a model is told about it).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> Docs-only follow-up that documents the `note` field semantics for `get_dependents` at the model-facing `SERVER_INSTRUCTIONS` and tool-description surfaces, plus the user-facing site guide. The prose accurately reflects the implementation: a `note` is emitted when the requested `filepath` cannot be resolved in the index, produced by either a manifest lookup (`findUnindexedPaths`) or a zero-chunks check (`!analysis.targetIndexed`), with the manifest-based note taking precedence so only one note is ever returned. No code behavior changed.
>
> - Added `note` semantics to `SERVER_INSTRUCTIONS` in `packages/cli/src/mcp/instructions.ts`
> - Expanded the `get_dependents` tool description in `packages/cli/src/mcp/tools.ts` to explain the two fallback checks and single-note guarantee
> - Mirrored the same explanation in `packages/site/docs/guide/mcp-tools.md`

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9f66459. Updates automatically on new commits.</sup>
<!-- /lien-stats -->