### PR TITLE
fix(parser,cli): resolve get_dependents risk-verdict contradiction, unify attribution caveats

### DIFF
--- a/.changeset/riskverdict-attribution-unify.md
+++ b/.changeset/riskverdict-attribution-unify.md
@@ -1,6 +1,6 @@
 ---
-"@liendev/parser": patch
-"@liendev/lien": patch
+"@liendev/parser": minor
+"@liendev/lien": minor
 ---
 
 Fix `get_dependents`' risk verdict contradicting its own components (#933),

--- a/.changeset/riskverdict-attribution-unify.md
+++ b/.changeset/riskverdict-attribution-unify.md
@@ -1,0 +1,43 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Fix `get_dependents`' risk verdict contradicting its own components (#933),
+and unify its three attribution-caveat flags into one field (#940).
+
+**#933**: `computeBlastRadiusRisk` only ever factored complexity into the
+verdict through `hasHighComplexityUncovered`, which requires an untested
+dependent to fire at all — so a file with zero untested dependents but a
+`critical`-complexity caller came back `riskLevel: "low"` while its own
+`complexityMetrics.complexityRiskBoost` read `"critical"` (confirmed on
+symfony/console's `Cursor.php`: 4 fully-tested production callers, max
+complexity 31, `riskLevel: "low"`). `riskLevel` is the field
+`instructions.ts` tells agents to gate on before editing an exported symbol,
+so the wrong verdict misled even though the underlying counts were correct.
+
+Fixed by adding an optional `complexityRiskBoost` input to
+`computeBlastRadiusRisk`: a `high`/`critical` boost now floors the verdict
+one tier below its own severity (`critical` → at least `high`, `high` → at
+least `medium`), regardless of test coverage — testedness lowers the odds
+of a *silent* break, it doesn't shrink the blast radius. The
+untested-and-high-complexity case (`hasHighComplexityUncovered`) already
+reaches full severity on its own and is unaffected; verified against gin's
+`bytesconv.StringToBytes` (1 untested, critical complexity) staying `high`,
+not escalating to `critical`.
+
+**#940**: `symbolAttributionDegraded`/`symbolAttributionNote`,
+`dependentAttributionIncomplete`/`dependentAttributionNote`, and `note` all
+meant some version of "this count isn't a verified clear," with three
+different names and shapes for a model to learn — and were mutually
+exclusive by construction, so a single field always sufficed. Replaced with
+one optional `attributionCaveat: { reason, note }`, where `reason` is
+`'unresolved-target' | 'symbol-attribution-degraded' |
+'dependent-attribution-incomplete'`. This is a breaking response-shape
+change with no deprecation window — acceptable pre-1.0, and the fields were
+only weeks old. `targetIndexed` stays internal, as before.
+
+Both `tools.ts`'s tool description and `instructions.ts`'s server
+instructions (the two surfaces a connecting model actually reads) are
+updated accordingly, along with the `symbol` parameter's own schema
+description and the `get_dependents` docs page.

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -374,6 +374,7 @@ async function computeAnnotationData(
     // separately on the display line below — different signal.
     maxDependentComplexity: result.complexityMetrics.maxComplexity,
     hasHighComplexityUncovered,
+    complexityRiskBoost: result.complexityMetrics.complexityRiskBoost,
   });
 
   return {

--- a/packages/cli/src/cli/api-delta-cmd.ts
+++ b/packages/cli/src/cli/api-delta-cmd.ts
@@ -101,6 +101,7 @@ function computeRisk(analysis: DependencyAnalysisResult): string {
     uncoveredDependents: uncoveredProductionDependents,
     maxDependentComplexity: maxComplexity > 0 ? maxComplexity : undefined,
     hasHighComplexityUncovered,
+    complexityRiskBoost: complexityMetrics.complexityRiskBoost,
   }).level;
 }
 

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -260,8 +260,14 @@ describe('handleGetDependents', () => {
       );
     });
 
-    it('should keep risk low when complexity is high but all dependents are tested', async () => {
-      // hasHighComplexityUncovered only fires when uncovered > 0.
+    it('should not report low risk when complexity is critical, even with full test coverage (#933)', async () => {
+      // Regression test for #933: a critical complexityRiskBoost must never
+      // be paired with riskLevel "low" -- being tested lowers the odds of a
+      // *silent* break, it doesn't shrink the blast radius of a
+      // critical-complexity caller. Before the fix, hasHighComplexityUncovered
+      // (the only path complexity fed into the verdict) required uncovered > 0
+      // to fire at all, so this exact shape came back "low" despite its own
+      // complexityRiskBoost reading "critical".
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({
           dependents: [{ filepath: 'src/a.ts', isTestFile: false }],
@@ -281,7 +287,39 @@ describe('handleGetDependents', () => {
       const result = await handleGetDependents({ filepath: 'src/utils.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.riskLevel).toBe('low');
+      expect(parsed.riskLevel).toBe('high');
+      expect(parsed.riskReasoning).toEqual(
+        expect.arrayContaining(['critical-complexity dependent regardless of test coverage']),
+      );
+    });
+
+    it('should not escalate a fully-tested untested-linked case above what an untested one already reaches (#933 regression guard)', async () => {
+      // The console/Cursor.php shape above must not overtake the "genuinely
+      // untested AND high-complexity" case -- testedness still matters, it
+      // just can no longer suppress the complexity signal entirely. A
+      // critical complexityRiskBoost paired with an actual untested
+      // high-complexity dependent stays "high", the same as before this fix
+      // (hasHighComplexityUncovered already reaches full severity on its own).
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: [{ filepath: 'src/a.ts', isTestFile: false }],
+          uncoveredProductionDependents: 1,
+          complexityMetrics: {
+            averageComplexity: 20,
+            maxComplexity: 30,
+            filesWithComplexityData: 1,
+            highComplexityDependents: [
+              { filepath: 'src/a.ts', maxComplexity: 30, avgComplexity: 20 },
+            ],
+            complexityRiskBoost: 'critical',
+          },
+        }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'src/utils.ts' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.riskLevel).toBe('high');
     });
   });
 
@@ -599,8 +637,8 @@ describe('handleGetDependents', () => {
     });
   });
 
-  describe('symbolAttributionDegraded (method/constructor symbols)', () => {
-    it('surfaces symbolAttributionDegraded and a note when the analyzer degrades to file-level', async () => {
+  describe('attributionCaveat: symbol-attribution-degraded (method/constructor symbols)', () => {
+    it('surfaces attributionCaveat when the analyzer degrades to file-level', async () => {
       vi.mocked(findDependents).mockResolvedValue({
         ...createMockAnalysis({
           dependents: [{ filepath: 'src/QuestionHelper.php', isTestFile: false }],
@@ -615,14 +653,14 @@ describe('handleGetDependents', () => {
       );
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.symbolAttributionDegraded).toBe(true);
-      expect(parsed.symbolAttributionNote).toContain('__construct');
-      expect(parsed.symbolAttributionNote).toContain('top-level exports');
+      expect(parsed.attributionCaveat.reason).toBe('symbol-attribution-degraded');
+      expect(parsed.attributionCaveat.note).toContain('__construct');
+      expect(parsed.attributionCaveat.note).toContain('top-level exports');
       expect(parsed.dependentCount).toBe(1);
       expect(parsed.totalUsageCount).toBeUndefined();
     });
 
-    it('omits symbolAttributionDegraded and the note for a normal, non-degraded symbol query', async () => {
+    it('omits attributionCaveat for a normal, non-degraded symbol query', async () => {
       vi.mocked(findDependents).mockResolvedValue({
         ...createMockAnalysis({ dependents: [{ filepath: 'src/a.ts', isTestFile: false }] }),
         totalUsageCount: 1,
@@ -634,13 +672,12 @@ describe('handleGetDependents', () => {
       );
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.symbolAttributionDegraded).toBeUndefined();
-      expect(parsed.symbolAttributionNote).toBeUndefined();
+      expect(parsed.attributionCaveat).toBeUndefined();
     });
   });
 
-  describe('dependentAttributionIncomplete (C# enclosing-namespace-access floor, #930)', () => {
-    it('surfaces dependentAttributionIncomplete and a note for a zero-dependent file-level query', async () => {
+  describe('attributionCaveat: dependent-attribution-incomplete (C# enclosing-namespace-access floor, #930)', () => {
+    it('surfaces attributionCaveat for a zero-dependent file-level query', async () => {
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({ dependents: [], dependentAttributionIncomplete: true }),
       );
@@ -652,19 +689,18 @@ describe('handleGetDependents', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.dependentCount).toBe(0);
-      expect(parsed.dependentAttributionIncomplete).toBe(true);
-      expect(parsed.dependentAttributionNote).toContain('Alignment.cs');
-      expect(parsed.dependentAttributionNote).toContain('the scan found nothing');
+      expect(parsed.attributionCaveat.reason).toBe('dependent-attribution-incomplete');
+      expect(parsed.attributionCaveat.note).toContain('Alignment.cs');
+      expect(parsed.attributionCaveat.note).toContain('the scan found nothing');
     });
 
-    it('omits dependentAttributionIncomplete and the note for a normal query', async () => {
+    it('omits attributionCaveat for a normal query', async () => {
       vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
 
       const result = await handleGetDependents({ filepath: 'src/utils/validate.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.dependentAttributionIncomplete).toBeUndefined();
-      expect(parsed.dependentAttributionNote).toBeUndefined();
+      expect(parsed.attributionCaveat).toBeUndefined();
     });
   });
 
@@ -765,18 +801,19 @@ describe('handleGetDependents', () => {
     });
   });
 
-  describe('unindexed path note (#927)', () => {
-    it('adds an unmissable note when the filepath has no manifest entry at all', async () => {
+  describe('attributionCaveat: unresolved-target, manifest-based (#927)', () => {
+    it('adds an unmissable attributionCaveat when the filepath has no manifest entry at all', async () => {
       vi.mocked(findUnindexedPaths).mockResolvedValue(['src/does/not/exist.ts']);
 
       const result = await handleGetDependents({ filepath: 'src/does/not/exist.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.note).toContain('⚠ Lien:');
-      expect(parsed.note).toContain('"src/does/not/exist.ts"');
+      expect(parsed.attributionCaveat.reason).toBe('unresolved-target');
+      expect(parsed.attributionCaveat.note).toContain('⚠ Lien:');
+      expect(parsed.attributionCaveat.note).toContain('"src/does/not/exist.ts"');
     });
 
-    it('adds no note when the filepath is indexed, regardless of dependentCount', async () => {
+    it('adds no attributionCaveat when the filepath is indexed, regardless of dependentCount', async () => {
       vi.mocked(findUnindexedPaths).mockResolvedValue([]);
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({ dependents: [], targetIndexed: true }),
@@ -786,12 +823,12 @@ describe('handleGetDependents', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.dependentCount).toBe(0);
-      expect(parsed).not.toHaveProperty('note');
+      expect(parsed).not.toHaveProperty('attributionCaveat');
     });
   });
 
-  describe('#928: unresolved-target note (chunk-based fallback)', () => {
-    it('adds an unmissable note when the target has no chunks in the index at all', async () => {
+  describe('attributionCaveat: unresolved-target, chunk-based fallback (#928)', () => {
+    it('adds an unmissable attributionCaveat when the target has no chunks in the index at all', async () => {
       // findUnindexedPaths defaults to [] in beforeEach (manifest has no
       // opinion here) -- this exercises the #928 chunk-based note on its own.
       vi.mocked(findDependents).mockResolvedValue(
@@ -803,11 +840,12 @@ describe('handleGetDependents', () => {
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.dependentCount).toBe(0);
       expect(parsed.riskLevel).toBe('low');
-      expect(parsed.note).toContain('⚠ Lien:');
-      expect(parsed.note).toContain('"src/does/not/exist.ts"');
+      expect(parsed.attributionCaveat.reason).toBe('unresolved-target');
+      expect(parsed.attributionCaveat.note).toContain('⚠ Lien:');
+      expect(parsed.attributionCaveat.note).toContain('"src/does/not/exist.ts"');
     });
 
-    it('adds no note when the target is indexed, regardless of dependentCount', async () => {
+    it('adds no attributionCaveat when the target is indexed, regardless of dependentCount', async () => {
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({ dependents: [], targetIndexed: true }),
       );
@@ -816,7 +854,7 @@ describe('handleGetDependents', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.dependentCount).toBe(0);
-      expect(parsed).not.toHaveProperty('note');
+      expect(parsed).not.toHaveProperty('attributionCaveat');
     });
 
     it('does not duplicate or contradict the #927 manifest note when both mechanisms would fire', async () => {
@@ -834,10 +872,11 @@ describe('handleGetDependents', () => {
       const result = await handleGetDependents({ filepath: 'src/does/not/exist.ts' }, mockCtx);
 
       const parsed = JSON.parse(result.content![0].text);
-      expect(parsed.note).toContain('⚠ Lien:');
-      // Exactly one note field, sourced from #927 (its wording, not #928's).
-      expect(parsed.note).toContain('not found in the index');
-      expect(parsed.note).not.toContain('has no chunks anywhere in the index');
+      expect(parsed.attributionCaveat.reason).toBe('unresolved-target');
+      expect(parsed.attributionCaveat.note).toContain('⚠ Lien:');
+      // Exactly one caveat, sourced from #927 (its wording, not #928's).
+      expect(parsed.attributionCaveat.note).toContain('not found in the index');
+      expect(parsed.attributionCaveat.note).not.toContain('has no chunks anywhere in the index');
     });
   });
 });

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -25,6 +25,36 @@ interface IndexInfo {
 }
 
 /**
+ * Why a `get_dependents` answer's counts can't be trusted as a verified
+ * clear (#940). Exactly one reason can ever apply to a given response --
+ * see `buildAttributionCaveat`'s doc comment for why these three are
+ * mutually exclusive by construction:
+ *
+ * - `unresolved-target`: `filepath` isn't resolvable in the index at all
+ *   (not in the manifest, or has zero chunks in the current scan -- #927,
+ *   #928, #937). Every count in the response is then a deliberate `0`, not
+ *   a fuzzy-matched answer.
+ * - `symbol-attribution-degraded`: `symbol` isn't a top-level export of
+ *   `filepath` (the shape of a method or constructor -- #931), so the
+ *   response was widened to file-level dependents instead of asserting an
+ *   unverifiable symbol-scoped count.
+ * - `dependent-attribution-incomplete`: a file-level query (no `symbol`)
+ *   came back with zero dependents in a language where the import graph
+ *   structurally can't see every real usage, e.g. C#'s `global using` /
+ *   implicit enclosing-namespace access (#930, #936).
+ */
+export type AttributionCaveatReason =
+  | 'unresolved-target'
+  | 'symbol-attribution-degraded'
+  | 'dependent-attribution-incomplete';
+
+export interface AttributionCaveat {
+  reason: AttributionCaveatReason;
+  /** Human-readable explanation of what happened and what to do about it. */
+  note: string;
+}
+
+/**
  * Response structure for get_dependents tool.
  */
 interface DependentsResponse {
@@ -46,36 +76,12 @@ interface DependentsResponse {
   dependents: DependentInfo[];
   complexityMetrics: ComplexityMetrics;
   /**
-   * Set either when `filepath` has no entry in the index manifest at all
-   * (see unindexed-paths.ts), or — when the manifest check doesn't already
-   * explain it — when `filepath` has zero chunks anywhere in the current
-   * scan (#928). Either way, every count above is then a deliberate `0`, not
-   * a fuzzy-matched answer: read this before trusting `dependentCount: 0` /
-   * `riskLevel: "low"` as "safe to edit". See `buildDependentsResponse` for
-   * the precedence between the two sources.
+   * Present when this answer's counts can't be trusted as a verified clear
+   * -- read `reason` to tell which of the three ways that can happen (see
+   * `AttributionCaveatReason`'s doc comment) and `note` for the specific
+   * explanation. Absent entirely on a normal, fully-attributed answer.
    */
-  note?: string;
-  /**
-   * True when `symbol` couldn't be attributed at the symbol level (it's not
-   * a top-level export of `filepath` -- the shape of a method or
-   * constructor) and the response was widened to file-level dependents
-   * instead of asserting an unverifiable symbol-scoped count. When set,
-   * treat `dependentCount`/`riskLevel` as a floor over ALL of this file's
-   * dependents, not a confirmed count of callers of `symbol` specifically.
-   */
-  symbolAttributionDegraded?: boolean;
-  /** Human-readable explanation, present only when `symbolAttributionDegraded` is true. */
-  symbolAttributionNote?: string;
-  /**
-   * True for a file-level query (no `symbol`) that found zero dependents in
-   * a language where the import graph structurally can't see every real
-   * usage (see `DependencyAnalysisResult.dependentAttributionIncomplete`).
-   * When set, `dependentCount: 0` / `riskLevel: "low"` means "nothing found,"
-   * not "nothing depends on this file" — don't treat it as a verified clear.
-   */
-  dependentAttributionIncomplete?: boolean;
-  /** Human-readable explanation, present only when `dependentAttributionIncomplete` is true. */
-  dependentAttributionNote?: string;
+  attributionCaveat?: AttributionCaveat;
 }
 
 /**
@@ -143,6 +149,7 @@ function computeRisk(analysis: DependencyAnalysisResult): BlastRadiusRisk {
     uncoveredDependents: uncoveredProductionDependents,
     maxDependentComplexity: maxComplexity > 0 ? maxComplexity : undefined,
     hasHighComplexityUncovered,
+    complexityRiskBoost: complexityMetrics.complexityRiskBoost,
   });
   return { ...risk, reasoning: clarifyCallerReasoning(risk.reasoning) };
 }
@@ -168,6 +175,74 @@ function clarifyCallerReasoning(reasoning: string[]): string[] {
 }
 
 /**
+ * Decide which (if any) attribution caveat applies, and build its note.
+ *
+ * The three reasons are mutually exclusive by construction, so at most one
+ * ever fires:
+ * - `unresolvedTargetNote` is only non-empty when `filepath` has no chunks
+ *   anywhere in the index, in which case `findDependents` returns an empty
+ *   `chunksByFile` up front -- so `symbolAttributionDegraded` (which
+ *   requires `chunksByFile.size > 0` to fire) and
+ *   `dependentAttributionIncomplete` (which explicitly skips when
+ *   `!targetIndexed`) can never also be set.
+ * - `symbolAttributionDegraded` only fires for a `symbol` query;
+ *   `dependentAttributionIncomplete` only fires for a file-level query (no
+ *   `symbol`) -- see `checkDependentAttributionIncomplete` in
+ *   dependency-analyzer.ts. So those two can't co-occur either.
+ *
+ * #927's manifest-based unresolved-target note takes precedence over #928's
+ * chunk-based one where both could apply (a typo'd/nonexistent path trips
+ * both for the same underlying reason); `unresolvedTargetNote` already
+ * encodes that precedence before this function sees it.
+ */
+function buildAttributionCaveat(
+  analysis: DependencyAnalysisResult,
+  filepath: string,
+  symbol: string | undefined,
+  unresolvedTargetNote: string | undefined,
+): AttributionCaveat | undefined {
+  if (unresolvedTargetNote) {
+    return { reason: 'unresolved-target', note: unresolvedTargetNote };
+  }
+  if (!analysis.targetIndexed) {
+    return {
+      reason: 'unresolved-target',
+      note:
+        `⚠ Lien: "${filepath}" has no chunks anywhere in the index — every count above ` +
+        'is a deliberate 0, not a confirmed empty dependency graph. This can mean the ' +
+        'path was never indexed, is misspelled (wrong directory prefix, wrong case), or ' +
+        'genuinely has no extractable content. Do not treat this as a low-risk or ' +
+        'dependency-free file; check for a typo before editing, try search_code or ' +
+        'list_functions to find the real path, or run "lien index" if the file was added ' +
+        'recently.',
+    };
+  }
+  if (analysis.symbolAttributionDegraded) {
+    return {
+      reason: 'symbol-attribution-degraded',
+      note:
+        `"${symbol}" doesn't appear in ${filepath}'s tracked top-level exports (likely a ` +
+        `method or constructor — no import statement names one of those independently of ` +
+        `its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, ` +
+        `riskLevel, and dependents below are the file-level answer (every file that imports ` +
+        `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`,
+    };
+  }
+  if (analysis.dependentAttributionIncomplete) {
+    return {
+      reason: 'dependent-attribution-incomplete',
+      note:
+        `No import-based dependents were found for ${filepath}, but its language lets real ` +
+        `callers use its exports with no per-file import naming it at all (C#'s "global using" ` +
+        `/ implicit enclosing-namespace member access). The import graph has no signal for ` +
+        `that usage shape, so dependentCount: 0 and riskLevel: "low" here mean "the scan found ` +
+        `nothing," not "nothing depends on this file" — don't treat this as a verified clear.`,
+    };
+  }
+  return undefined;
+}
+
+/**
  * Build the response object from analysis results.
  */
 function buildDependentsResponse(
@@ -175,7 +250,7 @@ function buildDependentsResponse(
   args: ValidatedArgs,
   risk: BlastRadiusRisk,
   indexInfo: IndexInfo,
-  note?: string,
+  unresolvedTargetNote?: string,
 ): DependentsResponse {
   const { symbol, filepath, depth } = args;
 
@@ -194,50 +269,20 @@ function buildDependentsResponse(
     complexityMetrics: analysis.complexityMetrics,
   };
 
-  // Add optional fields
   if (symbol) {
     response.symbol = symbol;
   }
   if (analysis.totalUsageCount !== undefined) {
     response.totalUsageCount = analysis.totalUsageCount;
   }
-  // #927's manifest-based note takes precedence: it's the more authoritative
-  // "is this path even part of the indexed project" signal (independent of
-  // chunk count), and in the overwhelming common case (a typo'd/nonexistent
-  // path) both it and the #928 chunk-based check below would fire for the
-  // same reason -- setting both would just be two notes saying the same
-  // thing. The #928 check still adds real value on its own for the narrower
-  // gap the manifest can't see: a path the manifest lists as indexed but
-  // that produced zero chunks in this scan (e.g. a genuinely empty file).
-  if (note) {
-    response.note = note;
-  } else if (!analysis.targetIndexed) {
-    response.note =
-      `⚠ Lien: "${filepath}" has no chunks anywhere in the index — every count above ` +
-      'is a deliberate 0, not a confirmed empty dependency graph. This can mean the ' +
-      'path was never indexed, is misspelled (wrong directory prefix, wrong case), or ' +
-      'genuinely has no extractable content. Do not treat this as a low-risk or ' +
-      'dependency-free file; check for a typo before editing, try search_code or ' +
-      'list_functions to find the real path, or run "lien index" if the file was added ' +
-      'recently.';
-  }
-  if (analysis.symbolAttributionDegraded) {
-    response.symbolAttributionDegraded = true;
-    response.symbolAttributionNote =
-      `"${symbol}" doesn't appear in ${filepath}'s tracked top-level exports (likely a ` +
-      `method or constructor — no import statement names one of those independently of ` +
-      `its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, ` +
-      `riskLevel, and dependents below are the file-level answer (every file that imports ` +
-      `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`;
-  }
-  if (analysis.dependentAttributionIncomplete) {
-    response.dependentAttributionIncomplete = true;
-    response.dependentAttributionNote =
-      `No import-based dependents were found for ${filepath}, but its language lets real ` +
-      `callers use its exports with no per-file import naming it at all (C#'s "global using" ` +
-      `/ implicit enclosing-namespace member access). The import graph has no signal for ` +
-      `that usage shape, so dependentCount: 0 and riskLevel: "low" here mean "the scan found ` +
-      `nothing," not "nothing depends on this file" — don't treat this as a verified clear.`;
+  const attributionCaveat = buildAttributionCaveat(
+    analysis,
+    filepath,
+    symbol,
+    unresolvedTargetNote,
+  );
+  if (attributionCaveat) {
+    response.attributionCaveat = attributionCaveat;
   }
 
   return response;

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -41,7 +41,8 @@ symbol:
   constructor whose call sites couldn't be confirmed — the counts are the
   wider file-level answer, not a verified count for symbol itself.
   "dependent-attribution-incomplete" means Lien could not SEE real callers
-  in this language (e.g. C#) — grep before concluding the symbol is unused.
+  in this language (e.g. C#) — grep before concluding the file is unused.
+  (This reason only fires for FILE-level queries, i.e. no "symbol" argument.)
   riskLevel is not adjusted for either of the latter two and may still read
   "low"; attributionCaveat is the authoritative signal in all three cases.
 

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -22,21 +22,28 @@ symbol:
   get_dependents({ filepath, symbol }) — check dependentCount and riskLevel.
   If riskLevel is "high" or "critical", list affected dependents to the user
   before editing. Read riskReasoning for the "why" (e.g. "14 callers, 3
-  untested, max complexity 18") before deciding how cautious to be.
+  untested, max complexity 18") before deciding how cautious to be. A
+  high/critical complexity signal among dependents always lifts riskLevel
+  above "low", even if every dependent is fully tested.
 
   For "what else could break?" impact analysis, pass depth: 2 (or up to 5) to
   walk the import graph transitively. Each dependent carries a 'hops' field;
   'truncated: true' means the BFS stopped at 'maxNodes' (default 500).
   Symbol-level queries stay at depth 1 — pass depth only for file-level.
 
-  If a result carries dependentAttributionIncomplete, a dependentCount of 0 and a
-  riskLevel of "low" mean Lien could not SEE the callers, not that there are none —
-  grep before concluding the symbol is unused. riskLevel is not adjusted for it.
-
-  If a result carries a note, filepath is not resolvable in the index at all
-  (never indexed, misspelled, or a typo'd directory prefix) — dependentCount: 0
-  and riskLevel: "low" then mean "unresolved", not "confirmed safe to change".
-  Fix the path (try search_code or list_functions) before trusting the result.
+  If a result carries attributionCaveat, dependentCount/riskLevel cannot be
+  trusted as a verified clear — never treat a low count (especially 0) as
+  "safe" or "unused" without checking it first. Its reason tells you why:
+  "unresolved-target" means filepath isn't in the index at all (never
+  indexed, misspelled, or a typo'd directory prefix) — fix the path (try
+  search_code or list_functions) before trusting anything else in the
+  result. "symbol-attribution-degraded" means symbol names a method or
+  constructor whose call sites couldn't be confirmed — the counts are the
+  wider file-level answer, not a verified count for symbol itself.
+  "dependent-attribution-incomplete" means Lien could not SEE real callers
+  in this language (e.g. C#) — grep before concluding the symbol is unused.
+  riskLevel is not adjusted for either of the latter two and may still read
+  "low"; attributionCaveat is the authoritative signal in all three cases.
 
 For discovery ("where is X?", "how does Y work?"), call search_code FIRST.
 It runs full-text BM25 keyword search over code, docstrings, and camelCase-split

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -40,9 +40,9 @@ export const GetDependentsSchema = z.object({
         "Response includes 'usages' array showing which functions call this symbol.\n\n" +
         "Also accepts a method or constructor name (e.g. '__construct', 'moveUp').\n" +
         "Those aren't top-level exports, so when call sites for one can't be " +
-        'confirmed, the response sets symbolAttributionDegraded: true and widens ' +
-        'dependentCount/riskLevel to the file-level answer rather than asserting an ' +
-        'unverifiable symbol-scoped count — check that flag before trusting a low count.',
+        "confirmed, the response sets attributionCaveat.reason: 'symbol-attribution-degraded' " +
+        'and widens dependentCount/riskLevel to the file-level answer rather than asserting an ' +
+        'unverifiable symbol-scoped count — check for attributionCaveat before trusting a low count.',
     ),
 
   depth: z

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -140,22 +140,31 @@ Example: get_dependents({ filepath: "src/utils/validate.ts" })
 
 Returns:
 - dependentCount / productionDependentCount / testDependentCount
-- riskLevel: "low" | "medium" | "high" | "critical"
+- riskLevel: "low" | "medium" | "high" | "critical" — a high/critical complexity
+  signal among dependents always lifts this above "low", even when every dependent
+  is fully tested (testedness lowers the chance of a *silent* break, it does not
+  shrink the blast radius). Check riskReasoning for which signal(s) drove it.
 - dependents[]: { filepath, isTestFile, usages[]? }
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
 - totalUsageCount?: number (when symbol parameter provided)
-- note?: present and explicit when \`filepath\` isn't resolvable in the index at all — a dependentCount of 0 / riskLevel "low" can otherwise look identical whether the file genuinely has no dependents or the path was never found. Two independent checks can produce it (not in the index manifest; or indexed with zero chunks for this exact path), but only ONE note is ever returned — never two competing explanations of the same zero.
-- symbolAttributionDegraded?: boolean + symbolAttributionNote?: string — set when
-  symbol names a method or constructor (not a top-level export) and call sites
-  couldn't be confirmed; dependentCount/riskLevel are then the file-level answer
-  (every importer of filepath), not a verified count of callers of symbol itself
-- dependentAttributionIncomplete?: boolean + dependentAttributionNote?: string — set
-  when a file-level query returns ZERO dependents in a language whose callers need no
-  per-file import (C# today: enclosing-namespace access under a \`global using\`). When
-  this is true, treat dependentCount 0 and riskLevel "low" as a FLOOR, not a finding —
-  it means Lien could not see callers, not that none exist. Verify with grep before
-  concluding a symbol is unused. riskLevel is not adjusted for this and may still read
-  "low"; the flag is the authoritative signal.`,
+- attributionCaveat?: { reason, note } — present whenever dependentCount/riskLevel
+  can't be trusted as a verified clear. ALWAYS check for this field before treating
+  a low dependentCount (especially 0) as "safe to edit" or "unused". \`reason\` is
+  one of:
+  - "unresolved-target": \`filepath\` isn't resolvable in the index at all (typo,
+    wrong directory prefix/case, or not indexed yet) — every count is a deliberate
+    0, not a confirmed empty dependency graph. Try search_code or list_functions to
+    find the real path, or run "lien index" if the file was added recently.
+  - "symbol-attribution-degraded": \`symbol\` names a method or constructor (not a
+    top-level export) and its call sites couldn't be confirmed; dependentCount/
+    riskLevel are the file-level answer (every importer of filepath), not a
+    verified count of callers of symbol itself.
+  - "dependent-attribution-incomplete": a file-level query (no \`symbol\`) returned
+    ZERO dependents in a language whose callers need no per-file import (C# today:
+    enclosing-namespace access under a \`global using\`). Treat dependentCount 0 and
+    riskLevel "low" as a FLOOR, not a finding — verify with grep before concluding
+    the file is unused.
+  At most one reason ever fires per response.`,
   ),
   toMCPToolSchema(
     GetComplexitySchema,

--- a/packages/parser/src/risk/blast-radius-risk.test.ts
+++ b/packages/parser/src/risk/blast-radius-risk.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { computeBlastRadiusRisk } from './blast-radius-risk.js';
+import { RISK_ORDER, type RiskLevel } from '../insights/types.js';
+
+const LEVELS: readonly RiskLevel[] = ['low', 'medium', 'high', 'critical'];
 
 describe('computeBlastRadiusRisk', () => {
   it('returns low with no reasoning when nothing is at risk', () => {
@@ -99,5 +102,80 @@ describe('computeBlastRadiusRisk', () => {
       uncoveredDependents: 0,
     });
     expect(missing.reasoning.some(r => r.startsWith('max complexity'))).toBe(false);
+  });
+
+  describe('complexityRiskBoost floor (#933)', () => {
+    it('never returns low when complexityRiskBoost is critical, even fully tested', () => {
+      const result = computeBlastRadiusRisk({
+        dependentCount: 4,
+        uncoveredDependents: 0,
+        maxDependentComplexity: 31,
+        complexityRiskBoost: 'critical',
+      });
+      expect(result.level).not.toBe('low');
+      expect(result.level).toBe('high');
+      expect(result.reasoning).toContain(
+        'critical-complexity dependent regardless of test coverage',
+      );
+    });
+
+    it('never returns low when complexityRiskBoost is high, even fully tested', () => {
+      const result = computeBlastRadiusRisk({
+        dependentCount: 2,
+        uncoveredDependents: 0,
+        maxDependentComplexity: 22,
+        complexityRiskBoost: 'high',
+      });
+      expect(result.level).not.toBe('low');
+      expect(result.level).toBe('medium');
+    });
+
+    it('does not change the outcome when complexityRiskBoost is medium or low', () => {
+      const medium = computeBlastRadiusRisk({
+        dependentCount: 8,
+        uncoveredDependents: 3,
+        maxDependentComplexity: 12,
+        complexityRiskBoost: 'medium',
+      });
+      expect(medium.level).toBe('medium');
+      expect(medium.reasoning.some(r => r.includes('regardless of test coverage'))).toBe(false);
+    });
+
+    it('does not lower or duplicate the reasoning when the untested+high-complexity path already reaches the same level (regression guard)', () => {
+      // The gin/bytesconv.go shape from #933's report: 4 callers, 1 untested,
+      // max complexity 27 (complexityRiskBoost "critical"), which already
+      // resolves to "high" via hasHighComplexityUncovered. The new floor
+      // (one tier below critical = "high") must not push this to "critical".
+      const result = computeBlastRadiusRisk({
+        dependentCount: 4,
+        uncoveredDependents: 1,
+        maxDependentComplexity: 27,
+        hasHighComplexityUncovered: true,
+        complexityRiskBoost: 'critical',
+      });
+      expect(result.level).toBe('high');
+      expect(result.reasoning).toContain('untested high-complexity dependent');
+      expect(result.reasoning.some(r => r.includes('regardless of test coverage'))).toBe(false);
+    });
+
+    it('is monotonic: riskLevel is never more than one tier below complexityRiskBoost', () => {
+      const scenarios: Array<
+        Omit<Parameters<typeof computeBlastRadiusRisk>[0], 'complexityRiskBoost'>
+      > = [
+        { dependentCount: 0, uncoveredDependents: 0 },
+        { dependentCount: 1, uncoveredDependents: 0 },
+        { dependentCount: 4, uncoveredDependents: 0 },
+        { dependentCount: 4, uncoveredDependents: 1, hasHighComplexityUncovered: true },
+        { dependentCount: 30, uncoveredDependents: 0 },
+        { dependentCount: 60, uncoveredDependents: 10, hasHighComplexityUncovered: true },
+      ];
+      for (const boost of LEVELS) {
+        for (const scenario of scenarios) {
+          const result = computeBlastRadiusRisk({ ...scenario, complexityRiskBoost: boost });
+          const floorRank = Math.max(0, RISK_ORDER[boost] - 1);
+          expect(RISK_ORDER[result.level]).toBeGreaterThanOrEqual(floorRank);
+        }
+      }
+    });
   });
 });

--- a/packages/parser/src/risk/blast-radius-risk.ts
+++ b/packages/parser/src/risk/blast-radius-risk.ts
@@ -7,7 +7,7 @@
  * review-side blast-radius injection.
  */
 
-import type { RiskLevel } from '../insights/types.js';
+import { RISK_ORDER, type RiskLevel } from '../insights/types.js';
 
 export interface BlastRadiusRiskInput {
   /** Distinct dependents across all hops. */
@@ -22,6 +22,23 @@ export interface BlastRadiusRiskInput {
    * specific complexity-report shape.
    */
   hasHighComplexityUncovered?: boolean;
+  /**
+   * Already-classified complexity tier across dependents (e.g.
+   * `ComplexityMetrics.complexityRiskBoost`), independent of test coverage.
+   * Optional -- callers that don't compute one (no floor applied) behave
+   * exactly as before this field existed.
+   *
+   * A high/critical complexity signal describes dependents that are hard to
+   * change safely; full test coverage lowers the odds of a *silent* break,
+   * it doesn't shrink that blast radius. Without this, a fully-tested file
+   * with a critical-complexity caller could come back `riskLevel: "low"`
+   * despite its own `complexityRiskBoost` reading `"critical"` (#933) --
+   * `classifyLevel` below only ever looked at complexity through
+   * `hasHighComplexityUncovered`, which requires an untested dependent to
+   * fire at all, so "high complexity, zero untested" had no path to
+   * escalate anything.
+   */
+  complexityRiskBoost?: RiskLevel;
 }
 
 export interface BlastRadiusRisk {
@@ -70,13 +87,46 @@ function classifyLevel(input: BlastRadiusRiskInput): RiskLevel {
   return 'low';
 }
 
+const LEVELS: readonly RiskLevel[] = ['low', 'medium', 'high', 'critical'];
+
+/**
+ * The floor a `complexityRiskBoost` alone contributes, one tier below its
+ * own severity: `critical` -> `high`, `high` -> `medium`, anything lower ->
+ * `low` (a no-op floor). `hasHighComplexityUncovered` already reaches the
+ * FULL severity when a dependent is both untested and high-complexity --
+ * this floor is what fires when nothing else did, so a critical/high
+ * complexity signal is never fully cancelled out by every dependent
+ * happening to be tested (#933), while the untested case still ends up
+ * strictly worse than the tested one (matching "being tested reduces the
+ * chance of a silent break, not the blast radius" from the issue).
+ */
+function complexityFloor(boost: RiskLevel | undefined): RiskLevel {
+  if (!boost) return 'low';
+  return LEVELS[Math.max(0, LEVELS.indexOf(boost) - 1)];
+}
+
 /**
  * Compute a consolidated risk level for a blast radius.
  *
  * Thresholds are deliberately conservative — the goal is to surface risk, not
  * to be statistically rigorous. Callers that want finer control should consume
  * the raw input fields directly.
+ *
+ * The result is monotonic in `complexityRiskBoost`: it is never raised below
+ * `complexityFloor(complexityRiskBoost)` (see that function's doc comment),
+ * so a `high`/`critical` boost can never be paired with a `low` verdict.
  */
 export function computeBlastRadiusRisk(input: BlastRadiusRiskInput): BlastRadiusRisk {
-  return { level: classifyLevel(input), reasoning: buildReasoning(input) };
+  const countLevel = classifyLevel(input);
+  const floor = complexityFloor(input.complexityRiskBoost);
+  const floorApplies = RISK_ORDER[floor] > RISK_ORDER[countLevel];
+  const reasoning = buildReasoning(input);
+  if (floorApplies) {
+    // Explain the escalation the same way `hasHighComplexityUncovered`'s
+    // 'untested high-complexity dependent' phrase does -- otherwise a reader
+    // sees "max complexity 31" next to a level that jumped and can't tell
+    // why full test coverage didn't prevent it.
+    reasoning.push(`${input.complexityRiskBoost}-complexity dependent regardless of test coverage`);
+  }
+  return { level: floorApplies ? floor : countLevel, reasoning };
 }

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -326,11 +326,26 @@ Is it safe to change this file?
 
 When `symbol` is provided, the response also includes `totalUsageCount` (number of tracked call sites across all files) and each dependent may include a `usages` array with `callerSymbol`, `line`, and `snippet` fields.
 
-`symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`) — those aren't top-level exports, so when call sites for one can't be confirmed, the response sets `symbolAttributionDegraded: true` plus a `symbolAttributionNote` and widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count. Check that flag before treating a low count as verified.
+### `attributionCaveat`
 
-A file-level query (no `symbol`) that finds zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930) — sets `dependentAttributionIncomplete: true` plus a `dependentAttributionNote`. `dependentCount: 0` / `riskLevel: "low"` in that case means "the import graph found nothing," not "nothing depends on this file" — check that flag too before treating a zero count as a verified all-clear.
+Three unrelated situations can each make `dependentCount`/`riskLevel` untrustworthy as a verified clear. Rather than three differently-named flags, the response carries a single optional field:
 
-When `filepath` isn't resolvable in the index at all — never indexed, misspelled, or a typo'd directory prefix — the response instead carries a `note` explaining that. `dependentCount: 0` / `riskLevel: "low"` in that case means "the path is unresolved," not "confirmed zero dependents"; the two can look identical unless you check for `note`. Two independent checks can produce it (the index manifest has no entry for the path at all; or the path resolves in the manifest but has zero chunks in the current scan), but only one `note` is ever returned for a given call — never two competing explanations of the same zero.
+```json
+{
+  "attributionCaveat": {
+    "reason": "unresolved-target",
+    "note": "..."
+  }
+}
+```
+
+`reason` is one of:
+
+- **`unresolved-target`** — `filepath` isn't resolvable in the index at all: never indexed, misspelled, or a typo'd directory prefix. `dependentCount: 0` / `riskLevel: "low"` then means "the path is unresolved," not "confirmed zero dependents." (Two independent checks can produce this — the index manifest has no entry for the path at all, or the path resolves in the manifest but has zero chunks in the current scan — but only one `attributionCaveat` is ever returned, never two competing explanations of the same zero.)
+- **`symbol-attribution-degraded`** — `symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`); those aren't top-level exports, so when call sites for one can't be confirmed, the response widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count.
+- **`dependent-attribution-incomplete`** — a file-level query (no `symbol`) found zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930). `dependentCount: 0` / `riskLevel: "low"` here means "the import graph found nothing," not "nothing depends on this file."
+
+At most one reason ever applies to a given response. Always check for `attributionCaveat` before treating a low (especially zero) `dependentCount` as a verified all-clear.
 
 ### Risk Levels
 
@@ -342,7 +357,7 @@ When `filepath` isn't resolvable in the index at all — never indexed, misspell
 | `critical` | 30+ | Major impact, extensive testing required |
 
 ::: tip Complexity-Aware Risk
-Risk level is boosted if dependents have high complexity. A file with 10 dependents but complex dependent code may be rated "high" instead of "medium".
+Risk level is boosted if dependents have high complexity. A file with 10 dependents but complex dependent code may be rated "high" instead of "medium". A high/critical complexity signal among dependents always lifts the level above "low", even when every dependent is fully tested — test coverage lowers the odds of a *silent* break, it doesn't shrink the blast radius.
 :::
 
 ## get_complexity


### PR DESCRIPTION
## Summary

Closes #933 and #940 — a coherence pass on `get_dependents`, done together
per the tracking issues since #940's unification touches the exact surface
#933's fix lives in.

### #933 — riskLevel contradicted its own components

`computeBlastRadiusRisk` (the shared risk primitive used by `get_dependents`,
`lien delta`, `annotate`, and review's blast-radius injection) only ever
factored dependent complexity into the verdict through
`hasHighComplexityUncovered`, which requires an untested dependent to fire
at all. A file with a **critical**-complexity dependent but **zero**
untested dependents therefore came back `riskLevel: "low"` while its own
`complexityMetrics.complexityRiskBoost` read `"critical"` — confirmed on
`symfony/console`'s `Cursor.php` (4 fully-tested production callers, max
complexity 31).

**Chosen invariant**: a `high`/`critical` `complexityRiskBoost` now floors
the verdict **one tier below its own severity** (`critical` → at least
`high`, `high` → at least `medium`), regardless of test coverage — testing
lowers the odds of a *silent* break, it doesn't shrink the blast radius.
I picked this over "riskLevel must not be low above some dependent count"
because it's the more surgical fix for the actual root cause (complexity
was computed but not wired into classification) and doesn't require picking
an arbitrary new count threshold. A monotonicity test in
`blast-radius-risk.test.ts` asserts `riskLevel` is never more than one tier
below `complexityRiskBoost` across a spread of scenarios.

The one-tier floor (not "clamp to the boost's own level") is what keeps the
already-correct gin `bytesconv.StringToBytes` case (1 untested dependent,
critical complexity, already `"high"` via `hasHighComplexityUncovered`)
from escalating to `"critical"` — it's the regression guard in the table
below.

### #940 — three attribution-caveat flags, one question

`symbolAttributionDegraded`/`symbolAttributionNote` (#931),
`dependentAttributionIncomplete`/`dependentAttributionNote` (#936), and
`note` (#927/#937) all mean some version of "this count/zero isn't a
verified clear." I judged the proposed shape **correct to build as-is**:

- The three are **mutually exclusive by construction** — verified by
  reading the actual control flow (`checkDependentAttributionIncomplete`
  early-returns when `symbol` is set or `!targetIndexed`;
  `symbolAttributionDegraded` requires `chunksByFile.size > 0`, which is
  false whenever `!targetIndexed`). A single `reason` enum loses no
  information versus three booleans.
- It's a genuine ergonomic win, not just cosmetic: a model checks one
  field's presence instead of three ORed conditions, and gets a stable,
  greppable identifier per case.
- This is a **breaking change** to the response shape with **no
  deprecation window**. Accepted given: `@liendev/lien` is pre-1.0 (0.71.x),
  the three flags being replaced are only weeks old, and the project has a
  track record of breaking MCP/response-shape changes without shims
  (LanceDB/embeddings removal, native-parser swap, etc.). An additive
  deprecated-fields-linger approach would add permanent surface for zero
  benefit at this stage.
- `targetIndexed` stays internal (drives the `unresolved-target` note,
  never promoted to a response field), per the non-goal in #940.

New shape: `attributionCaveat?: { reason: 'unresolved-target' |
'symbol-attribution-degraded' | 'dependent-attribution-incomplete'; note:
string }`.

### Where this is documented (model-facing, not just packages/site)

This exact campaign shipped a correct fix twice that was invisible to its
consumer (documented only in `packages/site`, with zero mentions in
`tools.ts`/`instructions.ts`). This PR updates all of:

- `packages/cli/src/mcp/tools.ts` — `get_dependents`'s tool description
- `packages/cli/src/mcp/instructions.ts` — server instructions sent to
  every connecting client
- `packages/cli/src/mcp/schemas/dependents.schema.ts` — the `symbol`
  param's own description (previously referenced the old
  `symbolAttributionDegraded` field name)
- `packages/site/docs/guide/mcp-tools.md` — human-facing docs

Verified against the **built bundle** (`packages/cli/dist/index.js`), not
just source: `attributionCaveat` appears 9×, the invariant sentence ("even
if every dependent is fully tested") is present, and the old field names
only remain where they should — the internal `DependencyAnalysisResult`
computation in `dependency-analyzer.ts`/`annotate-cmd.ts`, which is a
separate surface out of scope for #940 (annotate's hook output never
carries `symbol`, so it never had `symbolAttributionDegraded` to unify in
the first place; it keeps its own `dependentAttributionIncomplete` field
unchanged).

## Dogfood evidence (real corpora, before/after)

Built the native parser locally, indexed each repo fresh
(`lien index --force`) immediately before every measurement, per the
protocol in `docs/dogfood/`. The shared corpus at
`/tmp/lien-dogfood-460173c9/gin` had uncommitted changes from a concurrent
agent's task (a renamed symbol) at measurement time, so the gin
measurements below use a clean private clone instead — same commit
(`34dac20`), verified via `git status --short` empty.

### console `Cursor.php` symbol `Cursor` — the #933 case

| | before | after |
|---|---|---|
| `riskLevel` | `"low"` | **`"high"`** |
| `riskReasoning` | `["4 production callers", "max complexity 31"]` | `[..., "critical-complexity dependent regardless of test coverage"]` |
| `complexityMetrics.complexityRiskBoost` | `"critical"` | `"critical"` (unchanged) |

### gin `bytesconv.go` symbol `StringToBytes` — regression guard, must stay `high`

| | before | after |
|---|---|---|
| `riskLevel` | `"high"` | **`"high"` (unchanged)** |
| `riskReasoning` | `["4 production callers", "1 untested", "max complexity 27", "untested high-complexity dependent"]` | identical |

### console `Cursor.php` symbol `__construct` — #940 symbol-attribution-degraded, combined with #933

```json
{
  "riskLevel": "high",
  "riskReasoning": ["4 production callers", "max complexity 31", "critical-complexity dependent regardless of test coverage"],
  "attributionCaveat": {
    "reason": "symbol-attribution-degraded",
    "note": "\"__construct\" doesn't appear in Cursor.php's tracked top-level exports ..."
  }
}
```

### serilog `Alignment.cs` (file-level) — #940 dependent-attribution-incomplete, unaffected by #933

`riskLevel: "low"` (no complexity data — correctly unaffected),
`attributionCaveat.reason: "dependent-attribution-incomplete"`.

### console `src/Command/Command.php` (nonexistent) — #940 unresolved-target, unaffected

`attributionCaveat.reason: "unresolved-target"`, note text unchanged
(`"not found in the index"` — #927's manifest-based wording, precedence
over #928's still intact).

### gin `binding/binding.go` — healthy file, entirely unaffected

`riskLevel: "medium"`, `complexityRiskBoost: "low"` — before and after
identical (floor only ever activates for `high`/`critical` boosts).

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — 0 errors (pre-existing warnings only, unrelated)
- [x] `npm run typecheck` — pass across all packages
- [x] `npm run build` — pass across all packages
- [x] `npm test` — 1296 CLI tests + parser/core/review/action suites, all pass
- [x] `node packages/cli/dist/index.js delta` — exit 0 (worsened-but-under-threshold only; `buildDependentsResponse` actually improved: cognitive 8 → 3)
- [x] `npm run docs:build` — pass, rendered HTML spot-checked for the new `attributionCaveat` section
- [x] New monotonicity + regression-guard tests in `blast-radius-risk.test.ts` and `get-dependents.test.ts`
- [x] Real-corpus dogfood before/after on 5 cases (table above), including one full end-to-end MCP call combining both fixes

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR fixes a coherence bug in `get_dependents` by wiring `complexityMetrics.complexityRiskBoost` into `computeBlastRadiusRisk` as a floor, so high/critical complexity can no longer be silenced to `low` by full test coverage. It also unifies three attribution-caveat flags into a single `attributionCaveat: { reason, note }` response field. The changes are well-tested for the parser/cli paths, but the review-side blast-radius caller was not updated to pass the new `complexityRiskBoost` parameter, leaving the original contradiction bug alive in PR review reports.
>
> - `computeBlastRadiusRisk` now accepts optional `complexityRiskBoost` and floors `riskLevel` one tier below high/critical boosts
> - `get_dependents` response replaces separate caveat flags with `attributionCaveat: { reason, note }`
> - Review's `buildEntry`/`computeGlobalRisk` still omit `complexityRiskBoost`, so the fix does not propagate to PR review blast-radius scoring

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0558218. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blast-radius risk scoring so critical or high complexity cannot be understated by test coverage.
  * Risk explanations now clarify when complexity influences the result regardless of coverage.

* **New Features**
  * Added a unified `attributionCaveat` response containing a reason and explanatory note.
  * Consolidated unresolved-target, degraded symbol attribution, and incomplete dependent attribution warnings.

* **Documentation**
  * Updated tool guidance, parameter descriptions, server instructions, and documentation to reflect the revised risk semantics and attribution response format.
  * Removed legacy attribution warning fields; this is a breaking response-shape change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->