### PR TITLE
fix(parser): resolve bare same-directory self-import specifier "." (#935)

### DIFF
--- a/.changeset/bare-dot-self-import.md
+++ b/.changeset/bare-dot-self-import.md
@@ -1,0 +1,37 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+#935: a bare same-directory self-import specifier (`import { x } from '.'`)
+was never resolved, so a same-directory barrel re-export test never
+associated with the sibling file(s) it directly imports.
+
+Root cause: `resolveRelativeImport` only recognized specifiers starting
+with `./` or `../`. JS/TS's import extractor stores the raw source text
+verbatim, and `import { x } from '.'`'s specifier is the literal string
+`"."` — no leading slash, so it fell through unresolved and was stored in
+chunk metadata exactly as written. None of `matchesFile`'s five strategies
+can match an unresolved `"."` against anything.
+
+Reproduced on a real indexed honojs/hono corpus:
+`src/middleware/jsx-renderer/index.test.tsx` imports its own directory's
+barrel via `from '.'`, and `lien annotate` reported "No test coverage" for
+`src/middleware/jsx-renderer/index.ts` despite the test directly exercising
+it. Same shape on `src/middleware/secure-headers/index.test.ts`.
+
+Fix: `resolveRelativeImport` now also matches the bare, slash-free `.`/`..`
+themselves (Node/TS module resolution treats them as "this directory" and
+"the parent directory", exactly like their slash-suffixed forms) via a
+single anchored regex, `RELATIVE_IMPORT_PATTERN`. This resolves to the
+importer's own directory (or its parent) the same way an already-supported
+`./` /`../` specifier does, so downstream matching needs no changes.
+Python's own leading-dot relative imports (`.foo`, `..pkg`) are unaffected —
+`PythonImportExtractor` already converts those to the `./`/`../`-prefixed
+form before this function runs (#904), so the new bare-dot case only ever
+fires for languages (JS/TS today) whose extractor stores the raw specifier
+as-is.
+
+Verified end-to-end on the real hono repro (both files now report their
+own test file under "Test coverage") and via a 25-file coverage sample
+across hono, gin, and flask confirming no regression.

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -641,6 +641,24 @@ from typing import Optional
       expect(imports).toContain('os');
       expect(imports).toContain('typing');
     });
+
+    it('resolves a bare same-directory self-import against the importer path (#935)', () => {
+      // `import { jsxRenderer } from '.'` -- the honojs/hono repro. The raw
+      // TS extractor stores the source text verbatim ("."), so resolution to
+      // the importer's own directory only happens when a filepath is passed
+      // through to resolveImportSpecifier/resolveRelativeImport.
+      const content = `import { jsxRenderer } from '.';`;
+
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(
+        parseResult.tree!.rootNode,
+        'typescript',
+        'src/middleware/jsx-renderer/index.test.tsx',
+      );
+
+      expect(imports).toContain('src/middleware/jsx-renderer');
+      expect(imports).not.toContain('.');
+    });
   });
 
   describe('extractImports - Go grouped imports (#863)', () => {

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -997,6 +997,30 @@ describe('resolveRelativeImport', () => {
     expect(bResolved).toBe('packages/parser/src/dependency-analyzer');
     expect(aResolved).not.toBe(bResolved);
   });
+
+  it('resolves a bare same-directory self-import (#935)', () => {
+    // `import { x } from '.'` in JS/TS — the extractor stores the raw source
+    // text verbatim (unlike Python, which converts its own bare-dot form to
+    // "./" before this function ever runs), so a literal "." must resolve the
+    // same way "./" already does: to the importer's own directory, with
+    // nothing joined after it.
+    expect(resolveRelativeImport('src/middleware/jsx-renderer/index.test.tsx', '.')).toBe(
+      'src/middleware/jsx-renderer',
+    );
+  });
+
+  it('resolves a bare parent-directory self-import (#935)', () => {
+    expect(resolveRelativeImport('src/middleware/jsx-renderer/nested/foo.ts', '..')).toBe(
+      'src/middleware/jsx-renderer',
+    );
+  });
+
+  it('matches the real hono repro end-to-end via matchesFile (#935)', () => {
+    // src/middleware/jsx-renderer/index.test.tsx: `import { jsxRenderer } from '.'`
+    // must associate with src/middleware/jsx-renderer/index.ts.
+    const resolved = resolveRelativeImport('src/middleware/jsx-renderer/index.test.tsx', '.');
+    expect(matchesFile(resolved, 'src/middleware/jsx-renderer/index')).toBe(true);
+  });
 });
 
 describe('resolveWorkspaceImport', () => {

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -631,33 +631,50 @@ function matchesPHPNamespace(importPath: string, targetPath: string): boolean {
 }
 
 /**
+ * Matches a relative import specifier: `./x`, `../x`, or the bare, slash-free
+ * `.`/`..` themselves (anchored so a longer dotted specifier like `.module`
+ * or `..pkg.thing` — an un-converted Python absolute-looking import, #904's
+ * doc comment below — never qualifies).
+ */
+const RELATIVE_IMPORT_PATTERN = /^\.\.?(\/|$)/;
+
+/**
  * Resolve a relative import specifier against its importer's file path.
  *
- * Only acts on specifiers starting with `./` or `../`. Package specifiers
- * (e.g. `@liendev/core`, `lodash`), dotted Python-style *absolute* imports,
- * and absolute paths pass through unchanged. Since #904, Python's leading-dot
- * *relative* imports (`.foo`, `..pkg`) DO reach this function too —
- * `PythonImportExtractor` converts them to this same `./`/`../`-prefixed
- * shape at extraction time (see `ast/languages/python.ts`'s
- * `convertPythonRelativeImport`) before `resolveImportSpecifier` calls this.
+ * Acts on specifiers matching `RELATIVE_IMPORT_PATTERN`: `./`/`../`-prefixed,
+ * or the bare `.`/`..` themselves (#935) — Node/TS module resolution treats a
+ * bare `.` as "this directory" and a bare `..` as "the parent directory"
+ * exactly like their slash-suffixed forms (`import { x } from '.'` in a
+ * same-directory barrel re-export test is the confirmed real-world shape: a
+ * genuine self-import that used to be stored as the literal, never-matching
+ * string `"."`). Package specifiers (e.g. `@liendev/core`, `lodash`), dotted
+ * Python-style *absolute* imports, and absolute paths pass through unchanged.
+ * Since #904, Python's leading-dot *relative* imports (`.foo`, `..pkg`) DO
+ * reach this function too — `PythonImportExtractor` converts them to this
+ * same `./`/`../`-prefixed shape at extraction time (see
+ * `ast/languages/python.ts`'s `convertPythonRelativeImport`) before
+ * `resolveImportSpecifier` calls this, so the bare-dot case added here never
+ * actually fires for Python; it exists for languages (JS/TS today) whose
+ * extractor stores the raw source literal as-is.
  *
  * Returns the resolved path in the same form as `importerFile` — relative when
  * `importerFile` is relative, absolute when absolute. Any trailing slash is
- * stripped: a bare `./` or `../` specifier (Python's `from . import X` /
- * `from .. import X`, converted with an empty remainder — see
- * `convertPythonRelativeImport`) resolves to the importer's own directory
- * with nothing joined after it, and `path.posix.normalize`/`join` leave that
- * directory's trailing slash intact, which would otherwise never
- * boundary-match a target path (those never carry one). The caller's
- * downstream normalization (`normalizePath`) is what ultimately strips
- * extensions and the workspace-root prefix, so no other work is needed here.
+ * stripped: a bare `./`/`.` or `../`/`..` specifier (Python's `from . import X`
+ * / `from .. import X`, converted with an empty remainder — see
+ * `convertPythonRelativeImport` — or JS/TS's own bare `'.'`/`'..'`) resolves
+ * to the importer's own directory (or its parent) with nothing joined after
+ * it, and `path.posix.normalize`/`join` leave that directory's trailing slash
+ * intact, which would otherwise never boundary-match a target path (those
+ * never carry one). The caller's downstream normalization (`normalizePath`)
+ * is what ultimately strips extensions and the workspace-root prefix, so no
+ * other work is needed here.
  *
  * @param importerFile - File path of the chunk doing the importing
  * @param specifier - The raw import specifier from source code
  * @returns Resolved path for relative specifiers; the original string otherwise
  */
 export function resolveRelativeImport(importerFile: string, specifier: string): string {
-  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+  if (!RELATIVE_IMPORT_PATTERN.test(specifier)) {
     return specifier;
   }
   const importerDir = path.posix.dirname(importerFile.replace(/\\/g, '/'));


### PR DESCRIPTION
## Summary
- Fixes #935: a bare same-directory self-import specifier (`import { x } from '.'`) was stored verbatim as the literal string `"."` in chunk metadata and never resolved to a path, so a same-directory barrel re-export test never associated with the target it directly imports.
- `resolveRelativeImport` only recognized specifiers starting with `./` or `../`. JS/TS's import extractor stores the raw source text as-is, so a bare `.` (no leading slash) fell straight through unresolved.
- Extended `resolveRelativeImport` to also match the bare, slash-free `.`/`..` themselves via a single anchored regex (`RELATIVE_IMPORT_PATTERN`) — Node/TS module resolution treats them as "this directory"/"the parent directory" exactly like their slash-suffixed forms. This is a narrow fix at the shared import-resolution layer (not `matchesFile`, per the issue's suggested direction), so it also benefits `get_dependents`, which shares the same pipeline.
- Python's own leading-dot relative imports (`.foo`, `..pkg`) are unaffected — `PythonImportExtractor` already converts those to `./`/`../`-prefixed form upstream (#904), so the new bare-dot branch only ever fires for languages (JS/TS today) whose extractor stores the raw specifier verbatim. Verified no leniency was reintroduced for any other language (see dogfood evidence below).
- Simplified the check to a single anchored regex rather than four OR'd string comparisons — `lien delta` actually reports this function's cognitive complexity *improving* (2 → 1) versus HEAD, not worsening.

## Dogfood evidence (real hono corpus, honojs/hono @ 224d2f5)

Built two CLIs — pre-fix (HEAD~1, native parser built) and this branch — and force-reindexed the same corpus copy with each before every measurement (learned the hard way: my first pass measured a stale/broken index and had to be redone from scratch).

**The two files named in the issue, before vs after:**

Before (`node <old-cli> annotate <file>`):
```
Lien impact for src/middleware/jsx-renderer/index.ts:
  • 8 files import this — ...; risk: high (8 callers, max complexity 32, untested high-complexity dependent).
  • No test coverage.

Lien impact for src/middleware/secure-headers/secure-headers.ts:
  • 9 files import this — ...; risk: high (9 callers, max complexity 32, untested high-complexity dependent).
  • No test coverage.
```

After (`node <new-cli> annotate <file>`):
```
Lien impact for src/middleware/jsx-renderer/index.ts:
  • 10 files import this — ...; risk: high (10 callers, max complexity 32, critical-complexity dependent regardless of test coverage).
  • Test coverage: src/middleware/jsx-renderer/index.test.tsx.

Lien impact for src/middleware/secure-headers/secure-headers.ts:
  • 11 files import this — ...; risk: high (11 callers, max complexity 32, critical-complexity dependent regardless of test coverage).
  • Test coverage: src/middleware/secure-headers/index.test.ts.
```

The dependent count also moves (+2 each) — the test files' own bare-`.` self-import is now correctly counted as a dependency edge too, a `get_dependents` accuracy bonus from fixing the shared resolution layer.

**25-file coverage sample, reindexed fresh before each measurement:**

| repo (lang) | before | after | flips |
|---|---|---|---|
| hono (TS) | 13/25 (52%) | 18/25 (72%) | +5, all `none → confident` |
| gin (Go) | 8/25 (32%) | 8/25 (32%) | 0 |
| flask (Python) | 9/25 (36%) | 9/25 (36%) | 0 |

Manually diffed all 5 hono flips against source — every one is a genuine bare-dot self-import newly resolving correctly:
- `context-storage/index.test.ts` / `pretty-json/index.test.ts`: the test file itself does `from '.'`.
- `cloudflare-workers/index.ts`, `jwk/index.ts`, `timeout/index.ts`: a sibling `*.test.ts` in the same directory imports the barrel via `from '.'` (`websocket.test.ts`, `jwk/index.test.ts`, `timeout/index.test.ts` respectively).

Zero flips on Go/Python confirms no cross-language leniency was reintroduced (mirrors #934's guard-scoping precedent).

## Test plan
- [x] `packages/parser/src/utils/path-matching.test.ts`: 3 new unit tests for `resolveRelativeImport`'s bare `.`/`..` handling + an end-to-end `matchesFile` pairing on the real hono shape (133/133 passing)
- [x] `packages/parser/src/ast/symbols.test.ts`: new integration test through the real TS parser + `extractImports` with a filepath, confirming `.` resolves to the importer's directory rather than staying literal (102/102 passing)
- [x] Full gate chain: `format:check`, `lint` (0 errors), `typecheck`, `build`, `test` (parser 378, cli 1296, review 1701, action 41 — all passing), `lien delta` (improved, not worsened)
- [x] Dogfood: real before/after against the honojs/hono corpus (see above) + cross-language regression check (gin, flask)

No new MCP response fields or documented limitations — this is a pure accuracy fix to existing `testAssociations`/`get_dependents` output, invisible at the schema level, so no `tools.ts`/`instructions.ts` doc changes are needed.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a narrow import-resolution bug where bare `.`/`..` specifiers (e.g. `import { x } from '.'`) were stored verbatim instead of being resolved to the importer's directory. The change is localized to `resolveRelativeImport` in `packages/parser/src/utils/path-matching.ts`, replacing the `./`/`../` prefix check with an anchored regex that also matches bare `.`/`..` while still excluding Python-style dotted imports like `.module` or `..pkg.thing`. The implementation correctly resolves the bare specifiers via `path.posix.join`/`normalize` and strips the trailing slash, and the added unit and integration tests cover the exact repro shapes. Documentation in the changeset and code comments accurately describes the behavior and the upstream Python conversion guard.
>
> - Added `RELATIVE_IMPORT_PATTERN` regex to `resolveRelativeImport` so bare `.` and `..` are treated as relative self/parent-directory imports
> - Added unit tests for `.`/`..` resolution and an end-to-end `matchesFile` test using the real hono repro shape
> - Added an integration test through the TypeScript parser confirming `extractImports` resolves `'.'` against the importer path

<sup>Reviewed by [Lien Review](https://lien.dev) for commit e7067f0. Updates automatically on new commits.</sup>
<!-- /lien-stats -->