### PR TITLE
fix(parser,cli): recover C# type-reference dependents for get_dependents (#930 part 2)

### DIFF
--- a/.changeset/csharp-type-reference-dependents.md
+++ b/.changeset/csharp-type-reference-dependents.md
@@ -1,0 +1,43 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Recover real C# `get_dependents` dependents lost to `global using` (#930,
+part 2). #932/#936 stopped the tool from fabricating dependents out of
+`GlobalUsings.cs` boilerplate and made the resulting zero honest
+(`dependentAttributionIncomplete`), but a file with `global using` in scope
+still reported `dependentCount: 0` / `riskLevel: "low"` even when it had
+real callers — honest-and-blind, not correct. Confirmed on a fresh
+serilog/serilog clone: `Alignment.cs` has 5 real production dependents and
+1 real test dependent, none reachable via a per-file import.
+
+Adds a lower-confidence recovery signal, `findCSharpTypeReferenceDependents`
+(`@liendev/parser`): for a file whose type name is declared exactly once
+project-wide (so a same-named reference elsewhere can't be an unrelated
+declaration — the C# compiler itself would refuse to build over that
+ambiguity), scan every other C# file's source text for an
+identifier-boundary occurrence of that name. Only attempted when the import
+graph found zero dependents for a file-level query on an
+`enclosingNamespaceAccess` language (C# today).
+
+Recovered dependents are tagged `confidence: "inferred"` on `DependentInfo`
+(a new optional field, absent on every ordinary import-verified dependent)
+and never folded in unhedged — the response also gets a new
+`attributionCaveat` reason, `"dependent-attribution-partial"`, explaining
+that the count is a recovered lower bound, not a verified/complete answer.
+`dependentAttributionIncomplete` now only fires when this recovery attempt
+*also* finds nothing. Both are purely additive: no existing field is
+removed, renamed, or changed shape.
+
+Verified end-to-end via the real MCP `get_dependents` tool against a fresh
+serilog/serilog clone: `Alignment.cs` goes from `dependentCount: 0` /
+`"low"` to all 5 real production dependents + its test dependent (`medium`
+risk); `PropertyToken.cs` (a file with a genuine import-verified test
+dependent) is unaffected; a 25-file serilog sample recovered dependents for
+21 files, left 2 honestly `dependent-attribution-incomplete` (no
+recoverable signal), and left 2 real import-based hits untouched; a
+TypeScript control (hono) confirmed zero cross-language impact.
+
+`tools.ts` and `instructions.ts` (the two model-facing surfaces) are
+updated accordingly.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -14,14 +14,18 @@ function createChunk(
     complexity: number;
     callSites: Array<{ symbol: string; line: number }>;
     symbolName: string;
+    symbolType: 'function' | 'method' | 'class' | 'interface';
+    content: string;
     startLine: number;
     endLine: number;
   }> = {},
 ): SearchResult {
   return {
-    content: overrides.callSites
-      ? overrides.callSites.map(cs => `  ${cs.symbol}()`).join('\n')
-      : 'test content',
+    content:
+      overrides.content ??
+      (overrides.callSites
+        ? overrides.callSites.map(cs => `  ${cs.symbol}()`).join('\n')
+        : 'test content'),
     metadata: {
       file,
       startLine: overrides.startLine ?? 1,
@@ -472,6 +476,96 @@ describe('findDependents', () => {
       const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog, 'Alignment');
 
       expect(result.dependentAttributionIncomplete).toBeUndefined();
+    });
+  });
+
+  describe('C# type-reference dependents recovery (#930 part 2)', () => {
+    it('recovers dependents via a uniquely-declared type name when the import graph found none', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Alignment.cs', {
+          exports: ['Alignment'],
+          symbolName: 'Alignment',
+          symbolType: 'class',
+          content: 'public class Alignment { }',
+        }),
+        createChunk('Padding.cs', {
+          symbolName: 'Apply',
+          symbolType: 'method',
+          content: 'Padding.Apply(output, value, in Alignment? alignment)',
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog);
+
+      expect(result.dependents).toHaveLength(1);
+      expect(result.dependents[0]).toMatchObject({
+        filepath: 'Padding.cs',
+        confidence: 'inferred',
+      });
+      expect(result.productionDependentCount).toBe(1);
+      expect(result.dependentAttributionPartial).toBe(true);
+      expect(result.dependentAttributionIncomplete).toBeUndefined();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('C# type-reference'));
+    });
+
+    it('still flags dependentAttributionIncomplete when the type-reference fallback also finds nothing', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Alignment.cs', {
+          exports: ['Alignment'],
+          symbolName: 'Alignment',
+          symbolType: 'class',
+          content: 'public class Alignment { }',
+        }),
+        createChunk('Unrelated.cs', { symbolName: 'DoStuff', symbolType: 'method' }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.dependentAttributionPartial).toBeUndefined();
+      expect(result.dependentAttributionIncomplete).toBe(true);
+    });
+
+    it('does not run the fallback for a SYMBOL-scoped query', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Alignment.cs', {
+          exports: ['Alignment'],
+          symbolName: 'Alignment',
+          symbolType: 'class',
+          content: 'public class Alignment { }',
+        }),
+        createChunk('Padding.cs', {
+          symbolName: 'Apply',
+          symbolType: 'method',
+          content: 'Padding.Apply(output, value, in Alignment? alignment)',
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'Alignment.cs', mockLog, 'Alignment');
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.dependentAttributionPartial).toBeUndefined();
+    });
+
+    it('does not run the fallback for a non-C# file (no enclosing-namespace access)', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/alignment.ts', {
+          exports: ['Alignment'],
+          symbolName: 'Alignment',
+          symbolType: 'class',
+          content: 'export class Alignment {}',
+        }),
+        createChunk('src/padding.ts', {
+          symbolName: 'apply',
+          symbolType: 'function',
+          content: 'Alignment.apply(output, value)',
+        }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/alignment.ts', mockLog);
+
+      expect(result.dependents).toHaveLength(0);
+      expect(result.dependentAttributionPartial).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -11,6 +11,7 @@ import {
   hasSingleFileImportSemantics,
   detectLanguage,
   hasEnclosingNamespaceAccess,
+  findCSharpTypeReferenceDependents,
   COMPLEXITY_THRESHOLDS,
 } from '@liendev/parser';
 
@@ -88,6 +89,18 @@ export interface DependentInfo {
   usages?: SymbolUsage[];
   /** Depth at which this dependent was first discovered (1 = direct). */
   hops?: number;
+  /**
+   * Present (`'inferred'`) only for a dependent recovered by the C#
+   * type-reference-matching fallback (#930's remaining half -- see
+   * `findCSharpTypeReferenceDependents`'s module doc) instead of a real
+   * import edge: a word-boundary text match against a uniquely-declared
+   * type name, not an import-verified association. Absent for every
+   * ordinary, import-verified dependent (the default, confident tier) -- a
+   * caller that needs to distinguish "verified" from "text-matched, lower
+   * confidence" should filter on this field rather than assuming every
+   * entry in `dependents` came from the import graph.
+   */
+  confidence?: 'inferred';
 }
 
 /**
@@ -120,17 +133,34 @@ export interface DependencyAnalysisResult {
   /**
    * True for a FILE-level query (no `symbol` requested) that came back with
    * zero dependents for a language where `hasEnclosingNamespaceAccess` is
-   * set (currently only C# -- see that flag's doc comment). Those languages
-   * let a real caller use `filepath`'s types with no per-file import
-   * statement naming it at all (C#'s `global using` / implicit
-   * enclosing-namespace member access -- #930), so the import-graph scan
-   * this function runs has no signal for that usage shape. `dependentCount:
-   * 0` / `riskLevel: "low"` in this case means "the import graph found
-   * nothing," not "nothing depends on this file" -- the same false-all-clear
-   * risk `symbolAttributionDegraded` guards against for symbol queries, just
-   * for the file-level answer instead.
+   * set (currently only C# -- see that flag's doc comment), EVEN AFTER
+   * attempting the type-reference-matching recovery below
+   * (`dependentAttributionPartial`). Those languages let a real caller use
+   * `filepath`'s types with no per-file import statement naming it at all
+   * (C#'s `global using` / implicit enclosing-namespace member access --
+   * #930), so the import-graph scan this function runs has no signal for
+   * that usage shape. `dependentCount: 0` / `riskLevel: "low"` in this case
+   * means "neither scan found anything," not "nothing depends on this
+   * file" -- the same false-all-clear risk `symbolAttributionDegraded`
+   * guards against for symbol queries, just for the file-level answer
+   * instead. Mutually exclusive with `dependentAttributionPartial`: this
+   * requires the final `dependents.length` to be zero; that one requires it
+   * to be positive.
    */
   dependentAttributionIncomplete?: boolean;
+  /**
+   * True for a FILE-level query (no `symbol`) where the import graph found
+   * zero dependents but the C# type-reference-matching fallback
+   * (`findCSharpTypeReferenceDependents`, #930's remaining half) recovered
+   * one or more. Those recovered entries are tagged `confidence: 'inferred'`
+   * on `DependentInfo` -- a word-boundary text match against a
+   * uniquely-declared type name, not an import-verified edge -- so
+   * `dependentCount`/`riskLevel` here are a recovered LOWER BOUND, not a
+   * verified/complete answer: the heuristic can still miss a real dependent
+   * that references the type via an alias, a generic type argument, or
+   * reflection, none of which spell the bare type name in a matchable way.
+   */
+  dependentAttributionPartial?: boolean;
   /**
    * False when the requested target has zero chunks anywhere in the scanned
    * index (#928) — i.e. it isn't a real file the indexer has seen, whether
@@ -589,6 +619,64 @@ interface ScanContext {
   log: (message: string, level?: 'warning') => void;
 }
 
+/**
+ * Resolve the final dependents list for one `findDependents` call: the
+ * import-graph answer (`buildDependentsList`), the C# type-reference
+ * recovery attempt (`enrichWithCSharpTypeReferenceDependents`, #930 part 2),
+ * and hop stamping/sorting -- grouped here so `findDependents` itself stays
+ * a thin orchestration shell rather than inlining all three steps.
+ */
+function resolveDependents(args: {
+  ctx: ScanContext;
+  chunksByFile: Map<string, SearchResult[]>;
+  hopsByFile: Map<string, number>;
+  symbol: string | undefined;
+  normalizedTarget: string;
+  targetFileChunks: SearchResult[];
+  filepath: string;
+  reExporterPaths: string[];
+  targetIndexed: boolean;
+}): {
+  dependents: DependentInfo[];
+  totalUsageCount?: number;
+  symbolAttributionDegraded?: boolean;
+  dependentAttributionPartial?: true;
+} {
+  const {
+    ctx,
+    chunksByFile,
+    hopsByFile,
+    symbol,
+    normalizedTarget,
+    targetFileChunks,
+    filepath,
+    reExporterPaths,
+    targetIndexed,
+  } = args;
+
+  const { dependents, totalUsageCount, symbolAttributionDegraded } = buildDependentsList(
+    chunksByFile,
+    symbol,
+    normalizedTarget,
+    ctx.normalizePathCached,
+    targetFileChunks,
+    filepath,
+    ctx.log,
+    reExporterPaths,
+  );
+  const dependentAttributionPartial = enrichWithCSharpTypeReferenceDependents(
+    ctx,
+    filepath,
+    normalizedTarget,
+    symbol,
+    targetIndexed,
+    dependents,
+  );
+  stampHopsAndSort(dependents, hopsByFile);
+
+  return { dependents, totalUsageCount, symbolAttributionDegraded, dependentAttributionPartial };
+}
+
 export async function findDependents(
   vectorDB: VectorDBInterface,
   filepath: string,
@@ -636,17 +724,18 @@ export async function findDependents(
   });
 
   const targetFileChunks = symbol ? (allChunksByFile.get(normalizedTarget) ?? []) : [];
-  const { dependents, totalUsageCount, symbolAttributionDegraded } = buildDependentsList(
-    chunksByFile,
-    symbol,
-    normalizedTarget,
-    normalizePathCached,
-    targetFileChunks,
-    filepath,
-    log,
-    reExporterPaths,
-  );
-  stampHopsAndSort(dependents, hopsByFile);
+  const { dependents, totalUsageCount, symbolAttributionDegraded, dependentAttributionPartial } =
+    resolveDependents({
+      ctx,
+      chunksByFile,
+      hopsByFile,
+      symbol,
+      normalizedTarget,
+      targetFileChunks,
+      filepath,
+      reExporterPaths,
+      targetIndexed,
+    });
 
   // Complexity metrics must be joined against the *resolved* dependents, not
   // the broader import-graph candidate set (`chunksByFile`) considered before
@@ -692,17 +781,94 @@ export async function findDependents(
     uncoveredProductionDependents,
     symbolAttributionDegraded,
     dependentAttributionIncomplete,
+    dependentAttributionPartial,
     targetIndexed,
   };
+}
+
+/**
+ * #930 (part 2): recover REAL production dependents for a C# file when the
+ * import graph found none, by scanning for identifier-boundary references
+ * to the target's uniquely-declared type name(s) across the corpus -- see
+ * `findCSharpTypeReferenceDependents`'s module doc for the full mechanism
+ * and why a type-declaration match (unlike a bare method-name match, #869)
+ * doesn't need Swift's extra type-shaped-driver gate.
+ *
+ * Deliberately narrower than the import-graph seed it supplements:
+ * - File-level only (`symbol` unset) -- there's no principled way to scope
+ *   a text match to one exported member.
+ * - Only attempted when the import graph found LITERALLY ZERO dependents --
+ *   avoids a corpus-wide content scan on every C# `get_dependents` call,
+ *   mirroring `checkDependentAttributionIncomplete`'s existing threshold.
+ *   A future PR could widen this to also run when the import graph found
+ *   *some* dependents (a mixed old/new-style C# project), but that's out of
+ *   scope here.
+ * - Only for `hasEnclosingNamespaceAccess` languages (currently C# only).
+ *
+ * Recovered entries are tagged `confidence: 'inferred'` (see
+ * `DependentInfo`) and deliberately NOT joined against `chunksByFile` for
+ * complexity-metrics purposes -- unlike a real import edge, there's no
+ * associated import-graph chunk set to attribute complexity to, so these
+ * dependents contribute to `dependentCount`/`productionDependentCount`/
+ * `riskLevel` but not to `complexityMetrics`. `uncoveredProductionDependents`
+ * still runs its own genuine import-based "is there a test importer of
+ * THIS dependent" check against each recovered file, so that count stays
+ * meaningful.
+ *
+ * Mutates `dependents` in place (pushes new entries); returns `true` when
+ * anything was recovered (for `dependentAttributionPartial`) or `undefined`
+ * otherwise -- matching this file's existing convention for optional
+ * boolean flags (e.g. `symbolAttributionDegraded`,
+ * `dependentAttributionIncomplete`), which are only ever `true` or absent,
+ * never an explicit `false`.
+ */
+function enrichWithCSharpTypeReferenceDependents(
+  ctx: ScanContext,
+  filepath: string,
+  normalizedTarget: string,
+  symbol: string | undefined,
+  targetIndexed: boolean,
+  dependents: DependentInfo[],
+): true | undefined {
+  if (symbol || dependents.length !== 0 || !targetIndexed) return undefined;
+
+  const targetLanguage = detectLanguage(filepath);
+  if (targetLanguage === null || !hasEnclosingNamespaceAccess(targetLanguage)) return undefined;
+
+  const targetChunks = ctx.allChunksByFile.get(normalizedTarget) ?? [];
+  const targetRawFile = targetChunks[0]?.metadata.file;
+  if (!targetRawFile) return undefined;
+
+  const allChunks = Array.from(ctx.allChunksByFile.values()).flat();
+  const inferredFiles = findCSharpTypeReferenceDependents(targetRawFile, allChunks);
+  if (inferredFiles.length === 0) return undefined;
+
+  const workspaceRoot = process.cwd().replace(/\\/g, '/');
+  for (const rawFile of inferredFiles) {
+    const canonicalFile = getCanonicalPath(rawFile, workspaceRoot);
+    dependents.push({
+      filepath: canonicalFile,
+      isTestFile: isTestFile(canonicalFile),
+      confidence: 'inferred',
+    });
+  }
+
+  ctx.log(
+    `Recovered ${inferredFiles.length} dependent(s) for ${filepath} via C# type-reference ` +
+      `matching (inferred from a uniquely-declared type name, not import-verified — #930)`,
+  );
+  return true;
 }
 
 /**
  * True for a file-level query (no `symbol` -- that case has its own
  * `symbolAttributionDegraded` handling above) that found zero dependents in
  * a language where the import graph structurally cannot see every real
- * usage (see `DependencyAnalysisResult.dependentAttributionIncomplete`'s
- * doc comment). Logs a warning when it fires, matching the logging
- * `buildDependentsList` already does for its own degradation case.
+ * usage, EVEN AFTER `enrichWithCSharpTypeReferenceDependents` above already
+ * had a chance to recover some (see
+ * `DependencyAnalysisResult.dependentAttributionIncomplete`'s doc comment).
+ * Logs a warning when it fires, matching the logging `buildDependentsList`
+ * already does for its own degradation case.
  *
  * Skipped when `targetIndexed` is false (#928): an unresolved target's zero
  * dependents already carries its own, more fundamental "unresolved" signal

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -46,6 +46,7 @@ describe('handleGetDependents', () => {
         isTestFile: boolean;
         usages?: Array<{ callerSymbol: string; line: number; snippet: string }>;
         hops?: number;
+        confidence?: 'inferred';
       }>;
       hitLimit?: boolean;
       complexityMetrics?: {
@@ -64,6 +65,7 @@ describe('handleGetDependents', () => {
       uncoveredProductionDependents?: number;
       symbolAttributionDegraded?: boolean;
       dependentAttributionIncomplete?: boolean;
+      dependentAttributionPartial?: boolean;
       targetIndexed?: boolean;
     } = {},
   ) {
@@ -91,6 +93,7 @@ describe('handleGetDependents', () => {
       uncoveredProductionDependents: overrides.uncoveredProductionDependents ?? 0,
       symbolAttributionDegraded: overrides.symbolAttributionDegraded,
       dependentAttributionIncomplete: overrides.dependentAttributionIncomplete,
+      dependentAttributionPartial: overrides.dependentAttributionPartial,
       targetIndexed: overrides.targetIndexed ?? true,
     };
   }
@@ -701,6 +704,52 @@ describe('handleGetDependents', () => {
 
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed.attributionCaveat).toBeUndefined();
+    });
+  });
+
+  describe('attributionCaveat: dependent-attribution-partial (C# type-reference recovery, #930 part 2)', () => {
+    it('surfaces attributionCaveat when the type-reference fallback recovered dependents', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: [
+            {
+              filepath: 'src/Serilog/Rendering/Padding.cs',
+              isTestFile: false,
+              confidence: 'inferred',
+            },
+          ],
+          dependentAttributionPartial: true,
+        }),
+      );
+
+      const result = await handleGetDependents(
+        { filepath: 'src/Serilog/Parsing/Alignment.cs' },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBe(1);
+      expect(parsed.dependents[0]).toMatchObject({
+        filepath: 'src/Serilog/Rendering/Padding.cs',
+        confidence: 'inferred',
+      });
+      expect(parsed.attributionCaveat.reason).toBe('dependent-attribution-partial');
+      expect(parsed.attributionCaveat.note).toContain('Alignment.cs');
+      expect(parsed.attributionCaveat.note).toContain('lower bound'.toUpperCase());
+    });
+
+    it('does not fire alongside dependent-attribution-incomplete', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({ dependents: [], dependentAttributionIncomplete: true }),
+      );
+
+      const result = await handleGetDependents(
+        { filepath: 'src/Serilog/Parsing/Alignment.cs' },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.attributionCaveat.reason).toBe('dependent-attribution-incomplete');
     });
   });
 

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -27,7 +27,7 @@ interface IndexInfo {
 /**
  * Why a `get_dependents` answer's counts can't be trusted as a verified
  * clear (#940). Exactly one reason can ever apply to a given response --
- * see `buildAttributionCaveat`'s doc comment for why these three are
+ * see `buildAttributionCaveat`'s doc comment for why these four are
  * mutually exclusive by construction:
  *
  * - `unresolved-target`: `filepath` isn't resolvable in the index at all
@@ -38,14 +38,21 @@ interface IndexInfo {
  *   `filepath` (the shape of a method or constructor -- #931), so the
  *   response was widened to file-level dependents instead of asserting an
  *   unverifiable symbol-scoped count.
+ * - `dependent-attribution-partial`: a file-level query (no `symbol`) found
+ *   zero import-based dependents, but the C# type-reference-matching
+ *   fallback recovered one or more (#930 part 2) -- those entries are
+ *   tagged `confidence: 'inferred'` in `dependents`, and the counts are a
+ *   recovered lower bound, not a verified/complete answer.
  * - `dependent-attribution-incomplete`: a file-level query (no `symbol`)
  *   came back with zero dependents in a language where the import graph
  *   structurally can't see every real usage, e.g. C#'s `global using` /
- *   implicit enclosing-namespace access (#930, #936).
+ *   implicit enclosing-namespace access (#930, #936), EVEN AFTER the
+ *   type-reference-matching fallback also found nothing.
  */
 export type AttributionCaveatReason =
   | 'unresolved-target'
   | 'symbol-attribution-degraded'
+  | 'dependent-attribution-partial'
   | 'dependent-attribution-incomplete';
 
 export interface AttributionCaveat {
@@ -77,7 +84,7 @@ interface DependentsResponse {
   complexityMetrics: ComplexityMetrics;
   /**
    * Present when this answer's counts can't be trusted as a verified clear
-   * -- read `reason` to tell which of the three ways that can happen (see
+   * -- read `reason` to tell which of the four ways that can happen (see
    * `AttributionCaveatReason`'s doc comment) and `note` for the specific
    * explanation. Absent entirely on a normal, fully-attributed answer.
    */
@@ -177,18 +184,24 @@ function clarifyCallerReasoning(reasoning: string[]): string[] {
 /**
  * Decide which (if any) attribution caveat applies, and build its note.
  *
- * The three reasons are mutually exclusive by construction, so at most one
+ * The four reasons are mutually exclusive by construction, so at most one
  * ever fires:
  * - `unresolvedTargetNote` is only non-empty when `filepath` has no chunks
  *   anywhere in the index, in which case `findDependents` returns an empty
  *   `chunksByFile` up front -- so `symbolAttributionDegraded` (which
- *   requires `chunksByFile.size > 0` to fire) and
- *   `dependentAttributionIncomplete` (which explicitly skips when
- *   `!targetIndexed`) can never also be set.
+ *   requires `chunksByFile.size > 0` to fire), `dependentAttributionPartial`,
+ *   and `dependentAttributionIncomplete` (both of which explicitly skip
+ *   when `!targetIndexed`) can never also be set.
  * - `symbolAttributionDegraded` only fires for a `symbol` query;
- *   `dependentAttributionIncomplete` only fires for a file-level query (no
- *   `symbol`) -- see `checkDependentAttributionIncomplete` in
- *   dependency-analyzer.ts. So those two can't co-occur either.
+ *   `dependentAttributionPartial`/`dependentAttributionIncomplete` only fire
+ *   for a file-level query (no `symbol`) -- see
+ *   `enrichWithCSharpTypeReferenceDependents`/
+ *   `checkDependentAttributionIncomplete` in dependency-analyzer.ts. So
+ *   those can't co-occur with `symbolAttributionDegraded` either.
+ * - `dependentAttributionPartial` requires the FINAL `dependents.length`
+ *   (after the type-reference-matching fallback runs) to be positive;
+ *   `dependentAttributionIncomplete` requires that same final count to be
+ *   zero. So those two can never both be set.
  *
  * #927's manifest-based unresolved-target note takes precedence over #928's
  * chunk-based one where both could apply (a typo'd/nonexistent path trips
@@ -226,6 +239,22 @@ function buildAttributionCaveat(
         `its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, ` +
         `riskLevel, and dependents below are the file-level answer (every file that imports ` +
         `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`,
+    };
+  }
+  if (analysis.dependentAttributionPartial) {
+    const inferredCount = analysis.dependents.filter(d => d.confidence === 'inferred').length;
+    return {
+      reason: 'dependent-attribution-partial',
+      note:
+        `The import graph found zero import-based dependents for ${filepath} (its language, C#, ` +
+        `lets real callers use its exports with no per-file import naming it at all — "global ` +
+        `using" / implicit enclosing-namespace member access), but ${inferredCount} of the ` +
+        `${analysis.dependents.length} dependent(s) below were recovered by matching a ` +
+        `uniquely-declared type name against other files' source text (marked ` +
+        `"confidence": "inferred" in \`dependents\`). Treat dependentCount/riskLevel as a ` +
+        `recovered LOWER BOUND, not a verified/complete answer — this heuristic can still miss a ` +
+        `real dependent that references the type via an alias, a generic type argument, or ` +
+        `reflection.`,
     };
   }
   if (analysis.dependentAttributionIncomplete) {

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -40,11 +40,16 @@ symbol:
   result. "symbol-attribution-degraded" means symbol names a method or
   constructor whose call sites couldn't be confirmed — the counts are the
   wider file-level answer, not a verified count for symbol itself.
-  "dependent-attribution-incomplete" means Lien could not SEE real callers
-  in this language (e.g. C#) — grep before concluding the file is unused.
-  (This reason only fires for FILE-level queries, i.e. no "symbol" argument.)
-  riskLevel is not adjusted for either of the latter two and may still read
-  "low"; attributionCaveat is the authoritative signal in all three cases.
+  "dependent-attribution-partial" means the import graph found nothing but
+  a lower-confidence text-matching fallback recovered some dependents
+  anyway (those entries carry confidence: "inferred") — treat the counts as
+  a recovered floor, not a complete answer. "dependent-attribution-incomplete"
+  means Lien could not SEE real callers in this language (e.g. C#) even
+  after that fallback ran — grep before concluding the file is unused.
+  (The latter two reasons only fire for FILE-level queries, i.e. no "symbol"
+  argument.) riskLevel is not adjusted for any of the latter three and may
+  still read "low"; attributionCaveat is the authoritative signal in all
+  four cases.
 
 For discovery ("where is X?", "how does Y work?"), call search_code FIRST.
 It runs full-text BM25 keyword search over code, docstrings, and camelCase-split

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -144,7 +144,11 @@ Returns:
   signal among dependents always lifts this above "low", even when every dependent
   is fully tested (testedness lowers the chance of a *silent* break, it does not
   shrink the blast radius). Check riskReasoning for which signal(s) drove it.
-- dependents[]: { filepath, isTestFile, usages[]? }
+- dependents[]: { filepath, isTestFile, usages[]?, confidence?: "inferred" }
+  \`confidence: "inferred"\` marks a dependent recovered by text-matching a
+  uniquely-declared type name (C#'s global-using gap, see
+  dependent-attribution-partial below) rather than a real import edge — absent
+  entirely on every ordinary, import-verified dependent.
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
 - totalUsageCount?: number (when symbol parameter provided)
 - attributionCaveat?: { reason, note } — present whenever dependentCount/riskLevel
@@ -159,11 +163,17 @@ Returns:
     top-level export) and its call sites couldn't be confirmed; dependentCount/
     riskLevel are the file-level answer (every importer of filepath), not a
     verified count of callers of symbol itself.
+  - "dependent-attribution-partial": a file-level query (no \`symbol\`) found ZERO
+    import-based dependents, but a lower-confidence text-matching fallback
+    recovered one or more (tagged \`confidence: "inferred"\` in dependents[], see
+    above). Treat dependentCount/riskLevel as a recovered FLOOR, not a
+    verified/complete answer — the fallback can still miss a real dependent that
+    references the type via an alias, a generic type argument, or reflection.
   - "dependent-attribution-incomplete": a file-level query (no \`symbol\`) returned
-    ZERO dependents in a language whose callers need no per-file import (C# today:
-    enclosing-namespace access under a \`global using\`). Treat dependentCount 0 and
-    riskLevel "low" as a FLOOR, not a finding — verify with grep before concluding
-    the file is unused.
+    ZERO dependents even after the fallback above also found nothing, in a
+    language whose callers need no per-file import (C# today: enclosing-namespace
+    access under a \`global using\`). Treat dependentCount 0 and riskLevel "low" as
+    a FLOOR, not a finding — verify with grep before concluding the file is unused.
   At most one reason ever fires per response.`,
   ),
   toMCPToolSchema(

--- a/packages/parser/src/csharp-type-reference-signals.test.ts
+++ b/packages/parser/src/csharp-type-reference-signals.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
+import type { CodeChunk } from './types.js';
+
+interface ChunkOptions {
+  file: string;
+  content?: string;
+  symbolName?: string;
+  symbolType?: 'class' | 'interface' | 'method' | 'function';
+}
+
+function makeChunk(opts: ChunkOptions): CodeChunk {
+  return {
+    content: opts.content ?? '',
+    metadata: {
+      file: opts.file,
+      startLine: 1,
+      endLine: 10,
+      type: opts.symbolType === 'class' || opts.symbolType === 'interface' ? 'class' : 'function',
+      language: 'csharp',
+      symbolName: opts.symbolName,
+      symbolType: opts.symbolType,
+    },
+  };
+}
+
+/** A real class/struct/record/enum declaration chunk. */
+function declChunk(file: string, symbolName: string): CodeChunk {
+  return makeChunk({
+    file,
+    content: `public class ${symbolName} { }`,
+    symbolName,
+    symbolType: 'class',
+  });
+}
+
+/** A production/test chunk whose body references `references` by name. */
+function usageChunk(file: string, references: string[]): CodeChunk {
+  return makeChunk({
+    file,
+    content: references.map(name => `${name}.Apply(output, value);`).join('\n'),
+    symbolName: 'SomeMethod',
+    symbolType: 'method',
+  });
+}
+
+describe('findCSharpTypeReferenceDependents', () => {
+  it('finds a file that references a uniquely-declared type via a word-boundary match', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('src/Rendering/Padding.cs', ['Alignment']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([
+      'src/Rendering/Padding.cs',
+    ]);
+  });
+
+  it('reproduces the real #930 serilog shape: property-access references still count', () => {
+    // `pt.Alignment` is a PROPERTY access, not a constructor/static call, but
+    // the property happens to share its type's name (idiomatic C#) — a
+    // word-boundary text match still (correctly, per real ground truth)
+    // attributes it as a dependent.
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      makeChunk({
+        file: 'src/Rendering/MessageTemplateRenderer.cs',
+        content: 'if (!pt.Alignment.HasValue) return;',
+        symbolName: 'Render',
+        symbolType: 'method',
+      }),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([
+      'src/Rendering/MessageTemplateRenderer.cs',
+    ]);
+  });
+
+  it('does not match a longer identifier that merely contains the type name as a substring', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('src/Parsing/MessageTemplateParser.cs', ['AlignmentDirection']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([]);
+  });
+
+  it('is case-sensitive: a lowercase local/parameter of the same spelling does not match', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('src/Rendering/Padding.cs', ['alignment']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([]);
+  });
+
+  it('excludes the declaring file itself', () => {
+    const chunks: CodeChunk[] = [declChunk('src/Parsing/Alignment.cs', 'Alignment')];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([]);
+  });
+
+  it('drops an ambiguous type name declared in more than one file', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/A/Options.cs', 'Options'),
+      declChunk('src/B/Options.cs', 'Options'),
+      usageChunk('src/C/Consumer.cs', ['Options']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/A/Options.cs', chunks)).toEqual([]);
+    expect(findCSharpTypeReferenceDependents('src/B/Options.cs', chunks)).toEqual([]);
+  });
+
+  it('includes a test file that references the type (not test-association-scoped)', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs', ['Alignment']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([
+      'test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs',
+    ]);
+  });
+
+  it('ignores non-C# files entirely, on both the declaration and usage side', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({
+        file: 'src/Parsing/Alignment.swift',
+        content: 'class Alignment {}',
+        symbolName: 'Alignment',
+        symbolType: 'class',
+      }),
+      makeChunk({
+        file: 'src/Rendering/Padding.go',
+        content: 'Alignment.Apply(w, v)',
+        symbolName: 'Apply',
+        symbolType: 'function',
+      }),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.swift', chunks)).toEqual([]);
+  });
+
+  it('returns nothing for a non-C# target file', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('src/Rendering/Padding.cs', ['Alignment']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.ts', chunks)).toEqual([]);
+  });
+
+  it('deduplicates multiple referencing chunks in the same file into one entry', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('src/Rendering/Padding.cs', ['Alignment']),
+      usageChunk('src/Rendering/Padding.cs', ['Alignment']),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks)).toEqual([
+      'src/Rendering/Padding.cs',
+    ]);
+  });
+
+  it('recovers all five real serilog dependents from a single uniquely-declared type', () => {
+    // Reproduces the exact #930 fixture: five real production files
+    // referencing `Alignment` via a mix of parameter types, property
+    // access, and local variable type declarations.
+    const chunks: CodeChunk[] = [
+      declChunk('src/Serilog/Rendering/Alignment.cs', 'Alignment'),
+      makeChunk({
+        file: 'src/Serilog/Rendering/Padding.cs',
+        content:
+          'public static void Apply(TextWriter output, string value, in Alignment? alignment)',
+        symbolName: 'Apply',
+        symbolType: 'method',
+      }),
+      makeChunk({
+        file: 'src/Serilog/Rendering/MessageTemplateRenderer.cs',
+        content: 'if (!pt.Alignment.HasValue) return;',
+        symbolName: 'Render',
+        symbolType: 'method',
+      }),
+      makeChunk({
+        file: 'src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs',
+        content: 'Padding.Apply(output, moniker, pt.Alignment);',
+        symbolName: 'Format',
+        symbolType: 'method',
+      }),
+      makeChunk({
+        file: 'src/Serilog/Parsing/PropertyToken.cs',
+        content: 'public Alignment? Alignment { get; }',
+        symbolName: 'Alignment',
+        symbolType: 'method',
+      }),
+      makeChunk({
+        file: 'src/Serilog/Parsing/MessageTemplateParser.cs',
+        content: 'Alignment? alignmentValue = null;',
+        symbolName: 'Parse',
+        symbolType: 'method',
+      }),
+    ];
+
+    expect(findCSharpTypeReferenceDependents('src/Serilog/Rendering/Alignment.cs', chunks)).toEqual(
+      [
+        'src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs',
+        'src/Serilog/Parsing/MessageTemplateParser.cs',
+        'src/Serilog/Parsing/PropertyToken.cs',
+        'src/Serilog/Rendering/MessageTemplateRenderer.cs',
+        'src/Serilog/Rendering/Padding.cs',
+      ],
+    );
+  });
+});

--- a/packages/parser/src/csharp-type-reference-signals.ts
+++ b/packages/parser/src/csharp-type-reference-signals.ts
@@ -98,7 +98,24 @@ function identifierBoundaryRe(name: string): RegExp {
   return new RegExp(`\\b${escapeForRegex(name)}\\b`);
 }
 
-/** True iff `chunk` is a C# type declaration (class/struct/record/enum/interface). */
+/**
+ * True iff `chunk` is a C# type declaration (class/struct/record/enum/interface).
+ *
+ * Checking only `'class' | 'interface'` is NOT a narrower test than the doc says:
+ * `csharp.ts` collapses `class_declaration`, `interface_declaration`,
+ * `struct_declaration`, `record_declaration` and `enum_declaration` into one case,
+ * so all five kinds surface as `'class'` (or `'interface'`). There is no distinct
+ * `'struct'`/`'record'`/`'enum'` symbolType to miss.
+ *
+ * Verified empirically rather than assumed: serilog's `public readonly struct
+ * Alignment` reports `symbolType: 'class'`, and its dependents are recovered.
+ *
+ * The filter is load-bearing for the uniqueness gate, not decoration. In the same
+ * corpus `Alignment` ALSO appears twice with `symbolType: 'method'` (a property on
+ * `PropertyToken` and one on the struct itself). Without restricting the declaration
+ * set to types, those would break the "exactly one file declares this name" check
+ * and suppress a real recovery.
+ */
 function isCSharpTypeDeclarationChunk(chunk: CodeChunk): boolean {
   return chunk.metadata.symbolType === 'class' || chunk.metadata.symbolType === 'interface';
 }

--- a/packages/parser/src/csharp-type-reference-signals.ts
+++ b/packages/parser/src/csharp-type-reference-signals.ts
@@ -1,0 +1,188 @@
+/**
+ * #930 (part 2): recover REAL production dependents for a C# file when the
+ * import graph finds none, because of `global using` / implicit enclosing-
+ * namespace access (see `csharp.ts`'s `isGlobalUsingDirective` and
+ * `enclosingNamespaceAccess` doc comments for the mechanism -- a file that
+ * genuinely uses a type declared elsewhere carries NO per-file import
+ * naming it at all).
+ *
+ * The import graph is structurally the wrong place to look for this: the
+ * information lives in type references, not import statements. This module
+ * recovers a DIFFERENT signal already sitting in the indexed chunk store: a
+ * type's declaring file, matched against every other C# chunk's raw source
+ * text for an identifier-boundary occurrence of that type's name.
+ *
+ * Association rule (source S declares type T -> dependent D references T):
+ *   1. T is declared (`class`/`struct`/`interface`/`record`/`enum`) in
+ *      EXACTLY ONE non-test C# file project-wide (S) -- see
+ *      `buildCSharpTypeOwnerMap`/`uniqueCSharpTypeOwners`. Ambiguous
+ *      (multiply-declared) names are dropped entirely, never guessed at.
+ *   2. D (any other C# chunk, production or test) contains an
+ *      identifier-boundary occurrence of T's name in its raw source text
+ *      (`identifierBoundaryRe` below -- plain `\b` semantics, deliberately
+ *      NOT `doc-reference-matching.ts`'s `wordBoundaryRe`: that primitive
+ *      treats `.`/`-` as identifier-CONTINUATION characters, correct for
+ *      markdown path/prose matching but wrong here -- `Alignment.Apply(...)`
+ *      and `pt.Alignment.HasValue` are the DOMINANT real C# usage shapes
+ *      (static member access, property access), and in both a `.`
+ *      genuinely DELIMITS `Alignment` from its neighbor rather than
+ *      continuing the same token).
+ *   3. D !== S.
+ *
+ * Why uniqueness alone is a strong enough gate here, unlike Swift's
+ * call-site symbol matching (`swift-symbol-usage-signals.ts`, #869): that
+ * signal had to additionally demote purely-lowercase-method-driven edges,
+ * because a bare METHOD name can collide with a stdlib protocol witness, an
+ * external package's same-named free function, or a same-named overload the
+ * indexer never sees. A bare TYPE name referenced unqualified doesn't have
+ * that problem in the same way: if a same-named external type were in
+ * unqualified scope at the same point, the C# compiler would refuse to
+ * build over the ambiguity rather than silently resolving one -- so "this
+ * project's only declaration of the name" is a much stronger match for "the
+ * declaration this reference actually resolves to" than it is for a method
+ * name. This module intentionally does NOT add Swift's multi-segment/
+ * type-shaped gates on top: every candidate here is already a real type
+ * declaration by construction (never a method/property name), so that
+ * problem class doesn't arise.
+ *
+ * What this does NOT solve: a word-boundary text match cannot distinguish a
+ * genuine type reference from an unrelated PROPERTY, FIELD, or PARAMETER
+ * that happens to share the exact same identifier (C# convention often
+ * names a property after its type, e.g. `Alignment? Alignment { get; }` on
+ * `PropertyToken` -- see the fixture below; this is actually the common
+ * case, not a false positive, but the matcher can't tell the two apart in
+ * principle). Nor can it catch a reference via an alias (`using A =
+ * Some.Alignment;`), a generic type argument written without the bare name
+ * on its own line in an unusual way, or reflection-based usage. Residual
+ * risk is accepted and hedged, not eliminated -- callers must surface this
+ * as a lower-confidence, non-import-verified signal (see
+ * `DependentInfo.confidence` in the CLI's dependency-analyzer.ts), never
+ * fold it in unhedged next to a real import edge.
+ *
+ * Verified against a real clone (serilog/serilog, the corpus that motivated
+ * #930): word-boundary matching for `Alignment` and `Padding` -- both
+ * uniquely-declared, single-segment PascalCase type names, the exact shape
+ * most likely to collide with an unrelated identifier -- reproduced all 5
+ * known real dependents of `Alignment.cs` (plus its one real test
+ * dependent) with ZERO false positives project-wide (checked via
+ * `grep -rlw` across the entire `src`+`test` tree, not just the 5 known
+ * files).
+ *
+ * Deliberately scoped to file-level `get_dependents` recovery (via the CLI's
+ * `dependency-analyzer.ts`), NOT test-association -- unlike Go/Java/Swift's
+ * same-shaped signals, which stay confined to `lien annotate`'s test-
+ * coverage line. #930's remaining gap is specifically that `get_dependents`
+ * itself reports a false `dependentCount: 0` / `riskLevel: "low"` "all
+ * clear" on a file that has 5 real callers -- an honesty label
+ * (`dependentAttributionIncomplete`, #936) already covers the "we don't
+ * know" case; this module is what lets the tool answer "we found some"
+ * instead, when it genuinely can.
+ */
+
+import type { CodeChunk } from './types.js';
+import { isTestFile } from './utils/path-matching.js';
+import { detectLanguage } from './ast/languages/registry.js';
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Plain identifier-boundary regex for `name` -- see the module doc comment
+ * for why this must NOT be `doc-reference-matching.ts`'s `wordBoundaryRe`.
+ * Standard `\b` semantics (word chars = `[A-Za-z0-9_]`) are exactly right
+ * for source code: `.`, `(`, `?`, whitespace, etc. are all genuine
+ * identifier delimiters in C#, never continuations of the same token.
+ */
+function identifierBoundaryRe(name: string): RegExp {
+  return new RegExp(`\\b${escapeForRegex(name)}\\b`);
+}
+
+/** True iff `chunk` is a C# type declaration (class/struct/record/enum/interface). */
+function isCSharpTypeDeclarationChunk(chunk: CodeChunk): boolean {
+  return chunk.metadata.symbolType === 'class' || chunk.metadata.symbolType === 'interface';
+}
+
+interface CSharpTypeDeclaration {
+  file: string;
+  typeName: string;
+}
+
+/** Non-test C# chunks that declare a type, keyed by their raw `symbolName`. */
+function collectCSharpTypeDeclarations(chunks: CodeChunk[]): CSharpTypeDeclaration[] {
+  const out: CSharpTypeDeclaration[] = [];
+  for (const chunk of chunks) {
+    const file = chunk.metadata.file;
+    if (detectLanguage(file) !== 'csharp' || isTestFile(file)) continue;
+    if (!isCSharpTypeDeclarationChunk(chunk)) continue;
+    const typeName = chunk.metadata.symbolName;
+    if (!typeName) continue;
+    out.push({ file, typeName });
+  }
+  return out;
+}
+
+/** Build type name -> declaring file(s), project-wide. */
+function buildCSharpTypeOwnerMap(declarations: CSharpTypeDeclaration[]): Map<string, Set<string>> {
+  const defMap = new Map<string, Set<string>>();
+  for (const decl of declarations) {
+    const files = defMap.get(decl.typeName) ?? new Set<string>();
+    files.add(decl.file);
+    defMap.set(decl.typeName, files);
+  }
+  return defMap;
+}
+
+/** Type names declared in EXACTLY ONE file project-wide, mapped to that file. */
+function uniqueCSharpTypeOwners(defMap: Map<string, Set<string>>): Map<string, string> {
+  const owners = new Map<string, string>();
+  for (const [typeName, files] of defMap) {
+    if (files.size === 1) owners.set(typeName, [...files][0]);
+  }
+  return owners;
+}
+
+/**
+ * Find C# files (any file, production or test) that reference one of
+ * `targetFile`'s uniquely-declared type names via a word-boundary text
+ * match, excluding `targetFile` itself. Returns a sorted, deduplicated list
+ * of filepaths -- empty when `targetFile` isn't a C# file, declares no
+ * uniquely-owned type, or genuinely has no textual referrers in `chunks`.
+ *
+ * `targetFile` must be the exact `chunk.metadata.file` string used by
+ * `targetFile`'s own chunks within `chunks` (not a separately-normalized
+ * path) -- this function does no path normalization of its own and relies
+ * on plain string equality throughout, mirroring
+ * `swift-symbol-usage-signals.ts`'s same discipline.
+ *
+ * `chunks` should be the FULL project chunk set -- uniqueness is a
+ * project-wide property, not scoped to `targetFile` alone.
+ */
+export function findCSharpTypeReferenceDependents(
+  targetFile: string,
+  chunks: CodeChunk[],
+): string[] {
+  if (detectLanguage(targetFile) !== 'csharp') return [];
+
+  const owners = uniqueCSharpTypeOwners(
+    buildCSharpTypeOwnerMap(collectCSharpTypeDeclarations(chunks)),
+  );
+  const targetTypeNames = [...owners.entries()]
+    .filter(([, file]) => file === targetFile)
+    .map(([typeName]) => typeName);
+  if (targetTypeNames.length === 0) return [];
+
+  const matchers = targetTypeNames.map(name => identifierBoundaryRe(name));
+  const found = new Set<string>();
+
+  for (const chunk of chunks) {
+    const file = chunk.metadata.file;
+    if (file === targetFile || found.has(file)) continue;
+    if (detectLanguage(file) !== 'csharp') continue;
+    if (matchers.some(re => re.test(chunk.content))) {
+      found.add(file);
+    }
+  }
+
+  return [...found].sort();
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -163,6 +163,11 @@ export {
   isTypeShapedIdentifier,
 } from './swift-symbol-usage-signals.js';
 
+// #930 (part 2): C#'s non-import type-reference dependents signal, used by
+// `get_dependents` (not test-association) -- see
+// csharp-type-reference-signals.ts's module doc.
+export { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
+
 // =============================================================================
 // GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)
 // =============================================================================


### PR DESCRIPTION
## Summary

Part 2 of #930. #932/#936/#938 stopped `get_dependents` from fabricating
dependents out of C#'s `GlobalUsings.cs` boilerplate and made the resulting
zero honest (`dependentAttributionIncomplete`) — but a file with `global
using` in scope still reported `dependentCount: 0` / `riskLevel: "low"` even
when it had real callers. Honest-and-blind is better than confidently-wrong,
and worse than correct.

- Adds `findCSharpTypeReferenceDependents` (`@liendev/parser`): for a target
  file whose type name is declared exactly once project-wide (so a
  same-named reference elsewhere can't be an unrelated declaration — the C#
  compiler itself would refuse to build over that ambiguity), scan every
  other C# file's source text for an identifier-boundary occurrence of that
  name. Only attempted when the import graph found zero dependents for a
  file-level query on an `enclosingNamespaceAccess` language (C# today) —
  mirrors the tier-1/tier-2 discipline from #926/#923's Go/Java/Swift
  same-shaped signals, but recovers *dependents* (`get_dependents`), not
  test-associations (which stay `lien annotate`-only).
- Recovered entries are tagged `confidence: "inferred"` on `DependentInfo` —
  a new optional field, never folded in unhedged next to an import-verified
  dependent.
- Adds a new `attributionCaveat` reason, `"dependent-attribution-partial"`,
  so callers know the count is a recovered lower bound, not a
  verified/complete answer. `dependentAttributionIncomplete` now only fires
  when this fallback *also* finds nothing.
- Purely additive: no existing field removed, renamed, or reshaped.
- `tools.ts` and `instructions.ts` (the two model-facing surfaces) updated
  and verified against the built bundle.

### Design judgment

1. **Extension point**: a new signal-generator module
   (`csharp-type-reference-signals.ts`) parallel to
   `go-same-directory-tests.ts`/`java-same-package-tests.ts`/
   `swift-symbol-usage-signals.ts`, but wired into the CLI's
   `dependency-analyzer.ts` (`get_dependents`) instead of
   `test-associations.ts` — a deliberate precedent break, since #930's
   remaining gap is specifically that `get_dependents` itself (not just
   `annotate`) reports a false all-clear.
2. **Type reference detection**: no new AST extraction needed. Existing
   symbol extraction already records each type declaration's name
   (`symbolType: 'class' | 'interface'` + `symbolName`); a project-wide
   uniqueness check on that name, combined with an identifier-boundary text
   scan of `chunk.content`, is the cheapest sound approach — verified
   against a real serilog clone with zero false positives project-wide
   (`grep -rlw` for both `Alignment` and `Padding`, not just the 5 known
   files).
3. **Confidence tiering**: mirrors #926 — recovered dependents are tagged
   `confidence: "inferred"`, never merged unhedged. Unlike Swift's
   call-site signal, no extra "type-shaped driver" gate is needed: every
   candidate here is already a real type declaration by construction, never
   a method/property name, so that collision class doesn't apply the same
   way.
4. **`attributionCaveat`**: `dependentAttributionIncomplete` (zero signal at
   all) and the new `dependentAttributionPartial` (fallback recovered
   something) are mutually exclusive by construction — the former requires
   the *final* `dependents.length` to be zero, the latter requires it to be
   positive.

## Verification (real MCP tool, fresh serilog/serilog clone, own build)

`src/Serilog/Parsing/Alignment.cs` — before (main): `dependentCount: 0`,
`riskLevel: "low"`. After:
```
dependentCount: 6 | riskLevel: medium
dependents: MessageTemplateTextFormatter.cs, MessageTemplateParser.cs,
            PropertyToken.cs, MessageTemplateRenderer.cs, Padding.cs,
            MessageTemplateParserTests.cs
caveat: dependent-attribution-partial
```
All 5 real production dependents + the real test dependent recovered, all
tagged `confidence: "inferred"`.

`src/Serilog/Parsing/PropertyToken.cs` (control — genuine import-verified
test dependent) — unaffected: `dependentCount: 1`, `riskLevel: low`, its one
real dependent carries no `confidence` field, no `attributionCaveat`.

Non-C# control (hono, fresh clone) — `src/router.ts`: 42 dependents via
ordinary import matching, zero `confidence` tags, no caveat — zero
cross-language impact.

25-file serilog sample: 21/25 recovered real dependents via the new signal
(risk correctly escalated from `low` to `medium`/etc.), 2/25 honestly left
`dependent-attribution-incomplete` (no recoverable signal), 2/25 already had
real import-based dependents (untouched), 0 errors.

## Gates

`format:check` / `lint` (0 errors) / `typecheck` / `build` / `test` (all
packages, 1457+378+1701+1302+41+27 = green) / `lien delta --base origin/main`
(1 crossing found and fixed via extraction into `resolveDependents`, exit 0
on the final run) — all run in a fresh worktree with its own `npm install` +
`build:native`.

## Test plan

- [x] New unit tests for `findCSharpTypeReferenceDependents` (11 cases,
      including a full reproduction of the 5-dependent serilog fixture)
- [x] New CLI tests for the enrichment gate + `attributionCaveat` branch
- [x] Full monorepo test suite green
- [x] `lien delta` clean
- [x] Live MCP tool verification against a real, freshly-cloned C# repo
      (before/after, control, non-C# control, 25-file sample)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved C# dependent-file detection when `global using` prevents import-graph attribution.
  - Recovered dependents are identified through type references and marked as inferred.
  - Added a `dependent-attribution-partial` caveat to clarify when results are lower-bound estimates.

- **Bug Fixes**
  - Fixed cases where valid C# dependents were incorrectly reported as zero.
  - Preserved incomplete-attribution warnings when recovery finds no matches.

- **Documentation**
  - Updated `get_dependents` guidance to explain inferred matches, confidence, and attribution caveats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a C# type-reference fallback to recover dependents that `global using` hides from the import graph. The new `findCSharpTypeReferenceDependents` signal scans uniquely-declared C# type names across the corpus and tags recovered dependents with `confidence: 'inferred'`. The CLI wires this into `get_dependents` only when the import graph returns zero file-level dependents for an `enclosingNamespaceAccess` language, and surfaces a new `dependent-attribution-partial` caveat. The implementation is additive, well-gated, and consistent with the documentation: the C# parser collapses struct/record/enum declarations to `symbolType: 'class'`, so the implementation's class/interface check does cover all five declaration kinds mentioned in the docs. No breaking changes or logic errors were found.
>
> - Added `findCSharpTypeReferenceDependents` parser signal for C# type-reference-based dependent recovery
> - Wired the fallback into CLI `get_dependents` with `confidence: 'inferred'` and `dependent-attribution-partial` caveat
> - Updated model-facing `tools.ts` and `instructions.ts` to describe the new caveat and confidence tier

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7044b20. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 669K/736K tokens
<!-- /lien:attestation -->