### PR TITLE
test(dogfood): measure a chosen build via LIEN_MCP_CLI; fix worktree gate-6 doc gap

### DIFF
--- a/docs/development/worktree-development.md
+++ b/docs/development/worktree-development.md
@@ -11,21 +11,28 @@ locally, so it isn't a blocker either. Verified empirically: `npm ci` in a
 scratch worktree of this branch completed in ~7s with no compile step.
 
 ```bash
-# From inside a fresh linked worktree — just works now.
+# From inside a fresh linked worktree.
 npm ci
 npm run build
+npm run build:native -w @liendev/parser-native   # required by gate 6, `lien delta`
 ```
 
 `@liendev/parser-native`'s Rust crate (`packages/parser-native`) is a
 separate matter: it isn't built by `npm install`/`npm ci` at all (see that
-package's own `build` script), so it's unaffected either way. If you're
-touching the Rust crate itself, see its README for the `cargo build`
-toolchain requirement; that's a `parser-native`-specific concern, not a
-worktree one.
+package's own `build` script). If you're touching the Rust crate itself, see
+its README for the `cargo build` toolchain requirement; that's a
+`parser-native`-specific concern, not a worktree one.
+
+Build it in every fresh worktree anyway, whatever you're changing. `lien delta`
+— gate 6 of the mandatory pre-commit chain in CLAUDE.md — parses your working
+tree, so it needs the native binding even if you only touched a script, a doc or
+a config. Without it the gate dies on an uncaught `NativeBindingLoadError`. The
+error does name the fix command, but you meet it at the end of the gate chain,
+having been told setup was already complete.
 
 ## A fresh worktree with no `node_modules` fails quietly, not loudly
 
-A worktree that hasn't had `npm ci` run in it yet does not error out and tell you so. Node's module resolution walks up the directory tree looking for `node_modules`, and a worktree under `.claude/worktrees/<name>` sits two directories below the main checkout, so resolution silently falls through to the main checkout's `node_modules` instead of the (missing) one in the worktree. If that main checkout's `node_modules` happens to be stale, for example missing the `@liendev/parser-native` symlink, the result is confusing `tsc` module-resolution errors that reference the main checkout's own paths, not an obvious prompt to run `npm ci`. Diagnose it with `ls node_modules` in the worktree itself: if it's missing or empty, that's the cause. The remedy is the same as above: run `npm ci` in the worktree (about 7 seconds) and `npm run build`, adding `npm run build:native -w @liendev/parser-native` if you're touching the AST/parser layer.
+A worktree that hasn't had `npm ci` run in it yet does not error out and tell you so. Node's module resolution walks up the directory tree looking for `node_modules`, and a worktree under `.claude/worktrees/<name>` sits two directories below the main checkout, so resolution silently falls through to the main checkout's `node_modules` instead of the (missing) one in the worktree. If that main checkout's `node_modules` happens to be stale, for example missing the `@liendev/parser-native` symlink, the result is confusing `tsc` module-resolution errors that reference the main checkout's own paths, not an obvious prompt to run `npm ci`. Diagnose it with `ls node_modules` in the worktree itself: if it's missing or empty, that's the cause. The remedy is the same as above: run `npm ci` in the worktree (about 7 seconds), `npm run build`, and `npm run build:native -w @liendev/parser-native`.
 
 ## Historical note
 

--- a/scripts/experiments/dogfood-oss/mcp-call.mjs
+++ b/scripts/experiments/dogfood-oss/mcp-call.mjs
@@ -11,7 +11,11 @@
  *   node mcp-call.mjs <repoDir> <toolName> '<jsonArgs>'
  *   node mcp-call.mjs <repoDir> --list
  *
- * Prints a JSON envelope: { ok, ms, tool, args, result?, error? }. Non-zero exit
+ * Set LIEN_MCP_CLI to measure a specific build instead of this repo's own
+ * packages/cli/dist/index.js — e.g. a published artifact:
+ *   LIEN_MCP_CLI=/tmp/probe/node_modules/@liendev/lien/dist/index.js
+ *
+ * Prints a JSON envelope: { ok, ms, cli, tool, args, result?, error? }. Non-zero exit
  * only on harness failure (spawn/connect); a tool-level error is a successful
  * measurement and exits 0 with ok:false.
  */
@@ -23,7 +27,17 @@ import path from 'node:path';
 
 const [repoDir, tool, rawArgs] = process.argv.slice(2);
 const REPO = path.resolve(import.meta.dirname, '../../..');
-const CLI = path.join(REPO, 'packages/cli/dist/index.js');
+
+// Which binary is under measurement is the single easiest thing to get wrong here:
+// this file resolves the CLI relative to ITS OWN repo root, so running one
+// worktree's copy silently measures that worktree's build. Round 1 of the dogfood
+// reported a working fix as broken twice for exactly that reason. LIEN_MCP_CLI
+// makes the target explicit (e.g. a published `npm install @liendev/lien` under
+// test), and the resolved path is echoed into every envelope so a measurement can
+// never be read without knowing which build produced it.
+const CLI = process.env.LIEN_MCP_CLI
+  ? path.resolve(process.env.LIEN_MCP_CLI)
+  : path.join(REPO, 'packages/cli/dist/index.js');
 
 function die(msg) {
   console.error(`mcp-call: ${msg}`);
@@ -32,7 +46,11 @@ function die(msg) {
 
 if (!repoDir || !tool) die("usage: mcp-call.mjs <repoDir> <toolName|--list> '<jsonArgs>'");
 if (!fs.existsSync(repoDir)) die(`repoDir does not exist: ${repoDir}`);
-if (!fs.existsSync(CLI)) die(`CLI not built at ${CLI}`);
+if (!fs.existsSync(CLI))
+  die(
+    `CLI not found at ${CLI}` +
+      (process.env.LIEN_MCP_CLI ? ' (from LIEN_MCP_CLI)' : ' — build it, or set LIEN_MCP_CLI'),
+  );
 
 // C1: refuse to measure anything inside the Lien checkout, whatever the caller asked.
 const resolved = fs.realpathSync(repoDir);
@@ -72,6 +90,7 @@ try {
         {
           ok: true,
           ms: elapsed(),
+          cli: CLI,
           serverInstructions: client.getInstructions?.() ?? null,
           tools: tools.tools.map(t => ({ name: t.name, inputSchema: t.inputSchema })),
         },
@@ -83,13 +102,14 @@ try {
     let envelope;
     try {
       const res = await client.callTool({ name: tool, arguments: args });
-      envelope = { ok: !res.isError, ms: elapsed(), tool, args, result: res };
+      envelope = { ok: !res.isError, ms: elapsed(), cli: CLI, tool, args, result: res };
     } catch (e) {
       // Protocol-level rejection (unknown tool, schema validation) — a real
       // measurement of the tool's failure mode, not a harness fault.
       envelope = {
         ok: false,
         ms: elapsed(),
+        cli: CLI,
         tool,
         args,
         error: { name: e.name, message: e.message, code: e.code },


### PR DESCRIPTION
Two small fixes found while dogfooding the **published** `@liendev/lien@0.72.0` artifact (round 2 of the foreign-repo dogfood). Round 1 verified all 13 of its fixes against a *locally built* binary via a PATH shim, which is not what users install — closing that gap needed an instrument change.

## 1. `mcp-call.mjs` could only ever measure its own checkout

It resolved the CLI as `<its own repo root>/packages/cli/dist/index.js`. So running one worktree's copy silently measured *that worktree's* build — the cause of two false conclusions in round 1, where a working fix was reported as broken because the binary under measurement was invisible in the output. It also made the published artifact unmeasurable.

`LIEN_MCP_CLI` now overrides the target, and the resolved path is echoed into every envelope as `cli`.

### Dogfood evidence — the five round-1 headline cases, replayed on the published npm artifact

Cold-installed `@liendev/lien@0.72.0` into an isolated npm cache (`added 234 packages in 7s`, exit 0, prebuilt native binary, no compile step), then re-indexed each corpus repo **with the published binary** (`index --force`) before measuring:

\`\`\`
serilog C# file           221ms  count=6 risk=medium caveat=dependent-attribution-partial
gin Go symbol             215ms  count=4 risk=high
console PHP symbol        297ms  count=6 risk=high
console FAKE path         264ms  count=0 risk=low caveat=unresolved-target
hono TS file (control)    250ms  count=15 risk=high

CLI under measurement: .../npm-cold/root/node_modules/@liendev/lien/dist/index.js
\`\`\`

5/5 exact match with round 1's expectations. All 13 fixes reach real users. The `CLI under measurement` line is the point of the change — before it, that claim was unverifiable.

## 2. `worktree-development.md` understated what a fresh worktree needs

The doc framed `npm run build:native` as conditional ("if you're touching the AST/parser layer"), but `lien delta` parses the working tree, so **gate 6 of the mandatory pre-commit chain needs the native binding whatever you edited**.

Found by running the gates in a fresh worktree after changing one `.mjs` script. Gates 1–5 passed; gate 6:

\`\`\`
NativeBindingLoadError: [lien] Failed to load the native parser binding
(@liendev/parser-native) on darwin-arm64: no prebuilt binary available for
"aarch64-apple-darwin" and no local dev build found at
<worktree>/packages/parser-native/parser-native.node.
Build it with: npm run build:native -w @liendev/parser-native
\`\`\`
exit 1, uncaught, stack through \`chunkFile → functionMetadataByKey → computeFileComplexityDelta\`.

The **error message itself is exemplary** — names the missing artifact, platform, exact build command, doc reference, and that there is no fallback since ADR-013. No product change needed; the doc was the gap. After `build:native`: \`lien delta — no complexity changes across 1 file(s) vs HEAD (71 ms)\`, exit 0.

## Gates

All six on the final tree: `format:check` ✅ · `lint` ✅ · `typecheck` ✅ · `build` ✅ · `test` ✅ (exit 0) · `lien delta` ✅ (exit 0, 71 ms).

No production code is touched — one test instrument and one doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated worktree setup guidance with clearer step-by-step instructions.
  * Clarified that the native parser build is required in every fresh worktree to prevent validation failures.

* **Chores**
  * Improved MCP development tooling to support custom CLI paths.
  * Enhanced command output with the CLI path used, making build and protocol errors easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR contains two small dogfood-driven fixes with no production code impact: it adds a `LIEN_MCP_CLI` environment override to the `mcp-call.mjs` test instrument so measurements can target a published artifact instead of the local build, and it updates `worktree-development.md` to state that `npm run build:native` is required in every fresh worktree because gate 6 (`lien delta`) parses the working tree. The instrument change is self-contained and correctly echoes the resolved CLI path into every output envelope; the doc change accurately reflects the mandatory pre-commit gate behavior described in CLAUDE.md and `.github/workflows/ci.yml`. No callers, exports, or runtime logic are affected.
>
> - mcp-call.mjs now respects LIEN_MCP_CLI and reports the measured CLI path in every envelope
> - worktree-development.md clarifies that build:native is required for gate 6 regardless of what files were edited

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 736b055. Updates automatically on new commits.</sup>
<!-- /lien-stats -->