### PR TITLE
fix(cli): clear habituation-guard risk floor for incomplete dependent attribution

### DIFF
--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -109,6 +109,24 @@ describe('belowRiskFloor (habituation guard)', () => {
   it('treats an unknown risk level as the lowest rank', () => {
     expect(belowRiskFloor('mystery', 0, 0, 'medium')).toBe(true);
   });
+
+  // Closes the gap Lien Review flagged on #938: isTrivial got the
+  // dependentAttributionIncomplete carve-out, this guard sat three lines
+  // below it and didn't — so a "0 dependents" annotation caused by
+  // undeterminable attribution (not by an actual absence of dependents)
+  // could still be silenced by --min-risk, restoring exactly the
+  // false-all-clear misreading #930/#936/#938 shipped to prevent.
+  it('clears the floor when dependent attribution is incomplete, even at the lowest risk level (#938 gap)', () => {
+    expect(belowRiskFloor('low', 0, 0, 'critical', true)).toBe(false);
+  });
+
+  it('still suppresses the same below-floor case when attribution is complete', () => {
+    expect(belowRiskFloor('low', 0, 0, 'critical', false)).toBe(true);
+  });
+
+  it('defaults dependentAttributionIncomplete to false — pre-existing 4-arg callers are unaffected', () => {
+    expect(belowRiskFloor('low', 0, 0, 'medium')).toBe(true);
+  });
 });
 
 describe('withHeadroomWarning', () => {

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -50,9 +50,10 @@ export interface AnnotateOptions {
   /**
    * Habituation-guard risk floor (`low` | `medium` | `high` | `critical`). When
    * set, a below-floor annotation is suppressed UNLESS it carries a complexity
-   * or headroom concern (those always fire). Unset / unknown / `low` never
-   * suppresses — the current always-on behavior. The read hook passes the
-   * `LIEN_ANNOTATE_MIN_RISK` env value here. See `belowRiskFloor`.
+   * or headroom concern, or an incomplete dependent-attribution result (those
+   * always fire). Unset / unknown / `low` never suppresses — the current
+   * always-on behavior. The read hook passes the `LIEN_ANNOTATE_MIN_RISK` env
+   * value here. See `belowRiskFloor`.
    */
   minRisk?: string;
 }
@@ -64,19 +65,28 @@ const RISK_RANK: Record<string, number> = { low: 0, medium: 1, high: 2, critical
  * Habituation guard: is this annotation below the configured risk floor and
  * therefore suppressible? A complexity or headroom concern always clears the
  * floor (those are the high-value plan-time nudges — never suppressed). An
- * unset or unrecognized floor never suppresses anything (fail-open: default =
- * current always-on behavior). Pure and exported for direct unit testing.
+ * incomplete dependent-attribution result also always clears the floor: a
+ * file with structurally-undeterminable dependents reads as "0 dependents"
+ * (i.e. low risk by construction), which is exactly the false-all-clear
+ * shape this guard must never suppress — mirrors `isTrivial`'s identical
+ * carve-out for the same flag (#930/#936/#938; this parameter closes the gap
+ * Lien Review flagged on #938: `isTrivial` got the carve-out, this guard sat
+ * three lines below it and didn't). An unset or unrecognized floor never
+ * suppresses anything (fail-open: default = current always-on behavior).
+ * Pure and exported for direct unit testing.
  */
 export function belowRiskFloor(
   riskLevel: string,
   complexityWarnings: number,
   headroomCount: number,
   minRisk?: string,
+  dependentAttributionIncomplete = false,
 ): boolean {
   if (!minRisk) return false;
   const floor = RISK_RANK[minRisk];
   if (floor === undefined) return false; // unknown floor → no suppression
-  if (complexityWarnings > 0 || headroomCount > 0) return false; // always emit high-value
+  // always emit high-value / honest-uncertainty signals
+  if (complexityWarnings > 0 || headroomCount > 0 || dependentAttributionIncomplete) return false;
   return (RISK_RANK[riskLevel] ?? 0) < floor;
 }
 
@@ -444,6 +454,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
         data.complexity.warningCount,
         data.headroom.entries.length,
         options?.minRisk,
+        data.dependentAttributionIncomplete,
       )
     ) {
       return;


### PR DESCRIPTION
## The bug

`belowRiskFloor` (habituation guard, opt-in via `--min-risk`) cleared its
suppression floor for complexity/headroom concerns but not for
`dependentAttributionIncomplete` -- the flag PR #938 added to `isTrivial` to
stop a "0 dependents" result (C# enclosing-namespace access -- #930/#936)
from reading as "safe to change" when the truth is "we couldn't tell." A
file with undeterminable dependents is low-risk *by construction* (zero
known dependents), so it fell below a `medium` floor and got silently
dropped -- restoring the exact false-all-clear misreading #938 shipped to
prevent.

This is live in the default shipped configuration, not an opt-in edge
case: `plugins/claude/hooks/annotate-read.sh` defaults
`LIEN_ANNOTATE_MIN_RISK` to `medium` on every read-time annotation.

**Lien Review caught this on #938 itself** -- stated in the lien-stats
summary prose, no inline comment, nobody triaged it, it shipped. This PR
closes that finding.

## `get_dependents` on `belowRiskFloor` before editing

Per CLAUDE.md's mandatory-tool-use rule, ran `get_dependents({ filepath:
"packages/cli/src/cli/annotate-cmd.ts", symbol: "belowRiskFloor" })`
before touching its signature: **`dependentCount: 0`, `riskLevel: "low"`**.
Confirmed with a plain grep too -- the only two references are the
function's own declaration and its single call site inside
`annotate-cmd.ts`; it's exported solely "for direct unit testing" per its
doc comment. Zero external dependents meant a defaulted trailing
parameter (matching #938's own pattern for `isTrivial`) was safe and
non-breaking by construction, not just by convention.

## The fix

- `belowRiskFloor` gains a 5th, defaulted (`= false`) parameter,
  `dependentAttributionIncomplete`, and treats it as high-value exactly
  like `complexityWarnings`/`headroomCount`: `if (... ||
  dependentAttributionIncomplete) return false;`.
- The call site in `run()` now passes `data.dependentAttributionIncomplete`
  through.
- Unit tests added to the existing `belowRiskFloor` describe block in
  `annotate-cmd.test.ts`, following its established pattern: floor-cleared
  case, still-suppressed case (flag explicitly `false`), and a
  backward-compat default-arg case.

## Coverage-flag decision: do NOT also clear the floor for it

The brief's tentative read was "no," reasoning that "test coverage not
determinable" is near-universal for Swift and would defeat the habituation
guard if it also cleared the floor. I measured this myself, exhaustively
(every file, not a sample) across 4 freshly-reindexed foreign-corpus repos
(own build, `index --force` first):

| repo | lang | files | dependents-not-determinable | coverage-not-determinable | coverage-inferred | coverage-confident |
|---|---|---|---|---|---|---|
| serilog | C# | 246 | **114 (46%)** | **246 (100%)** | 0 | 0 |
| Alamofire | Swift | 98 | 0 | 81 (83%) | 17 (17%) | 0 |
| console | PHP | 361 | 0 | 0 | 0 | 174 |
| gin | Go | 99 | 0 | 0 | 0 | 25 |

Verdict: **no, the coverage flag should not also clear the floor.** The
brief's Swift-only framing undersold the case for "no" -- coverage-not-
determinable is 100% in this C# corpus too (not just Swift's 83%+17%),
because both `wholeModuleImports` (Swift) and `enclosingNamespaceAccess`
(C#) make it structurally undecidable from imports. Clearing the floor for
it would mean *every* Swift and C# file always prints, which is exactly
the blanket-annotation outcome the habituation guard exists to prevent.

**Where I correct the brief's numbers, with data:** the brief estimated
dependents-not-determinable at "1 file across serilog's 254 .cs" (~0.4%,
"rare"). My exhaustive run found **114/246 (46%)** on this same repo with
this same build. This isn't a measurement bug -- I spot-checked it: Serilog
is organized as one hierarchical namespace tree (`Serilog`, `Serilog.Core`,
`Serilog.Debugging`, `Serilog.Tests`, ...), so C#'s enclosing-namespace
lookup lets the *entire* codebase reference `Serilog`'s own members with
zero `using` directives -- e.g. `ILogger.cs` genuinely has 0 import-graph-
determinable dependents even though it's the library's central interface,
and `LogTests.cs` (`namespace Serilog.Tests`) reaches `Log` the same way.
This is the mandatory fix in this PR, so it ships regardless of rarity --
but the rarity assumption doesn't hold for hierarchical-single-namespace
C# libraries, and I'd flag that as worth a follow-up look (not in scope
here): the same "false all-clear" argument that justifies always-clearing
the floor for this flag applies at real scale on this style of C# repo,
not as a rare edge case.

## Dogfood evidence (own build, foreign corpus, not this repo)

Corpus: `/tmp/lien-dogfood-460173c9/serilog` (Serilog, disposable clone,
reindexed with `node packages/cli/dist/index.js index --force` from this
branch before every measurement; left `git status --short` clean
afterwards).

**CLI, before the fix** (temporarily stashed the fix, rebuilt, ran):
```
$ node <mybuild> annotate src/Serilog/Capturing/PropertyBinder.cs
Lien impact for src/Serilog/Capturing/PropertyBinder.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).

$ node <mybuild> annotate src/Serilog/Capturing/PropertyBinder.cs --min-risk medium
(no output -- suppressed, reproducing the bug on my own build)
```

**CLI, after the fix** (stash popped, rebuilt):
```
$ node <mybuild> annotate src/Serilog/Capturing/PropertyBinder.cs --min-risk medium
Lien impact for src/Serilog/Capturing/PropertyBinder.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).
```

**Coverage-only file still suppressed as designed** (Alamofire,
`Example/Source/AppDelegate.swift`, no dependents concern, only the
coverage note):
```
$ node <mybuild> annotate Example/Source/AppDelegate.swift --min-risk medium
(no output -- still suppressed, per the coverage-flag decision above)
```

**Hook end-to-end** (`plugins/claude/hooks/annotate-read.sh`, real stdin
shape, `lien` resolved via a `PATH`-local wrapper pointing at this build,
distinct `session_id` per run to avoid the per-session touchfile
suppression):

Before (stashed fix, rebuilt), `session_id: "floorfix-before-1"`:
```
$ echo '{"tool_name":"Read","tool_input":{"file_path":"src/Serilog/Capturing/PropertyBinder.cs"},"cwd":"/tmp/lien-dogfood-460173c9/serilog","session_id":"floorfix-before-1"}' | annotate-read.sh
(empty stdout -- no hookSpecificOutput emitted at all)
```

After (fix restored, rebuilt), `session_id: "floorfix-after-1"`:
```
$ echo '{"tool_name":"Read","tool_input":{"file_path":"src/Serilog/Capturing/PropertyBinder.cs"},"cwd":"/tmp/lien-dogfood-460173c9/serilog","session_id":"floorfix-after-1"}' | annotate-read.sh
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Lien impact for src/Serilog/Capturing/PropertyBinder.cs:\n  • Dependents not determinable from imports (enclosing-namespace access).\n  • Test coverage not determinable from imports (enclosing-namespace access)."}}
```

`additionalContext` now carries the honesty note through to the agent,
exactly where it was silently dropped before.

## Gates

All six pre-commit gates green: `format:check`, `lint`, `typecheck`,
`build`, `test` (1305 passed in `cli`, full monorepo suite green),
`lien delta` (exit 0 -- 2 pre-existing functions worsened but not crossed:
`belowRiskFloor` cyclomatic 5→6, `run` time 36m→37m, neither over
threshold).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR closes a gap in the annotate command's habituation guard: `belowRiskFloor` now clears the suppression floor when `dependentAttributionIncomplete` is true, matching the existing carve-out in `isTrivial`. The change is narrowly scoped to `annotate-cmd.ts` and its tests, with a defaulted trailing parameter that preserves backward compatibility for the single internal caller. Tests cover the new boundary (flag true clears floor, flag false stays suppressed, default arg unchanged) and the author verified the only external impact path is the read hook's `--min-risk` behavior.
>
> - `belowRiskFloor` gains a defaulted `dependentAttributionIncomplete` parameter that returns false (do not suppress) when true
> - `run()` now passes `data.dependentAttributionIncomplete` into the guard
> - Unit tests added for the cleared-floor, still-suppressed, and default-arg cases

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2e1c126. Updates automatically on new commits.</sup>
<!-- /lien-stats -->