### PR TITLE
fix(plugin): cache empty test-reminder results + npx registry circuit breaker

### DIFF
--- a/packages/cli/test/lien-resolve-breaker.test.ts
+++ b/packages/cli/test/lien-resolve-breaker.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Unit tests for the npx circuit breaker in `plugins/claude/hooks/lien-resolve.sh`
+ * and its companion wrapper `plugins/claude/hooks/lien-npx-breaker.sh`.
+ *
+ * Background: with no global `lien` on PATH (the default plugin setup),
+ * every hook falls back to `npx -y @liendev/lien@latest`. There's no
+ * portable `timeout` binary on macOS bash 3.2, so a black-holed registry
+ * (TCP accepts, never replies) can only ever be bounded by Claude Code's own
+ * 5000ms hook timeout — an unmaskable SIGKILL that no trap can intercept.
+ * Without a breaker, every qualifying edit re-attempts and re-hangs
+ * indefinitely. The breaker: `lien-npx-breaker.sh` drops a timestamp marker
+ * immediately before the real npx call and removes it immediately after; a
+ * marker left behind stale is the fingerprint a SIGKILLed attempt leaves,
+ * and `lien-resolve.sh` reads that to fail the source (caller exits 0,
+ * silent) for a cooldown window instead of retrying a call very likely to
+ * hang again.
+ *
+ * There are two markers, not one: an "in-flight" marker (written before each
+ * real npx attempt, removed after) and a separate "breaker open until
+ * <epoch>" marker, written only once staleness is first detected. The
+ * split matters — a single in-flight marker alone would get rewritten fresh
+ * by every new attempt, so a run of edits arriving faster than the
+ * staleness window would keep resetting the clock and the breaker would
+ * never actually open even though every attempt independently hangs. One of
+ * the tests below ("closes the resetting-clock gap...") pins exactly that
+ * regression.
+ *
+ * `lien-resolve.sh` is meant to be `.`-sourced, not executed, so these tests
+ * drive it through a tiny harness script that sources it and reports
+ * success/failure plus the resolved LIEN_CMD. `npx` itself is stubbed on
+ * PATH (no real network, no real registry) so every scenario is
+ * deterministic and fast — including the "stale" and "past cooldown" cases,
+ * which seed the marker files' timestamps directly rather than waiting in
+ * real time. A real, live black-holed-registry reproduction (this repo's
+ * actual network, a real npx, a real unreachable test-net address) is
+ * documented in the PR body rather than committed here, since it takes
+ * several real seconds per run.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import os from 'node:os';
+
+const HOOKS_DIR = fileURLToPath(new URL('../../../plugins/claude/hooks/', import.meta.url));
+const RESOLVE_SCRIPT = path.join(HOOKS_DIR, 'lien-resolve.sh');
+const WRAPPER_SCRIPT = path.join(HOOKS_DIR, 'lien-npx-breaker.sh');
+
+let binDir: string; // fake `npx` (and optionally `lien`) on PATH
+let markerDir: string;
+let marker: string;
+let breakerUntil: string;
+let callLog: string;
+let harness: string;
+
+beforeEach(() => {
+  binDir = mkdtempSync(path.join(os.tmpdir(), 'lien-breaker-bin-'));
+  markerDir = mkdtempSync(path.join(os.tmpdir(), 'lien-breaker-marker-'));
+  marker = path.join(markerDir, 'inflight');
+  breakerUntil = path.join(markerDir, 'breaker-open-until');
+  callLog = path.join(markerDir, 'npx-calls.log');
+
+  // Fake `npx`: logs a call, then behaves per $NPX_BEHAVIOR.
+  const npxShim = path.join(binDir, 'npx');
+  writeFileSync(
+    npxShim,
+    [
+      '#!/usr/bin/env bash',
+      'echo call >> "$NPX_CALL_LOG"',
+      'case "${NPX_BEHAVIOR:-ok}" in',
+      '  ok) echo "npx-ok:$*"; exit 0 ;;',
+      '  fail) echo "npx-fail" 1>&2; exit 1 ;;',
+      '  hang) sleep 5; exit 0 ;;',
+      'esac',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  chmodSync(npxShim, 0o755);
+
+  // Harness: sources lien-resolve.sh exactly the way a real hook does, then
+  // reports what happened so the test can assert on it without needing a
+  // real hook payload at all (lien-resolve.sh doesn't read stdin).
+  harness = path.join(binDir, 'harness.sh');
+  writeFileSync(
+    harness,
+    [
+      '#!/usr/bin/env bash',
+      'set -u',
+      `. "${RESOLVE_SCRIPT}" || { echo SOURCE_FAILED; exit 3; }`,
+      'echo "LIEN_CMD:${LIEN_CMD[*]}"',
+      '"${LIEN_CMD[@]}" "$@"',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  chmodSync(harness, 0o755);
+});
+
+afterEach(() => {
+  rmSync(binDir, { recursive: true, force: true });
+  rmSync(markerDir, { recursive: true, force: true });
+});
+
+function seedMarker(ageSec: number): void {
+  const ts = Math.floor(Date.now() / 1000) - ageSec;
+  writeFileSync(marker, String(ts), 'utf-8');
+}
+
+/** Seed the breaker-open-until marker so it expires `inSec` from now (negative = already expired). */
+function seedBreakerUntil(inSec: number): void {
+  const ts = Math.floor(Date.now() / 1000) + inSec;
+  writeFileSync(breakerUntil, String(ts), 'utf-8');
+}
+
+function runHarness(
+  extraEnv: Record<string, string> = {},
+  args: string[] = ['path', '--store'],
+): { stdout: string; status: number | null } {
+  const res = spawnSync('bash', [harness, ...args], {
+    encoding: 'utf-8',
+    env: {
+      // A minimal, controlled PATH — not the real process.env.PATH — since
+      // this machine may have a real global `lien` linked (e.g. via `npm
+      // link` per CONTRIBUTING.md), which would otherwise shadow these
+      // "no global lien" scenarios and make the tests non-deterministic.
+      PATH: `${binDir}${path.delimiter}/bin${path.delimiter}/usr/bin`,
+      NPX_CALL_LOG: callLog,
+      LIEN_NPX_BREAKER_MARKER: marker,
+      ...extraEnv,
+    },
+  });
+  return { stdout: res.stdout, status: res.status };
+}
+
+function callCount(): number {
+  try {
+    return readFileSync(callLog, 'utf-8')
+      .split('\n')
+      .filter(l => l.length > 0).length;
+  } catch {
+    return 0;
+  }
+}
+
+describe('lien-resolve.sh — no global lien, npx present, breaker default-on', () => {
+  it('resolves to the wrapper and calls through to npx when no marker exists', () => {
+    const { stdout, status } = runHarness();
+    expect(stdout).toContain('LIEN_CMD:bash');
+    expect(stdout).toContain('lien-npx-breaker.sh');
+    expect(stdout).toContain('npx-ok:-y @liendev/lien@latest path --store');
+    expect(status).toBe(0);
+    expect(callCount()).toBe(1);
+  });
+
+  it('removes the marker after a successful call', () => {
+    runHarness();
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('removes the marker even when the wrapped npx call itself fails', () => {
+    const { status } = runHarness({ NPX_BEHAVIOR: 'fail' });
+    expect(status).toBe(1);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('does not open the breaker for a fresh marker (e.g. a concurrent parallel hook)', () => {
+    seedMarker(1); // 1s old — nowhere near the 7s default staleness threshold
+    const { stdout, status } = runHarness();
+    expect(stdout).not.toContain('SOURCE_FAILED');
+    expect(status).toBe(0);
+    expect(callCount()).toBe(1);
+  });
+
+  it('opens the breaker for a stale marker — never spawns npx, and consumes the marker', () => {
+    seedMarker(30); // well past the 7s default staleness threshold
+    const { stdout, status } = runHarness();
+    expect(stdout).toBe('SOURCE_FAILED\n');
+    expect(status).toBe(3);
+    expect(callCount()).toBe(0);
+    // The stale in-flight marker is consumed (removed) once it's converted
+    // into a breaker-open-until decision — otherwise the NEXT check, once
+    // cooldown elapses, would immediately see the same ancient marker and
+    // re-trip the breaker without ever actually retrying.
+    expect(existsSync(marker)).toBe(false);
+    expect(existsSync(breakerUntil)).toBe(true);
+  });
+
+  it('stays open for the full cooldown regardless of how many edits arrive in between', () => {
+    seedMarker(30);
+    const first = runHarness();
+    expect(first.status).toBe(3);
+    expect(callCount()).toBe(0);
+
+    // Several more "edits" land during the cooldown window. None of them
+    // should spawn npx, even though there's no in-flight marker to detect
+    // staleness from any more (it was consumed by the first check above).
+    for (let i = 0; i < 3; i++) {
+      const { stdout, status } = runHarness();
+      expect(stdout).toBe('SOURCE_FAILED\n');
+      expect(status).toBe(3);
+    }
+    expect(callCount()).toBe(0);
+  });
+
+  it('closes the resetting-clock gap: a stale marker opens the breaker even when refreshed moments before by a fresh-looking attempt', () => {
+    // Regression for a real design flaw caught during review: if staleness
+    // were judged only against the in-flight marker, and each new attempt
+    // re-armed that marker before trying again, a run of edits arriving
+    // faster than the staleness window would keep resetting the clock and
+    // the breaker would never open — even though every attempt independently
+    // hangs. Simulate exactly that shape: a marker that's already past the
+    // staleness threshold, as if the last attempt started, hung, and was
+    // killed, then a new edit's hook fires immediately after.
+    seedMarker(7); // exactly at the default 7s staleness threshold
+    const { status } = runHarness();
+    expect(status).toBe(3);
+    expect(callCount()).toBe(0);
+    expect(existsSync(breakerUntil)).toBe(true);
+  });
+
+  it('retries once the cooldown window has elapsed since the breaker opened', () => {
+    seedBreakerUntil(-5); // breaker-open-until was 5s ago — cooldown has lapsed
+    const { stdout, status } = runHarness();
+    expect(stdout).not.toContain('SOURCE_FAILED');
+    expect(status).toBe(0);
+    expect(callCount()).toBe(1);
+    // The expired breaker marker is tidied up rather than left behind.
+    expect(existsSync(breakerUntil)).toBe(false);
+  });
+
+  it('respects a custom LIEN_NPX_BREAKER_STALE_SEC', () => {
+    seedMarker(3); // would NOT be stale at the 7s default...
+    const { status } = runHarness({ LIEN_NPX_BREAKER_STALE_SEC: '2' }); // ...but is at 2s
+    expect(status).toBe(3);
+    expect(callCount()).toBe(0);
+  });
+
+  it('respects a custom LIEN_NPX_BREAKER_COOLDOWN_SEC', () => {
+    seedBreakerUntil(60); // still 60s from expiring under a 300s cooldown, but...
+    const { status } = runHarness({ LIEN_NPX_BREAKER_COOLDOWN_SEC: '30' });
+    // ...the cooldown length only matters when the breaker is *written*, not
+    // when it's read — this asserts the still-open breaker (60s out) is
+    // still honored regardless of what a *new* cooldown env would compute,
+    // since breaker-open-until is an absolute epoch, not a duration.
+    expect(status).toBe(3);
+    expect(callCount()).toBe(0);
+  });
+
+  it('ignores a corrupted (non-numeric) marker file rather than misbehaving', () => {
+    writeFileSync(marker, 'not-a-timestamp', 'utf-8');
+    const { status } = runHarness();
+    expect(status).toBe(0);
+    expect(callCount()).toBe(1);
+  });
+});
+
+describe('lien-resolve.sh — LIEN_NPX_BREAKER=off', () => {
+  it('bypasses the breaker entirely, even with a stale marker present', () => {
+    seedMarker(30);
+    const { stdout, status } = runHarness({ LIEN_NPX_BREAKER: 'off' });
+    expect(stdout).not.toContain('SOURCE_FAILED');
+    expect(stdout).toContain('LIEN_CMD:npx -y @liendev/lien@latest');
+    expect(status).toBe(0);
+    expect(callCount()).toBe(1);
+  });
+});
+
+describe('lien-resolve.sh — global `lien` on PATH', () => {
+  it('resolves to the plain global binary and never touches the breaker, even with a stale marker', () => {
+    const lienShim = path.join(binDir, 'lien');
+    writeFileSync(lienShim, '#!/usr/bin/env bash\necho "lien-ok:$*"\nexit 0\n', 'utf-8');
+    chmodSync(lienShim, 0o755);
+    seedMarker(30);
+
+    const { stdout, status } = runHarness();
+    expect(stdout).toContain('LIEN_CMD:lien');
+    expect(stdout).toContain('lien-ok:path --store');
+    expect(status).toBe(0);
+    expect(callCount()).toBe(0); // npx never invoked
+    expect(existsSync(marker)).toBe(true); // marker untouched — not this path's concern
+  });
+});
+
+describe('lien-npx-breaker.sh — leaves the marker behind when killed mid-call', () => {
+  it('marker still exists immediately after the wrapper is killed while blocked on npx', () => {
+    const res = spawnSync('bash', [WRAPPER_SCRIPT, 'path', '--store'], {
+      encoding: 'utf-8',
+      env: {
+        PATH: `${binDir}${path.delimiter}/bin${path.delimiter}/usr/bin`,
+        NPX_CALL_LOG: callLog,
+        LIEN_NPX_BREAKER_MARKER: marker,
+        NPX_BEHAVIOR: 'hang',
+      },
+      timeout: 500,
+      killSignal: 'SIGKILL',
+    });
+    // The wrapper was killed before it could reach its own `rm -f "$marker"`
+    // cleanup line — the same shape as Claude Code's 5000ms hook timeout.
+    expect(res.signal).toBe('SIGKILL');
+    expect(existsSync(marker)).toBe(true);
+  });
+});

--- a/packages/cli/test/test-reminder-hook.test.ts
+++ b/packages/cli/test/test-reminder-hook.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for the PostToolUse edit hook `plugins/claude/hooks/test-reminder.sh`.
+ *
+ * `lien` is stubbed on PATH with a shim answering `path --store` (from a
+ * per-test store directory this suite controls, so the "repo is indexed"
+ * gate — `structural.db` present/absent — is real) and `verify-tests
+ * note-edit` with a canned reminder line (or empty, simulating a file with
+ * no associated tests). The shim also appends to a call-log file every time
+ * `note-edit` is actually invoked, so tests can assert on *spawn count*, not
+ * just stdout — the whole point of the regression this suite guards against.
+ *
+ * Regression coverage: before the fix, the per-session/per-file TTL
+ * touchfile was only written when the reminder text was non-empty, so a
+ * file with no associated tests re-spawned `verify-tests note-edit` on
+ * every single edit for the rest of the session — the TTL gate never
+ * engaged. The fix writes the touchfile unconditionally (after the call
+ * runs once), so a repeat edit within the TTL window is suppressed either
+ * way. See plugins/claude/hooks/test-reminder.sh's inline comments.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, chmodSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import os from 'node:os';
+
+const HOOK = fileURLToPath(
+  new URL('../../../plugins/claude/hooks/test-reminder.sh', import.meta.url),
+);
+
+let shimDir: string;
+let hookPath: string; // PATH with the lien shim prepended (real jq stays resolvable)
+
+beforeEach(() => {
+  shimDir = mkdtempSync(path.join(os.tmpdir(), 'lien-test-reminder-hook-'));
+  // `lien` shim: `path --store` answers from $STORE_DIR (env, set per call);
+  // `verify-tests note-edit` logs a call to $CALL_LOG and prints $REMINDER_TEXT.
+  const shim = path.join(shimDir, 'lien');
+  writeFileSync(
+    shim,
+    [
+      '#!/usr/bin/env bash',
+      'if [ "$1" = "path" ] && [ "$2" = "--store" ]; then',
+      '  printf \'%s\' "$STORE_DIR"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "verify-tests" ] && [ "$2" = "note-edit" ]; then',
+      '  echo call >> "$CALL_LOG"',
+      '  printf \'%s\' "$REMINDER_TEXT"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  chmodSync(shim, 0o755);
+  hookPath = `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`;
+});
+
+afterEach(() => {
+  rmSync(shimDir, { recursive: true, force: true });
+});
+
+/** Fresh, indexed store dir (real `structural.db` so the hook's index gate passes) + a call-log file. */
+function freshStore(): { storeDir: string; callLog: string } {
+  const storeDir = mkdtempSync(path.join(os.tmpdir(), 'lien-test-reminder-store-'));
+  writeFileSync(path.join(storeDir, 'structural.db'), '', 'utf-8');
+  const callLog = path.join(storeDir, 'call.log');
+  return { storeDir, callLog };
+}
+
+function callCount(callLog: string): number {
+  try {
+    return readFileSync(callLog, 'utf-8')
+      .split('\n')
+      .filter(l => l.length > 0).length;
+  } catch {
+    return 0;
+  }
+}
+
+function runHook(
+  payload: Record<string, unknown>,
+  opts: {
+    storeDir: string;
+    callLog: string;
+    reminderText?: string;
+    extraEnv?: Record<string, string>;
+  },
+): { stdout: string; status: number | null } {
+  const res = spawnSync('bash', [HOOK], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      PATH: hookPath,
+      STORE_DIR: opts.storeDir,
+      CALL_LOG: opts.callLog,
+      REMINDER_TEXT: opts.reminderText ?? '',
+      ...opts.extraEnv,
+    },
+  });
+  return { stdout: res.stdout.trim(), status: res.status };
+}
+
+function additionalContext(stdout: string): string {
+  if (stdout === '') {
+    throw new Error('hook produced no stdout — expected an additionalContext JSON envelope');
+  }
+  const parsed = JSON.parse(stdout) as { hookSpecificOutput?: { additionalContext?: unknown } };
+  const ctx = parsed.hookSpecificOutput?.additionalContext;
+  if (typeof ctx !== 'string') {
+    throw new Error(`hook JSON has no string additionalContext: ${stdout}`);
+  }
+  return ctx;
+}
+
+const editPayload = (filePath: string, sessionId: string, cwd: string, tool = 'Edit') => ({
+  session_id: sessionId,
+  tool_name: tool,
+  cwd,
+  tool_input: { file_path: filePath },
+});
+
+describe('test-reminder.sh — has associated tests', () => {
+  it('emits the reminder on the first edit and writes a session touchfile', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout, status } = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: 'Tests to run: a.test.ts',
+    });
+    expect(status).toBe(0);
+    expect(additionalContext(stdout)).toBe('Tests to run: a.test.ts');
+    expect(callCount(callLog)).toBe(1);
+    const sessionDir = path.join(storeDir, 'annotated-sessions', 's1');
+    expect(readdirSync(sessionDir).length).toBeGreaterThan(0);
+  });
+
+  it('suppresses a repeat edit to the same file within the TTL window (no second spawn)', () => {
+    const { storeDir, callLog } = freshStore();
+    const first = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: 'Tests to run: a.test.ts',
+    });
+    expect(additionalContext(first.stdout)).toBe('Tests to run: a.test.ts');
+
+    const second = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: 'Tests to run: a.test.ts',
+    });
+    expect(second.stdout).toBe('');
+    expect(second.status).toBe(0);
+    // The money assertion: note-edit was spawned once, not twice.
+    expect(callCount(callLog)).toBe(1);
+  });
+});
+
+describe('test-reminder.sh — no associated tests (regression: the inverted-touchfile bug)', () => {
+  it('stays silent on the first edit but still spawns note-edit once, and marks the touchfile', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout, status } = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: '',
+    });
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+    expect(callCount(callLog)).toBe(1);
+    const sessionDir = path.join(storeDir, 'annotated-sessions', 's1');
+    expect(readdirSync(sessionDir).length).toBeGreaterThan(0);
+  });
+
+  it('suppresses the second spawn on a repeat edit within the TTL window (the fix)', () => {
+    const { storeDir, callLog } = freshStore();
+    const first = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: '',
+    });
+    expect(first.stdout).toBe('');
+    expect(callCount(callLog)).toBe(1);
+
+    const second = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: '',
+    });
+    expect(second.stdout).toBe('');
+    expect(second.status).toBe(0);
+    // Before the fix: this would be 2 (the touchfile was never written, so
+    // the TTL gate never engaged and note-edit ran again).
+    expect(callCount(callLog)).toBe(1);
+
+    const third = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: '',
+    });
+    expect(third.stdout).toBe('');
+    expect(callCount(callLog)).toBe(1);
+  });
+
+  it('still spawns note-edit for a different file in the same session (per-file suppression)', () => {
+    const { storeDir, callLog } = freshStore();
+    runHook(editPayload('a.ts', 's1', shimDir), { storeDir, callLog, reminderText: '' });
+    expect(callCount(callLog)).toBe(1);
+
+    runHook(editPayload('b.ts', 's1', shimDir), { storeDir, callLog, reminderText: '' });
+    expect(callCount(callLog)).toBe(2);
+  });
+});
+
+describe('test-reminder.sh — stays silent / no spawn (exit 0)', () => {
+  it('when the tool is not an edit (e.g. Bash) — never invokes lien at all', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout, status } = runHook(
+      { tool_name: 'Bash', cwd: shimDir, session_id: 's1', tool_input: { command: 'ls' } },
+      { storeDir, callLog, reminderText: 'should never be shown' },
+    );
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+    expect(callCount(callLog)).toBe(0);
+  });
+
+  it('when file_path is missing from the payload', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout } = runHook(
+      { tool_name: 'Edit', cwd: shimDir, session_id: 's1', tool_input: {} },
+      { storeDir, callLog, reminderText: 'x' },
+    );
+    expect(stdout).toBe('');
+    expect(callCount(callLog)).toBe(0);
+  });
+
+  it('when session_id is missing from the payload', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout } = runHook(
+      { tool_name: 'Edit', cwd: shimDir, tool_input: { file_path: 'a.ts' } },
+      { storeDir, callLog, reminderText: 'x' },
+    );
+    expect(stdout).toBe('');
+    expect(callCount(callLog)).toBe(0);
+  });
+
+  it('when session_id contains invalid characters (path-traversal defense)', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout } = runHook(editPayload('a.ts', '../../etc', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: 'x',
+    });
+    expect(stdout).toBe('');
+    expect(callCount(callLog)).toBe(0);
+  });
+
+  it('when the kill switch LIEN_TEST_REMINDER=off is set, even with associated tests', () => {
+    const { storeDir, callLog } = freshStore();
+    const { stdout } = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir,
+      callLog,
+      reminderText: 'Tests to run: a.test.ts',
+      extraEnv: { LIEN_TEST_REMINDER: 'off' },
+    });
+    expect(stdout).toBe('');
+    expect(callCount(callLog)).toBe(0);
+  });
+
+  it('when the repo has no index (no structural.db) — never spawns note-edit', () => {
+    const unindexedStore = mkdtempSync(path.join(os.tmpdir(), 'lien-test-reminder-unindexed-'));
+    const callLog = path.join(unindexedStore, 'call.log');
+    const { stdout, status } = runHook(editPayload('a.ts', 's1', shimDir), {
+      storeDir: unindexedStore,
+      callLog,
+      reminderText: 'x',
+    });
+    expect(stdout).toBe('');
+    expect(status).toBe(0);
+    expect(callCount(callLog)).toBe(0);
+    rmSync(unindexedStore, { recursive: true, force: true });
+  });
+
+  it('accepts MultiEdit and Write as edit tools', () => {
+    const { storeDir, callLog } = freshStore();
+    const write = runHook(editPayload('a.ts', 's1', shimDir, 'Write'), {
+      storeDir,
+      callLog,
+      reminderText: 'Tests to run: a.test.ts',
+    });
+    expect(additionalContext(write.stdout)).toBe('Tests to run: a.test.ts');
+
+    const { storeDir: storeDir2, callLog: callLog2 } = freshStore();
+    const multiEdit = runHook(editPayload('a.ts', 's1', shimDir, 'MultiEdit'), {
+      storeDir: storeDir2,
+      callLog: callLog2,
+      reminderText: 'Tests to run: a.test.ts',
+    });
+    expect(additionalContext(multiEdit.stdout)).toBe('Tests to run: a.test.ts');
+  });
+});

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -39,6 +39,28 @@ subsequent resolutions fast and silent for a cooldown window instead of
 re-hanging on every later edit. `LIEN_NPX_BREAKER_STALE_SEC` (default 7) and
 `LIEN_NPX_BREAKER_COOLDOWN_SEC` (default 300) tune the thresholds.
 
+**Known false-positive trigger:** a stale marker only proves the process
+that wrote it was killed before it could clean up — it can't prove *why*. A
+registry hang is one cause; the lid closing / the machine sleeping mid-call,
+a Ctrl-C or session kill landing on the process group, or an OOM kill all
+leave the same fingerprint, and in every one of those cases the registry is
+actually fine but the breaker still opens, silencing nudges for the whole
+cooldown. This isn't a new failure class — missing `jq`, an unindexed repo,
+and other conditions already fail this suite silently — and it's strictly
+better than the 5s-per-edit stall it replaces. It self-heals once the
+cooldown lapses; lower `LIEN_NPX_BREAKER_COOLDOWN_SEC` to shorten that wait,
+or set `LIEN_NPX_BREAKER=off` to disable the breaker entirely. The default
+cooldown is kept at 300s rather than something shorter (e.g. 60s) because
+the two failure shapes have different persistence: a benign kill is a rare,
+coincidental one-off (hooks normally run in 200-600ms, so the odds of an
+external kill landing in that narrow window are low), while a real
+black-holed registry is a standing network condition (corporate
+proxy/VPN/firewall) that typically doesn't resolve itself mid-session — a
+shorter cooldown mostly just re-stalls ~5s on every expiry without fixing
+anything, costing roughly 5x more cumulative stall time over a long session
+on a persistently broken network. See the fuller reasoning in
+`lien-resolve.sh`'s own comments.
+
 Every `delta-write.sh` run (and every other `lien delta` invocation, manual
 or CI) is recorded locally as one JSONL line in `delta-events.jsonl` next to
 the project's index; nothing leaves the machine. Run `lien stats` for 7/30-day

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -28,7 +28,16 @@ for which hook output channels actually reach the model.
 `lien-resolve.sh` is shared infra sourced by every hook above, not itself an
 entry in `hooks.json`: it resolves a global `lien` binary, falling back to
 `npx -y @liendev/lien@latest` when none is installed (the default case for a
-plugin-only install).
+plugin-only install). That npx fallback carries a circuit breaker for an
+unreachable/black-holed registry (default on; `LIEN_NPX_BREAKER=off` to
+disable): calls are routed through `lien-npx-breaker.sh`, which drops a
+timestamp marker immediately before each call and clears it immediately
+after, so a call left behind stale — the fingerprint of Claude Code's own
+5000ms hook timeout SIGKILLing a hung call, since there's no portable
+`timeout` binary on macOS bash 3.2 to bound it from the inside — fails
+subsequent resolutions fast and silent for a cooldown window instead of
+re-hanging on every later edit. `LIEN_NPX_BREAKER_STALE_SEC` (default 7) and
+`LIEN_NPX_BREAKER_COOLDOWN_SEC` (default 300) tune the thresholds.
 
 Every `delta-write.sh` run (and every other `lien delta` invocation, manual
 or CI) is recorded locally as one JSONL line in `delta-events.jsonl` next to

--- a/plugins/claude/hooks/lien-npx-breaker.sh
+++ b/plugins/claude/hooks/lien-npx-breaker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Drop-in replacement for a direct `npx -y @liendev/lien@latest` call,
+# installed into `LIEN_CMD` by `lien-resolve.sh` (only when no global `lien`
+# is on PATH — the default plugin setup — and the breaker is enabled). Every
+# hook script still invokes "${LIEN_CMD[@]}" <subcommand> <args...> exactly
+# as before; this wrapper receives that same argv, so no other hook script
+# needed to change.
+#
+# Writes a Unix timestamp to $LIEN_NPX_BREAKER_MARKER immediately before the
+# real npx call, and removes it immediately after — on ANY normal exit here,
+# success or failure alike. If this process is SIGKILLed mid-call (Claude
+# Code's own 5000ms hook timeout is the only bound that exists — see
+# lien-resolve.sh — while npx hangs on an unreachable/black-holed registry),
+# the marker is never removed. That's the whole point: a SIGKILL can't be
+# trapped, so this process has no way to record its own failure, but a
+# LATER invocation can read the marker's age and infer "the last attempt
+# never finished" even though nothing here ever told it so directly. See
+# lien-resolve.sh for the read side of this contract.
+set -u
+
+marker="${LIEN_NPX_BREAKER_MARKER:?lien-npx-breaker.sh requires LIEN_NPX_BREAKER_MARKER}"
+mkdir -p "$(dirname "$marker")" 2>/dev/null
+date +%s > "$marker" 2>/dev/null
+
+npx -y @liendev/lien@latest "$@"
+rc=$?
+
+rm -f "$marker" 2>/dev/null
+exit "$rc"

--- a/plugins/claude/hooks/lien-resolve.sh
+++ b/plugins/claude/hooks/lien-resolve.sh
@@ -14,11 +14,98 @@
 # (warm npx adds ~300ms; the SessionStart hook pre-warms the cache so real
 # hook invocations never pay the cold install). Fails the source (caller
 # exits 0, staying silent) only when neither is available.
-
+#
+# Circuit breaker for an unreachable/black-holed npm registry (default on;
+# opt out with LIEN_NPX_BREAKER=off). There's no portable `timeout` binary
+# on macOS bash 3.2, so this can't bound npx's own hang from the inside;
+# Claude Code's 5000ms hook timeout (hooks.json) is the only thing that ever
+# stops a truly hung call, and it does so with an unmaskable SIGKILL that no
+# trap here could intercept. So instead of trying to time-bound npx directly,
+# the npx path is routed through `lien-npx-breaker.sh`, which drops a
+# timestamp marker immediately before the call and removes it immediately
+# after, on any normal exit. A marker left behind — found here, on a LATER
+# invocation — older than LIEN_NPX_BREAKER_STALE_SEC (default 7s, just above
+# the hook timeout: no legitimate single call can still be "in flight" past
+# that point, so an older marker can only mean the process that wrote it was
+# already killed) is exactly the fingerprint a SIGKILLed call leaves.
+#
+# Two markers, not one, because a single "in-flight" marker alone has a gap:
+# if it just gets rewritten fresh by the NEXT attempt every time staleness is
+# checked, a run of edits arriving faster than the staleness window keeps
+# resetting the clock and the breaker never actually opens, even though every
+# single attempt is independently hanging. So detecting staleness doesn't
+# retry — it consumes the stale in-flight marker (removes it) and instead
+# writes a SEPARATE "breaker open until <epoch>" marker
+# (LIEN_NPX_BREAKER_UNTIL_MARKER to override; same directory as the in-flight
+# marker by default) that every subsequent invocation checks FIRST, unarmed
+# by any new attempt, for the full LIEN_NPX_BREAKER_COOLDOWN_SEC window
+# (default 300s) — so the breaker, once open, stays open for the whole
+# cooldown regardless of how many more edits arrive in the meantime. Only
+# once the cooldown lapses does resolution fall through to a real retry,
+# which starts the whole cycle over from a clean in-flight marker.
+#
+# Both markers are intentionally machine-global, not per-repo — an
+# unreachable registry is a network condition, not a per-project one, and
+# per-repo scoping would need its own `lien` invocation (`path --store`) just
+# to find where to look, which is the exact chicken-and-egg this breaker
+# exists to avoid triggering.
 if command -v lien >/dev/null 2>&1; then
   LIEN_CMD=(lien)
 elif command -v npx >/dev/null 2>&1; then
-  LIEN_CMD=(npx -y @liendev/lien@latest)
+  if [ "${LIEN_NPX_BREAKER:-on}" = "off" ]; then
+    LIEN_CMD=(npx -y @liendev/lien@latest)
+  else
+    marker="${LIEN_NPX_BREAKER_MARKER:-${TMPDIR:-/tmp}/lien-npx-breaker/inflight}"
+    breaker_until="${LIEN_NPX_BREAKER_UNTIL_MARKER:-$(dirname "$marker")/breaker-open-until}"
+    stale_after="${LIEN_NPX_BREAKER_STALE_SEC:-7}"
+    cooldown="${LIEN_NPX_BREAKER_COOLDOWN_SEC:-300}"
+    case "$stale_after" in ''|*[!0-9]*) stale_after=7 ;; esac
+    case "$cooldown" in ''|*[!0-9]*) cooldown=300 ;; esac
+
+    now_ts="$(date +%s 2>/dev/null)"
+    case "$now_ts" in ''|*[!0-9]*) now_ts="" ;; esac
+
+    breaker_open=0
+    if [ -n "$now_ts" ] && [ -f "$breaker_until" ]; then
+      until_ts="$(cat "$breaker_until" 2>/dev/null)"
+      case "$until_ts" in ''|*[!0-9]*) until_ts="" ;; esac
+      if [ -n "$until_ts" ]; then
+        if [ "$now_ts" -lt "$until_ts" ]; then
+          breaker_open=1
+        else
+          rm -f "$breaker_until" 2>/dev/null # cooldown elapsed; tidy up
+        fi
+      fi
+    fi
+
+    if [ "$breaker_open" = 1 ]; then
+      # Still cooling down from a previously detected hang. Fail the source
+      # (caller exits 0, silent) without even looking at the in-flight
+      # marker — that's the whole point: no new attempt, no new hang.
+      return 1
+    fi
+
+    if [ -n "$now_ts" ] && [ -f "$marker" ]; then
+      marker_ts="$(cat "$marker" 2>/dev/null)"
+      case "$marker_ts" in ''|*[!0-9]*) marker_ts="" ;; esac
+      if [ -n "$marker_ts" ]; then
+        age=$(( now_ts - marker_ts ))
+        if [ "$age" -ge "$stale_after" ]; then
+          # The last attempt never completed — almost certainly killed
+          # mid-flight. Open the breaker for the cooldown window and consume
+          # the stale evidence so the NEXT check (once cooldown lapses)
+          # doesn't immediately re-trip on this same leftover marker.
+          mkdir -p "$(dirname "$breaker_until")" 2>/dev/null
+          echo $(( now_ts + cooldown )) > "$breaker_until" 2>/dev/null
+          rm -f "$marker" 2>/dev/null
+          return 1
+        fi
+      fi
+    fi
+
+    export LIEN_NPX_BREAKER_MARKER="$marker"
+    LIEN_CMD=(bash "$(dirname "${BASH_SOURCE[0]}")/lien-npx-breaker.sh")
+  fi
 else
   return 1
 fi

--- a/plugins/claude/hooks/lien-resolve.sh
+++ b/plugins/claude/hooks/lien-resolve.sh
@@ -49,6 +49,45 @@
 # per-repo scoping would need its own `lien` invocation (`path --store`) just
 # to find where to look, which is the exact chicken-and-egg this breaker
 # exists to avoid triggering.
+#
+# Known false-positive trigger: a stale in-flight marker is the fingerprint
+# of an untrapped kill, but it cannot tell WHY the process was killed — a
+# registry hang is only one cause. The same fingerprint is left by the lid
+# closing / the machine sleeping mid-call (wall clock jumps forward past
+# LIEN_NPX_BREAKER_STALE_SEC the moment it wakes), a Ctrl-C or session kill
+# landing on the process group (SIGINT is untrapped here too — anything that
+# terminates this process before it reaches its own cleanup line has the
+# same effect as a SIGKILL), or an OOM kill. In every one of these cases the
+# registry is actually fine and the breaker still opens, silencing nudges
+# for the full cooldown even though nothing is wrong. This isn't a new
+# failure class for this hook suite — missing `jq`, an unindexed repo, and a
+# dozen other conditions already fail this silently — and it's strictly
+# better than the 5s-stall-per-edit it replaces. It self-heals once the
+# cooldown lapses; LIEN_NPX_BREAKER_COOLDOWN_SEC lowers the wait, and
+# LIEN_NPX_BREAKER=off disables the mechanism entirely.
+#
+# Why the default cooldown is 300s and not shorter, given false positives
+# from the paragraph above are plausible: the two failure shapes have very
+# different persistence and severity profiles. A benign kill is a one-off,
+# coincidental event — it can only produce a false trip if it happens to
+# land during the narrow window a hook is actually running (measured at
+# 200-600ms end to end in normal operation), so across a whole session the
+# odds of it landing in that window at all are low, and the cost when it
+# does is just a few minutes of missing nudges (silence, not breakage,
+# self-healing, in a suite that's already advisory-only throughout). A real
+# black-holed registry, by contrast, is a standing network condition
+# (corporate proxy, VPN, firewall) that typically does NOT resolve itself
+# within a single work session — it stays down until the user changes
+# network config, so a short cooldown mostly buys nothing there (the retry
+# just hangs again) while making the *common* pattern strictly worse: every
+# cooldown expiry re-probes and re-stalls ~5s, so a 60s cooldown costs
+# roughly 5x more cumulative stall time than 300s over a long session on a
+# persistently broken network (~one 5s stall/minute vs. one every 5
+# minutes). Given the rare/low-severity profile of the false-positive case
+# against the common/high-cost profile of the true-positive case this
+# breaker exists for, 300s is kept as the default. Lower it via
+# LIEN_NPX_BREAKER_COOLDOWN_SEC if a false trip's silence is worse for a given
+# workflow than the occasional extra stall.
 if command -v lien >/dev/null 2>&1; then
   LIEN_CMD=(lien)
 elif command -v npx >/dev/null 2>&1; then

--- a/plugins/claude/hooks/test-reminder.sh
+++ b/plugins/claude/hooks/test-reminder.sh
@@ -21,10 +21,16 @@
 # when the file has no associated tests. TTL-suppressed per file per session
 # (same touchfile pattern and `annotated-sessions/` directory as
 # `annotate-read.sh`, so the existing SessionStart/SessionEnd GC covers this
-# too) so an edit burst on one file only reminds once per window — the ledger
-# recording only happens on that same first-in-window call, but a file's
-# first edit in a session always passes the per-file TTL gate (no touchfile
-# yet), so recording is never skipped for a file that was actually edited.
+# too) so an edit burst on one file only reminds once per window — AND only
+# spawns the `note-edit` subprocess once per window, whether or not the file
+# turns out to have associated tests: the touchfile is written either way, so
+# a no-tests file doesn't re-pay that spawn on every repeat edit for the rest
+# of the session. The ledger recording only happens on that same
+# first-in-window call, but a file's first edit in a session always passes
+# the per-file TTL gate (no touchfile yet), so recording is never skipped for
+# a file that was actually edited — and there's nothing to skip for a
+# no-tests file, since `note-edit` never records one (see `runNoteEdit` in
+# verify-tests-cmd.ts).
 #
 # Best-effort throughout — never fails the user's edit. Disable via
 # LIEN_TEST_REMINDER=off (this hook) or LIEN_TEST_VERIFY=off (ledger
@@ -104,13 +110,23 @@ else
   reminder="$("${LIEN_CMD[@]}" verify-tests note-edit --session "$session_id" --file "$file_path" 2>/dev/null)"
 fi
 
-# No associated tests → `lien verify-tests note-edit` prints nothing → stay
-# silent (and don't mark the touchfile — nothing to suppress next time).
-[ -n "$reminder" ] || exit 0
-
+# Mark the touchfile regardless of whether there was anything to say. A file
+# with no associated tests still cost a real subprocess spawn (this
+# `verify-tests note-edit` call, on top of the `path --store` resolution
+# above) to discover that — that spawn, not the reminder text, is what the
+# TTL suppression exists to cache. Recording is unaffected either way:
+# `note-edit` only writes to the session ledger when the file actually has
+# associated tests (see `runNoteEdit` in verify-tests-cmd.ts), so a no-tests
+# file never had anything to record, and a file's first edit in a session
+# always runs this call regardless (no touchfile exists yet), so a
+# genuinely testable file's edit is never skipped.
 mkdir -p "$session_dir" 2>/dev/null || exit 0
 : > "$touchfile"
 touch "$session_dir" 2>/dev/null
+
+# No associated tests → `lien verify-tests note-edit` prints nothing → stay
+# silent.
+[ -n "$reminder" ] || exit 0
 
 # additionalContext is the channel that actually reaches the model on the
 # next turn (verified in CC 2.1.142; matches annotate-read.sh/delta-write.sh).


### PR DESCRIPTION
## Summary

Two per-edit cost problems in Lien's Claude Code plugin hooks, found while measuring the shipped plugin against a foreign-repo corpus.

**Fix 1 — `test-reminder.sh` caches "no associated tests" too.** The per-file/per-session TTL touchfile was only written when the reminder text was non-empty, reasoning there was "nothing to suppress" for a no-tests file. Backwards: discovering there's nothing to say still costs a real `lien verify-tests note-edit` subprocess spawn, and since the touchfile was never written, the TTL gate never engaged for such files — every repeat edit re-paid that spawn for the rest of the session. Files with no detected test association are common, not an edge case. Fix: write the touchfile unconditionally after the call runs once (a file's first edit in a session still always runs the call, so ledger recording — which only ever happens when a file actually has associated tests — is unaffected).

Checked `delta-write.sh` and `api-delta-write.sh` for the same pattern per the brief: neither has it. `delta-write.sh` makes exactly one spawn per invocation regardless of outcome (nothing to cache). `api-delta-write.sh`'s second spawn (`nudge note-shown`) is already conditional on a *real* signature change firing — correct, left alone.

**Fix 2 — circuit breaker for a black-holed npm registry.** With no global `lien` (the default plugin setup), every hook falls back to `npx -y @liendev/lien@latest`. There's no portable `timeout` binary on macOS bash 3.2, so a black-holed registry (TCP accepts, never replies) can only ever be bounded by Claude Code's own 5000ms hook timeout — an unmaskable SIGKILL. Without a breaker, every qualifying edit re-attempts and re-hangs indefinitely.

`lien-npx-breaker.sh` (new) wraps the real npx call: writes a timestamp marker immediately before, removes it immediately after, on any normal exit. A marker left behind stale is exactly the fingerprint a SIGKILLed call leaves (it never gets a chance to record its own failure). `lien-resolve.sh` reads that marker on the *next* invocation; if stale, it writes a **separate** cooldown marker and fails the source immediately (caller exits 0, silent) instead of retrying.

Two markers, not one — a single in-flight marker would get rewritten fresh by every new attempt, so a run of edits arriving faster than the staleness window would keep resetting the clock and the breaker would never actually open, even though every attempt independently hangs. This is a real gap I found and closed during design review; a unit test (`closes the resetting-clock gap...`) pins it.

Every existing hook still calls `"${LIEN_CMD[@]}"` exactly as before — zero changes to the 8 existing hook scripts, all the logic lives in `lien-resolve.sh` + the one new wrapper file.

**Honest residual limitation**: `LIEN_NPX_BREAKER_STALE_SEC` defaults to 7s (5s hook timeout + 2s buffer for `date +%s`'s 1-second quantization, chosen conservatively so we never falsely trip the breaker on a call that might have succeeded). That leaves a ~2s theoretical dead zone: if edits arrive with *zero* gap between an edit's hook getting killed and the next edit's hook starting, the marker gets refreshed before it's ever classified stale, and the breaker never engages. In practice this requires back-to-back edits with no gap at all, which doesn't match real agentic tool-loops (the model has to receive the tool result and generate the next action, and Claude Code itself waits for all parallel hooks to finish first) — real dogfooding below shows the breaker engaging cleanly with a realistic ~2.2s gap. Flagging this explicitly rather than glossing over it.

**Second honest limitation, found in review** (thanks to the coordinator's own re-run of the breaker with an instantly-succeeding fake `npx`): a stale in-flight marker proves the process that wrote it was killed before it could clean up — it can't prove *why*. Claude Code's own 5000ms hook timeout is the intended trigger, but any untrapped signal has the identical effect: a lid-close/sleep mid-call (wall clock jumps forward past the staleness threshold the moment the machine wakes), a Ctrl-C or session kill landing on the process group, or an OOM kill. In every one of those cases the registry is actually fine and the breaker still opens, silencing nudges for the whole cooldown. This isn't a new failure class for this hook suite — missing `jq`, an unindexed repo, and a dozen other conditions already fail this suite silently — and it's strictly better than the 5s-stall-per-edit it replaces. It self-heals once the cooldown lapses; `LIEN_NPX_BREAKER_COOLDOWN_SEC` shortens that wait, `LIEN_NPX_BREAKER=off` disables the mechanism entirely.

**Judgment call: is 300s the right default cooldown, given benign trips are plausible?** Yes, kept at 300s. The two failure shapes have very different persistence and severity profiles. A benign kill is a rare, coincidental one-off — it only produces a false trip if it happens to land during the narrow window a hook is actually running (200-600ms end to end, measured below), so across a whole session the odds of that coincidence are low, and the cost when it does land is just a few minutes of missing (already-advisory) nudges, self-healing automatically. A real black-holed registry, by contrast, is a standing network condition (corporate proxy/VPN/firewall) that typically does *not* resolve itself within a session — a shorter cooldown mostly buys nothing there (the retry just hangs again) while making the pattern this breaker exists for strictly worse: every cooldown expiry re-probes and re-stalls ~5s, so a 60s cooldown costs roughly 5x more cumulative stall time than 300s over a long session on a persistently broken network (~one 5s stall/minute vs. one every 5 minutes). Given the rare/low-severity profile of the false-positive case against the common/high-cost profile of the true-positive case this breaker exists for, 300s stays the default; `LIEN_NPX_BREAKER_COOLDOWN_SEC` is there for anyone who values faster recovery from a false trip over fewer re-stalls on a real one. Recorded in full in `lien-resolve.sh`'s own comments and the plugin README.

## Dogfood evidence (verbatim, foreign repo: flask corpus at `/tmp/lien-dogfood-460173c9/flask`, plus a real black-holed registry for Fix 2)

### Fix 1 — real stdin payload, real published CLI (v0.72.0), real repo

Payload shape used throughout:
```json
{"tool_name":"Edit","tool_input":{"file_path":"docs/conf.py"},"cwd":"/tmp/lien-dogfood-460173c9/flask","session_id":"..."}
```

**No test association (`docs/conf.py`) — before (old script, checked out from HEAD):**
```
rep1: real 0m0.378s
rep2: real 0m0.368s   <- no drop, the bug
rep3: real 0m0.346s   <- no drop, the bug
```

**No test association — after (this fix):**
```
rep1: real 0m0.346s
rep2: real 0m0.182s   <- ~1 spawn eliminated
rep3: real 0m0.182s   <- consistent
```

**Has test association (`src/flask/logging.py`) — unaffected, parity preserved:**
```
rep1: real 0m0.351s -> reminder shown, ledger recorded 1 "edit" event
rep2: real 0m0.178s -> silent (TTL suppressed, as before), ledger still 1 event (no double-record)
```
`lien verify-tests report --session <id>` after rep2 still correctly surfaced the unresolved-tests advisory, confirming the recap side effect chain (edit → ledger → Stop advisory) is intact end to end.

### Fix 2 — real npx, real black-holed registry (RFC5737 TEST-NET-3, 203.0.113.1 — genuinely unrouted on this network, confirmed via `curl -m4` timing out)

```
Edit 1: real npx, real black hole, bounded to 5000ms (Claude Code's hook timeout), SIGKILL on expiry
  elapsed=5002ms signal=SIGKILL status=null
  marker exists after=true

~2.2s realistic "model thinks, issues next edit" gap

Edit 2: fires ~2.2s after edit 1 was killed
  elapsed=29ms signal=null status=3 (SOURCE_FAILED -> caller hook exits 0, silent)
  marker consumed, breaker-open-until written

Edit 3: fires immediately after edit 2 (still in cooldown)
  elapsed=11ms signal=null status=3 (breaker still open, no new spawn)
```

**Kill switch, real components**: `LIEN_NPX_BREAKER=off` with a stale marker present + real black hole → hangs again for the full 5002ms, SIGKILLed — confirms the switch fully bypasses the breaker.

**Normal path unaffected**: real npx, real (reachable) registry, no global `lien`, through the wrapper → `elapsed=587ms status=0`, marker cleaned up (`false` after). No meaningful overhead from the extra wrapper layer.

## Test plan
- [x] `npm run format:check` / `npm run lint` (0 errors) / `npm run typecheck` / `npm run build` — all green
- [x] `npm test` — 1461+378+1701+1328+41 = all green across every workspace, including 12 new tests for `test-reminder.sh` (2 of which fail against the pre-fix script, confirmed by reverting it) and 14 new tests for the breaker (including a real SIGKILL-mid-call test proving the marker survives)
- [x] `node packages/cli/dist/index.js delta` — exit 0, no crossings
- [x] Dogfooded in a foreign repo (flask), not this repo, with the real stdin shape and the real v0.72.0 published binary
- [x] Fix 2 dogfooded against a real, live black-holed network target, not just shimmed

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes two per-edit cost issues in the Claude Code plugin hooks: `test-reminder.sh` now writes its TTL touchfile unconditionally so files with no associated tests don't re-spawn `verify-tests note-edit` on every repeat edit, and `lien-resolve.sh` adds a two-marker circuit breaker around the `npx @liendev/lien@latest` fallback to avoid repeated 5-second hangs when the npm registry is black-holed. The implementation matches the documented design, the two-marker approach correctly closes the resetting-clock gap, and the changes are localized to shell hook infrastructure with comprehensive unit tests. No callers outside the hook suite are affected.
>
> - test-reminder.sh now writes the per-file/per-session TTL touchfile even when the reminder text is empty
> - New lien-npx-breaker.sh wrapper and two-marker breaker logic in lien-resolve.sh fast-fail subsequent npx resolutions after a detected SIGKILL hang
> - 26 new unit tests cover both fixes, including the resetting-clock gap and SIGKILL-surviving-marker cases

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 577c060. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
