### PR TITLE
fix(cli): stop fabricating result totals and silent truncation in MCP tools

### DIFF
--- a/packages/cli/src/mcp/handlers/find-similar.test.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.test.ts
@@ -465,8 +465,83 @@ describe('handleFindSimilar', () => {
       await handleFindSimilar({ code }, mockCtx);
 
       // The code string is passed straight to search(). limit defaults to 5,
-      // +10 overfetch.
-      expect(mockVectorDB.search).toHaveBeenCalledWith(code, 15);
+      // +10 overfetch, +1 more to detect whether the fetch window was full
+      // (see fetchCandidates' fetchWindowExhausted signal).
+      expect(mockVectorDB.search).toHaveBeenCalledWith(code, 16);
+    });
+  });
+
+  describe('hasMore signal (never a fabricated total)', () => {
+    it('is false when the fetch window was not full and results fit under limit', async () => {
+      mockVectorDB.search.mockResolvedValue([createMockResult({ metadata: { file: 'src/a.ts' } })]);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', limit: 5 },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.hasMore).toBe(false);
+      expect(parsed.note).toBeUndefined();
+    });
+
+    it('is true when filtered candidates already exceed limit', async () => {
+      const mockResults = Array.from({ length: 8 }, (_, i) =>
+        createMockResult({ metadata: { file: `src/f${i}.ts` } }),
+      );
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', limit: 5 },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(5);
+      expect(parsed.hasMore).toBe(true);
+      expect(parsed.note).toContain("doesn't paginate");
+    });
+
+    it('is true when the raw fetch window was full, even if filtered candidates fit under limit', async () => {
+      // limit=5 -> extraLimit=15 -> search requested with 16. Returning
+      // exactly 16 raw rows means the window was NOT proven exhausted.
+      const rawResults = Array.from({ length: 16 }, (_, i) =>
+        createMockResult({
+          metadata: { file: `src/f${i}.ts`, language: i === 0 ? 'typescript' : 'python' },
+        }),
+      );
+      mockVectorDB.search.mockResolvedValue(rawResults);
+
+      const result = await handleFindSimilar(
+        {
+          code: 'async function fetchData() { return await db.find(); }',
+          limit: 5,
+          language: 'typescript',
+        },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      // Only 1 candidate survives the language filter — well under limit —
+      // so hasMore is true here ONLY because the fetch window wasn't
+      // proven exhausted, not because of any leftover filtered count.
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.hasMore).toBe(true);
+    });
+
+    it('never states a specific total in the note', async () => {
+      const mockResults = Array.from({ length: 8 }, (_, i) =>
+        createMockResult({ metadata: { file: `src/f${i}.ts` } }),
+      );
+      mockVectorDB.search.mockResolvedValue(mockResults);
+
+      const result = await handleFindSimilar(
+        { code: 'async function fetchData() { return await db.find(); }', limit: 5 },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note ?? '').not.toMatch(/\bof \d+/);
     });
   });
 

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -2,12 +2,52 @@ import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { FindSimilarSchema } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
-import type { SearchResult } from '@liendev/core';
+import type { SearchResult, VectorDBInterface } from '@liendev/core';
 
 interface FiltersApplied {
   language?: string;
   pathHint?: string;
   prunedLowRelevance: number;
+}
+
+/**
+ * Fetch similarity candidates, over-fetching by one row beyond the existing
+ * `extraLimit` headroom so we can tell — for free — whether the underlying
+ * FTS match set extends beyond what was fetched.
+ *
+ * We deliberately do NOT run a separate COUNT query for an exact total: the
+ * dedup/self-match/language/pathHint/relevance-pruning filters run in JS
+ * *after* this fetch, so even a precise FTS match count wouldn't equal "the
+ * number of results this tool would actually return" — getting that would
+ * mean dropping the SQL-side LIMIT entirely (a real added cost on a large
+ * repo for a common term), for a number that's still not the true total.
+ * The extra row is trimmed back off immediately so normal result selection
+ * downstream is unaffected — this only adds the `fetchWindowExhausted` signal.
+ */
+async function fetchCandidates(
+  vectorDB: VectorDBInterface,
+  code: string,
+  extraLimit: number,
+): Promise<{ results: SearchResult[]; fetchWindowExhausted: boolean }> {
+  const rawResults = await vectorDB.search(code, extraLimit + 1);
+  return {
+    results: rawResults.slice(0, extraLimit),
+    fetchWindowExhausted: rawResults.length <= extraLimit,
+  };
+}
+
+/**
+ * Build the diagnostic note, if any. Never states a specific total — only
+ * what's actually known (empty, or capped with more possibly available).
+ */
+function buildNote(finalCount: number, hasMore: boolean): string | undefined {
+  if (finalCount === 0) {
+    return '0 results. Ensure the code snippet is at least 24 characters and representative of the pattern. Try grep for exact string matches.';
+  }
+  if (hasMore) {
+    return "More similar matches may exist beyond this page — find_similar doesn't paginate. Raise limit (max 20) or narrow with language/pathHint.";
+  }
+  return undefined;
 }
 
 /**
@@ -38,6 +78,39 @@ function pruneIrrelevantResults(results: SearchResult[]): {
   return { filtered, prunedCount: beforePrune - filtered.length };
 }
 
+/** Drop the input snippet's own chunk from results (exact-content self-match). */
+function excludeSelfMatch(results: SearchResult[], code: string): SearchResult[] {
+  const inputCode = code.trim();
+  return results.filter(r => r.score >= 0.1 || r.content.trim() !== inputCode);
+}
+
+/**
+ * Apply language/pathHint filters and prune low-relevance results,
+ * tracking which filters actually ran for the filtersApplied diagnostic.
+ */
+function applyFilters(
+  results: SearchResult[],
+  language: string | undefined,
+  pathHint: string | undefined,
+): { filtered: SearchResult[]; filtersApplied: FiltersApplied } {
+  let filtered = results;
+  const filtersApplied: FiltersApplied = { prunedLowRelevance: 0 };
+
+  if (language) {
+    filtersApplied.language = language;
+    filtered = applyLanguageFilter(filtered, language);
+  }
+  if (pathHint) {
+    filtersApplied.pathHint = pathHint;
+    filtered = applyPathHintFilter(filtered, pathHint);
+  }
+
+  const pruned = pruneIrrelevantResults(filtered);
+  filtersApplied.prunedLowRelevance = pruned.prunedCount;
+
+  return { filtered: pruned.filtered, filtersApplied };
+}
+
 /**
  * Handle find_similar tool calls.
  *
@@ -53,45 +126,38 @@ export async function handleFindSimilar(args: unknown, ctx: ToolContext): Promis
 
     const limit = validatedArgs.limit ?? 5;
     const extraLimit = limit + 10;
-    let results = await vectorDB.search(validatedArgs.code, extraLimit);
 
-    // Deduplicate and filter out self-matches
-    results = deduplicateResults(results);
-    const inputCode = validatedArgs.code.trim();
-    results = results.filter(r => {
-      if (r.score >= 0.1) return true;
-      return r.content.trim() !== inputCode;
-    });
+    const { results: fetched, fetchWindowExhausted } = await fetchCandidates(
+      vectorDB,
+      validatedArgs.code,
+      extraLimit,
+    );
 
-    const filtersApplied: FiltersApplied = { prunedLowRelevance: 0 };
-
-    // Apply filters sequentially
-    if (validatedArgs.language) {
-      filtersApplied.language = validatedArgs.language;
-      results = applyLanguageFilter(results, validatedArgs.language);
-    }
-
-    if (validatedArgs.pathHint) {
-      filtersApplied.pathHint = validatedArgs.pathHint;
-      results = applyPathHintFilter(results, validatedArgs.pathHint);
-    }
-
-    const { filtered, prunedCount } = pruneIrrelevantResults(results);
-    filtersApplied.prunedLowRelevance = prunedCount;
+    const deduped = excludeSelfMatch(deduplicateResults(fetched), validatedArgs.code);
+    const { filtered, filtersApplied } = applyFilters(
+      deduped,
+      validatedArgs.language,
+      validatedArgs.pathHint,
+    );
 
     const finalResults = filtered.slice(0, limit);
     log(`Found ${finalResults.length} similar chunks`);
 
-    const hasFilters =
-      filtersApplied.language || filtersApplied.pathHint || filtersApplied.prunedLowRelevance > 0;
+    const hasFilters = Boolean(
+      filtersApplied.language || filtersApplied.pathHint || filtersApplied.prunedLowRelevance > 0,
+    );
+    // hasMore is a lower bound, never a fabricated total: true if we already
+    // have more filtered candidates than `limit` shows, OR the underlying
+    // fetch window wasn't proven exhausted (see fetchCandidates).
+    const hasMore = filtered.length > limit || !fetchWindowExhausted;
+    const note = buildNote(finalResults.length, hasMore);
 
     return {
       indexInfo: getIndexMetadata(),
       results: shapeResults(finalResults, 'find_similar'),
+      hasMore,
       ...(hasFilters && { filtersApplied }),
-      ...(finalResults.length === 0 && {
-        note: '0 results. Ensure the code snippet is at least 24 characters and representative of the pattern. Try grep for exact string matches.',
-      }),
+      ...(note && { note }),
     };
   })(args);
 }

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -720,7 +720,12 @@ describe('handleListFunctions', () => {
       expect(parsed.hasMore).toBe(true);
       expect(parsed.nextOffset).toBe(10);
       expect(parsed.note).toBeDefined();
-      expect(parsed.note).toContain('offset:10');
+      expect(parsed.note).toContain('nextOffset');
+      // Never bake a specific offset number into the note: applyResponseBudget
+      // can correct the structured nextOffset field after the fact (see
+      // response-budget.test.ts), but can't safely rewrite a number embedded
+      // in prose — so the note must point at the field, not repeat its value.
+      expect(parsed.note).not.toMatch(/\boffset:\d+/);
       // Never assert a specific "of N" total — the true total isn't computed.
       expect(parsed.note).not.toMatch(/\bof \d+/);
     });
@@ -734,6 +739,45 @@ describe('handleListFunctions', () => {
       expect(parsed.results).toHaveLength(5);
       expect(parsed.hasMore).toBe(false);
       expect(parsed.note).toBeUndefined();
+    });
+
+    it('should correct nextOffset when applyResponseBudget drops items downstream (no paging gap)', async () => {
+      // Regression: a handler-computed nextOffset assumes the full pre-cut
+      // page was delivered (offset + limit). applyResponseBudget runs inside
+      // wrapToolHandler on every real call (exercised end-to-end here, not
+      // mocked away) and can drop items afterward for response size — if
+      // nextOffset isn't corrected to match what was ACTUALLY shown, paging
+      // with it silently skips exactly the items the size cap dropped. Found
+      // dogfooding against sidekiq: a 50-item page collapsed to 23 by the
+      // size cap still advised nextOffset:50, skipping 27 real, never-shown
+      // symbols (confirmed by querying offset:23 directly afterward).
+      const bigContent = 'x'.repeat(2000);
+      const results = Array.from({ length: 40 }, (_, i) => ({
+        content: bigContent,
+        metadata: {
+          file: `s/${i}.ts`,
+          startLine: 1,
+          endLine: 5,
+          type: 'function' as const,
+          language: 'typescript',
+          symbolName: `f${i}`,
+          symbolType: 'function',
+        },
+        score: 1,
+        relevance: 'highly_relevant' as const,
+      }));
+      mockVectorDB.querySymbols.mockResolvedValue(results);
+
+      // 40 candidates, limit 30 -> pre-budget: paginatedResults has 30 items,
+      // hasMore=true, nextOffset=30. Each item is ~2KB, so 30 of them blow
+      // the 12K response budget and applyResponseBudget must drop some.
+      const result = await handleListFunctions({ limit: 30 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results.length).toBeLessThan(30);
+      expect(parsed.hasMore).toBe(true);
+      // Must equal offset(0) + what was actually shown, never offset + limit.
+      expect(parsed.nextOffset).toBe(parsed.results.length);
     });
 
     it('should include pagination metadata in content scan fallback', async () => {

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -683,7 +683,7 @@ describe('handleListFunctions', () => {
       expect(parsed.nextOffset).toBe(15);
     });
 
-    it('should return hasMore=false when all results fit', async () => {
+    it('should return hasMore=false when all results fit, but still include a usable nextOffset', async () => {
       mockVectorDB.querySymbols.mockResolvedValue(makeResults(5));
 
       const result = await handleListFunctions({ limit: 10 }, mockCtx);
@@ -692,7 +692,11 @@ describe('handleListFunctions', () => {
       expect(parsed.results).toHaveLength(5);
 
       expect(parsed.hasMore).toBe(false);
-      expect(parsed.nextOffset).toBeUndefined();
+      // nextOffset is present whenever ANY result is shown, regardless of
+      // hasMore — not just when hasMore is true — so that if a size cap
+      // later forces hasMore true, there's already a field to correct (see
+      // response-budget.ts and the regression test below for why).
+      expect(parsed.nextOffset).toBe(5);
     });
 
     it('should return empty results when offset is beyond result count', async () => {
@@ -778,6 +782,45 @@ describe('handleListFunctions', () => {
       expect(parsed.hasMore).toBe(true);
       // Must equal offset(0) + what was actually shown, never offset + limit.
       expect(parsed.nextOffset).toBe(parsed.results.length);
+    });
+
+    it('adds a usable nextOffset and a note when a genuinely-final page still needs a size-cap drop', async () => {
+      // Regression (CodeRabbit finding on #948): paginateResults only
+      // included `nextOffset` when IT computed hasMore:true. If the
+      // pre-budget page looked final (exactly `limit` items fetched ->
+      // hasMore:false, no nextOffset at all) but its CONTENT is still large
+      // enough for applyResponseBudget to drop items afterward, the forced
+      // hasMore:true had no cursor to correct, because none ever existed.
+      const bigContent = 'x'.repeat(3000);
+      const limit = 20;
+      const results = Array.from({ length: limit }, (_, i) => ({
+        content: bigContent,
+        metadata: {
+          file: `s/${i}.ts`,
+          startLine: 1,
+          endLine: 5,
+          type: 'function' as const,
+          language: 'typescript',
+          symbolName: `f${i}`,
+          symbolType: 'function',
+        },
+        score: 1,
+        relevance: 'highly_relevant' as const,
+      }));
+      // Exactly `limit` items -> dedupedResults.length(20) > offset(0)+limit(20)
+      // is FALSE, so paginateResults computes hasMore:false pre-budget.
+      mockVectorDB.querySymbols.mockResolvedValue(results);
+
+      const result = await handleListFunctions({ limit }, mockCtx);
+      const parsed = JSON.parse(result.content![0].text);
+
+      // 20 * 3000 chars blows the 12K budget, so items must actually drop.
+      expect(parsed.results.length).toBeLessThan(limit);
+      expect(parsed.hasMore).toBe(true);
+      expect(parsed.nextOffset).toBe(parsed.results.length);
+      // Not just "a" note — it must actually point at the (now-present,
+      // now-corrected) cursor, not just describe the size cap in isolation.
+      expect(parsed.note).toContain('nextOffset');
     });
 
     it('should include pagination metadata in content scan fallback', async () => {

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -706,6 +706,36 @@ describe('handleListFunctions', () => {
       expect(parsed.hasMore).toBe(false);
     });
 
+    it('should surface a note when genuinely truncated, without stating a fabricated total', async () => {
+      // Regression test: a full page with more results beyond it used to be
+      // completely silent (no note at all), even though hasMore/nextOffset
+      // were correctly set. See the response-budget fabricated-total bug this
+      // pairs with.
+      mockVectorDB.querySymbols.mockResolvedValue(makeResults(30));
+
+      const result = await handleListFunctions({ limit: 10 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(10);
+      expect(parsed.hasMore).toBe(true);
+      expect(parsed.nextOffset).toBe(10);
+      expect(parsed.note).toBeDefined();
+      expect(parsed.note).toContain('offset:10');
+      // Never assert a specific "of N" total — the true total isn't computed.
+      expect(parsed.note).not.toMatch(/\bof \d+/);
+    });
+
+    it('should not include a truncation note when all results fit (complete, no false total)', async () => {
+      mockVectorDB.querySymbols.mockResolvedValue(makeResults(5));
+
+      const result = await handleListFunctions({ limit: 10 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(5);
+      expect(parsed.hasMore).toBe(false);
+      expect(parsed.note).toBeUndefined();
+    });
+
     it('should include pagination metadata in content scan fallback', async () => {
       mockVectorDB.querySymbols.mockRejectedValue(new Error('fail'));
       mockVectorDB.scanWithFilter.mockResolvedValue(makeResults(30));

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -134,12 +134,15 @@ export async function handleListFunctions(args: unknown, ctx: ToolContext): Prom
         'No results for this page. The offset is beyond the available results; try reducing or resetting the offset to 0.',
       );
     } else if (hasMore) {
-      // Deliberately no item count here: the true total isn't computed (see
-      // paginateResults), and a count captured at this point can go stale if
-      // applyResponseBudget drops further items downstream for response size.
-      // hasMore/nextOffset (top-level fields) are the source of truth.
+      // Deliberately no item count OR offset number baked into this string:
+      // the true total isn't computed (see paginateResults), and BOTH a
+      // count and this nextOffset value can go stale if applyResponseBudget
+      // drops further items downstream for response size — it corrects the
+      // structured `nextOffset` field when that happens, but can't safely
+      // rewrite an arbitrary number embedded in prose. Point at the field
+      // instead of repeating its value, so the two can never disagree.
       notes.push(
-        `More matches exist beyond this page. Use offset:${nextOffset} or narrow pattern/symbolType/language to see them.`,
+        'More matches exist beyond this page. See nextOffset to continue, or narrow pattern/symbolType/language.',
       );
     }
     if (queryResult.method === 'content') {

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -86,6 +86,15 @@ async function queryWithFallback(
 
 /**
  * Deduplicate and paginate results.
+ *
+ * `nextOffset` is included whenever at least one result is shown —
+ * deliberately NOT gated on `hasMore`. A page that looks complete here
+ * (`hasMore: false`, e.g. exactly `limit` items fetched) can still get
+ * items dropped later by applyResponseBudget for response size, which
+ * forces `hasMore` true after the fact; that correction needs an existing
+ * `nextOffset` field to adjust (see response-budget.ts). Always offset +
+ * (what was actually returned), so it's never past the shown items even
+ * before any downstream size-cut.
  */
 function paginateResults(results: SearchResult[], offset: number, limit: number): PaginationResult {
   const dedupedResults = deduplicateResults(results);
@@ -95,7 +104,7 @@ function paginateResults(results: SearchResult[], offset: number, limit: number)
   return {
     paginatedResults,
     hasMore,
-    ...(hasMore ? { nextOffset: offset + limit } : {}),
+    ...(paginatedResults.length > 0 ? { nextOffset: offset + paginatedResults.length } : {}),
   };
 }
 

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -133,6 +133,14 @@ export async function handleListFunctions(args: unknown, ctx: ToolContext): Prom
       notes.push(
         'No results for this page. The offset is beyond the available results; try reducing or resetting the offset to 0.',
       );
+    } else if (hasMore) {
+      // Deliberately no item count here: the true total isn't computed (see
+      // paginateResults), and a count captured at this point can go stale if
+      // applyResponseBudget drops further items downstream for response size.
+      // hasMore/nextOffset (top-level fields) are the source of truth.
+      notes.push(
+        `More matches exist beyond this page. Use offset:${nextOffset} or narrow pattern/symbolType/language to see them.`,
+      );
     }
     if (queryResult.method === 'content') {
       notes.push('Using content search. Run "lien index" to enable faster symbol-based queries.');

--- a/packages/cli/src/mcp/schemas/symbols.schema.ts
+++ b/packages/cli/src/mcp/schemas/symbols.schema.ts
@@ -11,7 +11,11 @@ export const ListFunctionsSchema = z.object({
     .max(200)
     .optional()
     .describe(
-      'Regex pattern to match symbol names.\n\n' +
+      'Regex pattern to match symbol names. Matching is CASE-INSENSITIVE ' +
+        "(e.g. '^Job$' also matches a lowercase job method). Results are not " +
+        'relevance-ranked, so an exact-case symbol can be pushed past the ' +
+        'first page by unrelated lowercase matches; page with offset or ' +
+        "narrow the pattern/symbolType if it doesn't appear.\n\n" +
         'Examples:\n' +
         "  - '.*Controller.*' to find all Controllers\n" +
         "  - 'handle.*' to find handlers\n" +

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -129,7 +129,7 @@ Returns:
 - enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - method: "symbols" | "content" (query method used)
 - hasMore: boolean — true means more results exist beyond this page (never a fabricated total; there is no "total matches" number in this response — only whether more exist and where to find them)
-- nextOffset?: number (offset for next page, when hasMore=true) — always reflects what THIS response actually contains, even when it was also trimmed for size (results.length items shown, none skipped). ALWAYS pass this value back verbatim rather than computing your own offset + limit — the response-size cap can shrink a page after the fact, and only this field is corrected for that.
+- nextOffset?: number — present whenever results is non-empty, REGARDLESS of hasMore (not only when hasMore=true). Always equals offset + results.length actually shown, even when the response was also trimmed for size. ALWAYS pass this value back verbatim rather than computing your own offset + limit — the response-size cap can shrink a page after the fact, and only this field is corrected for that.
 - note?: when hasMore is true, points at nextOffset rather than repeating its value in prose (the same size trimming above can shrink nextOffset after the note text is already written) — trust the nextOffset field, not any number in note`,
   ),
   toMCPToolSchema(

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -54,7 +54,8 @@ Returns:
 - results[]: { content, score, relevance, metadata: { file, startLine, endLine, language?, symbolName?, signature?, enclosingSymbol? } }
 - enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - relevance: "highly_relevant" | "relevant" | "loosely_related" (not_relevant auto-filtered)
-- filtersApplied?: { language?, pathHint?, prunedLowRelevance: number }`,
+- filtersApplied?: { language?, pathHint?, prunedLowRelevance: number }
+- hasMore: boolean — a LOWER BOUND, not a total (this tool doesn't paginate): true means more candidates likely exist beyond what's shown; false means the underlying search was exhausted. Never a fabricated count — raise limit (max 20) or narrow with language/pathHint to see more.`,
   ),
   toMCPToolSchema(
     GetFilesContextSchema,
@@ -119,14 +120,17 @@ Filter by symbol type (function, method, class, interface) to narrow results.
 
 10x faster than search_code for structural/architectural queries. Use search_code instead when searching by what code DOES.
 
+\`pattern\` matching is CASE-INSENSITIVE — '^Job$' also matches a lowercase job method. Results are NOT relevance-ranked (declaration order), so a symbol you expect to see can be pushed past the current page by unrelated lowercase matches that simply appear earlier; page with \`offset\` or narrow \`pattern\`/\`symbolType\`/\`language\` if it doesn't appear.
+
 Results are paginated (default: 50, max: 200). Use \`offset\` to page through large result sets.
 
 Returns:
 - results[]: { content, metadata: { file, startLine, endLine, language?, symbolName?, symbolType?, signature?, enclosingSymbol? } }
 - enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - method: "symbols" | "content" (query method used)
-- hasMore: boolean (more results available)
-- nextOffset?: number (offset for next page, when hasMore=true)`,
+- hasMore: boolean — true means more results exist beyond this page (never a fabricated total; there is no "total matches" number in this response — only whether more exist and where to find them)
+- nextOffset?: number (offset for next page, when hasMore=true)
+- note?: when hasMore is true, explains how to see more (offset/narrower filters) — always trust hasMore/nextOffset over any count mentioned in note, which can describe a smaller page than what's shown if the response was also trimmed for size`,
   ),
   toMCPToolSchema(
     GetDependentsSchema,

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -129,8 +129,8 @@ Returns:
 - enclosingSymbol: "Class.method" for methods, "functionName" for standalone functions, absent for block chunks
 - method: "symbols" | "content" (query method used)
 - hasMore: boolean — true means more results exist beyond this page (never a fabricated total; there is no "total matches" number in this response — only whether more exist and where to find them)
-- nextOffset?: number (offset for next page, when hasMore=true)
-- note?: when hasMore is true, explains how to see more (offset/narrower filters) — always trust hasMore/nextOffset over any count mentioned in note, which can describe a smaller page than what's shown if the response was also trimmed for size`,
+- nextOffset?: number (offset for next page, when hasMore=true) — always reflects what THIS response actually contains, even when it was also trimmed for size (results.length items shown, none skipped). ALWAYS pass this value back verbatim rather than computing your own offset + limit — the response-size cap can shrink a page after the fact, and only this field is corrected for that.
+- note?: when hasMore is true, points at nextOffset rather than repeating its value in prose (the same size trimming above can shrink nextOffset after the note text is already written) — trust the nextOffset field, not any number in note`,
   ),
   toMCPToolSchema(
     GetDependentsSchema,

--- a/packages/cli/src/mcp/utils/response-budget.test.ts
+++ b/packages/cli/src/mcp/utils/response-budget.test.ts
@@ -93,7 +93,10 @@ describe('applyResponseBudget', () => {
     expect(truncation).toBeDefined();
     expect(truncation!.originalItemCount).toBe(50);
     expect(truncation!.finalItemCount).toBeLessThan(50);
-    expect(truncation!.message).toMatch(/^Showing \d+ of 50 results \(truncated\)/);
+    expect(truncation!.message).toMatch(/^Showing \d+ results \(response-size cap;/);
+    // Never claim "of 50" as if 50 were the true match total — it's just
+    // the pre-trim array size this function was handed.
+    expect(truncation!.message).not.toMatch(/\bof 50\b/);
     const res = result as typeof input;
     expect(res.results.length).toBeLessThan(50);
   });
@@ -172,7 +175,7 @@ describe('applyResponseBudget', () => {
     expect(truncation!.finalChars).toBeLessThanOrEqual(DEFAULT_BUDGET);
     expect(truncation!.originalItemCount).toBe(10);
     expect(truncation!.finalItemCount).toBeGreaterThan(0);
-    expect(truncation!.message).toMatch(/Use narrower filters or smaller limit/);
+    expect(truncation!.message).toMatch(/Narrow filters or lower limit/);
   });
 
   it('Phase 1 message says "content trimmed" when no items are dropped', () => {
@@ -189,13 +192,40 @@ describe('applyResponseBudget', () => {
     expect(truncation!.message).toContain('content trimmed to fit');
   });
 
-  it('Phase 2 message says "Showing X of Y" when items are dropped', () => {
+  it('Phase 2 message reports a drop count, never a fabricated total', () => {
     const input = makeResultsResponse(50, 1000);
     const { truncation } = applyResponseBudget(input);
 
     expect(truncation).toBeDefined();
     expect(truncation!.finalItemCount).toBeLessThan(truncation!.originalItemCount);
-    expect(truncation!.message).toMatch(/^Showing \d+ of 50 results \(truncated\)/);
+    expect(truncation!.message).toMatch(/^Showing \d+ results \(response-size cap;/);
+    expect(truncation!.message).toContain('not the underlying match count');
+    expect(truncation!.message).not.toMatch(/\bof 50\b/);
+  });
+
+  it('forces hasMore to true when items are dropped, even if the tool had set it false', () => {
+    const input = { ...makeResultsResponse(50, 1000), hasMore: false };
+    const { result, truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    expect(truncation!.finalItemCount).toBeLessThan(truncation!.originalItemCount);
+    expect((result as { hasMore: boolean }).hasMore).toBe(true);
+  });
+
+  it('does not add a hasMore field where none existed', () => {
+    const input = makeResultsResponse(50, 1000);
+    const { result } = applyResponseBudget(input);
+
+    expect(result as object).not.toHaveProperty('hasMore');
+  });
+
+  it('leaves hasMore untouched when only content is trimmed (no items dropped)', () => {
+    const input = { ...makeResultsResponse(3, 5000), hasMore: false };
+    const { result, truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    expect(truncation!.finalItemCount).toBe(truncation!.originalItemCount);
+    expect((result as { hasMore: boolean }).hasMore).toBe(false);
   });
 
   it('returns unchanged for non-object results', () => {

--- a/packages/cli/src/mcp/utils/response-budget.test.ts
+++ b/packages/cli/src/mcp/utils/response-budget.test.ts
@@ -247,6 +247,44 @@ describe('applyResponseBudget', () => {
     expect(res.nextOffset).toBe(res.results.length);
   });
 
+  it('mentions nextOffset in the message when a cursor is present and gets corrected', () => {
+    const input = { ...makeResultsResponse(50, 1000), hasMore: true, nextOffset: 50 };
+    const { truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    expect(truncation!.message).toContain('nextOffset');
+  });
+
+  it('never mentions nextOffset in the message when no such field exists (other tools)', () => {
+    // get_files_context / get_complexity / search_code / find_similar shapes
+    // have no pagination cursor at all — the message must not reference one
+    // that isn't there.
+    const input = makeResultsResponse(50, 1000);
+    const { truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    expect(truncation!.message).not.toContain('nextOffset');
+  });
+
+  it('corrects nextOffset and forces hasMore even when the page looked complete upstream', () => {
+    // A page that computed hasMore:false (e.g. exactly `limit` items) can
+    // still carry a nextOffset if the tool always includes one whenever any
+    // result is shown (see list-functions.ts's paginateResults). This is
+    // exactly the shape that reaches applyResponseBudget in that case —
+    // confirms the correction works whether hasMore started true or false.
+    const input = { ...makeResultsResponse(50, 1000), hasMore: false, nextOffset: 50 };
+    const { result, truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    const dropped = truncation!.originalItemCount - truncation!.finalItemCount;
+    expect(dropped).toBeGreaterThan(0);
+    const res = result as { hasMore: boolean; nextOffset: number; results: unknown[] };
+    expect(res.hasMore).toBe(true);
+    expect(res.nextOffset).toBe(50 - dropped);
+    expect(res.nextOffset).toBe(res.results.length);
+    expect(truncation!.message).toContain('nextOffset');
+  });
+
   it('does not touch nextOffset when no items are dropped', () => {
     const input = { ...makeResultsResponse(3, 5000), hasMore: false, nextOffset: 3 };
     const { result, truncation } = applyResponseBudget(input);

--- a/packages/cli/src/mcp/utils/response-budget.test.ts
+++ b/packages/cli/src/mcp/utils/response-budget.test.ts
@@ -228,6 +228,41 @@ describe('applyResponseBudget', () => {
     expect((result as { hasMore: boolean }).hasMore).toBe(false);
   });
 
+  it('corrects nextOffset by the drop count so paging never skips dropped items', () => {
+    // Regression: a pagination cursor computed upstream (offset + limit)
+    // assumes the full pre-cut page was delivered. Found dogfooding
+    // list_functions against sidekiq: a 50-item page collapsed to 23 by this
+    // size cap still advised nextOffset:50 — skipping the 27 real items that
+    // were fetched but silently dropped here. nextOffset must shrink by
+    // exactly the drop count instead.
+    const input = { ...makeResultsResponse(50, 1000), hasMore: true, nextOffset: 50 };
+    const { result, truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    const dropped = truncation!.originalItemCount - truncation!.finalItemCount;
+    expect(dropped).toBeGreaterThan(0);
+    const res = result as { nextOffset: number; results: unknown[] };
+    expect(res.nextOffset).toBe(50 - dropped);
+    // The corrected cursor must point exactly at the first item NOT shown.
+    expect(res.nextOffset).toBe(res.results.length);
+  });
+
+  it('does not touch nextOffset when no items are dropped', () => {
+    const input = { ...makeResultsResponse(3, 5000), hasMore: false, nextOffset: 3 };
+    const { result, truncation } = applyResponseBudget(input);
+
+    expect(truncation).toBeDefined();
+    expect(truncation!.finalItemCount).toBe(truncation!.originalItemCount);
+    expect((result as { nextOffset: number }).nextOffset).toBe(3);
+  });
+
+  it('does not add a nextOffset field where none existed', () => {
+    const input = makeResultsResponse(50, 1000);
+    const { result } = applyResponseBudget(input);
+
+    expect(result as object).not.toHaveProperty('nextOffset');
+  });
+
   it('returns unchanged for non-object results', () => {
     const out = applyResponseBudget('just a string');
     expect(out.result).toBe('just a string');

--- a/packages/cli/src/mcp/utils/response-budget.ts
+++ b/packages/cli/src/mcp/utils/response-budget.ts
@@ -127,6 +127,60 @@ function walk(node: unknown, found: Array<Array<{ content: string }>>): void {
   }
 }
 
+/**
+ * Build the truncation message.
+ *
+ * `originalItemCount` is just the size of the array THIS function was
+ * handed — already capped upstream by whatever limit/offset/over-fetch the
+ * tool applied — never the true number of matches in the index. Saying
+ * "of {originalItemCount}" reads as a total and isn't one (see the bug this
+ * fixes: list_functions/find_similar reported "of 50"/"of 200" that was
+ * really just the request's own limit echoed back). State only what this
+ * function actually knows: how many survived ITS OWN size cut, and that
+ * more may exist — never a specific total. `hasPagingCursor` adds a pointer
+ * to the (now-corrected) `nextOffset` field instead of repeating its value.
+ */
+function buildMessage(
+  itemsDropped: boolean,
+  finalItemCount: number,
+  drop: number,
+  hasPagingCursor: boolean,
+): string {
+  if (!itemsDropped) {
+    return `Showing all ${finalItemCount} results (content trimmed to fit response size). Narrow filters or lower limit for full content.`;
+  }
+  const cursorHint = hasPagingCursor ? ' See nextOffset for the next page.' : '';
+  return `Showing ${finalItemCount} results (response-size cap; ${drop} more dropped here — not the underlying match count).${cursorHint} Narrow filters or lower limit for complete results.`;
+}
+
+/**
+ * If items were actually dropped, this response is provably incomplete —
+ * never let a stale `hasMore: false` (set upstream before this size cap
+ * ran) claim otherwise. And if a `nextOffset` pagination cursor is present,
+ * it was computed assuming the full pre-cut page was delivered (offset +
+ * limit) — correct it by the same drop count, or paging with it silently
+ * skips exactly the items this cut just dropped (verified: a dropped-by-25
+ * response advising nextOffset:50 actually needed nextOffset:25 to avoid a
+ * gap). Tool-side prose must never bake in the OLD number here — this is
+ * the only place that can still be corrected after the fact, since
+ * arbitrary note text can't be safely rewritten.
+ *
+ * A page that looked genuinely complete upstream (hasMore:false, so no
+ * nextOffset was ever set) can ALSO still need items dropped here purely
+ * for byte size — list_functions now always includes nextOffset whenever it
+ * shows at least one result (see its paginateResults), specifically so this
+ * correction always has a field to adjust in that case too, instead of
+ * forcing hasMore:true with no cursor at all.
+ */
+function correctPaginationFields(obj: Record<string, unknown>, drop: number): void {
+  if ('hasMore' in obj) {
+    obj.hasMore = true;
+  }
+  if (typeof obj.nextOffset === 'number') {
+    obj.nextOffset -= drop;
+  }
+}
+
 function buildResult(
   cloned: unknown,
   originalChars: number,
@@ -137,37 +191,16 @@ function buildResult(
   const finalChars = measureSize(cloned);
   const finalItemCount = arrays.reduce((sum, arr) => sum + arr.length, 0);
   const itemsDropped = finalItemCount < originalItemCount;
+  const drop = originalItemCount - finalItemCount;
+  const obj = cloned && typeof cloned === 'object' ? (cloned as Record<string, unknown>) : null;
+  // Checked before correctPaginationFields mutates below, purely to shape
+  // the message — presence doesn't change, only the corrected value does.
+  const hasPagingCursor = itemsDropped && obj !== null && typeof obj.nextOffset === 'number';
 
-  // `originalItemCount` is just the size of the array THIS function was
-  // handed — already capped upstream by whatever limit/offset/over-fetch the
-  // tool applied — never the true number of matches in the index. Saying
-  // "of {originalItemCount}" reads as a total and isn't one (see the bug
-  // this fixes: list_functions/find_similar reported "of 50"/"of 200" that
-  // was really just the request's own limit echoed back). State only what
-  // this function actually knows: how many survived ITS OWN size cut, and
-  // that more may exist — never a specific total.
-  const message = itemsDropped
-    ? `Showing ${finalItemCount} results (response-size cap; ${originalItemCount - finalItemCount} more dropped here — not the underlying match count). Narrow filters or lower limit for complete results.`
-    : `Showing all ${finalItemCount} results (content trimmed to fit response size). Narrow filters or lower limit for full content.`;
+  const message = buildMessage(itemsDropped, finalItemCount, drop, hasPagingCursor);
 
-  // If items were actually dropped, this response is provably incomplete —
-  // never let a stale `hasMore: false` (set upstream before this size cap
-  // ran) claim otherwise. And if a `nextOffset` pagination cursor is
-  // present, it was computed assuming the full pre-cut page was delivered
-  // (offset + limit) — correct it by the same drop count, or paging with it
-  // silently skips exactly the items this cut just dropped (verified: a
-  // dropped-by-25 response advising nextOffset:50 actually needed
-  // nextOffset:25 to avoid a gap). Tool-side prose must never bake in the
-  // OLD number here — this is the only place that can still be corrected
-  // after the fact, since arbitrary note text can't be safely rewritten.
-  if (itemsDropped && cloned && typeof cloned === 'object') {
-    const obj = cloned as Record<string, unknown>;
-    if ('hasMore' in obj) {
-      obj.hasMore = true;
-    }
-    if (typeof obj.nextOffset === 'number') {
-      obj.nextOffset -= originalItemCount - finalItemCount;
-    }
+  if (itemsDropped && obj) {
+    correctPaginationFields(obj, drop);
   }
 
   return {

--- a/packages/cli/src/mcp/utils/response-budget.ts
+++ b/packages/cli/src/mcp/utils/response-budget.ts
@@ -152,9 +152,22 @@ function buildResult(
 
   // If items were actually dropped, this response is provably incomplete —
   // never let a stale `hasMore: false` (set upstream before this size cap
-  // ran) claim otherwise.
-  if (itemsDropped && cloned && typeof cloned === 'object' && 'hasMore' in cloned) {
-    (cloned as Record<string, unknown>).hasMore = true;
+  // ran) claim otherwise. And if a `nextOffset` pagination cursor is
+  // present, it was computed assuming the full pre-cut page was delivered
+  // (offset + limit) — correct it by the same drop count, or paging with it
+  // silently skips exactly the items this cut just dropped (verified: a
+  // dropped-by-25 response advising nextOffset:50 actually needed
+  // nextOffset:25 to avoid a gap). Tool-side prose must never bake in the
+  // OLD number here — this is the only place that can still be corrected
+  // after the fact, since arbitrary note text can't be safely rewritten.
+  if (itemsDropped && cloned && typeof cloned === 'object') {
+    const obj = cloned as Record<string, unknown>;
+    if ('hasMore' in obj) {
+      obj.hasMore = true;
+    }
+    if (typeof obj.nextOffset === 'number') {
+      obj.nextOffset -= originalItemCount - finalItemCount;
+    }
   }
 
   return {

--- a/packages/cli/src/mcp/utils/response-budget.ts
+++ b/packages/cli/src/mcp/utils/response-budget.ts
@@ -136,11 +136,26 @@ function buildResult(
 ): { result: unknown; truncation: TruncationInfo } {
   const finalChars = measureSize(cloned);
   const finalItemCount = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const itemsDropped = finalItemCount < originalItemCount;
 
-  const message =
-    finalItemCount < originalItemCount
-      ? `Showing ${finalItemCount} of ${originalItemCount} results (truncated). Use narrower filters or smaller limit for complete results.`
-      : `Showing all ${finalItemCount} results (content trimmed to fit). Use narrower filters or smaller limit for complete results.`;
+  // `originalItemCount` is just the size of the array THIS function was
+  // handed — already capped upstream by whatever limit/offset/over-fetch the
+  // tool applied — never the true number of matches in the index. Saying
+  // "of {originalItemCount}" reads as a total and isn't one (see the bug
+  // this fixes: list_functions/find_similar reported "of 50"/"of 200" that
+  // was really just the request's own limit echoed back). State only what
+  // this function actually knows: how many survived ITS OWN size cut, and
+  // that more may exist — never a specific total.
+  const message = itemsDropped
+    ? `Showing ${finalItemCount} results (response-size cap; ${originalItemCount - finalItemCount} more dropped here — not the underlying match count). Narrow filters or lower limit for complete results.`
+    : `Showing all ${finalItemCount} results (content trimmed to fit response size). Narrow filters or lower limit for full content.`;
+
+  // If items were actually dropped, this response is provably incomplete —
+  // never let a stale `hasMore: false` (set upstream before this size cap
+  // ran) claim otherwise.
+  if (itemsDropped && cloned && typeof cloned === 'object' && 'hasMore' in cloned) {
+    (cloned as Record<string, unknown>).hasMore = true;
+  }
 
   return {
     result: cloned,


### PR DESCRIPTION
## Bug

`list_functions`/`find_similar` truncation notes were both dishonest and, worse, sometimes silent:

1. **Fabricated total.** `applyResponseBudget` (the byte-size-cap helper `wrapToolHandler` runs on *every* tool response) built its `"Showing X of Y results"` note from whatever array the handler handed it — an array already capped by the request's own `limit`/`offset`. Whenever the true match count exceeded that cap, `Y` came out numerically identical to the request's `limit`, so the "total" was really just the request echoed back.
2. **Silent truncation.** When that capped array happened to fit under the byte budget, the helper no-opped entirely — no note at all — even for a genuinely-truncated page where `hasMore`/`nextOffset` were already correctly set.

## Root cause

**One shared helper** (`packages/cli/src/mcp/utils/response-budget.ts`), confirmed by grepping the whole `packages/cli/src/mcp` tree for `"Showing"` — no tool-specific handler builds this kind of message itself. That's why the same signature showed up independently in both `list_functions` and `find_similar`.

## Fix

- **`response-budget.ts`**: never states a total anymore. It reports only what it actually knows — how many items survived *its own* size cut, and how many it dropped — and explicitly disclaims that the "before" count is not the underlying match total. If the response object has a `hasMore` field, dropping items now forces it `true` (a stale `hasMore:false` set upstream can never survive a later size-cut silently).
- **`list-functions.ts`**: adds the missing note for the previously-silent "full page, more exist" case. Deliberately doesn't cite an item count in that note — a count captured here could go stale if `applyResponseBudget` drops further items downstream. `hasMore`/`nextOffset` (already correct) remain the source of truth.
- **`find-similar.ts`**: adds a `hasMore` field via a cheap 1-row SQL over-fetch (same trick `list_functions` already uses), instead of a real `COUNT` query. Decision + reasoning below.
- **`symbols.schema.ts` / `tools.ts`**: documents that `list_functions`'s `pattern` matching is case-insensitive and results are unranked (declaration order) — a real symbol can be pushed behind unrelated lowercase matches.

### Total: computed for free vs. not worth a query

`querySymbols`/`scanWithFilter` (SqliteBackend) currently read the *entire* table and filter in JS before slicing to `limit` — no SQL `LIMIT` at all — so the true total is, today, sitting in memory for free. I considered threading it through, but rejected it:
- It's an **accidental implementation detail**, not part of the interface contract — a reasonable future optimization (e.g. pushing the pattern filter into SQL) could reintroduce exactly this bug silently if code depended on "secretly returns everything."
- `scanWithFilter` alone has ~10 call sites across `packages/cli` and `packages/core` (get_files_context, get_complexity, get_dependents, the CLI complexity command, dependency-analyzer, …) — changing its return shape is a much bigger blast radius than this bug warrants.
- The brief's own suggested default remedy — "capped at N, more may exist, make `hasMore` truthful" — already fully closes both defects without touching any signature.

For `find_similar`, an exact total would need a **real, separate `COUNT` query** (find_similar's SQL layer *does* apply a hard `LIMIT`, unlike list_functions). I chose not to add it: the dedup/self-match/language/pathHint/relevance-pruning filters all run in JS *after* the fetch, so even a precise FTS match count wouldn't equal "the number of results this tool would actually return" — spending a real query for a number that's still not the true total isn't a good trade. The 1-row over-fetch gives an honest, free lower-bound `hasMore` instead.

### Case-insensitivity: documented, not changed

Confirmed: `safeRegex` (`packages/core/src/utils/safe-regex.ts`) always compiles with the `i` flag, used by both `list_functions`'s pattern matching and `scanWithFilter`. It has 22 dependents — changing match semantics is a real breaking change for existing callers, and per the repro below, the bigger practical harm (a present symbol looking absent) came from the fabricated total, which this PR fixes. Documented case-insensitivity plus the (also-now-documented) fact that results are unranked in `symbols.schema.ts` and `tools.ts`.

## Addendum 1: nextOffset could skip budget-dropped items (found in review, fixed `dc5ba183`)

A reviewer caught a second-order gap: `list_functions`'s pagination cursor (`nextOffset = offset + limit`) assumed the full pre-cut page was delivered. When `applyResponseBudget` drops items *after* that cursor was computed, the cursor still pointed past the dropped items — advising an offset that would silently skip them. Verified live against sidekiq: a 50-item page collapsed to 24 by the size cap still advised `nextOffset:50`; querying `offset:24` directly afterward surfaced 26 real, never-shown symbols that `offset:50` would have skipped entirely.

Also checked whether `list_functions` ordering is even stable enough for offset-based paging to be sound at all: an identical repeat query against an unchanged index returned identical items in identical order, so ordering is deterministic. (A reviewer's own repro showing two different offsets landing on the same symbol most likely reflects the shared dogfood corpus being reindexed by another concurrently-running agent between their sequential calls, not nondeterminism in this ordering — the corpus is explicitly shared across concurrent agents.)

Fix: `applyResponseBudget` now corrects `nextOffset` by the same drop count it uses to force `hasMore: true`, so the cursor always equals `offset + (items actually delivered)`. Also removed the offset *number* `list_functions` baked into its own note string — a number embedded in prose can't be corrected after the fact the way a structured field can (this would otherwise have left the note and the field disagreeing: note says "use offset:50", field correctly says 24). The note now points at the `nextOffset` field instead of repeating its value.

## Addendum 2: a genuinely-final page could still lack any cursor at all (CodeRabbit finding, fixed `1255be4f`)

CodeRabbit flagged a residual gap in addendum 1's fix, and I reproduced it with a directed test before touching anything (a reviewer had tried and correctly couldn't reproduce it at runtime — every live page they tried legitimately had `hasMore:true` with a correct cursor already, because it's a narrow boundary condition):

`paginateResults` only ever included `nextOffset` in its own output when **it** computed `hasMore:true`. A page that looks genuinely complete there — e.g. exactly `limit` items fetched, so `hasMore:false` and no `nextOffset` at all — can still have `applyResponseBudget` drop items afterward purely for byte size. In that case the size-cap correctly forces `hasMore:true` (addendum 1's fix), but `typeof nextOffset === 'number'` was false, so there was nothing to correct — the client got `hasMore:true` with **no `nextOffset`**. There *was* still a note (response-budget's generic size-cap message always gets appended by `tool-wrapper.ts` regardless), just not `list-functions.ts`'s own pagination-specific one, since that branch had already evaluated `hasMore:false` before the cap ran, and the generic note had nothing to point at since no cursor existed.

Confirmed directly with a test: mocking exactly `limit` (20) large (~3KB) results and calling with that same `limit` — pre-fix, the response came back `hasMore:true`, `note: "Showing 3 results (response-size cap; 17 more dropped here...)"`, and `nextOffset: undefined`.

Fix: `paginateResults` now includes `nextOffset` (`offset + results actually shown`) whenever there's at least one result, decoupled from `hasMore` entirely. `hasMore` stays the "is it worth paging" signal; `nextOffset` is now unconditionally the "where would I resume" value, so `applyResponseBudget`'s correction always has a field to adjust. Also had `response-budget.ts` mention `nextOffset` directly in its own message when it corrects one (since `list-functions.ts`'s own note doesn't fire on this exact path). Extracted `buildMessage`/`correctPaginationFields` out of `buildResult` to keep it readable as this logic accumulated across three rounds.

## Dogfood evidence (sidekiq, foreign repo, my own build — `node packages/cli/dist/index.js index --force` before every measurement)

`list_functions({ pattern: ".*" })`:

**Before** (HEAD, pre-fix):
```
limit=10  results=10 hasMore=true  nextOffset=10  note=undefined
limit=50  results=24 hasMore=true  nextOffset=50  note="Showing 24 of 50 results (truncated). Use narrower filters or smaller limit for complete results."
limit=200 results=24 hasMore=true  nextOffset=200 note="Showing 24 of 200 results (truncated). Use narrower filters or smaller limit for complete results."
```

**After** (this branch, current HEAD `1255be4f`):
```
limit=50, offset=0  results=24 hasMore=true nextOffset=24
  note="More matches exist beyond this page. See nextOffset to continue, or narrow pattern/symbolType/language.
        Showing 24 results (response-size cap; 26 more dropped here — not the underlying match count). See nextOffset for the next page. Narrow filters or lower limit for complete results."
```

`limit:10` is no longer silent; no note implies "50"/"200" is a real total (the real total, confirmed by paging with `limit:20` to exhaustion, is **703** indexed symbols — not the 23-24 either a reviewer or I originally assumed from a byte-budget-truncated read); and `nextOffset` (24, not 50) now points exactly at the first item not shown — confirmed by querying `offset:24` directly and diffing against the `offset:0` page: no gap, no overlap.

`find_similar` (same repo, after fix):
```
limit=3  results=3 hasMore=true note="More similar matches may exist beyond this page — find_similar doesn't paginate. Raise limit (max 20) or narrow with language/pathHint."
limit=20 results=8 hasMore=true note="More similar matches may exist beyond this page — find_similar doesn't paginate. Raise limit (max 20) or narrow with language/pathHint."
```

Case-insensitivity repro (`list_functions({ pattern: "^Job$", language: "ruby" })`): matches lowercase `job` at `lib/sidekiq/api.rb:1338` alongside 7 real `Job` class definitions — confirms the reported behavior, now documented in the schema/tool description.

## Testing

- Truncated-with-note, complete-with-no-false-total, and `hasMore` correctness in both directions (`list-functions.test.ts`, `find-similar.test.ts`).
- `response-budget.test.ts`: forced-`hasMore`-true behavior, new message wording, `nextOffset` correction, and the message's conditional "see nextOffset" hint.
- Two end-to-end regression tests in `list-functions.test.ts` that exercise the real `wrapToolHandler`/`applyResponseBudget` pipeline (not a mock) with oversized content to force an actual budget drop — one for a page that started `hasMore:true`, one for a page that started `hasMore:false` (the CodeRabbit-found gap).
- All six gates green locally: `format:check`, `lint` (0 errors), `typecheck`, `build`, `test` (all workspaces), `lien delta` (exit 0 against both `HEAD` and `origin/main` — some functions show a complexity increase but none crosses its threshold).

## Test plan
- [x] CI green
- [x] Dogfooded against a foreign repo (sidekiq) with own build, before/after evidence above
- [ ] Triage Lien Review findings before merge

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes MCP tool responses that were fabricating result totals or silently omitting truncation notes. The changes are localized to response-budget handling, list_functions pagination messaging, and find_similar's honest lower-bound hasMore signal. All modified logic is covered by targeted unit tests, and the documentation in schemas/tools now accurately describes case-insensitive matching and unranked results.
>
> - applyResponseBudget no longer reports a fabricated 'of Y' total; it reports only items that survived its own size cap and forces hasMore:true when items are dropped.
> - list_functions now surfaces a note for the previously-silent 'full page with more results' case, without citing a stale item count.
> - find_similar adds a cheap +1 over-fetch to produce an honest hasMore lower bound instead of a fabricated total.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1255be4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

