### PR TITLE
fix(parser): Ruby modules invisible as symbols; nested types lose parentClass

### DIFF
--- a/.changeset/ruby-module-nested-parent-class.md
+++ b/.changeset/ruby-module-nested-parent-class.md
@@ -1,0 +1,61 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Two symbol-extraction gaps (#949), both reproduced against the published
+0.72.0 artifact on foreign repos and confirmed to still repro on the
+published binary before this fix:
+
+**Ruby `module` declarations were invisible as symbols.** `list_functions`
+could not find `module Sidekiq` (sidekiq's own root namespace, at
+`lib/sidekiq.rb:42`) or `module Job` (its central job mixin) at all — a
+regex query for either returned zero hits. Root cause: `RubyTraverser`
+treats `module` as a transparent namespace so `module → class → method`
+still yields method chunks (deliberately, to avoid breaking the container
+depth budget `isTargetNode` enforces), but that meant the module's own AST
+node was never pushed to the chunker's node list, so it never became a
+chunk/symbol at all — the dead `case 'module'` branch in
+`RubySymbolExtractor.extractSymbol` was structurally unreachable. Fixed by
+adding a `transparentContainerTypes` field to `LanguageTraverser` (optional,
+undefined for every other language — a no-op): the chunker now emits a
+chunk for a node in this list while still traversing its children at the
+same depth, keeping the transparency for nested content. Module contents
+(nested classes/methods) were never the problem — they were already fully
+indexed; only the module's own entry was missing.
+
+`module`'s `symbolType` is `interface`, not `class` — a Ruby module can
+never be instantiated, so `class` would misdescribe it. `interface` is an
+imperfect but honest fit (closest of the four existing `SymbolInfo` types
+to a mixin contributing shared behavior, similar to a Rust trait), chosen
+over adding a fifth `module` type to avoid rippling into the `symbolType`
+filter, MCP schemas, and every consumer of the closed four-value enum — the
+same tradeoff `csharp.ts` made mapping properties to `method` rather than
+adding a `property` type.
+
+**Nested type declarations never reported a `parentClass`.** A type
+declared directly inside another type (Java/C#'s `public static class
+Builder` nested in `Retrofit`, `RequestFactory`, etc. — confirmed on
+square/retrofit; C#'s `ContextStackBookmark` nested in `LogContext`,
+`SelfLogFailureListener` nested in `SelfLog` — confirmed on
+serilog/serilog) always reported `parentClass: null`, making
+same-named nested types (six `Builder` results) indistinguishable except
+by file path. Root cause: the chunker already resolves the enclosing
+type's name for every top-level node via `findParentContainerName` (not
+just methods), but each language's `extractClassInfo`/`extractInterfaceInfo`/
+etc. either didn't accept the parameter at all or silently dropped it.
+Fixed for C#, Java, Python, Swift, and Kotlin (all of which support real
+nested type declarations) by threading `parentClass` through every
+type-declaration handler, the same way it already worked for methods. The
+existing `enclosingSymbol` MCP metadata field is derived from `parentClass`
++ `symbolName`, so it's fixed for free with no separate change.
+
+Not fixed (no repro path, confirmed by traverser inspection): JavaScript/
+TypeScript (no `class_declaration`-in-`class_declaration` construct — a TS
+namespace nesting classes is a related, separate, still-open gap), PHP (no
+nested class-declaration construct), Go (flat structure by design, no
+containers at all), Rust (`impl`/`trait` blocks cannot nest in valid Rust;
+a `mod` nested in another `mod` doesn't interact with `parentClass` since
+`mod` isn't a class-like container — though Rust's `mod` shares Ruby's
+Bug 1 shape, invisible as its own symbol, which is out of scope here and
+left as a follow-up).

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -373,6 +373,17 @@ function findTopLevelNodes(
       return;
     }
 
+    // Transparent containers (e.g. Ruby's `module`): emit a chunk for the
+    // node itself, but — unlike shouldExtractChildren above — keep
+    // traversing its children at the SAME depth instead of depth + 1. That's
+    // what makes them "transparent" for the depth budget `isTargetNode`
+    // enforces: a class (or method) nested inside one must still be found as
+    // if the transparent container weren't there. See
+    // `LanguageTraverser.transparentContainerTypes`'s doc comment.
+    if (traverser.transparentContainerTypes?.includes(node.type)) {
+      nodes.push(node);
+    }
+
     // Traverse children of traversable nodes
     if (!traverser.shouldTraverseChildren(node)) return;
     for (const child of node.namedChildren) {

--- a/packages/parser/src/ast/languages/csharp.test.ts
+++ b/packages/parser/src/ast/languages/csharp.test.ts
@@ -462,6 +462,56 @@ using Newtonsoft.Json;
       expect(symbol!.signature).toBe('enum Color');
     });
 
+    // #949: a nested type declaration (class/interface/struct/record/enum
+    // declared directly inside another type) previously reported
+    // parentClass: undefined regardless of nesting — only the
+    // method/property handlers accepted the parameter. These pin that every
+    // type-declaration handler now carries it through, the same way it
+    // already worked for methods.
+    it('should attach the enclosing type as parentClass for a nested class_declaration', () => {
+      const code = 'public class Outer { public class Inner {} }';
+      const root = mustParse(code, 'csharp');
+      const innerNode = findAllNodes(root, 'class_declaration')[1]!;
+      const symbol = symbolExtractor.extractSymbol(innerNode, code, 'Outer');
+      expect(symbol!.name).toBe('Inner');
+      expect(symbol!.type).toBe('class');
+      expect(symbol!.parentClass).toBe('Outer');
+    });
+
+    it('should attach the enclosing type as parentClass for a nested interface_declaration', () => {
+      const code = 'public class Outer { public interface IInner {} }';
+      const root = mustParse(code, 'csharp');
+      const ifaceNode = findNode(root, 'interface_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(ifaceNode, code, 'Outer');
+      expect(symbol!.parentClass).toBe('Outer');
+    });
+
+    it('should attach the enclosing type as parentClass for a nested struct/record/enum', () => {
+      const structCode = 'public class Outer { public struct Inner {} }';
+      const structSymbol = symbolExtractor.extractSymbol(
+        findNode(mustParse(structCode, 'csharp'), 'struct_declaration')!,
+        structCode,
+        'Outer',
+      );
+      expect(structSymbol!.parentClass).toBe('Outer');
+
+      const recordCode = 'public class Outer { public record Inner(string Name) {} }';
+      const recordSymbol = symbolExtractor.extractSymbol(
+        findNode(mustParse(recordCode, 'csharp'), 'record_declaration')!,
+        recordCode,
+        'Outer',
+      );
+      expect(recordSymbol!.parentClass).toBe('Outer');
+
+      const enumCode = 'public class Outer { public enum Inner { A, B } }';
+      const enumSymbol = symbolExtractor.extractSymbol(
+        findNode(mustParse(enumCode, 'csharp'), 'enum_declaration')!,
+        enumCode,
+        'Outer',
+      );
+      expect(enumSymbol!.parentClass).toBe('Outer');
+    });
+
     it('should extract return type from method', () => {
       const code = `public class Foo {
     public string GetName() { return ""; }
@@ -690,6 +740,24 @@ using Newtonsoft.Json;
       );
       expect(ctorChunk).toBeDefined();
       expect(ctorChunk?.metadata.parentClass).toBe('User');
+    });
+
+    // #949 end-to-end repro: a nested class (`public static class Builder`
+    // inside `public class Retrofit`) previously reported parentClass: null,
+    // making it indistinguishable from an unrelated same-named nested
+    // `Builder` in a different file.
+    it('should attach the enclosing class as parentClass for a nested class chunk', () => {
+      const content = `public class Retrofit {
+    public static class Builder {
+        public Retrofit Build() { return null; }
+    }
+}`;
+
+      const chunks = chunkByAST('Retrofit.cs', content);
+      const builderChunk = chunks.find(c => c.metadata.symbolName === 'Builder');
+      expect(builderChunk).toBeDefined();
+      expect(builderChunk?.metadata.symbolType).toBe('class');
+      expect(builderChunk?.metadata.parentClass).toBe('Retrofit');
     });
 
     it('should chunk C# interfaces', () => {

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -359,6 +359,17 @@ export class CSharpImportExtractor implements LanguageImportExtractor {
  * - property_declaration (public string Name { get; set; } / public int Count => …)
  * - indexer_declaration (public int this[int index] { get; set; })
  *
+ * `parentClass` is threaded into every type-declaration handler (not just
+ * methods/properties) so a nested type (`public class Retrofit { public class
+ * Builder { ... } }`) reports its enclosing type — the chunker
+ * (`ast/chunker.ts`'s `processTopLevelNode`) already resolves this via
+ * `CSharpTraverser.findParentContainerName` for every top-level node
+ * regardless of kind; previously only the method/property handlers accepted
+ * the parameter, so a nested class/interface/struct/record/enum silently lost
+ * it (#949 — surfaced as `list_functions` being unable to tell one nested
+ * `Builder` from an unrelated same-named nested `Builder` elsewhere in the
+ * codebase).
+ *
  * Call sites: invocation_expression (direct calls and obj.Method() calls)
  */
 export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
@@ -381,15 +392,15 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       case 'constructor_declaration':
         return this.extractConstructorInfo(node, content, parentClass);
       case 'class_declaration':
-        return this.extractClassInfo(node);
+        return this.extractClassInfo(node, parentClass);
       case 'interface_declaration':
-        return this.extractInterfaceInfo(node);
+        return this.extractInterfaceInfo(node, parentClass);
       case 'struct_declaration':
-        return this.extractStructInfo(node);
+        return this.extractStructInfo(node, parentClass);
       case 'record_declaration':
-        return this.extractRecordInfo(node);
+        return this.extractRecordInfo(node, parentClass);
       case 'enum_declaration':
-        return this.extractEnumInfo(node);
+        return this.extractEnumInfo(node, parentClass);
       case 'property_declaration':
       case 'indexer_declaration':
         return this.extractPropertyInfo(node, content, parentClass);
@@ -499,7 +510,7 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -508,11 +519,12 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `class ${nameNode.text}`,
     };
   }
 
-  private extractInterfaceInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractInterfaceInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -521,11 +533,12 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       type: 'interface',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `interface ${nameNode.text}`,
     };
   }
 
-  private extractStructInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractStructInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -534,11 +547,12 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `struct ${nameNode.text}`,
     };
   }
 
-  private extractRecordInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractRecordInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -547,11 +561,12 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `record ${nameNode.text}`,
     };
   }
 
-  private extractEnumInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractEnumInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -560,6 +575,7 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `enum ${nameNode.text}`,
     };
   }

--- a/packages/parser/src/ast/languages/java.test.ts
+++ b/packages/parser/src/ast/languages/java.test.ts
@@ -429,6 +429,49 @@ describe('Java Language', () => {
       expect(symbol!.signature).toBe('record Point');
     });
 
+    // #949: a nested type declaration (class/interface/enum/record declared
+    // directly inside another type) previously reported parentClass:
+    // undefined regardless of nesting — only the method/constructor handlers
+    // accepted the parameter. This is the confirmed real-world repro
+    // (Retrofit's `Retrofit.Builder`, `RequestFactory.Builder`, etc. all
+    // reported parentClass: null, making six same-named `Builder` results
+    // indistinguishable except by file path).
+    it('should attach the enclosing type as parentClass for a nested class_declaration', () => {
+      const code = 'public class Retrofit { public static final class Builder {} }';
+      const root = mustParse(code, 'java');
+      const innerNode = findAllNodes(root, 'class_declaration')[1]!;
+      const symbol = symbolExtractor.extractSymbol(innerNode, code, 'Retrofit');
+      expect(symbol!.name).toBe('Builder');
+      expect(symbol!.type).toBe('class');
+      expect(symbol!.parentClass).toBe('Retrofit');
+    });
+
+    it('should attach the enclosing type as parentClass for a nested interface/enum/record', () => {
+      const ifaceCode = 'public class Outer { public interface Inner {} }';
+      const ifaceSymbol = symbolExtractor.extractSymbol(
+        findNode(mustParse(ifaceCode, 'java'), 'interface_declaration')!,
+        ifaceCode,
+        'Outer',
+      );
+      expect(ifaceSymbol!.parentClass).toBe('Outer');
+
+      const enumCode = 'public class Outer { public enum Inner { A, B } }';
+      const enumSymbol = symbolExtractor.extractSymbol(
+        findNode(mustParse(enumCode, 'java'), 'enum_declaration')!,
+        enumCode,
+        'Outer',
+      );
+      expect(enumSymbol!.parentClass).toBe('Outer');
+
+      const recordCode = 'public class Outer { public record Inner(String name) {} }';
+      const recordSymbol = symbolExtractor.extractSymbol(
+        findNode(mustParse(recordCode, 'java'), 'record_declaration')!,
+        recordCode,
+        'Outer',
+      );
+      expect(recordSymbol!.parentClass).toBe('Outer');
+    });
+
     it('should extract return type from method', () => {
       const code = `public class Foo {
     public String getName() { return ""; }
@@ -550,6 +593,24 @@ describe('Java Language', () => {
       );
       expect(ctorChunk).toBeDefined();
       expect(ctorChunk?.metadata.parentClass).toBe('User');
+    });
+
+    // #949 end-to-end repro: a nested class (`public static final class
+    // Builder` inside `public class Retrofit`) previously reported
+    // parentClass: null via list_functions, making it indistinguishable from
+    // an unrelated same-named nested `Builder` in a different file.
+    it('should attach the enclosing class as parentClass for a nested class chunk', () => {
+      const content = `public class Retrofit {
+    public static final class Builder {
+        public Retrofit build() { return null; }
+    }
+}`;
+
+      const chunks = chunkByAST('Retrofit.java', content);
+      const builderChunk = chunks.find(c => c.metadata.symbolName === 'Builder');
+      expect(builderChunk).toBeDefined();
+      expect(builderChunk?.metadata.symbolType).toBe('class');
+      expect(builderChunk?.metadata.parentClass).toBe('Retrofit');
     });
 
     it('should chunk Java interfaces', () => {

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -326,6 +326,17 @@ export class JavaImportExtractor implements LanguageImportExtractor {
  * - enum_declaration (enum MyEnum {})
  * - record_declaration (record MyRecord(int x) {})
  *
+ * `parentClass` is threaded into every type-declaration handler (not just
+ * methods/constructors) so a nested type (`class Retrofit { public static
+ * final class Builder { ... } }`) reports its enclosing type — the chunker
+ * (`ast/chunker.ts`'s `processTopLevelNode`) already resolves this via
+ * `JavaTraverser.findParentContainerName` for every top-level node regardless
+ * of kind; previously only the method/constructor handlers accepted the
+ * parameter, so a nested class/interface/enum/record silently lost it (#949 —
+ * this is the confirmed repro: `Retrofit.Builder`, `RequestFactory.Builder`,
+ * etc. all reported `parentClass: null`, making six same-named `Builder`
+ * results indistinguishable except by file path).
+ *
  * Call sites: method_invocation (direct calls and object.method() calls)
  */
 export class JavaSymbolExtractor implements LanguageSymbolExtractor {
@@ -345,13 +356,13 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       case 'constructor_declaration':
         return this.extractConstructorInfo(node, content, parentClass);
       case 'class_declaration':
-        return this.extractClassInfo(node);
+        return this.extractClassInfo(node, parentClass);
       case 'interface_declaration':
-        return this.extractInterfaceInfo(node);
+        return this.extractInterfaceInfo(node, parentClass);
       case 'enum_declaration':
-        return this.extractEnumInfo(node);
+        return this.extractEnumInfo(node, parentClass);
       case 'record_declaration':
-        return this.extractRecordInfo(node);
+        return this.extractRecordInfo(node, parentClass);
       default:
         return null;
     }
@@ -419,7 +430,7 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -428,11 +439,12 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `class ${nameNode.text}`,
     };
   }
 
-  private extractInterfaceInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractInterfaceInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -441,11 +453,12 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       type: 'interface',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `interface ${nameNode.text}`,
     };
   }
 
-  private extractEnumInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractEnumInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -454,11 +467,12 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `enum ${nameNode.text}`,
     };
   }
 
-  private extractRecordInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractRecordInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -467,6 +481,7 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `record ${nameNode.text}`,
     };
   }

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -241,6 +241,28 @@ describe('Kotlin Language', () => {
       expect(obj).toMatchObject({ name: 'Registry', type: 'class', signature: 'object Registry' });
     });
 
+    // #949: nested/inner classes and objects are idiomatic in Kotlin, but
+    // extractClassInfo/extractObjectInfo previously ignored the parentClass
+    // argument entirely — a nested type always reported parentClass:
+    // undefined regardless of nesting.
+    it('attaches the enclosing class as parentClass for a nested class declaration', () => {
+      const src = 'class Outer {\n  class Inner {}\n}\n';
+      const nodes = findAllNodes(parse(src), 'class_declaration');
+      const inner = nodes[1]!;
+      const sym = symbolExtractor.extractSymbol(inner, src, 'Outer')!;
+      expect(sym.name).toBe('Inner');
+      expect(sym.type).toBe('class');
+      expect(sym.parentClass).toBe('Outer');
+    });
+
+    it('attaches the enclosing class as parentClass for a nested object declaration', () => {
+      const src = 'class Outer {\n  object Inner {}\n}\n';
+      const objNode = findNode(parse(src), 'object_declaration')!;
+      const sym = symbolExtractor.extractSymbol(objNode, src, 'Outer')!;
+      expect(sym.name).toBe('Inner');
+      expect(sym.parentClass).toBe('Outer');
+    });
+
     it('extracts call sites for direct and navigation calls', () => {
       const src = 'fun run() {\n  foo()\n  obj.bar.baz()\n}\n';
       const calls = findAllNodes(parse(src), 'call_expression');
@@ -312,6 +334,18 @@ fun topLevelHelper(x: Int): Int = x + 1
       const place = bySymbol('place', 'method');
       expect(place).toBeDefined();
       expect(place?.metadata.complexity ?? 0).toBeGreaterThan(1);
+    });
+
+    // #949: nested/inner classes are idiomatic in Kotlin; a nested class
+    // declaration previously reported parentClass: undefined regardless of
+    // nesting.
+    it('attaches the enclosing class as parentClass for a nested class chunk', () => {
+      const nestedSource = 'class Outer {\n  class Inner {\n    val x: Int = 0\n  }\n}\n';
+      const nestedChunks = chunkByAST('Outer.kt', nestedSource);
+      const inner = nestedChunks.find(c => c.metadata.symbolName === 'Inner');
+      expect(inner).toBeDefined();
+      expect(inner?.metadata.symbolType).toBe('class');
+      expect(inner?.metadata.parentClass).toBe('Outer');
     });
   });
 });

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -395,9 +395,9 @@ export class KotlinSymbolExtractor implements LanguageSymbolExtractor {
       case 'function_declaration':
         return this.extractFunctionInfo(node, content, parentClass);
       case 'class_declaration':
-        return this.extractClassInfo(node);
+        return this.extractClassInfo(node, parentClass);
       case 'object_declaration':
-        return this.extractObjectInfo(node);
+        return this.extractObjectInfo(node, parentClass);
       default:
         return null;
     }
@@ -444,23 +444,30 @@ export class KotlinSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: SyntaxNode): SymbolInfo | null {
+  /**
+   * `parentClass` is threaded through so a nested/inner class or object —
+   * idiomatic in Kotlin (`class Outer { class Nested { ... } }`,
+   * `class Outer { inner class Inner { ... } }`) — reports its enclosing
+   * type. `KotlinTraverser.findParentContainerName` already resolves this for
+   * every top-level node, not just functions (#949).
+   */
+  private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
 
     if (hasTokenChild(node, 'interface')) {
-      return this.makeSymbol(node, name, 'interface', `interface ${name}`);
+      return this.makeSymbol(node, name, 'interface', `interface ${name}`, parentClass);
     }
     if (hasTokenChild(node, 'enum')) {
-      return this.makeSymbol(node, name, 'class', `enum class ${name}`);
+      return this.makeSymbol(node, name, 'class', `enum class ${name}`, parentClass);
     }
-    return this.makeSymbol(node, name, 'class', `class ${name}`);
+    return this.makeSymbol(node, name, 'class', `class ${name}`, parentClass);
   }
 
-  private extractObjectInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractObjectInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
-    return this.makeSymbol(node, name, 'class', `object ${name}`);
+    return this.makeSymbol(node, name, 'class', `object ${name}`, parentClass);
   }
 
   private makeSymbol(
@@ -468,12 +475,14 @@ export class KotlinSymbolExtractor implements LanguageSymbolExtractor {
     name: string,
     type: SymbolInfo['type'],
     signature: string,
+    parentClass?: string,
   ): SymbolInfo {
     return {
       name,
       type,
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature,
     };
   }

--- a/packages/parser/src/ast/languages/python.test.ts
+++ b/packages/parser/src/ast/languages/python.test.ts
@@ -437,6 +437,23 @@ describe('Python Language', () => {
       expect(symbol!.signature).toBe('class Calculator');
     });
 
+    // #949: a nested class declared directly inside another class's body
+    // previously reported parentClass: undefined regardless of nesting —
+    // extractClassInfo didn't accept the parameter at all, even though
+    // PythonTraverser.findParentContainerName already resolves the enclosing
+    // class name for every top-level node, not just methods.
+    it('should attach the enclosing class as parentClass for a nested class_definition', () => {
+      const code = 'class Outer:\n    class Inner:\n        pass\n';
+      const root = mustParse(code, 'python');
+      const outerBody = root.namedChild(0)!.childForFieldName('body')!;
+      const innerNode = outerBody.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(innerNode, code, 'Outer');
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('Inner');
+      expect(symbol!.type).toBe('class');
+      expect(symbol!.parentClass).toBe('Outer');
+    });
+
     it('should return null for an unrecognized node type', () => {
       const code = 'x = 5\n';
       const root = mustParse(code, 'python');
@@ -562,6 +579,16 @@ describe('Python Language', () => {
       expect(addChunk).toBeDefined();
       expect(addChunk?.metadata.symbolType).toBe('method');
       expect(addChunk?.metadata.parentClass).toBe('Calculator');
+    });
+
+    it('should attach the enclosing class as parentClass for a nested class chunk (#949)', () => {
+      const content = 'class Outer:\n    class Inner:\n        pass\n';
+      const chunks = chunkByAST('outer.py', content);
+
+      const innerChunk = chunks.find(c => c.metadata.symbolName === 'Inner');
+      expect(innerChunk).toBeDefined();
+      expect(innerChunk?.metadata.symbolType).toBe('class');
+      expect(innerChunk?.metadata.parentClass).toBe('Outer');
     });
 
     describe('decorated definitions (regression: PR fixing #critical decorator chunking bug)', () => {

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -415,6 +415,11 @@ export class PythonImportExtractor implements LanguageImportExtractor {
  * - async_function_definition (async def foo():)
  * - class_definition (class Foo:)
  *
+ * `parentClass` is threaded into `extractClassInfo` (not just function
+ * extraction) so a nested class (`class Outer:\n    class Inner: ...`)
+ * reports its enclosing class — `PythonTraverser.findParentContainerName`
+ * already resolves this for every top-level node, not just methods (#949).
+ *
  * Call sites: call (foo(), obj.method())
  */
 export class PythonSymbolExtractor implements LanguageSymbolExtractor {
@@ -431,7 +436,7 @@ export class PythonSymbolExtractor implements LanguageSymbolExtractor {
       case 'async_function_definition':
         return this.extractFunctionInfo(node, content, parentClass);
       case 'class_definition':
-        return this.extractClassInfo(node);
+        return this.extractClassInfo(node, parentClass);
       case 'decorated_definition':
         return this.extractDecoratedInfo(node, content, parentClass);
       default:
@@ -510,7 +515,7 @@ export class PythonSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
@@ -519,6 +524,7 @@ export class PythonSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature: `class ${nameNode.text}`,
     };
   }

--- a/packages/parser/src/ast/languages/ruby.test.ts
+++ b/packages/parser/src/ast/languages/ruby.test.ts
@@ -34,6 +34,13 @@ describe('Ruby Language', () => {
       expect(traverser.shouldTraverseChildren(moduleNode)).toBe(true);
     });
 
+    it('should mark module as a transparent container (chunked, but not depth-costly)', () => {
+      // #949: module still isn't in containerTypes (see the test above — it
+      // must stay depth-free), but it must now be listed so chunker.ts emits
+      // a chunk/symbol for the module node itself.
+      expect(traverser.transparentContainerTypes).toContain('module');
+    });
+
     it('should extract children from class bodies', () => {
       const classNode = parse('class Foo\n  def bar; end\nend').namedChild(0)!;
       expect(traverser.shouldExtractChildren(classNode)).toBe(true);
@@ -229,12 +236,33 @@ describe('Ruby Language', () => {
       expect(symbol.signature).toBe('class User');
     });
 
-    it('should extract a module as a class-typed symbol', () => {
+    it('should extract a module as an interface-typed symbol (not class — a module is not instantiable)', () => {
       const code = 'module Billing\nend';
       const symbol = symbolExtractor.extractSymbol(firstNamed(code), code)!;
-      expect(symbol.type).toBe('class');
+      expect(symbol.type).toBe('interface');
       expect(symbol.name).toBe('Billing');
       expect(symbol.signature).toBe('module Billing');
+    });
+
+    it('should attach the enclosing module as parentClass for a nested module', () => {
+      const code = 'module Outer\n  module Inner\n  end\nend';
+      const root = parse(code);
+      const outerBody = root.namedChild(0)!.childForFieldName('body')!;
+      const innerModuleNode = outerBody.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(innerModuleNode, code, 'Outer')!;
+      expect(symbol.name).toBe('Inner');
+      expect(symbol.parentClass).toBe('Outer');
+    });
+
+    it('should attach the enclosing module as parentClass for a nested class', () => {
+      const code = 'module Billing\n  class Invoice\n  end\nend';
+      const symbol = symbolExtractor.extractSymbol(
+        firstNamed('class Invoice\nend'),
+        code,
+        'Billing',
+      )!;
+      expect(symbol.type).toBe('class');
+      expect(symbol.parentClass).toBe('Billing');
     });
 
     it('should extract a direct call site', () => {
@@ -341,6 +369,47 @@ describe('Ruby Language', () => {
     it('should chunk a standalone top-level method', () => {
       const chunks = chunkByAST('util.rb', 'def slugify(text)\n  text.downcase\nend');
       expect(chunks.some(c => c.metadata.symbolName === 'slugify')).toBe(true);
+    });
+
+    // #949: `module` was previously invisible to chunking entirely — a
+    // library's root namespace module (e.g. Sidekiq's `module Sidekiq`) was
+    // unfindable via list_functions/search_code even though everything
+    // nested inside it was chunked fine. These pin that the module itself now
+    // produces its own symbol/chunk, without breaking the nested class/method
+    // chunks the "transparent namespace" traversal already produced.
+    it('should also chunk the wrapping module itself as a symbol', () => {
+      const chunks = chunkByAST('billing.rb', RUBY_FILE);
+      const billingModule = chunks.find(c => c.metadata.symbolName === 'Billing');
+      expect(billingModule).toBeDefined();
+      expect(billingModule?.metadata.symbolType).toBe('interface');
+      expect(billingModule?.metadata.signature).toBe('module Billing');
+    });
+
+    it('should attach the wrapping module as parentClass for a directly-nested class', () => {
+      const chunks = chunkByAST('billing.rb', RUBY_FILE);
+      const creditService = chunks.find(c => c.metadata.symbolName === 'CreditService');
+      expect(creditService?.metadata.parentClass).toBe('Billing');
+    });
+
+    it('should still chunk methods nested two levels deep (module → class → method)', () => {
+      // Guards the depth-budget concern `transparentContainerTypes` exists to
+      // avoid: if `module` ever counted toward container depth, `charge`
+      // (module → class → method) would fall outside the one-container-deep
+      // budget `isTargetNode` enforces and silently disappear.
+      const chunks = chunkByAST('billing.rb', RUBY_FILE);
+      const charge = chunks.find(c => c.metadata.symbolName === 'charge');
+      expect(charge).toBeDefined();
+      expect(charge?.metadata.parentClass).toBe('CreditService');
+    });
+
+    it('should find a top-level module with no nested class', () => {
+      const chunks = chunkByAST(
+        'helpers.rb',
+        'module Helpers\n  def self.format(x)\n    x\n  end\nend',
+      );
+      const helpersModule = chunks.find(c => c.metadata.symbolName === 'Helpers');
+      expect(helpersModule).toBeDefined();
+      expect(helpersModule?.metadata.symbolType).toBe('interface');
     });
   });
 });

--- a/packages/parser/src/ast/languages/ruby.ts
+++ b/packages/parser/src/ast/languages/ruby.ts
@@ -73,6 +73,17 @@ export class RubyTraverser implements LanguageTraverser {
     'singleton_class', // `class << self`
   ];
 
+  // `module` is transparent for the depth budget (see shouldTraverseChildren
+  // below) but must still be independently discoverable as a symbol — e.g.
+  // `module Sidekiq` at the top of a library is its root namespace, and was
+  // previously invisible to `list_functions`/`search_code` entirely (#949).
+  // See `LanguageTraverser.transparentContainerTypes`'s doc comment for why
+  // this is a separate list from `containerTypes` rather than folding module
+  // into it (that would cost it a depth level and break the common
+  // `module → class → method` shape — see the depth-budget note on
+  // `shouldTraverseChildren`).
+  transparentContainerTypes = ['module'];
+
   declarationTypes: string[] = [];
 
   functionTypes = ['method', 'singleton_method'];
@@ -214,8 +225,9 @@ export class RubyImportExtractor implements LanguageImportExtractor {
  * Handles:
  * - method (def foo)
  * - singleton_method (def self.foo)
- * - class (class Foo)
- * - module (module Foo) — mapped to the 'class' symbol type
+ * - class (class Foo) — 'class' symbol type
+ * - module (module Foo) — 'interface' symbol type (see extractModuleInfo's
+ *   doc comment for why)
  *
  * Call sites: call (foo(), obj.method())
  */
@@ -228,9 +240,9 @@ export class RubySymbolExtractor implements LanguageSymbolExtractor {
       case 'singleton_method':
         return this.extractMethodInfo(node, content, parentClass);
       case 'class':
-        return this.extractClassInfo(node, 'class');
+        return this.extractClassInfo(node, parentClass);
       case 'module':
-        return this.extractClassInfo(node, 'module');
+        return this.extractModuleInfo(node, parentClass);
       default:
         return null;
     }
@@ -269,22 +281,60 @@ export class RubySymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: SyntaxNode, keyword: 'class' | 'module'): SymbolInfo | null {
+  private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
 
     // superclass node text includes the leading `<` (e.g. `< Base`).
     const superclass = node.childForFieldName('superclass');
     const signature = superclass
-      ? `${keyword} ${nameNode.text} ${superclass.text}`
-      : `${keyword} ${nameNode.text}`;
+      ? `class ${nameNode.text} ${superclass.text}`
+      : `class ${nameNode.text}`;
 
     return {
       name: nameNode.text,
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature,
+    };
+  }
+
+  /**
+   * `module` maps to the 'interface' symbol type, not 'class' — a module can
+   * never be instantiated (`Foo.new` is a `NoMethodError` for a module), so
+   * `class` would misdescribe it. `interface` is an imperfect but honest
+   * fit: it's the closest of `SymbolInfo['type']`'s four existing values to
+   * how Ruby actually uses a module — as a mixin (`include`/`extend`) that
+   * contributes behavior without state of its own, the same non-instantiable
+   * "shared behavior" role `interface` already plays for Java/C#/Kotlin
+   * interfaces and Swift protocols (and, closer still, Rust traits, which are
+   * genuinely mixed into implementing types much like a Ruby module is).
+   * It's a weaker fit for a module used purely as a namespace (e.g. a
+   * library's root `module Sidekiq`), but that's still strictly more honest
+   * than `class`, which would claim instantiability the module doesn't have.
+   *
+   * A dedicated `module` symbol type would be the more precise label, but
+   * `SymbolInfo['type']`/the MCP `symbolType` filter enum is a small, closed
+   * set threaded through `list_functions`'s filter, `signature-delta.ts`,
+   * complexity/risk scoring, and every formatter — adding a fifth value for
+   * one language's gap is exactly the ripple `csharp.ts` (see
+   * `extractPropertyInfo`'s doc comment) deliberately avoided for its own
+   * single-language gap. This makes the same call: reuse the closest
+   * existing bucket rather than widen the shared enum.
+   */
+  private extractModuleInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+
+    return {
+      name: nameNode.text,
+      type: 'interface',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: `module ${nameNode.text}`,
     };
   }
 }

--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -240,6 +240,29 @@ describe('Swift Language', () => {
       expect(sym.parentClass).toBe('Repo');
     });
 
+    // #949: nested types are idiomatic in Swift (a type declared directly
+    // inside another type's body), but extractClassInfo/extractProtocolInfo
+    // previously ignored the parentClass argument entirely — a nested type
+    // always reported parentClass: undefined regardless of nesting.
+    it('attaches the enclosing type as parentClass for a nested class/struct declaration', () => {
+      const src = 'struct Outer {\n  struct Inner {}\n}\n';
+      const nodes = findAllNodes(parse(src), 'class_declaration');
+      const inner = nodes[1]!;
+      const sym = symbolExtractor.extractSymbol(inner, src, 'Outer')!;
+      expect(sym.name).toBe('Inner');
+      expect(sym.type).toBe('class');
+      expect(sym.parentClass).toBe('Outer');
+    });
+
+    it('attaches the enclosing type as parentClass for a nested protocol declaration', () => {
+      const src = 'struct Outer {\n  protocol Inner {}\n}\n';
+      const proto = findNode(parse(src), 'protocol_declaration')!;
+      const sym = symbolExtractor.extractSymbol(proto, src, 'Outer')!;
+      expect(sym.name).toBe('Inner');
+      expect(sym.type).toBe('interface');
+      expect(sym.parentClass).toBe('Outer');
+    });
+
     it('extracts call sites for direct and navigation calls', () => {
       const src = 'func run() {\n  foo()\n  obj.bar.baz()\n}\n';
       const calls = findAllNodes(parse(src), 'call_expression');
@@ -334,6 +357,17 @@ func topLevelHelper(_ x: Int) -> Int { return x + 1 }
       const place = bySymbol('place', 'method');
       expect(place).toBeDefined();
       expect(place?.metadata.complexity ?? 0).toBeGreaterThan(1);
+    });
+
+    // #949: nested types are idiomatic in Swift; a nested type declaration
+    // previously reported parentClass: undefined regardless of nesting.
+    it('attaches the enclosing type as parentClass for a nested type chunk', () => {
+      const nestedSource = 'struct Outer {\n  struct Inner {\n    let x: Int\n  }\n}\n';
+      const nestedChunks = chunkByAST('Outer.swift', nestedSource);
+      const inner = nestedChunks.find(c => c.metadata.symbolName === 'Inner');
+      expect(inner).toBeDefined();
+      expect(inner?.metadata.symbolType).toBe('class');
+      expect(inner?.metadata.parentClass).toBe('Outer');
     });
   });
 });

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -350,9 +350,9 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
       case 'subscript_declaration':
         return this.extractFunctionInfo(node, content, parentClass);
       case 'class_declaration':
-        return this.extractClassInfo(node);
+        return this.extractClassInfo(node, parentClass);
       case 'protocol_declaration':
-        return this.extractProtocolInfo(node);
+        return this.extractProtocolInfo(node, parentClass);
       default:
         return null;
     }
@@ -415,17 +415,24 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
-  private extractClassInfo(node: SyntaxNode): SymbolInfo | null {
+  /**
+   * `parentClass` is threaded through so a nested type — idiomatic in Swift
+   * (a `class`/`struct`/`enum` declared directly inside another type's body,
+   * or a protocol nested inside a type) — reports its enclosing type.
+   * `SwiftTraverser.findParentContainerName` already resolves this for every
+   * top-level node, not just methods (#949).
+   */
+  private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
     const keyword = declarationKeyword(node);
-    return this.makeSymbol(node, name, 'class', `${keyword} ${name}`);
+    return this.makeSymbol(node, name, 'class', `${keyword} ${name}`, parentClass);
   }
 
-  private extractProtocolInfo(node: SyntaxNode): SymbolInfo | null {
+  private extractProtocolInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
-    return this.makeSymbol(node, name, 'interface', `protocol ${name}`);
+    return this.makeSymbol(node, name, 'interface', `protocol ${name}`, parentClass);
   }
 
   private makeSymbol(
@@ -433,12 +440,14 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
     name: string,
     type: SymbolInfo['type'],
     signature: string,
+    parentClass?: string,
   ): SymbolInfo {
     return {
       name,
       type,
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
+      parentClass,
       signature,
     };
   }

--- a/packages/parser/src/ast/traversers/types.ts
+++ b/packages/parser/src/ast/traversers/types.ts
@@ -33,6 +33,22 @@ export interface LanguageTraverser {
   containerTypes: string[];
 
   /**
+   * AST node types that should be emitted as their own chunk/symbol — like
+   * `containerTypes` — but that must NOT count toward the container-depth
+   * budget `isTargetNode` enforces (see `ast/chunker.ts`'s `findTopLevelNodes`).
+   *
+   * Ruby's `module` is the motivating case: it can wrap an arbitrary chain of
+   * classes/methods (`module Foo; class Bar; def baz; end; end; end`) and must
+   * stay "transparent" for depth purposes — exactly what `shouldTraverseChildren`
+   * already does for it — while still being independently discoverable as a
+   * symbol in its own right (previously it was invisible to `list_functions`
+   * entirely). Optional and undefined for every language without an equivalent
+   * construct, which is a complete no-op: chunker only checks this list when
+   * it is present.
+   */
+  transparentContainerTypes?: string[];
+
+  /**
    * AST node types that represent variable declarations that might contain functions
    * (e.g., 'lexical_declaration' for TypeScript const/let with arrow functions)
    */


### PR DESCRIPTION
Fixes #949.

## Bug 1 — Ruby `module` declarations were invisible as symbols

`RubyTraverser` treats `module` as a transparent namespace (deliberately —
`module → class → method` must still yield method chunks without costing
the one-container-deep budget `isTargetNode` enforces), but that meant the
module's own AST node was **never pushed to the chunker's node list at
all** — it never became a chunk/symbol. The `case 'module'` branch in
`RubySymbolExtractor.extractSymbol` was structurally unreachable dead code.

**Fix:** added an optional `transparentContainerTypes` field to
`LanguageTraverser` (undefined/no-op for every other language). When a
node's type is in this list, `chunker.ts`'s `findTopLevelNodes` now emits a
chunk for it while still traversing its children at the *same* depth
(unlike `containerTypes`, which increments depth) — so it's independently
discoverable without disturbing the depth budget nested content relies on.
Ruby's `RubyTraverser` sets `transparentContainerTypes = ['module']`.

**Adjacent question the brief asked me to check:** module *bodies* were
never the problem. The BEFORE probe below shows a method (`def job`)
nested inside a class inside a module was already correctly indexed with
`parent='Work'` — proving nested content was always fully chunked. Only
the module's own symbol entry was missing. Chunk count for sidekiq went
from ~2068 → 2186 (+118, matching the number of files that reopen various
modules) — a small, additive increase, not a change to existing chunks.

**`symbolType` decision:** `module` maps to `interface`, not `class`. A
Ruby module can never be instantiated, so `class` would misdescribe it
(the brief explicitly called this out as wrong). Adding a 5th `module`
value to `SymbolInfo['type']` would ripple into the `list_functions`
`symbolType` filter's enum, MCP schemas, `signature-delta.ts`,
complexity/risk scoring, and every formatter — the exact ripple
`csharp.ts` deliberately avoided by mapping properties to `method` instead
of adding a `property` type (see `extractPropertyInfo`'s comment). I made
the same call: `interface` is an imperfect but honest fit — the closest
existing bucket to how Ruby actually uses a module (a mixin contributing
shared behavior via `include`/`extend`, without state of its own — the
same non-instantiable role `interface`/trait already plays elsewhere). It's
weaker for a pure-namespace module (`module Sidekiq`), but still strictly
more honest than claiming instantiability via `class`. Since `interface` is
already an accepted `symbolType` value, filtering by it works end-to-end
with zero schema changes.

## Bug 2 — nested type declarations never reported `parentClass`

`ast/chunker.ts`'s `processTopLevelNode` already resolves the enclosing
type's name for **every** top-level node (via `findParentContainerName`),
not just methods. But each language's `extractClassInfo`/
`extractInterfaceInfo`/`extractStructInfo`/`extractRecordInfo`/
`extractEnumInfo`/`extractObjectInfo`/`extractProtocolInfo` either didn't
accept a `parentClass` parameter at all, or accepted it and silently
dropped it before constructing the returned `SymbolInfo`. Only the
method/constructor/property handlers ever threaded it through.

**Fixed:** C#, Java, Python, Swift, Kotlin — threaded `parentClass` through
every type-declaration handler, identical to how it already worked for
methods. `enclosingSymbol` (MCP metadata) is *derived* from `parentClass` +
`symbolName` in `metadata-shaper.ts`, so it's fixed for free — no separate
change needed there.

**Not fixed — scoped honestly:**
- **JavaScript/TypeScript:** no repro path. JS/TS has no `class_declaration`
  nested inside another `class_declaration`'s body (a class body holds
  `method_definition`/`field_definition`, not nested class declarations). A
  related but separate, still-open gap: TypeScript `namespace`/`module`
  blocks aren't chunked at all (same shape as Ruby's Bug 1, different
  construct) — out of scope here.
- **PHP:** no repro path — PHP has no nested class-declaration construct.
- **Go:** no repro path — flat structure by design, `containerTypes = []`,
  confirmed by the traverser's own doc comment.
- **Rust:** no repro path — `impl`/`trait` blocks cannot nest inside each
  other in valid Rust. Rust's `mod` does share Ruby's Bug-1 shape (also
  transparently traversed, also never its own chunk/symbol) — that's a
  real, separate gap I found while auditing, noted here as a follow-up
  observation but deliberately not fixed (out of scope; Ruby was the only
  language named in the brief for Bug 1).

## `get_dependents` before editing

- `LanguageTraverser` (traversers/types.ts): 12 dependents (every language
  file implements it), riskLevel **high** — but the added field is
  optional, so all 12 implementers compile unchanged. Confirmed via full
  build + 1483-test parser suite, all green.
- `RubySymbolExtractor`: 1 dependent (its own test file), riskLevel low.
- `CSharpSymbolExtractor` / `JavaSymbolExtractor`: 1 dependent each (own
  test files), riskLevel low.
- `chunkByAST`: 16 dependents (2 production, 14 test), riskLevel low — its
  public signature is unchanged; only internal traversal logic gained one
  additive branch.

## Dogfooding — verbatim, my build, foreign repos (never Lien itself)

Reindexed with **my build** (`node packages/cli/dist/index.js index
--force`) before every measurement. BEFORE state captured by first
reindexing each repo with the **published 0.71.0** binary (`lien index
--force`) to confirm the bug still reproduces pre-fix, exactly as
described in the brief.

### `/tmp/lien-dogfood-460173c9/sidekiq` — Ruby, Bug 1

BEFORE (published 0.71.0 index):

    probe ^Sidekiq$ ruby
    n=0

    probe ^Job$ ruby
    n=1
      name=job type=method parent=Work file=lib/sidekiq/api.rb:1338 sig="def job"

    probe ^Client$ ruby   (control)
    n=2
      name=Client type=class parent=None file=lib/sidekiq/client.rb:8 sig="class Client"
      name=Client type=class parent=None file=lib/sidekiq/middleware/i18n.rb:12 sig="class Client"

AFTER (my build, reindexed):

    probe ^Sidekiq$ ruby
    n=50
      name=Sidekiq type=interface parent=None file=lib/sidekiq.rb:42 sig="module Sidekiq"
      ... (49 more files that reopen the module)

    probe ^Job$ ruby
    n=8
      name=Job type=interface parent=Sidekiq file=lib/sidekiq/job.rb:44 sig="module Job"
      name=job type=method parent=Work file=lib/sidekiq/api.rb:1338 sig="def job"
      ... (6 more Job module reopenings)

    probe ^Client$ ruby   (control — also now correctly parent-labeled, bonus)
    n=2
      name=Client type=class parent=Sidekiq file=lib/sidekiq/client.rb:8 sig="class Client"
      name=Client type=class parent=Sidekiq::Middleware::I18n file=lib/sidekiq/middleware/i18n.rb:12 sig="class Client"

`module Sidekiq` (the library's root namespace, `lib/sidekiq.rb:42`) and
`module Job` (sidekiq's central job mixin, `lib/sidekiq/job.rb:44`) are now
both found, correctly labeled `interface`, with correct parentClass for
nested reopenings.

### `/tmp/lien-dogfood-460173c9/retrofit` — Java, Bug 2

BEFORE (published 0.71.0 index):

    probe ^Builder$ java
    n=6
      name=Builder type=class parent=None file=retrofit/src/main/java/retrofit2/Retrofit.java:483
      name=Builder type=class parent=None file=retrofit/src/main/java/retrofit2/RequestFactory.java:145
      name=Builder type=class parent=None file=retrofit-mock/src/main/java/retrofit2/mock/MockRetrofit.java:52
      name=Builder type=class parent=None file=samples/src/main/java/com/example/retrofit/AnnotatedConverters.java:47
      name=Builder type=class parent=None file=retrofit-converters/wire/.../Phone.java:68
      name=Builder type=class parent=None file=retrofit-converters/wire/.../CrashingPhone.java:69

AFTER (my build, reindexed):

    probe ^Builder$ java
    n=6
      name=Builder type=class parent=Retrofit file=retrofit/src/main/java/retrofit2/Retrofit.java:483
      name=Builder type=class parent=RequestFactory file=retrofit/src/main/java/retrofit2/RequestFactory.java:145
      name=Builder type=class parent=MockRetrofit file=retrofit-mock/src/main/java/retrofit2/mock/MockRetrofit.java:52
      name=Builder type=class parent=AnnotatedConverterFactory file=samples/src/main/java/com/example/retrofit/AnnotatedConverters.java:47
      name=Builder type=class parent=Phone file=retrofit-converters/wire/.../Phone.java:68
      name=Builder type=class parent=CrashingPhone file=retrofit-converters/wire/.../CrashingPhone.java:69

All six `Builder` results are now distinguishable by their real enclosing
type instead of only by file path.

Regression check — a real top-level (non-nested) class still reports
`parent=None` correctly:

    probe ^Retrofit$ java class
    n=1
      name=Retrofit type=class parent=None file=retrofit/src/main/java/retrofit2/Retrofit.java:65

### `/tmp/lien-dogfood-460173c9/serilog` — C#, Bug 2 (verifying the brief's claim)

BEFORE (published 0.71.0 index):

    probe ^ContextStackBookmark$ csharp
    n=1
      name=ContextStackBookmark type=class parent=None file=src/Serilog/Context/LogContext.cs:213

    probe ^SelfLogFailureListener$ csharp
    n=1
      name=SelfLogFailureListener type=class parent=None file=src/Serilog/Debugging/SelfLog.cs:84

AFTER (my build, reindexed):

    probe ^ContextStackBookmark$ csharp
    n=1
      name=ContextStackBookmark type=class parent=LogContext file=src/Serilog/Context/LogContext.cs:213

    probe ^SelfLogFailureListener$ csharp
    n=1
      name=SelfLogFailureListener type=class parent=SelfLog file=src/Serilog/Debugging/SelfLog.cs:84

Confirms the brief's C# claim exactly.

(`probe` = a small script calling `db.querySymbols({ pattern, language,
symbolType })` directly — the same call `list_functions` makes — against
each project's real on-disk index. All three corpus repos were clean
before and after; nothing was pushed or left dirty.)

## Gates (all green)

    npm run format:check   pass
    npm run lint            pass (0 errors, only pre-existing warnings)
    npm run typecheck       pass
    npm run build           pass
    npm test                pass — 1483/1483 parser, 1701 root, 1302 cli, 41 action
    lien delta              pass — exit 0, 22 advisory "worsened" (well within
                             budget, from the new parentClass param on 20
                             methods across 6 files), 2 improved, 0 new
                             threshold crossings
    npm run test:e2e:ruby   pass
    npm run test:e2e:java   pass

## Test plan
- [x] Per-language unit tests added for both bugs (Ruby, C#, Java, Python,
      Swift, Kotlin) following each file's existing test patterns
- [x] Chunker-level (`chunkByAST`) integration tests for both bugs
- [x] Full monorepo gate chain green
- [x] `lien delta` — no new complexity crossings
- [x] Ruby + Java E2E suites green
- [x] Dogfooded on 3 foreign repos (sidekiq, retrofit, serilog) with
      before/after evidence above, using my own build, never the Lien repo

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes two symbol-extraction gaps: Ruby `module` declarations are now emitted as `interface`-typed symbols without breaking the transparent namespace traversal that keeps nested methods discoverable, and nested type declarations in C#, Java, Python, Swift, and Kotlin now correctly carry `parentClass`. The change is additive and well-isolated: `transparentContainerTypes` is optional on `LanguageTraverser` (a no-op for all other languages), and `parentClass` is simply threaded through type handlers that already received it for methods. The implementation preserves the existing depth budget for Ruby (`module` children are traversed at the same depth), and the dogfooding data shows only new symbol entries with no mutation of existing chunks. All touched logic is covered by new per-language and chunker-level tests, and the full gate chain passed.
>
> - Added optional `LanguageTraverser.transparentContainerTypes` and used it in `chunker.ts` so Ruby `module` nodes become chunks while their children are still traversed transparently.
> - Mapped Ruby `module` to `interface` symbol type and added `extractModuleInfo` with `parentClass` support.
> - Threaded `parentClass` through every type-declaration handler in C#, Java, Kotlin, Python, and Swift so nested classes/interfaces/structs/records/enums/objects/protocols report their enclosing type.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 45b4c90. Updates automatically on new commits.</sup>
<!-- /lien-stats -->