### PR TITLE
fix(cli): stop MCP notes asserting causes they haven't established

### DIFF
--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -382,8 +382,18 @@ describe('findDependents', () => {
       // the structural signature of an unresolvable symbol query. Reporting
       // the symbol-scoped zero here would read as "no callers, safe to
       // change" even though QuestionHelper.php genuinely imports Cursor.php.
+      // The constructor DOES get its own chunk in the real index (methods and
+      // constructors are chunked individually) -- included here so
+      // `symbolFoundInFile` correctly reads this as a real, evidenced
+      // method/constructor rather than an absent/typo'd name.
       mockDB.scanAll.mockResolvedValue([
         createChunk('Cursor.php', { exports: ['Cursor'] }),
+        createChunk('Cursor.php', {
+          symbolName: '__construct',
+          symbolType: 'method',
+          startLine: 5,
+          endLine: 8,
+        }),
         createChunk('QuestionHelper.php', {
           imports: ['Cursor'],
           importedSymbols: { Cursor: ['Cursor'] },
@@ -393,11 +403,37 @@ describe('findDependents', () => {
       const result = await findDependents(mockDB as any, 'Cursor.php', mockLog, '__construct');
 
       expect(result.symbolAttributionDegraded).toBe(true);
+      expect(result.symbolFoundInFile).toBe(true);
       expect(result.dependents).toHaveLength(1);
       expect(result.dependents[0].filepath).toBe('QuestionHelper.php');
       expect(result.totalUsageCount).toBeUndefined();
       expect(mockLog).toHaveBeenCalledWith(
         expect.stringContaining("isn't a top-level export"),
+        'warning',
+      );
+    });
+
+    it('degrades to file-level dependents and reports symbolFoundInFile: false for a name absent from the file entirely (typo/hallucinated/removed)', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('Cursor.php', { exports: ['Cursor'] }),
+        createChunk('QuestionHelper.php', {
+          imports: ['Cursor'],
+          importedSymbols: { Cursor: ['Cursor'] },
+        }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'Cursor.php',
+        mockLog,
+        'totallyMadeUpSymbolXYZ123',
+      );
+
+      expect(result.symbolAttributionDegraded).toBe(true);
+      expect(result.symbolFoundInFile).toBe(false);
+      expect(result.dependents).toHaveLength(1);
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("doesn't appear anywhere in"),
         'warning',
       );
     });

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -131,6 +131,19 @@ export interface DependencyAnalysisResult {
    */
   symbolAttributionDegraded?: boolean;
   /**
+   * Only meaningful when `symbolAttributionDegraded` is `true`. Whether
+   * `symbol` was found ANYWHERE among the target file's own indexed chunks
+   * (as a chunk's own `symbolName` -- methods, constructors, and nested
+   * functions/classes each get their own chunk -- or inside that chunk's
+   * `symbols` bag), as opposed to a top-level export specifically. `true`
+   * backs up the "likely a method or constructor" reading; `false` means the
+   * name doesn't appear in this file's indexed chunks at all, which is just
+   * as consistent with a typo, a hallucinated symbol, or one that used to
+   * exist and was removed -- a caller wording the caveat should hedge
+   * instead of asserting the method/constructor cause in that case.
+   */
+  symbolFoundInFile?: boolean;
+  /**
    * True for a FILE-level query (no `symbol` requested) that came back with
    * zero dependents for a language where `hasEnclosingNamespaceAccess` is
    * set (currently only C# -- see that flag's doc comment), EVEN AFTER
@@ -424,7 +437,12 @@ function buildDependentsList(
   filepath: string,
   log: (message: string, level?: 'warning') => void,
   reExporterPaths: string[] = [],
-): { dependents: DependentInfo[]; totalUsageCount?: number; symbolAttributionDegraded?: boolean } {
+): {
+  dependents: DependentInfo[];
+  totalUsageCount?: number;
+  symbolAttributionDegraded?: boolean;
+  symbolFoundInFile?: boolean;
+} {
   if (symbol) {
     const exportsSymbol = validateSymbolExport(targetFileChunks, symbol, filepath, log);
 
@@ -438,13 +456,21 @@ function buildDependentsList(
     );
 
     if (!exportsSymbol && symbolResult.dependents.length === 0 && chunksByFile.size > 0) {
+      const foundInFile = symbolFoundInFileChunks(targetFileChunks, symbol);
       log(
-        `Note: "${symbol}" isn't a top-level export of ${filepath} (likely a method or ` +
-          `constructor) — symbol-level usage could not be confirmed. Falling back to ` +
-          `file-level dependents.`,
+        foundInFile
+          ? `Note: "${symbol}" isn't a top-level export of ${filepath} (likely a method or ` +
+              `constructor) — symbol-level usage could not be confirmed. Falling back to ` +
+              `file-level dependents.`
+          : `Note: "${symbol}" doesn't appear anywhere in ${filepath}'s indexed chunks — ` +
+              `possibly a typo or a removed symbol. Falling back to file-level dependents.`,
         'warning',
       );
-      return { ...buildFileLevelDependents(chunksByFile), symbolAttributionDegraded: true };
+      return {
+        ...buildFileLevelDependents(chunksByFile),
+        symbolAttributionDegraded: true,
+        symbolFoundInFile: foundInFile,
+      };
     }
 
     return symbolResult;
@@ -494,6 +520,33 @@ function validateSymbolExport(
   }
 
   return exportsSymbol;
+}
+
+/**
+ * Whether `symbol` shows up anywhere among the target file's OWN chunks --
+ * as a chunk's `symbolName` (methods, constructors, and nested
+ * functions/classes each get their own chunk with `symbolName` set to their
+ * own name, not just the file-level `exports` list) or inside that chunk's
+ * `symbols` bag. `validateSymbolExport` above only answers "is this a
+ * top-level export"; this answers the different, narrower question "does
+ * this name appear in the file AT ALL" -- used to word
+ * `symbolAttributionDegraded`'s caveat honestly instead of always guessing
+ * "method or constructor". A hit here means that guess is backed by
+ * evidence; no hit means `symbol` may just as easily be a typo, a
+ * hallucinated name, or a symbol that used to exist and was removed, and the
+ * caveat should say so instead of picking one cause with false confidence.
+ */
+function symbolFoundInFileChunks(targetFileChunks: SearchResult[], symbol: string): boolean {
+  return targetFileChunks.some(chunk => {
+    const { symbolName, symbols } = chunk.metadata;
+    if (symbolName === symbol) return true;
+    if (!symbols) return false;
+    return (
+      symbols.functions.includes(symbol) ||
+      symbols.classes.includes(symbol) ||
+      symbols.interfaces.includes(symbol)
+    );
+  });
 }
 
 /**
@@ -640,6 +693,7 @@ function resolveDependents(args: {
   dependents: DependentInfo[];
   totalUsageCount?: number;
   symbolAttributionDegraded?: boolean;
+  symbolFoundInFile?: boolean;
   dependentAttributionPartial?: true;
 } {
   const {
@@ -654,16 +708,17 @@ function resolveDependents(args: {
     targetIndexed,
   } = args;
 
-  const { dependents, totalUsageCount, symbolAttributionDegraded } = buildDependentsList(
-    chunksByFile,
-    symbol,
-    normalizedTarget,
-    ctx.normalizePathCached,
-    targetFileChunks,
-    filepath,
-    ctx.log,
-    reExporterPaths,
-  );
+  const { dependents, totalUsageCount, symbolAttributionDegraded, symbolFoundInFile } =
+    buildDependentsList(
+      chunksByFile,
+      symbol,
+      normalizedTarget,
+      ctx.normalizePathCached,
+      targetFileChunks,
+      filepath,
+      ctx.log,
+      reExporterPaths,
+    );
   const dependentAttributionPartial = enrichWithCSharpTypeReferenceDependents(
     ctx,
     filepath,
@@ -674,7 +729,13 @@ function resolveDependents(args: {
   );
   stampHopsAndSort(dependents, hopsByFile);
 
-  return { dependents, totalUsageCount, symbolAttributionDegraded, dependentAttributionPartial };
+  return {
+    dependents,
+    totalUsageCount,
+    symbolAttributionDegraded,
+    symbolFoundInFile,
+    dependentAttributionPartial,
+  };
 }
 
 export async function findDependents(
@@ -724,18 +785,23 @@ export async function findDependents(
   });
 
   const targetFileChunks = symbol ? (allChunksByFile.get(normalizedTarget) ?? []) : [];
-  const { dependents, totalUsageCount, symbolAttributionDegraded, dependentAttributionPartial } =
-    resolveDependents({
-      ctx,
-      chunksByFile,
-      hopsByFile,
-      symbol,
-      normalizedTarget,
-      targetFileChunks,
-      filepath,
-      reExporterPaths,
-      targetIndexed,
-    });
+  const {
+    dependents,
+    totalUsageCount,
+    symbolAttributionDegraded,
+    symbolFoundInFile,
+    dependentAttributionPartial,
+  } = resolveDependents({
+    ctx,
+    chunksByFile,
+    hopsByFile,
+    symbol,
+    normalizedTarget,
+    targetFileChunks,
+    filepath,
+    reExporterPaths,
+    targetIndexed,
+  });
 
   // Complexity metrics must be joined against the *resolved* dependents, not
   // the broader import-graph candidate set (`chunksByFile`) considered before
@@ -780,6 +846,7 @@ export async function findDependents(
     truncated,
     uncoveredProductionDependents,
     symbolAttributionDegraded,
+    symbolFoundInFile,
     dependentAttributionIncomplete,
     dependentAttributionPartial,
     targetIndexed,

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -64,6 +64,7 @@ describe('handleGetDependents', () => {
       truncated?: boolean;
       uncoveredProductionDependents?: number;
       symbolAttributionDegraded?: boolean;
+      symbolFoundInFile?: boolean;
       dependentAttributionIncomplete?: boolean;
       dependentAttributionPartial?: boolean;
       targetIndexed?: boolean;
@@ -92,6 +93,7 @@ describe('handleGetDependents', () => {
       truncated: overrides.truncated ?? false,
       uncoveredProductionDependents: overrides.uncoveredProductionDependents ?? 0,
       symbolAttributionDegraded: overrides.symbolAttributionDegraded,
+      symbolFoundInFile: overrides.symbolFoundInFile,
       dependentAttributionIncomplete: overrides.dependentAttributionIncomplete,
       dependentAttributionPartial: overrides.dependentAttributionPartial,
       targetIndexed: overrides.targetIndexed ?? true,
@@ -641,11 +643,12 @@ describe('handleGetDependents', () => {
   });
 
   describe('attributionCaveat: symbol-attribution-degraded (method/constructor symbols)', () => {
-    it('surfaces attributionCaveat when the analyzer degrades to file-level', async () => {
+    it('surfaces attributionCaveat when the analyzer degrades to file-level (symbol confirmed present, e.g. a real method/constructor)', async () => {
       vi.mocked(findDependents).mockResolvedValue({
         ...createMockAnalysis({
           dependents: [{ filepath: 'src/QuestionHelper.php', isTestFile: false }],
           symbolAttributionDegraded: true,
+          symbolFoundInFile: true,
         }),
         totalUsageCount: undefined,
       });
@@ -659,6 +662,35 @@ describe('handleGetDependents', () => {
       expect(parsed.attributionCaveat.reason).toBe('symbol-attribution-degraded');
       expect(parsed.attributionCaveat.note).toContain('__construct');
       expect(parsed.attributionCaveat.note).toContain('top-level exports');
+      expect(parsed.attributionCaveat.note).toContain('likely a method or constructor');
+      expect(parsed.dependentCount).toBe(1);
+      expect(parsed.totalUsageCount).toBeUndefined();
+    });
+
+    it('hedges instead of asserting "method or constructor" when the symbol is absent from the file entirely (typo/hallucinated/removed)', async () => {
+      vi.mocked(findDependents).mockResolvedValue({
+        ...createMockAnalysis({
+          dependents: [{ filepath: 'src/QuestionHelper.php', isTestFile: false }],
+          symbolAttributionDegraded: true,
+          symbolFoundInFile: false,
+        }),
+        totalUsageCount: undefined,
+      });
+
+      const result = await handleGetDependents(
+        { filepath: 'src/Cursor.php', symbol: 'totallyMadeUpSymbolXYZ123' },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.attributionCaveat.reason).toBe('symbol-attribution-degraded');
+      expect(parsed.attributionCaveat.note).toContain('totallyMadeUpSymbolXYZ123');
+      // Must NOT confidently assert the method/constructor cause when it
+      // hasn't been established.
+      expect(parsed.attributionCaveat.note).not.toContain('likely a method or constructor');
+      expect(parsed.attributionCaveat.note).toMatch(/typo|hallucinated|removed/);
+      // The file-level-answer explanation must survive intact either way.
+      expect(parsed.attributionCaveat.note).toContain('file-level answer');
       expect(parsed.dependentCount).toBe(1);
       expect(parsed.totalUsageCount).toBeUndefined();
     });

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -231,15 +231,29 @@ function buildAttributionCaveat(
     };
   }
   if (analysis.symbolAttributionDegraded) {
-    return {
-      reason: 'symbol-attribution-degraded',
-      note:
-        `"${symbol}" doesn't appear in ${filepath}'s tracked top-level exports (likely a ` +
+    // "Not a top-level export, no confirmed call sites" has more than one
+    // real cause: a genuine method/constructor and a typo'd/hallucinated/
+    // removed symbol look identical on that signal alone.
+    // `symbolFoundInFile` is the cheap, already-scanned check that tells them
+    // apart (does `symbol` match ANY chunk in the file, not just its
+    // top-level exports) — only assert the method/constructor reading when
+    // it's actually backed by a hit; otherwise hedge across the real
+    // possibilities instead of confidently naming the wrong one. The second
+    // sentence (file-level answer, not a verified per-symbol count) holds
+    // either way and stays identical.
+    const note = analysis.symbolFoundInFile
+      ? `"${symbol}" doesn't appear in ${filepath}'s tracked top-level exports (likely a ` +
         `method or constructor — no import statement names one of those independently of ` +
         `its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, ` +
         `riskLevel, and dependents below are the file-level answer (every file that imports ` +
-        `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`,
-    };
+        `${filepath}) rather than a verified count of callers of "${symbol}" specifically.`
+      : `"${symbol}" doesn't appear anywhere in ${filepath} — not as a top-level export, nor in ` +
+        `any indexed chunk of the file. This may be a typo, a hallucinated name, or a symbol ` +
+        `that used to exist and was removed. Symbol-level call sites couldn't be confirmed, so ` +
+        `dependentCount, riskLevel, and dependents below are the file-level answer (every file ` +
+        `that imports ${filepath}) rather than a verified count of callers of "${symbol}" ` +
+        `specifically.`;
+    return { reason: 'symbol-attribution-degraded', note };
   }
   if (analysis.dependentAttributionPartial) {
     const inferredCount = analysis.dependents.filter(d => d.confidence === 'inferred').length;

--- a/packages/cli/src/mcp/handlers/list-functions.test.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.test.ts
@@ -14,6 +14,7 @@ describe('handleListFunctions', () => {
   let mockVectorDB: {
     querySymbols: ReturnType<typeof vi.fn>;
     scanWithFilter: ReturnType<typeof vi.fn>;
+    hasData: ReturnType<typeof vi.fn>;
   };
 
   let mockCtx: ToolContext;
@@ -24,6 +25,9 @@ describe('handleListFunctions', () => {
     mockVectorDB = {
       querySymbols: vi.fn(),
       scanWithFilter: vi.fn(),
+      // Healthy-index default; individual tests override to `false` to
+      // exercise the "structural store has no data at all" path.
+      hasData: vi.fn().mockResolvedValue(true),
     };
 
     mockCtx = {
@@ -521,7 +525,7 @@ describe('handleListFunctions', () => {
   });
 
   describe('empty result diagnostics', () => {
-    it('should include diagnostic note when no results are found', async () => {
+    it('should include a hedged diagnostic note (not a query-is-wrong claim) when the index is present but empty for this query', async () => {
       mockVectorDB.querySymbols.mockResolvedValue([]);
       mockVectorDB.scanWithFilter.mockResolvedValue([]);
 
@@ -532,6 +536,40 @@ describe('handleListFunctions', () => {
       expect(parsed.note).toContain('0 results');
       expect(parsed.note).toContain('search_code');
       expect(parsed.note).toContain('symbolType');
+      // Must not assert absence as fact, and must surface staleness (a
+      // recent, not-yet-reindexed edit) as a live possibility alongside
+      // query tuning — not lead with "your pattern is wrong".
+      expect(parsed.note).toContain("doesn't confirm");
+      expect(parsed.note).toContain('lien index');
+    });
+
+    it('should escalate to the unmissable no-index warning when the structural store has no data at all', async () => {
+      mockVectorDB.querySymbols.mockResolvedValue([]);
+      mockVectorDB.scanWithFilter.mockResolvedValue([]);
+      mockVectorDB.hasData.mockResolvedValue(false);
+
+      const result = await handleListFunctions({ pattern: 'StringToBytes' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+      expect(parsed.note).toContain('correctness prerequisite');
+      // The stronger, established-fact warning replaces the query-tuning
+      // advice entirely — it doesn't get diluted by also suggesting the
+      // pattern might be the problem.
+      expect(parsed.note).not.toContain('Try a broader regex');
+    });
+
+    it('should not repeat the no-index warning as a redundant "enable faster queries" nudge', async () => {
+      mockVectorDB.querySymbols.mockResolvedValue([]);
+      mockVectorDB.scanWithFilter.mockResolvedValue([]);
+      mockVectorDB.hasData.mockResolvedValue(false);
+
+      const result = await handleListFunctions({ pattern: 'StringToBytes' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).not.toContain('enable faster symbol-based queries');
     });
   });
 

--- a/packages/cli/src/mcp/handlers/list-functions.ts
+++ b/packages/cli/src/mcp/handlers/list-functions.ts
@@ -2,6 +2,7 @@ import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { ListFunctionsSchema } from '../schemas/index.js';
 import type { ListFunctionsInput } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
+import { formatNoIndexNote } from '../utils/unindexed-paths.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import { safeRegex } from '@liendev/core';
 import type { VectorDBInterface, SearchResult } from '@liendev/core';
@@ -126,15 +127,35 @@ export async function handleListFunctions(args: unknown, ctx: ToolContext): Prom
 
     const notes: string[] = [];
     if (queryResult.results.length === 0) {
-      notes.push(
-        '0 results. Try a broader regex pattern (e.g. ".*") or omit the symbolType filter. Use search_code for behavior-based queries.',
-      );
+      // A totally empty structural store (never indexed, cleared, or moved
+      // aside) makes "0 results" look identical to a confident "genuinely not
+      // in the code" — which is exactly backwards. Only claim that harder
+      // fact when it's actually established (`hasData()`); otherwise a
+      // healthy-but-not-yet-reindexed store (the far more common case: a file
+      // was just edited and hasn't been reindexed) is just as consistent with
+      // these 0 results, so the note must not pick "your pattern is wrong" as
+      // the cause either.
+      if (!(await vectorDB.hasData())) {
+        notes.push(formatNoIndexNote());
+      } else {
+        notes.push(
+          "0 results. This doesn't confirm the symbol/pattern is absent from the code — a " +
+            'recent edit may not be reindexed yet. If this file changed recently, run "lien ' +
+            'index" and retry before concluding it\'s missing. Otherwise, try a broader regex ' +
+            'pattern (e.g. ".*"), omit the symbolType filter, or use search_code for ' +
+            'behavior-based queries.',
+        );
+      }
     } else if (paginatedResults.length === 0 && offset > 0) {
       notes.push(
         'No results for this page. The offset is beyond the available results; try reducing or resetting the offset to 0.',
       );
     }
-    if (queryResult.method === 'content') {
+    // Only a performance nudge (content scan found real results just via the
+    // slower fallback path) — the 0-results branch above already covers
+    // "run lien index" for the empty-store/stale-store cases, so don't repeat
+    // it redundantly here when there's nothing to actually show for it.
+    if (queryResult.method === 'content' && queryResult.results.length > 0) {
       notes.push('Using content search. Run "lien index" to enable faster symbol-based queries.');
     }
 

--- a/packages/cli/src/mcp/handlers/search-code.test.ts
+++ b/packages/cli/src/mcp/handlers/search-code.test.ts
@@ -44,6 +44,7 @@ describe('handleSearchCode', () => {
 
   let mockVectorDB: {
     search: ReturnType<typeof vi.fn>;
+    hasData: ReturnType<typeof vi.fn>;
   };
 
   let mockCtx: ToolContext;
@@ -53,6 +54,9 @@ describe('handleSearchCode', () => {
 
     mockVectorDB = {
       search: vi.fn(),
+      // Healthy-index default; individual tests override to `false` to
+      // exercise the "structural store has no data at all" path.
+      hasData: vi.fn().mockResolvedValue(true),
     };
 
     mockCtx = {
@@ -144,7 +148,7 @@ describe('handleSearchCode', () => {
       expect(parsed.indexInfo).toBeDefined();
     });
 
-    it('should include diagnostic note when search returns empty results', async () => {
+    it('should include a hedged diagnostic note (not a query-is-wrong claim) when the index is present but empty for this query', async () => {
       mockVectorDB.search.mockResolvedValue([]);
 
       const result = await handleSearchCode({ query: 'nonexistent feature' }, mockCtx);
@@ -154,6 +158,25 @@ describe('handleSearchCode', () => {
       expect(parsed.note).toContain('0 results');
       expect(parsed.note).toContain('grep');
       expect(parsed.note).toContain('lien index');
+      // Must not assert absence as fact — staleness (a recent, not-yet-
+      // reindexed edit) is just as consistent with 0 results here.
+      expect(parsed.note).toContain("doesn't confirm");
+    });
+
+    it('should escalate to the unmissable no-index warning when the structural store has no data at all', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+      mockVectorDB.hasData.mockResolvedValue(false);
+
+      const result = await handleSearchCode({ query: 'stale_probe_marker' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+      expect(parsed.note).toContain('correctness prerequisite');
+      // The established-fact warning replaces the query-phrasing advice
+      // rather than diluting it with an unverified alternate cause.
+      expect(parsed.note).not.toContain('query with concrete keywords');
     });
   });
 

--- a/packages/cli/src/mcp/handlers/search-code.ts
+++ b/packages/cli/src/mcp/handlers/search-code.ts
@@ -1,6 +1,7 @@
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { SearchCodeSchema } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
+import { formatNoIndexNote } from '../utils/unindexed-paths.js';
 import type { ToolContext, MCPToolResult, LogFn } from '../types.js';
 import type { VectorDBInterface, SearchResult } from '@liendev/core';
 
@@ -66,9 +67,22 @@ export async function handleSearchCode(args: unknown, ctx: ToolContext): Promise
     const shaped = shapeResults(results, 'search_code');
 
     if (shaped.length === 0) {
-      notes.push(
-        '0 results. Search is lexical: query with concrete keywords or identifiers that appear in the code (function names, domain terms), not natural-language questions. Or use grep for exact string matches. If the codebase was recently updated, run "lien index".',
-      );
+      // Same reasoning as list_functions: only assert the harder "no index at
+      // all" fact when `hasData()` actually establishes it. A healthy index
+      // that just hasn't caught up with a recent edit produces the exact same
+      // 0 results, so the fallback note below must not read as "your query
+      // phrasing is the problem" — it's one of several live possibilities.
+      if (!(await vectorDB.hasData())) {
+        notes.push(formatNoIndexNote());
+      } else {
+        notes.push(
+          "0 results. This doesn't confirm the code doesn't exist — a recent edit may not be " +
+            'reindexed yet. If this file changed recently, run "lien index" and retry first. ' +
+            'Otherwise, query with concrete keywords or identifiers that appear in the code ' +
+            '(function names, domain terms, not natural-language questions), or use grep for ' +
+            'exact string matches.',
+        );
+      }
     }
 
     return {

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -37,9 +37,11 @@ symbol:
   "unresolved-target" means filepath isn't in the index at all (never
   indexed, misspelled, or a typo'd directory prefix) — fix the path (try
   search_code or list_functions) before trusting anything else in the
-  result. "symbol-attribution-degraded" means symbol names a method or
-  constructor whose call sites couldn't be confirmed — the counts are the
-  wider file-level answer, not a verified count for symbol itself.
+  result. "symbol-attribution-degraded" means symbol isn't a top-level
+  export and its call sites couldn't be confirmed — it may be a real
+  method/constructor, or it may be a typo'd/hallucinated/removed name (the
+  note says which); either way the counts are the wider file-level answer,
+  not a verified count for symbol itself.
   "dependent-attribution-partial" means the import graph found nothing but
   a lower-confidence text-matching fallback recovered some dependents
   anyway (those entries carry confidence: "inferred") — treat the counts as

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -159,8 +159,9 @@ Returns:
     wrong directory prefix/case, or not indexed yet) — every count is a deliberate
     0, not a confirmed empty dependency graph. Try search_code or list_functions to
     find the real path, or run "lien index" if the file was added recently.
-  - "symbol-attribution-degraded": \`symbol\` names a method or constructor (not a
-    top-level export) and its call sites couldn't be confirmed; dependentCount/
+  - "symbol-attribution-degraded": \`symbol\` isn't a top-level export and its call
+    sites couldn't be confirmed — may be a real method/constructor, or a
+    typo'd/hallucinated/removed name (\`note\` says which); dependentCount/
     riskLevel are the file-level answer (every importer of filepath), not a
     verified count of callers of symbol itself.
   - "dependent-attribution-partial": a file-level query (no \`symbol\`) found ZERO

--- a/packages/cli/src/mcp/utils/unindexed-paths.test.ts
+++ b/packages/cli/src/mcp/utils/unindexed-paths.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { findUnindexedPaths, formatUnindexedPathsNote } from './unindexed-paths.js';
+import {
+  findUnindexedPaths,
+  formatUnindexedPathsNote,
+  formatNoIndexNote,
+} from './unindexed-paths.js';
 import type { VectorDBInterface } from '@liendev/core';
 
 const getIndexedFilesMock = vi.fn<() => Promise<string[]>>();
@@ -89,5 +93,25 @@ describe('formatUnindexedPathsNote', () => {
     expect(note).toContain('⚠ Lien:');
     expect(note).toContain('"src/Command/Command.php"');
     expect(note).toContain('"does/not/exist.php"');
+  });
+});
+
+describe('formatNoIndexNote', () => {
+  it('is unmissable (⚠ Lien: prefix) and states "no data" as an established fact, not a guess', () => {
+    const note = formatNoIndexNote();
+    expect(note).toContain('⚠ Lien:');
+    expect(note).toContain('no data');
+  });
+
+  it('frames "lien index" as a correctness prerequisite, not a speed optimization', () => {
+    const note = formatNoIndexNote();
+    expect(note).toContain('lien index');
+    expect(note).toContain('correctness prerequisite');
+    expect(note).not.toContain('faster');
+  });
+
+  it('does not assert the symbol/pattern is absent from the code', () => {
+    const note = formatNoIndexNote();
+    expect(note).toMatch(/do not conclude/i);
   });
 });

--- a/packages/cli/src/mcp/utils/unindexed-paths.ts
+++ b/packages/cli/src/mcp/utils/unindexed-paths.ts
@@ -58,3 +58,25 @@ export function formatUnindexedPathsNote(unindexedPaths: readonly string[]): str
     `or list_functions to find the real path, or run "lien index" if the file was added recently.`
   );
 }
+
+/**
+ * Render an unmissable note for the DIFFERENT, whole-index version of the
+ * problem `formatUnindexedPathsNote` covers: not "this one path is unknown"
+ * but "the structural store has no data at all" (never indexed, cleared, or
+ * moved aside). `search_code` and `list_functions` have no filepath to check
+ * against the manifest -- a symbol/pattern query over an empty store looks
+ * identical to a real, confident "not found in the code", which is exactly
+ * backwards. Same `⚠ Lien:`-prefixed, unmissable tone as
+ * `formatUnindexedPathsNote` and `get_dependents`'s `unresolved-target`
+ * caveat, deliberately not guessing WHY the store is empty (never indexed vs.
+ * mid-rebuild vs. wiped) since that isn't reliably knowable from here --
+ * "run lien index" is the correct next step regardless of which it is.
+ */
+export function formatNoIndexNote(): string {
+  return (
+    `⚠ Lien: this project's structural index has no data — 0 results here means "nothing ` +
+    `has been indexed", not "not found in the code". Do not conclude the symbol/pattern is ` +
+    `absent. Run "lien index" (a correctness prerequisite here, not a speed optimization) ` +
+    `and retry.`
+  );
+}


### PR DESCRIPTION
## Summary

Two model-facing honesty defects in Lien's MCP output, both reproduced against a foreign repo with our own build (not the published 0.72.0, per the repo's dogfood method — behavior matched byte-for-byte where the transcripts overlapped).

**Bug 1 — `list_functions`/`search_code` blamed the query on 0 results, even when the real cause was the index.** Two distinct triggers turned out to share one defect: (a) a missing/empty structural index, and (b) — found while reproducing (a), and the far more common real-world case — a *present, healthy-looking* index that simply hasn't caught up with a recent edit yet. Both produce identical "0 results", and the old note picked "your regex/query is wrong" as the cause regardless.

**Bug 2 — `get_dependents`'s `symbol-attribution-degraded` caveat asserted "likely a method or constructor"** for *any* symbol that isn't a top-level export, even a symbol that never existed anywhere in the file (typo, hallucination, or a since-removed symbol).

## Fix

**Bug 1:** `list_functions` and `search_code` now check `vectorDB.hasData()` when a query returns 0 results:
- If the structural store genuinely has **no data at all** (never indexed, cleared, or moved aside) — an established fact — escalate to an unmissable `⚠ Lien:` warning, reusing the existing pattern from `get_dependents`'s `unresolved-target` caveat (new `formatNoIndexNote()` alongside `formatUnindexedPathsNote()` in `unindexed-paths.ts`). States plainly that "lien index" here is a correctness prerequisite, not a speed optimization.
- Otherwise (index present, just 0 matches — which includes the stale-edit case) — hedge instead of blaming the query: state that this doesn't confirm the symbol/pattern is absent, name "hasn't been reindexed yet" as a live possibility, and *then* offer query-tuning as one option among several, not the diagnosis.

**Bug 2:** `get_dependents`'s degraded-caveat path now checks whether `symbol` appears **anywhere** in the target file's own indexed chunks (`symbolFoundInFileChunks` in `dependency-analyzer.ts` — a chunk's own `symbolName`, since methods/constructors get their own chunk, not just the file's top-level `exports`). A hit backs the existing "likely a method or constructor" wording (unchanged, byte-for-byte); no hit switches to an honest hedge ("may be a typo, a hallucinated name, or a symbol that used to exist and was removed"). The file-level-answer explanation (second half of the note) is identical either way. Plumbed through as `symbolFoundInFile` on `DependencyAnalysisResult` → `resolveDependents` → `buildDependentsList`.

`instructions.ts` (`SERVER_INSTRUCTIONS`, sent to every connecting MCP client) carried the same "means symbol names a method or constructor" overclaim for `symbol-attribution-degraded` — updated to match, kept tight (one added clause). The `CLAUDE.md` ↔ `SERVER_INSTRUCTIONS` sync test still passes.

Preserved as required: all four `attributionCaveat.reason` values (`unresolved-target`, `symbol-attribution-degraded`, `dependent-attribution-partial`, `dependent-attribution-incomplete`) unchanged; ran `get_dependents` on `findDependents`/`DependencyAnalysisResult` before touching their shape (2 production callers, low risk — `get-dependents.ts`, `annotate-cmd.ts`).

## Scope decision (asked for explicitly)

`indexInfo` (`reindexInProgress`, `pendingFileCount`, `msSinceLastReindex`) still looks "healthy" even when `handleAutoIndexing`'s fire-and-forget background reindex is actively running — it was never wired through `reindexStateManager`, only the file-watcher/incremental paths were. That's a real, separate gap (the note's honesty no longer depends on it, since `hasData()` is checked directly), and fixing it means threading state through a detached `void indexCodebase(...)` call — a bigger, independent change. Left out of this PR; flagging as a follow-up rather than silently expanding scope.

## Dogfood evidence (own build, foreign repos, `/tmp/lien-dogfood-460173c9`)

All captured with `LIEN_MCP_CLI=packages/cli/dist/index.js node scripts/experiments/dogfood-oss/mcp-call.mjs <repo> <tool> '<args>'`. Repos reset with `git checkout -- . && git clean -fd` afterward; the one moved-aside index (gin) was restored and re-verified healthy.

### Bug 1a — missing index (gin, index directory moved aside)

**Before** (`list_functions`, pattern `StringToBytes` — a function that unquestionably exists in `internal/bytesconv/bytesconv.go`):
```json
"note": "0 results. Try a broader regex pattern (e.g. \".*\") or omit the symbolType filter. Use search_code for behavior-based queries. Using content search. Run \"lien index\" to enable faster symbol-based queries."
```
(`indexInfo.indexVersion: 0`, `indexDate: "Unknown"`)

**After:**
```json
"note": "⚠ Lien: this project's structural index has no data — 0 results here means \"nothing has been indexed\", not \"not found in the code\". Do not conclude the symbol/pattern is absent. Run \"lien index\" (a correctness prerequisite here, not a speed optimization) and retry."
```

### Bug 1b — stale index, healthy-looking `indexInfo` (flask; appended `def stale_probe_marker()` to `src/flask/helpers.py`, did NOT reindex)

**Before** (`list_functions`, pattern `stale_probe_marker`):
```json
"indexInfo": {"reindexInProgress": false, "pendingFileCount": 0, "msSinceLastReindex": 18841, ...},
"note": "0 results. Try a broader regex pattern (e.g. \".*\") or omit the symbolType filter. Use search_code for behavior-based queries. Using content search. Run \"lien index\" to enable faster symbol-based queries."
```

**After:**
```json
"note": "0 results. This doesn't confirm the symbol/pattern is absent from the code — a recent edit may not be reindexed yet. If this file changed recently, run \"lien index\" and retry before concluding it's missing. Otherwise, try a broader regex pattern (e.g. \".*\"), omit the symbolType filter, or use search_code for behavior-based queries."
```

`search_code` (query `stale_probe_marker`) — same shape:
- **Before:** `"0 results. Search is lexical: query with concrete keywords or identifiers that appear in the code (function names, domain terms), not natural-language questions. Or use grep for exact string matches. If the codebase was recently updated, run \"lien index\"."`
- **After:** `"0 results. This doesn't confirm the code doesn't exist — a recent edit may not be reindexed yet. If this file changed recently, run \"lien index\" and retry first. Otherwise, query with concrete keywords or identifiers that appear in the code (function names, domain terms, not natural-language questions), or use grep for exact string matches."`

### Bug 2 — `get_dependents`, flask, `src/flask/helpers.py`, symbol `totallyMadeUpSymbolXYZ123` (never existed anywhere in the repo)

**Before** (captured from the pre-fix build via `git checkout HEAD~1 --`, rebuilt, ran, then restored):
```json
{
  "reason": "symbol-attribution-degraded",
  "note": "\"totallyMadeUpSymbolXYZ123\" doesn't appear in src/flask/helpers.py's tracked top-level exports (likely a method or constructor — no import statement names one of those independently of its class/package). Symbol-level call sites couldn't be confirmed, so dependentCount, riskLevel, and dependents below are the file-level answer (every file that imports src/flask/helpers.py) rather than a verified count of callers of \"totallyMadeUpSymbolXYZ123\" specifically."
}
```

**After:**
```json
{
  "reason": "symbol-attribution-degraded",
  "note": "\"totallyMadeUpSymbolXYZ123\" doesn't appear anywhere in src/flask/helpers.py — not as a top-level export, nor in any indexed chunk of the file. This may be a typo, a hallucinated name, or a symbol that used to exist and was removed. Symbol-level call sites couldn't be confirmed, so dependentCount, riskLevel, and dependents below are the file-level answer (every file that imports src/flask/helpers.py) rather than a verified count of callers of \"totallyMadeUpSymbolXYZ123\" specifically."
}
```

**Good case unaffected** (flask, symbol `__enter__` — a real method on `_CollectErrors`):
```json
"note": "\"__enter__\" doesn't appear in src/flask/helpers.py's tracked top-level exports (likely a method or constructor — no import statement names one of those independently of its class/package). Symbol-level call sites couldn't be confirmed, ..."
```
— unchanged wording, confirming the fix only changes behavior when the symbol truly isn't found.

## Test plan

- [x] `npm run format:check` / `npm run lint` (0 errors, only pre-existing warnings) / `npm run typecheck` / `npm run build` / `npm test` (1310 + 41 tests, all green)
- [x] `lien delta --base origin/main`: exit 0, no new threshold crossings (touched functions worsened slightly — e.g. `handleListFunctions` cognitive 8→12 — but all comfortably under the 15 default)
- [x] New/updated unit tests for both text paths: `list-functions.test.ts`, `search-code.test.ts`, `unindexed-paths.test.ts` (new `formatNoIndexNote` describe block), `dependency-analyzer.test.ts` (new `symbolFoundInFile: false` case), `get-dependents.test.ts` (new hedge-vs-assert case)
- [x] Live dogfood in two foreign repos (Go/gin, Python/flask), own build, before/after captured above

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR tightens MCP honesty messaging for `list_functions`, `search_code`, and `get_dependents` by distinguishing an empty structural index from a stale-but-present one, and by hedging `symbol-attribution-degraded` when the requested symbol isn't found anywhere in the target file. The logic changes are well-scoped, thoroughly tested, and the new `symbolFoundInFile` field is optional so existing callers remain compatible. No concrete bugs producing wrong output or breaking callers were found.
>
> - `list_functions` and `search_code` now call `vectorDB.hasData()` to escalate a truly empty index while hedging on a present-but-stale index.
> - `get_dependents` now passes `symbolFoundInFile` through `DependencyAnalysisResult` so the caveat wording matches whether the symbol was actually found in the file's chunks.
> - New `formatNoIndexNote()` helper reuses the existing `⚠ Lien:` warning pattern.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 22a92d4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->