### PR TITLE
fix(cli): stop name-filtered test runs from silently disabling the verification nudge

### DIFF
--- a/docs/architecture/test-verification-nudge.md
+++ b/docs/architecture/test-verification-nudge.md
@@ -276,6 +276,61 @@ vs. rspec `-e`, cargo-nextest's `run` keyword vs. `cargo test`'s positional,
 and now `cargo test`'s own compile-config flags vs. its own positional. All
 three are now pinned as regression tests in `test-run-matcher.test.ts`.
 
+##### A fourth instance: pnpm's own `--filter`/`-F` workspace selector (2026-07-29)
+
+Review of the cargo fix above found one more case of the same hazard, then a
+second, independent review of *that* claim corrected its direction: `pnpm
+test --filter <selector>` (the workspace selector placed AFTER the script
+name, rather than the `pnpm --filter <selector> test` form already absorbed
+whole by its own anchored `RUNNER_PATTERNS` entry) has a selector value that
+routinely contains `/` for a scoped package name (`@hono/core`). Without a
+dedicated skip, that value was independently scanned by the generic
+path-token check and misread as a real scope-narrowing FILE — flipping a
+genuinely broad run to a falsely narrow "scoped to `./@hono/core`" (the
+review's first pass called this a suppression risk; a second, independently
+verified pass established the direction is actually the opposite — a false
+NAG, not a false silence, since a broad-run-misread-as-scoped can only ever
+*reduce* claimed coverage, never expand it). Fixed by adding
+`PNPM_TEST_VALUE_FLAGS` (`--filter`, `-F`), skipped as flag+value via
+`valueSkipFlagsFor` exactly like `CARGO_TEST_VALUE_FLAGS`, but gated on the
+generic `pnpm test`/`pnpm test:script` match specifically (`isPnpmTestRunner`)
+so dotnet/swift's unrelated test-NAME use of the identical `--filter`
+spelling is untouched.
+
+The same review also surfaced, independently of the misclassification bug,
+that the `--filter=selector` single-token form placed BEFORE the script
+(`pnpm --filter=@hono/core test`) matched no `RUNNER_PATTERNS` entry at all —
+pnpm's own docs show this `=` form as the canonical way to write an
+exclusion selector (`--filter=!foo`), so a real, documented, non-exotic
+invocation always nagged. Fixed by widening the dedicated anchored pnpm
+pattern to `(?:--filter|-F)(?:\s+\S+|=\S+)` (both the space and `=` forms,
+both the long flag and its documented short alias).
+
+A sweep of every other per-runner name-filter flag's `=` form (`pytest
+-k=`/`-m=`, `rspec -e=`/`--example=`, `mocha --grep=`/`-g=`, `go test
+-run=`, `vitest`/`jest -t=`/`--testNamePattern=`, `dotnet`/`swift
+--filter=`) found no equivalent gap: `isNameFilterFlag`'s existing
+`token.startsWith(`${flag}=`)` check already recognizes all of them —
+verified directly against `classifyTestCommand`, all still correctly
+name-filtered. A separate finding while investigating (`turbo test
+--filter=web`) is NOT a `--filter` bug at all: `turbo` is not a recognized
+runner in `RUNNER_PATTERNS` at all, so the command is simply unclassified
+and falls through to the safe fail-open default (nags because no run was
+ever recorded) — unrelated to this fix and out of scope (adding `turbo`
+support was never requested and isn't a regression).
+
+This is the **fourth** instance of the identical short-flag/value-collision
+hazard class in this file. A generalized "flag arity table" (mapping every
+recognized flag per runner to a consumes-value/semantics tag) was considered
+in place of a fourth targeted allow-list entry, but rejected for now: the
+existing per-concern, per-runner-family lookup idiom (`nameFilterFlagsFor`,
+`valueSkipFlagsFor`) already generalizes to this fourth case with one small,
+independently testable addition each, matching this module's stated
+conservative-allow-list philosophy; a unified table would be a structural
+reorganization with no additional correctness benefit over what's here,
+and would cost a larger, riskier diff for a module already this
+security-sensitive to the nudge's credibility.
+
 ## C. `lien verify-tests <subcommand>`
 
 A command group (`packages/cli/src/cli/verify-tests-cmd.ts`), like `lien

--- a/docs/architecture/test-verification-nudge.md
+++ b/docs/architecture/test-verification-nudge.md
@@ -137,7 +137,7 @@ interface TestRunClassification { isTestRun: boolean; broad: boolean; scopeToken
    or ends in a source extension (reusing `getSupportedExtensions()` from
    `@liendev/parser` rather than hand-maintaining a second extension list —
    a test file shares its language's extension, so "ends in a source
-   extension" already covers the test-ish case). Two token classes are
+   extension" already covers the test-ish case). Three token classes are
    excluded from ever counting as a scoping argument even when they'd
    otherwise qualify: a workspace-scope flag's value (`-w`/`--workspace`,
    e.g. `@liendev/core`, which contains a `/`), and a config-flag's value
@@ -330,6 +330,64 @@ conservative-allow-list philosophy; a unified table would be a structural
 reorganization with no additional correctness benefit over what's here,
 and would cost a larger, riskier diff for a module already this
 security-sensitive to the nudge's credibility.
+
+##### A scope-broadening flag does NOT make a name-filtered run `broad` — selection and scope are independent axes (2026-07-30)
+
+A review pass suggested that `go test -run TestFoo ./...` /
+`go test -run TestFoo .` and `cargo test foo --workspace` /
+`cargo test foo --all` should classify as `broad`, on the reasoning that
+`./...`/`--workspace`/`--all` are "broad-scope indicators." **This is wrong,
+and the classifier's existing behavior (no change needed) is correct** —
+verified directly against `classifyTestCommand` and independently re-verified
+against a real Go module (gin) with `internal/bytesconv` (4 test functions,
+none named `TestFoo`):
+
+```
+go test -run TestFoo ./...      => name-filtered (NAGS)  -- executes none of bytesconv's 4 tests
+go test -run TestFoo .          => name-filtered (NAGS)
+cargo test foo --workspace      => name-filtered (NAGS)
+cargo test foo --all            => name-filtered (NAGS)
+go test ./...                   => broad (SILENT)  -- no name filter, real whole-suite coverage
+cargo test --workspace          => broad (SILENT)
+cargo test --all                => broad (SILENT)
+```
+
+The reasoning: **which packages/crates get compiled and which tests within
+them actually execute are two independent axes.** `./...`/`--workspace`/
+`--all` answer the first question (compile everything reachable) — genuinely
+scope-broadening, correctly contributing no scoping restriction on their
+own. `-run TestFoo` / a bare positional test name answer the second,
+completely orthogonal question (of the tests that got compiled, run only
+ones matching this name) — and that restriction does not evaporate just
+because the first axis was maximally broadened. `go test -run TestFoo ./...`
+compiles every package in the module and then, within each one, runs only
+tests whose name matches `TestFoo` — the overwhelming majority of real test
+functions across the module (e.g. all 4 in `bytesconv`, none named `TestFoo`)
+never execute. Treating this as `broad` would make it functionally identical
+to running nothing at all while still marking every edited file in the
+session "verified" — precisely the false-"tests ran" bug this whole feature
+exists to close, just reached via a scope flag instead of a bare name.
+
+The classifier already gets this right by construction, not by any special
+case: a scope-broadening flag either lands in a genuinely orthogonal
+skip-flag set (`--workspace`/`-w` in the global `WORKSPACE_SCOPE_FLAGS`,
+consumed as flag+value and contributing nothing) or is excluded from
+path-likeness entirely (`./...` via `GLOB_ALL_TOKENS`) — in both cases it
+simply produces **no scoping evidence of its own**, neither for nor against
+name-filtering. The *separate* name-filter evidence (`-run`'s presence, or
+cargo's bare positional) is tracked independently and is what actually
+decides `broad` vs. name-filtered here; a scope flag appearing in the same
+command never suppresses that independently-collected evidence. This is
+exactly the axis-independence the `--workspace`/`--all`/`./...` case
+requires, achieved for free by not having any code path that treats "a
+scope flag is present" as license to ignore other evidence in the same
+segment. **Do not "fix" this by making a scope-broadening flag force
+`broad` regardless of a name filter also present in the same command** — that
+is, verbatim, the false-silence bug from the top of this document, just
+triggered by a different flag.
+
+Regression tests for all seven commands above are pinned in
+`test-run-matcher.test.ts`.
 
 ## C. `lien verify-tests <subcommand>`
 

--- a/docs/architecture/test-verification-nudge.md
+++ b/docs/architecture/test-verification-nudge.md
@@ -204,7 +204,7 @@ naming conventions (Python's `test_foo.py`, Go's `foo_test.go`, Ruby's
 `foo_spec.rb`) fall back to exact-basename matching, which already covers
 the common case of a run naming the real associated test file.
 
-#### Name-filtered runs are neither `broad` nor `scoped` (2026-07-29, #946)
+#### Name-filtered runs are neither `broad` nor `scoped` (2026-07-29)
 
 A run scoped by test **name** rather than file/directory (`pytest -k expr`,
 `dotnet test --filter expr`, `go test -run regex`, a bare `cargo test name`,
@@ -467,7 +467,7 @@ each script:
   `stop_hook_active` never arrives.
 - **Fail-open**: malformed (non-JSON) stdin and a payload missing
   `session_id` both exited 0 with no output, for both new hooks.
-- **Name-filtered runs (2026-07-29, #946)**, dogfooded end-to-end in a
+- **Name-filtered runs (2026-07-29)**, dogfooded end-to-end in a
   foreign repo (flask, not this one) via `test-reminder.sh`/`test-run-note.sh`
   with real stdin: an edit + a `tool_input.command: "pytest -k
   test_totally_unrelated_name"` payload, on the pre-fix build, produced

--- a/docs/architecture/test-verification-nudge.md
+++ b/docs/architecture/test-verification-nudge.md
@@ -245,6 +245,37 @@ absorbed by its own anchored runner pattern before this scan ever runs, so
 the shared spelling with dotnet/swift's name filter never collides in
 practice.
 
+##### A third instance of the same hazard, caught in review: `cargo test`'s own value-taking flags (2026-07-29)
+
+Review of the fix above found that `cargo test`'s bare-positional detection
+was too aggressive: `cargo test --features foo`, `-p my_crate`,
+`--manifest-path <path>`, `--target <triple>`, `--profile <name>`, and `-j
+<n>` all take a bare VALUE in the exact textual position a positional test
+name would sit, and none of them narrow which tests run — the run stays
+genuinely broad. Before this follow-up, that value was misread as a bare
+positional test name (`sawBareToken`), flipping a genuinely broad run to
+falsely name-filtered — the opposite direction from the original bug, but
+still wrong, and a real regression relative to the pre-existing behavior for
+these commands. Fixed by adding `CARGO_TEST_VALUE_FLAGS`
+(`valueSkipFlagsFor` in `test-run-matcher.ts`), skipped as flag+value the
+same way `WORKSPACE_SCOPE_FLAGS`/`CONFIG_FLAGS` already are, but kept
+cargo-test-specific rather than global (a couple of these flag spellings,
+e.g. `-j`, aren't universally safe to blanket-skip for every runner).
+
+`--test <name>` (cargo's specific-integration-test-binary-target filter) is
+deliberately excluded from that skip set: unlike the flags above, it
+genuinely narrows which tests run, so its value is left to flow through as
+an ordinary bare token — landing on the same name-filtered (not broad, not
+falsely "scoped") outcome as a plain `cargo test <name>`, the safe fallback
+for a target name this module has no infrastructure to resolve against a
+real file path.
+
+This is the **third** instance of the identical hazard class in one file
+(bare/short-flag values misread across an unrelated boundary): tox `-e`
+vs. rspec `-e`, cargo-nextest's `run` keyword vs. `cargo test`'s positional,
+and now `cargo test`'s own compile-config flags vs. its own positional. All
+three are now pinned as regression tests in `test-run-matcher.test.ts`.
+
 ## C. `lien verify-tests <subcommand>`
 
 A command group (`packages/cli/src/cli/verify-tests-cmd.ts`), like `lien

--- a/docs/architecture/test-verification-nudge.md
+++ b/docs/architecture/test-verification-nudge.md
@@ -137,17 +137,27 @@ interface TestRunClassification { isTestRun: boolean; broad: boolean; scopeToken
    or ends in a source extension (reusing `getSupportedExtensions()` from
    `@liendev/parser` rather than hand-maintaining a second extension list —
    a test file shares its language's extension, so "ends in a source
-   extension" already covers the test-ish case). Three token classes are
+   extension" already covers the test-ish case). Two token classes are
    excluded from ever counting as a scoping argument even when they'd
-   otherwise qualify: a workspace-scope flag's value
-   (`-w`/`--workspace`/`--filter`, e.g. `@liendev/core`, which contains a
-   `/`), a config-flag's value (`-c`/`--config`, e.g. `vitest.config.ts`,
-   which ends in a source extension) or any bare token matching
-   `*.config.*` even without a preceding flag, and Go's glob-all convention
-   (`./...`).
-4. A segment with no scoping tokens is `broad` (whole-suite/workspace run);
-   any `broad` segment makes the whole command's classification `broad`,
-   even if another segment in the same command also named specific files.
+   otherwise qualify: a workspace-scope flag's value (`-w`/`--workspace`,
+   e.g. `@liendev/core`, which contains a `/`), and a config-flag's value
+   (`-c`/`--config`, e.g. `vitest.config.ts`, which ends in a source
+   extension) or any bare token matching `*.config.*` even without a
+   preceding flag, and Go's glob-all convention (`./...`).
+4. Separately, the remainder is checked for a **name filter** — a flag
+   from a per-runner-family allow-list (`pytest -k`/`-m`, `dotnet
+   test`/`swift test --filter`, `rspec -e`/`--example`, `mocha
+   --grep`/`-g`, `go test -run`, `vitest`/`jest -t`/`--testNamePattern`),
+   or, for `cargo test` specifically, a bare positional argument (its own
+   `[TESTNAME]` convention — see the deviation note below for why this
+   can't just be "any bare leftover token"). A segment with a path-like
+   scoping token is `scoped` regardless of any name filter also present
+   (a path always wins). Otherwise: a name-filtered segment is neither
+   `broad` nor a `scopeTokens` contributor (see below); only a segment with
+   *no* scoping evidence of either kind is `broad`. Any `broad` segment
+   makes the whole command's classification `broad`, even if another
+   segment in the same command also named specific files or was itself
+   name-filtered.
 
 ### `computeUnverifiedFiles(edits, runs)`
 
@@ -193,6 +203,47 @@ tests (`auth.ts`/`oauth.test.ts`, `user.ts`/`superuser.test.ts`,
 naming conventions (Python's `test_foo.py`, Go's `foo_test.go`, Ruby's
 `foo_spec.rb`) fall back to exact-basename matching, which already covers
 the common case of a run naming the real associated test file.
+
+#### Name-filtered runs are neither `broad` nor `scoped` (2026-07-29, #946)
+
+A run scoped by test **name** rather than file/directory (`pytest -k expr`,
+`dotnet test --filter expr`, `go test -run regex`, a bare `cargo test name`,
+...) has no path-like scope token at all. Before this fix, `classifyTestCommand`
+had exactly two outcomes — `scoped` (path tokens found) or `broad` (none
+found) — so every name-filtered run fell into `broad` by construction, and
+`computeUnverifiedFiles`'s any-broad-run silence rule then marked the
+*entire* session's edit set "verified" off the back of one arbitrarily-named,
+unrelated test. Confirmed on the released 0.72.0: an edit with no test run at
+all correctly nagged, but the identical edit followed by
+`pytest -k test_totally_unrelated_name` went completely silent.
+
+Fixed by adding a third classification outcome — name-filtered — reached
+when the remainder carries recognized name-filter evidence (a
+per-runner-family flag, or `cargo test`'s bare positional) but no path
+token. A name-filtered run keeps `isTestRun: true` (something genuinely ran)
+but sets neither `broad` nor a `scopeTokens` entry, so
+`computeUnverifiedFiles` treats it exactly as if no run had been observed:
+it neither silences the report nor "covers" any file. This is the same
+fail-safe bias as the substring-matching deviation above — a false nag costs
+one already-escape-hatched line of text, a false "everything is verified"
+disables the whole mechanism.
+
+The flag allow-list is deliberately **per runner family**, not one global
+set, because two runners in this same allow-list reuse an identical short
+flag spelling for unrelated purposes: tox's `-e ENV` selects which
+*configured environment* to run (still that environment's whole suite — not
+a named test), while rspec's `-e NAME` names one example. A global `-e`
+recognition would have wrongly flipped `tox -e py311` (must stay `broad`)
+into name-filtered. The same reasoning kept `cargo test <name>`'s bare
+positional special-cased to exactly that runner (`POSITIONAL_NAME_FILTER_RUNNERS`
+in `test-run-matcher.ts`) rather than "any bare leftover token" — the latter
+would also have wrongly swallowed cargo-nextest's required `run` subcommand
+keyword and Gradle's `-x <task>`/`--exclude-task <task>` exclusion value,
+both bare tokens with unrelated meaning. `--filter` also moved out of the
+workspace-scope flag set entirely: pnpm's `--filter <pkg> test` is fully
+absorbed by its own anchored runner pattern before this scan ever runs, so
+the shared spelling with dotnet/swift's name filter never collides in
+practice.
 
 ## C. `lien verify-tests <subcommand>`
 
@@ -416,6 +467,16 @@ each script:
   `stop_hook_active` never arrives.
 - **Fail-open**: malformed (non-JSON) stdin and a payload missing
   `session_id` both exited 0 with no output, for both new hooks.
+- **Name-filtered runs (2026-07-29, #946)**, dogfooded end-to-end in a
+  foreign repo (flask, not this one) via `test-reminder.sh`/`test-run-note.sh`
+  with real stdin: an edit + a `tool_input.command: "pytest -k
+  test_totally_unrelated_name"` payload, on the pre-fix build, produced
+  empty `report` output (the bug); the identical sequence on the fixed
+  build produced the full advisory, matching the no-run control exactly.
+  A genuinely broad run (`python -m pytest`, no filter) still produced
+  empty `report` output on the fixed build (no regression), and a
+  file-scoped run naming an unrelated file (`pytest
+  tests/test_totally_unrelated_module.py`) still nagged.
 - **`test-reminder.sh` (rewired)**: a real `Edit` payload produced the
   identical `additionalContext` reminder text as before **and** recorded
   the edit into `test-sessions/<sessionId>.jsonl` in the same invocation —

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -48,7 +48,11 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['./vendor/bin/phpunit', true, true, []],
     ['composer test', true, true, []],
     ['swift test', true, true, []],
-    ['swift test --filter HTTPHeadersTests', true, true, []],
+    // #946: `--filter` here names a suite, not a path/workspace — a
+    // name-filtered run (see the name-filter table below), NOT broad. This
+    // used to be (incorrectly) broad because `--filter` was globally
+    // skip-invisible via WORKSPACE_SCOPE_FLAGS.
+    ['swift test --filter HTTPHeadersTests', true, false, []],
     ['./gradlew test', true, true, []],
     ['./gradlew :exposed-core:test', true, true, []],
     ['gradlew test', true, true, []],
@@ -144,6 +148,55 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     // Composed: a wrapper around tox.
     ['uv run tox run', true, true, []],
     ['uv run tox -e py311 -- tests/test_x.py', true, false, ['tests/test_x.py']],
+    // #946: a run scoped by test NAME rather than file/directory has no
+    // path-like scope token, so before this fix it fell back to `broad`
+    // (silently marking the whole session's edits "verified"). Each of
+    // these must come back name-filtered: isTestRun, NOT broad, and no
+    // scopeTokens — see the module doc comment and computeUnverifiedFiles
+    // describe block below for what that third state means downstream.
+    ['pytest -k test_totally_unrelated_name', true, false, []],
+    ['pytest -k "some expr"', true, false, []],
+    ['pytest -m slow', true, false, []],
+    ['dotnet test --filter FullyQualifiedName~Some.Unrelated.Test', true, false, []],
+    ['dotnet test --filter=Category=Foo', true, false, []],
+    ['rspec -e "some unrelated example"', true, false, []],
+    ['rspec --example "some unrelated example"', true, false, []],
+    ['bundle exec rspec -e "some unrelated example"', true, false, []],
+    ["mocha --grep 'unrelated pattern'", true, false, []],
+    ['mocha -g unrelated', true, false, []],
+    ['go test -run TestUnrelated', true, false, []],
+    ['go test -run=TestUnrelated', true, false, []],
+    ['cargo test test_unrelated_name', true, false, []],
+    ['vitest -t "unrelated name"', true, false, []],
+    ['jest -t "unrelated name"', true, false, []],
+    ['jest --testNamePattern "unrelated name"', true, false, []],
+    ['npx vitest run -t "unrelated name"', true, false, []],
+    ['swift test --filter HTTPHeadersTests', true, false, []],
+    // Compound: a path present alongside a name filter must still scope
+    // normally by the path — the name filter must not downgrade it.
+    ['pytest -k name tests/test_helpers.py', true, false, ['tests/test_helpers.py']],
+    [
+      'dotnet test --filter FullyQualifiedName~Foo tests/FooTests.cs',
+      true,
+      false,
+      ['tests/FooTests.cs'],
+    ],
+    // Negative guards: these must NOT be swept up as name-filtered and must
+    // stay exactly as before. tox's `-e ENV` looks identical in shape to
+    // rspec's `-e NAME` but means something unrelated (which configured
+    // environment to run, not a named test) — this is the concrete
+    // collision the per-runner-family flag scoping in NAME_FILTER_FLAGS
+    // exists to avoid.
+    ['tox -e py311', true, true, []],
+    // cargo-nextest's required `run` subcommand keyword is a bare token in
+    // the same position a `cargo test <name>` filter would be, but it must
+    // not be misread as one.
+    ['cargo nextest run', true, true, []],
+    // Gradle's exclude-task flags take a bare task-name VALUE in the same
+    // position a name filter's value would sit, but excluding a task is the
+    // opposite of "ran a named test" and must stay broad.
+    ['./gradlew test -x integrationTest', true, true, []],
+    ['./gradlew --exclude-task integrationTest test', true, true, []],
   ])('%s -> isTestRun=%s broad=%s scopeTokens=%j', (command, isTestRun, broad, scopeTokens) => {
     expect(classifyTestCommand(command)).toEqual({ isTestRun, broad, scopeTokens });
   });
@@ -355,6 +408,49 @@ describe('computeUnverifiedFiles', () => {
     it('a directory scope token without a leading ./ still matches (go test pkg/x/...)', () => {
       const edits = new Map([['pkg/cmd/label/list.go', ['pkg/cmd/label/list_test.go']]]);
       const runs = [{ isTestRun: true, broad: false, scopeTokens: ['pkg/cmd/label/...'] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
+    });
+  });
+
+  // #946: name-filtered runs (`classifyTestCommand` returning `isTestRun:
+  // true, broad: false, scopeTokens: []`) must behave, downstream in
+  // computeUnverifiedFiles, exactly as if no run had been observed at all —
+  // neither silencing the report (that was the bug: a name-filtered run
+  // used to come back `broad: true` and clear every edited file) nor
+  // crashing on the empty scopeTokens array.
+  describe('name-filtered runs contribute no coverage (#946)', () => {
+    it('a lone name-filtered run leaves every edited file unverified, same as no run at all', () => {
+      const edits = new Map([
+        ['src/foo.ts', ['src/foo.test.ts']],
+        ['src/bar.ts', ['src/bar.test.ts']],
+      ]);
+      const runs = [{ isTestRun: true, broad: false, scopeTokens: [] }];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([
+        { file: 'src/foo.ts', tests: ['src/foo.test.ts'] },
+        { file: 'src/bar.ts', tests: ['src/bar.test.ts'] },
+      ]);
+    });
+
+    it('a name-filtered run alongside a real scoped run only clears the scoped file, not the rest', () => {
+      const edits = new Map([
+        ['src/foo.ts', ['src/foo.test.ts']],
+        ['src/bar.ts', ['src/bar.test.ts']],
+      ]);
+      const runs = [
+        { isTestRun: true, broad: false, scopeTokens: [] }, // e.g. pytest -k unrelated_name
+        { isTestRun: true, broad: false, scopeTokens: ['src/foo.test.ts'] },
+      ];
+      expect(computeUnverifiedFiles(edits, runs)).toEqual([
+        { file: 'src/bar.ts', tests: ['src/bar.test.ts'] },
+      ]);
+    });
+
+    it('a genuinely broad run alongside a name-filtered run still clears everything', () => {
+      const edits = new Map([['src/foo.ts', ['src/foo.test.ts']]]);
+      const runs = [
+        { isTestRun: true, broad: false, scopeTokens: [] }, // name-filtered
+        { isTestRun: true, broad: true, scopeTokens: [] }, // e.g. npm test
+      ];
       expect(computeUnverifiedFiles(edits, runs)).toEqual([]);
     });
   });

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -256,6 +256,23 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['pnpm -F hono test', true, true, []],
     ['pnpm -F @hono/core test', true, true, []],
     ['pnpm --filter=!excluded-pkg test', true, true, []],
+    // Rejected review suggestion, pinned as regression (2026-07-30): a
+    // scope-broadening flag (which packages/crates get COMPILED) must NOT
+    // suppress independent name-filter evidence (which tests, among those
+    // compiled, actually EXECUTE) — selection and scope are independent
+    // axes. See the matching doc section in
+    // docs/architecture/test-verification-nudge.md. Making these `broad`
+    // instead would be the exact false-silence bug this file exists to fix,
+    // just triggered by a scope flag instead of a bare name.
+    ['go test -run TestFoo ./...', true, false, []],
+    ['go test -run TestFoo .', true, false, []],
+    ['cargo test foo --workspace', true, false, []],
+    ['cargo test foo --all', true, false, []],
+    // Contrast: the SAME scope-broadening flags, with no name filter
+    // present at all, correctly stay broad (real whole-suite coverage).
+    ['go test ./...', true, true, []],
+    ['cargo test --workspace', true, true, []],
+    ['cargo test --all', true, true, []],
   ])('%s -> isTestRun=%s broad=%s scopeTokens=%j', (command, isTestRun, broad, scopeTokens) => {
     expect(classifyTestCommand(command)).toEqual({ isTestRun, broad, scopeTokens });
   });

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -197,6 +197,38 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     // opposite of "ran a named test" and must stay broad.
     ['./gradlew test -x integrationTest', true, true, []],
     ['./gradlew --exclude-task integrationTest test', true, true, []],
+    // Regression (caught in review): `cargo test`'s own build/compile-config
+    // flags take a bare VALUE in the exact same position a positional test
+    // name would sit (`cargo test [TESTNAME]`) — the third instance of this
+    // hazard class in this file (after tox `-e`/rspec `-e` and cargo-nextest's
+    // `run`). None of these narrow which tests run; the value must not be
+    // misread as a test name, and the run must stay `broad`.
+    ['cargo test --features foo', true, true, []],
+    ['cargo test -F foo', true, true, []],
+    ['cargo test --features=foo', true, true, []],
+    ['cargo test -p my_crate', true, true, []],
+    ['cargo test --package my_crate', true, true, []],
+    ['cargo test --exclude other_crate', true, true, []],
+    ['cargo test --manifest-path ./Cargo.toml', true, true, []],
+    ['cargo test --lockfile-path ./Cargo.lock', true, true, []],
+    ['cargo test --target x86_64-unknown-linux-gnu', true, true, []],
+    ['cargo test --target-dir ./target', true, true, []],
+    ['cargo test --profile release', true, true, []],
+    ['cargo test -j 4', true, true, []],
+    ['cargo test --jobs 4', true, true, []],
+    ['cargo test --color always', true, true, []],
+    ['cargo test --message-format json', true, true, []],
+    // A build-config flag alongside a genuine positional test name must
+    // still be recognized as name-filtered by that name — the flag-value
+    // skip must not eat the real positional too.
+    ['cargo test --features foo some_unrelated_name', true, false, []],
+    // `--test <name>` selects a specific integration-test BINARY target by
+    // name, not a file path and not a build-config value — it genuinely
+    // narrows which tests run, so (unlike the build-config flags above) it
+    // is deliberately NOT skipped. There's no infrastructure here to resolve
+    // a bare target name against a real file, so it lands on the same safe
+    // name-filtered (not broad) outcome as a plain `cargo test <name>`.
+    ['cargo test --test integration_test', true, false, []],
   ])('%s -> isTestRun=%s broad=%s scopeTokens=%j', (command, isTestRun, broad, scopeTokens) => {
     expect(classifyTestCommand(command)).toEqual({ isTestRun, broad, scopeTokens });
   });

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -229,6 +229,33 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     // a bare target name against a real file, so it lands on the same safe
     // name-filtered (not broad) outcome as a plain `cargo test <name>`.
     ['cargo test --test integration_test', true, false, []],
+    // Regression (caught in review, then corrected on direction): pnpm's own
+    // `--filter`/`-F` workspace selector (https://pnpm.io/filtering) is a
+    // FOURTH instance of the same short-flag-collision hazard class. A
+    // scoped package name routinely contains "/" (`@hono/core`), which the
+    // generic path-token scan misread as a real scope-narrowing file when
+    // `--filter` appeared AFTER the script name — flipping a genuinely broad
+    // run to falsely narrow. Both orderings (`--filter` before/after the
+    // script) and both forms (`--filter <val>` / `--filter=<val>`) must stay
+    // broad, plus the documented `-F` alias.
+    ['pnpm test --filter hono', true, true, []],
+    ['pnpm test --filter @hono/core', true, true, []],
+    ['pnpm test --filter=hono', true, true, []],
+    ['pnpm test --filter=@hono/core', true, true, []],
+    ['pnpm test -F hono', true, true, []],
+    ['pnpm test -F @hono/core', true, true, []],
+    ['pnpm --filter hono test', true, true, []],
+    ['pnpm --filter @hono/core test', true, true, []],
+    // The "=" form before the script wasn't matched by ANY runner pattern at
+    // all before this fix (isTestRun: false) — pnpm's own docs show
+    // `--filter=selector` as the canonical exclusion form
+    // (`--filter=!foo`), so this always nagged even though it's a
+    // documented, common invocation.
+    ['pnpm --filter=hono test', true, true, []],
+    ['pnpm --filter=@hono/core test', true, true, []],
+    ['pnpm -F hono test', true, true, []],
+    ['pnpm -F @hono/core test', true, true, []],
+    ['pnpm --filter=!excluded-pkg test', true, true, []],
   ])('%s -> isTestRun=%s broad=%s scopeTokens=%j', (command, isTestRun, broad, scopeTokens) => {
     expect(classifyTestCommand(command)).toEqual({ isTestRun, broad, scopeTokens });
   });

--- a/packages/cli/src/utils/test-run-matcher.test.ts
+++ b/packages/cli/src/utils/test-run-matcher.test.ts
@@ -48,7 +48,7 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     ['./vendor/bin/phpunit', true, true, []],
     ['composer test', true, true, []],
     ['swift test', true, true, []],
-    // #946: `--filter` here names a suite, not a path/workspace — a
+    // 2026-07-29: `--filter` here names a suite, not a path/workspace — a
     // name-filtered run (see the name-filter table below), NOT broad. This
     // used to be (incorrectly) broad because `--filter` was globally
     // skip-invisible via WORKSPACE_SCOPE_FLAGS.
@@ -148,7 +148,7 @@ describe('classifyTestCommand — broad vs scoped classification table', () => {
     // Composed: a wrapper around tox.
     ['uv run tox run', true, true, []],
     ['uv run tox -e py311 -- tests/test_x.py', true, false, ['tests/test_x.py']],
-    // #946: a run scoped by test NAME rather than file/directory has no
+    // 2026-07-29: a run scoped by test NAME rather than file/directory has no
     // path-like scope token, so before this fix it fell back to `broad`
     // (silently marking the whole session's edits "verified"). Each of
     // these must come back name-filtered: isTestRun, NOT broad, and no
@@ -412,13 +412,13 @@ describe('computeUnverifiedFiles', () => {
     });
   });
 
-  // #946: name-filtered runs (`classifyTestCommand` returning `isTestRun:
+  // 2026-07-29: name-filtered runs (`classifyTestCommand` returning `isTestRun:
   // true, broad: false, scopeTokens: []`) must behave, downstream in
   // computeUnverifiedFiles, exactly as if no run had been observed at all —
   // neither silencing the report (that was the bug: a name-filtered run
   // used to come back `broad: true` and clear every edited file) nor
   // crashing on the empty scopeTokens array.
-  describe('name-filtered runs contribute no coverage (#946)', () => {
+  describe('name-filtered runs contribute no coverage', () => {
     it('a lone name-filtered run leaves every edited file unverified, same as no run at all', () => {
       const edits = new Map([
         ['src/foo.ts', ['src/foo.test.ts']],

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -16,6 +16,17 @@
  * substring containment let an unrelated run (`oauth.test.ts` covering
  * `auth.ts`) silently suppress a real nag, which is a worse failure mode
  * than an occasional false nag the escape-hatch wording already absorbs.
+ *
+ * A run scoped by test NAME rather than by file/directory (`pytest -k expr`,
+ * `dotnet test --filter expr`, `go test -run regex`, a bare `cargo test
+ * name`, ...) is neither `broad` NOR does it contribute any `scopeTokens` —
+ * see the `NAME_FILTER_FLAGS`/`POSITIONAL_NAME_FILTER_RUNNERS` handling in
+ * `classifyTestCommand` below. It tells us *some* test ran, but not which
+ * files it covered, so `computeUnverifiedFiles` must keep nagging exactly as
+ * if no run had been observed at all — the same fail-safe bias as the
+ * substring-matching deviation above: a false nag costs one line of
+ * (already-escape-hatched) text, a false "everything is verified" silently
+ * disables the whole mechanism.
  */
 
 import path from 'node:path';
@@ -122,7 +133,82 @@ function stripLeadingWrappersAndEnv(segment: string): string {
 // `npm test -w @liendev/core` must classify as broad even though
 // "@liendev/core" contains a "/". The flag and its value are both skipped
 // before scanning for path-like tokens.
-const WORKSPACE_SCOPE_FLAGS = new Set(['-w', '--workspace', '--filter']);
+//
+// `--filter` is deliberately NOT here even though pnpm also uses it for
+// workspace scoping (`pnpm --filter my-pkg test`): that form is matched
+// whole by its own anchored RUNNER_PATTERNS entry above (the flag+value
+// never reach this remainder scan at all), whereas dotnet/swift/nx reuse
+// the same flag spelling for a test-NAME filter, which must NOT be silently
+// swallowed — see NAME_FILTER_FLAGS below.
+const WORKSPACE_SCOPE_FLAGS = new Set(['-w', '--workspace']);
+
+// Flags whose value narrows a run to specific test NAMES rather than a
+// file/directory/workspace — `pytest -k expr`, `dotnet test --filter expr`,
+// `rspec -e name`, `mocha --grep pattern`, `go test -run regex`, `vitest -t`
+// / `jest -t` (or `--testNamePattern`). Recognizing one of these flags marks
+// the run as name-filtered: some tests genuinely ran, but which files they
+// covered is unknowable from the command line alone, so (per the module doc
+// comment) the run must end up neither `broad` nor contributing a
+// `scopeTokens` entry — never silently "verified", never a hard failure
+// either. A bare `cargo test <name>` has no flag at all (see
+// `POSITIONAL_NAME_FILTER_RUNNERS` below for that positional case).
+//
+// Deliberately PER-RUNNER-FAMILY, not one global set: a couple of these
+// short flag spellings are reused with UNRELATED meaning by another runner
+// in this same file. Concretely, tox's `-e ENV` selects which configured
+// environment to run (still that environment's whole configured suite, not
+// a named test — see the `tox`/`nox` comment on RUNNER_PATTERNS), which is
+// NOT the same thing as rspec's `-e NAME` (a single named example).
+// Recognizing bare `-e` globally would wrongly flip `tox -e py311` from
+// broad (correct, must not regress) to name-filtered.
+const PYTEST_NAME_FILTER_FLAGS = new Set(['-k', '-m']);
+const RSPEC_NAME_FILTER_FLAGS = new Set(['-e', '--example']);
+const MOCHA_NAME_FILTER_FLAGS = new Set(['--grep', '-g']);
+const GO_TEST_NAME_FILTER_FLAGS = new Set(['-run']);
+// vitest and jest share the same Jest-descended CLI convention.
+const JS_TEST_NAME_FILTER_FLAGS = new Set(['-t', '--testNamePattern']);
+// dotnet and swift both spell their (unrelated-to-pnpm/nx) test-name filter
+// `--filter`; pnpm's own `--filter` is fully absorbed by its dedicated
+// anchored RUNNER_PATTERNS entry before reaching this lookup at all, so
+// there is no collision in practice despite the shared spelling.
+const DOTNET_SWIFT_NAME_FILTER_FLAGS = new Set(['--filter']);
+const NO_NAME_FILTER_FLAGS: ReadonlySet<string> = new Set();
+
+/** Which name-filter flags apply for the runner `matchedRunnerText` (`match[0]`) identified — empty when that runner has none. */
+function nameFilterFlagsFor(matchedRunnerText: string): ReadonlySet<string> {
+  const text = matchedRunnerText.trim();
+  if (/pytest$/.test(text)) return PYTEST_NAME_FILTER_FLAGS;
+  if (/rspec$/.test(text)) return RSPEC_NAME_FILTER_FLAGS;
+  if (/^mocha$/.test(text)) return MOCHA_NAME_FILTER_FLAGS;
+  if (/^go\s+test$/.test(text)) return GO_TEST_NAME_FILTER_FLAGS;
+  if (/vitest$/.test(text) || /^jest$/.test(text)) return JS_TEST_NAME_FILTER_FLAGS;
+  if (/^dotnet\s+test$/.test(text) || /^swift\s+test$/.test(text)) {
+    return DOTNET_SWIFT_NAME_FILTER_FLAGS;
+  }
+  return NO_NAME_FILTER_FLAGS;
+}
+
+/** `token` is one of `flags`, bare or as its `--flag=value` single-token form. */
+function isNameFilterFlag(token: string, flags: ReadonlySet<string>): boolean {
+  if (flags.has(token)) return true;
+  return [...flags].some(flag => token.startsWith(`${flag}=`));
+}
+
+// Runners whose own CLI convention narrows to a named test via a BARE
+// positional argument — no flag at all — so the generic isNameFilterFlag
+// scan above can't see it. `cargo test [TESTNAME]` is the one such form
+// among RUNNER_PATTERNS; every other name-filter above is flag-driven.
+// Deliberately keyed on the exact matched runner text (`match[0]`, e.g.
+// "cargo test") rather than "any bare leftover token", which would also
+// wrongly swallow `cargo nextest run`'s required `run` subcommand keyword
+// and Gradle's `-x <task>`/`--exclude-task <task>` exclusion VALUE (both are
+// bare tokens with a completely different meaning) — see the matching
+// negative test cases in test-run-matcher.test.ts.
+const POSITIONAL_NAME_FILTER_RUNNERS = new Set(['cargo test']);
+
+function isPositionalNameFilterRunner(matchedRunnerText: string): boolean {
+  return POSITIONAL_NAME_FILTER_RUNNERS.has(matchedRunnerText.trim());
+}
 
 // Flags whose value is a config file path, not a test/source file —
 // `vitest --config vitest.config.ts` runs whatever the config's own
@@ -181,8 +267,9 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^dotnet\s+test(?=\s|$)/,
   /^deno\s+test(?=\s|$)/,
   // Swift/SwiftPM's one canonical test-invocation form. `--filter X` names a
-  // suite, not a path; `--filter` is already a workspace-scope flag above so
-  // it and its value are skipped, leaving this broad.
+  // suite, not a path — recognized as a name filter (see
+  // DOTNET_SWIFT_NAME_FILTER_FLAGS), so this stays name-filtered (not
+  // broad, not scoped) rather than either extreme.
   /^swift\s+test(?=\s|$)/,
   /^gradle\s+test(?=\s|$)/,
   // Gradle wrapper script (the near-universal per-project convention,
@@ -211,13 +298,15 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^nx\s+test(?:\s+\S+)?(?=\s|$)/,
   // #905: tox (Python's test-orchestration tool, alongside nox) had no entry
   // at all. Bare `tox`/`tox run`/`tox -e py311` run the whole configured
-  // suite for that environment — no file is named, so these stay broad (the
-  // existing scope-token scan below already treats `-e`'s value as an
-  // ordinary non-path token). tox's own convention for narrowing is the `--`
-  // passthrough (`tox -e py311 -- tests/test_x.py`), forwarding args to the
-  // env's underlying test command — the same generic path-token scan that
-  // already handles `npm test -- path/to/x.test.ts` picks up a path-like
-  // token after `--` for free, since `--` itself is skipped as a flag.
+  // suite for that environment — no file is named, so these stay broad.
+  // tox's `-e ENV` is deliberately NOT in any NAME_FILTER_FLAGS set (it
+  // selects an environment, not a named test — the value is just an
+  // ordinary non-path token the scope scan ignores). tox's own convention
+  // for narrowing is the `--` passthrough (`tox -e py311 --
+  // tests/test_x.py`), forwarding args to the env's underlying test
+  // command — the same generic path-token scan that already handles `npm
+  // test -- path/to/x.test.ts` picks up a path-like token after `--` for
+  // free, since `--` itself is skipped as a flag.
   /^tox(\s+run)?(?=\s|$)/,
   /^python[0-9.]*\s+-m\s+tox(?=\s|$)/,
   // nox: same shape and same passthrough (`nox -s test -- tests/test_x.py`).
@@ -245,27 +334,54 @@ function isPathLikeToken(token: string, extensions: ReadonlySet<string>): boolea
   return [...extensions].some(ext => token.endsWith(ext));
 }
 
+interface ScopeScanResult {
+  /** Path-like tokens found (see `isPathLikeToken`) — a genuine file/directory scope. */
+  pathTokens: string[];
+  /** A recognized name-filter flag (`NAME_FILTER_FLAGS`) was present in the remainder. */
+  sawNameFilterFlag: boolean;
+  /** A bare (non-flag, non-path) token was present — only meaningful for `POSITIONAL_NAME_FILTER_RUNNERS`. */
+  sawBareToken: boolean;
+}
+
 /**
  * Scan the remainder of a segment after its matched runner keyword for
  * scoping arguments. Skips flags (dash-prefixed) and, for workspace-scope
  * and config flags specifically, their value too (a manual index loop is
  * required here to look ahead one token — not a tree-sitter AST walk, so the
  * codebase's array-methods-only rule for SyntaxNode iteration doesn't
- * apply).
+ * apply). A name-filter flag's own value is deliberately NOT skipped as a
+ * pair (unlike workspace-scope/config flags): the flag's mere presence is
+ * enough to signal "name-filtered", and letting its value fall through the
+ * ordinary path-token check for free still promotes it to a real scope
+ * token on the rare occasion it happens to look like a path.
  */
-function extractPathLikeTokens(remainder: string, extensions: ReadonlySet<string>): string[] {
+function extractPathLikeTokens(
+  remainder: string,
+  extensions: ReadonlySet<string>,
+  nameFilterFlags: ReadonlySet<string>,
+): ScopeScanResult {
   const tokens = remainder.trim().split(/\s+/).filter(Boolean);
-  const found: string[] = [];
+  const pathTokens: string[] = [];
+  let sawNameFilterFlag = false;
+  let sawBareToken = false;
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
     if (WORKSPACE_SCOPE_FLAGS.has(token) || CONFIG_FLAGS.has(token)) {
       i++; // also skip the flag's value
       continue;
     }
+    if (isNameFilterFlag(token, nameFilterFlags)) {
+      sawNameFilterFlag = true;
+      continue;
+    }
     if (token.startsWith('-')) continue;
-    if (isPathLikeToken(token, extensions)) found.push(token);
+    if (isPathLikeToken(token, extensions)) {
+      pathTokens.push(token);
+    } else {
+      sawBareToken = true;
+    }
   }
-  return found;
+  return { pathTokens, sawNameFilterFlag, sawBareToken };
 }
 
 /**
@@ -274,6 +390,12 @@ function extractPathLikeTokens(remainder: string, extensions: ReadonlySet<string
  * least one matching segment carries no scoping argument, the whole
  * classification is `broad` (a whole-suite run is present) even if another
  * segment in the same command also named specific files.
+ *
+ * A segment that instead carries a test-NAME filter (a `NAME_FILTER_FLAGS`
+ * flag, or a bare positional for a `POSITIONAL_NAME_FILTER_RUNNERS` runner)
+ * and no path tokens is neither `broad` nor a contributor to `scopeTokens` —
+ * see the module doc comment for why "ran, scope unknown" must not be
+ * conflated with "ran the whole suite".
  */
 export function classifyTestCommand(command: string): TestRunClassification {
   const extensions = sourceExtensions();
@@ -291,11 +413,19 @@ export function classifyTestCommand(command: string): TestRunClassification {
     if (!match) continue;
     isTestRun = true;
     const remainder = segment.slice(match[0].length);
-    const pathTokens = extractPathLikeTokens(remainder, extensions);
-    if (pathTokens.length === 0) {
-      broad = true;
-    } else {
+    const { pathTokens, sawNameFilterFlag, sawBareToken } = extractPathLikeTokens(
+      remainder,
+      extensions,
+      nameFilterFlagsFor(match[0]),
+    );
+    if (pathTokens.length > 0) {
       pathTokens.forEach(t => scopeTokens.add(t));
+      continue;
+    }
+    const nameFiltered =
+      sawNameFilterFlag || (sawBareToken && isPositionalNameFilterRunner(match[0]));
+    if (!nameFiltered) {
+      broad = true;
     }
   }
 

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -135,11 +135,14 @@ function stripLeadingWrappersAndEnv(segment: string): string {
 // before scanning for path-like tokens.
 //
 // `--filter` is deliberately NOT here even though pnpm also uses it for
-// workspace scoping (`pnpm --filter my-pkg test`): that form is matched
-// whole by its own anchored RUNNER_PATTERNS entry above (the flag+value
-// never reach this remainder scan at all), whereas dotnet/swift/nx reuse
-// the same flag spelling for a test-NAME filter, which must NOT be silently
-// swallowed — see NAME_FILTER_FLAGS below.
+// workspace scoping: `pnpm --filter my-pkg test` (filter BEFORE the script)
+// is matched whole by its own anchored RUNNER_PATTERNS entry above (the
+// flag+value never reach this remainder scan at all); `pnpm test --filter
+// my-pkg` (filter AFTER) is instead handled by the pnpm-specific
+// `PNPM_TEST_VALUE_FLAGS` below, scoped to that ordering only — a global
+// entry here would also swallow dotnet/swift's unrelated test-NAME use of
+// the identical spelling, which must NOT be silently skipped (see
+// NAME_FILTER_FLAGS below).
 const WORKSPACE_SCOPE_FLAGS = new Set(['-w', '--workspace']);
 
 // Flags whose value narrows a run to specific test NAMES rather than a
@@ -167,10 +170,13 @@ const MOCHA_NAME_FILTER_FLAGS = new Set(['--grep', '-g']);
 const GO_TEST_NAME_FILTER_FLAGS = new Set(['-run']);
 // vitest and jest share the same Jest-descended CLI convention.
 const JS_TEST_NAME_FILTER_FLAGS = new Set(['-t', '--testNamePattern']);
-// dotnet and swift both spell their (unrelated-to-pnpm/nx) test-name filter
-// `--filter`; pnpm's own `--filter` is fully absorbed by its dedicated
-// anchored RUNNER_PATTERNS entry before reaching this lookup at all, so
-// there is no collision in practice despite the shared spelling.
+// dotnet and swift both spell their (unrelated-to-pnpm) test-name filter
+// `--filter`. pnpm's own `--filter` is either fully absorbed by its
+// dedicated anchored RUNNER_PATTERNS entry (filter BEFORE the script) or
+// handled by the pnpm-specific `PNPM_TEST_VALUE_FLAGS` value-skip (filter
+// AFTER) — `nameFilterFlagsFor` only returns this set for `dotnet test`/
+// `swift test` specifically, so there is no collision in practice despite
+// the shared spelling.
 const DOTNET_SWIFT_NAME_FILTER_FLAGS = new Set(['--filter']);
 const NO_NAME_FILTER_FLAGS: ReadonlySet<string> = new Set();
 
@@ -248,11 +254,30 @@ const CARGO_TEST_VALUE_FLAGS = new Set([
 ]);
 const NO_VALUE_SKIP_FLAGS: ReadonlySet<string> = new Set();
 
+// pnpm's own `--filter`/`-F` (https://pnpm.io/filtering), when it appears
+// AFTER the script name (`pnpm test --filter <selector>`) rather than before
+// it (`pnpm --filter <selector> test`, already fully absorbed by its own
+// anchored RUNNER_PATTERNS entry above). A package selector routinely
+// contains "/" (a scope, `@hono/core`) — caught in review: without this set,
+// that value was independently scanned and misread as a PATH-like scope
+// token, flipping a genuinely broad `pnpm test --filter @hono/core` to a
+// falsely narrow "scoped to ./@hono/core" — the fourth instance of the same
+// short-flag-collision hazard in this file. The `--filter=value` single-token
+// form doesn't need an entry here: it already starts with `-`, so it's
+// caught by the generic dash-prefix skip before ever reaching the path check
+// (verified: `pnpm test --filter=@hono/core` already classifies broad).
+const PNPM_TEST_VALUE_FLAGS = new Set(['--filter', '-F']);
+
+/** True for the generic `pnpm test`/`pnpm test:script` match — i.e. NOT the dedicated `pnpm --filter <pkg> test` anchored form, where `--filter` never reaches this scan at all. */
+function isPnpmTestRunner(matchedRunnerText: string): boolean {
+  return /^pnpm\s+test(:\S*)?$/.test(matchedRunnerText.trim());
+}
+
 /** Which extra flag+value pairs should be fully skipped (beyond the universal WORKSPACE_SCOPE_FLAGS/CONFIG_FLAGS) for the runner `matchedRunnerText` identified. */
 function valueSkipFlagsFor(matchedRunnerText: string): ReadonlySet<string> {
-  return isPositionalNameFilterRunner(matchedRunnerText)
-    ? CARGO_TEST_VALUE_FLAGS
-    : NO_VALUE_SKIP_FLAGS;
+  if (isPositionalNameFilterRunner(matchedRunnerText)) return CARGO_TEST_VALUE_FLAGS;
+  if (isPnpmTestRunner(matchedRunnerText)) return PNPM_TEST_VALUE_FLAGS;
+  return NO_VALUE_SKIP_FLAGS;
 }
 
 // Flags whose value is a config file path, not a test/source file —
@@ -283,7 +308,15 @@ const RUNNER_PATTERNS: RegExp[] = [
   /^npm\s+test(?=\s|$)/,
   /^npm\s+t(?=\s|$)/,
   /^yarn\s+test(:\S*)?(?=\s|$)/,
-  /^pnpm\s+--filter\s+\S+\s+test(?=\s|$)/,
+  // pnpm's own workspace selector (https://pnpm.io/filtering), `--filter` or
+  // its documented `-F` alias, BEFORE the script name. `(?:\s+\S+|=\S+)`
+  // accepts both the space-separated form (`--filter <selector>`) and the
+  // single-token `=` form pnpm's own docs also show (`--filter=selector`) —
+  // caught in review: the `=` form was previously unrecognized entirely
+  // (`pnpm --filter=@hono/core test` matched no pattern at all), always
+  // nagging even though pnpm's docs list it as the canonical way to exclude
+  // a package (`--filter=!foo`).
+  /^pnpm\s+(?:--filter|-F)(?:\s+\S+|=\S+)\s+test(?=\s|$)/,
   /^pnpm\s+test(:\S*)?(?=\s|$)/,
   /^bun\s+test(?=\s|$)/,
   /^npx\s+vitest(?=\s|$)/,

--- a/packages/cli/src/utils/test-run-matcher.ts
+++ b/packages/cli/src/utils/test-run-matcher.ts
@@ -210,6 +210,51 @@ function isPositionalNameFilterRunner(matchedRunnerText: string): boolean {
   return POSITIONAL_NAME_FILTER_RUNNERS.has(matchedRunnerText.trim());
 }
 
+// `cargo test`'s own build/compile-config flags that take a value — NONE of
+// these narrow which tests run at all (they configure feature flags, which
+// package/manifest/target/profile to build, or job parallelism), so the run
+// stays whatever the rest of the command implies (broad, absent any other
+// scoping). Without this set, `extractPathLikeTokens`'s bare-token tracking
+// (feeding `isPositionalNameFilterRunner` above) misread e.g. `--features
+// foo`'s value "foo" as a bare positional TEST NAME, flipping a genuinely
+// broad `cargo test --features foo` to falsely name-filtered — caught in
+// review (the same collision hazard as tox `-e`/rspec `-e`, and
+// cargo-nextest's `run` keyword, just a third instance of it). Skipped as
+// flag+value, same mechanism as WORKSPACE_SCOPE_FLAGS/CONFIG_FLAGS, but kept
+// cargo-test-specific (via `valueSkipFlagsFor`) rather than global, since
+// e.g. `-j`/`--target` aren't universally safe to blanket-skip for every
+// runner. `--test <name>` (a specific integration-test-binary target) is
+// deliberately NOT here: it doesn't configure the build, it selects which
+// tests run, so its value should keep flowing through as an ordinary bare
+// token — landing on the same name-filtered (not broad, not silently
+// "scoped") outcome as a plain positional filter, which is the safe
+// direction for a target name we don't have infrastructure to resolve
+// against real file paths.
+const CARGO_TEST_VALUE_FLAGS = new Set([
+  '-p',
+  '--package',
+  '--exclude',
+  '--manifest-path',
+  '--lockfile-path',
+  '--target',
+  '--target-dir',
+  '--profile',
+  '-j',
+  '--jobs',
+  '-F',
+  '--features',
+  '--color',
+  '--message-format',
+]);
+const NO_VALUE_SKIP_FLAGS: ReadonlySet<string> = new Set();
+
+/** Which extra flag+value pairs should be fully skipped (beyond the universal WORKSPACE_SCOPE_FLAGS/CONFIG_FLAGS) for the runner `matchedRunnerText` identified. */
+function valueSkipFlagsFor(matchedRunnerText: string): ReadonlySet<string> {
+  return isPositionalNameFilterRunner(matchedRunnerText)
+    ? CARGO_TEST_VALUE_FLAGS
+    : NO_VALUE_SKIP_FLAGS;
+}
+
 // Flags whose value is a config file path, not a test/source file —
 // `vitest --config vitest.config.ts` runs whatever the config's own
 // `include` pattern selects (typically the whole suite), not just the named
@@ -345,20 +390,25 @@ interface ScopeScanResult {
 
 /**
  * Scan the remainder of a segment after its matched runner keyword for
- * scoping arguments. Skips flags (dash-prefixed) and, for workspace-scope
- * and config flags specifically, their value too (a manual index loop is
- * required here to look ahead one token — not a tree-sitter AST walk, so the
- * codebase's array-methods-only rule for SyntaxNode iteration doesn't
- * apply). A name-filter flag's own value is deliberately NOT skipped as a
- * pair (unlike workspace-scope/config flags): the flag's mere presence is
- * enough to signal "name-filtered", and letting its value fall through the
- * ordinary path-token check for free still promotes it to a real scope
- * token on the rare occasion it happens to look like a path.
+ * scoping arguments. Skips flags (dash-prefixed) and, for workspace-scope,
+ * config, and runner-specific value-taking flags specifically, their value
+ * too (a manual index loop is required here to look ahead one token — not a
+ * tree-sitter AST walk, so the codebase's array-methods-only rule for
+ * SyntaxNode iteration doesn't apply). `valueSkipFlags` (from
+ * `valueSkipFlagsFor`) covers flags whose value would otherwise be
+ * misread as scoping evidence — e.g. `cargo test --features foo`'s "foo"
+ * looking like a bare positional test name. A name-filter flag's own value,
+ * by contrast, is deliberately NOT skipped as a pair (unlike these): the
+ * flag's mere presence is enough to signal "name-filtered", and letting its
+ * value fall through the ordinary path-token check for free still promotes
+ * it to a real scope token on the rare occasion it happens to look like a
+ * path.
  */
 function extractPathLikeTokens(
   remainder: string,
   extensions: ReadonlySet<string>,
   nameFilterFlags: ReadonlySet<string>,
+  valueSkipFlags: ReadonlySet<string>,
 ): ScopeScanResult {
   const tokens = remainder.trim().split(/\s+/).filter(Boolean);
   const pathTokens: string[] = [];
@@ -366,7 +416,7 @@ function extractPathLikeTokens(
   let sawBareToken = false;
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
-    if (WORKSPACE_SCOPE_FLAGS.has(token) || CONFIG_FLAGS.has(token)) {
+    if (WORKSPACE_SCOPE_FLAGS.has(token) || CONFIG_FLAGS.has(token) || valueSkipFlags.has(token)) {
       i++; // also skip the flag's value
       continue;
     }
@@ -417,6 +467,7 @@ export function classifyTestCommand(command: string): TestRunClassification {
       remainder,
       extensions,
       nameFilterFlagsFor(match[0]),
+      valueSkipFlagsFor(match[0]),
     );
     if (pathTokens.length > 0) {
       pathTokens.forEach(t => scopeTokens.add(t));


### PR DESCRIPTION
## The bug

`classifyTestCommand` (`packages/cli/src/utils/test-run-matcher.ts`) had exactly
two outcomes: `scoped` (a path-like token found after the runner keyword) or
`broad` (none found). A run scoped by test **NAME** rather than file/directory
(`pytest -k expr`, `dotnet test --filter expr`, `rspec -e name`, `mocha --grep
pattern`, `go test -run regex`, a bare `cargo test name`, `vitest`/`jest -t`)
has no path-like token at all, so it fell into `broad` by construction.
`computeUnverifiedFiles` treats any `broad` run as "the whole edit set was
exercised," so one arbitrarily-named, completely unrelated test run silently
marked every edited file in the session as verified — the false-"tests ran"
direction, which disables the Stop-hook nudge (`recap-stop.sh`) invisibly.

Confirmed on the released 0.72.0 (see dogfood evidence below): an edit with no
test run at all correctly nags; the identical edit followed by
`pytest -k test_totally_unrelated_name` goes completely silent.

## Which runners actually reproduce (verified, not assumed)

All 8 named in the bug report reproduce, confirmed by direct calls to
`classifyTestCommand` before the fix:

| Command | Before | After |
| --- | --- | --- |
| `pytest -k test_totally_unrelated_name` | `broad:true` | `broad:false` |
| `dotnet test --filter FullyQualifiedName~Some.Unrelated.Test` | `broad:true` | `broad:false` |
| `rspec -e "some unrelated example"` | `broad:true` | `broad:false` |
| `mocha --grep 'unrelated pattern'` | `broad:true` | `broad:false` |
| `go test -run TestUnrelated` | `broad:true` | `broad:false` |
| `cargo test test_unrelated_name` | `broad:true` | `broad:false` |
| `vitest -t "unrelated name"` | `broad:true` | `broad:false` |
| `jest -t "unrelated name"` | `broad:true` | `broad:false` |

Compound case (`pytest -k name tests/test_helpers.py`) correctly stays
scoped-by-path in both before and after — a path present must not be
downgraded by a name filter, which it wasn't and still isn't.

**Bonus find, same underlying bug**: `swift test --filter HTTPHeadersTests`
also reproduced (`--filter` was globally invisible via
`WORKSPACE_SCOPE_FLAGS`), fixed by the same mechanism. Updated the one
existing unit test that pinned this as `broad:true`.

## The model chosen, and why

**Option (a)** from the brief: a name-filtered run is a third classification
outcome — "ran, scope unknown" — that is neither `broad` nor a `scopeTokens`
contributor. `computeUnverifiedFiles` only has ONE call site that branches on
`.broad` (itself), so this needed no interface change to `TestRunClassification`
or `computeUnverifiedFiles` at all: a run that's `{isTestRun: true, broad:
false, scopeTokens: []}` already behaves exactly like "no run observed" for
coverage purposes, for free.

Recognition is a **per-runner-family flag allow-list**
(`PYTEST_NAME_FILTER_FLAGS`, `RSPEC_NAME_FILTER_FLAGS`, etc. in
`test-run-matcher.ts`), not one global set, and `cargo test`'s bare positional
argument is special-cased to exactly that runner
(`POSITIONAL_NAME_FILTER_RUNNERS`). Two collisions a naive global/generic
implementation would have hit, both now pinned as regression tests:

- **tox's `-e ENV`** (environment selector, must stay `broad`) vs. **rspec's
  `-e NAME`** (example filter) — identical spelling, unrelated meaning. A
  global `-e` flag would have wrongly flipped `tox -e py311` to name-filtered.
- **`cargo nextest run`**'s required `run` subcommand keyword, and Gradle's
  `-x <task>`/`--exclude-task <task>` exclusion value — both bare tokens in
  the same textual position a name filter's value would sit, but with
  unrelated meaning. A generic "any bare leftover token is a name filter"
  rule (my first draft) would have wrongly reclassified both.

Option (c) (matching the filter expression against real associated test
names) is out of scope — the brief called it "probably out of scope" and I
agree: the filter is a plain-text expression/regex evaluated by the target
runner (e.g. pytest's `-k` supports Python boolean expressions over test
names/markers), not a simple string to compare against file names, and
getting it right per-ecosystem is a much larger project for a small marginal
precision gain over the "just don't drop the nag" fix here.

## What's out of scope / not attempted

- Maven's `-Dtest=ClassName` filter uses the same failure mode (starts with
  `-D`, so it's silently skipped as a flag today) but wasn't in the brief's
  runner list and isn't fixed here.
- Any deeper file-name-matching against the filter expression's own text
  (option c above).

## Verification

- Unit tests: `packages/cli/src/utils/test-run-matcher.test.ts` — 151 tests
  (was 124), covering: the flag form and equals-form for each of the 8
  runners, the compound name+path case, the swift `--filter` fix, the
  tox/cargo-nextest/gradle negative-collision regressions, and a new
  `computeUnverifiedFiles` describe block pinning that a name-filtered run
  contributes no coverage (alone, alongside a real scoped run, and alongside
  a genuinely broad run).
- All six gates green locally: `format:check`, `lint` (pre-existing warnings
  only, 0 errors), `typecheck`, `build`, `test` (1461+378+1701+1332+41+27,
  all packages), `lien delta` (exit 0 — two functions "worsened" in cognitive
  complexity, none crossed a threshold).

### Dogfood evidence (mandatory, foreign repo, real hook stdin)

Run against `/tmp/lien-dogfood-460173c9/flask` (clean working tree,
re-indexed with `index --force` before measuring), driven through the real
`test-reminder.sh`/`test-run-note.sh` hook scripts with the true PostToolUse
stdin shape — not just direct CLI calls for the Bash-command classification
step:

```
# CONTROL -- edit recorded, no test run at all: correctly nags
$ lien verify-tests note-edit --session S1 --file src/flask/helpers.py
Lien: you changed src/flask/helpers.py -- associated tests: tests/test_helpers.py, ...
$ lien verify-tests report --session S1
Before finishing: these files you edited this session have associated tests I
did not observe running in a Bash command:
  - src/flask/helpers.py -> tests/test_helpers.py (+35 more)
...

# BEFORE (pre-fix build, same repo, same commands): silent -- bug reproduced
$ lien verify-tests note-edit --session before --file src/flask/helpers.py
Lien: you changed ... (same as above)
$ echo '{"session_id":"before","tool_name":"Bash","tool_input":{"command":"pytest -k test_totally_unrelated_name"},"cwd":"..."}' | test-run-note.sh
$ lien verify-tests report --session before
(completely silent)

# AFTER (fixed build, same repo, same commands): nags -- bug fixed
$ lien verify-tests note-edit --session after --file src/flask/helpers.py
Lien: you changed ... (same as above)
$ echo '{"session_id":"after","tool_name":"Bash","tool_input":{"command":"pytest -k test_totally_unrelated_name"},"cwd":"..."}' | test-run-note.sh
$ lien verify-tests report --session after
Before finishing: these files you edited this session have associated tests I
did not observe running in a Bash command:
  - src/flask/helpers.py -> tests/test_helpers.py (+35 more)
...
```

The "before" build was produced by stashing this PR's diff, rebuilding
`packages/cli`, running the repro, then popping the stash and rebuilding
again -- not the npm-published binary, because concurrent agents in this
session had corrupted the shared npx cache (`npx -y @liendev/lien@0.72.0`
was resolving to a stale 0.65.0 despite the registry confirming 0.72.0 is
current). This gives an equally valid, more controlled A/B since it isolates
exactly this diff.

Regression checks on the fixed build, same repo:
- Genuinely broad run (`python -m pytest`, no filter) -> `report` still silent
  (correctly suppresses).
- File-scoped run naming an unrelated file (`pytest
  tests/test_totally_unrelated_module.py`) -> `report` still nags (correctly
  does NOT suppress).

Flask repo left clean (`git status --porcelain` empty) -- no repo files were
touched, only `lien` CLI state under `~/.lien`.

## Note on Lien MCP tool usage

Per CLAUDE.md, ran `get_files_context` before editing and `get_dependents`
before touching the exported `classifyTestCommand`/`TestRunClassification`/
`computeUnverifiedFiles` symbols. The `plugin:lien` MCP server itself
returned a stale index throughout this session (pinned to a different
branch/commit, unaffected by `lien index --force` run from this worktree --
a known multi-agent-fleet quirk, not something this PR could fix), so
dependent analysis was cross-checked manually via `grep` for
`classifyTestCommand`/`computeUnverifiedFiles`/`.broad` call sites across
`packages/`; only `verify-tests-cmd.ts` and `recap-cmd.ts` (import-only)
consume these exports, both unaffected by the interface (no signature
change).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real bug where name-filtered test commands (e.g., `pytest -k`, `go test -run`, `cargo test <name>`) were misclassified as broad runs, causing the test-verification nudge to be silently disabled. The fix introduces a third classification outcome — name-filtered (`isTestRun: true, broad: false, scopeTokens: []`) — which `computeUnverifiedFiles` already treats as "no coverage evidence," so no caller interface changes were required. The implementation uses per-runner-family flag allow-lists and runner-specific value-skip sets to avoid known collisions (tox `-e` vs. rspec `-e`, cargo-nextest's `run` keyword, cargo build-config flags, pnpm workspace `--filter`). The change is extensively regression-tested, including negative guards and the disputed scope-broadening cases (`go test -run Foo ./...`, `cargo test foo --workspace`), which the author has documented as intentionally name-filtered per the fail-safe bias. No code defects were found.
>
> - Name-filtered runs now return `{isTestRun: true, broad: false, scopeTokens: []}` instead of `{broad: true}`, preventing false suppression of the verification nudge.
> - Added per-runner-family name-filter flag detection and cargo-test-specific positional name filter handling with value-skip sets for cargo and pnpm.
> - Public `TestRunClassification` interface unchanged; callers `verify-tests-cmd.ts` and `recap-cmd.ts` require no updates.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 83dd774. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-run detection for name-filtered commands such as `pytest -k`, `jest -t`, and similar options.
  * Prevented filtered test runs from being incorrectly treated as full-suite runs or suppressing verification advisories.
  * Corrected handling of value-taking `cargo test` options to avoid misclassifying their values as test scopes.

* **Documentation**
  * Updated guidance and examples for test-run verification behavior, including end-to-end scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->