### PR TITLE
fix(parser,cli): resolve directory-shaped relative imports to their entry file, stop get_dependents fan-out (#953)

### DIFF
--- a/.changeset/fix-directory-import-fanout.md
+++ b/.changeset/fix-directory-import-fanout.md
@@ -1,0 +1,57 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+#953: `get_dependents` fabricated direct (`hops:1`) dependency edges for any
+relative import that resolves to a bare DIRECTORY path instead of a real
+file — a confident wrong answer, with no caveat, that fed straight into
+`riskLevel`.
+
+Confirmed via the foreign-repo dogfood on honojs/hono:
+`src/middleware/jwt/index.ts`'s only outward-facing statement is
+`import type {} from '../..'` (a dots-only, empty type import). This resolves
+(correctly) to the bare directory `src`, but nothing then resolved `src` to
+its real entry point (`src/index.ts`). Left as a bare directory name, the
+specifier fuzzy-matched via `matchesFile`'s Python Strategy 5
+(`matchesParentPythonPackage`) against EVERY file anywhere under `src/` — for
+a TypeScript importer with no Python semantics at all. `get_dependents` for
+`src/utils/color.ts` reported `dependentCount: 13` (true: 4), `riskLevel:
+"high"` (true: `"medium"`); `src/utils/url.ts` reported 3 of its 12
+production dependents as fabricated. This is the same false-hub shape #929
+already diagnosed (Python's own doc comment names this exact hono repro) but
+left unguarded on the two call sites that build `get_dependents`' actual
+result (`findDependentChunks`'s fuzzy loop in both
+`packages/parser/src/dependency-analyzer.ts` and
+`packages/cli/src/mcp/handlers/dependency-analyzer.ts`), rather than the
+guarded `importMatchesTarget` primitive #929 introduced.
+
+Two-part fix:
+
+- **Root cause: resolve a directory-shaped relative import to its real entry
+  point.** A new `resolveJsDirectoryIndex` (`packages/parser/src/js-directory-index.ts`)
+  checks whether a relative-resolved specifier names a real on-disk directory
+  and, if so, redirects it to that directory's `index.<ext>` file (mirrors
+  `workspace-packages.ts`'s entry-file detection, scoped to a single
+  directory). `../..` now resolves to `src/index`, which participates in
+  ordinary EXACT matching — no fuzzy strategy involved at all. This is what
+  keeps `jwt/index.ts` et al. correctly attributed as `hops:1` dependents of
+  `src/index.ts` (the file `../..` actually names) instead of just deleting
+  the edge outright. Generalizes beyond the dots-only case: a named directory
+  import (`../utils` where `src/utils/index.ts` exists) is fixed the same
+  way.
+- **Residual guard: gate Python Strategy 5 per chunk.** For the case where no
+  entry file exists (so the directory-index resolution is a no-op), both
+  `addFuzzyMatchChunks` implementations now re-derive the #929 guard per
+  chunk — mirroring the existing #887 per-chunk pattern — so a non-Python
+  importer's coincidental bare-word match can never count. Real Python
+  bare-package matching (`import flask` -> `flask/__init__.py` and children)
+  is untouched.
+
+Verified the BFS depth mechanics needed no changes: once the seed (depth-1)
+edges are correct, `depth: 2+` results clean up for free (checked live on the
+hono corpus).
+
+Also: `get_dependents`'s response echoed the *requested* `depth` even for a
+symbol-scoped query, where `depth > 1` is documented as ignored (symbol
+queries always run at depth 1). Now echoes the depth that actually ran.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -201,6 +201,83 @@ describe('findDependents', () => {
     });
   });
 
+  describe('#953 Python-strategy fan-out on a bare directory specifier', () => {
+    it('does not credit a TypeScript file whose resolved import is a bare directory as a dependent of an unrelated file under that directory', async () => {
+      // Simulates what resolveRelativeImport produces for a dots-only
+      // specifier like '../..' (from src/middleware/jwt/index.ts) when the
+      // directory has no index.<ext> for resolveJsDirectoryIndex to
+      // redirect to: the bare directory name 'src' is left in `imports`.
+      // Without the #953 guard, matchesFile's Python Strategy 5
+      // (matchesParentPythonPackage) fuzzy-matches this against EVERY file
+      // under src/ -- the exact hono/TypeScript repro that inflated
+      // riskLevel with fabricated edges.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/middleware/jwt/index.ts', { imports: ['src'] }),
+        createChunk('src/utils/color.ts', { exports: ['x'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/utils/color.ts', mockLog);
+
+      expect(result.dependents.map(d => d.filepath)).not.toContain('src/middleware/jwt/index.ts');
+      expect(result.dependents).toHaveLength(0);
+    });
+
+    it('still credits a genuine Python bare-package import as a dependent (real Strategy 5 semantic preserved)', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('app/consumer.py', { imports: ['src'] }),
+        createChunk('src/utils/helpers.py', { exports: ['x'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/utils/helpers.py', mockLog);
+
+      expect(result.dependents.map(d => d.filepath)).toContain('app/consumer.py');
+    });
+
+    it('a directory-index-resolved import ("src/index") is still a genuine, exact-match hops:1 dependent of src/index.ts', async () => {
+      // Once resolveJsDirectoryIndex has done its job (tested at the
+      // symbols.ts/js-directory-index.ts layer), the resolved specifier is
+      // an ordinary exact-match file path -- the "don't over-delete" half
+      // of #953: jwt/index.ts et al. must remain real dependents of
+      // src/index.ts, not just stop being fabricated dependents of
+      // unrelated files.
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/middleware/jwt/index.ts', { imports: ['src/index'] }),
+        createChunk('src/index.ts', { exports: ['Hono'] }),
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/index.ts', mockLog);
+
+      expect(result.dependents.map(d => d.filepath)).toContain('src/middleware/jwt/index.ts');
+      expect(result.dependents.find(d => d.filepath === 'src/middleware/jwt/index.ts')?.hops).toBe(
+        1,
+      );
+    });
+
+    it('a fabricated bare-directory seed edge does not pollute depth 2+ transitively once fixed', async () => {
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/middleware/jwt/index.ts', { imports: ['src'] }),
+        createChunk('src/utils/color.ts', { exports: ['x'] }),
+        // A genuine depth-2 dependent of jwt/index.ts -- must not
+        // transitively inherit the (now-fixed) fabricated depth-1 edge to
+        // color.ts.
+        createChunk('src/app.ts', { imports: ['src/middleware/jwt/index.ts'] }),
+      ]);
+
+      const result = await findDependents(
+        mockDB as any,
+        'src/utils/color.ts',
+        mockLog,
+        undefined,
+        undefined,
+        2,
+      );
+
+      const filepaths = result.dependents.map(d => d.filepath);
+      expect(filepaths).not.toContain('src/middleware/jwt/index.ts');
+      expect(filepaths).not.toContain('src/app.ts');
+    });
+  });
+
   describe('re-export chains / barrel files', () => {
     it('should find transitive dependents through barrel file re-exports', async () => {
       // target.ts exports Foo

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -9,6 +9,7 @@ import {
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
   hasSingleFileImportSemantics,
+  hasPythonModuleSemantics,
   detectLanguage,
   hasEnclosingNamespaceAccess,
   findCSharpTypeReferenceDependents,
@@ -1179,6 +1180,19 @@ function hasTestImporter(filepath: string, ctx: ScanContext): boolean {
  * comment. `importMatchesTarget` (used by every match-side call site that
  * *does* have a single importer file) makes the same derivation once,
  * up front.
+ *
+ * #953: applies the same per-chunk treatment for `matchesFile`'s Python
+ * Strategy 5 (`matchesParentPythonPackage`'s bare-specifier matching) --
+ * see that function's own #929 doc comment for the confirmed hono/TypeScript
+ * false-hub this guards against: a resolved bare directory specifier (e.g.
+ * `src`, left over when no `index.<ext>` entry file exists for
+ * `resolveJsDirectoryIndex` to redirect to -- see
+ * `@liendev/parser`'s `js-directory-index.ts`) fuzzy-matching every file
+ * under that directory for a chunk with no Python semantics at all.
+ * `pythonOnlyMatch` is true exactly when Strategy 5 was the ONLY reason the
+ * top-of-function permissive gate matched; a genuinely Python chunk still
+ * passes (its own bare-package match IS the real semantic), same as
+ * `hasSingleFileImportSemantics` above.
  */
 function addFuzzyMatchChunks(
   normalizedImport: string,
@@ -1190,9 +1204,11 @@ function addFuzzyMatchChunks(
 
   const ambiguous =
     normalizedImport.includes('/') && !matchesFile(normalizedImport, normalizedTarget, true);
+  const pythonOnlyMatch = !matchesFile(normalizedImport, normalizedTarget, false, false);
 
   for (const chunk of chunks) {
     if (ambiguous && hasSingleFileImportSemantics(chunk.metadata.file)) continue;
+    if (pythonOnlyMatch && !hasPythonModuleSemantics(chunk.metadata.file)) continue;
     addChunk(chunk);
   }
 }

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -779,6 +779,22 @@ describe('handleGetDependents', () => {
       expect(parsed.depth).toBe(2);
     });
 
+    it('echoes the EFFECTIVE depth (1), not the requested one, for a symbol-scoped query', async () => {
+      // depth > 1 is documented as ignored for symbol queries (runBfsIfRequested
+      // in dependency-analyzer.ts never runs BFS when `symbol` is set) -- but
+      // the response used to echo back the requested `depth` unchanged, letting
+      // a caller believe a multi-hop symbol walk ran when it didn't.
+      vi.mocked(findDependents).mockResolvedValue(createMockAnalysis());
+
+      const result = await handleGetDependents(
+        { filepath: 'src/target.ts', symbol: 'doStuff', depth: 3 },
+        mockCtx,
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.depth).toBe(1);
+    });
+
     it('should surface truncated and totalImpacted in the response', async () => {
       vi.mocked(findDependents).mockResolvedValue(
         createMockAnalysis({

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -68,6 +68,15 @@ interface DependentsResponse {
   indexInfo: IndexInfo;
   filepath: string;
   symbol?: string;
+  /**
+   * The depth that actually ran, NOT necessarily the requested `depth` arg.
+   * A symbol-scoped query (`symbol` set) always runs at depth 1 regardless
+   * of what was requested — `runBfsIfRequested` in `dependency-analyzer.ts`
+   * skips BFS entirely for symbol queries, since transitive symbol-renaming
+   * chains are out of scope. Echoing the requested value unchanged in that
+   * case would let a caller believe a multi-hop symbol walk ran when it
+   * didn't.
+   */
   depth: number;
   dependentCount: number;
   productionDependentCount: number;
@@ -282,11 +291,14 @@ function buildDependentsResponse(
   unresolvedTargetNote?: string,
 ): DependentsResponse {
   const { symbol, filepath, depth } = args;
+  // Symbol queries always run at depth 1 (see `depth`'s doc comment above) —
+  // echo the depth that actually ran, not the requested value.
+  const effectiveDepth = symbol ? 1 : depth;
 
   const response: DependentsResponse = {
     indexInfo,
     filepath,
-    depth,
+    depth: effectiveDepth,
     dependentCount: analysis.dependents.length,
     productionDependentCount: analysis.productionDependentCount,
     testDependentCount: analysis.testDependentCount,

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -113,6 +113,11 @@ const RESOLVE_WORKSPACE_PACKAGES: ReadonlySet<SupportedLanguage> = new Set([
  * `undefined` (rather than an object with empty/absent fields) when nothing
  * is found, so the corresponding resolution step is skipped entirely for
  * projects that don't need it.
+ *
+ * JS/TS always gets `resolveDirectoryIndex: true` (#953, no detection step
+ * needed — unlike PHP/Go/Python/Rust's manifest/filesystem detection, a
+ * directory's `index.<ext>` entry file is checked per-specifier at
+ * resolution time, in `resolveJsDirectoryIndex` itself).
  */
 function buildManifestRoots(
   language: SupportedLanguage,
@@ -138,6 +143,10 @@ function buildManifestRoots(
   if (language === 'rust') {
     const rustCrateMap = resolveRustCrateMap(workspaceRoot);
     return rustCrateMap.size > 0 ? { rustCrateMap } : undefined;
+  }
+
+  if (language === 'javascript' || language === 'typescript') {
+    return { resolveDirectoryIndex: true, workspaceRoot };
   }
 
   return undefined;

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import { parseAST } from './parser.js';
 import {
   extractImports,
@@ -658,6 +661,121 @@ from typing import Optional
 
       expect(imports).toContain('src/middleware/jsx-renderer');
       expect(imports).not.toContain('.');
+    });
+  });
+
+  describe('extractImports - directory-index resolution (#953)', () => {
+    let testDir: string;
+
+    beforeEach(async () => {
+      testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-js-directory-index-resolve-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    async function writeFile(relPath: string, content: string): Promise<void> {
+      const abs = path.join(testDir, relPath);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, content);
+    }
+
+    it('resolves a dots-only "../.." import to its directory entry point when index.ts exists', async () => {
+      // The real honojs/hono repro: src/middleware/jwt/index.ts has
+      // `import type {} from '../..'` -- an empty, dots-only type import
+      // that resolves (pre-#953) to the bare directory `src`, which then
+      // fuzzy-matched every file under src/ as a "dependent" (matchesFile's
+      // Python Strategy 5). #953 resolves it to src/index instead, so it
+      // participates in ordinary exact matching.
+      await writeFile('src/index.ts', 'export {};\n');
+      await writeFile('src/utils/color.ts', 'export {};\n');
+
+      const content = `import type {} from '../..';`;
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(
+        parseResult.tree!.rootNode,
+        'typescript',
+        'src/middleware/jwt/index.ts',
+        undefined,
+        { resolveDirectoryIndex: true, workspaceRoot: testDir },
+      );
+
+      expect(imports).toContain('src/index');
+      expect(imports).not.toContain('src');
+    });
+
+    it('resolves a named directory import ("../utils") to its entry point when src/utils/index.ts exists', async () => {
+      await writeFile('src/utils/index.ts', 'export {};\n');
+      await writeFile('src/utils/color.ts', 'export {};\n');
+
+      const content = `import { helpers } from '../utils';`;
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(
+        parseResult.tree!.rootNode,
+        'typescript',
+        'src/middleware/foo.ts',
+        undefined,
+        { resolveDirectoryIndex: true, workspaceRoot: testDir },
+      );
+
+      expect(imports).toContain('src/utils/index');
+      expect(imports).not.toContain('src/utils');
+    });
+
+    it('leaves a bare directory specifier unchanged when the directory has no index.<ext>', async () => {
+      await writeFile('src/utils/color.ts', 'export {};\n');
+      // src/ itself has no index.ts of its own.
+
+      const content = `import type {} from '../..';`;
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(
+        parseResult.tree!.rootNode,
+        'typescript',
+        'src/middleware/jwt/index.ts',
+        undefined,
+        { resolveDirectoryIndex: true, workspaceRoot: testDir },
+      );
+
+      expect(imports).toContain('src');
+    });
+
+    it('still resolves a bare same-directory self-import "." (#942/#935) to its own directory entry file', async () => {
+      await writeFile('src/middleware/jsx-renderer/index.tsx', 'export const jsxRenderer = 1;\n');
+
+      const content = `import { jsxRenderer } from '.';`;
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(
+        parseResult.tree!.rootNode,
+        'typescript',
+        'src/middleware/jsx-renderer/index.tsx',
+        undefined,
+        { resolveDirectoryIndex: true, workspaceRoot: testDir },
+      );
+
+      // Resolves all the way to the importer's own file -- a correct exact
+      // self-match, rather than a fuzzy one.
+      expect(imports).toContain('src/middleware/jsx-renderer/index');
+    });
+
+    it('is a no-op for a bare external package specifier even when it collides with a real directory name', async () => {
+      await writeFile('zod/index.ts', 'export {};\n');
+
+      const content = `import { z } from 'zod';`;
+      const parseResult = parseAST(content, 'typescript');
+      const imports = extractImports(
+        parseResult.tree!.rootNode,
+        'typescript',
+        'src/schema.ts',
+        undefined,
+        { resolveDirectoryIndex: true, workspaceRoot: testDir },
+      );
+
+      // 'zod' never went through resolveRelativeImport (it's not a relative
+      // specifier), so directory-index resolution must not touch it even
+      // though a same-named directory happens to exist on disk.
+      expect(imports).toContain('zod');
+      expect(imports).not.toContain('zod/index');
     });
   });
 

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -7,6 +7,7 @@ import { resolveRelativeImport, resolveWorkspaceImport } from '../utils/path-mat
 import { resolvePsr4Import } from '../php-psr4.js';
 import { resolveGoModuleImport } from '../go-module.js';
 import { resolvePythonSrcLayoutImport } from '../python-src-layout.js';
+import { resolveJsDirectoryIndex } from '../js-directory-index.js';
 
 /**
  * Per-project manifest-declared import-root mappings, threaded through as a
@@ -29,13 +30,25 @@ export interface ManifestRoots {
   /** Python src-layout root directory (`src`), when detected on disk. */
   pythonSrcLayoutRoot?: string;
   /**
-   * Absolute workspace root, needed only alongside `pythonSrcLayoutRoot`:
-   * `resolvePythonSrcLayoutImport` verifies each candidate path actually
-   * exists on disk (see `../python-src-layout.ts`) before rewriting a
-   * specifier, to avoid misresolving one nested Python project's own
-   * package against an unrelated, outer `src/` root.
+   * Absolute workspace root, needed alongside `pythonSrcLayoutRoot` (see its
+   * own doc comment) and `resolveDirectoryIndex` (below): both verify a
+   * candidate path actually exists on disk before rewriting a specifier.
    */
   workspaceRoot?: string;
+  /**
+   * When true, a relative import that resolves to a bare directory path
+   * (e.g. `../..` joined against its importer's directory, producing `src`)
+   * is further resolved to that directory's real `index.<ext>` entry file,
+   * when one exists on disk (#953 — see `../js-directory-index.ts`). Set
+   * only for JS/TS (`ast/chunker.ts`'s `buildManifestRoots`): a bare
+   * directory specifier left unresolved falls through to `matchesFile`'s
+   * fuzzy-matching strategies, each tuned for a DIFFERENT language's real
+   * multi-file semantics (Go's package directories, Python's package
+   * `__init__.py`) — for a JS/TS importer neither applies, so the bare
+   * specifier fabricates a dependent edge to every file under that
+   * directory instead of the one real edge.
+   */
+  resolveDirectoryIndex?: true;
   /**
    * Rust Cargo workspace crate name (underscore form) -> crate `src/` dir map
    * (#903). Unlike `psr4Map`/`goModulePrefix`, this is NOT consumed by
@@ -98,12 +111,14 @@ function collectImportNodes(rootNode: SyntaxNode, nodeTypeSet: Set<string>): Syn
 }
 
 /**
- * Resolve a single raw import specifier in three steps, each a no-op when its
+ * Resolve a single raw import specifier in four steps, each a no-op when its
  * respective input isn't provided, so behavior for existing callers is
  * unchanged:
  * 1. Relative specifiers (`./foo`, `../bar`) against the importer's directory.
- * 2. Workspace package specifiers (`@scope/pkg`) against the `workspacePackages` map.
- * 3. Manifest-declared import roots (PHP PSR-4, Go module prefix) against `manifestRoots`.
+ * 2. A relative specifier that resolved to a bare DIRECTORY (`#953`) against
+ *    that directory's real `index.<ext>` entry file, JS/TS only.
+ * 3. Workspace package specifiers (`@scope/pkg`) against the `workspacePackages` map.
+ * 4. Manifest-declared import roots (PHP PSR-4, Go module prefix) against `manifestRoots`.
  */
 function resolveImportSpecifier(
   specifier: string,
@@ -112,10 +127,31 @@ function resolveImportSpecifier(
   manifestRoots: ManifestRoots | undefined,
 ): string {
   const relResolved = filepath ? resolveRelativeImport(filepath, specifier) : specifier;
+  const dirResolved = resolveDirectoryIndexIfRelative(specifier, relResolved, manifestRoots);
   const wsResolved = workspacePackages
-    ? resolveWorkspaceImport(relResolved, workspacePackages)
-    : relResolved;
+    ? resolveWorkspaceImport(dirResolved, workspacePackages)
+    : dirResolved;
   return resolveManifestRoot(wsResolved, manifestRoots);
+}
+
+/**
+ * Apply `resolveJsDirectoryIndex` (#953) to a relative-resolved specifier,
+ * but only when it actually WAS relative (`relResolved !== originalSpecifier`
+ * -- `resolveRelativeImport` is a no-op for bare/external specifiers like
+ * `'lodash'` or `'@scope/pkg'`) and the importer's language opted in
+ * (`manifestRoots.resolveDirectoryIndex`, set for JS/TS only -- see
+ * `ast/chunker.ts`'s `buildManifestRoots`). Skipping the check entirely for
+ * non-relative specifiers avoids an unnecessary filesystem stat for every
+ * bare external package import.
+ */
+function resolveDirectoryIndexIfRelative(
+  originalSpecifier: string,
+  relResolved: string,
+  manifestRoots: ManifestRoots | undefined,
+): string {
+  if (relResolved === originalSpecifier) return relResolved;
+  if (!manifestRoots?.resolveDirectoryIndex || !manifestRoots.workspaceRoot) return relResolved;
+  return resolveJsDirectoryIndex(relResolved, manifestRoots.workspaceRoot);
 }
 
 /** Apply step 3 (manifest-root resolution) of `resolveImportSpecifier`. */

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -588,6 +588,34 @@ describe('analyzeDependencies', () => {
       expect(filepaths).not.toContain('lib/pkg/consumer.rb');
     });
   });
+
+  describe('#953 Python-strategy fan-out on a bare directory specifier (addFuzzyMatchChunks)', () => {
+    it('does not credit a TypeScript file with a resolved bare-directory import as a dependent of an unrelated file under that directory', () => {
+      // Simulates what `resolveRelativeImport` produces for a dots-only
+      // specifier like `'../..'` (from src/middleware/jwt/index.ts) when the
+      // directory has no `index.<ext>` for `resolveJsDirectoryIndex` to
+      // redirect to: the bare directory name `src` is left in `imports`.
+      // Without the #953 guard, `matchesFile`'s Python Strategy 5
+      // (`matchesParentPythonPackage('src', 'src/utils/color')`) fuzzy-
+      // matches this against EVERY file under src/ -- fabricating a
+      // dependent edge with no real relationship to the target (the exact
+      // hono/TypeScript repro from `matchesFile`'s own #929 doc comment).
+      const chunks: CodeChunk[] = [createChunk('src/middleware/jwt/index.ts', ['src'])];
+
+      const result = analyzeDependencies('src/utils/color.ts', chunks, workspaceRoot);
+
+      expect(result.dependents.map(d => d.filepath)).not.toContain('src/middleware/jwt/index.ts');
+      expect(result.dependentCount).toBe(0);
+    });
+
+    it('still credits a genuine Python bare-package import as a dependent (real Strategy 5 semantic preserved)', () => {
+      const chunks: CodeChunk[] = [createChunk('app/consumer.py', ['src'])];
+
+      const result = analyzeDependencies('src/utils/helpers.py', chunks, workspaceRoot);
+
+      expect(result.dependents.map(d => d.filepath)).toContain('app/consumer.py');
+    });
+  });
 });
 
 // Direct unit coverage for the shared re-export intersection algorithm,

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -8,6 +8,7 @@ import {
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
   hasSingleFileImportSemantics,
+  hasPythonModuleSemantics,
 } from './utils/path-matching.js';
 import { RISK_ORDER } from './insights/types.js';
 
@@ -138,6 +139,18 @@ function buildImportIndex(
  * comment. `importMatchesTarget` (used by every match-side call site that
  * *does* have a single importer file) makes the same derivation once,
  * up front.
+ *
+ * #953: applies the same per-chunk treatment for `matchesFile`'s Python
+ * Strategy 5 (`matchesParentPythonPackage`'s bare-specifier matching) --
+ * see that function's own #929 doc comment for the confirmed hono/TypeScript
+ * false-hub this guards against: a resolved bare directory specifier (e.g.
+ * `src`, left over when no `index.<ext>` entry file exists for
+ * `resolveJsDirectoryIndex` to redirect to -- see `../js-directory-index.ts`)
+ * fuzzy-matching every file under that directory for a chunk with no Python
+ * semantics at all. `pythonOnlyMatch` is true exactly when Strategy 5 was
+ * the ONLY reason the top-of-function permissive gate matched; a genuinely
+ * Python chunk still passes (its own bare-package match IS the real
+ * semantic), same as `hasSingleFileImportSemantics` above.
  */
 function addFuzzyMatchChunks(
   normalizedImport: string,
@@ -149,9 +162,11 @@ function addFuzzyMatchChunks(
 
   const ambiguous =
     normalizedImport.includes('/') && !matchesFile(normalizedImport, normalizedTarget, true);
+  const pythonOnlyMatch = !matchesFile(normalizedImport, normalizedTarget, false, false);
 
   for (const chunk of chunks) {
     if (ambiguous && hasSingleFileImportSemantics(chunk.metadata.file)) continue;
+    if (pythonOnlyMatch && !hasPythonModuleSemantics(chunk.metadata.file)) continue;
     addChunk(chunk);
   }
 }

--- a/packages/parser/src/js-directory-index.test.ts
+++ b/packages/parser/src/js-directory-index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { resolveJsDirectoryIndex, clearJsDirectoryIndexCache } from './js-directory-index.js';
+
+describe('resolveJsDirectoryIndex', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-js-directory-index-'));
+  });
+
+  afterEach(async () => {
+    clearJsDirectoryIndexCache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it('is a no-op when workspaceRoot is undefined', () => {
+    expect(resolveJsDirectoryIndex('src', undefined)).toBe('src');
+  });
+
+  it('is a no-op when the specifier is not a directory at all', async () => {
+    await writeFile('src/utils/color.ts', 'export {};\n');
+    expect(resolveJsDirectoryIndex('src/utils/color', testDir)).toBe('src/utils/color');
+  });
+
+  it('resolves a bare directory to its index.ts entry file', async () => {
+    await writeFile('src/index.ts', 'export {};\n');
+    expect(resolveJsDirectoryIndex('src', testDir)).toBe('src/index');
+  });
+
+  it('resolves a nested directory to its index.tsx entry file', async () => {
+    await writeFile('src/utils/index.tsx', 'export {};\n');
+    expect(resolveJsDirectoryIndex('src/utils', testDir)).toBe('src/utils/index');
+  });
+
+  it('tries index candidates in priority order (.ts before .js)', async () => {
+    await writeFile('src/index.js', 'module.exports = {};\n');
+    await writeFile('src/index.ts', 'export {};\n');
+    expect(resolveJsDirectoryIndex('src', testDir)).toBe('src/index');
+  });
+
+  it('is a no-op when the directory exists but has no recognized index file', async () => {
+    await writeFile('src/loose.ts', 'export {};\n');
+    expect(resolveJsDirectoryIndex('src', testDir)).toBe('src');
+  });
+
+  it('caches the resolved entry file per directory', async () => {
+    await writeFile('src/index.ts', 'export {};\n');
+    const first = resolveJsDirectoryIndex('src', testDir);
+    // Removing the entry file after the first call should not change the
+    // cached result within the same process -- mirrors resolveGoModulePrefix's
+    // caching contract.
+    await fs.rm(path.join(testDir, 'src', 'index.ts'));
+    const second = resolveJsDirectoryIndex('src', testDir);
+
+    expect(second).toBe(first);
+    expect(second).toBe('src/index');
+  });
+});

--- a/packages/parser/src/js-directory-index.ts
+++ b/packages/parser/src/js-directory-index.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Resolves a JS/TS relative import that points at a DIRECTORY (rather than a
+ * file) to that directory's real module entry point, using Node/TypeScript's
+ * own `index.<ext>` convention. A sibling to `workspace-packages.ts`'s
+ * entry-file detection, scoped to a single directory rather than a whole npm
+ * workspace package.
+ *
+ * Closes #953: `resolveRelativeImport` (`./utils/path-matching.ts`) correctly
+ * joins a specifier like `../..` against its importer's directory (producing
+ * e.g. `src`), but a bare directory name names no file of its own. Left
+ * unresolved, it falls through to `matchesFile`'s fuzzy-matching strategies —
+ * Strategy 2's Go-shaped "package directory" leniency, or Strategy 5's Python
+ * bare-module matching (`matchesParentPythonPackage`) — each tuned for a
+ * REAL multi-file-package semantic in a *different* language. For a
+ * TypeScript relative import neither applies, so the bare directory
+ * specifier fabricates a dependent edge to every file anywhere under that
+ * directory instead of the one real edge: the directory's own entry point.
+ * Resolving `src` -> `src/index` here means the specifier now names one
+ * concrete file, so it participates in ordinary EXACT-match resolution — no
+ * fuzzy-strategy involvement needed for this shape at all. See
+ * `dependency-analyzer.ts`'s `addFuzzyMatchChunks` for the match-time half of
+ * this fix (a residual guard for the directory-has-no-entry-file case this
+ * function can't do anything about).
+ *
+ * Silence beats invention when the directory has no recognized entry file:
+ * this returns `specifier` UNCHANGED rather than guessing, so downstream
+ * matching still has to prove a real edge exists.
+ */
+
+const INDEX_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+/** Per-absolute-directory cache: the `index.<ext>` filename it resolved to, or `null`. */
+const directoryEntryCache = new Map<string, string | null>();
+
+/** Clears the cached directory-entry lookups. Exported for test isolation. */
+export function clearJsDirectoryIndexCache(): void {
+  directoryEntryCache.clear();
+}
+
+function isDirectory(absPath: string): boolean {
+  try {
+    return fs.statSync(absPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Find (or retrieve from cache) the `index.<ext>` file inside `absDir`, if any. */
+function findIndexFile(absDir: string): string | null {
+  const cached = directoryEntryCache.get(absDir);
+  if (cached !== undefined) return cached;
+
+  let found: string | null = null;
+  for (const ext of INDEX_EXTENSIONS) {
+    if (fs.existsSync(path.join(absDir, `index${ext}`))) {
+      found = `index${ext}`;
+      break;
+    }
+  }
+  directoryEntryCache.set(absDir, found);
+  return found;
+}
+
+/**
+ * Resolve `specifier` (already relative-resolved to a workspace-relative-ish
+ * path by `resolveRelativeImport`) to `<specifier>/index` when it names a
+ * real on-disk directory with a recognized `index.<ext>` entry file, using
+ * `workspaceRoot` to build the absolute path for the filesystem check.
+ *
+ * No-op (`specifier` unchanged) when:
+ * - `workspaceRoot` is undefined.
+ * - `<workspaceRoot>/<specifier>` isn't a directory at all — the common
+ *   case: an ordinary file-shaped relative import, already correctly matched
+ *   without this step.
+ * - It IS a directory but has no recognized `index.<ext>` file (a directory
+ *   of loose files with no barrel) — left unresolved rather than guessed;
+ *   `dependency-analyzer.ts`'s per-chunk Python-strategy guard is the
+ *   residual defense for this case.
+ *
+ * @param specifier - The already relative-resolved specifier.
+ * @param workspaceRoot - Absolute path to the project root (for the existence check).
+ */
+export function resolveJsDirectoryIndex(
+  specifier: string,
+  workspaceRoot: string | undefined,
+): string {
+  if (!workspaceRoot) return specifier;
+
+  const absCandidate = path.join(workspaceRoot, specifier);
+  if (!isDirectory(absCandidate)) return specifier;
+
+  const entryFile = findIndexFile(absCandidate);
+  if (!entryFile) return specifier;
+
+  const entryBase = entryFile.replace(/\.[^.]+$/, '');
+  return `${specifier}/${entryBase}`;
+}


### PR DESCRIPTION
## Summary

Fixes a data-fabrication bug in `get_dependents`: a relative import that resolves to a bare **directory** path (rather than a file) fuzzy-matched against every file under that directory, fabricating `hops:1` dependent edges with no caveat, inflating `riskLevel`.

**Root cause** (confirmed, not the diagnosis in the brief but adjacent to it): `resolveRelativeImport` correctly joins a dots-only specifier like `'../..'` (from `src/middleware/jwt/index.ts`) against its importer's directory, producing the bare path `src` — but nothing then resolves `src` to its real entry point (`src/index.ts`). Left as a bare directory name, `src` satisfies `matchesFile`'s Python Strategy 5 bare-word regex (`matchesParentPythonPackage`) and fuzzy-matches against **every file anywhere under `src/`** — for a TypeScript importer with no Python semantics at all. This is the *exact* hono/TypeScript repro `matchesFile`'s own `#929` doc comment already names as a confirmed false-hub — but that fix (`allowPythonModuleMatching`) only guards `importMatchesTarget`'s call sites; `findDependentChunks`'s fuzzy loop (in both `packages/parser/src/dependency-analyzer.ts` and `packages/cli/src/mcp/handlers/dependency-analyzer.ts` — the latter is what actually backs `get_dependents`) calls raw `matchesFile` and was explicitly left unguarded, per that same doc comment's own admission.

## Fix (two layers)

1. **Root cause — resolve the directory to its real entry file.** New `packages/parser/src/js-directory-index.ts` (`resolveJsDirectoryIndex`) checks whether a relative-resolved specifier names a real on-disk directory and, if so, redirects it to that directory's `index.<ext>` file (mirrors `workspace-packages.ts`'s existing entry-file detection, scoped to one directory instead of a whole npm package). `'../..'` now resolves to `src/index`, an ordinary **exact match** — no fuzzy strategy involved at all. This is the part that keeps `jwt/index.ts` et al. correctly attributed as `hops:1` dependents of `src/index.ts` (the file `'../..'` actually names), instead of just deleting the fabricated edges outright.
   - Wired in via a new `ManifestRoots.resolveDirectoryIndex` flag, set only for JS/TS (`ast/chunker.ts`'s `buildManifestRoots`), applied only when the specifier was genuinely relative (skips the fs check entirely for bare external packages like `'lodash'`).
2. **Residual guard — gate Python Strategy 5 per chunk.** For a directory with no entry file (so #1 is a no-op), both `addFuzzyMatchChunks` implementations (parser + CLI) now re-derive the #929 guard **per chunk**, mirroring the existing #887 per-chunk pattern (`hasSingleFileImportSemantics`): a match that only succeeds via Strategy 5 is dropped unless the importer is genuinely Python. Real Python bare-package matching (`import flask` → `flask/__init__.py` + children) is untouched — verified with a dedicated regression test.

Also fixes a small, related honesty gap: `get_dependents` echoed the *requested* `depth` even for a symbol-scoped query, where `depth > 1` is documented as ignored (symbol queries always run at depth 1 — verified). Included here rather than split out: one-line fix, same file, same "does the response say what actually happened" theme as the caveat vocabulary this PR touches.

## Root cause note (pushback on the brief's diagnosis)

The brief's inference was correct in spirit but the actual defect is two-layered, not one: fixing *only* the directory→entry-point resolution (layer 1) is necessary to avoid **over-deleting** real edges (jwt/index.ts's only claim to being a dependent of anything is this exact bare-directory specifier — a guard-only fix would have wrongly zeroed it out too). Fixing *only* the Python-strategy guard (layer 2) without layer 1 would have done exactly that. Both were needed; verified with tests pinning each half separately.

## Scope questions — answered with evidence

**1. Does this generalize beyond dots-only specifiers?** Yes. Tested `..`, `../..`, `../../..`, `.`, `./`, `../`, and a **named** directory import (`../utils` where `src/utils/index.ts` exists — the common barrel-import shape). All resolve correctly via layer 1. A directory import with **no** `index.<ext>` present is a known residual gap for layer 1 (falls back to layer 2's guard, which drops the edge rather than fabricating — never silently wrong, but also never over-attributed to a directory that isn't a real barrel). Did not test: a directory whose entry point is declared via `package.json` `main`/`exports` rather than the `index.<ext>` convention — out of scope per YAGNI (that's the existing `resolveWorkspacePackageEntries` mechanism's job for actual workspace package roots; an arbitrary *internal* subdirectory with its own `package.json` is rare enough that I didn't add it).

**2. Does it affect other languages?** Tested Python explicitly: a genuine Python bare-package import (`import flask` → matches `flask/__init__.py` and children) is preserved by construction (guard only fires for a *non*-Python importer). `resolveDirectoryIndex` is gated to JS/TS only (`ast/chunker.ts`), so Python's own relative-import resolution (`from . import x` / `from .. import y`, already routed through the same `resolveRelativeImport`) is untouched — ran the Python E2E suite (`test:e2e:python` on `pallets/requests`) to confirm no regression. Did **not** test Java/Kotlin package imports, PHP, or Go directly against this specific bug shape — those languages don't use filesystem-relative `./`/`../` specifiers the way JS/TS/Python do, so `resolveJsDirectoryIndex` never runs for them at all (gated by `RESOLVE_RELATIVE_IMPORTS`/`resolveDirectoryIndex`'s language checks); I did not independently verify they have no *analogous* bare-specifier fabrication path of their own.

**3. Does the fix clean up depth 2+ for free?** Yes — verified live on hono: at `depth:2`, the fabricated seed files (`jwt/index.ts`, `ip-restriction/index.ts`, `bun/conninfo.ts`) are absent, with no special-casing needed. The BFS/depth mechanics themselves needed zero changes, matching the earlier audit's finding that they're structurally sound.

## Before / after — hono corpus, my own build, re-indexed with `index --force`

Reproduced with `git stash` (removes the fix) → rebuild → reindex → measure BEFORE, then `git stash pop` → rebuild → reindex → measure AFTER, so this is a true controlled comparison in one environment (not a diff against the published 0.72.0 binary). Queried through a real MCP client/server round-trip (`StdioClientTransport` against `node dist/index.js serve -r <hono>`), not a synthetic unit test.

**`src/utils/color.ts` (depth:1)**

| | BEFORE | AFTER |
|---|---|---|
| `dependentCount` | 13 | **4** |
| `productionDependentCount` | 6 | **3** |
| `riskLevel` | high | **medium** |
| fabricated prod files | `jwt/index.ts`, `ip-restriction/index.ts`, `bun/conninfo.ts` | **gone** |
| fabricated test files | 6 unrelated `.test.ts`/`.test.tsx` files (also via the same bare-`src` fan-out — broader than the brief's 3-file report) | **gone** |

**`src/utils/url.ts` (depth:1)**

| | BEFORE | AFTER |
|---|---|---|
| `dependentCount` | 20 | **11** |
| `productionDependentCount` | 12 | **9** |
| `riskLevel` | high | high (genuinely — url.ts has real high-complexity dependents) |
| fabricated files | same 3 as above | **gone** |

**`src/index.ts` (depth:1) — confirming no over-delete**

```
src/middleware/jwt/index.ts: hops=1
src/middleware/ip-restriction/index.ts: hops=1
src/adapter/bun/conninfo.ts: hops=1
src/index.ts total dependentCount=13
```
Identical before and after — these three files remain correctly attributed as real `hops:1` dependents of `src/index.ts` (the file `'../..'` actually names).

**`depth:2` on `src/utils/color.ts` (AFTER)** — the three fabricated files are absent (not just re-labeled `hops:2`); 5 real depth-2 dependents surfaced instead.

**Symbol-query depth echo (AFTER)** — `get_dependents({filepath: "src/utils/color.ts", symbol: "getColorEnabled", depth: 3})` now echoes `depth: 1` (previously echoed `3`).

## Verification

- All 6 gates green: `format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`, `build`, `test` (1310/1310 across the monorepo), `lien delta` (exit 0 — several functions "worsened" in complexity but none crossed threshold; `addFuzzyMatchChunks` 6→9 cognitive, `buildManifestRoots` 9→11, both comfortably under threshold).
- `test:e2e:typescript` (Zod), `test:e2e:javascript` (Express), `test:e2e:python` (Requests) all green against real clones.
- New unit tests: `packages/parser/src/js-directory-index.test.ts` (direct fs-backed tests for the new resolver), `packages/parser/src/ast/symbols.test.ts` (end-to-end extraction, including a `'.'`/#942 regression pin proving the self-import fix still works — now resolving to an exact self-match instead of a fuzzy one), `packages/parser/src/dependency-analyzer.test.ts` and `packages/cli/src/mcp/handlers/dependency-analyzer.test.ts` (both `addFuzzyMatchChunks` copies, incl. the depth-2 propagation check and the "don't over-delete" check), `packages/cli/src/mcp/handlers/get-dependents.test.ts` (depth-echo fix).
- `get_files_context`/`get_dependents` were consulted before editing each touched file per this repo's own MCP-tool policy (via the plugin's server, pointed at a slightly stale index of the main checkout — used for impact/test-association context only, not for correctness of this change).

## Test plan

- [x] All 6 pre-commit gates pass
- [x] TypeScript/JavaScript/Python E2E suites pass
- [x] Regression tests for `'../..'`, named directory imports, and `'.'` (#942)
- [x] Live before/after dogfood on hono via real MCP round-trip, verbatim numbers above
- [x] Confirmed depth 2+ cleans up transitively
- [x] Confirmed genuine `src/index.ts` dependents are not over-deleted

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a data-fabrication bug in `get_dependents` where directory-shaped relative imports (e.g. `../..` resolving to `src`) were left as bare directory names and fuzzy-matched via Python Strategy 5 against every file under that directory. The two-layer fix resolves such specifiers to their `index.<ext>` entry file for JS/TS, and adds a per-chunk guard dropping Strategy 5 matches for non-Python importers when no entry file exists. It also corrects the depth echoed in symbol-scoped queries. The changes are localized, well-tested, and the residual guard logic correctly distinguishes Python-only matches from other legitimate match strategies.
>
> - Added `resolveJsDirectoryIndex` to redirect JS/TS directory imports to their `index.<ext>` entry file
> - Added per-chunk `pythonOnlyMatch` guard in both parser and CLI `addFuzzyMatchChunks` to suppress Python Strategy 5 fan-out for non-Python importers
> - Made `get_dependents` echo the effective depth (1) for symbol-scoped queries instead of the requested depth

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2684e43. Updates automatically on new commits.</sup>
<!-- /lien-stats -->