### PR TITLE
fix(plugin): let the test-run hook see tox/nox runs

### DIFF
--- a/plugins/claude/hooks/test-run-note.sh
+++ b/plugins/claude/hooks/test-run-note.sh
@@ -52,8 +52,15 @@ esac
 # match here only costs one extra `lien` invocation that then classifies the
 # command precisely and may still decide not to record it; a false NEGATIVE
 # here would silently drop a real test run, which this list is sized to avoid.
+# `tox`/`nox` are the one family whose invocation need not contain any of the
+# other substrings — `tox`, `tox run`, `tox -e py311`, `python -m tox` all lack
+# "test" entirely — so without them here the matcher's own tox/nox patterns
+# (RUNNER_PATTERNS, added in #905) were unreachable through this hook: a full
+# tox run was silently never recorded, and the recap then nagged about tests the
+# user had in fact run. Found by dogfooding the hook against a real `tox -e`
+# command rather than by reading either list.
 case "$command_str" in
-  *test*|*vitest*|*jest*|*pytest*|*rspec*|*phpunit*|*mocha*|*dotnet*|*gradle*|*mvn*|*deno*|*'npm t'*) ;;
+  *test*|*vitest*|*jest*|*pytest*|*rspec*|*phpunit*|*mocha*|*dotnet*|*gradle*|*mvn*|*deno*|*tox*|*nox*|*'npm t'*) ;;
   *) exit 0 ;;
 esac
 


### PR DESCRIPTION
One-line fix to the coarse pre-filter in `plugins/claude/hooks/test-run-note.sh`, found while dogfooding the test-verification nudge in a foreign repo.

## The gap

The hook gates commands through a substring list before invoking the CLI. Its own comment states the intent:

> Deliberately generous — a false match here only costs one extra `lien` invocation … a false **NEGATIVE** here would silently drop a real test run, which this list is sized to avoid.

But `tox`/`nox` are the one runner family whose invocation need not contain any listed substring — `tox`, `tox run`, `tox -e py311`, `python -m tox` contain no `"test"` anywhere:

```
$ echo "tox -e py311" | grep -c "test"
0
```

Meanwhile the matcher **does** support them — `packages/cli/src/utils/test-run-matcher.ts:310`:
```js
/^tox(\s+run)?(?=\s|$)/,
/^python[0-9.]*\s+-m\s+tox(?=\s|$)/,
```

So the tox/nox patterns added in #905 were unreachable through this hook: a full `tox` run was never recorded, and the session recap then nagged about tests the user had in fact just run. A false nag is the safe direction, so nothing was silently mis-verified — but the CLI-side support was dead code through its primary consumer.

Found by piping a real `tox -e py311` command through the hook, not by reading the two lists against each other.

## Dogfood evidence

Real hook, real stdin shape, published-equivalent build, foreign repo `/tmp/lien-dogfood-460173c9/flask` (force-reindexed first). `SILENT` = a broad run was recorded so the recap correctly stays quiet; `NAGS` = no run recorded.

**After the fix:**
```
tox                       => SILENT (run recorded)
tox -e py311              => SILENT (run recorded)
python -m tox             => SILENT (run recorded)
nox                       => SILENT (run recorded)
```
(all four were `NAGS` before — prefiltered out before the CLI was ever called)

**No regression — non-test commands still ignored:**
```
git commit -m fix         => NAGS (not recorded)
echo hello                => NAGS (not recorded)
ls -la                    => NAGS (not recorded)
```

**No regression — real broad runs still recorded:**
```
npm test                  => SILENT (run recorded)
pytest                    => SILENT (run recorded)
```

A false prefilter match is harmless by design: it costs one `lien` invocation that then classifies the command precisely and declines, which is exactly what happens for a path containing "tox".

## Gates

`bash -n` ✅ · `format:check` ✅ · `lint` ✅ (0 errors) · `typecheck` ✅ · `build` ✅ · `test` ✅ (1701 + 1339 + 41, exit 0) · `lien delta` ✅ (exit 0, 32 ms). No shellcheck configured in CI.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 92 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 11 high-risk file(s) with 556 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 35 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**
>
> Expands the coarse pre-filter in `plugins/claude/hooks/test-run-note.sh` to pass `tox` and `nox` invocations through to the CLI test-run matcher. Without this, commands like `tox -e py311` or `python -m tox` were dropped before the matcher could classify them, leaving the CLI-side tox/nox patterns unreachable and causing false recap nags. The change is a one-line substring addition; false positives are harmless by design because the CLI still performs precise classification.
>
> - Added `*tox*` and `*nox*` to the shell hook's substring pre-filter so tox/nox commands reach the CLI matcher
> - Updated the inline comment to document why tox/nox need explicit inclusion despite not containing 'test'

<sup>Reviewed by [Lien Review](https://lien.dev) for commit b9e6667. Updates automatically on new commits.</sup>
<!-- /lien-stats -->