### PR TITLE
docs(mcp): pick the discovery tool by what you already know

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Lien provides lexical (FTS5) code search and dependency analysis via MCP. These 
 - `search_code` is full-text (BM25) keyword search over code, docstrings, and camelCase-split identifiers — query with concrete keywords/identifiers/domain terms, not natural-language questions. There are no embeddings, so meaning-only paraphrases that share no words with the code won't match.
 - Use `search_code` for: "authenticate user session", "index codebase pipeline", "file watcher debounce" — words that appear in the code
 - Use grep/glob ONLY for: exact symbol names, literal strings, config keys, TODOs (or `list_functions` for a single exact symbol name)
+- **Zero results is not proof of absence.** If the index hasn't caught up with a recent edit, a symbol that exists on disk is unfindable and the tool cannot tell you which case you're in. Before concluding something doesn't exist — or acting on a plausible-looking result set that omits what you asked for — grep for it, or re-run after `lien index`.
 
 ### When to Use Other Tools
 

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -6,8 +6,9 @@
  */
 export const SERVER_INSTRUCTIONS = `Lien provides fast lexical code search and dependency analysis over this codebase.
 Use Lien tools proactively — they complement grep/glob rather than replace each
-other. Prefer Lien for keyword discovery and structural impact; use grep only
-for exact literals (error strings, config keys, TODOs).
+other. Prefer Lien for keyword discovery and structural impact; use grep for
+things you can name exactly: a known symbol name, an error string, a config key,
+a TODO.
 
 REQUIRED before Edit/Write on any file:
   get_files_context({ filepaths }) — returns imports, callSites, and test
@@ -53,13 +54,23 @@ symbol:
   still read "low"; attributionCaveat is the authoritative signal in all
   four cases.
 
-For discovery ("where is X?", "how does Y work?"), call search_code FIRST.
-It runs full-text BM25 keyword search over code, docstrings, and camelCase-split
-identifiers. Query with concrete KEYWORDS, identifiers, and domain terms
-("chunk overlap config", "parse import statement") — NOT natural-language
-questions. There are no embeddings, so a meaning-only paraphrase that shares no
-words with the code will not match; use vocabulary that appears in the code or
-comments. For an exact symbol name, prefer list_functions.
+For discovery ("where is X?", "how does Y work?"), choose by what you already
+know. If you know the exact name, go straight to list_functions (a symbol) or
+grep (a literal) — do not paraphrase a name you already have. If you know the
+concept but not the name, call search_code BEFORE falling back to grep/glob.
+
+search_code runs full-text BM25 keyword search over code, docstrings, and
+camelCase-split identifiers. Query with concrete KEYWORDS, identifiers, and
+domain terms ("chunk overlap config", "parse import statement") — NOT
+natural-language questions. There are no embeddings, so a meaning-only paraphrase
+that shares no words with the code will not match; use vocabulary that appears in
+the code or comments.
+
+Zero results is NOT proof of absence. The index may simply not have caught up
+with a recent edit, in which case a symbol that exists on disk is unfindable and
+the tool cannot tell you which case you are in. Before concluding something does
+not exist, grep for it, or re-run after "lien index". Same rule for a result set
+that looks plausible but omits what you asked for.
 
 Tool selection:
   search_code       — keyword/full-text discovery


### PR DESCRIPTION
Sharpens the discovery guidance in `SERVER_INSTRUCTIONS` (the string every MCP client receives on `initialize`) and mirrors one addition into CLAUDE.md. No policy change, no new tools, no code paths touched.

## The drift

`instructions.ts` said, unconditionally:

> For discovery ("where is X?", "how does Y work?"), call **search_code FIRST**.

…while its own opening paragraph reserved grep for *"exact literals (error strings, config keys, TODOs)"* — omitting exact symbol names entirely.

CLAUDE.md already had the correct split:

> Use grep/glob ONLY for: exact symbol names, literal strings, config keys, TODOs (or `list_functions` for a single exact symbol name)

So this was one-directional drift, and the text a **model** actually receives was the wrong half. An agent that already knows the identifier it wants was being told to paraphrase it into a BM25 query first.

## What changed

Reframed around what the caller already knows:

- exact symbol name → `list_functions` (or grep) — *don't paraphrase a name you already have*
- exact literal → grep
- concept, but not the name → `search_code`, before falling back to grep/glob

Same tools, same BM25 / camelCase-split / no-embeddings caveats. The sync test (`instructions.claude-md-sync.test.ts`) still passes — it requires both texts to carry the discovery framing and all three caveats, which they do.

## Plus a lesson from the post-release dogfood

Both texts now state that **zero results is not proof of absence**:

> The index may simply not have caught up with a recent edit, in which case a symbol that exists on disk is unfindable and the tool cannot tell you which case you are in. Before concluding something does not exist, grep for it, or re-run after "lien index". Same rule for a result set that looks plausible but omits what you asked for.

This is not hypothetical — I hit it during round 2. I searched for a symbol added after the last index, got back five results ranked `"highly_relevant"`, **none of which contained it**, and published a conclusion I later had to retract. Plain grep found it immediately. #951 fixed the tool-side note for this case; this is the always-on guidance half.

## Dogfood evidence

The change only matters if it reaches a client, so verified through a real MCP `initialize` round-trip against a foreign repo (`gin`), reading back `serverInstructions` (whitespace-normalised, since the text wraps):

```
grep for things you can name exactly             PRESENT
If you know the concept but not the name         PRESENT
do not paraphrase a name you already have        PRESENT
Zero results is NOT proof of absence             PRESENT
re-run after "lien index"                        PRESENT
```
serverInstructions length: 4647 chars.

## Gates

`format:check` ✅ · `lint` ✅ · `typecheck` ✅ · `build` ✅ · `test` ✅ (1701 + 1361 + 41, exit 0, incl. the 6 sync tests) · `lien delta` ✅ (exit 0, 49 ms).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR updates two guidance surfaces — the MCP `SERVER_INSTRUCTIONS` string and `CLAUDE.md` — to refine discovery-tool selection by what the caller already knows and to warn that zero results are not proof of absence. No code paths, exports, or tool behavior changed; the guidance remains consistent with the existing lexical-search implementation and the `lien index` refresh workflow already referenced in the tool descriptions.
>
> - Reframed `SERVER_INSTRUCTIONS` discovery guidance around exact-name vs. concept-unknown cases.
> - Added the 'zero results is not proof of absence' caveat to both `SERVER_INSTRUCTIONS` and `CLAUDE.md`.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d170015. Updates automatically on new commits.</sup>
<!-- /lien-stats -->