### PR TITLE
fix(review): itemize bug findings in the PR description, not just prose

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -898,6 +898,42 @@ function formatExtraSummary(finding: ReviewFinding): string {
 }
 
 /**
+ * Render one finding as a single, discrete bullet: severity emoji, category,
+ * symbol (if present), the exact `file:line`, the message, and the
+ * suggestion (if present). Shared by the PR-description findings list and
+ * the out-of-diff promoted review so a finding reads identically wherever it
+ * surfaces.
+ */
+function formatFindingBullet(f: ReviewFinding, opts?: { outsideDiff?: boolean }): string {
+  const emoji = f.severity === 'error' ? '🔴' : f.severity === 'warning' ? '🟡' : 'ℹ️';
+  const category = f.category.replace(/_/g, ' ');
+  const symbol = f.symbolName ? ` in \`${f.symbolName}\`` : '';
+  const tag = opts?.outsideDiff ? ' *(outside this diff)*' : '';
+  const suggestion = f.suggestion ? `\n  💡 *${f.suggestion}*` : '';
+  return `- ${emoji} **${category}**${symbol} — \`${f.filepath}:${f.line}\`${tag}\n  ${f.message}${suggestion}`;
+}
+
+/**
+ * Itemize bug findings as their own PR-description section — one discrete
+ * bullet per finding, each carrying its own `file:line`. The header count
+ * (`bugFindings.length`) and this list are always the same array, so a
+ * reader is never left trusting free-form overview prose (or having to find
+ * a separate inline/out-of-diff review comment) to learn what the N counted
+ * issues actually are. Returns `[]` for a clean PR so the section is simply
+ * absent — not an empty heading — keeping the zero-finding render visually
+ * distinct from the one-finding render.
+ *
+ * Split out (rather than inlined in `buildDescription`) because
+ * `buildDescription` is already near its cyclomatic-complexity budget; a
+ * spread of this array adds no branch to that function.
+ */
+function buildFindingsSection(bugFindings: ReviewFinding[]): string[] {
+  if (bugFindings.length === 0) return [];
+  const bullets = bugFindings.map(f => formatFindingBullet(f));
+  return [`**Findings (${bugFindings.length})**\n\n${bullets.join('\n\n')}`];
+}
+
+/**
  * Build the PR description section using GitHub's callout blockquote syntax.
  * Uses > [!NOTE] for clean PRs, > [!WARNING] when issues are found. The first
  * summary drives the callout; any further summaries render as appended
@@ -938,7 +974,9 @@ function buildDescription(
     }
   }
 
-  const parts: string[] = [lines.join('\n')];
+  // The itemized findings list — see buildFindingsSection's doc comment for
+  // why the count and this list can never drift apart.
+  const parts: string[] = [lines.join('\n'), ...buildFindingsSection(bugFindings)];
 
   for (const extra of summaryFindings.slice(1)) {
     parts.push(formatExtraSummary(extra));
@@ -1010,13 +1048,7 @@ export function buildOutOfDiffReviewBody(findings: ReviewFinding[], marker: stri
   const intro =
     'Caused by changes in this PR but on lines GitHub cannot attach an inline ' +
     'comment to (outside the diff hunks):';
-  const bullets = findings.map(f => {
-    const emoji = f.severity === 'error' ? '🔴' : f.severity === 'warning' ? '🟡' : 'ℹ️';
-    const category = f.category.replace(/_/g, ' ');
-    const symbol = f.symbolName ? ` in \`${f.symbolName}\`` : '';
-    const suggestion = f.suggestion ? `\n  💡 *${f.suggestion}*` : '';
-    return `- ${emoji} **${category}**${symbol} — \`${f.filepath}:${f.line}\` *(outside this diff)*\n  ${f.message}${suggestion}`;
-  });
+  const bullets = findings.map(f => formatFindingBullet(f, { outsideDiff: true }));
   return `${marker}outside-diff -->\n${headline}\n\n${intro}\n\n${bullets.join('\n\n')}`;
 }
 

--- a/packages/review/test/plugins-agent-out-of-diff.test.ts
+++ b/packages/review/test/plugins-agent-out-of-diff.test.ts
@@ -24,6 +24,28 @@ function bug(overrides?: Partial<ReviewFinding>): ReviewFinding {
   };
 }
 
+/** A `summary`-category finding, the shape `appendSummaryFinding` produces. */
+function summaryFinding(overrides?: {
+  riskLevel?: string;
+  overview?: string;
+  keyChanges?: string[];
+}): ReviewFinding {
+  const overview = overrides?.overview ?? 'This PR looks fine overall.';
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'info',
+    category: 'summary',
+    message: overview,
+    metadata: {
+      riskLevel: overrides?.riskLevel ?? 'low',
+      overview,
+      keyChanges: overrides?.keyChanges ?? [],
+    },
+  };
+}
+
 const MARKER = '<!-- lien-plugin:agent-review:';
 
 /** A PresentContext that records every posting call for assertions. */
@@ -36,6 +58,7 @@ function recordingContext(overrides?: {
   postInlineComments: ReturnType<typeof vi.fn>;
   postReviewComment: ReturnType<typeof vi.fn>;
   minimizeOutdatedComments: ReturnType<typeof vi.fn>;
+  appendDescription: ReturnType<typeof vi.fn>;
 } {
   const calls: string[] = [];
   const postInlineComments = vi.fn(async (findings: ReviewFinding[]) => {
@@ -49,6 +72,7 @@ function recordingContext(overrides?: {
     calls.push('minimizeOutdatedComments');
     return 0;
   });
+  const appendDescription = vi.fn();
 
   const pr = {
     owner: 'o',
@@ -69,13 +93,20 @@ function recordingContext(overrides?: {
     logger: silentLogger,
     addAnnotations: vi.fn(),
     appendSummary: vi.fn(),
-    appendDescription: vi.fn(),
+    appendDescription,
     postInlineComments,
     postReviewComment,
     minimizeOutdatedComments,
   } as unknown as PresentContext;
 
-  return { ctx, calls, postInlineComments, postReviewComment, minimizeOutdatedComments };
+  return {
+    ctx,
+    calls,
+    postInlineComments,
+    postReviewComment,
+    minimizeOutdatedComments,
+    appendDescription,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -299,5 +330,139 @@ describe('AgentReviewPlugin.present — promoted-body dedup across re-runs', () 
     expect(body2).toBe(body1);
     // Each run minimizes before reposting → no double-posting accumulation.
     expect(run2.minimizeOutdatedComments).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR description — itemized findings (the "narrated, not itemised" bug:
+// the header count was already accurate, but the description carried no
+// guaranteed rendering of what the counted issues actually were — a real
+// finding could sit only in free-form overview prose, or only in a separate
+// inline/out-of-diff review comment the description never pointed to).
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPlugin.present — description itemizes bug findings', () => {
+  const plugin = new AgentReviewPlugin();
+
+  it('renders a discrete, locatable bullet for each bug finding, matching the header count', async () => {
+    const { ctx, appendDescription } = recordingContext();
+    const finding = bug({
+      filepath: 'packages/cli/src/cli/annotate-cmd.ts',
+      line: 70,
+      symbolName: 'belowRiskFloor',
+      category: 'logic_error',
+      message: 'The habituation guard does not clear the floor for dependentAttributionIncomplete.',
+      suggestion: 'Add the parameter and return false when true.',
+    });
+
+    await plugin.present([finding, summaryFinding()], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('**1 issue found**');
+    expect(description).toContain('**Findings (1)**');
+    expect(description).toContain('🟡 **logic error** in `belowRiskFloor`');
+    expect(description).toContain('`packages/cli/src/cli/annotate-cmd.ts:70`');
+    expect(description).toContain(
+      'The habituation guard does not clear the floor for dependentAttributionIncomplete.',
+    );
+    expect(description).toContain('💡 *Add the parameter and return false when true.*');
+  });
+
+  it('omits the Findings section entirely on a clean PR — zero reads unambiguously differently from one', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([summaryFinding({ overview: 'Nothing wrong here.' })], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).not.toContain('**Findings');
+    expect(description).not.toContain('issue found');
+    expect(description).toContain('> [!NOTE]');
+  });
+
+  it('surfaces the finding in the description even when the overview prose says nothing is wrong (the #944 shape)', async () => {
+    const { ctx, appendDescription } = recordingContext();
+    const finding = bug({
+      filepath: 'scripts/experiments/dogfood-oss/trial.mjs',
+      line: 34,
+      category: 'logic_error',
+      message: 'trial.mjs still hardcodes the CLI path the sibling script just made configurable.',
+    });
+
+    await plugin.present(
+      [
+        finding,
+        summaryFinding({
+          overview: 'No callers, exports, or runtime logic are affected.',
+          keyChanges: ['mcp-call.mjs now respects LIEN_MCP_CLI'],
+        }),
+      ],
+      ctx,
+    );
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    // The prose alone never mentions the bug — this was the trap: the count
+    // was accurate (1), but nothing in the description said what it was.
+    expect(description).toContain('No callers, exports, or runtime logic are affected.');
+    expect(description).toContain('**Findings (1)**');
+    expect(description).toContain(
+      'trial.mjs still hardcodes the CLI path the sibling script just made configurable.',
+    );
+  });
+
+  it('keeps the header count and the itemized list in lockstep for multiple findings', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present(
+      [
+        bug({ filepath: 'a.ts', line: 1, message: 'first finding' }),
+        bug({ filepath: 'b.ts', line: 2, message: 'second finding' }),
+        summaryFinding(),
+      ],
+      ctx,
+    );
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('**2 issues found**');
+    expect(description).toContain('**Findings (2)**');
+    expect(description).toContain('first finding');
+    expect(description).toContain('second finding');
+  });
+
+  it('does not conflate descriptive keyChanges bullets with the itemized findings bullets', async () => {
+    // The #954/#951 shape: keyChanges bullets describe the diff, not the
+    // problem. Both must render, but distinguishably — under separate,
+    // clearly labeled sections rather than one flat bullet list.
+    const { ctx, appendDescription } = recordingContext();
+    const finding = bug({
+      filepath: 'packages/cli/src/utils/test-run-matcher.ts',
+      line: 143,
+      category: 'logic_error',
+      message: 'Removing --filter from WORKSPACE_SCOPE_FLAGS regresses pnpm test --filter <pkg>.',
+    });
+
+    await plugin.present(
+      [
+        finding,
+        summaryFinding({
+          overview: 'This PR fixes a genuine bug in test-run classification.',
+          keyChanges: [
+            'Name-filtered runs now return {isTestRun: true, broad: false}.',
+            'Per-runner-family flag allow-lists avoid collisions.',
+          ],
+        }),
+      ],
+      ctx,
+    );
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    const findingsIdx = description.indexOf('**Findings (1)**');
+    const keyChangeIdx = description.indexOf('Name-filtered runs now return');
+    expect(findingsIdx).toBeGreaterThan(-1);
+    expect(keyChangeIdx).toBeGreaterThan(-1);
+    // The keyChanges bullets stay inside the callout blockquote (`>` prefix);
+    // the findings section is its own block outside it — never merged into
+    // one undifferentiated bullet list.
+    expect(description).toContain('> - Name-filtered runs now return');
+    expect(description).not.toContain('> - Removing --filter');
   });
 });


### PR DESCRIPTION
## What was actually wrong

Investigated the four PRs cited as evidence (`gh api .../pulls/N/reviews` and `/comments`, not just `gh pr view`'s body) before touching anything. The diagnosis in the brief doesn't fully hold up — here's what the data actually shows.

**Hypothesis 1 ("the count is inflated by a summary-type finding") — does not hold.** `bugFindings` in `present()` already excludes `category === 'summary'` and `category === 'architectural'`, and requires `line > 0`. `AgentFinding.severity` is typed `'error' | 'warning'` only — a bug-category finding can never be `'info'`. Checked all four PRs' real GitHub data: in every "N issue(s) found" case, N exactly matched N real, well-formed findings (file:line, message, suggestion) that existed somewhere on GitHub. The count was never wrong.

**Hypothesis 2 ("no inline comment was posted") — partially wrong, and for a more interesting reason than "no inline comment."** Checked `pulls/{n}/comments` and `pulls/{n}/reviews`:
- **#938, #944**: 0 inline comments — correct, because the findings were *unanchorable* (their line isn't in a diff hunk), so they were correctly promoted to a separate "outside this diff" **review comment** — fully itemized, with file:line, category, and a suggestion. The itemization already existed. It just wasn't in the *description*.
- **#954**: had **2 real inline comments**, each fully itemized with file:line and a fix suggestion. The "0 inline comments" claim is simply false for this PR.
- **#951**: by the time I read it, the head commit's description showed 0 bug findings (the developer had already fixed the wording bug the earlier review caught) — the "2 issues... outside this diff" review comment visible today is a stale leftover from an earlier commit in the same PR.

**The real defect**: `buildDescription()` — the function that renders the `lien-stats` block actually embedded in the PR body — never itemizes `bugFindings` itself. It shows a count (accurate) and free-form LLM overview/keyChanges prose (which may or may not restate the bug, entirely at the model's discretion — compare #938/#954, which happened to mention it, against #944, which didn't). The itemized, well-formed version of the same finding exists elsewhere on GitHub (an inline comment, or a promoted "outside this diff" review comment) — but the *one place most readers actually look*, the PR description, never shows it and never points to it. That's how #938's correct, specific, actionable finding shipped anyway: the reader read the description, saw a paragraph that used hedge language mid-sentence, and moved on.

Also confirmed `buildCheckTitle`/`buildCheckSummary` in `engine.ts` *do* have an unfiltered-count bug (they'd count the always-present `summary` finding as an "issue"), but that whole check-run code path is dead — `review-pr.ts` is the only production caller of `engine.present()` and always passes `skipCheckRun: true`. Left it alone; noting it here rather than fixing unreachable code in the same PR.

## The fix (deterministic, renderer-only — no calibration run)

`packages/review/src/plugins/agent/index.ts`:
- New `formatFindingBullet()` — one discrete bullet per finding: severity emoji, category, symbol, `file:line`, message, suggestion. Extracted from `buildOutOfDiffReviewBody`'s inline `.map()`, now shared.
- New `buildFindingsSection(bugFindings)` — returns a `**Findings (N)**` section (or `[]` on a clean PR) itemizing every bug finding with `formatFindingBullet`. `N` here is the exact same array driving the header count, so they can never drift apart.
- `buildDescription()` now spreads that section into `parts` right after the callout. `buildDescription` was already at 14/15 cyclomatic (flagged by `get_files_context`'s complexity-headroom warning), so the branch lives inside `buildFindingsSection` instead of inline — the spread adds no branch to `buildDescription` itself. `lien delta` confirms: `buildDescription` cyclomatic is unchanged.

This is a pure rendering/counting change — the `bugFindings` array (filepath, line, message, suggestion, severity) already existed; this only changes how `buildDescription` renders it. **No prompt or rule changes, so no `test:harness --calibrate` run was needed or performed** — this is the "counting and rendering are deterministic; make them unit-testable with zero LLM spend" case from CLAUDE.md, not the harness-gated case.

`get_dependents({filepath: "packages/review/src/plugins/agent/index.ts", symbol: "buildOutOfDiffReviewBody"})`: 1 dependent (its own test file), risk low — internal refactor only, no signature change.

## Tests

Extended `packages/review/test/plugins-agent-out-of-diff.test.ts` (already the home for `buildOutOfDiffReviewBody`/`partitionByDiffAnchorability` tests) with 5 new cases exercising `AgentReviewPlugin.present()` end to end via the mocked `appendDescription`:
- itemizes a single bug finding with a bullet matching the header count
- omits the `**Findings` section entirely on a clean PR (zero vs one now differ beyond NOTE/WARNING)
- the exact #944 shape: positive-sounding overview prose + a real bug finding — the finding now surfaces regardless of what the prose says
- header count and itemized list stay in lockstep for 2 findings
- keyChanges bullets (description of the diff) and findings bullets (the problem) never merge into one undifferentiated list

22/22 tests pass in `plugins-agent-out-of-diff.test.ts`; full suite green.

## Dogfood evidence — before/after, reconstructed from real fixtures

Generated with a throwaway script (`.wip/render-compare.mjs`, gitignored, not part of this PR) that runs the *real* `AgentReviewPlugin.present()` from the built package for "AFTER", against the exact pre-this-PR `buildDescription` body (copied verbatim from git history) for "BEFORE" — same `ReviewFinding` fixtures into both. Case 1 fixture is synthesized (zero-finding); Cases 2 and 3 use **verbatim finding/overview/keyChanges text pulled from the real, merged PRs #938 and #944** via `gh api repos/getlien/lien/pulls/{938,944}/reviews` and `gh pr view`.

### Case 1 — zero findings (unchanged, as it should be)
```
> [!NOTE]
> **Low Risk**
>
> This PR adds a small utility function with full test coverage and no callers outside the new test file.
>
> - Adds formatDuration() with tests covering ms/s/m boundaries.
```
Identical before and after — a clean PR was never the problem.

### Case 2 — one real finding (PR #938's actual finding, verbatim)

**BEFORE** (what actually shipped — the bug reached release 0.72.0):
```
> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR threads the dependentAttributionIncomplete signal from findDependents through annotate's AnnotationData, prints an honesty label when zero dependents are indeterminate, and prevents isTrivial from suppressing such annotations. The change is narrow and well-tested for the isTrivial path. The only gap is that belowRiskFloor's habituation guard does not also clear the floor for dependentAttributionIncomplete, so --min-risk can still silence the annotation in exactly the case the PR aims to surface.
>
> - AnnotationData carries dependentAttributionIncomplete from findDependents
> - emitAnnotation prints a 'Dependents not determinable...' line for incomplete-attribution zeros
> - isTrivial gains a defaulted 5th parameter and never suppresses when the flag is true
```
The bug is in there — as a clause in sentence three of the paragraph. No bullet, no file:line, easy to skim past. (It was skimmed past.)

**AFTER** — same finding, same overview, plus the new section:
```
> [!WARNING]
> **1 issue found** · Low Risk
>
> [... same overview and keyChanges as above, unchanged ...]

**Findings (1)**

- 🟡 **logic error** in `belowRiskFloor` — `packages/cli/src/cli/annotate-cmd.ts:70`
  The PR prevents isTrivial from suppressing annotations when dependentAttributionIncomplete is true, but belowRiskFloor still allows suppression via --min-risk. A C# file with zero import-visible dependents and dependentAttributionIncomplete=true will be silently suppressed under --min-risk medium even though the same signal is treated as a non-suppressible plan-time nudge in isTrivial.
  💡 *Add dependentAttributionIncomplete as an optional parameter to belowRiskFloor and return false when it is true, mirroring isTrivial: `if (dependentAttributionIncomplete) return false;`. Pass data.dependentAttributionIncomplete from the call site in run at line 441.*
```

### Case 3 — the #944 shape: overview reads entirely positive, but 1 issue really was found

**BEFORE** — this is the actual rendered text on #944 today:
```
> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR contains two small dogfood-driven fixes with no production code impact: [...] No callers, exports, or runtime logic are affected.
>
> - mcp-call.mjs now respects LIEN_MCP_CLI and reports the measured CLI path in every envelope
> - worktree-development.md clarifies that build:native is required for gate 6 regardless of what files were edited
```
Reads as "1 issue found" over a paragraph that asserts nothing is wrong, backed by two bullets that are both pure change-description. The real finding (`trial.mjs`/`provision.mjs` still hardcode the path the sibling script just made configurable) is real — it's sitting in a separate "outside this diff" review comment the description never mentions.

**AFTER** — same overview and keyChanges (untouched), plus:
```
**Findings (1)**

- 🟡 **logic error** — `scripts/experiments/dogfood-oss/trial.mjs:34`
  mcp-call.mjs at line 30 replaced the hardcoded packages/cli/dist/index.js path with a LIEN_MCP_CLI-aware resolution so the measured binary is explicit, but trial.mjs:34 and provision.mjs:22 in the same dogfood-oss kit still hardcode path.join(REPO, 'packages/cli/dist/index.js'). Running either from a non-main worktree will silently measure that worktree's build (or fail to measure a published artifact), the exact bug the PR fixed in mcp-call.mjs.
  💡 *Apply the same LIEN_MCP_CLI conditional to trial.mjs and provision.mjs, or hoist the resolution into a shared helper imported by all dogfood-oss scripts so the target CLI is defined once.*
```
Now the description alone tells the reader exactly what's wrong and where — no more relying on prose that happened to stay silent, and no separate review comment to go hunting for.

## Gates

All run in this worktree after `npm ci` (a fresh worktree — the worktree-development.md gotcha: no `node_modules` meant module resolution was silently falling through to the main checkout's, until `npm ci` here fixed it) + `npm run build` + `npm run build:native -w @liendev/parser-native`:

- `format:check` passed, exit 0
- `lint` passed, exit 0 (0 errors, 38 pre-existing warnings, none in touched files)
- `typecheck` passed, exit 0
- `build` passed, exit 0
- `test` passed, exit 0 — 1361 (cli) + 57 (review, incl. 22/22 in the extended test file) + 41 (action) all passing
- `lien delta` passed, exit 0:
  ```
  packages/review/src/plugins/agent/index.ts
    ⚠ pre-exist buildDescription         time 71m → 75m
    · new      formatFindingBullet      cognitive – → 5
    · new      buildFindingsSection     cognitive – → 1
    ✓ improved buildOutOfDiffReviewBody cognitive 5 → 1

  packages/review/test/plugins-agent-out-of-diff.test.ts
    ⚠ worsened recordingContext         time 40m → 44m
    · new      summaryFinding           cyclomatic – → 1

  ⚠ 1 worsened · ✓ 1 improved · 2 files
  ```
  `buildDescription`'s only flagged metric is a pre-existing Halstead-time advisory (unchanged cyclomatic — the whole point of the `buildFindingsSection` extraction); nothing new crosses a threshold.

Not merging — opening for review per instructions.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +4 |


> [!NOTE]
> **Low Risk**
>
> This PR is a deterministic renderer-only refactor that itemizes bug findings in the PR description. It extracts a shared `formatFindingBullet()` helper, adds a `buildFindingsSection()` renderer, and updates `buildDescription()` to include the itemized list. The header count and the itemized list are driven by the same `bugFindings` array, so they cannot drift. The change is well-covered by 5 new unit tests and touches no prompts, rules, or public signatures. The only other surface affected is `buildOutOfDiffReviewBody()`, which now shares the same bullet formatter — a behavior-preserving deduplication.
>
> - New `formatFindingBullet()` and `buildFindingsSection()` helpers render discrete, locatable findings bullets for the PR description.
> - `buildDescription()` now appends the itemized findings section right after the callout, using the same `bugFindings` array that drives the header count.
> - `buildOutOfDiffReviewBody()` refactored to use the shared `formatFindingBullet()` helper with the `outsideDiff` tag.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit edbfe30. Updates automatically on new commits.</sup>
<!-- /lien-stats -->