### PR TITLE
test(dogfood): one shared CLI resolver for the whole dogfood kit

### DIFF
--- a/scripts/experiments/dogfood-oss/corpus-manifest.json
+++ b/scripts/experiments/dogfood-oss/corpus-manifest.json
@@ -1,196 +1,9 @@
 {
-  "corpusRoot": "/tmp/lien-dogfood-460173c9",
-  "cliVersion": "0.71.1",
+  "corpusRoot": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus",
+  "cliVersion": "0.72.0",
+  "cliPath": "/Users/alfhenderson/Code/lien/.claude/worktrees/dogfood-round2/packages/cli/dist/index.js",
+  "cliSource": "local-build",
   "repos": [
-    {
-      "repo": "Alamofire/Alamofire",
-      "lang": "swift",
-      "tier": "known",
-      "ext": [
-        ".swift"
-      ],
-      "dir": "/tmp/lien-dogfood-460173c9/Alamofire",
-      "sha": "0455bfb650893e86ad07ace16e5f2d36dadf46f4",
-      "c1Advisory": [],
-      "c1": "clean",
-      "sourceFileCount": 98,
-      "indexMs": 243,
-      "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 104ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
-      "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/Alamofire-eb47b9b7",
-        "indexStatus": "exists",
-        "indexFiles": 4,
-        "lastModified": "2026-07-29T05:36:50.965Z",
-        "lastReindex": "2026-07-28T22:29:02.617Z",
-        "git": {
-          "enabled": true,
-          "branch": "master",
-          "commit": "0455bfb6"
-        },
-        "features": {
-          "fileWatching": true,
-          "gitDetection": true
-        },
-        "backend": "sqlite",
-        "search": "lexical",
-        "settings": {
-          "concurrency": 4,
-          "chunkSize": 75,
-          "chunkOverlap": 10
-        }
-      },
-      "associations": {
-        "sampled": 25,
-        "withTests": 0,
-        "inferred": 5,
-        "anyCoverage": 5,
-        "pct": 0,
-        "pctIncludingInferred": 20,
-        "examples": [
-          {
-            "file": "Example/Source/AppDelegate.swift",
-            "annotation": "Lien impact for Example/Source/AppDelegate.swift:\n  • Test coverage not determinable from imports (whole-module import)."
-          },
-          {
-            "file": "Package.swift",
-            "annotation": "Lien impact for Package.swift:\n  • Test coverage not determinable from imports (whole-module import)."
-          },
-          {
-            "file": "Package@swift-6.2.swift",
-            "annotation": "Lien impact for Package@swift-6.2.swift:\n  • Test coverage not determinable from imports (whole-module import)."
-          }
-        ]
-      },
-      "status": "OK"
-    },
-    {
-      "repo": "gin-gonic/gin",
-      "lang": "go",
-      "tier": "known",
-      "ext": [
-        ".go"
-      ],
-      "dir": "/tmp/lien-dogfood-460173c9/gin",
-      "sha": "34dac209ffb6ef85cc78c5d217bbb7ad001d68fd",
-      "c1Advisory": [],
-      "c1": "clean",
-      "sourceFileCount": 99,
-      "indexMs": 252,
-      "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 114ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠹\u001b[39m Indexing your TODO comments (so many TODOs)...\u001b[32m✔\u001b[39m \u001b[32mUpdated 6 files, removed 0 (6/6)\u001b[39m",
-      "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/gin-414c34fd",
-        "indexStatus": "exists",
-        "indexFiles": 10,
-        "lastModified": "2026-07-29T05:36:37.612Z",
-        "lastReindex": "2026-07-29T05:36:37.596Z",
-        "git": {
-          "enabled": true,
-          "branch": "master",
-          "commit": "34dac209"
-        },
-        "features": {
-          "fileWatching": true,
-          "gitDetection": true
-        },
-        "backend": "sqlite",
-        "search": "lexical",
-        "settings": {
-          "concurrency": 4,
-          "chunkSize": 75,
-          "chunkOverlap": 10
-        }
-      },
-      "associations": {
-        "sampled": 25,
-        "withTests": 16,
-        "inferred": 0,
-        "anyCoverage": 16,
-        "pct": 64,
-        "pctIncludingInferred": 64,
-        "examples": [
-          {
-            "file": "binding/binding.go",
-            "annotation": "Lien impact for binding/binding.go:\n  • 6 files import this — mode.go, deprecated.go, context.go, mode_test.go, +2 more; risk: medium (6 callers, 3 untested, max complexity 14).\n  • Test coverage: mode_test.go, deprecated_test.go (+2 more)."
-          },
-          {
-            "file": "binding/binding_test.go",
-            "annotation": "Lien impact for binding/binding_test.go:\n  • 6 files import this — mode.go, deprecated.go, context.go, mode_test.go, +2 more; risk: medium (6 callers, 3 untested, max complexity 14).\n  • Test coverage: mode_test.go, deprecated_test.go (+1 more)."
-          },
-          {
-            "file": "binding/default_validator_benchmark_test.go",
-            "annotation": "Lien impact for binding/default_validator_benchmark_test.go:\n  • 6 files import this — mode.go, deprecated.go, context.go, mode_test.go, +2 more; risk: medium (6 callers, 3 untested, max complexity 14).\n  • Test coverage: mode_test.go, deprecated_test.go (+1 more)."
-          }
-        ]
-      },
-      "status": "OK"
-    },
-    {
-      "repo": "honojs/hono",
-      "lang": "typescript",
-      "tier": "fresh",
-      "ext": [
-        ".ts"
-      ],
-      "dir": "/tmp/lien-dogfood-460173c9/hono",
-      "sha": "224d2f5cbf2b4bc2ebb7482d0592149a8d9f0574",
-      "c1Advisory": [],
-      "c1": "clean",
-      "sourceFileCount": 324,
-      "indexMs": 273,
-      "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 128ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
-      "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/hono-b008d2e1",
-        "indexStatus": "exists",
-        "indexFiles": 12,
-        "lastModified": "2026-07-29T05:38:44.247Z",
-        "lastReindex": "2026-07-29T05:36:56.656Z",
-        "git": {
-          "enabled": true,
-          "branch": "main",
-          "commit": "224d2f5c"
-        },
-        "features": {
-          "fileWatching": true,
-          "gitDetection": true
-        },
-        "backend": "sqlite",
-        "search": "lexical",
-        "settings": {
-          "concurrency": 4,
-          "chunkSize": 75,
-          "chunkOverlap": 10
-        }
-      },
-      "associations": {
-        "sampled": 25,
-        "withTests": 21,
-        "inferred": 0,
-        "anyCoverage": 21,
-        "pct": 84,
-        "pctIncludingInferred": 84,
-        "examples": [
-          {
-            "file": "benchmarks/http-server/benchmark.ts",
-            "annotation": "⚠ Lien: buildVersion cognitive 21/15 (over) — avoid adding complexity here; prefer extraction.\nLien impact for benchmarks/http-server/benchmark.ts:\n  • No test coverage."
-          },
-          {
-            "file": "build/build.ts",
-            "annotation": "⚠ Lien: addExtension cognitive 12/15 — avoid adding complexity here; prefer extraction.\nLien impact for build/build.ts:\n  • No test coverage."
-          },
-          {
-            "file": "runtime-tests/fastly/index.test.ts",
-            "annotation": "Lien impact for runtime-tests/fastly/index.test.ts:\n  • No test coverage."
-          }
-        ]
-      },
-      "status": "OK"
-    },
     {
       "repo": "pallets/flask",
       "lang": "python",
@@ -198,21 +11,21 @@
       "ext": [
         ".py"
       ],
-      "dir": "/tmp/lien-dogfood-460173c9/flask",
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/flask",
       "sha": "36e4a824f340fdee7ed50937ba8e7f6bc7d17f81",
       "c1Advisory": [],
       "c1": "clean",
       "sourceFileCount": 83,
-      "indexMs": 224,
+      "indexMs": 221,
       "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 87ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "indexTail": "\u001b[2m  Completed in 78ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
       "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/flask-7b1419a5",
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/flask-f12d6805",
         "indexStatus": "exists",
         "indexFiles": 4,
-        "lastModified": "2026-07-29T05:36:32.538Z",
-        "lastReindex": "2026-07-28T22:32:30.652Z",
+        "lastModified": "2026-07-29T21:55:57.427Z",
+        "lastReindex": "2026-07-29T21:52:46.972Z",
         "git": {
           "enabled": true,
           "branch": "main",
@@ -255,27 +68,405 @@
       "status": "OK"
     },
     {
+      "repo": "gin-gonic/gin",
+      "lang": "go",
+      "tier": "known",
+      "ext": [
+        ".go"
+      ],
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/gin",
+      "sha": "34dac209ffb6ef85cc78c5d217bbb7ad001d68fd",
+      "c1Advisory": [],
+      "c1": "clean",
+      "sourceFileCount": 99,
+      "indexMs": 205,
+      "indexOk": true,
+      "indexTail": "\u001b[2m  Completed in 59ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "status_json": {
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/gin-afa825f6",
+        "indexStatus": "exists",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:03.018Z",
+        "lastReindex": "2026-07-29T21:51:13.405Z",
+        "git": {
+          "enabled": true,
+          "branch": "master",
+          "commit": "34dac209"
+        },
+        "features": {
+          "fileWatching": true,
+          "gitDetection": true
+        },
+        "backend": "sqlite",
+        "search": "lexical",
+        "settings": {
+          "concurrency": 4,
+          "chunkSize": 75,
+          "chunkOverlap": 10
+        }
+      },
+      "associations": {
+        "sampled": 25,
+        "withTests": 7,
+        "inferred": 0,
+        "anyCoverage": 7,
+        "pct": 28,
+        "pctIncludingInferred": 28,
+        "examples": [
+          {
+            "file": "binding/binding.go",
+            "annotation": "Lien impact for binding/binding.go:\n  • 6 files import this — mode.go, deprecated.go, context.go, mode_test.go, +2 more; risk: medium (6 callers, 3 untested, max complexity 14).\n  • Test coverage: mode_test.go, deprecated_test.go (+2 more)."
+          },
+          {
+            "file": "binding/binding_test.go",
+            "annotation": "Lien impact for binding/binding_test.go:\n  • Test coverage (package-level, no dedicated test file for this specific file): binding/yaml_test.go, binding/validate_test.go (+10 more)."
+          },
+          {
+            "file": "binding/default_validator_benchmark_test.go",
+            "annotation": "Lien impact for binding/default_validator_benchmark_test.go:\n  • Test coverage (package-level, no dedicated test file for this specific file): binding/yaml_test.go, binding/validate_test.go (+10 more)."
+          }
+        ]
+      },
+      "status": "OK"
+    },
+    {
+      "repo": "tokio-rs/tokio",
+      "lang": "rust",
+      "tier": "known",
+      "ext": [
+        ".rs"
+      ],
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/tokio",
+      "sha": "4308c74a65218e8ebea1a84e09c0ba4b0882f881",
+      "c1Advisory": [],
+      "c1": "clean",
+      "sourceFileCount": 790,
+      "indexMs": 282,
+      "indexOk": true,
+      "indexTail": "\u001b[2m  Completed in 136ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "status_json": {
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/tokio-c6d255de",
+        "indexStatus": "exists",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:08.398Z",
+        "lastReindex": "2026-07-29T21:51:22.014Z",
+        "git": {
+          "enabled": true,
+          "branch": "master",
+          "commit": "4308c74a"
+        },
+        "features": {
+          "fileWatching": true,
+          "gitDetection": true
+        },
+        "backend": "sqlite",
+        "search": "lexical",
+        "settings": {
+          "concurrency": 4,
+          "chunkSize": 75,
+          "chunkOverlap": 10
+        }
+      },
+      "associations": {
+        "sampled": 25,
+        "withTests": 15,
+        "inferred": 0,
+        "anyCoverage": 15,
+        "pct": 60,
+        "pctIncludingInferred": 60,
+        "examples": [
+          {
+            "file": "benches/copy.rs",
+            "annotation": "Lien impact for benches/copy.rs:\n  • No test coverage."
+          },
+          {
+            "file": "examples/print_each_packet.rs",
+            "annotation": "Lien impact for examples/print_each_packet.rs:\n  • No test coverage."
+          },
+          {
+            "file": "tokio-macros/src/lib.rs",
+            "annotation": "Lien impact for tokio-macros/src/lib.rs:\n  • No test coverage."
+          }
+        ]
+      },
+      "status": "OK"
+    },
+    {
+      "repo": "Alamofire/Alamofire",
+      "lang": "swift",
+      "tier": "known",
+      "ext": [
+        ".swift"
+      ],
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/Alamofire",
+      "sha": "0455bfb650893e86ad07ace16e5f2d36dadf46f4",
+      "c1Advisory": [],
+      "c1": "clean",
+      "sourceFileCount": 98,
+      "indexMs": 260,
+      "indexOk": true,
+      "indexTail": "\u001b[2m  Completed in 108ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "status_json": {
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/Alamofire-d992bbec",
+        "indexStatus": "exists",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:16.749Z",
+        "lastReindex": "2026-07-29T21:51:32.762Z",
+        "git": {
+          "enabled": true,
+          "branch": "master",
+          "commit": "0455bfb6"
+        },
+        "features": {
+          "fileWatching": true,
+          "gitDetection": true
+        },
+        "backend": "sqlite",
+        "search": "lexical",
+        "settings": {
+          "concurrency": 4,
+          "chunkSize": 75,
+          "chunkOverlap": 10
+        }
+      },
+      "associations": {
+        "sampled": 25,
+        "withTests": 0,
+        "inferred": 5,
+        "anyCoverage": 5,
+        "pct": 0,
+        "pctIncludingInferred": 20,
+        "examples": [
+          {
+            "file": "Example/Source/AppDelegate.swift",
+            "annotation": "Lien impact for Example/Source/AppDelegate.swift:\n  • Test coverage not determinable from imports (whole-module import)."
+          },
+          {
+            "file": "Package.swift",
+            "annotation": "Lien impact for Package.swift:\n  • Test coverage not determinable from imports (whole-module import)."
+          },
+          {
+            "file": "Package@swift-6.2.swift",
+            "annotation": "Lien impact for Package@swift-6.2.swift:\n  • Test coverage not determinable from imports (whole-module import)."
+          }
+        ]
+      },
+      "status": "OK"
+    },
+    {
+      "repo": "honojs/hono",
+      "lang": "typescript",
+      "tier": "fresh",
+      "ext": [
+        ".ts"
+      ],
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/hono",
+      "sha": "224d2f5cbf2b4bc2ebb7482d0592149a8d9f0574",
+      "c1Advisory": [],
+      "c1": "clean",
+      "sourceFileCount": 324,
+      "indexMs": 283,
+      "indexOk": true,
+      "indexTail": "\u001b[2m  Completed in 132ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "status_json": {
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/hono-57af421c",
+        "indexStatus": "exists",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:22.487Z",
+        "lastReindex": "2026-07-29T21:51:40.684Z",
+        "git": {
+          "enabled": true,
+          "branch": "main",
+          "commit": "224d2f5c"
+        },
+        "features": {
+          "fileWatching": true,
+          "gitDetection": true
+        },
+        "backend": "sqlite",
+        "search": "lexical",
+        "settings": {
+          "concurrency": 4,
+          "chunkSize": 75,
+          "chunkOverlap": 10
+        }
+      },
+      "associations": {
+        "sampled": 25,
+        "withTests": 14,
+        "inferred": 0,
+        "anyCoverage": 14,
+        "pct": 56,
+        "pctIncludingInferred": 56,
+        "examples": [
+          {
+            "file": "benchmarks/http-server/benchmark.ts",
+            "annotation": "⚠ Lien: buildVersion cognitive 21/15 (over) — avoid adding complexity here; prefer extraction.\nLien impact for benchmarks/http-server/benchmark.ts:\n  • No test coverage."
+          },
+          {
+            "file": "build/build.ts",
+            "annotation": "⚠ Lien: addExtension cognitive 12/15 — avoid adding complexity here; prefer extraction.\nLien impact for build/build.ts:\n  • No test coverage."
+          },
+          {
+            "file": "runtime-tests/fastly/index.test.ts",
+            "annotation": "Lien impact for runtime-tests/fastly/index.test.ts:\n  • No test coverage."
+          }
+        ]
+      },
+      "status": "OK"
+    },
+    {
+      "repo": "square/retrofit",
+      "lang": "java",
+      "tier": "fresh",
+      "ext": [
+        ".java"
+      ],
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/retrofit",
+      "sha": "d0b112dad073b7fe49c953ebc46ff1b424cb1e51",
+      "c1Advisory": [],
+      "c1": "clean",
+      "sourceFileCount": 306,
+      "indexMs": 433,
+      "indexOk": true,
+      "indexTail": "\u001b[2m  Completed in 284ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "status_json": {
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/retrofit-ebf969ae",
+        "indexStatus": "exists",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:27.716Z",
+        "lastReindex": "2026-07-29T21:51:47.898Z",
+        "git": {
+          "enabled": true,
+          "branch": "trunk",
+          "commit": "d0b112da"
+        },
+        "features": {
+          "fileWatching": true,
+          "gitDetection": true
+        },
+        "backend": "sqlite",
+        "search": "lexical",
+        "settings": {
+          "concurrency": 4,
+          "chunkSize": 75,
+          "chunkOverlap": 10
+        }
+      },
+      "associations": {
+        "sampled": 25,
+        "withTests": 2,
+        "inferred": 0,
+        "anyCoverage": 2,
+        "pct": 8,
+        "pctIncludingInferred": 8,
+        "examples": [
+          {
+            "file": "retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java",
+            "annotation": "Lien impact for retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java:\n  • Test coverage (package-level, no dedicated test file for this specific file): retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java, retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleWithSchedulerTest.java (+17 more)."
+          },
+          {
+            "file": "retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java",
+            "annotation": "Lien impact for retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java:\n  • Test coverage (package-level, no dedicated test file for this specific file): retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java, retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleWithSchedulerTest.java (+16 more)."
+          },
+          {
+            "file": "retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaPluginsResetRule.java",
+            "annotation": "Lien impact for retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaPluginsResetRule.java:\n  • Test coverage (package-level, no dedicated test file for this specific file): retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java, retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleWithSchedulerTest.java (+16 more)."
+          }
+        ]
+      },
+      "status": "OK"
+    },
+    {
+      "repo": "symfony/console",
+      "lang": "php",
+      "tier": "fresh",
+      "ext": [
+        ".php"
+      ],
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/console",
+      "sha": "535e18a1b8925f6c01a55b171d157ab66c2ace15",
+      "c1Advisory": [],
+      "c1": "clean",
+      "sourceFileCount": 361,
+      "indexMs": 264,
+      "indexOk": true,
+      "indexTail": "\u001b[2m  Completed in 113ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "status_json": {
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/console-be826fe2",
+        "indexStatus": "exists",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:35.093Z",
+        "lastReindex": "2026-07-29T21:53:29.666Z",
+        "git": {
+          "enabled": true,
+          "branch": "8.2",
+          "commit": "535e18a1"
+        },
+        "features": {
+          "fileWatching": true,
+          "gitDetection": true
+        },
+        "backend": "sqlite",
+        "search": "lexical",
+        "settings": {
+          "concurrency": 4,
+          "chunkSize": 75,
+          "chunkOverlap": 10
+        }
+      },
+      "associations": {
+        "sampled": 25,
+        "withTests": 12,
+        "inferred": 0,
+        "anyCoverage": 12,
+        "pct": 48,
+        "pctIncludingInferred": 48,
+        "examples": [
+          {
+            "file": "Application.php",
+            "annotation": "⚠ Lien: Application.doRunCommand cognitive 67/15 (over), Application.find cognitive 50/15 (over), Application.doRun cognitive 37/15 (over), … and 7 more at/near budget — avoid adding complexity here; prefer extraction.\nLien impact for Application.php:\n  • 33 files import this — Tester/ApplicationTester.php, Messenger/RunCommandMessageHandler.php, Descriptor/XmlDescriptor.php, Descriptor/TextDescri"
+          },
+          {
+            "file": "ArgumentResolver/ValueResolver/UidValueResolver.php",
+            "annotation": "Lien impact for ArgumentResolver/ValueResolver/UidValueResolver.php:\n  • 3 files import this — Resources/config/console.php, ArgumentResolver/ArgumentResolver.php, Tests/ArgumentResolver/ValueResolver/UidValueResolverTest.php; risk: medium (3 callers, 1 untested, max complexity 25).\n  • Test coverage: Tests/ArgumentResolver/ValueResolver/UidValueResolverTest.php."
+          },
+          {
+            "file": "Attribute/ValueResolver.php",
+            "annotation": "Lien impact for Attribute/ValueResolver.php:\n  • 1 file imports this — ArgumentResolver/ArgumentResolver.php; risk: medium (1 caller, max complexity 25, high-complexity dependent regardless of test coverage).\n  • No test coverage."
+          }
+        ]
+      },
+      "status": "OK"
+    },
+    {
       "repo": "serilog/serilog",
       "lang": "csharp",
       "tier": "fresh",
       "ext": [
         ".cs"
       ],
-      "dir": "/tmp/lien-dogfood-460173c9/serilog",
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/serilog",
       "sha": "07d39cfb2928076ecd902a61d295f90d74fe1fa5",
       "c1Advisory": [],
       "c1": "clean",
       "sourceFileCount": 216,
-      "indexMs": 299,
+      "indexMs": 580,
       "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 138ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "indexTail": "\u001b[2m  Completed in 144ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
       "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/serilog-163a5271",
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/serilog-9e498246",
         "indexStatus": "exists",
-        "indexFiles": 9,
-        "lastModified": "2026-07-29T05:38:37.974Z",
-        "lastReindex": "2026-07-29T05:29:28.965Z",
+        "indexFiles": 4,
+        "lastModified": "2026-07-29T21:56:49.342Z",
+        "lastReindex": "2026-07-29T21:52:05.416Z",
         "git": {
           "enabled": true,
           "branch": "dev",
@@ -295,23 +486,23 @@
       },
       "associations": {
         "sampled": 25,
-        "withTests": 1,
+        "withTests": 0,
         "inferred": 0,
-        "anyCoverage": 1,
-        "pct": 4,
-        "pctIncludingInferred": 4,
+        "anyCoverage": 0,
+        "pct": 0,
+        "pctIncludingInferred": 0,
         "examples": [
           {
             "file": "src/Serilog/Capturing/DepthLimiter.cs",
-            "annotation": "Lien impact for src/Serilog/Capturing/DepthLimiter.cs:\n  • Test coverage not determinable from imports (enclosing-namespace access)."
+            "annotation": "Lien impact for src/Serilog/Capturing/DepthLimiter.cs:\n  • 1 file imports this — src/Serilog/Capturing/PropertyValueConverter.cs; risk: medium (1 caller, 1 untested).\n  • Test coverage not determinable from imports (enclosing-namespace access)."
           },
           {
             "file": "src/Serilog/Configuration/LoggerDestructuringConfiguration.cs",
-            "annotation": "Lien impact for src/Serilog/Configuration/LoggerDestructuringConfiguration.cs:\n  • Test coverage not determinable from imports (enclosing-namespace access)."
+            "annotation": "Lien impact for src/Serilog/Configuration/LoggerDestructuringConfiguration.cs:\n  • 6 files import this — src/Serilog/LoggerConfiguration.cs, src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs, src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs, src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs, +2 more; risk: medium (6 callers, 4 untested).\n  • Test c"
           },
           {
             "file": "src/Serilog/Context/LogContextEnricher.cs",
-            "annotation": "Lien impact for src/Serilog/Context/LogContextEnricher.cs:\n  • Test coverage not determinable from imports (enclosing-namespace access)."
+            "annotation": "Lien impact for src/Serilog/Context/LogContextEnricher.cs:\n  • 1 file imports this — src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs; risk: medium (1 caller, 1 untested).\n  • Test coverage not determinable from imports (enclosing-namespace access)."
           }
         ]
       },
@@ -324,21 +515,21 @@
       "ext": [
         ".rb"
       ],
-      "dir": "/tmp/lien-dogfood-460173c9/sidekiq",
+      "dir": "/var/folders/wz/5n5ln_sn3bgbl82s883l7y580000gp/T/lien-dogfood-corpus/sidekiq",
       "sha": "27ec98218bfcf6a90080e1852a0bee16ff4e3c80",
       "c1Advisory": [],
       "c1": "clean",
       "sourceFileCount": 168,
       "indexMs": 241,
       "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 101ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
+      "indexTail": "\u001b[2m  Completed in 99ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
       "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/sidekiq-400db6dd",
+        "version": "0.72.0",
+        "indexPath": "/Users/alfhenderson/.lien/indices/sidekiq-71073837",
         "indexStatus": "exists",
         "indexFiles": 4,
-        "lastModified": "2026-07-29T05:37:20.957Z",
-        "lastReindex": "2026-07-28T22:33:17.848Z",
+        "lastModified": "2026-07-29T21:56:55.319Z",
+        "lastReindex": "2026-07-29T21:53:42.068Z",
         "git": {
           "enabled": true,
           "branch": "main",
@@ -370,200 +561,11 @@
           },
           {
             "file": "lib/sidekiq.rb",
-            "annotation": "Lien impact for lib/sidekiq.rb:\n  • 15 files import this — examples/por.rb, lib/sidekiq/web.rb, lib/sidekiq/testing.rb, lib/sidekiq/test_api.rb, +11 more; risk: medium (15 callers, 4 untested, max complexity 13).\n  • Test coverage: test/sharding_test.rb, test/iterable/active_record_enumerator_test.rb (+2 more)."
+            "annotation": "Lien impact for lib/sidekiq.rb:\n  • 15 files import this — examples/por.rb, lib/sidekiq/web.rb, lib/sidekiq/testing.rb, lib/sidekiq/test_api.rb, +11 more; risk: medium (15 callers, 4 untested, max complexity 13).\n  • Test coverage: test/sharding_test.rb, test/iterable/csv_enumerator_test.rb (+2 more)."
           },
           {
             "file": "lib/sidekiq/config.rb",
             "annotation": "Lien impact for lib/sidekiq/config.rb:\n  • 2 files import this — lib/sidekiq.rb, lib/sidekiq/cli.rb; risk: low (2 callers, max complexity 13).\n  • No test coverage."
-          }
-        ]
-      },
-      "status": "OK"
-    },
-    {
-      "repo": "square/retrofit",
-      "lang": "java",
-      "tier": "fresh",
-      "ext": [
-        ".java"
-      ],
-      "dir": "/tmp/lien-dogfood-460173c9/retrofit",
-      "sha": "d0b112dad073b7fe49c953ebc46ff1b424cb1e51",
-      "c1Advisory": [],
-      "c1": "clean",
-      "sourceFileCount": 306,
-      "indexMs": 420,
-      "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 281ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
-      "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/retrofit-a6deda25",
-        "indexStatus": "exists",
-        "indexFiles": 4,
-        "lastModified": "2026-07-29T05:37:01.771Z",
-        "lastReindex": "2026-07-28T22:29:15.351Z",
-        "git": {
-          "enabled": true,
-          "branch": "trunk",
-          "commit": "d0b112da"
-        },
-        "features": {
-          "fileWatching": true,
-          "gitDetection": true
-        },
-        "backend": "sqlite",
-        "search": "lexical",
-        "settings": {
-          "concurrency": 4,
-          "chunkSize": 75,
-          "chunkOverlap": 10
-        }
-      },
-      "associations": {
-        "sampled": 25,
-        "withTests": 5,
-        "inferred": 0,
-        "anyCoverage": 5,
-        "pct": 20,
-        "pctIncludingInferred": 20,
-        "examples": [
-          {
-            "file": "retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java",
-            "annotation": "Lien impact for retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java:\n  • Test coverage (package-level, no dedicated test file for this specific file): retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java, retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleWithSchedulerTest.java (+17 more)."
-          },
-          {
-            "file": "retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java",
-            "annotation": "Lien impact for retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java:\n  • Test coverage (package-level, no dedicated test file for this specific file): retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java, retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleWithSchedulerTest.java (+16 more)."
-          },
-          {
-            "file": "retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaPluginsResetRule.java",
-            "annotation": "Lien impact for retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaPluginsResetRule.java:\n  • Test coverage (package-level, no dedicated test file for this specific file): retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java, retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleWithSchedulerTest.java (+16 more)."
-          }
-        ]
-      },
-      "status": "OK"
-    },
-    {
-      "repo": "symfony/console",
-      "lang": "php",
-      "tier": "fresh",
-      "ext": [
-        ".php"
-      ],
-      "dir": "/tmp/lien-dogfood-460173c9/console",
-      "sha": "535e18a1b8925f6c01a55b171d157ab66c2ace15",
-      "c1Advisory": [],
-      "c1": "clean",
-      "sourceFileCount": 361,
-      "indexMs": 264,
-      "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 122ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠹\u001b[39m Indexing your TODO comments (so many TODOs)...\u001b[32m✔\u001b[39m \u001b[32mUpdated 1 file, removed 0 (1/1)\u001b[39m",
-      "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/console-50b99aa9",
-        "indexStatus": "exists",
-        "indexFiles": 7,
-        "lastModified": "2026-07-29T05:37:09.319Z",
-        "lastReindex": "2026-07-29T05:37:09.304Z",
-        "git": {
-          "enabled": true,
-          "branch": "8.2",
-          "commit": "535e18a1"
-        },
-        "features": {
-          "fileWatching": true,
-          "gitDetection": true
-        },
-        "backend": "sqlite",
-        "search": "lexical",
-        "settings": {
-          "concurrency": 4,
-          "chunkSize": 75,
-          "chunkOverlap": 10
-        }
-      },
-      "associations": {
-        "sampled": 25,
-        "withTests": 12,
-        "inferred": 0,
-        "anyCoverage": 12,
-        "pct": 48,
-        "pctIncludingInferred": 48,
-        "examples": [
-          {
-            "file": "Application.php",
-            "annotation": "⚠ Lien: Application.doRunCommand cognitive 67/15 (over), Application.find cognitive 50/15 (over), Application.doRun cognitive 37/15 (over), … and 7 more at/near budget — avoid adding complexity here; prefer extraction.\nLien impact for Application.php:\n  • 33 files import this — Tester/ApplicationTester.php, Messenger/RunCommandMessageHandler.php, Descriptor/XmlDescriptor.php, Descriptor/ReStructur"
-          },
-          {
-            "file": "ArgumentResolver/ValueResolver/UidValueResolver.php",
-            "annotation": "Lien impact for ArgumentResolver/ValueResolver/UidValueResolver.php:\n  • 3 files import this — Resources/config/console.php, ArgumentResolver/ArgumentResolver.php, Tests/ArgumentResolver/ValueResolver/UidValueResolverTest.php; risk: medium (3 callers, 1 untested, max complexity 25).\n  • Test coverage: Tests/ArgumentResolver/ValueResolver/UidValueResolverTest.php."
-          },
-          {
-            "file": "Attribute/ValueResolver.php",
-            "annotation": "Lien impact for Attribute/ValueResolver.php:\n  • 1 file imports this — ArgumentResolver/ArgumentResolver.php; risk: low (1 caller, max complexity 25).\n  • No test coverage."
-          }
-        ]
-      },
-      "status": "OK"
-    },
-    {
-      "repo": "tokio-rs/tokio",
-      "lang": "rust",
-      "tier": "known",
-      "ext": [
-        ".rs"
-      ],
-      "dir": "/tmp/lien-dogfood-460173c9/tokio",
-      "sha": "1a2dbbaa21389ad0b9d20f77e869698c5cab5d68",
-      "c1Advisory": [],
-      "c1": "clean",
-      "sourceFileCount": 790,
-      "indexMs": 268,
-      "indexOk": true,
-      "indexTail": "\u001b[2m  Completed in 128ms\u001b[22m\n- Starting indexing...\n\u001b[36m⠋\u001b[39m Reading your spaghetti code (no judgment)...\u001b[36m⠙\u001b[39m Reading your spaghetti code (no judgment)...\u001b[32m✔\u001b[39m \u001b[32mIndex is up to date - no changes detected\u001b[39m",
-      "status_json": {
-        "version": "0.71.1",
-        "indexPath": "/Users/alfhenderson/.lien/indices/tokio-b45f30ed",
-        "indexStatus": "exists",
-        "indexFiles": 5,
-        "lastModified": "2026-07-29T05:36:42.890Z",
-        "lastReindex": "2026-07-28T22:28:53.484Z",
-        "git": {
-          "enabled": true,
-          "branch": "master",
-          "commit": "1a2dbbaa"
-        },
-        "features": {
-          "fileWatching": true,
-          "gitDetection": true
-        },
-        "backend": "sqlite",
-        "search": "lexical",
-        "settings": {
-          "concurrency": 4,
-          "chunkSize": 75,
-          "chunkOverlap": 10
-        }
-      },
-      "associations": {
-        "sampled": 25,
-        "withTests": 15,
-        "inferred": 0,
-        "anyCoverage": 15,
-        "pct": 60,
-        "pctIncludingInferred": 60,
-        "examples": [
-          {
-            "file": "benches/copy.rs",
-            "annotation": "Lien impact for benches/copy.rs:\n  • 80 files import this — tokio/src/fs/mod.rs, tokio/src/io/util/copy_bidirectional.rs, examples/udp-codec.rs, benches/time_timeout.rs, +76 more; risk: critical (80 callers, 8 untested, max complexity 6).\n  • No test coverage."
-          },
-          {
-            "file": "examples/print_each_packet.rs",
-            "annotation": "Lien impact for examples/print_each_packet.rs:\n  • No test coverage."
-          },
-          {
-            "file": "tokio-macros/src/lib.rs",
-            "annotation": "Lien impact for tokio-macros/src/lib.rs:\n  • No test coverage."
           }
         ]
       },

--- a/scripts/experiments/dogfood-oss/mcp-call.mjs
+++ b/scripts/experiments/dogfood-oss/mcp-call.mjs
@@ -24,20 +24,16 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import fs from 'node:fs';
 import path from 'node:path';
+import { resolveCli } from './resolve-cli.mjs';
 
 const [repoDir, tool, rawArgs] = process.argv.slice(2);
 const REPO = path.resolve(import.meta.dirname, '../../..');
 
-// Which binary is under measurement is the single easiest thing to get wrong here:
-// this file resolves the CLI relative to ITS OWN repo root, so running one
-// worktree's copy silently measures that worktree's build. Round 1 of the dogfood
-// reported a working fix as broken twice for exactly that reason. LIEN_MCP_CLI
-// makes the target explicit (e.g. a published `npm install @liendev/lien` under
-// test), and the resolved path is echoed into every envelope so a measurement can
-// never be read without knowing which build produced it.
-const CLI = process.env.LIEN_MCP_CLI
-  ? path.resolve(process.env.LIEN_MCP_CLI)
-  : path.join(REPO, 'packages/cli/dist/index.js');
+// Which binary is under measurement is the single easiest thing to get wrong here
+// (see resolve-cli.mjs for why this is shared rather than computed per script). The
+// resolved path is echoed into every envelope so a measurement can never be read
+// without knowing which build produced it.
+const { cli: CLI } = resolveCli(REPO);
 
 function die(msg) {
   console.error(`mcp-call: ${msg}`);

--- a/scripts/experiments/dogfood-oss/provision.mjs
+++ b/scripts/experiments/dogfood-oss/provision.mjs
@@ -17,9 +17,14 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { resolveCli, assertCliExists } from './resolve-cli.mjs';
 
 const REPO = path.resolve(import.meta.dirname, '../../..');
-const CLI = path.join(REPO, 'packages/cli/dist/index.js');
+// Shared resolver — see resolve-cli.mjs. The manifest records which build indexed
+// the corpus, because an index written by a different build is not a valid
+// substrate for measuring this one.
+const CLI_RESOLVED = resolveCli(REPO);
+const CLI = CLI_RESOLVED.cli;
 // Default deliberately AVOIDS $CLAUDE_JOB_DIR: that lives under `~/.claude/`, and
 // Claude Code treats everything beneath it as a sensitive file, so an agent trial in
 // a corpus there completes its whole investigation and then has its Edit DENIED.
@@ -191,10 +196,7 @@ function associationCoverage(dir, files) {
 
 // ─── run ──────────────────────────────────────────────────────────────────────
 
-if (!fs.existsSync(CLI)) {
-  console.error(`FATAL: CLI not built at ${CLI} — run \`npm run build\` first.`);
-  process.exit(1);
-}
+assertCliExists(CLI_RESOLVED, 'provision');
 
 const rootScan = ancestorViolations(CORPUS_ROOT);
 if (rootScan.blocking.length) {
@@ -215,6 +217,11 @@ console.log('');
 const manifest = {
   corpusRoot: CORPUS_ROOT,
   cliVersion: sh('node', [CLI, '--version'], REPO).out.trim(),
+  // Which build indexed this corpus, and how it was chosen. An index written by a
+  // different build is not a valid substrate for measuring this one, and round 1
+  // produced several false findings that way.
+  cliPath: CLI,
+  cliSource: CLI_RESOLVED.source,
   repos: [],
 };
 const targets = only ? CORPUS.filter(c => c.lang === only) : CORPUS;
@@ -277,7 +284,8 @@ for (const c of targets) {
     }
     rec.associations = associationCoverage(dest, files);
     const a = rec.associations;
-    const inferredNote = a.inferred > 0 ? ` + ${a.inferred} inferred = ${a.pctIncludingInferred}%` : '';
+    const inferredNote =
+      a.inferred > 0 ? ` + ${a.inferred} inferred = ${a.pctIncludingInferred}%` : '';
     console.log(
       `   ✓ ${rec.sourceFileCount} ${c.lang} files, indexed in ${rec.indexMs}ms; ` +
         `coverage ${a.pct}% confident${inferredNote} (${a.withTests}/${a.sampled} sampled)`,
@@ -296,8 +304,8 @@ const outPath = path.join(import.meta.dirname, 'corpus-manifest.json');
 if (only && fs.existsSync(outPath)) {
   const prior = JSON.parse(fs.readFileSync(outPath, 'utf8'));
   const refreshed = new Set(manifest.repos.map(r => r.repo));
-  manifest.repos = [...prior.repos.filter(r => !refreshed.has(r.repo)), ...manifest.repos].sort((a, b) =>
-    a.repo.localeCompare(b.repo),
+  manifest.repos = [...prior.repos.filter(r => !refreshed.has(r.repo)), ...manifest.repos].sort(
+    (a, b) => a.repo.localeCompare(b.repo),
   );
 }
 fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2));

--- a/scripts/experiments/dogfood-oss/resolve-cli.mjs
+++ b/scripts/experiments/dogfood-oss/resolve-cli.mjs
@@ -1,0 +1,61 @@
+/**
+ * Single source of truth for WHICH lien build the dogfood kit measures.
+ *
+ * Every script here used to compute this itself as
+ * `path.join(REPO, 'packages/cli/dist/index.js')`, where REPO is resolved from the
+ * script's own location. That silently measures whichever worktree the script was
+ * copied into, and it cannot target a published artifact at all — the two failure
+ * modes that produced false conclusions in round 1 of the foreign-repo dogfood
+ * (a working fix reported as broken, twice) and again in round 2 (a stale ambient
+ * build's answers attributed to the current release).
+ *
+ * `mcp-call.mjs` was fixed in isolation first, which left `trial.mjs` and
+ * `provision.mjs` on the old hardcoded path — Lien Review caught exactly that on
+ * the PR and the finding was dismissed as noise; hours later a trial run hit it and
+ * had to hand-patch a copy of `trial.mjs` to point at the published build. Hence one
+ * shared resolver rather than three conditionals: the whole class of bug this kit
+ * keeps rediscovering is "a decision implemented at N sites, fixed at fewer than N."
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolve the CLI entry point under measurement.
+ *
+ * Precedence:
+ *   1. LIEN_DOGFOOD_CLI  — the target build (e.g. a published npm install)
+ *   2. LIEN_MCP_CLI      — legacy alias, kept because it is documented in PR #944
+ *                          and in the round-2 report; prefer the name above
+ *   3. <repoRoot>/packages/cli/dist/index.js — this checkout's local build
+ *
+ * @param {string} repoRoot absolute path to the lien checkout the caller belongs to
+ * @returns {{ cli: string, source: 'LIEN_DOGFOOD_CLI'|'LIEN_MCP_CLI'|'local-build' }}
+ */
+export function resolveCli(repoRoot) {
+  const override = process.env.LIEN_DOGFOOD_CLI || process.env.LIEN_MCP_CLI;
+  if (override) {
+    return {
+      cli: path.resolve(override),
+      source: process.env.LIEN_DOGFOOD_CLI ? 'LIEN_DOGFOOD_CLI' : 'LIEN_MCP_CLI',
+    };
+  }
+  return { cli: path.join(repoRoot, 'packages/cli/dist/index.js'), source: 'local-build' };
+}
+
+/**
+ * Fail loudly when the resolved CLI does not exist, naming the override that chose
+ * it. A missing published artifact and a missing local build need different fixes,
+ * so the message has to say which one was asked for.
+ *
+ * @param {{ cli: string, source: string }} resolved
+ * @param {string} scriptName for the error prefix
+ */
+export function assertCliExists(resolved, scriptName) {
+  if (fs.existsSync(resolved.cli)) return;
+  const hint =
+    resolved.source === 'local-build'
+      ? 'run `npm run build` first, or set LIEN_DOGFOOD_CLI to a built artifact'
+      : `from ${resolved.source}`;
+  console.error(`${scriptName}: CLI not found at ${resolved.cli} — ${hint}`);
+  process.exit(1);
+}

--- a/scripts/experiments/dogfood-oss/trial.mjs
+++ b/scripts/experiments/dogfood-oss/trial.mjs
@@ -28,10 +28,15 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { resolveCli, assertCliExists } from './resolve-cli.mjs';
 
 const KIT = import.meta.dirname;
 const REPO = path.resolve(KIT, '../../..');
-const CLI = path.join(REPO, 'packages/cli/dist/index.js');
+// Shared resolver: this used to hardcode the local build, so running trial.mjs from
+// a non-main worktree silently measured that worktree — and a published artifact was
+// unmeasurable, forcing a hand-patched copy mid-run. See resolve-cli.mjs.
+const CLI_RESOLVED = resolveCli(REPO);
+const CLI = CLI_RESOLVED.cli;
 const PLUGIN_HOOKS = path.join(REPO, 'plugins/claude/hooks');
 const HOOKS_JSON = path.join(PLUGIN_HOOKS, 'hooks.json');
 const MANIFEST = path.join(KIT, 'corpus-manifest.json');
@@ -108,7 +113,7 @@ function gitReset(dir) {
 
 if (!fs.existsSync(MANIFEST)) die(`no manifest at ${MANIFEST} — run provision.mjs first`);
 if (!fs.existsSync(TASKS)) die(`no tasks at ${TASKS}`);
-if (!fs.existsSync(CLI)) die(`CLI not built at ${CLI}`);
+assertCliExists(CLI_RESOLVED, 'trial');
 
 const manifest = readJson(MANIFEST);
 const tasks = readJson(TASKS);
@@ -169,7 +174,13 @@ gitReset(repo.dir);
 // randomising, so a re-run of the same trial reuses the same session id and the
 // nudge-events rows stay joinable to the trial that produced them.
 const h = crypto.createHash('sha256').update(`${repoKey}/${taskId}/${repo.sha}`).digest('hex');
-const sessionId = [h.slice(0, 8), h.slice(8, 12), '4' + h.slice(13, 16), '8' + h.slice(17, 20), h.slice(20, 32)].join('-');
+const sessionId = [
+  h.slice(0, 8),
+  h.slice(8, 12),
+  '4' + h.slice(13, 16),
+  '8' + h.slice(17, 20),
+  h.slice(20, 32),
+].join('-');
 const args = [
   '-p',
   task.prompt,
@@ -249,8 +260,17 @@ for (const f of ['nudge-events.jsonl', 'delta-events.jsonl']) {
 // against the same file at the same SHA.
 const reconstructed = [];
 for (const e of events.filter(e => e.kind === 'shown' && e.file)) {
-  const r = spawnSync('node', [CLI, 'annotate', e.file], { cwd: repo.dir, encoding: 'utf8', timeout: 60_000 });
-  reconstructed.push({ nudge: e.nudge, file: e.file, symbol: e.symbol ?? null, claimText: (r.stdout || '').trim() });
+  const r = spawnSync('node', [CLI, 'annotate', e.file], {
+    cwd: repo.dir,
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  reconstructed.push({
+    nudge: e.nudge,
+    file: e.file,
+    symbol: e.symbol ?? null,
+    claimText: (r.stdout || '').trim(),
+  });
 }
 
 const result = {


### PR DESCRIPTION
Closes a real finding **Lien Review made on #944 that I dismissed and merged past.** Test-instrument only; no production code.

## The finding I ignored

#944 taught `mcp-call.mjs` to resolve the measured CLI from an env override, because resolving it from the script's own repo root silently measures whichever worktree the script sits in — and cannot target a published artifact at all. It fixed **one of three** scripts.

Lien Review said so, on that PR, naming both remaining files:

> `mcp-call.mjs` at line 30 replaced the hardcoded `packages/cli/dist/index.js` path with a `LIEN_MCP_CLI`-aware resolution so the measured binary is explicit, but `trial.mjs:34` and `provision.mjs:22` in the same dogfood-oss kit still hardcode `path.join(REPO, 'packages/cli/dist/index.js')`. Running either from a non-main worktree will silently measure that worktree's build (or fail to measure a published artifact), the exact bug the PR fixed in mcp-call.mjs.
> 💡 *Apply the same conditional to trial.mjs and provision.mjs, or hoist the resolution into a shared helper imported by all dogfood-oss scripts so the target CLI is defined once.*

I read the header count as phantom and merged. **Hours later a trial run hit exactly this** and had to hand-patch its own copy of `trial.mjs` to point at the published build — which I recorded as an "instrument limitation" without connecting it to the finding I'd dismissed. The finding was correct, specific, and had already told me the fix.

(I found it only because a separate investigation showed I'd been querying `pulls/{n}/comments` and never `pulls/{n}/reviews`, where unanchorable findings are promoted. My "the engine narrates findings instead of itemising them" premise was wrong — it itemises them on an endpoint I wasn't reading.)

## The fix

A shared `resolve-cli.mjs` rather than two more copies of the conditional. The recurring defect in this repo is *a decision implemented at N sites and fixed at fewer than N* — five separate instances this round, one needing the identical fix in two literal copies of the same function — and this kit had just demonstrated it on the very PR that introduced the pattern.

- `resolveCli(repoRoot)` — single source of truth. `LIEN_DOGFOOD_CLI` is the name; **`LIEN_MCP_CLI` stays as an alias** because #944 documented it and it's in active use.
- `assertCliExists(resolved, script)` — names *which* override chose the path, since a missing published artifact and a missing local build need different fixes.
- `provision.mjs` records `cliPath`/`cliSource` in the corpus manifest, so an index can be traced to the build that wrote it. Round 1 produced several false findings from indices written by a different build.

## Dogfood evidence

`mcp-call.mjs` — the `cli` field tracks the override, both names, against foreign repo `gin`:
```
LIEN_DOGFOOD_CLI   published   | count= 4
LIEN_MCP_CLI       published   | count= 4     (legacy alias still honoured)
none               local-build | count= 4
```

`trial.mjs` — previously ignored the env entirely; now resolves and reports its source:
```
LIEN_DOGFOOD_CLI=/nope/missing.js  → trial: CLI not found at /nope/missing.js — from LIEN_DOGFOOD_CLI
LIEN_MCP_CLI=/nope/missing.js      → trial: CLI not found at /nope/missing.js — from LIEN_MCP_CLI
LIEN_DOGFOOD_CLI=<published> --list → hono	T1	api-delta-write.sh (blast radius)
```

`provision.mjs` — same:
```
LIEN_DOGFOOD_CLI=/nope/missing.js → provision: CLI not found at /nope/missing.js — from LIEN_DOGFOOD_CLI
no override                       → corpus root: /var/folders/.../lien-dogfood-corpus
```

All four modules load-tested by real ESM import (not `node --check` — that passes on a temporal-dead-zone reference that fails at module init, which bit this kit once already).

## Gates

`format:check` ✅ · `lint` ✅ · `typecheck` ✅ · `build` ✅ · `test` ✅ (exit 0) · `lien delta` ✅ (exit 0 — two new helpers at cognitive 3 and 2, no crossings). Also `prettier --check` on the kit itself, which the repo's `format:check` glob doesn't cover.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR extracts a shared CLI resolver for the dogfood-oss test kit and switches mcp-call.mjs, provision.mjs, and trial.mjs to use it. It is test instrumentation only; no production code is touched. The new resolve-cli.mjs correctly honors LIEN_DOGFOOD_CLI with LIEN_MCP_CLI as a legacy alias, falls back to the local build, and fails loudly with a source-specific message when the resolved path does not exist. provision.mjs now records cliPath/cliSource in the manifest so downstream measurements can trace which build wrote an index. The changes are straightforward and consistent.
>
> - New shared scripts/experiments/dogfood-oss/resolve-cli.mjs with resolveCli() and assertCliExists().
> - mcp-call.mjs, provision.mjs, and trial.mjs now resolve the measured CLI via the shared helper instead of hardcoding packages/cli/dist/index.js.
> - provision.mjs persists cliPath and cliSource into corpus-manifest.json for build provenance.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ef077a2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->