### PR TITLE
fix(cli): canonicalize both sides before relativizing a nudge/annotate path

### DIFF
--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -483,6 +483,41 @@ describe('annotateCommand (integration)', () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
+  // Regression: `resolvePaths` used to compute `path.relative(rootDir, abs)`
+  // without canonicalizing either side. `rootDir` (from `resolveProjectRoot`
+  // -> `process.cwd()`) is already realpath'd by the OS, but an absolute
+  // `file` arriving verbatim (an MCP tool's `file_path` reused from a prior
+  // Read/Edit) is not — so a symlinked ancestor (macOS `/tmp` -> `/private/tmp`)
+  // made `path.relative` straddle two different roots, computed a `..`-prefixed
+  // path, and made `resolvePaths` wrongly reject a file that genuinely is
+  // inside the project. Without the fix this test's `annotateCommand` call
+  // returns silently (`resolvePaths` -> null); with it, it reaches the same
+  // "no index found" branch the plain-relative-path test below hits.
+  it('resolves an absolute path through a symlinked ancestor instead of silently rejecting it', async () => {
+    const fs = await import('fs/promises');
+    const repoRoot = path.resolve(process.cwd(), '..', '..');
+    const linkPath = path.join(
+      os.tmpdir(),
+      `lien-annotate-symlink-test-${process.pid}-${Date.now()}`,
+    );
+    try {
+      await fs.symlink(repoRoot, linkPath, 'dir');
+    } catch {
+      return; // platform can't create symlinks — skip cleanly rather than fail
+    }
+    try {
+      const target = path.join(linkPath, 'packages/cli/src/cli/index.ts');
+      await annotateCommand(target);
+      expect(errSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0]).toContain(
+        'Lien: no index found at the resolved project root',
+      );
+    } finally {
+      await fs.rm(linkPath, { force: true }).catch(() => undefined);
+    }
+  });
+
   // #894: this used to be silent (an empty-but-plausible "no dependents/no
   // test coverage" annotation, or nothing at all) — now it's a loud,
   // one-line warning via stdout (never stderr — the read-hook pipes lien

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -29,6 +29,7 @@ import {
 } from '../mcp/handlers/get-files-context.js';
 import { resolveProjectRoot } from './project-root.js';
 import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/paths.js';
+import { canonicalizePath } from '../utils/canonicalize-path.js';
 
 // Complexity threshold lives in @liendev/core (dependency-analyzer's
 // COMPLEXITY_THRESHOLDS.HIGH_COMPLEXITY_DEPENDENT = 10) and surfaces
@@ -164,7 +165,15 @@ function resolvePaths(file: string): ResolvedPaths | null {
   // Compute project-root-relative form from the validated abs so it
   // matches whatever Lien's indexer stored. Reject paths outside the
   // root (path.relative would produce a `..`-prefixed traversal).
-  const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
+  //
+  // Canonicalize both sides first: `rootDir` is derived from `process.cwd()`
+  // (already realpath'd by the OS), but an absolute `file` passed straight
+  // through (e.g. an MCP tool's `file_path` reused from a prior Read/Edit)
+  // has not been. Under a symlinked ancestor (macOS `/tmp` -> `/private/tmp`)
+  // that mismatch makes `path.relative` straddle two different roots and
+  // return a `..`-laden path even for a file genuinely inside the project —
+  // which this function would then (wrongly) reject as "outside the root".
+  const rel = path.relative(canonicalizePath(rootDir), canonicalizePath(abs)).replace(/\\/g, '/');
   if (!rel || rel.startsWith('..')) return null;
   const filepath = rel as RelativePath;
 

--- a/packages/cli/src/utils/canonicalize-path.test.ts
+++ b/packages/cli/src/utils/canonicalize-path.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { canonicalizePath } from './canonicalize-path.js';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-canonicalize-path-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('canonicalizePath', () => {
+  it('resolves an existing path to its realpath (a no-op when there is no symlink)', async () => {
+    const filePath = path.join(tmpRoot, 'foo.ts');
+    await fs.writeFile(filePath, '', 'utf-8');
+    expect(canonicalizePath(filePath)).toBe(await fs.realpath(filePath));
+  });
+
+  it('resolves a path through a symlinked ancestor to the real (symlink-free) path', async () => {
+    const realDir = path.join(tmpRoot, 'real');
+    await fs.mkdir(realDir, { recursive: true });
+    const filePath = path.join(realDir, 'foo.ts');
+    await fs.writeFile(filePath, '', 'utf-8');
+
+    const linkDir = path.join(tmpRoot, 'link');
+    try {
+      await fs.symlink(realDir, linkDir, 'dir');
+    } catch {
+      return; // platform can't create symlinks (e.g. unprivileged Windows) — skip cleanly
+    }
+
+    const viaLink = path.join(linkDir, 'foo.ts');
+    expect(canonicalizePath(viaLink)).toBe(await fs.realpath(filePath));
+    // And it must actually have resolved something — the symlinked route and
+    // the real route were different strings to begin with.
+    expect(viaLink).not.toBe(canonicalizePath(viaLink));
+  });
+
+  it('falls back to realpath-ing the parent directory when the leaf does not exist', async () => {
+    const missing = path.join(tmpRoot, 'deleted.ts');
+    expect(canonicalizePath(missing)).toBe(path.join(await fs.realpath(tmpRoot), 'deleted.ts'));
+  });
+
+  it('falls back to the input unchanged when neither the path nor its parent exists (never throws)', () => {
+    const deeplyMissing = path.join(tmpRoot, 'gone', 'also-gone', 'foo.ts');
+    expect(() => canonicalizePath(deeplyMissing)).not.toThrow();
+    expect(canonicalizePath(deeplyMissing)).toBe(deeplyMissing);
+  });
+});

--- a/packages/cli/src/utils/canonicalize-path.ts
+++ b/packages/cli/src/utils/canonicalize-path.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve `p` to its canonical (symlink-free) form so a later `path.relative`
+ * against another canonicalized path can't straddle a symlinked ancestor —
+ * e.g. macOS's `/tmp` -> `/private/tmp` — and compute a relative path between
+ * two different roots (`../../../../tmp/...` instead of the intended
+ * `src/foo.ts`). `process.cwd()` already returns the OS-canonicalized form,
+ * but a path arriving as a raw argument (an MCP tool's `filepath`, a hook's
+ * `tool_input.file_path`) does not, so the mismatch only shows up once both
+ * sides are compared.
+ *
+ * Never throws: `fs.realpathSync` throws on a path that doesn't exist (a
+ * plausible, non-exceptional case here — these run inside hooks and CLI
+ * commands that must never crash on a stale or mistyped path). Falls back to
+ * realpath-ing the parent directory and re-attaching the basename (handles a
+ * deleted file whose containing directory still exists), and finally to `p`
+ * unchanged if even that fails.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export function canonicalizePath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    try {
+      return path.join(fs.realpathSync(path.dirname(p)), path.basename(p));
+    } catch {
+      return p;
+    }
+  }
+}

--- a/packages/cli/src/utils/nudge-events.test.ts
+++ b/packages/cli/src/utils/nudge-events.test.ts
@@ -171,6 +171,88 @@ describe('recordNudgeShown / recordNudgeSignal helpers', () => {
   });
 });
 
+// The `rootDir` fake above never exists on disk, so it only exercises
+// `canonicalizePath`'s final (identity) fallback — never actual symlink
+// resolution. These use real temp directories to exercise the realpath path
+// that macOS's `/tmp` -> `/private/tmp` boundary hits in production.
+describe('toRepoRelativeFile (via recordNudgeShown/Signal) — realpath canonicalization', () => {
+  let realRoot: string;
+
+  beforeEach(async () => {
+    realRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-nudge-realpath-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(realRoot, { recursive: true, force: true });
+  });
+
+  it('resolves an absolute file through a symlinked root to the same repo-relative form (macOS /tmp -> /private/tmp shape)', async () => {
+    await fs.mkdir(path.join(realRoot, 'src'), { recursive: true });
+    await fs.writeFile(path.join(realRoot, 'src', 'foo.ts'), '', 'utf-8');
+
+    const linkDir = path.join(os.tmpdir(), `lien-nudge-realpath-link-${process.pid}-${Date.now()}`);
+    try {
+      await fs.symlink(realRoot, linkDir, 'dir');
+    } catch {
+      return; // platform can't create symlinks — skip cleanly rather than fail
+    }
+    try {
+      // rootDir is the CANONICAL root (as `resolveProjectRoot(process.cwd())`
+      // would produce), while `file` arrives through the symlinked route (as
+      // an MCP arg or hook `tool_input.file_path` would) — the exact mismatch
+      // that produced the `../../../../tmp/...` bug.
+      await recordNudgeShown(realRoot, {
+        sessionId: 's',
+        nudge: 'annotate',
+        file: path.join(linkDir, 'src', 'foo.ts'),
+      });
+      const [e] = await readNudgeEvents(realRoot);
+      expect(e).toMatchObject({ file: 'src/foo.ts' });
+    } finally {
+      await fs.rm(linkDir, { force: true }).catch(() => undefined);
+    }
+  });
+
+  it('resolves an absolute file with no symlink involved to the same repo-relative form (no regression)', async () => {
+    await fs.mkdir(path.join(realRoot, 'src'), { recursive: true });
+    await fs.writeFile(path.join(realRoot, 'src', 'foo.ts'), '', 'utf-8');
+
+    await recordNudgeSignal(realRoot, {
+      sessionId: 's',
+      signal: 'get_dependents',
+      file: path.join(realRoot, 'src', 'foo.ts'),
+    });
+    const [e] = await readNudgeEvents(realRoot);
+    expect(e).toMatchObject({ file: 'src/foo.ts' });
+  });
+
+  it('omits an absolute file that resolves outside the repo rather than recording a bogus in-repo path', async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-nudge-outside-test-'));
+    try {
+      const outsideFile = path.join(outsideDir, 'evil.ts');
+      await fs.writeFile(outsideFile, '', 'utf-8');
+
+      await recordNudgeShown(realRoot, { sessionId: 's', nudge: 'annotate', file: outsideFile });
+      const [e] = await readNudgeEvents(realRoot);
+      expect('file' in e).toBe(false);
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still relativizes correctly when the file itself no longer exists but its parent directory does', async () => {
+    await fs.mkdir(path.join(realRoot, 'src'), { recursive: true });
+
+    await recordNudgeSignal(realRoot, {
+      sessionId: 's',
+      signal: 'get_files_context',
+      file: path.join(realRoot, 'src', 'deleted.ts'),
+    });
+    const [e] = await readNudgeEvents(realRoot);
+    expect(e).toMatchObject({ file: 'src/deleted.ts' });
+  });
+});
+
 describe('validation on read', () => {
   it('skips a torn/corrupted line rather than failing the whole read', async () => {
     const good = shownEvent();

--- a/packages/cli/src/utils/nudge-events.ts
+++ b/packages/cli/src/utils/nudge-events.ts
@@ -30,6 +30,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { getIndexDir } from '@liendev/parser';
+import { canonicalizePath } from './canonicalize-path.js';
 
 export const NUDGE_EVENTS_FILENAME = 'nudge-events.jsonl';
 
@@ -123,11 +124,23 @@ export async function recordNudgeEvent(rootDir: string, event: NudgeEvent): Prom
  * relativized against `rootDir`; an already-relative path is only slash-
  * normalized (relativizing it again would resolve it against cwd and corrupt
  * it). An empty/undefined path passes through as undefined.
+ *
+ * Both sides are canonicalized (`canonicalizePath`) before relativizing: an
+ * absolute `file` arriving verbatim from an MCP arg or a hook's
+ * `tool_input.file_path` won't have gone through realpath the way `rootDir`
+ * (derived from `process.cwd()`) already has, so a symlinked ancestor (macOS
+ * `/tmp` -> `/private/tmp`) would otherwise make `path.relative` straddle two
+ * different roots and produce a nonsense `../../../../tmp/...` path instead
+ * of `src/foo.ts`. An absolute path that canonicalizes to somewhere outside
+ * `rootDir` is dropped (returns undefined) rather than recorded as a bogus
+ * in-repo path.
  */
 function toRepoRelativeFile(rootDir: string, file?: string): string | undefined {
   if (!file) return undefined;
   if (!path.isAbsolute(file)) return file.replace(/\\/g, '/');
-  return path.relative(rootDir, file).replace(/\\/g, '/');
+  const rel = path.relative(canonicalizePath(rootDir), canonicalizePath(file)).replace(/\\/g, '/');
+  if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return undefined;
+  return rel;
 }
 
 /** Stamp `now` and record a nudge-shown event. `file` is normalized to project-relative; `file`/`symbol` omitted when empty. */


### PR DESCRIPTION
## Summary

`toRepoRelativeFile` (`packages/cli/src/utils/nudge-events.ts`) computed
`path.relative(rootDir, file)` without canonicalizing either side. `rootDir`
derives from `process.cwd()`, which the OS already realpaths, but an absolute
`file` arriving verbatim from an MCP arg or a hook's `tool_input.file_path`
has not been. Under a symlinked ancestor (macOS `/tmp` -> `/private/tmp`)
that mismatch made `path.relative` straddle two different roots and log a
nonsense `../../../../tmp/...` path instead of `src/foo.ts` — silently
corrupting the shown/signal join the nudge funnels depend on (and #916 is
about to make that funnel load-bearing).

**A second site had the identical hazard.** `annotate-cmd.ts`'s
`resolvePaths` does the same `path.relative(rootDir, abs)` with the same
missing canonicalization. There the effect is worse than corrupted data: the
`..`-prefixed result trips the "outside the project root" rejection, so
`lien annotate` — and the read-hook's nudge-shown recording, which only
fires after a non-empty annotation — goes **completely silent** for a file
that is genuinely inside the repo, whenever the Read hook's absolute
`file_path` sits behind a symlinked cwd.

## Fix

Both sites now canonicalize `rootDir` and the file argument before computing
the relative path, via a new shared `canonicalizePath` helper
(`packages/cli/src/utils/canonicalize-path.ts`): `fs.realpathSync`, falling
back to realpath-ing the parent directory (a deleted file whose directory
still exists), falling back to the input unchanged as the last resort (never
throws — these run inside hooks that must never crash). A result that still
escapes the root after canonicalizing is now rejected/omitted rather than
recorded as a bogus in-repo path.

- `packages/cli/src/utils/nudge-events.ts` — `toRepoRelativeFile`
- `packages/cli/src/cli/annotate-cmd.ts` — `resolvePaths`
- `packages/cli/src/utils/canonicalize-path.ts` — new shared helper (2 call
  sites in this same PR; not extracting would have meant hand-copying the
  realpath/fallback logic twice in one diff)

I greped the rest of the tree for the same `path.relative(rootDir-ish, ...)`
shape (`delta-git.ts`, `incremental.ts`, `chunk-only-index.ts`, `init.ts`,
`agent-tools.ts`, `dependency-analyzer.ts`, a test-harness `toRepoRelative` in
`packages/review/test/harness/capture-pr.ts`). Only these two were affected:
- `delta-git.ts` already canonicalizes both sides (its own `canonicalize()`,
  same shape) — that's the pattern this PR mirrors.
- `agent-tools.ts` realpaths `rootDir` once up front (line 475) and reuses it
  consistently, so no mismatch.
- `incremental.ts` / `chunk-only-index.ts` / `init.ts` take an explicit,
  already-consistent `rootDir` from the same construction path as their file
  arguments — no `process.cwd()`-vs-raw-arg split.
- `capture-pr.ts`'s `toRepoRelative` is offline test-harness tooling (not
  runtime telemetry, no `process.cwd()` involved); flagged but left alone —
  fixing test-harness code isn't in scope for a production telemetry bug fix.

**One correction to the bug brief**: the brief said `delta-write.sh` records
shown-events through `toRepoRelativeFile`. It doesn't — only `annotate-read.sh`
and `api-delta-write.sh` call `nudge note-shown`; `delta-write.sh` only prints
a warning (the `delta` nudge's "shown" side is intentionally derived from
`delta-events.jsonl` instead, per this file's own header comment). Doesn't
change the fix, just flagging so the record is accurate.

**Overlap with #916 (telemetry-stamp, in parallel)**: touched
`nudge-events.ts` because that's literally the reported bug's file. Diff
there is 15 lines, isolated to `toRepoRelativeFile` and its import — should
merge cleanly either order.

## Reproduced

Confirmed both bugs myself before fixing, using the foreign-repo dogfood
corpus at `/tmp/lien-dogfood-460173c9/hono` (macOS `/tmp` -> `/private/tmp`
is exactly the symlink boundary that triggers this) — never the Lien repo
itself. Re-indexed with my own build before every measurement; reset with
`git checkout -- . && git clean -fd` between runs; never pushed; varied
`session_id` on every run.

### Bug 1 — CLI form (matches the issue's repro exactly)

Before (`nudge-events.jsonl`):
```json
{"kind":"signal","timestamp":"2026-07-29T21:45:47.330Z","sessionId":"repro-cli-before","signal":"get_dependents","file":"../../../../tmp/lien-dogfood-460173c9/hono/src/context.ts","symbol":"Context"}
```

After (same command, fixed build, fresh session):
```json
{"kind":"signal","timestamp":"2026-07-29T21:56:37.242Z","sessionId":"repro-cli-after-v2","signal":"get_dependents","file":"src/context.ts","symbol":"Context"}
```

### Bug 1 — real hook (`nudge-signal.sh`), true MCP PostToolUse stdin shape

Input piped to the hook:
```json
{"tool_name":"mcp__plugin_lien_lien__get_dependents","tool_input":{"filepath":"/tmp/lien-dogfood-460173c9/hono/src/context.ts","symbol":"Context"},"cwd":"/tmp/lien-dogfood-460173c9/hono","session_id":"repro-hook-before-1"}
```
Before → logged: `"file":"../../../../tmp/lien-dogfood-460173c9/hono/src/context.ts"`
After (session `repro-hook-after-v2`) → logged: `"file":"src/context.ts"`

### Bug 2 — real hook (`annotate-read.sh`), true Read PostToolUse stdin shape

Input piped to the hook:
```json
{"tool_name":"Read","tool_input":{"file_path":"/tmp/lien-dogfood-460173c9/hono/src/context.ts"},"cwd":"/tmp/lien-dogfood-460173c9/hono","session_id":"repro-hook-before-shown-1"}
```
Before → hook exits 0, **prints nothing at all** (no `hookSpecificOutput`,
no annotation reaches the model, no `note-shown` recorded — confirmed via
`bash -x` trace: `annotation=` came back empty because `resolvePaths`
rejected the symlinked absolute path as "outside the root").

After (session `repro-hook-after-shown-v2`), same file, real annotation data:
```json
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"⚠ Lien: Context.#newResponse cognitive 22/15 (over), Context.res cognitive 15/15 (over) — avoid adding complexity here; prefer extraction.\nLien impact for src/context.ts:\n  • 79 files import this — src/types.ts, src/index.ts, src/hono-base.ts, src/compose.ts, +75 more; risk: critical (79 callers, 10 untested, max complexity 33, untested high-complexity dependent).\n  • Test coverage: src/types.test.ts, src/hono.test.ts (+29 more)."}}
```
And the recorded shown event is correctly relativized:
```json
{"kind":"shown","timestamp":"2026-07-29T21:57:01.552Z","sessionId":"repro-hook-after-shown-v2","nudge":"annotate","file":"src/context.ts"}
```

## Gates

All six green on this worktree (fresh `npm ci` + `npm run build` +
`npm run build:native -w @liendev/parser-native`):
- `format:check` — pass
- `lint` — pass, 0 errors (pre-existing warnings elsewhere, unrelated)
- `typecheck` — pass
- `build` — pass
- `test` — 1370 + 41 tests pass (cli + action workspaces), including 4 new
  `canonicalize-path.test.ts` tests, 4 new symlink/outside-repo/nonexistent
  cases in `nudge-events.test.ts`, and 1 new regression test in
  `annotate-cmd.test.ts`
- `lien delta` — exit 0; only "worsened"/"new" advisory markers (no
  crossings): `resolvePaths` time 31m→33m, `toRepoRelativeFile` cognitive
  2→4, new `canonicalizePath` cognitive 3

## Test plan

- [x] Unit: absolute path through a real symlink resolves to the same
      repo-relative form as the real path
- [x] Unit: absolute path with no symlink involved (no regression)
- [x] Unit: already-relative path passes through unchanged (existing test,
      still green)
- [x] Unit: absolute path outside the repo — `file` field omitted, not a
      bogus `..`-path
- [x] Unit: file no longer exists but its parent directory does — still
      relativizes correctly (`fs.realpathSync` throws, parent-dir fallback
      catches it)
- [x] `canonicalizePath` unit tests (existing path, symlinked path,
      nonexistent leaf w/ existing parent, deeply nonexistent path)
- [x] Dogfood: both bugs reproduced and fixed via real hooks + real MCP-shaped
      stdin, in a genuinely symlinked foreign repo, evidence above

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a realpath/canonicalization bug in two CLI path-relativization sites (`toRepoRelativeFile` and `resolvePaths`) by introducing a shared `canonicalizePath` helper that never throws. The change is narrow, well-scoped, and covered by new unit and integration tests. Both call sites correctly drop paths that still escape the project root after canonicalization, and downstream callers already handle omitted/null file fields safely. No breaking changes or silent wrong-output paths were found.
>
> - Added `canonicalizePath` helper with realpath + parent-dir fallback + identity fallback
> - Updated `toRepoRelativeFile` to canonicalize both sides and reject escaping paths
> - Updated `resolvePaths` to accept files reached through symlinked ancestors

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fb9100f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->