### PR TITLE
fix(parser): type-declaration signature drops generics and base/heritage list

### DIFF
--- a/.changeset/type-declaration-signature-heritage.md
+++ b/.changeset/type-declaration-signature-heritage.md
@@ -1,0 +1,41 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+`signature` for a class/interface/struct/record/enum (and Rust's
+impl/trait) dropped generic type parameters and the base-type/interface
+list entirely — found in a post-release audit of the published 0.72.0
+artifact. `list_functions` on serilog reported `LogEventPropertyValueVisitor<TState,
+TResult>` as bare `class LogEventPropertyValueVisitor` and `Logger :
+ILogger, ILogEventSink, IDisposable` as bare `class Logger`, discarding
+exactly the information a model needs to tell one symbol from another and
+to judge blast radius before changing it (`signature` is what
+`list_functions`/`get_dependents` show, not the source).
+
+Confirmed the same gap and fixed it in six languages: **C#**
+(`class`/`interface`/`struct`/`record`, including `record struct`, plus
+`enum`'s base type, e.g. `enum Status : byte`), **Java**
+(`class`/`interface`/`enum`/`record`), **Kotlin**
+(`class`/`interface`/`object`), **TypeScript** (`class`/`interface`, plus
+plain JavaScript's `extends` clause, which shares the same code path),
+**Swift** (`class`/`struct`/`actor`/`enum`/`extension`/`protocol`), and
+**Rust** (`impl`/`trait` — an `impl` block's `signature` now names the
+trait it implements, e.g. `impl<T> Trait for Type<T>`, previously just
+`impl Type`, silently losing the single most useful fact about an impl
+block). Generic constraints (`where T : class, new()` / Rust's
+`where`-clauses) are deliberately excluded, not truncated — out of scope,
+since a "some constraints, some not" signature would be worse than none.
+
+Also fixed as a direct consequence, found via dogfooding against Serilog's
+actual `Logger` class: a base/heritage list that itself spans multiple
+physical lines (e.g. a base wrapped in a C# `#if`/`#endif` preprocessor
+block) previously leaked raw newlines into `signature`; all six languages
+now collapse it to a single line via a new shared `collapseWhitespace`
+helper, matching the existing `extractSignature` convention.
+
+Checked but left unchanged (already correct, not touched): Ruby's `class …
+< Base` already includes its superclass. Checked and found to share the
+same gap but out of scope for this fix (no generics/heritage list in the
+task's brief, left as a follow-up): PHP and Python's `class` declarations,
+and Go's generic `type Foo[T any] struct`.

--- a/packages/parser/src/ast/extractors/symbol-helpers.ts
+++ b/packages/parser/src/ast/extractors/symbol-helpers.ts
@@ -50,6 +50,21 @@ export function clampSignatureLength(signature: string): string {
 }
 
 /**
+ * Collapse a node's raw text to a single line for signature-building,
+ * mirroring `extractSignature`'s `.replace(/\s+/g, ' ').trim()` convention.
+ * A grammar node's text can itself span multiple physical lines even when
+ * it's a small, single "clause" — e.g. a C# `base_list` wrapping a
+ * conditionally-compiled member in a preprocessor block (`: ILogger\n#if
+ * X\n, IAsyncDisposable\n#endif`), found via dogfooding a real class
+ * (Serilog's `Logger`) rather than a hypothetical case. Returns `''` for
+ * `undefined`/absent nodes so callers can compose pieces without a null
+ * check at every call site.
+ */
+export function collapseWhitespace(text: string | undefined): string {
+  return text ? text.replace(/\s+/g, ' ').trim() : '';
+}
+
+/**
  * Extract parameter list from function node
  *
  * Note: The `_content` parameter is unused in this function, but is kept for API consistency

--- a/packages/parser/src/ast/languages/csharp.test.ts
+++ b/packages/parser/src/ast/languages/csharp.test.ts
@@ -418,6 +418,36 @@ using Newtonsoft.Json;
       expect(symbol!.signature).toBe('class Calculator');
     });
 
+    // Post-release audit of 0.72.0: `signature` dropped generic type
+    // parameters and the base-type/interface list entirely, e.g.
+    // `LogEventPropertyValueVisitor<TState, TResult>` and
+    // `Logger : ILogger, ILogEventSink, IDisposable` both came back as just
+    // `class Logger`/`class LogEventPropertyValueVisitor` — the single most
+    // useful fact about a class for deciding whether it's the one you want.
+    it('should include generic type parameters in a class signature', () => {
+      const code = 'public class LogEventPropertyValueVisitor<TState, TResult> {}';
+      const root = mustParse(code, 'csharp');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe('class LogEventPropertyValueVisitor<TState, TResult>');
+    });
+
+    it('should include the base-type/interface list in a class signature', () => {
+      const code = 'public class Logger : ILogger, ILogEventSink, IDisposable {}';
+      const root = mustParse(code, 'csharp');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe('class Logger : ILogger, ILogEventSink, IDisposable');
+    });
+
+    it('should exclude generic constraints (`where`) from a class signature', () => {
+      const code = 'public class Constrained<T> : Base where T : class, new() {}';
+      const root = mustParse(code, 'csharp');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe('class Constrained<T> : Base');
+    });
+
     it('should extract interface_declaration info', () => {
       const code = 'public interface IRepository {}';
       const root = mustParse(code, 'csharp');
@@ -427,6 +457,14 @@ using Newtonsoft.Json;
       expect(symbol!.name).toBe('IRepository');
       expect(symbol!.type).toBe('interface');
       expect(symbol!.signature).toBe('interface IRepository');
+    });
+
+    it('should include generic type parameters and base interfaces in an interface signature', () => {
+      const code = 'public interface IFoo<T> : IBar<T>, IBaz {}';
+      const root = mustParse(code, 'csharp');
+      const ifaceNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(ifaceNode, code);
+      expect(symbol!.signature).toBe('interface IFoo<T> : IBar<T>, IBaz');
     });
 
     it('should extract struct_declaration info', () => {
@@ -440,6 +478,14 @@ using Newtonsoft.Json;
       expect(symbol!.signature).toBe('struct Point');
     });
 
+    it('should include the base-interface list in a struct signature', () => {
+      const code = 'public readonly struct Vec3 : IVec {}';
+      const root = mustParse(code, 'csharp');
+      const structNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(structNode, code);
+      expect(symbol!.signature).toBe('struct Vec3 : IVec');
+    });
+
     it('should extract record_declaration info', () => {
       const code = 'public record Person(string Name) {}';
       const root = mustParse(code, 'csharp');
@@ -451,6 +497,15 @@ using Newtonsoft.Json;
       expect(symbol!.signature).toBe('record Person');
     });
 
+    it('should include the base-interface list in a record signature, including record struct', () => {
+      const code = 'public record struct Point(int X, int Y) : IPoint;';
+      const root = mustParse(code, 'csharp');
+      const recordNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(recordNode, code);
+      expect(symbol!.name).toBe('Point');
+      expect(symbol!.signature).toBe('record Point : IPoint');
+    });
+
     it('should extract enum_declaration info', () => {
       const code = 'public enum Color { Red, Green, Blue }';
       const root = mustParse(code, 'csharp');
@@ -460,6 +515,14 @@ using Newtonsoft.Json;
       expect(symbol!.name).toBe('Color');
       expect(symbol!.type).toBe('class');
       expect(symbol!.signature).toBe('enum Color');
+    });
+
+    it('should include the base (underlying integer) type in an enum signature', () => {
+      const code = 'public enum Status : byte { A, B }';
+      const root = mustParse(code, 'csharp');
+      const enumNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(enumNode, code);
+      expect(symbol!.signature).toBe('enum Status : byte');
     });
 
     // #949: a nested type declaration (class/interface/struct/record/enum

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -10,6 +10,7 @@ import {
   extractSignature,
   extractParameters,
   clampSignatureLength,
+  collapseWhitespace,
 } from '../extractors/symbol-helpers.js';
 import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
 import { calculateComplexity } from '../complexity/index.js';
@@ -520,7 +521,7 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `class ${nameNode.text}`,
+      signature: clampSignatureLength(`class ${nameNode.text}${typeParamsAndBaseList(node)}`),
     };
   }
 
@@ -534,7 +535,7 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `interface ${nameNode.text}`,
+      signature: clampSignatureLength(`interface ${nameNode.text}${typeParamsAndBaseList(node)}`),
     };
   }
 
@@ -548,7 +549,7 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `struct ${nameNode.text}`,
+      signature: clampSignatureLength(`struct ${nameNode.text}${typeParamsAndBaseList(node)}`),
     };
   }
 
@@ -562,7 +563,7 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `record ${nameNode.text}`,
+      signature: clampSignatureLength(`record ${nameNode.text}${typeParamsAndBaseList(node)}`),
     };
   }
 
@@ -576,7 +577,10 @@ export class CSharpSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `enum ${nameNode.text}`,
+      // Enums have no type parameters in C#, but can carry a base list — the
+      // underlying integer type (`enum Status : byte`) — so this still runs
+      // through the shared helper rather than a bespoke one-off.
+      signature: clampSignatureLength(`enum ${nameNode.text}${typeParamsAndBaseList(node)}`),
     };
   }
 }
@@ -602,6 +606,42 @@ const ACCESS_MODIFIERS = new Set(['public', 'private', 'protected', 'internal'])
  */
 function hasExplicitAccessModifier(node: SyntaxNode): boolean {
   return node.children.some(child => child.type === 'modifier' && ACCESS_MODIFIERS.has(child.text));
+}
+
+/**
+ * Generic type parameters and base-type/interface list, exactly as the
+ * source declares them (found in a post-release audit of 0.72.0: `signature`
+ * for a type declaration reported only its bare keyword and name, so
+ * `LogEventPropertyValueVisitor<TState, TResult>` lost its type parameters
+ * entirely and `Logger : ILogger, ILogEventSink, IDisposable` came back as
+ * bare `class Logger` — the single most useful fact about that class,
+ * gone). `type_parameter_list` and `base_list` are not registered grammar
+ * fields on class/struct/record/interface declarations (only
+ * `delegate_declaration` happens to expose `type_parameters` as a field), so
+ * both are found by scanning `namedChildren` instead of
+ * `childForFieldName` — this works uniformly across all four container
+ * kinds, including `record struct` (still a `record_declaration` node under
+ * the hood) and enum's base list (its underlying integer type, e.g. `enum
+ * Status : byte` — enums have no type parameters in C#, but do have this).
+ *
+ * Deliberately excludes `type_parameter_constraints_clause` (`where T :
+ * class, new()`): building the signature from just these two named pieces,
+ * rather than slicing the raw source text across the whole declaration
+ * head, means the constraint clause — which sits between the base list and
+ * the body — is never captured at all, not partially.
+ *
+ * Whitespace is collapsed to a single line (matching `extractSignature`'s
+ * convention): a base list can itself span multiple physical lines, e.g.
+ * Serilog's `Logger` class wraps a conditionally-compiled base in a
+ * preprocessor block (`class Logger : ILogger\n#if X\n, IAsyncDisposable\n#endif\n{`)
+ * — found via dogfooding against the real repo, not a hypothetical case.
+ */
+function typeParamsAndBaseList(node: SyntaxNode): string {
+  const typeParams = node.namedChildren.find(child => child.type === 'type_parameter_list');
+  const baseList = node.namedChildren.find(child => child.type === 'base_list');
+  const typeParamsText = collapseWhitespace(typeParams?.text);
+  const baseListText = collapseWhitespace(baseList?.text);
+  return `${typeParamsText}${baseListText ? ` ${baseListText}` : ''}`;
 }
 
 /**

--- a/packages/parser/src/ast/languages/java.test.ts
+++ b/packages/parser/src/ast/languages/java.test.ts
@@ -396,6 +396,18 @@ describe('Java Language', () => {
       expect(symbol!.signature).toBe('class Calculator');
     });
 
+    // Same underlying bug as the C# fix: `signature` dropped generic type
+    // parameters and extends/implements heritage entirely.
+    it('should include generic type parameters and extends/implements heritage in a class signature', () => {
+      const code = 'class Foo<T extends Comparable<T>> extends Bar<T> implements Baz, Qux {}';
+      const root = mustParse(code, 'java');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe(
+        'class Foo<T extends Comparable<T>> extends Bar<T> implements Baz, Qux',
+      );
+    });
+
     it('should extract interface_declaration info', () => {
       const code = 'public interface Repository {}';
       const root = mustParse(code, 'java');
@@ -405,6 +417,14 @@ describe('Java Language', () => {
       expect(symbol!.name).toBe('Repository');
       expect(symbol!.type).toBe('interface');
       expect(symbol!.signature).toBe('interface Repository');
+    });
+
+    it('should include generic type parameters and extends heritage in an interface signature', () => {
+      const code = 'interface IFoo<T> extends IBar<T>, IBaz {}';
+      const root = mustParse(code, 'java');
+      const ifaceNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(ifaceNode, code);
+      expect(symbol!.signature).toBe('interface IFoo<T> extends IBar<T>, IBaz');
     });
 
     it('should extract enum_declaration info', () => {
@@ -418,6 +438,14 @@ describe('Java Language', () => {
       expect(symbol!.signature).toBe('enum Color');
     });
 
+    it('should include implements heritage in an enum signature (no type parameters in Java)', () => {
+      const code = 'enum Status implements Foo {}';
+      const root = mustParse(code, 'java');
+      const enumNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(enumNode, code);
+      expect(symbol!.signature).toBe('enum Status implements Foo');
+    });
+
     it('should extract record_declaration info', () => {
       const code = 'public record Point(int x, int y) {}';
       const root = mustParse(code, 'java');
@@ -427,6 +455,14 @@ describe('Java Language', () => {
       expect(symbol!.name).toBe('Point');
       expect(symbol!.type).toBe('class');
       expect(symbol!.signature).toBe('record Point');
+    });
+
+    it('should include implements heritage in a record signature', () => {
+      const code = 'record Person(int x, int y) implements Foo {}';
+      const root = mustParse(code, 'java');
+      const recordNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(recordNode, code);
+      expect(symbol!.signature).toBe('record Person implements Foo');
     });
 
     // #949: a nested type declaration (class/interface/enum/record declared

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -7,7 +7,12 @@ import type {
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
 import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
-import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
+import {
+  extractSignature,
+  extractParameters,
+  clampSignatureLength,
+  collapseWhitespace,
+} from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -440,7 +445,7 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `class ${nameNode.text}`,
+      signature: clampSignatureLength(`class ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
 
@@ -454,7 +459,7 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `interface ${nameNode.text}`,
+      signature: clampSignatureLength(`interface ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
 
@@ -468,7 +473,10 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `enum ${nameNode.text}`,
+      // Enums have no type parameters in Java, but can implement interfaces
+      // (`enum Status implements Foo`) — `typeParamsAndHeritage` still
+      // applies cleanly since it's a no-op for the type-parameters half.
+      signature: clampSignatureLength(`enum ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
 
@@ -482,7 +490,7 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `record ${nameNode.text}`,
+      signature: clampSignatureLength(`record ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
 }
@@ -500,6 +508,33 @@ function hasPublicModifier(node: SyntaxNode): boolean {
   const modifiers = node.children.find(child => child.type === 'modifiers');
   if (!modifiers) return false;
   return modifiers.children.some(child => child.type === 'public');
+}
+
+/**
+ * Generic type parameters and extends/implements heritage, exactly as
+ * declared in source — the Java analog of C#'s `typeParamsAndBaseList`
+ * (same underlying bug: `signature` for a type declaration reported only
+ * its bare keyword and name, dropping `<T extends Comparable<T>>` and
+ * `extends Bar<T> implements Baz, Qux` entirely). `type_parameters` and
+ * `superclass`/`interfaces` (class/enum/record) are registered grammar
+ * fields, but `extends_interfaces` (an interface extending other
+ * interfaces) is NOT a field on `interface_declaration`, so it's found by
+ * scanning `namedChildren` for consistency with the fielded case.
+ *
+ * Whitespace is collapsed to a single line (`collapseWhitespace`, matching
+ * `extractSignature`'s convention) — a heritage clause can itself span
+ * multiple physical lines (long generic bounds, an interleaved comment),
+ * which would otherwise leak newlines into `signature`.
+ */
+function typeParamsAndHeritage(node: SyntaxNode): string {
+  const typeParams = collapseWhitespace(node.childForFieldName('type_parameters')?.text);
+  const superclass = collapseWhitespace(node.childForFieldName('superclass')?.text);
+  const interfaces = collapseWhitespace(
+    node.childForFieldName('interfaces')?.text ??
+      node.namedChildren.find(child => child.type === 'extends_interfaces')?.text,
+  );
+  const heritage = [superclass, interfaces].filter(Boolean).join(' ');
+  return `${typeParams}${heritage ? ` ${heritage}` : ''}`;
 }
 
 /**

--- a/packages/parser/src/ast/languages/javascript.test.ts
+++ b/packages/parser/src/ast/languages/javascript.test.ts
@@ -371,6 +371,18 @@ exports.bar = 42;`;
       expect(symbol).not.toBeNull();
       expect(symbol!.name).toBe('EventEmitter');
       expect(symbol!.type).toBe('class');
+      expect(symbol!.signature).toBe('class EventEmitter');
+    });
+
+    // Same underlying bug as the C#/Java/Kotlin fix: `signature` dropped the
+    // `extends` clause entirely, e.g. `class Foo extends Bar` came back as
+    // bare `class Foo`. Plain JS has no generics, so this only covers heritage.
+    it('should include extends heritage in a class signature', () => {
+      const code = 'class Foo extends Bar {}';
+      const root = mustParse(code, 'javascript');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe('class Foo extends Bar');
     });
 
     it('should extract method info with parent class', () => {

--- a/packages/parser/src/ast/languages/javascript.ts
+++ b/packages/parser/src/ast/languages/javascript.ts
@@ -11,6 +11,8 @@ import {
   extractSignature,
   extractParameters,
   extractReturnType,
+  clampSignatureLength,
+  collapseWhitespace,
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -568,6 +570,30 @@ export class TypeScriptImportExtractor extends JavaScriptImportExtractor {}
 // =============================================================================
 
 /**
+ * Generic type parameters (TypeScript only — always absent when parsed with
+ * the plain JavaScript grammar) and extends/implements heritage, exactly as
+ * declared in source — the JS/TS analog of C#'s `typeParamsAndBaseList`/
+ * Java's `typeParamsAndHeritage` (same underlying bug: `signature` for a
+ * class/interface reported only its bare keyword and name, so `class
+ * Foo<T> extends Bar<T> implements Baz, Qux` came back as bare `class Foo`).
+ * A class's `extends`+`implements` clauses are a single `class_heritage`
+ * node (e.g. `"extends Bar<T> implements Baz, Qux"`); an interface's is a
+ * separate `extends_type_clause` (e.g. `"extends IBar<T>, IBaz"` — TS
+ * interfaces can't `implements`). Neither `type_parameters` nor either
+ * heritage node is a registered field, so all three are found by node type.
+ * Each piece is passed through `collapseWhitespace` in case the clause
+ * spans multiple physical lines.
+ */
+function typeParamsAndHeritage(node: SyntaxNode): string {
+  const typeParams = collapseWhitespace(node.childForFieldName('type_parameters')?.text);
+  const heritage = collapseWhitespace(
+    node.namedChildren.find(child => child.type === 'class_heritage')?.text ??
+      node.namedChildren.find(child => child.type === 'extends_type_clause')?.text,
+  );
+  return `${typeParams}${heritage ? ` ${heritage}` : ''}`;
+}
+
+/**
  * JavaScript/TypeScript symbol extractor
  *
  * Extracts symbol info from function declarations, arrow functions,
@@ -712,7 +738,7 @@ export class JavaScriptSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
-      signature: `class ${nameNode.text}`,
+      signature: clampSignatureLength(`class ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
 
@@ -725,7 +751,7 @@ export class JavaScriptSymbolExtractor implements LanguageSymbolExtractor {
       type: 'interface',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
-      signature: `interface ${nameNode.text}`,
+      signature: clampSignatureLength(`interface ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
 }

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -241,6 +241,28 @@ describe('Kotlin Language', () => {
       expect(obj).toMatchObject({ name: 'Registry', type: 'class', signature: 'object Registry' });
     });
 
+    // Same underlying bug as the C#/Java fix: `signature` dropped generic
+    // type parameters and the supertype list entirely.
+    it('includes generic type parameters and the supertype list in class/interface/object signatures', () => {
+      const cls = symbolExtractor.extractSymbol(
+        findNode(parse('class Foo<T> : Bar<T>(), Baz'), 'class_declaration')!,
+        '',
+      )!;
+      expect(cls.signature).toBe('class Foo<T> : Bar<T>(), Baz');
+
+      const iface = symbolExtractor.extractSymbol(
+        findNode(parse('interface IFoo<T> : IBar<T>, IBaz'), 'class_declaration')!,
+        '',
+      )!;
+      expect(iface.signature).toBe('interface IFoo<T> : IBar<T>, IBaz');
+
+      const obj = symbolExtractor.extractSymbol(
+        findNode(parse('object Singleton : Base()'), 'object_declaration')!,
+        '',
+      )!;
+      expect(obj.signature).toBe('object Singleton : Base()');
+    });
+
     // #949: nested/inner classes and objects are idiomatic in Kotlin, but
     // extractClassInfo/extractObjectInfo previously ignored the parentClass
     // argument entirely — a nested type always reported parentClass:

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -7,6 +7,7 @@ import type {
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
 import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
+import { collapseWhitespace } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -59,6 +60,28 @@ function functionName(node: SyntaxNode): string | undefined {
 /** The declared name of a class/object declaration (`type_identifier`). */
 function declarationName(node: SyntaxNode): string | undefined {
   return childByType(node, 'type_identifier')?.text;
+}
+
+/**
+ * Generic type parameters and supertype list, exactly as declared in source
+ * — the Kotlin analog of C#'s `typeParamsAndBaseList`/Java's
+ * `typeParamsAndHeritage` (same underlying bug: `signature` for a class/
+ * interface/object reported only its bare keyword and name). Kotlin
+ * supertypes are `delegation_specifier` children directly under the
+ * class/object declaration (no wrapping node), following a literal `:`
+ * token — e.g. `class Foo<T> : Bar<T>(), Baz`. Neither `type_parameters` nor
+ * `delegation_specifier` is a registered field (the fwcd grammar assigns
+ * none — see the file-level note above), so both are found by node type.
+ * Each piece is passed through `collapseWhitespace` in case a supertype
+ * list spans multiple physical lines (the same whitespace-collapsing
+ * convention `functionSignature` below applies inline).
+ */
+function typeParamsAndSupertypes(node: SyntaxNode): string {
+  const typeParams = collapseWhitespace(childByType(node, 'type_parameters')?.text);
+  const supertypes = node.namedChildren.filter(child => child.type === 'delegation_specifier');
+  const supertypesText =
+    supertypes.length > 0 ? ` : ${supertypes.map(s => collapseWhitespace(s.text)).join(', ')}` : '';
+  return `${typeParams}${supertypesText}`;
 }
 
 const SIGNATURE_MAX = 200;
@@ -454,20 +477,39 @@ export class KotlinSymbolExtractor implements LanguageSymbolExtractor {
   private extractClassInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
+    const suffix = typeParamsAndSupertypes(node);
 
     if (hasTokenChild(node, 'interface')) {
-      return this.makeSymbol(node, name, 'interface', `interface ${name}`, parentClass);
+      return this.makeSymbol(
+        node,
+        name,
+        'interface',
+        clamp(`interface ${name}${suffix}`),
+        parentClass,
+      );
     }
     if (hasTokenChild(node, 'enum')) {
-      return this.makeSymbol(node, name, 'class', `enum class ${name}`, parentClass);
+      return this.makeSymbol(
+        node,
+        name,
+        'class',
+        clamp(`enum class ${name}${suffix}`),
+        parentClass,
+      );
     }
-    return this.makeSymbol(node, name, 'class', `class ${name}`, parentClass);
+    return this.makeSymbol(node, name, 'class', clamp(`class ${name}${suffix}`), parentClass);
   }
 
   private extractObjectInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
-    return this.makeSymbol(node, name, 'class', `object ${name}`, parentClass);
+    return this.makeSymbol(
+      node,
+      name,
+      'class',
+      clamp(`object ${name}${typeParamsAndSupertypes(node)}`),
+      parentClass,
+    );
   }
 
   private makeSymbol(

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -549,6 +549,20 @@ pub static COUNTER: i32 = 0;`;
       expect(symbol!.signature).toBe('impl UserService');
     });
 
+    // Same underlying bug as the C#/Java/Kotlin/TS/Swift fix: `signature`
+    // dropped generic type parameters and the implemented trait entirely, so
+    // `impl<T> Trait for Type<T>` came back as bare `impl Type` — losing the
+    // one fact (which trait this impl provides) that's most useful for
+    // deciding whether it's the impl you want.
+    it('should include generic type parameters and the implemented trait in an impl signature', () => {
+      const code = 'impl<T> Trait for Type<T> { fn m(&self) {} }';
+      const root = mustParse(code, 'rust');
+      const implNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(implNode, code);
+      expect(symbol!.name).toBe('Type<T>');
+      expect(symbol!.signature).toBe('impl<T> Trait for Type<T>');
+    });
+
     it('should extract trait_item as interface', () => {
       const code = 'trait Validate { fn validate(&self) -> bool; }';
       const root = mustParse(code, 'rust');
@@ -558,6 +572,14 @@ pub static COUNTER: i32 = 0;`;
       expect(symbol!.name).toBe('Validate');
       expect(symbol!.type).toBe('interface');
       expect(symbol!.signature).toBe('trait Validate');
+    });
+
+    it('should include generic type parameters and supertraits in a trait signature', () => {
+      const code = 'trait Foo<T>: Bar + Baz { fn m(&self); }';
+      const root = mustParse(code, 'rust');
+      const traitNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(traitNode, code);
+      expect(symbol!.signature).toBe('trait Foo<T>: Bar + Baz');
     });
 
     it('should extract call site from direct function call', () => {

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -11,6 +11,8 @@ import {
   extractSignature,
   extractParameters,
   extractReturnType,
+  clampSignatureLength,
+  collapseWhitespace,
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 import { resolveRustCrateImport } from '../../rust-crate-map.js';
@@ -722,29 +724,59 @@ export class RustSymbolExtractor implements LanguageSymbolExtractor {
     };
   }
 
+  /**
+   * `impl<T> Trait for Type<T>` — the trait being implemented (if any) is
+   * arguably the single most useful fact about an impl block (which
+   * behavior it provides), and the generic parameters distinguish a
+   * blanket/generic impl from a concrete one; `signature` used to report
+   * neither, just `impl Type`. `type`, `trait`, and `type_parameters` are
+   * all registered fields on `impl_item`. Deliberately excludes the
+   * trailing `where_clause` (an unnamed child, not a field) — same
+   * out-of-scope call as C#'s generic constraints. Each piece is passed
+   * through `collapseWhitespace` in case it spans multiple physical lines.
+   */
   private extractImplInfo(node: SyntaxNode): SymbolInfo | null {
     const typeNode = node.childForFieldName('type');
     if (!typeNode) return null;
+
+    const typeParams = collapseWhitespace(node.childForFieldName('type_parameters')?.text);
+    const traitNode = node.childForFieldName('trait');
+    const typeText = collapseWhitespace(typeNode.text);
+    const signature = traitNode
+      ? `impl${typeParams} ${collapseWhitespace(traitNode.text)} for ${typeText}`
+      : `impl${typeParams} ${typeText}`;
 
     return {
       name: typeNode.text,
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
-      signature: `impl ${typeNode.text}`,
+      signature: clampSignatureLength(signature),
     };
   }
 
+  /**
+   * `trait Foo<T>: Bar + Baz` — `bounds` (supertraits) and `type_parameters`
+   * are both registered fields on `trait_item`; `bounds.text` already
+   * includes its leading `:` (e.g. `": Bar + Baz"`). Each piece is passed
+   * through `collapseWhitespace` in case it spans multiple physical lines.
+   */
   private extractTraitInfo(node: SyntaxNode): SymbolInfo | null {
     const nameNode = node.childForFieldName('name');
     if (!nameNode) return null;
+
+    const typeParams = collapseWhitespace(node.childForFieldName('type_parameters')?.text);
+    // `bounds.text` already includes its leading ": " (e.g. ": Bar + Baz"),
+    // so no extra space is added here — matches Rust style (`Foo<T>: Bar`),
+    // unlike C#/Kotlin, which conventionally put a space before the colon.
+    const bounds = collapseWhitespace(node.childForFieldName('bounds')?.text);
 
     return {
       name: nameNode.text,
       type: 'interface',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
-      signature: `trait ${nameNode.text}`,
+      signature: clampSignatureLength(`trait ${nameNode.text}${typeParams}${bounds}`),
     };
   }
 }

--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -219,6 +219,29 @@ describe('Swift Language', () => {
       expect(cls).toMatchObject({ name: 'Bar', type: 'class', signature: 'class Bar' });
     });
 
+    // Same underlying bug as the C#/Java/Kotlin/TS fix: `signature` dropped
+    // generic type parameters and the inheritance clause entirely, so
+    // `class Foo<T>: Bar, Baz` came back as bare `class Foo`.
+    it('includes generic type parameters and the inheritance clause in class/struct/protocol signatures', () => {
+      const cls = symbolExtractor.extractSymbol(
+        findNode(parse('class Foo<T>: Bar, Baz {}'), 'class_declaration')!,
+        '',
+      )!;
+      expect(cls.signature).toBe('class Foo<T>: Bar, Baz');
+
+      const struct = symbolExtractor.extractSymbol(
+        findNode(parse('struct Point<T> {}'), 'class_declaration')!,
+        '',
+      )!;
+      expect(struct.signature).toBe('struct Point<T>');
+
+      const proto = symbolExtractor.extractSymbol(
+        findNode(parse('protocol IFoo: IBar, IBaz {}'), 'protocol_declaration')!,
+        '',
+      )!;
+      expect(proto.signature).toBe('protocol IFoo: IBar, IBaz');
+    });
+
     it('maps a protocol to an interface', () => {
       const proto = symbolExtractor.extractSymbol(
         findNode(parse('protocol Drawable { func draw() }'), 'protocol_declaration')!,

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -7,7 +7,12 @@ import type {
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
 import { toImportPathsArray, toImportSymbolsArray } from '../extractors/types.js';
-import { extractSignature, extractReturnType } from '../extractors/symbol-helpers.js';
+import {
+  extractSignature,
+  extractReturnType,
+  clampSignatureLength,
+  collapseWhitespace,
+} from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -48,6 +53,30 @@ function declarationKeyword(node: SyntaxNode): string {
 /** The declared name of a class/protocol declaration (handles `extension`'s `user_type`). */
 function declarationName(node: SyntaxNode): string | undefined {
   return node.childForFieldName('name')?.text;
+}
+
+/**
+ * Generic type parameters and inheritance clause, exactly as declared in
+ * source — the Swift analog of C#'s `typeParamsAndBaseList`/Java's
+ * `typeParamsAndHeritage` (same underlying bug: `signature` reported only
+ * the bare keyword and name). Covers both a class/struct/actor/enum's
+ * superclass-and-protocol list and a protocol's own supertype list — both
+ * are the same `inheritance_specifier` children in this grammar, e.g.
+ * `class Foo<T>: Bar, Baz` or `protocol IFoo: IBar, IBaz`. Neither
+ * `type_parameters` nor `inheritance_specifier` is a registered field, so
+ * both are found by node type. Each piece is passed through
+ * `collapseWhitespace` in case the clause spans multiple physical lines.
+ */
+function typeParamsAndInheritance(node: SyntaxNode): string {
+  const typeParams = collapseWhitespace(childByType(node, 'type_parameters')?.text);
+  const inheritance = node.namedChildren.filter(child => child.type === 'inheritance_specifier');
+  // No space before the colon: `Foo<T>: Bar, Baz`, matching Swift style
+  // (unlike C#/Kotlin, which conventionally do put a space there).
+  const inheritanceText =
+    inheritance.length > 0
+      ? `: ${inheritance.map(i => collapseWhitespace(i.text)).join(', ')}`
+      : '';
+  return `${typeParams}${inheritanceText}`;
 }
 
 /**
@@ -426,13 +455,15 @@ export class SwiftSymbolExtractor implements LanguageSymbolExtractor {
     const name = declarationName(node);
     if (!name) return null;
     const keyword = declarationKeyword(node);
-    return this.makeSymbol(node, name, 'class', `${keyword} ${name}`, parentClass);
+    const signature = clampSignatureLength(`${keyword} ${name}${typeParamsAndInheritance(node)}`);
+    return this.makeSymbol(node, name, 'class', signature, parentClass);
   }
 
   private extractProtocolInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
     const name = declarationName(node);
     if (!name) return null;
-    return this.makeSymbol(node, name, 'interface', `protocol ${name}`, parentClass);
+    const signature = clampSignatureLength(`protocol ${name}${typeParamsAndInheritance(node)}`);
+    return this.makeSymbol(node, name, 'interface', signature, parentClass);
   }
 
   private makeSymbol(

--- a/packages/parser/src/ast/languages/typescript.test.ts
+++ b/packages/parser/src/ast/languages/typescript.test.ts
@@ -97,6 +97,31 @@ export { foo } from './module';`;
       expect(symbol!.type).toBe('interface');
     });
 
+    // Same underlying bug as the C#/Java/Kotlin fix: `signature` dropped
+    // generic type parameters and extends/implements heritage entirely, so
+    // `class Foo<T> extends Bar<T> implements Baz, Qux` came back as bare
+    // `class Foo`.
+    it('should include generic type parameters and extends/implements heritage in a class signature', () => {
+      const code = 'class Foo<T> extends Bar<T> implements Baz, Qux {}';
+      const root = mustParse(code, 'typescript');
+      const symbol = symbolExtractor.extractSymbol(root.namedChild(0)!, code);
+      expect(symbol!.signature).toBe('class Foo<T> extends Bar<T> implements Baz, Qux');
+    });
+
+    it('should include generic type parameters and extends heritage in an interface signature', () => {
+      const code = 'interface IFoo<T> extends IBar<T>, IBaz {}';
+      const root = mustParse(code, 'typescript');
+      const symbol = symbolExtractor.extractSymbol(root.namedChild(0)!, code);
+      expect(symbol!.signature).toBe('interface IFoo<T> extends IBar<T>, IBaz');
+    });
+
+    it('should include generic type parameters and heritage in an abstract class signature', () => {
+      const code = 'abstract class AFoo<T> extends Bar<T> implements Baz {}';
+      const root = mustParse(code, 'typescript');
+      const symbol = symbolExtractor.extractSymbol(root.namedChild(0)!, code);
+      expect(symbol!.signature).toBe('class AFoo<T> extends Bar<T> implements Baz');
+    });
+
     it('should extract call sites from member expressions', () => {
       const root = mustParse('obj.method();', 'typescript');
       const callExpr = root.namedChild(0)!.namedChild(0)!;

--- a/packages/parser/src/ast/native/__fixtures__/extractor-parity.json
+++ b/packages/parser/src/ast/native/__fixtures__/extractor-parity.json
@@ -67,7 +67,7 @@
         },
         "symbolName": "Greeting",
         "symbolType": "class",
-        "signature": "class Greeting",
+        "signature": "class Greeting implements Greeter",
         "imports": ["helper"],
         "exports": ["Greeter", "Greeting"],
         "importedSymbols": {
@@ -217,7 +217,7 @@
         },
         "symbolName": "Greeter",
         "symbolType": "class",
-        "signature": "class Greeter",
+        "signature": "class Greeter: Greeting",
         "imports": [],
         "exports": ["Greeting", "message", "Greeter", "init", "add", "String"]
       }


### PR DESCRIPTION
## Summary

`signature` for a class/interface/struct/record/enum (and Rust's impl/trait) reported only the bare keyword and name, discarding generic type parameters and the base-type/interface list entirely. Found in a post-release audit of the published 0.72.0 artifact. `signature` is what `list_functions`/`get_dependents` show a model to decide whether a symbol is the one it wants — `class Logger` gives no hint it implements `ILogger`/`ILogEventSink`/`IDisposable`, and a generic class rendered without its parameters is indistinguishable from a non-generic one of the same name.

Verified the bug against my own build first (not trusting the bug table as given) before fixing.

## Scope and judgment calls

- **How much to include**: the full type-parameter list and base/interface list, verbatim from source (not reformatted) — no separate truncation scheme; the existing 200-char `clampSignatureLength` convention (already used for method/property signatures in this codebase) is reused as-is.
- **Generic constraints** (`where T : class, new()` in C#, Rust's `where` clauses): out of scope, and excluded entirely rather than partially. Built the signature from the two *named* pieces (type-param list + base list) rather than slicing raw source across the whole declaration head — the constraint clause sits after the base list and is never captured at all, not "half" captured.
- **Which C# kinds needed this**: `class`, `interface`, `struct`, `record` (including `record struct`, still a `record_declaration` node), and `enum` (which has no type parameters but does have a base list — its underlying integer type, e.g. `enum Status : byte`). **`delegate` was left alone**: delegates aren't extracted as symbols at all today (`delegate_declaration` isn't in `CSharpTraverser`'s target/container lists) — that's a separate, pre-existing gap (missing entirely, not a lossy signature), and adding a new symbol kind is out of scope for a signature-formatting fix.
- **Other languages** — checked all five named in the brief, all five turned out to have the identical gap, all five fixed:
  - **Java**: `class`/`interface`/`enum`/`record` — dropped `<T extends Comparable<T>>` and `extends Bar<T> implements Baz, Qux` entirely.
  - **Kotlin**: `class`/`interface`/`object` (objects included too — same code path, one extra line).
  - **TypeScript**: `class`/`interface` — and plain **JavaScript**'s `extends` clause got fixed as a direct consequence, since `TypeScriptSymbolExtractor` reuses the JS base's `extractClassInfo` unchanged.
  - **Swift**: `class`/`struct`/`actor`/`enum`/`extension`/`protocol` (all share one grammar node, distinguished by keyword).
  - **Rust**: `impl`/`trait`. This one is arguably the most severe of the six — an `impl` block's `signature` said just `impl Type`, silently dropping *which trait it implements*, the single most useful fact about an impl block. Now `impl<T> Trait for Type<T>`.
  - **Checked, left unchanged (already correct)**: Ruby's `class Foo < Base` already includes the superclass in `signature` — did not touch it.
  - **Checked, found broken, explicitly out of scope**: PHP and Python's `class` declarations have the identical `` `class ${name}` `` bug (no extends/implements or base-class list), and Go's `type Foo[T any] struct` drops its type parameters. None of these were named in the brief; flagging as a follow-up rather than silently expanding scope.

### A bug found via dogfooding, not the original brief

Re-indexing Serilog's real `Logger` class surfaced a second bug: its base list spans multiple physical lines in source (wrapped in a `#if FEATURE_ASYNCDISPOSABLE` / `#endif` preprocessor block), and naively concatenating raw node text leaked literal newlines into `signature`. Fixed by adding a shared `collapseWhitespace` helper (`packages/parser/src/ast/extractors/symbol-helpers.ts`) matching the existing `extractSignature` whitespace-collapsing convention, applied in all six languages. Without this, the "after" evidence below would have been a multi-line string.

## Duplicated extraction paths

Grepped for every place a C#/Java/Kotlin/TS/Swift/Rust class-like signature is built (`` signature: `class ...` `` style literals across `packages/`) to make sure I wasn't fixing N of M sites. Each language has exactly one production code path (`extractClassInfo`/`extractInterfaceInfo`/etc. per language file) — no second copy in `packages/review` or elsewhere.

## Dogfood evidence (foreign repos, never the Lien repo)

Re-indexed with my own build (`node packages/cli/dist/index.js index --force`) before every measurement, via `scripts/experiments/dogfood-oss/mcp-call.mjs` against the real MCP tool.

**C# — `/tmp/lien-dogfood-460173c9/serilog`** (`git stash` to build pre-fix code for "before", `git stash pop` to restore the fix for "after" — same repo, same tool, only the build differs):

| Symbol | Before | After |
|---|---|---|
| `LogEventPropertyValueVisitor` | `"class LogEventPropertyValueVisitor"` | `"class LogEventPropertyValueVisitor<TState, TResult>"` |
| `Logger` | `"class Logger"` | `"class Logger : ILogger, ILogEventSink, IDisposable #if FEATURE_ASYNCDISPOSABLE , IAsyncDisposable"` |

(The real `Logger` source is `class Logger : ILogger, ILogEventSink, IDisposable` followed by a conditional `#if FEATURE_ASYNCDISPOSABLE` / `, IAsyncDisposable` / `#endif` block before the opening brace — the preprocessor tokens are honestly reflected since they're part of the base list's raw span; `#endif` itself falls just outside the node.)

**Java — `/tmp/lien-dogfood-460173c9/retrofit`** (second language, same before/after method):

| Symbol | Before | After |
|---|---|---|
| `Call` (`retrofit2/Call.java`) | `"interface Call"` | `"interface Call<T> extends Cloneable"` |

Kotlin, Swift, Rust, and TypeScript were verified via unit tests (new cases per language, see below) and the full E2E suite (`Klaxon`, `SwiftyJSON`, `Anyhow`, `Zod`) rather than a second before/after repo capture, given the brief only required one additional language beyond C#.

## Testing

- New unit tests per language (existing per-language test files, following their existing pattern): `csharp.test.ts`, `java.test.ts`, `kotlin.test.ts`, `javascript.test.ts`, `typescript.test.ts`, `swift.test.ts`, `rust.test.ts` — covering generics, heritage/base lists, and the `where`-clause exclusion.
- Regenerated the two frozen golden-fixture signatures in `packages/parser/src/ast/native/__fixtures__/extractor-parity.json` that this fix legitimately changes (`class Greeting` → `class Greeting implements Greeter`, `class Greeter` → `class Greeter: Greeting`) — both fixture sources already declared this heritage; the golden output was simply wrong. Verified the diff is exactly these two lines (reformatted with prettier to avoid unrelated array-formatting noise).
- `npm run format:check` / `lint` / `typecheck` / `build` / `test` (root, all packages) — all pass.
- `lien delta` — exit 0, no new-over-threshold crossings (only advisory "worsened" warnings on functions that grew a few lines, all well under threshold).
- `npm run test:e2e:csharp/java/kotlin/swift/rust/typescript/javascript -w packages/cli` — all pass (14/14 each).

## Not done

- C# `delegate_declaration` isn't indexed as a symbol at all (separate, pre-existing gap).
- PHP, Python (`class` heritage) and Go (generic `type Foo[T any] struct`) share the same underlying gap but weren't named in the brief — flagging, not fixing, to avoid scope creep.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a parser bug where class/interface/struct/record/enum (and Rust impl/trait) signatures dropped generic type parameters and base/heritage lists. It adds a shared `collapseWhitespace` helper, applies `clampSignatureLength` consistently, and updates six language extractors (C#, Java, Kotlin, JavaScript/TypeScript, Swift, Rust) with targeted tests and regenerated golden fixtures. The changes are additive, well-covered by unit tests, and do not alter exported APIs or caller contracts.
>
> - Added `collapseWhitespace` helper in `symbol-helpers.ts` to normalize multi-line signature fragments.
> - Extended type-declaration signatures across six languages to include generic parameters and base/heritage clauses.
> - Applied existing 200-character signature clamping consistently to the new signatures.
> - Updated per-language tests and two native fixture signatures to reflect the corrected output.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d47817c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 598K/842K tokens
<!-- /lien:attestation -->