### PR TITLE
fix(core): stop concurrent MCP tool calls from crashing lien serve on a torn-down index

### DIFF
--- a/.changeset/sqlite-open-race-retry.md
+++ b/.changeset/sqlite-open-race-retry.md
@@ -1,0 +1,51 @@
+---
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+Concurrent MCP tool calls against a cold or rebuilding index could kill the
+server connection outright, surfacing to the client as
+`MCP error -32000: Connection closed` rather than a tool-level error. Observed
+at roughly a 50% failure rate with four servers racing on one brand-new
+`structural.db`.
+
+Root cause: `openDatabase()` set the `busy_timeout` pragma *after*
+`journal_mode`/`synchronous`. `busy_timeout` only governs pragmas issued after
+it, so a process losing the create/open race hit an uncaught
+`SQLITE_BUSY: database is locked` inside `initializeComponents()` and called
+`process.exit(1)` — **before the MCP transport had connected**, which is why the
+client lost the whole server instead of one call. At higher concurrency a second
+error class appeared during WAL-mode conversion (`SQLITE_IOERR`/`SQLITE_CANTOPEN`)
+that `busy_timeout`'s internal retry does not cover at all.
+
+`busy_timeout` now goes first, and every cross-process-racy open is wrapped in
+`withOpenRetry` — a jittered linear backoff (the jitter matters: without it,
+processes that started racing together retry in lockstep and keep re-colliding).
+
+**The retry budget is deliberately bounded by the plugin's hook timeout.** Three
+hooks (`annotate-read`, `augment-explore-task`, `api-delta-write`) invoke CLI
+commands that call `createVectorDB().initialize()`, and Claude Code kills a hook
+at 5000 ms with an unmaskable SIGKILL. A ladder that outlived that would leave the
+stale in-flight marker that the npx circuit breaker reads as an unreachable
+registry, silencing every nudge for its 300-second cooldown. The budget is
+therefore 16 attempts × 25 ms — a computed 3904 ms worst case with max jitter,
+about 1.1 s of headroom — and a regression test forces max jitter, sums the real
+requested delays, and fails if a future constant change breaks that ceiling.
+
+Disclosed honestly: this bound leaves a small residual. The originally reported
+shape (N=4) is clean across 14 trials, but N=6 is 9/10 and N=10 is 5/6. Tighter
+budgets were measured and are *worse* (1730 ms / 2153 ms / 2579 ms configurations
+all showed 15–33% failure at N=6, so base-delay size matters independently of
+total time). Closing that residual properly means degrading to an honest
+empty-index answer instead of exiting when the ladder is exhausted, which is
+tracked separately.
+
+Also fixes a latent bug in `SqliteBackend.reconnect()` and
+`OverlayBackend.reconnect()`, and a worse one introduced while fixing it: both
+closed the *old* handle in a `finally`, so on the failure path — where the swap
+never happened and the "old" handle still **was** `this.db` — the live connection
+was closed, leaving the backend holding a closed database for the rest of the
+process instead of continuing on the still-valid old one. The close now happens
+only after a successful swap, in both backends (`OverlayBackend` retires two
+handles), with a deterministic regression test per backend that forces the open to
+fail and asserts the backend still works.

--- a/packages/core/src/vectordb/overlay-backend.test.ts
+++ b/packages/core/src/vectordb/overlay-backend.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import { getIndexDir } from '@liendev/parser';
+import type { ChunkMetadata } from '@liendev/parser';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
 import { indexCodebase } from '../indexer/index.js';
 import { buildOverlay } from '../indexer/overlay-index.js';
@@ -218,5 +219,44 @@ describe('OverlayBackend degrades gracefully when the base is unavailable', () =
     // FTS still works against the overlay alone.
     const hits = await overlay.search('onlySymbol', 10);
     expect(hits.some(h => h.metadata.file === 'only.ts')).toBe(true);
+  });
+});
+
+describe('OverlayBackend.reconnect()', () => {
+  let bogusBaseDir: string;
+  let worktreeDir: string;
+  let overlay: OverlayBackend;
+
+  beforeEach(async () => {
+    bogusBaseDir = await createTestDir();
+    worktreeDir = await createTestDir();
+    overlay = new OverlayBackend(worktreeDir, getIndexDir(bogusBaseDir));
+    await overlay.initialize();
+    const metadata: ChunkMetadata = {
+      file: 'a.ts',
+      startLine: 1,
+      endLine: 2,
+      type: 'function',
+      language: 'typescript',
+    };
+    await overlay.insertBatch([metadata], ['content']);
+  });
+
+  afterEach(async () => {
+    overlay.close();
+    await cleanupTestDir(bogusBaseDir);
+    await cleanupTestDir(worktreeDir);
+  });
+
+  // Regression test mirroring SqliteBackend's reconnect() fix: the previous
+  // `close()` (nulls overlayDb/baseDb) then `initialize()` order left a real
+  // window where a concurrent read hit "Overlay database not initialized".
+  // Deterministic because of JS's run-to-completion-until-first-`await`
+  // semantics, not because of timing luck.
+  it('never leaves overlayDb null while a reconnect is in flight', async () => {
+    const reconnectPromise = overlay.reconnect();
+    await expect(overlay.scanAll()).resolves.toHaveLength(1);
+    await reconnectPromise;
+    await expect(overlay.scanAll()).resolves.toHaveLength(1);
   });
 });

--- a/packages/core/src/vectordb/overlay-backend.test.ts
+++ b/packages/core/src/vectordb/overlay-backend.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import { getIndexDir } from '@liendev/parser';
@@ -257,6 +257,32 @@ describe('OverlayBackend.reconnect()', () => {
     const reconnectPromise = overlay.reconnect();
     await expect(overlay.scanAll()).resolves.toHaveLength(1);
     await reconnectPromise;
+    await expect(overlay.scanAll()).resolves.toHaveLength(1);
+  });
+
+  it('leaves overlayDb/baseDb as the still-usable OLD connections when the new one fails to open', async () => {
+    // Regression test for a real bug introduced by the fix above: the first
+    // version closed `oldOverlayDb`/`oldBaseDb` unconditionally in a
+    // `finally` block. On the FAILURE path (opening the new overlay
+    // connection throws — e.g. an exhausted withOpenRetry ladder — via
+    // fs.mkdir here, the first step inside reconnect()'s try block), the
+    // swap to `this.overlayDb = newOverlayDb` never runs, so the "old"
+    // handles still ARE `this.overlayDb`/`this.baseDb` — closing them
+    // anyway poisons both for the rest of the process instead of leaving
+    // the still-valid old connections in place. Deterministic: forces
+    // fs.mkdir to reject once, no timing involved.
+    const mkdirSpy = vi.spyOn(fs, 'mkdir').mockRejectedValueOnce(new Error('simulated failure'));
+
+    await expect(overlay.reconnect()).rejects.toThrow(/Failed to reconnect/);
+
+    mkdirSpy.mockRestore();
+
+    // Still usable: the pre-existing overlay data must still be readable —
+    // NOT a closed handle.
+    await expect(overlay.scanAll()).resolves.toHaveLength(1);
+
+    // And a subsequent, successful reconnect still works normally.
+    await overlay.reconnect();
     await expect(overlay.scanAll()).resolves.toHaveLength(1);
   });
 });

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -507,36 +507,54 @@ export class OverlayBackend implements VectorDBInterface {
   }
 
   /**
-   * Reconnect WITHOUT ever leaving `overlayDb`/`baseDb` null: build both new
-   * connections first, swap them in, and only then close the retired ones.
+   * Reconnect WITHOUT ever leaving `overlayDb`/`baseDb` null OR closed-but-
+   * still-referenced: build the new overlay connection first, swap it in,
+   * and only THEN close the retired ones — and only on the success path.
    * Same rationale as `SqliteBackend.reconnect()` — `checkAndReconnect` runs
-   * this on the shared instance concurrent tool handlers use, and a
-   * close-then-open order leaves a real window where `requireOverlay()`
-   * throws "Overlay database not initialized" mid-request.
+   * this on the shared instance concurrent tool handlers use, so both
+   * failure modes are user-visible, not internal bookkeeping:
+   *  - close-then-open (the original bug): a null window where
+   *    `requireOverlay()` throws "Overlay database not initialized".
+   *  - closing the old handles unconditionally in a `finally` (a regression
+   *    introduced while fixing the first one): when opening the new overlay
+   *    connection itself throws — e.g. the retry ladder in `withOpenRetry`
+   *    is exhausted — the swap below never runs, so `oldOverlayDb`/
+   *    `oldBaseDb` still ARE `this.overlayDb`/`this.baseDb`. Closing them
+   *    anyway poisons both for the rest of the process instead of leaving
+   *    the still-valid old connections in place. The fix: the closes only
+   *    happen after `this.overlayDb = newOverlayDb` — i.e. only once the
+   *    new connection has actually taken over.
    */
   async reconnect(): Promise<void> {
     const oldOverlayDb = this.overlayDb;
     const oldBaseDb = this.baseDb;
+    let newOverlayDb: DatabaseType.Database;
     try {
       await fs.mkdir(this.dbPath, { recursive: true });
-      const newOverlayDb = await withOpenRetry(() => openOverlayDatabase(this.overlayDbFilePath));
-      this.overlayDb = newOverlayDb;
-      this.openBase(); // sets this.baseDb directly; own try/catch, non-fatal
-      this.baseHashes = await this.loadBaseHashes();
-      this.currentVersion = await readVersionFile(this.dbPath);
+      newOverlayDb = await withOpenRetry(() => openOverlayDatabase(this.overlayDbFilePath));
     } catch (error) {
+      // Opening the new overlay connection failed (including an exhausted
+      // withOpenRetry ladder) — `this.overlayDb`/`this.baseDb` are
+      // untouched, still the valid old connections.
       throw wrapError(error, 'Failed to reconnect to overlay database');
-    } finally {
-      try {
-        oldOverlayDb?.close();
-      } catch {
-        // Best-effort: already swapped away.
-      }
-      try {
-        oldBaseDb?.close();
-      } catch {
-        // Best-effort: already swapped away.
-      }
+    }
+
+    this.overlayDb = newOverlayDb;
+    this.openBase(); // sets this.baseDb directly; own try/catch, non-fatal
+    this.baseHashes = await this.loadBaseHashes();
+    this.currentVersion = await readVersionFile(this.dbPath);
+
+    // Only reachable once the swap above succeeded, so the old handles are
+    // genuinely retired — safe to close.
+    try {
+      oldOverlayDb?.close();
+    } catch {
+      // Best-effort: already swapped away.
+    }
+    try {
+      oldBaseDb?.close();
+    } catch {
+      // Best-effort: already swapped away.
     }
   }
 

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -35,6 +35,7 @@ import {
   OVERLAY_META,
   STRUCTURAL_DB_FILENAME,
 } from './sqlite/overlay-schema.js';
+import { withOpenRetry } from './sqlite/schema.js';
 
 const MANIFEST_FILE = 'manifest.json';
 
@@ -98,7 +99,9 @@ export class OverlayBackend implements VectorDBInterface {
   async initialize(): Promise<void> {
     try {
       await fs.mkdir(this.dbPath, { recursive: true });
-      this.overlayDb = openOverlayDatabase(this.overlayDbFilePath);
+      // withOpenRetry: the overlay file may be brand-new, with other worktree
+      // serves racing to create/open it at the same instant.
+      this.overlayDb = await withOpenRetry(() => openOverlayDatabase(this.overlayDbFilePath));
       this.openBase();
       this.baseHashes = await this.loadBaseHashes();
       this.currentVersion = await readVersionFile(this.dbPath);
@@ -503,12 +506,37 @@ export class OverlayBackend implements VectorDBInterface {
     }
   }
 
+  /**
+   * Reconnect WITHOUT ever leaving `overlayDb`/`baseDb` null: build both new
+   * connections first, swap them in, and only then close the retired ones.
+   * Same rationale as `SqliteBackend.reconnect()` — `checkAndReconnect` runs
+   * this on the shared instance concurrent tool handlers use, and a
+   * close-then-open order leaves a real window where `requireOverlay()`
+   * throws "Overlay database not initialized" mid-request.
+   */
   async reconnect(): Promise<void> {
+    const oldOverlayDb = this.overlayDb;
+    const oldBaseDb = this.baseDb;
     try {
-      this.close();
-      await this.initialize();
+      await fs.mkdir(this.dbPath, { recursive: true });
+      const newOverlayDb = await withOpenRetry(() => openOverlayDatabase(this.overlayDbFilePath));
+      this.overlayDb = newOverlayDb;
+      this.openBase(); // sets this.baseDb directly; own try/catch, non-fatal
+      this.baseHashes = await this.loadBaseHashes();
+      this.currentVersion = await readVersionFile(this.dbPath);
     } catch (error) {
       throw wrapError(error, 'Failed to reconnect to overlay database');
+    } finally {
+      try {
+        oldOverlayDb?.close();
+      } catch {
+        // Best-effort: already swapped away.
+      }
+      try {
+        oldBaseDb?.close();
+      } catch {
+        // Best-effort: already swapped away.
+      }
     }
   }
 

--- a/packages/core/src/vectordb/sqlite/schema.test.ts
+++ b/packages/core/src/vectordb/sqlite/schema.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { createTestDir, cleanupTestDir } from '../../test/helpers/test-db.js';
+import { openDatabase, withOpenRetry } from './schema.js';
+
+/** A `better-sqlite3`-shaped error: `SqliteError` sets `.code`, not a message
+ *  prefix, so that's what production code (and this mock) must match on. */
+function sqliteError(code: string): Error & { code: string } {
+  const err = new Error(`simulated ${code}`) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+describe('openDatabase', () => {
+  it('sets busy_timeout before journal_mode/synchronous', async () => {
+    // Regression test for the actual root cause of a reproduced MCP-server
+    // crash: several `lien serve` processes racing to create/open the SAME
+    // brand-new index file threw an uncaught `SQLITE_BUSY: database is
+    // locked` — because busy_timeout was applied AFTER journal_mode, so it
+    // wasn't yet in effect for the pragma calls that could hit lock
+    // contention. Asserting call ORDER (not just final pragma state) is what
+    // actually locks the fix in — a reorder regression wouldn't otherwise be
+    // visible from the pragma's steady-state value.
+    const dir = await createTestDir();
+    try {
+      const dbFilePath = path.join(dir, 'structural.db');
+      const calls: string[] = [];
+      const originalPragma = Database.prototype.pragma;
+
+      (Database.prototype as any).pragma = function (source: string, ...rest: unknown[]) {
+        calls.push(source);
+
+        return (originalPragma as any).apply(this, [source, ...rest]);
+      };
+
+      let db;
+      try {
+        db = openDatabase(dbFilePath);
+      } finally {
+        Database.prototype.pragma = originalPragma;
+      }
+      db.close();
+
+      expect(calls[0]).toBe('busy_timeout = 5000');
+      expect(calls).toEqual(['busy_timeout = 5000', 'journal_mode = WAL', 'synchronous = NORMAL']);
+    } finally {
+      await cleanupTestDir(dir);
+    }
+  });
+});
+
+describe('withOpenRetry', () => {
+  it('returns the result immediately when open succeeds on the first try', async () => {
+    const open = vi.fn(() => 'db-handle');
+    await expect(withOpenRetry(open)).resolves.toBe('db-handle');
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries past transient SQLite open errors and eventually succeeds', async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const codes = ['SQLITE_BUSY', 'SQLITE_IOERR', 'SQLITE_CANTOPEN'];
+      const open = vi.fn(() => {
+        calls += 1;
+        if (calls <= codes.length) throw sqliteError(codes[calls - 1]);
+        return 'db-handle';
+      });
+
+      const resultPromise = withOpenRetry(open);
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe('db-handle');
+      expect(open).toHaveBeenCalledTimes(codes.length + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry a non-transient error', async () => {
+    const err = new Error('permission denied');
+    const open = vi.fn(() => {
+      throw err;
+    });
+    await expect(withOpenRetry(open)).rejects.toBe(err);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up and rethrows the last error after exhausting all attempts', async () => {
+    vi.useFakeTimers();
+    try {
+      const open = vi.fn(() => {
+        throw sqliteError('SQLITE_BUSY');
+      });
+
+      const resultPromise = withOpenRetry(open);
+      // Attach a rejection handler immediately so draining fake timers below
+      // doesn't trigger an unhandled-rejection warning before the final
+      // `await expect(...).rejects...` attaches its own handler.
+      const settled = resultPromise.catch((error: unknown) => ({ error }));
+      await vi.runAllTimersAsync();
+
+      const outcome = await settled;
+      expect(outcome).toHaveProperty('error');
+      expect((outcome as { error: unknown }).error).toMatchObject({ code: 'SQLITE_BUSY' });
+      // Bounded attempts, not silently-infinite retry.
+      expect(open.mock.calls.length).toBeGreaterThan(1);
+      expect(open.mock.calls.length).toBeLessThan(50);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/core/src/vectordb/sqlite/schema.test.ts
+++ b/packages/core/src/vectordb/sqlite/schema.test.ts
@@ -111,4 +111,53 @@ describe('withOpenRetry', () => {
       vi.useRealTimers();
     }
   });
+
+  it('keeps the worst-case (max jitter) total retry wait well under the 5000ms hook timeout', async () => {
+    // plugins/claude/hooks/hooks.json gives every hook a 5000ms timeout, and
+    // several hooks (annotate-read, augment-explore-task, api-delta-write)
+    // invoke a `lien` command that runs through this exact ladder
+    // (createVectorDB().initialize() -> openConnection -> withOpenRetry). If
+    // the ladder's own worst-case wait approaches that ceiling, Claude Code
+    // SIGKILLs the hook process mid-retry — a failure lien-npx-breaker.sh
+    // cannot distinguish from a hung npm registry, since both leave the same
+    // stale in-flight marker. That trips the breaker and silences every
+    // nudge for its 300s cooldown. This asserts the REAL computed worst
+    // case (recording every delay actually requested, under forced maximum
+    // jitter), not the doc comment's claim, so a future constant change that
+    // drifts back toward the hook timeout fails loudly here.
+    const originalRandom = Math.random;
+    const originalSetTimeout = global.setTimeout;
+    const delays: number[] = [];
+    Math.random = () => 1; // forces the max +30% jitter on every backoff
+
+    (global as any).setTimeout = (fn: (...args: unknown[]) => void, ms?: number) => {
+      delays.push(ms ?? 0);
+      return originalSetTimeout(fn, 0); // record the ask; don't actually wait
+    };
+
+    try {
+      const open = vi.fn(() => {
+        throw sqliteError('SQLITE_BUSY');
+      });
+      await expect(withOpenRetry(open)).rejects.toMatchObject({ code: 'SQLITE_BUSY' });
+    } finally {
+      Math.random = originalRandom;
+      global.setTimeout = originalSetTimeout;
+    }
+
+    const worstCaseTotalMs = delays.reduce((sum, d) => sum + d, 0);
+    const HOOK_TIMEOUT_MS = 5000;
+    // Real headroom for actual open work + bash/npx/node overhead, not a
+    // near-miss of the timeout. The budget was tuned to leave ~1.1s of
+    // headroom (computed worst case ~3904ms) — see the OPEN_RETRY_ATTEMPTS
+    // doc comment for why it isn't larger: a longer ladder measurably
+    // improves reliability at higher concurrency, but ~1s of headroom is
+    // judged the minimum safe margin given hooks already take 200-600ms in
+    // normal operation (lien-npx-breaker.sh), so this only leaves room to
+    // grow the budget, not shrink the margin further.
+    expect(worstCaseTotalMs).toBeLessThan(HOOK_TIMEOUT_MS - 1000);
+    // Still meaningfully retrying (this budget wasn't gutted to make the
+    // ceiling trivially true).
+    expect(delays.length).toBeGreaterThan(5);
+  });
 });

--- a/packages/core/src/vectordb/sqlite/schema.ts
+++ b/packages/core/src/vectordb/sqlite/schema.ts
@@ -118,12 +118,112 @@ END;
  * Open (creating if needed) the structural store and ensure schema exists.
  * busy_timeout lets the MCP server watcher and a concurrent CLI index run
  * both hold write handles without immediate SQLITE_BUSY failures.
+ *
+ * busy_timeout MUST be the first pragma set on the connection. It only
+ * applies to statements issued after it: on a brand-new/just-deleted index
+ * file, several `lien serve` processes can race to open + schema-create the
+ * same file (e.g. an agent firing multiple MCP tool calls in parallel right
+ * after the index was wiped). If `journal_mode`/`synchronous` run first with
+ * no busy_timeout yet configured, one loser gets an immediate uncaught
+ * `SQLITE_BUSY: database is locked` instead of a bounded wait+retry — which
+ * crashes that process before it ever reaches `server.connect()`, and the
+ * MCP client sees the whole connection drop (`-32000`), not a tool-level
+ * error.
+ *
+ * busy_timeout alone does NOT close the whole race, though: at higher
+ * concurrency (several processes truly creating the file for the first time
+ * at once, not just contending for a lock on an existing one), the WAL-mode
+ * conversion itself can throw `SQLITE_IOERR`/`SQLITE_CANTOPEN` — a different
+ * error class busy_timeout's internal retry does not cover. Callers that open
+ * this file from a context where cross-process races are plausible (the MCP
+ * server's own connection, a background reindex) MUST wrap the call in
+ * `withOpenRetry` below rather than call this directly. See
+ * `SqliteBackend.openConnection`/`clear` and `OverlayBackend.initialize`/
+ * `reconnect` for the call sites, and schema.test.ts for the reproduction.
  */
 export function openDatabase(dbFilePath: string): Database.Database {
   const db = new Database(dbFilePath);
+  db.pragma('busy_timeout = 5000');
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
-  db.pragma('busy_timeout = 5000');
   db.exec(SCHEMA_SQL);
   return db;
+}
+
+/**
+ * Attempts before `withOpenRetry` gives up on a retryable open failure.
+ * Deliberately generous (well beyond what a handful of concurrent MCP tool
+ * calls needs): measured under a synthetic 10-processes-racing-one-brand-new
+ * -file stress test, `SQLITE_IOERR` during the WAL-mode conversion recurred
+ * across several retries in a row before settling — a lower budget left a
+ * small but real tail of crashes at that concurrency. Total worst-case wait
+ * (sum of all backoffs, see `openRetryDelayMs`) stays well under the ~1-2s a
+ * full background reindex takes anyway, so this only adds latency to the
+ * unlucky first caller hitting a torn-down index, never to steady state.
+ */
+const OPEN_RETRY_ATTEMPTS = 20;
+/** Backoff unit; see `openRetryDelayMs` for the jittered schedule this drives. */
+const OPEN_RETRY_BASE_DELAY_MS = 25;
+
+/**
+ * Backoff for retry attempt N (1-indexed): linear growth plus up to ±30%
+ * jitter. The jitter matters here specifically — without it, several
+ * processes that started racing at nearly the same instant also retry in
+ * near-lockstep, so they keep re-colliding on the same schedule instead of
+ * spreading out and letting one of them win.
+ */
+function openRetryDelayMs(attempt: number): number {
+  const base = OPEN_RETRY_BASE_DELAY_MS * attempt;
+  const jitter = base * 0.3 * (Math.random() * 2 - 1);
+  return Math.max(1, Math.round(base + jitter));
+}
+
+/**
+ * True for the SQLite error codes multiple processes racing to create/open
+ * the SAME database file — most often one that's brand-new or was just
+ * deleted — can throw. `busy_timeout` already covers ordinary lock waits on
+ * an EXISTING file; these extra codes are the lower-level I/O races specific
+ * to concurrent first-time creation, which busy_timeout's built-in retry does
+ * not reach.
+ */
+function isTransientSqliteOpenError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  const code = (error as { code: unknown }).code;
+  return (
+    code === 'SQLITE_BUSY' ||
+    code === 'SQLITE_BUSY_SNAPSHOT' ||
+    code === 'SQLITE_LOCKED' ||
+    code === 'SQLITE_IOERR' ||
+    code === 'SQLITE_CANTOPEN'
+  );
+}
+
+/**
+ * Run `open` — a function that opens/creates a fresh SQLite connection to a
+ * file other processes might be racing to open/create at the same moment —
+ * retrying with a short backoff on `isTransientSqliteOpenError`. Each retry
+ * calls `open` again from scratch (never reuses a handle from a failed
+ * attempt: a half-succeeded pragma/exec can leave that `Database` object
+ * unusable), so by the time all processes have settled on who created the
+ * file, every caller converges on a working connection instead of the first
+ * unlucky one crashing its whole process.
+ *
+ * Non-transient errors (bad path, permissions, disk full) rethrow
+ * immediately — this is scoped to the specific "several processes just
+ * raced to touch the same file" window, not a general-purpose DB-open retry.
+ */
+export async function withOpenRetry<T>(open: () => T): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < OPEN_RETRY_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise(resolve => setTimeout(resolve, openRetryDelayMs(attempt)));
+    }
+    try {
+      return open();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientSqliteOpenError(error)) throw error;
+    }
+  }
+  throw lastError;
 }

--- a/packages/core/src/vectordb/sqlite/schema.ts
+++ b/packages/core/src/vectordb/sqlite/schema.ts
@@ -152,16 +152,48 @@ export function openDatabase(dbFilePath: string): Database.Database {
 
 /**
  * Attempts before `withOpenRetry` gives up on a retryable open failure.
- * Deliberately generous (well beyond what a handful of concurrent MCP tool
- * calls needs): measured under a synthetic 10-processes-racing-one-brand-new
- * -file stress test, `SQLITE_IOERR` during the WAL-mode conversion recurred
- * across several retries in a row before settling — a lower budget left a
- * small but real tail of crashes at that concurrency. Total worst-case wait
- * (sum of all backoffs, see `openRetryDelayMs`) stays well under the ~1-2s a
- * full background reindex takes anyway, so this only adds latency to the
- * unlucky first caller hitting a torn-down index, never to steady state.
+ * Sized against TWO constraints in tension with each other, not just "make
+ * the stress test pass":
+ *
+ * 1. A hard ceiling this MUST fit under: `plugins/claude/hooks/hooks.json`
+ *    gives every hook a 5000ms timeout, and several hooks (`annotate-read`,
+ *    `augment-explore-task`, `api-delta-write`) invoke a `lien` CLI command
+ *    that calls `createVectorDB().initialize()` — i.e. they run through
+ *    this exact retry ladder. A ladder whose own worst-case wait approaches
+ *    or exceeds 5000ms would get its hook process SIGKILLed mid-retry by
+ *    Claude Code, and `lien-npx-breaker.sh` cannot tell that SIGKILL apart
+ *    from an unreachable npm registry: it leaves the same stale in-flight
+ *    marker either way, tripping `lien-npx-breaker.sh`'s circuit breaker
+ *    and silencing ALL nudges for its 300s cooldown.
+ * 2. Reliability under real concurrency — a synthetic N-processes-racing-
+ *    one-brand-new-file stress test.
+ *
+ * These trade off against each other, and (1) wins: a ladder long enough to
+ * survive 20 racing processes cleanly (~6.2s worst case) cannot fit under a
+ * 5000ms hook timeout at all, let alone with headroom, so it isn't an option
+ * regardless of reliability. With the constants below, the worst-case (max
+ * +30% jitter) summed wait across all `OPEN_RETRY_ATTEMPTS - 1` backoffs
+ * computes to 3904ms — leaving real (~1.1s) but not huge headroom under the
+ * hook timeout for the actual open work, bash/npx process overhead, and node
+ * startup. schema.test.ts asserts this computed ceiling directly (not this
+ * comment's claim), so a future constant change that drifts it back toward
+ * the hook timeout fails loudly there instead of silently in production.
+ *
+ * Measured empirically at this budget (repeated trials, disposable foreign
+ * repo, index deleted before each run): the ORIGINAL reported bug's exact
+ * shape (4 concurrent `lien serve` processes) is fully clean (0 failures
+ * across repeated runs). At higher realistic-but-uncommon concurrency (6-10
+ * concurrent processes racing the same brand-new file) a SMALL residual
+ * remains — roughly 1 in 6-10 trials still hit the crash this PR exists to
+ * fix, vs. 0 in dozens of trials at the (hook-timeout-incompatible) ~6.2s
+ * budget. This is the real, disclosed tradeoff of fitting under the hook
+ * timeout, not an oversight: see the PR discussion for the full measurement
+ * and the case for a complementary fix (never `process.exit()` the MCP
+ * server on an exhausted retry ladder; degrade to an honest empty answer
+ * instead, matching the single-call case) that would close this gap without
+ * needing a longer ladder.
  */
-const OPEN_RETRY_ATTEMPTS = 20;
+const OPEN_RETRY_ATTEMPTS = 16;
 /** Backoff unit; see `openRetryDelayMs` for the jittered schedule this drives. */
 const OPEN_RETRY_BASE_DELAY_MS = 25;
 

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
@@ -277,6 +277,53 @@ describe('SqliteBackend', () => {
     });
   });
 
+  describe('reconnect', () => {
+    // Regression test for a real, reproduced MCP-server concurrency bug:
+    // `checkAndReconnect` runs `reconnect()` on the SAME vectorDB instance
+    // concurrent tool handlers share. The original implementation was
+    // `this.close(); await this.initialize();` — `close()` runs fully
+    // synchronously, nulling `this.db` BEFORE the first `await`. Any
+    // concurrent call that read `this.db` in that window (even one already
+    // in flight, not just a new one) hit `requireDb()`'s "Vector database
+    // not initialized" — a real failure observed under load, not a
+    // hypothetical. This is a deterministic unit test on the guard itself
+    // (never leave `this.db` null mid-swap) rather than a timing-dependent
+    // integration test: JS's run-to-completion-until-first-`await` semantics
+    // make the assertion below exact, not probabilistic.
+    it('never leaves this.db null while a reconnect is in flight', async () => {
+      await insertOne(db, makeChunk().metadata, 'content');
+
+      // reconnect() is async but its body doesn't touch `this.db` until AFTER
+      // its first await resolves (inside openConnection's `fs.mkdir`). So the
+      // very next line runs while the OLD implementation would already have
+      // nulled `this.db` synchronously, and the NEW one has not yet touched it.
+      const reconnectPromise = db.reconnect();
+
+      // A concurrent read landing in that exact window must see a working
+      // connection — old data via the still-open OLD handle — never throw.
+      await expect(db.scanAll()).resolves.toHaveLength(1);
+
+      await reconnectPromise;
+
+      // And the swap actually completed: reads still work post-reconnect.
+      await expect(db.scanAll()).resolves.toHaveLength(1);
+    });
+
+    it('picks up data written to the file between initialize and reconnect', async () => {
+      // Simulate an external process writing to the same structural.db
+      // (e.g. `lien index` running concurrently) between this connection's
+      // initial open and a version-triggered reconnect.
+      const raw = new Database(path.join(db.dbPath, 'structural.db'));
+      raw.pragma('journal_mode = WAL');
+      raw.exec(`INSERT INTO chunks (file, content) VALUES ('external.ts', 'external content')`);
+      raw.close();
+
+      await db.reconnect();
+      const results = await db.scanAll();
+      expect(results.map(r => r.metadata.file)).toContain('external.ts');
+    });
+  });
+
   describe('checkVersion', () => {
     it('detects a newer version once, then throttles for 1 second', async () => {
       // updateFile writes a fresh version file (currentVersion starts at 0).

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -321,6 +321,34 @@ describe('SqliteBackend', () => {
       await db.reconnect();
       const results = await db.scanAll();
       expect(results.map(r => r.metadata.file)).toContain('external.ts');
+    });
+
+    it('leaves this.db as the still-usable OLD connection when the new one fails to open', async () => {
+      // Regression test for a real bug introduced by the very fix above:
+      // the first version closed `oldDb` unconditionally in a `finally`
+      // block. On the FAILURE path (openConnection() throws — e.g. an
+      // exhausted withOpenRetry ladder), the swap to `this.db = db` never
+      // runs, so `oldDb` still IS `this.db` — closing it there poisons
+      // `this.db` with a closed handle for the rest of the process, instead
+      // of leaving the still-valid old connection in place. Deterministic:
+      // forces the private `openConnection()` to reject, no timing involved.
+      await insertOne(db, makeChunk().metadata, 'content');
+
+      const spy = vi
+        .spyOn(db as any, 'openConnection')
+        .mockRejectedValueOnce(new Error('simulated exhausted retry ladder'));
+
+      await expect(db.reconnect()).rejects.toThrow(/Failed to reconnect/);
+
+      // this.db must still be the OLD connection, open and usable — NOT a
+      // closed handle. A read must still succeed with the old data intact.
+      await expect(db.scanAll()).resolves.toHaveLength(1);
+
+      spy.mockRestore();
+
+      // A subsequent, successful reconnect still works normally afterward.
+      await db.reconnect();
+      await expect(db.scanAll()).resolves.toHaveLength(1);
     });
   });
 

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.ts
@@ -13,7 +13,7 @@ import {
   matchesSymbolFilter,
   buildLegacySymbols,
 } from '../filters.js';
-import { openDatabase, STRUCTURAL_DB_FILENAME } from './schema.js';
+import { openDatabase, withOpenRetry, STRUCTURAL_DB_FILENAME } from './schema.js';
 import { recordToUnscoredResult, buildSearchResultMetadata } from './row-mapping.js';
 import {
   normalizeFileFilter,
@@ -62,12 +62,25 @@ export class SqliteBackend implements VectorDBInterface {
 
   async initialize(): Promise<void> {
     try {
-      await fs.mkdir(this.dbPath, { recursive: true });
-      this.db = openDatabase(this.dbFilePath);
-      this.currentVersion = await readVersionFile(this.dbPath);
+      const { db, version } = await this.openConnection();
+      this.db = db;
+      this.currentVersion = version;
     } catch (error: unknown) {
       throw wrapError(error, 'Failed to initialize vector database', { dbPath: this.dbPath });
     }
+  }
+
+  /** Open a fresh connection + read its version stamp, without touching
+   *  `this.db`/`this.currentVersion`. Shared by `initialize()` (nothing to
+   *  swap yet) and `reconnect()` (which needs the new connection built
+   *  BEFORE it retires the old one — see `reconnect()`). */
+  private async openConnection(): Promise<{ db: DatabaseType.Database; version: number }> {
+    await fs.mkdir(this.dbPath, { recursive: true });
+    // withOpenRetry: this file may be brand-new or just-deleted, with other
+    // `lien serve` processes racing to create/open it at the same instant.
+    const db = await withOpenRetry(() => openDatabase(this.dbFilePath));
+    const version = await readVersionFile(this.dbPath);
+    return { db, version };
   }
 
   async insertBatch(metadatas: ChunkMetadata[], contents: string[]): Promise<void> {
@@ -205,7 +218,10 @@ export class SqliteBackend implements VectorDBInterface {
         fs.rm(f, { force: true }),
       ),
     );
-    this.db = openDatabase(this.dbFilePath);
+    // withOpenRetry: performFullIndex runs this on its OWN SqliteBackend
+    // instance while the MCP server's shared instance may be reconnecting
+    // onto the same (just-recreated) file at the same time.
+    this.db = await withOpenRetry(() => openDatabase(this.dbFilePath));
   }
 
   async checkVersion(): Promise<boolean> {
@@ -238,12 +254,30 @@ export class SqliteBackend implements VectorDBInterface {
     }
   }
 
+  /**
+   * Reconnect WITHOUT ever leaving `this.db` null: build the new connection
+   * first, swap it in, and only then close the old one. `checkAndReconnect`
+   * (the MCP server's version-check poll) runs this on the SAME vectorDB
+   * instance concurrent tool handlers share — the previous close-then-open
+   * order left a real (reproduced) window where a concurrent handler's
+   * `requireDb()` would throw "Vector database not initialized" mid-request.
+   * Old-handle-until-swap, never null, closes that window entirely.
+   */
   async reconnect(): Promise<void> {
+    const oldDb = this.db;
     try {
-      this.close();
-      await this.initialize();
+      const { db, version } = await this.openConnection();
+      this.db = db;
+      this.currentVersion = version;
     } catch (error) {
       throw wrapError(error, 'Failed to reconnect to vector database');
+    } finally {
+      try {
+        oldDb?.close();
+      } catch {
+        // Best-effort: `this.db` has already swapped to the new connection,
+        // so a failure closing the retired handle isn't user-visible.
+      }
     }
   }
 

--- a/packages/core/src/vectordb/sqlite/sqlite-backend.ts
+++ b/packages/core/src/vectordb/sqlite/sqlite-backend.ts
@@ -255,29 +255,47 @@ export class SqliteBackend implements VectorDBInterface {
   }
 
   /**
-   * Reconnect WITHOUT ever leaving `this.db` null: build the new connection
-   * first, swap it in, and only then close the old one. `checkAndReconnect`
+   * Reconnect WITHOUT ever leaving `this.db` null OR closed-but-still-
+   * referenced: build the new connection first, swap it in, and only THEN
+   * close the old one — and only on the success path. `checkAndReconnect`
    * (the MCP server's version-check poll) runs this on the SAME vectorDB
-   * instance concurrent tool handlers share — the previous close-then-open
-   * order left a real (reproduced) window where a concurrent handler's
-   * `requireDb()` would throw "Vector database not initialized" mid-request.
-   * Old-handle-until-swap, never null, closes that window entirely.
+   * instance concurrent tool handlers share, so both failure modes are
+   * user-visible, not internal bookkeeping:
+   *  - close-then-open (the original bug): a null window where a concurrent
+   *    handler's `requireDb()` throws "Vector database not initialized".
+   *  - closing the old handle unconditionally in a `finally` (a regression
+   *    introduced while fixing the first one): when `openConnection()`
+   *    itself throws — e.g. the retry ladder in `withOpenRetry` is
+   *    exhausted — the swap above never runs, so `oldDb` still IS `this.db`.
+   *    Closing it anyway poisons `this.db` with a closed handle for the
+   *    rest of the process; every later call sees a closed-connection error
+   *    instead of continuing on the still-valid old connection. The fix:
+   *    the close only happens after `this.db = db` — i.e. only once the new
+   *    connection has actually taken over — never in a path where the swap
+   *    didn't happen.
    */
   async reconnect(): Promise<void> {
     const oldDb = this.db;
+    let db: DatabaseType.Database;
+    let version: number;
     try {
-      const { db, version } = await this.openConnection();
-      this.db = db;
-      this.currentVersion = version;
+      ({ db, version } = await this.openConnection());
     } catch (error) {
+      // openConnection() failed (including an exhausted withOpenRetry
+      // ladder) — `this.db` is untouched, still the valid old connection.
       throw wrapError(error, 'Failed to reconnect to vector database');
-    } finally {
-      try {
-        oldDb?.close();
-      } catch {
-        // Best-effort: `this.db` has already swapped to the new connection,
-        // so a failure closing the retired handle isn't user-visible.
-      }
+    }
+
+    this.db = db;
+    this.currentVersion = version;
+
+    // Only reachable once the swap above succeeded, so `oldDb` is genuinely
+    // retired — safe to close.
+    try {
+      oldDb?.close();
+    } catch {
+      // Best-effort: `this.db` already points at the new connection, so a
+      // failure closing the retired handle isn't user-visible.
     }
   }
 


### PR DESCRIPTION
## Summary

Investigated a post-release audit finding: firing 4 MCP tool calls in tight
parallel against a **just-deleted** index produced `-32000: Connection
closed` for 2 of 4 calls. The original diagnosis ("SQLite lock contention
between concurrent auto-rebuild attempts") was a plausible inference, not a
confirmed root cause. This PR reproduces it, finds the real root cause(s),
and fixes them.

## Shape tested

Per the brief, `scripts/experiments/dogfood-oss/mcp-call.mjs` spawns one
server per call, which isn't a true concurrency test. I wrote a
purpose-built stdio MCP client (throwaway, not committed) that tested two
distinct shapes:

1. **N servers racing on one SQLite file** — N separate `lien serve`
   processes, each firing one real tool call via the MCP protocol, all
   spawned/connected concurrently against the same (deleted) index. **This
   is the shape that reproduces the bug**, and matches the audit's own
   `mcp-call.mjs`-per-call setup.
2. **One server, N in-flight requests** — a single `lien serve` process
   with several tool calls fired without awaiting each other (including a
   sustained burst over ~2.5s to catch the background-rebuild window). No
   crash from this shape, though it did surface a second, non-crashing bug
   (see below).

## Root causes (two, both fixed)

**1. Pragma ordering bug → uncaught `SQLITE_BUSY` during server bootstrap
(the actual `-32000`)**

`openDatabase()` in `packages/core/src/vectordb/sqlite/schema.ts` set
`busy_timeout` **after** `journal_mode`/`synchronous`. Those earlier pragma
calls had no retry protection yet, so when several `lien serve` processes
raced to create/open the same brand-new `structural.db`, one process got an
immediate uncaught `SQLITE_BUSY: database is locked` inside
`initializeComponents()`, which calls `process.exit(1)` — **before the MCP
transport ever connects**. The client sees the whole connection drop, not a
tool-level error, because there's no tool call in flight yet to attach an
error to.

At higher concurrency (~8-15 racing processes), a *different* error class
also appeared: `SQLITE_IOERR`/`SQLITE_CANTOPEN` during the WAL-mode
conversion on a truly-first-time file creation — an I/O race busy_timeout's
built-in retry does not cover.

Fix: reordered pragmas (`busy_timeout` first), plus `withOpenRetry()` — a
jittered-backoff retry wrapper around the whole open, used at every call
site that opens a fresh connection in a context where cross-process races
are plausible (`SqliteBackend.openConnection`/`clear`,
`OverlayBackend.initialize`/`reconnect`).

**2. `reconnect()` left `this.db`/`overlayDb` null mid-swap (a real, but
non-crashing, bug)**

`checkAndReconnect()` (called at the top of every MCP tool handler) can run
`vectorDB.reconnect()` on the **same shared instance** concurrent tool
handlers use. The old `reconnect()` did `close()` (nulls `this.db`
synchronously) then `await initialize()` — a real async window where a
concurrent handler's `requireDb()` threw `"Vector database not
initialized"`. Reproduced in the burst test (1 failure in 76 calls). This
one **already degraded correctly** — `wrapToolHandler` catches it and
returns `isError: true`, never killing the connection — but it was still a
confusing, avoidable internal error.

Fix: `reconnect()` now builds the new connection first, swaps it in, and
only then closes the old one (same for `OverlayBackend`) — `this.db` is
never null while a concurrent call might read it.

## Dogfood evidence (foreign repo, disposable clone)

Cloned `gin` aside to `/tmp/` (never the shared corpus, never the Lien
repo) and deleted its index before each run.

**Before fix** (4 concurrent tool calls, `lien serve` × 4):
```
[repro] multi-server: spawning 4 servers, connecting concurrently...
[repro] server 1 FAILED TO CONNECT: McpError: MCP error -32000: Connection closed
[repro] server 2 FAILED TO CONNECT: McpError: MCP error -32000: Connection closed

=== CALL RESULTS ===
[0] label=0 tool=search_code ok=true ms=2
[1] label=1 tool=list_functions ok=false ms=0 error=Error: Not connected
[2] label=2 tool=get_files_context ok=false ms=0 error=Error: Not connected
[3] label=3 tool=get_complexity ok=true ms=4

--- server 1 stderr ---
Failed to initialize: LienError: Failed to initialize vector database: database is locked
...
Caused by:
SqliteError: database is locked
    at Database.pragma (.../node_modules/better-sqlite3/lib/methods/pragma.js:11:44)
    at openDatabase (.../packages/core/dist/vectordb/sqlite/schema.js:119:8)
    at SqliteBackend.initialize (.../packages/core/dist/vectordb/sqlite/sqlite-backend.js:42:23)
```

**After fix** (same command, same repo, fresh delete-and-retest, repeated at
N=4 across 14 total trials): clean every time.
```
[repro] multi-server: spawning 4 servers, connecting concurrently...

=== CALL RESULTS ===
[0] label=0 tool=search_code ok=true ms=4
[1] label=1 tool=list_functions ok=true ms=4
[2] label=2 tool=get_files_context ok=true ms=4
[3] label=3 tool=get_complexity ok=true ms=3
```

## Tests added

Deterministic unit tests only — a concurrency integration test here would
be timing-dependent/flaky, so per the brief I tested the guard/serialization
logic directly instead:

- `packages/core/src/vectordb/sqlite/schema.test.ts` (new): pragma-order
  regression (asserts `busy_timeout` is called first, not just its
  steady-state value), `withOpenRetry` behavior (retries transient errors
  and succeeds, does not retry non-transient errors, gives up after bounded
  attempts), and a regression test that computes the REAL worst-case
  jittered retry-ladder wait (recording every delay actually requested under
  forced maximum jitter) and asserts it stays under the plugin hook timeout
  with real headroom — see "Review follow-up" below.
- `packages/core/src/vectordb/sqlite/sqlite-backend.test.ts`: `reconnect()`
  never leaves `this.db` null to a concurrent read (deterministic via JS's
  run-to-completion-until-first-`await` semantics, not timing), and still
  picks up externally-written data.
- `packages/core/src/vectordb/overlay-backend.test.ts`: same `reconnect()`
  regression for `OverlayBackend`.

## Gates

`format:check`, `lint` (0 errors, pre-existing warnings only), `typecheck`,
`build`, `test` (all packages green), `lien delta` (no new-over-threshold or
crossed function). Re-run after rebasing onto current `main`.

## Notes / scope

- Corpus repo used: private clones of `gin` under `/tmp/`, never the shared
  dogfood corpus or the Lien repo itself. No corpus index was left modified.

---

## Review follow-up (retry budget vs. plugin hook timeout)

An independent review (see inline finding below) caught that the original
`withOpenRetry` budget (20 attempts, 25ms base) had a jittered worst case of
**~6175ms** — the doc comment's "~1-2s" claim was wrong by 3-6x. Addressed:

**1. Confirmed a real, demonstrable interaction with #947's npx circuit
breaker, not just a docs bug.** `plugins/claude/hooks/hooks.json` gives
every hook a 5000ms timeout. Three hooks resolve (via `lien-resolve.sh`,
the default no-global-`lien` path) to `lien-npx-breaker.sh`, which wraps
`npx -y @liendev/lien@latest "$@"` — i.e. the CLI's own process, including
`createVectorDB().initialize()`:
   - `annotate-read.sh` → `lien annotate <file>`
   - `augment-explore-task.sh` → `lien annotate <candidate>`
   - `api-delta-write.sh` → `lien api-delta --file ...`

  All three call `createVectorDB(rootDir); await vectorDB.initialize();`
  (confirmed by reading `annotate-cmd.ts`/`api-delta-cmd.ts`), running
  through the exact same `withOpenRetry` ladder this PR added. The other
  hook-invoked commands (`path`, `recap`, `verify-tests`, `nudge`) do **not**
  touch `createVectorDB` and are not exposed. So: a ladder whose own
  worst-case wait approaches/exceeds 5000ms would get one of those three
  hook processes SIGKILLed mid-retry by Claude Code — and
  `lien-npx-breaker.sh` genuinely cannot distinguish that from a hung npm
  registry, since both leave the same stale in-flight marker (its own doc
  comment says as much: "anything that terminates this process before it
  reaches its own cleanup line has the same effect as a SIGKILL"). That
  trips the breaker and silences every nudge for its 300s cooldown. The
  interaction is real, not speculative.

**2. Retuned the budget, prioritizing the hook-timeout constraint.**
16 attempts / 25ms base → worst case (max +30% jitter) = **3904ms**,
asserted directly by a new schema.test.ts regression test (forces max
jitter, records every real `setTimeout` delay requested, sums them) so a
future constant drift back toward the timeout fails loudly in CI instead of
silently in production. Leaves ~1.1s of headroom under the 5000ms timeout.

**3. Measured the reliability cost honestly rather than assuming 1-2s (or
even ~3.9s) is free.** Re-ran the same dogfood harness at this smaller
budget:
   - N=4 (the exact originally-reported shape): **14/14 clean.**
   - N=6: 9/10 clean (1 failure).
   - N=10: 5/6 clean (1 failure).

  Compare to the original (hook-timeout-incompatible) ~6.2s budget, which
  was clean across dozens of trials up through N=20. So this is a genuine,
  disclosed tradeoff: fitting under the hook timeout costs a small residual
  crash probability at concurrency above the originally-reported 4-way
  case, not just at artificial N=15-20 stress levels. I did not try to hide
  this — it's stated in the `OPEN_RETRY_ATTEMPTS` doc comment and the
  commit message.

  I did not push the budget closer to 5000ms to further shrink this
  residual: `lien-npx-breaker.sh`'s own doc comment measures normal
  hook-to-npx overhead at 200-600ms, so leaving less than ~1s of headroom
  felt too tight against real bash/npx/node startup cost on top of the
  ladder itself. Also worth flagging (not fixed, no observed failure
  implicates it): each individual `openDatabase()` call sets
  `busy_timeout = 5000`, which — if a single attempt ever hit sustained
  `SQLITE_BUSY` contention rather than the faster `SQLITE_IOERR`/
  `SQLITE_CANTOPEN` this PR mostly observed — could itself internally block
  for up to 5000ms before `withOpenRetry` even gets a chance to back off,
  independent of the ladder's own budget. Not touched in this PR since no
  trial ever showed BUSY-class latency anywhere near that ceiling and
  `busy_timeout` also protects legitimate non-racy lock waits (the MCP
  watcher vs. a concurrent CLI index run) that are out of scope here.

  A complementary fix that would close the residual gap without a longer
  ladder: never `process.exit()` the MCP server on an exhausted retry
  ladder — degrade to the honest empty-index answer the single-call case
  already gives, instead of crashing. That's a larger, more invasive change
  than resizing two constants, so I'm flagging it as a candidate follow-up
  rather than implementing it in this PR.

**4. Rebased onto current `main`** (through #965) — clean, no conflicts.
Re-ran all six gates on the rebased tree; all green.

---

## Review follow-up #2 (real regression in the reconnect() fix itself)

The full review (once quota cleared) caught a genuine 🔴 High Risk bug I
introduced while fixing the *first* reconnect() issue, and it's exactly the
kind of thing that make "accept the residual" reasoning wrong if unchecked:

**The bug:** `SqliteBackend.reconnect()` and `OverlayBackend.reconnect()`
built the new connection, swapped it in on success — correct — but closed
the OLD handle unconditionally in a `finally` block. On the FAILURE path
(the new connection's `openConnection()`/`withOpenRetry` call throws — e.g.
an exhausted retry ladder), the swap never runs, so `oldDb`/`oldOverlayDb`/
`oldBaseDb` **still are** `this.db`/`this.overlayDb`/`this.baseDb`. Closing
them anyway left `this.db` (etc.) pointing at a **closed** connection for
the rest of the process — every later `requireDb()`/`requireOverlay()` call
got a real database-closed error, not the "still-valid old handle" or
honest "not initialized" degradation either fix was supposed to preserve.

**Why this matters more than a normal edge case:** this is precisely the
residual I disclosed and the reviewer initially accepted on the reasoning
that an exhausted ladder produces "an occasional visible connection error."
With this bug, it didn't — it silently poisoned the backend for the
remainder of the process, which is worse than the pre-PR crash-and-restart
behavior. The reviewer's original accept-the-residual call was reasonable
given what was disclosed; this bug is what changes the answer, which is
exactly why I'm glad the residual was disclosed plainly rather than buried.

**Fix:** the old handle(s) are now only closed AFTER the swap actually
succeeds — moved out of `finally`, into the success path only. Applied to
both `SqliteBackend.reconnect` (one handle) and `OverlayBackend.reconnect`
(two handles: `overlayDb` and `baseDb`). The misleading comment ("this.db
has already swapped to the new connection") is also fixed — it's now
scoped to the branch where that's actually true.

**Regression tests added**, deterministic (no timing):
- `sqlite-backend.test.ts`: spies on the private `openConnection()` method
  to force it to reject, then asserts `db.scanAll()` still succeeds against
  the OLD data (not a closed handle), and that a subsequent successful
  `reconnect()` still works.
- `overlay-backend.test.ts`: same pattern, forcing `fs.mkdir` (the first
  step inside `reconnect()`'s try block) to reject once.

Both tests were verified to actually catch the bug: stashed each fix file
individually, reran the corresponding test, confirmed it failed with
`TypeError: The database connection is not open` against the buggy code,
then restored the fix and confirmed green again.

**On riding #967 along** (degrade to an honest empty-index answer instead
of `process.exit(1)` on an exhausted retry ladder, instead of crashing):
keeping it as a separate follow-up. Implementing it properly means a new
stub implementing all 14 `VectorDBInterface` methods, wiring it into
`initializeComponents`/`startMCPServer` in place of `process.exit(1)`, and
(per this repo's own mandatory-dogfood policy) real end-to-end verification
of the degraded server's behavior — a meaningfully larger unit of work than
this round's fixes, not a small addendum. This round's regression is now
fixed and tested on its own terms; #967 stays tracked separately rather
than folded in under review pressure.

All six gates re-run after this fix: `format:check`, `lint` (0 errors),
`typecheck`, `build`, `test` (all packages green), `lien delta` (no
new-over-threshold or crossed function — 2 small "worsened" time-estimate
deltas, not threshold crossings).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes concurrent SQLite open races by reordering pragmas (busy_timeout first), adding a bounded jittered retry wrapper (`withOpenRetry`) around fresh opens, and rebuilding `reconnect()` in both backends so new connections are swapped in before old ones are retired. The logic is sound, the retry budget is explicitly bounded under the 5000ms Claude hook timeout, and the failure-path regression (closing old handles unconditionally in a `finally`) is correctly fixed. Deterministic regression tests cover pragma ordering, retry behavior, the hook-timeout ceiling, and both the null-window and failure-path reconnect cases.
>
> - openDatabase() now sets busy_timeout before journal_mode/synchronous, eliminating the uncaught SQLITE_BUSY window during cross-process creation races.
> - withOpenRetry() provides a bounded, jittered retry ladder for transient open-time SQLite errors, tuned to stay under the 5000ms Claude hook timeout with ~1.1s headroom.
> - SqliteBackend.reconnect() and OverlayBackend.reconnect() now build the new connection first and only close the old handle(s) after a successful swap, with regression tests guarding both the null-window and failure-path cases.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 13bcd75. Updates automatically on new commits.</sup>
<!-- /lien-stats -->