### PR TITLE
chore: add the missing changesets for the round-2 fixes

### DIFF
--- a/.changeset/canonicalize-relativized-paths.md
+++ b/.changeset/canonicalize-relativized-paths.md
@@ -17,7 +17,7 @@ from `process.cwd()`, which the OS returns already realpath-resolved. Two
   trips an "outside the project root" rejection, so `lien annotate` produced **no
   output at all** for a real in-repo file. Confirmed on the released build:
 
-```
+```console
 $ lien annotate /abs/path/behind/symlink/src/utils/url.ts
 (nothing)
 $ lien annotate src/utils/url.ts

--- a/.changeset/canonicalize-relativized-paths.md
+++ b/.changeset/canonicalize-relativized-paths.md
@@ -1,0 +1,43 @@
+---
+'@liendev/lien': patch
+---
+
+The read-time impact nudge was **completely silent** for any project whose path
+resolves through a symlink — which includes every macOS project under `/tmp` or
+`/var`, and any repo reached via a symlinked ancestor.
+
+Claude Code sends an **absolute** `tool_input.file_path`, while `rootDir` comes
+from `process.cwd()`, which the OS returns already realpath-resolved. Two
+`path.relative` sites compared one against the other without canonicalizing:
+
+- `toRepoRelativeFile` (`nudge-events.ts`) logged
+  `"file": "../../../../tmp/lien-dogfood-460173c9/hono/src/context.ts"` instead of
+  `"src/context.ts"`, corrupting the paths the `lien stats` funnel joins on.
+- `resolvePaths` (`annotate-cmd.ts`) — the worse one. There a `..`-prefixed result
+  trips an "outside the project root" rejection, so `lien annotate` produced **no
+  output at all** for a real in-repo file. Confirmed on the released build:
+
+```
+$ lien annotate /abs/path/behind/symlink/src/utils/url.ts
+(nothing)
+$ lien annotate src/utils/url.ts
+⚠ Lien: _getQueryParam cognitive 45/15 (over) ...
+Lien impact for src/utils/url.ts: • 11 files import this ...
+```
+
+Since `annotate-read.sh` only emits when the annotation is non-empty, the entire
+read-time nudge — and its shown-event recording — vanished for affected users,
+with nothing to indicate it. A nudge that fails by not appearing is
+indistinguishable from a nudge with nothing to say.
+
+Both sites now canonicalize `rootDir` and the file argument through a shared
+`canonicalizePath` (`fs.realpathSync`, falling back to the parent directory for a
+path that no longer exists, then to identity — it never throws, because these run
+inside hooks on every edit), and reject a result that still escapes the root rather
+than recording it.
+
+Other `path.relative(process.cwd(), …)` sites were audited and ruled out:
+`delta-git.ts` already had its own equivalent fix (the pattern this mirrors),
+`agent-tools.ts` realpaths `rootDir` once up front, and the indexer paths take
+`rootDir` from the same construction as their file arguments. The review harness's
+`toRepoRelative` is offline tooling, not runtime telemetry, and was left alone.

--- a/.changeset/discovery-tool-selection-guidance.md
+++ b/.changeset/discovery-tool-selection-guidance.md
@@ -1,0 +1,32 @@
+---
+'@liendev/lien': patch
+---
+
+`SERVER_INSTRUCTIONS` — the always-on guidance every MCP client receives on
+`initialize` — told models to "call `search_code` FIRST" for discovery,
+unconditionally, while its own opening paragraph reserved grep for "exact
+literals" and omitted exact symbol names entirely. So an agent that already knew
+the identifier it wanted was being instructed to paraphrase it into a BM25 query
+first.
+
+CLAUDE.md already carried the correct split ("Use grep/glob ONLY for: exact symbol
+names, literal strings, config keys, TODOs"), so this was one-directional drift —
+and the surface a **model** actually reads was the wrong half.
+
+Reframed around what the caller already knows: an exact symbol name goes to
+`list_functions`, an exact literal to grep — *don't paraphrase a name you already
+have* — and a concept without a name goes to `search_code` before falling back to
+grep/glob. Same tools, same BM25 / camelCase-split / no-embeddings caveats, no new
+policy.
+
+Both texts also now state that **zero results is not proof of absence**: an index
+that hasn't caught up with a recent edit makes a symbol that exists on disk
+unfindable, and the tool cannot tell you which case you're in. Observed during the
+post-release dogfood — a search for a symbol added after the last index returned
+five results ranked `"highly_relevant"`, none of which contained it, and grep found
+it immediately. The tool-side half of that honesty is in the same release; this is
+the always-on guidance half.
+
+The hand-sync between these two documents is guarded by
+`instructions.claude-md-sync.test.ts`, which requires both to carry the discovery
+framing and all three search caveats.

--- a/.changeset/mcp-notes-stop-asserting-causes.md
+++ b/.changeset/mcp-notes-stop-asserting-causes.md
@@ -9,7 +9,7 @@ and wrong, which is the failure mode a consuming model cannot detect.
 gin's index moved aside, a search for `StringToBytes` — which unquestionably
 exists — returned:
 
-```
+```json
 "results": [], "note": "0 results. Try a broader regex pattern (e.g. \".*\")
 or omit the symbolType filter. ... Run \"lien index\" to enable faster
 symbol-based queries."

--- a/.changeset/mcp-notes-stop-asserting-causes.md
+++ b/.changeset/mcp-notes-stop-asserting-causes.md
@@ -1,0 +1,49 @@
+---
+'@liendev/lien': patch
+---
+
+Two MCP notes asserted a cause they had not established — plausible, specific,
+and wrong, which is the failure mode a consuming model cannot detect.
+
+**`list_functions` / `search_code` blamed your query for a missing index.** With
+gin's index moved aside, a search for `StringToBytes` — which unquestionably
+exists — returned:
+
+```
+"results": [], "note": "0 results. Try a broader regex pattern (e.g. \".*\")
+or omit the symbolType filter. ... Run \"lien index\" to enable faster
+symbol-based queries."
+```
+
+Three compounding problems: the advice asserted the search had *run* and the
+query was at fault; "to enable **faster** queries" framed indexing as a
+performance upgrade when it was a correctness prerequisite; and `indexInfo` in the
+same payload advertised an index dated *today* with `pendingFileCount: 0`, so
+nothing contradicted a "fresh index, symbol absent" reading.
+
+Both tools now call `vectorDB.hasData()` on a zero-result response. A genuinely
+empty index escalates to an unmissable `⚠ Lien:` warning (new
+`formatNoIndexNote()`, reusing the pattern `get_dependents` already had from
+#927). An index that is present but has no match for this query hedges instead of
+blaming the query — which also covers the far more common case found during the
+dogfood: **an index that simply hasn't caught up with a recent edit.** Appending a
+function to flask's `helpers.py` and searching for it immediately returned zero
+results with the query-tuning advice, while `indexInfo` reported a 2.7-second-old
+reindex and `pendingFileCount: 0`. An agent that writes a function and cannot then
+find it will conclude it misnamed something.
+
+**`get_dependents` claimed a symbol was "likely a method or constructor" when it
+had never existed.** The `symbol-attribution-degraded` caveat emitted one
+hardcoded explanation for at least three distinct causes — a real
+method/constructor, a typo'd or hallucinated name, and a symbol that was removed.
+Byte-identical wording for `totallyMadeUpSymbolXYZ123` (which appears nowhere in
+the repo) and for a genuine constructor. Those readings warrant opposite next
+actions: "proceed with the file-level answer" versus "check the name". The caveat
+now checks whether the symbol appears anywhere in the target file's indexed chunks
+and words each case honestly, keeping the genuinely useful part — that the numbers
+below are file-level, not verified symbol callers — unchanged either way.
+
+Both `SERVER_INSTRUCTIONS` and the `tools.ts` tool descriptions carried the same
+overclaim and were corrected. The `tools.ts` half was itself caught by Lien Review
+on the first pass of this fix, which had updated only `instructions.ts` — the two
+surfaces a model reads must move together.

--- a/.changeset/name-filtered-test-runs.md
+++ b/.changeset/name-filtered-test-runs.md
@@ -11,7 +11,7 @@ token, so it fell into `broad` by construction, and `computeUnverifiedFiles`
 treats any broad run as evidence the whole edit set was exercised. Reproduced
 end-to-end on the published 0.72.0 binary against pallets/flask:
 
-```
+```text
 # edit recorded, no test run — correctly nags
 • src/flask/helpers.py → tests/test_helpers.py (+35 more)
 

--- a/.changeset/name-filtered-test-runs.md
+++ b/.changeset/name-filtered-test-runs.md
@@ -1,0 +1,53 @@
+---
+'@liendev/lien': patch
+---
+
+A single unrelated test run silently disabled the did-you-run-the-tests nudge for
+an entire session.
+
+`classifyTestCommand` had only two outcomes: `scoped` (a path-like token was
+found) or `broad` (none was). A run scoped by test **name** carries no path-like
+token, so it fell into `broad` by construction, and `computeUnverifiedFiles`
+treats any broad run as evidence the whole edit set was exercised. Reproduced
+end-to-end on the published 0.72.0 binary against pallets/flask:
+
+```
+# edit recorded, no test run — correctly nags
+• src/flask/helpers.py → tests/test_helpers.py (+35 more)
+
+# same edit, then: pytest -k test_totally_unrelated_name
+(completely silent)
+```
+
+Verified reproducing on all eight runners checked, plus one found while
+investigating (`swift test --filter`, invisible through a different path):
+`pytest -k`, `dotnet test --filter`, `rspec -e`, `mocha --grep`, `go test -run`,
+`cargo test <name>`, `vitest -t`, `jest -t`.
+
+This is the false-"tests ran" direction, and it invisibly switches off the
+mechanism a foreign-repo trial showed actually changes agent behaviour — the Stop
+recap blocking a finish is what sent that agent back to run the check it had
+skipped.
+
+Adds a third classification outcome — name-filtered — that is neither `broad` nor
+a `scopeTokens` contributor, so a name-filtered run no longer licenses "everything
+is verified". The fail-safe direction is to keep nagging: the nudge already carries
+its own escape hatch ("if you already ran them, disregard and stop again"), so a
+false nag costs one line while a false silence costs the whole mechanism.
+
+Recognition uses **per-runner-family flag allow-lists rather than one global set**,
+because the same spelling means different things per ecosystem — `tox -e py311`
+selects an environment while `rspec -e NAME` selects a test, and a global set would
+have wrongly un-broadened tox. Runner-specific value-skip sets keep build-config
+flags from being misread as positional test names (`cargo test --features foo`,
+`-p`, `--manifest-path`) and keep pnpm's workspace `--filter` broad (including the
+`--filter=@scope/pkg` form, and the `pnpm --filter=<sel> test` ordering which
+previously matched no runner pattern at all). Both collisions are pinned by
+regression tests.
+
+Documented explicitly, with tests, because a review raised it twice: **a
+scope-broadening flag does not make a name-filtered run broad.** `./...`,
+`.`, `--workspace` and `--all` broaden which *packages* compile; `-run Foo` and a
+bare positional still filter which *tests execute*. `go test -run TestFoo ./...`
+runs none of an unrelated file's tests, so it correctly nags — treating it as broad
+would reintroduce this very bug.

--- a/.changeset/response-budget-honest-pagination.md
+++ b/.changeset/response-budget-honest-pagination.md
@@ -1,0 +1,44 @@
+---
+'@liendev/lien': minor
+---
+
+`list_functions` and `find_similar` reported result counts that could not be
+trusted, and — worse — hid real truncation. **This changes the response
+contract for `nextOffset`, so callers that computed their own offsets should
+read the note below.**
+
+Three distinct defects, all in `applyResponseBudget`
+(`packages/cli/src/mcp/utils/response-budget.ts`), which builds its note from an
+array the handler had *already* capped by the request's own `limit`:
+
+1. **A total that tracked the request, not reality.** On sidekiq (true total:
+   703 symbols) the same `pattern: ".*"` query reported `Showing 23 of 50` at
+   `limit: 50` and `Showing 23 of 200` at `limit: 200`. Literally true — 23 of
+   the N fetched — but any reader takes the denominator as the total, so it
+   understated 703 by more than an order of magnitude. The note no longer states
+   a total at all; it reports only what the size cap itself dropped.
+2. **Silent truncation.** At `limit: 10` the page genuinely *was* cut off and
+   the tool said nothing. `hasMore` is now forced true whenever items are
+   dropped, so a stale upstream `hasMore: false` cannot survive a trim, and
+   `list_functions` emits a note for the previously-silent case.
+3. **A pagination cursor that skipped items.** `nextOffset` was computed as
+   `offset + limit` *before* the size cap ran, so following the tool's own advice
+   after a trimmed page silently skipped the dropped entries. Verified on an
+   isolated sidekiq clone: page 0 returned 24 items and advised `offset: 50`,
+   losing 26 real symbols. `nextOffset` is now corrected by the same drop count
+   and always equals `offset + items actually delivered`.
+
+**Contract change:** `nextOffset` is now present whenever `results` is non-empty,
+**regardless of `hasMore`** — previously it appeared only when `hasMore` was true,
+which meant a final page that the size cap then trimmed ended up `hasMore: true`
+with no cursor at all and no way to reach the rest. `hasMore` now answers "is it
+worth paging?" and `nextOffset` answers "where would I resume?". Always pass
+`nextOffset` back verbatim rather than computing `offset + limit` yourself; the
+size cap can shrink a page after the fact and only that field is corrected for it.
+`tools.ts` documents this.
+
+Also documented (behaviour unchanged): `list_functions` pattern matching is
+case-insensitive and unranked, which was previously undocumented and interacted
+badly with the bogus totals — a real `class Request` in Alamofire didn't surface
+until `offset: 50`, behind lowercase test-method matches, while the "total" was
+misleading throughout.

--- a/.changeset/risk-floor-attribution-incomplete.md
+++ b/.changeset/risk-floor-attribution-incomplete.md
@@ -1,0 +1,52 @@
+---
+'@liendev/lien': patch
+---
+
+The habituation guard's risk floor silenced the "Dependents not determinable
+from imports" annotation — the exact message #938/#939 shipped to prevent an
+agent reading an unknown as a zero — **in the default plugin configuration**.
+
+`annotate-cmd.ts` runs two suppression gates back to back. #938 taught
+`isTrivial` about `dependentAttributionIncomplete`; `belowRiskFloor`, three
+lines below it, never learned. A file whose dependents are indeterminable has
+low risk *by construction* (zero **known** dependents), so it fell below a
+`medium` floor and was dropped. This was not opt-in: `annotate-read.sh:68` sets
+`min_risk="${LIEN_ANNOTATE_MIN_RISK:-medium}"` and passes `--min-risk` on every
+read-time annotation.
+
+Reproduced on the published 0.72.0 binary against serilog/serilog:
+
+```
+$ lien annotate src/Serilog/Capturing/PropertyBinder.cs
+Lien impact for src/Serilog/Capturing/PropertyBinder.cs:
+  • Dependents not determinable from imports (enclosing-namespace access).
+  • Test coverage not determinable from imports (enclosing-namespace access).
+
+$ lien annotate src/Serilog/Capturing/PropertyBinder.cs --min-risk medium
+(no output — suppressed)
+```
+
+Not an edge case: an exhaustive pass found **114 of 216** serilog `.cs` files
+(53%) carry that note. Serilog is one hierarchical namespace tree, so C#'s
+enclosing-namespace access lets the whole library reference its own members
+with zero `using` directives — `ILogger.cs`, the central interface, genuinely
+has no import-determinable dependents. For C# of this shape, suppression was
+the common path.
+
+`belowRiskFloor` now takes `dependentAttributionIncomplete` as a defaulted
+trailing parameter (matching #938's own approach for `isTrivial`) and treats it
+as high-value, clearing the floor exactly as `complexityWarnings` and
+`headroomCount` already do.
+
+Deliberately **not** extended to the sibling "Test coverage not determinable"
+flag, measured across four freshly re-indexed corpora: coverage-indeterminable
+is 100% of serilog's C# files and 83% of Alamofire's Swift files, because
+`wholeModuleImports` (Swift) and `enclosingNamespaceAccess` (C#) make coverage
+structurally undecidable from imports. Clearing the floor for it would
+blanket-annotate two entire language ecosystems — precisely what the
+habituation guard exists to prevent. Dependents-indeterminable is the rarer,
+higher-signal flag and the right one to promote.
+
+This was reported by Lien Review on #938 itself, correctly and specifically,
+and shipped anyway because the finding was stated in summary prose rather than
+as an addressable item — see #958 and #960.

--- a/.changeset/risk-floor-attribution-incomplete.md
+++ b/.changeset/risk-floor-attribution-incomplete.md
@@ -16,7 +16,7 @@ read-time annotation.
 
 Reproduced on the published 0.72.0 binary against serilog/serilog:
 
-```
+```console
 $ lien annotate src/Serilog/Capturing/PropertyBinder.cs
 Lien impact for src/Serilog/Capturing/PropertyBinder.cs:
   • Dependents not determinable from imports (enclosing-namespace access).


### PR DESCRIPTION
Changeset-only. No code.

## Why

Twelve code-changing PRs merged after 0.72.0; **three** carried changesets. The code ships either way — changesets control version numbering and CHANGELOG text, not what gets published — but two things were wrong:

1. **The changelog would have named about a quarter of the release.** Missing entries included the ones a user most needs: the risk floor muting the dependents-indeterminable note *in the default configuration*, the read nudge being entirely silent for symlinked project paths, the test nudge switched off by one narrow test run, and a change to `nextOffset` semantics.
2. **The release was heading out as `0.72.1`** — a patch bump for a set containing an output-contract change and two behaviour changes where warnings now fire that previously didn't.

## What this adds

Six entries, all `@liendev/lien` (verified per PR — see below):

| Change | Bump |
|---|---|
| Risk floor silenced the "dependents not determinable" note by default (114 of 216 serilog `.cs` files) | patch |
| Response-budget pagination: fabricated totals, silent truncation, `nextOffset` skipping items | **minor** |
| MCP notes asserting unestablished causes (missing index blamed on the query; "likely a method or constructor" for names that never existed) | patch |
| Name-filtered test runs silently disabling the did-you-run-the-tests nudge | patch |
| Path canonicalization — read nudge entirely silent behind a symlink | patch |
| Discovery-tool guidance drift between `SERVER_INSTRUCTIONS` and CLAUDE.md | patch |

The pagination entry is **minor** deliberately: `nextOffset` is now present whenever `results` is non-empty *regardless of `hasMore`*, and callers must stop computing `offset + limit` themselves because the size cap can shrink a page after the fact. That is a contract change and should not hide inside a patch.

## Deliberately no changeset

Checked per PR rather than assumed, using `gh pr diff --name-only`:

- **#945, #947, #956** — `plugins/` only. `packages/cli/package.json` has `files: ["dist","README.md","LICENSE"]`, so the plugin is not in the published artifact (it installs from the repo via the marketplace). #947's only `packages/cli` files are two test files.
- **#960** — `packages/review`, which is private/unpublished.
- **#944, #961** — `scripts/` and `docs/` only.

## Verification

```
$ npx changeset status
minor: @liendev/lien, @liendev/parser, @liendev/core
patch: @liendev/action, @liendev/review
```

So the release becomes **0.73.0**, not 0.72.1.

All six gates green: `format:check` ✅ · `lint` ✅ · `typecheck` ✅ · `build` ✅ · `test` ✅ · `lien delta` ✅ (exit 0). `prettier --check .changeset/*.md` also clean.

Once this merges, #952 (`changeset-release/main`) will regenerate with the full changelog and the corrected version, and can then be merged to publish.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 93 pre-existing issues repo-wide (none introduced).
🔗 **Impact**: 11 high-risk file(s) with 559 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 10 | — |
| 🧠 mental load | 36 | — |
| ⏱️ time to understand | 45 | — |
| 🐛 estimated bugs | 2 | — |


> [!NOTE]
> **Low Risk**
>
> Adds six missing changesets for already-merged round-2 fixes so the next release carries the correct CHANGELOG entries and version bump. The changesets describe five patch-level bug fixes (symlinked-path read nudge silence, MCP overclaiming causes, name-filtered test runs disabling the test nudge, discovery guidance drift, and risk-floor default muting) and one minor-level output-contract change (response-budget pagination with corrected `nextOffset` semantics). No source code is modified; the only effect is that the release will be 0.73.0 rather than 0.72.1 and the changelog will be complete.
>
> - Adds changeset for pagination contract change marked as minor, ensuring release becomes 0.73.0 instead of 0.72.1
> - Adds five patch changesets documenting user-visible fixes that were missing from the changelog
> - All entries target `@liendev/lien`; no code or behavior changes

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4b5fbaf. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored read-time guidance for projects accessed through symlinked paths.
  * Improved test-run detection so name-filtered tests continue to provide appropriate verification reminders.
  * Preserved important dependency-related risk warnings when attribution is incomplete.
  * Improved handling of empty indexes and recently updated symbols in code search tools.
  * Corrected pagination totals, truncation indicators, and continuation cursors for large results.

* **Documentation**
  * Updated discovery guidance and search caveats to provide clearer, more reliable next steps.
  * Clarified that empty search results do not necessarily prove a symbol or concept is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->