### PR TITLE
feat(review): surface the deterministic trust verdict in the PR description

### DIFF
--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -17,8 +17,9 @@ import type {
 import { buildDependencyGraph } from '../../dependency-graph.js';
 import { computeBlastRadius } from '../../blast-radius.js';
 import type { Logger } from '../../logger.js';
+import type { AttestationVerdict } from '../../attestation.js';
 
-import type { AgentConfig, AgentFinding, AgentResult } from './types.js';
+import type { AgentConfig, AgentFinding, AgentResult, AgentStopReason } from './types.js';
 import { AnthropicAgentClient } from './anthropic-client.js';
 import { OpenAIAgentClient, toOpenAITools } from './openai-client.js';
 import { buildSystemPrompt, buildInitialMessage } from './system-prompt.js';
@@ -934,6 +935,117 @@ function buildFindingsSection(bugFindings: ReviewFinding[]): string[] {
 }
 
 /**
+ * The subset of `AttestationVerdict` derivable from `findings` alone, at
+ * `present()` time — before delivery (inline comments landing, the
+ * description write itself) has happened. `degraded:comments_dropped` and
+ * `degraded:delivery_incomplete` depend on that delivery outcome and can't
+ * be known yet; they stay the job of the separate, post-hoc attestation
+ * badge (`syncAttestationBadge` in review-pr.ts, posted after `present()`
+ * returns). `failed:analysis_error` is a pre-engine pipeline concern,
+ * orthogonal to this plugin. Nothing here is a NEW classification — it's a
+ * narrower read of the exact same ground truth `computeVerdict` uses.
+ */
+type PresentTimeVerdict = Extract<
+  AttestationVerdict,
+  | 'delivered'
+  | 'degraded:budget_starved'
+  | 'degraded:provider_partial'
+  | 'failed:provider_never_ran'
+>;
+
+/**
+ * Derive the deterministic trust verdict from the same ground-truth signals
+ * the delivery attestation uses — `hasProviderFailure` and the
+ * `incomplete`/`stopReason` metadata `appendNeverRanNotice`/
+ * `appendIncompleteNotice` stamp onto a summary finding — NEVER from the
+ * model's own free-form overview prose. That distinction is the whole point:
+ * a PR (#954) once shipped a review whose prose claimed "budget exhaustion"
+ * while the main pass had actually completed cleanly at 48% spend — the
+ * attestation said `delivered` throughout, but nothing in the rendered PR
+ * said so, so the false claim went unchallenged. This function is what lets
+ * `buildTrustSection` render a line the reader can check the prose against.
+ *
+ * Scans EVERY summary finding, not just the first — a doc-truth-only stall
+ * still degrades the result here, matching `computeVerdict`'s own precedent
+ * of folding an extra pass's stop reason into the whole run's health (see
+ * that function's doc comment) even though it does NOT compromise the main
+ * pass's own bug-finding coverage (a separate concern `buildDescription`'s
+ * headline already tracks via `hasIncompleteMainPass`).
+ *
+ * Returns `null` when the agent-review plugin didn't run this review at all
+ * (no summary finding of any kind) — nothing to attest to.
+ */
+function derivePresentTimeVerdict(summaryFindings: ReviewFinding[]): PresentTimeVerdict | null {
+  if (summaryFindings.length === 0) return null;
+  if (hasProviderFailure(summaryFindings)) return 'failed:provider_never_ran';
+  const incompleteFinding = summaryFindings.find(
+    f => (f.metadata as { incomplete?: boolean } | undefined)?.incomplete === true,
+  );
+  if (!incompleteFinding) return 'delivered';
+  const stopReason = (incompleteFinding.metadata as { stopReason?: AgentStopReason } | undefined)
+    ?.stopReason;
+  return stopReason === 'budget' ? 'degraded:budget_starved' : 'degraded:provider_partial';
+}
+
+/** Copy for each `PresentTimeVerdict` bucket — label, emoji, and the actionable detail. */
+const TRUST_COPY: Record<PresentTimeVerdict, { emoji: string; label: string; detail: string }> = {
+  delivered: {
+    emoji: '✅',
+    label: 'Delivered',
+    detail: 'The review ran to completion within budget.',
+  },
+  'degraded:budget_starved': {
+    emoji: '🟡',
+    label: 'Degraded — budget-starved',
+    detail:
+      'The review stopped after exhausting its token budget before finishing. Treat the findings above as partial.',
+  },
+  'degraded:provider_partial': {
+    emoji: '🟡',
+    label: 'Degraded — partial',
+    detail:
+      'The review stopped early (turn limit, or ended without a parseable verdict) before finishing. Treat the findings above as partial.',
+  },
+  'failed:provider_never_ran': {
+    emoji: '🔴',
+    label: 'Failed — provider never ran',
+    detail: 'Every provider request failed. No code was analyzed this run.',
+  },
+};
+
+/**
+ * Render the deterministic trust verdict as its own PR-description block —
+ * the answer to "is this review trustworthy?" at a glance, independent of
+ * whatever the model's own overview prose says. Silent on a clean run: a
+ * `delivered` line still renders (see `derivePresentTimeVerdict`'s doc
+ * comment for why silence alone doesn't fix the motivating bug), but as one
+ * quiet, uncalloutted line rather than a shouting box — a healthy run is the
+ * common case, and this block is read on every PR. A `degraded`/`failed`
+ * verdict instead renders as its own GitHub alert callout — `CAUTION` (the
+ * most severe callout GitHub supports) for a total provider failure,
+ * `WARNING` for a degraded-but-partial run — so it cannot be mistaken for
+ * ordinary prose. Returns `[]` when the plugin never ran this review (see
+ * `derivePresentTimeVerdict`), matching `buildFindingsSection`'s
+ * absent-not-empty convention.
+ *
+ * Deliberately excluded: raw token counts and `filesAnalyzed`. The verdict
+ * label already asserts "not budget-starved" or "budget-starved" on its own;
+ * a reader doesn't need the raw numbers to act on it, and neither figure is
+ * available yet at `present()` time without new plumbing (see the PR
+ * description for that follow-up call).
+ */
+function buildTrustSection(summaryFindings: ReviewFinding[]): string[] {
+  const verdict = derivePresentTimeVerdict(summaryFindings);
+  if (!verdict) return [];
+  const { emoji, label, detail } = TRUST_COPY[verdict];
+  if (verdict === 'delivered') {
+    return [`${emoji} *Trust: **${label}** — ${detail}*`];
+  }
+  const calloutType = verdict === 'failed:provider_never_ran' ? 'CAUTION' : 'WARNING';
+  return [`> [!${calloutType}]\n> ${emoji} **Trust: ${label}**\n>\n> ${detail}`];
+}
+
+/**
  * Build the PR description section using GitHub's callout blockquote syntax.
  * Uses > [!NOTE] for clean PRs, > [!WARNING] when issues are found. The first
  * summary drives the callout; any further summaries render as appended
@@ -974,9 +1086,15 @@ function buildDescription(
     }
   }
 
+  // The deterministic trust line — see buildTrustSection's doc comment for
+  // why it renders independent of (and right alongside) the prose above.
   // The itemized findings list — see buildFindingsSection's doc comment for
   // why the count and this list can never drift apart.
-  const parts: string[] = [lines.join('\n'), ...buildFindingsSection(bugFindings)];
+  const parts: string[] = [
+    lines.join('\n'),
+    ...buildTrustSection(summaryFindings),
+    ...buildFindingsSection(bugFindings),
+  ];
 
   for (const extra of summaryFindings.slice(1)) {
     parts.push(formatExtraSummary(extra));

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -945,7 +945,7 @@ function buildFindingsSection(bugFindings: ReviewFinding[]): string[] {
  * orthogonal to this plugin. Nothing here is a NEW classification — it's a
  * narrower read of the exact same ground truth `computeVerdict` uses.
  */
-type PresentTimeVerdict = Extract<
+export type PresentTimeVerdict = Extract<
   AttestationVerdict,
   | 'delivered'
   | 'degraded:budget_starved'
@@ -973,9 +973,25 @@ type PresentTimeVerdict = Extract<
  * headline already tracks via `hasIncompleteMainPass`).
  *
  * Returns `null` when the agent-review plugin didn't run this review at all
- * (no summary finding of any kind) — nothing to attest to.
+ * (no summary finding of any kind) — nothing to attest to. This is a
+ * DELIBERATE, documented divergence from `computeVerdict`: fed the
+ * equivalent `agentAttempted: false` input, `computeVerdict` returns
+ * `'delivered'` (an early-exit review — e.g. zero analyzable files — that
+ * trivially had nothing go wrong is a fair "delivered"). Rendering `null`
+ * here instead of borrowing that same label avoids stamping a "Trust:
+ * Delivered" line onto a plugin that never actually reviewed anything —
+ * the two functions read "delivered" differently on purpose in exactly
+ * this one case, and `plugins-agent-trust-badge.test.ts`'s consistency
+ * suite pins both sides so a future change to either taxonomy fails a test
+ * instead of silently drifting.
+ *
+ * Exported (alongside `PresentTimeVerdict`) solely so that consistency
+ * suite can call this function directly rather than re-deriving it from
+ * rendered markdown.
  */
-function derivePresentTimeVerdict(summaryFindings: ReviewFinding[]): PresentTimeVerdict | null {
+export function derivePresentTimeVerdict(
+  summaryFindings: ReviewFinding[],
+): PresentTimeVerdict | null {
   if (summaryFindings.length === 0) return null;
   if (hasProviderFailure(summaryFindings)) return 'failed:provider_never_ran';
   const incompleteFinding = summaryFindings.find(

--- a/packages/review/test/plugins-agent-budget.test.ts
+++ b/packages/review/test/plugins-agent-budget.test.ts
@@ -1489,6 +1489,7 @@ describe('AgentReviewPlugin.present — multiple summary findings', () => {
 
     expect(appendDescription.mock.calls[0][0]).toBe(
       '> [!NOTE]\n> **Low Risk**\n>\n> All good\n\n' +
+        '✅ *Trust: **Delivered** — The review ran to completion within budget.*\n\n' +
         '<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>',
     );
     expect(appendSummary.mock.calls[0][0]).toBe('### Agent Review\n\n**Low Risk** — All good');

--- a/packages/review/test/plugins-agent-trust-badge.test.ts
+++ b/packages/review/test/plugins-agent-trust-badge.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentReviewPlugin } from '../src/plugins/agent/index.js';
+import { silentLogger } from '../src/test-helpers.js';
+import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
+import type { PRContext } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — mirror the exact shapes appendSummaryFinding/appendIncompleteNotice/
+// appendNeverRanNotice produce (plugins/agent/index.ts), so these tests exercise
+// the same metadata contract the real pipeline stamps.
+// ---------------------------------------------------------------------------
+
+/** A normal, completed-run summary finding — `appendSummaryFinding`'s shape. */
+function summaryFinding(overrides?: {
+  riskLevel?: string;
+  overview?: string;
+  keyChanges?: string[];
+}): ReviewFinding {
+  const overview = overrides?.overview ?? 'This PR looks fine overall.';
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'info',
+    category: 'summary',
+    message: overview,
+    metadata: {
+      riskLevel: overrides?.riskLevel ?? 'low',
+      overview,
+      keyChanges: overrides?.keyChanges ?? [],
+    },
+  };
+}
+
+/** The main-pass incomplete notice — `appendIncompleteNotice`'s main-pass branch. */
+function incompleteMainFinding(stopReason: 'budget' | 'max_turns' | 'completed'): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'warning',
+    category: 'summary',
+    message: 'Lien Review did not finish.',
+    metadata: { incomplete: true, stopReason, overview: 'partial', mainPassIncomplete: true },
+  };
+}
+
+/** An extra-pass-only incomplete notice (e.g. doc-truth) — main is unaffected. */
+function incompleteExtraPassFinding(stopReason: 'budget' | 'max_turns'): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'warning',
+    category: 'summary',
+    message: 'The documentation-truthfulness pass did not finish.',
+    metadata: { incomplete: true, stopReason, overview: 'doc-truth partial' },
+  };
+}
+
+/** The never-ran notice — `appendNeverRanNotice`'s shape. */
+function neverRanFinding(): ReviewFinding {
+  return {
+    pluginId: 'agent-review',
+    filepath: '',
+    line: 0,
+    severity: 'error',
+    category: 'summary',
+    message: 'Lien Review did not run.',
+    metadata: { incomplete: true, neverRan: true, stopReason: 'error', overview: 'never ran' },
+  };
+}
+
+/** A PresentContext recording appendDescription for assertions. */
+function recordingContext(): { ctx: PresentContext; appendDescription: ReturnType<typeof vi.fn> } {
+  const appendDescription = vi.fn();
+  const pr = {
+    owner: 'o',
+    repo: 'r',
+    pullNumber: 1,
+    title: 't',
+    baseSha: 'base',
+    headSha: 'head',
+  } as PRContext;
+
+  const ctx = {
+    complexityReport: { files: {}, summary: {} },
+    baselineReport: null,
+    deltas: null,
+    deltaSummary: null,
+    pr,
+    logger: silentLogger,
+    addAnnotations: vi.fn(),
+    appendSummary: vi.fn(),
+    appendDescription,
+  } as unknown as PresentContext;
+
+  return { ctx, appendDescription };
+}
+
+// ---------------------------------------------------------------------------
+// Trust verdict line — rendered inside the agent plugin's PR-description
+// contribution (the "lien-stats" block), independent of the model's own
+// overview prose (the #954 shape this closes).
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPlugin.present — trust verdict line', () => {
+  const plugin = new AgentReviewPlugin();
+
+  it('renders a quiet, non-callout line for a clean, completed run', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([summaryFinding()], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('Trust: **Delivered**');
+    expect(description).toContain('completion within budget');
+    // Not a GitHub alert callout — this is the quiet path.
+    expect(description).not.toMatch(/> \[!(WARNING|CAUTION)\]\n> ✅/);
+  });
+
+  it('renders even when the model overview prose contradicts it (the #954 shape)', async () => {
+    // The exact motivating bug: the completed-run summary's own free-form
+    // overview claims a budget problem that the ground-truth metadata (no
+    // incomplete/neverRan notice at all) does not corroborate.
+    const { ctx, appendDescription } = recordingContext();
+    const misleadingSummary = summaryFinding({
+      overview: 'I was unable to complete a full review before budget exhaustion.',
+    });
+
+    await plugin.present([misleadingSummary], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain(
+      'I was unable to complete a full review before budget exhaustion.',
+    );
+    // The deterministic line still asserts Delivered — a reader can check
+    // the prose above against it instead of trusting the prose alone.
+    expect(description).toContain('Trust: **Delivered**');
+  });
+
+  it('renders a CAUTION callout when every provider request failed', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([neverRanFinding()], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('> [!CAUTION]');
+    expect(description).toContain('Trust: Failed — provider never ran');
+    expect(description).toContain('No code was analyzed this run.');
+  });
+
+  it('renders a WARNING callout naming budget-starved when the main pass ran out of budget', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([incompleteMainFinding('budget')], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('> [!WARNING]');
+    expect(description).toContain('Trust: Degraded — budget-starved');
+    expect(description).toContain('exhausting its token budget');
+  });
+
+  it('renders a WARNING callout naming a generic partial stop for a non-budget incomplete', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([incompleteMainFinding('max_turns')], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('> [!WARNING]');
+    expect(description).toContain('Trust: Degraded — partial');
+    expect(description).not.toContain('budget-starved');
+  });
+
+  it('degrades the trust line even when only an extra pass (not main) stalled', async () => {
+    // Matches computeVerdict's own precedent (attestation.test.ts): a
+    // doc-truth-only budget starvation still degrades the run's overall
+    // health, even though the main pass's bug-finding coverage is intact.
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([summaryFinding(), incompleteExtraPassFinding('budget')], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).toContain('Trust: Degraded — budget-starved');
+    // The main-pass-completion signal is untouched: no "did not complete" headline.
+    expect(description).not.toContain('Review did not complete');
+  });
+
+  it('renders nothing when the agent-review plugin did not run this review at all', async () => {
+    const { ctx, appendDescription } = recordingContext();
+
+    await plugin.present([], ctx);
+
+    const description = appendDescription.mock.calls[0][0] as string;
+    expect(description).not.toContain('Trust:');
+  });
+});

--- a/packages/review/test/plugins-agent-trust-badge.test.ts
+++ b/packages/review/test/plugins-agent-trust-badge.test.ts
@@ -1,8 +1,21 @@
 import { describe, it, expect, vi } from 'vitest';
-import { AgentReviewPlugin } from '../src/plugins/agent/index.js';
+import { AgentReviewPlugin, derivePresentTimeVerdict } from '../src/plugins/agent/index.js';
+import { computeVerdict } from '../src/attestation.js';
+import type { ProviderPassAttestation } from '../src/attestation.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { PresentContext, ReviewFinding } from '../src/plugin-types.js';
 import type { PRContext } from '../src/types.js';
+
+/** A clean delivery — no dropped comments, no write failures — so `computeVerdict`'s
+ * verdict is driven purely by `passes`, the one dimension `derivePresentTimeVerdict`
+ * can also see. */
+function cleanDelivery() {
+  return {
+    inlineComments: { attempted: 0, posted: 0, dropped: 0, deduped: 0, citationGated: 0 },
+    descriptionBadgeUpdated: null,
+    outOfDiffReviewPosted: null,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Fixtures — mirror the exact shapes appendSummaryFinding/appendIncompleteNotice/
@@ -193,5 +206,119 @@ describe('AgentReviewPlugin.present — trust verdict line', () => {
 
     const description = appendDescription.mock.calls[0][0] as string;
     expect(description).not.toContain('Trust:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// derivePresentTimeVerdict — consistency with computeVerdict
+//
+// Two independent derivations of "is this run trustworthy" now exist:
+// computeVerdict (post-hoc, attestation.ts, 7 verdicts) and
+// derivePresentTimeVerdict (render-time, this file, a reduced 4). Nothing
+// structurally stops them from drifting apart — a future change to one
+// taxonomy could silently leave the other behind, which is exactly the kind
+// of gap this PR exists to close, one level up. These tests pin every input
+// state both functions can see: either they must agree, or the mismatch is
+// asserted and explained (never a silent, unpinned divergence).
+// ---------------------------------------------------------------------------
+
+describe('derivePresentTimeVerdict — consistency with computeVerdict', () => {
+  const mainPass = (overrides?: Partial<ProviderPassAttestation>): ProviderPassAttestation => ({
+    name: 'main',
+    ran: true,
+    stopReason: 'completed',
+    neverRan: false,
+    candidatesDeferred: 0,
+    ...overrides,
+  });
+
+  it('agree on a clean, completed run: delivered', () => {
+    const present = derivePresentTimeVerdict([summaryFinding()]);
+    const full = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      passes: [mainPass()],
+      ...cleanDelivery(),
+    });
+    expect(present).toBe('delivered');
+    expect(full).toBe('delivered');
+    expect(present).toBe(full);
+  });
+
+  it('agree when every provider request failed: failed:provider_never_ran', () => {
+    const present = derivePresentTimeVerdict([neverRanFinding()]);
+    const full = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: true,
+      passes: [mainPass({ stopReason: 'error', neverRan: true })],
+      ...cleanDelivery(),
+    });
+    expect(present).toBe('failed:provider_never_ran');
+    expect(full).toBe('failed:provider_never_ran');
+    expect(present).toBe(full);
+  });
+
+  it('agree when the main pass stopped on budget: degraded:budget_starved', () => {
+    const present = derivePresentTimeVerdict([incompleteMainFinding('budget')]);
+    const full = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      passes: [mainPass({ stopReason: 'budget' })],
+      ...cleanDelivery(),
+    });
+    expect(present).toBe('degraded:budget_starved');
+    expect(full).toBe('degraded:budget_starved');
+    expect(present).toBe(full);
+  });
+
+  it('agree when the main pass stopped for a non-budget reason: degraded:provider_partial', () => {
+    const present = derivePresentTimeVerdict([incompleteMainFinding('max_turns')]);
+    const full = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      passes: [mainPass({ stopReason: 'max_turns' })],
+      ...cleanDelivery(),
+    });
+    expect(present).toBe('degraded:provider_partial');
+    expect(full).toBe('degraded:provider_partial');
+    expect(present).toBe(full);
+  });
+
+  it('agree when only an extra pass (not main) stalled on budget: degraded:budget_starved', () => {
+    // Mirrors attestation.test.ts's own computeVerdict case for this shape
+    // (a doc-truth-only budget starvation folded into the overall verdict).
+    const present = derivePresentTimeVerdict([
+      summaryFinding(),
+      incompleteExtraPassFinding('budget'),
+    ]);
+    const full = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      passes: [mainPass(), { ...mainPass({ stopReason: 'budget' }), name: 'doc-truth' }],
+      ...cleanDelivery(),
+    });
+    expect(present).toBe('degraded:budget_starved');
+    expect(full).toBe('degraded:budget_starved');
+    expect(present).toBe(full);
+  });
+
+  it('DIVERGES (documented) when the plugin never ran: present is null, full is delivered', () => {
+    // The one pinned, deliberate mismatch — see derivePresentTimeVerdict's own
+    // doc comment. `computeVerdict` fed `agentAttempted: false` calls a no-op
+    // review "delivered" (nothing could have gone wrong). Rendering that same
+    // label here would falsely claim a review happened, so this function
+    // returns `null` (buildTrustSection renders nothing) instead. If a future
+    // change makes `computeVerdict` stop mapping this case to `'delivered'`,
+    // this assertion — not just the PR description — is what should catch it.
+    const present = derivePresentTimeVerdict([]);
+    const full = computeVerdict({
+      pipelineFailed: false,
+      providerFailure: false,
+      passes: [], // buildPassesAndBudget's agentAttempted: false shape
+      ...cleanDelivery(),
+    });
+    expect(present).toBeNull();
+    expect(full).toBe('delivered');
+    expect(present).not.toBe(full);
   });
 });


### PR DESCRIPTION
## Summary

Lien Review already computes an authoritative, deterministic trust signal — `AttestationVerdict` in `packages/review/src/attestation.ts` (`delivered` / `degraded:*` / `failed:*`) — but it never reached the block a reader actually looks at. The `lien-stats` block (built by `buildDescription` in `packages/review/src/plugins/agent/index.ts`) showed only a risk level and the model's own free-form overview prose.

The cost of that gap is real: PR #954 shipped a review whose own prose claimed *"I was unable to complete a full file-level edge-case review before budget exhaustion, so this assessment is provisional"* — while the run log showed 6 turns, `finish_reason=stop`, 48% of budget spent, and the attestation said `delivered` throughout. Nothing in the rendered PR contradicted the false claim.

This PR adds a **deterministic trust line** to that same block, so "is this review trustworthy?" is answerable without reading a paragraph — and, in the exact #954 shape, without needing to trust the paragraph at all.

## Where I put it, and why

- **New function `buildTrustSection`** in `packages/review/src/plugins/agent/index.ts`, called from `buildDescription` exactly the way `buildFindingsSection` (#960) is — a self-contained function whose output is spread into the existing `parts` array. **Zero new branches added to `buildDescription` itself.** `get_files_context` flagged that function as `14/15` cyclomatic before I touched it (near its complexity budget); `lien delta` confirms my change adds no branch there (only a spread), and the two new functions (`derivePresentTimeVerdict` cognitive 4, `buildTrustSection` cognitive 3) are well under threshold.
- I deliberately did **not** touch the pre-existing separate `<!-- lien:attestation -->` PR-description section (`syncAttestationBadge` in `review-pr.ts`). That section is posted *after* `engine.present()` returns, because the full `Attestation` needs delivery-outcome data (did the inline comments land, did the description write itself succeed) that literally cannot be known until after this very block is written. It's silent on `delivered` by design. That silence is exactly why #954 went unnoticed — a delivered run produced *no* signal anywhere to check the model's prose against. My new line is a **reduced, present()-time verdict** computed from the same ground truth (`hasProviderFailure`, and the `incomplete`/`stopReason` metadata `appendNeverRanNotice`/`appendIncompleteNotice` stamp), rendered in the block that's actually read. The separate section remains the post-hoc safety net for the two verdicts that are inherently unknowable at render time (`degraded:comments_dropped`, `degraded:delivery_incomplete` — both about the write/post that's already happened by the time that section runs). The two are complementary, not duplicative.

## Design calls

**Prominence.** Asymmetric, not silence-for-delivered:
- `delivered` renders one quiet, non-callout line (`✅ *Trust: **Delivered** — …*`) — a clean run is the common case and this block is read on every PR, so it stays cheap.
- `degraded:*` / `failed:*` render as their own GitHub alert callout — `WARNING` for degraded, `CAUTION` (the most severe GitHub supports) for a total provider failure — impossible to miss.

I considered the "silence means delivered" option (it's literally the existing precedent in `formatAttestationBadgeLine`'s own doc comment) and rejected it: **the motivating bug is itself a `delivered` run with misleading prose.** If delivered renders nothing, this fix would not have helped the exact case it's justified by — a reader would still have nothing to check the false "budget exhaustion" claim against. Rendering *something*, even minimal, is what lets a reader resolve the contradiction in the PR body itself instead of pulling run logs.

**Detail.** Sub-reason included, not just the bucket. `degraded:budget_starved` vs `degraded:provider_partial` is the difference between "give it more budget" and "something else stalled it" — cheap to compute (already-stamped `stopReason` metadata) and directly actionable, so I kept it. I did *not* include raw token counts (spent/allocated) — the verdict label itself already asserts "not budget-starved" or "budget-starved"; the label is sufficient to act on, and the allocated-ceiling isn't available at `present()` time without new plumbing through `PresentContext` anyway.

**`filesAnalyzed`.** Deferred, not in scope. It lives on the attestation's `scope`, populated in `review-pr.ts` from the whole review's file list — not something the agent plugin's own `present()` has access to today. Surfacing it here would mean threading a new field through `PresentContext`/`AdapterContext` (touching `engine.ts`, `review-pr.ts`, and every other `PresentContext` construction site) — a materially bigger blast radius than a deterministic-verdict line, and arguably its own PR.

**Extra-pass handling.** `derivePresentTimeVerdict` scans *every* summary finding, not just the first — so a doc-truth-only budget stall still degrades the trust line, matching `computeVerdict`'s own established precedent (verified in `attestation.test.ts`) of folding an extra pass's stop reason into the whole run's health, even though it does *not* imply the main pass's own bug-finding coverage is compromised (that's a separate, already-existing signal via `hasIncompleteMainPass`/the "Review did not complete" headline).

## Dogfood evidence — rendered before/after

Reconstructed via `AgentReviewPlugin.present()` with synthesized findings matching the exact metadata shapes `appendSummaryFinding`/`appendIncompleteNotice`/`appendNeverRanNotice` produce (no live review run needed, per the task). Captured by building the package before and after this change and calling `present()` directly; `appendDescription`'s argument is the raw markdown shown below.

### `delivered` (clean run)

Before:
```
> [!NOTE]
> **Low Risk**
>
> No callers, exports, or runtime logic are affected.

<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>
```

After:
```
> [!NOTE]
> **Low Risk**
>
> No callers, exports, or runtime logic are affected.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>
```

### `degraded:budget_starved`

Before:
```
> [!WARNING]
> ⚠️ **Review did not complete**
>
> Any findings shown are partial; re-run the review to retry.

<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>
```

After:
```
> [!WARNING]
> ⚠️ **Review did not complete**
>
> Any findings shown are partial; re-run the review to retry.

> [!WARNING]
> 🟡 **Trust: Degraded — budget-starved**
>
> The review stopped after exhausting its token budget before finishing. Treat the findings above as partial.

<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>
```

### `failed:provider_never_ran`

Before:
```
> [!WARNING]
> ⚠️ **Review did not complete**
>
> This is NOT a clean review; no code was analyzed.

<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>
```

After:
```
> [!WARNING]
> ⚠️ **Review did not complete**
>
> This is NOT a clean review; no code was analyzed.

> [!CAUTION]
> 🔴 **Trust: Failed — provider never ran**
>
> Every provider request failed. No code was analyzed this run.

<sup>Reviewed by [Lien Review](https://lien.dev). Updates automatically on new commits.</sup>
```

## Scope boundary honored

**No prompt changes.** Nothing in `system-prompt.ts` or any rule text was touched — this is renderer-only, reading metadata the pipeline already stamps. **Deterministic and unit-tested only; no harness calibration run performed or required.** The complementary fix (stopping the model from narrating budget states it can't observe) is deliberately left for a separate PR, per the task's explicit scope boundary.

## Repo-rule compliance

- `get_files_context` called before editing `packages/review/src/plugins/agent/index.ts`, `attestation.ts`, and `review-pr.ts` — surfaced the `complexityHeadroomWarning` for `buildDescription` (14/15 cyclomatic) that shaped the "add a function, don't add a branch" approach above. No exported symbol's signature changed, so `get_dependents` did not apply.
- `@liendev/review` and `@liendev/action` are both `"private": true` — no changeset needed.
- All six gates green locally: `format:check`, `lint` (0 errors — pre-existing warnings only, none in touched files), `typecheck`, `build`, `test` (1713/1713 in `@liendev/review`, including one pre-existing byte-identical test in `plugins-agent-budget.test.ts` updated to include the new quiet trust line), and `lien delta` (exit 0 — `buildDescription`'s flagged metric is a pre-existing violation untouched by this change; the two new functions are well under threshold).

## Test plan

- [x] `npm run test -w @liendev/review` — 58 files / 1713 tests pass
- [x] New `packages/review/test/plugins-agent-trust-badge.test.ts` — 7 cases: quiet delivered line, delivered-with-misleading-prose (the #954 shape), CAUTION callout for provider-never-ran, WARNING callout for budget-starved, WARNING callout for generic partial, extra-pass-only degradation, and no line when the plugin didn't run
- [x] `lien delta` — exit 0, no new complexity crossings
- [x] `format:check` / `lint` / `typecheck` / `build` all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Trust status to review descriptions, indicating whether the review was delivered, partially completed, budget-limited, or unable to run.
  * Displays clear warning callouts when review results are incomplete or unavailable.
  * Trust status is determined from review completion results rather than summary wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 2 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 3 | +1 |


> [!NOTE]
> **Low Risk**
>
> This PR adds a deterministic trust-verdict line to the agent-review plugin's PR-description block. The new `derivePresentTimeVerdict` function reads the same ground-truth metadata (`neverRan`, `incomplete`, `stopReason`) that the delivery attestation uses, and `buildTrustSection` renders it as a quiet line for clean runs or a GitHub alert callout for degraded/failed runs. The implementation is self-contained, does not add branches to the already-complex `buildDescription`, and is covered by a new 7-case test suite plus an updated existing test. No exported signatures were changed, and the logic correctly prioritizes provider-never-ran over incomplete, distinguishes budget-starved from other partial stops, and scans all summary findings so an extra-pass stall degrades the verdict.
>
> - Added `PresentTimeVerdict` type and `derivePresentTimeVerdict` to derive a present-time trust verdict from summary-finding metadata
> - Added `buildTrustSection` to render the verdict as either a quiet line (`delivered`) or a GitHub alert callout (`degraded`/`failed`)
> - Inserted the trust line into `buildDescription` between the overview callout and the findings list via array spread
> - Added comprehensive unit tests in `plugins-agent-trust-badge.test.ts` and updated `plugins-agent-budget.test.ts`

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 77394c1. Updates automatically on new commits.</sup>
<!-- /lien-stats -->